### PR TITLE
fix: Set terminal cursor color via OSC 12 for theme visibility

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1946,6 +1946,9 @@ impl Editor {
         if !theme_name.is_empty() {
             self.theme = crate::view::theme::Theme::from_name(theme_name);
 
+            // Set terminal cursor color to match theme
+            self.theme.set_terminal_cursor_color();
+
             // Update the config in memory
             self.config.theme = self.theme.name.clone().into();
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -657,6 +657,9 @@ impl Editor {
         // Load theme from config
         let theme = crate::view::theme::Theme::from_name(&config.theme);
 
+        // Set terminal cursor color to match theme
+        theme.set_terminal_cursor_color();
+
         tracing::info!(
             "Grammar registry has {} syntaxes",
             grammar_registry.available_syntaxes().len()

--- a/src/main.rs
+++ b/src/main.rs
@@ -416,6 +416,7 @@ fn initialize_app(args: &Args) -> io::Result<SetupState> {
         let _ = crossterm::execute!(stdout(), crossterm::event::DisableMouseCapture);
         let _ = stdout().execute(DisableBracketedPaste);
         let _ = stdout().execute(SetCursorStyle::DefaultUserShape);
+        fresh::view::theme::Theme::reset_terminal_cursor_color();
         let _ = stdout().execute(PopKeyboardEnhancementFlags);
         let _ = disable_raw_mode();
         let _ = stdout().execute(LeaveAlternateScreen);
@@ -771,6 +772,7 @@ fn main() -> io::Result<()> {
     let _ = crossterm::execute!(stdout(), crossterm::event::DisableMouseCapture);
     let _ = stdout().execute(DisableBracketedPaste);
     let _ = stdout().execute(SetCursorStyle::DefaultUserShape);
+    fresh::view::theme::Theme::reset_terminal_cursor_color();
     let _ = stdout().execute(PopKeyboardEnhancementFlags);
     disable_raw_mode()?;
     stdout().execute(LeaveAlternateScreen)?;

--- a/src/view/ui/split_rendering.rs
+++ b/src/view/ui/split_rendering.rs
@@ -2563,7 +2563,9 @@ impl SplitRenderer {
                     if !have_cursor {
                         if let Some(bp) = byte_pos {
                             if bp == primary_cursor_position && char_width(ch) == 0 {
-                                cursor_screen_x = gutter_width as u16 + visible_char_count as u16;
+                                // Account for horizontal scrolling by subtracting left_col
+                                cursor_screen_x = gutter_width as u16
+                                    + col_offset.saturating_sub(left_col) as u16;
                                 cursor_screen_y = lines.len() as u16;
                                 have_cursor = true;
                             }

--- a/tests/e2e/theme.rs
+++ b/tests/e2e/theme.rs
@@ -60,7 +60,7 @@ fn test_theme_loading_from_config_high_contrast() {
     // Verify some high-contrast theme colors (from Theme::high_contrast() Rust fallback)
     assert_eq!(theme.editor_bg, Color::Black);
     assert_eq!(theme.editor_fg, Color::White);
-    assert_eq!(theme.cursor, Color::Yellow);
+    assert_eq!(theme.cursor, Color::White);
     assert_eq!(theme.tab_active_fg, Color::Black);
     assert_eq!(theme.tab_active_bg, Color::Yellow);
 }


### PR DESCRIPTION
Previously, the cursor was invisible at end of line in the light theme because the terminal hardware cursor color wasn't set. The cursor used whatever the terminal's default color was (often white), which was invisible on a white background.

Changes:
- Add color_to_rgb() helper to convert ratatui Color to RGB values
- Add Theme::set_terminal_cursor_color() using OSC 12 escape sequence
- Add Theme::reset_terminal_cursor_color() using OSC 112
- Set cursor color at startup, on theme change, and reset on exit/panic
- Change dark and high-contrast theme cursor colors to white
- Fix horizontal scroll cursor position calculation
