### PR TITLE
Fix page-down lag in large buffers

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -4774,6 +4774,13 @@ impl Editor {
         let _span = tracing::trace_span!("render").entered();
         let size = frame.area();
 
+        // Sync viewport with cursor position if needed (deferred from event processing)
+        // This batches multiple cursor movements into a single viewport update
+        if let Some(state) = self.buffers.get_mut(&self.active_buffer) {
+            let primary_cursor = *state.cursors.primary();
+            state.viewport.sync_with_cursor(&mut state.buffer, &primary_cursor);
+        }
+
         // If help is visible, render help page instead
         if self.help_renderer.is_visible() {
             self.help_renderer

--- a/src/state.rs
+++ b/src/state.rs
@@ -166,10 +166,8 @@ impl EditorState {
                     };
                 }
 
-                // Smart scroll to keep cursor visible
-                if let Some(cursor) = self.cursors.get(*cursor_id) {
-                    self.viewport.ensure_visible(&mut self.buffer, cursor);
-                }
+                // Defer viewport sync to rendering time for better performance
+                self.viewport.mark_needs_sync();
             }
 
             Event::Delete {
@@ -217,10 +215,8 @@ impl EditorState {
                     };
                 }
 
-                // Smart scroll to keep cursor visible
-                if let Some(cursor) = self.cursors.get(*cursor_id) {
-                    self.viewport.ensure_visible(&mut self.buffer, cursor);
-                }
+                // Defer viewport sync to rendering time for better performance
+                self.viewport.mark_needs_sync();
             }
 
             Event::MoveCursor {
@@ -234,10 +230,10 @@ impl EditorState {
                     cursor.position = *new_position;
                     cursor.anchor = *new_anchor;
                     cursor.sticky_column = *new_sticky_column;
-
-                    // Smart scroll to keep cursor visible
-                    self.viewport.ensure_visible(&mut self.buffer, cursor);
                 }
+
+                // Defer viewport sync to rendering time for better performance
+                self.viewport.mark_needs_sync();
 
                 // Update primary cursor line number if this is the primary cursor
                 // For MoveCursor events, we lose absolute line tracking and switch to Relative


### PR DESCRIPTION
When holding Page Down, the application was rendering one frame for every keypress event, causing visible lag as the render queue couldn't keep up with rapid input.

Changes:
- Add viewport dirty flag system to batch cursor movements
- Defer viewport.ensure_visible() calls until render time
- Implement 60fps frame rate limiting in main event loop
- Process multiple input events between frames when input rate exceeds 60fps

This allows the editor to process input events faster than it renders, eliminating the lag when holding navigation keys like Page Down.