### PR TITLE
fix: route bracket paste to terminal PTY in terminal mode

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -537,6 +537,12 @@ impl Editor {
             return;
         }
 
+        // If in terminal mode, send paste to the terminal PTY
+        if self.terminal_mode {
+            self.send_terminal_input(normalized.as_bytes());
+            return;
+        }
+
         // Convert to buffer's line ending format
         let buffer_line_ending = self.active_state().buffer.line_ending();
         let paste_text = match buffer_line_ending {


### PR DESCRIPTION
Fixes #1056

paste_text() was always inserting into the editor buffer, even when in terminal mode. Bracket paste events (CrosstermEvent::Paste) now route to send_terminal_input() when terminal_mode is active, matching the behavior of the TerminalPaste action.

Add e2e test that opens a terminal, starts cat, simulates a bracket paste via paste_text(), and verifies the text reaches the PTY.