### PR TITLE
Discard diagnostics from stopped LSP servers

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -124,6 +124,20 @@ impl Editor {
         diagnostics: Vec<Diagnostic>,
         server_name: String,
     ) {
+        // Discard diagnostics from servers that have been shut down.  The async
+        // bridge may still contain queued messages from a server that was stopped
+        // between the time it sent the notification and when we drain the channel.
+        if let Some(lsp) = &self.lsp {
+            if !lsp.has_server_named(&server_name) {
+                tracing::debug!(
+                    "Dropping diagnostics from stopped server '{}' for {}",
+                    server_name,
+                    uri
+                );
+                return;
+            }
+        }
+
         tracing::debug!(
             "Processing {} push diagnostics from '{}' for {}",
             diagnostics.len(),

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -540,6 +540,13 @@ impl LspManager {
             .unwrap_or(&[])
     }
 
+    /// Check if a server with the given name exists (across all languages).
+    pub fn has_server_named(&self, server_name: &str) -> bool {
+        self.handles
+            .values()
+            .any(|handles| handles.iter().any(|sh| sh.name == server_name))
+    }
+
     /// Get all mutable handles for a language.
     pub fn get_handles_mut(&mut self, language: &str) -> &mut [ServerHandle] {
         self.handles


### PR DESCRIPTION
## Summary
Prevent stale diagnostic messages from stopped LSP servers from being processed. This fixes a race condition where diagnostics queued in the async bridge could arrive after a server has been shut down.

## Changes
- **async_messages.rs**: Added validation in `push_diagnostics` to check if the server sending diagnostics still exists before processing them. If the server has been stopped, the diagnostics are logged and discarded.
- **manager.rs**: Added `has_server_named()` method to check if a server with a given name exists across all language servers.

## Implementation Details
The fix addresses a timing issue where:
1. An LSP server sends a diagnostic notification
2. The server is shut down before the notification is processed
3. The queued diagnostic message is drained from the async channel and would be processed against a non-existent server

By checking server existence before processing diagnostics, we prevent errors and ensure only active servers' diagnostics are handled.

https://claude.ai/code/session_011xbCrKtjmoryKXSoKx8bDu