### PR TITLE
fix: update paths after workspace restructuring

### DIFF
--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build AppImage
         run: |
-          ./scripts/build-appimage.sh binary "$VERSION" "${{ matrix.arch }}"
+          ./crates/fresh-editor/scripts/build-appimage.sh binary "$VERSION" "${{ matrix.arch }}"
 
       - name: Upload AppImage
         uses: actions/upload-artifact@v6

--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -96,6 +96,10 @@ jobs:
             in_sha { next }
             { print }
           ' PKGBUILD > PKGBUILD.tmp && mv PKGBUILD.tmp PKGBUILD
+          # Update paths for workspace restructuring (plugins/keymaps/themes moved to crates/fresh-editor/)
+          sed -i 's|cp -r plugins |cp -r crates/fresh-editor/plugins |g' PKGBUILD
+          sed -i 's|cp -r keymaps |cp -r crates/fresh-editor/keymaps |g' PKGBUILD
+          sed -i 's|cp -r themes |cp -r crates/fresh-editor/themes |g' PKGBUILD
           echo "Updated PKGBUILD:"
           cat PKGBUILD
 

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -28,27 +28,28 @@ jobs:
 
       - name: Extract pre-built binary
         run: |
-          mkdir -p target/release
+          # Flatpak manifest expects binary at crates/fresh-editor/target/release/
+          mkdir -p crates/fresh-editor/target/release
           cd artifacts
           tar -xJf fresh-editor-x86_64-unknown-linux-gnu.tar.xz
-          cp fresh-editor-x86_64-unknown-linux-gnu/fresh ../target/release/
+          cp fresh-editor-x86_64-unknown-linux-gnu/fresh ../crates/fresh-editor/target/release/
 
       - name: Strip binary
         run: |
-          strip --strip-all target/release/fresh
-          ls -lh target/release/fresh
+          strip --strip-all crates/fresh-editor/target/release/fresh
+          ls -lh crates/fresh-editor/target/release/fresh
 
       - name: Update metainfo version
         run: |
           VERSION="${{ inputs.version }}"
           DATE=$(date +%Y-%m-%d)
-          sed -i "s/<release version=\"[^\"]*\"/<release version=\"$VERSION\"/" flatpak/io.github.sinelaw.fresh.metainfo.xml
-          sed -i "s/date=\"[^\"]*\"/date=\"$DATE\"/" flatpak/io.github.sinelaw.fresh.metainfo.xml
+          sed -i "s/<release version=\"[^\"]*\"/<release version=\"$VERSION\"/" crates/fresh-editor/flatpak/io.github.sinelaw.fresh.metainfo.xml
+          sed -i "s/date=\"[^\"]*\"/date=\"$DATE\"/" crates/fresh-editor/flatpak/io.github.sinelaw.fresh.metainfo.xml
 
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          manifest-path: flatpak/io.github.sinelaw.fresh.yml
+          manifest-path: crates/fresh-editor/flatpak/io.github.sinelaw.fresh.yml
           bundle: fresh-editor-${{ inputs.version }}-x86_64.flatpak
           upload-artifact: false
 

--- a/.github/workflows/musl-builds.yml
+++ b/.github/workflows/musl-builds.yml
@@ -66,8 +66,8 @@ jobs:
           mkdir -p "${ARCHIVE_NAME}"
           cp target/${{ matrix.target }}/release/fresh "${ARCHIVE_NAME}/"
           cp README.md LICENSE "${ARCHIVE_NAME}/" 2>/dev/null || true
-          cp -r plugins "${ARCHIVE_NAME}/" 2>/dev/null || true
-          cp -r themes "${ARCHIVE_NAME}/" 2>/dev/null || true
+          cp -r crates/fresh-editor/plugins "${ARCHIVE_NAME}/" 2>/dev/null || true
+          cp -r crates/fresh-editor/themes "${ARCHIVE_NAME}/" 2>/dev/null || true
 
           tar -czvf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
           sha256sum "${ARCHIVE_NAME}.tar.gz" > "${ARCHIVE_NAME}.tar.gz.sha256"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -228,8 +228,8 @@ jobs:
 
           # Copy supporting files
           cp README.md LICENSE CHANGELOG.md npm-package/ 2>/dev/null || true
-          cp -r plugins npm-package/ 2>/dev/null || true
-          cp -r themes npm-package/ 2>/dev/null || true
+          cp -r crates/fresh-editor/plugins npm-package/ 2>/dev/null || true
+          cp -r crates/fresh-editor/themes npm-package/ 2>/dev/null || true
 
           # Create the tarball
           cd npm-package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,8 +151,8 @@ jobs:
           mkdir -p "${ARCHIVE_NAME}"
           cp target/${{ matrix.target }}/release/fresh "${ARCHIVE_NAME}/"
           cp README.md LICENSE CHANGELOG.md "${ARCHIVE_NAME}/"
-          cp -r plugins "${ARCHIVE_NAME}/"
-          cp -r themes "${ARCHIVE_NAME}/"
+          cp -r crates/fresh-editor/plugins "${ARCHIVE_NAME}/"
+          cp -r crates/fresh-editor/themes "${ARCHIVE_NAME}/"
 
           if [ "${{ matrix.archive_ext }}" = "tar.xz" ]; then
             tar -cJvf "${ARCHIVE_NAME}.tar.xz" "${ARCHIVE_NAME}"
@@ -170,8 +170,8 @@ jobs:
           New-Item -ItemType Directory -Path $ARCHIVE_NAME -Force
           Copy-Item "target/${{ matrix.target }}/release/fresh.exe" "$ARCHIVE_NAME/"
           Copy-Item "README.md", "LICENSE", "CHANGELOG.md" "$ARCHIVE_NAME/"
-          Copy-Item -Recurse "plugins" "$ARCHIVE_NAME/"
-          Copy-Item -Recurse "themes" "$ARCHIVE_NAME/"
+          Copy-Item -Recurse "crates/fresh-editor/plugins" "$ARCHIVE_NAME/"
+          Copy-Item -Recurse "crates/fresh-editor/themes" "$ARCHIVE_NAME/"
 
           Compress-Archive -Path "$ARCHIVE_NAME/*" -DestinationPath "$ARCHIVE_NAME.zip"
           $hash = (Get-FileHash "$ARCHIVE_NAME.zip" -Algorithm SHA256).Hash.ToLower()
@@ -246,15 +246,15 @@ jobs:
         run: |
           # Copy JS files from npm-package template
           mkdir -p dist-npm
-          cp npm-package/*.js dist-npm/
+          cp crates/fresh-editor/npm-package/*.js dist-npm/
 
           # Create package.json from template with version
-          sed "s/VERSION_PLACEHOLDER/${VERSION}/g" npm-package/package.json.template > dist-npm/package.json
+          sed "s/VERSION_PLACEHOLDER/${VERSION}/g" crates/fresh-editor/npm-package/package.json.template > dist-npm/package.json
 
           # Copy supporting files
           cp README.md LICENSE CHANGELOG.md dist-npm/
-          cp -r plugins dist-npm/
-          cp -r themes dist-npm/
+          cp -r crates/fresh-editor/plugins dist-npm/
+          cp -r crates/fresh-editor/themes dist-npm/
 
           # Create the tarball
           cd dist-npm
@@ -500,15 +500,15 @@ jobs:
         run: |
           # Copy JS files from npm-package template
           mkdir -p dist-npm
-          cp npm-package/*.js dist-npm/
+          cp crates/fresh-editor/npm-package/*.js dist-npm/
 
           # Create package.json from template with version
-          sed "s/VERSION_PLACEHOLDER/${VERSION}/g" npm-package/package.json.template > dist-npm/package.json
+          sed "s/VERSION_PLACEHOLDER/${VERSION}/g" crates/fresh-editor/npm-package/package.json.template > dist-npm/package.json
 
           # Copy supporting files
           cp README.md LICENSE CHANGELOG.md dist-npm/
-          cp -r plugins dist-npm/
-          cp -r themes dist-npm/
+          cp -r crates/fresh-editor/plugins dist-npm/
+          cp -r crates/fresh-editor/themes dist-npm/
 
           # Create the tarball
           cd dist-npm

--- a/crates/fresh-editor/Cargo.toml
+++ b/crates/fresh-editor/Cargo.toml
@@ -160,13 +160,13 @@ assets = [
     # Binary goes in /usr/share/fresh-editor/ alongside plugins
     ["../../target/release/fresh", "usr/share/fresh-editor/", "755"],
     ["../../README.md", "usr/share/doc/fresh-editor/", "644"],
-    ["../../plugins/*", "usr/share/fresh-editor/plugins/", "644"],
-    ["../../plugins/lib/*", "usr/share/fresh-editor/plugins/lib/", "644"],
-    ["../../plugins/examples/*", "usr/share/fresh-editor/plugins/examples/", "644"],
-    ["../../themes/*", "usr/share/fresh-editor/themes/", "644"],
+    ["plugins/*", "usr/share/fresh-editor/plugins/", "644"],
+    ["plugins/lib/*", "usr/share/fresh-editor/plugins/lib/", "644"],
+    ["plugins/examples/*", "usr/share/fresh-editor/plugins/examples/", "644"],
+    ["themes/*", "usr/share/fresh-editor/themes/", "644"],
 ]
 # Maintainer scripts to create/remove symlink at /usr/bin/fresh
-maintainer-scripts = "../../debian/"
+maintainer-scripts = "debian/"
 extended-description = """
 Fresh is a lightweight, fast terminal-based text editor with LSP support
 and TypeScript plugins. It provides syntax highlighting, code completion,
@@ -178,14 +178,14 @@ assets = [
     # Binary goes in /usr/share/fresh-editor/ alongside plugins
     { source = "../../target/release/fresh", dest = "/usr/share/fresh-editor/fresh", mode = "755" },
     # Wrapper script in /usr/bin for PATH access
-    { source = "../../scripts/fresh-wrapper.sh", dest = "/usr/bin/fresh", mode = "755" },
+    { source = "scripts/fresh-wrapper.sh", dest = "/usr/bin/fresh", mode = "755" },
     { source = "../../README.md", dest = "/usr/share/doc/fresh-editor/README.md", mode = "644" },
-    { source = "../../plugins/*.ts", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
-    { source = "../../plugins/*.json", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
-    { source = "../../plugins/*.md", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
-    { source = "../../plugins/lib/*", dest = "/usr/share/fresh-editor/plugins/lib/", mode = "644" },
-    { source = "../../plugins/examples/*", dest = "/usr/share/fresh-editor/plugins/examples/", mode = "644" },
-    { source = "../../themes/*.json", dest = "/usr/share/fresh-editor/themes/", mode = "644" },
+    { source = "plugins/*.ts", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
+    { source = "plugins/*.json", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
+    { source = "plugins/*.md", dest = "/usr/share/fresh-editor/plugins/", mode = "644" },
+    { source = "plugins/lib/*", dest = "/usr/share/fresh-editor/plugins/lib/", mode = "644" },
+    { source = "plugins/examples/*", dest = "/usr/share/fresh-editor/plugins/examples/", mode = "644" },
+    { source = "themes/*.json", dest = "/usr/share/fresh-editor/themes/", mode = "644" },
 ]
 # posttrans runs after ALL transaction operations complete - needed because older versions
 # (<=0.1.56) had a preuninstall script that removes /usr/bin/fresh, which deletes our wrapper

--- a/flake.nix
+++ b/flake.nix
@@ -50,14 +50,17 @@
             (lib.fileset.fileFilter (file: file.hasExt "js") unfilteredRoot)
             # Keep sublime-syntax grammar files (used by include_str! in grammar_registry.rs)
             (lib.fileset.fileFilter (file: file.hasExt "sublime-syntax") unfilteredRoot)
+            # Runtime assets in crates/fresh-editor
+            ./crates/fresh-editor/keymaps
+            ./crates/fresh-editor/locales
+            ./crates/fresh-editor/plugins
+            ./crates/fresh-editor/queries
+            ./crates/fresh-editor/themes
+            ./crates/fresh-editor/types
+            # Test files
+            ./crates/fresh-editor/tests
+            # Documentation
             ./docs
-            ./keymaps
-            ./locales
-            ./plugins
-            ./queries
-            ./tests
-            ./themes
-            ./types
           ];
         };
 
@@ -123,11 +126,10 @@
             # Include runtime assets
             postInstall = ''
               mkdir -p $out/share/fresh-editor
-
-                cp -r queries $out/share/fresh-editor/
-                cp -r themes $out/share/fresh-editor/
-                cp -r keymaps $out/share/fresh-editor/
-                cp -r plugins $out/share/fresh-editor/
+              cp -r crates/fresh-editor/queries $out/share/fresh-editor/
+              cp -r crates/fresh-editor/themes $out/share/fresh-editor/
+              cp -r crates/fresh-editor/keymaps $out/share/fresh-editor/
+              cp -r crates/fresh-editor/plugins $out/share/fresh-editor/
             '';
           }
         );


### PR DESCRIPTION
Files moved from repo root to crates/fresh-editor/ in the workspace refactoring. This updates all packaging and CI paths:

- flake.nix: Update source paths for nix build
- release.yml: Update plugin/theme/npm-package paths
- musl-builds.yml: Update plugin/theme paths
- release-npm.yml: Update plugin/theme paths
- appimage-build.yml: Update script path
- flatpak-build.yml: Update manifest and binary paths
- Cargo.toml: Update cargo-deb and cargo-generate-rpm asset paths