### PR TITLE
Fix word selection with accented characters

### DIFF
--- a/crates/fresh-editor/src/primitives/word_navigation.rs
+++ b/crates/fresh-editor/src/primitives/word_navigation.rs
@@ -186,13 +186,27 @@ pub fn find_word_start(buffer: &Buffer, pos: usize) -> usize {
     let buf_len = buffer.len();
     let pos = pos.min(buf_len);
 
-    // Only read a small window around the position for efficiency
+    // Only read a small window around the position for efficiency.
+    // Extend `end` past `pos` so we never truncate a multi-byte UTF-8 character
+    // at the cursor position.
+    const MAX_UTF8_CHAR_LEN: usize = 4;
     let start = pos.saturating_sub(1000);
-    let end = (pos + 1).min(buf_len);
+    let end = (pos + MAX_UTF8_CHAR_LEN).min(buf_len);
     let bytes = buffer.slice_bytes(start..end);
     let text = String::from_utf8_lossy(&bytes);
 
-    let offset = text.len() - (end - pos); // map byte pos into text
+    // Map `pos` into the (possibly lossy-decoded) string. When the window
+    // start splits a multi-byte sequence, `from_utf8_lossy` replaces it with a
+    // 3-byte U+FFFD which shifts byte offsets. Snap to the nearest grapheme
+    // boundary so we never index into the middle of a character.
+    let offset = {
+        let raw = (pos - start).min(text.len());
+        if text.is_char_boundary(raw) {
+            raw
+        } else {
+            next_grapheme_boundary(&text, raw)
+        }
+    };
     let mut current_idx = offset;
 
     // If we're at the end or at a non-word character, step left once

--- a/crates/fresh-editor/tests/e2e/selection.rs
+++ b/crates/fresh-editor/tests/e2e/selection.rs
@@ -196,6 +196,94 @@ fn test_select_word_at_end() {
     assert_eq!(selected_text, "hello", "Should select the word 'hello'");
 }
 
+/// Test select word with accented characters (issue #1332)
+/// Ctrl+W on "hibajavítás" with cursor on 'í' should select the entire word,
+/// not just "hibajav".
+///
+/// Iterates character-by-character over words from multiple languages (including
+/// accented Latin, Cyrillic, CJK, Thai, emoji, and combining diacritics) and
+/// verifies that Ctrl+W selects the correct word at every cursor position.
+#[test]
+fn test_select_word_accented_characters() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use unicode_segmentation::UnicodeSegmentation;
+
+    // Each entry: (full word, expected Ctrl+W selection at every grapheme position)
+    // For single-word entries the expected selection equals the word itself.
+    // Spaces between words let us also test that Ctrl+W from whitespace selects
+    // an adjacent word rather than nothing.
+    let test_words: &[(&str, &str)] = &[
+        // Original bug report - Hungarian
+        ("hibajavítás", "hibajavítás"),
+        // German
+        ("Änderung", "Änderung"),
+        // French
+        ("résumé", "résumé"),
+        // Czech
+        ("příliš", "příliš"),
+        // Polish
+        ("żółć", "żółć"),
+        // Cyrillic (Russian)
+        ("Привет", "Привет"),
+        // Greek
+        ("Ελληνικά", "Ελληνικά"),
+        // Korean (Hangul)
+        ("안녕하세요", "안녕하세요"),
+        // Japanese Hiragana
+        ("こんにちは", "こんにちは"),
+        // CJK
+        ("你好世界", "你好世界"),
+        // Combining diacritics: e + combining acute = "é"
+        ("caf\u{0065}\u{0301}", "caf\u{0065}\u{0301}"),
+        // Emoji (single grapheme word) — treated as punctuation by the classifier,
+        // so Ctrl+W from the emoji should select the emoji cluster itself.
+        ("🇫🇷", "🇫🇷"),
+        ("👨\u{200D}👩\u{200D}👧", "👨\u{200D}👩\u{200D}👧"),
+    ];
+
+    for &(word, expected) in test_words {
+        let grapheme_count = word.graphemes(true).count();
+
+        for grapheme_idx in 0..grapheme_count {
+            let mut harness = EditorTestHarness::new(80, 24).unwrap();
+            let _fixture = harness.load_buffer_from_text(word).unwrap();
+
+            // Position cursor at grapheme_idx
+            harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+            for _ in 0..grapheme_idx {
+                harness
+                    .send_key(KeyCode::Right, KeyModifiers::NONE)
+                    .unwrap();
+            }
+
+            // Select word with Ctrl+W
+            harness
+                .send_key(KeyCode::Char('w'), KeyModifiers::CONTROL)
+                .unwrap();
+
+            let cursor = harness.editor().active_cursors().primary();
+            let selection = cursor.selection_range();
+            assert!(
+                selection.is_some(),
+                "No selection for word {:?} at grapheme index {}",
+                word,
+                grapheme_idx,
+            );
+
+            let range = selection.unwrap();
+            let selected_text = harness
+                .editor_mut()
+                .active_state_mut()
+                .get_text_range(range.start, range.end);
+            assert_eq!(
+                selected_text, expected,
+                "Wrong selection for word {:?} at grapheme index {}: got {:?}",
+                word, grapheme_idx, selected_text,
+            );
+        }
+    }
+}
+
 /// Test select line functionality (Ctrl+L)
 #[test]
 fn test_select_line() {


### PR DESCRIPTION
## Summary
Fixed word selection (Ctrl+W) to correctly handle words containing accented and multi-byte UTF-8 characters. Previously, selecting a word with the cursor on an accented character would only select up to that character instead of the entire word.

## Key Changes
- **word_navigation.rs**: Fixed `find_word_start()` function to properly handle multi-byte UTF-8 characters:
  - Extended the read window end by `MAX_UTF8_CHAR_LEN` (4 bytes) to ensure multi-byte characters at the cursor position are never truncated
  - Simplified offset calculation from `text.len() - (end - pos)` to `pos - start` for clarity and correctness
  - Added clarifying comments about UTF-8 character handling

- **selection.rs**: Added comprehensive test case `test_select_word_accented_characters()` that:
  - Tests word selection on "hibajavítás" with cursor positioned on the accented 'í'
  - Verifies the entire word is selected, not just the portion before the accented character
  - Addresses issue #1332

## Implementation Details
The root cause was that the byte window used for word boundary detection could be truncated in the middle of a multi-byte UTF-8 character. By extending the window end by up to 4 bytes (the maximum UTF-8 character length), we ensure complete characters are always available for grapheme boundary detection.

https://claude.ai/code/session_01QBcyqDAMuDRQns1rnYUJMh