### PR TITLE
Fix checkbox mouse click support in Find UI

### DIFF
--- a/src/app/mouse_input.rs
+++ b/src/app/mouse_input.rs
@@ -673,6 +673,20 @@ impl Editor {
             }
         }
 
+        // Check search options bar checkboxes
+        if let Some(ref layout) = self.cached_layout.search_options_layout {
+            use crate::view::ui::status_bar::SearchOptionsHover;
+            if let Some(hover) = layout.checkbox_at(col, row) {
+                return Some(match hover {
+                    SearchOptionsHover::CaseSensitive => HoverTarget::SearchOptionCaseSensitive,
+                    SearchOptionsHover::WholeWord => HoverTarget::SearchOptionWholeWord,
+                    SearchOptionsHover::Regex => HoverTarget::SearchOptionRegex,
+                    SearchOptionsHover::ConfirmEach => HoverTarget::SearchOptionConfirmEach,
+                    SearchOptionsHover::None => return None,
+                });
+            }
+        }
+
         // No hover target
         None
     }
@@ -962,6 +976,28 @@ impl Editor {
                     if row == warn_row && col >= warn_start && col < warn_end {
                         return self.handle_action(Action::ShowWarnings);
                     }
+                }
+            }
+        }
+
+        // Check if click is on search options checkboxes
+        if let Some(ref layout) = self.cached_layout.search_options_layout.clone() {
+            use crate::view::ui::status_bar::SearchOptionsHover;
+            if let Some(hover) = layout.checkbox_at(col, row) {
+                match hover {
+                    SearchOptionsHover::CaseSensitive => {
+                        return self.handle_action(Action::ToggleSearchCaseSensitive);
+                    }
+                    SearchOptionsHover::WholeWord => {
+                        return self.handle_action(Action::ToggleSearchWholeWord);
+                    }
+                    SearchOptionsHover::Regex => {
+                        return self.handle_action(Action::ToggleSearchRegex);
+                    }
+                    SearchOptionsHover::ConfirmEach => {
+                        return self.handle_action(Action::ToggleSearchConfirmEach);
+                    }
+                    SearchOptionsHover::None => {}
                 }
             }
         }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -489,7 +489,17 @@ impl Editor {
                 }
             });
 
-            StatusBarRenderer::render_search_options(
+            // Determine hover state for search options
+            use crate::view::ui::status_bar::SearchOptionsHover;
+            let search_options_hover = match &self.mouse_state.hover_target {
+                Some(HoverTarget::SearchOptionCaseSensitive) => SearchOptionsHover::CaseSensitive,
+                Some(HoverTarget::SearchOptionWholeWord) => SearchOptionsHover::WholeWord,
+                Some(HoverTarget::SearchOptionRegex) => SearchOptionsHover::Regex,
+                Some(HoverTarget::SearchOptionConfirmEach) => SearchOptionsHover::ConfirmEach,
+                _ => SearchOptionsHover::None,
+            };
+
+            let search_options_layout = StatusBarRenderer::render_search_options(
                 frame,
                 main_chunks[search_options_idx],
                 self.search_case_sensitive,
@@ -498,7 +508,11 @@ impl Editor {
                 confirm_each,
                 &theme,
                 &keybindings_cloned,
+                search_options_hover,
             );
+            self.cached_layout.search_options_layout = Some(search_options_layout);
+        } else {
+            self.cached_layout.search_options_layout = None;
         }
 
         // Render prompt line if active

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -331,6 +331,14 @@ pub enum HoverTarget {
     StatusBarLspIndicator,
     /// Hovering over the status bar warning badge
     StatusBarWarningBadge,
+    /// Hovering over the search options "Case Sensitive" checkbox
+    SearchOptionCaseSensitive,
+    /// Hovering over the search options "Whole Word" checkbox
+    SearchOptionWholeWord,
+    /// Hovering over the search options "Regex" checkbox
+    SearchOptionRegex,
+    /// Hovering over the search options "Confirm Each" checkbox
+    SearchOptionConfirmEach,
 }
 
 /// Mouse state tracking
@@ -434,4 +442,6 @@ pub(crate) struct CachedLayout {
     pub status_bar_lsp_area: Option<(u16, u16, u16)>,
     /// Status bar warning badge area (row, start_col, end_col)
     pub status_bar_warning_area: Option<(u16, u16, u16)>,
+    /// Search options layout for checkbox hit testing
+    pub search_options_layout: Option<crate::view::ui::status_bar::SearchOptionsLayout>,
 }


### PR DESCRIPTION
- Add HoverTarget variants for search option checkboxes (CaseSensitive, WholeWord, Regex, ConfirmEach)
- Add SearchOptionsLayout struct to track checkbox hit areas
- Add SearchOptionsHover enum for hover state tracking
- Update render_search_options to accept hover state and return layout
- Add hover detection in compute_hover_target
- Add click handling to toggle search options via mouse
- Style hovered checkboxes with theme-defined colors (menu_hover_fg/bg)

Fixes #519