### PR TITLE
docs: Add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,7 @@ cargo build --release
 Copyright (c) Noam Lewis
 
 This project is licensed under the GNU General Public License v2.0 (GPL-2.0).
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=sinelaw/fresh&type=date&legend=top-left)](https://www.star-history.com/#sinelaw/fresh&type=date&legend=top-left)


### PR DESCRIPTION
## Description
This PR adds a **Star History** chart to the bottom of the `README.md`.

## Motivation
Visualizing the project's star growth helps demonstrate momentum and popularity to new visitors. It acts as social proof and is a standard practice for growing open-source projects.

## Changes
- Inserted the `star-history.com` image link at the end of the README file.