### PR TITLE
Add toggle inlay hints checkbox to menu

### DIFF
--- a/src/app/menu_context.rs
+++ b/src/app/menu_context.rs
@@ -21,6 +21,7 @@ impl Editor {
         let file_explorer_focused = self.is_file_explorer_focused();
         let mouse_capture = self.mouse_enabled;
         let mouse_hover = self.config.editor.mouse_hover_enabled;
+        let inlay_hints = self.config.editor.enable_inlay_hints;
         let has_selection = self.has_active_selection();
         let menu_bar = self.menu_bar_visible;
 
@@ -42,6 +43,7 @@ impl Editor {
             .set(context_keys::FILE_EXPLORER_FOCUSED, file_explorer_focused)
             .set(context_keys::MOUSE_CAPTURE, mouse_capture)
             .set(context_keys::MOUSE_HOVER, mouse_hover)
+            .set(context_keys::INLAY_HINTS, inlay_hints)
             .set(context_keys::LSP_AVAILABLE, lsp_available)
             .set(context_keys::FILE_EXPLORER_SHOW_HIDDEN, show_hidden)
             .set(context_keys::FILE_EXPLORER_SHOW_GITIGNORED, show_gitignored)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1959,7 +1959,7 @@ impl Config {
                         action: "toggle_inlay_hints".to_string(),
                         args: HashMap::new(),
                         when: Some(context_keys::LSP_AVAILABLE.to_string()),
-                        checkbox: None,
+                        checkbox: Some(context_keys::INLAY_HINTS.to_string()),
                     },
                     MenuItem::Action {
                         label: "Toggle Mouse Hover".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,7 @@ pub mod context_keys {
     pub const FILE_EXPLORER_SHOW_GITIGNORED: &str = "file_explorer_show_gitignored";
     pub const HAS_SELECTION: &str = "has_selection";
     pub const FORMATTER_AVAILABLE: &str = "formatter_available";
+    pub const INLAY_HINTS: &str = "inlay_hints";
 }
 
 /// Configuration for process resource limits


### PR DESCRIPTION
Add INLAY_HINTS context key and sync it with editor state so the menu checkbox reflects the current inlay hints enabled/disabled state, matching the pattern used by Toggle Mouse Hover.