### PR TITLE
Fix mouse scroll to target viewport under pointer, not focused split

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1437,10 +1437,11 @@ impl Editor {
             }
         }
 
-        // Otherwise, scroll the editor in the active split
-        // Use SplitViewState's viewport (View events go to SplitViewState, not EditorState)
-        let active_split = self.split_manager.active_split();
-        let buffer_id = self.active_buffer();
+        // Scroll the split under the mouse pointer (not necessarily the focused split).
+        // Fall back to the active split if the pointer isn't over any split area.
+        let (target_split, buffer_id) = self
+            .split_at_position(col, row)
+            .unwrap_or_else(|| (self.split_manager.active_split(), self.active_buffer()));
 
         // Check if this is a composite buffer - if so, use composite scroll
         if self.is_composite_buffer(buffer_id) {
@@ -1451,7 +1452,7 @@ impl Editor {
                 .unwrap_or(0);
             if let Some(view_state) = self
                 .composite_view_states
-                .get_mut(&(active_split, buffer_id))
+                .get_mut(&(target_split, buffer_id))
             {
                 view_state.scroll(delta as isize, max_row);
                 tracing::trace!(
@@ -1466,13 +1467,13 @@ impl Editor {
         // Get view_transform tokens from SplitViewState (if any)
         let view_transform_tokens = self
             .split_view_states
-            .get(&active_split)
+            .get(&target_split)
             .and_then(|vs| vs.view_transform.as_ref())
             .map(|vt| vt.tokens.clone());
 
         // Get mutable references to both buffer state and view state
         let state = self.buffers.get_mut(&buffer_id);
-        let view_state = self.split_view_states.get_mut(&active_split);
+        let view_state = self.split_view_states.get_mut(&target_split);
 
         if let (Some(state), Some(view_state)) = (state, view_state) {
             let buffer = &mut state.buffer;
@@ -1536,13 +1537,16 @@ impl Editor {
     /// Handle horizontal scroll (Shift+ScrollWheel or native ScrollLeft/ScrollRight)
     pub(super) fn handle_horizontal_scroll(
         &mut self,
-        _col: u16,
-        _row: u16,
+        col: u16,
+        row: u16,
         delta: i32,
     ) -> AnyhowResult<()> {
-        let active_split = self.split_manager.active_split();
+        let target_split = self
+            .split_at_position(col, row)
+            .map(|(id, _)| id)
+            .unwrap_or_else(|| self.split_manager.active_split());
 
-        if let Some(view_state) = self.split_view_states.get_mut(&active_split) {
+        if let Some(view_state) = self.split_view_states.get_mut(&target_split) {
             // Don't scroll horizontally when line wrap is enabled
             if view_state.viewport.line_wrap_enabled {
                 return Ok(());

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -730,6 +730,29 @@ impl Editor {
             .is_some_and(|layout| layout.contains(col, row))
     }
 
+    /// Find the split whose content or scrollbar area contains (col, row).
+    /// Returns the split id and its buffer id, or None if not over any split.
+    pub(super) fn split_at_position(&self, col: u16, row: u16) -> Option<(LeafId, BufferId)> {
+        for &(split_id, buffer_id, content_rect, scrollbar_rect, _, _) in
+            &self.cached_layout.split_areas
+        {
+            let in_content = col >= content_rect.x
+                && col < content_rect.x + content_rect.width
+                && row >= content_rect.y
+                && row < content_rect.y + content_rect.height;
+            let in_scrollbar = scrollbar_rect.width > 0
+                && scrollbar_rect.height > 0
+                && col >= scrollbar_rect.x
+                && col < scrollbar_rect.x + scrollbar_rect.width
+                && row >= scrollbar_rect.y
+                && row < scrollbar_rect.y + scrollbar_rect.height;
+            if in_content || in_scrollbar {
+                return Some((split_id, buffer_id));
+            }
+        }
+        None
+    }
+
     /// Compute what hover target is at the given position
     fn compute_hover_target(&self, col: u16, row: u16) -> Option<HoverTarget> {
         // Check tab context menu first (it's rendered on top)

--- a/crates/fresh-editor/tests/e2e/split_view_expectations.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_expectations.rs
@@ -46,6 +46,19 @@ fn prev_split(harness: &mut EditorTestHarness) {
     harness.render().unwrap();
 }
 
+/// Helper: Navigate to next split via command palette
+fn next_split(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("next split").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
 /// Helper: Close the active split via command palette
 fn close_split(harness: &mut EditorTestHarness) {
     harness
@@ -820,4 +833,59 @@ fn test_cursor_movement_after_split_switch() {
 
     // Verify screen position changed
     assert_ne!(screen_x1, screen_x2, "Screen cursor X should have moved");
+}
+
+/// Test that mouse scroll wheel scrolls the viewport under the pointer, not the focused one
+#[test]
+fn test_scroll_wheel_targets_viewport_under_pointer() {
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+
+    // Create long content so both splits can scroll
+    let long_text = (1..=100)
+        .map(|i| format!("Line {}", i))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let _fixture = harness.load_buffer_from_text(&long_text).unwrap();
+
+    // Scroll to top
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Create horizontal split - focus moves to the new (bottom) split
+    split_horizontal(&mut harness);
+
+    // Scroll to top in second (bottom) split too
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Navigate back to first (top) split so it's the focused one
+    prev_split(&mut harness);
+
+    // Confirm first split is focused and at top
+    let top_byte_first_split = harness.top_byte();
+
+    // Now scroll down with mouse wheel over the BOTTOM split (row 30 is in bottom half).
+    // The focused split is the TOP one, so if the bug exists, the top split scrolls instead.
+    for _ in 0..5 {
+        harness.mouse_scroll_down(60, 30).unwrap();
+    }
+
+    // Check that the focused (top) split did NOT scroll
+    let top_byte_first_after = harness.top_byte();
+    assert_eq!(
+        top_byte_first_after, top_byte_first_split,
+        "Focused (top) split should NOT have scrolled when mouse was over bottom split"
+    );
+
+    // Switch to the bottom split and check it DID scroll
+    next_split(&mut harness);
+    let top_byte_second_after = harness.top_byte();
+    assert_ne!(
+        top_byte_second_after, top_byte_first_split,
+        "Bottom split (under mouse pointer) should have scrolled"
+    );
 }


### PR DESCRIPTION
## Summary
Fixed a bug where mouse scroll wheel events would scroll the focused split instead of the split under the mouse pointer. This is particularly noticeable in split view layouts where the user might want to scroll a non-focused split.

## Key Changes
- **Added `split_at_position()` helper method** in `mouse_input.rs` to determine which split (if any) contains a given screen coordinate, checking both content and scrollbar areas
- **Updated `handle_scroll()` in `input.rs`** to use the split under the mouse pointer instead of always using the active split, with fallback to active split if pointer is not over any split
- **Updated `handle_horizontal_scroll()` in `input.rs`** to apply the same pointer-based targeting logic for horizontal scrolling
- **Added comprehensive test** `test_scroll_wheel_targets_viewport_under_pointer()` that verifies:
  - Mouse scroll over a non-focused split scrolls that split, not the focused one
  - The focused split remains unaffected when scrolling over another split
- **Added helper function** `next_split()` in test file to navigate to the next split via command palette

## Implementation Details
The fix leverages the existing `cached_layout.split_areas` which contains layout information for all splits including their content rectangles and scrollbar rectangles. The new `split_at_position()` method iterates through these areas to find which split contains the mouse coordinates, enabling proper pointer-based targeting for scroll events.

https://claude.ai/code/session_017qpTrUm734qpaSQ5tvKdo9