### PR TITLE
 fix cursor can't go to the final line #622

### DIFF
--- a/src/primitives/line_iterator.rs
+++ b/src/primitives/line_iterator.rs
@@ -605,6 +605,7 @@ mod tests {
         // CRLF content: "abc\r\ndef\r\nghi\r\n"
         // Bytes: a=0, b=1, c=2, \r=3, \n=4, d=5, e=6, f=7, \r=8, \n=9, g=10, h=11, i=12, \r=13, \n=14
         let content = b"abc\r\ndef\r\nghi\r\n";
+        let buffer_len = content.len();
         let mut buffer = TextBuffer::from_bytes(content.to_vec());
 
         let mut iter = buffer.line_iterator(0, 80);
@@ -627,7 +628,13 @@ mod tests {
         );
         assert_eq!(line_content, "ghi\r\n", "Third line content");
 
-        // No more lines
+        // Trailing CRLF means there's an empty synthetic line at EOF
+        let (pos, line_content) = iter
+            .next()
+            .expect("Should emit empty line after trailing CRLF");
+        assert_eq!(pos, buffer_len, "Empty line should start at EOF");
+        assert_eq!(line_content, "", "Empty line content");
+
         assert!(iter.next().is_none(), "Should have no more lines");
     }
 

--- a/src/view/viewport.rs
+++ b/src/view/viewport.rs
@@ -488,26 +488,6 @@ impl Viewport {
             viewport_height
         );
 
-        // Check if buffer ends with newline (which creates a phantom empty line)
-        let buffer_ends_with_newline = buffer_len > 0 && {
-            let last_byte_slice = buffer.slice_bytes(buffer_len - 1..buffer_len);
-            !last_byte_slice.is_empty() && last_byte_slice[0] == b'\n'
-        };
-
-        tracing::trace!(
-            "DEBUG: buffer_ends_with_newline={}",
-            buffer_ends_with_newline
-        );
-
-        // Account for the phantom line if buffer ends with newline
-        if buffer_ends_with_newline {
-            lines_visible += 1;
-            tracing::trace!(
-                "DEBUG: After adding phantom line, lines_visible={}",
-                lines_visible
-            );
-        }
-
         // If we have enough lines to fill the viewport, we're good
         if lines_visible >= viewport_height {
             tracing::trace!(


### PR DESCRIPTION
fix #622

Fixed LineIterator so it emits the synthetic empty line that exists conceptually after a trailing newline. This allows MoveDown at EOF in a fresh buffer (with “new file” default content of \n) to see another line instead of stopping.

Added regression test test_line_iterator_trailing_newline_emits_empty_line