### PR TITLE
Drain pending LSP requests on stdout reader exit

### DIFF
--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -2718,6 +2718,30 @@ impl LspTask {
                     }
                 }
             }
+            // Drain all pending requests so the command loop doesn't block
+            // forever waiting for responses that will never arrive.
+            {
+                let mut pending_guard = pending.lock().unwrap();
+                let count = pending_guard.len();
+                if count > 0 {
+                    tracing::info!(
+                        "LSP stdout reader: draining {} pending requests for {}",
+                        count,
+                        language
+                    );
+                    for (id, tx) in pending_guard.drain() {
+                        tracing::debug!(
+                            "LSP stdout reader: failing pending request id={} for {}",
+                            id,
+                            language
+                        );
+                        let _ = tx.send(Err(
+                            "LSP server connection closed while awaiting response".to_string(),
+                        ));
+                    }
+                }
+            }
+
             tracing::info!("LSP stdout reader task exiting for {}", language);
         });
     }


### PR DESCRIPTION
## Summary
Added cleanup logic to drain all pending LSP requests when the stdout reader task exits, preventing the command loop from blocking indefinitely while waiting for responses that will never arrive.

## Key Changes
- Added a drain operation for all pending requests in the `pending` map when the LSP stdout reader task is shutting down
- Sends an error response ("LSP server connection closed while awaiting response") to all pending request channels to unblock any waiting callers
- Added informational logging to track the number of drained requests and debug logging for each failed request

## Implementation Details
- The drain operation is protected by the `pending` mutex lock to ensure thread-safe access
- Only performs the drain if there are pending requests (`count > 0`)
- Uses `pending_guard.drain()` to consume and iterate over all pending requests, ensuring they are removed from the map
- Gracefully handles send failures with `let _ = tx.send(...)` to avoid panics if receivers have already been dropped

https://claude.ai/code/session_01ByN5Uz8P4A4vPtA3VNdJ54