### PR TITLE
Use YAML sublime-syntax for language pack init and docs

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1385,7 +1385,7 @@ pub enum PluginCommand {
     RegisterGrammar {
         /// Language identifier (e.g., "elixir", "zig")
         language: String,
-        /// Path to the grammar file (.tmLanguage.json or .sublime-syntax)
+        /// Path to the grammar file (.sublime-syntax or .tmLanguage)
         grammar_path: String,
         /// File extensions to associate with this grammar (e.g., ["ex", "exs"])
         extensions: Vec<String>,

--- a/crates/fresh-editor/plugins/schemas/package.schema.json
+++ b/crates/fresh-editor/plugins/schemas/package.schema.json
@@ -98,7 +98,7 @@
           "properties": {
             "file": {
               "type": "string",
-              "description": "Path to TextMate grammar file (.tmLanguage.json)"
+              "description": "Path to grammar file (.sublime-syntax recommended, or .tmLanguage)"
             },
             "extensions": {
               "type": "array",

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -146,7 +146,7 @@ fn uri_to_path(uri: &lsp_types::Uri) -> Result<PathBuf, String> {
 pub struct PendingGrammar {
     /// Language identifier (e.g., "elixir")
     pub language: String,
-    /// Path to the grammar file (.tmLanguage.json or .sublime-syntax)
+    /// Path to the grammar file (.sublime-syntax or .tmLanguage)
     pub grammar_path: String,
     /// File extensions to associate with this grammar
     pub extensions: Vec<String>,

--- a/crates/fresh-editor/src/primitives/grammar/loader.rs
+++ b/crates/fresh-editor/src/primitives/grammar/loader.rs
@@ -233,14 +233,14 @@ fn process_manifest(
     }
 }
 
-/// Load a grammar directly from a .tmLanguage.json file.
+/// Load a grammar directly from a .sublime-syntax or .tmLanguage file.
 fn load_direct_grammar(
     loader: &dyn GrammarLoader,
     dir: &Path,
     builder: &mut SyntaxSetBuilder,
     found_any: &mut bool,
 ) {
-    // Look for .tmLanguage.json or .sublime-syntax files
+    // Look for .sublime-syntax or .tmLanguage files
     let entries = match loader.read_dir(dir) {
         Ok(e) => e,
         Err(_) => return,
@@ -249,10 +249,7 @@ fn load_direct_grammar(
     for path in entries {
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-        if file_name.ends_with(".tmLanguage.json")
-            || file_name.ends_with(".tmLanguage")
-            || file_name.ends_with(".sublime-syntax")
-        {
+        if file_name.ends_with(".tmLanguage") || file_name.ends_with(".sublime-syntax") {
             if let Err(e) = builder.add_from_folder(dir, false) {
                 tracing::warn!("Failed to load grammar from {:?}: {}", dir, e);
             } else {

--- a/crates/fresh-editor/tests/e2e/plugins/language_pack.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/language_pack.rs
@@ -22,27 +22,23 @@ fn test_register_grammar_api() {
     let grammars_dir = plugins_dir.join("grammars");
     fs::create_dir(&grammars_dir).unwrap();
 
-    // Create a minimal TextMate grammar for a test language
-    let test_grammar = r#"{
-        "name": "TestLang",
-        "scopeName": "source.testlang",
-        "fileTypes": ["tl"],
-        "patterns": [
-            {
-                "match": "\\b(fn|let|if|else)\\b",
-                "name": "keyword.control.testlang"
-            },
-            {
-                "match": "//.*$",
-                "name": "comment.line.testlang"
-            },
-            {
-                "match": "\"[^\"]*\"",
-                "name": "string.quoted.double.testlang"
-            }
-        ]
-    }"#;
-    let grammar_path = grammars_dir.join("testlang.tmLanguage.json");
+    // Create a minimal Sublime syntax grammar for a test language
+    let test_grammar = r#"%YAML 1.2
+---
+name: TestLang
+scope: source.testlang
+file_extensions: [tl]
+
+contexts:
+  main:
+    - match: \b(fn|let|if|else)\b
+      scope: keyword.control.testlang
+    - match: //.*$
+      scope: comment.line.testlang
+    - match: '"[^"]*"'
+      scope: string.quoted.double.testlang
+"#;
+    let grammar_path = grammars_dir.join("testlang.sublime-syntax");
     fs::write(&grammar_path, test_grammar).unwrap();
 
     // Create a plugin that registers the grammar
@@ -154,16 +150,19 @@ fn test_grammar_extension_detection() {
     let grammars_dir = plugins_dir.join("grammars");
     fs::create_dir(&grammars_dir).unwrap();
 
-    // Minimal grammar
-    let test_grammar = r#"{
-        "name": "CustomScript",
-        "scopeName": "source.customscript",
-        "fileTypes": ["cscript", "cs2"],
-        "patterns": [
-            { "match": "\\bprint\\b", "name": "keyword.other" }
-        ]
-    }"#;
-    let grammar_path = grammars_dir.join("customscript.tmLanguage.json");
+    // Minimal grammar in Sublime syntax format
+    let test_grammar = r#"%YAML 1.2
+---
+name: CustomScript
+scope: source.customscript
+file_extensions: [cscript, cs2]
+
+contexts:
+  main:
+    - match: \bprint\b
+      scope: keyword.other
+"#;
+    let grammar_path = grammars_dir.join("customscript.sublime-syntax");
     fs::write(&grammar_path, test_grammar).unwrap();
 
     let test_plugin = format!(

--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -2,6 +2,18 @@
 
 Welcome to the Fresh plugin development guide! This document will walk you through the process of creating your own plugins for Fresh.
 
+## Package Types
+
+Fresh supports three types of packages:
+
+| Type | Description | Guide |
+|------|-------------|-------|
+| **Plugin** | TypeScript code extending editor functionality | This page |
+| **Theme** | Color schemes for the editor | See `:pkg init theme` |
+| **Language Pack** | Syntax highlighting, language config, and LSP | [Language Packs](./language-packs.md) |
+
+Use `fresh --init` to scaffold any package type.
+
 ## Introduction
 
 Fresh plugins are written in **TypeScript** and run in a sandboxed Deno environment. This provides a safe and modern development experience with access to a powerful set of APIs for extending the editor.

--- a/docs/plugins/development/language-packs.md
+++ b/docs/plugins/development/language-packs.md
@@ -1,0 +1,235 @@
+# Creating Language Packs
+
+Language packs add syntax highlighting, language configuration, and LSP support for new languages in Fresh.
+
+## Quick Start
+
+Use the CLI to scaffold a new language pack:
+
+```bash
+fresh --init language
+```
+
+This creates a directory with the basic structure:
+```
+my-language/
+├── package.json          # Package manifest
+├── grammars/
+│   └── syntax.sublime-syntax  # Sublime syntax grammar (YAML)
+├── validate.sh           # Validation script
+└── README.md
+```
+
+## Package Structure
+
+### package.json
+
+The manifest configures the language pack:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/sinelaw/fresh/main/crates/fresh-editor/plugins/schemas/package.schema.json",
+  "name": "my-language",
+  "version": "0.1.0",
+  "description": "Language support for MyLang",
+  "type": "language",
+  "author": "Your Name",
+  "license": "MIT",
+  "fresh": {
+    "grammar": {
+      "file": "grammars/syntax.sublime-syntax",
+      "extensions": ["mylang", "ml"]
+    },
+    "language": {
+      "commentPrefix": "//",
+      "blockCommentStart": "/*",
+      "blockCommentEnd": "*/",
+      "tabSize": 4,
+      "autoIndent": true
+    },
+    "lsp": {
+      "command": "my-language-server",
+      "args": ["--stdio"],
+      "autoStart": true
+    }
+  }
+}
+```
+
+### Grammar Configuration
+
+| Field | Description |
+|-------|-------------|
+| `file` | Path to the grammar file (relative to package root) |
+| `extensions` | File extensions this grammar handles (without dots) |
+| `firstLine` | Optional regex for shebang detection |
+
+### Language Configuration
+
+| Field | Description |
+|-------|-------------|
+| `commentPrefix` | Line comment prefix (e.g., `//`, `#`, `--`) |
+| `blockCommentStart` | Block comment opening (e.g., `/*`, `<!--`) |
+| `blockCommentEnd` | Block comment closing (e.g., `*/`, `-->`) |
+| `tabSize` | Default indentation width |
+| `useTabs` | Use tabs instead of spaces |
+| `autoIndent` | Enable automatic indentation |
+| `formatter.command` | Formatter command (e.g., `prettier`) |
+| `formatter.args` | Arguments for the formatter |
+
+### LSP Configuration
+
+| Field | Description |
+|-------|-------------|
+| `command` | LSP server executable |
+| `args` | Arguments to pass to the server |
+| `autoStart` | Start server when opening matching files |
+| `initializationOptions` | Custom LSP initialization options |
+
+## Finding Existing Grammars
+
+Before writing a grammar from scratch, search online for existing Sublime Text or TextMate grammars:
+
+1. **Search GitHub** for `<language> sublime-syntax` or `<language> tmLanguage`
+2. **Check VS Code extensions** - many use TextMate/Sublime grammars
+3. **Browse [Package Control](https://packagecontrol.io/)** - Sublime Text's package repository
+
+When using an existing grammar:
+
+1. **Check the license** - ensure it allows redistribution (MIT, Apache, BSD are common)
+2. **Include a copy of the license** in your `grammars/` directory (e.g., `grammars/LICENSE`)
+3. **Credit the original author** in your README and package description
+
+Example attribution in README:
+```markdown
+## Grammar Attribution
+
+The syntax grammar is derived from [original-package](https://github.com/user/repo)
+by Original Author, licensed under MIT. See `grammars/LICENSE` for details.
+```
+
+## Writing Sublime Syntax Grammars
+
+Fresh uses Sublime Text's `.sublime-syntax` format (YAML-based). This is the recommended format because:
+- More readable than JSON TextMate grammars
+- Better tooling and documentation
+- Supports advanced features like contexts and includes
+
+### Basic Structure
+
+```yaml
+%YAML 1.2
+---
+name: My Language
+scope: source.mylang
+file_extensions: [mylang, ml]
+
+contexts:
+  main:
+    - include: comments
+    - include: strings
+    - include: keywords
+    - include: numbers
+
+  comments:
+    - match: //.*$
+      scope: comment.line.double-slash
+
+    - match: /\*
+      scope: punctuation.definition.comment.begin
+      push:
+        - meta_scope: comment.block
+        - match: \*/
+          scope: punctuation.definition.comment.end
+          pop: true
+
+  strings:
+    - match: '"'
+      scope: punctuation.definition.string.begin
+      push:
+        - meta_scope: string.quoted.double
+        - match: \\.
+          scope: constant.character.escape
+        - match: '"'
+          scope: punctuation.definition.string.end
+          pop: true
+
+  keywords:
+    - match: \b(if|else|while|for|return|fn|let|const)\b
+      scope: keyword.control
+
+  numbers:
+    - match: \b[0-9]+(\.[0-9]+)?\b
+      scope: constant.numeric
+```
+
+### Key Concepts
+
+**Scopes**: Define how text is styled. Common scopes include:
+- `comment.line`, `comment.block` - Comments
+- `string.quoted.single`, `string.quoted.double` - Strings
+- `keyword.control`, `keyword.operator` - Keywords
+- `constant.numeric`, `constant.language` - Constants
+- `entity.name.function`, `entity.name.class` - Declarations
+- `variable.parameter`, `variable.other` - Variables
+
+**Contexts**: Named states for the parser. Use `push`/`pop` for nested structures.
+
+**Includes**: Reuse rules across contexts with `include`.
+
+### Resources
+
+- [Sublime Text Syntax Documentation](https://www.sublimetext.com/docs/syntax.html)
+- [Scope Naming Conventions](https://www.sublimetext.com/docs/scope_naming.html)
+- [TextMate Grammar Reference](https://macromates.com/manual/en/language_grammars)
+
+## Examples
+
+### Minimal Example
+
+See the [Solidity language pack](https://github.com/sinelaw/fresh-plugins/tree/main/languages/solidity):
+
+```
+languages/solidity/
+├── package.json
+├── grammars/
+│   ├── solidity.sublime-syntax
+│   └── LICENSE
+├── validate.sh
+└── README.md
+```
+
+### Grammar with Embedded Languages
+
+See the [Templ language pack](https://github.com/sinelaw/fresh-plugins/tree/main/languages/templ) for an example that extends Go syntax:
+
+```yaml
+%YAML 1.2
+---
+name: Templ
+scope: source.go.templ
+extends: Packages/Go/Go.sublime-syntax
+
+file_extensions:
+  - templ
+
+contexts:
+  # Custom rules that extend the base Go grammar
+```
+
+## Testing
+
+1. **Local testing**: Copy your language pack to `~/.config/fresh/grammars/`
+2. **Validate manifest**: Run `./validate.sh` in your package directory
+3. **Restart Fresh** to load the new grammar
+
+## Publishing
+
+1. Push your package to a public Git repository
+2. Submit a PR to [fresh-plugins-registry](https://github.com/sinelaw/fresh-plugins-registry)
+3. Add your package to `languages.json`
+
+After approval, users can install with:
+```
+:pkg install your-language
+```

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,6 +1,12 @@
 # Plugins
 
-Fresh's functionality can be extended with plugins written in TypeScript. Fresh comes with a few useful plugins out of the box:
+Fresh's functionality can be extended with packages:
+
+*   **Plugins:** TypeScript code that extends editor functionality
+*   **Themes:** Color schemes for syntax highlighting and UI
+*   **Language Packs:** Syntax highlighting, language configuration, and LSP support for new languages
+
+Fresh comes with a few useful plugins out of the box:
 
 *   **TODO Highlighter:** Highlights `TODO`, `FIXME`, and other keywords in your comments.
 *   **Git Grep:** Interactively search through your Git repository.
@@ -10,7 +16,7 @@ Fresh's functionality can be extended with plugins written in TypeScript. Fresh 
 
 ## Package Manager
 
-Fresh includes a built-in package manager for installing plugins and themes from git repositories.
+Fresh includes a built-in package manager for installing plugins, themes, and language packs from git repositories.
 
 ### Installing Packages
 
@@ -47,6 +53,7 @@ This installs only the `packages/rainbow-brackets` directory from the repository
 Installed packages are stored in:
 - **Plugins:** `~/.config/fresh/plugins/packages/`
 - **Themes:** `~/.config/fresh/themes/packages/`
+- **Language Packs:** `~/.config/fresh/grammars/`
 
 Each package is a git repository, so you can update manually with `git pull` if needed.
 
@@ -66,6 +73,21 @@ By default, Fresh uses the official package registry. You can add additional reg
 ```
 
 Run `pkg: Sync Registry` to fetch the latest package lists.
+
+## Creating Packages
+
+Use the CLI to scaffold new packages:
+
+```bash
+fresh --init           # Interactive mode
+fresh --init plugin    # Create a plugin
+fresh --init theme     # Create a theme
+fresh --init language  # Create a language pack
+```
+
+For detailed guides, see:
+- [Plugin Development](./development/)
+- [Language Packs](./development/language-packs.md)
 
 ## Clangd helper plugin
 


### PR DESCRIPTION
- Update `fresh --init language` to generate .sublime-syntax (YAML) instead of .tmLanguage.json which syntect cannot load
- Add comprehensive language pack documentation with guidance on finding existing grammars online and proper license attribution
- Remove .tmLanguage.json from supported formats in grammar loader
- Update tests to use sublime-syntax format
- Update schema and API comments to reflect supported formats