### PR TITLE
Fix nix flake: include sublime-syntax grammar files in source filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,8 @@
             (craneLib.fileset.commonCargoSources unfilteredRoot)
             # Also keep any javascript files
             (lib.fileset.fileFilter (file: file.hasExt "js") unfilteredRoot)
+            # Keep sublime-syntax grammar files (used by include_str! in grammar_registry.rs)
+            (lib.fileset.fileFilter (file: file.hasExt "sublime-syntax") unfilteredRoot)
             ./docs
             ./keymaps
             ./plugins


### PR DESCRIPTION
## Summary
The source filter in `flake.nix` was missing `.sublime-syntax` files, causing the nix build to fail.

## Problem
Building with `nix build` or `nix run github:sinelaw/fresh` fails with:
```
error: couldn't read `src/primitives/../grammars/toml.sublime-syntax`: No such file or directory (os error 2)
  --> src/primitives/grammar_registry.rs:17:28
   |
17 | const TOML_GRAMMAR: &str = include_str!("../grammars/toml.sublime-syntax");
   |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

## Fix
Add a fileset filter to include `.sublime-syntax` files, similar to how `.js` files are already included:
```nix
(lib.fileset.fileFilter (file: file.hasExt "sublime-syntax") unfilteredRoot)
```

## Test plan
- [x] `nix build github:tufloc/fresh` succeeds
- [x] `nix run github:tufloc/fresh` launches the editor