### PR TITLE
Reduce log noise by disabling span events and moving hot-path logs to trace

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1031,7 +1031,7 @@ impl Editor {
             .any(|c| !matches!(c, fresh_core::api::PluginCommand::HookCompleted { .. }));
 
         let cmd_names: Vec<String> = commands.iter().map(|c| c.debug_variant_name()).collect();
-        tracing::info!(
+        tracing::trace!(
             count = commands.len(),
             cmds = ?cmd_names,
             "process_plugin_commands"

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -4107,7 +4107,7 @@ impl Editor {
             bridge.try_recv_all()
         };
         let needs_render = !messages.is_empty();
-        tracing::info!(
+        tracing::trace!(
             async_message_count = messages.len(),
             "received async messages"
         );

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -356,7 +356,7 @@ impl Editor {
             if !commands.is_empty() {
                 let cmd_names: Vec<String> =
                     commands.iter().map(|c| c.debug_variant_name()).collect();
-                tracing::info!(count = commands.len(), cmds = ?cmd_names, "process_commands during render");
+                tracing::trace!(count = commands.len(), cmds = ?cmd_names, "process_commands during render");
             }
             for command in commands {
                 if let Err(e) = self.handle_plugin_command(command) {

--- a/crates/fresh-editor/src/model/buffer.rs
+++ b/crates/fresh-editor/src/model/buffer.rs
@@ -1583,7 +1583,7 @@ impl TextBuffer {
         // has been restructured for non-edit reasons (viewport chunk loading,
         // line-scan preparation, search-scan splits).
         if !self.modified {
-            tracing::info!("diff_since_saved: not modified → equal");
+            tracing::trace!("diff_since_saved: not modified → equal");
             return PieceTreeDiff {
                 equal: true,
                 byte_ranges: Vec::new(),
@@ -1595,7 +1595,7 @@ impl TextBuffer {
         // Quick check: if tree roots are identical (Arc pointer equality),
         // the content is definitely the same.
         if Arc::ptr_eq(&self.saved_root, &self.piece_tree.root()) {
-            tracing::info!("diff_since_saved: Arc::ptr_eq fast path → equal");
+            tracing::trace!("diff_since_saved: Arc::ptr_eq fast path → equal");
             return PieceTreeDiff {
                 equal: true,
                 byte_ranges: Vec::new(),
@@ -1610,7 +1610,7 @@ impl TextBuffer {
 
         // If structure says trees are equal (same pieces in same order), we're done
         if structure_diff.equal {
-            tracing::info!(
+            tracing::trace!(
                 "diff_since_saved: structure equal, line_ranges={}",
                 structure_diff
                     .line_ranges
@@ -1636,7 +1636,7 @@ impl TextBuffer {
         if total_changed_bytes <= MAX_VERIFY_BYTES && !structure_diff.byte_ranges.is_empty() {
             // Check if content in the changed ranges is actually different
             if self.verify_content_differs_in_ranges(&structure_diff.byte_ranges) {
-                tracing::info!(
+                tracing::trace!(
                     "diff_since_saved: content differs, byte_ranges={}, line_ranges={}",
                     structure_diff.byte_ranges.len(),
                     structure_diff
@@ -2301,7 +2301,7 @@ impl TextBuffer {
         // Cap the estimate at the remaining bytes in the document
         let remaining_bytes = self.total_bytes().saturating_sub(start_offset);
         let bytes_to_load = estimated_bytes.min(remaining_bytes);
-        tracing::info!(
+        tracing::trace!(
             bytes_to_load,
             total_bytes = self.total_bytes(),
             "prepare_viewport loading"

--- a/crates/fresh-editor/src/services/tracing_setup.rs
+++ b/crates/fresh-editor/src/services/tracing_setup.rs
@@ -55,9 +55,15 @@ pub fn build_subscriber(
         .add_directive("swc_ecma_transforms_base=info".parse().unwrap())
         .add_directive("swc_common=info".parse().unwrap());
 
+    let span_events = if std::env::var("FRESH_LOG_SPANS").is_ok() {
+        fmt::format::FmtSpan::CLOSE
+    } else {
+        fmt::format::FmtSpan::NONE
+    };
+
     let fmt_layer = fmt::layer()
         .with_writer(Arc::new(log_file))
-        .with_span_events(fmt::format::FmtSpan::CLOSE);
+        .with_span_events(span_events);
 
     tracing_subscriber::registry()
         .with(fmt_layer)

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -506,7 +506,7 @@ impl EditorState {
                 extend_to_line_end,
                 url,
             } => {
-                tracing::debug!(
+                tracing::trace!(
                     "AddOverlay: namespace={:?}, range={:?}, face={:?}, priority={}",
                     namespace,
                     range,
@@ -529,7 +529,7 @@ impl EditorState {
                 overlay.url = url.clone();
 
                 let actual_range = overlay.range(&self.marker_list);
-                tracing::debug!(
+                tracing::trace!(
                     "Created overlay with markers - actual range: {:?}, handle={:?}",
                     actual_range,
                     overlay.handle
@@ -539,7 +539,7 @@ impl EditorState {
             }
 
             Event::RemoveOverlay { handle } => {
-                tracing::debug!("RemoveOverlay: handle={:?}", handle);
+                tracing::trace!("RemoveOverlay: handle={:?}", handle);
                 self.overlays
                     .remove_by_handle(handle, &mut self.marker_list);
             }
@@ -549,7 +549,7 @@ impl EditorState {
             }
 
             Event::ClearNamespace { namespace } => {
-                tracing::debug!("ClearNamespace: namespace={:?}", namespace);
+                tracing::trace!("ClearNamespace: namespace={:?}", namespace);
                 self.overlays
                     .clear_namespace(namespace, &mut self.marker_list);
             }

--- a/crates/fresh-editor/src/view/conceal.rs
+++ b/crates/fresh-editor/src/view/conceal.rs
@@ -160,7 +160,7 @@ impl ConcealManager {
                 .iter()
                 .map(|(r, repl)| format!("{}..{}={}", r.start, r.end, repl.unwrap_or("hide")))
                 .collect();
-            tracing::info!(
+            tracing::trace!(
                 "[conceal] query_viewport({start}..{end}): {} ranges: {}",
                 results.len(),
                 summary.join(", ")

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -454,7 +454,7 @@ impl TabsRenderer {
         // Only clamp to prevent negative or extreme values
         let max_offset = total_width.saturating_sub(max_width);
         let offset = tab_scroll_offset.min(total_width);
-        tracing::debug!(
+        tracing::trace!(
             "render_for_split: tab_scroll_offset={}, max_offset={}, offset={}, total={}, max_width={}",
             tab_scroll_offset, max_offset, offset, total_width, max_width
         );

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -616,7 +616,7 @@ impl JsEditorApi {
     // === Logging ===
 
     pub fn debug(&self, msg: String) {
-        tracing::info!("Plugin.debug: {}", msg);
+        tracing::trace!("Plugin.debug: {}", msg);
     }
 
     pub fn info(&self, msg: String) {


### PR DESCRIPTION
Span close events (time.busy/time.idle) accounted for ~90% of log volume and are now off by default. Set FRESH_LOG_SPANS=1 to re-enable.

Moved 12 high-frequency log sites to trace!: diff_since_saved, prepare_viewport, async message counts, plugin command processing, overlay/conceal operations, tab rendering, and Plugin.debug output. Reduces typical log from ~266MB to ~5-10MB.