### PR TITLE
fix: cache embedded plugins in XDG cache dir instead of /tmp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ path = "src/lib.rs"
 default = ["plugins", "runtime", "embed-plugins"]
 plugins = ["dep:deno_core", "dep:deno_ast", "dep:deno_error"]
 # Embed plugins into the binary as a fallback when no disk plugins are found
-embed-plugins = ["plugins", "dep:include_dir", "dep:tempfile"]
+embed-plugins = ["plugins", "dep:include_dir", "dep:dirs", "dep:trash"]
 # Feature for optional development binaries (generate_schema, event_debug)
 dev-bins = []
 # Runtime feature includes all heavy dependencies needed for the actual editor


### PR DESCRIPTION
Previously, embedded plugins were extracted to /tmp with .keep() which disabled automatic cleanup, causing thousands of orphaned directories to accumulate over test runs (~5GB of leaked temp dirs).

Now plugins are cached at ~/.cache/fresh/embedded-plugins/{content_hash}/ with the hash computed at build time. This means:
- No re-extraction if plugins haven't changed
- Old cache versions are moved to trash (not permanently deleted)
- No more /tmp pollution