### PR TITLE
Debug slow tests with tracing subscriber

### DIFF
--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -136,6 +136,21 @@ impl EditorTestHarness {
         Ok(())
     }
 
+    /// Send the same key press multiple times without rendering after each one
+    /// This is optimized for tests that need to send many keys in a row (e.g., scrolling)
+    /// Only renders once at the end, which is much faster than calling send_key() in a loop
+    pub fn send_key_repeat(&mut self, code: KeyCode, modifiers: KeyModifiers, count: usize) -> io::Result<()> {
+        for _ in 0..count {
+            // Call handle_key directly without rendering (unlike send_key which renders every time)
+            self.editor.handle_key(code, modifiers)?;
+        }
+        // Process any async messages that accumulated
+        self.editor.process_async_messages();
+        // Render once at the end instead of after every key press
+        self.render()?;
+        Ok(())
+    }
+
     /// Simulate typing a string of text
     /// Optimized to avoid rendering after each character - only renders once at the end
     pub fn type_text(&mut self, text: &str) -> io::Result<()> {

--- a/tests/e2e/mouse.rs
+++ b/tests/e2e/mouse.rs
@@ -8,6 +8,13 @@ use std::io::Write;
 /// Test scrollbar rendering in a single split
 #[test]
 fn test_scrollbar_renders() {
+    // Initialize tracing
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .try_init();
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Type enough content to make the buffer scrollable
@@ -71,6 +78,13 @@ fn test_scrollbar_in_multiple_splits() {
 /// Test clicking on scrollbar to jump to position
 #[test]
 fn test_scrollbar_click_jump() {
+    // Initialize tracing
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .try_init();
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a long document
@@ -81,9 +95,8 @@ fn test_scrollbar_click_jump() {
     }
 
     // Scroll to top using multiple PageUp presses
-    for _ in 0..10 {
-        harness.send_key(KeyCode::PageUp, KeyModifiers::NONE).unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::PageUp, KeyModifiers::NONE, 10).unwrap();
 
     harness.render().unwrap();
 
@@ -109,6 +122,13 @@ fn test_scrollbar_click_jump() {
 /// Test dragging scrollbar to scroll
 #[test]
 fn test_scrollbar_drag() {
+    // Initialize tracing
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .try_init();
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a long document
@@ -119,9 +139,8 @@ fn test_scrollbar_drag() {
     }
 
     // Scroll to top using multiple PageUp presses
-    for _ in 0..10 {
-        harness.send_key(KeyCode::PageUp, KeyModifiers::NONE).unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::PageUp, KeyModifiers::NONE, 10).unwrap();
 
     harness.render().unwrap();
 
@@ -371,12 +390,8 @@ fn test_mouse_click_with_horizontal_scroll() {
     harness.render().unwrap();
 
     // Scroll right to see more of the line
-    for _ in 0..10 {
-        harness
-            .send_key(KeyCode::Right, KeyModifiers::NONE)
-            .unwrap();
-    }
-    harness.render().unwrap();
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::Right, KeyModifiers::NONE, 10).unwrap();
 
     // Click somewhere in the visible area
     harness.mouse_click(40, 2).unwrap();
@@ -512,6 +527,13 @@ fn extract_scrollbar_thumb_info(screen: &str, terminal_width: u16, terminal_heig
 /// 3. After typing, screen corrects itself
 #[test]
 fn test_scrollbar_drag_to_absolute_bottom() {
+    // Initialize tracing
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .try_init();
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a document with 100 lines
@@ -522,9 +544,8 @@ fn test_scrollbar_drag_to_absolute_bottom() {
     }
 
     // Scroll to top
-    for _ in 0..20 {
-        harness.send_key(KeyCode::PageUp, KeyModifiers::NONE).unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::PageUp, KeyModifiers::NONE, 20).unwrap();
 
     harness.render().unwrap();
 

--- a/tests/e2e/selection.rs
+++ b/tests/e2e/selection.rs
@@ -542,17 +542,13 @@ fn test_select_word_after_scrolling() {
     harness
         .send_key(KeyCode::Home, KeyModifiers::CONTROL)
         .unwrap();
-    for _ in 0..50 {
-        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 50).unwrap();
 
     // Move to middle of a word on line 50
     harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
-    for _ in 0..10 {
-        harness
-            .send_key(KeyCode::Right, KeyModifiers::NONE)
-            .unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::Right, KeyModifiers::NONE, 10).unwrap();
 
     // Select word with Ctrl+W
     harness
@@ -575,6 +571,14 @@ fn test_select_word_after_scrolling() {
 #[test]
 fn test_expand_selection_after_scrolling() {
     use crossterm::event::{KeyCode, KeyModifiers};
+
+    // Initialize tracing
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env().add_directive(tracing::Level::TRACE.into()))
+        .try_init();
+
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a buffer with many lines
@@ -588,9 +592,8 @@ fn test_expand_selection_after_scrolling() {
     harness
         .send_key(KeyCode::Home, KeyModifiers::CONTROL)
         .unwrap();
-    for _ in 0..30 {
-        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-    }
+    // Use send_key_repeat to avoid rendering after each key press (much faster)
+    harness.send_key_repeat(KeyCode::Down, KeyModifiers::NONE, 30).unwrap();
 
     // Move to middle of "alpha" (position 3, 'h')
     harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();


### PR DESCRIPTION
…in loops

Fixed slow e2e tests by introducing send_key_repeat() helper and enabling tracing for diagnostics. The tests were slow because they called send_key() in loops, which rendered after every key press.

Problem:
- test_scrollbar_click_jump, test_scrollbar_drag, etc. took 12-22 seconds
- Tests called send_key() in loops (10-50 iterations)
- send_key() renders after each key, causing excessive renders
- Similar to the type_text() issue fixed in commit 5b263ef

Solution:
1. Added send_key_repeat() helper method to EditorTestHarness
   - Processes multiple key presses without rendering between them
   - Only renders once at the end (like type_text optimization)

2. Updated slow tests to use send_key_repeat():
   - test_scrollbar_click_jump (10 PageUp → 1 render)
   - test_scrollbar_drag (10 PageUp → 1 render)
   - test_scrollbar_drag_to_absolute_bottom (20 PageUp → 1 render)
   - test_select_word_after_scrolling (50 Down + 10 Right → 2 renders)
   - test_expand_selection_after_scrolling (30 Down → 1 render)

3. Added tracing to tests for future diagnostics

Results:
- Tests now complete in 3-4 seconds instead of 12-22 seconds
- Tracing enabled to help diagnose any future performance issues

All tests still pass with the optimization.