### PR TITLE
Enable software cursor in Zellij terminal multiplexer

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -2767,6 +2767,15 @@ fn real_main() -> AnyhowResult<()> {
             editor.set_gpm_active(true);
         }
 
+        // Detect Zellij terminal multiplexer and enable software cursor.
+        // Zellij suppresses hardware cursor show/hide sequences from child
+        // processes, causing the cursor to disappear when navigating.
+        // Using a software cursor (REVERSED cell styling) works around this.
+        if std::env::var_os("ZELLIJ").is_some() {
+            tracing::info!("Detected Zellij environment, enabling software cursor");
+            editor.set_software_cursor_only(true);
+        }
+
         if first_run {
             handle_first_run_setup(
                 &mut editor,


### PR DESCRIPTION
## Summary
Added automatic detection of the Zellij terminal multiplexer environment to enable software cursor rendering, working around a compatibility issue where Zellij suppresses hardware cursor control sequences from child processes.

## Changes
- Added environment variable check for `ZELLIJ` to detect when the editor is running inside Zellij
- When Zellij is detected, automatically enable software cursor mode via `editor.set_software_cursor_only(true)`
- Added informational logging when Zellij environment is detected

## Implementation Details
The fix addresses a specific issue where Zellij suppresses hardware cursor show/hide sequences from child processes, causing the cursor to disappear during navigation. By using a software cursor (rendered via reversed cell styling), the editor remains usable in Zellij environments without requiring manual configuration from users.

https://claude.ai/code/session_01Pt2cyFGqHG5NLMEtLVoZH4