### PR TITLE
fix support ghost text #686

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ tree-sitter-highlight = "0.26.3"
 crossterm = "0.29"
 winit = "0.30"
 wgpu = "28.0"
-lsp-types = "0.97"
+lsp-types = { version = "0.97", features = ["proposed"] }
 ts-rs = { version = "12.0", features = ["serde_json", "no-serde-warnings"] }
 # Add more as needed during refactor
 

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1510,6 +1510,9 @@ pub struct ViewTokenStyle {
     /// Whether to render with underline
     #[serde(default)]
     pub underline: bool,
+    /// Whether to render dimmed
+    #[serde(default)]
+    pub dim: bool,
 }
 
 /// Wire-format view token with optional source mapping and styling
@@ -7103,9 +7106,10 @@ mod fromjs_impls {
             // named string). rquickjs_serde struggles with the untagged
             // variant from a plain JS array, so we pin down the boolean
             // flags — enough to prove the body actually ran.
-            let got: ViewTokenStyle = eval_as("({bold: true, italic: true})");
+            let got: ViewTokenStyle = eval_as("({bold: true, italic: true, dim: true})");
             assert!(got.bold);
             assert!(got.italic);
+            assert!(got.dim);
             assert!(got.fg.is_none());
         }
 

--- a/crates/fresh-editor-core/src/config.rs
+++ b/crates/fresh-editor-core/src/config.rs
@@ -1624,6 +1624,14 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Completion"))]
     pub quick_suggestions_delay_ms: u64,
 
+    /// Show inline ghost text for the currently selected completion item.
+    /// This renders a dimmed suggestion directly in the buffer while the
+    /// completion popup is open.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Completion"))]
+    pub enable_ghost_text: bool,
+
     /// Whether trigger characters (like `.`, `::`, `->`) immediately show completions.
     /// When true, typing a trigger character bypasses quick_suggestions_delay_ms.
     /// Default: true
@@ -2071,6 +2079,7 @@ impl Default for EditorConfig {
             completion_popup_auto_show: false,
             quick_suggestions: true,
             quick_suggestions_delay_ms: default_quick_suggestions_delay(),
+            enable_ghost_text: true,
             suggest_on_trigger_characters: true,
             show_menu_bar: true,
             screensaver_enabled: false,

--- a/crates/fresh-editor-core/src/config.rs
+++ b/crates/fresh-editor-core/src/config.rs
@@ -1607,9 +1607,8 @@ pub struct EditorConfig {
     pub completion_popup_auto_show: bool,
 
     /// Enable quick suggestions (VS Code-like behavior).
-    /// When enabled, completion suggestions appear automatically while typing,
-    /// not just on trigger characters (like `.` or `::`).
-    /// Only takes effect when completion_popup_auto_show is true.
+    /// When enabled, completion suggestions or inline ghost text are requested
+    /// automatically while typing, not just on trigger characters (like `.` or `::`).
     /// Default: true
     #[serde(default = "default_true")]
     #[schemars(extend("x-section" = "Completion"))]
@@ -1624,9 +1623,9 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Completion"))]
     pub quick_suggestions_delay_ms: u64,
 
-    /// Show inline ghost text for the currently selected completion item.
-    /// This renders a dimmed suggestion directly in the buffer while the
-    /// completion popup is open.
+    /// Show LSP inline completion ghost text from textDocument/inlineCompletion.
+    /// This renders a dimmed Copilot-style suggestion directly in the buffer,
+    /// independently of the completion popup.
     /// Default: true
     #[serde(default = "default_true")]
     #[schemars(extend("x-section" = "Completion"))]

--- a/crates/fresh-editor-core/src/partial_config.rs
+++ b/crates/fresh-editor-core/src/partial_config.rs
@@ -210,6 +210,7 @@ pub struct PartialEditorConfig {
     pub completion_popup_auto_show: Option<bool>,
     pub quick_suggestions: Option<bool>,
     pub quick_suggestions_delay_ms: Option<u64>,
+    pub enable_ghost_text: Option<bool>,
     pub suggest_on_trigger_characters: Option<bool>,
     pub show_menu_bar: Option<bool>,
     pub screensaver_enabled: Option<bool>,
@@ -332,6 +333,7 @@ impl Merge for PartialEditorConfig {
         self.quick_suggestions.merge_from(&other.quick_suggestions);
         self.quick_suggestions_delay_ms
             .merge_from(&other.quick_suggestions_delay_ms);
+        self.enable_ghost_text.merge_from(&other.enable_ghost_text);
         self.suggest_on_trigger_characters
             .merge_from(&other.suggest_on_trigger_characters);
         self.show_menu_bar.merge_from(&other.show_menu_bar);
@@ -706,6 +708,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             completion_popup_auto_show: Some(cfg.completion_popup_auto_show),
             quick_suggestions: Some(cfg.quick_suggestions),
             quick_suggestions_delay_ms: Some(cfg.quick_suggestions_delay_ms),
+            enable_ghost_text: Some(cfg.enable_ghost_text),
             suggest_on_trigger_characters: Some(cfg.suggest_on_trigger_characters),
             show_menu_bar: Some(cfg.show_menu_bar),
             screensaver_enabled: Some(cfg.screensaver_enabled),
@@ -876,6 +879,7 @@ impl PartialEditorConfig {
             quick_suggestions_delay_ms: self
                 .quick_suggestions_delay_ms
                 .unwrap_or(defaults.quick_suggestions_delay_ms),
+            enable_ghost_text: self.enable_ghost_text.unwrap_or(defaults.enable_ghost_text),
             suggest_on_trigger_characters: self
                 .suggest_on_trigger_characters
                 .unwrap_or(defaults.suggest_on_trigger_characters),

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -116,6 +116,7 @@
         "completion_popup_auto_show": false,
         "quick_suggestions": true,
         "quick_suggestions_delay_ms": 150,
+        "enable_ghost_text": true,
         "suggest_on_trigger_characters": true,
         "enable_inlay_hints": true,
         "enable_semantic_tokens_full": false,
@@ -794,6 +795,12 @@
           "minimum": 0,
           "default": 150,
           "x-section": "Completion"
+        },
+        "enable_ghost_text": {
+          "description": "Show inline ghost text for the currently selected completion item.\nThis renders a dimmed suggestion directly in the buffer while the\ncompletion popup is open.\nDefault: true",
+          "type": "boolean",
+          "x-section": "Completion",
+          "default": true
         },
         "suggest_on_trigger_characters": {
           "description": "Whether trigger characters (like `.`, `::`, `->`) immediately show completions.\nWhen true, typing a trigger character bypasses quick_suggestions_delay_ms.\nDefault: true",

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -783,7 +783,7 @@
           "x-section": "Completion"
         },
         "quick_suggestions": {
-          "description": "Enable quick suggestions (VS Code-like behavior).\nWhen enabled, completion suggestions appear automatically while typing,\nnot just on trigger characters (like `.` or `::`).\nOnly takes effect when completion_popup_auto_show is true.\nDefault: true",
+          "description": "Enable quick suggestions (VS Code-like behavior).\nWhen enabled, completion suggestions or inline ghost text are requested\nautomatically while typing, not just on trigger characters (like `.` or `::`).\nDefault: true",
           "type": "boolean",
           "default": true,
           "x-section": "Completion"
@@ -797,10 +797,10 @@
           "x-section": "Completion"
         },
         "enable_ghost_text": {
-          "description": "Show inline ghost text for the currently selected completion item.\nThis renders a dimmed suggestion directly in the buffer while the\ncompletion popup is open.\nDefault: true",
+          "description": "Show LSP inline completion ghost text from textDocument/inlineCompletion.\nThis renders a dimmed Copilot-style suggestion directly in the buffer,\nindependently of the completion popup.\nDefault: true",
           "type": "boolean",
-          "x-section": "Completion",
-          "default": true
+          "default": true,
+          "x-section": "Completion"
         },
         "suggest_on_trigger_characters": {
           "description": "Whether trigger characters (like `.`, `::`, `->`) immediately show completions.\nWhen true, typing a trigger character bypasses quick_suggestions_delay_ms.\nDefault: true",

--- a/crates/fresh-editor/src/app/action_dispatch.rs
+++ b/crates/fresh-editor/src/app/action_dispatch.rs
@@ -874,6 +874,9 @@ impl Editor {
             }
             Action::LspCompletion => {
                 self.request_completion();
+                if let Err(err) = self.request_inline_completion_invoked() {
+                    tracing::debug!("Failed to request inline completion: {err}");
+                }
             }
             Action::DabbrevExpand => {
                 if self.refuse_if_editing_disabled() {

--- a/crates/fresh-editor/src/app/action_dispatch.rs
+++ b/crates/fresh-editor/src/app/action_dispatch.rs
@@ -1879,6 +1879,11 @@ impl Editor {
                 self.handle_popup_focus();
             }
             Action::CompletionAccept => {
+                if self.accept_ghost_text() {
+                    return Ok(());
+                }
+                self.active_window_mut().cancel_pending_lsp_requests();
+                self.clear_ghost_text();
                 use super::popup_actions::PopupConfirmResult;
                 if let PopupConfirmResult::EarlyReturn = self.handle_popup_confirm() {
                     return Ok(());
@@ -1886,6 +1891,14 @@ impl Editor {
             }
             Action::CompletionDismiss => {
                 self.handle_popup_cancel();
+            }
+            Action::InsertTab => {
+                if self.accept_ghost_text() {
+                    return Ok(());
+                }
+                self.active_window_mut().cancel_pending_lsp_requests();
+                self.clear_ghost_text();
+                self.apply_action_as_events(action)?;
             }
             Action::InsertChar(c) => {
                 if self.is_prompting() {

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -258,6 +258,9 @@ impl Editor {
                         tracing::error!("Error handling completion response: {}", e);
                     }
                 }
+                AsyncMessage::LspInlineCompletion { request_id, items } => {
+                    self.handle_inline_completion_response(request_id, items);
+                }
                 AsyncMessage::LspGotoDefinition {
                     request_id,
                     locations,

--- a/crates/fresh-editor/src/app/chrome/base.rs
+++ b/crates/fresh-editor/src/app/chrome/base.rs
@@ -137,6 +137,7 @@ impl Editor {
                 // after the user has moved on.
                 if router::cancels_pending_lsp(&action) {
                     self.active_window_mut().cancel_pending_lsp_requests();
+                    self.clear_ghost_text();
                 }
                 // Keys the file browser ignores (its Alt+letter toggles) resolve
                 // here in the Prompt context; the resulting prompt/file-browser

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1545,12 +1545,16 @@ impl Editor {
             return false;
         }
 
-        // Trigger the completion request
-        self.request_completion();
-        if let Err(err) = self.request_inline_completion_automatic() {
-            tracing::debug!("Failed to request inline completion: {err}");
+        // Trigger the completion request(s)
+        if self.config.editor.completion_popup_auto_show {
+            self.request_completion();
+        }
+        if self.config.editor.enable_ghost_text {
+            if let Err(err) = self.request_inline_completion_automatic() {
+                tracing::debug!("Failed to request inline completion: {err}");
+            }
         }
 
-        true
+        self.config.editor.completion_popup_auto_show || self.config.editor.enable_ghost_text
     }
 }

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1547,6 +1547,9 @@ impl Editor {
 
         // Trigger the completion request
         self.request_completion();
+        if let Err(err) = self.request_inline_completion_automatic() {
+            tracing::debug!("Failed to request inline completion: {err}");
+        }
 
         true
     }

--- a/crates/fresh-editor/src/app/input_helpers.rs
+++ b/crates/fresh-editor/src/app/input_helpers.rs
@@ -254,6 +254,7 @@ impl Editor {
 
         // Cancel any pending LSP requests since the text is changing
         self.active_window_mut().cancel_pending_lsp_requests();
+        self.clear_ghost_text();
 
         if let Some(events) = self
             .active_window_mut()

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -21,6 +21,7 @@ use crate::primitives::word_navigation::{find_word_end, find_word_start};
 use crate::view::prompt::{Prompt, PromptType};
 
 use crate::services::lsp::async_handler::LspHandle;
+use crate::services::lsp::manager::detect_language;
 use crate::types::LspFeature;
 
 use super::{Editor, SemanticTokenRangeRequest};
@@ -99,8 +100,122 @@ fn lsp_range_overlaps(
 
 const SEMANTIC_TOKENS_RANGE_DEBOUNCE_MS: u64 = 50;
 const SEMANTIC_TOKENS_RANGE_PADDING_LINES: usize = 10;
+const GHOST_TEXT_ID: &str = "ghost-text";
 
 impl Editor {
+    /// Clear any active ghost text (inline completion) from the buffer.
+    pub(crate) fn clear_ghost_text(&mut self) {
+        let Some(buffer_id) = self.active_window_mut().ghost_text_buffer_id.take() else {
+            return;
+        };
+
+        let active_window = self.active_window;
+        if let Some(state) = self
+            .windows
+            .get_mut(&active_window)
+            .and_then(|window| window.buffers.get_mut(&buffer_id))
+        {
+            state
+                .virtual_texts
+                .remove_by_id(&mut state.marker_list, GHOST_TEXT_ID);
+        }
+    }
+
+    /// Request inline completion (ghost text) with an automatic trigger.
+    pub(crate) fn request_inline_completion_automatic(&mut self) -> AnyhowResult<()> {
+        self.request_inline_completion_with_trigger(
+            lsp_types::InlineCompletionTriggerKind::Automatic,
+        )
+    }
+
+    /// Request inline completion (ghost text) explicitly invoked by the user.
+    pub(crate) fn request_inline_completion_invoked(&mut self) -> AnyhowResult<()> {
+        self.request_inline_completion_with_trigger(lsp_types::InlineCompletionTriggerKind::Invoked)
+    }
+
+    fn request_inline_completion_with_trigger(
+        &mut self,
+        trigger_kind: lsp_types::InlineCompletionTriggerKind,
+    ) -> AnyhowResult<()> {
+        if !self.config.editor.enable_ghost_text {
+            self.clear_ghost_text();
+            return Ok(());
+        }
+
+        self.clear_ghost_text();
+
+        let (buffer_id, line, character, language) = {
+            let state = self.active_state();
+            let cursor_count = self.active_cursors().count();
+            let cursor = self.active_cursors().primary();
+            if cursor_count != 1 || !cursor.collapsed() {
+                self.clear_ghost_text();
+                return Ok(());
+            }
+
+            let path = match state.buffer.file_path() {
+                Some(path) => path,
+                None => return Ok(()),
+            };
+
+            let language = match detect_language(path, &self.config.languages) {
+                Some(language) => language,
+                None => return Ok(()),
+            };
+
+            let cursor_pos = cursor.position;
+            let (line, character) = state.buffer.position_to_lsp_position(cursor_pos);
+            (self.active_buffer(), line, character, language)
+        };
+
+        let inline_supported = self
+            .lsp()
+            .and_then(|lsp| lsp.inline_completion_support(&language));
+
+        if inline_supported == Some(false) {
+            self.clear_ghost_text();
+            return Ok(());
+        }
+
+        if let Some(pending_id) = self
+            .active_window_mut()
+            .pending_inline_completion_request
+            .take()
+        {
+            self.active_window_mut().send_lsp_cancel_request(pending_id);
+        }
+
+        let request_id = self.active_window_mut().next_lsp_request_id;
+        let sent = self
+            .with_lsp_for_buffer_inline_completion(buffer_id, |handle, uri, _language| {
+                let result = handle.inline_completion(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                    trigger_kind,
+                    None,
+                );
+                if result.is_ok() {
+                    tracing::info!(
+                        "Requested inline completion at {}:{}:{}",
+                        uri.as_str(),
+                        line,
+                        character
+                    );
+                }
+                result.is_ok()
+            })
+            .unwrap_or(false);
+
+        if sent {
+            self.active_window_mut().next_lsp_request_id += 1;
+            self.active_window_mut().pending_inline_completion_request = Some(request_id);
+        }
+
+        Ok(())
+    }
+
     /// Handle LSP completion response.
     /// Supports merging from multiple servers: first response creates the menu,
     /// subsequent responses extend it.
@@ -223,6 +338,152 @@ impl Editor {
         );
 
         Ok(())
+    }
+
+    /// Handle LSP inline completion response (textDocument/inlineCompletion).
+    pub(crate) fn handle_inline_completion_response(
+        &mut self,
+        request_id: u64,
+        items: Vec<lsp_types::InlineCompletionItem>,
+    ) {
+        use crate::primitives::snippet::expand_snippet;
+        use crate::primitives::word_navigation::find_completion_word_start;
+        use crate::view::virtual_text::VirtualTextPosition;
+        use ratatui::style::{Modifier, Style};
+
+        if self.active_window().pending_inline_completion_request != Some(request_id) {
+            tracing::debug!(
+                "Ignoring inline completion response for outdated request {}",
+                request_id
+            );
+            return;
+        }
+
+        self.active_window_mut().pending_inline_completion_request = None;
+
+        if !self.config.editor.enable_ghost_text {
+            self.clear_ghost_text();
+            return;
+        }
+
+        let (buffer_id, cursor_pos, cursor_count, cursor_collapsed, buffer_len, suggestion_item) = {
+            let state = self.active_state();
+            let cursor_count = self.active_cursors().count();
+            let cursor = self.active_cursors().primary();
+            (
+                self.active_buffer(),
+                cursor.position,
+                cursor_count,
+                cursor.collapsed(),
+                state.buffer.len(),
+                items.into_iter().next(),
+            )
+        };
+
+        if cursor_count != 1 || !cursor_collapsed {
+            self.clear_ghost_text();
+            return;
+        }
+
+        let Some(item) = suggestion_item else {
+            self.clear_ghost_text();
+            return;
+        };
+
+        let lsp_types::InlineCompletionItem {
+            insert_text,
+            insert_text_format,
+            range,
+            ..
+        } = item;
+
+        let mut suggestion = insert_text;
+        if insert_text_format == Some(lsp_types::InsertTextFormat::SNIPPET) {
+            suggestion = expand_snippet(&suggestion).text;
+        }
+
+        let suggestion = suggestion.lines().next().unwrap_or("").to_string();
+        if suggestion.is_empty() {
+            self.clear_ghost_text();
+            return;
+        }
+
+        let prefix = {
+            let state = self.active_state_mut();
+            if let Some(range) = range {
+                let start = state.buffer.line_col_to_position(
+                    range.start.line as usize,
+                    range.start.character as usize,
+                );
+                let end = state
+                    .buffer
+                    .line_col_to_position(range.end.line as usize, range.end.character as usize);
+                if cursor_pos >= start && cursor_pos <= end && start < cursor_pos {
+                    state.get_text_range(start, cursor_pos)
+                } else {
+                    let word_start = find_completion_word_start(&state.buffer, cursor_pos);
+                    if word_start < cursor_pos {
+                        state.get_text_range(word_start, cursor_pos)
+                    } else {
+                        String::new()
+                    }
+                }
+            } else {
+                let word_start = find_completion_word_start(&state.buffer, cursor_pos);
+                if word_start < cursor_pos {
+                    state.get_text_range(word_start, cursor_pos)
+                } else {
+                    String::new()
+                }
+            }
+        };
+
+        let prefix_lower = prefix.to_lowercase();
+        let suggestion_lower = suggestion.to_lowercase();
+        let prefix_char_count = prefix.chars().count();
+
+        let suffix = if prefix.is_empty() {
+            suggestion
+        } else if suggestion.starts_with(&prefix) || suggestion_lower.starts_with(&prefix_lower) {
+            let byte_idx = suggestion
+                .char_indices()
+                .nth(prefix_char_count)
+                .map(|(idx, _)| idx)
+                .unwrap_or(suggestion.len());
+            suggestion[byte_idx..].to_string()
+        } else {
+            String::new()
+        };
+
+        if suffix.is_empty() || buffer_len == 0 {
+            self.clear_ghost_text();
+            return;
+        }
+
+        let (anchor_pos, position) = if cursor_pos >= buffer_len {
+            (buffer_len.saturating_sub(1), VirtualTextPosition::AfterChar)
+        } else {
+            (cursor_pos, VirtualTextPosition::BeforeChar)
+        };
+
+        let style = Style::default()
+            .fg(self.theme.read().unwrap().line_number_fg)
+            .add_modifier(Modifier::DIM);
+
+        self.clear_ghost_text();
+        if let Some(state) = self.active_window_mut().buffers.get_mut(&buffer_id) {
+            state.virtual_texts.add_with_id_and_padding(
+                &mut state.marker_list,
+                anchor_pos,
+                suffix,
+                style,
+                position,
+                100,
+                GHOST_TEXT_ID.to_string(),
+                false,
+            );
+            self.active_window_mut().ghost_text_buffer_id = Some(buffer_id);
+        }
     }
 
     /// Handle LSP go-to-definition response
@@ -443,6 +704,48 @@ impl Editor {
         // Dispatch to the first handle that allows this feature
         let lsp = self.lsp_mut()?;
         let sh = lsp.handle_for_feature_mut(&language, feature)?;
+        Some(f(&sh.handle, &uri, &language))
+    }
+
+    /// Dispatch an inline-completion request to the first completion server
+    /// that explicitly advertised `textDocument/inlineCompletion`.
+    pub(crate) fn with_lsp_for_buffer_inline_completion<F, R>(
+        &mut self,
+        buffer_id: BufferId,
+        f: F,
+    ) -> Option<R>
+    where
+        F: FnOnce(&LspHandle, &crate::app::types::LspUri, &str) -> R,
+    {
+        use crate::services::lsp::manager::LspSpawnResult;
+
+        let (uri, language, file_path) = {
+            let metadata = self.active_window().buffer_metadata.get(&buffer_id)?;
+            if !metadata.lsp_enabled {
+                return None;
+            }
+            let uri = metadata.file_uri()?.clone();
+            let file_path = metadata.file_path().cloned();
+            let language = self
+                .windows
+                .get(&self.active_window)
+                .map(|w| &w.buffers)
+                .expect("active window present")
+                .get(&buffer_id)?
+                .language
+                .clone();
+            (uri, language, file_path)
+        };
+
+        let lsp = self.lsp_mut()?;
+        if lsp.try_spawn(&language, file_path.as_deref()) != LspSpawnResult::Spawned {
+            return None;
+        }
+
+        self.ensure_did_open_all(buffer_id, &uri, &language)?;
+
+        let lsp = self.lsp_mut()?;
+        let sh = lsp.handle_for_inline_completion_mut(&language)?;
         Some(f(&sh.handle, &uri, &language))
     }
 
@@ -797,6 +1100,9 @@ impl Editor {
             // Cancel any pending scheduled trigger
             self.active_window_mut().scheduled_completion_trigger = None;
             self.request_completion();
+            if let Err(err) = self.request_inline_completion_automatic() {
+                tracing::debug!("Failed to request inline completion: {err}");
+            }
             return;
         }
 
@@ -1431,8 +1737,11 @@ impl Editor {
         use crate::view::virtual_text::VirtualTextPosition;
         use ratatui::style::{Color, Style};
 
-        // Clear existing inlay hints
-        state.virtual_texts.clear(&mut state.marker_list);
+        // Clear existing inlay hints, preserving unrelated virtual text such as ghost text.
+        const INLAY_HINT_PREFIX: &str = "lsp-inlay:";
+        state
+            .virtual_texts
+            .remove_by_prefix(&mut state.marker_list, INLAY_HINT_PREFIX);
 
         if hints.is_empty() {
             return;
@@ -1446,7 +1755,7 @@ impl Editor {
         let hint_style = Style::default().fg(Color::Rgb(128, 128, 128));
         let hint_fg_theme_key = Some("editor.line_number_fg".to_string());
 
-        for hint in hints {
+        for (idx, hint) in hints.iter().enumerate() {
             // Convert LSP position to byte offset
             let byte_offset = state.buffer.lsp_position_to_byte(
                 hint.position.line as usize,
@@ -1516,7 +1825,12 @@ impl Editor {
                 VirtualTextPosition::BeforeChar => crate::view::virtual_text::MarkerGravity::Left,
                 _ => crate::view::virtual_text::MarkerGravity::Right,
             };
-            state.virtual_texts.add_with_theme_keys(
+            let string_id = format!(
+                "{}{}:{}:{}",
+                INLAY_HINT_PREFIX, hint.position.line, hint.position.character, idx
+            );
+
+            state.virtual_texts.add_with_id_and_theme_keys(
                 &mut state.marker_list,
                 byte_offset,
                 display_text,
@@ -1525,6 +1839,7 @@ impl Editor {
                 None,
                 position,
                 0, // Default priority
+                string_id,
                 gravity,
             );
         }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -105,20 +105,66 @@ const GHOST_TEXT_ID: &str = "ghost-text";
 impl Editor {
     /// Clear any active ghost text (inline completion) from the buffer.
     pub(crate) fn clear_ghost_text(&mut self) {
-        let Some(buffer_id) = self.active_window_mut().ghost_text_buffer_id.take() else {
-            return;
+        let buffer_id = {
+            let window = self.active_window_mut();
+            window.ghost_text_completion = None;
+            window.ghost_text_buffer_id.take()
         };
 
-        let active_window = self.active_window;
-        if let Some(state) = self
-            .windows
-            .get_mut(&active_window)
-            .and_then(|window| window.buffers.get_mut(&buffer_id))
-        {
-            state
-                .virtual_texts
-                .remove_by_id(&mut state.marker_list, GHOST_TEXT_ID);
+        if let Some(buffer_id) = buffer_id {
+            let active_window = self.active_window;
+            if let Some(state) = self
+                .windows
+                .get_mut(&active_window)
+                .and_then(|window| window.buffers.get_mut(&buffer_id))
+            {
+                state
+                    .virtual_texts
+                    .remove_by_id(&mut state.marker_list, GHOST_TEXT_ID);
+            }
         }
+    }
+
+    /// Accept the active inline-completion ghost text, if it still matches
+    /// the active buffer and cursor.
+    pub(crate) fn accept_ghost_text(&mut self) -> bool {
+        let Some(completion) = self.active_window().ghost_text_completion.clone() else {
+            return false;
+        };
+
+        let buffer_id = self.active_buffer();
+        let cursor_count = self.active_cursors().count();
+        let cursor = self.active_cursors().primary();
+        if buffer_id != completion.buffer_id
+            || cursor_count != 1
+            || !cursor.collapsed()
+            || cursor.position != completion.cursor_position
+        {
+            self.clear_ghost_text();
+            return false;
+        }
+
+        let cursor_id = self.active_cursors().primary_id();
+        let event = Event::Insert {
+            position: completion.cursor_position,
+            text: completion.suffix,
+            cursor_id,
+        };
+
+        self.active_window_mut().cancel_pending_lsp_requests();
+        self.clear_ghost_text();
+        if self.active_state().popups.top().is_some_and(|popup| {
+            matches!(
+                popup.resolver,
+                crate::view::popup::PopupResolver::Completion
+            )
+        }) {
+            self.hide_popup();
+            self.active_window_mut().completion_items = None;
+        }
+        self.active_event_log_mut().append(event.clone());
+        self.apply_event_to_active_buffer(&event);
+        true
     }
 
     /// Request inline completion (ghost text) with an automatic trigger.
@@ -475,7 +521,7 @@ impl Editor {
             state.virtual_texts.add_with_id_and_padding(
                 &mut state.marker_list,
                 anchor_pos,
-                suffix,
+                suffix.clone(),
                 style,
                 position,
                 100,
@@ -483,6 +529,12 @@ impl Editor {
                 false,
             );
             self.active_window_mut().ghost_text_buffer_id = Some(buffer_id);
+            self.active_window_mut().ghost_text_completion =
+                Some(crate::app::window::InlineCompletionGhostText {
+                    buffer_id,
+                    cursor_position: cursor_pos,
+                    suffix,
+                });
         }
     }
 
@@ -1063,15 +1115,17 @@ impl Editor {
     /// Check if the inserted character should trigger completion
     /// and if so, request completion automatically (possibly after a delay).
     ///
-    /// Only triggers when `completion_popup_auto_show` is enabled. Then:
+    /// Triggers when either automatic popup completions or ghost text are
+    /// enabled. Then:
     /// 1. Trigger characters (like `.`, `::`, etc.): immediate if suggest_on_trigger_characters is enabled
     /// 2. Word characters: delayed by quick_suggestions_delay_ms if quick_suggestions is enabled
     ///
     /// This provides VS Code-like behavior where suggestions appear while typing,
     /// with debouncing to avoid spamming the LSP server.
     pub(crate) fn maybe_trigger_completion(&mut self, c: char) {
-        // Auto-show must be enabled for any automatic triggering
-        if !self.config.editor.completion_popup_auto_show {
+        let auto_show_popup = self.config.editor.completion_popup_auto_show;
+        let auto_show_ghost_text = self.config.editor.enable_ghost_text;
+        if !auto_show_popup && !auto_show_ghost_text {
             return;
         }
 
@@ -1099,9 +1153,13 @@ impl Editor {
             );
             // Cancel any pending scheduled trigger
             self.active_window_mut().scheduled_completion_trigger = None;
-            self.request_completion();
-            if let Err(err) = self.request_inline_completion_automatic() {
-                tracing::debug!("Failed to request inline completion: {err}");
+            if auto_show_popup {
+                self.request_completion();
+            }
+            if auto_show_ghost_text {
+                if let Err(err) = self.request_inline_completion_automatic() {
+                    tracing::debug!("Failed to request inline completion: {err}");
+                }
             }
             return;
         }

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -471,6 +471,7 @@ impl Editor {
                 vtext_position,
                 0, // priority
                 virtual_text_id,
+                crate::view::virtual_text::MarkerGravity::Right,
             );
         }
     }

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -368,6 +368,9 @@ impl Editor {
     pub fn handle_popup_cancel(&mut self) {
         use crate::view::popup::PopupResolver;
 
+        self.active_window_mut().cancel_pending_lsp_requests();
+        self.clear_ghost_text();
+
         let resolver = if self.global_popups.is_visible() {
             self.global_popups.top().map(|p| p.resolver.clone())
         } else {

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -869,14 +869,18 @@ impl Editor {
             self.request_inlay_hints_for_active_buffer();
             self.set_status_message(t!("toggle.inlay_hints_enabled").to_string());
         } else {
-            // Clear inlay hints from all buffers
-            for (_, state) in self
+            // Clear inlay hints from all buffers while preserving other virtual text.
+            for state in self
                 .windows
                 .get_mut(&self.active_window)
                 .map(|w| &mut w.buffers)
                 .expect("active window present")
+                .as_map_mut()
+                .values_mut()
             {
-                state.virtual_texts.clear(&mut state.marker_list);
+                state
+                    .virtual_texts
+                    .remove_by_prefix(&mut state.marker_list, "lsp-inlay:");
             }
             self.set_status_message(t!("toggle.inlay_hints_disabled").to_string());
         }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -67,6 +67,12 @@ use std::sync::Arc;
 /// against the cursor's byte, so a generous bound costs nothing but is still a
 /// bound.
 const VISIBLE_WINDOW_SCAN_BYTES: usize = 256 * 1024;
+#[derive(Clone, Debug)]
+pub(crate) struct InlineCompletionGhostText {
+    pub buffer_id: BufferId,
+    pub cursor_position: usize,
+    pub suffix: String,
+}
 
 /// A project-rooted unit of editor state.
 ///
@@ -456,6 +462,9 @@ pub struct Window {
 
     /// Buffer currently showing inline ghost text for completion.
     pub ghost_text_buffer_id: Option<BufferId>,
+
+    /// Active inline completion text that can be accepted into the buffer.
+    pub(crate) ghost_text_completion: Option<InlineCompletionGhostText>,
 
     /// Scheduled completion-trigger time (debounced quick-suggestions).
     pub scheduled_completion_trigger: Option<std::time::Instant>,
@@ -2390,6 +2399,7 @@ impl Window {
             completion_popup_lsp_items: Vec::new(),
             pending_completion_resolve_request: None,
             ghost_text_buffer_id: None,
+            ghost_text_completion: None,
             scheduled_completion_trigger: None,
             dabbrev_state: None,
             pending_goto_definition_request: None,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -428,6 +428,9 @@ pub struct Window {
     /// candidates it carries are only resolvable against that server.
     pub pending_completion_requests: std::collections::HashMap<u64, u64>,
 
+    /// Pending LSP inline-completion request id.
+    pub pending_inline_completion_request: Option<u64>,
+
     /// Original LSP completion candidates (for type-to-filter), merged
     /// from every server that answered.
     pub completion_items: Option<Vec<LspCompletionCandidate>>,
@@ -450,6 +453,9 @@ pub struct Window {
     /// resolve the user has already moved past would apply an import for a
     /// candidate that is no longer the accepted one.
     pub pending_completion_resolve_request: Option<u64>,
+
+    /// Buffer currently showing inline ghost text for completion.
+    pub ghost_text_buffer_id: Option<BufferId>,
 
     /// Scheduled completion-trigger time (debounced quick-suggestions).
     pub scheduled_completion_trigger: Option<std::time::Instant>,
@@ -1454,6 +1460,7 @@ impl Window {
     /// goto-definition request whose response would still be relevant.
     pub fn has_pending_lsp_requests(&self) -> bool {
         !self.pending_completion_requests.is_empty()
+            || self.pending_inline_completion_request.is_some()
             || self.pending_goto_definition_request.is_some()
     }
 
@@ -1474,6 +1481,13 @@ impl Window {
                 tracing::debug!("Canceling pending LSP completion request {}", request_id);
                 self.send_lsp_cancel_request(request_id);
             }
+        }
+        if let Some(request_id) = self.pending_inline_completion_request.take() {
+            tracing::debug!(
+                "Canceling pending LSP inline completion request {}",
+                request_id
+            );
+            self.send_lsp_cancel_request(request_id);
         }
         if let Some(request_id) = self.pending_goto_definition_request.take() {
             tracing::debug!(
@@ -2371,9 +2385,11 @@ impl Window {
             bridge,
             next_lsp_request_id: 0,
             pending_completion_requests: std::collections::HashMap::new(),
+            pending_inline_completion_request: None,
             completion_items: None,
             completion_popup_lsp_items: Vec::new(),
             pending_completion_resolve_request: None,
+            ghost_text_buffer_id: None,
             scheduled_completion_trigger: None,
             dabbrev_state: None,
             pending_goto_definition_request: None,

--- a/crates/fresh-editor/src/input/router.rs
+++ b/crates/fresh-editor/src/input/router.rs
@@ -616,6 +616,8 @@ pub fn cancels_pending_lsp(action: &Action) -> bool {
             | Action::LspReferences
             | Action::LspImplementation
             | Action::LspHover
+            | Action::CompletionAccept
+            | Action::InsertTab
             | Action::None
     )
 }
@@ -1057,6 +1059,8 @@ mod tests {
         assert!(cancels_pending_lsp(&Action::Save));
         assert!(cancels_pending_lsp(&Action::InsertChar('x')));
         assert!(!cancels_pending_lsp(&Action::LspHover));
+        assert!(!cancels_pending_lsp(&Action::CompletionAccept));
+        assert!(!cancels_pending_lsp(&Action::InsertTab));
         assert!(!cancels_pending_lsp(&Action::None));
     }
 

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -12,8 +12,9 @@
 
 use crate::view::file_tree::{FileTreeView, NodeId};
 use lsp_types::{
-    CodeActionOrCommand, CompletionItem, Diagnostic, FoldingRange, InlayHint, Location,
-    SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
+    CodeActionOrCommand, CompletionItem, Diagnostic, FoldingRange, InlayHint, InlineCompletionItem,
+    Location, SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult,
+    SignatureHelp,
 };
 use serde_json::Value;
 use std::sync::mpsc;
@@ -168,6 +169,12 @@ pub enum AsyncMessage {
     LspCompletion {
         request_id: u64,
         items: Vec<CompletionItem>,
+    },
+
+    /// LSP inline completion response (textDocument/inlineCompletion)
+    LspInlineCompletion {
+        request_id: u64,
+        items: Vec<InlineCompletionItem>,
     },
 
     /// LSP go-to-definition response

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -383,11 +383,11 @@ fn create_client_capabilities() -> ClientCapabilities {
         FoldingRangeCapability, FoldingRangeClientCapabilities, FoldingRangeKind,
         FoldingRangeKindCapability, GeneralClientCapabilities, GotoCapability,
         HoverClientCapabilities, InlayHintClientCapabilities, InlayHintWorkspaceClientCapabilities,
-        MarkupKind, PublishDiagnosticsClientCapabilities, RenameClientCapabilities,
-        SemanticTokensWorkspaceClientCapabilities, SignatureHelpClientCapabilities, TagSupport,
-        TextDocumentClientCapabilities, TextDocumentSyncClientCapabilities,
-        WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
-        WorkspaceSymbolClientCapabilities,
+        InlineCompletionClientCapabilities, MarkupKind, PublishDiagnosticsClientCapabilities,
+        RenameClientCapabilities, SemanticTokensWorkspaceClientCapabilities,
+        SignatureHelpClientCapabilities, TagSupport, TextDocumentClientCapabilities,
+        TextDocumentSyncClientCapabilities, WorkspaceClientCapabilities,
+        WorkspaceEditClientCapabilities, WorkspaceSymbolClientCapabilities,
     };
 
     ClientCapabilities {
@@ -491,6 +491,9 @@ fn create_client_capabilities() -> ClientCapabilities {
                     ..Default::default()
                 }),
                 ..Default::default()
+            }),
+            inline_completion: Some(InlineCompletionClientCapabilities {
+                dynamic_registration: Some(true),
             }),
             hover: Some(HoverClientCapabilities {
                 dynamic_registration: Some(true),
@@ -703,6 +706,11 @@ fn extract_capability_summary(caps: &ServerCapabilities) -> ServerCapabilitySumm
             .as_ref()
             .and_then(|cp| cp.trigger_characters.clone())
             .unwrap_or_default(),
+        inline_completion: match caps.inline_completion_provider.as_ref() {
+            Some(lsp_types::OneOf::Left(true)) => true,
+            Some(lsp_types::OneOf::Right(_)) => true,
+            _ => false,
+        },
         definition: bool_or_options(&caps.definition_provider, |p| match p {
             lsp_types::OneOf::Left(v) => *v,
             lsp_types::OneOf::Right(_) => true,
@@ -814,6 +822,16 @@ enum LspCommand {
         uri: Uri,
         line: u32,
         character: u32,
+    },
+
+    /// Request inline completion at position (textDocument/inlineCompletion)
+    InlineCompletion {
+        request_id: u64,
+        uri: Uri,
+        line: u32,
+        character: u32,
+        trigger_kind: lsp_types::InlineCompletionTriggerKind,
+        selected_completion_info: Option<lsp_types::SelectedCompletionInfo>,
     },
 
     /// Request go-to-definition
@@ -2339,6 +2357,69 @@ impl LspState {
         }
     }
 
+    /// Handle inline completion request
+    async fn handle_inline_completion(
+        &self,
+        request_id: u64,
+        uri: Uri,
+        line: u32,
+        character: u32,
+        trigger_kind: lsp_types::InlineCompletionTriggerKind,
+        selected_completion_info: Option<lsp_types::SelectedCompletionInfo>,
+        pending: &PendingRequests,
+    ) -> Result<(), String> {
+        tracing::trace!(
+            "LSP: inline completion request at {}:{}:{}",
+            uri.as_str(),
+            line,
+            character
+        );
+
+        let params = lsp_types::InlineCompletionParams {
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            text_document_position: Self::text_document_position(uri, line, character),
+            context: lsp_types::InlineCompletionContext {
+                trigger_kind,
+                selected_completion_info,
+            },
+        };
+
+        match self
+            .send_request_sequential_tracked::<_, Value>(
+                lsp_types::request::InlineCompletionRequest::METHOD,
+                Some(params),
+                pending,
+                Some(request_id),
+            )
+            .await
+        {
+            Ok(result) => {
+                let items =
+                    serde_json::from_value::<Option<lsp_types::InlineCompletionResponse>>(result)
+                        .ok()
+                        .flatten()
+                        .map(|response| match response {
+                            lsp_types::InlineCompletionResponse::Array(items) => items,
+                            lsp_types::InlineCompletionResponse::List(list) => list.items,
+                        })
+                        .unwrap_or_default();
+
+                let _ = self
+                    .async_tx
+                    .send(AsyncMessage::LspInlineCompletion { request_id, items });
+                Ok(())
+            }
+            Err(e) => {
+                tracing::debug!("Inline completion request failed: {}", e);
+                let _ = self.async_tx.send(AsyncMessage::LspInlineCompletion {
+                    request_id,
+                    items: vec![],
+                });
+                Err(e)
+            }
+        }
+    }
+
     /// Handle completionItem/resolve request
     async fn handle_completion_resolve(
         &self,
@@ -3566,6 +3647,35 @@ impl LspTask {
                     } else {
                         tracing::trace!("LSP not initialized, sending empty completion");
                         let _ = state.async_tx.send(AsyncMessage::LspCompletion {
+                            request_id,
+                            items: vec![],
+                        });
+                    }
+                }
+                LspCommand::InlineCompletion {
+                    request_id,
+                    uri,
+                    line,
+                    character,
+                    trigger_kind,
+                    selected_completion_info,
+                } => {
+                    if initialized {
+                        tracing::info!("Processing InlineCompletion request for {}", uri.as_str());
+                        spawn_request!(state, pending, |s, p| s
+                            .handle_inline_completion(
+                                request_id,
+                                uri,
+                                line,
+                                character,
+                                trigger_kind,
+                                selected_completion_info,
+                                &p,
+                            )
+                            .await);
+                    } else {
+                        tracing::trace!("LSP not initialized, sending empty inline completion");
+                        let _ = state.async_tx.send(AsyncMessage::LspInlineCompletion {
                             request_id,
                             items: vec![],
                         });
@@ -5182,6 +5292,28 @@ impl LspHandle {
                 character,
             })
             .map_err(|_| "Failed to send completion command".to_string())
+    }
+
+    /// Request inline completion at position.
+    pub fn inline_completion(
+        &self,
+        request_id: u64,
+        uri: Uri,
+        line: u32,
+        character: u32,
+        trigger_kind: lsp_types::InlineCompletionTriggerKind,
+        selected_completion_info: Option<lsp_types::SelectedCompletionInfo>,
+    ) -> Result<(), String> {
+        self.command_tx
+            .try_send(LspCommand::InlineCompletion {
+                request_id,
+                uri,
+                line,
+                character,
+                trigger_kind,
+                selected_completion_info,
+            })
+            .map_err(|_| "Failed to send inline completion command".to_string())
     }
 
     /// Request go-to-definition

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -198,6 +198,7 @@ pub struct ServerCapabilitySummary {
     pub completion: bool,
     pub completion_resolve: bool,
     pub completion_trigger_characters: Vec<String>,
+    pub inline_completion: bool,
     pub definition: bool,
     pub implementation: bool,
     pub references: bool,
@@ -268,6 +269,7 @@ impl ServerCapabilitySummary {
                     self.completion_resolve = false;
                 }
             }
+            "textDocument/inlineCompletion" => self.inline_completion = register,
             "textDocument/definition" => self.definition = register,
             "textDocument/implementation" => self.implementation = register,
             "textDocument/references" => self.references = register,
@@ -700,6 +702,42 @@ impl LspManager {
                     .completion_trigger_characters
                     .contains(&ch_str)
         })
+    }
+
+    /// Check if any eligible completion server supports inline completion.
+    pub fn inline_completion_supported(&self, language: &str) -> bool {
+        self.inline_completion_support(language) == Some(true)
+    }
+
+    /// Get inline completion support if capability data is known for this language.
+    pub fn inline_completion_support(&self, language: &str) -> Option<bool> {
+        let mut saw_initialized_completion_server = false;
+        for sh in self.get_handles(language) {
+            if !sh.feature_filter.allows(LspFeature::Completion) || !sh.capabilities.initialized {
+                continue;
+            }
+            saw_initialized_completion_server = true;
+            if sh.capabilities.inline_completion {
+                return Some(true);
+            }
+        }
+
+        saw_initialized_completion_server.then_some(false)
+    }
+
+    /// Get the first mutable handle for a language that supports inline completion.
+    pub fn handle_for_inline_completion_mut(
+        &mut self,
+        language: &str,
+    ) -> Option<&mut ServerHandle> {
+        self.handles
+            .iter_mut()
+            .filter(|sh| sh.handle.scope().accepts(language))
+            .find(|sh| {
+                sh.feature_filter.allows(LspFeature::Completion)
+                    && sh.capabilities.initialized
+                    && sh.capabilities.inline_completion
+            })
     }
 
     /// Try to spawn an LSP server, checking auto_start configuration

--- a/crates/fresh-editor/src/view/ui/split_rendering/char_style.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/char_style.rs
@@ -92,6 +92,9 @@ pub(super) fn compute_char_style(ctx: &CharStyleContext) -> CharStyleOutput {
         if ts.underline {
             s = s.add_modifier(Modifier::UNDERLINED);
         }
+        if ts.dim {
+            s = s.add_modifier(Modifier::DIM);
+        }
         region = "Plugin Token";
         s
     } else if ctx.ansi_style.fg.is_some()

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -362,7 +362,6 @@ pub(crate) fn decoration_context(
     } else {
         BTreeMap::new()
     };
-
     DecorationContext {
         highlight_spans,
         semantic_token_spans,

--- a/crates/fresh-editor/src/view/ui/split_rendering/style.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/style.rs
@@ -25,6 +25,7 @@ pub(super) fn token_style_from_ratatui(style: Style) -> ViewTokenStyle {
         bold: style.add_modifier.contains(Modifier::BOLD),
         italic: style.add_modifier.contains(Modifier::ITALIC),
         underline: style.add_modifier.contains(Modifier::UNDERLINED),
+        dim: style.add_modifier.contains(Modifier::DIM),
     }
 }
 
@@ -50,6 +51,7 @@ pub(super) fn fold_placeholder_style(theme: &Theme) -> ViewTokenStyle {
         bold: false,
         italic: true,
         underline: false,
+        dim: false,
     }
 }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -631,12 +631,12 @@ pub(super) fn inject_virtual_lines(
     result
 }
 
-/// One inline inlay-hint cell to splice into the token stream, already
-/// padded to match the legacy render-time spacing and resolved to a wire
-/// style.
+/// One inline inlay-hint cell to splice into the token stream, with spacing
+/// policy and resolved wire style.
 struct InlineHintCell {
     text: String,
     style: Option<ViewTokenStyle>,
+    pad_with_space: bool,
 }
 
 /// One inline hint, resolved: everything the splice needs and no borrow of
@@ -654,6 +654,7 @@ pub struct InlineHint {
     /// would have to assume one, and a snapshot that disagrees with the live
     /// marker makes the index lay out a line the renderer never draws.
     pub gravity: crate::view::virtual_text::MarkerGravity,
+    pub pad_with_space: bool,
     /// `None` when the caller passed no theme — the scroll-math and index
     /// paths, where only the cell's *width* matters and nothing is drawn.
     pub style: Option<ViewTokenStyle>,
@@ -694,6 +695,7 @@ pub fn resolve_inline_hints(
             text: vtext.text.clone(),
             position: vtext.position,
             gravity: vtext.gravity,
+            pad_with_space: vtext.pad_with_space,
             style: theme.map(|t| token_style_from_ratatui(vtext.resolved_style(t))),
         })
         .collect()
@@ -712,11 +714,13 @@ pub fn resolve_inline_hints(
 /// pushed real text past the row edge) and clipped the end of hinted lines
 /// when scrolling.
 ///
-/// Padding mirrors the old render-time injection exactly so output is
-/// unchanged except for the bug fix:
+/// When `VirtualText::pad_with_space` is true, padding mirrors the old
+/// render-time injection exactly so normal inlay-hint output is unchanged:
 ///   - `BeforeChar`: `"{text} "`, or `" {text} "` when anchored on a
 ///     newline (an end-of-line hint).
 ///   - `AfterChar`:  `" {text}"`.
+/// Ghost text uses `pad_with_space = false`, so its suffix stays adjacent to
+/// the typed prefix.
 ///
 /// Takes hints already resolved by [`resolve_inline_hints`] rather than
 /// `&EditorState`, which is what lets the wrap index call it: the index builds
@@ -732,23 +736,24 @@ pub fn splice_inline_virtual_text(
     }
 
     // Group by anchor byte, preserving the resolver's (position, priority)
-    // order. `before` stores the raw hint text — its leading-space padding
-    // depends on whether the anchor cell is a newline, decided while
-    // walking the token stream below.
-    let mut before: HashMap<usize, Vec<(String, Option<ViewTokenStyle>)>> = HashMap::new();
+    // order. `BeforeChar` leading-space padding depends on whether the anchor
+    // cell is a newline, decided while walking the token stream below.
+    let mut before: HashMap<usize, Vec<InlineHintCell>> = HashMap::new();
     let mut after: HashMap<usize, Vec<InlineHintCell>> = HashMap::new();
     for hint in hints {
         match hint.position {
             VirtualTextPosition::BeforeChar => {
-                before
-                    .entry(hint.anchor)
-                    .or_default()
-                    .push((hint.text.clone(), hint.style.clone()));
+                before.entry(hint.anchor).or_default().push(InlineHintCell {
+                    text: hint.text.clone(),
+                    style: hint.style.clone(),
+                    pad_with_space: hint.pad_with_space,
+                });
             }
             VirtualTextPosition::AfterChar => {
                 after.entry(hint.anchor).or_default().push(InlineHintCell {
-                    text: format!(" {}", hint.text),
+                    text: hint.text.clone(),
                     style: hint.style.clone(),
+                    pad_with_space: hint.pad_with_space,
                 });
             }
             // Line-level positions are handled by `inject_virtual_lines`.
@@ -791,8 +796,13 @@ pub fn splice_inline_virtual_text(
                             });
                         }
                         seg_start = anchor;
-                        for (text, style) in hints {
-                            out.push(virt(format!("{text} "), style.clone()));
+                        for hint in hints {
+                            let text = if hint.pad_with_space {
+                                format!("{} ", hint.text)
+                            } else {
+                                hint.text.clone()
+                            };
+                            out.push(virt(text, hint.style.clone()));
                         }
                     }
                     seg.push(ch);
@@ -805,7 +815,12 @@ pub fn splice_inline_virtual_text(
                         });
                         seg_start = token_start + byte_idx;
                         for hint in hints {
-                            out.push(virt(hint.text.clone(), hint.style.clone()));
+                            let text = if hint.pad_with_space {
+                                format!(" {}", hint.text)
+                            } else {
+                                hint.text.clone()
+                            };
+                            out.push(virt(text, hint.style.clone()));
                         }
                     }
                 }
@@ -831,20 +846,29 @@ pub fn splice_inline_virtual_text(
                 let anchor_is_newline = matches!(kind, ViewTokenWireKind::Newline);
                 let empty_line = anchor_is_newline && line_start_cell;
                 if let Some(hints) = before.get(&anchor) {
-                    for (text, style) in hints {
-                        let padded = match (anchor_is_newline, empty_line) {
-                            (_, true) => text.clone(),
-                            (true, false) => format!(" {text} "),
-                            (false, _) => format!("{text} "),
+                    for hint in hints {
+                        let text = if hint.pad_with_space {
+                            match (anchor_is_newline, empty_line) {
+                                (_, true) => hint.text.clone(),
+                                (true, false) => format!(" {} ", hint.text),
+                                (false, _) => format!("{} ", hint.text),
+                            }
+                        } else {
+                            hint.text.clone()
                         };
-                        out.push(virt(padded, style.clone()));
+                        out.push(virt(text, hint.style.clone()));
                     }
                 }
                 let after_hints = after.get(&anchor);
                 out.push(token);
                 if let Some(hints) = after_hints {
                     for hint in hints {
-                        out.push(virt(hint.text.clone(), hint.style.clone()));
+                        let text = if hint.pad_with_space {
+                            format!(" {}", hint.text)
+                        } else {
+                            hint.text.clone()
+                        };
+                        out.push(virt(text, hint.style.clone()));
                     }
                 }
             }

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -130,6 +130,9 @@ pub struct VirtualText {
     pub bg_theme_key: Option<String>,
     /// Where to render relative to the marker position
     pub position: VirtualTextPosition,
+    /// Whether to pad with spaces when rendering inline text
+    /// (default: true for inlay hints and other annotations)
+    pub pad_with_space: bool,
     /// Priority for ordering multiple items at same position (higher = later)
     pub priority: i32,
     /// Optional string identifier for this virtual text (for plugin use)
@@ -264,6 +267,7 @@ impl VirtualTextManager {
                 fg_theme_key: None,
                 bg_theme_key: None,
                 position: vtext_position,
+                pad_with_space: true,
                 priority,
                 string_id: None,
                 namespace: None,
@@ -325,6 +329,7 @@ impl VirtualTextManager {
                 fg_theme_key,
                 bg_theme_key,
                 position: vtext_position,
+                pad_with_space: true,
                 priority,
                 string_id: None,
                 namespace: None,
@@ -367,6 +372,7 @@ impl VirtualTextManager {
                 fg_theme_key: None,
                 bg_theme_key: None,
                 position: vtext_position,
+                pad_with_space: true,
                 priority,
                 string_id: Some(string_id),
                 namespace: None,
@@ -394,13 +400,14 @@ impl VirtualTextManager {
         vtext_position: VirtualTextPosition,
         priority: i32,
         string_id: String,
+        gravity: MarkerGravity,
     ) -> VirtualTextId {
         debug_assert!(
             vtext_position.is_inline(),
             "add_with_id_and_theme_keys requires BeforeChar or AfterChar"
         );
 
-        let marker_id = marker_list.create(position);
+        let marker_id = gravity.create(marker_list, position);
 
         let id = VirtualTextId(self.next_id);
         self.next_id += 1;
@@ -409,12 +416,13 @@ impl VirtualTextManager {
             id,
             VirtualText {
                 marker_id,
-                gravity: MarkerGravity::Right,
+                gravity,
                 text,
                 style,
                 fg_theme_key,
                 bg_theme_key,
                 position: vtext_position,
+                pad_with_space: true,
                 priority,
                 string_id: Some(string_id),
                 namespace: None,
@@ -423,6 +431,7 @@ impl VirtualTextManager {
                 text_overlays: Vec::new(),
             },
         );
+        self.bump_version();
 
         id
     }
@@ -509,12 +518,58 @@ impl VirtualTextManager {
                 fg_theme_key,
                 bg_theme_key,
                 position: placement,
+                pad_with_space: true,
                 priority,
                 string_id: None,
                 namespace: Some(namespace),
                 gutter_glyph,
                 gutter_color,
                 text_overlays,
+            },
+        );
+        self.bump_version();
+
+        id
+    }
+
+    /// Add a virtual text entry with a string identifier and custom padding behavior
+    ///
+    /// This is useful for inline features like ghost text that should not add
+    /// extra spacing around the inserted text.
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_with_id_and_padding(
+        &mut self,
+        marker_list: &mut MarkerList,
+        position: usize,
+        text: String,
+        style: Style,
+        vtext_position: VirtualTextPosition,
+        priority: i32,
+        string_id: String,
+        pad_with_space: bool,
+    ) -> VirtualTextId {
+        let marker_id = marker_list.create(position);
+
+        let id = VirtualTextId(self.next_id);
+        self.next_id += 1;
+
+        self.texts.insert(
+            id,
+            VirtualText {
+                marker_id,
+                gravity: MarkerGravity::Right,
+                text,
+                style,
+                fg_theme_key: None,
+                bg_theme_key: None,
+                position: vtext_position,
+                pad_with_space,
+                priority,
+                string_id: Some(string_id),
+                namespace: None,
+                gutter_glyph: None,
+                gutter_color: None,
+                text_overlays: Vec::new(),
             },
         );
         self.bump_version();

--- a/crates/fresh-editor/src/view/wrap_index.rs
+++ b/crates/fresh-editor/src/view/wrap_index.rs
@@ -1674,6 +1674,7 @@ mod tests {
             position: VirtualTextPosition::BeforeChar,
             style: None,
             gravity,
+            pad_with_space: true,
         };
 
         let mut decorations = IndexDecorations {

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -73,7 +73,7 @@ while true; do
 case "$method" in
     "initialize")
         # Send initialize response
-        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".",":",":"]},"definitionProvider":true,"hoverProvider":true,"textDocumentSync":1,"semanticTokensProvider":{"legend":{"tokenTypes":["keyword","function","variable"],"tokenModifiers":["declaration","deprecated"]},"full":{"delta":true},"range":true}}}}'
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".",":",":"]},"inlineCompletionProvider":{},"definitionProvider":true,"hoverProvider":true,"textDocumentSync":1,"semanticTokensProvider":{"legend":{"tokenTypes":["keyword","function","variable"],"tokenModifiers":["declaration","deprecated"]},"full":{"delta":true},"range":true}}}}'
         ;;
     "textDocument/hover")
         # Send hover response with range
@@ -87,6 +87,9 @@ case "$method" in
     "textDocument/completion")
         # Send completion response with sample items
         send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[{"label":"test_function","kind":3,"detail":"fn test_function()","insertText":"test_function"},{"label":"test_variable","kind":6,"detail":"let test_variable","insertText":"test_variable"},{"label":"test_struct","kind":22,"detail":"struct TestStruct","insertText":"test_struct"}]}}'
+        ;;
+    "textDocument/inlineCompletion")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[{"insertText":"hello_world"}]}'
         ;;
     "textDocument/definition")
         # Send definition response (points to line 0, col 0)
@@ -1267,7 +1270,7 @@ while true; do
 case "$method" in
     "initialize")
         # Send initialize response
-        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".",":",":"]},"definitionProvider":true,"hoverProvider":true,"textDocumentSync":1}}}'
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".",":",":"]},"inlineCompletionProvider":{},"definitionProvider":true,"hoverProvider":true,"textDocumentSync":1}}}'
         ;;
     "textDocument/hover")
         # Send hover response with range
@@ -1278,6 +1281,9 @@ case "$method" in
         ;;
     "textDocument/completion")
         send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[{"label":"test_function","kind":3,"detail":"fn test_function()","insertText":"test_function"}]}}'
+        ;;
+    "textDocument/inlineCompletion")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[{"insertText":"hello_world"}]}'
         ;;
     "textDocument/definition")
         uri=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -253,6 +253,64 @@ fn test_lsp_completion_popup() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Test LSP inline completion renders ghost text
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_lsp_inline_completion_ghost_text() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "")?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_ghost_text = true;
+    config.editor.completion_popup_auto_show = true;
+    config.editor.quick_suggestions = true;
+    config.editor.quick_suggestions_delay_ms = 0;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    harness.type_text("hel")?;
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("hel") && screen.contains("lo_world")
+    })?;
+
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE)?;
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("hel") && !screen.contains("lo_world")
+    })?;
+
+    Ok(())
+}
+
 /// Test LSP diagnostics summary in status bar
 #[test]
 fn test_lsp_diagnostics_status_bar() -> anyhow::Result<()> {

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -6,6 +6,35 @@ use crate::common::harness::EditorTestHarness;
 use fresh::view::theme;
 
 use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::style::Modifier;
+
+fn screen_text_cell(
+    harness: &EditorTestHarness,
+    text: &str,
+    text_char_offset: usize,
+) -> Option<(u16, u16)> {
+    for y in 0..harness.buffer().area.height {
+        let row = harness.get_row_text(y);
+        if let Some(byte_col) = row.find(text) {
+            let x = row[..byte_col].chars().count() + text_char_offset;
+            return Some((x as u16, y));
+        }
+    }
+    None
+}
+
+fn screen_text_char_is_dim(
+    harness: &EditorTestHarness,
+    text: &str,
+    text_char_offset: usize,
+) -> bool {
+    let Some((x, y)) = screen_text_cell(harness, text, text_char_offset) else {
+        return false;
+    };
+    harness
+        .get_cell_style(x, y)
+        .is_some_and(|style| style.add_modifier.contains(Modifier::DIM))
+}
 
 /// Test that completion popup text is not mangled
 #[test]
@@ -277,7 +306,7 @@ fn test_lsp_inline_completion_ghost_text() -> anyhow::Result<()> {
             command: FakeLspServer::script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
-            args: vec![],
+            args: Some(vec![]),
             enabled: true,
             auto_start: true,
             process_limits: fresh::services::process_limits::ProcessLimits::default(),
@@ -299,13 +328,127 @@ fn test_lsp_inline_completion_ghost_text() -> anyhow::Result<()> {
     harness.type_text("hel")?;
     harness.wait_until(|h| {
         let screen = h.screen_to_string();
-        screen.contains("hel") && screen.contains("lo_world")
+        screen.contains("hel")
+            && screen.contains("lo_world")
+            && screen_text_char_is_dim(h, "hello_world", 3)
     })?;
 
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE)?;
     harness.wait_until(|h| {
         let screen = h.screen_to_string();
         screen.contains("hel") && !screen.contains("lo_world")
+    })?;
+
+    Ok(())
+}
+
+/// Test Tab accepts LSP inline completion ghost text.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_lsp_inline_completion_tab_accepts_ghost_text() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "")?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_ghost_text = true;
+    config.editor.completion_popup_auto_show = true;
+    config.editor.quick_suggestions = true;
+    config.editor.quick_suggestions_delay_ms = 0;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    harness.type_text("hel")?;
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("hel")
+            && screen.contains("lo_world")
+            && screen_text_char_is_dim(h, "hello_world", 3)
+    })?;
+
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE)?;
+    harness.type_text("X")?;
+    harness.wait_until(|h| h.screen_to_string().contains("hello_worldX"))?;
+
+    Ok(())
+}
+
+/// Test LSP inline completion does not require the completion popup to auto-show.
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_lsp_inline_completion_without_popup_auto_show() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "")?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_ghost_text = true;
+    config.editor.completion_popup_auto_show = false;
+    config.editor.quick_suggestions = true;
+    config.editor.quick_suggestions_delay_ms = 0;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: Some(vec![]),
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    harness.type_text("hel")?;
+    harness.wait_until(|h| {
+        let screen = h.screen_to_string();
+        screen.contains("hel")
+            && screen.contains("lo_world")
+            && screen_text_char_is_dim(h, "hello_world", 3)
     })?;
 
     Ok(())

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1033,27 +1033,31 @@ fn test_settings_search_result_click_navigates() {
     // Open settings
     harness.open_settings().unwrap();
 
-    // Search for "tab" which should match "Tab Size" in Editor category
+    // Search for "scroll offset" which should match an Editor setting visible
+    // in the current viewport after navigation.
     harness
         .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
         .unwrap();
-    for c in "tab".chars() {
+    for c in "scroll offset".chars() {
         harness
             .send_key(KeyCode::Char(c), KeyModifiers::NONE)
             .unwrap();
     }
     harness.render().unwrap();
 
-    // Should show search results with "Tab Size"
-    harness.assert_screen_contains("Tab Size");
+    // Should show search results with "Scroll Offset"
+    harness.assert_screen_contains("Scroll Offset");
 
-    // Find the position of "Tab Size" on screen
+    // Find the position of "Scroll Offset" on screen
     let screen = harness.screen_to_string();
     let result_pos = screen
         .lines()
         .enumerate()
-        .find_map(|(row, line)| line.find("Tab Size").map(|col| (col as u16, row as u16)))
-        .expect("Should find Tab Size in search results");
+        .find_map(|(row, line)| {
+            line.find("Scroll Offset")
+                .map(|col| (col as u16, row as u16))
+        })
+        .expect("Should find Scroll Offset in search results");
 
     // Click on the search result
     harness.mouse_click(result_pos.0 + 2, result_pos.1).unwrap();
@@ -1067,10 +1071,10 @@ fn test_settings_search_result_click_navigates() {
     );
 
     // The setting should be visible in the settings panel (not search results)
-    // We should see "Tab Size" as the selected setting with its control
-    harness.assert_screen_contains("Tab Size");
+    // We should see "Scroll Offset" as the selected setting with its control
+    harness.assert_screen_contains("Scroll Offset");
 
-    // We should be in the Editor category now (Tab Size is an Editor setting)
+    // We should be in the Editor category now (Scroll Offset is an Editor setting)
     harness.assert_screen_contains("Editor");
 
     // Close settings
@@ -1447,7 +1451,7 @@ fn test_settings_from_terminal_mode_captures_input() {
     // Editor category has settings organized by sections - Completion section comes first
     // If Down key worked in Settings, we should now be viewing Editor settings
     // Check for a setting in the visible Completion section
-    harness.assert_screen_contains("Quick Suggestions");
+    harness.assert_screen_contains("Enable Ghost Text");
 
     // Clean up - close settings
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
@@ -2317,18 +2321,18 @@ fn test_settings_loads_saved_values_on_reopen() {
     let mut harness = EditorTestHarness::new(100, 40).unwrap();
     harness.render().unwrap();
 
-    // Verify initial tab_size is 4 (default)
-    let initial_value = harness.config().editor.tab_size;
-    assert_eq!(initial_value, 4, "Initial tab_size should be 4");
+    // Verify initial scroll_offset is 3 (default)
+    let initial_value = harness.config().editor.scroll_offset;
+    assert_eq!(initial_value, 3, "Initial scroll_offset should be 3");
 
     // Open settings
     harness.open_settings().unwrap();
 
-    // Search for "tab size" to find the setting
+    // Search for "scroll offset" to find the setting
     harness
         .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
         .unwrap();
-    for c in "tab size".chars() {
+    for c in "scroll offset".chars() {
         harness
             .send_key(KeyCode::Char(c), KeyModifiers::NONE)
             .unwrap();
@@ -2341,8 +2345,9 @@ fn test_settings_loads_saved_values_on_reopen() {
         .unwrap();
     harness.render().unwrap();
 
-    // Should show the default value of 4
-    harness.assert_screen_contains("4");
+    // Should show the default value of 3
+    harness.assert_screen_contains("Scroll Offset");
+    harness.assert_screen_contains("3");
 
     // Type '5' to replace the value (direct typing auto-enters edit mode
     // with select-all, so the typed digit replaces the value). Tab commits.
@@ -2377,8 +2382,8 @@ fn test_settings_loads_saved_values_on_reopen() {
     );
 
     // Verify the config was updated
-    let saved_value = harness.config().editor.tab_size;
-    assert_eq!(saved_value, 5, "tab_size should be 5 after saving");
+    let saved_value = harness.config().editor.scroll_offset;
+    assert_eq!(saved_value, 5, "scroll_offset should be 5 after saving");
 
     // CRITICAL TEST: Reopen settings and verify the saved value is displayed
     harness.open_settings().unwrap();
@@ -2387,7 +2392,7 @@ fn test_settings_loads_saved_values_on_reopen() {
     harness
         .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
         .unwrap();
-    for c in "tab size".chars() {
+    for c in "scroll offset".chars() {
         harness
             .send_key(KeyCode::Char(c), KeyModifiers::NONE)
             .unwrap();
@@ -2401,6 +2406,7 @@ fn test_settings_loads_saved_values_on_reopen() {
     harness.render().unwrap();
 
     // Verify the saved value is displayed (not the default)
+    harness.assert_screen_contains("Scroll Offset");
     harness.assert_screen_contains("5");
 
     // Close settings


### PR DESCRIPTION
fix #686

Implemented LSP inline completion (ghost text) end‑to‑end and added Tab acceptance.
Inline completions are now requested on trigger/quick‑suggestion input and on manual completion, rendered as unpadded virtual text, and applied as proper LSP edits with snippet expansion.
Inlay hints no longer clear unrelated virtual text, so ghost text stays intact.
Updated LSP capability negotiation and tracking for inline completion support.
