### PR TITLE
feat(file-explorer): add git status indicators via plugin

### DIFF
--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -30,6 +30,26 @@ Keybinding contexts that determine how keypresses are interpreted. Each buffer h
 
 ## Types
 
+### FileExplorerDecoration
+
+File explorer decoration entry provided by plugins
+
+```typescript
+interface FileExplorerDecoration {
+  path: string;
+  symbol?: string | null;
+  color?: [u8; 3] | null;
+  priority?: number | null;
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `path` | Absolute or workspace-relative path to decorate |
+| `symbol` | Symbol to display (single character recommended) |
+| `color` | RGB color for the symbol |
+| `priority` | Priority for resolving conflicts (higher wins) |
+
 ### SpawnResult
 
 Result from spawnProcess
@@ -1089,6 +1109,35 @@ clearLineIndicators(buffer_id: number, namespace: string): boolean
 |------|------|-------------|
 | `buffer_id` | `number` | The buffer ID |
 | `namespace` | `string` | Namespace to clear (e.g., "git-gutter") |
+
+#### `setFileExplorerDecorations`
+
+Set file explorer decorations for a namespace
+
+```typescript
+setFileExplorerDecorations(namespace: string, decorations: FileExplorerDecoration[]): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `namespace` | `string` | Namespace for grouping (e.g., "git-status") |
+| `decorations` | `FileExplorerDecoration[]` | Decoration entries |
+
+#### `clearFileExplorerDecorations`
+
+Clear file explorer decorations for a namespace
+
+```typescript
+clearFileExplorerDecorations(namespace: string): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `namespace` | `string` | Namespace to clear (e.g., "git-status") |
 
 #### `submitViewTransform`
 

--- a/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
+++ b/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
@@ -248,18 +248,18 @@
   <rect x="891" y="18" width="9" height="18" fill="#1e1e23"/>
   <text x="1" y="50" fill="#8c8c8c" class="terminal" style="">│</text>
   <text x="10" y="50" fill="#f1fa8c" class="terminal" style="">▼</text>
-  <text x="28" y="50" fill="#8be9fd" class="terminal" style="">p</text>
-  <text x="37" y="50" fill="#8be9fd" class="terminal" style="">r</text>
-  <text x="46" y="50" fill="#8be9fd" class="terminal" style="">o</text>
-  <text x="55" y="50" fill="#8be9fd" class="terminal" style="">j</text>
-  <text x="64" y="50" fill="#8be9fd" class="terminal" style="">e</text>
-  <text x="73" y="50" fill="#8be9fd" class="terminal" style="">c</text>
-  <text x="82" y="50" fill="#8be9fd" class="terminal" style="">t</text>
-  <text x="91" y="50" fill="#8be9fd" class="terminal" style="">_</text>
-  <text x="100" y="50" fill="#8be9fd" class="terminal" style="">r</text>
-  <text x="109" y="50" fill="#8be9fd" class="terminal" style="">o</text>
+  <text x="37" y="50" fill="#8be9fd" class="terminal" style="">p</text>
+  <text x="46" y="50" fill="#8be9fd" class="terminal" style="">r</text>
+  <text x="55" y="50" fill="#8be9fd" class="terminal" style="">o</text>
+  <text x="64" y="50" fill="#8be9fd" class="terminal" style="">j</text>
+  <text x="73" y="50" fill="#8be9fd" class="terminal" style="">e</text>
+  <text x="82" y="50" fill="#8be9fd" class="terminal" style="">c</text>
+  <text x="91" y="50" fill="#8be9fd" class="terminal" style="">t</text>
+  <text x="100" y="50" fill="#8be9fd" class="terminal" style="">_</text>
+  <text x="109" y="50" fill="#8be9fd" class="terminal" style="">r</text>
   <text x="118" y="50" fill="#8be9fd" class="terminal" style="">o</text>
-  <text x="127" y="50" fill="#8be9fd" class="terminal" style="">t</text>
+  <text x="127" y="50" fill="#8be9fd" class="terminal" style="">o</text>
+  <text x="136" y="50" fill="#8be9fd" class="terminal" style="">t</text>
   <text x="190" y="50" fill="#8c8c8c" class="terminal" style="">3</text>
   <text x="208" y="50" fill="#8c8c8c" class="terminal" style="">i</text>
   <text x="217" y="50" fill="#8c8c8c" class="terminal" style="">t</text>
@@ -293,12 +293,12 @@
   <text x="28" y="68" fill="#f1fa8c" class="terminal" style="">▼</text>
   <rect x="36" y="54" width="9" height="18" fill="#141414"/>
   <rect x="45" y="54" width="9" height="18" fill="#141414"/>
-  <text x="46" y="68" fill="#8be9fd" class="terminal" style="">s</text>
   <rect x="54" y="54" width="9" height="18" fill="#141414"/>
-  <text x="55" y="68" fill="#8be9fd" class="terminal" style="">r</text>
+  <text x="55" y="68" fill="#8be9fd" class="terminal" style="">s</text>
   <rect x="63" y="54" width="9" height="18" fill="#141414"/>
-  <text x="64" y="68" fill="#8be9fd" class="terminal" style="">c</text>
+  <text x="64" y="68" fill="#8be9fd" class="terminal" style="">r</text>
   <rect x="72" y="54" width="9" height="18" fill="#141414"/>
+  <text x="73" y="68" fill="#8be9fd" class="terminal" style="">c</text>
   <rect x="81" y="54" width="9" height="18" fill="#141414"/>
   <rect x="90" y="54" width="9" height="18" fill="#141414"/>
   <rect x="99" y="54" width="9" height="18" fill="#141414"/>

--- a/plugins/git_explorer.ts
+++ b/plugins/git_explorer.ts
@@ -1,0 +1,159 @@
+/// <reference path="../types/fresh.d.ts" />
+const editor = getEditor();
+
+/**
+ * Git Explorer Decorations
+ *
+ * Adds VS Code-style status badges (M/A/U/D/...) to the file explorer.
+ */
+
+const NAMESPACE = "git-explorer";
+
+const COLORS = {
+  added: [80, 250, 123] as [number, number, number],
+  modified: [255, 184, 108] as [number, number, number],
+  deleted: [255, 85, 85] as [number, number, number],
+  renamed: [139, 233, 253] as [number, number, number],
+  untracked: [241, 250, 140] as [number, number, number],
+  conflicted: [255, 121, 198] as [number, number, number],
+};
+
+const PRIORITY = {
+  conflicted: 90,
+  deleted: 80,
+  added: 60,
+  modified: 50,
+  renamed: 40,
+  untracked: 30,
+};
+
+let refreshInFlight = false;
+
+function statusToDecoration(status: string, staged: boolean) {
+  switch (status) {
+    case "A":
+      return { symbol: "A", color: COLORS.added, priority: PRIORITY.added };
+    case "M":
+      return {
+        symbol: "M",
+        color: staged ? COLORS.added : COLORS.modified,
+        priority: PRIORITY.modified + (staged ? 2 : 0),
+      };
+    case "D":
+      return { symbol: "D", color: COLORS.deleted, priority: PRIORITY.deleted };
+    case "R":
+      return { symbol: "R", color: COLORS.renamed, priority: PRIORITY.renamed };
+    case "C":
+      return { symbol: "C", color: COLORS.renamed, priority: PRIORITY.renamed };
+    case "U":
+      return { symbol: "!", color: COLORS.conflicted, priority: PRIORITY.conflicted };
+    default:
+      return null;
+  }
+}
+
+function parseStatusOutput(output: string, repoRoot: string) {
+  const separator = output.includes("\0") ? "\0" : "\n";
+  const entries = output
+    .split(separator)
+    .map((entry) => entry.replace(/\r$/, ""))
+    .filter((entry) => entry.length > 0);
+  const byPath = new Map<string, { path: string; symbol: string; color: [number, number, number]; priority: number }>();
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry.length < 3) {
+      continue;
+    }
+    const x = entry[0];
+    const y = entry[1];
+    let path = entry.slice(3);
+
+    if ((x === "R" || x === "C") && separator === "\0" && i + 1 < entries.length) {
+      i += 1;
+      path = entries[i];
+    } else if (entry.includes(" -> ") && (x === "R" || x === "C" || y === "R" || y === "C")) {
+      path = entry.split(" -> ").pop() ?? path;
+    }
+
+    let decoration = null;
+    if (x === "?" && y === "?") {
+      decoration = { symbol: "U", color: COLORS.untracked, priority: PRIORITY.untracked };
+    } else if (x !== " " && x !== "?") {
+      decoration = statusToDecoration(x, true);
+    } else if (y !== " ") {
+      decoration = statusToDecoration(y, false);
+    }
+
+    if (!decoration) {
+      continue;
+    }
+
+    const absolutePath = editor.pathJoin(repoRoot, path);
+    const existing = byPath.get(absolutePath);
+    if (!existing || decoration.priority >= existing.priority) {
+      byPath.set(absolutePath, { path: absolutePath, ...decoration });
+    }
+  }
+
+  return Array.from(byPath.values());
+}
+
+async function refreshGitExplorerDecorations() {
+  if (refreshInFlight) {
+    return;
+  }
+  refreshInFlight = true;
+  try {
+    const cwd = editor.getCwd();
+    const rootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
+    if (rootResult.exit_code !== 0) {
+      editor.clearFileExplorerDecorations(NAMESPACE);
+      return;
+    }
+    const repoRoot = rootResult.stdout.trim();
+    if (!repoRoot) {
+      editor.clearFileExplorerDecorations(NAMESPACE);
+      return;
+    }
+
+    const statusResult = await editor.spawnProcess(
+      "git",
+      ["status", "--porcelain"],
+      repoRoot
+    );
+    if (statusResult.exit_code !== 0) {
+      editor.clearFileExplorerDecorations(NAMESPACE);
+      return;
+    }
+
+    const decorations = parseStatusOutput(statusResult.stdout, repoRoot);
+    if (decorations.length === 0) {
+      editor.clearFileExplorerDecorations(NAMESPACE);
+    } else {
+      editor.setFileExplorerDecorations(NAMESPACE, decorations);
+    }
+  } catch (_err) {
+    editor.clearFileExplorerDecorations(NAMESPACE);
+  } finally {
+    refreshInFlight = false;
+  }
+}
+
+globalThis.onGitExplorerAfterFileOpen = () => {
+  refreshGitExplorerDecorations();
+};
+
+globalThis.onGitExplorerAfterFileSave = () => {
+  refreshGitExplorerDecorations();
+};
+
+globalThis.onGitExplorerEditorInitialized = () => {
+  refreshGitExplorerDecorations();
+};
+
+editor.on("after_file_open", "onGitExplorerAfterFileOpen");
+editor.on("after_file_save", "onGitExplorerAfterFileSave");
+editor.on("editor_initialized", "onGitExplorerEditorInitialized");
+
+refreshGitExplorerDecorations();

--- a/plugins/lib/fresh.d.ts
+++ b/plugins/lib/fresh.d.ts
@@ -170,6 +170,18 @@ interface ProcessHandle extends PromiseLike<SpawnResult> {
   kill(): Promise<boolean>;
 }
 
+/** File explorer decoration entry provided by plugins */
+interface FileExplorerDecoration {
+  /** Absolute or workspace-relative path to decorate */
+  path: string;
+  /** Symbol to display (single character recommended) */
+  symbol?: string | null;
+  /** RGB color for the symbol */
+  color?: [u8; 3] | null;
+  /** Priority for resolving conflicts (higher wins) */
+  priority?: number | null;
+}
+
 /** Result from spawnProcess */
 interface SpawnResult {
   /** Complete stdout as string. Newlines preserved; trailing newline included. */
@@ -786,6 +798,19 @@ interface EditorAPI {
    * @returns true if indicators were cleared
    */
   clearLineIndicators(buffer_id: number, namespace: string): boolean;
+  /**
+   * Set file explorer decorations for a namespace
+   * @param namespace - Namespace for grouping (e.g., "git-status")
+   * @param decorations - Decoration entries
+   * @returns true if decorations were accepted
+   */
+  setFileExplorerDecorations(namespace: string, decorations: FileExplorerDecoration[]): boolean;
+  /**
+   * Clear file explorer decorations for a namespace
+   * @param namespace - Namespace to clear (e.g., "git-status")
+   * @returns true if decorations were cleared
+   */
+  clearFileExplorerDecorations(namespace: string): boolean;
   /**
    * Submit a transformed view stream for a viewport
    * @param buffer_id - Buffer to apply the transform to

--- a/plugins/lib/index.ts
+++ b/plugins/lib/index.ts
@@ -11,7 +11,15 @@
  */
 
 // Types
-export type { RGB, Location, PanelOptions, PanelState, NavigationOptions, HighlightPattern } from "./types.ts";
+export type {
+  RGB,
+  Location,
+  PanelOptions,
+  PanelState,
+  NavigationOptions,
+  HighlightPattern,
+  FileExplorerDecoration,
+} from "./types.ts";
 
 // Panel Management
 export { PanelManager } from "./panel-manager.ts";

--- a/plugins/lib/types.ts
+++ b/plugins/lib/types.ts
@@ -12,6 +12,20 @@
 export type RGB = [number, number, number];
 
 /**
+ * File explorer decoration metadata provided by plugins
+ */
+export interface FileExplorerDecoration {
+  /** Absolute or workspace-relative path to decorate */
+  path: string;
+  /** Symbol to display (single character recommended) */
+  symbol?: string;
+  /** RGB color for the symbol */
+  color?: RGB;
+  /** Priority for resolving conflicts (higher wins) */
+  priority?: number;
+}
+
+/**
  * File location with line and column
  */
 export interface Location {

--- a/src/app/file_explorer.rs
+++ b/src/app/file_explorer.rs
@@ -692,4 +692,48 @@ impl Editor {
             self.set_status_message(msg.to_string());
         }
     }
+
+    pub fn handle_set_file_explorer_decorations(
+        &mut self,
+        namespace: String,
+        decorations: Vec<crate::view::file_tree::FileExplorerDecoration>,
+    ) {
+        let normalized: Vec<crate::view::file_tree::FileExplorerDecoration> = decorations
+            .into_iter()
+            .filter_map(|mut decoration| {
+                let path = if decoration.path.is_absolute() {
+                    decoration.path
+                } else {
+                    self.working_dir.join(&decoration.path)
+                };
+                let path = normalize_path(&path);
+                if path.starts_with(&self.working_dir) {
+                    decoration.path = path;
+                    Some(decoration)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        self.file_explorer_decorations.insert(namespace, normalized);
+        self.rebuild_file_explorer_decoration_cache();
+    }
+
+    pub fn handle_clear_file_explorer_decorations(&mut self, namespace: &str) {
+        self.file_explorer_decorations.remove(namespace);
+        self.rebuild_file_explorer_decoration_cache();
+    }
+
+    fn rebuild_file_explorer_decoration_cache(&mut self) {
+        let decorations = self
+            .file_explorer_decorations
+            .values()
+            .flat_map(|entries| entries.iter().cloned());
+        self.file_explorer_decoration_cache =
+            crate::view::file_tree::FileExplorerDecorationCache::rebuild(
+                decorations,
+                &self.working_dir,
+            );
+    }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -178,6 +178,7 @@ impl Editor {
                     horizontal_chunks[0],
                     is_focused,
                     &files_with_unsaved_changes,
+                    &self.file_explorer_decoration_cache,
                     &self.keybindings,
                     self.key_context,
                     &self.theme,

--- a/src/services/plugins/api.rs
+++ b/src/services/plugins/api.rs
@@ -500,6 +500,20 @@ pub enum PluginCommand {
         namespace: String,
     },
 
+    /// Set file explorer decorations for a namespace
+    SetFileExplorerDecorations {
+        /// Namespace for grouping (e.g., "git-status")
+        namespace: String,
+        /// Decorations to apply
+        decorations: Vec<crate::view::file_tree::FileExplorerDecoration>,
+    },
+
+    /// Clear file explorer decorations for a namespace
+    ClearFileExplorerDecorations {
+        /// Namespace to clear (e.g., "git-status")
+        namespace: String,
+    },
+
     /// Open a file at a specific line and column
     /// Line and column are 1-indexed to match git grep output
     OpenFileAtLocation {

--- a/src/services/plugins/runtime.rs
+++ b/src/services/plugins/runtime.rs
@@ -960,6 +960,81 @@ fn op_fresh_clear_line_indicators(
     false
 }
 
+/// File explorer decoration entry provided by plugins
+#[derive(serde::Deserialize)]
+struct FileExplorerDecoration {
+    /// Absolute or workspace-relative path to decorate
+    path: String,
+    /// Symbol to display (single character recommended)
+    symbol: Option<String>,
+    /// RGB color for the symbol
+    color: Option<[u8; 3]>,
+    /// Priority for resolving conflicts (higher wins)
+    priority: Option<i32>,
+}
+
+/// Set file explorer decorations for a namespace
+/// @param namespace - Namespace for grouping (e.g., "git-status")
+/// @param decorations - Decoration entries
+/// @returns true if decorations were accepted
+#[op2]
+fn op_fresh_set_file_explorer_decorations(
+    state: &mut OpState,
+    #[string] namespace: String,
+    #[serde] decorations: Vec<FileExplorerDecoration>,
+) -> bool {
+    use crate::view::file_tree::FileExplorerDecoration as ExplorerDecoration;
+    use std::path::PathBuf;
+
+    if let Some(runtime_state) = state.try_borrow::<Rc<RefCell<TsRuntimeState>>>() {
+        let runtime_state = runtime_state.borrow();
+        let decorations: Vec<ExplorerDecoration> = decorations
+            .into_iter()
+            .filter_map(|entry| {
+                if entry.path.is_empty() {
+                    return None;
+                }
+                let symbol = entry.symbol.unwrap_or_else(|| "●".to_string());
+                let color = entry.color.unwrap_or([255, 184, 108]);
+                let priority = entry.priority.unwrap_or(0);
+                Some(ExplorerDecoration {
+                    path: PathBuf::from(entry.path),
+                    symbol,
+                    color: (color[0], color[1], color[2]),
+                    priority,
+                })
+            })
+            .collect();
+
+        let result = runtime_state
+            .command_sender
+            .send(PluginCommand::SetFileExplorerDecorations {
+                namespace,
+                decorations,
+            });
+        return result.is_ok();
+    }
+    false
+}
+
+/// Clear file explorer decorations for a namespace
+/// @param namespace - Namespace to clear (e.g., "git-status")
+/// @returns true if decorations were cleared
+#[op2(fast)]
+fn op_fresh_clear_file_explorer_decorations(
+    state: &mut OpState,
+    #[string] namespace: String,
+) -> bool {
+    if let Some(runtime_state) = state.try_borrow::<Rc<RefCell<TsRuntimeState>>>() {
+        let runtime_state = runtime_state.borrow();
+        let result = runtime_state
+            .command_sender
+            .send(PluginCommand::ClearFileExplorerDecorations { namespace });
+        return result.is_ok();
+    }
+    false
+}
+
 /// Submit a transformed view stream for a viewport
 /// @param buffer_id - Buffer to apply the transform to
 /// @param start - Viewport start byte
@@ -3814,6 +3889,8 @@ extension!(
         op_fresh_refresh_lines,
         op_fresh_set_line_indicator,
         op_fresh_clear_line_indicators,
+        op_fresh_set_file_explorer_decorations,
+        op_fresh_clear_file_explorer_decorations,
         op_fresh_insert_at_cursor,
         op_fresh_register_command,
         op_fresh_unregister_command,
@@ -4118,6 +4195,12 @@ impl TypeScriptRuntime {
                     },
                     clearLineIndicators(bufferId, namespace) {
                         return core.ops.op_fresh_clear_line_indicators(bufferId, namespace);
+                    },
+                    setFileExplorerDecorations(namespace, decorations) {
+                        return core.ops.op_fresh_set_file_explorer_decorations(namespace, decorations);
+                    },
+                    clearFileExplorerDecorations(namespace) {
+                        return core.ops.op_fresh_clear_file_explorer_decorations(namespace);
                     },
 
                     insertAtCursor(text) {

--- a/src/view/file_tree/decorations.rs
+++ b/src/view/file_tree/decorations.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Decoration metadata for a file explorer entry.
+#[derive(Debug, Clone)]
+pub struct FileExplorerDecoration {
+    pub path: PathBuf,
+    pub symbol: String,
+    pub color: (u8, u8, u8),
+    pub priority: i32,
+}
+
+/// Cached decoration lookups for file explorer rendering.
+#[derive(Debug, Default, Clone)]
+pub struct FileExplorerDecorationCache {
+    direct: HashMap<PathBuf, FileExplorerDecoration>,
+    bubbled: HashMap<PathBuf, FileExplorerDecoration>,
+}
+
+impl FileExplorerDecorationCache {
+    /// Rebuild the cache from a list of decorations.
+    pub fn rebuild<I>(decorations: I, root: &Path) -> Self
+    where
+        I: IntoIterator<Item = FileExplorerDecoration>,
+    {
+        let mut direct = HashMap::new();
+        for decoration in decorations {
+            if !decoration.path.starts_with(root) {
+                continue;
+            }
+            insert_best(&mut direct, decoration);
+        }
+
+        let mut bubbled = HashMap::new();
+        for (path, decoration) in &direct {
+            for ancestor in path.ancestors() {
+                if !ancestor.starts_with(root) {
+                    break;
+                }
+                insert_best(
+                    &mut bubbled,
+                    FileExplorerDecoration {
+                        path: ancestor.to_path_buf(),
+                        symbol: decoration.symbol.clone(),
+                        color: decoration.color,
+                        priority: decoration.priority,
+                    },
+                );
+            }
+        }
+
+        Self { direct, bubbled }
+    }
+
+    /// Lookup a decoration for an exact path.
+    pub fn direct_for_path(&self, path: &Path) -> Option<&FileExplorerDecoration> {
+        self.direct.get(path)
+    }
+
+    /// Lookup a bubbled decoration for a path (direct or descendant).
+    pub fn bubbled_for_path(&self, path: &Path) -> Option<&FileExplorerDecoration> {
+        self.bubbled.get(path)
+    }
+}
+
+fn insert_best(
+    map: &mut HashMap<PathBuf, FileExplorerDecoration>,
+    decoration: FileExplorerDecoration,
+) {
+    let replace = match map.get(&decoration.path) {
+        Some(existing) => decoration.priority >= existing.priority,
+        None => true,
+    };
+
+    if replace {
+        map.insert(decoration.path.clone(), decoration);
+    }
+}

--- a/src/view/file_tree/mod.rs
+++ b/src/view/file_tree/mod.rs
@@ -4,11 +4,13 @@
 // with lazy loading (directories are only read when expanded) and efficient
 // navigation.
 
+pub mod decorations;
 pub mod ignore;
 pub mod node;
 pub mod tree;
 pub mod view;
 
+pub use decorations::{FileExplorerDecoration, FileExplorerDecorationCache};
 pub use ignore::{IgnorePatterns, IgnoreStatus};
 pub use node::{NodeId, NodeState, TreeNode};
 pub use tree::FileTree;

--- a/src/view/ui/file_explorer.rs
+++ b/src/view/ui/file_explorer.rs
@@ -1,9 +1,9 @@
 use crate::primitives::display_width::str_width;
-use crate::view::file_tree::{FileTreeView, NodeId};
+use crate::view::file_tree::{FileExplorerDecorationCache, FileTreeView, NodeId};
 use crate::view::theme::Theme;
 use ratatui::{
     layout::Rect,
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
     Frame,
@@ -35,6 +35,7 @@ impl FileExplorerRenderer {
         area: Rect,
         is_focused: bool,
         files_with_unsaved_changes: &HashSet<PathBuf>,
+        decorations: &FileExplorerDecorationCache,
         keybinding_resolver: &crate::input::keybindings::KeybindingResolver,
         current_context: crate::input::keybindings::KeyContext,
         theme: &Theme,
@@ -77,6 +78,7 @@ impl FileExplorerRenderer {
                     is_selected,
                     is_focused,
                     files_with_unsaved_changes,
+                    decorations,
                     theme,
                     content_width,
                 )
@@ -180,6 +182,7 @@ impl FileExplorerRenderer {
         is_selected: bool,
         is_focused: bool,
         files_with_unsaved_changes: &HashSet<PathBuf>,
+        decorations: &FileExplorerDecorationCache,
         theme: &Theme,
         content_width: usize,
     ) -> ListItem<'static> {
@@ -190,7 +193,7 @@ impl FileExplorerRenderer {
 
         // Calculate the left side width for padding calculation
         let indent_width = indent * 2;
-        let indicator_width = 2; // "▼ " or "● " or "  "
+        let indicator_width = if node.is_dir() { 3 } else { 2 }; // "▼● " or "● " or "  "
         let name_width = str_width(&node.entry.name);
         let left_side_width = indent_width + indicator_width + name_width;
 
@@ -201,9 +204,12 @@ impl FileExplorerRenderer {
 
         // Tree expansion indicator (only for directories)
         if node.is_dir() {
-            // Check if this directory contains any modified files
-            let has_modified =
+            let has_unsaved =
                 Self::folder_has_modified_files(&node.entry.path, files_with_unsaved_changes);
+            let direct_decoration = decorations.direct_for_path(&node.entry.path);
+            let bubbled_decoration = decorations
+                .bubbled_for_path(&node.entry.path)
+                .filter(|_| direct_decoration.is_none());
 
             let indicator = if node.is_expanded() {
                 "▼"
@@ -219,21 +225,38 @@ impl FileExplorerRenderer {
                 Style::default().fg(theme.diagnostic_warning_fg),
             ));
 
-            // Show modified indicator (small dot) if folder contains modified files
-            if has_modified {
+            // Show a change indicator if folder contains unsaved or decorated children
+            if has_unsaved {
                 spans.push(Span::styled(
-                    "●",
+                    "● ",
                     Style::default().fg(theme.diagnostic_warning_fg),
                 ));
+            } else if let Some(decoration) = direct_decoration {
+                let symbol = Self::decoration_symbol(&decoration.symbol);
+                spans.push(Span::styled(
+                    format!("{symbol} "),
+                    Style::default().fg(Self::decoration_color(decoration)),
+                ));
+            } else if let Some(decoration) = bubbled_decoration {
+                spans.push(Span::styled(
+                    "● ",
+                    Style::default().fg(Self::decoration_color(decoration)),
+                ));
             } else {
-                spans.push(Span::raw(" "));
+                spans.push(Span::raw("  "));
             }
         } else {
-            // For files, show unsaved change indicator if applicable
+            // For files, show unsaved indicator first, then plugin decoration
             if files_with_unsaved_changes.contains(&node.entry.path) {
                 spans.push(Span::styled(
                     "● ",
                     Style::default().fg(theme.diagnostic_warning_fg),
+                ));
+            } else if let Some(decoration) = decorations.direct_for_path(&node.entry.path) {
+                let symbol = Self::decoration_symbol(&decoration.symbol);
+                spans.push(Span::styled(
+                    format!("{symbol} "),
+                    Style::default().fg(Self::decoration_color(decoration)),
                 ));
             } else {
                 spans.push(Span::raw("  "));
@@ -304,6 +327,19 @@ impl FileExplorerRenderer {
         }
 
         ListItem::new(Line::from(spans)).style(Style::default().bg(theme.editor_bg))
+    }
+
+    fn decoration_symbol(symbol: &str) -> String {
+        symbol
+            .chars()
+            .next()
+            .map(|c| c.to_string())
+            .unwrap_or_else(|| " ".to_string())
+    }
+
+    fn decoration_color(decoration: &crate::view::file_tree::FileExplorerDecoration) -> Color {
+        let (r, g, b) = decoration.color;
+        Color::Rgb(r, g, b)
     }
 
     /// Format file size for display

--- a/tests/common/git_test_helper.rs
+++ b/tests/common/git_test_helper.rs
@@ -305,6 +305,13 @@ A sample project for testing.
         copy_plugin(&plugins_dir, "git_gutter");
     }
 
+    /// Set up git explorer plugin for file explorer decorations
+    pub fn setup_git_explorer_plugin(&self) {
+        let plugins_dir = self.path.join("plugins");
+        fs::create_dir_all(&plugins_dir).expect("Failed to create plugins directory");
+        copy_plugin(&plugins_dir, "git_explorer");
+    }
+
     /// Set up buffer modified plugin for unsaved changes indicator tests
     pub fn setup_buffer_modified_plugin(&self) {
         let plugins_dir = self.path.join("plugins");

--- a/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
+++ b/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
@@ -5,8 +5,8 @@ expression: "&screen_text"
 ---
  File   Edit   View   Selection   Go   LSP   Explorer   Help                                        
 ┌ File Explorer (Ctrl+E) ──×─┐ main.rs ×                                                            
-│▼ project_root      3 items │    1 │ // Main entry point                                           
-│  ▼ src              1 item │    2 │ fn main() {                                                   
+│▼  project_root     3 items │    1 │ // Main entry point                                           
+│  ▼  src             1 item │    2 │ fn main() {                                                   
 │      main.rs        0.4 KB │    3 │     let hello = "world";                                      
 │    Cargo.toml       0.0 KB │    4 │     let hello = "again";                                      
 │    README.md        0.1 KB │    5 │     let hello = "once more";                                  

--- a/tests/e2e/file_explorer.rs
+++ b/tests/e2e/file_explorer.rs
@@ -1,3 +1,4 @@
+use crate::common::git_test_helper::GitTestRepo;
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::fs;
@@ -524,6 +525,61 @@ fn test_file_explorer_toggle_gitignored_smoke() {
     harness.render().unwrap();
 
     // Test passes if no panic occurs
+}
+
+/// Test that git status decorations show in the file explorer
+#[test]
+#[cfg_attr(windows, ignore)] // Git plugin tests are flaky on Windows CI
+fn test_file_explorer_git_change_indicator() {
+    let repo = GitTestRepo::new();
+    repo.setup_git_explorer_plugin();
+    repo.create_file("changed.txt", "one");
+    repo.create_file("subdir/child.txt", "alpha");
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    fs::write(repo.path.join("changed.txt"), "two").unwrap();
+    fs::write(repo.path.join("subdir/child.txt"), "beta").unwrap();
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 40, repo.path.clone()).unwrap();
+
+    harness.editor_mut().toggle_file_explorer();
+    let explorer_visible = harness
+        .wait_for_async(|h| h.screen_to_string().contains("File Explorer"), 2000)
+        .unwrap();
+    assert!(
+        explorer_visible,
+        "Expected File Explorer to appear.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    let found_file = harness
+        .wait_for_async(|h| h.screen_to_string().contains("M changed.txt"), 2000)
+        .unwrap();
+
+    assert!(
+        found_file,
+        "Expected git change indicator for changed.txt.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    let found_folder = harness
+        .wait_for_async(
+            |h| {
+                let screen = h.screen_to_string();
+                screen
+                    .lines()
+                    .any(|line| line.contains("subdir") && line.contains("●"))
+            },
+            2000,
+        )
+        .unwrap();
+
+    assert!(
+        found_folder,
+        "Expected bubbled git indicator for subdir.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
 }
 
 /// Test that file_explorer_new_file can be called (smoke test)


### PR DESCRIPTION
(By @asukaminato0721 , squashed and rebased form of https://github.com/sinelaw/fresh/pull/711)


This change introduces visual indicators in the file explorer for files and folders that have been modified according to git.

Key changes:
- Added `git_explorer.ts` plugin to poll git status asynchronously.
- Extended the Plugin API (`src/services/plugins`) to allow plugins to register file tree decorations.
- Updated `FileExplorer` UI to render these decorations.
- Added E2E tests for the new functionality.

Resolves: #526