### PR TITLE
Corrected insertion logic to properly handle multibyte characters

### DIFF
--- a/crates/fresh-editor/plugins/examples/hello_world.ts
+++ b/crates/fresh-editor/plugins/examples/hello_world.ts
@@ -21,15 +21,23 @@ async function quote_selection() : void {
   const bufText = await 
       editor.getBufferText(bufferId, startSelection, endSelection);
 
-  const success1 = editor.insertText(bufferId, startSelection, "'");
-  if (!success1) {
-    editor.setStatus("Failed to insert start quote");
+  // Important! Insertions must be done on byte boundaries. But the text
+  // may be UTF-8 character and may be multiple bytes.
+  // Assumption: a proper selection will be on UTF-8 character boundaries
+  // Therefore: 
+  //   a. instert the end quote first to avoid moving the entire string 
+  //      to the right
+  //   b. insert the start quote second which can now push the string
+  //      to the right without any problems.
+  let success = editor.insertText(bufferId, endSelection, "'");
+  if (!success) {
+    editor.setStatus("Failed to insert end quote");
     return;
   }
 
-  const success2 = editor.insertText(bufferId, endSelection+1, "'");
-  if (!success2) {
-    editor.setStatus("Failed to insert end quote");
+  success = editor.insertText(bufferId, startSelection, "'");
+  if (!success) {
+    editor.setStatus("Failed to insert start quote");
     return
   }
   const statusMessage = `Quoted: ${bufText}`;


### PR DESCRIPTION
After doing some more plugin work I realized that my example of quoting a selected string made the assumption that the selected text was single byte characters. I have corrected this and added comments to explain why the right quote was done first, then the left quote.

Namely, if the left quote is done first, then the string will shift right, perhaps by multiple bytes (if a curly quote is used). Then the cursor.selection.end will no longer be valid for the right quote position.

Another approach would be to use deleteRange to simply remove the original string and then insert the entire string with quotes. This is what I do in my own plugin where I handle title casing a string.