### PR TITLE
Refactor buffer rendering to separate layout computation from drawing

### DIFF
--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -784,6 +784,9 @@ pub(crate) struct CachedLayout {
     pub search_options_layout: Option<crate::view::ui::status_bar::SearchOptionsLayout>,
     /// Menu bar layout for hit testing
     pub menu_layout: Option<crate::view::ui::menu::MenuLayout>,
+    /// Last frame dimensions — used by recompute_layout for macro replay
+    pub last_frame_width: u16,
+    pub last_frame_height: u16,
 }
 
 impl CachedLayout {


### PR DESCRIPTION
## Summary
This PR refactors the buffer rendering pipeline to separate pure layout computation from frame drawing, enabling macro replay to keep cached view line mappings fresh between actions without paying the cost of full rendering.

## Key Changes

- **New `BufferLayoutOutput` struct**: Encapsulates all layout computation results (view line mappings, render output, compose layout, etc.) that the drawing phase needs.

- **Split `render_buffer_in_split` into two phases**:
  - `compute_buffer_layout()`: Pure layout computation with no frame/drawing involved. Handles viewport synchronization, cursor visibility, view data building, and line rendering calculations.
  - `draw_buffer_in_split()`: Consumes `BufferLayoutOutput` to render into a frame. Handles background application, cursor positioning, rulers, and compose guides.
  - `render_buffer_in_split()`: Convenience wrapper that calls both phases in sequence for backward compatibility.

- **New `compute_content_layout()` method**: Layout-only path that computes view line mappings for all visible splits without drawing. Used by macro replay to keep cached layout fresh between actions.

- **Macro replay improvements**:
  - Added `recompute_layout()` to the Editor that recomputes view line mappings without rendering.
  - Modified `play_macro()` to call `recompute_layout()` between each replayed action, ensuring visual-line movements (MoveLineEnd, MoveUp, MoveDown) see correct, up-to-date layout information.
  - Added guard in `record_macro_action()` to prevent recording actions during macro playback.
  - Store frame dimensions in `CachedLayout` for use during macro replay.

- **New test**: `test_macro_move_line_end_uses_current_line_length()` verifies that MoveLineEnd during macro replay uses the current line length, not stale cached layout from before the macro modified the line.

## Implementation Details

The refactoring maintains the same rendering output while enabling efficient layout-only updates. The `compute_buffer_layout()` method performs all the complex viewport synchronization, view data building, and line rendering that was previously interleaved with drawing code. This allows macro replay to keep layout information synchronized with buffer state changes without the overhead of frame rendering.

The separation also improves code clarity by making the distinction between layout concerns (viewport, scrolling, line wrapping) and drawing concerns (colors, styles, cursor rendering) explicit.

https://claude.ai/code/session_018ouHiU7feNhapjWFNr9fJn