### PR TITLE
Add LSP support to project

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -130,10 +130,12 @@ This plan aims to evolve the LSP client to be performant, full-featured, and rob
 - [ ] **Semantic Tokens:** Implement `textDocument/semanticTokens` for more advanced and accurate syntax highlighting.
 - [ ] **Document & Workspace Symbols:** Implement `textDocument/documentSymbol` for an outline/breadcrumb view and `workspace/symbol` for project-wide symbol search.
 - [ ] **Inlay Hints:** Display inlay hints (`textDocument/inlayHint`) for type annotations and parameter names.
-- [ ] **Progress Reporting:** Handle `$/progress` notifications from the server to show activity indicators in the UI (e.g., for indexing).
-- [ ] **Server Communication & Logging:**
-    - [ ] Handle `window/logMessage` to display server logs for debugging.
-    - [ ] Handle `window/showMessage` and `window/showMessageRequest` to show info/warnings and ask questions.
+- [x] **Progress Reporting:** Handle `$/progress` notifications from the server to show activity indicators in the UI (e.g., for indexing). ✅ **COMPLETE** (Nov 2025)
+- [x] **Server Communication & Logging:** ✅ **PARTIAL** (Nov 2025)
+    - [x] Handle `window/logMessage` to capture server logs (stored for future viewer).
+    - [x] Handle `window/showMessage` to show info/warnings in status bar.
+    - [x] Server status indicators (starting/initializing/running/error) displayed in status bar.
+    - [ ] Log viewer panel (view captured logs in dedicated UI).
 - [ ] **Document Formatting:** Add commands for `textDocument/formatting` and `textDocument/rangeFormatting`.
 - [ ] **Call Hierarchy / Type Hierarchy:** Implement `callHierarchy/incomingCalls` and `typeHierarchy/supertypes`.
 - [ ] **Code Lens / Folding Ranges:** Implement `textDocument/codeLens` and `textDocument/foldingRange`.

--- a/src/async_bridge.rs
+++ b/src/async_bridge.rs
@@ -99,6 +99,69 @@ pub enum AsyncMessage {
         /// Exit code
         exit_code: i32,
     },
+
+    /// LSP progress notification ($/progress)
+    LspProgress {
+        language: String,
+        token: String,
+        value: LspProgressValue,
+    },
+
+    /// LSP window message (window/showMessage)
+    LspWindowMessage {
+        language: String,
+        message_type: LspMessageType,
+        message: String,
+    },
+
+    /// LSP log message (window/logMessage)
+    LspLogMessage {
+        language: String,
+        message_type: LspMessageType,
+        message: String,
+    },
+
+    /// LSP server status update
+    LspStatusUpdate {
+        language: String,
+        status: LspServerStatus,
+    },
+}
+
+/// LSP progress value types
+#[derive(Debug, Clone)]
+pub enum LspProgressValue {
+    Begin {
+        title: String,
+        message: Option<String>,
+        percentage: Option<u32>,
+    },
+    Report {
+        message: Option<String>,
+        percentage: Option<u32>,
+    },
+    End {
+        message: Option<String>,
+    },
+}
+
+/// LSP message type (corresponds to MessageType in LSP spec)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LspMessageType {
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Log = 4,
+}
+
+/// LSP server status
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LspServerStatus {
+    Starting,
+    Initializing,
+    Running,
+    Error,
+    Shutdown,
 }
 
 /// Bridge between async Tokio runtime and sync main loop


### PR DESCRIPTION
This commit significantly improves LSP transparency and user experience by adding comprehensive progress reporting, server status indicators, and message handling.

**New Features:**

1. **Progress Reporting ($/progress)**
   - Handle $/progress notifications from LSP servers
   - Track begin/report/end progress events with titles, messages, and percentages
   - Display active progress operations in status bar with real-time updates
   - Multiple progress tokens supported simultaneously

2. **Window Messages (window/showMessage)**
   - Capture and display window/showMessage notifications
   - Show error and warning messages in status bar immediately
   - Store last 100 messages for future log viewer
   - Log all messages to tracing for debugging

3. **Log Messages (window/logMessage)**
   - Capture window/logMessage notifications from LSP servers
   - Store last 500 log messages with timestamps
   - Full message history available for future log viewer panel
   - All logs also sent to tracing system

4. **Server Status Indicators**
   - Track LSP server lifecycle states: Starting, Initializing, Running, Error, Shutdown
   - Display server status in status bar (e.g., "LSP [rust: ready, typescript: initializing]")
   - Status updates sent on spawn, initialization, completion, and errors
   - Clear visibility into what each language server is doing

**Implementation Details:**

- Added new AsyncMessage variants: LspProgress, LspWindowMessage, LspLogMessage, LspStatusUpdate
- Added LspProgressValue enum for begin/report/end progress events
- Added LspMessageType enum for Error/Warning/Info/Log levels
- Added LspServerStatus enum for server lifecycle states
- Editor now tracks progress (by token), messages, logs, and server statuses
- Status bar automatically updated based on active progress or server statuses
- Messages kept in bounded buffers (100 window messages, 500 log messages)

**Status Bar Updates:**

- Active progress shown with: "LSP (lang): title - message (percentage%)"
- When no progress active: "LSP [lang1: status1, lang2: status2, ...]"
- Error/warning messages temporarily override progress display
- Clear, concise status information always visible

**Future Work:**

- Request cancellation ($/cancelRequest) - track and cancel in-flight requests
- Dedicated log viewer panel - browse captured messages with filtering
- Log viewer command binding (e.g., Ctrl+Alt+L)

**Testing:**

- All code compiles successfully
- New message types integrate seamlessly with existing async bridge
- Status bar updates work correctly with progress and server status
- Message buffering prevents memory growth

This makes the LSP experience significantly less opaque, addressing the main goal of improving progress reporting, status visibility, and message handling.