### PR TITLE
Fix Home/End keys to navigate visual line boundaries with wrapping

### DIFF
--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -817,4 +817,53 @@ impl CachedLayout {
 
         Some((new_pos, goal_visual_col))
     }
+
+    /// Get the start byte position of the visual row containing the given byte position.
+    /// If the cursor is already at the visual row start and this is a wrapped continuation,
+    /// moves to the previous visual row's start (within the same logical line).
+    /// Get the start byte position of the visual row containing the given byte position.
+    /// When `allow_advance` is true and the cursor is already at the row start,
+    /// moves to the previous visual row's start.
+    pub fn visual_line_start(
+        &self,
+        split_id: SplitId,
+        byte_pos: usize,
+        allow_advance: bool,
+    ) -> Option<usize> {
+        let mappings = self.view_line_mappings.get(&split_id)?;
+        let row_idx = self.find_visual_row(split_id, byte_pos)?;
+        let row = mappings.get(row_idx)?;
+        let row_start = row.first_source_byte()?;
+
+        if allow_advance && byte_pos == row_start && row_idx > 0 {
+            let prev_row = mappings.get(row_idx - 1)?;
+            prev_row.first_source_byte()
+        } else {
+            Some(row_start)
+        }
+    }
+
+    /// Get the end byte position of the visual row containing the given byte position.
+    /// If the cursor is already at the visual row end and the next row is a wrapped continuation,
+    /// moves to the next visual row's end (within the same logical line).
+    /// Get the end byte position of the visual row containing the given byte position.
+    /// When `allow_advance` is true and the cursor is already at the row end,
+    /// advances to the next visual row's end.
+    pub fn visual_line_end(
+        &self,
+        split_id: SplitId,
+        byte_pos: usize,
+        allow_advance: bool,
+    ) -> Option<usize> {
+        let mappings = self.view_line_mappings.get(&split_id)?;
+        let row_idx = self.find_visual_row(split_id, byte_pos)?;
+        let row = mappings.get(row_idx)?;
+
+        if allow_advance && byte_pos == row.line_end_byte && row_idx + 1 < mappings.len() {
+            let next_row = mappings.get(row_idx + 1)?;
+            Some(next_row.line_end_byte)
+        } else {
+            Some(row.line_end_byte)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This PR fixes the Home and End key behavior when line wrapping is enabled. Previously, these keys would navigate to the physical line boundaries, causing unwanted horizontal scrolling and breaking the visual line wrapping. Now they correctly navigate to the visual (wrapped) line segment boundaries.

## Key Changes

- **Added visual line navigation methods** (`visual_line_start` and `visual_line_end`) to `CachedLayout` that:
  - Move to the start/end of the current visual line segment
  - If already at a segment boundary, move to the previous/next segment's boundary
  - This allows repeated presses to traverse all wrapped segments

- **Refactored action handling in `Editor::handle_visual_line_action`**:
  - Introduced `VisualAction` enum to classify movement types (UpDown, LineEnd, LineStart)
  - Extended support from just Up/Down/SelectUp/SelectDown to include Home/End variants
  - Unified the movement logic to handle all visual line actions consistently

- **Updated test expectations** in `line_wrapping.rs`:
  - Modified tests to verify End key goes to visual line end (not physical line end)
  - Modified tests to verify Home key goes to visual line start (not physical line start)
  - Added new comprehensive tests (`test_end_key_goes_to_visual_line_end` and `test_home_key_goes_to_visual_line_start`) that verify the multi-segment navigation behavior
  - Changed test setup to use `Ctrl+Home` for reliable document start navigation instead of plain Home

## Implementation Details

The fix maintains the existing visual line movement infrastructure (using `cached_layout`) and extends it to handle Home/End keys. The behavior now matches common editor conventions where Home/End navigate visual line boundaries when wrapping is enabled, allowing users to move through wrapped content intuitively without triggering horizontal scrolling.

Fixes issue #979.

https://claude.ai/code/session_013hWNMU6WorYT8LwikgVHCb