### PR TITLE
Debug slow e2e tests taking 180+ seconds

### DIFF
--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -137,10 +137,15 @@ impl EditorTestHarness {
     }
 
     /// Simulate typing a string of text
+    /// Optimized to avoid rendering after each character - only renders once at the end
     pub fn type_text(&mut self, text: &str) -> io::Result<()> {
         for ch in text.chars() {
-            self.send_key(KeyCode::Char(ch), KeyModifiers::NONE)?;
+            // Call handle_key directly without rendering (unlike send_key which renders every time)
+            self.editor.handle_key(KeyCode::Char(ch), KeyModifiers::NONE)?;
         }
+        // Process any async messages that accumulated during typing
+        self.editor.process_async_messages();
+        // Render once at the end instead of after every character
         self.render()?;
         Ok(())
     }


### PR DESCRIPTION
…nders

The mouse and selection e2e tests were taking 180+ seconds instead of <1s due to rendering after every character typed. This commit fixes the performance issue by optimizing the `type_text()` method in the test harness.

Problem:
- `type_text()` called `send_key()` for each character
- `send_key()` called `render()` after every keystroke
- Tests typing 100 lines (~1700 chars) resulted in 1700+ render calls
- Each render is expensive: redraws terminal, recalculates syntax highlighting, scrollbar positions, etc.

Solution:
- Make `type_text()` call `editor.handle_key()` directly without rendering
- Call `process_async_messages()` once after all characters
- Call `render()` once at the end instead of after each character
- This reduces 1700+ renders to just 1 render

Results:
- test_scrollbar_drag: 183s → 2.52s (~71x faster)
- test_scrollbar_click_jump: 195s → 3.25s (~60x faster)
- test_scrollbar_drag_to_absolute_bottom: 195s → 2.44s (~80x faster)
- test_select_word_after_scrolling: now passes quickly

All tests still pass correctly with the optimization.