### PR TITLE
fix(plugin): make markdown compose commands visible in command palette

### DIFF
--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -664,8 +664,34 @@ interface EditorAPI {
 	copyToClipboard(text: string): void;
 	setClipboard(text: string): void;
 	/**
-	* Register a command - reads plugin name from __pluginName__ global
-	* context is optional - can be omitted, null, undefined, or a string
+	* Register a command that will appear in the command palette.
+	* 
+	* # Arguments
+	* 
+	* * `name` - Command name displayed in the palette. Prefix with `%` for i18n
+	* lookup (e.g., `"%cmd.my_command"` looks up `"cmd.my_command"` in the
+	* plugin's i18n strings).
+	* * `description` - Command description. Also supports `%` prefix for i18n.
+	* * `handler_name` - Name of a global JavaScript function to call when the
+	* command is executed.
+	* * `context` - Optional visibility filter. Controls when the command appears
+	* in the command palette:
+	* - `null`, `undefined`, or omitted: Command is **always visible** in the
+	* palette (recommended for most commands).
+	* - A string (e.g., `"vi-normal"`): Command is only visible when this
+	* context is active. Contexts are activated via `setContext()` or by
+	* the buffer's mode. Use this for mode-specific commands (e.g., vim
+	* normal mode commands).
+	* 
+	* # Example
+	* 
+	* ```javascript
+	* // Always-visible command (recommended)
+	* editor.registerCommand("%cmd.my_action", "%cmd.my_action_desc", "myHandler", null);
+	* 
+	* // Context-restricted command (only visible when "vi-normal" context is active)
+	* editor.registerCommand("Vi: Join Lines", "Join current line with next", "viJoinLines", "vi-normal");
+	* ```
 	*/
 	registerCommand(name: string, description: string, handlerName: string, context?: unknown): boolean;
 	/**

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -599,14 +599,14 @@ editor.registerCommand(
   "%cmd.toggle_compose",
   "%cmd.toggle_compose_desc",
   "markdownToggleCompose",
-  "normal"
+  null
 );
 
 editor.registerCommand(
   "%cmd.set_compose_width",
   "%cmd.set_compose_width_desc",
   "markdownSetComposeWidth",
-  "normal"
+  null
 );
 
 // Initialization

--- a/crates/fresh-editor/src/i18n.rs
+++ b/crates/fresh-editor/src/i18n.rs
@@ -47,12 +47,6 @@ pub fn translate_plugin_string(
     let plugin_map: &HashMap<String, HashMap<String, String>> = match all_strings.get(plugin_name) {
         Some(m) => m,
         None => {
-            tracing::debug!(
-                "translate_plugin_string: plugin '{}' not found (available: {:?}), returning key '{}'",
-                plugin_name,
-                all_strings.keys().collect::<Vec<_>>(),
-                key
-            );
             return key.to_string();
         }
     };
@@ -64,13 +58,6 @@ pub fn translate_plugin_string(
     let template: &String = match lang_map.and_then(|m| m.get(key)) {
         Some(t) => t,
         None => {
-            tracing::debug!(
-                "translate_plugin_string: key '{}' not found for plugin '{}' (locale='{}', available keys: {:?})",
-                key,
-                plugin_name,
-                locale,
-                plugin_map.get(&locale).or_else(|| plugin_map.get("en")).map(|m| m.keys().take(5).collect::<Vec<_>>())
-            );
             return key.to_string();
         }
     };

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -561,8 +561,34 @@ impl JsEditorApi {
 
     // === Command Registration ===
 
-    /// Register a command - reads plugin name from __pluginName__ global
-    /// context is optional - can be omitted, null, undefined, or a string
+    /// Register a command that will appear in the command palette.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - Command name displayed in the palette. Prefix with `%` for i18n
+    ///   lookup (e.g., `"%cmd.my_command"` looks up `"cmd.my_command"` in the
+    ///   plugin's i18n strings).
+    /// * `description` - Command description. Also supports `%` prefix for i18n.
+    /// * `handler_name` - Name of a global JavaScript function to call when the
+    ///   command is executed.
+    /// * `context` - Optional visibility filter. Controls when the command appears
+    ///   in the command palette:
+    ///   - `null`, `undefined`, or omitted: Command is **always visible** in the
+    ///     palette (recommended for most commands).
+    ///   - A string (e.g., `"vi-normal"`): Command is only visible when this
+    ///     context is active. Contexts are activated via `setContext()` or by
+    ///     the buffer's mode. Use this for mode-specific commands (e.g., vim
+    ///     normal mode commands).
+    ///
+    /// # Example
+    ///
+    /// ```javascript
+    /// // Always-visible command (recommended)
+    /// editor.registerCommand("%cmd.my_action", "%cmd.my_action_desc", "myHandler", null);
+    ///
+    /// // Context-restricted command (only visible when "vi-normal" context is active)
+    /// editor.registerCommand("Vi: Join Lines", "Join current line with next", "viJoinLines", "vi-normal");
+    /// ```
     pub fn register_command<'js>(
         &self,
         _ctx: rquickjs::Ctx<'js>,


### PR DESCRIPTION
The markdown_compose plugin was registering commands with context="normal", which caused them to be hidden unless that specific context was active. Changed to null so commands are always visible, matching how other plugins like pkg.ts register their commands.

Also added comprehensive documentation for the register_command function explaining the context parameter behavior.