### PR TITLE
fix: use backpressure instead of try_send for streaming data (#1059)

### DIFF
--- a/crates/fresh-editor/src/services/remote/mod.rs
+++ b/crates/fresh-editor/src/services/remote/mod.rs
@@ -10,9 +10,16 @@ mod protocol;
 mod spawner;
 
 pub use channel::AgentChannel;
+/// Test-only global: microseconds to sleep per chunk in the consumer loop.
+/// Defaults to 0 (no delay). Set non-zero from tests to simulate slow consumers.
+#[doc(hidden)]
+pub use channel::TEST_RECV_DELAY_US;
 /// Re-export for integration tests - spawns a local agent without SSH
 #[doc(hidden)]
 pub use connection::spawn_local_agent;
+/// Like `spawn_local_agent` but with a custom data channel capacity.
+#[doc(hidden)]
+pub use connection::spawn_local_agent_with_capacity;
 pub use connection::{ConnectionParams, SshConnection};
 pub use filesystem::RemoteFileSystem;
 pub use protocol::{


### PR DESCRIPTION
The bounded mpsc channel in AgentChannel::handle_response used try_send which silently drops data when the channel is full. On macOS, OS thread scheduling causes the consumer to lag behind the producer enough to overflow the 64-slot buffer, resulting in intermittent data loss when loading large files via remote (SSH) editing.

Changed handle_response to async with send().await for backpressure. Added configurable channel capacity, a test-only consumer delay hook, shadow buffer random-ops test, and a deterministic regression test.