### PR TITLE
Fix file URI roundtrip tests to account for path normalization

### DIFF
--- a/crates/fresh-core/src/file_uri.rs
+++ b/crates/fresh-core/src/file_uri.rs
@@ -554,7 +554,10 @@ mod tests {
                 let path = PathBuf::from(format!("/tmp/{comp}/file.txt"));
                 if let Some(uri) = path_to_file_uri(&path) {
                     let back = file_uri_to_path(&uri).unwrap();
-                    prop_assert_eq!(back, path, "roundtrip failed");
+                    // path_to_file_uri uses Path::components() which normalises
+                    // away `.` and `..`, matching the `url` crate's behaviour.
+                    let normalised: PathBuf = path.components().collect();
+                    prop_assert_eq!(back, normalised, "roundtrip failed");
                 }
             }
 
@@ -593,7 +596,10 @@ mod tests {
                 let path = PathBuf::from(format!("/tmp/{comp}/file.txt"));
                 if let Some(uri) = path_to_lsp_uri(&path) {
                     let back = lsp_uri_to_path(&uri).unwrap();
-                    prop_assert_eq!(back, path);
+                    // path_to_lsp_uri uses Path::components() which normalises
+                    // away `.` and `..`, matching the `url` crate's behaviour.
+                    let normalised: PathBuf = path.components().collect();
+                    prop_assert_eq!(back, normalised);
                 }
             }
 


### PR DESCRIPTION
## Summary
Updated the file URI roundtrip tests to correctly handle path normalization performed by the `Path::components()` method used internally by `path_to_file_uri` and `path_to_lsp_uri`.

## Changes
- Modified `file_uri_to_path` roundtrip test to normalize the original path before comparison, since `path_to_file_uri` normalizes paths by removing `.` and `..` components
- Modified `lsp_uri_to_path` roundtrip test with the same normalization logic
- Added explanatory comments documenting that path normalization matches the behavior of the `url` crate

## Details
The tests were comparing the roundtrip result against the original path, but the conversion functions normalize paths using `Path::components()`, which removes `.` and `..` entries. This caused test failures when the generated paths contained these components. The fix normalizes the expected path before comparison to match what the conversion functions actually produce.

https://claude.ai/code/session_015FnTqhDFxEZSZBmESJKaoD