### PR TITLE
Add directory argument support with auto file explorer

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -887,6 +887,13 @@ impl Editor {
         }
     }
 
+    /// Show the file explorer (does not toggle - ensures it's visible)
+    pub fn show_file_explorer(&mut self) {
+        if !self.file_explorer_visible {
+            self.toggle_file_explorer();
+        }
+    }
+
     /// Set the active buffer and trigger all necessary side effects
     ///
     /// This is the centralized method for switching buffers. It:


### PR DESCRIPTION
When a directory is passed as a command line argument (instead of a file):
- Use that directory as the working directory
- Open an empty buffer
- Automatically show and expand the file explorer to that directory

This improves the user experience when launching the editor from a specific directory path, making it easy to browse and select files from that location.

Changes:
- main.rs: Detect if argument is directory vs file, handle accordingly
- editor.rs: Add show_file_explorer() method to ensure explorer is visible