### PR TITLE
Fix file dialog layout for checkbox and shortcuts

### DIFF
--- a/src/app/file_open_input.rs
+++ b/src/app/file_open_input.rs
@@ -485,7 +485,7 @@ impl Editor {
                 .map(|s| s.shortcuts.iter().map(|sc| sc.label.as_str()).collect())
                 .unwrap_or_default();
 
-            if let Some(shortcut_idx) = layout.nav_shortcut_at(x, &shortcut_labels) {
+            if let Some(shortcut_idx) = layout.nav_shortcut_at(x, y, &shortcut_labels) {
                 // Get the path from the shortcut and navigate there
                 let target_path = self
                     .file_open_state
@@ -579,7 +579,7 @@ impl Editor {
                 .map(|s| s.shortcuts.iter().map(|sc| sc.label.as_str()).collect())
                 .unwrap_or_default();
 
-            if let Some(idx) = layout.nav_shortcut_at(x, &shortcut_labels) {
+            if let Some(idx) = layout.nav_shortcut_at(x, y, &shortcut_labels) {
                 return Some(HoverTarget::FileBrowserNavShortcut(idx));
             }
         }

--- a/tests/e2e/file_browser.rs
+++ b/tests/e2e/file_browser.rs
@@ -996,12 +996,12 @@ fn test_file_browser_toggle_hidden_checkbox_click() {
         })
         .expect("Should find Show Hidden checkbox row");
 
-    // Click on the checkbox area (right side of the line)
-    // The checkbox " ☐ Show Hidden " is at the right edge
+    // Click on the checkbox area (left side of the row)
+    // The checkbox " ☐ Show Hidden (Alt+.)" is at the left side on its own row
     harness
         .send_mouse(MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
-            column: 72, // Right side where checkbox is
+            column: 10, // Left side where checkbox is
             row: checkbox_row as u16,
             modifiers: KeyModifiers::NONE,
         })


### PR DESCRIPTION
Prevents the "Show Hidden" checkbox label from being truncated when there are many platform shortcuts (like on Windows with multiple drive letters). The checkbox now appears on its own row above the navigation shortcuts, ensuring the full label is always visible.

Fixes #558