### PR TITLE
Ignore or Fix failing Windows build tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -873,7 +873,9 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+// Property tests use Unix-style path generation strategy, skip on Windows
+// where path parsing differs (drive letters like C: conflict with :line:col parsing)
+#[cfg(all(test, not(windows)))]
 mod proptests {
     use super::*;
     use proptest::prelude::*;

--- a/src/services/plugins/runtime.rs
+++ b/src/services/plugins/runtime.rs
@@ -4803,6 +4803,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(unix)]
     async fn test_path_is_absolute() {
         let mut runtime = TypeScriptRuntime::new().unwrap();
 
@@ -4810,7 +4811,7 @@ mod tests {
             .execute_script(
                 "<test_path_is_absolute>",
                 r#"
-                // Test absolute paths
+                // Test absolute paths (Unix)
                 if (!editor.pathIsAbsolute("/home/user")) {
                     throw new Error("/home/user should be absolute");
                 }
@@ -4819,6 +4820,47 @@ mod tests {
                 }
 
                 // Test relative paths
+                if (editor.pathIsAbsolute("src/main.rs")) {
+                    throw new Error("src/main.rs should not be absolute");
+                }
+                if (editor.pathIsAbsolute(".")) {
+                    throw new Error(". should not be absolute");
+                }
+                if (editor.pathIsAbsolute("..")) {
+                    throw new Error(".. should not be absolute");
+                }
+
+                console.log("Path is absolute test passed!");
+                "#,
+            )
+            .await;
+        assert!(result.is_ok(), "Path is absolute test failed: {:?}", result);
+    }
+
+    #[tokio::test]
+    #[cfg(windows)]
+    async fn test_path_is_absolute() {
+        let mut runtime = TypeScriptRuntime::new().unwrap();
+
+        let result = runtime
+            .execute_script(
+                "<test_path_is_absolute>",
+                r#"
+                // Test absolute paths (Windows)
+                if (!editor.pathIsAbsolute("C:\\Users\\test")) {
+                    throw new Error("C:\\Users\\test should be absolute");
+                }
+                if (!editor.pathIsAbsolute("C:/Users/test")) {
+                    throw new Error("C:/Users/test should be absolute");
+                }
+                if (!editor.pathIsAbsolute("D:\\")) {
+                    throw new Error("D:\\ should be absolute");
+                }
+
+                // Test relative paths
+                if (editor.pathIsAbsolute("src\\main.rs")) {
+                    throw new Error("src\\main.rs should not be absolute");
+                }
                 if (editor.pathIsAbsolute("src/main.rs")) {
                     throw new Error("src/main.rs should not be absolute");
                 }

--- a/src/services/recovery/types.rs
+++ b/src/services/recovery/types.rs
@@ -440,17 +440,17 @@ mod tests {
 
     #[test]
     fn test_is_process_running_self() {
-        // Our own process should be running (on Unix)
-        #[cfg(unix)]
+        // Our own process should be running (on Unix and Windows)
+        #[cfg(any(unix, windows))]
         assert!(is_process_running(std::process::id()));
-        // On non-Unix, is_process_running always returns false
-        #[cfg(not(unix))]
+        // On other platforms, is_process_running always returns false
+        #[cfg(not(any(unix, windows)))]
         assert!(!is_process_running(std::process::id()));
     }
 
     #[test]
     fn test_is_process_running_invalid() {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             // Test with a PID that definitely doesn't exist
             // Find a PID that's not running by searching high PIDs
@@ -462,9 +462,9 @@ mod tests {
                 assert!(!is_process_running(test_pid));
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(not(any(unix, windows)))]
         {
-            // On non-Unix platforms, is_process_running always returns false
+            // On other platforms, is_process_running always returns false
             assert!(!is_process_running(1));
             assert!(!is_process_running(999999999));
         }

--- a/tests/e2e/file_browser.rs
+++ b/tests/e2e/file_browser.rs
@@ -826,6 +826,7 @@ fn test_file_browser_click_updates_prompt() {
 
 /// Test that opening file browser with a buffer in a subdir shows correct prompt path
 #[test]
+#[cfg_attr(windows, ignore)] // Uses Unix-style path separators in assertions
 fn test_file_browser_prompt_shows_buffer_directory() {
     // Use wide terminal because macOS temp paths can be very long
     let mut harness = EditorTestHarness::with_temp_project(160, 24).unwrap();

--- a/tests/e2e/git.rs
+++ b/tests/e2e/git.rs
@@ -457,6 +457,7 @@ fn test_git_find_file_selection_navigation() {
 
 /// Test git find file confirm - opens selected file
 #[test]
+#[cfg_attr(windows, ignore)] // Git plugin tests timeout on Windows CI
 fn test_git_find_file_confirm_opens_file() {
     let repo = GitTestRepo::new();
     repo.setup_typical_project();

--- a/tests/e2e/gutter.rs
+++ b/tests/e2e/gutter.rs
@@ -547,6 +547,7 @@ fn test_git_gutter_untracked_file() {
 
 /// Test that buffer modified shows indicators for unsaved changes
 #[test]
+#[cfg_attr(windows, ignore)] // Uses git plugins which timeout on Windows CI
 fn test_buffer_modified_shows_on_edit() {
     let repo = GitTestRepo::new();
     repo.setup_typical_project();
@@ -591,6 +592,7 @@ fn test_buffer_modified_shows_on_edit() {
 
 /// Test that buffer modified clears after save
 #[test]
+#[cfg_attr(windows, ignore)] // Uses git plugins which timeout on Windows CI
 fn test_buffer_modified_clears_after_save() {
     let repo = GitTestRepo::new();
     repo.setup_typical_project();

--- a/tests/e2e/lsp.rs
+++ b/tests/e2e/lsp.rs
@@ -3051,6 +3051,7 @@ fn test_pull_diagnostics_result_id_tracking() -> std::io::Result<()> {
 /// 2. The find_references plugin receives the results
 /// 3. The references panel opens without hanging
 #[test]
+#[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_lsp_find_references() -> std::io::Result<()> {
     use std::time::Duration;
     use tracing_subscriber::{fmt, prelude::*, EnvFilter};

--- a/tests/e2e/plugin.rs
+++ b/tests/e2e/plugin.rs
@@ -649,6 +649,7 @@ fn test_todo_highlighter_updates_on_delete() {
 /// Test diagnostics panel plugin loads and creates a virtual buffer split
 /// This verifies the full implementation with LSP-like diagnostics display
 #[test]
+#[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_diagnostics_panel_plugin_loads() {
     use crate::common::fake_lsp::FakeLspServer;
 
@@ -1595,6 +1596,7 @@ fn test_clangd_plugin_file_status_notification() -> std::io::Result<()> {
 
 /// Ensure the clangd plugin uses editor.sendLspRequest successfully
 #[test]
+#[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_clangd_plugin_switch_source_header() -> std::io::Result<()> {
     init_tracing_from_env();
     let _fake_server = FakeLspServer::spawn()?;
@@ -1798,6 +1800,7 @@ editor.setStatus("Test source plugin loaded!");
 
 /// Test that diagnostics from fake LSP are stored and accessible via getAllDiagnostics API
 #[test]
+#[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_diagnostics_api_with_fake_lsp() -> std::io::Result<()> {
     init_tracing_from_env();
     let _fake_server = FakeLspServer::spawn()?;

--- a/tests/e2e/prompt.rs
+++ b/tests/e2e/prompt.rs
@@ -411,6 +411,7 @@ fn test_save_as_nested_path() {
 /// When the path + input would exceed 90% of the prompt width, the path should be
 /// truncated to show: /first/[...]/last/components/
 #[test]
+#[cfg_attr(windows, ignore)] // Path truncation format differs on Windows
 fn test_open_file_prompt_truncates_long_paths() {
     use crossterm::event::{KeyCode, KeyModifiers};
     use std::fs;

--- a/tests/e2e/visual_regression.rs
+++ b/tests/e2e/visual_regression.rs
@@ -20,6 +20,7 @@ use std::fs;
 /// - Split view: NO
 /// - Command palette: CLOSED
 #[test]
+#[cfg_attr(windows, ignore)] // Visual regression tests require consistent terminal rendering
 fn visual_comprehensive_a() {
     let mut harness = EditorTestHarness::with_temp_project(100, 30).unwrap();
     let project_dir = harness.project_dir().unwrap();


### PR DESCRIPTION
Changes:
- test_path_is_absolute: Split into Unix/Windows variants with appropriate paths
- test_is_process_running_self: Update expectation to match Windows impl
- proptests: Skip on Windows (Unix-style path strategy conflicts with Windows paths)
- E2E tests using bash-based fake LSP servers: Skip on Windows
- E2E tests using git plugins that timeout: Skip on Windows
- Visual regression tests: Skip on Windows (terminal rendering differences)
- Path truncation tests: Skip on Windows (format differences)