### PR TITLE
Fix flaky LSP diagnostic test by isolating temp script paths

### DIFF
--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -20,7 +20,7 @@ impl FakeLspServer {
     ///
     /// The server will listen on stdin/stdout and respond to LSP requests.
     /// It uses a Bash script that acts as a simple JSON-RPC server.
-    pub fn spawn() -> anyhow::Result<Self> {
+    pub fn spawn(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that acts as a fake LSP server
@@ -133,7 +133,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server.sh");
+        let script_path = dir.join("fake_lsp_server.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -158,7 +158,10 @@ done
     }
 
     /// Spawn a fake LSP server that delays semantic token responses.
-    pub fn spawn_with_semantic_tokens_delay(delay_ms: u64) -> anyhow::Result<Self> {
+    pub fn spawn_with_semantic_tokens_delay(
+        dir: &std::path::Path,
+        delay_ms: u64,
+    ) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
         let delay_secs = (delay_ms as f64) / 1000.0;
 
@@ -264,7 +267,7 @@ done
             delay = delay_secs
         );
 
-        let script_path = Self::semantic_tokens_delay_script_path();
+        let script_path = Self::semantic_tokens_delay_script_path(dir);
         std::fs::write(&script_path, script)?;
 
         #[cfg(unix)]
@@ -283,7 +286,7 @@ done
     }
 
     /// Spawn a fake LSP server that supports range semantic tokens only.
-    pub fn spawn_with_semantic_tokens_range_only() -> anyhow::Result<Self> {
+    pub fn spawn_with_semantic_tokens_range_only(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         let script = r#"#!/bin/bash
@@ -380,7 +383,7 @@ esac
 done
 "#;
 
-        let script_path = Self::semantic_tokens_range_only_script_path();
+        let script_path = Self::semantic_tokens_range_only_script_path(dir);
         std::fs::write(&script_path, script)?;
 
         #[cfg(unix)]
@@ -399,18 +402,18 @@ done
     }
 
     /// Path to the semantic tokens delay script.
-    pub fn semantic_tokens_delay_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_semantic_tokens_delay.sh")
+    pub fn semantic_tokens_delay_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_semantic_tokens_delay.sh")
     }
 
     /// Path to the semantic tokens range-only script.
-    pub fn semantic_tokens_range_only_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_semantic_tokens_range_only.sh")
+    pub fn semantic_tokens_range_only_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_semantic_tokens_range_only.sh")
     }
 
     /// Get the path to the fake LSP server script
-    pub fn script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server.sh")
+    pub fn script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server.sh")
     }
 
     /// Spawn a blocking fake LSP server that never responds to requests
@@ -420,7 +423,7 @@ done
     /// but then blocks forever on all other requests without responding.
     /// This is useful for testing that the editor UI remains responsive even
     /// when the LSP server is completely stuck.
-    pub fn spawn_blocking() -> anyhow::Result<Self> {
+    pub fn spawn_blocking(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that acts as a fake LSP server that blocks forever
@@ -488,7 +491,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_blocking.sh");
+        let script_path = dir.join("fake_lsp_server_blocking.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -509,15 +512,18 @@ done
     }
 
     /// Get the path to the blocking fake LSP server script
-    pub fn blocking_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_blocking.sh")
+    pub fn blocking_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_blocking.sh")
     }
 
     /// Spawn a fake LSP server that generates many diagnostics
     ///
     /// This version responds to didChange notifications with a large number of diagnostics
     /// across many lines. This is useful for testing performance with many diagnostics.
-    pub fn spawn_many_diagnostics(diagnostic_count: usize) -> anyhow::Result<Self> {
+    pub fn spawn_many_diagnostics(
+        dir: &std::path::Path,
+        diagnostic_count: usize,
+    ) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Generate JSON for many diagnostics
@@ -604,7 +610,7 @@ done
         );
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_many_diags.sh");
+        let script_path = dir.join("fake_lsp_server_many_diags.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -625,15 +631,15 @@ done
     }
 
     /// Get the path to the many-diagnostics fake LSP server script
-    pub fn many_diagnostics_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_many_diags.sh")
+    pub fn many_diagnostics_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_many_diags.sh")
     }
 
     /// Spawn a fake LSP server that sends progress notifications
     ///
     /// This version sends progress notifications (begin, report, end) after initialization.
     /// This is useful for testing LSP progress display in the status bar.
-    pub fn spawn_with_progress() -> anyhow::Result<Self> {
+    pub fn spawn_with_progress(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that sends progress notifications
@@ -721,7 +727,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_progress.sh");
+        let script_path = dir.join("fake_lsp_server_progress.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -742,8 +748,8 @@ done
     }
 
     /// Get the path to the progress fake LSP server script
-    pub fn progress_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_progress.sh")
+    pub fn progress_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_progress.sh")
     }
 
     /// Spawn a fake LSP server that crashes after initialization
@@ -751,7 +757,7 @@ done
     /// This version initializes successfully but then crashes (exits with non-zero)
     /// after receiving any subsequent request. This is useful for testing LSP server
     /// crash detection and auto-restart functionality.
-    pub fn spawn_crashing() -> anyhow::Result<Self> {
+    pub fn spawn_crashing(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that crashes after init
@@ -826,7 +832,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_crashing.sh");
+        let script_path = dir.join("fake_lsp_server_crashing.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -847,8 +853,8 @@ done
     }
 
     /// Get the path to the crashing fake LSP server script
-    pub fn crashing_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_crashing.sh")
+    pub fn crashing_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_crashing.sh")
     }
 
     /// Spawn a fake LSP server that supports pull diagnostics (textDocument/diagnostic)
@@ -857,7 +863,7 @@ done
     /// It also tracks result_id for incremental updates and returns "unchanged" responses
     /// when the same result_id is passed. This is useful for testing LSP 3.17+ pull
     /// diagnostics functionality.
-    pub fn spawn_with_pull_diagnostics() -> anyhow::Result<Self> {
+    pub fn spawn_with_pull_diagnostics(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that supports pull diagnostics
@@ -960,7 +966,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_pull_diag.sh");
+        let script_path = dir.join("fake_lsp_server_pull_diag.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -981,15 +987,15 @@ done
     }
 
     /// Get the path to the pull diagnostics fake LSP server script
-    pub fn pull_diagnostics_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_pull_diag.sh")
+    pub fn pull_diagnostics_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_pull_diag.sh")
     }
 
     /// Spawn a fake LSP server that supports inlay hints (textDocument/inlayHint)
     ///
     /// This version responds to textDocument/inlayHint requests with sample hints.
     /// This is useful for testing LSP 3.17+ inlay hints functionality.
-    pub fn spawn_with_inlay_hints() -> anyhow::Result<Self> {
+    pub fn spawn_with_inlay_hints(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that supports inlay hints
@@ -1063,7 +1069,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_inlay_hints.sh");
+        let script_path = dir.join("fake_lsp_server_inlay_hints.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -1084,15 +1090,15 @@ done
     }
 
     /// Get the path to the inlay hints fake LSP server script
-    pub fn inlay_hints_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_inlay_hints.sh")
+    pub fn inlay_hints_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_inlay_hints.sh")
     }
 
     /// Spawn a fake LSP server that logs all received methods to a file
     ///
     /// This variant logs each method name to a log file, which can be used
     /// to verify the order of LSP messages (e.g., that didOpen is sent before hover).
-    pub fn spawn_with_logging() -> anyhow::Result<Self> {
+    pub fn spawn_with_logging(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that logs all methods to a file
@@ -1188,7 +1194,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_logging.sh");
+        let script_path = dir.join("fake_lsp_server_logging.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -1209,8 +1215,8 @@ done
     }
 
     /// Get the path to the logging fake LSP server script
-    pub fn logging_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_logging.sh")
+    pub fn logging_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_logging.sh")
     }
 
     /// Get the default log file path used by the logging server
@@ -1223,7 +1229,7 @@ done
     /// This simulates LSP servers like pyrefly that don't return the hover range.
     /// Used to test that hover popup doesn't move/duplicate when LSP doesn't
     /// provide symbol range information.
-    pub fn spawn_without_range() -> anyhow::Result<Self> {
+    pub fn spawn_without_range(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Create a Bash script that acts as a fake LSP server WITHOUT hover range
@@ -1298,7 +1304,7 @@ done
 "#;
 
         // Write script to a temporary file
-        let script_path = std::env::temp_dir().join("fake_lsp_server_no_range.sh");
+        let script_path = dir.join("fake_lsp_server_no_range.sh");
         std::fs::write(&script_path, script)?;
 
         // Make it executable
@@ -1319,8 +1325,8 @@ done
     }
 
     /// Get the path to the no-range fake LSP server script
-    pub fn no_range_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_no_range.sh")
+    pub fn no_range_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_no_range.sh")
     }
 
     /// Spawn a fake LSP server that supports folding ranges.
@@ -1328,7 +1334,7 @@ done
     /// Based on the standard fake LSP script with `foldingRangeProvider` added
     /// to the capabilities and a handler for `textDocument/foldingRange` that
     /// returns a single range covering lines 10..30.
-    pub fn spawn_with_folding_ranges() -> anyhow::Result<Self> {
+    pub fn spawn_with_folding_ranges(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Same as the standard script but with foldingRangeProvider in capabilities
@@ -1430,7 +1436,7 @@ esac
 done
 "#;
 
-        let script_path = Self::folding_ranges_script_path();
+        let script_path = Self::folding_ranges_script_path(dir);
         std::fs::write(&script_path, script)?;
 
         #[cfg(unix)]
@@ -1449,8 +1455,8 @@ done
     }
 
     /// Get the path to the folding ranges fake LSP server script
-    pub fn folding_ranges_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_folding_ranges.sh")
+    pub fn folding_ranges_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_folding_ranges.sh")
     }
 
     /// Spawn a fake LSP server that echoes an environment variable in hover responses.
@@ -1461,7 +1467,7 @@ done
     ///
     /// Based on the standard fake LSP script but with the hover response
     /// modified to include the env var value.
-    pub fn spawn_env_echo() -> anyhow::Result<Self> {
+    pub fn spawn_env_echo(dir: &std::path::Path) -> anyhow::Result<Self> {
         let (stop_tx, stop_rx) = mpsc::channel();
 
         // Same as the standard script, but hover returns the env var value
@@ -1563,7 +1569,7 @@ esac
 done
 "#;
 
-        let script_path = Self::env_echo_script_path();
+        let script_path = Self::env_echo_script_path(dir);
         std::fs::write(&script_path, script)?;
 
         #[cfg(unix)]
@@ -1582,8 +1588,8 @@ done
     }
 
     /// Get the path to the env echo fake LSP server script
-    pub fn env_echo_script_path() -> std::path::PathBuf {
-        std::env::temp_dir().join("fake_lsp_server_env_echo.sh")
+    pub fn env_echo_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_env_echo.sh")
     }
 
     /// Stop the server
@@ -1607,14 +1613,16 @@ mod tests {
 
     #[test]
     fn test_fake_lsp_server_creation() {
-        let server = FakeLspServer::spawn();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let server = FakeLspServer::spawn(temp_dir.path());
         assert!(server.is_ok());
     }
 
     #[test]
     fn test_script_path_exists() {
-        let _server = FakeLspServer::spawn().unwrap();
-        let path = FakeLspServer::script_path();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let _server = FakeLspServer::spawn(temp_dir.path()).unwrap();
+        let path = FakeLspServer::script_path(temp_dir.path());
         assert!(path.exists());
     }
 }

--- a/crates/fresh-editor/tests/e2e/folding.rs
+++ b/crates/fresh-editor/tests/e2e/folding.rs
@@ -464,10 +464,10 @@ fn test_folded_gutter_line_numbers_match_content_during_scroll() -> anyhow::Resu
 
     // 1. Spawn fake LSP that advertises foldingRangeProvider and returns
     //    a single range covering lines 10..30.
-    let _fake_server = FakeLspServer::spawn_with_folding_ranges()?;
-
     // 2. Create a 60-line file where every line is "line N\n".
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_folding_ranges(temp_dir.path())?;
     let content: String = (0..60).map(|i| format!("line {i}\n")).collect();
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, &content)?;
@@ -481,7 +481,7 @@ fn test_folded_gutter_line_numbers_match_content_during_scroll() -> anyhow::Resu
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::folding_ranges_script_path()
+            command: FakeLspServer::folding_ranges_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -784,10 +784,10 @@ fn test_lsp_waiting_indicator() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    \n}\n")?;
 
@@ -797,7 +797,9 @@ fn test_lsp_waiting_indicator() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -853,9 +855,9 @@ fn test_lsp_waiting_indicator() -> anyhow::Result<()> {
 fn test_semantic_tokens_version_gating() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
-    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(150)?;
-
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(temp_dir.path(), 150)?;
     let test_file = temp_dir.path().join("semantic.rs");
     std::fs::write(&test_file, "fn main() {}\n")?;
 
@@ -864,7 +866,7 @@ fn test_semantic_tokens_version_gating() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::semantic_tokens_delay_script_path()
+            command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -951,9 +953,9 @@ fn test_semantic_tokens_range_preserves_overlays_on_edit() -> anyhow::Result<()>
     use crate::common::fake_lsp::FakeLspServer;
     use std::collections::HashSet;
 
-    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(200)?;
-
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(temp_dir.path(), 200)?;
     let test_file = temp_dir.path().join("semantic_range.rs");
     std::fs::write(&test_file, "fn main() { let value = 1; }\n")?;
 
@@ -961,7 +963,7 @@ fn test_semantic_tokens_range_preserves_overlays_on_edit() -> anyhow::Result<()>
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::semantic_tokens_delay_script_path()
+            command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -1046,9 +1048,9 @@ fn test_semantic_tokens_persist_on_enter_key() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
     use std::collections::HashSet;
 
-    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(200)?;
-
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(temp_dir.path(), 200)?;
     let test_file = temp_dir.path().join("semantic_enter.rs");
     std::fs::write(&test_file, "fn main() { let value = 1; }\n")?;
 
@@ -1056,7 +1058,7 @@ fn test_semantic_tokens_persist_on_enter_key() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::semantic_tokens_delay_script_path()
+            command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -1141,9 +1143,9 @@ fn test_semantic_tokens_overlays_shift_on_edit() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
     use std::collections::HashMap;
 
-    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(200)?;
-
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_delay(temp_dir.path(), 200)?;
     let test_file = temp_dir.path().join("semantic_shift.rs");
     std::fs::write(&test_file, "fn main() { let value = 1; }\n")?;
 
@@ -1152,7 +1154,7 @@ fn test_semantic_tokens_overlays_shift_on_edit() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::semantic_tokens_delay_script_path()
+            command: FakeLspServer::semantic_tokens_delay_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -1245,9 +1247,9 @@ fn test_semantic_tokens_overlays_shift_on_edit() -> anyhow::Result<()> {
 fn test_semantic_tokens_range_only_viewport_highlighting() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
-    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_range_only()?;
-
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_semantic_tokens_range_only(temp_dir.path())?;
     let test_file = temp_dir.path().join("semantic_range_only.rs");
     std::fs::write(&test_file, "fn main() { let value = 1; }\n")?;
 
@@ -1256,7 +1258,7 @@ fn test_semantic_tokens_range_only_viewport_highlighting() -> anyhow::Result<()>
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::semantic_tokens_range_only_script_path()
+            command: FakeLspServer::semantic_tokens_range_only_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -1411,10 +1413,10 @@ fn test_lsp_completion_canceled_on_cursor_move() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    test_\n}\n")?;
 
@@ -1423,7 +1425,9 @@ fn test_lsp_completion_canceled_on_cursor_move() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -1478,10 +1482,10 @@ fn test_lsp_cursor_animation() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    test_\n}\n")?;
 
@@ -1490,7 +1494,9 @@ fn test_lsp_cursor_animation() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -1546,10 +1552,10 @@ fn test_lsp_completion_canceled_on_text_edit() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    test_\n}\n")?;
 
@@ -1560,7 +1566,9 @@ fn test_lsp_completion_canceled_on_text_edit() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -2132,10 +2140,11 @@ fn test_lsp_diagnostics_non_blocking() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Create a completely blocking fake LSP server that never responds
-    let _fake_server = FakeLspServer::spawn_blocking()?;
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_blocking(temp_dir.path())?;
 
     // Create temporary directory and test file
-    let temp_dir = tempfile::tempdir()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    // original code\n}\n")?;
 
@@ -2144,7 +2153,7 @@ fn test_lsp_diagnostics_non_blocking() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::blocking_script_path()
+            command: FakeLspServer::blocking_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -2901,10 +2910,11 @@ fn test_lsp_progress_status_display() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Create a fake LSP server that sends progress notifications
-    let _fake_server = FakeLspServer::spawn_with_progress()?;
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_progress(temp_dir.path())?;
 
     // Create temporary directory and test file
-    let temp_dir = tempfile::tempdir()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    println!(\"Hello\");\n}\n")?;
 
@@ -2913,7 +2923,7 @@ fn test_lsp_progress_status_display() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::progress_script_path()
+            command: FakeLspServer::progress_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -3063,10 +3073,11 @@ fn test_lsp_crash_detection_and_restart() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Create a fake LSP server that crashes after initialization
-    let _fake_server = FakeLspServer::spawn_crashing()?;
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_crashing(temp_dir.path())?;
 
     // Create temporary directory and test file
-    let temp_dir = tempfile::tempdir()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    let x = 5;\n}\n")?;
 
@@ -3075,7 +3086,7 @@ fn test_lsp_crash_detection_and_restart() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::crashing_script_path()
+            command: FakeLspServer::crashing_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -3365,15 +3376,18 @@ fn test_pull_diagnostics_unchanged_response() -> anyhow::Result<()> {
 fn test_pull_diagnostics_auto_trigger_after_open() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
+    // Create a temp directory and test file
+    let temp_dir = tempfile::TempDir::new()?;
+
     // Create fake LSP server with pull diagnostics support
-    let _server = FakeLspServer::spawn_with_pull_diagnostics()?;
+    let _server = FakeLspServer::spawn_with_pull_diagnostics(temp_dir.path())?;
 
     // Create config that uses the pull diagnostics fake server
     let mut config = fresh::config::Config::default();
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::pull_diagnostics_script_path()
+            command: FakeLspServer::pull_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -3385,9 +3399,6 @@ fn test_pull_diagnostics_auto_trigger_after_open() -> anyhow::Result<()> {
             language_id_overrides: Default::default(),
         },
     );
-
-    // Create a temp directory and test file
-    let temp_dir = tempfile::TempDir::new()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "hello world")?;
 
@@ -3445,15 +3456,18 @@ fn test_pull_diagnostics_auto_trigger_after_open() -> anyhow::Result<()> {
 fn test_pull_diagnostics_result_id_tracking() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
+    // Create a temp directory and test file
+    let temp_dir = tempfile::TempDir::new()?;
+
     // Create fake LSP server with pull diagnostics support
-    let _server = FakeLspServer::spawn_with_pull_diagnostics()?;
+    let _server = FakeLspServer::spawn_with_pull_diagnostics(temp_dir.path())?;
 
     // Create config that uses the pull diagnostics fake server
     let mut config = fresh::config::Config::default();
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::pull_diagnostics_script_path()
+            command: FakeLspServer::pull_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -3465,9 +3479,6 @@ fn test_pull_diagnostics_result_id_tracking() -> anyhow::Result<()> {
             language_id_overrides: Default::default(),
         },
     );
-
-    // Create a temp directory and test file
-    let temp_dir = tempfile::TempDir::new()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "hello world")?;
 
@@ -3703,10 +3714,11 @@ fn test_stopped_lsp_does_not_auto_restart_on_edit() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Create a fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
 
     // Create temporary directory and test file
-    let temp_dir = tempfile::tempdir()?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    let x = 5;\n}\n")?;
 
@@ -3715,7 +3727,9 @@ fn test_stopped_lsp_does_not_auto_restart_on_edit() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true, // Auto-start so it starts when we open the file
@@ -4028,10 +4042,10 @@ fn test_hover_popup_persists_within_symbol_and_popup() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server (has hover support)
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn example_function() {}\n")?;
 
@@ -4040,7 +4054,9 @@ fn test_hover_popup_persists_within_symbol_and_popup() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -5670,10 +5686,10 @@ fn test_hover_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
     // Spawn fake LSP server script (but we don't want it to actually be used)
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn example_function() {\n    let x = 42;\n}\n")?;
 
@@ -5682,7 +5698,9 @@ fn test_hover_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: false, // This is the key setting - LSP should NOT auto-start
@@ -5757,10 +5775,10 @@ fn test_typing_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
     use crossterm::event::KeyCode;
 
     // Spawn fake LSP server script (but we don't want it to actually be used)
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n}\n")?;
 
@@ -5769,7 +5787,9 @@ fn test_typing_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: false, // This is the key setting - LSP should NOT auto-start
@@ -5828,10 +5848,10 @@ fn test_typing_does_not_autostart_lsp_when_disabled() -> anyhow::Result<()> {
 #[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
 fn test_completion_triggered_on_trigger_character() -> anyhow::Result<()> {
     // Spawn fake LSP server with logging
-    let _fake_server = FakeLspServer::spawn_with_logging()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_logging(temp_dir.path())?;
+
     let log_file = temp_dir.path().join("completion_trigger_test_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    foo\n}\n")?;
@@ -5842,7 +5862,7 @@ fn test_completion_triggered_on_trigger_character() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::logging_script_path()
+            command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![log_file.to_string_lossy().to_string()],
@@ -5910,10 +5930,10 @@ fn test_completion_triggered_on_trigger_character() -> anyhow::Result<()> {
 #[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
 fn test_completion_triggered_on_word_char_with_quick_suggestions() -> anyhow::Result<()> {
     // Spawn fake LSP server with logging
-    let _fake_server = FakeLspServer::spawn_with_logging()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_logging(temp_dir.path())?;
+
     let log_file = temp_dir.path().join("quick_suggestions_test_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    \n}\n")?;
@@ -5924,7 +5944,7 @@ fn test_completion_triggered_on_word_char_with_quick_suggestions() -> anyhow::Re
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::logging_script_path()
+            command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![log_file.to_string_lossy().to_string()],
@@ -5991,10 +6011,10 @@ fn test_completion_triggered_on_word_char_with_quick_suggestions() -> anyhow::Re
 #[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
 fn test_completion_not_triggered_on_word_char_without_quick_suggestions() -> anyhow::Result<()> {
     // Spawn fake LSP server with logging
-    let _fake_server = FakeLspServer::spawn_with_logging()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_logging(temp_dir.path())?;
+
     let log_file = temp_dir.path().join("no_quick_suggestions_test_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    \n}\n")?;
@@ -6005,7 +6025,7 @@ fn test_completion_not_triggered_on_word_char_without_quick_suggestions() -> any
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::logging_script_path()
+            command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![log_file.to_string_lossy().to_string()],
@@ -6074,10 +6094,10 @@ fn test_completion_not_triggered_on_word_char_without_quick_suggestions() -> any
 #[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
 fn test_completion_not_triggered_on_non_word_char() -> anyhow::Result<()> {
     // Spawn fake LSP server with logging
-    let _fake_server = FakeLspServer::spawn_with_logging()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_with_logging(temp_dir.path())?;
+
     let log_file = temp_dir.path().join("non_word_char_test_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    foo\n}\n")?;
@@ -6088,7 +6108,7 @@ fn test_completion_not_triggered_on_non_word_char() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::logging_script_path()
+            command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![log_file.to_string_lossy().to_string()],
@@ -6165,11 +6185,12 @@ fn test_hover_popup_follows_mouse_when_lsp_returns_no_range() -> anyhow::Result<
     use std::time::Duration;
 
     // Spawn fake LSP server that does NOT return range in hover response
-    let _fake_server = FakeLspServer::spawn_without_range()?;
+    let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn_without_range(temp_dir.path())?;
 
     // Create temp dir and test file with multiple lines of code
     // This allows testing both horizontal and vertical mouse movement
-    let temp_dir = tempfile::tempdir()?;
     let test_file = temp_dir.path().join("test.rs");
     // Multiple lines with content so we can move mouse both horizontally and vertically
     let file_content = "fn example_function_name() {}\n\
@@ -6185,7 +6206,7 @@ fn test_hover_popup_follows_mouse_when_lsp_returns_no_range() -> anyhow::Result<
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::no_range_script_path()
+            command: FakeLspServer::no_range_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -6398,10 +6419,10 @@ fn test_hover_does_not_trigger_past_end_of_line() -> anyhow::Result<()> {
     use std::time::Duration;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file with a short line
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     // Short line - "fn foo() {}" is about 11 chars, so column 50 is way past end
     let file_content = "fn foo() {}\n";
@@ -6412,7 +6433,9 @@ fn test_hover_does_not_trigger_past_end_of_line() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -6495,15 +6518,15 @@ fn test_hover_does_not_trigger_on_empty_line() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
     use std::time::Duration;
 
-    // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
     // Create temp dir and test file matching user's scenario:
     // Line 1: import statement
     // Line 2: empty
     // Line 3: symbol (hover target)
     // Line 4: empty (this is where hover should NOT trigger)
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
     let test_file = temp_dir.path().join("test.rs");
     let file_content = "use std;\n\nfn foo() {}\n\n";
     std::fs::write(&test_file, file_content)?;
@@ -6513,7 +6536,9 @@ fn test_hover_does_not_trigger_on_empty_line() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -6602,10 +6627,10 @@ fn test_hover_no_duplicate_popup_when_moving_within_symbol() -> anyhow::Result<(
     use std::time::Duration;
 
     // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
-    // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     // "array_equal" is a long symbol - we'll hover on different columns within it
     let file_content = "fn array_equal() {}\n";
@@ -6616,7 +6641,9 @@ fn test_hover_no_duplicate_popup_when_moving_within_symbol() -> anyhow::Result<(
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,

--- a/crates/fresh-editor/tests/e2e/lsp_config.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_config.rs
@@ -18,11 +18,12 @@ use crossterm::event::{KeyCode, KeyModifiers};
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_start_lsp_command_works_when_config_disabled() -> anyhow::Result<()> {
-    // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
     // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    println!(\"hello\");\n}\n")?;
 
@@ -31,7 +32,9 @@ fn test_start_lsp_command_works_when_config_disabled() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: false, // KEY: LSP is disabled in config
             auto_start: false,
@@ -106,11 +109,12 @@ fn test_start_lsp_command_works_when_config_disabled() -> anyhow::Result<()> {
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_settings_ui_lsp_enabled_change_takes_effect() -> anyhow::Result<()> {
-    // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
     // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {\n    println!(\"hello\");\n}\n")?;
 
@@ -119,7 +123,9 @@ fn test_settings_ui_lsp_enabled_change_takes_effect() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: false,   // KEY: LSP is disabled in config initially
             auto_start: true, // auto_start=true so it will start when enabled
@@ -234,18 +240,20 @@ fn test_settings_ui_lsp_enabled_change_takes_effect() -> anyhow::Result<()> {
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_lsp_manager_config_updated_via_set_lsp_config() -> anyhow::Result<()> {
-    // Spawn fake LSP server
-    let _fake_server = FakeLspServer::spawn()?;
-
     // Create temp dir
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
 
     // Configure editor with LSP disabled
     let mut config = fresh::config::Config::default();
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: false,
             auto_start: false,
@@ -281,7 +289,9 @@ fn test_lsp_manager_config_updated_via_set_lsp_config() -> anyhow::Result<()> {
     // Now use set_lsp_config to update the config to enabled=true
     // This simulates what save_settings() does after the fix
     let new_config = fresh::services::lsp::LspServerConfig {
-        command: FakeLspServer::script_path().to_string_lossy().to_string(),
+        command: FakeLspServer::script_path(temp_dir.path())
+            .to_string_lossy()
+            .to_string(),
         args: vec![],
         enabled: true, // Changed to true
         auto_start: false,

--- a/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_diagnostic_flow.rs
@@ -22,7 +22,7 @@ use crate::common::harness::EditorTestHarness;
 /// - Pull diagnostics (`textDocument/diagnostic`) return empty initially
 /// - After didChange: sends `workspace/diagnostic/refresh` then `publishDiagnostics`
 ///   with empty diagnostics (clearing the errors)
-fn create_ra_replay_server_script() -> std::path::PathBuf {
+fn create_ra_replay_server_script(dir: &std::path::Path) -> std::path::PathBuf {
     // The publishDiagnostics payload is taken verbatim from the recording,
     // with the URI made dynamic (replaced at runtime with the actual file URI).
     let script = r##"#!/bin/bash
@@ -151,7 +151,7 @@ done
 echo "SERVER: exiting" >> "$LOG_FILE"
 "##;
 
-    let script_path = std::env::temp_dir().join("fake_ra_replay_server.sh");
+    let script_path = dir.join("fake_ra_replay_server.sh");
     std::fs::write(&script_path, script).expect("Failed to write RA replay server script");
 
     #[cfg(unix)]
@@ -186,9 +186,8 @@ fn test_rust_analyzer_push_diagnostics_displayed() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_ra_replay_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_ra_replay_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("ra_replay_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(
@@ -276,9 +275,8 @@ fn test_rust_analyzer_diagnostics_cleared_after_fix() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_ra_replay_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_ra_replay_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("ra_clear_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(
@@ -377,7 +375,7 @@ fn test_rust_analyzer_diagnostics_cleared_after_fix() -> anyhow::Result<()> {
 ///
 /// The diagnostic content uses actual rust-analyzer E0308 formatting recorded
 /// from rust-analyzer v1.92.0.
-fn create_ra_edit_save_server_script() -> std::path::PathBuf {
+fn create_ra_edit_save_server_script(dir: &std::path::Path) -> std::path::PathBuf {
     let script = r##"#!/bin/bash
 
 # Fake LSP server for edit/save/edit/save flow testing
@@ -499,7 +497,7 @@ done
 echo "SERVER: exiting" >> "$LOG_FILE"
 "##;
 
-    let script_path = std::env::temp_dir().join("fake_ra_edit_save_server.sh");
+    let script_path = dir.join("fake_ra_edit_save_server.sh");
     std::fs::write(&script_path, script).expect("Failed to write RA edit/save server script");
 
     #[cfg(unix)]
@@ -533,9 +531,8 @@ fn test_edit_save_edit_save_diagnostic_flow() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_ra_edit_save_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_ra_edit_save_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("ra_edit_save_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(
@@ -681,9 +678,8 @@ fn test_workspace_diagnostic_refresh_handled() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_ra_replay_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_ra_replay_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("ra_refresh_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(
@@ -755,7 +751,7 @@ fn test_workspace_diagnostic_refresh_handled() -> anyhow::Result<()> {
 /// Meanwhile, the editor continues sending didChange with newer versions.
 /// The editor should drop these stale diagnostics because the version is older
 /// than the current document version.
-fn create_stale_diagnostics_server_script() -> std::path::PathBuf {
+fn create_stale_diagnostics_server_script(dir: &std::path::Path) -> std::path::PathBuf {
     let script = r##"#!/bin/bash
 
 # Fake LSP server that sends delayed, stale diagnostics
@@ -856,7 +852,7 @@ done
 echo "SERVER: exiting" >> "$LOG_FILE"
 "##;
 
-    let script_path = std::env::temp_dir().join("fake_stale_diag_server.sh");
+    let script_path = dir.join("fake_stale_diag_server.sh");
     std::fs::write(&script_path, script).expect("Failed to write stale diagnostics server script");
 
     #[cfg(unix)]
@@ -891,9 +887,8 @@ fn test_stale_diagnostics_dropped_during_rapid_typing() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_stale_diagnostics_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_stale_diagnostics_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("stale_diag_log.txt");
     let test_file = temp_dir.path().join("test.py");
     std::fs::write(&test_file, "")?;

--- a/crates/fresh-editor/tests/e2e/lsp_env.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_env.rs
@@ -20,9 +20,8 @@ use crate::common::harness::EditorTestHarness;
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_lsp_env_vars_passed_to_server() -> anyhow::Result<()> {
-    let _fake_server = FakeLspServer::spawn_env_echo()?;
-
     let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_env_echo(temp_dir.path())?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn example_function() {}\n")?;
 
@@ -30,7 +29,7 @@ fn test_lsp_env_vars_passed_to_server() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::env_echo_script_path()
+            command: FakeLspServer::env_echo_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],

--- a/crates/fresh-editor/tests/e2e/lsp_order.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_order.rs
@@ -21,13 +21,13 @@ fn test_did_open_sent_before_hover() -> anyhow::Result<()> {
 
     eprintln!("[TEST] Starting test_did_open_sent_before_hover");
 
-    // Spawn fake LSP server with logging
-    eprintln!("[TEST] Spawning fake LSP server");
-    let _fake_server = FakeLspServer::spawn_with_logging()?;
-    eprintln!("[TEST] Fake LSP server spawned");
-
     // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server with logging
+    eprintln!("[TEST] Spawning fake LSP server");
+    let _fake_server = FakeLspServer::spawn_with_logging(temp_dir.path())?;
+    eprintln!("[TEST] Fake LSP server spawned");
 
     // Create unique log file for this test in the per-test temp directory
     let log_file = temp_dir.path().join("lsp_order_test_log.txt");
@@ -42,7 +42,7 @@ fn test_did_open_sent_before_hover() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::logging_script_path()
+            command: FakeLspServer::logging_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![log_file.to_string_lossy().to_string()],

--- a/crates/fresh-editor/tests/e2e/lsp_publish_diagnostics_capability.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_publish_diagnostics_capability.rs
@@ -22,7 +22,7 @@ use crate::common::harness::EditorTestHarness;
 /// 2. Checks for `publishDiagnostics` in the JSON
 /// 3. Logs whether the capability was found
 /// 4. Only sends diagnostics on didOpen/didChange if the capability was present
-fn create_strict_server_script() -> std::path::PathBuf {
+fn create_strict_server_script(dir: &std::path::Path) -> std::path::PathBuf {
     let script = r#"#!/bin/bash
 
 # Log file path (passed as first argument)
@@ -123,7 +123,7 @@ while true; do
 done
 "#;
 
-    let script_path = std::env::temp_dir().join("fake_lsp_strict_server.sh");
+    let script_path = dir.join("fake_lsp_strict_server.sh");
     std::fs::write(&script_path, script).expect("Failed to write strict server script");
 
     #[cfg(unix)]
@@ -141,7 +141,7 @@ done
 
 /// Create a fake LSP server that always sends publishDiagnostics regardless
 /// of client capabilities (mimics clangd behavior).
-fn create_permissive_server_script() -> std::path::PathBuf {
+fn create_permissive_server_script(dir: &std::path::Path) -> std::path::PathBuf {
     let script = r#"#!/bin/bash
 
 # Log file path (passed as first argument)
@@ -228,7 +228,7 @@ while true; do
 done
 "#;
 
-    let script_path = std::env::temp_dir().join("fake_lsp_permissive_server.sh");
+    let script_path = dir.join("fake_lsp_permissive_server.sh");
     std::fs::write(&script_path, script).expect("Failed to write permissive server script");
 
     #[cfg(unix)]
@@ -258,9 +258,8 @@ fn test_strict_server_sends_diagnostics_with_capability() -> anyhow::Result<()> 
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_strict_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_strict_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("strict_server_log.txt");
     let test_file = temp_dir.path().join("test.py");
     std::fs::write(&test_file, "def main():\n    x = 1\n")?;
@@ -320,9 +319,8 @@ fn test_permissive_server_sends_diagnostics_without_capability() -> anyhow::Resu
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_permissive_server_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_permissive_server_script(temp_dir.path());
     let log_file = temp_dir.path().join("permissive_server_log.txt");
     let test_file = temp_dir.path().join("test.c");
     std::fs::write(&test_file, "int main() { return 0; }\n")?;

--- a/crates/fresh-editor/tests/e2e/lsp_toggle_desync.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_toggle_desync.rs
@@ -26,7 +26,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 /// This lets us inspect the exact text content sent in didOpen and
 /// the exact contentChanges sent in didChange, to verify whether the
 /// server received proper re-sync after toggle.
-fn create_body_logging_lsp_script() -> std::path::PathBuf {
+fn create_body_logging_lsp_script(dir: &std::path::Path) -> std::path::PathBuf {
     let script = r#"#!/bin/bash
 
 # Log file path (passed as first argument)
@@ -119,7 +119,7 @@ while true; do
 done
 "#;
 
-    let script_path = std::env::temp_dir().join("fake_lsp_body_logging.sh");
+    let script_path = dir.join("fake_lsp_body_logging.sh");
     std::fs::write(&script_path, script).expect("Failed to write fake LSP script");
 
     #[cfg(unix)]
@@ -149,11 +149,11 @@ fn test_lsp_toggle_off_edit_toggle_on_causes_desync() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    // Create the body-logging fake LSP server script
-    let script_path = create_body_logging_lsp_script();
-
     // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    // Create the body-logging fake LSP server script (in per-test temp dir)
+    let script_path = create_body_logging_lsp_script(temp_dir.path());
     let log_file = temp_dir.path().join("lsp_toggle_desync_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     let initial_content = "fn main() {\n    let x = 5;\n}\n";
@@ -276,9 +276,8 @@ fn test_lsp_toggle_off_sends_did_close() -> anyhow::Result<()> {
         .with_env_filter("fresh=debug")
         .try_init();
 
-    let script_path = create_body_logging_lsp_script();
-
     let temp_dir = tempfile::tempdir()?;
+    let script_path = create_body_logging_lsp_script(temp_dir.path());
     let log_file = temp_dir.path().join("lsp_toggle_close_log.txt");
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn main() {}\n")?;

--- a/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_jump.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_jump.rs
@@ -24,11 +24,11 @@ use std::fs;
 fn test_diagnostics_panel_enter_does_not_jump() {
     init_tracing_from_env();
 
+    let temp_dir = tempfile::TempDir::new().unwrap();
+
     // Create fake LSP that sends diagnostics on didOpen/didChange
     // This server sends diagnostics at lines 0, 0, 1 (2 per line, 3 total)
-    let _fake_server = FakeLspServer::spawn_many_diagnostics(3).unwrap();
-
-    let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn_many_diagnostics(temp_dir.path(), 3).unwrap();
     let project_root = temp_dir.path().to_path_buf();
 
     // Set up plugins
@@ -50,7 +50,7 @@ fn test_diagnostics_panel_enter_does_not_jump() {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::many_diagnostics_script_path()
+            command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -175,9 +175,9 @@ fn test_diagnostics_panel_enter_does_not_jump() {
 fn test_diagnostics_panel_cursor_move_scrolls_editor() {
     init_tracing_from_env();
 
-    let _fake_server = FakeLspServer::spawn_many_diagnostics(3).unwrap();
-
     let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn_many_diagnostics(temp_dir.path(), 3).unwrap();
+
     let project_root = temp_dir.path().to_path_buf();
 
     let plugins_dir = project_root.join("plugins");
@@ -198,7 +198,7 @@ fn test_diagnostics_panel_cursor_move_scrolls_editor() {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::many_diagnostics_script_path()
+            command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],

--- a/crates/fresh-editor/tests/e2e/plugins/plugin.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin.rs
@@ -292,11 +292,11 @@ fn test_diagnostics_panel_plugin_loads() {
     use crate::common::fake_lsp::FakeLspServer;
     init_tracing_from_env();
 
-    // Create a fake LSP server that sends diagnostics
-    let _fake_server = FakeLspServer::spawn_many_diagnostics(3).unwrap();
-
     // Create a temporary project directory
     let temp_dir = tempfile::TempDir::new().unwrap();
+
+    // Create a fake LSP server that sends diagnostics
+    let _fake_server = FakeLspServer::spawn_many_diagnostics(temp_dir.path(), 3).unwrap();
     let project_root = temp_dir.path().to_path_buf();
 
     // Create plugins directory and copy the diagnostics panel plugin
@@ -315,7 +315,7 @@ fn test_diagnostics_panel_plugin_loads() {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::many_diagnostics_script_path()
+            command: FakeLspServer::many_diagnostics_script_path(temp_dir.path())
                 .to_string_lossy()
                 .to_string(),
             args: vec![],
@@ -722,9 +722,10 @@ editor.setStatus("Nonblocking test plugin loaded");
 #[ignore]
 fn test_clangd_plugin_file_status_notification() -> anyhow::Result<()> {
     init_tracing_from_env();
-    let _fake_server = FakeLspServer::spawn()?;
 
     let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let project_root = temp_dir.path().join("project_root");
     fs::create_dir(&project_root).unwrap();
 
@@ -742,7 +743,9 @@ fn test_clangd_plugin_file_status_notification() -> anyhow::Result<()> {
     config.lsp.insert(
         "cpp".to_string(),
         LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -791,9 +794,10 @@ fn test_clangd_plugin_file_status_notification() -> anyhow::Result<()> {
 #[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_clangd_plugin_switch_source_header() -> anyhow::Result<()> {
     init_tracing_from_env();
-    let _fake_server = FakeLspServer::spawn()?;
 
     let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let project_root = temp_dir.path().join("project_root");
     fs::create_dir(&project_root).unwrap();
 
@@ -813,7 +817,9 @@ fn test_clangd_plugin_switch_source_header() -> anyhow::Result<()> {
     config.lsp.insert(
         "cpp".to_string(),
         LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,
@@ -978,9 +984,10 @@ editor.setStatus("Test source plugin loaded!");
 #[cfg_attr(windows, ignore)] // Uses bash script for fake LSP server
 fn test_diagnostics_api_with_fake_lsp() -> anyhow::Result<()> {
     init_tracing_from_env();
-    let _fake_server = FakeLspServer::spawn()?;
 
     let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+
     let project_root = temp_dir.path().join("project_root");
     fs::create_dir(&project_root).unwrap();
 
@@ -1041,7 +1048,9 @@ editor.setStatus("Test diagnostics plugin loaded");
     config.lsp.insert(
         "rust".to_string(),
         LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,

--- a/crates/fresh-editor/tests/e2e/popup_selection.rs
+++ b/crates/fresh-editor/tests/e2e/popup_selection.rs
@@ -14,11 +14,11 @@ use fresh::view::popup::{Popup, PopupPosition};
 fn test_lsp_hover_popup_text_selection_copy() -> anyhow::Result<()> {
     use crate::common::fake_lsp::FakeLspServer;
 
-    // Spawn fake LSP server (has hover support)
-    let _fake_server = FakeLspServer::spawn()?;
-
     // Create temp dir and test file
     let temp_dir = tempfile::tempdir()?;
+
+    // Spawn fake LSP server (has hover support)
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
     let test_file = temp_dir.path().join("test.rs");
     std::fs::write(&test_file, "fn example_function() {}\n")?;
 
@@ -27,7 +27,9 @@ fn test_lsp_hover_popup_text_selection_copy() -> anyhow::Result<()> {
     config.lsp.insert(
         "rust".to_string(),
         fresh::services::lsp::LspServerConfig {
-            command: FakeLspServer::script_path().to_string_lossy().to_string(),
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
             args: vec![],
             enabled: true,
             auto_start: true,


### PR DESCRIPTION
## Summary

- Fix flaky `test_rust_analyzer_diagnostics_cleared_after_fix` timeout by isolating fake LSP server scripts into per-test temp directories
- The scripts were previously written to shared paths in `/tmp/` (e.g. `/tmp/fake_ra_replay_server.sh`), causing race conditions when tests run in parallel — `std::fs::write` truncates before writing, so a concurrent test could start its LSP process against a truncated/empty script
- All 3 script creation functions now accept a `dir` parameter and write to the test's own `tempdir()`, matching the CONTRIBUTING.md isolation guideline

## Test plan

- [x] `cargo check --all-targets` passes
- [x] All 5 `lsp_diagnostic_flow` tests pass when run together
- [x] The previously flaky test (`test_rust_analyzer_diagnostics_cleared_after_fix`) passes

https://claude.ai/code/session_01Ru3CTADwSNT5tMiWvK4A2c