### PR TITLE
Add Lua syntax highlighting support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tree-sitter-c-sharp = "0.23.1"
 tree-sitter-php = "0.24.2"
 tree-sitter-ruby = "0.23.1"
 tree-sitter-bash = "0.25.0"
+tree-sitter-lua = "0.2.0"
 # tree-sitter-markdown = "0.7.1"  # Disabled due to tree-sitter version conflict (uses 0.19.5 instead of 0.25.x)
 
 [dev-dependencies]

--- a/docs/LANGUAGES.md
+++ b/docs/LANGUAGES.md
@@ -27,6 +27,7 @@ This document outlines the editor's support for various programming languages, i
 | **PHP** | `.php` | `tree-sitter-php` | ✅ | ❌ |
 | **Ruby** | `.rb` | `tree-sitter-ruby` | ✅ | ❌ |
 | **Bash** | `.sh`, `.bash` | `tree-sitter-bash` | ✅ | ❌ |
+| **Lua** | `.lua` | `tree-sitter-lua` | ✅ | ❌ |
 
 **Legend:**
 - ✅ = Implemented and working

--- a/queries/lua/indents.scm
+++ b/queries/lua/indents.scm
@@ -1,0 +1,21 @@
+; Indent after opening blocks
+[
+  (block)
+  (function_definition)
+  (function_declaration)
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (repeat_statement)
+  (do_statement)
+  (table_constructor)
+] @indent
+
+; Dedent closing delimiters
+[
+  "end"
+  "}"
+  "]"
+  ")"
+  "until"
+] @dedent

--- a/src/highlighter.rs
+++ b/src/highlighter.rs
@@ -44,6 +44,7 @@ pub enum Language {
     Php,
     Ruby,
     Bash,
+    Lua,
     // Markdown,  // Disabled due to tree-sitter version conflict
 }
 
@@ -66,6 +67,7 @@ impl Language {
             "php" => Some(Language::Php),
             "rb" => Some(Language::Ruby),
             "sh" | "bash" => Some(Language::Bash),
+            "lua" => Some(Language::Lua),
             // "md" => Some(Language::Markdown),  // Disabled
             _ => None,
         }
@@ -469,6 +471,32 @@ impl Language {
                 ]);
 
                 Ok(config)
+            }
+            Language::Lua => {
+                let mut config = HighlightConfiguration::new(
+                    tree_sitter_lua::LANGUAGE.into(),
+                    "lua",
+                    tree_sitter_lua::HIGHLIGHTS_QUERY,
+                    "", // injections query
+                    "", // locals query
+                )
+                .map_err(|e| format!("Failed to create Lua highlight config: {e}"))?;
+
+                config.configure(&[
+                    "attribute",
+                    "comment",
+                    "constant",
+                    "function",
+                    "keyword",
+                    "number",
+                    "operator",
+                    "property",
+                    "string",
+                    "type",
+                    "variable",
+                ]);
+
+                Ok(config)
             } // Language::Markdown => {
               //     // Disabled due to tree-sitter version conflict
               //     Err("Markdown highlighting not available".to_string())
@@ -591,7 +619,7 @@ impl Language {
                 10 => Color::White,   // variable
                 _ => Color::White,    // default
             },
-            Language::Php | Language::Ruby | Language::Bash => match index {
+            Language::Php | Language::Ruby | Language::Bash | Language::Lua => match index {
                 0 => Color::Cyan,     // attribute
                 1 => Color::DarkGray, // comment
                 2 => Color::Magenta,  // constant
@@ -863,6 +891,9 @@ mod tests {
 
         let path = std::path::Path::new("test.bash");
         assert!(matches!(Language::from_path(path), Some(Language::Bash)));
+
+        let path = std::path::Path::new("test.lua");
+        assert!(matches!(Language::from_path(path), Some(Language::Lua)));
 
         // Markdown disabled due to tree-sitter version conflict
         // let path = std::path::Path::new("test.md");

--- a/src/indent.rs
+++ b/src/indent.rs
@@ -135,6 +135,11 @@ impl IndentCalculator {
                 tree_sitter_php::LANGUAGE_PHP.into(),
                 include_str!("../queries/php/indents.scm"),
             ),
+            Language::Lua => (
+                "lua",
+                tree_sitter_lua::LANGUAGE.into(),
+                include_str!("../queries/lua/indents.scm"),
+            ),
             Language::CSharp => {
                 // C# doesn't have a highlight query, skip indent support for now
                 tracing::warn!("Auto-indent not supported for C#");

--- a/tests/e2e/visual_regression.rs
+++ b/tests/e2e/visual_regression.rs
@@ -1155,6 +1155,11 @@ fn visual_multi_language_highlighting() {
             "hello.sh",
             include_str!("../fixtures/syntax_highlighting/hello.sh"),
         ),
+        (
+            "Lua",
+            "hello.lua",
+            include_str!("../fixtures/syntax_highlighting/hello.lua"),
+        ),
     ];
 
     // Create all test files

--- a/tests/fixtures/syntax_highlighting/hello.lua
+++ b/tests/fixtures/syntax_highlighting/hello.lua
@@ -1,0 +1,23 @@
+#!/usr/bin/env lua
+
+-- Greeting function with string formatting
+function greet(name)
+    return string.format("Hello, %s!", name)
+end
+
+-- Table with mixed content
+local config = {
+    version = "1.0",
+    enabled = true,
+    count = 42
+}
+
+-- Main execution with conditional logic
+if arg then
+    local message = greet("World")
+    print(message)
+
+    for i = 1, 3 do
+        print("Iteration: " .. i)
+    end
+end


### PR DESCRIPTION
This commit adds complete Lua language support to the editor:

- Added tree-sitter-lua dependency to Cargo.toml
- Added Language::Lua enum variant and file extension mapping (.lua) in highlighter.rs
- Configured Lua syntax highlighting with tree-sitter highlighting queries
- Added Lua auto-indent support with indents.scm query file
- Created hello.lua test fixture demonstrating various Lua syntax
- Updated visual regression tests to include Lua
- Updated LANGUAGES.md documentation

Lua files will now get syntax highlighting with proper color mapping for keywords, functions, strings, comments, and other language constructs. Auto-indentation works for blocks, function definitions, if statements, for/while/repeat loops, and tables.