### PR TITLE
Add file URI to path conversion utilities for cross-platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,6 +1282,7 @@ dependencies = [
  "tokio",
  "tracing",
  "ts-rs",
+ "url",
 ]
 
 [[package]]

--- a/crates/fresh-editor/plugins/clangd_support.ts
+++ b/crates/fresh-editor/plugins/clangd_support.ts
@@ -36,22 +36,14 @@ function detectLanguage(path: string): string | null {
 }
 
 function pathToFileUri(path: string): string {
-  let normalized = path.replace(/\\/g, "/");
-  if (!normalized.startsWith("/")) {
-    normalized = "/" + normalized;
-  }
-  return "file://" + encodeURI(normalized);
+  return editor.pathToFileUri(path);
 }
 
 function fileUriToPath(uri: string): string {
   if (!uri.startsWith("file://")) {
     return uri;
   }
-  let path = decodeURI(uri.substring("file://".length));
-  if (path.startsWith("/") && path.length > 2 && path[2] === ":") {
-    path = path.substring(1);
-  }
-  return path;
+  return editor.fileUriToPath(uri) || uri;
 }
 
 function setClangdStatus(message: string): void {

--- a/crates/fresh-editor/plugins/csharp_support.ts
+++ b/crates/fresh-editor/plugins/csharp_support.ts
@@ -186,7 +186,7 @@ globalThis.on_csharp_file_open = async function (data: AfterFileOpenData): Promi
       configuredProjectRoots.add(projectRoot);
 
       // Convert path to file:// URI
-      const rootUri = `file://${projectRoot}`;
+      const rootUri = editor.pathToFileUri(projectRoot);
       editor.debug(`csharp_support: Setting LSP root URI to ${rootUri}`);
       editor.setLspRootUri("csharp", rootUri);
     }

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -260,7 +260,7 @@ type BufferInfo = {
 	view_mode: string;
 	/**
 	* True if any split showing this buffer has compose mode enabled.
-	* Plugins should use this (not view_mode) to decide whether to maintain
+	* Plugins should use this (not `view_mode`) to decide whether to maintain
 	* decorations, since decorations live on the buffer and are filtered
 	* per-split at render time.
 	*/
@@ -835,6 +835,18 @@ interface EditorAPI {
 	* Check if path is absolute
 	*/
 	pathIsAbsolute(path: string): boolean;
+	/**
+	* Convert a file:// URI to a local file path.
+	* Handles percent-decoding and Windows drive letters.
+	* Returns an empty string if the URI is not a valid file URI.
+	*/
+	fileUriToPath(uri: string): string;
+	/**
+	* Convert a local file path to a file:// URI.
+	* Handles Windows drive letters and special characters.
+	* Returns an empty string if the path cannot be converted.
+	*/
+	pathToFileUri(path: string): string;
 	/**
 	* Get the UTF-8 byte length of a JavaScript string.
 	* 

--- a/crates/fresh-plugin-runtime/Cargo.toml
+++ b/crates/fresh-plugin-runtime/Cargo.toml
@@ -21,6 +21,7 @@ fresh-parser-js.workspace = true
 fresh-plugin-api-macros.workspace = true
 ts-rs.workspace = true
 lsp-types.workspace = true
+url = "2.5"
 oxc_allocator.workspace = true
 oxc_parser.workspace = true
 oxc_codegen.workspace = true


### PR DESCRIPTION
## Summary
This PR adds two new utility functions to the editor API for converting between file:// URIs and local file paths, with proper handling of percent-encoding and Windows drive letters. It also updates the diagnostics panel plugin to use these utilities for more robust URI/path comparison.

## Key Changes
- **New Editor API methods**:
  - `fileUriToPath(uri: string): string` - Converts file:// URIs to local file paths, handling percent-decoding and Windows drive letters
  - `pathToFileUri(path: string): string` - Converts local file paths to file:// URIs, handling Windows paths and special characters
  - Both methods return empty strings on invalid input

- **Diagnostics panel improvements**:
  - Updated `uriToPath()` to use the new `fileUriToPath()` method instead of naive string slicing
  - Changed filtering logic to compare decoded paths instead of raw URIs, avoiding encoding mismatches
  - Fixed sorting to properly handle URI-encoded paths by decoding them before comparison

- **Type definitions**:
  - Added TypeScript declarations for the new `fileUriToPath` and `pathToFileUri` methods
  - Minor documentation fix in `BufferInfo` type (backtick formatting)

- **Dependencies**:
  - Added `url = "2.5"` crate for robust URI parsing and file path conversion

## Implementation Details
The implementation leverages the `url` crate's `Url::parse()` and `Url::from_file_path()` methods, which properly handle:
- Percent-decoding of special characters (e.g., `%20` → space)
- Windows drive letter handling (e.g., `C:` in file URIs)
- Cross-platform path normalization

The diagnostics panel now decodes URIs before comparing paths, which resolves issues where percent-encoded URIs wouldn't match their decoded equivalents (addressing issue #1071 for Windows paths with encoded colons).

https://claude.ai/code/session_0159EPTCQzeQuadLSwTQYyDC