### PR TITLE
Include PNG icon files in Nix flake build sources

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,8 @@
               (lib.fileset.fileFilter (file: file.hasExt "sublime-syntax") unfilteredRoot)
               # Font files (used by include_bytes! in fresh-gui and fresh-editor)
               (lib.fileset.fileFilter (file: file.hasExt "ttf") unfilteredRoot)
+              # Icon files (used by include_bytes! in fresh-gui)
+              (lib.fileset.fileFilter (file: file.hasExt "png") unfilteredRoot)
               # Runtime assets in crates/fresh-editor
               ./crates/fresh-editor/docs
               ./crates/fresh-editor/keymaps


### PR DESCRIPTION
## Summary
Added PNG image files to the Nix flake's source file set to support icon assets used by the fresh-gui crate.

## Changes
- Added a file filter to include all `.png` files in the build sources, similar to existing filters for `.ttf` font files
- This enables `include_bytes!` macros in fresh-gui to properly embed PNG icon files during compilation

## Details
The change mirrors the existing pattern for font files (`.ttf`) by using `lib.fileset.fileFilter` to match files with the `.png` extension. This ensures that icon assets referenced in the fresh-gui crate are available during the Nix build process.

https://claude.ai/code/session_01WeaGNYeQM5bQvKtAsj3cuo