### PR TITLE
Support untracked files in Review Diff and drill-down views

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1172,9 +1172,9 @@ async function review_drill_down() {
                 else if (line.startsWith(' ')) { oldCount++; newCount++; }
             }
             return {
-                oldStart: fh.oldRange.start - 1,  // Convert to 0-indexed
+                oldStart: Math.max(0, fh.oldRange.start - 1),  // Convert to 0-indexed (0 for new files)
                 oldCount: oldCount || 1,
-                newStart: fh.range.start - 1,     // Convert to 0-indexed
+                newStart: Math.max(0, fh.range.start - 1),     // Convert to 0-indexed
                 newCount: newCount || 1
             };
         });
@@ -1763,9 +1763,9 @@ async function side_by_side_diff_current_file() {
 
     // Convert hunks to composite buffer format
     const compositeHunks: TsCompositeHunk[] = fileHunks.map(h => ({
-        oldStart: h.oldRange.start - 1,  // Convert to 0-indexed
-        oldCount: h.oldRange.end - h.oldRange.start + 1,
-        newStart: h.range.start - 1,     // Convert to 0-indexed
+        oldStart: Math.max(0, h.oldRange.start - 1),  // Convert to 0-indexed (0 for new files)
+        oldCount: Math.max(1, h.oldRange.end - h.oldRange.start + 1),
+        newStart: Math.max(0, h.range.start - 1),     // Convert to 0-indexed
         newCount: h.range.end - h.range.start + 1
     }));
 

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -1453,3 +1453,99 @@ pub fn new_function() {
         screen
     );
 }
+
+/// Test that drill-down (side-by-side diff) works for newly added (untracked) files
+/// Before the fix, review_drill_down() would fail because git show HEAD:<file> errors
+/// for files that don't exist in HEAD, causing a silent early return.
+/// Reproduces https://github.com/sinelaw/fresh/issues/1452
+#[test]
+fn test_review_diff_drill_down_added_file() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+
+    // Create an initial commit
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    // Create a brand new untracked file
+    let new_file_path = repo.path.join("src/new_module.rs");
+    let new_file_content = r#"/// A brand new module
+pub fn new_function() {
+    println!("This is a new file!");
+}
+"#;
+    fs::write(&new_file_path, new_file_content).expect("Failed to create new file");
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    // Open any file to start
+    let main_rs_path = repo.path.join("src/main.rs");
+    harness.open_file(&main_rs_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("main"))
+        .unwrap();
+
+    // Trigger Review Diff
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Review Diff").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Wait for Review Diff to complete and show the untracked file's hunk
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            !screen.contains("Generating Review Diff Stream") && screen.contains("hunks")
+        })
+        .unwrap();
+
+    // Navigate to the first hunk using 'n' (next hunk), then drill down with Enter
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Wait for side-by-side diff view to open - tab shows "*Diff: <filename>*"
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("*Diff:") || screen.contains("OLD (HEAD)")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Drill-down (added file) screen:\n{}", screen);
+
+    // Before the fix, git show HEAD:<file> would fail for untracked files
+    // and the drill-down would silently abort with "failed" status
+    assert!(
+        !screen.contains("TypeError"),
+        "Should not show any TypeError. Screen:\n{}",
+        screen
+    );
+
+    // The new file content should be visible in the side-by-side view
+    assert!(
+        screen.contains("new_function") || screen.contains("brand new"),
+        "Side-by-side diff should show the new file's content. Screen:\n{}",
+        screen
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds support for displaying newly added (untracked) files in the Review Diff feature and enables drill-down (side-by-side diff) functionality for these files. Previously, untracked files were silently ignored or caused errors when attempting to view their diffs.

## Key Changes

- **getGitDiff()**: Added logic to detect untracked files using `git ls-files --others --exclude-standard` and include them in the hunks list using `git diff --no-index` to compare against `/dev/null`

- **review_drill_down()**: Modified to handle files that don't exist in HEAD (new untracked files) by setting `oldContent` to an empty string instead of failing with an error status. Added bounds checking with `Math.max(0, ...)` to handle 0-indexed ranges for new files.

- **side_by_side_diff_current_file()**: Enhanced to detect untracked files and use `git diff --no-index` for them instead of `git diff HEAD`. Sets `oldContent` to empty string for untracked files and marks their type as 'add' instead of 'modify'. Added bounds checking for range calculations.

## Implementation Details

- Untracked files are identified using `git ls-files --others --exclude-standard`
- For untracked files, diffs are generated using `git diff --no-index --unified=3 -- /dev/null <file>` which compares the file against an empty file
- The `git diff --no-index` command exits with code 1 when differences exist (expected behavior), so exit code checking is adjusted accordingly
- Old content for untracked files is represented as an empty string in side-by-side views
- Range calculations use `Math.max(0, ...)` to ensure 0-indexed values don't go negative for new files

Fixes https://github.com/sinelaw/fresh/issues/1452

https://claude.ai/code/session_01FRuvQoMXwZGn282mdG5pYp