### PR TITLE
Add clipboard configuration to control copy/paste methods

### DIFF
--- a/crates/fresh-editor/config.example.json
+++ b/crates/fresh-editor/config.example.json
@@ -31,6 +31,10 @@
     "custom_ignore_patterns": [],
     "width": 0.3
   },
+  "clipboard": {
+    "use_osc52": true,
+    "use_system_clipboard": true
+  },
   "terminal": {
     "jump_to_end_on_output": true
   },

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -88,6 +88,14 @@
         "show_hidden": false
       }
     },
+    "clipboard": {
+      "description": "Clipboard settings (which clipboard methods to use)",
+      "$ref": "#/$defs/ClipboardConfig",
+      "default": {
+        "use_osc52": true,
+        "use_system_clipboard": true
+      }
+    },
     "terminal": {
       "description": "Terminal settings",
       "$ref": "#/$defs/TerminalConfig",
@@ -526,6 +534,22 @@
           "description": "Whether to show hidden files (starting with .) by default in Open File dialog",
           "type": "boolean",
           "default": false
+        }
+      }
+    },
+    "ClipboardConfig": {
+      "description": "Clipboard configuration\n\nControls which clipboard methods are used for copy/paste operations.\nBy default, all methods are enabled and the editor tries them in order:\n1. OSC 52 escape sequences (works in modern terminals like Kitty, Alacritty, Wezterm)\n2. System clipboard via X11/Wayland APIs (works in Gnome Console, XFCE Terminal, etc.)\n3. Internal clipboard (always available as fallback)\n\nIf you experience hangs or issues (e.g., when using PuTTY or certain SSH setups),\nyou can disable specific methods.",
+      "type": "object",
+      "properties": {
+        "use_osc52": {
+          "description": "Enable OSC 52 escape sequences for clipboard access (default: true)\nDisable this if your terminal doesn't support OSC 52 or if it causes hangs",
+          "type": "boolean",
+          "default": true
+        },
+        "use_system_clipboard": {
+          "description": "Enable system clipboard access via X11/Wayland APIs (default: true)\nDisable this if you don't have a display server or it causes issues",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1290,6 +1290,9 @@ impl Editor {
             composite_view_states: HashMap::new(),
         };
 
+        // Apply clipboard configuration
+        editor.clipboard.apply_config(&editor.config.clipboard);
+
         #[cfg(feature = "plugins")]
         {
             editor.update_plugin_state_snapshot();

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -259,6 +259,9 @@ impl Editor {
         // Always reload keybindings (complex types don't implement PartialEq)
         self.keybindings = KeybindingResolver::new(&self.config);
 
+        // Update clipboard configuration
+        self.clipboard.apply_config(&self.config.clipboard);
+
         // Update LSP configs
         if let Some(ref mut lsp) = self.lsp {
             for (language, lsp_config) in &self.config.lsp {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -381,6 +381,10 @@ pub struct Config {
     #[serde(default)]
     pub file_browser: FileBrowserConfig,
 
+    /// Clipboard settings (which clipboard methods to use)
+    #[serde(default)]
+    pub clipboard: ClipboardConfig,
+
     /// Terminal settings
     #[serde(default)]
     pub terminal: TerminalConfig,
@@ -853,6 +857,38 @@ pub struct FileExplorerConfig {
 
 fn default_explorer_width() -> f32 {
     0.3 // 30% of screen width
+}
+
+/// Clipboard configuration
+///
+/// Controls which clipboard methods are used for copy/paste operations.
+/// By default, all methods are enabled and the editor tries them in order:
+/// 1. OSC 52 escape sequences (works in modern terminals like Kitty, Alacritty, Wezterm)
+/// 2. System clipboard via X11/Wayland APIs (works in Gnome Console, XFCE Terminal, etc.)
+/// 3. Internal clipboard (always available as fallback)
+///
+/// If you experience hangs or issues (e.g., when using PuTTY or certain SSH setups),
+/// you can disable specific methods.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ClipboardConfig {
+    /// Enable OSC 52 escape sequences for clipboard access (default: true)
+    /// Disable this if your terminal doesn't support OSC 52 or if it causes hangs
+    #[serde(default = "default_true")]
+    pub use_osc52: bool,
+
+    /// Enable system clipboard access via X11/Wayland APIs (default: true)
+    /// Disable this if you don't have a display server or it causes issues
+    #[serde(default = "default_true")]
+    pub use_system_clipboard: bool,
+}
+
+impl Default for ClipboardConfig {
+    fn default() -> Self {
+        Self {
+            use_osc52: true,
+            use_system_clipboard: true,
+        }
+    }
 }
 
 /// Terminal configuration
@@ -1337,6 +1373,7 @@ impl Default for Config {
             editor: EditorConfig::default(),
             file_explorer: FileExplorerConfig::default(),
             file_browser: FileBrowserConfig::default(),
+            clipboard: ClipboardConfig::default(),
             terminal: TerminalConfig::default(),
             keybindings: vec![], // User customizations only; defaults come from active_keybinding_map
             keybinding_maps: HashMap::new(), // User-defined maps go here

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -877,7 +877,9 @@ fn test_settings_from_terminal_mode_captures_input() {
     harness.assert_screen_contains("Settings");
 
     // Now try to use Settings navigation - press Down to navigate categories
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    // Categories: General, Clipboard, Editor, ...
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Clipboard
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Editor
     harness.render().unwrap();
 
     // The Settings should respond to navigation, not the terminal
@@ -1076,7 +1078,9 @@ fn test_settings_descriptions_render_properly() {
     harness.open_settings().unwrap();
 
     // Navigate to Editor category which has settings with descriptions
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    // Categories: General, Clipboard, Editor, ...
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Clipboard
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Editor
     harness.render().unwrap();
 
     // Switch to settings panel
@@ -1278,8 +1282,9 @@ fn test_settings_percentage_value_saves_correctly() {
     // Open settings
     harness.open_settings().unwrap();
 
-    // Navigate to File Explorer category (down three times from General)
-    // Categories: General, Editor, File Browser, File Explorer, Menu, Terminal, Warnings
+    // Navigate to File Explorer category (down four times from General)
+    // Categories: General, Clipboard, Editor, File Browser, File Explorer, ...
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Clipboard
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Editor
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // File Browser
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // File Explorer
@@ -1778,15 +1783,15 @@ fn test_category_selection_indicator_visible() {
         screen
     );
 
-    // Navigate down to Editor category
+    // Navigate down to Clipboard category
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
 
-    // Now Editor should have the ">" indicator
+    // Now Clipboard should have the ">" indicator
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains(">● Editor") || screen.contains(">  Editor"),
-        "Expected '>' indicator on Editor category when focused. Screen: {}",
+        screen.contains(">● Clipboard") || screen.contains(">  Clipboard"),
+        "Expected '>' indicator on Clipboard category when focused. Screen: {}",
         screen
     );
 
@@ -1794,12 +1799,12 @@ fn test_category_selection_indicator_visible() {
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
 
-    // Now Editor should not have the ">" indicator (panel not focused)
-    harness.assert_screen_not_contains(">● Editor");
-    harness.assert_screen_not_contains(">  Editor");
+    // Now Clipboard should not have the ">" indicator (panel not focused)
+    harness.assert_screen_not_contains(">● Clipboard");
+    harness.assert_screen_not_contains(">  Clipboard");
 
-    // But Editor should still be visible (just highlighted differently)
-    harness.assert_screen_contains("Editor");
+    // But Clipboard should still be visible (just highlighted differently)
+    harness.assert_screen_contains("Clipboard");
 
     // Close settings
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();


### PR DESCRIPTION
## Summary
This PR adds configurable clipboard settings to allow users to disable specific clipboard methods (OSC 52 escape sequences and/or system clipboard access) that may cause issues in certain environments.

## Key Changes
- **New `ClipboardConfig` struct** in `config.rs` with two boolean flags:
  - `use_osc52`: Enable/disable OSC 52 escape sequences (default: true)
  - `use_system_clipboard`: Enable/disable X11/Wayland system clipboard access (default: true)

- **Updated `Clipboard` service** to respect configuration:
  - Added `use_osc52` and `use_system_clipboard` fields
  - New `apply_config()` method to update settings from editor config
  - Wrapped all OSC 52 and system clipboard operations with configuration checks
  - Methods gracefully skip disabled clipboard access paths

- **Configuration integration**:
  - Added `PartialClipboardConfig` for config file parsing and merging
  - Integrated clipboard config into the 4-level config overlay system
  - Updated example config file with clipboard settings
  - Applied config on editor initialization and config reload

- **Test coverage**:
  - Added tests for disabling OSC 52
  - Added tests for disabling system clipboard
  - Added test for internal-only mode (both methods disabled)

## Implementation Details
- Configuration is applied in two places: editor initialization (`app/mod.rs`) and config reload (`app/toggle_actions.rs`)
- All system clipboard operations are now wrapped in `if self.use_system_clipboard` checks
- OSC 52 operations are wrapped in `if self.use_osc52` checks
- The internal clipboard always remains available as a fallback
- Indentation changes reflect the new conditional wrapping of clipboard operations

https://claude.ai/code/session_01NQiyzWyeF9GZmCuXE9FMVo