### PR TITLE
Persist file explorer toggle settings across sessions

### DIFF
--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -748,28 +748,49 @@ impl Editor {
     }
 
     pub fn file_explorer_toggle_hidden(&mut self) {
-        if let Some(explorer) = &mut self.file_explorer {
+        let show_hidden = if let Some(explorer) = &mut self.file_explorer {
             explorer.toggle_show_hidden();
-            let msg = if explorer.ignore_patterns().show_hidden() {
-                t!("explorer.showing_hidden")
-            } else {
-                t!("explorer.hiding_hidden")
-            };
-            self.set_status_message(msg.to_string());
-        }
+            explorer.ignore_patterns().show_hidden()
+        } else {
+            return;
+        };
+
+        let msg = if show_hidden {
+            t!("explorer.showing_hidden")
+        } else {
+            t!("explorer.hiding_hidden")
+        };
+        self.set_status_message(msg.to_string());
+
+        // Persist to config so the setting survives across sessions
+        self.config.file_explorer.show_hidden = show_hidden;
+        self.persist_config_change(
+            "/file_explorer/show_hidden",
+            serde_json::Value::Bool(show_hidden),
+        );
     }
 
     pub fn file_explorer_toggle_gitignored(&mut self) {
-        if let Some(explorer) = &mut self.file_explorer {
+        let show_gitignored = if let Some(explorer) = &mut self.file_explorer {
             explorer.toggle_show_gitignored();
-            let show = explorer.ignore_patterns().show_gitignored();
-            let msg = if show {
-                t!("explorer.showing_gitignored")
-            } else {
-                t!("explorer.hiding_gitignored")
-            };
-            self.set_status_message(msg.to_string());
-        }
+            explorer.ignore_patterns().show_gitignored()
+        } else {
+            return;
+        };
+
+        let msg = if show_gitignored {
+            t!("explorer.showing_gitignored")
+        } else {
+            t!("explorer.hiding_gitignored")
+        };
+        self.set_status_message(msg.to_string());
+
+        // Persist to config so the setting survives across sessions
+        self.config.file_explorer.show_gitignored = show_gitignored;
+        self.persist_config_change(
+            "/file_explorer/show_gitignored",
+            serde_json::Value::Bool(show_gitignored),
+        );
     }
 
     /// Clear the file explorer search

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -325,4 +325,17 @@ impl Editor {
         // Emit event so plugins know themes changed
         self.emit_event("themes_changed", serde_json::json!({}));
     }
+
+    /// Persist a single config change to the user config file.
+    ///
+    /// Used when toggling settings via menu/command palette so that
+    /// the change is saved immediately (matching the settings UI behavior).
+    pub(super) fn persist_config_change(&self, json_pointer: &str, value: serde_json::Value) {
+        let resolver = ConfigResolver::new(self.dir_context.clone(), self.working_dir.clone());
+        let changes = std::collections::HashMap::from([(json_pointer.to_string(), value)]);
+        let deletions = std::collections::HashSet::new();
+        if let Err(e) = resolver.save_changes_to_layer(&changes, &deletions, ConfigLayer::User) {
+            tracing::error!("Failed to persist config change {}: {}", json_pointer, e);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds persistence for file explorer toggle settings (`show_hidden` and `show_gitignored`) so that user preferences are saved and restored across editor sessions.

## Key Changes
- **Refactored toggle methods**: Restructured `file_explorer_toggle_hidden()` and `file_explorer_toggle_gitignored()` to extract the toggle state and handle early returns more cleanly
- **Added config persistence**: Both toggle methods now call `persist_config_change()` to save the setting to the user config file immediately after toggling
- **New helper method**: Introduced `persist_config_change()` in `toggle_actions.rs` to handle persisting individual config changes using the `ConfigResolver`, matching the behavior of the settings UI

## Implementation Details
- The toggle state is captured in a variable before the early return, allowing the persistence logic to be executed outside the conditional block
- Config changes are persisted using JSON pointer paths (`/file_explorer/show_hidden` and `/file_explorer/show_gitignored`)
- Errors during persistence are logged but don't interrupt the user experience
- The implementation follows the existing pattern used for other settings persistence in the codebase

https://claude.ai/code/session_017wsEscsCSN4ScxvZ2hQJn3