### PR TITLE
Extract file path to LSP URI conversion into reusable function

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1220,9 +1220,7 @@ impl Editor {
                     Some(c) => c,
                     None => continue, // Skip buffers that aren't fully loaded
                 };
-                let uri: Option<lsp_types::Uri> = url::Url::from_file_path(&path)
-                    .ok()
-                    .and_then(|u| u.as_str().parse::<lsp_types::Uri>().ok());
+                let uri: Option<lsp_types::Uri> = super::types::file_path_to_lsp_uri(&path);
 
                 if let Some(uri) = uri {
                     let lang_id = state.language.clone();

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -728,9 +728,7 @@ impl Editor {
                         // Update the buffer metadata
                         if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
                             // Compute new URI
-                            let file_uri = url::Url::from_file_path(&new_path)
-                                .ok()
-                                .and_then(|u| u.as_str().parse::<lsp_types::Uri>().ok());
+                            let file_uri = super::types::file_path_to_lsp_uri(&new_path);
 
                             // Update kind with new path and URI
                             metadata.kind = super::BufferKind::File {

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -618,10 +618,7 @@ impl Editor {
     pub(crate) fn notify_lsp_file_changed(&mut self, path: &Path) {
         use crate::services::lsp::manager::LspSpawnResult;
 
-        let Ok(uri) = url::Url::from_file_path(path) else {
-            return;
-        };
-        let Ok(lsp_uri) = uri.as_str().parse::<lsp_types::Uri>() else {
+        let Some(lsp_uri) = super::types::file_path_to_lsp_uri(path) else {
             return;
         };
 

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -80,10 +80,7 @@ impl Editor {
                 continue; // Skip buffers that aren't fully loaded
             };
 
-            let Some(uri) = url::Url::from_file_path(&buf_path)
-                .ok()
-                .and_then(|u| u.as_str().parse::<lsp_types::Uri>().ok())
-            else {
+            let Some(uri) = super::types::file_path_to_lsp_uri(&buf_path) else {
                 continue;
             };
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1097,9 +1097,7 @@ impl Editor {
         buffer_metadata.insert(buffer_id, BufferMetadata::new());
 
         // Initialize LSP manager with current working directory as root
-        let root_uri = url::Url::from_file_path(&working_dir)
-            .ok()
-            .and_then(|u| u.as_str().parse::<lsp_types::Uri>().ok());
+        let root_uri = types::file_path_to_lsp_uri(&working_dir);
 
         // Create Tokio runtime for async I/O (LSP, file watching, git, etc.)
         let tokio_runtime = tokio::runtime::Builder::new_multi_thread()

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -216,9 +216,7 @@ impl BufferMetadata {
     /// * `working_dir` - The canonical working directory for computing relative display name
     pub fn with_file(path: PathBuf, working_dir: &Path) -> Self {
         // Compute URI from the absolute path
-        let file_uri = url::Url::from_file_path(&path)
-            .ok()
-            .and_then(|u| u.as_str().parse::<lsp_types::Uri>().ok());
+        let file_uri = file_path_to_lsp_uri(&path);
 
         // Compute display name (project-relative when under working_dir, else absolute path).
         // Use canonicalized forms first to handle macOS /var -> /private/var differences.
@@ -987,5 +985,107 @@ impl CachedLayout {
         } else {
             Some(row.line_end_byte)
         }
+    }
+}
+
+/// Convert a file path to an `lsp_types::Uri`.
+///
+/// Uses `url::Url::from_file_path` for initial encoding, then percent-encodes
+/// characters that the `url` crate (WHATWG) leaves raw but that `lsp_types::Uri`
+/// (strict RFC 3986) rejects — specifically `[`, `]`, `{`, `}`, `|`, `^`, and `` ` ``.
+pub fn file_path_to_lsp_uri(path: &Path) -> Option<lsp_types::Uri> {
+    let url = url::Url::from_file_path(path).ok()?;
+    let url_str = url.as_str();
+
+    // Fast path: if no problematic characters, parse directly
+    if !url_str
+        .bytes()
+        .any(|b| matches!(b, b'[' | b']' | b'{' | b'}' | b'|' | b'^' | b'`'))
+    {
+        return url_str.parse::<lsp_types::Uri>().ok();
+    }
+
+    // Percent-encode characters that url (WHATWG) allows but lsp_types::Uri (RFC 3986) rejects
+    let mut encoded = String::with_capacity(url_str.len() + 16);
+    for byte in url_str.bytes() {
+        match byte {
+            b'[' => encoded.push_str("%5B"),
+            b']' => encoded.push_str("%5D"),
+            b'{' => encoded.push_str("%7B"),
+            b'}' => encoded.push_str("%7D"),
+            b'|' => encoded.push_str("%7C"),
+            b'^' => encoded.push_str("%5E"),
+            b'`' => encoded.push_str("%60"),
+            _ => encoded.push(byte as char),
+        }
+    }
+    encoded.parse::<lsp_types::Uri>().ok()
+}
+
+#[cfg(test)]
+mod uri_encoding_tests {
+    use super::*;
+
+    /// Helper to get a platform-appropriate absolute path for testing.
+    /// On Windows, url::Url::from_file_path rejects Unix-style paths.
+    fn abs_path(suffix: &str) -> PathBuf {
+        std::env::temp_dir().join(suffix)
+    }
+
+    #[test]
+    fn test_brackets_in_path() {
+        let path = abs_path("MY_PROJECTS [temp]/gogame/main.go");
+        let uri = file_path_to_lsp_uri(&path);
+        assert!(
+            uri.is_some(),
+            "URI should be computed for path with brackets"
+        );
+        let uri = uri.unwrap();
+        assert!(
+            uri.as_str().contains("%5Btemp%5D"),
+            "Brackets should be percent-encoded: {}",
+            uri.as_str()
+        );
+    }
+
+    #[test]
+    fn test_spaces_in_path() {
+        let path = abs_path("My Projects/src/main.go");
+        let uri = file_path_to_lsp_uri(&path);
+        assert!(uri.is_some(), "URI should be computed for path with spaces");
+    }
+
+    #[test]
+    fn test_normal_path() {
+        let path = abs_path("project/main.go");
+        let uri = file_path_to_lsp_uri(&path);
+        assert!(uri.is_some(), "URI should be computed for normal path");
+        let s = uri.unwrap().as_str().to_string();
+        assert!(s.starts_with("file:///"), "Should be a file URI: {}", s);
+        assert!(
+            s.ends_with("project/main.go"),
+            "Should end with the path: {}",
+            s
+        );
+    }
+
+    #[test]
+    fn test_relative_path_returns_none() {
+        let path = PathBuf::from("main.go");
+        assert!(file_path_to_lsp_uri(&path).is_none());
+    }
+
+    #[test]
+    fn test_all_special_chars() {
+        let path = abs_path("a[b]c{d}e^g`h/file.rs");
+        let uri = file_path_to_lsp_uri(&path);
+        assert!(uri.is_some(), "Should handle all special characters");
+        let s = uri.unwrap().as_str().to_string();
+        assert!(!s.contains('['), "[ should be encoded in {}", s);
+        assert!(!s.contains(']'), "] should be encoded in {}", s);
+        assert!(!s.contains('{'), "{{ should be encoded in {}", s);
+        assert!(!s.contains('}'), "}} should be encoded in {}", s);
+        assert!(!s.contains('^'), "^ should be encoded in {}", s);
+        assert!(!s.contains('`'), "` should be encoded in {}", s);
     }
 }


### PR DESCRIPTION
## Summary
Refactored file path to LSP URI conversion logic into a dedicated, reusable function with proper handling of special characters that differ between WHATWG URL encoding and RFC 3986 strict encoding.

## Key Changes
- **New utility function**: Added `file_path_to_lsp_uri()` in `types.rs` that converts file paths to `lsp_types::Uri` with special character handling
  - Handles characters that WHATWG URL encoding allows but RFC 3986 rejects: `[`, `]`, `{`, `}`, `|`, `^`, `` ` ``
  - Includes fast path optimization for paths without problematic characters
  - Percent-encodes special characters when necessary
- **Consolidated duplicated logic**: Replaced 5 instances of inline `url::Url::from_file_path()` + `.parse::<lsp_types::Uri>()` chains across multiple files:
  - `types.rs` (BufferMetadata::with_file)
  - `file_operations.rs` (notify_lsp_file_changed)
  - `async_messages.rs` (language server initialization)
  - `file_explorer.rs` (buffer rename handling)
  - `lsp_actions.rs` (LSP initialization)
  - `mod.rs` (Editor initialization)
- **Comprehensive test coverage**: Added 5 unit tests covering:
  - Paths with brackets
  - Paths with spaces
  - Normal paths
  - Relative paths (should return None)
  - All special characters together

## Implementation Details
The function uses a two-stage approach:
1. Fast path: If no problematic characters exist, parse the URL string directly
2. Slow path: Percent-encode special characters before parsing, ensuring compatibility with strict RFC 3986 validation

This addresses a real issue where file paths containing brackets (e.g., `[temp]`) would fail to convert to valid LSP URIs.

https://claude.ai/code/session_01EVLoKHY33k4bSLqZwoZqGR