### PR TITLE
fix: Add missing semantic_highlight_cache initialization

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -307,6 +307,7 @@ impl EditorState {
             compose_prev_line_numbers: None,
             compose_column_guides: None,
             view_transform: None,
+            semantic_highlight_cache: SemanticHighlightCache::new(),
         })
     }
 


### PR DESCRIPTION
## Summary
The `from_content` constructor was missing the `semantic_highlight_cache` field initialization, causing compilation to fail.

This was introduced in commit 14e24ec which added the field to EditorState but didn't update all constructors.

## Test
- `cargo check` passes after this fix