### PR TITLE
Pass theme keys to core instead of resolving colors client-side

### DIFF
--- a/crates/fresh-editor/plugins/theme_editor.ts
+++ b/crates/fresh-editor/plugins/theme_editor.ts
@@ -450,70 +450,19 @@ const state: ThemeEditorState = {
 // =============================================================================
 
 /**
- * UI palette for the theme editor's own chrome. Each role is resolved from
- * the currently-active theme so the editor inherits the host theme's look,
- * with a luma-chosen hardcoded palette as a safety net for themes that
- * don't define the keys we look up.
- */
-interface UIColors {
-  sectionHeader: OverlayColorSpec;
-  fieldName: OverlayColorSpec;
-  customValue: OverlayColorSpec;
-  description: OverlayColorSpec;
-  footer: OverlayColorSpec;
-  selectionBg: OverlayColorSpec;
-  divider: OverlayColorSpec;
-  header: OverlayColorSpec;
-  pickerLabel: OverlayColorSpec;
-  pickerValue: OverlayColorSpec;
-  pickerFocusBg: OverlayColorSpec;
-  filterText: OverlayColorSpec;
-}
-
-/**
- * Fallback palette for dark host themes. Used when the active theme doesn't
- * define the keys in THEME_KEY_CANDIDATES (or when we can't read its data).
- */
-const DARK_FALLBACK: UIColors = {
-  sectionHeader: [255, 200, 100],
-  fieldName: [200, 200, 255],
-  customValue: [100, 255, 100],
-  description: [120, 120, 120],
-  footer: [100, 100, 100],
-  selectionBg: [50, 50, 80],
-  divider: [60, 60, 80],
-  header: [100, 180, 255],
-  pickerLabel: [180, 180, 200],
-  pickerValue: [255, 255, 255],
-  pickerFocusBg: [40, 60, 100],
-  filterText: [200, 200, 100],
-};
-
-/**
- * Fallback palette for light host themes. Dark fg and light bg highlights
- * so text stays legible on near-white backgrounds.
- */
-const LIGHT_FALLBACK: UIColors = {
-  sectionHeader: [160, 90, 0],
-  fieldName: [30, 50, 140],
-  customValue: [0, 120, 0],
-  description: [95, 95, 95],
-  footer: [90, 90, 90],
-  selectionBg: [210, 225, 250],
-  divider: [180, 180, 195],
-  header: [20, 80, 180],
-  pickerLabel: [70, 70, 90],
-  pickerValue: [0, 0, 0],
-  pickerFocusBg: [200, 220, 255],
-  filterText: [140, 90, 0],
-};
-
-/**
- * For each UI role, an ordered list of theme key paths to try. The first
- * path that resolves to a usable color wins; otherwise we fall back to the
- * hardcoded palette.
+ * UI palette for the theme editor's own chrome.
  *
- * Important: we can only use keys that the theme defines as readable on
+ * Each role maps to a theme-key path (e.g. `"syntax.keyword"`). The plugin
+ * passes these strings straight through to the core as
+ * `OverlayColorSpec::ThemeKey`, and the core's renderer resolves them
+ * against the *currently-active* theme on every frame
+ * (see `OverlayFace::from_options` → `OverlayFace::ThemedStyle`, and the
+ * render-time lookup in `split_rendering.rs`). That means the theme editor
+ * inherits the host theme's look and automatically picks up theme switches
+ * without the plugin having to rebuild its overlays or even be notified —
+ * the `resolve_theme_key` lookup runs with the new theme on the next render.
+ *
+ * Important: we only use keys that the theme defines as readable on
  * `editor.bg` (since that's the background the theme editor draws over).
  * That rules out `ui.menu_*`, `ui.tab_*`, etc. — those are designed for
  * their own bg pairs (e.g. `ui.menu_active_fg` on `ui.menu_active_bg`) and
@@ -521,100 +470,26 @@ const LIGHT_FALLBACK: UIColors = {
  * high-contrast, where `ui.menu_active_fg` is pure black). So we only pull
  * from `editor.*` and `syntax.*`, and lean on bold + distinct syntax roles
  * to give each UI element its own visual identity.
- */
-const THEME_KEY_CANDIDATES: Record<keyof UIColors, readonly string[]> = {
-  sectionHeader: ["syntax.keyword", "syntax.function", "editor.fg"],
-  fieldName:     ["editor.fg"],
-  customValue:   ["syntax.string", "syntax.constant", "editor.fg"],
-  description:   ["syntax.comment", "editor.line_number_fg", "editor.whitespace_indicator_fg"],
-  footer:        ["editor.line_number_fg", "editor.fg"],
-  selectionBg:   ["editor.selection_bg", "editor.current_line_bg"],
-  divider:       ["editor.line_number_fg", "editor.whitespace_indicator_fg"],
-  header:        ["syntax.keyword", "syntax.function", "editor.fg"],
-  pickerLabel:   ["editor.fg"],
-  pickerValue:   ["syntax.constant", "syntax.function", "editor.fg"],
-  pickerFocusBg: ["editor.selection_bg", "editor.current_line_bg"],
-  filterText:    ["syntax.function", "syntax.constant", "editor.fg"],
-};
-
-/**
- * Active UI palette. Rebuilt at render time from the currently-applied
- * editor theme so the theme editor inherits that theme's look.
  *
- * This is separate from `state.themeData` (the theme being *edited*) — what
- * matters for the editor UI's own contrast is the theme the terminal is
- * actually rendering with, not the theme data the user is mutating.
+ * We don't need a client-side fallback chain: the core's `Theme` struct has
+ * serde defaults for every field, so `resolve_theme_key` always returns a
+ * value for any key listed here — a stub theme file can omit them and the
+ * defaults still apply.
  */
-let colors: UIColors = DARK_FALLBACK;
-
-/**
- * Resolve a theme value at one of the candidate paths into an
- * OverlayColorSpec. Accepts RGB 3-tuples and recognised named colors
- * ("Red", "Blue", …); rejects "Default"/"Reset" since those are
- * transparent and would give no contrast.
- */
-function resolveThemeColor(
-  themeData: Record<string, unknown>,
-  candidates: readonly string[]
-): OverlayColorSpec | null {
-  for (const path of candidates) {
-    const value = getNestedValue(themeData, path);
-    if (Array.isArray(value) && value.length === 3 &&
-        typeof value[0] === "number" &&
-        typeof value[1] === "number" &&
-        typeof value[2] === "number") {
-      return [value[0], value[1], value[2]];
-    }
-    if (typeof value === "string" && value in NAMED_COLORS) {
-      return value;
-    }
-  }
-  return null;
-}
-
-/**
- * Rebuild the `colors` palette from the active editor theme. For each
- * UI role we try the theme-key candidates in order, then fall back to
- * the luma-chosen hardcoded palette for any role the theme doesn't
- * cover. Safe to call on every redraw.
- */
-function updateActiveColorsFromConfig(): void {
-  let themeData: Record<string, unknown> | null = null;
-  try {
-    const config = editor.getConfig() as Record<string, unknown> | null;
-    const themeKey = (config?.theme as string) || "dark";
-    themeData = editor.getThemeData(themeKey) as Record<string, unknown> | null;
-  } catch {
-    themeData = null;
-  }
-
-  // Pick the fallback palette based on the theme's editor.bg luma, so any
-  // roles missing from the theme still land in the right contrast bucket.
-  let fallback: UIColors = DARK_FALLBACK;
-  if (themeData) {
-    const bg = getNestedValue(themeData, "editor.bg");
-    if (Array.isArray(bg) && bg.length === 3 &&
-        typeof bg[0] === "number" &&
-        typeof bg[1] === "number" &&
-        typeof bg[2] === "number") {
-      // Rec. 601 luma; threshold picked so near-white bgs flip to LIGHT.
-      const luma = 0.299 * bg[0] + 0.587 * bg[1] + 0.114 * bg[2];
-      fallback = luma > 140 ? LIGHT_FALLBACK : DARK_FALLBACK;
-    }
-  }
-
-  if (!themeData) {
-    colors = fallback;
-    return;
-  }
-
-  const resolved = {} as UIColors;
-  for (const role of Object.keys(THEME_KEY_CANDIDATES) as Array<keyof UIColors>) {
-    const fromTheme = resolveThemeColor(themeData, THEME_KEY_CANDIDATES[role]);
-    resolved[role] = fromTheme ?? fallback[role];
-  }
-  colors = resolved;
-}
+const colors = {
+  sectionHeader: "syntax.keyword",
+  fieldName:     "editor.fg",
+  customValue:   "syntax.string",
+  description:   "syntax.comment",
+  footer:        "editor.line_number_fg",
+  selectionBg:   "editor.selection_bg",
+  divider:       "editor.line_number_fg",
+  header:        "syntax.keyword",
+  pickerLabel:   "editor.fg",
+  pickerValue:   "syntax.constant",
+  pickerFocusBg: "editor.selection_bg",
+  filterText:    "syntax.function",
+} as const satisfies Record<string, OverlayColorSpec>;
 
 // =============================================================================
 // Keyboard Shortcuts (defined once, used in mode and i18n)
@@ -1561,12 +1436,6 @@ function buildFooterPanelEntries(): TextPropertyEntry[] {
 
 function updateDisplay(): void {
   isUpdatingDisplay = true;
-
-  // Pick the right UI palette for the currently-active editor theme so the
-  // theme editor stays readable on both light and dark themes. Done on every
-  // refresh (cheap in-memory lookup) so switching the active theme while the
-  // editor is open takes effect on the next redraw.
-  updateActiveColorsFromConfig();
 
   // Always refresh viewport dimensions
   const viewport = editor.getViewport();

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2826,3 +2826,178 @@ fn test_review_diff_file_replaced_with_directory() {
         harness.screen_to_string()
     );
 }
+
+/// Regression test: switching the active theme via "Select Theme" while a
+/// Review Diff (audit_mode) virtual buffer is open must update the colors of
+/// the diff hunk backgrounds in that buffer to reflect the new theme.
+///
+/// The audit_mode plugin attaches overlays to its virtual buffer with theme
+/// key references like `"editor.diff_add_bg"` / `"editor.diff_remove_bg"`.
+/// These are stored as `OverlayFace::ThemedStyle` so they resolve at render
+/// time — so when the active theme changes, the next render should pick up
+/// the new theme's values.
+///
+/// Dark theme: `diff_add_bg` = [30, 60, 30], `diff_remove_bg` = [70, 30, 30]
+/// Light theme: `diff_add_bg` = [200, 255, 200], `diff_remove_bg` = [255, 200, 200]
+#[test]
+fn test_review_diff_colors_update_on_theme_change() {
+    use ratatui::style::Color;
+
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+
+    // Commit the initial project, then modify a file so the diff has hunks.
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    let main_rs_path = repo.path.join("src/main.rs");
+    let modified_content = r#"fn main() {
+    println!("DIFF_NEW_LINE");
+    let config = load_config();
+    start_server(config);
+}
+
+fn load_config() -> Config {
+    Config::default()
+}
+
+fn start_server(config: Config) {
+    println!("Starting server...");
+}
+"#;
+    fs::write(&main_rs_path, modified_content).expect("Failed to modify file");
+
+    // Start in the dark theme so we have well-known expected colors.
+    let mut config = Config::default();
+    config.theme = "dark".into();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(140, 40, config, repo.path.clone()).unwrap();
+
+    harness.open_file(&main_rs_path).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("DIFF_NEW_LINE"))
+        .unwrap();
+
+    // Open Review Diff via the command palette.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Review Diff").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            !s.contains("Generating Review Diff Stream") && s.contains("DIFF_NEW_LINE")
+        })
+        .unwrap();
+    harness.render().unwrap();
+
+    // Find the added line ("+    println!(...DIFF_NEW_LINE..)") inside the diff
+    // panel. Its background should be the dark theme's `diff_add_bg`.
+    let dark_add_bg = Color::Rgb(30, 60, 30);
+    let dark_remove_bg = Color::Rgb(70, 30, 30);
+
+    let add_pos = harness
+        .find_text_on_screen("DIFF_NEW_LINE")
+        .expect("DIFF_NEW_LINE should be visible in the review diff buffer");
+    let add_style = harness
+        .get_cell_style(add_pos.0, add_pos.1)
+        .expect("cell should have a style");
+    assert_eq!(
+        add_style.bg,
+        Some(dark_add_bg),
+        "With dark theme, diff_add_bg should be {:?}, got {:?}. Screen:\n{}",
+        dark_add_bg,
+        add_style.bg,
+        harness.screen_to_string(),
+    );
+
+    // The removed line should carry dark_remove_bg.
+    let rem_pos = harness
+        .find_text_on_screen("Hello, world!")
+        .expect("original 'Hello, world!' should be visible as a removed line");
+    let rem_style = harness
+        .get_cell_style(rem_pos.0, rem_pos.1)
+        .expect("cell should have a style");
+    assert_eq!(
+        rem_style.bg,
+        Some(dark_remove_bg),
+        "With dark theme, diff_remove_bg should be {:?}, got {:?}. Screen:\n{}",
+        dark_remove_bg,
+        rem_style.bg,
+        harness.screen_to_string(),
+    );
+
+    // --- Switch to the light theme ---
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Select Theme").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_screen_contains("Select theme").unwrap();
+
+    // Clear the pre-filled current theme name and type "light".
+    for _ in 0..20 {
+        harness
+            .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.type_text("light").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+
+    // --- Verify the plugin buffer picked up the new theme's diff colors ---
+    let light_add_bg = Color::Rgb(200, 255, 200);
+    let light_remove_bg = Color::Rgb(255, 200, 200);
+
+    let add_pos = harness
+        .find_text_on_screen("DIFF_NEW_LINE")
+        .expect("DIFF_NEW_LINE should still be visible after theme switch");
+    let add_style = harness
+        .get_cell_style(add_pos.0, add_pos.1)
+        .expect("cell should have a style");
+    assert_eq!(
+        add_style.bg,
+        Some(light_add_bg),
+        "After switching to light theme, diff_add_bg in the Review Diff plugin buffer \
+         should be {:?}, got {:?}. The plugin buffer's overlays were not refreshed for \
+         the new theme. Screen:\n{}",
+        light_add_bg,
+        add_style.bg,
+        harness.screen_to_string(),
+    );
+
+    let rem_pos = harness
+        .find_text_on_screen("Hello, world!")
+        .expect("original 'Hello, world!' should still be visible");
+    let rem_style = harness
+        .get_cell_style(rem_pos.0, rem_pos.1)
+        .expect("cell should have a style");
+    assert_eq!(
+        rem_style.bg,
+        Some(light_remove_bg),
+        "After switching to light theme, diff_remove_bg in the Review Diff plugin buffer \
+         should be {:?}, got {:?}. The plugin buffer's overlays were not refreshed for \
+         the new theme. Screen:\n{}",
+        light_remove_bg,
+        rem_style.bg,
+        harness.screen_to_string(),
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -3952,28 +3952,24 @@ fn test_named_color_swatch_uses_native_ansi_color() {
         .unwrap();
 }
 
-/// Bug reproduction (currently failing — `#[ignore]`d so CI stays green).
+/// Regression test: switching the active theme via "Select Theme" while a
+/// theme-editor plugin buffer is open must refresh the overlay colors the
+/// plugin painted with.
 ///
-/// Switching the active theme via "Select Theme" while a theme-editor
-/// plugin virtual buffer is open leaves the plugin-provided overlay colors
-/// stale. The `theme_editor` plugin builds its UI by calling
-/// `setPanelContent` once with `TextPropertyEntry`s whose styles contain
-/// hardcoded RGB values (e.g. `colors.header = [100, 180, 255]`). These get
-/// baked into `OverlayFace::Style { style }` at
-/// `set_virtual_buffer_content` time and never refresh, so after a theme
-/// switch the plugin buffer still paints text with the old theme's
-/// hardcoded RGB values while the rest of the editor has moved to the new
-/// theme.
+/// The bug was that the plugin resolved its UI palette client-side — it
+/// read `editor.getThemeData()` in JS, dug out the RGB tuple for
+/// `syntax.keyword`, and handed the RGB array to `setVirtualBufferContent`.
+/// That made the overlay an `OverlayFace::Style` with baked RGB, so the
+/// core's render-time theme-key resolver (`split_rendering.rs` →
+/// `ThemedStyle` branch) was bypassed and a theme switch left the buffer
+/// painted in the old theme's colors.
 ///
-/// Plugin buffers should be re-asked to paint themselves after a theme
-/// change (e.g. via a `theme_changed` plugin hook, or by having plugins
-/// use theme keys like audit_mode does). This test reproduces the missing
-/// behaviour: after switching from dark to light, the theme-editor header
-/// text's fg should change, but it stays at the dark-theme RGB.
-///
-/// TODO: remove `#[ignore]` once the bug is fixed.
+/// The fix is to pass theme-key strings (e.g. `"syntax.keyword"`) straight
+/// through to the core. `OverlayFace::from_options` then stores the key
+/// in `ThemedStyle { fg_theme: Some("syntax.keyword"), .. }` and the next
+/// render resolves it against `ctx.theme` — which is the new theme after
+/// `apply_theme`.
 #[test]
-#[ignore = "Reproduces #TODO: plugin buffer overlay colors not refreshed on theme change"]
 fn test_theme_editor_colors_update_on_theme_change() {
     init_tracing_from_env();
 

--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -3952,6 +3952,145 @@ fn test_named_color_swatch_uses_native_ansi_color() {
         .unwrap();
 }
 
+/// Bug reproduction (currently failing — `#[ignore]`d so CI stays green).
+///
+/// Switching the active theme via "Select Theme" while a theme-editor
+/// plugin virtual buffer is open leaves the plugin-provided overlay colors
+/// stale. The `theme_editor` plugin builds its UI by calling
+/// `setPanelContent` once with `TextPropertyEntry`s whose styles contain
+/// hardcoded RGB values (e.g. `colors.header = [100, 180, 255]`). These get
+/// baked into `OverlayFace::Style { style }` at
+/// `set_virtual_buffer_content` time and never refresh, so after a theme
+/// switch the plugin buffer still paints text with the old theme's
+/// hardcoded RGB values while the rest of the editor has moved to the new
+/// theme.
+///
+/// Plugin buffers should be re-asked to paint themselves after a theme
+/// change (e.g. via a `theme_changed` plugin hook, or by having plugins
+/// use theme keys like audit_mode does). This test reproduces the missing
+/// behaviour: after switching from dark to light, the theme-editor header
+/// text's fg should change, but it stays at the dark-theme RGB.
+///
+/// TODO: remove `#[ignore]` once the bug is fixed.
+#[test]
+#[ignore = "Reproduces #TODO: plugin buffer overlay colors not refreshed on theme change"]
+fn test_theme_editor_colors_update_on_theme_change() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "theme_editor");
+
+    let mut config = fresh::config::Config::default();
+    config.theme = "dark".into();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(140, 40, config, project_root).unwrap();
+
+    harness.render().unwrap();
+
+    // Open the theme editor with "dark" selected.
+    open_theme_editor(&mut harness);
+
+    // The "Theme Editor:" header row carries a hardcoded `colors.header`
+    // fg of [100, 180, 255] (blue) AND the buffer's default editor.bg.
+    // Record both the text-cell and an empty cell on the same row.
+    let header_pos = harness
+        .find_text_on_screen("Theme Editor:")
+        .expect("'Theme Editor:' header should be visible in the theme editor buffer");
+    let dark_header_fg = harness
+        .get_cell_style(header_pos.0, header_pos.1)
+        .expect("header cell should have a style")
+        .fg;
+
+    // Sample a cell well to the right on the same row where there's no text
+    // (so we get the buffer's default bg, not an overlay).
+    let empty_col = header_pos.0.saturating_add(60);
+    let dark_row_empty_bg = harness
+        .get_cell_style(empty_col, header_pos.1)
+        .expect("cell should have a style")
+        .bg;
+    assert_eq!(
+        dark_row_empty_bg,
+        Some(Color::Rgb(30, 30, 30)),
+        "With dark theme, theme editor buffer empty cells should have bg [30,30,30], got {:?}. \
+         Screen:\n{}",
+        dark_row_empty_bg,
+        harness.screen_to_string(),
+    );
+
+    // --- Switch to the light theme via the command palette ---
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Select Theme").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_screen_contains("Select theme").unwrap();
+
+    for _ in 0..20 {
+        harness
+            .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.type_text("light").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+
+    // After the switch, both the buffer background AND the hardcoded header
+    // fg should reflect the new theme. In particular, the plugin's cached
+    // overlay-styles (baked RGB) should be refreshed so they don't stay as
+    // the dark theme's values against the new light bg.
+    let header_pos = harness
+        .find_text_on_screen("Theme Editor:")
+        .expect("'Theme Editor:' header should still be visible after theme switch");
+    let empty_col = header_pos.0.saturating_add(60);
+    let light_row_empty_bg = harness
+        .get_cell_style(empty_col, header_pos.1)
+        .expect("cell should have a style")
+        .bg;
+    assert_eq!(
+        light_row_empty_bg,
+        Some(Color::Rgb(255, 255, 255)),
+        "After switching to light theme, theme editor buffer empty cells should have \
+         bg [255,255,255], got {:?}. Screen:\n{}",
+        light_row_empty_bg,
+        harness.screen_to_string(),
+    );
+
+    let light_header_fg = harness
+        .get_cell_style(header_pos.0, header_pos.1)
+        .expect("header cell should have a style")
+        .fg;
+
+    // BUG REPRODUCTION: the plugin-provided header highlight fg is baked at
+    // `setVirtualBufferContent` time and does not refresh when the theme
+    // changes. We assert that the fg DOES change — this is the behaviour
+    // the user expects, and it currently fails because the plugin's
+    // hardcoded RGB highlights never get re-applied.
+    assert_ne!(
+        light_header_fg,
+        dark_header_fg,
+        "After switching themes, the theme editor's header-text fg should be refreshed \
+         (expected it to differ from the dark-theme value {:?}). The plugin-provided \
+         overlay colors appear to be baked at creation time and never refreshed on \
+         theme change. Screen:\n{}",
+        dark_header_fg,
+        harness.screen_to_string(),
+    );
+}
+
 /// Find the fg color of the swatch (██) on a given screen row.
 /// Scans the left panel area (columns 0-37) for cells where fg == bg,
 /// which indicates a color swatch.


### PR DESCRIPTION
## Summary

This change eliminates client-side theme color resolution in the theme_editor plugin by passing theme-key strings (e.g., `"syntax.keyword"`) directly to the core renderer instead of resolving RGB values in JavaScript. This allows overlay colors to automatically update when the active theme changes, without requiring the plugin to rebuild its overlays.

## Key Changes

- **Removed client-side color resolution logic**: Deleted `UIColors` interface, `DARK_FALLBACK`/`LIGHT_FALLBACK` palettes, `THEME_KEY_CANDIDATES` mapping, `resolveThemeColor()`, and `updateActiveColorsFromConfig()` functions from `theme_editor.ts`

- **Simplified color palette to theme-key strings**: Converted the `colors` object from a runtime-computed palette of RGB tuples to a static mapping of UI roles to theme-key strings (e.g., `sectionHeader: "syntax.keyword"`)

- **Removed palette update call**: Eliminated the `updateActiveColorsFromConfig()` call from `updateDisplay()` since colors are no longer computed at render time

- **Added regression tests**: Created two comprehensive e2e tests that verify overlay colors update correctly when switching themes:
  - `test_theme_editor_colors_update_on_theme_change()` in `theme_editor.rs` - validates the theme editor's own UI colors refresh
  - `test_review_diff_colors_update_on_theme_change()` in `audit_mode.rs` - validates that plugin buffers with themed overlays pick up new theme values

## Implementation Details

The core's renderer now handles all theme-key resolution at render time via `OverlayFace::ThemedStyle`. When `setVirtualBufferContent` receives a theme-key string, it's stored as `OverlayFace::ThemedStyle { fg_theme: Some("syntax.keyword"), .. }`. On each render, the core's `split_rendering.rs` resolves these keys against the currently-active theme (`ctx.theme`), so theme switches automatically take effect without plugin intervention.

This approach leverages the core's serde defaults for theme fields, eliminating the need for client-side fallback chains while ensuring all referenced keys have sensible defaults.

https://claude.ai/code/session_0115zSf7KDybHGWWCGJ2ows8