### PR TITLE
Add menu_bar_mnemonics config option to toggle Alt+letter shortcuts

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -36,6 +36,7 @@
         "wrap_indent": true,
         "syntax_highlighting": true,
         "show_menu_bar": true,
+        "menu_bar_mnemonics": true,
         "show_tab_bar": true,
         "show_status_bar": true,
         "show_prompt_line": true,
@@ -268,6 +269,12 @@
         },
         "show_menu_bar": {
           "description": "Whether the menu bar is visible by default.\nThe menu bar provides access to menus (File, Edit, View, etc.) at the top of the screen.\nCan be toggled at runtime via command palette or keybinding.\nDefault: true",
+          "type": "boolean",
+          "default": true,
+          "x-section": "Display"
+        },
+        "menu_bar_mnemonics": {
+          "description": "Whether menu bar mnemonics (Alt+letter shortcuts) are enabled.\nWhen enabled, pressing Alt+F opens the File menu, Alt+E opens Edit, etc.\nDisabling this frees up Alt+letter keybindings for other actions.\nDefault: true",
           "type": "boolean",
           "default": true,
           "x-section": "Display"

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -865,7 +865,9 @@ impl Editor {
                 }
             }
             Action::MenuOpen(menu_name) => {
-                self.handle_menu_open(&menu_name);
+                if self.config.editor.menu_bar_mnemonics {
+                    self.handle_menu_open(&menu_name);
+                }
             }
 
             Action::SwitchKeybindingMap(map_name) => {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -965,6 +965,7 @@ impl Editor {
                 &self.keybindings,
                 &self.theme,
                 self.mouse_state.hover_target.as_ref(),
+                self.config.editor.menu_bar_mnemonics,
             ));
         } else {
             self.cached_layout.menu_layout = None;

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -581,6 +581,14 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub show_menu_bar: bool,
 
+    /// Whether menu bar mnemonics (Alt+letter shortcuts) are enabled.
+    /// When enabled, pressing Alt+F opens the File menu, Alt+E opens Edit, etc.
+    /// Disabling this frees up Alt+letter keybindings for other actions.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub menu_bar_mnemonics: bool,
+
     /// Whether the tab bar is visible by default.
     /// The tab bar shows open files in each split pane.
     /// Can be toggled at runtime via command palette or keybinding.
@@ -1139,6 +1147,7 @@ impl Default for EditorConfig {
             suggest_on_trigger_characters: true,
             accept_suggestion_on_enter: default_accept_suggestion_on_enter(),
             show_menu_bar: true,
+            menu_bar_mnemonics: true,
             show_tab_bar: true,
             show_status_bar: true,
             show_prompt_line: true,

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -183,6 +183,7 @@ pub struct PartialEditorConfig {
     pub suggest_on_trigger_characters: Option<bool>,
     pub accept_suggestion_on_enter: Option<AcceptSuggestionOnEnter>,
     pub show_menu_bar: Option<bool>,
+    pub menu_bar_mnemonics: Option<bool>,
     pub show_tab_bar: Option<bool>,
     pub show_status_bar: Option<bool>,
     pub show_prompt_line: Option<bool>,
@@ -274,6 +275,8 @@ impl Merge for PartialEditorConfig {
         self.accept_suggestion_on_enter
             .merge_from(&other.accept_suggestion_on_enter);
         self.show_menu_bar.merge_from(&other.show_menu_bar);
+        self.menu_bar_mnemonics
+            .merge_from(&other.menu_bar_mnemonics);
         self.show_tab_bar.merge_from(&other.show_tab_bar);
         self.show_status_bar.merge_from(&other.show_status_bar);
         self.show_prompt_line.merge_from(&other.show_prompt_line);
@@ -538,6 +541,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             suggest_on_trigger_characters: Some(cfg.suggest_on_trigger_characters),
             accept_suggestion_on_enter: Some(cfg.accept_suggestion_on_enter),
             show_menu_bar: Some(cfg.show_menu_bar),
+            menu_bar_mnemonics: Some(cfg.menu_bar_mnemonics),
             show_tab_bar: Some(cfg.show_tab_bar),
             show_status_bar: Some(cfg.show_status_bar),
             show_prompt_line: Some(cfg.show_prompt_line),
@@ -660,6 +664,9 @@ impl PartialEditorConfig {
                 .accept_suggestion_on_enter
                 .unwrap_or(defaults.accept_suggestion_on_enter),
             show_menu_bar: self.show_menu_bar.unwrap_or(defaults.show_menu_bar),
+            menu_bar_mnemonics: self
+                .menu_bar_mnemonics
+                .unwrap_or(defaults.menu_bar_mnemonics),
             show_tab_bar: self.show_tab_bar.unwrap_or(defaults.show_tab_bar),
             show_status_bar: self.show_status_bar.unwrap_or(defaults.show_status_bar),
             show_prompt_line: self.show_prompt_line.unwrap_or(defaults.show_prompt_line),

--- a/crates/fresh-editor/src/view/ui/menu.rs
+++ b/crates/fresh-editor/src/view/ui/menu.rs
@@ -498,6 +498,7 @@ impl MenuRenderer {
         keybindings: &crate::input::keybindings::KeybindingResolver,
         theme: &Theme,
         hover_target: Option<&crate::app::HoverTarget>,
+        mnemonics_enabled: bool,
     ) -> MenuLayout {
         let mut layout = MenuLayout::new(area);
         // Combine config menus with plugin menus, expanding any DynamicSubmenus
@@ -557,7 +558,11 @@ impl MenuRenderer {
                 .push((idx, Rect::new(current_x, area.y, label_width, 1)));
 
             // Check for mnemonic character (Alt+letter keybinding)
-            let mnemonic = keybindings.find_menu_mnemonic(&menu.label);
+            let mnemonic = if mnemonics_enabled {
+                keybindings.find_menu_mnemonic(&menu.label)
+            } else {
+                None
+            };
 
             // Build the label with underlined mnemonic
             spans.push(Span::styled(" ", base_style));


### PR DESCRIPTION
## Summary
This PR adds a new configuration option `menu_bar_mnemonics` that allows users to enable or disable menu bar mnemonics (Alt+letter keyboard shortcuts). When disabled, Alt+letter keybindings are freed up for other custom actions.

## Key Changes
- Added `menu_bar_mnemonics: bool` configuration field to `EditorConfig` with a default value of `true`
- Updated `PartialEditorConfig` to include the new field for partial configuration merging
- Modified menu rendering logic to conditionally display mnemonics based on the config setting
- Updated menu open action handler to respect the mnemonics enabled setting
- Added comprehensive documentation describing the feature and its purpose
- Updated JSON schema and default configuration files to reflect the new option

## Implementation Details
- The configuration option is placed in the "Display" section alongside other UI visibility settings
- When `menu_bar_mnemonics` is `false`, the `find_menu_mnemonic()` call returns `None`, preventing mnemonic detection and display
- Menu open actions triggered by Alt+letter keybindings are ignored when mnemonics are disabled, allowing those keybindings to be used for other purposes
- The setting is properly integrated into the configuration merge system for handling partial configs

https://claude.ai/code/session_01AFWRduS66itxAaaESEawNw