### PR TITLE
Bump fresh-winterm to 0.2.18 and add to version bump script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fresh-parser-js = { version = "0.2.18", path = "crates/fresh-parser-js" }
 fresh-languages = { version = "0.2.18", path = "crates/fresh-languages" }
 fresh-plugin-runtime = { version = "0.2.18", path = "crates/fresh-plugin-runtime" }
 fresh-plugin-api-macros = { version = "0.2.18", path = "crates/fresh-plugin-api-macros" }
-fresh-winterm = { version = "0.2.17", path = "crates/fresh-winterm" }
+fresh-winterm = { version = "0.2.18", path = "crates/fresh-winterm" }
 
 # External crates
 serde = { version = "1.0", features = ["derive"] }

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -24,6 +24,7 @@ LOCAL_CRATES = [
     "fresh-languages",
     "fresh-plugin-runtime",
     "fresh-plugin-api-macros",
+    "fresh-winterm",
 ]
 
 def print_usage():


### PR DESCRIPTION
## Summary
Updates the `fresh-winterm` crate to version 0.2.18 and ensures it's included in the automated version bumping process.

## Changes
- Updated `fresh-winterm` dependency version from 0.2.17 to 0.2.18 in Cargo.toml
- Added `fresh-winterm` to the crates list in the version bump script to ensure it's included in future version updates alongside other internal crates

## Details
This change aligns the `fresh-winterm` crate version with the rest of the workspace (0.2.18) and prevents it from being missed during automated version bumps in the future.

https://claude.ai/code/session_018D1aGVuT8V8MfTdtzn4M12