### PR TITLE
Replace AppImage extraction instructions with tar.xz archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Download the latest release for your platform from the [releases page](https://g
 **Step 0:** Determine the architecture and release tag to download if you are too lazy to fulfill the tip above (`jq` required).
 
 ```bash
-ARCH=$(uname -m | sed -e 's/arm64/aarch64/' -e 's/armv8l/aarch64/)
+ARCH=$(uname -m | sed -e 's/arm64/aarch64/' -e 's/armv8l/aarch64/')
 RELEASE_TAG=$(curl -s https://api.github.com/repos/sinelaw/fresh/releases/latest | jq -r .tag_name)
 ```
 


### PR DESCRIPTION
## Changes made

* Add more to the "prebuilt binaries" section.
* Remove the suggestion for AppImage extraction as an optimization.
* Suggest instead the installation of other prebuilt binaries.

## Regarding the new code blocks

The new code blocks inside the instructions are normally meant to be done separately, but they were also designed in such a way that the user can blindly copy-paste all the code blocks without change and the installation would still succeed.

## Verification

The new code blocks inside the instructions have been tried and tested in an isolated `archlinux:latest` Docker container.

What I did was:

```sh
# Clear out the outdated images
docker image rm 'archlinux:latest'
docker image prune

# Pull the latest image
docker pull 'archlinux:latest'

# Start a shell in the Arch Linux container
docker run --rm -it archlinux bash
```

Then, inside the container:

```sh
cd ~
pacman -Syu
pacman -S curl jq which

export PATH="$PATH:$HOME/.local/bin"

# ... and then just copy-paste the whole thing ...

which fresh # to check if fresh was successfully installed
fresh # to check if fresh can run without issues
```

> [!TIP]
> The `docker` command above can be replaced with `podman` and it should work perfectly fine.