### PR TITLE
feat: implement multi-stage save with sudo fallback (#301)

### DIFF
--- a/locales/cs.json
+++ b/locales/cs.json
@@ -877,6 +877,8 @@
   "prompt.quit_modified_many": "%{count} bufferů má neuložené změny. (%{discard_key})ahodit a ukončit, (%{cancel_key})rušit? ",
   "prompt.quit_modified_one": "1 buffer má neuložené změny. (%{discard_key})ahodit a ukončit, (%{cancel_key})rušit? ",
   "prompt.revert_confirm": "Buffer má neuložené změny. (%{revert_key})rátit, (%{cancel_key})rušit? ",
+  "prompt.sudo_save_confirm": "Přístup odepřen. Uložit pomocí sudo? (a)no, (N)e: ",
+  "prompt.sudo_save_failed": "Uložení pomocí sudo selhalo: %{error}",
   "register.must_be_digit": "Registr %{type} musí být 0-9",
   "register.not_specified": "Registr není zadán",
   "replace.completed": "Nahrazeno %{count} výskytů '%{search}'",

--- a/locales/de.json
+++ b/locales/de.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} Buffer haben ungespeicherte Änderungen. (%{discard_key})erwerfen und beenden, (%{cancel_key})bbrechen? ",
   "prompt.quit_modified_one": "1 Buffer hat ungespeicherte Änderungen. (%{discard_key})erwerfen und beenden, (%{cancel_key})bbrechen? ",
   "prompt.revert_confirm": "Buffer hat ungespeicherte Änderungen. (%{revert_key})ückgängig, (%{cancel_key})bbrechen? ",
+  "prompt.sudo_save_confirm": "Keine Berechtigung. Mit sudo speichern? (j)a, (N)ein: ",
+  "prompt.sudo_save_failed": "Speichern mit sudo fehlgeschlagen: %{error}",
   "register.must_be_digit": "%{type}-Register muss 0-9 sein",
   "register.not_specified": "Kein Register angegeben",
   "replace.completed": "%{count} Vorkommen von '%{search}' ersetzt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} buffers have unsaved changes. (%{discard_key})iscard and quit, (%{cancel_key})ancel? ",
   "prompt.quit_modified_one": "1 buffer has unsaved changes. (%{discard_key})iscard and quit, (%{cancel_key})ancel? ",
   "prompt.revert_confirm": "Buffer has unsaved changes. (%{revert_key})evert, (%{cancel_key})ancel? ",
+  "prompt.sudo_save_confirm": "Permission denied. Save with sudo? (y)es, (N)o: ",
+  "prompt.sudo_save_failed": "Sudo save failed: %{error}",
   "register.must_be_digit": "%{type} register must be 0-9",
   "register.not_specified": "No register specified",
   "replace.completed": "Replaced %{count} occurrence(s) of '%{search}'",

--- a/locales/es.json
+++ b/locales/es.json
@@ -877,6 +877,8 @@
   "prompt.quit_modified_many": "%{count} buffers tienen cambios sin guardar. (%{discard_key})escartar y salir, (%{cancel_key})ancelar? ",
   "prompt.quit_modified_one": "1 buffer tiene cambios sin guardar. (%{discard_key})escartar y salir, (%{cancel_key})ancelar? ",
   "prompt.revert_confirm": "El buffer tiene cambios sin guardar. (%{revert_key})evertir, (%{cancel_key})ancelar? ",
+  "prompt.sudo_save_confirm": "Permiso denegado. ¿Guardar con sudo? (s)í, (N)o: ",
+  "prompt.sudo_save_failed": "Error al guardar con sudo: %{error}",
   "register.must_be_digit": "El registro %{type} debe ser 0-9",
   "register.not_specified": "No se especificó registro",
   "replace.completed": "Se reemplazaron %{count} ocurrencia(s) de '%{search}'",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} buffers ont des modifications non sauvegardées. (%{discard_key})éfausser et quitter, (%{cancel_key})nnuler? ",
   "prompt.quit_modified_one": "1 buffer a des modifications non sauvegardées. (%{discard_key})éfausser et quitter, (%{cancel_key})nnuler? ",
   "prompt.revert_confirm": "Le buffer a des modifications non sauvegardées. (%{revert_key})établir, (%{cancel_key})nnuler? ",
+  "prompt.sudo_save_confirm": "Permission refusée. Enregistrer avec sudo ? (o)ui, (N)on : ",
+  "prompt.sudo_save_failed": "L'enregistrement avec sudo a échoué : %{error}",
   "register.must_be_digit": "Le registre %{type} doit être 0-9",
   "register.not_specified": "Aucun registre spécifié",
   "replace.completed": "%{count} occurrence(s) de '%{search}' remplacée(s)",

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count}個のバッファに未保存の変更があります。(%{discard_key})破棄して終了, (%{cancel_key})キャンセル? ",
   "prompt.quit_modified_one": "1つのバッファに未保存の変更があります。(%{discard_key})破棄して終了, (%{cancel_key})キャンセル? ",
   "prompt.revert_confirm": "バッファに未保存の変更があります。(%{revert_key})元に戻す, (%{cancel_key})キャンセル? ",
+  "prompt.sudo_save_confirm": "アクセスが拒否されました。sudo で保存しますか? (y)はい, (N)いいえ: ",
+  "prompt.sudo_save_failed": "sudo での保存に失敗しました: %{error}",
   "register.must_be_digit": "%{type} レジスタは0-9である必要があります",
   "register.not_specified": "レジスタが指定されていません",
   "replace.completed": "'%{search}' を %{count} 件置換しました",

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count}개의 버퍼에 저장되지 않은 변경사항이 있습니다. (%{discard_key})삭제 후 종료, (%{cancel_key})취소? ",
   "prompt.quit_modified_one": "1개의 버퍼에 저장되지 않은 변경사항이 있습니다. (%{discard_key})삭제 후 종료, (%{cancel_key})취소? ",
   "prompt.revert_confirm": "버퍼에 저장되지 않은 변경사항이 있습니다. (%{revert_key})되돌리기, (%{cancel_key})취소? ",
+  "prompt.sudo_save_confirm": "권한이 거부되었습니다. sudo로 저장하시겠습니까? (y)예, (N)아니요: ",
+  "prompt.sudo_save_failed": "sudo 저장 실패: %{error}",
   "register.must_be_digit": "%{type} 레지스터는 0-9여야 합니다",
   "register.not_specified": "레지스터가 지정되지 않음",
   "replace.completed": "'%{search}'을(를) %{count}개 바꿨습니다",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} buffers têm alterações não salvas. (%{discard_key})escartar e sair, (%{cancel_key})ancelar? ",
   "prompt.quit_modified_one": "1 buffer tem alterações não salvas. (%{discard_key})escartar e sair, (%{cancel_key})ancelar? ",
   "prompt.revert_confirm": "O buffer tem alterações não salvas. (%{revert_key})everter, (%{cancel_key})ancelar? ",
+  "prompt.sudo_save_confirm": "Permissão negada. Salvar com sudo? (s)im, (N)ão: ",
+  "prompt.sudo_save_failed": "Falha ao salvar com sudo: %{error}",
   "register.must_be_digit": "Registrador %{type} deve ser 0-9",
   "register.not_specified": "Registrador não especificado",
   "replace.completed": "%{count} ocorrência(s) de '%{search}' substituída(s)",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} буферов имеют несохранённые изменения. (%{discard_key})тменить и выйти, (%{cancel_key})тмена? ",
   "prompt.quit_modified_one": "1 буфер имеет несохранённые изменения. (%{discard_key})тменить и выйти, (%{cancel_key})тмена? ",
   "prompt.revert_confirm": "Буфер имеет несохранённые изменения. (%{revert_key})осстановить, (%{cancel_key})тмена? ",
+  "prompt.sudo_save_confirm": "Доступ запрещен. Сохранить с помощью sudo? (д)а, (Н)ет: ",
+  "prompt.sudo_save_failed": "Ошибка сохранения через sudo: %{error}",
   "register.must_be_digit": "%{type} регистр должен быть 0-9",
   "register.not_specified": "Регистр не указан",
   "replace.completed": "Заменено %{count} вхождений '%{search}'",

--- a/locales/th.json
+++ b/locales/th.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "มี %{count} บัฟเฟอร์ที่ยังไม่ได้บันทึก. (%{discard_key})ิ้งแล้วออก, (%{cancel_key})กเลิก? ",
   "prompt.quit_modified_one": "มี 1 บัฟเฟอร์ที่ยังไม่ได้บันทึก. (%{discard_key})ิ้งแล้วออก, (%{cancel_key})กเลิก? ",
   "prompt.revert_confirm": "บัฟเฟอร์มีการเปลี่ยนแปลงที่ยังไม่ได้บันทึก. (%{revert_key})้อนกลับ, (%{cancel_key})กเลิก? ",
+  "prompt.sudo_save_confirm": "การเข้าถึงถูกปฏิเสธ บันทึกด้วย sudo หรือไม่? (y)ใช่, (N)ไม่: ",
+  "prompt.sudo_save_failed": "บันทึกด้วย sudo ล้มเหลว: %{error}",
   "register.must_be_digit": "เรจิสเตอร์ %{type} ต้องเป็นตัวเลข 0-9",
   "register.not_specified": "ไม่ได้ระบุเรจิสเตอร์",
   "replace.completed": "แทนที่แล้ว %{count} จุด",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count} буферів мають незбережені зміни. (%{discard_key})кинути і вийти, (%{cancel_key})касувати? ",
   "prompt.quit_modified_one": "1 буфер має незбережені зміни. (%{discard_key})кинути і вийти, (%{cancel_key})касувати? ",
   "prompt.revert_confirm": "Буфер має незбережені зміни. (%{revert_key})ідновити, (%{cancel_key})касувати? ",
+  "prompt.sudo_save_confirm": "Доступ заборонено. Зберегти за допомогою sudo? (y) - так, (N) - ні: ",
+  "prompt.sudo_save_failed": "Помилка збереження через sudo: %{error}",
   "register.must_be_digit": "%{type} регістр має бути 0-9",
   "register.not_specified": "Регістр не вказано",
   "replace.completed": "Замінено %{count} входжень '%{search}'",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -876,6 +876,8 @@
   "prompt.quit_modified_many": "%{count}个缓冲区有未保存的更改。(%{discard_key})丢弃并退出, (%{cancel_key})取消? ",
   "prompt.quit_modified_one": "1个缓冲区有未保存的更改。(%{discard_key})丢弃并退出, (%{cancel_key})取消? ",
   "prompt.revert_confirm": "缓冲区有未保存的更改。(%{revert_key})还原, (%{cancel_key})取消? ",
+  "prompt.sudo_save_confirm": "权限不足。使用 sudo 保存？(y)是，(N)否：",
+  "prompt.sudo_save_failed": "Sudo 保存失败：%{error}",
   "register.must_be_digit": "%{type} 寄存器必须为0-9",
   "register.not_specified": "未指定寄存器",
   "replace.completed": "已替换 %{count} 处 '%{search}'",

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -463,6 +463,9 @@ pub struct Editor {
     /// Recovery service for auto-save and crash recovery
     recovery_service: RecoveryService,
 
+    /// Request a full terminal clear and redraw on the next frame
+    full_redraw_requested: bool,
+
     /// Time source for testable time operations
     time_source: SharedTimeSource,
 
@@ -962,6 +965,7 @@ impl Editor {
                 };
                 RecoveryService::with_config_and_dir(recovery_config, dir_context.recovery_dir())
             },
+            full_redraw_requested: false,
             time_source: time_source.clone(),
             last_auto_save: time_source.now(),
             active_custom_contexts: HashSet::new(),
@@ -2279,6 +2283,19 @@ impl Editor {
 
     /// Request the editor to restart with a new working directory
     /// This triggers a clean shutdown and restart with the new project root
+    /// Request a full hardware terminal clear and redraw on the next frame.
+    /// Used after external commands have messed up the terminal state.
+    pub fn request_full_redraw(&mut self) {
+        self.full_redraw_requested = true;
+    }
+
+    /// Check if a full redraw was requested, and clear the flag.
+    pub fn take_full_redraw_request(&mut self) -> bool {
+        let requested = self.full_redraw_requested;
+        self.full_redraw_requested = false;
+        requested
+    }
+
     pub fn request_restart(&mut self, new_working_dir: PathBuf) {
         tracing::info!(
             "Restart requested with new working directory: {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -901,6 +901,12 @@ where
             tracing::debug!("Auto-save error: {}", e);
         }
 
+        // Handle hard redraw requests (e.g. after returning from sudo)
+        if editor.take_full_redraw_request() {
+            terminal.clear()?;
+            needs_render = true;
+        }
+
         if editor.should_quit() {
             if session_enabled {
                 if let Err(e) = editor.save_session() {

--- a/src/view/prompt.rs
+++ b/src/view/prompt.rs
@@ -77,6 +77,10 @@ pub enum PromptType {
     ConfirmRevert,
     /// Confirm saving over a file that changed on disk
     ConfirmSaveConflict,
+    /// Confirm saving with sudo after permission denied
+    ConfirmSudoSave {
+        info: crate::model::buffer::SudoSaveRequired,
+    },
     /// Confirm overwriting an existing file during SaveAs
     ConfirmOverwriteFile { path: std::path::PathBuf },
     /// Confirm closing a modified buffer (save/discard/cancel)


### PR DESCRIPTION
Refactors file saving to use a multi-stage approach with temp files and atomic renames, falling back to a sudo prompt when permission is denied.

Key changes:
- Implemented multi-stage `save_to_file` with temp file and cross-device fallbacks.
- Added `ConfirmSudoSave` prompt and TUI suspension for sudo command execution.
- Improved terminal management with hard redraws and prompt clearing.
- Added localization and comprehensive unit tests for save scenarios.
- Fixed file mode masking for chmod compatibility.

Fixes #301 