### PR TITLE
fix: Skip hidden menus when navigating with arrow keys

### DIFF
--- a/crates/fresh-editor/src/app/event_debug.rs
+++ b/crates/fresh-editor/src/app/event_debug.rs
@@ -172,7 +172,6 @@ impl Default for EventDebug {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossterm::event::KeyEventKind;
 
     #[test]
     fn test_event_debug_creation() {

--- a/crates/fresh-editor/src/app/menu_actions.rs
+++ b/crates/fresh-editor/src/app/menu_actions.rs
@@ -54,8 +54,8 @@ impl Editor {
     /// Handle MenuLeft action - close submenu or go to previous menu.
     pub fn handle_menu_left(&mut self) {
         if !self.menu_state.close_submenu() {
-            let total_menus = self.menus.menus.len() + self.menu_state.plugin_menus.len();
-            self.menu_state.prev_menu(total_menus);
+            let all_menus = self.all_menus();
+            self.menu_state.prev_menu(&all_menus);
         }
     }
 
@@ -63,8 +63,7 @@ impl Editor {
     pub fn handle_menu_right(&mut self) {
         let all_menus = self.all_menus();
         if !self.menu_state.open_submenu(&all_menus) {
-            let total_menus = self.menus.menus.len() + self.menu_state.plugin_menus.len();
-            self.menu_state.next_menu(total_menus);
+            self.menu_state.next_menu(&all_menus);
         }
     }
 

--- a/crates/fresh-editor/src/view/ui/menu_input.rs
+++ b/crates/fresh-editor/src/view/ui/menu_input.rs
@@ -71,7 +71,7 @@ impl InputHandler for MenuInputHandler<'_> {
                 // If in a submenu, close it and go back to parent
                 // Otherwise, go to the previous menu
                 if !self.state.close_submenu() {
-                    self.state.prev_menu(self.menus.len());
+                    self.state.prev_menu(self.menus);
                 }
                 InputResult::Consumed
             }
@@ -79,7 +79,7 @@ impl InputHandler for MenuInputHandler<'_> {
                 // If on a submenu item, open it
                 // Otherwise, go to the next menu
                 if !self.state.open_submenu(self.menus) {
-                    self.state.next_menu(self.menus.len());
+                    self.state.next_menu(self.menus);
                 }
                 InputResult::Consumed
             }

--- a/crates/fresh-editor/tests/e2e/explorer_menu.rs
+++ b/crates/fresh-editor/tests/e2e/explorer_menu.rs
@@ -171,6 +171,10 @@ fn test_explorer_menu_left_right_navigation() {
     let mut harness = EditorTestHarness::new(100, 30).unwrap();
     harness.render().unwrap();
 
+    // Focus file explorer so Explorer menu becomes visible
+    harness.editor_mut().focus_file_explorer();
+    harness.render().unwrap();
+
     // Open Explorer menu
     harness
         .send_key(KeyCode::Char('x'), KeyModifiers::ALT)

--- a/crates/fresh-editor/tests/e2e/menu_bar.rs
+++ b/crates/fresh-editor/tests/e2e/menu_bar.rs
@@ -859,3 +859,36 @@ fn test_tab_selection_click_works_with_menu_bar_hidden() {
          The click was intercepted by the menu bar handler instead of reaching the tab."
     );
 }
+
+/// Test that arrow key navigation skips hidden menus
+/// When file explorer is not focused, the Explorer menu is hidden.
+/// Pressing Left from Help menu should skip the hidden Explorer menu and go to LSP menu.
+#[test]
+fn test_menu_arrow_navigation_skips_hidden_menus() {
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+    harness.render().unwrap();
+
+    // Verify file explorer is not focused (Explorer menu should be hidden)
+    // By default, the editor focuses the text buffer, not the file explorer
+
+    // Open Help menu (the rightmost menu)
+    harness
+        .send_key(KeyCode::Char('h'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Verify Help menu is open
+    harness.assert_screen_contains("Show Fresh Manual");
+
+    // Press Left to navigate to previous menu
+    // Expected: Should go to LSP menu (skipping hidden Explorer menu)
+    // Bug: Goes to hidden Explorer menu instead
+    harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Should show LSP menu items, not Explorer menu items
+    // LSP menu has "Restart Server" and "Stop Server"
+    // Explorer menu has "New Folder" which should NOT be visible
+    harness.assert_screen_not_contains("New Folder");
+    harness.assert_screen_contains("Restart Server");
+}


### PR DESCRIPTION
Arrow key navigation between menus now respects the menu's `when` condition. Previously, pressing Left/Right would navigate to hidden menus (e.g., the Explorer menu when file explorer is not focused). Now hidden menus are skipped.