### PR TITLE
Fix LSP support for PKGBUILD files

### DIFF
--- a/src/app/buffer_management.rs
+++ b/src/app/buffer_management.rs
@@ -150,12 +150,13 @@ impl Editor {
 
         // Create the editor state - either load from file or create empty buffer
         let mut state = if file_exists {
-            EditorState::from_file(
+            EditorState::from_file_with_languages(
                 path,
                 self.terminal_width,
                 self.terminal_height,
                 self.config.editor.large_file_threshold_bytes as usize,
                 &self.grammar_registry,
+                &self.config.languages,
             )?
         } else {
             // File doesn't exist - create empty buffer with the file path set
@@ -503,14 +504,15 @@ impl Editor {
         // Get file size for status message before loading
         let file_size = std::fs::metadata(temp_path)?.len() as usize;
 
-        // Load from temp file using EditorState::from_file
+        // Load from temp file using EditorState::from_file_with_languages
         // This enables lazy chunk loading for large inputs (>100MB by default)
-        let mut state = EditorState::from_file(
+        let mut state = EditorState::from_file_with_languages(
             temp_path,
             self.terminal_width,
             self.terminal_height,
             self.config.editor.large_file_threshold_bytes as usize,
             &self.grammar_registry,
+            &self.config.languages,
         )?;
 
         // Clear the file path so the buffer is "unnamed" for save purposes

--- a/src/app/file_operations.rs
+++ b/src/app/file_operations.rs
@@ -118,12 +118,13 @@ impl Editor {
         let old_cursors = self.active_state().cursors.clone();
 
         // Load the file content fresh from disk
-        let mut new_state = EditorState::from_file(
+        let mut new_state = EditorState::from_file_with_languages(
             &path,
             self.terminal_width,
             self.terminal_height,
             self.config.editor.large_file_threshold_bytes as usize,
             &self.grammar_registry,
+            &self.config.languages,
         )?;
 
         // Restore cursor positions (clamped to valid range for new file size)
@@ -560,12 +561,13 @@ impl Editor {
     /// cursors (clamped to valid positions), but does NOT touch any viewport state.
     fn revert_buffer_by_id(&mut self, buffer_id: BufferId, path: &Path) -> io::Result<()> {
         // Load the file content fresh from disk
-        let new_state = EditorState::from_file(
+        let new_state = EditorState::from_file_with_languages(
             path,
             self.terminal_width,
             self.terminal_height,
             self.config.editor.large_file_threshold_bytes as usize,
             &self.grammar_registry,
+            &self.config.languages,
         )?;
 
         // Get the new file size for clamping

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -643,12 +643,13 @@ impl Editor {
         }
 
         let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-        if let Ok(new_state) = EditorState::from_file(
+        if let Ok(new_state) = EditorState::from_file_with_languages(
             backing_path,
             self.terminal_width,
             self.terminal_height,
             large_file_threshold,
             &self.grammar_registry,
+            &self.config.languages,
         ) {
             if let Some(state) = self.buffers.get_mut(&buffer_id) {
                 *state = new_state;

--- a/src/app/terminal.rs
+++ b/src/app/terminal.rs
@@ -430,12 +430,13 @@ impl Editor {
 
             // Reload buffer from the backing file (reusing existing file loading)
             let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-            if let Ok(new_state) = EditorState::from_file(
+            if let Ok(new_state) = EditorState::from_file_with_languages(
                 &backing_file,
                 self.terminal_width,
                 self.terminal_height,
                 large_file_threshold,
                 &self.grammar_registry,
+                &self.config.languages,
             ) {
                 // Replace buffer state
                 if let Some(state) = self.buffers.get_mut(&buffer_id) {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1368,6 +1368,9 @@ impl Config {
                     ".zshenv".to_string(),
                     ".zlogin".to_string(),
                     ".zlogout".to_string(),
+                    // Common shell script files without extensions
+                    "PKGBUILD".to_string(),
+                    "APKBUILD".to_string(),
                 ],
                 grammar: "bash".to_string(),
                 comment_prefix: Some("#".to_string()),

--- a/src/state.rs
+++ b/src/state.rs
@@ -234,6 +234,76 @@ impl EditorState {
         })
     }
 
+    /// Create an editor state from a file with language configuration.
+    ///
+    /// This version uses the provided languages configuration for syntax detection,
+    /// allowing user-configured filename patterns to be respected for highlighting.
+    ///
+    /// Note: width/height parameters are kept for backward compatibility but
+    /// are no longer used - viewport is now owned by SplitViewState.
+    pub fn from_file_with_languages(
+        path: &std::path::Path,
+        _width: u16,
+        _height: u16,
+        large_file_threshold: usize,
+        registry: &GrammarRegistry,
+        languages: &std::collections::HashMap<String, crate::config::LanguageConfig>,
+    ) -> std::io::Result<Self> {
+        let buffer = Buffer::load_from_file(path, large_file_threshold)?;
+
+        // Create highlighter using HighlightEngine with language config
+        let highlighter = HighlightEngine::for_file_with_languages(path, registry, languages);
+        tracing::debug!(
+            "Created highlighter for {:?} (backend: {})",
+            path,
+            highlighter.backend_name()
+        );
+
+        // Initialize semantic highlighter with language if available
+        let language = Language::from_path(path);
+        let mut semantic_highlighter = SemanticHighlighter::new();
+        if let Some(lang) = language {
+            semantic_highlighter.set_language(&lang);
+        }
+
+        // Initialize marker list with buffer size
+        let mut marker_list = MarkerList::new();
+        if buffer.len() > 0 {
+            tracing::debug!(
+                "Initializing marker list for file with {} bytes",
+                buffer.len()
+            );
+            marker_list.adjust_for_insert(0, buffer.len());
+        }
+
+        Ok(Self {
+            buffer,
+            cursors: Cursors::new(),
+            highlighter,
+            indent_calculator: RefCell::new(IndentCalculator::new()),
+            overlays: OverlayManager::new(),
+            marker_list,
+            virtual_texts: VirtualTextManager::new(),
+            popups: PopupManager::new(),
+            margins: MarginManager::new(),
+            primary_cursor_line_number: LineNumber::Absolute(0), // Start at line 0
+            mode: "insert".to_string(),
+            text_properties: TextPropertyManager::new(),
+            show_cursors: true,
+            editing_disabled: false,
+            show_whitespace_tabs: true,
+            use_tabs: false,
+            tab_size: 4, // Default tab size
+            semantic_highlighter,
+            view_mode: ViewMode::Source,
+            debug_highlight_mode: false,
+            compose_width: None,
+            compose_prev_line_numbers: None,
+            compose_column_guides: None,
+            view_transform: None,
+        })
+    }
+
     /// Handle an Insert event - adjusts markers, buffer, highlighter, cursors, and line numbers
     fn apply_insert(
         &mut self,


### PR DESCRIPTION
Previously, syntax highlighting used a hardcoded list of filename mappings (in GrammarRegistry) that was separate from the languages config. This meant users couldn't customize filename patterns like PKGBUILD via their config file and have syntax highlighting work correctly.

This commit:
- Adds PKGBUILD and APKBUILD to default bash filenames (for both LSP and syntax highlighting to work out of the box)
- Adds find_syntax_for_file_with_languages() to GrammarRegistry that checks user-configured language filenames/extensions before falling back to built-in detection
- Updates HighlightEngine with for_file_with_languages() method
- Updates EditorState::from_file_with_languages() to thread the config
- Updates all callers to pass the languages config

Now both LSP and syntax highlighting use the same source of truth (the languages config), so users can configure custom filename patterns like PKGBUILD via their ~/.config/fresh/config.json and have it work for both LSP and syntax highlighting.

Fixes #565