### PR TITLE
Add GitHub Action to update Homebrew formula on release

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,18 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Homebrew formula
+        uses: dawidd6/action-homebrew-bump-formula@v4
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          formula: fresh-editor
+          # The action automatically uses the release tag to determine the version
+          # and downloads the tarball to calculate the SHA256


### PR DESCRIPTION
We can already install `fresh` via `brew install fresh-editor`.

This workflow triggers automatically when a GitHub release is published, it uses the dawidd6/action-homebrew-bump-formula action to create a PR to Homebrew/homebrew-core (it automatically calculates the new SHA256 from the release tarball and submits the PR for review by Homebrew maintainers).

For this to work, you need to create a HOMEBREW_TAP_TOKEN secret in your repository settings: Go to your GitHub account > Settings > Developer settings > Personal access tokens > Fine-grained tokens > Create a new token with:
Repository access  > Select Homebrew/homebrew-core with permissions "Contents: Read and write, Pull requests: Read and write". Finally, add the token as a repository secret named HOMEBREW_TAP_TOKEN in your fresh repository (Settings > Secrets and variables > Actions).
