### PR TITLE
Exclude fresh-gui from default workspace builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ members = [
     "crates/fresh-plugin-api-macros",
     "crates/fresh-winterm",
 ]
+default-members = [
+    "crates/fresh-editor",
+    "crates/fresh-core",
+    "crates/fresh-parser-js",
+    "crates/fresh-languages",
+    "crates/fresh-plugin-runtime",
+    "crates/fresh-plugin-api-macros",
+    "crates/fresh-winterm",
+]
 
 [workspace.package]
 version = "0.2.18"


### PR DESCRIPTION
Add default-members to workspace so that `cargo build`/`cargo test` skip the fresh-gui crate unless the gui feature is explicitly enabled.