### PR TITLE
Add winget publishing to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -541,3 +541,12 @@ jobs:
     if: ${{ needs.plan.outputs.publishing == 'true' && needs.plan.outputs.is_prerelease != 'true' }}
     uses: ./.github/workflows/cargo-publish.yml
     secrets: inherit
+
+  # Publish to Windows Package Manager (winget)
+  publish-winget:
+    needs: [plan, release]
+    if: ${{ needs.plan.outputs.publishing == 'true' && needs.plan.outputs.is_prerelease != 'true' }}
+    uses: ./.github/workflows/winget-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,47 @@
+# Publish to Windows Package Manager (winget) after a release is created
+# Based on: https://github.com/github/copilot-cli/blob/v0.0.368-2/.github/workflows/winget.yml
+
+name: Publish to winget
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.87)'
+        required: true
+        type: string
+
+jobs:
+  publish-winget:
+    name: Submit to WinGet repository
+    runs-on: windows-latest
+
+    # wingetcreate reads this env var for the GitHub token needed for submitting a PR
+    # See https://aka.ms/winget-create-token
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.WINGET_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Submit package using wingetcreate
+        shell: pwsh
+        run: |
+          $packageId = "sinelaw.fresh-editor"
+          $packageVersion = "${{ inputs.version }}"
+          $installerUrl = "https://github.com/sinelaw/fresh/releases/download/v${packageVersion}/fresh-editor-x86_64-pc-windows-msvc.zip"
+
+          # Download wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+
+          # Update package using wingetcreate
+          # Uses user scope by default (configured in existing manifest or via first manual submission)
+          .\wingetcreate.exe update $packageId `
+            --version $packageVersion `
+            --urls "$installerUrl|x64" `
+            --submit

--- a/crates/fresh-editor/winget/sinelaw.fresh-editor.yaml.template
+++ b/crates/fresh-editor/winget/sinelaw.fresh-editor.yaml.template
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.singleton.1.6.0.schema.json
+# Winget manifest for fresh-editor
+#
+# This template is used for the initial submission to winget-pkgs.
+# Replace VERSION_PLACEHOLDER with the version (e.g., 0.1.87) and
+# HASH_PLACEHOLDER with the SHA256 hash of the installer zip.
+#
+# Key configuration: Scope is set to "user" (no admin required).
+# Subsequent releases use wingetcreate update which preserves this setting.
+
+PackageIdentifier: sinelaw.fresh-editor
+PackageVersion: VERSION_PLACEHOLDER
+PackageLocale: en-US
+Publisher: sinelaw
+PublisherUrl: https://github.com/sinelaw
+PublisherSupportUrl: https://github.com/sinelaw/fresh/issues
+Author: Noam Lewis
+PackageName: fresh-editor
+PackageUrl: https://github.com/sinelaw/fresh
+License: GPL-2.0
+LicenseUrl: https://github.com/sinelaw/fresh/blob/main/LICENSE
+Copyright: Copyright (c) sinelaw
+ShortDescription: A modern terminal-based text editor with TypeScript plugin support
+Description: Fresh is a modern terminal-based text editor. It features LSP support, syntax highlighting, multi-cursor editing, TypeScript plugins, and an intuitive interface.
+Tags:
+  - editor
+  - terminal
+  - text-editor
+  - tui
+  - lsp
+  - syntax-highlighting
+  - plugins
+ReleaseNotesUrl: https://github.com/sinelaw/fresh/releases/tag/vVERSION_PLACEHOLDER
+Installers:
+  - Architecture: x64
+    InstallerType: zip
+    InstallerUrl: https://github.com/sinelaw/fresh/releases/download/vVERSION_PLACEHOLDER/fresh-editor-x86_64-pc-windows-msvc.zip
+    InstallerSha256: HASH_PLACEHOLDER
+    # Install to user scope by default (no admin required)
+    Scope: user
+    NestedInstallerType: portable
+    NestedInstallerFiles:
+      - RelativeFilePath: fresh-editor-x86_64-pc-windows-msvc\fresh.exe
+        PortableCommandAlias: fresh
+ManifestType: singleton
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Add Windows Package Manager (winget) publishing support following the copilot-cli pattern:
- Create winget-publish.yml workflow using wingetcreate update --submit
- Add manifest template with user scope by default (no admin required)
- Integrate into release.yml for automatic publishing on non-prerelease versions

The template is kept for the initial manual submission to winget-pkgs. Subsequent releases use wingetcreate update which preserves the user scope.