### PR TITLE
Add validation for FileSystem::read_range contract compliance

### DIFF
--- a/crates/fresh-editor/src/services/remote/agent.py
+++ b/crates/fresh-editor/src/services/remote/agent.py
@@ -292,8 +292,16 @@ def cmd_patch(id, p):
         with open(src, "rb") as orig, open(tmp, "wb") as out:
             for op in ops:
                 if "copy" in op:
-                    orig.seek(op["copy"]["off"])
-                    data = orig.read(op["copy"]["len"])
+                    off = op["copy"]["off"]
+                    length = op["copy"]["len"]
+                    orig.seek(off)
+                    data = orig.read(length)
+                    # Validate we read the expected number of bytes
+                    if len(data) != length:
+                        raise IOError(
+                            f"cmd_patch copy: expected {length} bytes at offset {off}, "
+                            f"got {len(data)} (src: {src})"
+                        )
                     out.write(data)
                 elif "insert" in op:
                     out.write(unb64(op["insert"]["data"]))


### PR DESCRIPTION
## Summary
This PR adds defense-in-depth validation to ensure that `FileSystem::read_range` implementations return exactly the requested number of bytes or error, preventing silent data corruption or panics downstream.

## Changes
- **piece_tree.rs**: Added assertion in `StringBuffer::load_from_file` to panic immediately if `FileSystem::read_range` returns fewer bytes than requested, rather than allowing the mismatch to cause issues later during save operations
- **remote/filesystem.rs**: Added validation in `RemoteFileSystem::read_range` to return `UnexpectedEof` error if the received content length doesn't match the requested length, with detailed error context including agent-reported size
- **remote/agent.py**: Added validation in `cmd_patch` copy operation to verify that `file.read()` returns the expected number of bytes, raising `IOError` on mismatch

## Implementation Details
- The validation in `piece_tree.rs` uses `assert_eq!` to fail fast with a clear error message, since this represents a contract violation by the FileSystem implementation
- The `RemoteFileSystem` validation includes the agent-reported size in the error message for debugging purposes, helping distinguish between truncation and metadata mismatches
- The Python agent validation mirrors the Rust-side checks, ensuring consistency across the remote protocol
- All error messages include relevant context (offset, expected/actual bytes, file path) to aid in diagnosing issues

This ensures the piece tree's assumption that `bytes` accurately reflects the loaded buffer size is always valid, preventing potential panics or data corruption.

https://claude.ai/code/session_01P7L7bf9yeUBTMkyHkVjWFD