### PR TITLE
Fix markdown compose mouse-wheel scroll and table rendering

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1066,10 +1066,13 @@ pub enum PluginCommand {
         position: usize,
         /// Full line content to display
         text: String,
-        /// Foreground color (RGB)
-        fg_color: (u8, u8, u8),
-        /// Background color (RGB), None = transparent
-        bg_color: Option<(u8, u8, u8)>,
+        /// Foreground color — RGB tuple or theme key string (e.g.
+        /// `"editor.line_number_fg"`).  Resolved at render time so the line
+        /// follows theme changes.
+        fg_color: Option<OverlayColorSpec>,
+        /// Background color — RGB tuple or theme key string.  None =
+        /// transparent (inherits from underlying viewport background).
+        bg_color: Option<OverlayColorSpec>,
         /// true = above the line containing position, false = below
         above: bool,
         /// Namespace for bulk removal (e.g., "git-blame")

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Otevřeno %{name}",
   "buffer.opened_binary": "Otevřeno %{name} [binární soubor, pouze pro čtení]",
   "buffer.preview_indicator": "(náhled)",
+  "buffer.switched": "Přepnuto na %{name}",
   "buffer.create_directory_confirm": "Adresář '%{name}' neexistuje. (v)ytvořit, (Z)rušit? ",
   "buffer.overwrite_confirm": "'%{name}' existuje. (p)řepsat, (Z)rušit? ",
   "buffer.revert_cancelled": "Obnovení zrušeno",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -304,6 +304,7 @@
   "buffer.opened": "%{name} geöffnet",
   "buffer.opened_binary": "%{name} geöffnet [Binärdatei, schreibgeschützt]",
   "buffer.preview_indicator": "(Vorschau)",
+  "buffer.switched": "Zu %{name} gewechselt",
   "buffer.create_directory_confirm": "Verzeichnis '%{name}' existiert nicht. (e)rstellen, (A)bbrechen? ",
   "buffer.overwrite_confirm": "'%{name}' existiert. (ü)berschreiben, (A)bbrechen? ",
   "buffer.revert_cancelled": "Zurücksetzen abgebrochen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -302,6 +302,7 @@
   "buffer.opened": "Opened %{name}",
   "buffer.opened_binary": "Opened %{name} [binary file, read-only]",
   "buffer.preview_indicator": "(preview)",
+  "buffer.switched": "Switched to %{name}",
   "buffer.create_directory_confirm": "Directory '%{name}' does not exist. (c)reate, (A)bort? ",
   "buffer.overwrite_confirm": "'%{name}' exists. (o)verwrite, (C)ancel? ",
   "buffer.revert_cancelled": "Revert cancelled",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Abierto %{name}",
   "buffer.opened_binary": "Abierto %{name} [archivo binario, solo lectura]",
   "buffer.preview_indicator": "(vista previa)",
+  "buffer.switched": "Cambiado a %{name}",
   "buffer.create_directory_confirm": "El directorio '%{name}' no existe. (c)rear, (C)ancelar? ",
   "buffer.overwrite_confirm": "'%{name}' existe. (s)obrescribir, (C)ancelar? ",
   "buffer.revert_cancelled": "Reversión cancelada",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -304,6 +304,7 @@
   "buffer.opened": "%{name} ouvert",
   "buffer.opened_binary": "%{name} ouvert [fichier binaire, lecture seule]",
   "buffer.preview_indicator": "(aperçu)",
+  "buffer.switched": "Basculé vers %{name}",
   "buffer.create_directory_confirm": "Le répertoire '%{name}' n'existe pas. (c)réer, (A)nnuler ? ",
   "buffer.overwrite_confirm": "'%{name}' existe. (é)craser, (A)nnuler ? ",
   "buffer.revert_cancelled": "Restauration annulée",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Aperto %{name}",
   "buffer.opened_binary": "Aperto %{name} [file binario, sola lettura]",
   "buffer.preview_indicator": "(anteprima)",
+  "buffer.switched": "Passato a %{name}",
   "buffer.create_directory_confirm": "La directory '%{name}' non esiste. (c)rea, (A)nnulla? ",
   "buffer.overwrite_confirm": "'%{name}' esiste già. (o)vrascrivi, (A)nnulla? ",
   "buffer.revert_cancelled": "Ripristino annullato",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -304,6 +304,7 @@
   "buffer.opened": "%{name}を開きました",
   "buffer.opened_binary": "%{name}を開きました [バイナリファイル、読み取り専用]",
   "buffer.preview_indicator": "(プレビュー)",
+  "buffer.switched": "%{name} に切り替えました",
   "buffer.create_directory_confirm": "ディレクトリ '%{name}' は存在しません。(c)作成, (A)中止? ",
   "buffer.overwrite_confirm": "'%{name}' は存在します。(o)上書き, (C)キャンセル? ",
   "buffer.revert_cancelled": "元に戻すをキャンセル",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -304,6 +304,7 @@
   "buffer.opened": "%{name} 열림",
   "buffer.opened_binary": "%{name} 열림 [바이너리 파일, 읽기 전용]",
   "buffer.preview_indicator": "(미리 보기)",
+  "buffer.switched": "%{name}(으)로 전환됨",
   "buffer.create_directory_confirm": "디렉토리 '%{name}'이(가) 존재하지 않습니다. (c)생성, (A)취소? ",
   "buffer.overwrite_confirm": "'%{name}' 존재함. (o)덮어쓰기, (C)취소? ",
   "buffer.revert_cancelled": "되돌리기 취소됨",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Aberto %{name}",
   "buffer.opened_binary": "Aberto %{name} [arquivo binário, somente leitura]",
   "buffer.preview_indicator": "(visualização)",
+  "buffer.switched": "Alternado para %{name}",
   "buffer.create_directory_confirm": "O diretório '%{name}' não existe. (c)riar, (C)ancelar? ",
   "buffer.overwrite_confirm": "'%{name}' existe. (s)obrescrever, (C)ancelar? ",
   "buffer.revert_cancelled": "Reversão cancelada",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Открыт %{name}",
   "buffer.opened_binary": "Открыт %{name} [бинарный файл, только чтение]",
   "buffer.preview_indicator": "(предпросмотр)",
+  "buffer.switched": "Переключено на %{name}",
   "buffer.create_directory_confirm": "Каталог '%{name}' не существует. (с)оздать, (О)тмена? ",
   "buffer.overwrite_confirm": "'%{name}' существует. (п)ерезаписать, (О)тмена? ",
   "buffer.revert_cancelled": "Откат отменён",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -304,6 +304,7 @@
   "buffer.opened": "เปิด %{name} แล้ว",
   "buffer.opened_binary": "เปิด %{name} แล้ว [ไฟล์ไบนารี, อ่านอย่างเดียว]",
   "buffer.preview_indicator": "(แสดงตัวอย่าง)",
+  "buffer.switched": "สลับไปที่ %{name}",
   "buffer.create_directory_confirm": "ไดเรกทอรี '%{name}' ไม่มีอยู่ (c)สร้าง, (A)ยกเลิก? ",
   "buffer.overwrite_confirm": "'%{name}' มีอยู่แล้ว. (o)เขียนทับ, (C)ยกเลิก? ",
   "buffer.revert_cancelled": "ยกเลิกการย้อนกลับ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Відкрито %{name}",
   "buffer.opened_binary": "Відкрито %{name} [двійковий файл, лише читання]",
   "buffer.preview_indicator": "(попередній перегляд)",
+  "buffer.switched": "Переключено на %{name}",
   "buffer.create_directory_confirm": "Каталог '%{name}' не існує. (с)творити, (С)касувати? ",
   "buffer.overwrite_confirm": "'%{name}' існує. (п)ерезаписати, (С)касувати? ",
   "buffer.revert_cancelled": "Відновлення скасовано",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -304,6 +304,7 @@
   "buffer.opened": "Đã mở %{name}",
   "buffer.opened_binary": "Đã mở %{name} [tệp nhị phân, chỉ đọc]",
   "buffer.preview_indicator": "(xem trước)",
+  "buffer.switched": "Đã chuyển sang %{name}",
   "buffer.create_directory_confirm": "Thư mục '%{name}' không tồn tại. (c) Tạo, (H) Hủy? ",
   "buffer.overwrite_confirm": "'%{name}' đã tồn tại. (o) Ghi đè, (C) Hủy? ",
   "buffer.revert_cancelled": "Đã hủy hoàn nguyên",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -304,6 +304,7 @@
   "buffer.opened": "已打开%{name}",
   "buffer.opened_binary": "已打开%{name} [二进制文件，只读]",
   "buffer.preview_indicator": "(预览)",
+  "buffer.switched": "已切换到 %{name}",
   "buffer.create_directory_confirm": "目录 '%{name}' 不存在。(c)创建，(A)取消？",
   "buffer.overwrite_confirm": "'%{name}' 已存在。(o)覆盖，(C)取消？",
   "buffer.revert_cancelled": "还原已取消",

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -381,12 +381,7 @@ function addBlameHeaders(): void {
       blameState.bufferId,
       block.startByte,        // anchor position
       headerText,             // text content
-      colors.headerFg[0],     // fg_r
-      colors.headerFg[1],     // fg_g
-      colors.headerFg[2],     // fg_b
-      colors.headerBg[0],     // bg_r
-      colors.headerBg[1],     // bg_g
-      colors.headerBg[2],     // bg_b
+      { fg: colors.headerFg, bg: colors.headerBg }, // colors (RGB tuples; passing theme key strings would also work)
       true,                   // above (LineAbove)
       BLAME_NAMESPACE,        // namespace for bulk removal
       0                       // priority

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1345,8 +1345,14 @@ interface EditorAPI {
 	clearVirtualTextNamespace(bufferId: number, namespace: string): boolean;
 	/**
 	* Add a virtual line (full line above/below a position)
+	* 
+	* The `options` object accepts:
+	* * `fg`, `bg` — either an `[r, g, b]` array (each `0..=255`) or a
+	* theme-key string (e.g. `"editor.line_number_fg"`).  Theme keys
+	* are resolved at render time so the line follows theme changes.
+	* Both default to `null` (no foreground / transparent background).
 	*/
-	addVirtualLine(bufferId: number, position: number, text: string, fgR: number, fgG: number, fgB: number, bgR: number, bgG: number, bgB: number, above: boolean, namespace: string, priority: number): boolean;
+	addVirtualLine(bufferId: number, position: number, text: string, options: Record<string, unknown>, above: boolean, namespace: string, priority: number): boolean;
 	/**
 	* Show a prompt and wait for user input (async)
 	* Returns the user input or null if cancelled

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -37,6 +37,11 @@ function setGlobalComposeEnabled(value: boolean): void {
 interface TableWidthInfo {
   maxW: number[];
   allocated: number[];
+  // True iff this row is the markdown source separator (`|---|---|---|`) — the
+  // border code uses this to avoid drawing a duplicate `├─┼─┤` next to it.
+  // Optional for backwards-compat with persisted view states from older
+  // sessions.
+  isSourceSep?: boolean;
 }
 
 // Helper: check whether the active split has compose mode for this buffer
@@ -89,6 +94,160 @@ const HTML_ENTITY_MAP: Record<string, string> = {
   yen: "\u00A5", cent: "\u00A2", sect: "\u00A7", para: "\u00B6",
   laquo: "\u00AB", raquo: "\u00BB", ensp: "\u2002", emsp: "\u2003", thinsp: "\u2009",
 };
+
+// =============================================================================
+// Table border virtual lines (top/bottom + inter-row separators)
+// =============================================================================
+//
+// Markdown tables source-encode only an underline-style separator between the
+// header and the first data row.  In compose mode we already conceal the
+// pipe characters into Unicode box-drawing (`│`, `├`, `┼`, `┤`).  This module
+// adds the *missing* visual frame: a `┌─┬─┐` top border above the header,
+// `├─┼─┤` separators between consecutive data rows (so each row reads as a
+// distinct cell), and a `└─┴─┘` bottom border below the last row.
+//
+// Implementation:
+//
+//   * Borders are virtual lines (no source bytes), keyed per-line via a
+//     unique namespace `md-tb-${lineNumber}`.  The namespace lets us
+//     clear+rebuild borders for one row without disturbing other tables.
+//   * "First/last/source-separator" classification is derived from the
+//     cached widthMap (a row is "known" iff it has a TableWidthInfo entry).
+//     This is cheap and stable across scrolls because widthMap accumulates.
+//   * Border column widths come from the same `allocated` widths used by
+//     processLineConceals, so the borders line up exactly with the cell
+//     conceals.
+
+/** Build a horizontal table border line of the given style for a row. */
+function buildTableBorderLine(
+  allocated: number[],
+  left: string,
+  mid: string,
+  right: string,
+): string {
+  // Each cell render is `│ <text padded to allocated[i] - 2> │` (2 chars of
+  // inside padding).  The matching border slot must therefore be
+  // `allocated[i]` wide of `─` characters between the corner/junction marks.
+  const parts: string[] = [];
+  for (let i = 0; i < allocated.length; i++) {
+    const fill = "─".repeat(Math.max(1, allocated[i]));
+    parts.push(fill);
+  }
+  return left + parts.join(mid) + right;
+}
+
+/** True if `lineContent` looks like a markdown table separator row. */
+function isTableSeparatorContent(lineContent: string): boolean {
+  return /^\|[-:\s|]+\|$/.test(lineContent.trim());
+}
+
+/** Re-emit the table border virtual lines for the given table-row group.
+ *
+ * Detects the group's first/last visible rows by consulting `widthMap`
+ * (which is updated by `processTableAlignment` before this runs).  A row at
+ * `lineNumber - 1` or `lineNumber + 1` that is *not* in `widthMap` is treated
+ * as the boundary of the table's visible extent.
+ */
+function processTableBorders(
+  bufferId: number,
+  lines: Array<{
+    line_number: number;
+    byte_start: number;
+    byte_end: number;
+    content: string;
+  }>,
+  widthMap: Map<number, TableWidthInfo>,
+): void {
+  // Light gray, on near-black (matches existing pipe→│ conceal styling).
+  const fg: [number, number, number] = [188, 188, 188];
+  const bg: [number, number, number] = [16, 16, 16];
+
+  for (const line of lines) {
+    const ns = `md-tb-${line.line_number}`;
+    // Always start by clearing this row's previous borders (handles
+    // edits that removed/widened the row, scrolls that change the
+    // first/last classification, etc.).
+    editor.clearVirtualTextNamespace(bufferId, ns);
+
+    const trimmed = line.content.trim();
+    const isTableRow = trimmed.startsWith("|") || trimmed.endsWith("|");
+    if (!isTableRow) continue;
+
+    const widthInfo = widthMap.get(line.line_number);
+    if (!widthInfo || widthInfo.allocated.length === 0) continue;
+
+    const allocated = widthInfo.allocated;
+    // Prefer the cached flag (set by processTableAlignment from the source
+    // text of this exact row); fall back to a regex check in case this row
+    // was loaded from a persisted view state without the flag.
+    const isSourceSep = widthInfo.isSourceSep === true
+      || isTableSeparatorContent(line.content);
+
+    const prevIsTable = widthMap.has(line.line_number - 1);
+    const nextIsTable = widthMap.has(line.line_number + 1);
+
+    // Top border: only above the very first known row of the table.
+    // ┌─┬─┐ — opens the frame above the header.
+    if (!prevIsTable) {
+      const top = buildTableBorderLine(allocated, "┌", "┬", "┐");
+      editor.addVirtualLine(
+        bufferId,
+        line.byte_start,
+        top,
+        fg[0], fg[1], fg[2],
+        bg[0], bg[1], bg[2],
+        true, // above
+        ns,
+        0,
+      );
+    }
+
+    // Inter-row separator: between consecutive *data* rows.
+    //
+    // Skip if either side is the source separator row (`|---|---|---|`)
+    // because the source already provides `├─┼─┤` there via conceals —
+    // adding another above/below would draw two adjacent separator lines.
+    //
+    // Drawn ABOVE the current row when its predecessor is also a (non-
+    // source-separator) table row, so each row owns the separator that
+    // appears above it.
+    const prevInfo = widthMap.get(line.line_number - 1);
+    const prevIsSourceSep = prevInfo?.isSourceSep === true;
+    if (prevIsTable && !isSourceSep && !prevIsSourceSep) {
+      const sep = buildTableBorderLine(allocated, "├", "┼", "┤");
+      editor.addVirtualLine(
+        bufferId,
+        line.byte_start,
+        sep,
+        fg[0], fg[1], fg[2],
+        bg[0], bg[1], bg[2],
+        true, // above
+        ns,
+        1,
+      );
+    }
+
+    // Bottom border: only below the last known row of the table.
+    // └─┴─┘ — closes the frame.  Anchor at the END of the row's bytes
+    // (one before the trailing newline) and place "below".
+    if (!nextIsTable) {
+      const bottom = buildTableBorderLine(allocated, "└", "┴", "┘");
+      // byte_end points just past the newline; anchor at last byte of
+      // the row content so the virtual line renders directly under it.
+      const anchor = Math.max(line.byte_start, line.byte_end - 1);
+      editor.addVirtualLine(
+        bufferId,
+        anchor,
+        bottom,
+        fg[0], fg[1], fg[2],
+        bg[0], bg[1], bg[2],
+        false, // below
+        ns,
+        0,
+      );
+    }
+  }
+}
 
 // =============================================================================
 // Block-based parser for hanging indent support
@@ -1375,18 +1534,25 @@ function processTableAlignment(
       if (allocGrew(widthMap.get(ln)!)) { needsRefresh = true; break; }
     }
 
-    // Store merged widths for all lines in the group AND propagate
-    // back to adjacent cached lines so they pick up wider columns
-    // without needing to be re-delivered by lines_changed.
-    const info: TableWidthInfo = { maxW: merged, allocated };
+    // Store merged widths for each line in the group.  We tag the source
+    // separator row (`|---|---|---|`) so the border renderer can skip
+    // drawing a duplicate `├─┼─┤` adjacent to it (the source separator is
+    // already concealed into one).  Each line gets its own info object so
+    // the per-row `isSourceSep` flag is independent.
     for (const line of group) {
-      widthMap.set(line.line_number, info);
+      const isSep = /^\|[-:\s|]+\|$/.test(line.content.trim());
+      widthMap.set(line.line_number, { maxW: merged, allocated, isSourceSep: isSep });
     }
+    // Adjacent cached lines (already-processed neighbours of this group)
+    // need their `allocated` updated but should keep their existing
+    // `isSourceSep` flag — they were classified when they were processed.
     for (let ln = firstLine - 1; widthMap.has(ln); ln--) {
-      widthMap.set(ln, info);
+      const prev = widthMap.get(ln)!;
+      widthMap.set(ln, { maxW: merged, allocated, isSourceSep: prev.isSourceSep });
     }
     for (let ln = lastLine + 1; widthMap.has(ln); ln++) {
-      widthMap.set(ln, info);
+      const prev = widthMap.get(ln)!;
+      widthMap.set(ln, { maxW: merged, allocated, isSourceSep: prev.isSourceSep });
     }
   }
 
@@ -1424,6 +1590,15 @@ function onMarkdownLinesChanged(data: {
   for (const line of data.lines) {
     processLineConceals(data.buffer_id, line.content, line.byte_start, line.byte_end, cursors, line.line_number);
     processLineSoftBreaks(data.buffer_id, line.content, line.byte_start, line.byte_end, cursors, line.line_number);
+  }
+
+  // Add/refresh table border virtual lines (top/bottom + inter-row separators).
+  // Runs AFTER processTableAlignment so the widthMap reflects the latest
+  // allocated widths, and AFTER processLineConceals so the borders we draw
+  // line up with the cell pipes the conceals produce.
+  const widthMapForBorders = getTableWidths(data.buffer_id);
+  if (widthMapForBorders) {
+    processTableBorders(data.buffer_id, data.lines, widthMapForBorders);
   }
 
   if (tableWidthsGrew) {

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -158,9 +158,14 @@ function processTableBorders(
   }>,
   widthMap: Map<number, TableWidthInfo>,
 ): void {
-  // Light gray, on near-black (matches existing pipe→│ conceal styling).
-  const fg: [number, number, number] = [188, 188, 188];
-  const bg: [number, number, number] = [16, 16, 16];
+  // Use theme keys (resolved at render time so the borders follow theme
+  // changes — same pattern as addOverlay's fg/bg options).
+  //
+  //   * fg → editor.line_number_fg (the same dim chrome colour the gutter
+  //     uses, which already exists in every theme)
+  //   * bg → editor.bg (matches the document background so the borders
+  //     blend in rather than carving an opaque slab through the page)
+  const borderOptions = { fg: "editor.line_number_fg", bg: "editor.bg" };
 
   for (const line of lines) {
     const ns = `md-tb-${line.line_number}`;
@@ -189,13 +194,11 @@ function processTableBorders(
     // Top border: only above the very first known row of the table.
     // ┌─┬─┐ — opens the frame above the header.
     if (!prevIsTable) {
-      const top = buildTableBorderLine(allocated, "┌", "┬", "┐");
       editor.addVirtualLine(
         bufferId,
         line.byte_start,
-        top,
-        fg[0], fg[1], fg[2],
-        bg[0], bg[1], bg[2],
+        buildTableBorderLine(allocated, "┌", "┬", "┐"),
+        borderOptions,
         true, // above
         ns,
         0,
@@ -214,13 +217,11 @@ function processTableBorders(
     const prevInfo = widthMap.get(line.line_number - 1);
     const prevIsSourceSep = prevInfo?.isSourceSep === true;
     if (prevIsTable && !isSourceSep && !prevIsSourceSep) {
-      const sep = buildTableBorderLine(allocated, "├", "┼", "┤");
       editor.addVirtualLine(
         bufferId,
         line.byte_start,
-        sep,
-        fg[0], fg[1], fg[2],
-        bg[0], bg[1], bg[2],
+        buildTableBorderLine(allocated, "├", "┼", "┤"),
+        borderOptions,
         true, // above
         ns,
         1,
@@ -231,16 +232,14 @@ function processTableBorders(
     // └─┴─┘ — closes the frame.  Anchor at the END of the row's bytes
     // (one before the trailing newline) and place "below".
     if (!nextIsTable) {
-      const bottom = buildTableBorderLine(allocated, "└", "┴", "┘");
       // byte_end points just past the newline; anchor at last byte of
       // the row content so the virtual line renders directly under it.
       const anchor = Math.max(line.byte_start, line.byte_end - 1);
       editor.addVirtualLine(
         bufferId,
         anchor,
-        bottom,
-        fg[0], fg[1], fg[2],
-        bg[0], bg[1], bg[2],
+        buildTableBorderLine(allocated, "└", "┴", "┘"),
+        borderOptions,
         false, // below
         ns,
         0,

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1537,6 +1537,13 @@ impl Editor {
         let view_state = self.split_view_states.get_mut(&target_split);
 
         if let (Some(state), Some(view_state)) = (state, view_state) {
+            // Collect plugin soft-break positions BEFORE re-borrowing the buffer
+            // so the viewport's visual-row math stays in lock-step with the
+            // renderer (e.g. markdown_compose adds hanging-indent breaks via
+            // addSoftBreak; without these the mouse wheel was either "absorbed"
+            // at long-wrap item boundaries or got clamped short of EOF,
+            // leaving the bottom half empty).
+            let soft_breaks = state.collect_soft_break_positions();
             let buffer = &mut state.buffer;
             let top_byte_before = view_state.viewport.top_byte;
             if let Some(tokens) = view_transform_tokens {
@@ -1549,15 +1556,19 @@ impl Editor {
                     .viewport
                     .scroll_view_lines(&view_lines, delta as isize);
             } else {
-                // No view transform - use traditional buffer-based scrolling
+                // No view transform - use traditional buffer-based scrolling.
                 if delta < 0 {
                     // Scroll up
                     let lines_to_scroll = delta.unsigned_abs() as usize;
-                    view_state.viewport.scroll_up(buffer, lines_to_scroll);
+                    view_state
+                        .viewport
+                        .scroll_up(buffer, &soft_breaks, lines_to_scroll);
                 } else {
                     // Scroll down
                     let lines_to_scroll = delta as usize;
-                    view_state.viewport.scroll_down(buffer, lines_to_scroll);
+                    view_state
+                        .viewport
+                        .scroll_down(buffer, &soft_breaks, lines_to_scroll);
                 }
             }
             // Skip ensure_visible so the scroll position isn't undone during render

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -3415,6 +3415,11 @@ impl Editor {
 
             // Get mutable references to both buffer and view state
             if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                // Collect plugin soft-break positions BEFORE re-borrowing the
+                // buffer so the viewport's visual-row math matches the renderer
+                // (avoids the wheel-absorbed / empty-bottom mouse-scroll bugs
+                // for compose-mode markdown — see scroll_down_visual).
+                let soft_breaks = state.collect_soft_break_positions();
                 let buffer = &mut state.buffer;
                 if let Some(view_state) = self.split_view_states.get_mut(&split_id) {
                     if let Some(tokens) = view_transform_tokens {
@@ -3427,13 +3432,17 @@ impl Editor {
                     } else {
                         // No view transform - use traditional buffer-based scrolling
                         if line_offset > 0 {
-                            view_state
-                                .viewport
-                                .scroll_down(buffer, line_offset as usize);
+                            view_state.viewport.scroll_down(
+                                buffer,
+                                &soft_breaks,
+                                line_offset as usize,
+                            );
                         } else {
-                            view_state
-                                .viewport
-                                .scroll_up(buffer, line_offset.unsigned_abs());
+                            view_state.viewport.scroll_up(
+                                buffer,
+                                &soft_breaks,
+                                line_offset.unsigned_abs(),
+                            );
                         }
                     }
                     // Mark to skip ensure_visible on next render so the scroll isn't undone

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -227,39 +227,74 @@ impl Editor {
     }
 
     /// Handle AddVirtualLine command
+    ///
+    /// Theme keys carried by the colour specs are NOT resolved here — they
+    /// are stashed verbatim on the VirtualText so the renderer can resolve
+    /// them against the live theme on every frame and the line follows
+    /// theme changes without the plugin re-emitting it.  Only RGB colour
+    /// specs and short colour names (`"Gray"`, `"DarkGray"`, …) are
+    /// pre-baked into the fallback `Style`.
     #[allow(clippy::too_many_arguments)]
     pub(super) fn handle_add_virtual_line(
         &mut self,
         buffer_id: BufferId,
         position: usize,
         text: String,
-        fg_color: (u8, u8, u8),
-        bg_color: Option<(u8, u8, u8)>,
+        fg_color: Option<fresh_core::api::OverlayColorSpec>,
+        bg_color: Option<fresh_core::api::OverlayColorSpec>,
         above: bool,
         namespace: String,
         priority: i32,
     ) {
-        if let Some(state) = self.buffers.get_mut(&buffer_id) {
-            use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
-            use ratatui::style::{Color, Style};
+        use crate::view::theme::named_color_from_str;
+        use crate::view::virtual_text::{VirtualTextNamespace, VirtualTextPosition};
+        use fresh_core::api::OverlayColorSpec;
+        use ratatui::style::{Color, Style};
 
+        // Split a colour spec into "fallback colour baked into Style" and
+        // "theme key resolved at render time".  Named colour strings are
+        // recognised eagerly here so they end up in the fallback Style
+        // (mirrors OverlayFace::from_options' policy).
+        fn split(spec: Option<OverlayColorSpec>) -> (Option<Color>, Option<String>) {
+            match spec {
+                Some(OverlayColorSpec::Rgb(r, g, b)) => (Some(Color::Rgb(r, g, b)), None),
+                Some(OverlayColorSpec::ThemeKey(key)) => {
+                    if let Some(color) = named_color_from_str(&key) {
+                        (Some(color), None)
+                    } else {
+                        (None, Some(key))
+                    }
+                }
+                None => (None, None),
+            }
+        }
+
+        let (fg_fallback, fg_theme_key) = split(fg_color);
+        let (bg_fallback, bg_theme_key) = split(bg_color);
+
+        let mut style = Style::default();
+        if let Some(c) = fg_fallback {
+            style = style.fg(c);
+        }
+        if let Some(c) = bg_fallback {
+            style = style.bg(c);
+        }
+
+        if let Some(state) = self.buffers.get_mut(&buffer_id) {
             let placement = if above {
                 VirtualTextPosition::LineAbove
             } else {
                 VirtualTextPosition::LineBelow
             };
-
-            let mut style = Style::default().fg(Color::Rgb(fg_color.0, fg_color.1, fg_color.2));
-            if let Some(bg) = bg_color {
-                style = style.bg(Color::Rgb(bg.0, bg.1, bg.2));
-            }
             let ns = VirtualTextNamespace::from_string(namespace);
 
-            state.virtual_texts.add_line(
+            state.virtual_texts.add_line_with_theme_keys(
                 &mut state.marker_list,
                 position,
                 text,
                 style,
+                fg_theme_key,
+                bg_theme_key,
                 placement,
                 ns,
                 priority,

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -1028,15 +1028,56 @@ impl CachedLayout {
         let mappings = self.view_line_mappings.get(&split_id)?;
         let current_row = self.find_visual_row(split_id, current_pos)?;
 
-        let target_row = if direction < 0 {
-            current_row.checked_sub(1)?
-        } else {
-            let next = current_row + 1;
-            if next >= mappings.len() {
-                return None;
-            }
-            next
+        // Walk past purely-virtual rows (e.g. markdown_compose table top/
+        // bottom borders and inter-row separators).  Those rows have no
+        // source mapping at all — their `char_source_bytes` are all `None`
+        // and their `line_end_byte` is inherited from the adjacent content
+        // row.  If MoveDown/MoveUp stopped on them the cursor would land on
+        // a byte that's already at the row above's end, which in turn
+        // causes Down-after-table to teleport back to an earlier position
+        // (regression exposed by markdown_compose's table border feature).
+        //
+        // A row is "navigable" iff at least one of its visual columns maps
+        // to a real source byte.  Skip entirely-virtual rows in the move
+        // direction until we hit a navigable one or run off the edge.
+        let mut target_row = current_row;
+        let navigable = |idx: usize| -> bool {
+            mappings
+                .get(idx)
+                .map(|m| m.char_source_bytes.iter().any(|b| b.is_some()))
+                .unwrap_or(false)
         };
+        loop {
+            target_row = if direction < 0 {
+                target_row.checked_sub(1)?
+            } else {
+                let next = target_row + 1;
+                if next >= mappings.len() {
+                    return None;
+                }
+                next
+            };
+            // Either the next row has real source content, or we've reached
+            // a legitimate non-source row that the rest of the editor
+            // already treats as a cursor stop (trailing empty line at EOF,
+            // implicit blank final line).  In either case stop walking.
+            if navigable(target_row) {
+                break;
+            }
+            let mapping = mappings.get(target_row)?;
+            let is_plugin_virtual =
+                mapping.visual_to_char.is_empty() || mapping.char_source_bytes.is_empty();
+            if !is_plugin_virtual {
+                // The row has columns but none carry a source byte — most
+                // likely a plugin-injected decoration with padding.  Keep
+                // looking.
+                continue;
+            }
+            // Empty mapping (no visual columns) is how EOF-related virtual
+            // rows are represented; those are legitimate cursor stops so we
+            // accept them and fall out of the loop.
+            break;
+        }
 
         let target_mapping = mappings.get(target_row)?;
 

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -1107,6 +1107,24 @@ impl EditorState {
         Ok(())
     }
 
+    /// Resolve all plugin-injected soft-break byte positions for this buffer.
+    ///
+    /// Returns a sorted slice suitable for passing to `Viewport::scroll_up` /
+    /// `scroll_down`, which use it to keep their visual-row counting in
+    /// lock-step with the renderer (which applies these same breaks via
+    /// `apply_soft_breaks`). Empty when no plugin is wrapping the buffer.
+    pub fn collect_soft_break_positions(&self) -> Vec<usize> {
+        if self.soft_breaks.is_empty() {
+            return Vec::new();
+        }
+        // query_viewport already returns positions sorted ascending.
+        self.soft_breaks
+            .query_viewport(0, self.buffer.len() + 1, &self.marker_list)
+            .into_iter()
+            .map(|(pos, _indent)| pos)
+            .collect()
+    }
+
     // ========== DocumentModel Helper Methods ==========
     // These methods provide convenient access to DocumentModel functionality
     // while maintaining backward compatibility with existing code.

--- a/crates/fresh-editor/src/view/ui/split_rendering.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering.rs
@@ -3097,7 +3097,7 @@ impl SplitRenderer {
         .collect();
 
         // Inject virtual lines (LineAbove/LineBelow) from VirtualTextManager
-        let lines = Self::inject_virtual_lines(source_lines, state);
+        let lines = Self::inject_virtual_lines(source_lines, state, theme);
         let placeholder_style = fold_placeholder_style(theme);
         let lines = Self::apply_folding(
             lines,
@@ -3332,7 +3332,11 @@ impl SplitRenderer {
     }
 
     /// Inject virtual lines (LineAbove/LineBelow) into the ViewLine stream
-    fn inject_virtual_lines(source_lines: Vec<ViewLine>, state: &EditorState) -> Vec<ViewLine> {
+    fn inject_virtual_lines(
+        source_lines: Vec<ViewLine>,
+        state: &EditorState,
+        theme: &crate::view::theme::Theme,
+    ) -> Vec<ViewLine> {
         use crate::view::virtual_text::VirtualTextPosition;
 
         // Get viewport byte range from source lines.
@@ -3381,7 +3385,14 @@ impl SplitRenderer {
                         && *anchor_pos < end
                         && vtext.position == VirtualTextPosition::LineAbove
                     {
-                        result.push(Self::create_virtual_line(&vtext.text, vtext.style));
+                        // Resolve theme keys against the live theme so the
+                        // virtual line follows theme changes (theme keys
+                        // are stored on the VirtualText itself, not
+                        // pre-baked into `style`).
+                        result.push(Self::create_virtual_line(
+                            &vtext.text,
+                            vtext.resolved_style(theme),
+                        ));
                     }
                 }
             }
@@ -3396,7 +3407,14 @@ impl SplitRenderer {
                         && *anchor_pos < end
                         && vtext.position == VirtualTextPosition::LineBelow
                     {
-                        result.push(Self::create_virtual_line(&vtext.text, vtext.style));
+                        // Resolve theme keys against the live theme so the
+                        // virtual line follows theme changes (theme keys
+                        // are stored on the VirtualText itself, not
+                        // pre-baked into `style`).
+                        result.push(Self::create_virtual_line(
+                            &vtext.text,
+                            vtext.resolved_style(theme),
+                        ));
                     }
                 }
             }
@@ -5342,7 +5360,7 @@ impl SplitRenderer {
                                     &mut line_spans,
                                     &mut line_view_map,
                                     text_with_space,
-                                    vtext.style,
+                                    vtext.resolved_style(theme),
                                     None,
                                 );
                             }
@@ -5420,7 +5438,7 @@ impl SplitRenderer {
                                     &mut line_spans,
                                     &mut line_view_map,
                                     text_with_space,
-                                    vtext.style,
+                                    vtext.resolved_style(theme),
                                     None,
                                 );
                             }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -990,10 +990,35 @@ impl StatusBarRenderer {
         }
 
         let left_items = Self::render_side(&config.left, ctx);
-        let right_items = Self::render_side(&config.right, ctx);
+        let mut right_items = Self::render_side(&config.right, ctx);
 
         const SEPARATOR: &str = " | ";
         let separator_width = str_width(SEPARATOR);
+
+        // Reserve a sane minimum for the left side so the buffer name and
+        // cursor position aren't truncated to a single character on narrow
+        // terminals (regression originally reported as
+        // `t  LF  ASCII  Markdown ...`).  Drop low-priority right elements
+        // (configured right-most first) until the remaining right side fits
+        // alongside that minimum left budget.  We never drop the *first*
+        // right element so the user keeps at least one piece of right-side
+        // status if any was configured.
+        let total_right_width: usize = right_items.iter().map(|(_, w, _)| *w).sum();
+        let left_min_target = available_width
+            .saturating_mul(2)
+            .saturating_div(5) // ~40% of width reserved for left when feasible
+            .min(40); // but never demand more than 40 cols even on wide terminals
+        let right_budget = available_width.saturating_sub(left_min_target + 1);
+        if total_right_width > right_budget && right_items.len() > 1 {
+            let mut current = total_right_width;
+            while current > right_budget && right_items.len() > 1 {
+                if let Some(dropped) = right_items.pop() {
+                    current = current.saturating_sub(dropped.1);
+                } else {
+                    break;
+                }
+            }
+        }
 
         let right_width: usize = right_items.iter().map(|(_, w, _)| *w).sum();
 

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -173,11 +173,44 @@ impl Viewport {
         1 + digits.max(4) + 3
     }
 
+    /// Count visual rows for a single logical line, accounting for plugin soft
+    /// breaks (e.g. markdown_compose's hanging-indent wrapping).
+    ///
+    /// `soft_breaks` is a sorted slice of byte positions where plugins have
+    /// injected line breaks. When any fall in `[line_start, line_end)`, those
+    /// breaks are authoritative for the visual row count (each soft break adds
+    /// one row). Otherwise we fall back to the width-based `wrap_line` count.
+    ///
+    /// This keeps the scroll math in lock-step with the renderer, which also
+    /// applies soft breaks before computing visual rows
+    /// (see split_rendering.rs: apply_soft_breaks).
+    fn count_visual_rows_for_line(
+        line_start: usize,
+        line_end: usize,
+        line_text: &str,
+        wrap_config: &WrapConfig,
+        soft_breaks: &[usize],
+    ) -> usize {
+        let lo = soft_breaks.partition_point(|&p| p < line_start);
+        let hi = soft_breaks.partition_point(|&p| p < line_end);
+        let break_count = hi.saturating_sub(lo);
+        if break_count > 0 {
+            // Plugin's soft breaks describe the actual on-screen wrapping;
+            // each break adds one visual row to the base row.
+            break_count + 1
+        } else {
+            wrap_line(line_text, wrap_config).len().max(1)
+        }
+    }
+
     /// Scroll up by N lines (byte-based)
     /// When line_wrap_enabled is true, scrolls by visual rows instead of logical lines
-    pub fn scroll_up(&mut self, buffer: &mut Buffer, lines: usize) {
+    ///
+    /// `soft_breaks` is a sorted slice of plugin-injected break byte positions.
+    /// Pass an empty slice when there are no plugin breaks (raw mode, etc.).
+    pub fn scroll_up(&mut self, buffer: &mut Buffer, soft_breaks: &[usize], lines: usize) {
         if self.line_wrap_enabled {
-            self.scroll_up_visual(buffer, lines);
+            self.scroll_up_visual(buffer, soft_breaks, lines);
         } else {
             let mut iter = buffer.line_iterator(self.top_byte, 80);
             for _ in 0..lines {
@@ -186,15 +219,18 @@ impl Viewport {
                 }
             }
             let new_position = iter.current_position();
-            self.set_top_byte_with_limit(buffer, new_position);
+            self.set_top_byte_with_limit(buffer, soft_breaks, new_position);
         }
     }
 
     /// Scroll down by N lines (byte-based)
     /// When line_wrap_enabled is true, scrolls by visual rows instead of logical lines
-    pub fn scroll_down(&mut self, buffer: &mut Buffer, lines: usize) {
+    ///
+    /// `soft_breaks` is a sorted slice of plugin-injected break byte positions.
+    /// Pass an empty slice when there are no plugin breaks (raw mode, etc.).
+    pub fn scroll_down(&mut self, buffer: &mut Buffer, soft_breaks: &[usize], lines: usize) {
         if self.line_wrap_enabled {
-            self.scroll_down_visual(buffer, lines);
+            self.scroll_down_visual(buffer, soft_breaks, lines);
         } else {
             let mut iter = buffer.line_iterator(self.top_byte, 80);
             for _ in 0..lines {
@@ -203,13 +239,13 @@ impl Viewport {
                 }
             }
             let new_position = iter.current_position();
-            self.set_top_byte_with_limit(buffer, new_position);
+            self.set_top_byte_with_limit(buffer, soft_breaks, new_position);
         }
     }
 
     /// Scroll up by N visual rows (for line-wrapped content)
     /// This counts wrapped segments, not logical lines
-    fn scroll_up_visual(&mut self, buffer: &mut Buffer, visual_rows: usize) {
+    fn scroll_up_visual(&mut self, buffer: &mut Buffer, soft_breaks: &[usize], visual_rows: usize) {
         if visual_rows == 0 {
             return;
         }
@@ -248,16 +284,22 @@ impl Viewport {
 
             // Get the line content to calculate how many visual rows it has
             let line_start = iter.current_position();
-            let line_content = if let Some((_, content)) = iter.next_line() {
-                content.trim_end_matches(['\n', '\r']).to_string()
+            let (line_end, line_content) = if let Some((_, content)) = iter.next_line() {
+                let end = iter.current_position();
+                (end, content.trim_end_matches(['\n', '\r']).to_string())
             } else {
-                String::new()
+                (line_start, String::new())
             };
             // Move back to the line start position
             iter = buffer.line_iterator(line_start, 80);
 
-            let segments = wrap_line(&line_content, &wrap_config);
-            let visual_rows_in_line = segments.len().max(1);
+            let visual_rows_in_line = Self::count_visual_rows_for_line(
+                line_start,
+                line_end,
+                &line_content,
+                &wrap_config,
+                soft_breaks,
+            );
 
             if visual_rows_in_line >= rows_remaining {
                 // This line has enough visual rows to satisfy the remaining scroll
@@ -278,7 +320,7 @@ impl Viewport {
 
     /// Scroll down by N visual rows (for line-wrapped content)
     /// This counts wrapped segments, not logical lines
-    fn scroll_down_visual(&mut self, buffer: &mut Buffer, visual_rows: usize) {
+    fn scroll_down_visual(&mut self, buffer: &mut Buffer, soft_breaks: &[usize], visual_rows: usize) {
         if visual_rows == 0 {
             return;
         }
@@ -289,21 +331,29 @@ impl Viewport {
         let buffer_len = buffer.len();
 
         let mut rows_remaining = visual_rows;
-        let mut iter = buffer.line_iterator(self.top_byte, 80);
+        let current_top = self.top_byte;
+        let mut iter = buffer.line_iterator(current_top, 80);
 
         // First, handle any existing top_view_line_offset
         // Get current line's visual row count to see how many rows are left in it
-        let current_line_content = if let Some((_, content)) = iter.next_line() {
+        let (current_line_end, current_line_content) = if let Some((_, content)) = iter.next_line()
+        {
+            let end = iter.current_position();
             let c = content.trim_end_matches(['\n', '\r']).to_string();
             // Reset iterator to start of this line for later use
-            iter = buffer.line_iterator(self.top_byte, 80);
-            c
+            iter = buffer.line_iterator(current_top, 80);
+            (end, c)
         } else {
-            String::new()
+            (current_top, String::new())
         };
 
-        let current_segments = wrap_line(&current_line_content, &wrap_config);
-        let current_visual_rows = current_segments.len().max(1);
+        let current_visual_rows = Self::count_visual_rows_for_line(
+            current_top,
+            current_line_end,
+            &current_line_content,
+            &wrap_config,
+            soft_breaks,
+        );
         let rows_left_in_current = current_visual_rows.saturating_sub(self.top_view_line_offset);
 
         if rows_remaining < rows_left_in_current {
@@ -328,27 +378,33 @@ impl Viewport {
 
             // Check for end of buffer
             if line_start >= buffer_len {
-                self.set_top_byte_with_limit(buffer, line_start);
+                self.set_top_byte_with_limit(buffer, soft_breaks, line_start);
                 return;
             }
 
-            let line_content = if let Some((_, content)) = iter.next_line() {
-                content.trim_end_matches(['\n', '\r']).to_string()
+            let (line_end, line_content) = if let Some((_, content)) = iter.next_line() {
+                let end = iter.current_position();
+                (end, content.trim_end_matches(['\n', '\r']).to_string())
             } else {
                 // End of buffer
-                self.set_top_byte_with_limit(buffer, line_start);
+                self.set_top_byte_with_limit(buffer, soft_breaks, line_start);
                 return;
             };
 
-            let segments = wrap_line(&line_content, &wrap_config);
-            let visual_rows_in_line = segments.len().max(1);
+            let visual_rows_in_line = Self::count_visual_rows_for_line(
+                line_start,
+                line_end,
+                &line_content,
+                &wrap_config,
+                soft_breaks,
+            );
 
             if rows_remaining < visual_rows_in_line {
                 // This line has enough visual rows to satisfy the scroll
                 self.top_byte = line_start;
                 self.top_view_line_offset = rows_remaining;
                 // Apply visual-row-aware scroll limit
-                self.apply_visual_scroll_limit(buffer, &wrap_config);
+                self.apply_visual_scroll_limit(buffer, soft_breaks, &wrap_config);
                 return;
             }
 
@@ -361,7 +417,7 @@ impl Viewport {
                 self.top_byte = next_pos;
                 self.top_view_line_offset = 0;
                 // Apply visual-row-aware scroll limit
-                self.apply_visual_scroll_limit(buffer, &wrap_config);
+                self.apply_visual_scroll_limit(buffer, soft_breaks, &wrap_config);
                 return;
             }
         }
@@ -370,7 +426,12 @@ impl Viewport {
     /// Apply visual-row-aware scroll limit to prevent over-scrolling.
     /// This ensures the viewport is always filled with content when possible.
     /// Returns true if position was adjusted, false if no adjustment needed.
-    fn apply_visual_scroll_limit(&mut self, buffer: &mut Buffer, wrap_config: &WrapConfig) {
+    fn apply_visual_scroll_limit(
+        &mut self,
+        buffer: &mut Buffer,
+        soft_breaks: &[usize],
+        wrap_config: &WrapConfig,
+    ) {
         let viewport_height = self.visible_line_count();
         if viewport_height == 0 {
             return;
@@ -381,18 +442,30 @@ impl Viewport {
         let mut iter = buffer.line_iterator(self.top_byte, 80);
 
         // First, count rows in current line (from top_view_line_offset to end)
-        if let Some((_, content)) = iter.next_line() {
+        if let Some((line_start, content)) = iter.next_line() {
+            let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
-            let segments = wrap_line(&line_content, wrap_config);
-            let line_visual_rows = segments.len().max(1);
+            let line_visual_rows = Self::count_visual_rows_for_line(
+                line_start,
+                line_end,
+                &line_content,
+                wrap_config,
+                soft_breaks,
+            );
             visual_rows_remaining += line_visual_rows.saturating_sub(self.top_view_line_offset);
         }
 
         // Count rows in subsequent lines
-        while let Some((_, content)) = iter.next_line() {
+        while let Some((line_start, content)) = iter.next_line() {
+            let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
-            let segments = wrap_line(&line_content, wrap_config);
-            visual_rows_remaining += segments.len().max(1);
+            visual_rows_remaining += Self::count_visual_rows_for_line(
+                line_start,
+                line_end,
+                &line_content,
+                wrap_config,
+                soft_breaks,
+            );
 
             // Early exit if we have enough rows
             if visual_rows_remaining >= viewport_height {
@@ -404,8 +477,12 @@ impl Viewport {
         // and set it directly (instead of calling scroll_up_visual which can be jumpy)
         if visual_rows_remaining < viewport_height {
             // Find the max scroll position by scanning from the beginning
-            let (max_byte, max_offset) =
-                self.find_max_visual_scroll_position(buffer, wrap_config, viewport_height);
+            let (max_byte, max_offset) = self.find_max_visual_scroll_position(
+                buffer,
+                soft_breaks,
+                wrap_config,
+                viewport_height,
+            );
             self.top_byte = max_byte;
             self.top_view_line_offset = max_offset;
         }
@@ -416,6 +493,7 @@ impl Viewport {
     fn find_max_visual_scroll_position(
         &self,
         buffer: &mut Buffer,
+        soft_breaks: &[usize],
         wrap_config: &WrapConfig,
         viewport_height: usize,
     ) -> (usize, usize) {
@@ -443,9 +521,15 @@ impl Viewport {
         let mut positions: Vec<(usize, usize)> = Vec::new();
         let mut iter = buffer.line_iterator(scan_start, 80);
         while let Some((line_start, content)) = iter.next_line() {
+            let line_end = iter.current_position();
             let line_content = content.trim_end_matches(['\n', '\r']).to_string();
-            let segments = wrap_line(&line_content, wrap_config);
-            let visual_rows_in_line = segments.len().max(1);
+            let visual_rows_in_line = Self::count_visual_rows_for_line(
+                line_start,
+                line_end,
+                &line_content,
+                wrap_config,
+                soft_breaks,
+            );
 
             for offset in 0..visual_rows_in_line {
                 positions.push((line_start, offset));
@@ -791,7 +875,12 @@ impl Viewport {
     /// Set top_byte with automatic scroll limit enforcement
     /// This prevents scrolling past the end of the buffer by ensuring
     /// the viewport can be filled from the proposed position
-    fn set_top_byte_with_limit(&mut self, buffer: &mut Buffer, proposed_top_byte: usize) {
+    fn set_top_byte_with_limit(
+        &mut self,
+        buffer: &mut Buffer,
+        soft_breaks: &[usize],
+        proposed_top_byte: usize,
+    ) {
         tracing::trace!(
             "DEBUG set_top_byte_with_limit: proposed_top_byte={}",
             proposed_top_byte
@@ -821,10 +910,16 @@ impl Viewport {
             let mut iter = buffer.line_iterator(proposed_top_byte, 80);
             let mut visual_rows = 0;
 
-            while let Some((_, content)) = iter.next_line() {
+            while let Some((line_start, content)) = iter.next_line() {
+                let line_end = iter.current_position();
                 let line_text = content.trim_end_matches(['\n', '\r']);
-                let segments = wrap_line(line_text, &wrap_config);
-                visual_rows += segments.len().max(1);
+                visual_rows += Self::count_visual_rows_for_line(
+                    line_start,
+                    line_end,
+                    line_text,
+                    &wrap_config,
+                    soft_breaks,
+                );
                 if visual_rows >= viewport_height {
                     self.top_byte = proposed_top_byte;
                     return;
@@ -838,8 +933,12 @@ impl Viewport {
 
             // Not enough visual rows to fill viewport from proposed position.
             // Use find_max_visual_scroll_position which correctly counts wrapped rows.
-            let (max_byte, max_offset) =
-                self.find_max_visual_scroll_position(buffer, &wrap_config, viewport_height);
+            let (max_byte, max_offset) = self.find_max_visual_scroll_position(
+                buffer,
+                soft_breaks,
+                &wrap_config,
+                viewport_height,
+            );
             // Only backtrack if the proposed position is past the maximum
             if proposed_top_byte > max_byte
                 || (proposed_top_byte == max_byte && self.top_view_line_offset > max_offset)
@@ -931,7 +1030,10 @@ impl Viewport {
         while current_line < line {
             if let Some((line_start, _)) = iter.next_line() {
                 if current_line + 1 == line {
-                    self.set_top_byte_with_limit(buffer, line_start);
+                    // Soft breaks unknown here (called from cursor flows that
+                    // don't have ready access to the buffer's marker state).
+                    // Pass empty: limit calc will use width-only wrap_line.
+                    self.set_top_byte_with_limit(buffer, &[], line_start);
                     return;
                 }
                 current_line += 1;
@@ -943,7 +1045,7 @@ impl Viewport {
 
         // If we didn't find the line, stay at the last valid position
         let target_position = iter.current_position();
-        self.set_top_byte_with_limit(buffer, target_position);
+        self.set_top_byte_with_limit(buffer, &[], target_position);
     }
 
     /// Scroll so the last view line sits at the bottom of the viewport.
@@ -1283,7 +1385,10 @@ impl Viewport {
                 }
 
                 let new_top_byte = iter.current_position();
-                self.set_top_byte_with_limit(buffer, new_top_byte);
+                // ensure_visible is called from cursor-driven flows that don't
+                // surface soft-break markers here; the limit calc falls back
+                // to width-only wrap_line counting.
+                self.set_top_byte_with_limit(buffer, &[], new_top_byte);
                 self.top_view_line_offset = 0;
             } else {
                 // Non-wrapped mode: count only visible lines when scanning backward
@@ -1316,7 +1421,10 @@ impl Viewport {
                 }
 
                 let new_top_byte = iter.current_position();
-                self.set_top_byte_with_limit(buffer, new_top_byte);
+                // ensure_visible is called from cursor-driven flows that don't
+                // surface soft-break markers here; the limit calc falls back
+                // to width-only wrap_line counting.
+                self.set_top_byte_with_limit(buffer, &[], new_top_byte);
                 self.top_view_line_offset = 0;
             }
         }
@@ -1394,7 +1502,8 @@ impl Viewport {
                 }
             }
             let position = iter.current_position();
-            self.set_top_byte_with_limit(buffer, position);
+            // Cursor-positioning flow: no soft-break info available here.
+            self.set_top_byte_with_limit(buffer, &[], position);
         }
     }
 
@@ -1508,7 +1617,8 @@ impl Viewport {
                 }
             }
             let position = iter.current_position();
-            self.set_top_byte_with_limit(buffer, position);
+            // Cursor-positioning flow: no soft-break info available here.
+            self.set_top_byte_with_limit(buffer, &[], position);
         } else {
             // Can't fit all cursors, ensure primary is visible
             let primary_cursor = sorted_cursors[0].1;
@@ -1600,16 +1710,16 @@ mod tests {
         let mut buffer = Buffer::from_str_test(&content);
         let mut vp = Viewport::new(80, 24);
 
-        vp.scroll_down(&mut buffer, 10);
+        vp.scroll_down(&mut buffer, &[], 10);
         // Check that we scrolled down (top_byte should be > 0)
         assert!(vp.top_byte > 0);
 
         let prev_top = vp.top_byte;
-        vp.scroll_up(&mut buffer, 5);
+        vp.scroll_up(&mut buffer, &[], 5);
         // Check that we scrolled up (top_byte should be less than before)
         assert!(vp.top_byte < prev_top);
 
-        vp.scroll_up(&mut buffer, 100);
+        vp.scroll_up(&mut buffer, &[], 100);
         assert_eq!(vp.top_byte, 0); // Can't scroll past 0
     }
 

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -320,7 +320,12 @@ impl Viewport {
 
     /// Scroll down by N visual rows (for line-wrapped content)
     /// This counts wrapped segments, not logical lines
-    fn scroll_down_visual(&mut self, buffer: &mut Buffer, soft_breaks: &[usize], visual_rows: usize) {
+    fn scroll_down_visual(
+        &mut self,
+        buffer: &mut Buffer,
+        soft_breaks: &[usize],
+        visual_rows: usize,
+    ) {
         if visual_rows == 0 {
             return;
         }

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -80,8 +80,17 @@ pub struct VirtualText {
     pub marker_id: MarkerId,
     /// Text to display (for LineAbove/LineBelow, this is the full line content)
     pub text: String,
-    /// Styling (typically dimmed/gray for hints)
+    /// Fallback styling, used when the theme-key fields below are unset OR
+    /// the keys don't resolve in the active theme.  The renderer composes
+    /// the final style by overlaying any resolved theme colours on top of
+    /// this fallback (see [`VirtualText::resolved_style`]).
     pub style: Style,
+    /// Optional theme key for the foreground colour (e.g.
+    /// `"editor.line_number_fg"`).  Resolved on every render so the line
+    /// follows live theme changes.
+    pub fg_theme_key: Option<String>,
+    /// Optional theme key for the background colour.
+    pub bg_theme_key: Option<String>,
     /// Where to render relative to the marker position
     pub position: VirtualTextPosition,
     /// Priority for ordering multiple items at same position (higher = later)
@@ -90,6 +99,29 @@ pub struct VirtualText {
     pub string_id: Option<String>,
     /// Optional namespace for bulk removal (like Overlay's namespace)
     pub namespace: Option<VirtualTextNamespace>,
+}
+
+impl VirtualText {
+    /// Resolve the on-screen `Style` for this entry against a live theme.
+    ///
+    /// Theme keys take precedence over the fallback `style`'s fg/bg.  If a
+    /// key fails to resolve (e.g. the theme doesn't define it), the
+    /// fallback colour is kept.  Modifiers from `style` (bold/italic/etc.)
+    /// always survive.
+    pub fn resolved_style(&self, theme: &crate::view::theme::Theme) -> Style {
+        let mut style = self.style;
+        if let Some(ref key) = self.fg_theme_key {
+            if let Some(color) = theme.resolve_theme_key(key) {
+                style = style.fg(color);
+            }
+        }
+        if let Some(ref key) = self.bg_theme_key {
+            if let Some(color) = theme.resolve_theme_key(key) {
+                style = style.bg(color);
+            }
+        }
+        style
+    }
 }
 
 /// Unique identifier for a virtual text entry
@@ -150,6 +182,8 @@ impl VirtualTextManager {
                 marker_id,
                 text,
                 style,
+                fg_theme_key: None,
+                bg_theme_key: None,
                 position: vtext_position,
                 priority,
                 string_id: None,
@@ -185,6 +219,8 @@ impl VirtualTextManager {
                 marker_id,
                 text,
                 style,
+                fg_theme_key: None,
+                bg_theme_key: None,
                 position: vtext_position,
                 priority,
                 string_id: Some(string_id),
@@ -218,6 +254,39 @@ impl VirtualTextManager {
         namespace: VirtualTextNamespace,
         priority: i32,
     ) -> VirtualTextId {
+        self.add_line_with_theme_keys(
+            marker_list,
+            position,
+            text,
+            style,
+            None,
+            None,
+            placement,
+            namespace,
+            priority,
+        )
+    }
+
+    /// Add a virtual line whose foreground/background colours are stored
+    /// as theme keys (resolved at render time so theme changes apply
+    /// live).
+    ///
+    /// `style` is the fallback used when a theme key fails to resolve;
+    /// `fg_theme_key` / `bg_theme_key` are the keys passed to
+    /// `Theme::resolve_theme_key` (e.g. `"editor.line_number_fg"`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_line_with_theme_keys(
+        &mut self,
+        marker_list: &mut MarkerList,
+        position: usize,
+        text: String,
+        style: Style,
+        fg_theme_key: Option<String>,
+        bg_theme_key: Option<String>,
+        placement: VirtualTextPosition,
+        namespace: VirtualTextNamespace,
+        priority: i32,
+    ) -> VirtualTextId {
         debug_assert!(
             placement.is_line(),
             "add_line requires LineAbove or LineBelow"
@@ -234,6 +303,8 @@ impl VirtualTextManager {
                 marker_id,
                 text,
                 style,
+                fg_theme_key,
+                bg_theme_key,
                 position: placement,
                 priority,
                 string_id: None,

--- a/crates/fresh-editor/tests/e2e/markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose.rs
@@ -2433,6 +2433,166 @@ End of document.
     );
 }
 
+/// Regression test for the Down-arrow / table-borders interaction:
+///
+/// Place the cursor on a line *before* the table, press Down repeatedly,
+/// and assert that each press advances by exactly one source line until
+/// the cursor reaches the line *after* the table.
+///
+/// The original bug (added together with the table-border virtual lines
+/// in markdown_compose) was that Down would land on a virtual border row
+/// (`┌─┬─┐`, `├─┼─┤`, `└─┴─┘`), which has no source mapping, and the
+/// cursor would either get stuck or rewind to the previous row's
+/// `line_end_byte`.  The fix in `move_visual_line` walks past purely-
+/// virtual rows; this test guards against regressions of that fix or the
+/// table-border feature itself.
+#[test]
+fn test_compose_mode_cursor_down_through_table_borders() {
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use crate::common::tracing::init_tracing_from_env;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    init_tracing_from_env();
+
+    // Small, deterministic fixture.  Lines are numbered for clarity:
+    //
+    //   1: # Before
+    //   2:
+    //   3: Line before table.
+    //   4:
+    //   5: | A | B | C |
+    //   6: |---|---|---|
+    //   7: | 1 | 2 | 3 |
+    //   8: | 4 | 5 | 6 |
+    //   9: | 7 | 8 | 9 |
+    //  10:
+    //  11: Line after table.
+    //
+    // Compose mode renders the table with the markdown_compose
+    // table-border feature, injecting `┌─┬─┐` above row 5, `├─┼─┤`
+    // between rows 7/8 and 8/9, and `└─┴─┘` below row 9.  These are
+    // virtual rows (no source mapping) — Down must skip past them so the
+    // cursor advances exactly one source line per press.
+    let md_content = "\
+# Before
+
+Line before table.
+
+| A | B | C |
+|---|---|---|
+| 1 | 2 | 3 |
+| 4 | 5 | 6 |
+| 7 | 8 | 9 |
+
+Line after table.
+";
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("cursor_through_table.md");
+    std::fs::write(&md_path, md_content).unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(80, 30, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    // Enable compose mode.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Wait for the table-border virtual lines to be injected.
+    // Top-border row contains `┌` and `┐`; bottom-border row contains `└`
+    // and `┘`.  Stable means both are present at the same time.
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("┌") && s.contains("┐") && s.contains("└") && s.contains("┘")
+        })
+        .unwrap();
+
+    // Navigate cursor to source line 3 ("Line before table.") — two Down
+    // presses from the heading on line 1.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Helper: read the buffer line number (0-indexed) the primary cursor
+    // is currently on.
+    let cursor_line = |h: &mut EditorTestHarness| -> usize {
+        let pos = h.cursor_position();
+        let content = h.get_buffer_content().unwrap();
+        content[..pos.min(content.len())]
+            .bytes()
+            .filter(|&b| b == b'\n')
+            .count()
+    };
+
+    // Sanity: cursor is on source line 2 (0-indexed) == line 3 in 1-indexed.
+    assert_eq!(
+        cursor_line(&mut harness),
+        2,
+        "Setup: cursor should start on 'Line before table.' (0-indexed line 2)"
+    );
+
+    // Press Down repeatedly through the table and into the after-table
+    // text, recording the cursor's source-line index after each press.
+    // Expected progression — one source line per press, no stalls, no
+    // skips, no rewinds, and crossing the table boundaries:
+    //
+    //   start: 2  (Line before table.)
+    //   after Down 1: 3  (blank)
+    //   after Down 2: 4  (header `| A | B | C |`)
+    //   after Down 3: 5  (source separator `|---|---|---|`)
+    //   after Down 4: 6  (`| 1 | 2 | 3 |`)
+    //   after Down 5: 7  (`| 4 | 5 | 6 |`)
+    //   after Down 6: 8  (`| 7 | 8 | 9 |`)
+    //   after Down 7: 9  (blank below table)
+    //   after Down 8: 10 (`Line after table.`)
+    let mut observed: Vec<usize> = vec![cursor_line(&mut harness)];
+    for _ in 0..8 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        observed.push(cursor_line(&mut harness));
+    }
+
+    let expected: Vec<usize> = (2..=10).collect();
+    assert_eq!(
+        observed, expected,
+        "Down-arrow progression through compose-mode table should advance \
+         exactly one source line per press, skipping virtual border rows. \
+         Observed line indices: {observed:?}, expected: {expected:?}"
+    );
+
+    // Final assertion: cursor must end on "Line after table.", not stuck
+    // on a virtual border row or rewound to an earlier table row.
+    let final_pos = harness.cursor_position();
+    let content = harness.get_buffer_content().unwrap();
+    let after_byte = content.find("Line after table.").unwrap();
+    assert!(
+        final_pos >= after_byte,
+        "After {} Down presses cursor should be at or past 'Line after table.' \
+         (byte {after_byte}), but is at byte {final_pos}",
+        observed.len() - 1,
+    );
+}
+
 /// Regression test: pressing Down through a document with tables (in compose mode)
 /// and then Up all the way back must produce monotonically increasing then
 /// monotonically decreasing cursor byte positions.  A jump to byte 0 mid-sequence

--- a/crates/fresh-editor/tests/e2e/markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose.rs
@@ -943,6 +943,152 @@ fn test_compose_mode_mouse_scroll_to_bottom() {
     );
 }
 
+/// Regression test for two compose-mode mouse-wheel scrolling bugs:
+///
+/// 1. **Wheel absorbed at long-wrap item boundaries.** With a numbered/bullet
+///    list whose items wrap to many visual rows under the markdown plugin's
+///    hanging-indent wrapping, every wheel event that landed on the start of
+///    the next item produced no movement — the scroll viewport stayed put.
+///
+/// 2. **Bottom half empty (mouse stops short of EOF).** With a long-wrap
+///    list at the very end of the document, the wheel-scroll math clamped
+///    the viewport short of the keyboard's `Ctrl+End` position, leaving the
+///    bottom of the visible area as `~` filler rows.
+///
+/// Both bugs share a root cause: `Viewport::scroll_down_visual` and friends
+/// counted visual rows using `wrap_line` on raw source text, which doesn't
+/// know about the plugin-injected hanging indent ("1. " marker → 3-column
+/// continuation indent). The plugin's `addSoftBreak` markers describe the
+/// *actual* on-screen wrapping, so those markers are now consulted by the
+/// scroll math (see `EditorState::collect_soft_break_positions`).
+///
+/// The test scrolls a small list-only fixture wheel-by-wheel and asserts
+/// that (a) every wheel makes monotonic progress (no stuck/absorbed
+/// events) and (b) the EOF marker becomes visible within the expected
+/// number of wheels.
+#[test]
+fn test_compose_mode_mouse_wheel_long_list_progresses_to_eof() {
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use crate::common::tracing::init_tracing_from_env;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    init_tracing_from_env();
+
+    // Build a tiny markdown file: 5 numbered list items, each a 99-word
+    // single line. Under markdown_compose at 60 columns each item wraps to
+    // roughly 13 visual rows (with a 3-column hanging indent). The bug
+    // described above made the wheel "absorb" one event per item start, so
+    // reaching EOF took materially more wheels than the keyboard.
+    let mut md = String::from("# Test\n\n");
+    for i in 1..=5 {
+        md.push_str(&format!("{}. Item {}: ", i, i));
+        for w in 1..=99 {
+            if w > 1 {
+                md.push(' ');
+            }
+            md.push_str(&format!("word{}", w));
+        }
+        md.push('\n');
+    }
+    md.push_str("\nEOF_MARKER\n");
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("scroll_repro.md");
+    std::fs::write(&md_path, md).unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(60, 24, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("scroll_repro.md");
+
+    // Enable compose mode.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Wait for compose decorations (the hanging-indent continuation rows
+    // start with at least three leading spaces).
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("   word")
+        })
+        .unwrap();
+
+    // Scroll wheel-by-wheel from the top, asserting monotonic progress and
+    // requiring EOF_MARKER to appear within a generous bound.
+    let (content_start, content_end) = harness.content_area_rows();
+    let mid_row = ((content_start + content_end) / 2) as u16;
+
+    // Visual cost of the document under the plugin's wrapping:
+    //   header (2 rows) + 5 items * ~14 rows + EOF (~3 rows) ≈ 75 rows.
+    // Each wheel advances 3 visual rows, so 25 wheels suffice; 60 leaves
+    // generous slack. With the bug, each item-start absorbed one wheel —
+    // 5 items × 1 = 5 extra wheels, *and* the apply_visual_scroll_limit
+    // clamp could refuse the last few wheels entirely, so this test would
+    // fail before the fix.
+    const MAX_WHEELS: usize = 60;
+
+    let mut prev_top: Option<String> = None;
+    let mut stuck_count = 0usize;
+    let mut wheels_used = 0usize;
+    for i in 1..=MAX_WHEELS {
+        harness.mouse_scroll_down(40, mid_row).unwrap();
+        wheels_used = i;
+
+        let screen = harness.screen_to_string();
+        if screen.contains("EOF_MARKER") {
+            break;
+        }
+
+        // Track per-wheel progress. The top of the visible content area must
+        // not stay identical for more than one wheel in a row — that would
+        // be the "absorbed wheel" symptom from the original bug report.
+        let lines: Vec<&str> = screen.lines().collect();
+        let top = lines
+            .get(content_start)
+            .copied()
+            .unwrap_or("")
+            .trim_end()
+            .to_string();
+        if Some(&top) == prev_top.as_ref() {
+            stuck_count += 1;
+            assert!(
+                stuck_count < 2,
+                "Mouse wheel produced no scroll progress for {stuck_count} consecutive events \
+                 at wheel #{i}. Top of viewport: {top:?}\nFull screen:\n{screen}"
+            );
+        } else {
+            stuck_count = 0;
+        }
+        prev_top = Some(top);
+    }
+
+    let final_screen = harness.screen_to_string();
+    assert!(
+        final_screen.contains("EOF_MARKER"),
+        "EOF_MARKER never became visible after {wheels_used} wheel events; \
+         the wheel scroll appears stuck short of EOF.\nFinal screen:\n{final_screen}"
+    );
+}
+
 /// Test that HTML entities are rendered as their Unicode characters in compose mode.
 ///
 /// Named entities like `&amp;`, `&mdash;`, `&nbsp;` and numeric entities like

--- a/crates/fresh-editor/tests/e2e/prompt.rs
+++ b/crates/fresh-editor/tests/e2e/prompt.rs
@@ -854,13 +854,12 @@ fn test_open_file_prompt_truncates_long_paths() {
         screen
     );
 
-    // The test.txt file should still be visible in the file browser
-    // (wait for directory to load)
-    harness.sleep(std::time::Duration::from_millis(100));
-    let _ = harness.editor_mut().process_async_messages();
-    harness.render().unwrap();
-
-    harness.assert_screen_contains("test.txt");
+    // The test.txt file should still be visible in the file browser.
+    // The directory listing is populated asynchronously (see
+    // "Loading..." placeholder) so wait for it indefinitely rather
+    // than relying on a fixed sleep — per CONTRIBUTING.md
+    // "No timeouts or time-sensitive tests".
+    harness.wait_for_screen_contains("test.txt").unwrap();
 }
 
 /// Test that Open File prompt shows completions popup immediately when opened (issue #193)

--- a/crates/fresh-editor/tests/plugins/test_view_marker.ts
+++ b/crates/fresh-editor/tests/plugins/test_view_marker.ts
@@ -48,8 +48,7 @@ function addTestHeaders(bufferId: number): void {
         bufferId,
         byteOffset,
         `── Header before line ${lineNum} ──`,
-        200, 200, 100,  // Yellow-ish fg
-        0, 0, 0,        // Black background (u8 values required)
+        { fg: [200, 200, 100], bg: [0, 0, 0] }, // Yellow-ish on black
         true,           // above
         TEST_NAMESPACE,
         0
@@ -64,8 +63,7 @@ function addTestHeaders(bufferId: number): void {
       bufferId,
       0,
       "== INTERLEAVED HEADER ==",
-      255, 255, 0,  // Yellow fg
-      0, 0, 0,      // Black background (u8 values required)
+      { fg: [255, 255, 0], bg: [0, 0, 0] }, // Yellow on black
       true,         // above
       TEST_NAMESPACE,
       -1  // lower priority to appear first
@@ -76,8 +74,7 @@ function addTestHeaders(bufferId: number): void {
       bufferId,
       0,
       "== HEADER AT BYTE 0 ==",
-      255, 255, 0,  // Yellow fg
-      0, 0, 0,      // Black background (u8 values required)
+      { fg: [255, 255, 0], bg: [0, 0, 0] }, // Yellow on black
       true,         // above
       TEST_NAMESPACE,
       0
@@ -89,8 +86,7 @@ function addTestHeaders(bufferId: number): void {
         bufferId,
         0,
         `Virtual pad ${i + 1}`,
-        180, 180, 180,  // Light gray fg
-        0, 0, 0,        // Black background (u8 values required)
+        { fg: [180, 180, 180], bg: [0, 0, 0] }, // Light gray on black
         true,           // above
         TEST_NAMESPACE,
         i + 1  // increasing priority so they appear in order after header

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -2543,22 +2543,45 @@ impl JsEditorApi {
     }
 
     /// Add a virtual line (full line above/below a position)
+    ///
+    /// The `options` object accepts:
+    ///   * `fg`, `bg` — either an `[r, g, b]` array (each `0..=255`) or a
+    ///     theme-key string (e.g. `"editor.line_number_fg"`).  Theme keys
+    ///     are resolved at render time so the line follows theme changes.
+    ///     Both default to `null` (no foreground / transparent background).
     #[allow(clippy::too_many_arguments)]
-    pub fn add_virtual_line(
+    pub fn add_virtual_line<'js>(
         &self,
+        _ctx: rquickjs::Ctx<'js>,
         buffer_id: u32,
         position: u32,
         text: String,
-        fg_r: u8,
-        fg_g: u8,
-        fg_b: u8,
-        bg_r: u8,
-        bg_g: u8,
-        bg_b: u8,
+        options: rquickjs::Object<'js>,
         above: bool,
         namespace: String,
         priority: i32,
-    ) -> bool {
+    ) -> rquickjs::Result<bool> {
+        use fresh_core::api::OverlayColorSpec;
+
+        // Same flexible parser as add_overlay: accepts theme key string or
+        // RGB array.  Returns None when the key is missing or unusable.
+        fn parse_color_spec(key: &str, obj: &rquickjs::Object<'_>) -> Option<OverlayColorSpec> {
+            if let Ok(theme_key) = obj.get::<_, String>(key) {
+                if !theme_key.is_empty() {
+                    return Some(OverlayColorSpec::ThemeKey(theme_key));
+                }
+            }
+            if let Ok(arr) = obj.get::<_, Vec<u8>>(key) {
+                if arr.len() >= 3 {
+                    return Some(OverlayColorSpec::Rgb(arr[0], arr[1], arr[2]));
+                }
+            }
+            None
+        }
+
+        let fg_color = parse_color_spec("fg", &options);
+        let bg_color = parse_color_spec("bg", &options);
+
         // Track namespace for cleanup on unload
         self.plugin_tracked_state
             .borrow_mut()
@@ -2567,18 +2590,19 @@ impl JsEditorApi {
             .virtual_line_namespaces
             .push((BufferId(buffer_id as usize), namespace.clone()));
 
-        self.command_sender
+        Ok(self
+            .command_sender
             .send(PluginCommand::AddVirtualLine {
                 buffer_id: BufferId(buffer_id as usize),
                 position: position as usize,
                 text,
-                fg_color: (fg_r, fg_g, fg_b),
-                bg_color: Some((bg_r, bg_g, bg_b)),
+                fg_color,
+                bg_color,
                 above,
                 namespace,
                 priority,
             })
-            .is_ok()
+            .is_ok())
     }
 
     // === Prompts ===

--- a/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
+++ b/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
@@ -260,7 +260,157 @@ Listed in rough priority order:
 
 ---
 
-## 6. Test Artifacts
+## 6. Mouse-Wheel Scrolling Bug (Compose Mode)
+
+User report:
+1. Long document with tables followed by long-wrapped bullet/numbered list at
+   the end → mouse wheel scrolls only "halfway"; keyboard navigation works.
+2. Scrolling up then down with the wheel sometimes leaves the bottom half of
+   the visible buffer blank until more wheels arrive.
+3. Both symptoms appear with slow, single wheel events — not just rapid bursts.
+
+### 6.1 Reproduction
+
+Fixture: `/tmp/ux_test/big_repro.md` (337 lines):
+- 99 medium paragraphs
+- 1 large 99-row table
+- 29 numbered list items, each containing a 200-word continuous paragraph
+  that wraps to ~16 visual rows in compose mode at width 60–100
+- A `FILE_END_MARKER_XYZZY` sentinel at EOF
+
+Steps (60×24 terminal):
+
+```
+fresh big_repro.md
+Ctrl+P → "Toggle Compose" → Enter
+Wheel-down ~250 times to land in the long-list area
+Send single wheel-down events with 0.3–0.4s spacing
+```
+
+### 6.2 Observed: every item-start "absorbs" one wheel event
+
+Captured top-row text after each single wheel event:
+
+```
+position before:  "   word139 word140 ... word145"   (Item 2's word139)
+after wheel #1:   "   word160 word161 ... word166"   (advanced 21 words ≈ 3 rows)  ✓
+after wheel #2:   "   word181 word182 ... word187"   (advanced ≈ 3 rows)            ✓
+after wheel #3:   "3. Item 3: word1 word2 ..."        (crossed item boundary)        ✓
+after wheel #4:   "3. Item 3: word1 word2 ..."        (NO ADVANCE — wheel lost)      ✗
+after wheel #5:   "   word25 word26 ... word32"      (back to advancing)             ✓
+```
+
+The pattern repeats deterministically at every item boundary — at "4. Item 4:"
+and "5. Item 5:" the same: one wheel produces no movement.
+
+Cumulatively, with 11 long-wrap items the user has to wheel ~11 extra times
+to traverse the same content as the keyboard's `Ctrl+End`, so mouse scrolling
+appears to "lag" or "only cover half".
+
+### 6.3 Root cause
+
+`crates/fresh-editor/src/app/input.rs:1539-1565` `handle_mouse_scroll` (compose
+path) calls `Viewport::scroll_view_lines` with the **stale**
+`view_transform.tokens` cached from the previous render's `SubmitViewTransform`
+response.
+
+`crates/fresh-editor/src/view/viewport.rs:476-504` `scroll_view_lines`:
+
+```rust
+let current_idx  = self.find_view_line_for_byte(view_lines, self.top_byte);
+let target_idx   = current_idx + line_offset;            // (signed)
+let max_top_idx  = view_lines.len().saturating_sub(viewport_height);
+let clamped_idx  = target_idx.min(max_top_idx);          // ← the trap
+self.top_byte    = source_byte_for(view_lines[clamped_idx]);
+```
+
+The plugin's transformed tokens cover only the visible viewport plus a small
+look-ahead (`build_base_tokens` reads `visible_count + 4` source lines —
+`crates/fresh-editor/src/view/ui/split_rendering.rs:3657`). After enough
+scrolls, `current_idx` lands at `max_top_idx`. The next wheel computes:
+
+```
+target_idx  = max_top_idx + 3
+clamped_idx = min(max_top_idx + 3, max_top_idx) = max_top_idx
+new_top_byte = source byte at view_lines[max_top_idx] = unchanged
+```
+
+So `top_byte` stays put. A *render fires* (we set `needs_render = true`),
+which fires a fresh `view_transform_request` for the same viewport, and the
+plugin's response writes back tokens whose first source byte equals the
+*current* `top_byte`. The next wheel event sees `current_idx = 0` again and
+can advance — until it hits `max_top_idx` again at the next item boundary.
+
+The "missing wheel" is the wheel event that fires *during* this stuck frame.
+It produces a render, but no scroll progress. With one absorbed wheel per
+item start, mouse scrolling effectively runs at a lower rate than keyboard
+PageDown/Ctrl+End on long-wrap content.
+
+### 6.4 Empty-bottom symptom (bug 2)
+
+Same root cause: when the user scrolls past the safe-coverage area of the
+stale tokens (e.g., from a `Ctrl+End` jump or rapid wheel burst), the
+renderer uses tokens whose source range no longer covers `top_byte`. The
+view-anchor logic in
+`crates/fresh-editor/src/view/ui/split_rendering.rs:4293-4326`
+`calculate_view_anchor` then falls through to
+`start_line_idx: 0`, but `view_lines[0]`'s source byte is *behind* `top_byte`,
+so the renderer either re-renders stale content or — when the iteration
+exhausts before filling the viewport — emits `~` filler rows for the rest of
+the screen. The next render with fresh tokens fixes it, but that one frame is
+visible to the user as "the bottom is empty until I wheel again".
+
+I observed this transiently after rapid wheel bursts (200+ events back-to-back),
+with the visible content being only the last item plus `~` rows below; the
+state was stable for >2 seconds before further input cleared it.
+
+### 6.5 Suggested fix
+
+Three viable directions, in increasing scope:
+
+**A. Cheap clamp fix (recommended starting point).**
+In `Viewport::scroll_view_lines`, when scrolling DOWN and `target_idx >
+max_top_idx`, fall back to advancing `top_byte` past the cached tokens'
+coverage by walking the *underlying buffer* for the remaining delta. Roughly:
+
+```rust
+let clamped_idx = target_idx.min(max_top_idx);
+if line_offset > 0 && target_idx > max_top_idx {
+    // Stale tokens don't cover the requested target.
+    // Advance by the cached portion now, and let the next render fetch
+    // fresh tokens for the rest. To prevent the wheel being "lost",
+    // also bump top_byte by at least one source line so we make progress.
+    let cached_delta = max_top_idx.saturating_sub(current_idx);
+    if cached_delta == 0 {
+        // No room left in the cache — advance to the next source line directly.
+        // (Fall through to a buffer-based scroll_down for `line_offset` rows.)
+    }
+}
+```
+
+**B. Invalidate stale tokens on scroll.** After `handle_mouse_scroll` mutates
+`top_byte`, mark `view_transform` as needing refresh and have the renderer
+prefer `base_tokens` until fresh ones arrive. Trades extra plugin work per
+wheel for predictable scrolling.
+
+**C. Make the look-ahead wider.** Bump `max_lines = visible_count + 4` to a
+larger constant (say `visible_count * 3`) so even long-wrapped paragraphs
+have enough cached view lines to absorb several wheel events between renders.
+Cheap, but masks the underlying race rather than fixing it.
+
+(A) is likely the right first cut: it's a small change in `viewport.rs`,
+preserves the fast path, and provably eliminates the "wheel absorbed at item
+boundary" symptom that I reproduced.
+
+### 6.6 Repro artifacts
+
+- `/tmp/ux_test/big_repro.md` — fixture
+- This evaluation, sections 6.1–6.4, contains the exact tmux SGR mouse
+  sequences (`\x1b[<65;col;rowM`) used to drive the wheel events.
+
+---
+
+## 7. Test Artifacts
 
 Generated during this evaluation and stored in `/tmp/ux_test/` on the test
 host:

--- a/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
+++ b/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
@@ -1,0 +1,279 @@
+# Markdown Compose – UX / Heuristic Evaluation
+
+**Branch:** `claude/test-markdown-compose-ux-QUMRZ`
+**Build:** `cargo build` (debug, unoptimized, debug assertions on)
+**Binary:** `target/debug/fresh`
+**Runner:** detached `tmux` session (`tui_ux_test`), 200×50 by default
+**Date:** 2026-04-13
+
+---
+
+## 1. Executive Summary
+
+The Markdown Compose feature is a working, structured "preview-while-editing"
+mode. It successfully conceals inline syntax (`**`, `*`, `` ` ``, `[…](…)`),
+draws clean Unicode tables, applies a centered page when an explicit width is
+configured, and round-trips back to the raw markdown losslessly.
+
+Two things impressed during testing:
+
+- **Bidirectional sync is solid.** All inline-syntax characters survive a
+  compose-on → edit → compose-off cycle (`**bold**`, `*italic*`,
+  `` `inline code` ``, full `[anchor](url)` link).
+- **Soft-wrap reflow is correct on resize.** A single 300-word logical line
+  wraps cleanly at word boundaries at both 200 and 60 columns, and the
+  scrollbar thumb tracks position correctly at TOP and END of a 791-line
+  document.
+
+The biggest friction points are around **discoverability and visibility of
+state**: there is no per-tab indication that a buffer is in Compose mode, the
+default command-palette ranking lists "Set Compose Width" *above* the more
+common "Toggle Compose/Preview" command, and the link-conceal behavior switches
+visibly when the cursor enters the link (potentially confusing). A few
+rendering issues (missing top/bottom table borders; flat single-color code
+blocks) and a couple of i18n leaks (`buffer.switched`) round out the
+catastrophe-free-but-rough picture.
+
+No panics, no document corruption, no scrollbar desync was observed.
+
+---
+
+## 2. Heuristic Violations (severity 0–4)
+
+| # | Heuristic | Issue | Severity |
+|---|-----------|-------|----------|
+| H1 | Visibility of System Status | No per-tab/per-buffer indicator that Compose is active. The tab strip shows `test_file.md* ×` identically in raw and compose; only the bottom status bar carries the cue. | 2 (Minor) |
+| H2 | Visibility of System Status | Status message contains an untranslated i18n key after a buffer switch: `buffer.switched` (should resolve to a localized string). | 1 (Cosmetic) |
+| H3 | Consistency & Standards | In the command palette, prefix-search "compose" surfaces `Markdown: Set Compose Width` *first* and the more frequently used `Markdown: Toggle Compose/Preview` second. New users hit Enter and land in the width prompt. | 2 (Minor) |
+| H4 | User Control & Freedom | Undo (`Ctrl+Z`) is character-granular even for a long burst of typed text. ~80 keystrokes required ~80 undos to revert a sentence. | 2 (Minor) |
+| H5 | Aesthetic & Minimalist Design | Tables render with inner row separator (`├─┼─┤`) but **no top or bottom border**. Visually the first row sits unsupported above the separator and the last row floats. | 2 (Minor) |
+| H6 | Aesthetic & Minimalist Design | Code-fence blocks render every line in a single `38;5;34` (green) color. No language-aware highlighting bleeds through compose mode despite TextMate grammar being declared as the highlighting source for raw. | 2 (Minor) |
+| H7 | Consistency & Standards | Cursor enters a link in compose: the conceal disappears and the line **stays raw** until the cursor moves away. Functionally correct, but the abrupt re-render with the cursor on the line makes it look like a rendering glitch the first time. | 2 (Minor) |
+| H8 | Visibility of System Status | The status bar text is not responsive: at 60 columns the buffer name and `Ln/Col` indicator are silently truncated to `t  LF  ASCII  Markdown …`, hiding cursor position entirely. | 3 (Major) |
+| H9 | Consistency & Standards | Compose mode width-jump test: `:23` (jump to raw line 23 == `\| 1 \| 2 \| 3 \|`) followed by 3× `→` lands the cursor at `Ln 24, Col 3` (i.e., on `End.`), skipping past the table cell entirely. The `→` arrow does not consistently traverse intra-cell positions. | 3 (Major) |
+| H10 | Error Prevention & Tolerance | Malformed input (`**unclosed`, `` ``` ``unclosed-fence``, broken `\| row \|`) does **not** crash, does **not** corrupt the buffer, and styling does not bleed into surrounding text. ✅ Pass — listed for completeness. | 0 (No problem) |
+| H11 | User Control & Freedom | Compose-mode toggle is per-buffer; it is not preserved when opening a new markdown file in the same session unless `Toggle Compose/Preview (All Files)` is used. The two commands are discoverable but the relationship is not explained. | 1 (Cosmetic) |
+| H12 | Aesthetic & Minimalist Design | Margin/page boundaries are visually clean: page background `48;5;16`, gutter background `48;5;232`, scrollbar `48;5;7`. No bleed observed at width 80 / terminal 200. ✅ | 0 (No problem) |
+
+---
+
+## 3. Visual / ANSI Evidence
+
+### 3.1 Conceal works inline; URL is appended (not hidden)
+
+Raw line:
+
+```
+- Third item with [a link](https://openai.com)
+```
+
+Rendered in compose:
+
+```
+- Third item with a link — https://openai.com
+```
+
+ANSI-decoded (SGR codes shown as `\e[…m`):
+
+```
+- Third item with \e[4ma link\e[0m \u2014 https://openai.com
+```
+
+`a link` is underlined (`\e[4m`); the URL is appended after an em-dash rather
+than being hidden. Heuristic test (Scenario F) suggested the URL should be
+*hidden*. Fresh's design instead exposes the URL — a defensible choice for
+terminal users (no hover affordance), but worth calling out as an explicit
+design intent in user docs.
+
+### 3.2 Scrollbar tracks correctly
+
+Right-most pane column on `big.md` (791 lines):
+
+| Position | Thumb rows (light bg `48;5;7`) | Track rows (dark bg `48;5;8`) |
+|----------|-------------------------------|-------------------------------|
+| `Ctrl+Home` (Ln 1) | rows 2–4 (top) | rows 5–47 |
+| `Ctrl+End` (Ln 792) | rows 45–47 (bottom) | rows 2–44 |
+
+Thumb size ≈ 6% which matches the 46-visible / 791-total ratio.
+
+### 3.3 Tables: missing borders
+
+```
+│ Col A │ Col B │ Col C │       <- header row, no ─── above
+├───────┼───────┼───────┤       <- inner separator
+│ a     │ b     │ c     │
+│ 1     │ 2     │ 3     │       <- last row, no ─── below
+```
+
+Suggested fix: render `┌─┬─┐` above the header and `└─┴─┘` below the final
+row.
+
+### 3.4 Code-fence highlighting is flat
+
+ANSI codes captured for the rust fence inside compose mode (lines L14–L18 of
+`scr_code.txt`):
+
+```
+L14 ```rust          codes: 38;5;34, 38;5;69        (header keyword colored)
+L15 fn main() {      codes: 38;5;34                 (entire body green)
+L16    println!(…);  codes: 38;5;34                 (entire body green)
+L17 }                codes: 38;5;34
+L18 ```              codes: 38;5;34
+```
+
+Compare to raw mode (pre-toggle), where the same fence shows additional colors
+for keywords/strings via the TextMate grammar. The plugin's own comment
+("Syntax highlighting is handled by the TextMate grammar (built-in to the
+editor)") implies parity, but compose collapses to a single code-block color.
+
+### 3.5 i18n leak
+
+After switching buffers via `#test`:
+
+```
+test_file.md | Ln 1, Col 1 | buffer.switched   LF  ASCII  …
+```
+
+The literal key `buffer.switched` is shown instead of the localized message.
+
+### 3.6 Status bar truncation at narrow widths
+
+At 60×30:
+
+```
+…
+~
+~
+t  LF  ASCII  Markdown   LSP (off)   [⚠ 1]  Palette: Ctrl+P
+```
+
+Buffer name and `Ln/Col` are clipped on the left. Cursor position becomes
+invisible — a tangible regression for anyone editing on a narrow split.
+
+---
+
+## 4. Flow-Specific Notes (Scenarios A–H)
+
+### A. Discoverability & Bidirectional Sync — **PASS with caveats**
+- Found via `Ctrl+P → "compose"`. First-listed match is `Set Compose Width`,
+  not `Toggle Compose/Preview` (H3). Recommend reordering or keyword-weighting
+  so "toggle" wins for the bare query "compose".
+- Edits made in compose mode round-trip cleanly. Verified by saving, toggling
+  off, and re-opening: `**bold**`, `*italic*`, `` `inline code` ``, and the
+  full link `[OpenAI](https://openai.com)` are all intact after editing the
+  *anchor text only* in compose.
+- Undo works but is per-keystroke (H4).
+
+### B. Absolute Navigation & Scrollbars — **PASS**
+- `Ctrl+End` jumped from Ln 1 to Ln 792 instantly on the 791-line file.
+- `Ctrl+Home` returned to Ln 1.
+- Scrollbar thumb position is accurate at both extremes (see §3.2).
+- `PageDown` from top of a small file (31 logical lines, ~46 visual rows)
+  jumped past EOF in one keystroke. This is correct behavior given file
+  length but worth noting that compose's vertical "weight" is larger than the
+  raw buffer (long paragraph wraps to ~13 visual rows).
+
+### C. Dynamic Line Wrapping & Resize Tolerance — **PASS**
+- 300-word single-paragraph input wrapped on word boundaries at both 200 and
+  60 columns.
+- Restarting the session at 60 columns (since `tmux resize-pane` is a no-op
+  in a single-pane session) reflowed the entire document instantly. No mid-word
+  splits observed.
+
+### D. Compose Mode Width Constraints — **PASS**
+- `Set Compose Width → 80` produced a centered text block within a 200-column
+  terminal. Left margin = 59 cols, content = 80 cols, right margin = 60 cols
+  (within ±1 of geometric center).
+- Margin and page background colors are distinct and clean (no bleed; see
+  §3.1 / H12).
+
+### E. Table Rendering & Cell Editing — **PARTIAL**
+- Tables render with Unicode box-drawing inner separators but **no outer
+  top/bottom borders** (H5).
+- Attempted to type `VERYLONGTEXT` into cell `a` after `:23 → →→→`. The
+  cursor instead landed on the next raw line (`End.`) and the text was
+  inserted there. The visual table cell was *not* the target. After undoing
+  and toggling compose off, the underlying table was clean (bug did not
+  damage data) but the cursor-mapping inside table cells is unreliable (H9).
+
+### F. Links & Hidden Syntax Masking — **PARTIAL**
+- Link text is shown underlined and the URL is appended after an em-dash —
+  it is not hidden in the strict NN/g sense.
+- Cursor position counts *raw* characters, so each `→` advances 1 column in
+  the underlying file, even through hidden brackets/URL chars.
+- When the cursor enters the link line, the line's conceal lifts and shows
+  raw `[OpenAI](https://openai.com)` until the cursor leaves. Re-mask is
+  immediate on cursor-leave. Functionally fine; visually surprising on first
+  encounter (H7).
+- Editing the anchor text and toggling compose off confirmed the URL was
+  preserved exactly.
+
+### G. Nested Blocks & Syntax Highlighting — **PARTIAL**
+- Blockquote, list, and inline code render with appropriate styling and
+  indentation.
+- Multi-line fenced code block renders body in a single uniform green color
+  (H6); language identifier (`rust`) is given a distinct color but body
+  syntax highlighting is absent inside compose.
+- Indentation levels and margin boundaries are respected.
+
+### H. Malformed Syntax Stress Test — **PASS**
+- Input: `**unclosed bold and broken table | row | only`,
+  `` ``` ``nope unclosed code``, `fn untrap() {`.
+- The renderer **did not panic**. The `fresh` process stayed alive (`ps`
+  confirmed PID 13475 unchanged).
+- Styling did **not** bleed into other paragraphs; the unclosed bold was
+  rendered as a literal asterisk, not as bold-on-everything-after.
+- Auto-pairing inserted matching backticks/parentheses for some inputs,
+  occasionally turning `**` into `*` + auto `*`. This is editor-wide
+  bracket-pair behavior, not specific to compose.
+
+---
+
+## 5. Recommended Follow-ups (engineering hand-off)
+
+Listed in rough priority order:
+
+1. **H8 (status bar truncation, severity 3)** — make status bar segments
+   responsive (drop low-priority segments first, keep `Ln/Col` last to drop).
+2. **H9 (cell-cursor mapping, severity 3)** — investigate `→` traversal
+   through compose-mode tables; current behavior skips into the next raw
+   line.
+3. **H5 (table top/bottom borders, severity 2)** — add `┌─┬─┐` and
+   `└─┴─┘` rows.
+4. **H3 (palette ranking, severity 2)** — boost `Toggle Compose/Preview`
+   for the query "compose".
+5. **H1 (per-tab indicator, severity 2)** — small marker (e.g. `◐` or `📖`
+   if emoji is acceptable; otherwise a textual `[c]`) on tabs whose buffer
+   is in compose.
+6. **H6 (fenced-code highlighting in compose, severity 2)** — pass through
+   TextMate grammar to compose's render path.
+7. **H7 (link reveal feels jumpy, severity 2)** — consider a softer
+   transition (e.g. show only `[anchor]` without the `(url)` when cursor is on
+   the anchor) to reduce the perceived layout shift.
+8. **H4 (undo granularity, severity 2)** — coalesce consecutive
+   character-insert events into a single undo stop (typical 1-second
+   word-boundary heuristic).
+9. **H2 (i18n leak, severity 1)** — add `buffer.switched` to locale files.
+10. **H11 (per-buffer vs. global compose, severity 1)** — surface a hint in
+    the toggle's status line ("ON for this buffer; use 'All Files' command
+    for default-on").
+
+---
+
+## 6. Test Artifacts
+
+Generated during this evaluation and stored in `/tmp/ux_test/` on the test
+host:
+
+- `test_file.md` — small mixed-syntax document (link, table, code fence,
+  list, blockquote)
+- `big.md` — 791-line document for scrollbar / navigation tests
+- `scr_initial.txt` — raw mode, ANSI-preserved capture
+- `scr_compose_on.txt` — compose mode, ANSI-preserved
+- `scr_end.txt` / `scr_end_ansi.txt` — `Ctrl+End` capture for scrollbar
+- `scr_top.txt` — `Ctrl+Home` capture for scrollbar
+- `scr_long_para.txt` / `scr_long_para_ansi.txt` — soft-wrap evidence (200 col)
+- `scr_narrow_60.txt` / `scr_narrow_top.txt` — soft-wrap evidence (60 col)
+- `scr_w80.txt` / `scr_w80_ansi.txt` — width-80 centering evidence
+- `scr_malformed.txt` — malformed syntax stress capture
+- `scr_code.txt` — code-fence highlighting capture

--- a/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
+++ b/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
@@ -307,105 +307,127 @@ Cumulatively, with 11 long-wrap items the user has to wheel ~11 extra times
 to traverse the same content as the keyboard's `Ctrl+End`, so mouse scrolling
 appears to "lag" or "only cover half".
 
-### 6.3 Root cause
+### 6.3 Root cause — scroll math ignores plugin soft-break markers
 
-`crates/fresh-editor/src/app/input.rs:1539-1565` `handle_mouse_scroll` (compose
-path) calls `Viewport::scroll_view_lines` with the **stale**
-`view_transform.tokens` cached from the previous render's `SubmitViewTransform`
-response.
+**Updated 2026-04-13** after the user clarified that the bug also reproduces
+with very slow, single wheel events. My initial hypothesis (race between
+`view_transform_request` and `SubmitViewTransform`) is wrong: the
+markdown_compose plugin no longer uses the view-transform pipeline at all
+for wrapping. From `crates/fresh-editor/plugins/markdown_compose.ts:1489`:
 
-`crates/fresh-editor/src/view/viewport.rs:476-504` `scroll_view_lines`:
+> `view_transform_request` is no longer needed — soft wrapping is handled by
+> marker-based soft breaks (computed in `lines_changed`).
 
-```rust
-let current_idx  = self.find_view_line_for_byte(view_lines, self.top_byte);
-let target_idx   = current_idx + line_offset;            // (signed)
-let max_top_idx  = view_lines.len().saturating_sub(viewport_height);
-let clamped_idx  = target_idx.min(max_top_idx);          // ← the trap
-self.top_byte    = source_byte_for(view_lines[clamped_idx]);
+So in compose mode `view_transform.tokens` is `None`,
+`handle_mouse_scroll` (input.rs:1551) takes the **buffer-based** branch and
+calls `Viewport::scroll_down`, which delegates to `scroll_down_visual`
+(viewport.rs:281-368) when line wrap is on.
+
+The bug is that `scroll_down_visual` (and friends `scroll_up_visual`,
+`apply_visual_scroll_limit`, `find_max_visual_scroll_position`,
+`set_top_byte_with_limit`) all count visual rows by calling `wrap_line`
+(`crates/fresh-editor/src/primitives/line_wrapping.rs:129`) on the raw
+source text. They are **completely unaware** of the markdown plugin's
+soft-break markers. `grep -n soft_break crates/fresh-editor/src/view/viewport.rs`
+returns zero matches.
+
+`wrap_line` only inserts a hanging indent when the *source* text starts
+with whitespace (`detect_indent` at `line_wrapping.rs:158`). A list item
+like `1. Item 1: word1 ... word199` has no leading whitespace, so
+`wrap_line` wraps it at the full viewport width — about 12 rows for the
+fixture. But the markdown plugin inserts a 3-column hanging indent on every
+continuation line (matching the visual width of the `"1. "` marker), giving
+~13 rows. A similar mismatch applies to bullets, blockquotes (`>` indent),
+and tables (column-aware widths).
+
+Concrete consequence: in `scroll_down_visual` at viewport.rs:309-313, the
+"can satisfy scroll within current line" early-return uses the wrong
+`current_visual_rows` count, so `top_view_line_offset` lands on the wrong
+visual row. When the renderer then composes the line with soft-break
+markers, it produces a different number of rows and the visible top doesn't
+match what the scroll handler intended.
+
+### 6.4 Empty-bottom symptom (bug 2) — same root cause
+
+Reproduced cleanly with `/tmp/ux_test/end_test.md` (a small file ending with
+five 99-word numbered list items + an `EOF_MARKER`) at 60×24, slow scroll
+(0.4s between single wheel events):
+
+```
+wheel #23  top: "   word97 word98 word99"
+wheel #24  top: "   word89 word90 word91 word92 word93 word94 word9"   ← jumped backward
+wheel #25  top: "   word89 ..."   (stuck)
+wheel #26..50  top: "   word89 ..."   (stuck — wheel produces no scroll)
 ```
 
-The plugin's transformed tokens cover only the visible viewport plus a small
-look-ahead (`build_base_tokens` reads `visible_count + 4` source lines —
-`crates/fresh-editor/src/view/ui/split_rendering.rs:3657`). After enough
-scrolls, `current_idx` lands at `max_top_idx`. The next wheel computes:
+At the stuck position the bottom of the viewport shows `EOF_MARKER` then 2
+empty rows, but `Ctrl+End` from this state shows that the file content
+extends three more wrap rows above the current top. So the mouse scroll
+*clamped* short of the keyboard's max-scroll position, and a couple of `~`
+filler rows became part of the visible viewport.
 
-```
-target_idx  = max_top_idx + 3
-clamped_idx = min(max_top_idx + 3, max_top_idx) = max_top_idx
-new_top_byte = source byte at view_lines[max_top_idx] = unchanged
-```
+The clamp comes from `apply_visual_scroll_limit` (viewport.rs:373-412). It
+uses `wrap_line` to count "visual rows from current position to end of
+buffer" and, when that count is less than `viewport_height`, calls
+`find_max_visual_scroll_position` to back the viewport up. Because the count
+under-estimates rows by ~1 per long-wrap item (no hanging indent in the
+math), the clamp triggers earlier than it should. The result is a viewport
+whose bottom is filled with `~` instead of the next-item-boundary content
+the user expects. Slow vs. fast scrolling makes no difference; the math
+mistake is deterministic.
 
-So `top_byte` stays put. A *render fires* (we set `needs_render = true`),
-which fires a fresh `view_transform_request` for the same viewport, and the
-plugin's response writes back tokens whose first source byte equals the
-*current* `top_byte`. The next wheel event sees `current_idx = 0` again and
-can advance — until it hits `max_top_idx` again at the next item boundary.
+### 6.5 Reproduction summary
 
-The "missing wheel" is the wheel event that fires *during* this stuck frame.
-It produces a render, but no scroll progress. With one absorbed wheel per
-item start, mouse scrolling effectively runs at a lower rate than keyboard
-PageDown/Ctrl+End on long-wrap content.
+| Symptom | Fixture | Reproduced |
+|---------|---------|------------|
+| Wheel-absorbed at long-list item boundary (bug 1) | `big_repro.md` 60×24 | Yes; 1 wheel "lost" per `N. Item N:` start |
+| Bottom empty / mouse stops short of EOF (bug 2) | `end_test.md` 60×24 | Yes; deterministic at 0.4s spacing |
+| Either symptom in raw (non-compose) mode | same fixtures | No — plugin soft-breaks are not applied |
+| Either symptom in compose mode without lists/long-wrap | small docs | No — wrap_line and plugin agree when there's no hanging indent |
 
-### 6.4 Empty-bottom symptom (bug 2)
+The deciding factor is the mismatch between `wrap_line`'s row count and the
+renderer's effective row count. Bullets, numbered lists, blockquotes, and
+fenced code (with leading whitespace from indented lists) all trigger a
+hanging-indent mismatch.
 
-Same root cause: when the user scrolls past the safe-coverage area of the
-stale tokens (e.g., from a `Ctrl+End` jump or rapid wheel burst), the
-renderer uses tokens whose source range no longer covers `top_byte`. The
-view-anchor logic in
-`crates/fresh-editor/src/view/ui/split_rendering.rs:4293-4326`
-`calculate_view_anchor` then falls through to
-`start_line_idx: 0`, but `view_lines[0]`'s source byte is *behind* `top_byte`,
-so the renderer either re-renders stale content or — when the iteration
-exhausts before filling the viewport — emits `~` filler rows for the rest of
-the screen. The next render with fresh tokens fixes it, but that one frame is
-visible to the user as "the bottom is empty until I wheel again".
+### 6.6 Suggested fix
 
-I observed this transiently after rapid wheel bursts (200+ events back-to-back),
-with the visible content being only the last item plus `~` rows below; the
-state was stable for >2 seconds before further input cleared it.
+The fix needs to reconcile scroll math with rendered layout. Three options
+in increasing scope:
 
-### 6.5 Suggested fix
+**A. Make `wrap_line` aware of list-marker hanging indent.** Detect a
+leading list/blockquote/numbered-list marker (`-`, `*`, `1.`, `>` etc.) in
+the source text and treat its visual width as the hanging indent for
+continuation lines. This brings `wrap_line` in line with the markdown
+plugin's wrapping for the common cases. Pure rust change in
+`primitives/line_wrapping.rs`. May still mis-count for tables / images
+where the plugin uses byte-position-specific breaks.
 
-Three viable directions, in increasing scope:
+**B. Have the viewport consult the buffer's `soft_breaks` markers.**
+Replace `wrap_line(line_content, &wrap_config)` in `scroll_down_visual`
+etc. with a function that returns `wrap_line`'s segments **plus** any
+soft-break markers in the line's byte range. This makes scroll math an
+exact inverse of what the renderer does; works for any plugin that adds
+soft breaks. Requires plumbing the buffer's marker list into the viewport
+(currently it's passed only `&mut Buffer`).
 
-**A. Cheap clamp fix (recommended starting point).**
-In `Viewport::scroll_view_lines`, when scrolling DOWN and `target_idx >
-max_top_idx`, fall back to advancing `top_byte` past the cached tokens'
-coverage by walking the *underlying buffer* for the remaining delta. Roughly:
+**C. Move all mouse-scroll math into the view-pipeline.** Render
+view-lines for the buffer's full visible region (or build them lazily) and
+walk those instead of re-wrapping the source. This is what
+`scroll_view_lines` does today for plugins that *do* use `view_transform`,
+just generalised to the soft-break case.
 
-```rust
-let clamped_idx = target_idx.min(max_top_idx);
-if line_offset > 0 && target_idx > max_top_idx {
-    // Stale tokens don't cover the requested target.
-    // Advance by the cached portion now, and let the next render fetch
-    // fresh tokens for the rest. To prevent the wheel being "lost",
-    // also bump top_byte by at least one source line so we make progress.
-    let cached_delta = max_top_idx.saturating_sub(current_idx);
-    if cached_delta == 0 {
-        // No room left in the cache — advance to the next source line directly.
-        // (Fall through to a buffer-based scroll_down for `line_offset` rows.)
-    }
-}
-```
+(B) is the most surgical fix: one extra parameter on `scroll_down_visual` /
+`scroll_up_visual` and a tweaked row-count helper. (A) would also fix this
+without any new plumbing but is less general (won't help table conceals).
 
-**B. Invalidate stale tokens on scroll.** After `handle_mouse_scroll` mutates
-`top_byte`, mark `view_transform` as needing refresh and have the renderer
-prefer `base_tokens` until fresh ones arrive. Trades extra plugin work per
-wheel for predictable scrolling.
+### 6.7 Repro artifacts
 
-**C. Make the look-ahead wider.** Bump `max_lines = visible_count + 4` to a
-larger constant (say `visible_count * 3`) so even long-wrapped paragraphs
-have enough cached view lines to absorb several wheel events between renders.
-Cheap, but masks the underlying race rather than fixing it.
-
-(A) is likely the right first cut: it's a small change in `viewport.rs`,
-preserves the fast path, and provably eliminates the "wheel absorbed at item
-boundary" symptom that I reproduced.
-
-### 6.6 Repro artifacts
-
-- `/tmp/ux_test/big_repro.md` — fixture
-- This evaluation, sections 6.1–6.4, contains the exact tmux SGR mouse
+- `/tmp/ux_test/big_repro.md` — paragraphs + 99-row table + 29 long-wrap
+  items + sentinel, used for the wheel-absorbed scenario
+- `/tmp/ux_test/end_test.md` — small file with 5 long-wrap items at the
+  end, used for the bottom-empty / mouse-stops-short scenario
+- This document, sections 6.1–6.5, contains the exact tmux SGR mouse
   sequences (`\x1b[<65;col;rowM`) used to drive the wheel events.
 
 ---

--- a/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
+++ b/docs/internal/MARKDOWN_COMPOSE_UX_EVAL.md
@@ -15,6 +15,14 @@ mode. It successfully conceals inline syntax (`**`, `*`, `` ` ``, `[…](…)`),
 draws clean Unicode tables, applies a centered page when an explicit width is
 configured, and round-trips back to the raw markdown losslessly.
 
+> **Update 2026-04-13:** after a second-pass reassessment against the fixed
+> binary, **none of the originally-flagged items remain at major severity**.
+> The two sev-3 issues (H8 status-bar truncation, H9 cursor-skip) are
+> resolved or were misdiagnosed; the mouse-wheel scroll bug found
+> separately (§6) is also fixed. The remaining open items are cosmetic,
+> editor-wide (not compose-specific), or defensible design choices — see
+> the "Bottom line on remaining issues" note after §2 for the breakdown.
+
 Two things impressed during testing:
 
 - **Bidirectional sync is solid.** All inline-syntax characters survive a
@@ -40,20 +48,86 @@ No panics, no document corruption, no scrollbar desync was observed.
 
 ## 2. Heuristic Violations (severity 0–4)
 
-| # | Heuristic | Issue | Severity |
-|---|-----------|-------|----------|
-| H1 | Visibility of System Status | No per-tab/per-buffer indicator that Compose is active. The tab strip shows `test_file.md* ×` identically in raw and compose; only the bottom status bar carries the cue. | 2 (Minor) |
-| H2 | Visibility of System Status | Status message contains an untranslated i18n key after a buffer switch: `buffer.switched` (should resolve to a localized string). | 1 (Cosmetic) |
-| H3 | Consistency & Standards | In the command palette, prefix-search "compose" surfaces `Markdown: Set Compose Width` *first* and the more frequently used `Markdown: Toggle Compose/Preview` second. New users hit Enter and land in the width prompt. | 2 (Minor) |
-| H4 | User Control & Freedom | Undo (`Ctrl+Z`) is character-granular even for a long burst of typed text. ~80 keystrokes required ~80 undos to revert a sentence. | 2 (Minor) |
-| H5 | Aesthetic & Minimalist Design | Tables render with inner row separator (`├─┼─┤`) but **no top or bottom border**. Visually the first row sits unsupported above the separator and the last row floats. | 2 (Minor) |
-| H6 | Aesthetic & Minimalist Design | Code-fence blocks render every line in a single `38;5;34` (green) color. No language-aware highlighting bleeds through compose mode despite TextMate grammar being declared as the highlighting source for raw. | 2 (Minor) |
-| H7 | Consistency & Standards | Cursor enters a link in compose: the conceal disappears and the line **stays raw** until the cursor moves away. Functionally correct, but the abrupt re-render with the cursor on the line makes it look like a rendering glitch the first time. | 2 (Minor) |
-| H8 | Visibility of System Status | The status bar text is not responsive: at 60 columns the buffer name and `Ln/Col` indicator are silently truncated to `t  LF  ASCII  Markdown …`, hiding cursor position entirely. | 3 (Major) |
-| H9 | Consistency & Standards | Compose mode width-jump test: `:23` (jump to raw line 23 == `\| 1 \| 2 \| 3 \|`) followed by 3× `→` lands the cursor at `Ln 24, Col 3` (i.e., on `End.`), skipping past the table cell entirely. The `→` arrow does not consistently traverse intra-cell positions. | 3 (Major) |
-| H10 | Error Prevention & Tolerance | Malformed input (`**unclosed`, `` ``` ``unclosed-fence``, broken `\| row \|`) does **not** crash, does **not** corrupt the buffer, and styling does not bleed into surrounding text. ✅ Pass — listed for completeness. | 0 (No problem) |
-| H11 | User Control & Freedom | Compose-mode toggle is per-buffer; it is not preserved when opening a new markdown file in the same session unless `Toggle Compose/Preview (All Files)` is used. The two commands are discoverable but the relationship is not explained. | 1 (Cosmetic) |
-| H12 | Aesthetic & Minimalist Design | Margin/page boundaries are visually clean: page background `48;5;16`, gutter background `48;5;232`, scrollbar `48;5;7`. No bleed observed at width 80 / terminal 200. ✅ | 0 (No problem) |
+> **Update 2026-04-13 (post-fix reassessment):** the `Status` column tracks
+> what was done about each issue after a fresh second-pass evaluation against
+> the fixed binary. Several entries were rated too high in the first pass —
+> H6 was not actually compose-specific (raw mode shows the same flat code
+> color, it's a markdown-grammar limitation), H9 was a misdiagnosis on my
+> part (`:23` correctly landed on the empty line below the table, not in
+> it), H7's reveal is actually surgical (only the link's brackets reveal,
+> not other inline syntax on the line). The "real" remaining issues are
+> mostly cosmetic and either editor-wide (not compose-specific) or
+> defensible design choices.
+
+| # | Heuristic | Issue | Severity (revised) | Status |
+|---|-----------|-------|--------------------|--------|
+| H1 | Visibility of System Status | No per-tab/per-buffer indicator that Compose is active. Tab strip identical in raw vs compose; only the bottom status bar carries the cue (briefly, as a transient message). | 1 (Cosmetic) | Defer — status bar already announces the toggle; persistent indicator is a nicety. |
+| H2 | Visibility of System Status | Status message contains an untranslated i18n key after a buffer switch: `buffer.switched`. | 1 (Cosmetic) | **Fixed** in `37234c2` (added key to all 14 locales). |
+| H3 | Consistency & Standards | Palette query "compose" surfaces `Markdown: Set Compose Width` first; "Toggle Compose/Preview" second. Alphabetical tiebreak for equally-scored fuzzy matches. New users hit Enter and land in the width prompt. | 2 (Minor) | Defer — the fuzzy scorer's tiebreak is technically correct; a different ranking just favors a different user. Frecency-tracking would be a non-trivial scope expansion. |
+| H4 | User Control & Freedom | `Ctrl+Z` is character-granular even for a long burst of typed text. ~80 keystrokes require ~80 undos to revert. | 2 (Minor) | Defer — editor-wide undo behavior, not compose-specific. Worth a separate "coalesce typing into word/burst undo" task. |
+| H5 | Aesthetic & Minimalist Design | Tables render the inner separator (`├─┼─┤`) but no top or bottom border. Header row sits unsupported, last row floats. | 2 (Minor / Cosmetic) | Defer — purely aesthetic, tables work. Plugin can use `addVirtualLine` to inject `┌─┬─┐` / `└─┴─┘` rows; tracked as a follow-up. |
+| H6 | Aesthetic & Minimalist Design | ~~Code-fence body uniform color in compose.~~ **Re-tested:** raw mode shows the same single color (`38;5;34`) — the markdown grammar treats fenced bodies as undifferentiated `code` tokens regardless of language tag. Not a compose regression. | 0 (Not compose-specific) | Ignore — pre-existing markdown-grammar behavior; fixing it requires routing language-tagged grammars through the markdown highlighter, which is a separate, sizeable workstream. |
+| H7 | Consistency & Standards | ~~Cursor on link reveals the entire raw line.~~ **Re-tested:** only the link itself reveals (brackets + URL), bold/italic/code conceals on the same line stay applied. The reveal is surgical, not whole-line. | 1 (Cosmetic) | Ignore — defensible UX (auto-reveal under cursor is the editing affordance). |
+| H8 | Visibility of System Status | Status bar truncation at narrow widths — buffer name and `Ln/Col` clipped at 60 columns. | 3 (Major) | **Fixed** in `f0bc652` (right-side now drops low-priority items to keep left-side budget). |
+| H9 | Consistency & Standards | ~~Cursor "skips past" table cells in compose.~~ **Misdiagnosed:** `:23` in the original test_file.md correctly landed on the empty line below the table (table ended at line 22), not inside it. Rights advanced one source byte at a time, which crossed into "End." as expected. Cursor walks `|`→`│` conceals correctly (verified with `h9_fixture.md`). The real friction is that compose hides line numbers, so users can't easily count raw lines for `:N` jumps. | 1 (Cosmetic — discoverability of raw line numbers in compose) | Ignore as bug — see §3.7 below. Optional follow-up: surface raw `Ln` near the cursor row even when the gutter is hidden. |
+| H10 | Error Prevention & Tolerance | Malformed input does not crash, corrupt, or bleed styling. ✅ | 0 | n/a |
+| H11 | User Control & Freedom | Per-buffer toggle vs `(All Files)` toggle — both commands carry descriptive subtitles in the palette. Minor learning curve. | 1 (Cosmetic) | Defer — well-described already. |
+| H12 | Aesthetic & Minimalist Design | Margin/page background boundaries are visually clean. ✅ | 0 | n/a |
+
+### Bottom line on remaining issues
+
+After the post-fix pass, **none of the remaining items are major bugs**. The
+sev-3 issues (H8, H9) are resolved or were misdiagnosed. Everything else is
+either:
+
+- **Cosmetic** (H1, H5, H11) — defer to follow-up polish work,
+- **Editor-wide / pre-existing** (H4, H6) — not compose-specific regressions
+  to fix here,
+- **Defensible design choice** (H3 alphabetical tiebreak; H7 surgical
+  reveal), or
+- **Misdiagnosed** (H9) — no code change needed.
+
+If we want to keep the polish bar high we should pick H1 (per-tab
+indicator) and H5 (table top/bottom borders) for a future small PR. They're
+both cosmetic but the most "this looks unfinished" of the lot.
+
+### 3.7 H9 reproduced and reassessed
+
+I re-ran the H9 scenario against `h9_fixture.md`:
+
+```
+Line 1: # H9 repro
+Line 2: (empty)
+Line 3: | A | B | C |
+Line 4: |---|---|---|
+Line 5: | a | b | c |
+Line 6: | 1 | 2 | 3 |
+Line 7: (empty)
+Line 8: End.
+```
+
+Compose on, then `:5` then `→×5`:
+
+```
+:5         → Ln 5, Col 1   (cursor on the leading `|`)
+Right ×5   → Ln 5, Col 6   (cursor on the 6th source char — the space
+                            between `a` and the second `|`)
+```
+
+The visual cursor moves to the second `│` separator at the same step.
+`|`→`│` is a same-width replacement, so the source-byte ↔ visual-col mapping
+is direct and the cursor walks it correctly.
+
+What I originally hit (and called a "skip past the cell"): in
+`test_file.md`, the table ended at line 22 and "End." was at line 24, so
+`:23` jumped to the **empty line between them** — not into the table.
+Subsequent `→` presses crossed the newline into "End." as expected for any
+editor that respects raw-source navigation.
+
+So the only honest finding here is that compose hides line numbers, which
+makes raw-line `:N` jumps harder to predict. A future enhancement could
+keep a faint `Ln N` annotation visible at the cursor's row in compose
+mode; the current behavior is not a bug.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR fixes critical mouse-wheel scrolling bugs in markdown compose mode and adds missing table borders. The root cause of the scroll issues was that viewport scroll math was counting visual rows using raw source text wrapping, while the markdown_compose plugin was injecting soft-break markers for hanging-indent wrapping. The two systems were out of sync, causing wheel events to be "absorbed" at list item boundaries and preventing scrolling to EOF.

## Key Changes

- **Fix mouse-wheel scroll math for compose mode**: Modified `Viewport::scroll_up_visual` and `scroll_down_visual` to accept and consult plugin soft-break positions when counting visual rows. Added `count_visual_rows_for_line` helper that prefers soft-break counts over raw `wrap_line` calculations, keeping scroll behavior in lock-step with the renderer.

- **Collect soft-break positions at scroll time**: Updated `Editor::handle_mouse_scroll` and `handle_key_input` to call `EditorState::collect_soft_break_positions()` before scrolling, ensuring the viewport has the authoritative soft-break list from the markdown_compose plugin.

- **Add table border virtual lines**: Implemented `processTableBorders` in markdown_compose.ts to render missing top (`┌─┬─┐`), inter-row (`├─┼─┤`), and bottom (`└─┴─┘`) borders for markdown tables. Borders are keyed per-line via virtual-line namespaces and respect the same column widths as cell conceals.

- **Fix status bar truncation on narrow terminals**: Modified `StatusBarRenderer::render` to reserve a minimum budget for left-side items (buffer name, cursor position) and drop low-priority right-side elements first when space is constrained, preventing `Ln/Col` from being clipped to a single character.

- **Add missing i18n key**: Added `buffer.switched` translation key to all 14 locale files (en, cs, de, es, fr, it, ja, ko, pt-BR, ru, th, uk, vi, zh-CN) to fix the untranslated key leak when switching buffers.

## Implementation Details

- Soft-break positions are collected as a sorted `Vec<usize>` of byte offsets and passed through the scroll call chain. The `partition_point` binary search efficiently determines which breaks fall within a given line's byte range.

- Table borders use the same `allocated` column widths computed by `processTableAlignment`, ensuring pixel-perfect alignment with the cell conceals.

- The status bar fix uses a priority-based drop strategy: right-side items are dropped from the right-most first, preserving at least one right element if any was configured.

- A regression test (`test_compose_mode_mouse_wheel_long_list_progresses_to_eof`) verifies that wheel events make monotonic progress through a long-wrap list and reach EOF within a reasonable bound.

https://claude.ai/code/session_01L2k2X83T54bqpR2JsMWj5C