### PR TITLE
Fix keyboard shortcuts with CapsLock active

### DIFF
--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -9,18 +9,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Terminals vary in how they report certain keys:
 /// - BackTab already encodes Shift+Tab, but some terminals also set SHIFT —
 ///   strip the redundant SHIFT so bindings defined as "BackTab" match.
-/// - Uppercase letters may arrive as `Char('P')` + SHIFT — normalize to
-///   `Char('p')` + SHIFT to match how `parse_key_string("P")` stores them.
+/// - Uppercase letters may arrive as `Char('P')` + SHIFT (real Shift press)
+///   or `Char('A')` without SHIFT (CapsLock on, kitty keyboard protocol).
+///   In both cases, lowercase the character and preserve the existing
+///   modifiers. This ensures CapsLock+Ctrl+A matches the `Ctrl+A` binding,
+///   while Shift+P still matches the `Shift+P` binding.
 fn normalize_key(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
     if code == KeyCode::BackTab {
         return (code, modifiers.difference(KeyModifiers::SHIFT));
     }
     if let KeyCode::Char(c) = code {
         if c.is_ascii_uppercase() {
-            return (
-                KeyCode::Char(c.to_ascii_lowercase()),
-                modifiers | KeyModifiers::SHIFT,
-            );
+            return (KeyCode::Char(c.to_ascii_lowercase()), modifiers);
         }
     }
     (code, modifiers)

--- a/crates/fresh-editor/tests/e2e/capslock_shortcuts.rs
+++ b/crates/fresh-editor/tests/e2e/capslock_shortcuts.rs
@@ -1,0 +1,140 @@
+//! E2E tests for keyboard shortcuts with CapsLock active.
+//!
+//! When CapsLock is on, terminals with the kitty keyboard protocol send
+//! uppercase characters (e.g. `Char('A')`) WITHOUT the SHIFT modifier.
+//! The editor must still resolve shortcuts like Ctrl+A (select all),
+//! Ctrl+C (copy), Ctrl+V (paste), Ctrl+X (cut), Ctrl+Z (undo), etc.
+//!
+//! Reproduces: CapsLock breaks Ctrl+A, Ctrl+C, Ctrl+V and other shortcuts
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Simulate CapsLock by sending an uppercase Char with CONTROL but no SHIFT.
+/// This is what terminals with kitty keyboard protocol report when CapsLock
+/// is on and the user presses Ctrl+<letter>.
+fn capslock_ctrl(c: char) -> (KeyCode, KeyModifiers) {
+    (KeyCode::Char(c.to_ascii_uppercase()), KeyModifiers::CONTROL)
+}
+
+#[test]
+fn test_capslock_ctrl_a_selects_all() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello world").unwrap();
+    harness.assert_buffer_content("hello world");
+
+    // CapsLock + Ctrl+A should select all text
+    let (code, mods) = capslock_ctrl('a');
+    harness.send_key(code, mods).unwrap();
+
+    // Typing should replace the selection
+    harness.type_text("X").unwrap();
+    harness.assert_buffer_content("X");
+}
+
+#[test]
+fn test_capslock_ctrl_c_copies() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello").unwrap();
+
+    // Select all with normal Ctrl+A
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // CapsLock + Ctrl+C should copy
+    let (code, mods) = capslock_ctrl('c');
+    harness.send_key(code, mods).unwrap();
+
+    // Move to end and paste with normal Ctrl+V
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    harness.assert_buffer_content("hellohello");
+}
+
+#[test]
+fn test_capslock_ctrl_v_pastes() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello").unwrap();
+
+    // Select all and copy normally
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // Move to end
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+
+    // CapsLock + Ctrl+V should paste
+    let (code, mods) = capslock_ctrl('v');
+    harness.send_key(code, mods).unwrap();
+
+    harness.assert_buffer_content("hellohello");
+}
+
+#[test]
+fn test_capslock_ctrl_x_cuts() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello").unwrap();
+
+    // Select all with normal Ctrl+A
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // CapsLock + Ctrl+X should cut
+    let (code, mods) = capslock_ctrl('x');
+    harness.send_key(code, mods).unwrap();
+
+    // Buffer should be empty after cut
+    harness.assert_buffer_content("");
+
+    // Paste should bring back the text
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.assert_buffer_content("hello");
+}
+
+#[test]
+fn test_capslock_ctrl_z_undoes() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello").unwrap();
+    harness.assert_buffer_content("hello");
+
+    // CapsLock + Ctrl+Z should undo (at least one character)
+    let (code, mods) = capslock_ctrl('z');
+    harness.send_key(code, mods).unwrap();
+
+    let content = harness.get_buffer_content().unwrap();
+    assert!(
+        content.len() < 5,
+        "Undo should have removed at least one character, got: {:?}",
+        content
+    );
+}
+
+#[test]
+fn test_capslock_ctrl_f_opens_search() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("hello world").unwrap();
+
+    // CapsLock + Ctrl+F should open search
+    let (code, mods) = capslock_ctrl('f');
+    harness.send_key(code, mods).unwrap();
+
+    // Search bar should be visible
+    harness.assert_screen_contains("Search:");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -8,6 +8,7 @@ pub mod block_selection;
 pub mod blog_showcases;
 pub mod buffer_lifecycle;
 pub mod buffer_settings_commands;
+pub mod capslock_shortcuts;
 pub mod case_conversion;
 pub mod command_palette;
 pub mod crash_repro;


### PR DESCRIPTION
## Summary
Fixes an issue where keyboard shortcuts (Ctrl+A, Ctrl+C, etc.) were broken when CapsLock was active. Terminals using the kitty keyboard protocol report uppercase characters without the SHIFT modifier when CapsLock is on, causing shortcuts to fail to match their bindings.

## Changes
- **Modified `normalize_key()` in `keybindings.rs`**: Changed the normalization logic for uppercase characters to preserve existing modifiers instead of always adding SHIFT. This allows CapsLock+Ctrl+A (reported as `Char('A')` + CONTROL) to correctly match the `Ctrl+A` binding, while still supporting explicit Shift+P presses.

- **Added comprehensive E2E tests in `capslock_shortcuts.rs`**: New test suite covering CapsLock behavior with common shortcuts:
  - Ctrl+A (select all)
  - Ctrl+C (copy)
  - Ctrl+V (paste)
  - Ctrl+X (cut)
  - Ctrl+Z (undo)
  - Ctrl+F (search)

## Implementation Details
The key insight is that uppercase characters can arrive in two ways:
1. Real Shift press: `Char('P')` + SHIFT modifier
2. CapsLock on (kitty protocol): `Char('A')` without SHIFT modifier

The fix normalizes both cases by lowercasing the character and preserving whatever modifiers were actually present, rather than unconditionally adding SHIFT. This ensures shortcuts work correctly regardless of how the terminal reports the key event.

https://claude.ai/code/session_012R7xrkBsSRcLwEguP76DCB