### PR TITLE
Implement plugin view state API and migrate markdown_compose

### DIFF
--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1169,6 +1169,17 @@ interface EditorAPI {
 	*/
 	setViewMode(bufferId: number, mode: string): boolean;
 	/**
+	* Set plugin-managed per-buffer view state.
+	* State is stored per-buffer per-split and persisted across sessions.
+	* Pass undefined/null as value to delete the key.
+	*/
+	setViewState(bufferId: number, key: string, value: unknown): boolean;
+	/**
+	* Get plugin-managed per-buffer view state.
+	* Returns undefined if the key is not set.
+	*/
+	getViewState(bufferId: number, key: string): unknown | undefined;
+	/**
 	* Enable or disable line wrapping for a buffer/split
 	*/
 	setLineWrap(bufferId: number, splitId: number | null, enabled: boolean): boolean;

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -694,6 +694,7 @@ impl Editor {
             },
             view_mode: Default::default(),
             compose_width: None,
+            plugin_state: std::collections::HashMap::new(),
         };
 
         // Save to disk

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -367,6 +367,7 @@ impl Editor {
             },
             view_mode: Default::default(),
             compose_width: None,
+            plugin_state: std::collections::HashMap::new(),
         };
 
         // Save to disk immediately
@@ -1036,6 +1037,7 @@ impl Editor {
                 SerializedViewMode::Compose => ViewMode::Compose,
             };
             buf_state.compose_width = file_state.compose_width;
+            buf_state.plugin_state = file_state.plugin_state.clone();
 
             tracing::trace!(
                 "Restored keyed state for {:?}: cursor={}, top_byte={}, view_mode={:?}",
@@ -1259,6 +1261,7 @@ fn serialize_split_view_state(
                                 ViewMode::Compose => SerializedViewMode::Compose,
                             },
                             compose_width: buf_state.compose_width,
+                            plugin_state: buf_state.plugin_state.clone(),
                         },
                     );
                 }

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -229,6 +229,27 @@ impl PluginManager {
         }
     }
 
+    /// Process commands, blocking until `HookCompleted` for the given hook arrives.
+    /// See [`PluginThreadHandle::process_commands_until_hook_completed`] for details.
+    pub fn process_commands_until_hook_completed(
+        &mut self,
+        hook_name: &str,
+        timeout: std::time::Duration,
+    ) -> Vec<super::api::PluginCommand> {
+        #[cfg(feature = "plugins")]
+        {
+            if let Some(ref mut manager) = self.inner {
+                return manager.process_commands_until_hook_completed(hook_name, timeout);
+            }
+            Vec::new()
+        }
+        #[cfg(not(feature = "plugins"))]
+        {
+            let _ = (hook_name, timeout);
+            Vec::new()
+        }
+    }
+
     /// Get the state snapshot handle for updating editor state.
     #[cfg(feature = "plugins")]
     pub fn state_snapshot_handle(&self) -> Option<Arc<RwLock<super::api::EditorStateSnapshot>>> {

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -91,6 +91,11 @@ pub struct BufferViewState {
     /// While true, incoming SubmitViewTransform commands are rejected as stale
     /// (their tokens have source_offsets from before the edit).
     pub view_transform_stale: bool,
+
+    /// Plugin-managed state (arbitrary key-value pairs).
+    /// Plugins can store per-buffer-per-split state here via the `setViewState`/`getViewState` API.
+    /// Persisted across sessions via workspace serialization.
+    pub plugin_state: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl BufferViewState {
@@ -105,6 +110,7 @@ impl BufferViewState {
             compose_prev_line_numbers: None,
             view_transform: None,
             view_transform_stale: false,
+            plugin_state: std::collections::HashMap::new(),
         }
     }
 }

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -177,6 +177,10 @@ pub struct SerializedFileState {
     /// Compose width for this buffer in this split
     #[serde(default)]
     pub compose_width: Option<u16>,
+
+    /// Plugin-managed state (arbitrary key-value pairs, persisted across sessions)
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub plugin_state: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -900,6 +904,7 @@ mod tests {
             },
             view_mode: SerializedViewMode::Source,
             compose_width: None,
+            plugin_state: HashMap::new(),
         };
 
         let json = serde_json::to_string(&file_state).unwrap();

--- a/crates/fresh-editor/tests/e2e/line_wrap_scroll_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/line_wrap_scroll_bugs.rs
@@ -370,26 +370,8 @@ fn test_mouse_wheel_with_multiline_file_one_long_line() {
         short_line1, short_line2, short_line3, long_line, short_line4, short_line5
     );
 
-    for ch in content.chars() {
-        if ch == '\n' {
-            harness
-                .send_key(
-                    crossterm::event::KeyCode::Enter,
-                    crossterm::event::KeyModifiers::NONE,
-                )
-                .unwrap();
-        } else {
-            harness.type_text(&ch.to_string()).unwrap();
-        }
-    }
-
-    // Move cursor to the beginning
-    harness
-        .send_key(
-            crossterm::event::KeyCode::Home,
-            crossterm::event::KeyModifiers::CONTROL,
-        )
-        .unwrap();
+    // Load via temp file — much faster than typing 2000+ chars one-by-one
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
     harness.render().unwrap();
 
     let screen_before = harness.screen_to_string();
@@ -467,27 +449,8 @@ fn test_scrollbar_click_with_multiline_file_one_long_line() {
         short_line1, short_line2, short_line3, long_line, short_line5, short_line6
     );
 
-    // Type the content
-    for ch in content.chars() {
-        if ch == '\n' {
-            harness
-                .send_key(
-                    crossterm::event::KeyCode::Enter,
-                    crossterm::event::KeyModifiers::NONE,
-                )
-                .unwrap();
-        } else {
-            harness.type_text(&ch.to_string()).unwrap();
-        }
-    }
-
-    // Move cursor to the beginning
-    harness
-        .send_key(
-            crossterm::event::KeyCode::Home,
-            crossterm::event::KeyModifiers::CONTROL,
-        )
-        .unwrap();
+    // Load via temp file — much faster than typing 2000+ chars one-by-one
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
     harness.render().unwrap();
 
     let screen_before = harness.screen_to_string();
@@ -556,25 +519,8 @@ fn test_scrollbar_drag_with_multiline_file_one_long_line() {
         short_line1, short_line2, short_line3, long_line, short_line5, short_line6
     );
 
-    for ch in content.chars() {
-        if ch == '\n' {
-            harness
-                .send_key(
-                    crossterm::event::KeyCode::Enter,
-                    crossterm::event::KeyModifiers::NONE,
-                )
-                .unwrap();
-        } else {
-            harness.type_text(&ch.to_string()).unwrap();
-        }
-    }
-
-    harness
-        .send_key(
-            crossterm::event::KeyCode::Home,
-            crossterm::event::KeyModifiers::CONTROL,
-        )
-        .unwrap();
+    // Load via temp file — much faster than typing 2000+ chars one-by-one
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
     harness.render().unwrap();
 
     let screen_before = harness.screen_to_string();

--- a/docs/internal/per-buffer-view-state-design.md
+++ b/docs/internal/per-buffer-view-state-design.md
@@ -3,49 +3,39 @@
 ## Status
 
 Core architecture: **Implemented** (February 14-15, 2026)
-Plugin API & migration: **Not started**
+Plugin API & migration: **Implemented** (February 15, 2026)
+Content-dependent state invalidation: **Not started**
 
 ## What Was Done
 
 The core per-buffer-per-view state system is fully in place:
 
-- **`BufferViewState` struct** (`view/split.rs`) — holds `cursors`, `viewport`, `view_mode`, `compose_width`, `compose_column_guides`, `view_transform`, and related fields per buffer per split.
+- **`BufferViewState` struct** (`view/split.rs`) — holds `cursors`, `viewport`, `view_mode`, `compose_width`, `compose_column_guides`, `view_transform`, `plugin_state`, and related fields per buffer per split.
 - **`SplitViewState` refactored** — buffer-specific fields replaced with `active_buffer: BufferId` and `keyed_states: HashMap<BufferId, BufferViewState>`. Accessors `active_state()` / `active_state_mut()` plus helpers (`buffer_state`, `ensure_buffer_state`, `remove_buffer_state`, `switch_buffer`). `Deref`/`DerefMut` impls proxy to the active state for backward compatibility.
 - **Cursor migration** — `EditorState.cursors` removed. Cursors live exclusively in `BufferViewState`; editing operations access them through the split view state. All cursor sync calls (`save_current_split_view_state` / `restore_current_split_view_state`) eliminated.
 - **`ComposeState` removed from `EditorState`** — `view_mode`, `compose_width`, and related fields now live only in `BufferViewState`.
-- **Workspace persistence** — `workspace.rs` stores per-file state (`view_mode`, `compose_width`, cursor, scroll) in `file_states: HashMap<PathBuf, SerializedFileState>` within each `SerializedSplitViewState`.
+- **Workspace persistence** — `workspace.rs` stores per-file state (`view_mode`, `compose_width`, cursor, scroll, `plugin_state`) in `file_states: HashMap<PathBuf, SerializedFileState>` within each `SerializedSplitViewState`.
+
+### Plugin state API
+
+- **`plugin_state: HashMap<String, serde_json::Value>`** added to `BufferViewState` — plugins can store arbitrary per-buffer-per-split state.
+- **`PluginCommand::SetViewState`** — JS plugins send state changes via the command channel; the handler persists values in `BufferViewState.plugin_state`.
+- **`EditorStateSnapshot.plugin_view_states`** — write-through cache in the snapshot allows immediate read-back within the same hook execution. The snapshot is populated from `BufferViewState.plugin_state` on each frame (using `or_insert` to preserve JS-side writes that haven't round-tripped yet). When the active split changes, the cache is fully repopulated.
+- **`JsEditorApi::set_view_state` / `get_view_state`** — `setViewState(bufferId, key, value)` writes through to the snapshot AND sends a command for Rust-side persistence. `getViewState(bufferId, key)` reads from the snapshot. Passing `null`/`undefined` as the value deletes the key.
+- **TypeScript declarations** — `setViewState` and `getViewState` added to `EditorAPI` in `fresh.d.ts`.
+- **Persistence** — `SerializedFileState.plugin_state` round-trips through workspace save/restore, so plugin state survives editor restarts.
+
+### markdown_compose plugin migration
+
+- **`composeBuffers` removed** — compose activation is tracked by `view_mode` in `BufferViewState` (via `editor.getBufferInfo().view_mode === "compose"`). A local `isComposing()` helper replaces all `composeBuffers.has()` checks.
+- **`tableColumnWidths` migrated** — replaced with `editor.setViewState(bufferId, "table-widths", ...)` / `editor.getViewState(bufferId, "table-widths")`. Table widths now persist across sessions and are independent per split. Helper functions `getTableWidths()`, `setTableWidths()`, `clearTableWidths()` handle Map↔Object conversion for JSON serialization.
+- **`lastCursorLine` migrated** — replaced with `editor.setViewState(bufferId, "last-cursor-line", line)` / `editor.getViewState(bufferId, "last-cursor-line")`.
+- **`enableMarkdownCompose` made idempotent** — safe to call when already in compose mode, enabling session restore without the old `composeBuffers` guard.
+- **`processBuffer` inlined** — its sole caller was `enableMarkdownCompose`; the `refreshLines` call is now inline.
 
 ## Remaining Work
 
-### 1. Plugin state API
-
-Expose `setViewState` / `getViewState` methods to the JS plugin runtime so plugins can store per-buffer-per-split state that persists across sessions.
-
-```typescript
-// Proposed additions to EditorAPI
-editor.setViewState(bufferId: number, key: string, value: unknown): void
-editor.getViewState(bufferId: number, key: string): unknown | undefined
-```
-
-Rust side: add a `plugin_state: HashMap<String, serde_json::Value>` field to `BufferViewState` and wire up host function handlers.
-
-### 2. Migrate `markdown_compose` plugin
-
-The plugin currently uses global JS-side structures that don't persist and aren't per-split:
-
-- `composeBuffers: Set<number>` — tracks which buffers are in compose mode
-- `tableColumnWidths: Map<number, Map<number, TableWidthInfo>>` — caches table column widths per buffer
-
-Migration steps:
-- Replace `composeBuffers` Set with `editor.getViewState(bufferId, "compose-active")` checks — compose activation is already tracked by `view_mode` in `BufferViewState`, so this Set may simply be removed.
-- Replace `tableColumnWidths` Map with `editor.setViewState(bufferId, "table-widths", ...)` so widths persist across sessions and are independent per split.
-- Remove the global state variables.
-
-### 3. Plugin state persistence
-
-Extend `SerializedFileState` in `workspace.rs` to include the `plugin_state` map so plugin-managed state round-trips through save/restore. Add a `buffer_view_restored` hook so plugins can react to restored state.
-
-### 4. Content-dependent state invalidation
+### Content-dependent state invalidation
 
 When a buffer is edited from one split, other splits viewing the same buffer should invalidate content-dependent plugin state (e.g., `tableColumnWidths`). Plugins can listen for `buffer_changed` events and mark cached state stale. This needs implementation and testing.
 
@@ -53,4 +43,4 @@ When a buffer is edited from one split, other splits viewing the same buffer sho
 
 - **Undo interaction**: View mode changes are not undoable (undo only covers buffer content). Recommendation: keep it this way, revisit if users report it as a problem.
 
-- **Same buffer, multiple splits**: Content is shared but view state is per-split. The `buffer_changed` hook for invalidating content-dependent plugin state needs testing once the plugin API is in place.
+- **Same buffer, multiple splits**: Content is shared but view state is per-split. The `buffer_changed` hook for invalidating content-dependent plugin state needs testing once content-dependent state invalidation is implemented.


### PR DESCRIPTION
## Summary

Implement a persistent per-buffer-per-split plugin state API (`setViewState`/`getViewState`) and migrate the `markdown_compose` plugin to use it. This enables plugins to store arbitrary state that survives editor restarts and is independent per split view.

## Key Changes

### Core Plugin State Infrastructure
- **Added `plugin_state` field to `BufferViewState`** — stores arbitrary key-value pairs per buffer per split
- **Implemented `PluginCommand::SetViewState`** — allows JS plugins to persist state changes via the command channel
- **Added write-through cache in `EditorStateSnapshot`** — `plugin_view_states` map enables immediate read-back within the same hook execution without waiting for round-trip
- **Exposed `setViewState`/`getViewState` API** — new methods in `JsEditorApi` for plugins to read/write state with automatic JSON serialization
- **Extended workspace persistence** — `SerializedFileState.plugin_state` round-trips through save/restore so plugin state survives editor restarts

### markdown_compose Plugin Migration
- **Removed `composeBuffers` Set** — replaced with `isComposing()` helper that checks `view_mode` from `BufferViewState` (source of truth)
- **Migrated `tableColumnWidths` Map** — now uses `setViewState(bufferId, "table-widths", ...)` for persistence across sessions and per-split independence
- **Migrated `lastCursorLine` Map** — now uses `setViewState(bufferId, "last-cursor-line", ...)` 
- **Made `enableMarkdownCompose` idempotent** — safe to call when already in compose mode, enabling proper session restore without guards
- **Inlined `processBuffer`** — simplified by moving its `refreshLines` call directly into `enableMarkdownCompose`
- **Added helper functions** — `getTableWidths()`, `setTableWidths()`, `clearTableWidths()` handle Map↔Object conversion for JSON serialization

### Implementation Details
- **Write-through semantics** — `setViewState` updates the snapshot immediately AND sends a command for Rust-side persistence, allowing `getViewState` to read back values within the same hook
- **Split-aware caching** — snapshot's `plugin_view_states` is fully repopulated when the active split changes; otherwise uses `or_insert` to preserve JS-side writes pending round-trip
- **Automatic cleanup** — plugin state is cleaned up automatically when buffers are removed from `keyed_states`
- **JSON serialization** — added `json_to_js_value()` helper in QuickJS backend to convert `serde_json::Value` back to JS values for `getViewState` returns

https://claude.ai/code/session_01XUPPzcL6o6JZnxeakDmEcr