### PR TITLE
Fix resend_did_open_for_language to send didOpen to all servers

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1253,11 +1253,19 @@ impl Editor {
                 if let Some(uri) = uri {
                     let lang_id = state.language.clone();
                     if let Some(lsp) = self.lsp.as_mut() {
-                        // LSP should already be running since we just restarted it
-                        if let Some(handle) = lsp.get_handle_mut(&lang_id) {
-                            let handle_id = handle.id();
-                            if let Err(e) = handle.did_open(uri, content, lang_id) {
-                                tracing::warn!("LSP did_open failed after restart: {}", e);
+                        // Send didOpen to ALL handles for this language, not just the first.
+                        // Each server needs its own didOpen notification.
+                        for sh in lsp.get_handles_mut(&lang_id) {
+                            let handle_id = sh.handle.id();
+                            if let Err(e) =
+                                sh.handle
+                                    .did_open(uri.clone(), content.clone(), lang_id.clone())
+                            {
+                                tracing::warn!(
+                                    "LSP did_open failed for '{}' after restart: {}",
+                                    sh.name,
+                                    e
+                                );
                             } else {
                                 // Mark buffer as opened with this handle so that
                                 // send_lsp_changes_for_buffer doesn't re-send didOpen


### PR DESCRIPTION
When multiple LSP servers are configured for the same language, resend_did_open_for_language only sent didOpen to the first handle (via get_handle_mut). The second server never received didOpen, causing "Document is not open in the session" errors for semantic token requests.

Send didOpen to all handles for the language, matching what ensure_did_open_all already does for the with_lsp_for_buffer path.