### PR TITLE
Fix stack overflow when playing macro that triggers PlayLastMacro

### DIFF
--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1070,6 +1070,25 @@ impl Editor {
                     }
                 }
             }
+            Action::PromptConfirmWithText(ref text) => {
+                // For macro playback: set the prompt text before confirming
+                if let Some(ref mut prompt) = self.prompt {
+                    prompt.set_input(text.clone());
+                    self.update_prompt_suggestions();
+                }
+                if let Some((input, prompt_type, selected_index)) = self.confirm_prompt() {
+                    use super::prompt_actions::PromptResult;
+                    match self.handle_prompt_confirm_input(input, prompt_type, selected_index) {
+                        PromptResult::ExecuteAction(action) => {
+                            return self.handle_action(action);
+                        }
+                        PromptResult::EarlyReturn => {
+                            return Ok(());
+                        }
+                        PromptResult::Done => {}
+                    }
+                }
+            }
             Action::PopupConfirm => {
                 use super::popup_actions::PopupConfirmResult;
                 if let PopupConfirmResult::EarlyReturn = self.handle_popup_confirm() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -468,6 +468,9 @@ pub struct Editor {
     /// Last recorded macro register (for F12 to replay)
     last_macro_register: Option<char>,
 
+    /// Flag to prevent recursive macro playback
+    macro_playing: bool,
+
     /// Pending plugin action receivers (for async action execution)
     #[cfg(feature = "plugins")]
     pending_plugin_actions: Vec<(
@@ -1026,6 +1029,7 @@ impl Editor {
             macros: HashMap::new(),
             macro_recording: None,
             last_macro_register: None,
+            macro_playing: false,
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),
             #[cfg(feature = "plugins")]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3487,6 +3487,11 @@ impl Editor {
 
     /// Play back a recorded macro
     pub(super) fn play_macro(&mut self, key: char) {
+        // Prevent recursive macro playback
+        if self.macro_playing {
+            return;
+        }
+
         if let Some(actions) = self.macros.get(&key).cloned() {
             if actions.is_empty() {
                 self.set_status_message(t!("macro.empty", key = key).to_string());
@@ -3495,14 +3500,16 @@ impl Editor {
 
             // Temporarily disable recording to avoid recording the playback
             let was_recording = self.macro_recording.take();
+            self.macro_playing = true;
 
             let action_count = actions.len();
             for action in actions {
                 let _ = self.handle_action(action);
             }
 
-            // Restore recording state
+            // Restore recording and playing state
             self.macro_recording = was_recording;
+            self.macro_playing = false;
 
             self.set_status_message(
                 t!("macro.played", key = key, count = action_count).to_string(),
@@ -3526,6 +3533,16 @@ impl Editor {
                 | Action::PromptRecordMacro
                 | Action::PromptPlayMacro
                 | Action::PlayLastMacro => {}
+                // When recording PromptConfirm, capture the current prompt text
+                // so it can be replayed correctly
+                Action::PromptConfirm => {
+                    if let Some(prompt) = &self.prompt {
+                        let text = prompt.get_text().to_string();
+                        state.actions.push(Action::PromptConfirmWithText(text));
+                    } else {
+                        state.actions.push(action.clone());
+                    }
+                }
                 _ => {
                     state.actions.push(action.clone());
                 }
@@ -3627,12 +3644,9 @@ impl Editor {
             if let Some(actions) = self.macros.get(&key) {
                 content.push_str(&format!("Macro '{}': {} actions\n", key, actions.len()));
 
-                // Show first few actions as preview
-                for (i, action) in actions.iter().take(5).enumerate() {
+                // Show all actions
+                for (i, action) in actions.iter().enumerate() {
                     content.push_str(&format!("  {}. {:?}\n", i + 1, action));
-                }
-                if actions.len() > 5 {
-                    content.push_str(&format!("  ... and {} more actions\n", actions.len() - 5));
                 }
                 content.push('\n');
             }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -2158,6 +2158,7 @@ pub fn action_to_events(
         | Action::PromptSetBookmark
         | Action::PromptJumpToBookmark
         | Action::PromptConfirm
+        | Action::PromptConfirmWithText(_)
         | Action::PromptCancel
         | Action::PromptBackspace
         | Action::PromptDelete

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -391,6 +391,8 @@ pub enum Action {
 
     // Prompt mode actions
     PromptConfirm,
+    /// PromptConfirm with recorded text for macro playback
+    PromptConfirmWithText(String),
     PromptCancel,
     PromptBackspace,
     PromptDelete,
@@ -1630,6 +1632,9 @@ impl KeybindingResolver {
             Action::DecreaseSplitSize => t!("action.decrease_split_size"),
             Action::ToggleMaximizeSplit => t!("action.toggle_maximize_split"),
             Action::PromptConfirm => t!("action.prompt_confirm"),
+            Action::PromptConfirmWithText(ref text) => {
+                format!("{} ({})", t!("action.prompt_confirm"), text).into()
+            }
             Action::PromptCancel => t!("action.prompt_cancel"),
             Action::PromptBackspace => t!("action.prompt_backspace"),
             Action::PromptDelete => t!("action.prompt_delete"),

--- a/tests/e2e/macros.rs
+++ b/tests/e2e/macros.rs
@@ -1,0 +1,328 @@
+use crate::common::harness::EditorTestHarness;
+
+/// Test that recording a macro and playing it back with "Play Last Macro" works
+/// This also verifies that PlayLastMacro doesn't cause infinite recursion
+#[test]
+fn test_macro_record_and_play_last() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.render().unwrap();
+
+    // Open command palette and start recording macro on register 0
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("Record Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should show prompt for register
+    harness.assert_screen_contains("Record macro (0-9):");
+
+    // Type '0' to select register 0
+    harness.type_text("0").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should show recording indicator
+    harness.assert_screen_contains("Recording");
+
+    // Type some text that will be recorded
+    harness.type_text("hello").unwrap();
+    harness.render().unwrap();
+
+    // Verify text was inserted
+    harness.assert_screen_contains("hello");
+
+    // Stop recording via command palette
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("Stop Recording").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should show macro saved message
+    harness.assert_screen_contains("Macro");
+
+    // Move to a new line
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Now play the last recorded macro via command palette
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("Play Last Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The macro should have played and inserted "hello" again
+    // We should now have "hello" on line 1 and "hello" on line 2
+    let screen = harness.screen_to_string();
+    let hello_count = screen.matches("hello").count();
+    assert!(
+        hello_count >= 2,
+        "Expected 'hello' to appear at least twice after playing macro, but found {} occurrences. Screen:\n{}",
+        hello_count,
+        screen
+    );
+
+    // Verify no stack overflow or error occurred
+    harness.assert_screen_not_contains("error");
+    harness.assert_screen_not_contains("overflow");
+}
+
+/// Test that recording a macro with multiple cursors and playing it back doesn't cause stack overflow
+/// This reproduces a bug where recording with multiple cursors active, then playing via "Play Last Macro"
+/// caused infinite recursion
+#[test]
+fn test_macro_with_multiple_cursors_no_overflow() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.render().unwrap();
+
+    // Add some initial lines of text
+    harness.type_text("line 1").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("line 2").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("line 3").unwrap();
+    harness.render().unwrap();
+
+    // Move cursor up to line 2
+    harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Start recording macro on register 0 via command palette
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Record Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("0").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should be recording
+    harness.assert_screen_contains("Recording");
+
+    // Add multiple cursors via command palette
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Add Cursor Above").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Type some text (with multiple cursors, should appear on multiple lines)
+    harness.type_text("X").unwrap();
+    harness.render().unwrap();
+
+    // Stop recording WITHOUT clearing cursors first - this was the bug trigger
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Stop Recording").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should show macro saved
+    harness.assert_screen_contains("Macro");
+
+    // Debug: Show what's in the macro
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("List Macros").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    let macro_list = harness.screen_to_string();
+    println!("=== MACRO LIST ===\n{}\n==================", macro_list);
+
+    // Close buffer and clear cursors
+    harness
+        .send_key(KeyCode::Char('q'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Clear cursors by pressing Escape
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Now try to play the last macro - this used to cause stack overflow
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Play Last Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // If we got here without crashing, the test passed
+    // The macro should have executed (adding cursor and typing X)
+    let screen = harness.screen_to_string();
+    println!("Screen after playing macro:\n{}", screen);
+
+    // Verify we see the X's that were typed
+    assert!(
+        screen.contains("X"),
+        "Macro should have typed 'X'. Screen:\n{}",
+        screen
+    );
+}
+
+/// Test that playing last macro when no macro was recorded shows appropriate message
+#[test]
+fn test_play_last_macro_when_none_recorded() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.render().unwrap();
+
+    // Try to play last macro when none has been recorded
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    harness.type_text("Play Last Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should show message that no macro was recorded
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("No macro") || screen.contains("no macro"),
+        "Expected message about no macro recorded. Screen:\n{}",
+        screen
+    );
+}
+
+/// Test that macro playback is undoable as a single operation
+#[test]
+fn test_macro_playback_is_undoable() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.render().unwrap();
+
+    // Start recording macro on register 0
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Record Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("0").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Type some text
+    harness.type_text("abc").unwrap();
+    harness.render().unwrap();
+
+    // Stop recording
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Stop Recording").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Move to new line
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Verify initial state - should have "abc" on first line
+    harness.assert_screen_contains("abc");
+
+    // Play the macro
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Play Last Macro").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Should now have "abc" twice
+    let screen = harness.screen_to_string();
+    let abc_count = screen.matches("abc").count();
+    assert!(
+        abc_count >= 2,
+        "Expected 'abc' twice after macro playback, found {}. Screen:\n{}",
+        abc_count,
+        screen
+    );
+
+    // Now undo - should undo the entire macro playback
+    harness
+        .send_key(KeyCode::Char('z'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // After one undo, the second "abc" should be gone
+    // (If macro playback is properly grouped, one undo removes all macro actions)
+    let screen_after_undo = harness.screen_to_string();
+    let abc_count_after = screen_after_undo.matches("abc").count();
+
+    // We expect at most 1 "abc" after undo (the original one typed during recording)
+    // Note: The first "abc" was typed during recording, so it has its own undo entry
+    assert!(
+        abc_count_after < abc_count,
+        "Undo should have removed macro playback. Before: {} 'abc', after: {}. Screen:\n{}",
+        abc_count,
+        abc_count_after,
+        screen_after_undo
+    );
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -24,6 +24,7 @@ pub mod live_grep;
 pub mod locale;
 pub mod lsp;
 pub mod lsp_order;
+pub mod macros;
 pub mod margin;
 pub mod markdown_compose;
 pub mod menu_bar;


### PR DESCRIPTION
- Add macro_playing flag to prevent recursive macro playback
- Record prompt text with PromptConfirmWithText for correct replay
- Show full macro actions in List Macros (no truncation)
- Add e2e tests for macro recording and playback

The bug occurred when a macro was played via "Play Last Macro" command, and the macro contained PromptConfirm. During playback, PromptConfirm would confirm whatever suggestion was currently selected (not the original input), which could trigger PlayLastMacro again, causing infinite recursion.

Fixes #764
