### PR TITLE
Fix theme persistence when JSON name differs from filename

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2557,8 +2557,11 @@ impl Editor {
                 // Set terminal cursor color to match theme
                 self.theme.set_terminal_cursor_color();
 
-                // Update the config in memory
-                self.config.theme = self.theme.name.clone().into();
+                // Update the config in memory using the normalized registry key,
+                // not the JSON name field, so that the config value can be looked
+                // up in the registry on restart (fixes #1001).
+                let normalized = crate::view::theme::normalize_theme_name(theme_name);
+                self.config.theme = normalized.into();
 
                 // Persist to config file
                 self.save_theme_to_config();


### PR DESCRIPTION
## Summary
Fixes issue #1001 where custom themes with JSON "name" fields that differ from their filenames (e.g., "Catppuccin Mocha" vs "catppuccin-mocha.json") would fail to load after editor restart. The root cause was that the config was being saved with the JSON name field instead of the normalized registry key, causing lookup failures on subsequent startups.

## Key Changes

- **Added `normalize_theme_name()` function** in `loader.rs`: Centralizes theme name normalization logic (lowercase + replace underscores and spaces with hyphens) to ensure consistent lookup and storage across the codebase.

- **Updated theme registry operations** to use the normalized name consistently:
  - `ThemeRegistry::get()` and `contains()` now use the new normalization function
  - Theme loading in `ThemeLoader::load_all()` normalizes both builtin and custom theme names before storing in the registry
  - File-based theme loading normalizes the filename-derived name

- **Fixed config persistence** in `input.rs`: When applying a theme, the config now saves the normalized registry key instead of the JSON "name" field. This ensures the saved theme name can be successfully looked up when the editor restarts.

- **Added comprehensive test coverage**:
  - Unit test for `normalize_theme_name()` covering various input formats
  - Regression test `test_issue_1001_theme_persists_after_restart_with_name_mismatch()` that simulates the full user workflow: selecting a custom theme via UI, restarting the editor, and verifying the theme loads correctly
  - Regression test `test_issue_1001_config_with_spaces_in_theme_name_loads_correctly()` for backward compatibility with configs that already contain space-containing theme names
  - Unit test `test_theme_name_mismatch_json_vs_filename()` verifying that themes are findable by both normalized filename and JSON name

## Implementation Details

The fix ensures that:
1. Theme names are normalized consistently across all operations (loading, lookup, storage)
2. The normalization handles casing, underscores, and spaces uniformly
3. Backward compatibility is maintained for configs with space-containing theme names
4. The registry key (normalized form) is what gets persisted to config.json, not the JSON "name" field

https://claude.ai/code/session_01PsGSGahdLAWsKrZXbbqi7Z