### PR TITLE
Track LSP capabilities per-server, not per-language

### DIFF
--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -2460,16 +2460,20 @@ impl Editor {
     /// Force check the mouse hover timer (for testing)
     /// This bypasses the normal 500ms delay
     pub fn force_check_mouse_hover(&mut self) -> bool {
-        // Temporarily mark the hover as ready by checking if state exists
         if let Some((byte_pos, _, screen_x, screen_y)) = self.mouse_state.lsp_hover_state {
             if !self.mouse_state.lsp_hover_request_sent {
-                self.mouse_state.lsp_hover_request_sent = true;
                 self.mouse_hover_screen_position = Some((screen_x, screen_y));
-                if let Err(e) = self.request_hover_at_position(byte_pos) {
-                    tracing::debug!("Failed to request hover: {}", e);
-                    return false;
+                match self.request_hover_at_position(byte_pos) {
+                    Ok(true) => {
+                        self.mouse_state.lsp_hover_request_sent = true;
+                        return true;
+                    }
+                    Ok(false) => return false, // no server ready, retry later
+                    Err(e) => {
+                        tracing::debug!("Failed to request hover: {}", e);
+                        return false;
+                    }
                 }
-                return true;
             }
         }
         false

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -647,7 +647,9 @@ impl Editor {
 
     /// Request LSP hover documentation at a specific byte position
     /// Used for mouse-triggered hover
-    pub(crate) fn request_hover_at_position(&mut self, byte_pos: usize) -> AnyhowResult<()> {
+    /// Returns `Ok(true)` if the request was dispatched, `Ok(false)` if no
+    /// eligible server was available (e.g. not yet initialized).
+    pub(crate) fn request_hover_at_position(&mut self, byte_pos: usize) -> AnyhowResult<bool> {
         // Get the current buffer
         let state = self.active_state();
 
@@ -691,7 +693,7 @@ impl Editor {
             self.lsp_status = "LSP: hover...".to_string();
         }
 
-        Ok(())
+        Ok(sent)
     }
 
     /// Handle hover response from LSP
@@ -2259,16 +2261,17 @@ impl Editor {
             return;
         };
 
+        // Ensure there is a running server
+        use crate::services::lsp::manager::LspSpawnResult;
+        if lsp.try_spawn(&language, file_path_for_spawn.as_deref()) != LspSpawnResult::Spawned {
+            return;
+        }
+
+        // Check that a server actually supports full semantic tokens
         if !lsp.semantic_tokens_full_supported(&language) {
             return;
         }
         if lsp.semantic_tokens_legend(&language).is_none() {
-            return;
-        }
-
-        // Ensure there is a running server
-        use crate::services::lsp::manager::LspSpawnResult;
-        if lsp.try_spawn(&language, file_path_for_spawn.as_deref()) != LspSpawnResult::Spawned {
             return;
         }
 
@@ -2286,12 +2289,13 @@ impl Editor {
             .semantic_tokens
             .as_ref()
             .and_then(|store| store.result_id.clone());
-        let supports_delta = lsp.semantic_tokens_full_delta_supported(&language);
-        let use_delta = previous_result_id.is_some() && supports_delta;
 
         let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::SemanticTokens) else {
             return;
         };
+        // Check capabilities on the specific server we'll send to
+        let supports_delta = sh.capabilities.semantic_tokens_full_delta;
+        let use_delta = previous_result_id.is_some() && supports_delta;
         let handle = &mut sh.handle;
 
         let request_id = self.next_lsp_request_id;
@@ -2383,8 +2387,14 @@ impl Editor {
             return;
         };
 
+        // Ensure there is a running server
+        use crate::services::lsp::manager::LspSpawnResult;
+        if lsp.try_spawn(&language, file_path.as_deref()) != LspSpawnResult::Spawned {
+            return;
+        }
+
         if !lsp.semantic_tokens_range_supported(&language) {
-            // Fall back to full document tokens if range not supported.
+            // Fall back to full document tokens if no server supports range.
             self.maybe_request_semantic_tokens(buffer_id);
             return;
         }
@@ -2392,15 +2402,14 @@ impl Editor {
             return;
         }
 
-        // Ensure there is a running server
-        use crate::services::lsp::manager::LspSpawnResult;
-        if lsp.try_spawn(&language, file_path.as_deref()) != LspSpawnResult::Spawned {
-            return;
-        }
-
         let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::SemanticTokens) else {
             return;
         };
+        // The handle_for_feature_mut check ensures has_capability(SemanticTokens) which is
+        // full || range. Double-check this specific server supports range.
+        if !sh.capabilities.semantic_tokens_range {
+            return;
+        }
         let handle = &mut sh.handle;
         let Some(state) = self.buffers.get(&buffer_id) else {
             return;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -2091,19 +2091,21 @@ impl Editor {
             return false;
         };
 
-        // Mark as sent before requesting (to prevent double-sending)
-        self.mouse_state.lsp_hover_request_sent = true;
-
         // Store mouse position for popup positioning
         self.mouse_hover_screen_position = Some((screen_x, screen_y));
 
-        // Request hover at the byte position
-        if let Err(e) = self.request_hover_at_position(byte_pos) {
-            tracing::debug!("Failed to request hover: {}", e);
-            return false;
+        // Request hover at the byte position — only mark as sent if dispatched
+        match self.request_hover_at_position(byte_pos) {
+            Ok(true) => {
+                self.mouse_state.lsp_hover_request_sent = true;
+                true
+            }
+            Ok(false) => false, // no server ready, timer will retry
+            Err(e) => {
+                tracing::debug!("Failed to request hover: {}", e);
+                false
+            }
         }
-
-        true
     }
 
     /// Check if semantic highlight debounce timer has expired
@@ -4524,35 +4526,19 @@ impl Editor {
                 }
                 AsyncMessage::LspInitialized {
                     language,
-                    completion_trigger_characters,
-                    semantic_tokens_legend,
-                    semantic_tokens_full,
-                    semantic_tokens_full_delta,
-                    semantic_tokens_range,
-                    folding_ranges_supported,
+                    server_name,
+                    capabilities,
                 } => {
-                    tracing::info!("LSP server initialized for language: {}", language);
-                    tracing::debug!(
-                        "LSP completion trigger characters for {}: {:?}",
-                        language,
-                        completion_trigger_characters
+                    tracing::info!(
+                        "LSP server '{}' initialized for language: {}",
+                        server_name,
+                        language
                     );
                     self.status_message = Some(format!("LSP ({}) ready", language));
 
-                    // Store completion trigger characters
+                    // Store capabilities on the specific server handle
                     if let Some(lsp) = &mut self.lsp {
-                        lsp.set_completion_trigger_characters(
-                            &language,
-                            completion_trigger_characters,
-                        );
-                        lsp.set_semantic_tokens_capabilities(
-                            &language,
-                            semantic_tokens_legend,
-                            semantic_tokens_full,
-                            semantic_tokens_full_delta,
-                            semantic_tokens_range,
-                        );
-                        lsp.set_folding_ranges_supported(&language, folding_ranges_supported);
+                        lsp.set_server_capabilities(&language, &server_name, capabilities);
                     }
 
                     // Send didOpen for all open buffers of this language

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -14,8 +14,7 @@ use crate::services::terminal::TerminalId;
 use crate::view::file_tree::{FileTreeView, NodeId};
 use lsp_types::{
     CodeActionOrCommand, CompletionItem, Diagnostic, FoldingRange, InlayHint, Location,
-    SemanticTokensFullDeltaResult, SemanticTokensLegend, SemanticTokensRangeResult,
-    SemanticTokensResult, SignatureHelp,
+    SemanticTokensFullDeltaResult, SemanticTokensRangeResult, SemanticTokensResult, SignatureHelp,
 };
 use serde_json::Value;
 use std::sync::mpsc;
@@ -42,18 +41,10 @@ pub enum AsyncMessage {
     /// LSP server initialized successfully
     LspInitialized {
         language: String,
-        /// Completion trigger characters from server capabilities
-        completion_trigger_characters: Vec<String>,
-        /// Legend describing semantic token types supported by the server
-        semantic_tokens_legend: Option<SemanticTokensLegend>,
-        /// Whether the server supports full document semantic tokens
-        semantic_tokens_full: bool,
-        /// Whether the server supports full document semantic token deltas
-        semantic_tokens_full_delta: bool,
-        /// Whether the server supports range semantic tokens
-        semantic_tokens_range: bool,
-        /// Whether the server supports folding ranges
-        folding_ranges_supported: bool,
+        /// Name of the specific server (for per-server capability tracking)
+        server_name: String,
+        /// Capabilities reported by this server
+        capabilities: crate::services::lsp::manager::ServerCapabilitySummary,
     },
 
     /// LSP server crashed or failed
@@ -376,12 +367,8 @@ mod tests {
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![".".to_string()],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 
@@ -392,11 +379,11 @@ mod tests {
         match &messages[0] {
             AsyncMessage::LspInitialized {
                 language,
-                completion_trigger_characters,
+                server_name,
                 ..
             } => {
                 assert_eq!(language, "rust");
-                assert_eq!(completion_trigger_characters, &vec![".".to_string()]);
+                assert_eq!(server_name, "test");
             }
             _ => panic!("Wrong message type"),
         }
@@ -411,23 +398,15 @@ mod tests {
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "typescript".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 
@@ -455,23 +434,15 @@ mod tests {
         sender1
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
         sender2
             .send(AsyncMessage::LspInitialized {
                 language: "typescript".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 
@@ -572,12 +543,8 @@ mod tests {
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 
@@ -594,12 +561,8 @@ mod tests {
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 
@@ -621,34 +584,22 @@ mod tests {
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "rust".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "typescript".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
         sender
             .send(AsyncMessage::LspInitialized {
                 language: "python".to_string(),
-                completion_trigger_characters: vec![],
-                semantic_tokens_legend: None,
-                semantic_tokens_full: false,
-                semantic_tokens_full_delta: false,
-                semantic_tokens_range: false,
-                folding_ranges_supported: false,
+                server_name: "test".to_string(),
+                capabilities: Default::default(),
             })
             .unwrap();
 

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -26,7 +26,7 @@ use lsp_types::{
     DidOpenTextDocumentParams, DidSaveTextDocumentParams, InitializeParams, InitializeResult,
     InitializedParams, PublishDiagnosticsParams, SemanticTokenModifier, SemanticTokenType,
     SemanticTokensClientCapabilities, SemanticTokensClientCapabilitiesRequests,
-    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensParams, SemanticTokensResult,
+    SemanticTokensFullOptions, SemanticTokensParams, SemanticTokensResult,
     SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentContentChangeEvent,
     TextDocumentIdentifier, TextDocumentItem, TokenFormat, Uri, VersionedTextDocumentIdentifier,
     WindowClientCapabilities, WorkspaceFolder,
@@ -356,52 +356,118 @@ fn create_client_capabilities() -> ClientCapabilities {
     }
 }
 
-fn extract_semantic_token_capability(
-    capabilities: &ServerCapabilities,
-) -> (Option<SemanticTokensLegend>, bool, bool, bool) {
-    capabilities
+use crate::services::lsp::manager::ServerCapabilitySummary;
+
+/// Extract a complete capability summary from the server's initialize response.
+///
+/// Follows the LSP 3.17 specification for each capability field:
+/// - `boolean | XxxOptions` → true if `true` or options present
+/// - Options-only fields (e.g. completionProvider) → true if present
+fn extract_capability_summary(caps: &ServerCapabilities) -> ServerCapabilitySummary {
+    let (sem_legend, sem_full, sem_full_delta, sem_range) = caps
         .semantic_tokens_provider
         .as_ref()
-        .map(|provider| match provider {
-            SemanticTokensServerCapabilities::SemanticTokensOptions(options) => (
-                Some(options.legend.clone()),
-                semantic_tokens_full_supported(&options.full),
-                semantic_tokens_full_delta_supported(&options.full),
-                options.range.unwrap_or(false),
-            ),
-            SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(options) => {
-                let legend = options.semantic_tokens_options.legend.clone();
-                let full = semantic_tokens_full_supported(&options.semantic_tokens_options.full);
-                let delta =
-                    semantic_tokens_full_delta_supported(&options.semantic_tokens_options.full);
-                let range = options.semantic_tokens_options.range.unwrap_or(false);
-                (Some(legend), full, delta, range)
-            }
+        .map(|provider| {
+            let (legend, full_opt) = match provider {
+                SemanticTokensServerCapabilities::SemanticTokensOptions(o) => {
+                    (o.legend.clone(), &o.full)
+                }
+                SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(o) => (
+                    o.semantic_tokens_options.legend.clone(),
+                    &o.semantic_tokens_options.full,
+                ),
+            };
+            let range = match provider {
+                SemanticTokensServerCapabilities::SemanticTokensOptions(o) => {
+                    o.range.unwrap_or(false)
+                }
+                SemanticTokensServerCapabilities::SemanticTokensRegistrationOptions(o) => {
+                    o.semantic_tokens_options.range.unwrap_or(false)
+                }
+            };
+            let full = match full_opt {
+                Some(SemanticTokensFullOptions::Bool(v)) => *v,
+                Some(SemanticTokensFullOptions::Delta { .. }) => true,
+                None => false,
+            };
+            let delta = match full_opt {
+                Some(SemanticTokensFullOptions::Delta { delta }) => delta.unwrap_or(false),
+                _ => false,
+            };
+            (Some(legend), full, delta, range)
         })
-        .unwrap_or((None, false, false, false))
-}
+        .unwrap_or((None, false, false, false));
 
-fn semantic_tokens_full_supported(full: &Option<SemanticTokensFullOptions>) -> bool {
-    match full {
-        Some(SemanticTokensFullOptions::Bool(v)) => *v,
-        Some(SemanticTokensFullOptions::Delta { .. }) => true,
-        None => false,
+    ServerCapabilitySummary {
+        initialized: false, // set to true by set_server_capabilities
+        hover: bool_or_options(&caps.hover_provider, |p| match p {
+            lsp_types::HoverProviderCapability::Simple(v) => *v,
+            lsp_types::HoverProviderCapability::Options(_) => true,
+        }),
+        completion: caps.completion_provider.is_some(),
+        completion_trigger_characters: caps
+            .completion_provider
+            .as_ref()
+            .and_then(|cp| cp.trigger_characters.clone())
+            .unwrap_or_default(),
+        definition: bool_or_options(&caps.definition_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        references: bool_or_options(&caps.references_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        document_formatting: bool_or_options(&caps.document_formatting_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        document_range_formatting: bool_or_options(&caps.document_range_formatting_provider, |p| {
+            match p {
+                lsp_types::OneOf::Left(v) => *v,
+                lsp_types::OneOf::Right(_) => true,
+            }
+        }),
+        rename: bool_or_options(&caps.rename_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        signature_help: caps.signature_help_provider.is_some(),
+        inlay_hints: bool_or_options(&caps.inlay_hint_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        folding_ranges: bool_or_options(&caps.folding_range_provider, |p| match p {
+            lsp_types::FoldingRangeProviderCapability::Simple(v) => *v,
+            _ => true,
+        }),
+        semantic_tokens_full: sem_full,
+        semantic_tokens_full_delta: sem_full_delta,
+        semantic_tokens_range: sem_range,
+        semantic_tokens_legend: sem_legend,
+        document_highlight: bool_or_options(&caps.document_highlight_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        code_action: bool_or_options(&caps.code_action_provider, |p| match p {
+            lsp_types::CodeActionProviderCapability::Simple(v) => *v,
+            lsp_types::CodeActionProviderCapability::Options(_) => true,
+        }),
+        document_symbols: bool_or_options(&caps.document_symbol_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        workspace_symbols: bool_or_options(&caps.workspace_symbol_provider, |p| match p {
+            lsp_types::OneOf::Left(v) => *v,
+            lsp_types::OneOf::Right(_) => true,
+        }),
+        diagnostics: caps.diagnostic_provider.is_some(),
     }
 }
 
-fn semantic_tokens_full_delta_supported(full: &Option<SemanticTokensFullOptions>) -> bool {
-    match full {
-        Some(SemanticTokensFullOptions::Delta { delta }) => delta.unwrap_or(false),
-        _ => false,
-    }
-}
-
-fn folding_ranges_supported(capabilities: &ServerCapabilities) -> bool {
-    match capabilities.folding_range_provider.as_ref() {
-        Some(lsp_types::FoldingRangeProviderCapability::Simple(v)) => *v,
-        Some(_) => true,
-        None => false,
-    }
+/// Helper: check an `Option<T>` capability field using a predicate.
+fn bool_or_options<T>(opt: &Option<T>, check: impl FnOnce(&T) -> bool) -> bool {
+    opt.as_ref().is_some_and(check)
 }
 
 /// Commands sent from the main loop to the LSP task
@@ -860,31 +926,13 @@ impl LspState {
 
         self.initialized = true;
 
-        // Extract completion trigger characters from server capabilities
-        let completion_trigger_characters = result
-            .capabilities
-            .completion_provider
-            .as_ref()
-            .and_then(|cp| cp.trigger_characters.clone())
-            .unwrap_or_default();
-
-        let (
-            semantic_tokens_legend,
-            semantic_tokens_full,
-            semantic_tokens_full_delta,
-            semantic_tokens_range,
-        ) = extract_semantic_token_capability(&result.capabilities);
-        let folding_ranges_supported = folding_ranges_supported(&result.capabilities);
+        let capabilities = extract_capability_summary(&result.capabilities);
 
         // Notify main loop
         let _ = self.async_tx.send(AsyncMessage::LspInitialized {
             language: self.language.clone(),
-            completion_trigger_characters,
-            semantic_tokens_legend,
-            semantic_tokens_full,
-            semantic_tokens_full_delta,
-            semantic_tokens_range,
-            folding_ranges_supported,
+            server_name: self.server_name.clone(),
+            capabilities,
         });
 
         // Send running status

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -106,8 +106,42 @@ pub fn detect_workspace_root(file_path: &Path, root_markers: &[String]) -> std::
     file_dir
 }
 
-/// A named LSP handle with feature filter metadata.
-/// Wraps an LspHandle with the server's display name and feature routing filter.
+/// Summary of capabilities reported by an LSP server during initialization.
+///
+/// This is extracted from `ServerCapabilities` in the `initialize` response
+/// and stored per-server so that requests are only sent to servers that
+/// actually support them. Follows the LSP 3.17 specification.
+///
+#[derive(Debug, Clone, Default)]
+pub struct ServerCapabilitySummary {
+    /// Whether capabilities have been received from the server.
+    /// When false, `has_capability()` defers to the handle's readiness state.
+    pub initialized: bool,
+    pub hover: bool,
+    pub completion: bool,
+    pub completion_trigger_characters: Vec<String>,
+    pub definition: bool,
+    pub references: bool,
+    pub document_formatting: bool,
+    pub document_range_formatting: bool,
+    pub rename: bool,
+    pub signature_help: bool,
+    pub inlay_hints: bool,
+    pub folding_ranges: bool,
+    pub semantic_tokens_full: bool,
+    pub semantic_tokens_full_delta: bool,
+    pub semantic_tokens_range: bool,
+    pub semantic_tokens_legend: Option<SemanticTokensLegend>,
+    pub document_highlight: bool,
+    pub code_action: bool,
+    pub document_symbols: bool,
+    pub workspace_symbols: bool,
+    pub diagnostics: bool,
+}
+
+/// A named LSP handle with feature filter metadata and per-server capabilities.
+/// Wraps an LspHandle with the server's display name, feature routing filter,
+/// and the capabilities reported by this specific server during initialization.
 pub struct ServerHandle {
     /// Display name for this server (e.g., "rust-analyzer", "eslint")
     pub name: String,
@@ -115,6 +149,45 @@ pub struct ServerHandle {
     pub handle: LspHandle,
     /// Feature filter controlling which LSP features this server handles
     pub feature_filter: FeatureFilter,
+    /// Capabilities reported by this server during initialization.
+    pub capabilities: ServerCapabilitySummary,
+}
+
+impl ServerHandle {
+    /// Check if this server has the actual capability for a feature.
+    ///
+    /// Checks the server's reported capabilities (from the `initialize` response).
+    /// Before initialization completes (capabilities not yet received), returns
+    /// `false` — the main loop must not route feature requests to servers whose
+    /// capabilities are unknown. Callers handle `None` from `handle_for_feature_mut`
+    /// by relying on existing retry mechanisms (render-cycle polling, timer retries,
+    /// or explicit re-requests from the `LspInitialized` handler).
+    pub fn has_capability(&self, feature: LspFeature) -> bool {
+        if !self.capabilities.initialized {
+            return false;
+        }
+        match feature {
+            LspFeature::Hover => self.capabilities.hover,
+            LspFeature::Completion => self.capabilities.completion,
+            LspFeature::Definition => self.capabilities.definition,
+            LspFeature::References => self.capabilities.references,
+            LspFeature::Format => {
+                self.capabilities.document_formatting || self.capabilities.document_range_formatting
+            }
+            LspFeature::Rename => self.capabilities.rename,
+            LspFeature::SignatureHelp => self.capabilities.signature_help,
+            LspFeature::InlayHints => self.capabilities.inlay_hints,
+            LspFeature::FoldingRange => self.capabilities.folding_ranges,
+            LspFeature::SemanticTokens => {
+                self.capabilities.semantic_tokens_full || self.capabilities.semantic_tokens_range
+            }
+            LspFeature::DocumentHighlight => self.capabilities.document_highlight,
+            LspFeature::CodeAction => self.capabilities.code_action,
+            LspFeature::DocumentSymbols => self.capabilities.document_symbols,
+            LspFeature::WorkspaceSymbols => self.capabilities.workspace_symbols,
+            LspFeature::Diagnostics => self.capabilities.diagnostics,
+        }
+    }
 }
 
 /// Manager for multiple language servers (async version)
@@ -153,24 +226,6 @@ pub struct LspManager {
     /// Languages that have been explicitly disabled/stopped by the user
     /// These will not auto-restart until user manually restarts them
     disabled_languages: HashSet<String>,
-
-    /// Completion trigger characters per language (from server capabilities)
-    completion_trigger_characters: HashMap<String, Vec<String>>,
-
-    /// Semantic token legends per language (from server capabilities)
-    semantic_token_legends: HashMap<String, SemanticTokensLegend>,
-
-    /// Whether a language supports full document semantic tokens
-    semantic_tokens_full_support: HashMap<String, bool>,
-
-    /// Whether a language supports full document semantic token deltas
-    semantic_tokens_full_delta_support: HashMap<String, bool>,
-
-    /// Whether a language supports range semantic tokens
-    semantic_tokens_range_support: HashMap<String, bool>,
-
-    /// Whether a language supports folding ranges
-    folding_ranges_support: HashMap<String, bool>,
 }
 
 impl LspManager {
@@ -188,12 +243,6 @@ impl LspManager {
             pending_restarts: HashMap::new(),
             allowed_languages: HashSet::new(),
             disabled_languages: HashSet::new(),
-            completion_trigger_characters: HashMap::new(),
-            semantic_token_legends: HashMap::new(),
-            semantic_tokens_full_support: HashMap::new(),
-            semantic_tokens_full_delta_support: HashMap::new(),
-            semantic_tokens_range_support: HashMap::new(),
-            folding_ranges_support: HashMap::new(),
         }
     }
 
@@ -223,87 +272,85 @@ impl LspManager {
         self.config.get(language).and_then(|v| v.first())
     }
 
-    /// Set completion trigger characters for a language
-    pub fn set_completion_trigger_characters(&mut self, language: &str, chars: Vec<String>) {
-        self.completion_trigger_characters
-            .insert(language.to_string(), chars);
-    }
-
-    /// Get completion trigger characters for a language
-    pub fn get_completion_trigger_characters(&self, language: &str) -> Option<&Vec<String>> {
-        self.completion_trigger_characters.get(language)
-    }
-
-    /// Store semantic token capability information for a language
-    pub fn set_semantic_tokens_capabilities(
+    /// Store capabilities on the specific server handle identified by server_name.
+    pub fn set_server_capabilities(
         &mut self,
         language: &str,
-        legend: Option<SemanticTokensLegend>,
-        full_support: bool,
-        full_delta_support: bool,
-        range_support: bool,
+        server_name: &str,
+        mut capabilities: ServerCapabilitySummary,
     ) {
-        if let Some(legend) = legend {
-            self.semantic_token_legends
-                .insert(language.to_string(), legend);
-        } else {
-            self.semantic_token_legends.remove(language);
+        capabilities.initialized = true;
+        if let Some(handles) = self.handles.get_mut(language) {
+            if let Some(sh) = handles.iter_mut().find(|sh| sh.name == server_name) {
+                sh.capabilities = capabilities;
+            }
         }
-        self.semantic_tokens_full_support
-            .insert(language.to_string(), full_support);
-        self.semantic_tokens_full_delta_support
-            .insert(language.to_string(), full_delta_support);
-        self.semantic_tokens_range_support
-            .insert(language.to_string(), range_support);
     }
 
-    /// Get the semantic token legend for a language (if provided by server)
+    /// Get the semantic token legend for a language from the first eligible server.
     pub fn semantic_tokens_legend(&self, language: &str) -> Option<&SemanticTokensLegend> {
-        self.semantic_token_legends.get(language)
+        self.handles.get(language)?.iter().find_map(|sh| {
+            if sh.feature_filter.allows(LspFeature::SemanticTokens)
+                && sh.has_capability(LspFeature::SemanticTokens)
+            {
+                sh.capabilities.semantic_tokens_legend.as_ref()
+            } else {
+                None
+            }
+        })
     }
 
-    /// Check if the language supports full semantic tokens
+    /// Check if any eligible server for the language supports full semantic tokens.
     pub fn semantic_tokens_full_supported(&self, language: &str) -> bool {
-        *self
-            .semantic_tokens_full_support
-            .get(language)
-            .unwrap_or(&false)
+        self.handles.get(language).is_some_and(|handles| {
+            handles.iter().any(|sh| {
+                sh.feature_filter.allows(LspFeature::SemanticTokens)
+                    && sh.capabilities.semantic_tokens_full
+            })
+        })
     }
 
-    /// Check if the language supports full semantic token deltas
+    /// Check if any eligible server for the language supports full semantic token deltas.
     pub fn semantic_tokens_full_delta_supported(&self, language: &str) -> bool {
-        *self
-            .semantic_tokens_full_delta_support
-            .get(language)
-            .unwrap_or(&false)
+        self.handles.get(language).is_some_and(|handles| {
+            handles.iter().any(|sh| {
+                sh.feature_filter.allows(LspFeature::SemanticTokens)
+                    && sh.capabilities.semantic_tokens_full_delta
+            })
+        })
     }
 
-    /// Check if the language supports range semantic tokens
+    /// Check if any eligible server for the language supports range semantic tokens.
     pub fn semantic_tokens_range_supported(&self, language: &str) -> bool {
-        *self
-            .semantic_tokens_range_support
-            .get(language)
-            .unwrap_or(&false)
+        self.handles.get(language).is_some_and(|handles| {
+            handles.iter().any(|sh| {
+                sh.feature_filter.allows(LspFeature::SemanticTokens)
+                    && sh.capabilities.semantic_tokens_range
+            })
+        })
     }
 
-    /// Store folding range capability information for a language
-    pub fn set_folding_ranges_supported(&mut self, language: &str, supported: bool) {
-        self.folding_ranges_support
-            .insert(language.to_string(), supported);
-    }
-
-    /// Check if the language supports folding ranges
+    /// Check if any eligible server for the language supports folding ranges.
     pub fn folding_ranges_supported(&self, language: &str) -> bool {
-        *self.folding_ranges_support.get(language).unwrap_or(&false)
+        self.handles.get(language).is_some_and(|handles| {
+            handles.iter().any(|sh| {
+                sh.feature_filter.allows(LspFeature::FoldingRange) && sh.capabilities.folding_ranges
+            })
+        })
     }
 
-    /// Check if a character is a completion trigger for any running language server
+    /// Check if a character is a completion trigger for any running language server.
     pub fn is_completion_trigger_char(&self, ch: char, language: &str) -> bool {
         let ch_str = ch.to_string();
-        self.completion_trigger_characters
-            .get(language)
-            .map(|chars| chars.contains(&ch_str))
-            .unwrap_or(false)
+        self.handles.get(language).is_some_and(|handles| {
+            handles.iter().any(|sh| {
+                sh.feature_filter.allows(LspFeature::Completion)
+                    && sh
+                        .capabilities
+                        .completion_trigger_characters
+                        .contains(&ch_str)
+            })
+        })
     }
 
     /// Try to spawn an LSP server, checking auto_start configuration
@@ -500,15 +547,18 @@ impl LspManager {
     }
 
     /// Get the first handle for a language that allows a given feature (for exclusive features).
+    /// For capability-gated features (semantic tokens, folding ranges), this also checks
+    /// that the server actually reported the capability during initialization.
     /// Returns `None` if no handle matches.
     pub fn handle_for_feature(&self, language: &str, feature: LspFeature) -> Option<&ServerHandle> {
         self.handles
             .get(language)?
             .iter()
-            .find(|sh| sh.feature_filter.allows(feature))
+            .find(|sh| sh.feature_filter.allows(feature) && sh.has_capability(feature))
     }
 
     /// Get the first mutable handle for a language that allows a given feature.
+    /// For capability-gated features, this also checks the server's actual capabilities.
     pub fn handle_for_feature_mut(
         &mut self,
         language: &str,
@@ -517,22 +567,24 @@ impl LspManager {
         self.handles
             .get_mut(language)?
             .iter_mut()
-            .find(|sh| sh.feature_filter.allows(feature))
+            .find(|sh| sh.feature_filter.allows(feature) && sh.has_capability(feature))
     }
 
     /// Get all handles for a language that allow a given feature (for merged features).
+    /// Like `handle_for_feature`, also checks per-server capabilities.
     pub fn handles_for_feature(&self, language: &str, feature: LspFeature) -> Vec<&ServerHandle> {
         self.handles
             .get(language)
             .map(|v| {
                 v.iter()
-                    .filter(|sh| sh.feature_filter.allows(feature))
+                    .filter(|sh| sh.feature_filter.allows(feature) && sh.has_capability(feature))
                     .collect()
             })
             .unwrap_or_default()
     }
 
     /// Get all mutable handles for a language that allow a given feature.
+    /// Like `handle_for_feature_mut`, also checks per-server capabilities.
     pub fn handles_for_feature_mut(
         &mut self,
         language: &str,
@@ -542,7 +594,7 @@ impl LspManager {
             .get_mut(language)
             .map(|v| {
                 v.iter_mut()
-                    .filter(|sh| sh.feature_filter.allows(feature))
+                    .filter(|sh| sh.feature_filter.allows(feature) && sh.has_capability(feature))
                     .collect()
             })
             .unwrap_or_default()
@@ -668,6 +720,7 @@ impl LspManager {
                         name: server_name,
                         handle,
                         feature_filter: config.feature_filter(),
+                        capabilities: ServerCapabilitySummary::default(),
                     });
                 }
                 Err(e) => {

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1592,6 +1592,108 @@ done
         dir.join("fake_lsp_server_env_echo.sh")
     }
 
+    /// Spawn a fake LSP server that does NOT support semantic tokens at all.
+    /// Used to reproduce multi-LSP capability mismatch bugs.
+    pub fn spawn_no_semantic_tokens(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+# Function to read a message
+read_message() {
+    # Read headers
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        # Empty line marks end of headers
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+
+    # Read content
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+# Function to send a message
+send_message() {
+    local message="$1"
+    local length=${#message}
+    echo -en "Content-Length: $length\r\n\r\n$message"
+}
+
+# Main loop
+while true; do
+    # Read incoming message
+    msg=$(read_message)
+
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    # Extract method from JSON
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+case "$method" in
+    "initialize")
+        # No semanticTokensProvider in capabilities
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"completionProvider":{"triggerCharacters":[".",":",":"]},"definitionProvider":true,"hoverProvider":true,"textDocumentSync":1}}}'
+        ;;
+    "textDocument/hover")
+        line=$(echo "$msg" | grep -o '"line":[0-9]*' | head -1 | cut -d':' -f2)
+        char=$(echo "$msg" | grep -o '"character":[0-9]*' | head -1 | cut -d':' -f2)
+        end_char=$((char + 10))
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"contents":{"kind":"markdown","value":"No semantic tokens server"},"range":{"start":{"line":'$line',"character":'$char'},"end":{"line":'$line',"character":'$end_char'}}}}'
+        ;;
+    "textDocument/completion")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[]}}'
+        ;;
+    "textDocument/didOpen")
+        ;;
+    "textDocument/didClose")
+        ;;
+    "textDocument/didChange")
+        ;;
+    "textDocument/didSave")
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+esac
+done
+"#;
+
+        let script_path = Self::no_semantic_tokens_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Path to the no-semantic-tokens script.
+    pub fn no_semantic_tokens_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_no_semantic_tokens.sh")
+    }
+
     /// Stop the server
     pub fn stop(&mut self) {
         let _ = self.stop_tx.send(());

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -2009,9 +2009,10 @@ impl EditorTestHarness {
         self.render()?;
         Ok(())
     }
-    /// Wait indefinitely for async operations until condition is met
-    /// Repeatedly processes async messages until condition is met (no timeout)
-    /// Use this for semantic events that must eventually occur
+    /// Wait indefinitely for async operations until condition is met.
+    /// Runs a full editor tick each iteration — the same work the real event
+    /// loop performs between frames — so that hover timers, debounced requests,
+    /// diagnostic pulls, and all other periodic checks fire naturally.
     ///
     /// Note: Uses a short real wall-clock sleep between iterations to allow
     /// async I/O operations (running on tokio runtime) time to complete.
@@ -2023,7 +2024,7 @@ impl EditorTestHarness {
 
         tracing::info!("waiting...");
         loop {
-            self.process_async_and_render()?;
+            self.tick_and_render()?;
             if condition(self) {
                 return Ok(());
             }

--- a/crates/fresh-editor/tests/e2e/lsp_multi_semantic_tokens.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_multi_semantic_tokens.rs
@@ -1,0 +1,97 @@
+/// Regression test: when two LSP servers are configured for the same language,
+/// the second server's capabilities overwrite the first's in the per-language
+/// capability map. This causes semantic token requests to be routed to the wrong
+/// server (handle_for_feature_mut returns the first server in the vec, regardless
+/// of which server actually advertised the capability).
+///
+/// Reproduces: "LSP response error: Method Not Found: textDocument/semanticTokens/range (code -32601)"
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::EditorTestHarness;
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "FakeLspServer uses Bash")]
+fn test_multi_lsp_semantic_tokens_capability_mismatch() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    // Server A: does NOT support semantic tokens at all
+    let _server_a = FakeLspServer::spawn_no_semantic_tokens(temp_dir.path())?;
+    // Server B: supports semantic tokens (full + range)
+    let _server_b = FakeLspServer::spawn(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test_multi.rs");
+    std::fs::write(&test_file, "fn main() { let value = 1; }\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_semantic_tokens_full = true;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![
+            // Server A first: no semantic tokens — but handle_for_feature_mut picks it
+            fresh::services::lsp::LspServerConfig {
+                command: FakeLspServer::no_semantic_tokens_script_path(temp_dir.path())
+                    .to_string_lossy()
+                    .to_string(),
+                args: vec![],
+                enabled: true,
+                auto_start: true,
+                name: Some("no-semtok".to_string()),
+                process_limits: fresh::services::process_limits::ProcessLimits::default(),
+                initialization_options: None,
+                env: Default::default(),
+                language_id_overrides: Default::default(),
+                root_markers: Default::default(),
+                only_features: None,
+                except_features: None,
+            },
+            // Server B second: has full semantic tokens support
+            fresh::services::lsp::LspServerConfig {
+                command: FakeLspServer::script_path(temp_dir.path())
+                    .to_string_lossy()
+                    .to_string(),
+                args: vec![],
+                enabled: true,
+                auto_start: true,
+                name: Some("with-semtok".to_string()),
+                process_limits: fresh::services::process_limits::ProcessLimits::default(),
+                initialization_options: None,
+                env: Default::default(),
+                language_id_overrides: Default::default(),
+                root_markers: Default::default(),
+                only_features: None,
+                except_features: None,
+            },
+        ]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        100,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for LSP to be running
+    harness.wait_until(|h| {
+        h.editor()
+            .running_lsp_servers()
+            .contains(&"rust".to_string())
+    })?;
+
+    // Semantic tokens should eventually appear. With the bug, the request is either
+    // routed to the wrong server (Method Not Found) or never made (capabilities
+    // overwritten to false), so this wait_until never completes and nextest times out.
+    let ns = fresh::services::lsp::semantic_tokens::lsp_semantic_tokens_namespace();
+    harness.wait_until(|h| {
+        let state = h.editor().active_state();
+        state
+            .overlays
+            .all()
+            .iter()
+            .any(|o| o.namespace.as_ref() == Some(&ns))
+    })?;
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -54,6 +54,7 @@ pub mod lsp_config;
 pub mod lsp_diagnostic_flow;
 pub mod lsp_env;
 pub mod lsp_goto_definition_readonly;
+pub mod lsp_multi_semantic_tokens;
 pub mod lsp_no_config;
 pub mod lsp_order;
 pub mod lsp_publish_diagnostics_capability;

--- a/crates/fresh-editor/tests/e2e/mouse.rs
+++ b/crates/fresh-editor/tests/e2e/mouse.rs
@@ -1637,18 +1637,12 @@ fn test_force_check_mouse_hover() {
         "Should have hover state"
     );
 
-    // Force check should return true (would trigger hover if LSP was available)
+    // Force check returns false when no LSP server is available — the request
+    // is not dispatched and the sent flag is not set, allowing retry later.
     let triggered = harness.editor_mut().force_check_mouse_hover();
     assert!(
-        triggered,
-        "force_check_mouse_hover should return true when hover state exists"
-    );
-
-    // Second call should return false (already sent)
-    let triggered_again = harness.editor_mut().force_check_mouse_hover();
-    assert!(
-        !triggered_again,
-        "Second force_check should return false (already sent)"
+        !triggered,
+        "force_check_mouse_hover should return false when no LSP server is available"
     );
 }
 

--- a/docs/internal/lsp-request-queuing-plan.md
+++ b/docs/internal/lsp-request-queuing-plan.md
@@ -1,0 +1,274 @@
+# LSP Request Queuing: Per-Server Capabilities and Init-Gated Dispatch
+
+## Problem
+
+Two related bugs in the LSP client:
+
+1. **Multi-server capability mismatch**: When multiple LSP servers are configured
+   for the same language, capabilities (semantic tokens, folding ranges, etc.)
+   are stored per-language. The second server's capabilities overwrite the
+   first's. `handle_for_feature_mut` then returns the wrong server — one that
+   doesn't actually support the requested feature. Produces:
+   `LSP response error: Method Not Found: textDocument/semanticTokens/range (code -32601)`
+
+2. **Init-window race**: `ServerHandle` entries are created in `force_spawn()`
+   before the `initialize` handshake completes. Feature requests sent during
+   this window go to servers whose capabilities are unknown. The async handler
+   returns empty/error responses, but the main loop has already committed state
+   (e.g. `lsp_hover_request_sent = true`) that prevents retry.
+
+## Current Architecture
+
+### Command flow
+
+```
+Main loop                          Async handler (tokio task)
+─────────                          ─────────────────────────
+force_spawn()
+  └─ LspHandle::spawn()
+       └─ handle.initialize()  ──>  LspCommand::Initialize
+                                      └─ send initialize request to server
+                                      └─ await response
+                                      └─ state.initialized = true
+                                      └─ replay pending_commands (didOpen, etc.)
+                                      └─ send LspInitialized to main loop
+                                      └─ send LspStatusUpdate(Running)
+
+handle.hover(...)  ──────────────>  LspCommand::Hover
+                                      └─ if state.initialized: handle
+                                      └─ else: send empty response back
+```
+
+### Existing queuing in the async handler
+
+The async handler already queues some commands before initialization:
+
+| Command type | Pre-init behavior |
+|---|---|
+| Notifications (didOpen, didChange, didClose, didSave) | **Queued** in `pending_commands`, replayed after init |
+| Semantic tokens, folding ranges | Return **error** "LSP not initialized" |
+| Hover, completion, definition, references, etc. | Return **empty response** |
+
+The empty/error responses are a problem: the main loop interprets them as
+"nothing found" rather than "server not ready, try again later".
+
+### The gap
+
+There are two separate init gates that are not synchronized:
+
+1. **Async handler** (`state.initialized`): set when the initialize handshake
+   completes, before `LspInitialized` is sent to the main loop.
+2. **Main loop** (`ServerCapabilitySummary.initialized`): set when
+   `LspInitialized` is processed, which happens later (async message delivery).
+
+Feature requests from the main loop can be sent to the async handler between
+these two points. The async handler will process them (since its
+`state.initialized` is true), but the main loop doesn't yet know the server's
+capabilities and may route to the wrong server in multi-server setups.
+
+## Design: Queue All Requests Until Capabilities Are Known
+
+### Principle
+
+**The main loop never sends feature requests to a server whose capabilities
+are unknown.** This is the VS Code LSP client model.
+
+### Changes
+
+#### 1. `has_capability` returns `false` before initialization
+
+```rust
+impl ServerHandle {
+    pub fn has_capability(&self, feature: LspFeature) -> bool {
+        if !self.capabilities.initialized {
+            return false;  // not ready yet
+        }
+        // ... check actual capabilities
+    }
+}
+```
+
+`handle_for_feature_mut` already calls `has_capability`, so uninitialized
+servers are automatically excluded from feature routing. No separate "pending
+handles" map needed.
+
+#### 2. Queue feature requests on the main loop when no server is ready
+
+Instead of silently failing when `handle_for_feature_mut` returns `None` (or
+`with_lsp_for_buffer` returns `None`), queue the request and replay it when
+`LspInitialized` arrives.
+
+Add to `App`:
+
+```rust
+/// Feature requests queued because no initialized server was available.
+/// Keyed by language. Replayed when LspInitialized is received.
+pending_feature_requests: HashMap<String, Vec<PendingFeatureRequest>>,
+```
+
+Where:
+
+```rust
+enum PendingFeatureRequest {
+    Hover { buffer_id: BufferId, byte_pos: usize, screen_x: u16, screen_y: u16 },
+    SemanticTokensFull { buffer_id: BufferId },
+    SemanticTokensRange { buffer_id: BufferId, start_line: usize, end_line: usize },
+    FoldingRanges { buffer_id: BufferId },
+    // Note: completion and definition are user-initiated and will be
+    // re-triggered naturally. No need to queue them.
+}
+```
+
+Only queue requests that are **editor-initiated** (triggered by render, timers,
+or initialization) — not user-initiated requests like completion or
+go-to-definition, which the user will re-trigger.
+
+#### 3. Replay pending requests on `LspInitialized`
+
+In the `LspInitialized` handler (app/mod.rs), after `set_server_capabilities`:
+
+```rust
+AsyncMessage::LspInitialized { language, server_name, capabilities } => {
+    // ... set capabilities on handle ...
+
+    // Replay any feature requests that were queued while waiting for init
+    if let Some(pending) = self.pending_feature_requests.remove(&language) {
+        for request in pending {
+            match request {
+                PendingFeatureRequest::Hover { buffer_id, byte_pos, screen_x, screen_y } => {
+                    self.mouse_hover_screen_position = Some((screen_x, screen_y));
+                    let _ = self.request_hover_at_position(byte_pos);
+                }
+                PendingFeatureRequest::SemanticTokensFull { buffer_id } => {
+                    self.schedule_semantic_tokens_full_refresh(buffer_id);
+                }
+                // ...
+            }
+        }
+    }
+
+    // These already handle the common case:
+    self.resend_did_open_for_language(&language);
+    self.request_semantic_tokens_for_language(&language);
+    self.request_folding_ranges_for_language(&language);
+}
+```
+
+Note: `request_semantic_tokens_for_language` and
+`request_folding_ranges_for_language` already exist and handle the
+semantic-tokens and folding-ranges cases. The main gap is **hover** — which
+currently has no retry mechanism.
+
+#### 4. Fix the hover "sent" flag
+
+The hover state machine must not mark a request as "sent" unless it was
+actually dispatched to a server:
+
+```rust
+pub fn force_check_mouse_hover(&mut self) -> bool {
+    if let Some((byte_pos, _, screen_x, screen_y)) = self.mouse_state.lsp_hover_state {
+        if !self.mouse_state.lsp_hover_request_sent {
+            self.mouse_hover_screen_position = Some((screen_x, screen_y));
+            match self.request_hover_at_position(byte_pos) {
+                Ok(true) => {
+                    self.mouse_state.lsp_hover_request_sent = true;
+                    return true;
+                }
+                Ok(false) => return false, // not sent, retry later
+                Err(e) => {
+                    tracing::debug!("Failed to request hover: {}", e);
+                    return false;
+                }
+            }
+        }
+    }
+    false
+}
+```
+
+Same fix for `check_mouse_hover_timer`.
+
+`request_hover_at_position` returns `Ok(bool)` — `true` if the request was
+dispatched, `false` if no server was available.
+
+#### 5. Remove the async handler's empty-response fallback
+
+Once the main loop properly gates requests, the async handler's pre-init
+empty/error responses become dead code. They can be simplified to:
+
+```rust
+LspCommand::Hover { .. } => {
+    if state.initialized {
+        // ... handle normally
+    }
+    // else: main loop should never send this before init.
+    // If it does, it's a bug — log a warning.
+}
+```
+
+This is a cleanup step, not strictly required, but makes the invariant
+explicit.
+
+### What does NOT need queuing
+
+| Request type | Why no queue needed |
+|---|---|
+| Completion | User-initiated (keystroke). User will type again. |
+| Go-to-definition | User-initiated (shortcut/click). User will trigger again. |
+| References | User-initiated. |
+| Rename | User-initiated. |
+| Signature help | Triggered on typing. Will re-trigger on next char. |
+| Code actions | User-initiated (lightbulb/shortcut). |
+| Document diagnostics | Pull-diagnostics are re-triggered on file changes. |
+| Inlay hints | Re-requested on server quiescence and document changes. |
+
+These all either retry naturally or are user-initiated.
+
+### What DOES need queuing or special handling
+
+| Request type | Current retry mechanism | Gap |
+|---|---|---|
+| Semantic tokens (full) | `request_semantic_tokens_for_language` on `LspInitialized` | None (already handled) |
+| Semantic tokens (range) | Requested every render cycle | None (already handled) |
+| Folding ranges | `request_folding_ranges_for_language` on `LspInitialized` | None (already handled) |
+| Hover | `check_mouse_hover_timer` fires once, sets sent flag | **Gap: flag prevents retry. Fix: don't set flag until confirmed sent.** |
+
+So the actual change is small:
+1. `has_capability` returns `false` before init (already done)
+2. Fix hover sent flag (the real bug)
+3. No explicit queue needed — existing retry mechanisms cover everything
+
+## Implementation order
+
+1. **Per-server capabilities** (done): `ServerCapabilitySummary` on
+   `ServerHandle`, `LspInitialized` carries `server_name` + capabilities,
+   `handle_for_feature_mut` checks `has_capability`.
+
+2. **`has_capability` returns `false` before init**: strict, correct behavior.
+
+3. **Fix hover sent flag**: `request_hover_at_position` returns `Ok(bool)`,
+   callers only set `lsp_hover_request_sent` on `Ok(true)`.
+
+4. **Verify all other callers**: audit every call to `handle_for_feature_mut`
+   / `with_lsp_for_buffer` to ensure they handle `None` gracefully (retry or
+   ignore, not poison state).
+
+5. **Optional cleanup**: remove async handler's pre-init empty/error responses,
+   replace with debug warnings.
+
+## Why not a full request queue?
+
+After analysis, a full main-loop request queue (`PendingFeatureRequest` enum)
+is unnecessary because:
+
+- Notifications (didOpen, didChange, etc.) are already queued by the async
+  handler's `pending_commands`.
+- Semantic tokens and folding ranges are already re-requested from the
+  `LspInitialized` handler.
+- Hover just needs the sent-flag fix to enable natural retry via the timer.
+- User-initiated requests (completion, definition, etc.) don't need queuing.
+
+The "VS Code model" of queuing all requests is only needed when the client
+wants to guarantee zero-loss delivery. In Fresh's architecture, the
+`LspInitialized` handler already triggers the right follow-up requests,
+so the simpler fix (gate + retry) achieves the same result.


### PR DESCRIPTION
When multiple LSP servers are configured for the same language, capabilities (semantic tokens, folding ranges, completion triggers, etc.) were stored in per-language HashMaps on LspManager. The second server's capabilities would overwrite the first's, causing requests to be routed to servers that don't support them (e.g. "Method Not Found: textDocument/semanticTokens/range").

Move all capability tracking into ServerHandle via a new ServerCapabilitySummary struct that captures every LSP capability from the initialize response. handle_for_feature_mut now checks has_capability() on each server, which returns false before LspInitialized is processed (no guessing) and checks actual reported capabilities after.

Also fixes:
- Hover sent-flag bug: check_mouse_hover_timer and force_check_mouse_hover now only set lsp_hover_request_sent when the request is actually dispatched, allowing natural retry when the server isn't ready yet.
- wait_until uses tick_and_render (full editor tick) instead of just process_async_and_render, so hover timers and other periodic checks fire during test waits, faithfully reproducing interactive behavior.