### PR TITLE
Add LSP binary probe and user-dismiss UI for status indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * **LSP Status Bar Indicator**: Redesigned to a stable-width `LSP (on/off/error)` status indicator with a spinner while a server is starting or working — no more status bar noise as progress messages arrive. Configured-but-dormant servers are now visible as `LSP (off)` so you can see at a glance that an LSP is available to start. Clicking opens a popup with per-server status and live progress under the server name.
 
+* **LSP Indicator: missing-binary detection and dismissable pill**: The LSP popup now probes each configured server's binary up-front, so opening the popup for a language like Python or Go on a system without `pylsp`/`gopls` installed labels the server "binary not in PATH" and replaces the actionable "Start" row with a disabled "Install … to enable" advisory — no more starting a server only to watch it fail. The popup also offers a "Disable LSP pill for {language}" row that mutes the indicator without touching your on-disk config (re-enable it from the same popup; dismissal is session-scoped). Plugins receive the same information through an extended `lsp_status_clicked` hook payload (`missing_servers`, `user_dismissed`).
+
 * **Diagnostics in Hover Popup**: When the cursor sits on a symbol that also carries an error, warning, or hint, the hover popup prepends the overlapping diagnostic (severity and source like `rustc`/`clippy`/`clangd`) above the hover body.
 
 * **C++ Header Detection**: Added heuristics to assign an `.h` files the C++ rather than C language. You can change it manually by clicking on the language in the status bar.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,7 @@ dependencies = [
  "unicode-width",
  "ureq",
  "vt100",
+ "which",
  "windows-sys 0.61.2",
  "winresource",
 ]
@@ -6549,6 +6550,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "widestring"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7010,6 +7023,12 @@ dependencies = [
  "toml 1.1.1+spec-1.1.0",
  "version_check",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/fresh-core/src/hooks.rs
+++ b/crates/fresh-core/src/hooks.rs
@@ -244,6 +244,16 @@ pub enum HookArgs {
         language: String,
         /// Whether there's an active error
         has_error: bool,
+        /// Commands of configured servers whose binaries are not on `$PATH`
+        /// (or absolute-path equivalents). Empty when every configured
+        /// server is installed. Plugins can inspect this to show tailored
+        /// install hints without waiting for a failed spawn.
+        missing_servers: Vec<String>,
+        /// Whether the user previously dismissed the LSP pill for this
+        /// language (via the popup's "Disable" action). Plugins seeing
+        /// this as `true` should offer "Enable" / "Install" rather than
+        /// "Start".
+        user_dismissed: bool,
     },
 
     /// User selected an action from an action popup
@@ -705,10 +715,14 @@ pub fn hook_args_to_json(args: &HookArgs) -> Result<serde_json::Value> {
         HookArgs::LspStatusClicked {
             language,
             has_error,
+            missing_servers,
+            user_dismissed,
         } => {
             serde_json::json!({
                 "language": language,
                 "has_error": has_error,
+                "missing_servers": missing_servers,
+                "user_dismissed": user_dismissed,
             })
         }
         HookArgs::ActionPopupResult {

--- a/crates/fresh-editor/Cargo.toml
+++ b/crates/fresh-editor/Cargo.toml
@@ -117,6 +117,11 @@ serde_json.workspace = true
 schemars.workspace = true
 rust-i18n.workspace = true
 once_cell.workspace = true
+# Cross-platform PATH / binary resolution.  Handles Windows PATHEXT
+# (.CMD/.BAT/.PS1 wrappers that npm -g creates for Node-based LSPs),
+# the Unix executable bit, symlinks, and App Execution Aliases on
+# Windows — all of which our previous hand-rolled probe missed.
+which = "6"
 
 # Runtime dependencies (optional, enabled by "runtime" feature)
 crossterm = { version = "0.29.0", features = ["osc52"], optional = true }

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -1819,12 +1819,32 @@ impl Editor {
             .map(|s| s.language.clone())
             .unwrap_or_else(|| "unknown".to_string());
 
+        // Compute the set of configured servers whose binaries are not
+        // resolvable — plugins and the popup itself both need this to
+        // decide between "offer to start" and "offer install help".
+        let missing_servers: Vec<String> = self
+            .config
+            .lsp
+            .get(&language)
+            .map(|cfg| {
+                cfg.as_slice()
+                    .iter()
+                    .filter(|c| c.enabled && !c.command.is_empty())
+                    .filter(|c| !crate::services::lsp::command_exists(&c.command))
+                    .map(|c| c.command.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let user_dismissed = self.is_lsp_language_user_dismissed(&language);
+
         // Fire the LspStatusClicked hook for plugins
         self.plugin_manager.run_hook(
             "lsp_status_clicked",
             crate::services::plugins::hooks::HookArgs::LspStatusClicked {
                 language: language.clone(),
                 has_error,
+                missing_servers,
+                user_dismissed,
             },
         );
 
@@ -1883,6 +1903,31 @@ impl Editor {
             })
             .unwrap_or_default();
 
+        // Per-server binary availability map (display_name → bool).
+        // `command_exists` is cached, so repeated popup opens or a
+        // refresh-while-open are cheap.  We look up by display name
+        // because `all_servers` below is built from display names;
+        // LspServerConfig::display_name() falls back to the command
+        // basename when no explicit `name` is set.
+        let missing_by_server: std::collections::HashMap<String, bool> = self
+            .config
+            .lsp
+            .get(language)
+            .map(|cfg| {
+                cfg.as_slice()
+                    .iter()
+                    .filter(|c| !c.command.is_empty())
+                    .map(|c| {
+                        (
+                            c.display_name(),
+                            !crate::services::lsp::command_exists(&c.command),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let user_dismissed = self.is_lsp_language_user_dismissed(language);
+
         if configured_servers.is_empty() && running_statuses.is_empty() {
             self.status_message = Some(t!("lsp.no_server_active").to_string());
             return;
@@ -1938,15 +1983,29 @@ impl Editor {
             let is_active = status
                 .map(|s| !matches!(s, LspServerStatus::Shutdown))
                 .unwrap_or(false);
+            // A server is "missing" only when it's NOT currently running
+            // (an absolute-path binary could have been removed mid-session,
+            // but the live server is still talking to us).
+            let binary_missing =
+                !is_active && missing_by_server.get(name).copied().unwrap_or(false);
 
             // Header: server name + status (data = None → not clickable,
-            // not underlined).
+            // not underlined).  Swap the "not running" label for a more
+            // actionable "binary not found" when we can see up-front that
+            // a start attempt would fail — this is the user-visible half
+            // of the pre-click probe.
             let (icon, label) = match status {
                 Some(LspServerStatus::Running) => ("●", "ready"),
                 Some(LspServerStatus::Error) => ("✗", "error"),
                 Some(LspServerStatus::Starting) => ("◌", "starting"),
                 Some(LspServerStatus::Initializing) => ("◌", "initializing"),
-                Some(LspServerStatus::Shutdown) | None => ("○", "not running"),
+                Some(LspServerStatus::Shutdown) | None => {
+                    if binary_missing {
+                        ("○", "binary not in PATH")
+                    } else {
+                        ("○", "not running")
+                    }
+                }
             };
             items.push(crate::view::popup::PopupListItem::new(format!(
                 "{} {} ({})",
@@ -1991,6 +2050,19 @@ impl Editor {
                         .with_data(stop_key.clone()),
                 );
                 action_keys.push((stop_key, format!("Stop {}", name)));
+            } else if binary_missing {
+                // Show a disabled advisory row instead of an actionable
+                // "Start" — clicking Start here would spawn, fail, and
+                // noise up the status area.  The per-language
+                // Install/Dismiss actions are added once at the end of
+                // the popup, below.
+                items.push(
+                    crate::view::popup::PopupListItem::new(format!(
+                        "    Install {} to enable",
+                        name
+                    ))
+                    .disabled(),
+                );
             } else {
                 // Start
                 let start_key = format!("start:{}", language);
@@ -2002,6 +2074,34 @@ impl Editor {
                     action_keys.push((start_key, format!("Start {}", name)));
                 }
             }
+        }
+
+        // Dismiss / Enable row — shown whenever the language has at
+        // least one configured server.  Gives the user a surface to
+        // mute the pill (dim style) and, later, to restore it.  We
+        // reuse `all_servers.is_empty()` as the "nothing here" signal
+        // since languages with zero configured-or-running servers
+        // already bailed out above.
+        if user_dismissed {
+            let enable_key = format!("enable:{}", language);
+            items.push(
+                crate::view::popup::PopupListItem::new(format!(
+                    "    Enable LSP pill for {}",
+                    language
+                ))
+                .with_data(enable_key.clone()),
+            );
+            action_keys.push((enable_key, format!("Enable LSP for {}", language)));
+        } else {
+            let dismiss_key = format!("dismiss:{}", language);
+            items.push(
+                crate::view::popup::PopupListItem::new(format!(
+                    "    Disable LSP pill for {}",
+                    language
+                ))
+                .with_data(dismiss_key.clone()),
+            );
+            action_keys.push((dismiss_key, format!("Disable LSP for {}", language)));
         }
 
         // View log action (always, at the end) — grayed out and

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -312,6 +312,25 @@ impl Editor {
         }
     }
 
+    /// Is the given language currently user-dismissed via the LSP popup?
+    pub fn is_lsp_language_user_dismissed(&self, language: &str) -> bool {
+        self.user_dismissed_lsp_languages.contains(language)
+    }
+
+    /// Dismiss the LSP pill for a language until the next editor session
+    /// (or until the user re-enables it from the popup). See docs on
+    /// `Editor::user_dismissed_lsp_languages` for the rationale.
+    pub fn dismiss_lsp_language(&mut self, language: &str) {
+        self.user_dismissed_lsp_languages
+            .insert(language.to_string());
+    }
+
+    /// Undo a previous dismissal — the pill returns to the normal
+    /// yellow `LSP (off)` for this language.
+    pub fn undismiss_lsp_language(&mut self, language: &str) {
+        self.user_dismissed_lsp_languages.remove(language);
+    }
+
     /// Handle an action from the LSP status details popup.
     ///
     /// Action keys have the format:
@@ -319,6 +338,8 @@ impl Editor {
     /// - `start:<language>` — start LSP server(s) for a language
     /// - `stop:<language>/<server_name>` — stop a specific server
     /// - `log:<language>` — open the LSP log file for the language
+    /// - `dismiss:<language>` — hide the pill for this language (dim style)
+    /// - `enable:<language>` — restore a dismissed language's pill
     pub fn handle_lsp_status_action(&mut self, action_key: &str) {
         if let Some(language) = action_key.strip_prefix("start:") {
             // Start/restart LSP for this language (same as the "Start/Restart LSP" command)
@@ -392,6 +413,15 @@ impl Editor {
             } else {
                 self.status_message = Some(format!("No log file found for {}", language));
             }
+        } else if let Some(language) = action_key.strip_prefix("dismiss:") {
+            self.dismiss_lsp_language(language);
+            self.status_message = Some(format!(
+                "LSP pill dimmed for {}. Click it to re-enable.",
+                language
+            ));
+        } else if let Some(language) = action_key.strip_prefix("enable:") {
+            self.undismiss_lsp_language(language);
+            self.status_message = Some(format!("LSP pill restored for {}.", language));
         }
     }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -793,6 +793,15 @@ pub struct Editor {
     /// Contains the list of (action_key, label) pairs for the popup items.
     pending_lsp_status_popup: Option<Vec<(String, String)>>,
 
+    /// Languages the user has interactively dismissed from the LSP popup.
+    ///
+    /// Separate from `LspServerConfig::enabled` (which is the persisted
+    /// config flag) so we can keep the status-bar pill visible in a
+    /// muted style — giving the user a re-enable surface without
+    /// mutating their on-disk config. Session-scoped; dismissal does not
+    /// survive editor restarts.
+    user_dismissed_lsp_languages: std::collections::HashSet<String>,
+
     /// Pending close buffer - buffer to close after SaveFileAs completes
     /// Used when closing a modified buffer that needs to be saved first
     pending_close_buffer: Option<BufferId>,
@@ -1674,6 +1683,7 @@ impl Editor {
             chord_state: Vec::new(),
             pending_lsp_confirmation: None,
             pending_lsp_status_popup: None,
+            user_dismissed_lsp_languages: std::collections::HashSet::new(),
             pending_close_buffer: None,
             auto_revert_enabled: true,
             last_auto_revert_poll: time_source.now(),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -32,6 +32,7 @@ fn compose_lsp_status(
     lsp_progress: &HashMap<String, LspProgressInfo>,
     lsp_server_statuses: &HashMap<(String, String), crate::services::async_bridge::LspServerStatus>,
     lsp_config: &HashMap<String, crate::types::LspLanguageConfig>,
+    user_dismissed_languages: &std::collections::HashSet<String>,
 ) -> (String, crate::view::ui::status_bar::LspIndicatorState) {
     use crate::services::async_bridge::LspServerStatus;
     use crate::view::ui::status_bar::LspIndicatorState;
@@ -127,7 +128,17 @@ fn compose_lsp_status(
         })
         .unwrap_or(0);
     if configured_count > 0 {
-        return (centered("LSP (off)"), LspIndicatorState::Off);
+        // User-dismissed languages keep the same `LSP (off)` text — only
+        // the style changes (handled by `element_style` via the
+        // `OffDismissed` variant).  We deliberately keep the pill
+        // visible rather than hiding it, so the user retains a
+        // discoverable surface to re-enable or view install help.
+        let state = if user_dismissed_languages.contains(current_language) {
+            LspIndicatorState::OffDismissed
+        } else {
+            LspIndicatorState::Off
+        };
+        return (centered("LSP (off)"), state);
     }
 
     // 5. Nothing configured and nothing running — no indicator.
@@ -741,6 +752,7 @@ impl Editor {
             &self.lsp_progress,
             &self.lsp_server_statuses,
             &self.config.lsp,
+            &self.user_dismissed_lsp_languages,
         );
         let theme = self.theme.clone();
         let keybindings_cloned = self.keybindings.read().unwrap().clone(); // Clone the keybindings

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -2634,40 +2634,15 @@ impl LspTask {
         })
     }
 
-    /// Check if a command exists in PATH or as an absolute path
-    fn command_exists(command: &str) -> bool {
-        use std::path::Path;
-
-        // If it's an absolute path, check if the file exists and is executable
-        if command.contains('/') || command.contains('\\') {
-            let path = Path::new(command);
-            return path.exists() && path.is_file();
-        }
-
-        // Otherwise, search in PATH
-        if let Ok(path_var) = std::env::var("PATH") {
-            #[cfg(unix)]
-            let separator = ':';
-            #[cfg(windows)]
-            let separator = ';';
-
-            for dir in path_var.split(separator) {
-                let full_path = Path::new(dir).join(command);
-                if full_path.exists() && full_path.is_file() {
-                    return true;
-                }
-                // On Windows, also check with .exe extension
-                #[cfg(windows)]
-                {
-                    let with_exe = Path::new(dir).join(format!("{}.exe", command));
-                    if with_exe.exists() && with_exe.is_file() {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        false
+    /// Check if a command exists in PATH or as an absolute path.
+    ///
+    /// Thin wrapper that forwards to the module-level
+    /// [`super::command_exists`] — the shared implementation lives at the
+    /// module root so the click-time probe (and any future non-spawn
+    /// callers) can reuse it without depending on the private
+    /// `LspTask` type.
+    pub(crate) fn command_exists(command: &str) -> bool {
+        super::command_exists_uncached(command)
     }
 
     /// Spawn the stdout reader task that continuously reads and dispatches LSP messages

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -2642,7 +2642,7 @@ impl LspTask {
     /// callers) can reuse it without depending on the private
     /// `LspTask` type.
     pub(crate) fn command_exists(command: &str) -> bool {
-        super::command_exists_uncached(command)
+        super::command_exists(command)
     }
 
     /// Spawn the stdout reader task that continuously reads and dispatches LSP messages

--- a/crates/fresh-editor/src/services/lsp/mod.rs
+++ b/crates/fresh-editor/src/services/lsp/mod.rs
@@ -121,3 +121,84 @@ pub mod semantic_tokens;
 
 // Re-export for public API (used by tests)
 pub use crate::types::LspServerConfig;
+
+/// Uncached check: does `command` resolve to an executable file?
+///
+/// - Absolute / path-containing commands: stat the file directly.
+/// - Bare names: walk `$PATH`, matching the first file-backed entry.
+/// - On Windows, also probes a `.exe` suffix.
+///
+/// Returns `false` for empty strings so callers don't need to special-case
+/// unset-command configs.
+pub(crate) fn command_exists_uncached(command: &str) -> bool {
+    use std::path::Path;
+
+    if command.is_empty() {
+        return false;
+    }
+
+    if command.contains('/') || command.contains('\\') {
+        let path = Path::new(command);
+        return path.exists() && path.is_file();
+    }
+
+    if let Ok(path_var) = std::env::var("PATH") {
+        #[cfg(unix)]
+        let separator = ':';
+        #[cfg(windows)]
+        let separator = ';';
+
+        for dir in path_var.split(separator) {
+            let full_path = Path::new(dir).join(command);
+            if full_path.exists() && full_path.is_file() {
+                return true;
+            }
+            #[cfg(windows)]
+            {
+                let with_exe = Path::new(dir).join(format!("{}.exe", command));
+                if with_exe.exists() && with_exe.is_file() {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
+
+/// Check whether an LSP server command is available on the current system,
+/// with a short TTL cache so repeat clicks on the status-bar indicator (or
+/// back-to-back spawn attempts) don't re-stat every PATH entry.
+///
+/// The cache TTL is deliberately short — users install missing binaries
+/// during a session and expect the indicator/popup to reflect that without
+/// a restart. One second is long enough to coalesce UI-driven probes
+/// (render, popup open, spawn attempt) and short enough that "I just
+/// installed pylsp" works on the next click.
+pub fn command_exists(command: &str) -> bool {
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    static CACHE: once_cell::sync::Lazy<Mutex<std::collections::HashMap<String, (Instant, bool)>>> =
+        once_cell::sync::Lazy::new(|| Mutex::new(std::collections::HashMap::new()));
+
+    const TTL: Duration = Duration::from_secs(1);
+
+    if command.is_empty() {
+        return false;
+    }
+
+    {
+        let cache = CACHE.lock().unwrap();
+        if let Some((when, exists)) = cache.get(command) {
+            if when.elapsed() < TTL {
+                return *exists;
+            }
+        }
+    }
+
+    let exists = command_exists_uncached(command);
+    let mut cache = CACHE.lock().unwrap();
+    cache.insert(command.to_string(), (Instant::now(), exists));
+    exists
+}

--- a/crates/fresh-editor/src/services/lsp/mod.rs
+++ b/crates/fresh-editor/src/services/lsp/mod.rs
@@ -124,9 +124,16 @@ pub use crate::types::LspServerConfig;
 
 /// Check whether an LSP server command is resolvable as an executable.
 ///
-/// - Absolute / path-containing commands: stat the file directly.
-/// - Bare names: walk `$PATH`, matching the first file-backed entry.
-/// - On Windows, also probes a `.exe` suffix.
+/// Delegates to the `which` crate, which handles the cross-platform
+/// edge cases our previous hand-rolled probe missed:
+///
+/// - **Windows `PATHEXT`**: Node-based LSPs (`typescript-language-server`,
+///   `vscode-html-language-server`, etc.) install as `.cmd` shims under
+///   `npm -g`. A bare `.exe` check treated those as missing.
+/// - **Unix executable bit**: `path.is_file()` is true for non-executable
+///   files; `which` additionally checks `mode & 0o111 != 0`.
+/// - **Symlinks, broken symlinks, absolute-path commands, quoted PATH
+///   entries, and Windows App Execution Aliases** — all handled.
 ///
 /// Returns `false` for empty strings so callers don't need to special-case
 /// unset-command configs.
@@ -137,37 +144,8 @@ pub use crate::types::LspServerConfig;
 /// actively hurt: freshly-installed binaries wouldn't be picked up until
 /// the TTL expired.
 pub fn command_exists(command: &str) -> bool {
-    use std::path::Path;
-
     if command.is_empty() {
         return false;
     }
-
-    if command.contains('/') || command.contains('\\') {
-        let path = Path::new(command);
-        return path.exists() && path.is_file();
-    }
-
-    if let Ok(path_var) = std::env::var("PATH") {
-        #[cfg(unix)]
-        let separator = ':';
-        #[cfg(windows)]
-        let separator = ';';
-
-        for dir in path_var.split(separator) {
-            let full_path = Path::new(dir).join(command);
-            if full_path.exists() && full_path.is_file() {
-                return true;
-            }
-            #[cfg(windows)]
-            {
-                let with_exe = Path::new(dir).join(format!("{}.exe", command));
-                if with_exe.exists() && with_exe.is_file() {
-                    return true;
-                }
-            }
-        }
-    }
-
-    false
+    which::which(command).is_ok()
 }

--- a/crates/fresh-editor/src/services/lsp/mod.rs
+++ b/crates/fresh-editor/src/services/lsp/mod.rs
@@ -122,7 +122,7 @@ pub mod semantic_tokens;
 // Re-export for public API (used by tests)
 pub use crate::types::LspServerConfig;
 
-/// Uncached check: does `command` resolve to an executable file?
+/// Check whether an LSP server command is resolvable as an executable.
 ///
 /// - Absolute / path-containing commands: stat the file directly.
 /// - Bare names: walk `$PATH`, matching the first file-backed entry.
@@ -130,7 +130,13 @@ pub use crate::types::LspServerConfig;
 ///
 /// Returns `false` for empty strings so callers don't need to special-case
 /// unset-command configs.
-pub(crate) fn command_exists_uncached(command: &str) -> bool {
+///
+/// Intentionally uncached: called at most a few times per user-driven
+/// action (pill click, spawn attempt) and the OS dentry cache already
+/// makes repeat `$PATH` walks essentially free. A stale cache would
+/// actively hurt: freshly-installed binaries wouldn't be picked up until
+/// the TTL expired.
+pub fn command_exists(command: &str) -> bool {
     use std::path::Path;
 
     if command.is_empty() {
@@ -164,41 +170,4 @@ pub(crate) fn command_exists_uncached(command: &str) -> bool {
     }
 
     false
-}
-
-/// Check whether an LSP server command is available on the current system,
-/// with a short TTL cache so repeat clicks on the status-bar indicator (or
-/// back-to-back spawn attempts) don't re-stat every PATH entry.
-///
-/// The cache TTL is deliberately short — users install missing binaries
-/// during a session and expect the indicator/popup to reflect that without
-/// a restart. One second is long enough to coalesce UI-driven probes
-/// (render, popup open, spawn attempt) and short enough that "I just
-/// installed pylsp" works on the next click.
-pub fn command_exists(command: &str) -> bool {
-    use std::sync::Mutex;
-    use std::time::{Duration, Instant};
-
-    static CACHE: once_cell::sync::Lazy<Mutex<std::collections::HashMap<String, (Instant, bool)>>> =
-        once_cell::sync::Lazy::new(|| Mutex::new(std::collections::HashMap::new()));
-
-    const TTL: Duration = Duration::from_secs(1);
-
-    if command.is_empty() {
-        return false;
-    }
-
-    {
-        let cache = CACHE.lock().unwrap();
-        if let Some((when, exists)) = cache.get(command) {
-            if when.elapsed() < TTL {
-                return *exists;
-            }
-        }
-    }
-
-    let exists = command_exists_uncached(command);
-    let mut cache = CACHE.lock().unwrap();
-    cache.insert(command.to_string(), (Instant::now(), exists));
-    exists
 }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -60,16 +60,22 @@ struct RenderedElement {
 /// nothing" fan-out into the three user-meaningful buckets the indicator
 /// actually needs to communicate:
 ///
-/// - `On`    — at least one server for this language is running
-/// - `Off`   — configured servers exist for this language, none are running
-/// - `Error` — at least one server for this language is in the Error state
-/// - `None`  — no LSP configured or running for this language
+/// - `On`            — at least one server for this language is running
+/// - `Off`           — configured servers exist for this language, none are running
+/// - `OffDismissed`  — like `Off`, but the user clicked "Disable" from the
+///                     popup; rendered with a muted style so it stops
+///                     shouting for attention while remaining clickable
+///                     (so the user can still open the popup to re-enable
+///                     or see install help).
+/// - `Error`         — at least one server for this language is in the Error state
+/// - `None`          — no LSP configured or running for this language
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum LspIndicatorState {
     #[default]
     None,
     On,
     Off,
+    OffDismissed,
     Error,
 }
 
@@ -832,6 +838,14 @@ impl StatusBarRenderer {
                         (theme.diagnostic_warning_fg, theme.diagnostic_warning_bg)
                     }
                     LspIndicatorState::On => (theme.diagnostic_info_fg, theme.diagnostic_info_bg),
+                    // Dismissed: fall back to the neutral status-bar
+                    // palette so the pill reads as low-priority.  We
+                    // intentionally don't introduce a dedicated theme
+                    // key — every theme already carries the plain
+                    // status-bar fg/bg, which reliably produces a
+                    // "muted" look next to the vivid error/warning/info
+                    // palettes above.
+                    LspIndicatorState::OffDismissed => (theme.status_bar_fg, theme.status_bar_bg),
                     LspIndicatorState::None => (theme.status_bar_fg, theme.status_bar_bg),
                 };
                 let mut style = Style::default().fg(fg).bg(bg);

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -1,0 +1,233 @@
+//! E2E tests: status-bar LSP indicator pre-click binary probe and the
+//! user-dismiss / re-enable flow.
+//!
+//! These tests cover the second-phase improvement documented in
+//! `CHANGELOG.md`: configured-but-dormant LSP servers are now probed
+//! for binary presence when the user opens the status popup, and the
+//! user has a surface in the popup to mute ("Disable LSP pill for …")
+//! or restore ("Enable LSP pill for …") the indicator without editing
+//! their on-disk config.
+//!
+//! The tests intentionally don't spawn real language servers — they
+//! drive the `LspServerConfig` + runtime state directly and read back
+//! via the public harness + editor accessors. The goal is to pin the
+//! *UX*: what rows appear in the popup, what happens to the indicator
+//! state when a row is invoked, and that the state transitions round
+//! trip cleanly.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+
+fn make_config_with_missing_rust_lsp() -> fresh::config::Config {
+    let mut config = fresh::config::Config::default();
+    // Deliberately point at a path that does NOT resolve on $PATH or
+    // disk, so the pre-click binary probe buckets this server into
+    // "missing". The command name includes a unique suffix so unrelated
+    // binaries installed on the test host can't accidentally satisfy
+    // the probe.
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "this-binary-definitely-does-not-exist-xyz123".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: false,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("fake-rust-analyzer".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+    config
+}
+
+/// Collect the currently-visible popup's list item text lines, in order.
+fn popup_items(harness: &EditorTestHarness) -> Vec<(String, Option<String>, bool)> {
+    harness
+        .editor()
+        .active_state()
+        .popups
+        .top()
+        .map(|p| match &p.content {
+            fresh::view::popup::PopupContent::List { items, .. } => items
+                .iter()
+                .map(|i| (i.text.clone(), i.data.clone(), i.disabled))
+                .collect(),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default()
+}
+
+/// Opening the LSP status popup for a language whose configured server
+/// binary cannot be found must:
+///   1. Annotate the server row with "binary not in PATH".
+///   2. Replace the usual actionable "Start …" row with a disabled
+///      advisory "Install … to enable".
+///   3. Offer a "Disable LSP pill for {lang}" action.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_missing_binary_popup_shows_advisory_and_dismiss() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_missing_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+
+    // The dormant indicator should appear — pre-condition for the rest
+    // of the test. Without it, the popup contents are a distraction
+    // because the real issue is upstream.
+    harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
+
+    // Open the popup the same way the status-bar click handler would.
+    harness.editor_mut().show_lsp_status_popup();
+
+    let items = popup_items(&harness);
+    assert!(!items.is_empty(), "LSP status popup should have items");
+
+    // 1. Header row reports the missing binary.
+    let header_row = items
+        .iter()
+        .find(|(t, _, _)| t.contains("fake-rust-analyzer"))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected a header row for fake-rust-analyzer, got: {:#?}",
+                items
+            )
+        });
+    assert!(
+        header_row.0.contains("binary not in PATH"),
+        "header row must annotate the missing binary. Row: {:?}",
+        header_row
+    );
+
+    // 2. No actionable "Start …" row; instead, a disabled advisory.
+    let start_row = items.iter().find(|(_, data, _)| {
+        data.as_deref()
+            .map(|d| d.starts_with("start:"))
+            .unwrap_or(false)
+    });
+    assert!(
+        start_row.is_none(),
+        "must NOT add a Start row for a missing-binary language. Items: {:#?}",
+        items
+    );
+    let install_row = items
+        .iter()
+        .find(|(t, _, _)| t.contains("Install fake-rust-analyzer"));
+    assert!(
+        install_row.is_some() && install_row.unwrap().2,
+        "expected a disabled 'Install …' advisory row. Items: {:#?}",
+        items
+    );
+
+    // 3. Dismiss action present.
+    let dismiss_row = items.iter().find(|(_, data, _)| {
+        data.as_deref()
+            .map(|d| d == "dismiss:rust")
+            .unwrap_or(false)
+    });
+    assert!(
+        dismiss_row.is_some(),
+        "expected a 'Disable LSP pill for rust' row. Items: {:#?}",
+        items
+    );
+
+    Ok(())
+}
+
+/// Dismissing a language transitions the indicator to the muted
+/// `OffDismissed` variant and surfaces an "Enable LSP pill for …"
+/// action in the popup. Re-enabling restores the yellow `Off` variant
+/// and the original "Disable …" action.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_missing_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
+
+    // Precondition: not dismissed.
+    assert!(
+        !harness.editor().is_lsp_language_user_dismissed("rust"),
+        "precondition: should not be dismissed"
+    );
+
+    // Dismiss directly through the action handler — this is what the
+    // popup dispatches when the user picks the "Disable LSP pill" row.
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("dismiss:rust");
+    assert!(
+        harness.editor().is_lsp_language_user_dismissed("rust"),
+        "after dismiss, language should be marked dismissed"
+    );
+
+    // Text of the pill stays `LSP (off)` — only the style changes,
+    // which is carried by `LspIndicatorState::OffDismissed` inside the
+    // render path (not observable from plain text).
+    let _ = harness.render();
+    assert!(
+        harness.get_status_bar().contains("LSP (off)"),
+        "text does not change on dismiss. status bar: {}",
+        harness.get_status_bar()
+    );
+
+    // Re-enable round-trips cleanly.
+    harness.editor_mut().handle_lsp_status_action("enable:rust");
+    assert!(
+        !harness.editor().is_lsp_language_user_dismissed("rust"),
+        "after enable, language should no longer be dismissed"
+    );
+
+    // Open the popup and confirm the action row text flipped back to
+    // the "Disable" form.
+    harness.editor_mut().show_lsp_status_popup();
+    let items = popup_items(&harness);
+    assert!(
+        items
+            .iter()
+            .any(|(_, data, _)| data.as_deref() == Some("dismiss:rust")),
+        "re-enabled state should show the Disable action again. Items: {:#?}",
+        items
+    );
+
+    // Dismiss once more and verify the popup now offers Enable.
+    // `show_lsp_status_popup` toggles, so call it to close first.
+    harness.editor_mut().show_lsp_status_popup();
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("dismiss:rust");
+    harness.editor_mut().show_lsp_status_popup();
+    let items = popup_items(&harness);
+    assert!(
+        items
+            .iter()
+            .any(|(_, data, _)| data.as_deref() == Some("enable:rust")),
+        "dismissed state should offer Enable action. Items: {:#?}",
+        items
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -67,6 +67,7 @@ pub mod lsp_diagnostic_flow;
 pub mod lsp_env;
 pub mod lsp_goto_definition_readonly;
 pub mod lsp_lifecycle_visibility;
+pub mod lsp_missing_binary_and_dismiss;
 pub mod lsp_multi_semantic_tokens;
 pub mod lsp_no_config;
 pub mod lsp_order;


### PR DESCRIPTION
## Summary

The status-bar `LSP (off)` pill previously conflated three distinct states: a configured server that simply hasn't been started, a server whose binary isn't installed at all, and a server the user has chosen to ignore. All three rendered identically in yellow, and the "binary missing" case was only discoverable by clicking Start and watching the spawn fail.

This PR probes binary availability when the user opens the LSP status popup and adds a dismissible variant of the pill so the user can mute it without editing their config.

## User-visible changes

- **Binary-missing detection in the popup.** Clicking the pill runs a cheap `$PATH` probe per configured server. Rows whose binary can't be found show `(binary not in PATH)` in the status line and replace the actionable `Start …` row with a disabled `Install … to enable` advisory — no more spawn-and-fail round trip to discover a missing install.
- **Dismissable pill.** Every popup gains a trailing toggle: `Disable LSP pill for {lang}` (or `Enable LSP pill for {lang}` once dismissed). Dismissing keeps the pill visible with the `LSP (off)` text but renders it in the neutral status-bar palette instead of the warning yellow — so it stops shouting, while remaining a clickable re-enable surface. Dismissal is session-scoped and does **not** touch the on-disk config.
- **Pill text is unchanged** in every state; only the style differentiates `Off` (yellow) from `OffDismissed` (muted).

## Plugin-facing changes

`lsp_status_clicked` hook payload is extended with:

- `missing_servers: string[]` — commands whose binaries aren't resolvable on this system.
- `user_dismissed: boolean` — whether the pill is currently dismissed for this language.

Plugins that currently gate on `has_error` (the ~15 `*-lsp.ts` install helpers) keep working unchanged; new plugins can drop the "wait for a failed spawn" pattern and react to the same signals the core popup uses.

## Implementation notes

- `services/lsp::command_exists` lifted to a module-level helper so the popup code and the spawn path share one implementation. No cache — repeat PATH walks hit the OS dentry cache and are effectively free; a TTL would only add staleness after a user installs a missing binary mid-session.
- `Editor::user_dismissed_lsp_languages: HashSet<String>` is runtime state only — the existing two-flag `enabled` / `auto_start` schema is untouched for backward compatibility with user configs.
- New `LspIndicatorState::OffDismissed` reuses the existing neutral status-bar fg/bg instead of introducing a new theme key (every theme already carries it).
- `compose_lsp_status` now takes the dismissed set and returns `OffDismissed` when every configured server for the language is dismissed.
- The spawn-failure path (`lsp_server_error` with `error_type: "not_found"`) is unchanged — existing plugin install helpers still catch the case where the user reaches Start some other way (command palette, keyboard shortcut).

## Out of scope (deferred)

- Install hints in config / plugin registry (copy-paste install commands in the popup).
- Consolidating the per-language `*-lsp.ts` install-popup boilerplate into a shared helper.
- Persisting dismissal across sessions.

## Test plan

- [x] `cargo test --test e2e_tests lsp_missing_binary_and_dismiss` — new suite passes (2/2).
- [x] `cargo test --test e2e_tests lsp_lifecycle_visibility` — unchanged (4/4).
- [x] `cargo test --test e2e_tests lsp_stop_stale_indicator` — unchanged (1/1).
- [x] `cargo test --test e2e_tests warning_indicators` — unchanged (9/9).
- [x] Reproduced the original bug in `tmux` with a debug build, opening Python/JS/TS/C/Go/Rust files on a host where only `rust-analyzer` is installed — confirmed every language rendered `LSP (off)` identically before the fix.
- [ ] Manual verification that the popup shows the new rows on the reproduction setup.

https://claude.ai/code/session_01AFurVGeD3hvScFtRJgXShW