### PR TITLE
add double click for file open dialog

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2437,6 +2437,25 @@ impl Editor {
 
         match mouse_event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                // detect double clicks, 500 ms is arbitrary but reasonable
+                if let Some(previous_click_time) = self.previous_click_time {
+                    let now = std::time::Instant::now();
+                    if now.duration_since(previous_click_time)
+                        < std::time::Duration::from_millis(500)
+                    {
+                        // Double click detected
+                        self.handle_mouse_double_click(col, row)?;
+                        self.previous_click_time = None; // Reset
+                        needs_render = true;
+                        return Ok(needs_render);
+                    } else {
+                        // Not a double click, update time
+                        self.previous_click_time = Some(now);
+                    }
+                } else {
+                    // First click, store time
+                    self.previous_click_time = Some(std::time::Instant::now());
+                }
                 self.handle_mouse_click(col, row)?;
                 needs_render = true;
             }
@@ -2812,6 +2831,18 @@ impl Editor {
         None
     }
 
+    /// Handle mouse double click (down event)
+    pub(super) fn handle_mouse_double_click(&mut self, col: u16, row: u16) -> std::io::Result<()> {
+        tracing::debug!("handle_mouse_double_click at col={}, row={}", col, row);
+
+        // is it in the file open dialog?
+        if self.handle_file_open_double_click(col, row) {
+            return Ok(());
+        }
+
+        // no - is it meant for the ???
+        Ok(())
+    }
     /// Handle mouse click (down event)
     pub(super) fn handle_mouse_click(&mut self, col: u16, row: u16) -> std::io::Result<()> {
         // Check if click is on suggestions (command palette, autocomplete)

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -431,6 +431,9 @@ pub struct Editor {
     /// When leaving a terminal while in terminal mode, its ID is added here.
     /// When switching to a terminal in this set, terminal mode is automatically re-entered.
     terminal_mode_resume: std::collections::HashSet<BufferId>,
+
+    /// Timestamp of the previous mouse click (for double-click detection)
+    previous_click_time: Option<std::time::Instant>,
 }
 
 impl Editor {
@@ -798,6 +801,7 @@ impl Editor {
             terminal_mode: false,
             keyboard_capture: false,
             terminal_mode_resume: std::collections::HashSet::new(),
+            previous_click_time: None,
         })
     }
 


### PR DESCRIPTION
see #277 

In fact this is not a windows issue. Its a new feature

Double click could be used elsewhere - say to extend selection in the main edit window -  so I have left a place holder for passing the event on

Crossterm does not report a double click event ( in fact it eats windows reporting of it ) so I have added simple detectioin based on time diff of 500ms. 