### PR TITLE
Recommend the more straightforward and standard way to install  the AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ brew install fresh-editor
 
 ### Arch Linux ([AUR](https://aur.archlinux.org/packages/fresh-editor-bin))
 
+**Binary package (recommended, faster install):**
+
+```bash
+git clone https://aur.archlinux.org/fresh-editor-bin.git
+cd fresh-editor-bin
+makepkg --install
+```
+
+**Build from source:**
+
+```bash
+git clone https://aur.archlinux.org/fresh-editor.git
+cd fresh-editor
+makepkg --install
+```
+
+**Using an AUR helper (such as `yay` or `paru`):**
+
 ```bash
 # Binary package (recommended, faster install)
 yay -S fresh-editor-bin


### PR DESCRIPTION
Reasons:
* Not all Arch Linux systems have AUR helpers installed.
* `git clone` and review is the official and recommended way to install AUR packages.
* Why suggest the user to install AUR helpers before installing `fresh-editor`?
* Why obstruct the knowledge behind AUR helpers?