### PR TITLE
fix(i18n): Fix locale.changed message not interpolating locale name

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -656,7 +656,7 @@
   "lines.action": "%{count} řádků %{action}",
   "lines.comment": "Zakomentovat",
   "lines.uncomment": "Odkomentovat",
-  "locale.changed": "Jazyk změněn na %{locale}",
+  "locale.changed": "Jazyk změněn na %{locale_name}",
   "locale.select_prompt": "Vybrat jazyk: ",
   "lsp.allow_once": "Povolit tentokrát",
   "lsp.allow_once_desc": "Spustit LSP server pro tuto relaci",

--- a/locales/de.json
+++ b/locales/de.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} Zeile(n) %{action}",
   "lines.comment": "Kommentieren",
   "lines.uncomment": "Auskommentieren",
-  "locale.changed": "Sprache geändert zu %{locale}",
+  "locale.changed": "Sprache geändert zu %{locale_name}",
   "locale.select_prompt": "Sprache auswählen: ",
   "lsp.allow_once": "Diesmal erlauben",
   "lsp.allow_once_desc": "LSP-Server für diese Sitzung starten",

--- a/locales/en.json
+++ b/locales/en.json
@@ -655,7 +655,7 @@
   "lines.action": "%{action}ed %{count} line(s)",
   "lines.comment": "Comment",
   "lines.uncomment": "Uncomment",
-  "locale.changed": "Locale changed to %{locale}",
+  "locale.changed": "Locale changed to %{locale_name}",
   "locale.select_prompt": "Select locale: ",
   "lsp.allow_once": "Allow this time",
   "lsp.allow_once_desc": "Start the LSP server for this session",

--- a/locales/es.json
+++ b/locales/es.json
@@ -656,7 +656,7 @@
   "lines.action": "%{count} línea(s) %{action}",
   "lines.comment": "Comentar",
   "lines.uncomment": "Descomentar",
-  "locale.changed": "Idioma cambiado a %{locale}",
+  "locale.changed": "Idioma cambiado a %{locale_name}",
   "locale.select_prompt": "Seleccionar idioma: ",
   "lsp.allow_once": "Permitir esta vez",
   "lsp.allow_once_desc": "Iniciar el servidor LSP para esta sesión",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} ligne(s) %{action}",
   "lines.comment": "Commenter",
   "lines.uncomment": "Décommenter",
-  "locale.changed": "Langue changée en %{locale}",
+  "locale.changed": "Langue changée en %{locale_name}",
   "locale.select_prompt": "Sélectionner la langue : ",
   "lsp.allow_once": "Autoriser cette fois",
   "lsp.allow_once_desc": "Démarrer le serveur LSP pour cette session",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} 行を%{action}しました",
   "lines.comment": "コメント",
   "lines.uncomment": "コメント解除",
-  "locale.changed": "ロケールが %{locale} に変更されました",
+  "locale.changed": "ロケールが %{locale_name} に変更されました",
   "locale.select_prompt": "ロケールを選択: ",
   "lsp.allow_once": "今回のみ許可",
   "lsp.allow_once_desc": "このセッションで LSP サーバーを起動",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count}줄 %{action}",
   "lines.comment": "주석 처리",
   "lines.uncomment": "주석 해제",
-  "locale.changed": "언어가 %{locale}(으)로 변경됨",
+  "locale.changed": "언어가 %{locale_name}(으)로 변경됨",
   "locale.select_prompt": "언어 선택: ",
   "lsp.allow_once": "이번만 허용",
   "lsp.allow_once_desc": "이 세션에서 LSP 서버 시작",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} linha(s) %{action}",
   "lines.comment": "Comentar",
   "lines.uncomment": "Descomentar",
-  "locale.changed": "Idioma alterado para %{locale}",
+  "locale.changed": "Idioma alterado para %{locale_name}",
   "locale.select_prompt": "Selecionar idioma: ",
   "lsp.allow_once": "Permitir desta vez",
   "lsp.allow_once_desc": "Iniciar o servidor LSP para esta sessão",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} строк %{action}",
   "lines.comment": "Закомментировать",
   "lines.uncomment": "Раскомментировать",
-  "locale.changed": "Язык изменён на %{locale}",
+  "locale.changed": "Язык изменён на %{locale_name}",
   "locale.select_prompt": "Выберите язык: ",
   "lsp.allow_once": "Разрешить сейчас",
   "lsp.allow_once_desc": "Запустить LSP-сервер для этой сессии",

--- a/locales/th.json
+++ b/locales/th.json
@@ -655,7 +655,7 @@
   "lines.action": "%{action}แล้ว %{count} บรรทัด",
   "lines.comment": "คอมเมนต์",
   "lines.uncomment": "ยกเลิกคอมเมนต์",
-  "locale.changed": "เปลี่ยนภาษาเป็น %{locale} แล้ว",
+  "locale.changed": "เปลี่ยนภาษาเป็น %{locale_name} แล้ว",
   "locale.select_prompt": "เลือกภาษา: ",
   "lsp.allow_once": "อนุญาตครั้งนี้",
   "lsp.allow_once_desc": "เริ่มเซิร์ฟเวอร์ LSP สำหรับเซสชันนี้",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -655,7 +655,7 @@
   "lines.action": "%{count} рядків %{action}",
   "lines.comment": "Закоментувати",
   "lines.uncomment": "Раскомментувати",
-  "locale.changed": "Мову змінено на %{locale}",
+  "locale.changed": "Мову змінено на %{locale_name}",
   "locale.select_prompt": "Виберіть мову: ",
   "lsp.allow_once": "Дозволити цього разу",
   "lsp.allow_once_desc": "Запустити LSP-сервер для цієї сесії",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -655,7 +655,7 @@
   "lines.action": "已%{action} %{count} 行",
   "lines.comment": "注释",
   "lines.uncomment": "取消注释",
-  "locale.changed": "语言已更改为 %{locale}",
+  "locale.changed": "语言已更改为 %{locale_name}",
   "locale.select_prompt": "选择语言：",
   "lsp.allow_once": "本次允许",
   "lsp.allow_once_desc": "为此会话启动 LSP 服务器",

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -2259,7 +2259,7 @@ impl Editor {
             // Persist to config file
             self.save_locale_to_config();
 
-            self.set_status_message(t!("locale.changed", locale = locale_name).to_string());
+            self.set_status_message(t!("locale.changed", locale_name = locale_name).to_string());
         }
     }
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -221,6 +221,20 @@ mod tests {
     }
 
     #[test]
+    fn test_locale_changed_interpolation() {
+        use rust_i18n::t;
+        set_locale("en");
+
+        // Test the locale.changed message interpolation
+        // Note: The placeholder is %{locale_name} not %{locale} because "locale"
+        // is a reserved parameter in rust_i18n that sets the translation locale.
+        let locale_name = "es";
+        let msg = t!("locale.changed", locale_name = locale_name).to_string();
+
+        assert_eq!(msg, "Locale changed to es");
+    }
+
+    #[test]
     fn test_available_locales_includes_en() {
         let locales = available_locales();
         assert!(


### PR DESCRIPTION
Fixes #624

The `locale` parameter name is reserved in rust_i18n's t!() macro - it controls which translation locale to use, not string interpolation. When calling t!("locale.changed", locale = name), rust_i18n would switch to that locale instead of interpolating the value.

Renamed the placeholder from %{locale} to %{locale_name} in all 12 locale files and updated the code to use the new parameter name.
