### PR TITLE
Fix deletion of custom keybindings with Shift+letter modifiers

### DIFF
--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -248,6 +248,7 @@ impl KeybindingEditor {
                         modifiers: *modifiers,
                         is_chord: false,
                         plugin_name: Some(section.clone()),
+                        original_config: None,
                     });
                 }
             }
@@ -269,6 +270,7 @@ impl KeybindingEditor {
                     modifiers: KeyModifiers::NONE,
                     is_chord: false,
                     plugin_name: None,
+                    original_config: None,
                 });
             }
         }
@@ -291,6 +293,7 @@ impl KeybindingEditor {
                         modifiers: KeyModifiers::NONE,
                         is_chord: false,
                         plugin_name,
+                        original_config: None,
                     });
                 }
             }
@@ -319,6 +322,11 @@ impl KeybindingEditor {
             // Chord binding
             let key_display = format_chord_keys(&kb.keys);
             let action_display = KeybindingResolver::format_action_from_str(&kb.action);
+            let original_config = if source == BindingSource::Custom {
+                Some(kb.clone())
+            } else {
+                None
+            };
             Some(ResolvedBinding {
                 key_display,
                 action: kb.action.clone(),
@@ -329,6 +337,7 @@ impl KeybindingEditor {
                 modifiers: KeyModifiers::NONE,
                 is_chord: true,
                 plugin_name: None,
+                original_config,
             })
         } else if !kb.key.is_empty() {
             // Single key binding
@@ -336,6 +345,11 @@ impl KeybindingEditor {
             let modifiers = KeybindingResolver::parse_modifiers_public(&kb.modifiers);
             let key_display = format_keybinding(&key_code, &modifiers);
             let action_display = KeybindingResolver::format_action_from_str(&kb.action);
+            let original_config = if source == BindingSource::Custom {
+                Some(kb.clone())
+            } else {
+                None
+            };
             Some(ResolvedBinding {
                 key_display,
                 action: kb.action.clone(),
@@ -346,6 +360,7 @@ impl KeybindingEditor {
                 modifiers,
                 is_chord: false,
                 plugin_name: None,
+                original_config,
             })
         } else {
             None
@@ -723,8 +738,14 @@ impl KeybindingEditor {
                 let binding = &self.bindings[idx];
                 let action_name = binding.action.clone();
 
-                // Build config-level Keybinding for matching during save
-                let config_kb = self.resolved_to_config_keybinding(binding);
+                // Use the original config-level Keybinding if available (for
+                // bindings loaded from config), otherwise reconstruct it.
+                // This avoids lossy round-trips through parse_key which
+                // lowercases key names (e.g. "N" → "n").
+                let config_kb = binding
+                    .original_config
+                    .clone()
+                    .unwrap_or_else(|| self.resolved_to_config_keybinding(binding));
 
                 // If this binding was added in the current session, just
                 // remove it from pending_adds. Otherwise track for removal
@@ -758,6 +779,7 @@ impl KeybindingEditor {
                         modifiers: KeyModifiers::NONE,
                         is_chord: false,
                         plugin_name: None,
+                        original_config: None,
                     });
                 }
 
@@ -803,6 +825,7 @@ impl KeybindingEditor {
                     modifiers: self.bindings[idx].modifiers,
                     is_chord: self.bindings[idx].is_chord,
                     plugin_name: self.bindings[idx].plugin_name.clone(),
+                    original_config: None,
                 };
                 self.has_changes = true;
 
@@ -820,6 +843,7 @@ impl KeybindingEditor {
                         modifiers: KeyModifiers::NONE,
                         is_chord: false,
                         plugin_name: None,
+                        original_config: None,
                     });
                 }
 
@@ -864,6 +888,7 @@ impl KeybindingEditor {
                     modifiers: self.bindings[idx].modifiers,
                     is_chord: self.bindings[idx].is_chord,
                     plugin_name: self.bindings[idx].plugin_name.clone(),
+                    original_config: None,
                 };
                 self.has_changes = true;
 
@@ -880,6 +905,7 @@ impl KeybindingEditor {
                         modifiers: KeyModifiers::NONE,
                         is_chord: false,
                         plugin_name: None,
+                        original_config: None,
                     });
                 }
 
@@ -982,6 +1008,7 @@ impl KeybindingEditor {
             modifiers,
             is_chord: false,
             plugin_name: preserved_plugin_name,
+            original_config: None,
         };
 
         if let Some(edit_idx) = dialog.editing_index {

--- a/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/helpers.rs
@@ -19,7 +19,7 @@ pub fn format_chord_keys(keys: &[KeyPress]) -> String {
 /// Convert a KeyCode back to a config-friendly name
 pub fn key_code_to_config_name(key_code: KeyCode) -> String {
     match key_code {
-        KeyCode::Char(c) => c.to_string(),
+        KeyCode::Char(c) => c.to_lowercase().to_string(),
         KeyCode::Enter => "Enter".to_string(),
         KeyCode::Tab => "Tab".to_string(),
         KeyCode::Backspace => "Backspace".to_string(),

--- a/crates/fresh-editor/src/app/keybinding_editor/types.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/types.rs
@@ -1,5 +1,6 @@
 //! Data types for the keybinding editor.
 
+use crate::config::Keybinding;
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::Rect;
 
@@ -50,6 +51,8 @@ pub struct ResolvedBinding {
     pub is_chord: bool,
     /// Plugin name this binding belongs to (None = builtin)
     pub plugin_name: Option<String>,
+    /// Original config-level Keybinding (preserved for Custom bindings loaded from config)
+    pub original_config: Option<Keybinding>,
 }
 
 /// Mode for the edit/add dialog

--- a/crates/fresh-editor/tests/e2e/keybinding_editor.rs
+++ b/crates/fresh-editor/tests/e2e/keybinding_editor.rs
@@ -1725,3 +1725,158 @@ fn test_keybinding_editor_captures_keys_over_terminal_mode() {
     // Keybinding editor should be closed now
     harness.assert_screen_not_contains("Keybinding Editor");
 }
+
+/// Regression test: deleting a custom keybinding that uses Shift+letter fails.
+/// The bug: when recording Shift+N, crossterm sends KeyCode::Char('N') (uppercase).
+/// key_code_to_config_name stores it as "N". After save+reload, parse_key lowercases
+/// it to KeyCode::Char('n'), so key_code_to_config_name returns "n". The deletion
+/// matching compares "N" (in config) vs "n" (from resolved round-trip) and fails.
+#[test]
+fn test_delete_shift_letter_binding_full_flow() {
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+
+    // === Phase 1: Add a custom binding Shift+N → search_next ===
+    open_keybinding_editor(&mut harness);
+
+    // Press 'a' to open Add dialog
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Add Keybinding");
+
+    // Record key: Shift+N (crossterm sends uppercase 'N' with SHIFT modifier)
+    harness
+        .send_key(KeyCode::Char('N'), KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Shift+N");
+
+    // Tab to Action field
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+
+    // Type "duplicate_line" and accept autocomplete
+    for ch in "duplicate_line".chars() {
+        harness
+            .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Tab to context, then to Save button, press Enter to save the dialog
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("modified");
+
+    // Save and close keybinding editor with Ctrl+S
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_not_contains("Keybinding Editor");
+
+    // === Phase 2: Reopen keybinding editor and delete the binding ===
+    open_keybinding_editor(&mut harness);
+
+    // Search for "duplicate_line"
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    for ch in "duplicate_line".chars() {
+        harness
+            .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Verify the custom binding appears
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Shift+N"),
+        "Before delete: table should show Shift+N.\nScreen:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains("custom"),
+        "Before delete: table should show 'custom' source.\nScreen:\n{}",
+        screen
+    );
+
+    // Navigate to the custom binding row
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let mut found_custom = false;
+    for _ in 0..10 {
+        let current_screen = harness.screen_to_string();
+        for line in current_screen.lines() {
+            if line.contains(">") && line.contains("custom") {
+                found_custom = true;
+                break;
+            }
+        }
+        if found_custom {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(found_custom, "Should find the custom binding row to delete");
+
+    // Delete the custom binding
+    harness
+        .send_key(KeyCode::Char('d'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Verify deletion happened in the UI
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Shift+N"),
+        "After delete (before save): Shift+N should be gone from the table.\nScreen:\n{}",
+        screen
+    );
+
+    // Save and close
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_not_contains("Keybinding Editor");
+
+    // === Phase 3: Reopen and verify the binding is truly gone (persisted) ===
+    open_keybinding_editor(&mut harness);
+
+    // Search for "duplicate_line"
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    for ch in "duplicate_line".chars() {
+        harness
+            .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Shift+N"),
+        "After save+reopen: Shift+N should NOT appear (deletion should persist).\nScreen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains("custom"),
+        "After save+reopen: 'custom' source should NOT appear.\nScreen:\n{}",
+        screen
+    );
+}


### PR DESCRIPTION
## Summary
Fixes a regression where deleting custom keybindings that use Shift+letter combinations (e.g., Shift+N) would fail. The bug occurred because key names were being lossy round-tripped through parsing, causing case mismatches during deletion matching.

## Root Cause
When recording Shift+N, crossterm sends `KeyCode::Char('N')` (uppercase). The editor stored this as "N" in the config. However, after save and reload, the `parse_key` function lowercases it to `KeyCode::Char('n')`, causing `key_code_to_config_name` to return "n". During deletion, the matching logic compared "N" (from config) vs "n" (from the round-trip) and failed to find the binding to delete.

## Key Changes
- **Added `original_config` field to `ResolvedBinding`**: Preserves the original `Keybinding` struct loaded from config for custom bindings, avoiding lossy round-trips through parse/format cycles.
- **Updated deletion logic**: Uses the preserved `original_config` when available instead of reconstructing the binding from resolved components, ensuring exact matching with the stored config.
- **Fixed `key_code_to_config_name`**: Now lowercases character keys to maintain consistency with the `parse_key` function, preventing case mismatches.
- **Added comprehensive regression test**: `test_delete_shift_letter_binding_full_flow` validates the complete flow of adding, saving, reloading, and deleting a Shift+letter binding.

## Implementation Details
- The `original_config` field is populated only for custom bindings loaded from the config file (not for builtin or newly-added bindings).
- All code paths that create `ResolvedBinding` instances have been updated to include the new field.
- The fix preserves backward compatibility by falling back to reconstructing the binding if `original_config` is not available.

https://claude.ai/code/session_0142Gz9LTeUnQsHodqVtf98g