### PR TITLE
Add support for Odin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "tree-sitter-javascript",
  "tree-sitter-json",
  "tree-sitter-lua",
+ "tree-sitter-odin",
  "tree-sitter-pascal",
  "tree-sitter-php",
  "tree-sitter-python",
@@ -4122,6 +4123,16 @@ name = "tree-sitter-lua"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb9adf0965fec58e7660cbb3a059dbb12ebeec9459e6dcbae3db004739641e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-odin"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24db210fe9ba2237c71c5030d7b146c7025420ba72dd8013d13cd822c3a8d77a"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ runtime = [
     "dep:tree-sitter-bash",
     "dep:tree-sitter-lua",
     "dep:tree-sitter-pascal",
+    "dep:tree-sitter-odin",
     "dep:lsp-types",
     "dep:url",
     "dep:tokio",
@@ -137,6 +138,7 @@ tree-sitter-ruby = { version = "0.23.1", optional = true }
 tree-sitter-bash = { version = "0.25.1", optional = true }
 tree-sitter-lua = { version = "0.2.0", optional = true }
 tree-sitter-pascal = { version = "0.10.2", optional = true }
+tree-sitter-odin = { version = "1.3.0", optional = true }
 anyhow = { version = "1.0.100", default-features = false, optional = true }
 dirs = { version = "6.0", optional = true }
 pulldown-cmark = { version = "0.13", default-features = false, optional = true }

--- a/queries/odin/indents.scm
+++ b/queries/odin/indents.scm
@@ -1,0 +1,31 @@
+; Indent after block-like constructs
+[
+  (block)
+  (struct_type)
+  (union_type)
+  (enum_type)
+  (bit_field_type)
+  (procedure_body)
+] @indent
+
+; Indent after control flow
+[
+  (if_statement)
+  (for_statement)
+  (switch_statement)
+  (when_statement)
+  (case_statement)
+] @indent
+
+; Indent procedure declarations and literals
+[
+  (procedure_declaration)
+  (procedure_literal)
+] @indent
+
+; Dedent closing delimiters
+[
+  "}"
+  "]"
+  ")"
+] @dedent

--- a/src/primitives/highlighter.rs
+++ b/src/primitives/highlighter.rs
@@ -144,6 +144,7 @@ pub enum Language {
     Bash,
     Lua,
     Pascal,
+    Odin,
     // Markdown,  // Disabled due to tree-sitter version conflict
 }
 
@@ -168,6 +169,7 @@ impl Language {
             "sh" | "bash" => Some(Language::Bash),
             "lua" => Some(Language::Lua),
             "pas" | "p" => Some(Language::Pascal),
+            "odin" => Some(Language::Odin),
             // "md" => Some(Language::Markdown),  // Disabled
             _ => None,
         }
@@ -636,6 +638,32 @@ impl Language {
                 .map_err(|e| format!("Failed to create Pascal highlight config: {e}"))?;
 
                 // Configure highlight names (even though we don't use highlights query)
+                config.configure(&[
+                    "attribute",
+                    "comment",
+                    "constant",
+                    "function",
+                    "keyword",
+                    "number",
+                    "operator",
+                    "property",
+                    "string",
+                    "type",
+                    "variable",
+                ]);
+
+                Ok(config)
+            }
+            Language::Odin => {
+                let mut config = HighlightConfiguration::new(
+                    tree_sitter_odin::LANGUAGE.into(),
+                    "odin",
+                    tree_sitter_odin::HIGHLIGHTS_QUERY,
+                    "", // injections query
+                    "", // locals query
+                )
+                .map_err(|e| format!("Failed to create Odin highlight config: {e}"))?;
+
                 config.configure(&[
                     "attribute",
                     "comment",

--- a/src/primitives/indent.rs
+++ b/src/primitives/indent.rs
@@ -150,6 +150,11 @@ impl IndentCalculator {
                 tree_sitter_pascal::LANGUAGE.into(),
                 include_str!("../../queries/pascal/indents.scm"),
             ),
+            Language::Odin => (
+                "odin",
+                tree_sitter_odin::LANGUAGE.into(),
+                include_str!("../../queries/odin/indents.scm"),
+            ),
         };
 
         // Check if we already have this config

--- a/src/primitives/semantic_highlight.rs
+++ b/src/primitives/semantic_highlight.rs
@@ -221,6 +221,7 @@ impl SemanticHighlighter {
             Language::HTML => tree_sitter_html::LANGUAGE.into(),
             Language::CSS => tree_sitter_css::LANGUAGE.into(),
             Language::CSharp => tree_sitter_c_sharp::LANGUAGE.into(),
+            Language::Odin => tree_sitter_odin::LANGUAGE.into(),
         };
 
         // Create parser


### PR DESCRIPTION
Needs to double check: `queries/odin/indents.scm`, it was vibe coded

For the tree sitter package, it's an outdated one, but the only one i could find on cargo

The up to date one is here: https://github.com/laytan/odin-tree-sitter, but i don't know how to include it, i know nothing about rust