### PR TITLE
Fix flaky theme editor test with scroll-lag race condition

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -3894,7 +3894,17 @@ fn test_named_color_swatch_uses_native_ansi_color() {
         }
         let before = selected_line(&harness);
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-        harness.wait_until(|h| selected_line(h) != before).unwrap();
+        // Wait until ▸ is visible AND on a different line. Without the
+        // is_some() guard, a transient scroll-lag frame (where ▸ is
+        // off-viewport) would satisfy `None != Some(old)`, letting the
+        // loop capture `before = None` on the next iteration and then
+        // block forever on `None != None`.
+        harness
+            .wait_until(|h| {
+                let cur = selected_line(h);
+                cur.is_some() && cur != before
+            })
+            .unwrap();
     }
 
     // Expand the UI section and wait semantically for the selected line
@@ -3924,7 +3934,12 @@ fn test_named_color_swatch_uses_native_ansi_color() {
         }
         let before = selected_line(&harness);
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-        harness.wait_until(|h| selected_line(h) != before).unwrap();
+        harness
+            .wait_until(|h| {
+                let cur = selected_line(h);
+                cur.is_some() && cur != before
+            })
+            .unwrap();
     }
 
     // Move selection away so the tab_active_fg row renders without the
@@ -3932,7 +3947,12 @@ fn test_named_color_swatch_uses_native_ansi_color() {
     // fg==bg swatch detection).
     let before = selected_line(&harness);
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-    harness.wait_until(|h| selected_line(h) != before).unwrap();
+    harness
+        .wait_until(|h| {
+            let cur = selected_line(h);
+            cur.is_some() && cur != before
+        })
+        .unwrap();
 
     // Wait for the tab_active_fg swatch to render with the correct native
     // ANSI Yellow color. On slow CI the plugin may not have finished


### PR DESCRIPTION
## Summary
Fixed a race condition in the `test_named_color_swatch_uses_native_ansi_color` test that could cause it to hang indefinitely due to transient scroll-lag frames.

## Key Changes
- Updated three `wait_until` conditions to check that the selected line is `Some` before comparing it to the previous value
- Added guards using `cur.is_some() && cur != before` instead of just `cur != before`
- This prevents the test from capturing `None` as the "before" value when the UI is temporarily off-viewport, which would cause the wait condition to never be satisfied

## Implementation Details
The issue occurred when scroll-lag caused the selection indicator (▸) to temporarily disappear from the viewport. The original condition `selected_line(h) != before` would be satisfied by the transient `None` value, allowing the loop to proceed and set `before = None`. On the next iteration, the condition `None != None` would never be true, causing the test to hang.

By adding the `is_some()` guard, we ensure the wait condition only succeeds when the selection is actually visible and has moved to a different line, preventing the race condition.

https://claude.ai/code/session_01RyM2mw2tFdXipZqeJrkp7V