### PR TITLE
Fix file browser scroll handling to require mouse over popup

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -238,8 +238,11 @@ impl Editor {
                 } else if self.handle_prompt_scroll(-3) {
                     // Check if prompt with suggestions is active and should handle scroll
                     needs_render = true;
-                } else if self.is_file_open_active() && self.handle_file_open_scroll(-3) {
-                    // Check if file browser is active and should handle scroll
+                } else if self.is_file_open_active()
+                    && self.is_mouse_over_file_browser(col, row)
+                    && self.handle_file_open_scroll(-3)
+                {
+                    // Check if file browser is active and mouse is over it
                     needs_render = true;
                 } else if self.is_mouse_over_any_popup(col, row) {
                     // Scroll the popup content (works for all popups including completion)
@@ -270,7 +273,10 @@ impl Editor {
                 } else if self.handle_prompt_scroll(3) {
                     // Check if prompt with suggestions is active and should handle scroll
                     needs_render = true;
-                } else if self.is_file_open_active() && self.handle_file_open_scroll(3) {
+                } else if self.is_file_open_active()
+                    && self.is_mouse_over_file_browser(col, row)
+                    && self.handle_file_open_scroll(3)
+                {
                     needs_render = true;
                 } else if self.is_mouse_over_any_popup(col, row) {
                     // Scroll the popup content (works for all popups including completion)
@@ -656,6 +662,13 @@ impl Editor {
         let layouts = popup_areas_to_layout_info(&self.cached_layout.popup_areas);
         let hit_tester = PopupHitTester::new(&layouts, &self.active_state().popups);
         hit_tester.is_over_popup(col, row)
+    }
+
+    /// Check if mouse position is over the file browser popup
+    fn is_mouse_over_file_browser(&self, col: u16, row: u16) -> bool {
+        self.file_browser_layout
+            .as_ref()
+            .is_some_and(|layout| layout.contains(col, row))
     }
 
     /// Compute what hover target is at the given position

--- a/crates/fresh-editor/src/view/ui/file_browser.rs
+++ b/crates/fresh-editor/src/view/ui/file_browser.rs
@@ -144,6 +144,7 @@ impl FileBrowserRenderer {
             render_scrollbar(frame, scrollbar_area, &scrollbar_state, &colors);
 
         Some(FileBrowserLayout {
+            popup_area: area,
             nav_area,
             header_area,
             list_area,
@@ -655,6 +656,8 @@ impl FileBrowserRenderer {
 /// Layout information for mouse hit testing
 #[derive(Debug, Clone)]
 pub struct FileBrowserLayout {
+    /// The overall popup area (including borders)
+    pub popup_area: Rect,
     /// Navigation shortcuts area
     pub nav_area: Rect,
     /// Column headers area
@@ -674,6 +677,14 @@ pub struct FileBrowserLayout {
 }
 
 impl FileBrowserLayout {
+    /// Check if a position is within the overall popup area (including borders)
+    pub fn contains(&self, x: u16, y: u16) -> bool {
+        x >= self.popup_area.x
+            && x < self.popup_area.x + self.popup_area.width
+            && y >= self.popup_area.y
+            && y < self.popup_area.y + self.popup_area.height
+    }
+
     /// Check if a position is within the file list area
     pub fn is_in_list(&self, x: u16, y: u16) -> bool {
         x >= self.list_area.x


### PR DESCRIPTION
## Summary
This PR fixes a bug where the file browser would scroll even when the mouse cursor was not positioned over it. The fix ensures that file browser scroll events only trigger when the mouse is actually hovering over the file browser popup.

## Key Changes
- Added `is_mouse_over_file_browser()` method to check if the mouse position is within the file browser popup bounds
- Updated both scroll up (wheel up) and scroll down (wheel down) handlers to verify the mouse is over the file browser before processing scroll events
- Added `popup_area` field to `FileBrowserLayout` to track the overall popup boundaries (including borders)
- Implemented `contains()` method on `FileBrowserLayout` to perform hit testing against the popup area

## Implementation Details
- The `is_mouse_over_file_browser()` method uses the existing `file_browser_layout` and delegates to the new `contains()` method for boundary checking
- The scroll handlers now follow a consistent pattern: check if file browser is active AND mouse is over it AND handle the scroll
- This brings the file browser scroll behavior in line with other popups that already check `is_mouse_over_any_popup()` before processing scroll events

https://claude.ai/code/session_01C12WPQM7xjjyosjTwtXX55