### PR TITLE
Fix AltGr+Shift not recognized as text input on Windows (#993)

### DIFF
--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -37,9 +37,13 @@ fn is_text_input_modifier(modifiers: KeyModifiers) -> bool {
         return true;
     }
 
-    // Windows: AltGr is reported as Ctrl+Alt by crossterm
+    // Windows: AltGr is reported as Ctrl+Alt by crossterm.
+    // AltGr+Shift is needed for some layouts (e.g. Italian: AltGr+Shift+è = '{').
+    // See: https://github.com/sinelaw/fresh/issues/993
     #[cfg(windows)]
-    if modifiers == (KeyModifiers::CONTROL | KeyModifiers::ALT) {
+    if modifiers == (KeyModifiers::CONTROL | KeyModifiers::ALT)
+        || modifiers == (KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT)
+    {
         return true;
     }
 

--- a/crates/fresh-editor/tests/e2e/altgr_shift.rs
+++ b/crates/fresh-editor/tests/e2e/altgr_shift.rs
@@ -1,0 +1,33 @@
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Test that AltGr+Shift character input works on Windows.
+///
+/// On Windows, crossterm reports AltGr as Ctrl+Alt. Some keyboard layouts
+/// (e.g. Italian) require AltGr+Shift to type certain characters like
+/// curly braces: AltGr+Shift+è = '{', AltGr+Shift+* = '}'.
+///
+/// Crossterm reports these as Ctrl+Alt+Shift + Char('{') / Char('}').
+/// The editor must recognize this modifier combination as text input.
+///
+/// Reproduces: https://github.com/sinelaw/fresh/issues/993
+#[test]
+#[cfg_attr(
+    not(windows),
+    ignore = "AltGr+Shift is a Windows-specific modifier mapping"
+)]
+fn test_altgr_shift_curly_braces() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Simulate AltGr+Shift+è producing '{' on an Italian keyboard.
+    // Crossterm reports AltGr as Ctrl+Alt, so AltGr+Shift = Ctrl+Alt+Shift.
+    let altgr_shift = KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SHIFT;
+
+    harness.send_key(KeyCode::Char('{'), altgr_shift).unwrap();
+
+    harness.assert_buffer_content("{");
+
+    harness.send_key(KeyCode::Char('}'), altgr_shift).unwrap();
+
+    harness.assert_buffer_content("{}");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+pub mod altgr_shift;
 pub mod ansi_cursor;
 pub mod auto_indent;
 pub mod auto_revert;


### PR DESCRIPTION
On keyboards like Italian, curly braces require AltGr+Shift (reported by crossterm as Ctrl+Alt+Shift). The editor only accepted Ctrl+Alt (AltGr without Shift), so these characters were silently dropped.