### PR TITLE
Exclude internal documentation from search index

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -152,11 +152,10 @@ export default defineConfig({
       provider: "local",
       options: {
         _render(src, env, md) {
-          const html = md.render(src, env);
           if (env.relativePath?.startsWith("internal/")) {
             return "";
           }
-          return html;
+          return md.render(src, env);
         },
       },
     },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -151,6 +151,7 @@ export default defineConfig({
     search: {
       provider: "local",
       options: {
+        detailedView: true,
         _render(src, env, md) {
           if (env.relativePath?.startsWith("internal/")) {
             return "";

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -148,7 +148,18 @@ export default defineConfig({
 
     socialLinks: [{ icon: "github", link: "https://github.com/sinelaw/fresh" }],
 
-    search: { provider: "local" },
+    search: {
+      provider: "local",
+      options: {
+        _render(src, env, md) {
+          const html = md.render(src, env);
+          if (env.relativePath?.startsWith("internal/")) {
+            return "";
+          }
+          return html;
+        },
+      },
+    },
 
     editLink: {
       pattern: "https://github.com/sinelaw/fresh/edit/master/docs/:path",


### PR DESCRIPTION
## Summary
Updated the VitePress search configuration to exclude internal documentation pages from the search index by implementing a custom render function.

## Changes
- Modified the search provider configuration from a simple string to an object with options
- Added a custom `_render` function that filters out pages in the `internal/` directory
- Pages matching the `internal/` path prefix now return empty strings instead of being indexed, effectively removing them from search results

## Implementation Details
The custom render function intercepts the markdown rendering process and checks if the document's `relativePath` starts with `"internal/"`. If it does, an empty string is returned instead of the rendered HTML, preventing those pages from appearing in search results while keeping them accessible via direct navigation.

https://claude.ai/code/session_01WnDaJ4qzuJiQaAkkmjkUnd