### PR TITLE
Include version and git hash in startup trace

### DIFF
--- a/crates/fresh-editor/build.rs
+++ b/crates/fresh-editor/build.rs
@@ -7,6 +7,21 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
+    // Embed git commit hash (gracefully falls back to "unknown" outside git)
+    let git_hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo::rustc-env=FRESH_GIT_HASH={}", git_hash);
+    if Path::new("../../.git/HEAD").exists() {
+        println!("cargo::rerun-if-changed=../../.git/HEAD");
+        println!("cargo::rerun-if-changed=../../.git/refs");
+    }
+
     // Rerun if locales change
     println!("cargo::rerun-if-changed=locales");
 

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1169,7 +1169,11 @@ fn initialize_app(args: &Args) -> AnyhowResult<SetupState> {
     // Clean up stale log files from dead processes on startup
     fresh::services::log_dirs::cleanup_stale_logs();
 
-    tracing::info!("Editor starting");
+    tracing::info!(
+        "Editor starting (v{} {})",
+        env!("CARGO_PKG_VERSION"),
+        env!("FRESH_GIT_HASH")
+    );
 
     signal_handler::install_signal_handlers();
     tracing::info!("Signal handlers installed");


### PR DESCRIPTION
Embed the short git commit hash at build time via build.rs and include both the version number and git hash in the first info trace on startup. Falls back to "unknown" when built outside a git environment.