### PR TITLE
Fix read-only detection for files not owned by current user

### DIFF
--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -304,12 +304,8 @@ impl Editor {
         }
 
         // Check if the file is read-only on disk (filesystem permissions)
-        if file_exists && !metadata.read_only {
-            if let Ok(file_meta) = self.filesystem.metadata(path) {
-                if file_meta.is_readonly {
-                    metadata.read_only = true;
-                }
-            }
+        if file_exists && !metadata.read_only && !self.filesystem.is_writable(path) {
+            metadata.read_only = true;
         }
 
         // Mark read-only files (library, binary, or filesystem-readonly) as editing-disabled

--- a/crates/fresh-editor/src/model/filesystem.rs
+++ b/crates/fresh-editor/src/model/filesystem.rs
@@ -217,7 +217,11 @@ impl FilePermissions {
         self.mode
     }
 
-    /// Check if readonly
+    /// Check if no write bits are set at all (any user).
+    ///
+    /// NOTE: On Unix, this only checks whether the mode has zero write bits.
+    /// It does NOT check whether the *current user* can write. For that,
+    /// use [`is_readonly_for_user`] with the appropriate uid/gid.
     pub fn is_readonly(&self) -> bool {
         #[cfg(unix)]
         {
@@ -227,6 +231,31 @@ impl FilePermissions {
         {
             self.readonly
         }
+    }
+
+    /// Check if the file is read-only for a specific user identified by
+    /// `user_uid` and a set of group IDs the user belongs to.
+    ///
+    /// On non-Unix platforms, falls back to the simple readonly flag.
+    #[cfg(unix)]
+    pub fn is_readonly_for_user(
+        &self,
+        user_uid: u32,
+        file_uid: u32,
+        file_gid: u32,
+        user_groups: &[u32],
+    ) -> bool {
+        // root can write to anything
+        if user_uid == 0 {
+            return false;
+        }
+        if user_uid == file_uid {
+            return self.mode & 0o200 == 0;
+        }
+        if user_groups.contains(&file_gid) {
+            return self.mode & 0o020 == 0;
+        }
+        self.mode & 0o002 == 0
     }
 }
 
@@ -505,6 +534,17 @@ pub trait FileSystem: Send + Sync {
 
     /// Check if path is a file
     fn is_file(&self, path: &Path) -> io::Result<bool>;
+
+    /// Check if the current user has write permission to the given path.
+    ///
+    /// On Unix, this considers file ownership, group membership (including
+    /// supplementary groups), and the relevant permission bits. On other
+    /// platforms it falls back to the standard readonly check.
+    ///
+    /// Returns `false` if the path doesn't exist or metadata can't be read.
+    fn is_writable(&self, path: &Path) -> bool {
+        self.metadata(path).map(|m| !m.is_readonly).unwrap_or(false)
+    }
 
     /// Set file permissions
     fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()>;
@@ -898,19 +938,51 @@ impl StdFileSystem {
             .is_some_and(|n| n.starts_with('.'))
     }
 
+    /// Get the current user's effective UID and all group IDs (primary + supplementary).
+    #[cfg(unix)]
+    pub fn current_user_groups() -> (u32, Vec<u32>) {
+        // SAFETY: these libc calls are always safe and have no failure modes
+        let euid = unsafe { libc::geteuid() };
+        let egid = unsafe { libc::getegid() };
+        let mut groups = vec![egid];
+
+        // Get supplementary groups
+        let ngroups = unsafe { libc::getgroups(0, std::ptr::null_mut()) };
+        if ngroups > 0 {
+            let mut sup_groups = vec![0 as libc::gid_t; ngroups as usize];
+            let n = unsafe { libc::getgroups(ngroups, sup_groups.as_mut_ptr()) };
+            if n > 0 {
+                sup_groups.truncate(n as usize);
+                for g in sup_groups {
+                    if g != egid {
+                        groups.push(g);
+                    }
+                }
+            }
+        }
+
+        (euid, groups)
+    }
+
     /// Build FileMetadata from std::fs::Metadata
     fn build_metadata(path: &Path, meta: &std::fs::Metadata) -> FileMetadata {
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
+            let file_uid = meta.uid();
+            let file_gid = meta.gid();
+            let permissions = FilePermissions::from_std(meta.permissions());
+            let (euid, user_groups) = Self::current_user_groups();
+            let is_readonly =
+                permissions.is_readonly_for_user(euid, file_uid, file_gid, &user_groups);
             FileMetadata {
                 size: meta.len(),
                 modified: meta.modified().ok(),
-                permissions: Some(FilePermissions::from_std(meta.permissions())),
+                permissions: Some(permissions),
                 is_hidden: Self::is_hidden(path),
-                is_readonly: meta.permissions().readonly(),
-                uid: Some(meta.uid()),
-                gid: Some(meta.gid()),
+                is_readonly,
+                uid: Some(file_uid),
+                gid: Some(file_gid),
             }
         }
         #[cfg(not(unix))]

--- a/crates/fresh-editor/src/services/remote/filesystem.rs
+++ b/crates/fresh-editor/src/services/remote/filesystem.rs
@@ -85,6 +85,14 @@ impl RemoteFileSystem {
 
         let is_hidden = name.starts_with('.');
         let permissions = FilePermissions::from_mode(rm.mode);
+
+        #[cfg(unix)]
+        let is_readonly = {
+            let (euid, user_groups) =
+                crate::model::filesystem::StdFileSystem::current_user_groups();
+            permissions.is_readonly_for_user(euid, rm.uid, rm.gid, &user_groups)
+        };
+        #[cfg(not(unix))]
         let is_readonly = permissions.is_readonly();
 
         let mut meta = FileMetadata::new(rm.size)
@@ -700,12 +708,22 @@ mod tests {
 
     #[test]
     fn test_convert_metadata() {
+        // Use the current user's uid/gid so the file appears writable regardless
+        // of which user runs the test (on Unix, is_readonly checks effective user).
+        #[cfg(unix)]
+        let (uid, gid) = {
+            let (euid, groups) = crate::model::filesystem::StdFileSystem::current_user_groups();
+            (euid, *groups.first().unwrap_or(&0u32))
+        };
+        #[cfg(not(unix))]
+        let (uid, gid) = (1000u32, 1000u32);
+
         let rm = RemoteMetadata {
             size: 1234,
             mtime: 1700000000,
             mode: 0o644,
-            uid: 1000,
-            gid: 1000,
+            uid,
+            gid,
             dir: false,
             file: true,
             link: false,

--- a/crates/fresh-editor/tests/e2e/sudo_save_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/sudo_save_prompt.rs
@@ -245,21 +245,21 @@ fn test_save_permission_denied_no_crash() {
     let _ = std::fs::set_permissions(&unwritable_dir, Permissions::from_mode(0o755));
 }
 
-/// Test saving a system file triggers in-place write path (issue #775)
+/// Test that opening a file owned by another user disables editing.
 ///
-/// This test attempts to reproduce the exact bug scenario:
-/// - Open a file owned by root (e.g., /etc/hosts)
-/// - The in-place write path is triggered because file owner != current user
-/// - Save should show sudo prompt, not crash
-///
-/// This test is ignored by default because it requires:
-/// 1. Running as non-root user
-/// 2. The system file to exist and be readable
-/// This test reproduces the bug from issue #775
+/// Files that the current user cannot write to (e.g. root-owned files with
+/// mode 0o644) should have editing disabled so the user can't accidentally
+/// modify them.
 #[test]
 #[cfg(unix)]
 fn test_save_root_owned_file_shows_sudo_prompt() {
     use std::os::unix::fs::MetadataExt;
+
+    // Root (uid 0) bypasses Unix file permission checks.
+    if unsafe { libc::getuid() } == 0 {
+        eprintln!("Skipping test: root bypasses file permission checks");
+        return;
+    }
 
     // Try to find a root-owned file that's world-readable
     let test_paths = ["/etc/hosts", "/etc/passwd", "/etc/resolv.conf"];
@@ -295,42 +295,15 @@ fn test_save_root_owned_file_shows_sudo_prompt() {
     harness.open_file(&file_path).unwrap();
     harness.render().unwrap();
 
-    // Modify the content (add a space at the beginning)
+    // Try to type — editing should be disabled since the file is not writable
     harness.type_text(" ").unwrap();
     harness.render().unwrap();
 
-    // Verify buffer is modified
-    harness.assert_screen_contains("*");
-
-    // Try to save - this triggers the in-place write path because file is owned by root
-    // BUG: This crashes with "Permission denied (os error 13)"
-    // EXPECTED: Shows "Permission denied. Save with sudo?" prompt
-    let save_result = harness.send_key(KeyCode::Char('s'), KeyModifiers::CONTROL);
-    assert!(
-        save_result.is_ok(),
-        "Save operation should not crash with permission denied: {:?}",
-        save_result
-    );
-
-    let render_result = harness.render();
-    assert!(
-        render_result.is_ok(),
-        "Render after save should not crash: {:?}",
-        render_result
-    );
-
-    // Should show sudo save prompt
+    // Buffer should NOT be modified (no "*" indicator) because editing is disabled
     let screen = harness.screen_to_string();
-    let shows_sudo_prompt = screen.contains("sudo") || screen.contains("Permission denied");
     assert!(
-        shows_sudo_prompt,
-        "Expected sudo save prompt when saving root-owned file. Screen:\n{}",
+        !screen.contains(" *"),
+        "Editing should be disabled for files the current user cannot write. Screen:\n{}",
         screen
     );
-
-    // Cancel the save (don't actually modify system file)
-    harness
-        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
 }


### PR DESCRIPTION
## Summary

- Fix `is_readonly` check which used `mode & 0o222 == 0` (any write bit), incorrectly returning `false` for files like `/usr/lib/python3.14/re/_compiler.py` (mode 0o644, owned by root) even when the current user can't write
- On Unix, now checks the effective user's actual permissions: compares file uid/gid against process euid/egid (including supplementary groups) and tests the relevant permission bit (owner/group/other)
- Add `is_writable()` method to `FileSystem` trait and `is_readonly_for_user()` to `FilePermissions` for cross-platform support
- Fix applies to both local (`StdFileSystem`) and remote (`RemoteFileSystem`) file access

## Test plan

- [x] Full test suite passes (3810 passed, 2 pre-existing failures unrelated to this change)
- [ ] Open a root-owned library file (e.g. via Go to Definition to Python stdlib) and verify editing is disabled
- [ ] Open a user-owned file and verify editing still works
- [ ] Verify root user can still edit root-owned files

https://claude.ai/code/session_017hfLnPv26w1CWENacLp7Tr