### PR TITLE
feat: add daily debouncing for telemetry and update checks

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -902,6 +902,8 @@ impl Editor {
             Some(
                 crate::services::release_checker::start_periodic_update_check(
                     crate::services::release_checker::DEFAULT_RELEASES_URL,
+                    time_source.clone(),
+                    dir_context.data_dir.clone(),
                 ),
             )
         } else {

--- a/src/services/release_checker.rs
+++ b/src/services/release_checker.rs
@@ -6,8 +6,9 @@
 //! - Provide appropriate update commands based on installation method
 //! - Periodic update checking with automatic re-spawn daily
 
+use super::time_source::SharedTimeSource;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, TryRecvError};
 use std::sync::Arc;
@@ -179,8 +180,17 @@ impl Drop for PeriodicUpdateChecker {
 ///
 /// The checker immediately runs the first check, then repeats daily.
 /// Results are available via `poll_result()` on the returned handle.
-pub fn start_periodic_update_check(releases_url: &str) -> PeriodicUpdateChecker {
-    start_periodic_update_check_with_interval(releases_url, DEFAULT_UPDATE_CHECK_INTERVAL)
+pub fn start_periodic_update_check(
+    releases_url: &str,
+    time_source: SharedTimeSource,
+    data_dir: PathBuf,
+) -> PeriodicUpdateChecker {
+    start_periodic_update_check_with_interval(
+        releases_url,
+        DEFAULT_UPDATE_CHECK_INTERVAL,
+        time_source,
+        data_dir,
+    )
 }
 
 /// Start a periodic update checker with a custom check interval.
@@ -191,9 +201,13 @@ pub fn start_periodic_update_check(releases_url: &str) -> PeriodicUpdateChecker 
 /// # Arguments
 /// * `releases_url` - The GitHub releases API URL to check
 /// * `check_interval` - Duration between checks
+/// * `time_source` - Time source for debouncing and sleep
+/// * `data_dir` - Data directory for storing the telemetry stamp file
 pub fn start_periodic_update_check_with_interval(
     releases_url: &str,
     check_interval: Duration,
+    time_source: SharedTimeSource,
+    data_dir: PathBuf,
 ) -> PeriodicUpdateChecker {
     tracing::debug!(
         "Starting periodic update checker with interval {:?}",
@@ -212,22 +226,27 @@ pub fn start_periodic_update_check_with_interval(
     };
 
     let handle = thread::spawn(move || {
-        // Run initial check immediately
-        let result = check_for_update(&url);
-        if tx.send(result).is_err() {
-            return; // Receiver dropped, exit
+        // Run initial check immediately, but only if not already done today (debounce)
+        if let Some(unique_id) =
+            super::telemetry::should_run_daily_check(time_source.as_ref(), &data_dir)
+        {
+            super::telemetry::track_open(&unique_id);
+            let result = check_for_update(&url);
+            if tx.send(result).is_err() {
+                return; // Receiver dropped, exit
+            }
         }
 
-        // Then check periodically
+        // Then check periodically (debouncing will naturally pass after 24 hours)
         loop {
             // Sleep in small increments to allow quick shutdown
-            let sleep_end = Instant::now() + check_interval;
-            while Instant::now() < sleep_end {
+            let sleep_end = time_source.now() + check_interval;
+            while time_source.now() < sleep_end {
                 if stop_signal_clone.load(Ordering::SeqCst) {
                     tracing::debug!("Periodic update checker stopping");
                     return;
                 }
-                thread::sleep(sleep_increment);
+                time_source.sleep(sleep_increment);
             }
 
             // Check if we should stop before making a new request
@@ -237,9 +256,15 @@ pub fn start_periodic_update_check_with_interval(
             }
 
             tracing::debug!("Periodic update check starting");
-            let result = check_for_update(&url);
-            if tx.send(result).is_err() {
-                return; // Receiver dropped, exit
+            // Debounce check - only proceed if a new day
+            if let Some(unique_id) =
+                super::telemetry::should_run_daily_check(time_source.as_ref(), &data_dir)
+            {
+                super::telemetry::track_open(&unique_id);
+                let result = check_for_update(&url);
+                if tx.send(result).is_err() {
+                    return; // Receiver dropped, exit
+                }
             }
         }
     });
@@ -257,14 +282,24 @@ pub fn start_periodic_update_check_with_interval(
 ///
 /// Returns a handle that can be used to query the result later.
 /// The check runs in a background thread and won't block.
-pub fn start_update_check(releases_url: &str) -> UpdateCheckHandle {
+/// Respects daily debouncing - if already checked today, no result will be sent.
+pub fn start_update_check(
+    releases_url: &str,
+    time_source: SharedTimeSource,
+    data_dir: PathBuf,
+) -> UpdateCheckHandle {
     tracing::debug!("Starting background update check");
     let url = releases_url.to_string();
     let (tx, rx) = mpsc::channel();
 
     let handle = thread::spawn(move || {
-        let result = check_for_update(&url);
-        let _ = tx.send(result);
+        if let Some(unique_id) =
+            super::telemetry::should_run_daily_check(time_source.as_ref(), &data_dir)
+        {
+            super::telemetry::track_open(&unique_id);
+            let result = check_for_update(&url);
+            let _ = tx.send(result);
+        }
     });
 
     UpdateCheckHandle {
@@ -405,9 +440,6 @@ pub fn is_newer_version(current: &str, latest: &str) -> bool {
 
 /// Check for a new release (blocking)
 pub fn check_for_update(releases_url: &str) -> Result<ReleaseCheckResult, String> {
-    // Send telemetry alongside update check
-    super::telemetry::track_open();
-
     let latest_version = fetch_latest_version(releases_url)?;
     let install_method = detect_install_method();
     let update_available = is_newer_version(CURRENT_VERSION, &latest_version);
@@ -631,11 +663,17 @@ mod tests {
 
     #[test]
     fn test_periodic_update_checker_with_local_server() {
-        // Test that the production periodic checker works with a real HTTP server
+        // Test that the periodic checker works with a real HTTP server
         let (stop_tx, url) = start_mock_release_server("99.0.0");
+        let time_source = super::super::time_source::TestTimeSource::shared();
+        let temp_dir = tempfile::tempdir().unwrap();
 
-        let mut checker =
-            start_periodic_update_check_with_interval(&url, Duration::from_millis(50));
+        let mut checker = start_periodic_update_check_with_interval(
+            &url,
+            Duration::from_millis(50),
+            time_source,
+            temp_dir.path().to_path_buf(),
+        );
 
         // Wait for initial result
         let start = Instant::now();
@@ -662,8 +700,15 @@ mod tests {
     fn test_periodic_update_checker_shutdown_clean() {
         // Test that the checker shuts down cleanly without hanging
         let (stop_tx, url) = start_mock_release_server("99.0.0");
+        let time_source = super::super::time_source::TestTimeSource::shared();
+        let temp_dir = tempfile::tempdir().unwrap();
 
-        let checker = start_periodic_update_check_with_interval(&url, Duration::from_millis(50));
+        let checker = start_periodic_update_check_with_interval(
+            &url,
+            Duration::from_millis(50),
+            time_source,
+            temp_dir.path().to_path_buf(),
+        );
 
         // Let it run briefly
         thread::sleep(Duration::from_millis(100));
@@ -684,25 +729,43 @@ mod tests {
     }
 
     #[test]
-    fn test_periodic_update_checker_multiple_cycles_production() {
-        // Test that the production checker produces multiple results over time
+    fn test_periodic_update_checker_multiple_cycles() {
+        // Test that the checker produces multiple results when time advances by days
         let (stop_tx, url) = start_mock_release_server("99.0.0");
+        let time_source = super::super::time_source::TestTimeSource::shared();
+        let temp_dir = tempfile::tempdir().unwrap();
 
-        let mut checker =
-            start_periodic_update_check_with_interval(&url, Duration::from_millis(30));
+        let mut checker = start_periodic_update_check_with_interval(
+            &url,
+            Duration::from_secs(86400),
+            time_source.clone(),
+            temp_dir.path().to_path_buf(),
+        );
 
         let mut result_count = 0;
         let start = Instant::now();
         let timeout = Duration::from_secs(2);
 
-        while start.elapsed() < timeout && result_count < 3 {
+        // Get initial result
+        while start.elapsed() < timeout && result_count < 1 {
             if checker.poll_result().is_some() {
                 result_count += 1;
             }
             thread::sleep(Duration::from_millis(10));
         }
 
-        // Should have received at least 2 results (initial + at least one periodic)
+        // Advance time by 1 day to trigger next check
+        time_source.advance(Duration::from_secs(86400));
+
+        // Wait for second result
+        let start2 = Instant::now();
+        while start2.elapsed() < timeout && result_count < 2 {
+            if checker.poll_result().is_some() {
+                result_count += 1;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
         assert!(
             result_count >= 2,
             "Expected at least 2 results, got {}",
@@ -717,9 +780,15 @@ mod tests {
     fn test_periodic_update_checker_no_update_when_current() {
         // Test behavior when server returns current version (no update)
         let (stop_tx, url) = start_mock_release_server(CURRENT_VERSION);
+        let time_source = super::super::time_source::TestTimeSource::shared();
+        let temp_dir = tempfile::tempdir().unwrap();
 
-        let mut checker =
-            start_periodic_update_check_with_interval(&url, Duration::from_secs(3600));
+        let mut checker = start_periodic_update_check_with_interval(
+            &url,
+            Duration::from_secs(3600),
+            time_source,
+            temp_dir.path().to_path_buf(),
+        );
 
         // Wait for initial result
         let start = Instant::now();
@@ -743,9 +812,16 @@ mod tests {
     fn test_periodic_update_checker_api_before_result() {
         // Test that API methods work correctly before any result is received
         let (stop_tx, url) = start_mock_release_server("99.0.0");
+        let time_source = super::super::time_source::TestTimeSource::shared();
+        let temp_dir = tempfile::tempdir().unwrap();
 
         // Use a very long interval so we only test the initial state
-        let checker = start_periodic_update_check_with_interval(&url, Duration::from_secs(3600));
+        let checker = start_periodic_update_check_with_interval(
+            &url,
+            Duration::from_secs(3600),
+            time_source,
+            temp_dir.path().to_path_buf(),
+        );
 
         // Immediately check (before result arrives)
         assert!(!checker.is_update_available());

--- a/src/services/telemetry.rs
+++ b/src/services/telemetry.rs
@@ -1,9 +1,16 @@
+use super::time_source::TimeSource;
 use serde::Serialize;
+use std::collections::hash_map::RandomState;
 use std::env::consts::{ARCH, OS};
+use std::fs;
+use std::hash::{BuildHasher, Hasher};
+use std::io::Write;
+use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
 
 const TELEMETRY_URL: &str = "https://t.getfresh.dev";
+const STAMP_FILE_NAME: &str = "telemetry_stamp";
 
 #[derive(Serialize, Default)]
 struct Event {
@@ -15,15 +22,112 @@ struct Event {
     command: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    uid: Option<String>,
 }
 
-/// Track app open
-pub fn track_open() {
+/// Stamp file data containing unique ID and last check date
+struct StampData {
+    unique_id: String,
+    last_date: String,
+}
+
+/// Get the path to the telemetry stamp file
+fn stamp_file_path(data_dir: &std::path::Path) -> PathBuf {
+    data_dir.join("fresh").join(STAMP_FILE_NAME)
+}
+
+/// Generate a random 64-bit hex string using std's RandomState
+fn generate_unique_id() -> String {
+    let state = RandomState::new();
+    let mut hasher = state.build_hasher();
+    // Add extra entropy from time and process ID
+    hasher.write_u128(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+    hasher.write_u32(std::process::id());
+    format!("{:016x}", hasher.finish())
+}
+
+/// Read stamp file data (unique_id and last_date)
+/// Returns None if file doesn't exist, can't be read, or is malformed.
+fn read_stamp_file(data_dir: &std::path::Path) -> Option<StampData> {
+    let path = stamp_file_path(data_dir);
+    let content = fs::read_to_string(&path).ok()?;
+    let mut lines = content.lines();
+    let unique_id = lines.next().filter(|s| !s.is_empty())?.to_string();
+    let last_date = lines.next().filter(|s| !s.is_empty())?.to_string();
+    // Validate date format (YYYY-MM-DD)
+    if last_date.len() != 10 || last_date.chars().filter(|&c| c == '-').count() != 2 {
+        return None;
+    }
+    Some(StampData {
+        unique_id,
+        last_date,
+    })
+}
+
+/// Write stamp file with unique_id and the given date
+fn write_stamp_file(data_dir: &std::path::Path, unique_id: &str, today: &str) -> bool {
+    let path = stamp_file_path(data_dir);
+
+    // Create parent directory if needed
+    if let Some(parent) = path.parent() {
+        if let Err(e) = fs::create_dir_all(parent) {
+            tracing::debug!("Failed to create telemetry stamp directory: {}", e);
+            return false;
+        }
+    }
+
+    let content = format!("{}\n{}\n", unique_id, today);
+    match fs::File::create(&path).and_then(|mut f| f.write_all(content.as_bytes())) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::debug!("Failed to write telemetry stamp file: {}", e);
+            false
+        }
+    }
+}
+
+/// Check if we should run the daily check (telemetry + update).
+/// Returns Some(unique_id) if we should proceed, None if already done today.
+pub fn should_run_daily_check(
+    time_source: &dyn TimeSource,
+    data_dir: &std::path::Path,
+) -> Option<String> {
+    let today = time_source.today_date_string();
+
+    match read_stamp_file(data_dir) {
+        Some(data) if data.last_date == today => {
+            // Already checked today, skip
+            tracing::debug!("Daily check already done today, skipping");
+            None
+        }
+        Some(data) => {
+            // Have ID but date is old, update stamp and proceed
+            write_stamp_file(data_dir, &data.unique_id, &today);
+            Some(data.unique_id)
+        }
+        None => {
+            // No stamp file, generate new ID
+            let unique_id = generate_unique_id();
+            write_stamp_file(data_dir, &unique_id, &today);
+            Some(unique_id)
+        }
+    }
+}
+
+/// Track app open with unique ID
+pub fn track_open(unique_id: &str) {
     let event = Event {
         version: Some(env!("CARGO_PKG_VERSION")),
         os: Some(format!("{}-{}", OS, ARCH)),
         command: Some("fresh"),
         value: std::env::var("TERM").ok(),
+        uid: Some(unique_id.to_string()),
     };
     send(event);
 }

--- a/tests/e2e/update_notification.rs
+++ b/tests/e2e/update_notification.rs
@@ -4,9 +4,11 @@ use crate::common::harness::EditorTestHarness;
 use fresh::services::release_checker::{
     start_periodic_update_check_with_interval, CURRENT_VERSION,
 };
+use fresh::services::time_source::TestTimeSource;
 use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
+use tempfile::tempdir;
 
 /// Test helper: start a local HTTP server that returns a mock release JSON
 /// Returns (stop_sender, url) - send to stop_sender to shut down the server
@@ -69,7 +71,14 @@ fn test_update_notification_appears_in_status_bar() {
     let mut harness = EditorTestHarness::new(100, 24).unwrap();
 
     // Create an update checker pointing to our mock server
-    let checker = start_periodic_update_check_with_interval(&url, Duration::from_secs(3600));
+    let time_source = TestTimeSource::shared();
+    let temp_dir = tempdir().unwrap();
+    let checker = start_periodic_update_check_with_interval(
+        &url,
+        Duration::from_secs(3600),
+        time_source,
+        temp_dir.path().to_path_buf(),
+    );
 
     // Inject the checker into the editor
     harness.editor_mut().set_update_checker(checker);
@@ -120,7 +129,14 @@ fn test_update_notification_not_shown_when_current() {
 
     let mut harness = EditorTestHarness::new(100, 24).unwrap();
 
-    let checker = start_periodic_update_check_with_interval(&url, Duration::from_secs(3600));
+    let time_source = TestTimeSource::shared();
+    let temp_dir = tempdir().unwrap();
+    let checker = start_periodic_update_check_with_interval(
+        &url,
+        Duration::from_secs(3600),
+        time_source,
+        temp_dir.path().to_path_buf(),
+    );
     harness.editor_mut().set_update_checker(checker);
 
     // Wait for the update check to complete
@@ -165,7 +181,14 @@ fn test_update_notification_positioned_near_ctrl_p() {
 
     let mut harness = EditorTestHarness::new(120, 24).unwrap();
 
-    let checker = start_periodic_update_check_with_interval(&url, Duration::from_secs(3600));
+    let time_source = TestTimeSource::shared();
+    let temp_dir = tempdir().unwrap();
+    let checker = start_periodic_update_check_with_interval(
+        &url,
+        Duration::from_secs(3600),
+        time_source,
+        temp_dir.path().to_path_buf(),
+    );
     harness.editor_mut().set_update_checker(checker);
 
     // Wait for update check


### PR DESCRIPTION
Debounce telemetry and update checks to once per day using a stamp file at ~/.local/share/fresh/telemetry_stamp. The stamp file stores:
- A unique ID (generated once, persisted forever) for DAU tracking
- The last check date (YYYY-MM-DD) for debouncing

Changes:
- Add should_run_daily_check() to telemetry module with TimeSource param
- Extend TimeSource trait with today_date_string() for calendar dates
- Update release_checker to accept SharedTimeSource from caller
- Pass time_source from Editor to update checker for testability
- Tests can advance time via TestTimeSource to trigger new day checks