### PR TITLE
Faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,10 @@ jobs:
         run: cargo generate-lockfile
       - name: Run tests (Linux — headless with Xvfb + lavapipe)
         if: runner.os == 'Linux'
-        run: xvfb-run cargo nextest run -j=4 --no-fail-fast --locked --all-features --all-targets
+        run: xvfb-run cargo nextest run -j=16 --no-fail-fast --locked --all-features --all-targets
         env:
           LIBGL_ALWAYS_SOFTWARE: "1"
           WGPU_BACKEND: "vulkan"
       - name: Run tests
         if: runner.os != 'Linux'
-        run: cargo nextest run -j=4 --no-fail-fast --locked --all-features --all-targets
+        run: cargo nextest run -j=16 --no-fail-fast --locked --all-features --all-targets


### PR DESCRIPTION
Raises CI test parallelism from `-j=4` to `-j=16`, to cut wall-clock time on the test jobs.
