### PR TITLE
Add Typst syntax highlighting support to Fresh editor

### DIFF
--- a/crates/fresh-editor/src/grammars/typst.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/typst.sublime-syntax
@@ -1,0 +1,323 @@
+%YAML 1.2
+---
+# Typst syntax highlighting for Fresh editor
+# Based on the official Typst TextMate grammar from https://github.com/typst/typst
+name: Typst
+file_extensions:
+  - typ
+scope: source.typst
+
+contexts:
+  main:
+    - include: comments
+    - include: markup
+
+  comments:
+    # Block comments (nestable)
+    - match: '/\*'
+      scope: punctuation.definition.comment.typst
+      push:
+        - meta_scope: comment.block.typst
+        - match: '\*/'
+          scope: punctuation.definition.comment.typst
+          pop: true
+        - include: comments
+    # Line comments
+    - match: '//.*$'
+      scope: comment.line.double-slash.typst
+
+  markup:
+    - include: comments
+    - include: escape
+    - include: headings
+    - include: raw-block
+    - include: raw-inline
+    - include: math
+    - include: bold
+    - include: italic
+    - include: link
+    - include: label
+    - include: reference
+    - include: list-unnumbered
+    - include: list-numbered
+    - include: list-description
+    - include: hash-keywords
+    - include: hash-function
+    - include: hash-variable
+    - include: special-chars
+
+  escape:
+    - match: '\\([\\\/\[\]{}#*_=~`$\-.]|u\{[0-9a-zA-Z]*\})'
+      scope: constant.character.escape.content.typst
+
+  special-chars:
+    # Em dash
+    - match: '---'
+      scope: constant.character.escape.typst
+    # En dash
+    - match: '--'
+      scope: constant.character.escape.typst
+    # Ellipsis
+    - match: '\.\.\.'
+      scope: constant.character.escape.typst
+    # Non-breaking space
+    - match: '~'
+      scope: constant.character.escape.typst
+
+  headings:
+    - match: '^\s*(=+)\s+'
+      captures:
+        1: punctuation.definition.heading.typst
+      push:
+        - meta_scope: markup.heading.typst
+        - match: '$'
+          pop: true
+        - include: markup
+
+  bold:
+    - match: '\*'
+      scope: punctuation.definition.bold.typst
+      push:
+        - meta_scope: markup.bold.typst
+        - match: '\*'
+          scope: punctuation.definition.bold.typst
+          pop: true
+        - include: markup
+
+  italic:
+    - match: '(?<=\s|^)_(?=\S)'
+      scope: punctuation.definition.italic.typst
+      push:
+        - meta_scope: markup.italic.typst
+        - match: '_'
+          scope: punctuation.definition.italic.typst
+          pop: true
+        - match: '$'
+          pop: true
+        - include: markup
+
+  raw-block:
+    - match: '(`{3,})\s*(\w+)?$'
+      captures:
+        1: punctuation.definition.raw.typst
+        2: constant.other.language-name.typst
+      push:
+        - meta_scope: markup.raw.block.typst
+        - match: '\1'
+          scope: punctuation.definition.raw.typst
+          pop: true
+
+  raw-inline:
+    - match: '`'
+      scope: punctuation.definition.raw.typst
+      push:
+        - meta_scope: markup.raw.inline.typst
+        - match: '`'
+          scope: punctuation.definition.raw.typst
+          pop: true
+
+  math:
+    - match: '\$'
+      scope: punctuation.definition.string.math.typst
+      push:
+        - meta_scope: string.other.math.typst
+        - match: '\$'
+          scope: punctuation.definition.string.math.typst
+          pop: true
+
+  link:
+    - match: 'https?://[0-9a-zA-Z~/%#&='',.;\+\?\-_]*'
+      scope: markup.underline.link.typst
+
+  label:
+    - match: '<[a-zA-Z_][a-zA-Z0-9_\-]*>'
+      scope: entity.other.label.typst
+
+  reference:
+    - match: '(@)[a-zA-Z_][a-zA-Z0-9_\-]*'
+      scope: entity.other.reference.typst
+      captures:
+        1: punctuation.definition.reference.typst
+
+  list-unnumbered:
+    - match: '^\s*(-)\s+'
+      captures:
+        1: punctuation.definition.list.unnumbered.typst
+
+  list-numbered:
+    - match: '^\s*([0-9]*\.|\+)\s+'
+      captures:
+        1: punctuation.definition.list.numbered.typst
+
+  list-description:
+    - match: '^\s*(/)\s+([^:]*:)'
+      captures:
+        1: punctuation.definition.list.description.typst
+        2: markup.list.term.typst
+
+  hash-keywords:
+    # Statement keywords that start code mode until end of line
+    - match: '(#)(let|set|show|context)\b'
+      captures:
+        0: keyword.other.typst
+        1: punctuation.definition.keyword.typst
+      push: code-line
+    # Control flow
+    - match: '(#)(if|else)\b'
+      captures:
+        0: keyword.control.conditional.typst
+        1: punctuation.definition.keyword.typst
+      push: code-line
+    # Loops
+    - match: '(#)(for|while)\b'
+      captures:
+        0: keyword.control.loop.typst
+        1: punctuation.definition.keyword.typst
+      push: code-line
+    # Break/continue
+    - match: '(#)(break|continue)\b'
+      captures:
+        0: keyword.control.loop.typst
+        1: punctuation.definition.keyword.typst
+    # Import/include
+    - match: '(#)(import|include|export)\b'
+      captures:
+        0: keyword.control.import.typst
+        1: punctuation.definition.keyword.typst
+      push: code-line
+    # Return
+    - match: '(#)(return)\b'
+      captures:
+        0: keyword.control.flow.typst
+        1: punctuation.definition.keyword.typst
+    # as/in standalone keywords
+    - match: '(#)(as|in)\b'
+      captures:
+        0: keyword.other.typst
+        1: punctuation.definition.keyword.typst
+
+  hash-function:
+    # Function call with parentheses or content block
+    - match: '(#)[a-zA-Z_][a-zA-Z0-9_\-]*!?(?=[\[\(])'
+      scope: entity.name.function.typst
+      captures:
+        1: punctuation.definition.function.typst
+
+  hash-variable:
+    # Variable interpolation
+    - match: '(#)[a-zA-Z_][.a-zA-Z0-9_\-]*'
+      scope: entity.other.interpolated.typst
+      captures:
+        1: punctuation.definition.variable.typst
+
+  code-line:
+    - match: '$'
+      pop: true
+    - match: '(?=\])'
+      pop: true
+    - include: code
+
+  code:
+    - include: comments
+    # Code block
+    - match: '\{'
+      scope: punctuation.definition.block.code.typst
+      push:
+        - match: '\}'
+          scope: punctuation.definition.block.code.typst
+          pop: true
+        - include: code
+    # Content block (back to markup mode)
+    - match: '\['
+      scope: punctuation.definition.block.content.typst
+      push:
+        - match: '\]'
+          scope: punctuation.definition.block.content.typst
+          pop: true
+        - include: markup
+    # Parenthesized group
+    - match: '\('
+      scope: punctuation.definition.group.typst
+      push:
+        - match: '\)'
+          scope: punctuation.definition.group.typst
+          pop: true
+        - include: arguments
+    # Strings
+    - match: '"'
+      scope: punctuation.definition.string.typst
+      push:
+        - meta_scope: string.quoted.double.typst
+        - match: '"'
+          scope: punctuation.definition.string.typst
+          pop: true
+        - match: '\\([\\\"nrt]|u\{?[0-9a-zA-Z]*\}?)'
+          scope: constant.character.escape.string.typst
+    # Math in code
+    - match: '\$'
+      scope: punctuation.definition.string.math.typst
+      push:
+        - meta_scope: string.other.math.typst
+        - match: '\$'
+          scope: punctuation.definition.string.math.typst
+          pop: true
+    # Code keywords
+    - match: '\b(let|as|in|set|show|context)\b'
+      scope: keyword.other.typst
+    - match: '\b(if|else)\b'
+      scope: keyword.control.conditional.typst
+    - match: '\b(for|while|break|continue)\b'
+      scope: keyword.control.loop.typst
+    - match: '\b(import|include|export)\b'
+      scope: keyword.control.import.typst
+    - match: '\b(return)\b'
+      scope: keyword.control.flow.typst
+    # Constants
+    - match: '\bnone\b'
+      scope: constant.language.none.typst
+    - match: '\bauto\b'
+      scope: constant.language.auto.typst
+    - match: '\b(true|false)\b'
+      scope: constant.language.boolean.typst
+    # Numbers with units
+    - match: '\b(\d*)?\.?\d+([eE][+-]?\d+)?(mm|pt|cm|in|em)\b'
+      scope: constant.numeric.length.typst
+    - match: '\b(\d*)?\.?\d+([eE][+-]?\d+)?(rad|deg)\b'
+      scope: constant.numeric.angle.typst
+    - match: '\b(\d*)?\.?\d+([eE][+-]?\d+)?%'
+      scope: constant.numeric.percentage.typst
+    - match: '\b(\d*)?\.?\d+([eE][+-]?\d+)?fr'
+      scope: constant.numeric.fr.typst
+    - match: '\b0x[0-9a-fA-F]+\b'
+      scope: constant.numeric.integer.typst
+    - match: '\b0b[01]+\b'
+      scope: constant.numeric.integer.typst
+    - match: '\b0o[0-7]+\b'
+      scope: constant.numeric.integer.typst
+    - match: '\b\d+\.\d+([eE][+-]?\d+)?\b'
+      scope: constant.numeric.float.typst
+    - match: '\b\d+\b'
+      scope: constant.numeric.integer.typst
+    # Operators
+    - match: '=>|\.\.'
+      scope: keyword.operator.typst
+    - match: '==|!=|<=|<|>=|>'
+      scope: keyword.operator.relational.typst
+    - match: '\+=|-=|\*=|/=|='
+      scope: keyword.operator.assignment.typst
+    - match: '\+|-|\*|/'
+      scope: keyword.operator.arithmetic.typst
+    - match: '\b(and|or|not)\b'
+      scope: keyword.operator.word.typst
+    # Function calls
+    - match: '\b[a-zA-Z_][a-zA-Z0-9_\-]*!?(?=[\[\(])'
+      scope: entity.name.function.typst
+    # Variables
+    - match: '\b[a-zA-Z_][a-zA-Z0-9_\-]*\b'
+      scope: variable.other.typst
+
+  arguments:
+    # Named arguments
+    - match: '\b[a-zA-Z_][a-zA-Z0-9_\-]*(?=\s*:)'
+      scope: variable.parameter.typst
+    - include: code

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -34,6 +34,9 @@ pub const GITCONFIG_GRAMMAR: &str = include_str!("../../grammars/gitconfig.subli
 /// Embedded Git Attributes grammar for .gitattributes
 pub const GITATTRIBUTES_GRAMMAR: &str = include_str!("../../grammars/gitattributes.sublime-syntax");
 
+/// Embedded Typst grammar (syntect doesn't include one)
+pub const TYPST_GRAMMAR: &str = include_str!("../../grammars/typst.sublime-syntax");
+
 /// Registry of all available TextMate grammars.
 ///
 /// This struct holds the compiled syntax set and provides lookup methods.
@@ -217,6 +220,17 @@ impl GrammarRegistry {
             }
             Err(e) => {
                 tracing::warn!("Failed to load embedded Git Attributes grammar: {}", e);
+            }
+        }
+
+        // Typst grammar
+        match SyntaxDefinition::load_from_str(TYPST_GRAMMAR, true, Some("Typst")) {
+            Ok(syntax) => {
+                builder.add(syntax);
+                tracing::debug!("Loaded embedded Typst grammar");
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load embedded Typst grammar: {}", e);
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR adds comprehensive syntax highlighting support for Typst (`.typ` files) to the Fresh editor by implementing a complete TextMate grammar definition and registering it with the grammar registry.

## Changes
- **New Typst Grammar File** (`crates/fresh-editor/src/grammars/typst.sublime-syntax`):
  - Added 323-line TextMate syntax definition based on the official Typst grammar
  - Supports all major Typst language features including:
    - Comments (line and nestable block comments)
    - Markup elements (headings, bold, italic, links, labels, references)
    - Raw code blocks and inline code
    - Math mode with `$...$` delimiters
    - Lists (unnumbered, numbered, and description lists)
    - Code mode with hash-prefixed keywords and functions
    - String literals with escape sequences
    - Numeric literals with units (length, angle, percentage, fr)
    - Operators (arithmetic, relational, assignment, logical)
    - Variable interpolation and function calls

- **Grammar Registry Update** (`crates/fresh-editor/src/primitives/grammar/types.rs`):
  - Added `TYPST_GRAMMAR` constant to embed the grammar definition
  - Registered Typst grammar in `GrammarRegistry::new()` with proper error handling and logging
  - Follows existing pattern for embedded grammars (similar to gitconfig and gitattributes)

## Implementation Details
- The grammar properly handles Typst's dual-mode nature (markup and code modes)
- Content blocks `[...]` correctly switch back to markup mode from code mode
- Code blocks `{...}` remain in code mode with proper nesting support
- Escape sequences and special characters (em dash, en dash, ellipsis) are highlighted
- All keyword categories are properly scoped for semantic highlighting

https://claude.ai/code/session_01LN45EgTYo63oa1vvqCPmUJ