### PR TITLE
Fix a shortcut text error in user_guide

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,7 +50,7 @@ Fresh provides a powerful set of editing features to help you be more productive
 
 Fresh includes a built-in file explorer to help you navigate your project's files.
 
-*   **Toggle:** Use `Ctrl+B` to open and close the file explorer.
+*   **Toggle:** Use `Ctrl+E` to open and close the file explorer.
 *   **Navigation:** Use the arrow keys to move up and down the file tree.
 *   **Open Files:** Press `Enter` to open the selected file.
 *   **Gitignore Support:** The file explorer respects your `.gitignore` file, hiding ignored files by default.


### PR DESCRIPTION
Before: `Toggle: Use Ctrl+B to open and close the file explorer.`
Now: `Toggle: Use Ctrl+E to open and close the file explorer.`
I used `fresh` for this modification :)