### PR TITLE
Fix go to line in large file mode

### DIFF
--- a/src/editor.rs
+++ b/src/editor.rs
@@ -7357,14 +7357,52 @@ impl Editor {
                                 Ok(line_num) if line_num > 0 => {
                                     let target_line = line_num.saturating_sub(1);
                                     let buffer_id = self.active_buffer;
+                                    let estimated_line_length = self.config.editor.estimated_line_length;
+
                                     if let Some(state) = self.buffers.get(&buffer_id) {
-                                        let max_line = state.buffer.line_count().unwrap_or(1).saturating_sub(1);
-                                        let actual_line = target_line.min(max_line);
-                                        let position = state.buffer.line_col_to_position(actual_line, 0);
                                         let cursor_id = state.cursors.primary_id();
                                         let old_position = state.cursors.primary().position;
                                         let old_anchor = state.cursors.primary().anchor;
                                         let old_sticky_column = state.cursors.primary().sticky_column;
+                                        let is_large_file = state.buffer.line_count().is_none();
+                                        let buffer_len = state.buffer.len();
+
+                                        let (position, status_message) = if is_large_file {
+                                            // Large file mode: estimate byte offset based on line number
+                                            let estimated_offset = target_line * estimated_line_length;
+                                            let clamped_offset = estimated_offset.min(buffer_len);
+
+                                            // Use LineIterator to find the actual line start at the estimated position
+                                            let position = if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                                                let iter = state.buffer.line_iterator(clamped_offset, estimated_line_length);
+                                                iter.current_position()
+                                            } else {
+                                                clamped_offset
+                                            };
+
+                                            let msg = format!(
+                                                "Jumped to estimated line {} (large file mode)",
+                                                line_num
+                                            );
+                                            (position, msg)
+                                        } else {
+                                            // Small file mode: use exact line position
+                                            let max_line = state.buffer.line_count().unwrap_or(1).saturating_sub(1);
+                                            let actual_line = target_line.min(max_line);
+                                            let position = state.buffer.line_col_to_position(actual_line, 0);
+
+                                            let msg = if target_line > max_line {
+                                                format!(
+                                                    "Line {} doesn't exist, jumped to line {}",
+                                                    line_num,
+                                                    actual_line + 1
+                                                )
+                                            } else {
+                                                format!("Jumped to line {}", line_num)
+                                            };
+                                            (position, msg)
+                                        };
+
                                         let event = crate::event::Event::MoveCursor {
                                             cursor_id,
                                             old_position,
@@ -7377,15 +7415,7 @@ impl Editor {
                                         if let Some(state) = self.buffers.get_mut(&buffer_id) {
                                             state.apply(&event);
                                         }
-                                        if target_line > max_line {
-                                            self.set_status_message(format!(
-                                                "Line {} doesn't exist, jumped to line {}",
-                                                line_num,
-                                                actual_line + 1
-                                            ));
-                                        } else {
-                                            self.set_status_message(format!("Jumped to line {}", line_num));
-                                        }
+                                        self.set_status_message(status_message);
                                     }
                                 }
                                 Ok(_) => {


### PR DESCRIPTION
In large file mode, line metadata is not available, so go-to-line now estimates the byte offset based on: target_line * estimated_line_length. The LineIterator then finds the actual line start at that position.

This provides a useful approximate navigation feature for large files where exact line positioning is not possible without scanning the entire file.