### PR TITLE
fix: Resolve compiler warnings breaking nix build

### DIFF
--- a/crates/fresh-editor/src/app/shell_command.rs
+++ b/crates/fresh-editor/src/app/shell_command.rs
@@ -248,6 +248,7 @@ impl Editor {
 
     /// Execute a shell command blocking the UI.
     /// This is used for commands like `sudo` where we might need to wait for completion.
+    #[allow(dead_code)]
     pub(crate) fn run_shell_command_blocking(&mut self, command: &str) -> anyhow::Result<()> {
         use crossterm::terminal::{
             disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,

--- a/crates/fresh-editor/src/model/piece_tree.rs
+++ b/crates/fresh-editor/src/model/piece_tree.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read, Seek, SeekFrom};
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
+++ b/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
@@ -28,11 +28,13 @@ pub fn bracket_highlight_namespace() -> OverlayNamespace {
 const BRACKET_PAIRS: &[(char, char)] = &[('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')];
 
 /// Check if a character is an opening bracket
+#[cfg(test)]
 fn is_opening_bracket(ch: char) -> bool {
     BRACKET_PAIRS.iter().any(|(open, _)| *open == ch)
 }
 
 /// Check if a character is a closing bracket
+#[cfg(test)]
 fn is_closing_bracket(ch: char) -> bool {
     BRACKET_PAIRS.iter().any(|(_, close)| *close == ch)
 }

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -441,7 +441,7 @@ impl TabsRenderer {
         let total_width: usize = all_tab_spans.iter().map(|(_, w)| w).sum();
         // Use rendered_buffer_ids (not split_buffers) to find active index,
         // since some buffers may have been skipped if not in buffers HashMap
-        let active_tab_idx = rendered_buffer_ids
+        let _active_tab_idx = rendered_buffer_ids
             .iter()
             .position(|id| *id == active_buffer);
 

--- a/crates/fresh-editor/tests/property_agent_tests.rs
+++ b/crates/fresh-editor/tests/property_agent_tests.rs
@@ -142,6 +142,7 @@ impl AgentHarness {
         resp.result?.get("exists")?.as_bool()
     }
 
+    #[allow(dead_code)]
     fn mkdir(&mut self, path: &str) -> Option<AgentResponse> {
         self.send_request("mkdir", serde_json::json!({"path": path}))
     }


### PR DESCRIPTION
Remove unused imports, suppress dead code warnings for intentionally unused code, and mark test-only functions with #[cfg(test)].