### PR TITLE
Add `--syncdeps` to `makepkg` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ brew install fresh-editor
 ```bash
 git clone https://aur.archlinux.org/fresh-editor-bin.git
 cd fresh-editor-bin
-makepkg --install
+makepkg --syncdeps --install
 ```
 
 **Build from source:**
@@ -70,7 +70,7 @@ makepkg --install
 ```bash
 git clone https://aur.archlinux.org/fresh-editor.git
 cd fresh-editor
-makepkg --install
+makepkg --syncdeps --install
 ```
 
 **Using an AUR helper (such as `yay` or `paru`):**


### PR DESCRIPTION
I failed to take into account that `makepkg` could fail due to missing dependencies.