### PR TITLE
Fix flaky e2e file browser tests

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5437,8 +5437,11 @@ mod tests {
     fn test_keybinding_new_defaults() {
         use crossterm::event::{KeyEvent, KeyEventKind, KeyEventState};
 
-        // Test that new keybindings are properly registered
-        let config = Config::default();
+        // Test that new keybindings are properly registered in the "default" keymap
+        // Note: We explicitly use "default" keymap, not Config::default() which uses
+        // platform-specific keymaps (e.g., "macos" on macOS has different bindings)
+        let mut config = Config::default();
+        config.active_keybinding_map = crate::config::KeybindingMapName("default".to_string());
         let resolver = KeybindingResolver::new(&config);
 
         // Test Ctrl+/ is ToggleComment (not CommandPalette)

--- a/tests/e2e/file_browser.rs
+++ b/tests/e2e/file_browser.rs
@@ -869,6 +869,12 @@ fn test_file_browser_prompt_shows_buffer_directory() {
         .wait_until(|h| h.screen_to_string().contains("Navigation:"))
         .expect("File browser should appear again");
 
+    // Wait for the file list to load - use semantic waiting for file list content
+    // The sibling file "input.rs" should appear when the directory listing completes
+    harness
+        .wait_until(|h| h.screen_to_string().contains("input.rs"))
+        .expect("File list should load and show sibling files");
+
     // The prompt should show the directory path of the open file
     // It will be an absolute path since the file was opened via direct path resolution
     let expected_suffix = "src/components/";
@@ -890,12 +896,8 @@ fn test_file_browser_prompt_shows_buffer_directory() {
         prompt_line,
     );
 
-    // The sibling file should be visible in the file list
+    // Verify all expected files are in the list (already waited for input.rs above)
     let screen = harness.screen_to_string();
-    assert!(
-        screen.contains("input.rs"),
-        "Should show sibling files in the same directory"
-    );
     assert!(
         screen.contains("button.rs"),
         "Should show the current file in the list"

--- a/tests/e2e/vi_mode.rs
+++ b/tests/e2e/vi_mode.rs
@@ -1004,12 +1004,16 @@ fn test_vi_colon_write_quit() {
     // Wait for buffer to close - we should now see test1.txt
     harness.wait_for_screen_contains("test1.txt").unwrap();
 
-    // Verify file was saved (read it back and check content)
-    let saved_content = fs::read_to_string(&fixture2.path).unwrap();
-    assert!(
-        saved_content.contains("X"),
-        "Saved file should contain the change"
-    );
+    // Wait for file to be written to disk using semantic waiting
+    // The file write is asynchronous, so we poll until the content appears
+    let fixture2_path = fixture2.path.clone();
+    harness
+        .wait_until(move |_h| {
+            fs::read_to_string(&fixture2_path)
+                .map(|content| content.contains("X"))
+                .unwrap_or(false)
+        })
+        .expect("Saved file should contain the change");
 }
 
 /// Test ':35' goes to line 35 and edits happen at the correct position


### PR DESCRIPTION
Apply README testing guidelines to four flaky tests:

- test_keybinding_new_defaults: Explicitly use "default" keymap instead of relying on platform-specific default (macOS uses different bindings)

- test_file_browser_prompt_shows_buffer_directory: Add wait_until for file list to load before asserting on content

- test_vi_colon_write_quit: Use semantic waiting for file write to complete instead of immediate file read after buffer close

- test_todo_highlighter_toggle: Replace fixed process_async_and_render calls with wait_until for highlight overlay to appear