### PR TITLE
Fix large file recovery saving entire file as chunks, add counters infra

### DIFF
--- a/crates/fresh-editor/src/model/buffer.rs
+++ b/crates/fresh-editor/src/model/buffer.rs
@@ -3229,6 +3229,26 @@ impl TextBuffer {
                 }
                 BufferLocation::Added(buffer_id) => {
                     if let Some(buffer) = self.buffers.iter().find(|b| b.id == buffer_id) {
+                        // Skip buffers that originate from the original file
+                        // (loaded by chunk_split_and_load for viewport display).
+                        // These have stored_file_offset set and are not user edits.
+                        //
+                        // Why Added and not Stored? The piece tree only has two
+                        // variants: Stored and Added. chunk_split_and_load marks
+                        // loaded chunks as Added(new_id) because
+                        // rebuild_with_pristine_saved_root interprets Stored
+                        // pieces' buffer_offset as a position in the original
+                        // file — but a chunk buffer starts at offset 0, so using
+                        // Stored would corrupt the rebuild logic. We rely on
+                        // stored_file_offset instead to distinguish "loaded from
+                        // disk" from "user edit". A third BufferLocation variant
+                        // (e.g. LoadedChunk) would make this distinction explicit
+                        // in the type system rather than requiring this runtime
+                        // check.
+                        if buffer.stored_file_offset.is_some() {
+                            stored_bytes_before += piece.bytes;
+                            continue;
+                        }
                         // Get the data from the buffer if loaded
                         if let Some(data) = buffer.get_data() {
                             // Extract just the portion this piece references

--- a/crates/fresh-editor/src/model/filesystem.rs
+++ b/crates/fresh-editor/src/model/filesystem.rs
@@ -929,7 +929,9 @@ impl StdFileSystem {
 impl FileSystem for StdFileSystem {
     // File Content Operations
     fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
-        std::fs::read(path)
+        let data = std::fs::read(path)?;
+        crate::services::counters::global().inc_disk_bytes_read(data.len() as u64);
+        Ok(data)
     }
 
     fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
@@ -937,6 +939,7 @@ impl FileSystem for StdFileSystem {
         file.seek(io::SeekFrom::Start(offset))?;
         let mut buffer = vec![0u8; len];
         file.read_exact(&mut buffer)?;
+        crate::services::counters::global().inc_disk_bytes_read(len as u64);
         Ok(buffer)
     }
 

--- a/crates/fresh-editor/src/services/counters.rs
+++ b/crates/fresh-editor/src/services/counters.rs
@@ -1,0 +1,57 @@
+//! Global performance counters for observability and testing.
+//!
+//! Atomic counters that can be incremented from anywhere and read/reset in tests.
+//! All operations use relaxed ordering — these are best-effort metrics, not
+//! synchronization primitives.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::LazyLock;
+
+static GLOBAL: LazyLock<Counters> = LazyLock::new(Counters::default);
+
+/// Access the global counters instance.
+pub fn global() -> &'static Counters {
+    &GLOBAL
+}
+
+#[derive(Debug, Default)]
+pub struct Counters {
+    /// Number of recovery chunk files loaded from disk.
+    pub recovery_chunks_loaded: AtomicU64,
+    /// Total bytes of recovery chunk data loaded into memory.
+    pub recovery_bytes_loaded: AtomicU64,
+    /// Total bytes read from disk via FileSystem trait methods.
+    pub disk_bytes_read: AtomicU64,
+}
+
+impl Counters {
+    pub fn reset(&self) {
+        self.recovery_chunks_loaded.store(0, Ordering::Relaxed);
+        self.recovery_bytes_loaded.store(0, Ordering::Relaxed);
+        self.disk_bytes_read.store(0, Ordering::Relaxed);
+    }
+
+    pub fn inc_recovery_chunks(&self, n: u64) {
+        self.recovery_chunks_loaded.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn inc_recovery_bytes(&self, n: u64) {
+        self.recovery_bytes_loaded.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn inc_disk_bytes_read(&self, n: u64) {
+        self.disk_bytes_read.fetch_add(n, Ordering::Relaxed);
+    }
+
+    pub fn get_recovery_chunks(&self) -> u64 {
+        self.recovery_chunks_loaded.load(Ordering::Relaxed)
+    }
+
+    pub fn get_recovery_bytes(&self) -> u64 {
+        self.recovery_bytes_loaded.load(Ordering::Relaxed)
+    }
+
+    pub fn get_disk_bytes_read(&self) -> u64 {
+        self.disk_bytes_read.load(Ordering::Relaxed)
+    }
+}

--- a/crates/fresh-editor/src/services/mod.rs
+++ b/crates/fresh-editor/src/services/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod async_bridge;
 pub mod clipboard;
+pub mod counters;
 pub mod fs;
 #[cfg(target_os = "linux")]
 pub mod gpm;

--- a/crates/fresh-editor/src/services/recovery/storage.rs
+++ b/crates/fresh-editor/src/services/recovery/storage.rs
@@ -416,6 +416,8 @@ impl RecoveryStorage {
             }
 
             let content = fs::read(&chunk_path)?;
+            crate::services::counters::global().inc_recovery_chunks(1);
+            crate::services::counters::global().inc_recovery_bytes(content.len() as u64);
 
             chunks.push(RecoveryChunk {
                 offset: chunk_meta.offset,

--- a/crates/fresh-editor/tests/e2e/recovery.rs
+++ b/crates/fresh-editor/tests/e2e/recovery.rs
@@ -1,7 +1,7 @@
 // End-to-end tests for file recovery feature
 
 use crate::common::fixtures::TestFixture;
-use crate::common::harness::EditorTestHarness;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::model::buffer::TextBuffer;
 use fresh::model::event::{CursorId, Event};
@@ -1164,5 +1164,124 @@ fn test_recovery_insert_at_end_of_large_file() {
         }
     } else {
         println!("No chunked recovery entry found");
+    }
+}
+
+/// Test that recovering a large file with small edits doesn't load the entire
+/// file into memory. Uses the global counters to verify bounded I/O.
+///
+/// Regression test for OOM during startup: a 418MB file with 3.2GB of recovery
+/// chunks was loaded entirely into memory during workspace restore.
+#[test]
+fn test_large_file_recovery_restore_has_bounded_io() {
+    use fresh::config::Config;
+    use fresh::config_io::DirectoryContext;
+    use fresh::services::counters;
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+
+    let file_path = project_dir.join("big_file.txt");
+
+    // Create an 11MB file
+    let file_size = 11 * 1024 * 1024;
+    let original_content = "X".repeat(file_size);
+    fs::write(&file_path, &original_content).unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open file, make small edit, shutdown
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+        config.editor.large_file_threshold_bytes = 1000; // Force large file mode
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        harness.open_file(&file_path).unwrap();
+        assert!(
+            harness.editor().active_state().buffer.is_large_file(),
+            "Should be in large file mode"
+        );
+
+        // Make a small edit at the beginning
+        harness.type_text("EDIT").unwrap();
+
+        // Trigger recovery save
+        harness.advance_time(std::time::Duration::from_millis(2100));
+        let saved = harness
+            .editor_mut()
+            .auto_recovery_save_dirty_buffers()
+            .unwrap();
+        assert!(saved > 0, "Should have saved recovery data");
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: restore and check that I/O is bounded
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+        config.editor.large_file_threshold_bytes = 1000;
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        // Reset counters before restore
+        counters::global().reset();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "Session should have been restored");
+
+        // Check that recovery didn't load excessive data
+        let recovery_bytes = counters::global().get_recovery_bytes();
+        let disk_bytes = counters::global().get_disk_bytes_read();
+
+        // Recovery chunks should be tiny (just "EDIT" + metadata)
+        let max_recovery_bytes = 1024 * 1024; // 1MB max for recovery chunks
+        assert!(
+            recovery_bytes < max_recovery_bytes,
+            "Recovery loaded {} bytes of chunk data, expected less than {} bytes. \
+             This suggests the entire file is being saved/loaded as recovery data!",
+            recovery_bytes,
+            max_recovery_bytes,
+        );
+
+        // Total disk reads should be much less than the full file size.
+        // Lazy loading means only the viewport portion gets read, not the whole 11MB.
+        let max_disk_bytes = file_size as u64 / 2; // Less than half the file
+        assert!(
+            disk_bytes < max_disk_bytes,
+            "Disk I/O was {} bytes during restore, expected less than {} bytes. \
+             This suggests lazy loading is not working — the entire {}MB file was read!",
+            disk_bytes,
+            max_disk_bytes,
+            file_size / (1024 * 1024),
+        );
+
+        println!(
+            "Recovery restore I/O: recovery_chunks={} bytes, disk_reads={} bytes, file_size={} bytes",
+            recovery_bytes, disk_bytes, file_size
+        );
     }
 }


### PR DESCRIPTION
get_recovery_chunks() treated all Added pieces as user modifications, but chunk_split_and_load() marks loaded-from-disk chunks as Added too (because Stored would break rebuild_with_pristine_saved_root's offset assumptions). Now skip Added buffers with stored_file_offset set, since those originate from the original file, not user edits.

Also adds a global atomic counters module (services/counters.rs) with recovery_bytes_loaded, recovery_chunks_loaded, and disk_bytes_read. These are instrumented in recovery storage and StdFileSystem, and used by a new e2e test that asserts bounded I/O during large file recovery.