### PR TITLE
Disable LSP commands for languages without LSP configuration

### DIFF
--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -594,6 +594,9 @@ impl Editor {
                     language
                 );
             }
+            LspSpawnResult::NotConfigured => {
+                tracing::debug!("No LSP server configured for language: {}", language);
+            }
             LspSpawnResult::Failed => {
                 tracing::warn!("Failed to spawn LSP client for language: {}", language);
             }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -469,6 +469,15 @@ impl Editor {
                     .buffer_metadata
                     .get(&self.active_buffer())
                     .and_then(|m| m.virtual_mode());
+                let has_lsp_config = {
+                    let language = self
+                        .buffers
+                        .get(&self.active_buffer())
+                        .map(|s| s.language.as_str());
+                    language
+                        .and_then(|lang| self.lsp.as_ref().and_then(|lsp| lsp.get_config(lang)))
+                        .is_some()
+                };
                 let suggestions = self.command_registry.read().unwrap().filter(
                     "",
                     self.key_context,
@@ -476,6 +485,7 @@ impl Editor {
                     self.has_active_selection(),
                     &self.active_custom_contexts,
                     active_buffer_mode,
+                    has_lsp_config,
                 );
                 self.start_prompt_with_suggestions(
                     t!("file.command_prompt").to_string(),

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -22,6 +22,18 @@ impl Editor {
         };
         let language = state.language.clone();
 
+        // Check if LSP is configured for this language before attempting restart
+        let lsp_configured = self
+            .lsp
+            .as_ref()
+            .and_then(|lsp| lsp.get_config(&language))
+            .is_some();
+
+        if !lsp_configured {
+            self.set_status_message(t!("lsp.no_server_configured").to_string());
+            return;
+        }
+
         // Attempt restart
         let Some(lsp) = self.lsp.as_mut() else {
             self.set_status_message(t!("lsp.no_manager").to_string());

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -3315,6 +3315,15 @@ impl Editor {
                 .buffer_metadata
                 .get(&self.active_buffer())
                 .and_then(|m| m.virtual_mode());
+            let has_lsp_config = {
+                let language = self
+                    .buffers
+                    .get(&self.active_buffer())
+                    .map(|s| s.language.as_str());
+                language
+                    .and_then(|lang| self.lsp.as_ref().and_then(|lsp| lsp.get_config(lang)))
+                    .is_some()
+            };
             self.command_registry.read().unwrap().filter(
                 query,
                 self.key_context,
@@ -3322,6 +3331,7 @@ impl Editor {
                 self.has_active_selection(),
                 &self.active_custom_contexts,
                 active_buffer_mode,
+                has_lsp_config,
             )
         } else if input.starts_with('#') {
             // Buffer mode
@@ -3456,6 +3466,7 @@ impl Editor {
                 .get(&self.active_buffer())
                 .and_then(|m| m.virtual_mode())
                 .map(|s| s.to_string()),
+            has_lsp_config: false, // Not needed for file suggestions
         };
 
         self.file_provider.suggestions(query, &context)
@@ -4010,6 +4021,15 @@ impl Editor {
                     .buffer_metadata
                     .get(&self.active_buffer())
                     .and_then(|m| m.virtual_mode());
+                let has_lsp_config = {
+                    let language = self
+                        .buffers
+                        .get(&self.active_buffer())
+                        .map(|s| s.language.as_str());
+                    language
+                        .and_then(|lang| self.lsp.as_ref().and_then(|lsp| lsp.get_config(lang)))
+                        .is_some()
+                };
                 if let Some(prompt) = &mut self.prompt {
                     // Use the underlying context (not Prompt context) for filtering
                     prompt.suggestions = self.command_registry.read().unwrap().filter(
@@ -4019,6 +4039,7 @@ impl Editor {
                         selection_active,
                         &self.active_custom_contexts,
                         active_buffer_mode,
+                        has_lsp_config,
                     );
                     prompt.selected_suggestion = if prompt.suggestions.is_empty() {
                         None

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -1128,6 +1128,15 @@ impl Editor {
                 .buffer_metadata
                 .get(&self.active_buffer())
                 .and_then(|m| m.virtual_mode());
+            let has_lsp_config = {
+                let language = self
+                    .buffers
+                    .get(&self.active_buffer())
+                    .map(|s| s.language.as_str());
+                language
+                    .and_then(|lang| self.lsp.as_ref().and_then(|lsp| lsp.get_config(lang)))
+                    .is_some()
+            };
 
             registry.filter(
                 query,
@@ -1136,6 +1145,7 @@ impl Editor {
                 selection_active,
                 &self.active_custom_contexts,
                 active_buffer_mode,
+                has_lsp_config,
             )
         };
 

--- a/crates/fresh-editor/src/input/command_registry.rs
+++ b/crates/fresh-editor/src/input/command_registry.rs
@@ -161,6 +161,9 @@ impl CommandRegistry {
     /// When query is not empty, commands are sorted by match quality (fzf-style scoring)
     /// with recency as tiebreaker for equal scores.
     /// Disabled commands always appear after enabled ones.
+    ///
+    /// `has_lsp_config` indicates whether the active buffer's language has an LSP server
+    /// configured. When false, LSP start/restart/toggle commands are disabled.
     pub fn filter(
         &self,
         query: &str,
@@ -169,6 +172,7 @@ impl CommandRegistry {
         selection_active: bool,
         active_custom_contexts: &std::collections::HashSet<String>,
         active_buffer_mode: Option<&str>,
+        has_lsp_config: bool,
     ) -> Vec<Suggestion> {
         let commands = self.get_all();
 
@@ -201,6 +205,12 @@ impl CommandRegistry {
             |cmd: &Command, score: i32, localized_name: String, localized_desc: String| {
                 let mut available = is_available(cmd);
                 if cmd.action == Action::FindInSelection && !selection_active {
+                    available = false;
+                }
+                // Disable LSP start/restart/toggle commands when no LSP is configured
+                if !has_lsp_config
+                    && matches!(cmd.action, Action::LspRestart | Action::LspToggleForBuffer)
+                {
                     available = false;
                 }
                 let keybinding =
@@ -482,6 +492,7 @@ mod tests {
             false,
             &empty_contexts,
             None,
+            true,
         );
         assert!(results.len() >= 2); // At least "Save File" + "Test Save"
 
@@ -526,6 +537,7 @@ mod tests {
             false,
             &empty_contexts,
             None,
+            true,
         );
         let popup_only = results.iter().find(|s| s.text == "Popup Only");
         assert!(popup_only.is_some());
@@ -539,6 +551,7 @@ mod tests {
             false,
             &empty_contexts,
             None,
+            true,
         );
         let normal_only = results.iter().find(|s| s.text == "Normal Only");
         assert!(normal_only.is_some());
@@ -637,6 +650,7 @@ mod tests {
             false,
             &empty_contexts,
             None,
+            true,
         );
 
         // Find positions of our test commands in results
@@ -713,6 +727,7 @@ mod tests {
             false,
             &empty_contexts,
             None,
+            true,
         );
 
         let save_pos = results.iter().position(|s| s.text == "Save File").unwrap();

--- a/crates/fresh-editor/src/input/quick_open/mod.rs
+++ b/crates/fresh-editor/src/input/quick_open/mod.rs
@@ -59,6 +59,8 @@ pub struct QuickOpenContext {
     pub custom_contexts: std::collections::HashSet<String>,
     /// Active buffer mode (e.g., "vi_normal")
     pub buffer_mode: Option<String>,
+    /// Whether the active buffer's language has an LSP server configured
+    pub has_lsp_config: bool,
 }
 
 /// Information about an open buffer

--- a/crates/fresh-editor/src/input/quick_open/providers.rs
+++ b/crates/fresh-editor/src/input/quick_open/providers.rs
@@ -65,6 +65,7 @@ impl QuickOpenProvider for CommandProvider {
             context.has_selection,
             &context.custom_contexts,
             context.buffer_mode.as_deref(),
+            context.has_lsp_config,
         )
     }
 
@@ -84,6 +85,7 @@ impl QuickOpenProvider for CommandProvider {
             context.has_selection,
             &context.custom_contexts,
             context.buffer_mode.as_deref(),
+            context.has_lsp_config,
         );
 
         if let Some(idx) = selected_index {
@@ -662,6 +664,7 @@ mod tests {
             key_context: crate::input::keybindings::KeyContext::Normal,
             custom_contexts: std::collections::HashSet::new(),
             buffer_mode: None,
+            has_lsp_config: true,
         }
     }
 

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -21,6 +21,8 @@ pub enum LspSpawnResult {
     /// Server is not configured for auto-start
     /// The server can still be started manually via command palette
     NotAutoStart,
+    /// No LSP server is configured for this language
+    NotConfigured,
     /// Server spawn failed or is disabled
     Failed,
 }
@@ -220,6 +222,7 @@ impl LspManager {
     /// It returns:
     /// - `LspSpawnResult::Spawned` if the server was spawned or already running
     /// - `LspSpawnResult::NotAutoStart` if auto_start is false and not manually allowed
+    /// - `LspSpawnResult::NotConfigured` if no LSP server is configured for the language
     /// - `LspSpawnResult::Failed` if spawn failed or language is disabled
     ///
     /// IMPORTANT: Callers should only call this when there is at least one buffer
@@ -234,7 +237,7 @@ impl LspManager {
         let config = match self.config.get(language) {
             Some(c) if c.enabled => c,
             Some(_) => return LspSpawnResult::Failed, // Disabled
-            None => return LspSpawnResult::Failed,    // Not configured
+            None => return LspSpawnResult::NotConfigured, // Not configured
         };
 
         // Check if we have runtime and bridge

--- a/crates/fresh-editor/tests/e2e/lsp_no_config.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_no_config.rs
@@ -1,0 +1,130 @@
+//! E2E tests for LSP commands on languages without LSP configuration
+//!
+//! Tests that LSP commands are properly disabled when the active buffer's
+//! language has no LSP server configured (e.g., plain text files).
+//!
+//! Refs: https://github.com/anthropics/fresh/issues/1168
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Test that "Start/Restart LSP" command is disabled for a language with
+/// no LSP configured (e.g., plain text).
+///
+/// Previously, executing this command would log a WARN
+/// "Failed to spawn LSP client for language: text" which is confusing
+/// since there's no LSP to spawn.
+#[test]
+fn test_start_lsp_disabled_for_unconfigured_language() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let test_file = temp_dir.path().join("readme.txt");
+    std::fs::write(&test_file, "Hello, this is a plain text file.\n")?;
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 30, temp_dir.path().to_path_buf())?;
+
+    // Open the text file - its language is "text" which has no LSP configured
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Open command palette
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_prompt()?;
+
+    // Type specific query to match the LSP restart command
+    harness.type_text("Start/Restart LSP")?;
+    harness.render()?;
+
+    // The "Start/Restart LSP" command should be visible in suggestions
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("LSP"),
+        "Command palette should show LSP-related command. Screen:\n{}",
+        screen
+    );
+
+    // Try to execute the command - it should be disabled
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.render()?;
+
+    // Should show "not available" since the command is disabled for this language
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("not available") || screen.contains("No LSP server configured"),
+        "Should show 'not available' or 'no LSP configured' message for text files. Screen:\n{}",
+        screen
+    );
+
+    // The warning indicator should NOT be active
+    assert!(
+        !harness.editor().get_warning_domains().has_any_warnings(),
+        "Opening a text file and trying to start LSP should not trigger a warning indicator"
+    );
+
+    Ok(())
+}
+
+/// Test that "Toggle LSP for Buffer" is also disabled for unconfigured languages.
+#[test]
+fn test_toggle_lsp_disabled_for_unconfigured_language() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let test_file = temp_dir.path().join("notes.txt");
+    std::fs::write(&test_file, "Just some notes.\n")?;
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 30, temp_dir.path().to_path_buf())?;
+
+    // Open the text file
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Open command palette
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_prompt()?;
+
+    // Type the full command name to ensure exact match
+    harness.type_text("Toggle LSP for Buffer")?;
+    harness.render()?;
+
+    // Try to execute the command - it should be disabled
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.render()?;
+
+    // Should show "not available" since the command is disabled for this language
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("not available") || screen.contains("No LSP server configured"),
+        "Should show 'not available' or 'no LSP configured' message. Screen:\n{}",
+        screen
+    );
+
+    Ok(())
+}
+
+/// Test that opening a plain text file does not produce an LSP warning.
+///
+/// The log level for "no LSP configured" should be debug, not warn.
+#[test]
+fn test_no_lsp_warning_for_text_file() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let test_file = temp_dir.path().join("plain.txt");
+    std::fs::write(&test_file, "No LSP warning should appear.\n")?;
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 30, temp_dir.path().to_path_buf())?;
+
+    // Open the text file
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Process any async messages
+    for _ in 0..5 {
+        harness.process_async_and_render()?;
+        harness.sleep(std::time::Duration::from_millis(10));
+    }
+
+    // No warnings should be active
+    assert!(
+        !harness.editor().get_warning_domains().has_any_warnings(),
+        "Opening a plain text file should not produce any warnings"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -42,6 +42,7 @@ pub mod lsp;
 pub mod lsp_completion_french_locale;
 pub mod lsp_completion_popup_behavior;
 pub mod lsp_config;
+pub mod lsp_no_config;
 pub mod lsp_order;
 pub mod lsp_publish_diagnostics_capability;
 pub mod lsp_toggle_desync;


### PR DESCRIPTION
## Summary
This PR prevents LSP-related commands from being executed when the active buffer's language has no LSP server configured, and ensures appropriate user feedback is provided in such cases.

## Key Changes

- **Command Registry Filtering**: Added `has_lsp_config` parameter to `CommandRegistry::filter()` to disable `LspRestart` and `LspToggleForBuffer` commands when the active buffer's language lacks LSP configuration.

- **LSP Configuration Detection**: Implemented logic across multiple entry points (`app/mod.rs`, `app/input.rs`, `app/prompt_actions.rs`) to check if the active buffer's language has an LSP server configured by querying `lsp.get_config(language)`.

- **LSP Manager Enhancement**: Added `LspSpawnResult::NotConfigured` variant to distinguish between languages that are disabled vs. not configured, allowing for more precise error handling.

- **User Feedback**: Modified `lsp_actions.rs` to display a user-friendly status message (`lsp.no_server_configured`) when attempting to restart LSP for an unconfigured language, instead of silently failing.

- **Logging Improvements**: Changed logging level from WARN to DEBUG in `file_operations.rs` when no LSP server is configured for a language, reducing noise in logs for expected scenarios.

- **Quick Open Integration**: Updated `QuickOpenContext` and `CommandProvider` to pass `has_lsp_config` information through the quick open system.

- **Comprehensive E2E Tests**: Added new test file `lsp_no_config.rs` with three test cases:
  - Verifies "Start/Restart LSP" command is disabled for plain text files
  - Verifies "Toggle LSP for Buffer" command is disabled for unconfigured languages
  - Confirms no warning indicators are triggered when opening text files

## Implementation Details

The solution checks LSP configuration at command filtering time rather than at execution time, preventing disabled commands from being selectable in the command palette. This provides immediate visual feedback to users that LSP commands are unavailable for their current buffer's language.

https://claude.ai/code/session_01GPJXrWa13XoqVujWUw3tEi