### PR TITLE
Rename project from "editor" to "fresh"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "editor"
+name = "fresh"
 version = "0.1.0"
 authors = ["Noam Lewis"]
 edition = "2021"
@@ -36,7 +36,7 @@ insta = { version = "1.43", features = ["yaml"] }
 ctor = "0.2"
 
 [[bench]]
-name = "editor_benchmarks"
+name = "fresh_benchmarks"
 harness = false
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Editor
+# Fresh
 
 A fast, lightweight terminal text editor written in Rust. Handles files of any size with instant startup, low memory usage, and modern IDE features.
 
-## Why This Editor?
+## Why Fresh?
 
 - **Instant load of huge files** - Open and edit 1GB+ files instantly with syntax highlighting
 - **Lightweight** - Minimal memory footprint, fast startup
@@ -65,13 +65,13 @@ cargo build --release
 
 ### Run
 ```bash
-./target/release/editor [file]
+./target/release/fresh [file]
 ```
 
 Open any file, including large files:
 ```bash
-./target/release/editor large_log_file.txt
-./target/release/editor src/main.rs
+./target/release/fresh large_log_file.txt
+./target/release/fresh src/main.rs
 ```
 
 ## Essential Keybindings
@@ -104,7 +104,7 @@ Press **Ctrl+H** inside the editor to see all keybindings.
 
 ## Configuration
 
-Configuration file: `~/.config/editor/config.json`
+Configuration file: `~/.config/fresh/config.json`
 
 ```json
 {
@@ -132,7 +132,7 @@ All keybindings, colors, and LSP servers are configurable.
 
 ## 🔒 Process Resource Limits
 
-The editor automatically limits memory and CPU usage of LSP servers (like `rust-analyzer`) to prevent them from making your system unresponsive. **Memory limiting works out of the box** on modern Linux systems.
+Fresh automatically limits memory and CPU usage of LSP servers (like `rust-analyzer`) to prevent them from making your system unresponsive. **Memory limiting works out of the box** on modern Linux systems.
 
 - **Default:** 50% of system memory, 90% CPU throttling
 - **When needed:** LSP servers consuming excessive resources
@@ -142,7 +142,7 @@ See [docs/PROCESS_LIMITS.md](docs/PROCESS_LIMITS.md) for detailed documentation,
 
 ## Large File Support
 
-This editor is designed to handle files of any size:
+Fresh is designed to handle files of any size:
 
 - **Instant loading** - Files open immediately regardless of size
 - **Viewport-only parsing** - Only highlights visible text (enables instant load of huge files)

--- a/benches/fresh_benchmarks.rs
+++ b/benches/fresh_benchmarks.rs
@@ -1,9 +1,9 @@
 // Benchmarks for critical editor operations
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use editor::buffer::Buffer;
-use editor::cursor::{Cursor, CursorId, Cursors};
-use editor::event::Event;
-use editor::state::EditorState;
+use fresh::buffer::Buffer;
+use fresh::cursor::{Cursor, CursorId, Cursors};
+use fresh::event::Event;
+use fresh::state::EditorState;
 
 /// Benchmark buffer insert operations
 fn bench_buffer_insert(c: &mut Criterion) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-A high-performance terminal text editor with async I/O and event-driven design.
+Fresh is a high-performance terminal text editor with async I/O and event-driven design.
 
 ## Core Design Principles
 

--- a/docs/PROCESS_LIMITS.md
+++ b/docs/PROCESS_LIMITS.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This editor automatically applies resource limits to LSP servers (like `rust-analyzer`, `typescript-language-server`, etc.) to prevent them from consuming excessive system resources and making your development environment unresponsive.
+Fresh automatically applies resource limits to LSP servers (like `rust-analyzer`, `typescript-language-server`, etc.) to prevent them from consuming excessive system resources and making your development environment unresponsive.
 
 ## Why This Matters
 
@@ -21,7 +21,7 @@ Resource limits prevent these issues by automatically constraining LSP servers t
 Using resource limits: memory=6815 MB (cgroup), CPU=90% (unavailable)
 ```
 
-The editor will limit each LSP server to **50% of system memory** by default. This happens automatically—no configuration required.
+Fresh will limit each LSP server to **50% of system memory** by default. This happens automatically—no configuration required.
 
 ## CPU Throttling (Optional Setup)
 
@@ -70,7 +70,7 @@ cat /sys/fs/cgroup/user.slice/user-$(id -u).slice/cgroup.controllers
 
 #### Verify It's Working
 
-After setup, check the editor logs (`/tmp/editor.log`). You should see:
+After setup, check the fresh logs (`/tmp/fresh.log`). You should see:
 
 ```
 Using resource limits: memory=6815 MB (cgroup), CPU=90% (cgroup)
@@ -83,7 +83,7 @@ If CPU still shows as `unavailable`, delegation may not have taken effect. Try:
 
 ## Configuration
 
-Limits are configurable per LSP server in `~/.config/editor/config.json`:
+Limits are configurable per LSP server in `~/.config/fresh/config.json`:
 
 ```json
 {
@@ -129,7 +129,7 @@ Limits are configurable per LSP server in `~/.config/editor/config.json`:
 
 ## How It Works
 
-The editor uses **cgroups v2** for resource limiting when available, with automatic fallbacks for compatibility.
+Fresh uses **cgroups v2** for resource limiting when available, with automatic fallbacks for compatibility.
 
 ### Memory Limiting
 
@@ -162,7 +162,7 @@ The editor uses **cgroups v2** for resource limiting when available, with automa
 
 ### Status Messages
 
-The editor logs show which methods are active:
+The fresh logs show which methods are active:
 
 | Message | Meaning |
 |---------|---------|
@@ -172,7 +172,7 @@ The editor logs show which methods are active:
 | `CPU=90% (cgroup)` | CPU throttling via cgroups v2 ✓ |
 | `CPU=90% (unavailable)` | CPU throttling not available (needs delegation) |
 
-Check `/tmp/editor.log` after starting the editor to see what's active.
+Check `/tmp/fresh.log` after starting fresh to see what's active.
 
 ## Platform Support
 
@@ -253,13 +253,13 @@ If cgroups unavailable, setrlimit fallback should still work (check logs).
 
 ### Cgroup Hierarchy
 
-The editor creates cgroups in this hierarchy:
+Fresh creates cgroups in this hierarchy:
 ```
 /sys/fs/cgroup/
 └── user.slice/
     └── user-1000.slice/
         └── user@1000.service/
-            └── editor-lsp-12345/    ← Created per LSP server
+            └── fresh-lsp-12345/    ← Created per LSP server
                 ├── cgroup.procs     ← Process moved here
                 ├── memory.max       ← Memory limit written here
                 └── cpu.max          ← CPU limit written here (if delegated)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,7 +22,7 @@ Core editing, multi-cursor, event-driven architecture, LSP integration (diagnost
 - [ ] Signature help
 - [ ] Inlay hints
 
-### Editor Features
+### Editing Features
 - [ ] Search & replace with regex
 - [ ] Rectangular selection (Alt+drag)
 - [ ] Auto-indent on newline

--- a/docs/VISUAL_REGRESSION_TESTING.md
+++ b/docs/VISUAL_REGRESSION_TESTING.md
@@ -184,7 +184,7 @@ When you create a PR with UI changes:
 ## File Structure
 
 ```
-editor/
+fresh/
 ├── docs/
 │   └── visual-regression/
 │       ├── tests/                      # Individual test docs (auto-generated, committed)
@@ -324,5 +324,5 @@ Potential improvements:
 ## See Also
 
 - [TESTING.md](TESTING.md) - General testing strategy
-- [ARCHITECTURE.md](ARCHITECTURE.md) - How the editor works
+- [ARCHITECTURE.md](ARCHITECTURE.md) - How fresh works
 - [insta documentation](https://insta.rs/) - Snapshot testing library

--- a/examples/file_explorer_demo.rs
+++ b/examples/file_explorer_demo.rs
@@ -4,9 +4,9 @@
 ///
 /// To run: cargo run --example file_explorer_demo
 
-use editor::file_tree::{FileTree, FileTreeView};
-use editor::fs::{FsManager, LocalFsBackend};
-use editor::ui::FileExplorerRenderer;
+use fresh::file_tree::{FileTree, FileTreeView};
+use fresh::fs::{FsManager, LocalFsBackend};
+use fresh::ui::FileExplorerRenderer;
 use std::env;
 use std::io;
 use std::path::PathBuf;

--- a/src/chunk_tree.rs
+++ b/src/chunk_tree.rs
@@ -15,7 +15,7 @@
 //!
 //! # Examples
 //! ```
-//! use editor::chunk_tree::{ChunkTree, ChunkTreeConfig};
+//! use fresh::chunk_tree::{ChunkTree, ChunkTreeConfig};
 //!
 //! let config = ChunkTreeConfig::new(4, 4);
 //! let tree = ChunkTree::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use editor::{config, editor::Editor, signal_handler};
+use fresh::{config, editor::Editor, signal_handler};
 use ratatui::Terminal;
 use std::{
     io::{self, stdout},

--- a/test.rs
+++ b/test.rs
@@ -7,7 +7,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use editor::{config, editor::Editor, signal_handler};
+use fresh::{config, editor::Editor, signal_handler};
 use ratatui::Terminal;
 use std::{
     io::{self, stdout},

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -1,7 +1,7 @@
 // EditorTestHarness - Virtual terminal environment for E2E testing
 
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
-use editor::{config::Config, editor::Editor};
+use fresh::{config::Config, editor::Editor};
 use ratatui::{backend::TestBackend, Terminal};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -211,7 +211,7 @@ impl EditorTestHarness {
     }
 
     /// Apply an event directly to the active buffer
-    pub fn apply_event(&mut self, event: editor::event::Event) -> io::Result<()> {
+    pub fn apply_event(&mut self, event: fresh::event::Event) -> io::Result<()> {
         self.editor.apply_event_to_active_buffer(event);
         Ok(())
     }

--- a/tests/e2e/lsp.rs
+++ b/tests/e2e/lsp.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 /// Test that completion popup text is not mangled
 #[test]
 fn test_lsp_completion_popup_text_not_mangled() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -79,7 +79,7 @@ fn test_lsp_completion_popup_text_not_mangled() -> std::io::Result<()> {
 /// Test that completion replaces current word, not appends
 #[test]
 fn test_lsp_completion_replaces_word() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -132,7 +132,7 @@ fn test_lsp_completion_replaces_word() -> std::io::Result<()> {
 /// Test LSP diagnostics display in the editor
 #[test]
 fn test_lsp_diagnostics_display() -> std::io::Result<()> {
-    use editor::event::{Event, OverlayFace, UnderlineStyle};
+    use fresh::event::{Event, OverlayFace, UnderlineStyle};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -168,7 +168,7 @@ fn test_lsp_diagnostics_display() -> std::io::Result<()> {
 /// Test LSP completion popup display
 #[test]
 fn test_lsp_completion_popup() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -240,7 +240,7 @@ fn test_lsp_completion_popup() -> std::io::Result<()> {
 /// Test LSP diagnostics summary in status bar
 #[test]
 fn test_lsp_diagnostics_status_bar() -> std::io::Result<()> {
-    use editor::event::{Event, OverlayFace};
+    use fresh::event::{Event, OverlayFace};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -290,7 +290,7 @@ fn test_lsp_diagnostics_status_bar() -> std::io::Result<()> {
 /// Test that diagnostics are removed when cleared
 #[test]
 fn test_lsp_clear_diagnostics() -> std::io::Result<()> {
-    use editor::event::{Event, OverlayFace};
+    use fresh::event::{Event, OverlayFace};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -337,7 +337,7 @@ fn test_lsp_clear_diagnostics() -> std::io::Result<()> {
 /// Test multiple completion items navigation
 #[test]
 fn test_lsp_completion_navigation() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -401,7 +401,7 @@ fn test_lsp_completion_navigation() -> std::io::Result<()> {
 /// Test popup cancel (Escape) doesn't insert anything
 #[test]
 fn test_lsp_completion_cancel() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -453,7 +453,7 @@ fn test_lsp_completion_cancel() -> std::io::Result<()> {
 /// Test completion after a dot preserves the prefix
 #[test]
 fn test_lsp_completion_after_dot() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -514,7 +514,7 @@ fn test_lsp_completion_after_dot() -> std::io::Result<()> {
 /// Test completion after typing a partial identifier after dot
 #[test]
 fn test_lsp_completion_after_dot_with_partial() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -563,7 +563,7 @@ fn test_lsp_completion_after_dot_with_partial() -> std::io::Result<()> {
 /// Test that completion filtering only shows matching items by prefix
 #[test]
 fn test_lsp_completion_filtering() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -616,7 +616,7 @@ fn test_lsp_completion_filtering() -> std::io::Result<()> {
     );
 
     if let Some(popup) = state.popups.top() {
-        if let editor::popup::PopupContent::List { items, .. } = &popup.content {
+        if let fresh::popup::PopupContent::List { items, .. } = &popup.content {
             // Should only have test_function and test_variable
             assert_eq!(
                 items.len(),
@@ -655,7 +655,7 @@ fn test_lsp_completion_filtering() -> std::io::Result<()> {
 /// Test that popup size is appropriate for the number of filtered items
 #[test]
 fn test_lsp_completion_popup_size() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 
@@ -785,7 +785,7 @@ fn test_lsp_waiting_indicator() -> std::io::Result<()> {
 /// Test that popup properly hides buffer text behind it
 #[test]
 fn test_lsp_completion_popup_hides_background() -> std::io::Result<()> {
-    use editor::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{Event, PopupContentData, PopupData, PopupListItemData, PopupPositionData};
 
     let mut harness = EditorTestHarness::new(80, 24)?;
 

--- a/tests/e2e/margin.rs
+++ b/tests/e2e/margin.rs
@@ -79,7 +79,7 @@ fn test_margin_disable_line_numbers() {
     harness.open_file(&file_path).unwrap();
 
     // Disable line numbers via event
-    harness.apply_event(editor::event::Event::SetLineNumbers { enabled: false }).unwrap();
+    harness.apply_event(fresh::event::Event::SetLineNumbers { enabled: false }).unwrap();
     harness.render().unwrap();
 
     let screen = harness.screen_to_string();
@@ -104,10 +104,10 @@ fn test_margin_custom_annotations() {
     harness.open_file(&file_path).unwrap();
 
     // Add a breakpoint annotation at line 2 (0-indexed)
-    harness.apply_event(editor::event::Event::AddMarginAnnotation {
+    harness.apply_event(fresh::event::Event::AddMarginAnnotation {
         line: 2,
-        position: editor::event::MarginPositionData::Left,
-        content: editor::event::MarginContentData::Symbol {
+        position: fresh::event::MarginPositionData::Left,
+        content: fresh::event::MarginContentData::Symbol {
             text: "●".to_string(),
             color: Some((255, 0, 0)), // Red
         },
@@ -124,7 +124,7 @@ fn test_margin_custom_annotations() {
     harness.assert_screen_contains("●");
 
     // Remove the annotation
-    harness.apply_event(editor::event::Event::RemoveMarginAnnotation {
+    harness.apply_event(fresh::event::Event::RemoveMarginAnnotation {
         annotation_id: "breakpoint-1".to_string(),
     }).unwrap();
 
@@ -248,14 +248,14 @@ fn test_margin_per_buffer_in_split_view() {
     harness.assert_screen_contains("File 2 Line 1");
 
     // Now disable line numbers in the active buffer (file2)
-    harness.apply_event(editor::event::Event::SetLineNumbers { enabled: false }).unwrap();
+    harness.apply_event(fresh::event::Event::SetLineNumbers { enabled: false }).unwrap();
 
     // Add a custom annotation to file1 (need to switch to file1 first)
     harness.send_key(KeyCode::Char('o'), KeyModifiers::ALT).unwrap(); // Switch to previous split
-    harness.apply_event(editor::event::Event::AddMarginAnnotation {
+    harness.apply_event(fresh::event::Event::AddMarginAnnotation {
         line: 0,
-        position: editor::event::MarginPositionData::Left,
-        content: editor::event::MarginContentData::Symbol {
+        position: fresh::event::MarginPositionData::Left,
+        content: fresh::event::MarginContentData::Symbol {
             text: "●".to_string(),
             color: Some((255, 0, 0)),
         },

--- a/tests/e2e/theme.rs
+++ b/tests/e2e/theme.rs
@@ -1,7 +1,7 @@
 // E2E tests for the theme system
 
 use crate::common::harness::EditorTestHarness;
-use editor::config::Config;
+use fresh::config::Config;
 use ratatui::style::Color;
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use editor::{
+use fresh::{
     event::{CursorId, Event, EventLog},
     state::EditorState,
 };
@@ -298,7 +298,7 @@ fn test_viewport_resize_maintains_cursor() {
 /// Test overlay events - adding and removing overlays
 #[test]
 fn test_overlay_events() {
-    use editor::event::{OverlayFace, UnderlineStyle};
+    use fresh::event::{OverlayFace, UnderlineStyle};
     
     let mut state = EditorState::new(80, 24);
     
@@ -363,7 +363,7 @@ fn test_overlay_events() {
 /// Test popup events - showing, navigating, and hiding popups
 #[test]
 fn test_popup_events() {
-    use editor::event::{PopupContentData, PopupData, PopupListItemData, PopupPositionData};
+    use fresh::event::{PopupContentData, PopupData, PopupListItemData, PopupPositionData};
     
     let mut state = EditorState::new(80, 24);
     
@@ -437,7 +437,7 @@ fn test_popup_events() {
 /// Test that overlays persist through undo/redo
 #[test]
 fn test_overlay_undo_redo() {
-    use editor::event::{OverlayFace, UnderlineStyle};
+    use fresh::event::{OverlayFace, UnderlineStyle};
 
     let mut log = EventLog::new();
     let mut state = EditorState::new(80, 24);
@@ -495,7 +495,7 @@ fn test_overlay_undo_redo() {
 /// Test LSP diagnostic to overlay conversion
 #[test]
 fn test_lsp_diagnostic_to_overlay() {
-    use editor::{buffer::Buffer, lsp_diagnostics::diagnostic_to_overlay};
+    use fresh::{buffer::Buffer, lsp_diagnostics::diagnostic_to_overlay};
     use lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range};
 
     let buffer = Buffer::from_str("let x = 5;\nlet y = 10;");
@@ -522,7 +522,7 @@ fn test_lsp_diagnostic_to_overlay() {
         data: None,
     };
 
-    let theme = editor::theme::Theme::dark();
+    let theme = fresh::theme::Theme::dark();
     let result = diagnostic_to_overlay(&diagnostic, &buffer, &theme);
     assert!(result.is_some());
 
@@ -537,7 +537,7 @@ fn test_lsp_diagnostic_to_overlay() {
 
     // Check face (should use theme's error background color)
     match face {
-        editor::overlay::OverlayFace::Background { color } => {
+        fresh::overlay::OverlayFace::Background { color } => {
             assert_eq!(color, theme.diagnostic_error_bg);
         }
         _ => panic!("Expected background face for error diagnostic"),
@@ -547,7 +547,7 @@ fn test_lsp_diagnostic_to_overlay() {
 /// Test overlay rendering with multiple priorities
 #[test]
 fn test_overlay_priority_layering() {
-    use editor::event::{OverlayFace, UnderlineStyle};
+    use fresh::event::{OverlayFace, UnderlineStyle};
 
     let mut state = EditorState::new(80, 24);
 
@@ -597,7 +597,7 @@ fn test_overlay_priority_layering() {
 #[test]
 fn test_diagnostic_overlay_visual_rendering() {
     use common::harness::EditorTestHarness;
-    use editor::event::{OverlayFace, UnderlineStyle};
+    use fresh::event::{OverlayFace, UnderlineStyle};
     use ratatui::style::{Color, Modifier};
 
     let mut harness = EditorTestHarness::new(80, 24).unwrap();


### PR DESCRIPTION
Updated all documentation and configuration files to reflect the new project name:

- Changed project name in Cargo.toml from "editor" to "fresh"
- Renamed binary references from ./target/release/editor to ./target/release/fresh
- Updated config directory path from ~/.config/editor to ~/.config/fresh
- Updated log file paths from /tmp/editor.log to /tmp/fresh.log
- Renamed benchmark file from editor_benchmarks.rs to fresh_benchmarks.rs
- Updated cgroup naming from editor-lsp-* to fresh-lsp-*
- Updated all project name references in documentation:
  - README.md: Project title and references
  - docs/ARCHITECTURE.md: Project description
  - docs/PROCESS_LIMITS.md: Application references
  - docs/VISUAL_REGRESSION.md: Visual test captions
  - docs/VISUAL_REGRESSION_TESTING.md: Directory structure references
  - docs/TODO.md: Feature section renamed to "Editing Features"

Note: Generic references to "editor" (as in "text editor" or component names like "Editor" struct) were intentionally kept unchanged to maintain clarity.