### PR TITLE
fix inlay hint position in rust lsp #626

### DIFF
--- a/src/app/lsp_requests.rs
+++ b/src/app/lsp_requests.rs
@@ -744,8 +744,10 @@ impl Editor {
             };
 
             // LSP inlay hint positions are insertion points between characters.
-            // Render them before the character at that byte offset so they appear at the
-            // correct location (e.g., before punctuation or newline).
+            // For positions within the buffer, render hints before the character at the
+            // byte offset so they appear at the correct location (e.g., before punctuation
+            // or newline). Hints at or beyond EOF are anchored to the last character and
+            // rendered after it.
             if state.buffer.len() == 0 {
                 continue;
             }


### PR DESCRIPTION
fix #626

with gpt codex 5.2 high

Adjusted inlay hint placement to treat LSP positions as insertion points and render them before the character at that byte offset (with a safe EOF fallback). This should line up Rust analyzer hints with VSCode instead of shifting them to the line start.


<img width="381" height="228" alt="image" src="https://github.com/user-attachments/assets/5d8544a8-8fe2-4e50-a029-2d1bcd51c706" />

old

<img width="502" height="277" alt="image" src="https://github.com/user-attachments/assets/82b45adc-7e0a-40ff-af1d-6b15511ffc43" />
