### PR TITLE
Fix flaky theme editor test with proper async wait

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -1977,17 +1977,14 @@ fn test_builtin_theme_requires_save_as() {
     harness
         .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.process_async_and_render().unwrap();
 
-    // Should show Save As prompt or message about requiring Save As
-    let screen = harness.screen_to_string();
-    let requires_save_as = screen.contains("Save theme as") || screen.contains("save as");
-
-    assert!(
-        requires_save_as,
-        "Builtin theme should require Save As. Screen:\n{}",
-        screen
-    );
+    // Wait for Save As prompt to appear (async plugin handler)
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("Save theme as") || screen.contains("save as")
+        })
+        .unwrap();
 }
 
 /// Test that color swatches are displayed next to color values


### PR DESCRIPTION
## Summary
Fixed a flaky test in the theme editor that was not properly waiting for asynchronous operations to complete before asserting on the UI state.

## Key Changes
- Replaced immediate `process_async_and_render()` call with a `wait_until()` polling mechanism that waits for the "Save As" prompt to actually appear on screen
- This ensures the test properly waits for the async plugin handler to complete before checking the screen state, rather than checking at an arbitrary point in time

## Implementation Details
The test was previously calling `process_async_and_render()` once and then immediately checking if the Save As prompt appeared. This created a race condition where the async handler might not have completed in time. The fix uses a `wait_until()` helper that polls the screen state until the expected prompt appears, making the test more reliable and deterministic.

https://claude.ai/code/session_0177mobiu9VBBz2vmKfPWw3Z