### PR TITLE
Add deep search support for composite controls (Map, TextList)

### DIFF
--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -8,7 +8,7 @@ use crate::primitives::display_width::str_width;
 
 use super::items::SettingControl;
 use super::layout::{SettingsHit, SettingsLayout};
-use super::search::SearchResult;
+use super::search::{DeepMatch, SearchResult};
 use super::state::SettingsState;
 use crate::view::controls::{
     render_dropdown_aligned, render_number_input_aligned, render_text_input_aligned,
@@ -2504,6 +2504,21 @@ fn render_search_result_item(
         }
     }
 
+    // Determine display name and description based on deep match
+    let (display_name, display_desc) = match &result.deep_match {
+        Some(DeepMatch::MapKey { key, .. }) => (key.clone(), Some(result.item.name.clone())),
+        Some(DeepMatch::MapValue {
+            matched_text, key, ..
+        }) => (
+            matched_text.clone(),
+            Some(format!("{} > {}", result.item.name, key)),
+        ),
+        Some(DeepMatch::TextListItem { text, .. }) => {
+            (text.clone(), Some(result.item.name.clone()))
+        }
+        None => (result.item.name.clone(), result.item.description.clone()),
+    };
+
     // First line: Setting name with highlighting
     let name_style = if is_selected {
         Style::default().fg(theme.settings_selected_fg)
@@ -2515,7 +2530,7 @@ fn render_search_result_item(
 
     // Build name with match highlighting
     let name_line = build_highlighted_text(
-        &result.item.name,
+        &display_name,
         &result.name_matches,
         name_style,
         Style::default()
@@ -2539,7 +2554,7 @@ fn render_search_result_item(
     );
 
     // Third line: Description (if any)
-    if let Some(ref desc) = result.item.description {
+    if let Some(ref desc) = display_desc {
         let desc_style = Style::default().fg(theme.line_number_fg);
         let truncated_desc = if desc.len() > area.width as usize - 2 {
             format!("  {}...", &desc[..area.width as usize - 5])

--- a/crates/fresh-editor/src/view/settings/search.rs
+++ b/crates/fresh-editor/src/view/settings/search.rs
@@ -3,7 +3,37 @@
 //! Provides fuzzy search over setting names and descriptions,
 //! with support for highlighting matching categories.
 
-use super::items::{SettingItem, SettingsPage};
+use super::items::{SettingControl, SettingItem, SettingsPage};
+
+/// Describes a match found inside a composite control (Map, TextList)
+#[derive(Debug, Clone)]
+pub enum DeepMatch {
+    /// Matched a map entry key (e.g., "python" in the languages map)
+    MapKey {
+        /// The key that matched
+        key: String,
+        /// Index of the entry in the map
+        entry_index: usize,
+    },
+    /// Matched a value nested inside a map entry (e.g., a field value)
+    MapValue {
+        /// The parent map key
+        key: String,
+        /// Index of the entry in the map
+        entry_index: usize,
+        /// JSON pointer to the matched field within the entry value
+        field_path: String,
+        /// The matched text
+        matched_text: String,
+    },
+    /// Matched a TextList item
+    TextListItem {
+        /// The item text that matched
+        text: String,
+        /// Index of the item in the list
+        item_index: usize,
+    },
+}
 
 /// A search result with match information
 #[derive(Debug, Clone)]
@@ -22,6 +52,8 @@ pub struct SearchResult {
     pub name_matches: Vec<usize>,
     /// Character indices that matched in the description (for highlighting)
     pub description_matches: Vec<usize>,
+    /// If this result matched something inside a composite control
+    pub deep_match: Option<DeepMatch>,
 }
 
 /// Perform fuzzy search over all settings
@@ -60,8 +92,19 @@ pub fn search_settings(pages: &[SettingsPage], query: &str) -> Vec<SearchResult>
                     score: total_score,
                     name_matches,
                     description_matches: desc_matches,
+                    deep_match: None,
                 });
             }
+
+            // Search inside composite controls (Map entries, TextList items)
+            search_composite_control(
+                &mut results,
+                page_index,
+                item_index,
+                item,
+                &page.name,
+                &query_lower,
+            );
         }
     }
 
@@ -73,6 +116,154 @@ pub fn search_settings(pages: &[SettingsPage], query: &str) -> Vec<SearchResult>
     });
 
     results
+}
+
+/// Search inside composite controls (Map, TextList) for deep matches
+fn search_composite_control(
+    results: &mut Vec<SearchResult>,
+    page_index: usize,
+    item_index: usize,
+    item: &SettingItem,
+    page_name: &str,
+    query_lower: &str,
+) {
+    match &item.control {
+        SettingControl::Map(map_state) => {
+            for (entry_idx, (key, value)) in map_state.entries.iter().enumerate() {
+                // Match on map key
+                let (key_score, key_matches) = fuzzy_match(&key.to_lowercase(), query_lower);
+                if key_score > 0 {
+                    results.push(SearchResult {
+                        page_index,
+                        item_index,
+                        item: item.clone(),
+                        breadcrumb: format!("{} > {}", page_name, key),
+                        score: key_score,
+                        name_matches: key_matches,
+                        description_matches: Vec::new(),
+                        deep_match: Some(DeepMatch::MapKey {
+                            key: key.clone(),
+                            entry_index: entry_idx,
+                        }),
+                    });
+                }
+
+                // Match on nested string values within the map entry
+                search_json_value(
+                    results,
+                    page_index,
+                    item_index,
+                    item,
+                    page_name,
+                    key,
+                    entry_idx,
+                    value,
+                    "",
+                    query_lower,
+                );
+            }
+        }
+        SettingControl::TextList(list_state) => {
+            for (list_idx, text) in list_state.items.iter().enumerate() {
+                let (score, matches) = fuzzy_match(&text.to_lowercase(), query_lower);
+                if score > 0 {
+                    results.push(SearchResult {
+                        page_index,
+                        item_index,
+                        item: item.clone(),
+                        breadcrumb: format!("{} > {}", page_name, item.name),
+                        score,
+                        name_matches: matches,
+                        description_matches: Vec::new(),
+                        deep_match: Some(DeepMatch::TextListItem {
+                            text: text.clone(),
+                            item_index: list_idx,
+                        }),
+                    });
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Recursively search JSON values for string matches
+fn search_json_value(
+    results: &mut Vec<SearchResult>,
+    page_index: usize,
+    item_index: usize,
+    item: &SettingItem,
+    page_name: &str,
+    map_key: &str,
+    entry_index: usize,
+    value: &serde_json::Value,
+    path: &str,
+    query_lower: &str,
+) {
+    match value {
+        serde_json::Value::String(s) => {
+            let (score, _) = fuzzy_match(&s.to_lowercase(), query_lower);
+            if score > 0 {
+                // Use the field name from path as the display name
+                let field_name = path.rsplit('/').next().unwrap_or(path).to_string();
+                let display_name = if field_name.is_empty() {
+                    s.clone()
+                } else {
+                    format!("{}: {}", field_name, s)
+                };
+                results.push(SearchResult {
+                    page_index,
+                    item_index,
+                    item: item.clone(),
+                    breadcrumb: format!("{} > {}", page_name, map_key),
+                    score,
+                    name_matches: Vec::new(),
+                    description_matches: Vec::new(),
+                    deep_match: Some(DeepMatch::MapValue {
+                        key: map_key.to_string(),
+                        entry_index,
+                        field_path: path.to_string(),
+                        matched_text: display_name,
+                    }),
+                });
+            }
+        }
+        serde_json::Value::Object(obj) => {
+            for (k, v) in obj {
+                let child_path = format!("{}/{}", path, k);
+                search_json_value(
+                    results,
+                    page_index,
+                    item_index,
+                    item,
+                    page_name,
+                    map_key,
+                    entry_index,
+                    v,
+                    &child_path,
+                    query_lower,
+                );
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                let child_path = format!("{}/{}", path, i);
+                search_json_value(
+                    results,
+                    page_index,
+                    item_index,
+                    item,
+                    page_name,
+                    map_key,
+                    entry_index,
+                    v,
+                    &child_path,
+                    query_lower,
+                );
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Perform fuzzy matching on a string
@@ -323,5 +514,151 @@ mod tests {
         assert_eq!(results[1].item.name, "Tab Size");
         // Then contains match (scored lower due to position)
         assert_eq!(results[2].item.name, "Default Tab");
+    }
+
+    fn make_map_item(
+        name: &str,
+        path: &str,
+        entries: Vec<(String, serde_json::Value)>,
+    ) -> SettingItem {
+        use crate::view::controls::MapState;
+        let mut map_state = MapState::new(name);
+        map_state.entries = entries;
+        SettingItem {
+            path: path.to_string(),
+            name: name.to_string(),
+            description: None,
+            control: SettingControl::Map(map_state),
+            default: None,
+            modified: false,
+            layer_source: crate::config_io::ConfigLayer::System,
+            read_only: false,
+            is_auto_managed: false,
+            section: None,
+            is_section_start: false,
+            layout_width: 0,
+        }
+    }
+
+    fn make_text_list_item(name: &str, path: &str, items: Vec<String>) -> SettingItem {
+        use crate::view::controls::TextListState;
+        let mut list_state = TextListState::new(name);
+        list_state.items = items;
+        SettingItem {
+            path: path.to_string(),
+            name: name.to_string(),
+            description: None,
+            control: SettingControl::TextList(list_state),
+            default: None,
+            modified: false,
+            layer_source: crate::config_io::ConfigLayer::System,
+            read_only: false,
+            is_auto_managed: false,
+            section: None,
+            is_section_start: false,
+            layout_width: 0,
+        }
+    }
+
+    #[test]
+    fn test_search_map_key() {
+        let pages = vec![make_page(
+            "Languages",
+            vec![make_map_item(
+                "Languages",
+                "/languages",
+                vec![
+                    ("python".to_string(), serde_json::json!({})),
+                    ("rust".to_string(), serde_json::json!({})),
+                ],
+            )],
+        )];
+
+        let results = search_settings(&pages, "python");
+        // Should find a deep match on the map key "python"
+        let deep_results: Vec<_> = results.iter().filter(|r| r.deep_match.is_some()).collect();
+        assert!(!deep_results.is_empty(), "Should find map key 'python'");
+        assert!(
+            matches!(&deep_results[0].deep_match, Some(DeepMatch::MapKey { key, .. }) if key == "python")
+        );
+        assert_eq!(deep_results[0].breadcrumb, "Languages > python");
+    }
+
+    #[test]
+    fn test_search_map_nested_value() {
+        let pages = vec![make_page(
+            "LSP",
+            vec![make_map_item(
+                "LSP",
+                "/lsp",
+                vec![(
+                    "rust".to_string(),
+                    serde_json::json!({"command": "rust-analyzer", "args": ["--stdio"]}),
+                )],
+            )],
+        )];
+
+        let results = search_settings(&pages, "rust-analyzer");
+        let deep_results: Vec<_> = results
+            .iter()
+            .filter(|r| matches!(&r.deep_match, Some(DeepMatch::MapValue { .. })))
+            .collect();
+        assert!(
+            !deep_results.is_empty(),
+            "Should find nested value 'rust-analyzer'"
+        );
+    }
+
+    #[test]
+    fn test_search_text_list_item() {
+        let pages = vec![make_page(
+            "Editor",
+            vec![make_text_list_item(
+                "File Extensions",
+                "/file_extensions",
+                vec!["py".to_string(), "rs".to_string(), "js".to_string()],
+            )],
+        )];
+
+        let results = search_settings(&pages, "py");
+        let deep_results: Vec<_> = results
+            .iter()
+            .filter(|r| matches!(&r.deep_match, Some(DeepMatch::TextListItem { .. })))
+            .collect();
+        assert!(!deep_results.is_empty(), "Should find text list item 'py'");
+    }
+
+    #[test]
+    fn test_deep_match_ranks_higher_than_fuzzy_noise() {
+        let pages = vec![
+            make_page(
+                "Editor",
+                vec![
+                    // "python" fuzzy-matches scattered chars in long names
+                    make_item(
+                        "Leading Spaces",
+                        Some("Show space indicators for leading whitespace"),
+                        "/editor/whitespace_spaces_leading",
+                    ),
+                ],
+            ),
+            make_page(
+                "Languages",
+                vec![make_map_item(
+                    "Languages",
+                    "/languages",
+                    vec![("python".to_string(), serde_json::json!({}))],
+                )],
+            ),
+        ];
+
+        let results = search_settings(&pages, "python");
+        assert!(!results.is_empty());
+        // The map key exact match on "python" should rank first
+        assert!(
+            matches!(&results[0].deep_match, Some(DeepMatch::MapKey { key, .. }) if key == "python"),
+            "Map key 'python' should rank above fuzzy noise, got: {:?}",
+            results[0].deep_match
+        );
     }
 }

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -7,7 +7,7 @@ use super::entry_dialog::EntryDialogState;
 use super::items::{control_to_value, SettingControl, SettingItem, SettingsPage};
 use super::layout::SettingsHit;
 use super::schema::{parse_schema, SettingCategory, SettingSchema};
-use super::search::{search_settings, SearchResult};
+use super::search::{search_settings, DeepMatch, SearchResult};
 use crate::config::Config;
 use crate::config_io::ConfigLayer;
 use crate::view::controls::FocusState;
@@ -849,14 +849,15 @@ impl SettingsState {
     /// Jump to the currently selected search result
     pub fn jump_to_search_result(&mut self) {
         // Extract values first to avoid borrow issues
-        let Some(&SearchResult {
-            page_index,
-            item_index,
-            ..
-        }) = self.search_results.get(self.selected_search_result)
+        let Some(result) = self
+            .search_results
+            .get(self.selected_search_result)
+            .cloned()
         else {
             return;
         };
+        let page_index = result.page_index;
+        let item_index = result.item_index;
 
         // Unfocus old item first
         self.update_control_focus(false);
@@ -872,9 +873,38 @@ impl SettingsState {
         }
         self.sub_focus = None;
         self.init_map_focus(true);
+
+        // Navigate into the deep match target if present
+        if let Some(ref deep_match) = result.deep_match {
+            self.jump_to_deep_match(deep_match);
+        }
+
         self.update_control_focus(true); // Focus the new item
         self.ensure_visible();
         self.cancel_search();
+    }
+
+    /// Navigate into a composite control to focus a specific deep match
+    fn jump_to_deep_match(&mut self, deep_match: &DeepMatch) {
+        match deep_match {
+            DeepMatch::MapKey { entry_index, .. } | DeepMatch::MapValue { entry_index, .. } => {
+                if let Some(item) = self.current_item_mut() {
+                    if let SettingControl::Map(ref mut map_state) = item.control {
+                        map_state.focused_entry = Some(*entry_index);
+                    }
+                }
+                self.update_map_sub_focus();
+            }
+            DeepMatch::TextListItem { item_index, .. } => {
+                if let Some(item) = self.current_item_mut() {
+                    if let SettingControl::TextList(ref mut list_state) = item.control {
+                        list_state.focused_item = Some(*item_index);
+                    }
+                }
+                // Update sub_focus for TextList
+                self.sub_focus = Some(1 + *item_index);
+            }
+        }
     }
 
     /// Get the currently selected search result


### PR DESCRIPTION
## Summary
Extends the settings search functionality to find and navigate to matches within composite controls like Maps and TextLists, enabling users to search for specific map keys, nested values, and list items.

## Key Changes

- **New `DeepMatch` enum**: Represents three types of matches within composite controls:
  - `MapKey`: Matches on map entry keys (e.g., "python" in a languages map)
  - `MapValue`: Matches on nested string values within map entries with JSON pointer paths
  - `TextListItem`: Matches on individual text list items

- **Enhanced `SearchResult`**: Added optional `deep_match` field to track matches within composite controls

- **New search functions**:
  - `search_composite_control()`: Searches Map and TextList controls for matches
  - `search_json_value()`: Recursively searches nested JSON structures within map values

- **Navigation support**: Updated `jump_to_search_result()` to navigate into composite controls and focus the matched entry/item via new `jump_to_deep_match()` method

- **Improved rendering**: Modified search result display to show appropriate names and descriptions for deep matches (e.g., showing the map key as breadcrumb, matched text as the primary display)

- **Comprehensive tests**: Added test cases for map key matching, nested value matching, text list item matching, and ranking behavior

## Implementation Details

- Deep matches are discovered during the main search loop and added as separate search results
- JSON value searching handles objects, arrays, and strings recursively, building JSON pointer paths for nested matches
- Search results are ranked by score, with exact deep matches naturally ranking higher than fuzzy matches on unrelated settings
- Navigation properly updates focus state in both Map and TextList controls to highlight the matched item

https://claude.ai/code/session_01JspYAK3s73f9Qy5PeLAG7c