### PR TITLE
Fix cursor visibility and command palette rendering in zellij

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3092,7 +3092,10 @@ where
         if needs_render && last_render.elapsed() >= FRAME_DURATION {
             {
                 let _span = tracing::info_span!("terminal_draw").entered();
+                use crossterm::ExecutableCommand;
+                stdout().execute(crossterm::terminal::BeginSynchronizedUpdate)?;
                 terminal.draw(|frame| editor.render(frame))?;
+                stdout().execute(crossterm::terminal::EndSynchronizedUpdate)?;
             }
             last_render = Instant::now();
             needs_render = false;


### PR DESCRIPTION
## Summary

Fixes #1255 — cursor disappearing and command palette not visible when running fresh inside zellij.

- Wrap `terminal.draw()` with crossterm's `BeginSynchronizedUpdate` / `EndSynchronizedUpdate` (DEC private mode 2026)
- This tells terminal multiplexers like zellij to batch the entire render atomically instead of displaying intermediate frames

## Root Cause

Without synchronized updates, zellij splits fresh's single render into **multiple output frames**. This causes two user-visible bugs:

1. **Command palette invisible until interaction**: Zellij emits a `SHOW_CURSOR` (signaling "frame complete") **13ms before** the palette content arrives. The terminal renders a phantom frame showing the editor without the palette. The palette only appears on the next frame — which in some cases doesn't arrive until the next user input.

2. **Cursor flickering/disappearing during navigation**: Zellij adds `HIDE_CURSOR`/`SHOW_CURSOR` pairs around its redraws. Without sync updates, intermediate states (cursor hidden, content partially drawn) are visible between frames.

## Verification

Measured palette rendering through zellij before and after:

| Metric | Before | After |
|---|---|---|
| Gap between SHOW_CURSOR and palette content | **+13.5ms** | **+0.0ms** |
| SHOW_CURSOR events before palette appears | **1** (phantom frame) | **0** |
| Output chunks from zellij | **2** (split render) | **1** (atomic) |

Cursor movement also now arrives in a single atomic chunk instead of being split across frames.

## Test plan

- [x] `cargo test --lib` — 95 passed, 0 failed
- [x] Verified palette opens atomically in zellij (0 phantom frames)
- [x] Verified cursor movement renders in single chunk through zellij
- [x] Verified synchronized update sequences (`?2026h`/`?2026l`) are emitted by fresh
- [ ] Manual testing in zellij by a user who can reproduce the original issue

https://claude.ai/code/session_01W6Pe5tA84E8rBjVcRNwCur