### PR TITLE
feat: Add showWhitespaceTabs support for language packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,10 @@ Thanks for contributing!
 
 7. **LSP**: Ensure LSP interactions follow the correct lifecycle (e.g., `didOpen` must always precede other requests to avoid server-side errors). Use the appropriate existing helpers for this pattern.
 
-8. **Regenerate plugin types**: After modifying the plugin API, run `cargo test -p fresh-plugin-runtime write_fresh_dts_file -- --ignored`
+8. **Regenerate plugin types and schemas**: After modifying the plugin API or config types:
+   - **TypeScript definitions** (`plugins/lib/fresh.d.ts`): Auto-generated from Rust types with `#[derive(TS)]`. Run: `cargo test -p fresh-plugin-runtime write_fresh_dts_file -- --ignored`
+   - **JSON schemas** (`plugins/config-schema.json`, `plugins/schemas/theme.schema.json`): Auto-generated from Rust types with `#[derive(JsonSchema)]`. Run: `./scripts/gen_schema.sh`
+   - **Package schema** (`plugins/schemas/package.schema.json`): Manually maintained - edit directly when adding new language pack fields
 
 9. **Type check plugins**: Run `crates/fresh-editor/plugins/check-types.sh` (requires `tsc`)
 

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1450,6 +1450,11 @@ pub struct LanguagePackConfig {
     #[serde(default)]
     pub auto_indent: Option<bool>,
 
+    /// Whether to show whitespace tab indicators (→) for this language
+    /// Defaults to true. Set to false for languages like Go/Hare that use tabs for indentation.
+    #[serde(default)]
+    pub show_whitespace_tabs: Option<bool>,
+
     /// Formatter configuration
     #[serde(default)]
     pub formatter: Option<FormatterPackConfig>,

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -559,6 +559,11 @@ type LanguagePackConfig = {
 	*/
 	autoIndent: boolean | null;
 	/**
+	* Whether to show whitespace tab indicators (→) for this language
+	* Defaults to true. Set to false for languages like Go/Hare that use tabs for indentation.
+	*/
+	showWhitespaceTabs: boolean | null;
+	/**
 	* Formatter configuration
 	*/
 	formatter: FormatterPackConfig | null;

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -92,6 +92,7 @@ interface PackageManifest {
       useTabs?: boolean;
       tabSize?: number;
       autoIndent?: boolean;
+      showWhitespaceTabs?: boolean;
       formatter?: {
         command: string;
         args?: string[];
@@ -828,6 +829,7 @@ async function loadLanguagePack(packageDir: string, manifest: PackageManifest): 
       useTabs: lang.useTabs ?? null,
       tabSize: lang.tabSize ?? null,
       autoIndent: lang.autoIndent ?? null,
+      showWhitespaceTabs: lang.showWhitespaceTabs ?? null,
       formatter: lang.formatter ? {
         command: lang.formatter.command,
         args: lang.formatter.args ?? [],

--- a/crates/fresh-editor/plugins/schemas/package.schema.json
+++ b/crates/fresh-editor/plugins/schemas/package.schema.json
@@ -140,6 +140,10 @@
               "type": "boolean",
               "description": "Enable automatic indentation"
             },
+            "showWhitespaceTabs": {
+              "type": "boolean",
+              "description": "Whether to show whitespace tab indicators (→). Defaults to true. Set to false for languages like Go/Hare that use tabs for indentation."
+            },
             "formatter": {
               "type": "object",
               "required": ["command"],

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1246,6 +1246,7 @@ impl Editor {
             auto_indent: config.auto_indent.unwrap_or(true),
             use_tabs: config.use_tabs.unwrap_or(false),
             tab_size: config.tab_size,
+            show_whitespace_tabs: config.show_whitespace_tabs.unwrap_or(true),
             formatter: config.formatter.map(|f| crate::config::FormatterConfig {
                 command: f.command,
                 args: f.args,


### PR DESCRIPTION
Add showWhitespaceTabs field to LanguagePackConfig to allow language packs to control whether tab indicators are displayed. This is useful for languages like Go and Hare that use tabs for indentation by convention.

- Add show_whitespace_tabs to LanguagePackConfig in fresh-core
- Update plugin_commands.rs to apply the setting
- Update pkg.ts to pass the field from package.json
- Update fresh.d.ts TypeScript definitions
- Update package.schema.json schema