### PR TITLE
Docs: Add cargo-binstall installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Fresh is engineered for speed. It delivers a low-latency experience, with text a
 | Fedora/RHEL | [.rpm](#fedorarhelopensuse-rpm) |
 | All platforms | [Pre-built binaries](#pre-built-binaries) |
 | npm | [npm / npx](#npm) |
+| Rust users (Fast) | [cargo-binstall](#using-cargo-binstall) |
 | Rust users | [crates.io](#from-cratesio) |
 | Developers | [From source](#from-source) |
 
@@ -93,6 +94,22 @@ Or try it without installing:
 
 ```bash
 npx @fresh-editor/fresh-editor
+```
+
+### Using cargo-binstall
+
+To install the binary directly without compiling (much faster than crates.io):
+
+First, install cargo-binstall if you haven't already
+
+```bash
+cargo install cargo-binstall
+```
+
+Then install fresh
+
+```bash
+cargo binstall fresh-editor
 ```
 
 ### From crates.io


### PR DESCRIPTION
## Description
This PR updates the `README.md` to include **`cargo-binstall`** as an installation method.

## Motivation
Currently, the `cargo install` method compiles the project from source, which can take a significant amount of time depending on the machine.

Since this project already publishes pre-built binaries in GitHub Releases with standard naming conventions, `cargo-binstall` works out-of-the-box. This allows users to install the binary directly in seconds, providing a much faster and smoother onboarding experience for Rust users.

## Changes
- Added a row for `cargo-binstall` in the **Installation** table.
- Added a detailed command section **above** the **From crates.io** section (to prioritize the faster installation method).

## Verification
I have tested this locally on my machine. The command correctly detects the release assets and installs the binary without issues.