### PR TITLE
Fix settings save bug dropping map entry keys in nested dialogs

### DIFF
--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1,4 +1,4 @@
-use crate::types::{context_keys, LspFeature, LspLanguageConfig, LspServerConfig, ProcessLimits};
+use crate::types::{context_keys, LspLanguageConfig, LspServerConfig, ProcessLimits};
 
 use rust_i18n::t;
 use schemars::JsonSchema;
@@ -4532,6 +4532,10 @@ impl Config {
         //
         // Disabled by default — enable via config or command palette after
         // installing: `cargo install --path crates/quicklsp`
+        //
+        // `only_features` is left unset so quicklsp can serve every feature it
+        // advertises via its server capabilities (including go-to-definition).
+        // Users who want to scope it down can set `only_features` explicitly.
         universal.insert(
             "quicklsp".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
@@ -4544,12 +4548,7 @@ impl Config {
                 env: Default::default(),
                 language_id_overrides: Default::default(),
                 name: Some("QuickLSP".to_string()),
-                only_features: Some(vec![
-                    LspFeature::Hover,
-                    LspFeature::SignatureHelp,
-                    LspFeature::DocumentSymbols,
-                    LspFeature::WorkspaceSymbols,
-                ]),
+                only_features: None,
                 except_features: None,
                 root_markers: vec![
                     "Cargo.toml".to_string(),
@@ -6159,6 +6158,14 @@ mod tests {
         assert_eq!(server.command, "quicklsp");
         assert!(!server.enabled, "quicklsp should be disabled by default");
         assert_eq!(server.name.as_deref(), Some("QuickLSP"));
+        // only_features must stay unset so quicklsp can serve every capability
+        // its server advertises — including go-to-definition. A restrictive
+        // whitelist here silently breaks F12 for users on a vanilla install.
+        assert!(
+            server.only_features.is_none(),
+            "quicklsp must not default to a feature whitelist"
+        );
+        assert!(server.except_features.is_none());
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -256,6 +256,30 @@ impl EntryDialogState {
         self.entry_key.clone()
     }
 
+    /// Full JSON pointer path to the entry this dialog edits.
+    ///
+    /// For an existing map entry under `/universal_lsp` with key `quicklsp`,
+    /// this returns `/universal_lsp/quicklsp`. For array items, `entry_key`
+    /// is the stringified index. For brand-new map entries whose key has
+    /// not been chosen yet, this falls back to `map_path` (the parent
+    /// container) — callers are expected to avoid writing at that path.
+    ///
+    /// Nested dialogs and any pending-change paths derived from this dialog
+    /// must be rooted here — not at `map_path` — otherwise the entry key
+    /// segment is dropped and changes land under `""` in the saved config.
+    pub fn entry_path(&self) -> String {
+        // Use the live key field so new entries pick up whatever the user
+        // has typed before opening a nested dialog. For existing entries
+        // the key field is read-only and equals `entry_key`, so this is
+        // consistent with the on-disk path.
+        let key = self.get_key();
+        if key.is_empty() {
+            self.map_path.clone()
+        } else {
+            format!("{}/{}", self.map_path, key)
+        }
+    }
+
     /// Get button count (3 for existing entries with Delete, 2 for new/no_delete entries)
     pub fn button_count(&self) -> usize {
         if self.is_new || self.no_delete {
@@ -1404,6 +1428,58 @@ mod tests {
 
         dialog.focus_prev();
         assert!(dialog.focus_on_buttons); // Wraps to buttons, not to read-only Key
+    }
+
+    #[test]
+    fn entry_path_joins_map_path_and_entry_key() {
+        let schema = create_test_schema();
+
+        // Existing entry: full path is map_path + "/" + entry_key
+        let existing = EntryDialogState::from_schema(
+            "rust".to_string(),
+            &serde_json::json!({}),
+            &schema,
+            "/lsp",
+            false,
+            false,
+        );
+        assert_eq!(existing.entry_path(), "/lsp/rust");
+
+        // New entry with no key typed yet falls back to the parent map path.
+        // Nested dialogs keyed off this are outside the scope of this test.
+        let new_entry = EntryDialogState::from_schema(
+            String::new(),
+            &serde_json::json!({}),
+            &schema,
+            "/lsp",
+            true,
+            false,
+        );
+        assert_eq!(new_entry.entry_path(), "/lsp");
+    }
+
+    #[test]
+    fn entry_path_tracks_live_key_edits_for_new_entries() {
+        let schema = create_test_schema();
+        let mut dialog = EntryDialogState::from_schema(
+            String::new(),
+            &serde_json::json!({}),
+            &schema,
+            "/universal_lsp",
+            true,
+            false,
+        );
+
+        // User types a key into the editable key field.
+        for item in dialog.items.iter_mut() {
+            if item.path == "__key__" {
+                if let SettingControl::Text(state) = &mut item.control {
+                    state.value = "myserver".to_string();
+                }
+            }
+        }
+
+        assert_eq!(dialog.entry_path(), "/universal_lsp/myserver");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -1145,7 +1145,21 @@ impl SettingsState {
         // Get info from the current dialog's focused field
         let nested_info = self.entry_dialog().and_then(|dialog| {
             let item = dialog.current_item()?;
-            let path = format!("{}/{}", dialog.map_path, item.path.trim_start_matches('/'));
+            // The nested dialog path must root at the current entry's full
+            // path, not just at `map_path`. Otherwise the entry key segment
+            // (e.g. `quicklsp` under `/universal_lsp`) is dropped and the
+            // nested save records a pending change at `/universal_lsp/`,
+            // which eventually writes an empty-string key into the config.
+            let base = dialog.entry_path();
+            let relative = item.path.trim_start_matches('/');
+            let path = if relative.is_empty() {
+                // `is_single_value` dialogs use an empty item path because
+                // the single non-key item IS the entry's value. In that
+                // case the nested dialog lives at the entry path itself.
+                base
+            } else {
+                format!("{}/{}", base, relative)
+            };
 
             match &item.control {
                 SettingControl::Map(map_state) => {
@@ -1322,17 +1336,20 @@ impl SettingsState {
         let is_nested = !self.entry_dialog_stack.is_empty();
 
         if is_nested {
-            // Nested dialog - update the parent dialog's ObjectArray item
-            // Extract the item path within the parent dialog by removing the parent's
-            // map_path prefix. For example, if array_path is "/lsp/" and the parent's
-            // map_path is "/lsp", the item path should be "" (the root value item).
-            let parent_map_path = self
+            // Nested dialog - update the parent dialog's ObjectArray item.
+            // Extract the item path within the parent dialog by stripping the
+            // parent's full entry path (map_path + "/" + entry_key) from the
+            // nested dialog's array path. For an is_single_value parent (e.g.
+            // a quicklsp entry whose value schema is an array), the inner
+            // ObjectArray item has path "" and the nested dialog lives exactly
+            // at the entry path, so the stripped item path is "".
+            let parent_entry_path = self
                 .entry_dialog_stack
                 .last()
-                .map(|p| p.map_path.as_str())
-                .unwrap_or("");
+                .map(|p| p.entry_path())
+                .unwrap_or_default();
             let item_path = array_path
-                .strip_prefix(parent_map_path)
+                .strip_prefix(parent_entry_path.as_str())
                 .unwrap_or(&array_path)
                 .trim_end_matches('/')
                 .to_string();
@@ -2586,5 +2603,156 @@ mod tests {
         // Switching layers clears pending changes
         state.cycle_target_layer();
         assert!(!state.has_changes());
+    }
+
+    /// Regression test for the quicklsp settings-save bug.
+    ///
+    /// When editing an existing map entry whose value schema is itself an
+    /// array (the `is_single_value` case — e.g. `universal_lsp.quicklsp`
+    /// where the value schema is `LspLanguageConfig` = array of
+    /// `LspServerConfig`), opening a nested ArrayItem dialog used to
+    /// compute its `map_path` from `parent.map_path + item.path` only —
+    /// dropping the entry key segment whenever `item.path` was `""`.
+    /// The nested dialog's save would then record a pending change at
+    /// `/universal_lsp/`, which downstream wrote an empty-string key
+    /// under `universal_lsp` in the saved config file.
+    ///
+    /// This test exercises the real `open_nested_entry_dialog` + save
+    /// path using a schema shaped like `LspLanguageConfig` and asserts:
+    /// 1. The nested dialog's `map_path` is the full entry path.
+    /// 2. The recorded pending-change path is the full entry path, not
+    ///    `/universal_lsp/` and not any `/universal_lsp/*` path with a
+    ///    trailing slash.
+    #[test]
+    fn nested_array_save_records_full_entry_path() {
+        // EntryDialogState is already re-exported via `use super::*;`.
+        // Pull in SettingType from the sibling schema module explicitly.
+        use crate::view::settings::schema::SettingType;
+
+        let config = test_config();
+        let mut state = SettingsState::new(TEST_SCHEMA, &config).unwrap();
+
+        // LspServerConfig-ish: a single "enabled" boolean field.
+        let item_schema = SettingSchema {
+            path: "/item".to_string(),
+            name: "Server".to_string(),
+            description: None,
+            setting_type: SettingType::Object {
+                properties: vec![SettingSchema {
+                    path: "/enabled".to_string(),
+                    name: "Enabled".to_string(),
+                    description: None,
+                    setting_type: SettingType::Boolean,
+                    default: Some(serde_json::json!(false)),
+                    read_only: false,
+                    section: None,
+                    order: None,
+                    nullable: false,
+                    enum_from: None,
+                }],
+            },
+            default: None,
+            read_only: false,
+            section: None,
+            order: None,
+            nullable: false,
+            enum_from: None,
+        };
+
+        // universal_lsp's value schema: ObjectArray of the item schema above.
+        // Note: path is "" just like the real schema parser produces for
+        // `parse_setting("value", "", ...)` — this is what drives the
+        // `is_single_value` code path in EntryDialogState::from_schema.
+        let value_schema = SettingSchema {
+            path: String::new(),
+            name: "value".to_string(),
+            description: None,
+            setting_type: SettingType::ObjectArray {
+                item_schema: Box::new(item_schema.clone()),
+                display_field: None,
+            },
+            default: None,
+            read_only: false,
+            section: None,
+            order: None,
+            nullable: false,
+            enum_from: None,
+        };
+
+        // Parent dialog: user is editing the existing "quicklsp" entry
+        // under /universal_lsp. This is the MapEntry dialog the real UI
+        // opens via `open_entry_dialog`.
+        let parent = EntryDialogState::from_schema(
+            "quicklsp".to_string(),
+            &serde_json::json!([{ "enabled": true }]),
+            &value_schema,
+            "/universal_lsp",
+            false, // existing entry
+            false,
+        );
+
+        // Precondition: is_single_value triggers and entry_path is correct.
+        assert!(
+            parent.is_single_value,
+            "array value_schema should trigger is_single_value path"
+        );
+        assert_eq!(parent.entry_path(), "/universal_lsp/quicklsp");
+
+        state.entry_dialog_stack.push(parent);
+
+        // Exercise the REAL open_nested_entry_dialog — this is the code
+        // path that used to produce the wrong path. The outer dialog's
+        // ObjectArray item is already focused with its first entry
+        // selected (init_object_array_focus in from_schema).
+        state.open_nested_entry_dialog();
+
+        // A nested dialog should have been pushed.
+        assert_eq!(
+            state.entry_dialog_stack.len(),
+            2,
+            "open_nested_entry_dialog should have pushed a nested dialog"
+        );
+
+        // CRITICAL (part 1): the nested dialog must root at the full
+        // entry path, not at the parent's map_path alone.
+        let nested_map_path = state
+            .entry_dialog_stack
+            .last()
+            .map(|d| d.map_path.clone())
+            .unwrap();
+        assert_eq!(
+            nested_map_path, "/universal_lsp/quicklsp",
+            "BUG: nested dialog's map_path dropped the 'quicklsp' key segment"
+        );
+
+        // Save the nested dialog via the normal dispatch.
+        state.save_entry_dialog();
+
+        // Nested dialog should be popped, parent still on the stack.
+        assert_eq!(state.entry_dialog_stack.len(), 1);
+
+        // CRITICAL (part 2): the pending change must be rooted at the
+        // full entry path, not at `/universal_lsp/` with a trailing slash.
+        assert!(
+            !state.pending_changes.contains_key("/universal_lsp/"),
+            "regression: pending change recorded under empty-key path /universal_lsp/. \
+             All keys: {:?}",
+            state.pending_changes.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !state
+                .pending_changes
+                .keys()
+                .any(|k| k.starts_with("/universal_lsp") && k.ends_with('/')),
+            "no /universal_lsp/* path should end in a trailing slash; got {:?}",
+            state.pending_changes.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            state
+                .pending_changes
+                .contains_key("/universal_lsp/quicklsp"),
+            "expected pending change at /universal_lsp/quicklsp, got {:?}",
+            state.pending_changes.keys().collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -116,6 +116,7 @@ pub mod settings_config_issue_806;
 pub mod settings_fallback_category;
 pub mod settings_lsp_entry_dialog_bugs;
 pub mod settings_paste;
+pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
 pub mod settings_scrolled_list_click;
 pub mod settings_ui_usability;

--- a/crates/fresh-editor/tests/e2e/settings_quicklsp_entry_bug.rs
+++ b/crates/fresh-editor/tests/e2e/settings_quicklsp_entry_bug.rs
@@ -1,0 +1,207 @@
+//! E2E regression for the quicklsp Settings-UI entry bug.
+//!
+//! Reported symptom: when editing the `universal_lsp → quicklsp` entry
+//! from Settings, saving writes the outer map key as `""` instead of
+//! `"quicklsp"`, e.g.:
+//!
+//! ```json
+//! {
+//!   "universal_lsp": {
+//!     "": [ ... ]
+//!   }
+//! }
+//! ```
+//!
+//! Root cause: the nested ArrayItem dialog opened for an `is_single_value`
+//! map entry (a map whose value schema is an array — like
+//! `LspLanguageConfig`) used to compute its `map_path` as
+//! `format!("{}/{}", parent.map_path, parent_item.path)` — dropping the
+//! entry key segment whenever `parent_item.path` was `""`. The resulting
+//! pending-change path `/universal_lsp/` then got written to disk via
+//! `set_json_pointer`, which created an empty-string child key.
+//!
+//! This test opens Settings, drills into `universal_lsp/quicklsp`, opens
+//! the nested item dialog for the existing server config, toggles
+//! `Enabled`, saves, and asserts the on-disk `config.json` contains a
+//! real `quicklsp` entry and NO empty-string sibling under `universal_lsp`.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config_io::DirectoryContext;
+use std::fs;
+use tempfile::TempDir;
+
+fn send_text(harness: &mut EditorTestHarness, text: &str) {
+    for c in text.chars() {
+        harness
+            .send_key(KeyCode::Char(c), KeyModifiers::NONE)
+            .unwrap();
+    }
+}
+
+/// Settings → universal_lsp → quicklsp round-trip must not corrupt the
+/// outer map key.
+#[test]
+fn quicklsp_entry_save_preserves_outer_map_key() {
+    // Isolated temp dir so the test doesn't touch the host config.
+    let temp_dir = TempDir::new().unwrap();
+    let config_dir = temp_dir.path().join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    let user_config_path = config_dir.join("config.json");
+
+    // Start from an empty user config — the default `quicklsp` entry comes
+    // from Config::default()'s built-in universal_lsp map.
+    fs::write(&user_config_path, r#"{}"#).unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir_all(&project_root).unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        160,
+        50,
+        HarnessOptions::new()
+            .with_working_dir(project_root)
+            .with_shared_dir_context(dir_context)
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+    harness.render().unwrap();
+
+    // Open Settings.
+    harness.open_settings().unwrap();
+
+    // Search for "quicklsp" to jump straight to the universal_lsp map.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    send_text(&mut harness, "quicklsp");
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Navigate down through the universal_lsp map entries until the
+    // quicklsp entry is focused (marked by the "[Enter to edit]" hint).
+    let mut found_quicklsp = false;
+    for _ in 0..30 {
+        let screen = harness.screen_to_string();
+        for line in screen.lines() {
+            if line.contains("quicklsp") && line.contains("[Enter to edit]") {
+                found_quicklsp = true;
+                break;
+            }
+        }
+        if found_quicklsp {
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(
+        found_quicklsp,
+        "Could not focus the universal_lsp → quicklsp entry. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Press Enter to open the outer Edit Value dialog for quicklsp.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Edit Value");
+    harness.assert_screen_contains("Key:quicklsp");
+
+    // The outer dialog focus lands on the ObjectArray (the single non-key
+    // item for this is_single_value map entry) with its first entry
+    // focused. Press Enter to drill into the nested Edit Item dialog.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Edit Item");
+    harness.assert_screen_contains("Command");
+
+    // Navigate to the Enabled toggle and flip it. We need a real change so
+    // that pending_changes is populated regardless of the buggy/fixed code
+    // path — otherwise save_settings would short-circuit on `!has_changes`.
+    let mut toggled = false;
+    for _ in 0..12 {
+        let screen = harness.screen_to_string();
+        let enabled_focused = screen.lines().any(|line| {
+            line.contains("Enabled") && (line.contains('>') || line.contains("[Space to toggle]"))
+        });
+        if enabled_focused {
+            harness
+                .send_key(KeyCode::Char(' '), KeyModifiers::NONE)
+                .unwrap();
+            harness.render().unwrap();
+            toggled = true;
+            break;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    assert!(
+        toggled,
+        "Could not reach the Enabled toggle inside the nested Edit Item dialog. \
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Save the nested dialog (Ctrl+Enter saves the current dialog from
+    // any mode — see input.rs handle_entry_dialog_input).
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Back at the outer dialog. Save it too so the whole entry flushes
+    // through the normal save path.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Save the Settings page (Ctrl+S) and wait for it to close.
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..20 {
+        harness.render().unwrap();
+        if !harness.editor().is_settings_open() {
+            break;
+        }
+    }
+    assert!(
+        !harness.editor().is_settings_open(),
+        "Settings should be closed after Ctrl+S"
+    );
+
+    // Read the saved config and verify invariants on universal_lsp.
+    let saved_content = fs::read_to_string(&user_config_path).unwrap();
+    eprintln!("Saved config after quicklsp edit:\n{}", saved_content);
+    let saved_json: serde_json::Value =
+        serde_json::from_str(&saved_content).expect("saved config must be valid JSON");
+
+    let universal_lsp = saved_json
+        .get("universal_lsp")
+        .and_then(|v| v.as_object())
+        .expect("expected universal_lsp to be saved as an object after editing quicklsp");
+
+    // CRITICAL: the outer map key must be "quicklsp", not "".
+    assert!(
+        !universal_lsp.contains_key(""),
+        "BUG: universal_lsp contains an empty-string key. The settings \
+         save flow dropped the 'quicklsp' key segment. Saved config:\n{}",
+        saved_content
+    );
+    assert!(
+        universal_lsp.contains_key("quicklsp"),
+        "universal_lsp must contain the 'quicklsp' entry after editing it. \
+         Saved config:\n{}",
+        saved_content
+    );
+
+    drop(temp_dir);
+}


### PR DESCRIPTION
## Summary

Fixes a regression where editing nested array items within map entries (specifically `universal_lsp → quicklsp`) would save with an empty-string key instead of the correct entry key. The bug occurred because nested dialog paths were computed from the parent's `map_path` alone, dropping the entry key segment when the item path was empty.

## Key Changes

- **`entry_dialog.rs`**: Added `entry_path()` method that returns the full JSON pointer path to the entry being edited (e.g., `/universal_lsp/quicklsp`), combining `map_path` and the entry key. This is now the authoritative path for nested dialogs and pending changes.

- **`state.rs`**: Updated `open_nested_entry_dialog()` to use `entry_path()` instead of `map_path` when computing nested dialog paths. For `is_single_value` entries (where the item path is empty), the nested dialog now correctly roots at the full entry path rather than the parent container path.

- **`state.rs`**: Fixed `save_entry_dialog()` to extract item paths relative to the parent's `entry_path()` instead of `map_path`, ensuring pending changes are recorded at the correct location.

- **`config.rs`**: Removed the restrictive `only_features` whitelist from the default quicklsp configuration. The server now advertises all its capabilities (including go-to-definition) by default, allowing users to opt-in to restrictions rather than silently breaking features on vanilla installs.

- **Added comprehensive E2E regression test** (`settings_quicklsp_entry_bug.rs`) that exercises the full Settings UI flow: opening Settings, navigating to `universal_lsp/quicklsp`, opening the nested item dialog, toggling a field, saving through both dialogs, and verifying the on-disk config contains the correct `quicklsp` key with no empty-string sibling.

- **Added unit tests** in `entry_dialog.rs` to verify `entry_path()` correctly joins map paths with entry keys and tracks live key edits for new entries.

## Implementation Details

The root cause was that `is_single_value` map entries (whose value schema is an array, like `LspLanguageConfig`) have an ObjectArray item with path `""`. When opening a nested ArrayItem dialog, the old code computed `map_path` as `parent.map_path + item.path`, which resulted in `/universal_lsp/` (dropping the `quicklsp` key). The pending change was then recorded at this truncated path, causing `set_json_pointer` to create an empty-string child key in the saved JSON.

The fix introduces `entry_path()` as the canonical full path to the entry, ensuring all nested dialogs and pending changes are rooted at the correct location.

https://claude.ai/code/session_01H4wSv5cJrAyXt8cqpoYPbV