### PR TITLE
Fix folder deletion crash in explorer

### DIFF
--- a/src/view/ui/file_explorer.rs
+++ b/src/view/ui/file_explorer.rs
@@ -49,6 +49,11 @@ impl FileExplorerRenderer {
         let scroll_offset = view.get_scroll_offset();
         let selected_index = view.get_selected_index();
 
+        // Clamp scroll_offset to valid range to prevent panic after tree mutations
+        // (e.g., when deleting a folder with many children while scrolled down)
+        // Issue #562: scroll_offset can become larger than display_nodes.len()
+        let scroll_offset = scroll_offset.min(display_nodes.len());
+
         // Only render the visible subset of items (for manual scroll control)
         // This prevents ratatui's List widget from auto-scrolling
         let visible_end = (scroll_offset + viewport_height).min(display_nodes.len());


### PR DESCRIPTION
Fixes #562: When a folder with many children is collapsed or deleted while scrolled down viewing those children, the scroll_offset could become larger than display_nodes.len(), causing a panic with: "range start index X out of range for slice of length Y"

The fix clamps scroll_offset to display_nodes.len() before slicing in the render function. This is a defensive fix that prevents the panic regardless of how the tree state changed.

Also updated the e2e test to properly reproduce the condition using folder collapse (which immediately shrinks the tree without needing confirmation dialogs).