### PR TITLE
Added example of how to bind a key to play a macro

### DIFF
--- a/docs/features/editing.md
+++ b/docs/features/editing.md
@@ -91,6 +91,32 @@ Record and replay sequences of keystrokes:
 
 Use the command palette (`Ctrl+P`) to access **Record Macro**, **Play Macro**, **Play Last Macro**, and **List Macros** commands.
 
+To bind a custom key to play a macro, follow the example below to add a `keybindings` section to your local `config.json`. 
+
+This example binds `alt+shift+!` to play macro 1 and `alt+shift+@` to play macro 2.
+
+```json
+{
+  "theme": "dracula",
+  "keybindings": [
+    {
+      "key": "!",
+      "modifiers": ["alt"],
+      "action": "play_macro",
+      "args": {"char": "1"},
+      "when": "normal"
+    },
+    {
+      "key": "@",
+      "modifiers": ["alt"],
+      "action": "play_macro",
+      "args": {"char": "2"},
+      "when": "normal"
+    }
+  ]
+}
+```
+
 ## Bookmarks
 
 Jump quickly between locations in your code:


### PR DESCRIPTION
After looking thru the codebase, I figured out how to bind keys to play macros. So I thought I'd a bit to your documentation. This may not be the right place, but feel free to use however you choose.

Thanks for developing such an awesome editor!