### PR TITLE
README: add architecture detection on deb/rpm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ yay -S fresh-editor
 Download and install the latest release:
 
 ```bash
-curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*\.deb" | cut -d '"' -f 4) -o fresh-editor.deb && sudo dpkg -i fresh-editor.deb
+curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*_$(dpkg --print-architecture)\.deb" | cut -d '"' -f 4) -o fresh-editor.deb && sudo dpkg -i fresh-editor.deb
 ```
 
 Or download the `.deb` file manually from the [releases page](https://github.com/sinelaw/fresh/releases).
@@ -99,7 +99,7 @@ Or download the `.deb` file manually from the [releases page](https://github.com
 Download and install the latest release:
 
 ```bash
-curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*\.rpm" | cut -d '"' -f 4) -o fresh-editor.rpm && sudo rpm -i fresh-editor.rpm
+curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*\.$(uname -m)\.rpm" | cut -d '"' -f 4) -o fresh-editor.rpm && sudo rpm -i fresh-editor.rpm
 ```
 
 Or download the `.rpm` file manually from the [releases page](https://github.com/sinelaw/fresh/releases).


### PR DESCRIPTION
Minor fix to deb/rpm install commands to ensure correct package is downloaded based on system architecture, assuming the standard Debian,Febora package naming convention.

The original `curl `command downloaded the first available deb/rpm package from the [release page](https://api.github.com/repos/sinelaw/fresh/releases/latest), which led to installation failure when system architecture didn't match.

### Changes
- deb command : package filtering with `dpkg --print-architecture`
```bash
curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*_$(dpkg --print-architecture)\.deb" | cut -d '"' -f 4) -o fresh-editor.deb && sudo dpkg -i fresh-editor.deb
```
- rpm command : package filtering with `uname -m`
```bash
curl -sL $(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | grep "browser_download_url.*\.$(uname -m)\.rpm" | cut -d '"' -f 4) -o fresh-editor.rpm && sudo rpm -i fresh-editor.rpm
```

### Testing
- Confirmed working on :
  - Debian(`Debian amd64`, `Debian arm64`) 
  - Fedora(`openSuse x86_64,` `openSuse aarm64`)