### PR TITLE
fix: use workspace version for fresh-plugin-api-macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,7 +996,7 @@ dependencies = [
 
 [[package]]
 name = "fresh-plugin-api-macros"
-version = "0.1.0"
+version = "0.1.77"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/fresh-plugin-api-macros/Cargo.toml
+++ b/crates/fresh-plugin-api-macros/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "fresh-plugin-api-macros"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
 description = "Proc macros for Fresh plugin API type-safe bindings"
 
 [lib]


### PR DESCRIPTION
This crate was missed in the workspace refactor (e8246d70) and had a hardcoded version instead of using version.workspace = true.