### PR TITLE
fix: resolve AppImage discovery failure in get_release_url

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,7 +113,7 @@ install_arch() {
 get_release_url() {
     # $1 = pattern (e.g., .deb or .rpm)
     # $2 = arch
-    url=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep "browser_download_url.*$2.*$1" | cut -d '"' -f 4 | head -n 1)
+    url=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest" | grep "browser_download_url.*$2.*${1%$}" | cut -d '"' -f 4 | head -n 1)
     echo "$url"
 }
 


### PR DESCRIPTION
## Description
While installing on a distribution that defaults to the AppImage fallback (such as **Void Linux**), the script fails to find the download URL even when the asset exists on GitHub.

## The Issue
The `get_release_url` function uses a regex with an end-of-line anchor (`$`). Because the GitHub API returns JSON where the URL is wrapped in double quotes, the anchor prevents a match.

**Current failure state:**
```bash
[INFO] Attempting AppImage install...
[WARN] No AppImage found for x86_64.
```

### The Fix
I updated the grep pattern to use `${1%$}`. This POSIX-compliant expansion strips the trailing `$` from the pattern, allowing it to match the filename regardless of the trailing quote in the JSON response.

### Testing
Tested on `x86_64` Void Linux. With this change, the script correctly identifies the following URL:
`https://github.com/sinelaw/fresh/releases/download/v0.2.21/fresh-editor-0.2.21-x86_64.AppImage`