### PR TITLE
Store file scroll/cursor positions globally per file, not per project

### DIFF
--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -31,10 +31,10 @@ use crate::state::EditorState;
 use crate::model::event::{BufferId, SplitDirection, SplitId};
 use crate::services::terminal::TerminalId;
 use crate::session::{
-    FileExplorerState, SearchOptions, SerializedBookmark, SerializedCursor, SerializedFileState,
-    SerializedScroll, SerializedSplitDirection, SerializedSplitNode, SerializedSplitViewState,
-    SerializedTabRef, SerializedTerminalSession, SerializedViewMode, Session,
-    SessionConfigOverrides, SessionError, SessionHistories, SESSION_VERSION,
+    FileExplorerState, PersistedFileSession, SearchOptions, SerializedBookmark, SerializedCursor,
+    SerializedFileState, SerializedScroll, SerializedSplitDirection, SerializedSplitNode,
+    SerializedSplitViewState, SerializedTabRef, SerializedTerminalSession, SerializedViewMode,
+    Session, SessionConfigOverrides, SessionError, SessionHistories, SESSION_VERSION,
 };
 use crate::state::ViewMode;
 use crate::view::split::{SplitNode, SplitViewState};
@@ -270,11 +270,75 @@ impl Editor {
     ///
     /// Ensures all active terminals have their visible screen synced to
     /// backing files before capturing the session.
+    /// Also saves global file states (scroll/cursor positions per file).
     pub fn save_session(&mut self) -> Result<(), SessionError> {
         // Ensure all terminal backing files have complete state before saving
         self.sync_all_terminal_backing_files();
+
+        // Save global file states for all open file buffers
+        self.save_all_global_file_states();
+
         let session = self.capture_session();
         session.save()
+    }
+
+    /// Save global file states for all open file buffers
+    fn save_all_global_file_states(&self) {
+        // Collect all file states from all splits
+        for (split_id, view_state) in &self.split_view_states {
+            // Get the active buffer for this split
+            let active_buffer = self
+                .split_manager
+                .root()
+                .get_leaves_with_rects(ratatui::layout::Rect::default())
+                .into_iter()
+                .find(|(sid, _, _)| *sid == *split_id)
+                .map(|(_, buffer_id, _)| buffer_id);
+
+            if let Some(buffer_id) = active_buffer {
+                self.save_buffer_file_state(buffer_id, view_state);
+            }
+        }
+    }
+
+    /// Save file state for a specific buffer (used when closing files and saving session)
+    fn save_buffer_file_state(&self, buffer_id: BufferId, view_state: &SplitViewState) {
+        // Get the file path for this buffer
+        let abs_path = match self.buffer_metadata.get(&buffer_id) {
+            Some(metadata) => match metadata.file_path() {
+                Some(path) => path.to_path_buf(),
+                None => return, // Not a file buffer
+            },
+            None => return,
+        };
+
+        // Capture the current state
+        let primary_cursor = view_state.cursors.primary();
+        let file_state = SerializedFileState {
+            cursor: SerializedCursor {
+                position: primary_cursor.position,
+                anchor: primary_cursor.anchor,
+                sticky_column: primary_cursor.sticky_column,
+            },
+            additional_cursors: view_state
+                .cursors
+                .iter()
+                .skip(1)
+                .map(|(_, cursor)| SerializedCursor {
+                    position: cursor.position,
+                    anchor: cursor.anchor,
+                    sticky_column: cursor.sticky_column,
+                })
+                .collect(),
+            scroll: SerializedScroll {
+                top_byte: view_state.viewport.top_byte,
+                top_view_line_offset: view_state.viewport.top_view_line_offset,
+                left_column: view_state.viewport.left_column,
+            },
+        };
+
+        // Save to disk immediately
+        PersistedFileSession::save(&abs_path, file_state);
     }
 
     /// Sync all active terminal visible screens to their backing files.

--- a/src/session.rs
+++ b/src/session.rs
@@ -34,6 +34,9 @@ use crate::input::input_history::get_data_dir;
 /// Current session file format version
 pub const SESSION_VERSION: u32 = 1;
 
+/// Current per-file session version
+pub const FILE_SESSION_VERSION: u32 = 1;
+
 /// Persisted session state for a working directory
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
@@ -283,6 +286,144 @@ pub struct SerializedTerminalSession {
     pub rows: u16,
     pub log_path: PathBuf,
     pub backing_path: PathBuf,
+}
+
+// ============================================================================
+// Global file state persistence (per-file, not per-project)
+// ============================================================================
+
+/// Individual file state stored in its own file
+///
+/// Each source file's scroll/cursor state is stored in a separate JSON file
+/// at `$XDG_DATA_HOME/fresh/file_states/{encoded_path}.json`.
+/// This allows concurrent editors to safely update different files without
+/// conflicts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedFileState {
+    /// Schema version for future migrations
+    pub version: u32,
+
+    /// The file state (cursor, scroll, etc.)
+    pub state: SerializedFileState,
+
+    /// Timestamp when last saved (Unix epoch seconds)
+    pub saved_at: u64,
+}
+
+impl PersistedFileState {
+    fn new(state: SerializedFileState) -> Self {
+        Self {
+            version: FILE_SESSION_VERSION,
+            state,
+            saved_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+        }
+    }
+}
+
+/// Per-file session storage for scroll/cursor positions
+///
+/// Unlike project sessions which store file states relative to a working directory,
+/// this stores file states by absolute path so they persist across projects.
+/// This means opening the same file from different projects (or without a project)
+/// will restore the same scroll/cursor position.
+///
+/// Each file's state is stored in a separate JSON file at
+/// `$XDG_DATA_HOME/fresh/file_states/{encoded_path}.json` to avoid conflicts
+/// between concurrent editors. States are loaded lazily when opening files
+/// and saved immediately when closing files or saving the session.
+pub struct PersistedFileSession;
+
+impl PersistedFileSession {
+    /// Get the directory for file state files
+    fn states_dir() -> io::Result<PathBuf> {
+        Ok(get_data_dir()?.join("file_states"))
+    }
+
+    /// Get the state file path for a source file
+    fn state_file_path(source_path: &Path) -> io::Result<PathBuf> {
+        let canonical = source_path
+            .canonicalize()
+            .unwrap_or_else(|_| source_path.to_path_buf());
+        let filename = format!("{}.json", encode_path_for_filename(&canonical));
+        Ok(Self::states_dir()?.join(filename))
+    }
+
+    /// Load the state for a file by its absolute path (from disk)
+    pub fn load(path: &Path) -> Option<SerializedFileState> {
+        let state_path = match Self::state_file_path(path) {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+
+        if !state_path.exists() {
+            return None;
+        }
+
+        let content = match std::fs::read_to_string(&state_path) {
+            Ok(c) => c,
+            Err(_) => return None,
+        };
+
+        let persisted: PersistedFileState = match serde_json::from_str(&content) {
+            Ok(p) => p,
+            Err(_) => return None,
+        };
+
+        // Check version compatibility
+        if persisted.version > FILE_SESSION_VERSION {
+            return None;
+        }
+
+        Some(persisted.state)
+    }
+
+    /// Save the state for a file by its absolute path (to disk, atomic write)
+    pub fn save(path: &Path, state: SerializedFileState) {
+        let state_path = match Self::state_file_path(path) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("Failed to get state path for {:?}: {}", path, e);
+                return;
+            }
+        };
+
+        // Ensure directory exists
+        if let Some(parent) = state_path.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                tracing::warn!("Failed to create state dir: {}", e);
+                return;
+            }
+        }
+
+        let persisted = PersistedFileState::new(state);
+        let content = match serde_json::to_string_pretty(&persisted) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to serialize file state: {}", e);
+                return;
+            }
+        };
+
+        // Write atomically: temp file + rename
+        let temp_path = state_path.with_extension("json.tmp");
+
+        let write_result = (|| -> io::Result<()> {
+            let mut file = std::fs::File::create(&temp_path)?;
+            file.write_all(content.as_bytes())?;
+            file.sync_all()?;
+            std::fs::rename(&temp_path, &state_path)?;
+            Ok(())
+        })();
+
+        if let Err(e) = write_result {
+            tracing::warn!("Failed to save file state for {:?}: {}", path, e);
+        } else {
+            tracing::trace!("File state saved for {:?}", path);
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
File positions are now stored in separate files at $XDG_DATA_HOME/fresh/file_states/{encoded_path}.json

This means opening a file from any project (or directly without a project) will restore the saved scroll/cursor position. Each file's state is stored separately to prevent conflicts between concurrent editors.

Key implementation details:
- PersistedFileSession: static methods for lazy load/save per file
- States loaded on file open, saved on file close and session save
- Atomic writes (temp file + rename) for crash safety
- Version field for future migrations

Fixes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)