### PR TITLE
Make log files read-only when opened in editor

### DIFF
--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -235,6 +235,7 @@ impl Editor {
 
         // Preserve user settings before reloading
         let old_buffer_settings = self.active_state().buffer_settings.clone();
+        let old_editing_disabled = self.active_state().editing_disabled;
 
         // Load the file content fresh from disk
         let mut new_state = EditorState::from_file_with_languages(
@@ -257,6 +258,7 @@ impl Editor {
         });
         // Restore user settings (tab size, indentation, etc.)
         new_state.buffer_settings = old_buffer_settings;
+        new_state.editing_disabled = old_editing_disabled;
         // Line number visibility is in per-split BufferViewState (survives buffer replacement)
 
         // Replace the current buffer with the new state
@@ -730,10 +732,10 @@ impl Editor {
                 }
             })
             .unwrap_or_default();
-        let old_buffer_settings = self
+        let (old_buffer_settings, old_editing_disabled) = self
             .buffers
             .get(&buffer_id)
-            .map(|s| s.buffer_settings.clone())
+            .map(|s| (s.buffer_settings.clone(), s.editing_disabled))
             .unwrap_or_default();
 
         // Load the file content fresh from disk
@@ -758,6 +760,7 @@ impl Editor {
         });
         // Restore user settings (tab size, indentation, etc.)
         new_state.buffer_settings = old_buffer_settings;
+        new_state.editing_disabled = old_editing_disabled;
         // Line number visibility is in per-split BufferViewState (survives buffer replacement)
 
         // Replace the buffer content

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1717,8 +1717,19 @@ impl Editor {
     pub fn open_status_log(&mut self) {
         if let Some(path) = self.status_log_path.clone() {
             // Use open_local_file since log files are always local
-            if let Err(e) = self.open_local_file(&path) {
-                tracing::error!("Failed to open status log: {}", e);
+            match self.open_local_file(&path) {
+                Ok(buffer_id) => {
+                    // Make the buffer read-only since it's a log file
+                    if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                        state.editing_disabled = true;
+                    }
+                    if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
+                        metadata.read_only = true;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to open status log: {}", e);
+                }
             }
         } else {
             self.set_status_message("Status log not available".to_string());
@@ -1763,8 +1774,19 @@ impl Editor {
     pub fn open_warning_log(&mut self) {
         if let Some(path) = self.warning_domains.general.log_path.clone() {
             // Use open_local_file since log files are always local
-            if let Err(e) = self.open_local_file(&path) {
-                tracing::error!("Failed to open warning log: {}", e);
+            match self.open_local_file(&path) {
+                Ok(buffer_id) => {
+                    // Make the buffer read-only since it's a log file
+                    if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                        state.editing_disabled = true;
+                    }
+                    if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
+                        metadata.read_only = true;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Failed to open warning log: {}", e);
+                }
             }
         }
     }

--- a/crates/fresh-editor/tests/e2e/warning_indicators.rs
+++ b/crates/fresh-editor/tests/e2e/warning_indicators.rs
@@ -8,6 +8,7 @@
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
+use std::io::Write;
 
 /// Test that ShowWarnings command appears in command palette
 #[test]
@@ -103,6 +104,63 @@ fn test_show_lsp_status_no_lsp() {
 
     // Should show "No LSP server active" status message
     harness.assert_screen_contains("No LSP server active");
+}
+
+/// Test that status log buffer stays read-only after revert
+///
+/// Reproduces the bug where opening a log file via the status bar sets
+/// editing_disabled, but when the file is updated and reverted,
+/// the flag was lost because revert_file() replaces the entire EditorState.
+#[test]
+fn test_status_log_stays_read_only_after_revert() {
+    let mut harness = EditorTestHarness::with_temp_project(100, 24).unwrap();
+    let project_dir = harness.project_dir().unwrap();
+    let log_path = project_dir.join("status.log");
+
+    // Create initial log file
+    {
+        let mut f = std::fs::File::create(&log_path).unwrap();
+        f.write_all(b"2025-01-01 00:00:00 Initial status\n")
+            .unwrap();
+        f.sync_all().unwrap();
+    }
+
+    // Set the status log path and open it
+    harness.editor_mut().set_status_log_path(log_path.clone());
+    harness.editor_mut().open_status_log();
+    harness.render().unwrap();
+
+    // Verify the buffer is read-only
+    assert!(
+        harness.editor().is_editing_disabled(),
+        "Status log buffer should be read-only immediately after opening"
+    );
+
+    // Update the file on disk (simulating new status messages being appended)
+    {
+        let mut f = std::fs::File::create(&log_path).unwrap();
+        f.write_all(b"2025-01-01 00:00:00 Initial status\n2025-01-01 00:00:01 New status\n")
+            .unwrap();
+        f.sync_all().unwrap();
+    }
+
+    // Trigger a revert (this is what auto-revert does when it detects the file changed)
+    let reverted = harness.editor_mut().revert_file().unwrap();
+    assert!(reverted, "revert_file should succeed");
+    harness.render().unwrap();
+
+    // Verify the buffer content was updated
+    let content = harness.get_buffer_content().unwrap_or_default();
+    assert!(
+        content.contains("New status"),
+        "Buffer should contain reverted content"
+    );
+
+    // The key assertion: editing_disabled must survive the revert
+    assert!(
+        harness.editor().is_editing_disabled(),
+        "Status log buffer should remain read-only after revert"
+    );
 }
 
 /// Test ClearWarnings command execution


### PR DESCRIPTION
## Summary
This change ensures that log files opened through the status log and warning log viewers are marked as read-only to prevent accidental modifications.

## Key Changes
- Modified `open_status_log()` to set both `editing_disabled` and `read_only` flags on the buffer after successfully opening the status log file
- Modified `open_warning_log()` to set both `editing_disabled` and `read_only` flags on the buffer after successfully opening the warning log file
- Refactored error handling from `if let Err()` to `match` statements to enable processing of the successful `Ok(buffer_id)` case

## Implementation Details
- When a log file is successfully opened, the returned `buffer_id` is used to access and modify both the buffer state and buffer metadata
- The `editing_disabled` flag prevents editing operations on the buffer
- The `read_only` flag marks the buffer metadata as read-only
- Error handling remains unchanged - failures to open log files are still logged as errors

https://claude.ai/code/session_01MeCkbY9yiEvx1zwY9opwwT