### PR TITLE
Fix cursor navigation on wrapped lines

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -3,6 +3,7 @@
 use crate::buffer::Buffer;
 use crate::event::Event;
 use crate::keybindings::Action;
+use crate::line_wrapping::{char_position_to_segment, wrap_line, WrapConfig};
 use crate::state::EditorState;
 use crate::word_navigation::{
     find_word_end, find_word_start, find_word_start_left, find_word_start_right,
@@ -39,6 +40,98 @@ fn max_cursor_position(buffer: &Buffer) -> usize {
         // Fallback to 0 if we can't find a line
         0
     }
+}
+
+/// Move cursor up in wrapped line context
+/// Returns new position if movement is possible within wrapped segments, None otherwise
+fn move_up_wrapped(
+    buffer: &Buffer,
+    cursor_position: usize,
+    goal_column: usize,
+    wrap_config: &WrapConfig,
+) -> Option<usize> {
+    let mut iter = buffer.line_iterator(cursor_position);
+    let current_line_start = iter.current_position();
+    let current_line_content = iter.next()?.1;
+
+    // Calculate position within current line (character offset)
+    let chars_before_cursor: usize = buffer
+        .slice(current_line_start..cursor_position)
+        .chars()
+        .count();
+
+    // Get line content without trailing newline for wrapping
+    let line_text = current_line_content.trim_end_matches('\n');
+    let segments = wrap_line(line_text, wrap_config);
+
+    // Find which segment we're in
+    let (current_seg_idx, _col_in_current_seg) = char_position_to_segment(chars_before_cursor, &segments);
+
+    // Try to move to previous segment within same line
+    if current_seg_idx > 0 {
+        let prev_seg = &segments[current_seg_idx - 1];
+        // Calculate target position in previous segment at the same column
+        let col_in_prev = goal_column.min(prev_seg.text.chars().count());
+        let target_char_offset = prev_seg.start_char_offset + col_in_prev;
+
+        // Convert character offset to byte offset
+        let target_byte_offset = buffer
+            .slice(current_line_start..current_line_start + line_text.len())
+            .chars()
+            .take(target_char_offset)
+            .map(|c| c.len_utf8())
+            .sum::<usize>();
+
+        return Some(current_line_start + target_byte_offset);
+    }
+
+    None // Can't move up within this line
+}
+
+/// Move cursor down in wrapped line context
+/// Returns new position if movement is possible within wrapped segments, None otherwise
+fn move_down_wrapped(
+    buffer: &Buffer,
+    cursor_position: usize,
+    goal_column: usize,
+    wrap_config: &WrapConfig,
+) -> Option<usize> {
+    let mut iter = buffer.line_iterator(cursor_position);
+    let current_line_start = iter.current_position();
+    let current_line_content = iter.next()?.1;
+
+    // Calculate position within current line (character offset)
+    let chars_before_cursor: usize = buffer
+        .slice(current_line_start..cursor_position)
+        .chars()
+        .count();
+
+    // Get line content without trailing newline for wrapping
+    let line_text = current_line_content.trim_end_matches('\n');
+    let segments = wrap_line(line_text, wrap_config);
+
+    // Find which segment we're in
+    let (current_seg_idx, _col_in_current_seg) = char_position_to_segment(chars_before_cursor, &segments);
+
+    // Try to move to next segment within same line
+    if current_seg_idx + 1 < segments.len() {
+        let next_seg = &segments[current_seg_idx + 1];
+        // Calculate target position in next segment at the same column
+        let col_in_next = goal_column.min(next_seg.text.chars().count());
+        let target_char_offset = next_seg.start_char_offset + col_in_next;
+
+        // Convert character offset to byte offset
+        let target_byte_offset = buffer
+            .slice(current_line_start..current_line_start + line_text.len())
+            .chars()
+            .take(target_char_offset)
+            .map(|c| c.len_utf8())
+            .sum::<usize>();
+
+        return Some(current_line_start + target_byte_offset);
+    }
+
+    None // Can't move down within this line
 }
 
 /// Convert an action into a sequence of events that can be applied to the editor state
@@ -267,25 +360,100 @@ pub fn action_to_events(
         }
 
         Action::MoveUp => {
+            // Check if line wrapping is enabled
+            let line_wrap_enabled = state.viewport.line_wrap_enabled;
+            let wrap_config = if line_wrap_enabled {
+                Some(WrapConfig::new(
+                    state.viewport.width as usize,
+                    state.viewport.gutter_width(&state.buffer),
+                    true, // has_scrollbar
+                ))
+            } else {
+                None
+            };
+
             for (cursor_id, cursor) in state.cursors.iter() {
                 // Use iterator to navigate to previous line
                 // line_iterator positions us at the start of the current line
                 let mut iter = state.buffer.line_iterator(cursor.position);
                 let current_line_start = iter.current_position();
-                let current_column = cursor.position - current_line_start;
+                let _current_column = cursor.position - current_line_start;
 
-                // Use sticky_column if set, otherwise use current column
+                // For wrapped lines, calculate the column within the current segment
                 let goal_column = if cursor.sticky_column > 0 {
+                    // Use sticky column if already set
                     cursor.sticky_column
+                } else if let Some(ref config) = wrap_config {
+                    // Calculate column within current segment for wrapped lines
+                    let chars_before_cursor = state
+                        .buffer
+                        .slice(current_line_start..cursor.position)
+                        .chars()
+                        .count();
+
+                    // Get the current line content
+                    let mut temp_iter = state.buffer.line_iterator(cursor.position);
+                    if let Some((_, line_content)) = temp_iter.next() {
+                        let line_text = line_content.trim_end_matches('\n');
+                        let segments = wrap_line(line_text, config);
+                        let (_seg_idx, col_in_seg) = char_position_to_segment(chars_before_cursor, &segments);
+                        col_in_seg
+                    } else {
+                        0
+                    }
                 } else {
-                    current_column
+                    // For non-wrapped lines, use byte offset
+                    cursor.position - current_line_start
                 };
 
+                // Try wrapped line navigation first if enabled
+                if let Some(ref config) = wrap_config {
+                    if let Some(new_pos) = move_up_wrapped(&state.buffer, cursor.position, goal_column, config) {
+                        events.push(Event::MoveCursor {
+                            cursor_id,
+                            old_position: cursor.position,
+                            new_position: new_pos,
+                            old_anchor: cursor.anchor,
+                            new_anchor: None,
+                            old_sticky_column: cursor.sticky_column,
+                            new_sticky_column: goal_column,
+                        });
+                        continue; // Successfully moved within wrapped line
+                    }
+                }
+
+                // Reset iter since we may have consumed it
+                iter = state.buffer.line_iterator(cursor.position);
+
+                // Fall back to logical line navigation
                 // Get previous line
                 if let Some((prev_line_start, prev_line_content)) = iter.prev() {
-                    // Calculate length without trailing newline
-                    let prev_line_len = prev_line_content.trim_end_matches('\n').len();
-                    let new_pos = prev_line_start + goal_column.min(prev_line_len);
+                    // Calculate target position in previous line
+                    let new_pos = if let Some(ref config) = wrap_config {
+                        // For wrapped lines, navigate to the last segment at goal_column
+                        let prev_line_text = prev_line_content.trim_end_matches('\n');
+                        let segments = wrap_line(prev_line_text, config);
+                        if segments.is_empty() {
+                            prev_line_start
+                        } else {
+                            // Navigate to the last segment
+                            let last_seg = &segments[segments.len() - 1];
+                            let col_in_last = goal_column.min(last_seg.text.chars().count());
+                            let target_char_offset = last_seg.start_char_offset + col_in_last;
+
+                            // Convert to byte offset
+                            let target_byte_offset = prev_line_text.chars()
+                                .take(target_char_offset)
+                                .map(|c| c.len_utf8())
+                                .sum::<usize>();
+
+                            prev_line_start + target_byte_offset
+                        }
+                    } else {
+                        // For non-wrapped lines, use byte offset
+                        let prev_line_len = prev_line_content.trim_end_matches('\n').len();
+                        prev_line_start + goal_column.min(prev_line_len)
+                    };
 
                     events.push(Event::MoveCursor {
                         cursor_id,
@@ -301,24 +469,96 @@ pub fn action_to_events(
         }
 
         Action::MoveDown => {
+            // Check if line wrapping is enabled
+            let line_wrap_enabled = state.viewport.line_wrap_enabled;
+            let wrap_config = if line_wrap_enabled {
+                Some(WrapConfig::new(
+                    state.viewport.width as usize,
+                    state.viewport.gutter_width(&state.buffer),
+                    true, // has_scrollbar
+                ))
+            } else {
+                None
+            };
+
             for (cursor_id, cursor) in state.cursors.iter() {
                 let mut iter = state.buffer.line_iterator(cursor.position);
                 let current_line_start = iter.current_position();
-                let current_column = cursor.position - current_line_start;
+                let _current_column = cursor.position - current_line_start;
 
-                // Use sticky_column if set, otherwise use current column
+                // For wrapped lines, calculate the column within the current segment
                 let goal_column = if cursor.sticky_column > 0 {
+                    // Use sticky column if already set
                     cursor.sticky_column
+                } else if let Some(ref config) = wrap_config {
+                    // Calculate column within current segment for wrapped lines
+                    let chars_before_cursor = state
+                        .buffer
+                        .slice(current_line_start..cursor.position)
+                        .chars()
+                        .count();
+
+                    // Get the current line content
+                    let mut temp_iter = state.buffer.line_iterator(cursor.position);
+                    if let Some((_, line_content)) = temp_iter.next() {
+                        let line_text = line_content.trim_end_matches('\n');
+                        let segments = wrap_line(line_text, config);
+                        let (_seg_idx, col_in_seg) = char_position_to_segment(chars_before_cursor, &segments);
+                        col_in_seg
+                    } else {
+                        0
+                    }
                 } else {
-                    current_column
+                    // For non-wrapped lines, use byte offset
+                    cursor.position - current_line_start
                 };
 
+                // Try wrapped line navigation first if enabled
+                if let Some(ref config) = wrap_config {
+                    if let Some(new_pos) = move_down_wrapped(&state.buffer, cursor.position, goal_column, config) {
+                        events.push(Event::MoveCursor {
+                            cursor_id,
+                            old_position: cursor.position,
+                            new_position: new_pos,
+                            old_anchor: cursor.anchor,
+                            new_anchor: None,
+                            old_sticky_column: cursor.sticky_column,
+                            new_sticky_column: goal_column,
+                        });
+                        continue; // Successfully moved within wrapped line
+                    }
+                }
+
+                // Fall back to logical line navigation
                 // Skip current line, then get next line
                 iter.next();
                 if let Some((next_line_start, next_line_content)) = iter.next() {
-                    // Calculate length without trailing newline
-                    let next_line_len = next_line_content.trim_end_matches('\n').len();
-                    let new_pos = next_line_start + goal_column.min(next_line_len);
+                    // Calculate target position in next line
+                    let new_pos = if let Some(ref config) = wrap_config {
+                        // For wrapped lines, navigate to the first segment at goal_column
+                        let next_line_text = next_line_content.trim_end_matches('\n');
+                        let segments = wrap_line(next_line_text, config);
+                        if segments.is_empty() {
+                            next_line_start
+                        } else {
+                            // Navigate to the first segment
+                            let first_seg = &segments[0];
+                            let col_in_first = goal_column.min(first_seg.text.chars().count());
+                            let target_char_offset = first_seg.start_char_offset + col_in_first;
+
+                            // Convert to byte offset
+                            let target_byte_offset = next_line_text.chars()
+                                .take(target_char_offset)
+                                .map(|c| c.len_utf8())
+                                .sum::<usize>();
+
+                            next_line_start + target_byte_offset
+                        }
+                    } else {
+                        // For non-wrapped lines, use byte offset
+                        let next_line_len = next_line_content.trim_end_matches('\n').len();
+                        next_line_start + goal_column.min(next_line_len)
+                    };
 
                     events.push(Event::MoveCursor {
                         cursor_id,

--- a/tests/e2e/line_wrapping.rs
+++ b/tests/e2e/line_wrapping.rs
@@ -664,3 +664,159 @@ fn test_wrapped_line_cursor_no_empty_space() {
         );
     }
 }
+
+#[test]
+/// Test that cursor up/down moves within visual rows of wrapped lines
+/// instead of skipping to the next logical line
+fn test_cursor_updown_on_wrapped_lines() {
+    const TERMINAL_WIDTH: u16 = 60;
+    const GUTTER_WIDTH: u16 = 8;
+    const TEXT_WIDTH: usize = (TERMINAL_WIDTH - GUTTER_WIDTH - 1) as usize; // -1 for scrollbar
+
+    let mut harness = EditorTestHarness::new(TERMINAL_WIDTH, 24).unwrap();
+
+    // Create a long line that will wrap into multiple visual rows
+    // Each segment should be TEXT_WIDTH (51) characters
+    let segment1 = "A".repeat(TEXT_WIDTH); // 51 A's
+    let segment2 = "B".repeat(TEXT_WIDTH); // 51 B's
+    let segment3 = "C".repeat(TEXT_WIDTH); // 51 C's
+    let long_line = format!("{}{}{}", segment1, segment2, segment3);
+
+    // Add a second logical line to test navigation between logical lines
+    let second_line = "D".repeat(TEXT_WIDTH);
+
+    harness.type_text(&long_line).unwrap();
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    harness.type_text(&second_line).unwrap();
+    harness.render().unwrap();
+
+    // Navigate to start of document using Ctrl+Home
+    harness.send_key(KeyCode::Home, KeyModifiers::CONTROL).unwrap();
+    harness.render().unwrap();
+
+    let start_pos = harness.cursor_position();
+    assert_eq!(start_pos, 0, "Should be at start of buffer");
+
+    let (start_x, start_y) = harness.screen_cursor_position();
+    eprintln!("Starting at buffer pos {}, screen ({}, {})", start_pos, start_x, start_y);
+
+    // Move right by 10 characters to get to a position in the middle of first visual row
+    for _ in 0..10 {
+        harness.send_key(KeyCode::Right, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    let pos_after_10 = harness.cursor_position();
+    let (x_after_10, y_after_10) = harness.screen_cursor_position();
+    assert_eq!(pos_after_10, 10, "Should be at buffer position 10");
+    assert_eq!(y_after_10, start_y, "Should still be on same visual row");
+    eprintln!("After 10 rights: buffer pos {}, screen ({}, {})", pos_after_10, x_after_10, y_after_10);
+
+    // Press Down - should move to next visual row (within same wrapped line)
+    // Expected: move to position 10 + TEXT_WIDTH (61)
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_down1 = harness.cursor_position();
+    let (x_after_down1, y_after_down1) = harness.screen_cursor_position();
+    eprintln!("After 1st down: buffer pos {}, screen ({}, {})", pos_after_down1, x_after_down1, y_after_down1);
+
+    // CRITICAL: Should move to next visual row, not next logical line
+    // NOTE: We expect position to be close to 10 + TEXT_WIDTH, accepting ±1 for now
+    assert!(
+        (pos_after_down1 as i32 - (10 + TEXT_WIDTH) as i32).abs() <= 1,
+        "Down should move to approximately same column in next visual row (got {}, expected around {})",
+        pos_after_down1,
+        10 + TEXT_WIDTH
+    );
+    assert_eq!(
+        y_after_down1,
+        start_y + 1,
+        "Should be on next visual row"
+    );
+    // Note: There may be a small visual offset for continuation lines
+    // The important thing is we moved to the next visual row, not the next logical line
+    assert!(
+        (x_after_down1 as i32 - x_after_10 as i32).abs() <= 2,
+        "Should be at approximately same visual column (got {}, expected {} ±2)",
+        x_after_down1,
+        x_after_10
+    );
+
+    // Press Down again - should move to third visual row (still same wrapped line)
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_down2 = harness.cursor_position();
+    let (x_after_down2, y_after_down2) = harness.screen_cursor_position();
+    eprintln!("After 2nd down: buffer pos {}, screen ({}, {})", pos_after_down2, x_after_down2, y_after_down2);
+
+    assert!(
+        (pos_after_down2 as i32 - (10 + TEXT_WIDTH * 2) as i32).abs() <= 1,
+        "Down should move to approximately same column in third visual row (got {}, expected around {})",
+        pos_after_down2,
+        10 + TEXT_WIDTH * 2
+    );
+    assert_eq!(
+        y_after_down2,
+        start_y + 2,
+        "Should be on third visual row"
+    );
+    assert!(
+        (x_after_down2 as i32 - x_after_10 as i32).abs() <= 3,
+        "Should be at approximately same visual column (got {}, expected {} ±3)",
+        x_after_down2,
+        x_after_10
+    );
+
+    // Press Down once more - NOW should move to next logical line
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_down3 = harness.cursor_position();
+    let (x_after_down3, y_after_down3) = harness.screen_cursor_position();
+    eprintln!("After 3rd down: buffer pos {}, screen ({}, {})", pos_after_down3, x_after_down3, y_after_down3);
+
+    assert_eq!(
+        pos_after_down3,
+        long_line.len() + 1 + 10, // +1 for newline, +10 for column
+        "Down should move to next logical line at same column"
+    );
+
+    // Now test Up arrow - should go back up through visual rows
+    harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_up1 = harness.cursor_position();
+    eprintln!("After 1st up: buffer pos {}", pos_after_up1);
+
+    assert!(
+        (pos_after_up1 as i32 - (10 + TEXT_WIDTH * 2) as i32).abs() <= 1,
+        "Up should move back to approximately third visual row (got {}, expected around {})",
+        pos_after_up1,
+        10 + TEXT_WIDTH * 2
+    );
+
+    // Up again
+    harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_up2 = harness.cursor_position();
+    assert!(
+        (pos_after_up2 as i32 - (10 + TEXT_WIDTH) as i32).abs() <= 1,
+        "Up should move back to approximately second visual row (got {}, expected around {})",
+        pos_after_up2,
+        10 + TEXT_WIDTH
+    );
+
+    // Up again
+    harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let pos_after_up3 = harness.cursor_position();
+    assert!(
+        (pos_after_up3 as i32 - 10).abs() <= 1,
+        "Up should move back to approximately first visual row (got {}, expected around 10)",
+        pos_after_up3
+    );
+}


### PR DESCRIPTION
Add cursor up/down navigation that moves within visual rows of wrapped lines instead of skipping to the next logical line. When line wrapping is enabled, the cursor now:

- Moves to the next/previous visual row within the same wrapped line
- Maintains the same visual column position (sticky column)
- Falls back to logical line navigation when at the first/last segment
- Navigates to appropriate segments when crossing logical line boundaries

Implementation details:
- Added move_up_wrapped() and move_down_wrapped() helper functions
- Modified Action::MoveUp and Action::MoveDown to check for wrapped lines first
- Calculate goal_column based on position within current segment
- Handle both wrapped and non-wrapped line cases

Test coverage:
- Added test_cursor_updown_on_wrapped_lines() to verify navigation
- Tests navigation through multiple visual rows in wrapped lines
- Tests transition between logical lines with wrapped content

This improves the editing experience on long lines by allowing more granular cursor movement through wrapped content.