### PR TITLE
Intercept event debug input before other key event processing

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -43,6 +43,14 @@ impl Editor {
         // Create key event for dispatch methods
         let key_event = crossterm::event::KeyEvent::new(code, modifiers);
 
+        // Event debug dialog intercepts ALL key events before any other processing.
+        // This must be checked here (not just in main.rs/gui) so it works in
+        // client/server mode where handle_key is called directly.
+        if self.is_event_debug_active() {
+            self.handle_event_debug_input(&key_event);
+            return Ok(());
+        }
+
         // Try terminal input dispatch first (handles terminal mode and re-entry)
         if self.dispatch_terminal_input(&key_event).is_some() {
             return Ok(());


### PR DESCRIPTION
## Summary
Moved event debug dialog input handling to the beginning of the key event processing pipeline in `Editor::handle_key()` to ensure it intercepts all key events before any other processing occurs.

## Key Changes
- Added early return check for `is_event_debug_active()` at the start of `handle_key()` method
- When event debug is active, `handle_event_debug_input()` is called and the method returns immediately
- This ensures the event debug dialog works correctly in both GUI and client/server modes where `handle_key()` is called directly

## Implementation Details
- The event debug check is placed after the `KeyEvent` is created but before terminal input dispatch
- Includes explanatory comments noting that this placement is critical for client/server mode compatibility
- The early return prevents any other input handlers from processing keys while the debug dialog is active

https://claude.ai/code/session_01KzhDmgYm4sGVDXNC1X4V8S