### PR TITLE
Update file explorer keybindings and click behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ See [getfresh.dev/docs](https://getfresh.dev/docs)
 
 * **Event Debug Dialog**: New diagnostic tool for troubleshooting keyboard and terminal issues. Shows raw key codes and modifiers as they are received, helping diagnose keybinding problems. Access via Command Palette → "Event Debug".
 
+* **File Explorer Keybindings**: Reorganized the keys and updated the docs. Ctrl+E now toggles focus between file explorer and editor. Ctrl+B toggles sidebar visibility. Single-click opens files without leaving explorer; double-click or Enter opens and focuses editor (#748).
+
 ### Bug Fixes
 
 * **Case Conversion Enhancement**: To Upper (Alt+U) and To Lower (Alt+L) now automatically select the current word when no text is selected, matching common editor behavior.

--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -31,6 +31,14 @@
       "when": "global"
     },
     {
+      "comment": "Ctrl+E -> Focus file explorer (switch focus between explorer and editor)",
+      "key": "e",
+      "modifiers": ["ctrl"],
+      "action": "focus_file_explorer",
+      "args": {},
+      "when": "normal"
+    },
+    {
       "key": "v",
       "modifiers": ["alt"],
       "action": "menu_open",
@@ -234,10 +242,10 @@
       "when": "normal"
     },
     {
-      "comment": "Normal context - Focus file explorer",
-      "key": "e",
+      "comment": "Normal context - Toggle sidebar/file explorer visibility",
+      "key": "b",
       "modifiers": ["ctrl"],
-      "action": "focus_file_explorer",
+      "action": "toggle_file_explorer",
       "args": {},
       "when": "normal"
     },
@@ -1525,9 +1533,26 @@
       "when": "file_explorer"
     },
     {
+      "comment": "Ctrl+E -> Focus editor (switch focus from explorer to editor)",
       "key": "e",
       "modifiers": ["ctrl"],
       "action": "focus_editor",
+      "args": {},
+      "when": "file_explorer"
+    },
+    {
+      "comment": "Alt+] -> Focus last focused editor split",
+      "key": "]",
+      "modifiers": ["alt"],
+      "action": "focus_editor",
+      "args": {},
+      "when": "file_explorer"
+    },
+    {
+      "comment": "Ctrl+B -> Toggle sidebar/file explorer visibility",
+      "key": "b",
+      "modifiers": ["ctrl"],
+      "action": "toggle_file_explorer",
       "args": {},
       "when": "file_explorer"
     },

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1954,10 +1954,14 @@ impl Editor {
                         // Toggle expand/collapse using the existing method
                         self.file_explorer_toggle_expand();
                     } else if node.is_file() {
-                        // Open the file using the existing method
-                        self.file_explorer_open_file()?;
-                        // Switch focus back to editor after opening file
-                        self.key_context = crate::input::keybindings::KeyContext::Normal;
+                        // Open the file but keep focus on file explorer (single click)
+                        // Double-click or Enter will focus the editor
+                        let path = node.entry.path.clone();
+                        let name = node.entry.name.clone();
+                        self.open_file(&path)?;
+                        self.set_status_message(
+                            rust_i18n::t!("explorer.opened_file", name = &name).to_string(),
+                        );
                     }
                 }
             }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -872,6 +872,19 @@ impl Editor {
             return Ok(());
         }
 
+        // Is it in the file explorer? Double-click opens file AND focuses editor
+        if let Some(explorer_area) = self.cached_layout.file_explorer_area {
+            if col >= explorer_area.x
+                && col < explorer_area.x + explorer_area.width
+                && row > explorer_area.y // Skip title bar
+                && row < explorer_area.y + explorer_area.height
+            {
+                // Open file and focus editor (via file_explorer_open_file which calls focus_editor)
+                self.file_explorer_open_file()?;
+                return Ok(());
+            }
+        }
+
         // Find which split/buffer was clicked and handle double-click
         let split_areas = self.cached_layout.split_areas.clone();
         for (split_id, buffer_id, content_rect, _scrollbar_rect, _thumb_start, _thumb_end) in

--- a/docs/features/file-explorer.md
+++ b/docs/features/file-explorer.md
@@ -2,7 +2,8 @@
 
 Fresh includes a built-in file explorer to help you navigate your project's files.
 
-*   **Toggle:** Use `Ctrl+E` to open and close the file explorer.
+*   **Toggle Sidebar:** Use `Ctrl+B` to show/hide the file explorer sidebar.
+*   **Focus:** Use `Ctrl+E` to switch focus between the file explorer and editor.
 *   **Navigation:** Use the arrow keys to move up and down the file tree.
-*   **Open Files:** Press `Enter` to open the selected file.
+*   **Open Files:** Press `Enter` to open the selected file and focus the editor. Single-click opens a file but keeps focus on the explorer; double-click opens and focuses the editor.
 *   **Gitignore Support:** The file explorer respects your `.gitignore` file, hiding ignored files by default.


### PR DESCRIPTION
- Ctrl+E: switch focus between file explorer and editor
- Ctrl+B: toggle sidebar visibility
- Alt+]: focus editor from file explorer
- Single click on file: opens file but keeps focus on explorer
- Double click on file: opens file and focuses editor
- Enter key on file: opens file and focuses editor (unchanged)

Fixes #748