### PR TITLE
Extend current-line highlight through inline diagnostics

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering.rs
@@ -5248,22 +5248,36 @@ impl SplitRenderer {
 
                         // Right-align: fill gap between code and diagnostic text
                         let padding = available.saturating_sub(display_width);
+                        let cursor_line_active =
+                            is_on_cursor_line && highlight_current_line && is_active;
                         if padding > 0 {
+                            let pad_style = if cursor_line_active {
+                                Style::default().bg(theme.current_line_bg)
+                            } else {
+                                Style::default()
+                            };
                             push_span_with_map(
                                 &mut line_spans,
                                 &mut line_view_map,
                                 " ".repeat(padding),
-                                Style::default(),
+                                pad_style,
                                 None,
                             );
                             visible_char_count += padding;
                         }
 
+                        // Apply current line background to diagnostic text when on cursor line
+                        let effective_diag_style = if cursor_line_active && diag_style.bg.is_none()
+                        {
+                            diag_style.bg(theme.current_line_bg)
+                        } else {
+                            *diag_style
+                        };
                         push_span_with_map(
                             &mut line_spans,
                             &mut line_view_map,
                             display,
-                            *diag_style,
+                            effective_diag_style,
                             None,
                         );
                         visible_char_count += display_width;

--- a/crates/fresh-editor/tests/e2e/inline_diagnostics.rs
+++ b/crates/fresh-editor/tests/e2e/inline_diagnostics.rs
@@ -116,6 +116,59 @@ fn test_inline_diagnostic_truncation() {
     harness.assert_screen_contains("this is a very lon…");
 }
 
+/// When the cursor is on a line with an inline diagnostic, the current-line
+/// highlight should extend across the full width of the line — including the
+/// padding gap and the diagnostic text itself — not stop at the end of the
+/// source code.
+#[test]
+fn test_current_line_highlight_extends_through_inline_diagnostic() {
+    let mut config = fresh::config::Config::default();
+    config.editor.diagnostics_inline_text = true;
+    config.editor.highlight_current_line = true;
+    config.editor.line_numbers = false;
+
+    let mut harness = EditorTestHarness::with_config(80, 10, config).unwrap();
+    harness.new_buffer().unwrap();
+    // Type short text so there's plenty of room for the diagnostic
+    harness.type_text("let x = bad;").unwrap();
+    harness.render().unwrap();
+
+    // Add error diagnostic
+    harness
+        .apply_event(diagnostic_overlay(8..11, 100, "type error"))
+        .unwrap();
+    harness.render().unwrap();
+
+    // Cursor is on line 0 (the only line), so current_line_bg should apply.
+    // Default theme is high-contrast, where current_line_bg = (20, 20, 20).
+    let current_line_bg = Color::Rgb(20, 20, 20);
+
+    // Find the content row that contains "let x = bad;"
+    let (code_x, content_row) = harness
+        .find_text_on_screen("let x")
+        .expect("should find code text on screen");
+
+    // Check a cell in the padding area between code end and diagnostic text.
+    // Code "let x = bad;" is 13 chars wide, so col code_x+20 is in the padding.
+    let pad_style = harness.get_cell_style(code_x + 20, content_row).unwrap();
+    assert_eq!(
+        pad_style.bg,
+        Some(current_line_bg),
+        "Padding between code and inline diagnostic should have current_line_bg on cursor line"
+    );
+
+    // Also check that the diagnostic text itself has the current_line_bg.
+    let (diag_x, diag_row) = harness
+        .find_text_on_screen("type error")
+        .expect("should find diagnostic text on screen");
+    let diag_style = harness.get_cell_style(diag_x, diag_row).unwrap();
+    assert_eq!(
+        diag_style.bg,
+        Some(current_line_bg),
+        "Inline diagnostic text should have current_line_bg on cursor line"
+    );
+}
+
 /// Reproduces the bug where a multi-line diagnostic highlight overlay disappears
 /// entirely when part of the highlighted region is scrolled out of the viewport.
 /// The overlay should still be visible on the lines that remain in view.


### PR DESCRIPTION
## Summary
Fix the current-line highlight to extend across the full width of the line when inline diagnostics are displayed, rather than stopping at the end of the source code.

## Changes
- **Padding gap styling**: Apply `current_line_bg` color to the padding space between code and inline diagnostic text when the cursor is on that line
- **Diagnostic text styling**: Apply `current_line_bg` color to the inline diagnostic text itself when the cursor is on that line and the diagnostic doesn't already have a background color
- **Test coverage**: Add `test_current_line_highlight_extends_through_inline_diagnostic()` to verify the highlight extends through both the padding area and diagnostic text

## Implementation Details
The fix modifies `split_rendering.rs` to check if the current line is active (`is_on_cursor_line && highlight_current_line && is_active`) and conditionally apply the theme's `current_line_bg` color to:
1. The padding span between code and diagnostic
2. The diagnostic text span (only if it doesn't already have a background color set)

This ensures visual consistency where the entire line, including diagnostic annotations, is highlighted when the cursor is present.

https://claude.ai/code/session_01WdLBw1y5c88C12RUffC6ji