### PR TITLE
Fix hanging indent calculation for tab-indented lines

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering.rs
@@ -3511,7 +3511,6 @@ impl SplitRenderer {
         gutter_width: usize,
         hanging_indent: bool,
     ) -> Vec<fresh_core::api::ViewTokenWire> {
-        use crate::primitives::display_width::str_width;
         use crate::primitives::visual_layout::visual_width;
         use fresh_core::api::{ViewTokenWire, ViewTokenWireKind};
 
@@ -3583,23 +3582,28 @@ impl SplitRenderer {
                 ViewTokenWireKind::Text(text) => {
                     // Measure leading whitespace at the start of a logical line
                     if measuring_indent {
-                        let leading_ws: usize = text
-                            .chars()
-                            .take_while(|c| *c == ' ' || *c == '\t')
-                            .map(|c| {
-                                if c == '\t' {
-                                    crate::primitives::display_width::char_width(c)
-                                } else {
-                                    1
-                                }
-                            })
-                            .sum();
-                        if leading_ws == text.chars().count() {
+                        let mut ws_char_count = 0usize;
+                        let mut ws_visual_width = 0usize;
+                        for c in text.chars() {
+                            if c == ' ' {
+                                ws_visual_width += 1;
+                                ws_char_count += 1;
+                            } else if c == '\t' {
+                                // Expand tab to next 4-column tab stop, matching detect_indent()
+                                let tab_stop = 4;
+                                let col = line_indent + ws_visual_width;
+                                ws_visual_width += tab_stop - (col % tab_stop);
+                                ws_char_count += 1;
+                            } else {
+                                break;
+                            }
+                        }
+                        if ws_char_count == text.chars().count() {
                             // Entire token is whitespace — accumulate and continue measuring
-                            line_indent += str_width(text);
+                            line_indent += ws_visual_width;
                         } else {
                             // Token has non-whitespace: finalize indent measurement
-                            line_indent += leading_ws;
+                            line_indent += ws_visual_width;
                             measuring_indent = false;
                         }
                         // Clamp indent to ensure continuation lines have room for content

--- a/crates/fresh-editor/tests/e2e/hanging_wrap_indent.rs
+++ b/crates/fresh-editor/tests/e2e/hanging_wrap_indent.rs
@@ -1,5 +1,6 @@
 use crate::common::harness::EditorTestHarness;
 use fresh::config::Config;
+use std::io::Write;
 
 /// Test that wrapped continuation lines are indented to match the leading whitespace
 /// of the original line when wrap_indent is enabled.
@@ -96,6 +97,54 @@ fn test_hanging_wrap_indent_disabled() {
     assert!(
         second_leading < 4,
         "With wrap_indent disabled, continuation should not be indented. \
+         Got {} leading spaces.\nSecond: {:?}\nScreen:\n{}",
+        second_leading,
+        second_content,
+        screen
+    );
+}
+
+/// Test that wrapped continuation lines are indented when the original line uses tab indentation.
+/// This is the same as test_hanging_wrap_indent_basic but with tabs instead of spaces.
+#[test]
+fn test_hanging_wrap_indent_with_tabs() {
+    let mut harness = EditorTestHarness::with_temp_project(60, 24).unwrap();
+
+    // Create a temp file with a tab-indented long line
+    let dir = harness.project_dir().unwrap();
+    let file_path = dir.join("tab_indent_test.txt");
+    {
+        let mut f = std::fs::File::create(&file_path).unwrap();
+        // One tab + long content that will wrap (tab expands to 4 cols in the editor)
+        writeln!(
+            f,
+            "\tThis is a long tab-indented line that will wrap around because it is too long to fit in a single visual line."
+        )
+        .unwrap();
+    }
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+
+    let content_lines: Vec<&str> = screen.lines().filter(|l| l.contains('│')).collect();
+
+    assert!(
+        content_lines.len() >= 2,
+        "Should have at least 2 content lines (original + wrapped). Got: {}.\nScreen:\n{}",
+        content_lines.len(),
+        screen
+    );
+
+    // The continuation line should have hanging indent matching the tab's visual width (4 spaces)
+    let second_line = content_lines[1];
+    let bar_pos = second_line.find('│').unwrap();
+    let second_content = &second_line[bar_pos + '│'.len_utf8()..];
+    let second_leading = second_content.chars().take_while(|c| *c == ' ').count();
+
+    assert!(
+        second_leading >= 4,
+        "Tab-indented continuation line should be indented by at least 4 spaces (matching tab width). \
          Got {} leading spaces.\nSecond: {:?}\nScreen:\n{}",
         second_leading,
         second_content,


### PR DESCRIPTION
## Summary
Fixed the hanging indent calculation in the text wrapping logic to properly handle tab characters by expanding them to the correct visual column positions, matching the tab stop behavior used elsewhere in the codebase.

## Key Changes
- **Fixed tab expansion in indent measurement**: Updated `measure_indent_and_wrap_tokens()` to correctly calculate the visual width of tabs by expanding them to the next 4-column tab stop, rather than using a fixed character width. This ensures continuation lines are indented to match the visual indentation of the original line.
- **Removed incorrect import**: Removed the unused `str_width` import that was being used incorrectly for tab handling.
- **Added test coverage**: Added `test_hanging_wrap_indent_with_tabs()` to verify that tab-indented lines wrap with proper hanging indent matching the tab's visual width.

## Implementation Details
The fix changes how leading whitespace is measured when determining hanging indent:
- Spaces continue to contribute 1 visual column each
- Tabs now expand to the next 4-column tab stop based on the current column position (`tab_stop - (col % tab_stop)`), rather than using a fixed width
- The visual width calculation now properly tracks both character count and visual width separately to handle the case where entire tokens are whitespace

This ensures that wrapped continuation lines align correctly with the visual indentation of tab-indented source lines.

https://claude.ai/code/session_01TUEEykqLVFiSjvbDgfCTZh