### PR TITLE
fix: Render multi-cursor at end of line correctly

### DIFF
--- a/src/view/ui/split_rendering.rs
+++ b/src/view/ui/split_rendering.rs
@@ -2592,6 +2592,9 @@ impl SplitRenderer {
                         let should_add_indicator =
                             if is_active { is_secondary_cursor } else { true };
                         if should_add_indicator {
+                            // Flush accumulated text before adding cursor indicator
+                            // so the indicator appears after the line content, not before
+                            span_acc.flush(&mut line_spans, &mut line_view_map);
                             let cursor_style = if is_active {
                                 Style::default()
                                     .fg(theme.editor_fg)


### PR DESCRIPTION
Fixes #632. When multiple cursors were at the end of lines (e.g., after pressing End key), secondary cursors were rendered at the start of the line instead of at the end.

The issue was that the span accumulator wasn't flushed before adding the cursor indicator for newline positions. This caused the cursor indicator to appear before the accumulated line content rather than after it.
