### PR TITLE
feat: add use_terminal_bg config option for transparent backgrounds

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -59,7 +59,8 @@
         "keyboard_report_all_keys_as_escape_codes": false,
         "quick_suggestions": true,
         "show_menu_bar": true,
-        "show_tab_bar": true
+        "show_tab_bar": true,
+        "use_terminal_bg": false
       }
     },
     "file_explorer": {
@@ -349,6 +350,11 @@
           "description": "Whether the tab bar is visible by default.\nThe tab bar shows open files in each split pane.\nCan be toggled at runtime via command palette or keybinding.\nDefault: true",
           "type": "boolean",
           "default": true
+        },
+        "use_terminal_bg": {
+          "description": "Use the terminal's default background color instead of the theme's editor background.\nWhen enabled, the editor background inherits from the terminal emulator,\nallowing transparency or custom terminal backgrounds to show through.\nDefault: false",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -380,6 +380,7 @@ impl Editor {
                 is_maximized,
                 self.config.editor.relative_line_numbers,
                 self.tab_bar_visible,
+                self.config.editor.use_terminal_bg,
             );
 
         // Detect viewport changes and fire hooks

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -567,6 +567,13 @@ pub struct EditorConfig {
     /// Default: true
     #[serde(default = "default_true")]
     pub show_tab_bar: bool,
+
+    /// Use the terminal's default background color instead of the theme's editor background.
+    /// When enabled, the editor background inherits from the terminal emulator,
+    /// allowing transparency or custom terminal backgrounds to show through.
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub use_terminal_bg: bool,
 }
 
 fn default_tab_size() -> usize {
@@ -663,6 +670,7 @@ impl Default for EditorConfig {
             quick_suggestions: true,
             show_menu_bar: true,
             show_tab_bar: true,
+            use_terminal_bg: false,
         }
     }
 }

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -161,6 +161,7 @@ pub struct PartialEditorConfig {
     pub quick_suggestions: Option<bool>,
     pub show_menu_bar: Option<bool>,
     pub show_tab_bar: Option<bool>,
+    pub use_terminal_bg: Option<bool>,
 }
 
 impl Merge for PartialEditorConfig {
@@ -214,6 +215,7 @@ impl Merge for PartialEditorConfig {
         self.quick_suggestions.merge_from(&other.quick_suggestions);
         self.show_menu_bar.merge_from(&other.show_menu_bar);
         self.show_tab_bar.merge_from(&other.show_tab_bar);
+        self.use_terminal_bg.merge_from(&other.use_terminal_bg);
     }
 }
 
@@ -391,6 +393,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             quick_suggestions: Some(cfg.quick_suggestions),
             show_menu_bar: Some(cfg.show_menu_bar),
             show_tab_bar: Some(cfg.show_tab_bar),
+            use_terminal_bg: Some(cfg.use_terminal_bg),
         }
     }
 }
@@ -467,6 +470,7 @@ impl PartialEditorConfig {
             quick_suggestions: self.quick_suggestions.unwrap_or(defaults.quick_suggestions),
             show_menu_bar: self.show_menu_bar.unwrap_or(defaults.show_menu_bar),
             show_tab_bar: self.show_tab_bar.unwrap_or(defaults.show_tab_bar),
+            use_terminal_bg: self.use_terminal_bg.unwrap_or(defaults.use_terminal_bg),
         }
     }
 }

--- a/scripts/gen_schema.sh
+++ b/scripts/gen_schema.sh
@@ -1,0 +1,1 @@
+cd "$(dirname "$0")/.." && cargo run --features dev-bins --bin generate_schema > crates/fresh-editor/plugins/config-schema.json


### PR DESCRIPTION
Add a boolean config option `editor.use_terminal_bg` that overrides the theme's editor background color with the terminal's default (Color::Reset), allowing terminal transparency or custom backgrounds to show through.

Fixes #640