### PR TITLE
Refactor tests to use test buffer

### DIFF
--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -117,6 +117,15 @@ impl EditorTestHarness {
         Ok(())
     }
 
+    /// Load text content into the editor by creating a temporary file and opening it
+    /// This is much faster than type_text() for large amounts of text in tests
+    /// Returns a TestFixture that must be kept alive for the duration of the test
+    pub fn load_buffer_from_text(&mut self, content: &str) -> io::Result<crate::common::fixtures::TestFixture> {
+        let fixture = crate::common::fixtures::TestFixture::new("test_buffer.txt", content)?;
+        self.open_file(&fixture.path)?;
+        Ok(fixture)
+    }
+
     /// Create a new empty buffer
     pub fn new_buffer(&mut self) -> io::Result<()> {
         self.editor.new_buffer();

--- a/tests/e2e/mouse.rs
+++ b/tests/e2e/mouse.rs
@@ -18,11 +18,10 @@ fn test_scrollbar_renders() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Type enough content to make the buffer scrollable
-    for i in 1..=50 {
-        harness
-            .type_text(&format!("Line {} with some content\n", i))
-            .unwrap();
-    }
+    let content: String = (1..=50)
+        .map(|i| format!("Line {} with some content\n", i))
+        .collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     harness.render().unwrap();
 
@@ -88,11 +87,10 @@ fn test_scrollbar_click_jump() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a long document
-    for i in 1..=100 {
-        harness
-            .type_text(&format!("Line {} content here\n", i))
-            .unwrap();
-    }
+    let content: String = (1..=100)
+        .map(|i| format!("Line {} content here\n", i))
+        .collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Scroll to top using multiple PageUp presses
     // Use send_key_repeat to avoid rendering after each key press (much faster)
@@ -132,11 +130,10 @@ fn test_scrollbar_drag() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a long document
-    for i in 1..=100 {
-        harness
-            .type_text(&format!("Line {} with text\n", i))
-            .unwrap();
-    }
+    let content: String = (1..=100)
+        .map(|i| format!("Line {} with text\n", i))
+        .collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Scroll to top using multiple PageUp presses
     // Use send_key_repeat to avoid rendering after each key press (much faster)
@@ -434,12 +431,13 @@ fn test_scrollbar_drag_to_top() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a long document
-    for i in 1..=100 {
-        harness
-            .type_text(&format!("Line {}\n", i))
-            .unwrap();
-    }
+    let content: String = (1..=100)
+        .map(|i| format!("Line {}\n", i))
+        .collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
+    // Move cursor to end to scroll down (loading from file starts at beginning)
+    harness.send_key(KeyCode::End, KeyModifiers::CONTROL).unwrap();
     harness.render().unwrap();
 
     // Cursor is at bottom, so we're scrolled down
@@ -537,11 +535,10 @@ fn test_scrollbar_drag_to_absolute_bottom() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a document with 100 lines
-    for i in 1..=100 {
-        harness
-            .type_text(&format!("Line {} content\n", i))
-            .unwrap();
-    }
+    let content: String = (1..=100)
+        .map(|i| format!("Line {} content\n", i))
+        .collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Scroll to top
     // Use send_key_repeat to avoid rendering after each key press (much faster)

--- a/tests/e2e/scrolling.rs
+++ b/tests/e2e/scrolling.rs
@@ -42,14 +42,14 @@ fn test_edits_persist_through_scrolling() {
 
     // Create content with many lines (more than viewport can show)
     // This ensures we can scroll away from edited content
-    let mut lines = Vec::new();
-    for i in 0..100 {
-        lines.push(format!("Line {i}"));
-    }
-    harness.type_text(&lines.join("\n")).unwrap();
+    let lines: Vec<String> = (0..100)
+        .map(|i| format!("Line {i}"))
+        .collect();
+    let content = lines.join("\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Verify initial content
-    harness.assert_buffer_content(&lines.join("\n"));
+    harness.assert_buffer_content(&content);
 
     // Go to the beginning of the document
     harness

--- a/tests/e2e/selection.rs
+++ b/tests/e2e/selection.rs
@@ -532,11 +532,11 @@ fn test_select_word_after_scrolling() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a buffer with many lines (more than viewport height)
-    let mut lines = Vec::new();
-    for i in 0..100 {
-        lines.push(format!("line{i} word{i} test{i}"));
-    }
-    harness.type_text(&lines.join("\n")).unwrap();
+    let content: String = (0..100)
+        .map(|i| format!("line{i} word{i} test{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Scroll down past the initial viewport
     harness
@@ -582,11 +582,11 @@ fn test_expand_selection_after_scrolling() {
     let mut harness = EditorTestHarness::new(80, 24).unwrap();
 
     // Create a buffer with many lines
-    let mut lines = Vec::new();
-    for i in 0..50 {
-        lines.push(format!("alpha beta gamma delta epsilon line{i}"));
-    }
-    harness.type_text(&lines.join("\n")).unwrap();
+    let content: String = (0..50)
+        .map(|i| format!("alpha beta gamma delta epsilon line{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
 
     // Scroll down to line 30
     harness


### PR DESCRIPTION
Changes:
- Added load_buffer_from_text() method to EditorTestHarness that creates a temporary file and opens it, which is much faster than typing text character-by-character
- Updated 8 slow e2e tests to use load_buffer_from_text():
  - test_scrollbar_drag_to_absolute_bottom
  - test_scrollbar_drag
  - test_scrollbar_renders
  - test_scrollbar_drag_to_top
  - test_scrollbar_click_jump
  - test_edits_persist_through_scrolling
  - test_expand_selection_after_scrolling
  - test_select_word_after_scrolling
- Fixed test_scrollbar_drag_to_top to move cursor to end after loading (since file loading starts cursor at beginning, unlike type_text)

This significantly improves test performance by loading prepared text buffers instead of simulating character-by-character input.