### PR TITLE
Add checkbox indicators for active keybinding map in menu

### DIFF
--- a/crates/fresh-editor/src/app/menu_context.rs
+++ b/crates/fresh-editor/src/app/menu_context.rs
@@ -64,9 +64,16 @@ impl Editor {
         let scroll_sync = self.same_buffer_scroll_sync;
         let has_same_buffer_splits = self.has_same_buffer_splits();
 
+        // Keybinding map state
+        let active_keymap: &str = &self.config.active_keybinding_map;
+
         // Apply all context values
         self.menu_state
             .context
+            .set(context_keys::KEYMAP_DEFAULT, active_keymap == "default")
+            .set(context_keys::KEYMAP_EMACS, active_keymap == "emacs")
+            .set(context_keys::KEYMAP_VSCODE, active_keymap == "vscode")
+            .set(context_keys::KEYMAP_MACOS_GUI, active_keymap == "macos-gui")
             .set(context_keys::LINE_NUMBERS, line_numbers)
             .set(context_keys::LINE_WRAP, line_wrap)
             .set(context_keys::COMPOSE_MODE, compose_mode)

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2115,7 +2115,7 @@ impl MenuConfig {
                                     map
                                 },
                                 when: None,
-                                checkbox: None,
+                                checkbox: Some(context_keys::KEYMAP_DEFAULT.to_string()),
                             },
                             MenuItem::Action {
                                 label: t!("menu.view.keybinding_emacs").to_string(),
@@ -2126,7 +2126,7 @@ impl MenuConfig {
                                     map
                                 },
                                 when: None,
-                                checkbox: None,
+                                checkbox: Some(context_keys::KEYMAP_EMACS.to_string()),
                             },
                             MenuItem::Action {
                                 label: t!("menu.view.keybinding_vscode").to_string(),
@@ -2137,7 +2137,7 @@ impl MenuConfig {
                                     map
                                 },
                                 when: None,
-                                checkbox: None,
+                                checkbox: Some(context_keys::KEYMAP_VSCODE.to_string()),
                             },
                             MenuItem::Action {
                                 label: "macOS GUI (⌘)".to_string(),
@@ -2148,7 +2148,7 @@ impl MenuConfig {
                                     map
                                 },
                                 when: None,
-                                checkbox: None,
+                                checkbox: Some(context_keys::KEYMAP_MACOS_GUI.to_string()),
                             },
                         ],
                     },

--- a/crates/fresh-editor/src/types.rs
+++ b/crates/fresh-editor/src/types.rs
@@ -30,6 +30,10 @@ pub mod context_keys {
     pub const HORIZONTAL_SCROLLBAR: &str = "horizontal_scrollbar";
     pub const SCROLL_SYNC: &str = "scroll_sync";
     pub const HAS_SAME_BUFFER_SPLITS: &str = "has_same_buffer_splits";
+    pub const KEYMAP_DEFAULT: &str = "keymap_default";
+    pub const KEYMAP_EMACS: &str = "keymap_emacs";
+    pub const KEYMAP_VSCODE: &str = "keymap_vscode";
+    pub const KEYMAP_MACOS_GUI: &str = "keymap_macos_gui";
 }
 
 /// Configuration for process resource limits


### PR DESCRIPTION
## Summary
This PR adds visual checkbox indicators to the keybinding map menu items to show which keymap is currently active. Users can now see at a glance which keybinding scheme (Default, Emacs, VSCode, or macOS GUI) is currently selected.

## Key Changes
- Added four new context keys to track the active keybinding map state:
  - `KEYMAP_DEFAULT`
  - `KEYMAP_EMACS`
  - `KEYMAP_VSCODE`
  - `KEYMAP_MACOS_GUI`

- Updated menu configuration to display checkboxes for each keybinding map menu item, bound to the corresponding context key

- Implemented context state management to evaluate which keymap is active by comparing against `config.active_keybinding_map` and set the appropriate context keys to `true`/`false`

## Implementation Details
The checkbox state is dynamically determined by comparing the editor's `active_keybinding_map` configuration value against each keymap option. This ensures the UI always reflects the current keybinding scheme without requiring manual state synchronization.

https://claude.ai/code/session_01H8WrKdLCwBVcCT5a7kagYy