### PR TITLE
Fix line number tracking for delete operations and relative line numbers

### DIFF
--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -374,7 +374,17 @@ impl EditorState {
         deleted_text: &str,
     ) {
         let len = range.len();
-        let newlines_deleted = deleted_text.matches('\n').count();
+
+        // Count newlines deleted BEFORE the primary cursor's original position.
+        // For backspace: cursor was at range.end, so all deleted newlines are before it.
+        // For forward delete: cursor was at range.start, so no deleted newlines are before it.
+        let primary_newlines_removed = if cursor_id == cursors.primary_id() {
+            let cursor_pos = cursors.get(cursor_id).map_or(range.start, |c| c.position);
+            let bytes_before_cursor = cursor_pos.saturating_sub(range.start).min(len);
+            deleted_text[..bytes_before_cursor].matches('\n').count()
+        } else {
+            0
+        };
 
         // CRITICAL: Adjust markers BEFORE modifying buffer
         self.marker_list.adjust_for_delete(range.start, len);
@@ -399,16 +409,16 @@ impl EditorState {
         }
 
         // Update primary cursor line number if this was the primary cursor
-        if cursor_id == cursors.primary_id() {
+        if cursor_id == cursors.primary_id() && primary_newlines_removed > 0 {
             self.primary_cursor_line_number = match self.primary_cursor_line_number {
                 LineNumber::Absolute(line) => {
-                    LineNumber::Absolute(line.saturating_sub(newlines_deleted))
+                    LineNumber::Absolute(line.saturating_sub(primary_newlines_removed))
                 }
                 LineNumber::Relative {
                     line,
                     from_cached_line,
                 } => LineNumber::Relative {
-                    line: line.saturating_sub(newlines_deleted),
+                    line: line.saturating_sub(primary_newlines_removed),
                     from_cached_line,
                 },
             };

--- a/crates/fresh-editor/src/view/ui/split_rendering.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering.rs
@@ -471,6 +471,8 @@ struct LeftMarginContext<'a> {
     fold_indicators: &'a BTreeMap<usize, FoldIndicator>,
     /// Line-start byte of the cursor line (for relative line numbers and cursor highlight)
     cursor_line_start_byte: usize,
+    /// 0-indexed line number of the cursor line (for relative line number calculation)
+    cursor_line_number: usize,
     /// Whether to show relative line numbers
     relative_line_numbers: bool,
     /// Whether to show line numbers in the gutter
@@ -586,7 +588,7 @@ fn render_left_margin(
             ctx.gutter_num + 1
         } else {
             // Show relative distance for other lines
-            ctx.gutter_num.abs_diff(ctx.cursor_line_start_byte)
+            ctx.gutter_num.abs_diff(ctx.cursor_line_number)
         };
         let rendered_text = format!(
             "{:>width$}",
@@ -4482,6 +4484,7 @@ impl SplitRenderer {
                     line_indicators,
                     fold_indicators: &decorations.fold_indicators,
                     cursor_line_start_byte,
+                    cursor_line_number: state.primary_cursor_line_number.value(),
                     relative_line_numbers,
                     show_line_numbers,
                     byte_offset_mode,

--- a/crates/fresh-editor/tests/e2e/line_number_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/line_number_bugs.rs
@@ -1,0 +1,114 @@
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Issue #1261: Deleting a newline below the cursor with Delete key
+/// incorrectly decrements the status bar line number.
+///
+/// Steps: open a 5-line file, move to line 3, press End then Delete.
+/// The cursor stays on (what is still) line 3 but the status bar
+/// incorrectly shows "Ln 2".
+#[test]
+fn test_delete_forward_does_not_decrement_status_bar_line_number() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 24).unwrap();
+    let project_dir = harness.project_dir().unwrap();
+    let file_path = project_dir.join("test.txt");
+    std::fs::write(&file_path, "line1\nline2\nline3\nline4\nline5\n").unwrap();
+
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Move cursor to line 3 (Down twice), then to end of line
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Verify we're on line 3
+    let status = harness.get_status_bar();
+    assert!(
+        status.contains("Ln 3"),
+        "Before delete, status bar should show Ln 3, got: {status}"
+    );
+
+    // Press Delete to merge line 4 into line 3
+    // This deletes the newline AFTER the cursor - cursor stays on line 3
+    harness
+        .send_key(KeyCode::Delete, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Buffer should now have merged line3 and line4
+    harness.assert_buffer_content("line1\nline2\nline3line4\nline5\n");
+
+    // Status bar should still show Ln 3 (cursor didn't move to a different line)
+    let status = harness.get_status_bar();
+    assert!(
+        status.contains("Ln 3"),
+        "After Delete at end of line 3, status bar should still show Ln 3, got: {status}"
+    );
+}
+
+/// Issue #1262: Relative line numbers use byte offset instead of line number,
+/// producing wildly wrong values.
+///
+/// With relative_line_numbers enabled and cursor on line 3 of a 5-line file,
+/// lines 1 and 2 should show "2" and "1" (distance from cursor), but
+/// instead show values based on byte offsets.
+#[test]
+fn test_relative_line_numbers_show_correct_distances() {
+    // Enable relative line numbers
+    let mut config = fresh::config::Config::default();
+    config.editor.relative_line_numbers = true;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 24, config).unwrap();
+    let project_dir = harness.project_dir().unwrap();
+    let file_path = project_dir.join("test.txt");
+    std::fs::write(&file_path, "line1\nline2\nline3\nline4\nline5\n").unwrap();
+
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Move cursor to line 3
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Screen with relative line numbers (cursor on line 3):\n{screen}");
+
+    // Cursor line should show absolute line number 3
+    // Lines above should show relative distance: line1 -> 2, line2 -> 1
+    // Lines below should show relative distance: line4 -> 1, line5 -> 2
+
+    // The cursor line (line 3) should show "3" (absolute, 1-indexed)
+    // Check that the screen contains the expected relative pattern:
+    //   2 | line1
+    //   1 | line2
+    //   3 | line3   <- absolute for cursor line
+    //   1 | line4
+    //   2 | line5
+
+    // Verify that line1 shows relative distance 2 (not some large byte-based number)
+    // and line2 shows relative distance 1
+    // We check for the pattern in the gutter area
+    assert!(
+        screen.contains("   2 │ line1") || screen.contains("   2│ line1"),
+        "Line 1 should show relative distance 2 from cursor on line 3, screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("   1 │ line2") || screen.contains("   1│ line2"),
+        "Line 2 should show relative distance 1 from cursor on line 3, screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("   3 │ line3") || screen.contains("   3│ line3"),
+        "Cursor line (line 3) should show absolute line number 3, screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("   1 │ line4") || screen.contains("   1│ line4"),
+        "Line 4 should show relative distance 1 from cursor on line 3, screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("   2 │ line5") || screen.contains("   2│ line5"),
+        "Line 5 should show relative distance 2 from cursor on line 3, screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -37,6 +37,7 @@ pub mod language_features_e2e;
 pub mod large_file_inplace_write_bug;
 pub mod large_file_mode;
 pub mod lifecycle;
+pub mod line_number_bugs;
 pub mod line_wrap_scroll_bugs;
 pub mod line_wrapping;
 pub mod live_grep;


### PR DESCRIPTION
## Summary
This PR fixes two bugs related to line number tracking in the editor:
1. The status bar line number was incorrectly decremented when using the Delete key to merge lines
2. Relative line numbers were calculated using byte offsets instead of actual line numbers, producing wildly incorrect values

## Key Changes

- **Fixed primary cursor line number tracking in `state.rs`**: Modified `on_delete` to only count newlines that were deleted *before* the cursor position. For forward delete (Delete key), the cursor is at the start of the deletion range, so no newlines before it are removed, preventing incorrect line number decrements. For backspace, the cursor is at the end of the range, so all deleted newlines are counted.

- **Fixed relative line number calculation in `split_rendering.rs`**: Changed the relative line number distance calculation from using `cursor_line_start_byte` (a byte offset) to `cursor_line_number` (the actual 0-indexed line number). This ensures relative line numbers show correct distances from the cursor line rather than nonsensical byte-based values.

- **Added comprehensive e2e tests in `line_number_bugs.rs`**: 
  - Test for Delete key not decrementing status bar line number when merging lines
  - Test for relative line numbers showing correct distances from cursor

## Implementation Details

The fix distinguishes between backspace and forward delete operations by checking the cursor position relative to the deletion range:
- **Backspace**: cursor is at `range.end`, so all deleted newlines are before it
- **Forward Delete**: cursor is at `range.start`, so no deleted newlines are before it

The relative line number fix is straightforward: use the actual line number value instead of a byte offset for distance calculations.

https://claude.ai/code/session_01CFe2oqiGBdUCnjSUpV1RuV