### PR TITLE
fix: improve theme editor Save As UX for built-in themes

### DIFF
--- a/crates/fresh-editor/plugins/theme_editor.i18n.json
+++ b/crates/fresh-editor/plugins/theme_editor.i18n.json
@@ -300,7 +300,9 @@
     "field.punctuation_bracket": "závorka",
     "field.punctuation_bracket_desc": "závorkas ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "oddělovač",
-    "field.punctuation_delimiter_desc": "oddělovačs (;, ,, .)"
+    "field.punctuation_delimiter_desc": "oddělovačs (;, ,, .)",
+    "suggestion.current_builtin": "(aktuální · vestavěný · pouze pro čtení)",
+    "prompt.save_as_builtin_error": "Nelze přepsat vestavěný motiv, zvolte jiný název: "
   },
   "de": {
     "cmd.edit_theme": "Theme bearbeiten",
@@ -603,7 +605,9 @@
     "field.punctuation_bracket": "Klammer",
     "field.punctuation_bracket_desc": "Klammern ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Trennzeichen",
-    "field.punctuation_delimiter_desc": "Trennzeichen (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Trennzeichen (;, ,, .)",
+    "suggestion.current_builtin": "(aktuell · eingebaut · schreibgeschützt)",
+    "prompt.save_as_builtin_error": "Eingebautes Theme kann nicht überschrieben werden, anderen Namen wählen: "
   },
   "en": {
     "cmd.edit_theme": "Edit Theme",
@@ -906,7 +910,9 @@
     "field.punctuation_bracket": "Punctuation Bracket",
     "field.punctuation_bracket_desc": "Brackets and parentheses ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Punctuation Delimiter",
-    "field.punctuation_delimiter_desc": "Delimiters and separators (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Delimiters and separators (;, ,, .)",
+    "suggestion.current_builtin": "(current · built-in · read-only)",
+    "prompt.save_as_builtin_error": "Can't override built-in theme, choose a different name: "
   },
   "es": {
     "cmd.edit_theme": "Editar tema",
@@ -1209,7 +1215,9 @@
     "field.punctuation_bracket": "Paréntesis",
     "field.punctuation_bracket_desc": "Paréntesis y corchetes ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Delimitador",
-    "field.punctuation_delimiter_desc": "Delimitadores y separadores (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Delimitadores y separadores (;, ,, .)",
+    "suggestion.current_builtin": "(actual · predefinido · solo lectura)",
+    "prompt.save_as_builtin_error": "No se puede sobrescribir un tema predefinido, elija otro nombre: "
   },
   "fr": {
     "cmd.edit_theme": "Modifier le theme",
@@ -1512,7 +1520,9 @@
     "field.punctuation_bracket": "Parenthese",
     "field.punctuation_bracket_desc": "Parentheses et crochets ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Delimiteur",
-    "field.punctuation_delimiter_desc": "Delimiteurs et separateurs (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Delimiteurs et separateurs (;, ,, .)",
+    "suggestion.current_builtin": "(actuel · intégré · lecture seule)",
+    "prompt.save_as_builtin_error": "Impossible de remplacer un thème intégré, choisissez un autre nom : "
   },
   "ja": {
     "cmd.edit_theme": "テーマを編集",
@@ -1815,7 +1825,9 @@
     "field.punctuation_bracket": "括弧",
     "field.punctuation_bracket_desc": "括弧 ({、}、(、)、[、])",
     "field.punctuation_delimiter": "区切り文字",
-    "field.punctuation_delimiter_desc": "区切り文字 (;、,、.)"
+    "field.punctuation_delimiter_desc": "区切り文字 (;、,、.)",
+    "suggestion.current_builtin": "(現在 · 組み込み · 読み取り専用)",
+    "prompt.save_as_builtin_error": "組み込みテーマは上書きできません。別の名前を入力してください: "
   },
   "ko": {
     "cmd.edit_theme": "편집 Theme",
@@ -2118,7 +2130,9 @@
     "field.punctuation_bracket": "괄호",
     "field.punctuation_bracket_desc": "괄호s ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "구분자",
-    "field.punctuation_delimiter_desc": "구분자s (;, ,, .)"
+    "field.punctuation_delimiter_desc": "구분자s (;, ,, .)",
+    "suggestion.current_builtin": "(현재 · 기본 제공 · 읽기 전용)",
+    "prompt.save_as_builtin_error": "기본 제공 테마를 덮어쓸 수 없습니다. 다른 이름을 입력하세요: "
   },
   "pt-BR": {
     "cmd.edit_theme": "editar Theme",
@@ -2421,7 +2435,9 @@
     "field.punctuation_bracket": "parêntese",
     "field.punctuation_bracket_desc": "parênteses ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "delimitador",
-    "field.punctuation_delimiter_desc": "delimitadors (;, ,, .)"
+    "field.punctuation_delimiter_desc": "delimitadors (;, ,, .)",
+    "suggestion.current_builtin": "(atual · integrado · somente leitura)",
+    "prompt.save_as_builtin_error": "Não é possível sobrescrever tema integrado, escolha outro nome: "
   },
   "ru": {
     "cmd.edit_theme": "редактировать Theme",
@@ -2724,7 +2740,9 @@
     "field.punctuation_bracket": "скобка",
     "field.punctuation_bracket_desc": "скобкаs ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "разделитель",
-    "field.punctuation_delimiter_desc": "разделительs (;, ,, .)"
+    "field.punctuation_delimiter_desc": "разделительs (;, ,, .)",
+    "suggestion.current_builtin": "(текущий · встроенная · только чтение)",
+    "prompt.save_as_builtin_error": "Невозможно перезаписать встроенную тему, выберите другое имя: "
   },
   "th": {
     "cmd.edit_theme": "แก้ไข Theme",
@@ -3027,7 +3045,9 @@
     "field.punctuation_bracket": "วงเล็บ",
     "field.punctuation_bracket_desc": "วงเล็บs ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "ตัวคั่น",
-    "field.punctuation_delimiter_desc": "ตัวคั่นs (;, ,, .)"
+    "field.punctuation_delimiter_desc": "ตัวคั่นs (;, ,, .)",
+    "suggestion.current_builtin": "(ปัจจุบัน · ในตัว · อ่านอย่างเดียว)",
+    "prompt.save_as_builtin_error": "ไม่สามารถเขียนทับธีมในตัวได้ กรุณาเลือกชื่ออื่น: "
   },
   "uk": {
     "cmd.edit_theme": "редагувати Theme",
@@ -3330,7 +3350,9 @@
     "field.punctuation_bracket": "дужка",
     "field.punctuation_bracket_desc": "дужкаs ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "роздільник",
-    "field.punctuation_delimiter_desc": "роздільникs (;, ,, .)"
+    "field.punctuation_delimiter_desc": "роздільникs (;, ,, .)",
+    "suggestion.current_builtin": "(поточний · вбудована · лише читання)",
+    "prompt.save_as_builtin_error": "Неможливо перезаписати вбудовану тему, виберіть іншу назву: "
   },
   "vi": {
     "cmd.edit_theme": "Chỉnh sửa giao diện",
@@ -3633,7 +3655,9 @@
     "field.punctuation_bracket": "Dấu ngoặc",
     "field.punctuation_bracket_desc": "Dấu ngoặc ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Dấu phân cách",
-    "field.punctuation_delimiter_desc": "Dấu phân cách (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Dấu phân cách (;, ,, .)",
+    "suggestion.current_builtin": "(hiện tại · có sẵn · chỉ đọc)",
+    "prompt.save_as_builtin_error": "Không thể ghi đè chủ đề có sẵn, chọn tên khác: "
   },
   "zh-CN": {
     "cmd.edit_theme": "编辑主题",
@@ -3936,7 +3960,9 @@
     "field.punctuation_bracket": "括号",
     "field.punctuation_bracket_desc": "括号 ({、}、(、)、[、])",
     "field.punctuation_delimiter": "分隔符",
-    "field.punctuation_delimiter_desc": "分隔符 (;、,、.)"
+    "field.punctuation_delimiter_desc": "分隔符 (;、,、.)",
+    "suggestion.current_builtin": "(当前 · 内置 · 只读)",
+    "prompt.save_as_builtin_error": "无法覆盖内置主题，请选择其他名称: "
   },
   "it": {
     "cmd.edit_theme": "Modifica tema",
@@ -4239,6 +4265,8 @@
     "field.punctuation_bracket": "Parentesi",
     "field.punctuation_bracket_desc": "Parentesi e parentesi quadre ({, }, (, ), [, ])",
     "field.punctuation_delimiter": "Delimitatore",
-    "field.punctuation_delimiter_desc": "Delimitatori e separatori (;, ,, .)"
+    "field.punctuation_delimiter_desc": "Delimitatori e separatori (;, ,, .)",
+    "suggestion.current_builtin": "(corrente · integrato · sola lettura)",
+    "prompt.save_as_builtin_error": "Impossibile sovrascrivere il tema integrato, scegli un altro nome: "
   }
 }

--- a/crates/fresh-editor/plugins/theme_editor.ts
+++ b/crates/fresh-editor/plugins/theme_editor.ts
@@ -355,6 +355,8 @@ interface ThemeEditorState {
   savedCursorPath: string | null;
   /** Whether to close the editor after a successful save */
   closeAfterSave: boolean;
+  /** Whether the Save As prompt has been pre-filled (to distinguish first vs second Enter) */
+  saveAsPreFilled: boolean;
   /** Which panel has focus */
   focusPanel: "tree" | "picker";
   /** Focus target within picker panel */
@@ -420,6 +422,7 @@ const state: ThemeEditorState = {
   isBuiltin: false,
   savedCursorPath: null,
   closeAfterSave: false,
+  saveAsPreFilled: false,
   focusPanel: "tree",
   pickerFocus: { type: "hex-input" },
   filterText: "",
@@ -1604,10 +1607,31 @@ async function onThemeSaveAsPromptConfirmed(args: {
 
   const name = args.input.trim();
   if (name) {
+    // If user accepted a suggestion without typing, pre-fill the prompt so they can edit the name
+    if (args.selected_index !== null && !state.saveAsPreFilled) {
+      state.saveAsPreFilled = true;
+      editor.startPromptWithInitial(editor.t("prompt.save_as"), "theme-save-as", name);
+      editor.setPromptSuggestions([{
+        text: state.themeName,
+        description: state.isBuiltin
+          ? editor.t("suggestion.current_builtin")
+          : editor.t("suggestion.current"),
+        value: state.themeName,
+      }]);
+      return true;
+    }
+    state.saveAsPreFilled = false;
+
     // Reject names that match a built-in theme
     if (state.builtinThemes.includes(name)) {
-      editor.setStatus(editor.t("error.name_is_builtin", { name }));
-      theme_editor_save_as();
+      editor.startPromptWithInitial(editor.t("prompt.save_as_builtin_error"), "theme-save-as", name);
+      editor.setPromptSuggestions([{
+        text: state.themeName,
+        description: state.isBuiltin
+          ? editor.t("suggestion.current_builtin")
+          : editor.t("suggestion.current"),
+        value: state.themeName,
+      }]);
       return true;
     }
 
@@ -2757,11 +2781,14 @@ function theme_editor_save_as() : void {
     state.savedCursorPath = getCurrentFieldPath();
   }
 
+  state.saveAsPreFilled = false;
   editor.startPrompt(editor.t("prompt.save_as"), "theme-save-as");
 
   editor.setPromptSuggestions([{
     text: state.themeName,
-    description: editor.t("suggestion.current"),
+    description: state.isBuiltin
+      ? editor.t("suggestion.current_builtin")
+      : editor.t("suggestion.current"),
     value: state.themeName,
   }]);
 }


### PR DESCRIPTION
When saving a built-in theme, the Save As prompt now clearly indicates the current name is read-only. Selecting the suggestion pre-fills the input for editing rather than submitting immediately, and attempting to use a built-in name shows an inline error in the prompt label.