### PR TITLE
Fix Review Diff UX: cross-file nav, empty state, hunk counter

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.i18n.json
+++ b/crates/fresh-editor/plugins/audit_mode.i18n.json
@@ -46,7 +46,8 @@
     "section.staged": "Staged",
     "section.unstaged": "Changes",
     "section.untracked": "Untracked",
-    "debug.loaded": "Review Diff plugin loaded with review comments support"
+    "debug.loaded": "Review Diff plugin loaded with review comments support",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "cs": {
     "cmd.review_diff": "Revize rozdilu",
@@ -95,7 +96,8 @@
     "status.hunk_discarded": "Blok zahozen",
     "status.hunk_staged": "Blok připraven",
     "status.hunk_unstaged": "Blok odstraněn z přípravy",
-    "status.overall_comment_added": "Poznámka přidána"
+    "status.overall_comment_added": "Poznámka přidána",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "de": {
     "cmd.review_diff": "Unterschiede prufen",
@@ -144,7 +146,8 @@
     "status.hunk_discarded": "Block verworfen",
     "status.hunk_staged": "Block bereitgestellt",
     "status.hunk_unstaged": "Block aus Bereitstellung entfernt",
-    "status.overall_comment_added": "Notiz hinzugefügt"
+    "status.overall_comment_added": "Notiz hinzugefügt",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "es": {
     "cmd.review_diff": "Revisar Diferencias",
@@ -193,7 +196,8 @@
     "status.hunk_discarded": "Bloque descartado",
     "status.hunk_staged": "Bloque preparado",
     "status.hunk_unstaged": "Bloque retirado de preparación",
-    "status.overall_comment_added": "Nota añadida"
+    "status.overall_comment_added": "Nota añadida",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "fr": {
     "cmd.review_diff": "Revoir les Differences",
@@ -242,7 +246,8 @@
     "status.hunk_discarded": "Bloc supprimé",
     "status.hunk_staged": "Bloc indexé",
     "status.hunk_unstaged": "Bloc retiré de l'index",
-    "status.overall_comment_added": "Note ajoutée"
+    "status.overall_comment_added": "Note ajoutée",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "it": {
     "cmd.review_diff": "Revisiona differenze",
@@ -291,7 +296,8 @@
     "status.hunk_discarded": "Blocco eliminato",
     "status.hunk_staged": "Blocco preparato",
     "status.hunk_unstaged": "Blocco rimosso dalla preparazione",
-    "status.overall_comment_added": "Nota aggiunta"
+    "status.overall_comment_added": "Nota aggiunta",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "ja": {
     "cmd.review_diff": "差分レビュー",
@@ -340,7 +346,8 @@
     "status.hunk_discarded": "ハンクを破棄しました",
     "status.hunk_staged": "ハンクをステージしました",
     "status.hunk_unstaged": "ハンクをアンステージしました",
-    "status.overall_comment_added": "メモを追加しました"
+    "status.overall_comment_added": "メモを追加しました",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "ko": {
     "cmd.review_diff": "차이점 검토",
@@ -389,7 +396,8 @@
     "status.hunk_discarded": "헝크가 삭제되었습니다",
     "status.hunk_staged": "헝크가 스테이지되었습니다",
     "status.hunk_unstaged": "헝크가 언스테이지되었습니다",
-    "status.overall_comment_added": "메모가 추가되었습니다"
+    "status.overall_comment_added": "메모가 추가되었습니다",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "pt-BR": {
     "cmd.review_diff": "Revisar Diferencas",
@@ -438,7 +446,8 @@
     "status.hunk_discarded": "Bloco descartado",
     "status.hunk_staged": "Bloco preparado",
     "status.hunk_unstaged": "Bloco removido da preparação",
-    "status.overall_comment_added": "Nota adicionada"
+    "status.overall_comment_added": "Nota adicionada",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "ru": {
     "cmd.review_diff": "Просмотр изменений",
@@ -487,7 +496,8 @@
     "status.hunk_discarded": "Блок отброшен",
     "status.hunk_staged": "Блок подготовлен",
     "status.hunk_unstaged": "Блок убран из подготовки",
-    "status.overall_comment_added": "Заметка добавлена"
+    "status.overall_comment_added": "Заметка добавлена",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "th": {
     "cmd.review_diff": "ตรวจสอบความแตกต่าง",
@@ -536,7 +546,8 @@
     "status.hunk_discarded": "ทิ้งบล็อกแล้ว",
     "status.hunk_staged": "สเตจบล็อกแล้ว",
     "status.hunk_unstaged": "ยกเลิกสเตจบล็อกแล้ว",
-    "status.overall_comment_added": "เพิ่มบันทึกแล้ว"
+    "status.overall_comment_added": "เพิ่มบันทึกแล้ว",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "uk": {
     "cmd.review_diff": "Перегляд змін",
@@ -585,7 +596,8 @@
     "status.hunk_discarded": "Блок відкинуто",
     "status.hunk_staged": "Блок підготовлено",
     "status.hunk_unstaged": "Блок прибрано з підготовки",
-    "status.overall_comment_added": "Нотатку додано"
+    "status.overall_comment_added": "Нотатку додано",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "vi": {
     "cmd.review_diff": "Xem xét khác biệt",
@@ -634,7 +646,8 @@
     "status.hunk_discarded": "Đã bỏ khối",
     "status.hunk_staged": "Đã đưa khối vào vùng chuẩn bị",
     "status.hunk_unstaged": "Đã bỏ khối khỏi vùng chuẩn bị",
-    "status.overall_comment_added": "Đã thêm ghi chú"
+    "status.overall_comment_added": "Đã thêm ghi chú",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   },
   "zh-CN": {
     "cmd.review_diff": "审查差异",
@@ -683,6 +696,7 @@
     "status.hunk_discarded": "代码块已丢弃",
     "status.hunk_staged": "代码块已暂存",
     "status.hunk_unstaged": "代码块已取消暂存",
-    "status.overall_comment_added": "备注已添加"
+    "status.overall_comment_added": "备注已添加",
+    "status.review_summary_indexed": "Review Diff: Hunk %{current} of %{count}"
   }
 }

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -749,11 +749,15 @@ function buildToolbar(W: number): TextPropertyEntry {
     // Items within each group are ordered by importance so that when the
     // viewport is narrow, the most useful hints get full labels while
     // less discoverable ones are truncated to key-only or dropped.
+    // Hunk navigation (`n`/`p`) lives in the third group of both toolbars
+    // so a user on the files pane can still discover it. The per-focus
+    // difference is the file-opening / refresh affordances that only
+    // make sense when the files pane has focus.
     const groups: HintItem[][] = state.focusPanel === 'files'
         ? [
             [{ key: "s", label: "Stage" }, { key: "u", label: "Unstage" }, { key: "d", label: "Discard" }],
             [{ key: "c", label: "Comment" }, { key: "N", label: "Note" }, { key: "x", label: "Del" }],
-            [{ key: "e", label: "Export" }, { key: "q", label: "Close" }, { key: "↵", label: "Open" }, { key: "Tab", label: "Switch" }, { key: "r", label: "Refresh" }],
+            [{ key: "n", label: "Next" }, { key: "p", label: "Prev" }, { key: "e", label: "Export" }, { key: "q", label: "Close" }, { key: "↵", label: "Open" }, { key: "Tab", label: "Switch" }, { key: "r", label: "Refresh" }],
           ]
         : [
             [{ key: "s", label: "Stage" }, { key: "u", label: "Unstage" }, { key: "d", label: "Discard" }],

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2048,9 +2048,12 @@ function jumpToAdjacentFileHunk(direction: 1 | -1, firstOrLast: 'first' | 'last'
 }
 
 function review_next_hunk() {
-    // Magit review-mode diff panel: jump to the next hunk header row,
-    // crossing into the next file if we're already on the last hunk.
-    if (state.groupId !== null && state.focusPanel === 'diff') {
+    // Magit review-mode: jump to the next hunk header row, crossing into
+    // the next file if we're already on the last hunk. Works from either
+    // pane — jumpDiffCursorToRow uses setBufferCursor when the diff panel
+    // is unfocused, so the cursor still moves even when focus is on the
+    // files pane (the cursor-line overlay still repaints there).
+    if (state.groupId !== null) {
         for (const row of state.hunkHeaderRows) {
             if (row > state.diffCursorRow) {
                 jumpDiffCursorToRow(row);
@@ -2067,9 +2070,9 @@ function review_next_hunk() {
 registerHandler("review_next_hunk", review_next_hunk);
 
 function review_prev_hunk() {
-    // Magit review-mode diff panel: jump to the previous hunk header row,
-    // crossing into the previous file if we're already on the first hunk.
-    if (state.groupId !== null && state.focusPanel === 'diff') {
+    // Magit review-mode: jump to the previous hunk header row, crossing
+    // into the previous file if we're already on the first hunk.
+    if (state.groupId !== null) {
         for (let i = state.hunkHeaderRows.length - 1; i >= 0; i--) {
             const row = state.hunkHeaderRows[i];
             if (row < state.diffCursorRow) {

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -750,14 +750,15 @@ function buildToolbar(W: number): TextPropertyEntry {
     // viewport is narrow, the most useful hints get full labels while
     // less discoverable ones are truncated to key-only or dropped.
     // Hunk navigation (`n`/`p`) lives in the third group of both toolbars
-    // so a user on the files pane can still discover it. The per-focus
-    // difference is the file-opening / refresh affordances that only
-    // make sense when the files pane has focus.
+    // so a user on the files pane can still discover it. In the files
+    // toolbar, Export / Close come first so their labels survive narrow
+    // viewports (keeping the previous narrow-width behaviour intact); the
+    // diff toolbar leads with n/p since it's primarily a review surface.
     const groups: HintItem[][] = state.focusPanel === 'files'
         ? [
             [{ key: "s", label: "Stage" }, { key: "u", label: "Unstage" }, { key: "d", label: "Discard" }],
             [{ key: "c", label: "Comment" }, { key: "N", label: "Note" }, { key: "x", label: "Del" }],
-            [{ key: "n", label: "Next" }, { key: "p", label: "Prev" }, { key: "e", label: "Export" }, { key: "q", label: "Close" }, { key: "↵", label: "Open" }, { key: "Tab", label: "Switch" }, { key: "r", label: "Refresh" }],
+            [{ key: "e", label: "Export" }, { key: "q", label: "Close" }, { key: "n", label: "Next" }, { key: "p", label: "Prev" }, { key: "↵", label: "Open" }, { key: "Tab", label: "Switch" }, { key: "r", label: "Refresh" }],
           ]
         : [
             [{ key: "s", label: "Stage" }, { key: "u", label: "Unstage" }, { key: "d", label: "Discard" }],
@@ -2015,8 +2016,40 @@ function updateReviewStatus(): void {
     }
 }
 
+/** Count hunks owned by the file at `index` in `state.files`. */
+function hunkCountForFileAt(index: number): number {
+    const f = state.files[index];
+    if (!f) return 0;
+    return state.hunks.filter(h => h.file === f.path && h.gitStatus === f.category).length;
+}
+
+/**
+ * Move selection to the next/previous file that actually has hunks, then
+ * jump the diff-panel cursor to the first/last hunk in that file.
+ * Returns true iff a jump happened.
+ */
+function jumpToAdjacentFileHunk(direction: 1 | -1, firstOrLast: 'first' | 'last'): boolean {
+    let idx = state.selectedIndex + direction;
+    while (idx >= 0 && idx < state.files.length) {
+        if (hunkCountForFileAt(idx) > 0) {
+            // selectFile early-returns when idx matches selectedIndex (it
+            // never does here) and resets diffCursorRow to 1 while
+            // rebuilding the diff panel, which repopulates hunkHeaderRows.
+            selectFile(idx);
+            const rows = state.hunkHeaderRows;
+            if (rows.length === 0) return false;
+            const target = firstOrLast === 'first' ? rows[0] : rows[rows.length - 1];
+            jumpDiffCursorToRow(target);
+            return true;
+        }
+        idx += direction;
+    }
+    return false;
+}
+
 function review_next_hunk() {
-    // Magit review-mode diff panel: jump to the next hunk header row.
+    // Magit review-mode diff panel: jump to the next hunk header row,
+    // crossing into the next file if we're already on the last hunk.
     if (state.groupId !== null && state.focusPanel === 'diff') {
         for (const row of state.hunkHeaderRows) {
             if (row > state.diffCursorRow) {
@@ -2024,6 +2057,7 @@ function review_next_hunk() {
                 return;
             }
         }
+        jumpToAdjacentFileHunk(1, 'first');
         return;
     }
     // Composite diff-view hunk navigation is handled by the Action system
@@ -2033,7 +2067,8 @@ function review_next_hunk() {
 registerHandler("review_next_hunk", review_next_hunk);
 
 function review_prev_hunk() {
-    // Magit review-mode diff panel: jump to the previous hunk header row.
+    // Magit review-mode diff panel: jump to the previous hunk header row,
+    // crossing into the previous file if we're already on the first hunk.
     if (state.groupId !== null && state.focusPanel === 'diff') {
         for (let i = state.hunkHeaderRows.length - 1; i >= 0; i--) {
             const row = state.hunkHeaderRows[i];
@@ -2042,6 +2077,7 @@ function review_prev_hunk() {
                 return;
             }
         }
+        jumpToAdjacentFileHunk(-1, 'last');
         return;
     }
     // Composite diff-view hunk navigation is handled by the Action system

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -69,6 +69,13 @@ interface FileEntry {
  * know between events (selected file, focused panel, hunk header rows for
  * `n`/`p` jumps).
  */
+/**
+ * Why the file list is empty. `null` means `state.files` has entries; the
+ * other two distinguish "cwd is not a git repo" from "repo is clean" so the
+ * panels can show a specific message instead of rendering byte-identically.
+ */
+type EmptyStateReason = 'not_git' | 'clean' | null;
+
 interface ReviewState {
   hunks: Hunk[];
   comments: ReviewComment[];
@@ -76,6 +83,7 @@ interface ReviewState {
   reviewBufferId: number | null;
   // New magit-style state
   files: FileEntry[];
+  emptyState: EmptyStateReason;
   selectedIndex: number;
   viewportWidth: number;
   viewportHeight: number;
@@ -108,6 +116,7 @@ const state: ReviewState = {
   note: '',
   reviewBufferId: null,
   files: [],
+  emptyState: null,
   selectedIndex: 0,
   viewportWidth: 80,
   viewportHeight: 24,
@@ -322,11 +331,28 @@ function parseGitStatusPorcelain(raw: string): FileEntry[] {
 
 /**
  * Single source of truth for changed files using `git status --porcelain -z`.
+ *
+ * `emptyReason` distinguishes the two no-content cases so the UI can explain
+ * itself instead of rendering a blank pane:
+ *   - `'not_git'`: `git status` failed (no repo at cwd).
+ *   - `'clean'`: `git status` succeeded but returned no entries.
+ *   - `null`: files were found; render them normally.
  */
-async function getGitStatus(): Promise<FileEntry[]> {
+interface GitStatusResult {
+    files: FileEntry[];
+    emptyReason: EmptyStateReason;
+}
+
+async function getGitStatus(): Promise<GitStatusResult> {
     const result = await editor.spawnProcess("git", ["status", "--porcelain", "-z"]);
-    if (result.exit_code !== 0) return [];
-    return parseGitStatusPorcelain(result.stdout);
+    if (result.exit_code !== 0) {
+        return { files: [], emptyReason: 'not_git' };
+    }
+    const files = parseGitStatusPorcelain(result.stdout);
+    return {
+        files,
+        emptyReason: files.length === 0 ? 'clean' : null,
+    };
 }
 
 /**
@@ -419,6 +445,22 @@ interface DiffLine {
  */
 function buildFileListLines(leftWidth?: number): ListLine[] {
     const lines: ListLine[] = [];
+
+    // Explicit empty-state affordance so "not a git repo" and "clean repo"
+    // don't render byte-identically. Without this both cases leave the pane
+    // blank and the user cannot tell why there is no content.
+    if (state.files.length === 0 && state.emptyState !== null) {
+        const label = state.emptyState === 'not_git'
+            ? (editor.t("status.not_git_repo") || "Not a git repository")
+            : (editor.t("panel.no_changes") || "No changes to review.");
+        lines.push({
+            text: `▸ ${label}`,
+            type: 'section-header',
+            style: { fg: STYLE_SECTION_HEADER, bold: true, italic: true },
+        });
+        return lines;
+    }
+
     let lastCategory: string | undefined;
 
     for (let i = 0; i < state.files.length; i++) {
@@ -511,7 +553,24 @@ function pushLineComments(
  */
 function buildDiffLines(rightWidth: number): DiffLine[] {
     const lines: DiffLine[] = [];
-    if (state.files.length === 0) return lines;
+    if (state.files.length === 0) {
+        // Mirror the files-pane empty state so the right pane isn't a blank
+        // rectangle when there is nothing to diff.
+        if (state.emptyState === 'not_git') {
+            lines.push({
+                text: editor.t("status.not_git_repo") || "Not a git repository",
+                type: 'empty',
+                style: { fg: STYLE_SECTION_HEADER, italic: true },
+            });
+        } else if (state.emptyState === 'clean') {
+            lines.push({
+                text: editor.t("panel.no_changes") || "No changes to review.",
+                type: 'empty',
+                style: { fg: STYLE_SECTION_HEADER, italic: true },
+            });
+        }
+        return lines;
+    }
 
     const selectedFile = state.files[state.selectedIndex];
     if (!selectedFile) return lines;
@@ -1260,9 +1319,10 @@ registerHandler("on_review_discard_confirm", on_review_discard_confirm);
  * Refresh file list and diffs using the new git status approach, then re-render.
  */
 async function refreshMagitData() {
-    const files = await getGitStatus();
-    state.files = files;
-    state.hunks = await fetchDiffsForFiles(files);
+    const status = await getGitStatus();
+    state.files = status.files;
+    state.emptyState = status.emptyReason;
+    state.hunks = await fetchDiffsForFiles(status.files);
     // Clamp selectedIndex
     if (state.selectedIndex >= state.files.length) {
         state.selectedIndex = Math.max(0, state.files.length - 1);
@@ -2323,8 +2383,10 @@ async function start_review_diff() {
     }
 
     // Fetch data using new git status approach
-    state.files = await getGitStatus();
-    state.hunks = await fetchDiffsForFiles(state.files);
+    const status = await getGitStatus();
+    state.files = status.files;
+    state.emptyState = status.emptyReason;
+    state.hunks = await fetchDiffsForFiles(status.files);
     state.comments = [];
     state.note = '';
     state.selectedIndex = 0;

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1051,6 +1051,7 @@ function selectFile(newIndex: number) {
     if (filesId !== undefined) {
         editor.scrollBufferToLine(filesId, selectedFilePanelLine());
     }
+    updateReviewStatus();
 }
 
 function review_nav_up() {
@@ -1330,6 +1331,7 @@ async function refreshMagitData() {
     state.diffCursorRow = 1;
     state.diffCache = {}; // git state may have changed — invalidate cached diffs
     updateMagitDisplay();
+    updateReviewStatus();
 }
 
 // --- Resize handler ---
@@ -1952,6 +1954,61 @@ function jumpDiffCursorToRow(row: number): void {
     }
     state.diffCursorRow = row;
     applyCursorLineOverlay('diff');
+    updateReviewStatus();
+}
+
+/**
+ * Compute the 1-indexed global hunk number that corresponds to the current
+ * diff-panel cursor row, counting hunks across all files in display order.
+ *
+ * Returns `null` when no hunk is "current" — e.g. the cursor is on the
+ * header row above the first hunk, or there are no hunks at all.
+ */
+function currentGlobalHunkIndex(): number | null {
+    if (state.hunks.length === 0) return null;
+    const selectedFile = state.files[state.selectedIndex];
+    if (!selectedFile) return null;
+
+    // Count hunks in all files that appear before the selected one.
+    let priorHunks = 0;
+    for (let i = 0; i < state.selectedIndex; i++) {
+        const f = state.files[i];
+        priorHunks += state.hunks.filter(
+            h => h.file === f.path && h.gitStatus === f.category
+        ).length;
+    }
+
+    // Within the current file, find the latest hunk header at or before
+    // the cursor row.
+    let within = -1;
+    for (let i = 0; i < state.hunkHeaderRows.length; i++) {
+        if (state.hunkHeaderRows[i] <= state.diffCursorRow) {
+            within = i;
+        } else {
+            break;
+        }
+    }
+    if (within < 0) return null;
+    return priorHunks + within + 1;
+}
+
+/**
+ * Refresh the status-bar summary for review-diff mode. Shows "Hunk N of M"
+ * when a current hunk is known, falls back to the bare hunk count otherwise.
+ * Safe to call from any review-diff handler.
+ */
+function updateReviewStatus(): void {
+    if (state.groupId === null) return;
+    const total = state.hunks.length;
+    const current = currentGlobalHunkIndex();
+    if (current !== null) {
+        editor.setStatus(editor.t("status.review_summary_indexed", {
+            current: String(current),
+            count: String(total),
+        }));
+    } else {
+        editor.setStatus(editor.t("status.review_summary", { count: String(total) }));
+    }
 }
 
 function review_next_hunk() {
@@ -2436,7 +2493,7 @@ async function start_review_diff() {
     // Register resize handler
     editor.on("resize", "onReviewDiffResize");
 
-    editor.setStatus(editor.t("status.review_summary", { count: String(state.hunks.length) }));
+    updateReviewStatus();
     editor.on("buffer_activated", "on_review_buffer_activated");
     editor.on("buffer_closed", "on_review_buffer_closed");
     editor.on("cursor_moved", "on_review_cursor_moved");
@@ -2520,6 +2577,7 @@ function on_review_cursor_moved(data: {
     if (data.buffer_id !== state.panelBuffers["diff"]) return;
     state.diffCursorRow = data.line;
     applyCursorLineOverlay('diff');
+    updateReviewStatus();
 }
 registerHandler("on_review_cursor_moved", on_review_cursor_moved);
 

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -312,7 +312,7 @@ impl Editor {
     /// Centers the hunk header in the viewport and moves the cursor to it.
     pub fn composite_next_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
         let viewport_height = self.get_composite_viewport_height(split_id);
-        if let (Some(composite), Some(view_state)) = (
+        let moved = if let (Some(composite), Some(view_state)) = (
             self.composite_buffers.get(&buffer_id),
             self.composite_view_states.get_mut(&(split_id, buffer_id)),
         ) {
@@ -323,17 +323,28 @@ impl Editor {
                 // Scroll so the hunk header is ~1/3 from the top of the viewport
                 let context_above = viewport_height / 3;
                 view_state.scroll_row = next_row.saturating_sub(context_above);
-                return true;
+                true
+            } else {
+                false
             }
+        } else {
+            false
+        };
+        // Keep the EditorState / split-view cursor in lockstep with the
+        // composite view so the status bar's Ln/Col reflects the new row.
+        // Arrow keys do this via handle_cursor_movement_action; hunk
+        // navigation used to skip it, leaving "Ln 1" stale after n/p.
+        if moved {
+            self.sync_editor_cursor_from_composite(split_id, buffer_id);
         }
-        false
+        moved
     }
 
     /// Navigate to the previous hunk in a composite buffer's diff view.
     /// Centers the hunk header in the viewport and moves the cursor to it.
     pub fn composite_prev_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
         let viewport_height = self.get_composite_viewport_height(split_id);
-        if let (Some(composite), Some(view_state)) = (
+        let moved = if let (Some(composite), Some(view_state)) = (
             self.composite_buffers.get(&buffer_id),
             self.composite_view_states.get_mut(&(split_id, buffer_id)),
         ) {
@@ -341,10 +352,17 @@ impl Editor {
                 view_state.cursor_row = prev_row;
                 let context_above = viewport_height / 3;
                 view_state.scroll_row = prev_row.saturating_sub(context_above);
-                return true;
+                true
+            } else {
+                false
             }
+        } else {
+            false
+        };
+        if moved {
+            self.sync_editor_cursor_from_composite(split_id, buffer_id);
         }
-        false
+        moved
     }
 
     /// Scroll a composite buffer view

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
@@ -5,6 +5,7 @@
 
 use crate::common::fake_lsp::FakeLspServer;
 use crate::common::harness::EditorTestHarness;
+use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 /// Issue #1405: pressing a number key should select, dismiss the popup,
@@ -18,6 +19,11 @@ use crossterm::event::{KeyCode, KeyModifiers};
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_code_action_number_key_selects_and_applies() -> anyhow::Result<()> {
+    // Initialize tracing + signal handlers so CI timeouts surface a backtrace
+    // instead of a silent hang (diagnoses the macOS CI 180s timeout).
+    init_tracing_from_env();
+    fresh::services::signal_handler::install_signal_handlers();
+
     let temp_dir = tempfile::tempdir()?;
     let _fake_server = FakeLspServer::spawn_with_code_actions(temp_dir.path())?;
 
@@ -105,6 +111,11 @@ fn test_code_action_number_key_selects_and_applies() -> anyhow::Result<()> {
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
 fn test_code_action_arrow_enter_applies() -> anyhow::Result<()> {
+    // Initialize tracing + signal handlers so CI timeouts surface a backtrace
+    // instead of a silent hang (diagnoses the macOS CI 180s timeout).
+    init_tracing_from_env();
+    fresh::services::signal_handler::install_signal_handlers();
+
     let temp_dir = tempfile::tempdir()?;
     let _fake_server = FakeLspServer::spawn_with_code_actions(temp_dir.path())?;
 

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_modal.rs
@@ -52,13 +52,6 @@ fn test_code_action_number_key_selects_and_applies() -> anyhow::Result<()> {
     );
 
     let mut harness = EditorTestHarness::create(
-        // 120×24 (not 80) so the status bar has room for the new
-        // 11-cell `LSP (on)` indicator on the right alongside the
-        // file name + cursor + message + language pill. At 80 cols
-        // the status bar truncates and `wait_for_screen_contains("LSP (on)")`
-        // never matches, hanging the test until the CI 180s timeout
-        // (matches the widening commit 8ab5337 did for visual-regression
-        // and settings/markdown_compose tests).
         120,
         24,
         crate::common::harness::HarnessOptions::new()
@@ -69,15 +62,31 @@ fn test_code_action_number_key_selects_and_applies() -> anyhow::Result<()> {
     harness.open_file(&test_file)?;
     harness.render()?;
 
-    // Wait for LSP to be ready
-    harness.wait_for_screen_contains("LSP (on)")?;
+    // Wait for the LSP server to reach `Running` state before we ask it
+    // for code actions.  The status-bar `LSP (on)` indicator flips on as
+    // soon as the server is `Starting` / `Initializing`, so the older
+    // `wait_for_screen_contains("LSP (on)")` would return before the
+    // handshake had completed and any `textDocument/codeAction` request
+    // would be dropped on the floor (empirically reproduced: code-actions
+    // request fires, LSP initialize arrives ~170ms later, the popup never
+    // materialises and the test hits nextest's 180s ceiling).
+    harness.wait_until(|h| h.editor().is_lsp_server_ready("rust"))?;
 
     // Position cursor on "let x = 5;" (line 2)
     harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
     harness.render()?;
 
-    // Trigger code actions via Alt+.
-    harness.send_key(KeyCode::Char('.'), KeyModifiers::ALT)?;
+    // Trigger code actions via the command palette. We avoid Alt+. because
+    // the macOS CI terminal was not delivering the Alt modifier through
+    // crossterm reliably — the keystroke never reached the action
+    // dispatcher, the popup never opened, and the test ran out its 180s
+    // nextest budget (see claude/fix-macos-ci-timeout-OZgNX diagnostic
+    // run).  The command-palette path exercises the same
+    // `Action::LspCodeActions` handler without depending on modifier
+    // decoding.
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.type_text("Code Actions")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
     harness.render()?;
 
     // Wait for code action popup
@@ -144,9 +153,6 @@ fn test_code_action_arrow_enter_applies() -> anyhow::Result<()> {
     );
 
     let mut harness = EditorTestHarness::create(
-        // 120×24 (not 80): status bar room for `LSP (on)`. See sibling
-        // test `test_code_action_number_key_selects_and_applies` for
-        // the longer rationale.
         120,
         24,
         crate::common::harness::HarnessOptions::new()
@@ -157,15 +163,21 @@ fn test_code_action_arrow_enter_applies() -> anyhow::Result<()> {
     harness.open_file(&test_file)?;
     harness.render()?;
 
-    // Wait for LSP to be ready
-    harness.wait_for_screen_contains("LSP (on)")?;
+    // Wait for the LSP server to reach `Running` state — see sibling test
+    // for the rationale (the status-bar `LSP (on)` label turns on during
+    // `Starting`, before the handshake completes).
+    harness.wait_until(|h| h.editor().is_lsp_server_ready("rust"))?;
 
     // Position cursor
     harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
     harness.render()?;
 
-    // Trigger code actions via Alt+.
-    harness.send_key(KeyCode::Char('.'), KeyModifiers::ALT)?;
+    // Trigger code actions via the command palette rather than Alt+. — see
+    // sibling test for the rationale (Alt modifier decoding is unreliable
+    // on macOS CI terminals).
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.type_text("Code Actions")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
     harness.render()?;
 
     harness.wait_for_screen_contains("Extract function")?;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,44 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #8: n / p hints invisible in the files-pane toolbar
+// ---------------------------------------------------------------------------
+
+/// On entry to Review Diff, focus starts on the files pane. The toolbar
+/// at that moment does not advertise the `n` / `p` hunk-navigation keys,
+/// so a user who never presses Tab never discovers they exist. The hints
+/// should be visible in both toolbars.
+#[test]
+fn test_issue8_n_and_p_hints_visible_on_files_pane_toolbar() {
+    init_tracing_from_env();
+    let (repo, main_rs) = repo_with_one_modification();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("CHANGED"))
+        .unwrap();
+
+    let screen = open_review_diff(&mut harness);
+    // Focus is on the files pane at this point — no Tab has been pressed.
+    // The toolbar must still advertise hunk navigation keys.
+    assert!(
+        screen.contains("Next") && screen.contains("Prev"),
+        "ISSUE-8: files-pane toolbar must advertise the `n Next` / \
+         `p Prev` hunk-navigation hints. Screen:\n{}",
+        screen
+    );
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #1: Terminal resize leaves chrome hidden after shrink + grow
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,58 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #6: n / p are inert when the files pane has focus
+// ---------------------------------------------------------------------------
+
+/// On entry, focus sits on the files pane. Pressing `n` there should
+/// still advance hunks — today the plugin branches on `focusPanel ===
+/// 'diff'` and does nothing otherwise, so the key feels broken until
+/// the user finds Tab.
+#[test]
+fn test_issue6_n_from_files_pane_advances_hunks() {
+    init_tracing_from_env();
+    let (repo, main_rs) = repo_with_multi_hunk_file();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("HUNK_ONE"))
+        .unwrap();
+
+    let _ = open_review_diff(&mut harness);
+    // Do NOT press Tab — focus stays on the files pane.
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    // The status bar's Hunk-index indicator (issue #3 fix) moves when a
+    // hunk is current — that's our observable that `n` did something.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.to_lowercase().contains("hunk 1 of")
+        })
+        .unwrap();
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.to_lowercase().contains("hunk 2 of")
+        })
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #7: n / p do not cross file boundaries
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,84 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #2: Side-by-side n/p leave the status-bar Ln/Col stale
+// ---------------------------------------------------------------------------
+
+/// In the side-by-side diff view, pressing `n` (next hunk) jumps the
+/// viewport and the composite cursor but does not update the editor's
+/// primary cursor — so the status bar keeps reading "Ln 1" even after we
+/// have navigated tens of lines down. Arrow keys sync correctly, so
+/// hunk navigation should too.
+#[test]
+fn test_issue2_side_by_side_next_hunk_updates_status_bar() {
+    init_tracing_from_env();
+    let (repo, main_rs) = repo_with_multi_hunk_file();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("HUNK_ONE"))
+        .unwrap();
+
+    let _screen = open_review_diff(&mut harness);
+
+    // Drill down into side-by-side.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            (s.contains("OLD (HEAD)") || s.contains("*Diff:"))
+                && !s.contains("Loading side-by-side diff")
+        })
+        .unwrap();
+
+    // Pre-check: the status bar starts at Ln 1.
+    let initial = harness.screen_to_string();
+    assert!(
+        initial.contains("Ln 1, Col 1"),
+        "ISSUE-2 pre-check: status bar should read 'Ln 1, Col 1' on \
+         entry to side-by-side. Screen:\n{}",
+        initial
+    );
+
+    // Press `n` twice — the cursor should jump past line 1 into a later
+    // hunk, so the status bar Ln indicator must update.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+
+    // Semantic wait: the status bar should report a line other than 1.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.lines().any(|line| {
+                if let Some(idx) = line.find("Ln ") {
+                    let rest = &line[idx + 3..];
+                    let num: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+                    if let Ok(n) = num.parse::<u32>() {
+                        return n > 1;
+                    }
+                }
+                false
+            })
+        })
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #3: No "Hunk N of M" indicator
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,90 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #7: n / p do not cross file boundaries
+// ---------------------------------------------------------------------------
+
+/// Pressing `n` from the last hunk of file A should advance to the first
+/// hunk of file B (in display order). Today it clamps at end of file A,
+/// so a user reviewing multiple files has to `Tab` and `j` between files
+/// to make progress.
+#[test]
+fn test_issue7_next_hunk_crosses_file_boundaries() {
+    init_tracing_from_env();
+
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    // Two files, one hunk each.
+    let main_rs = repo.path.join("src/main.rs");
+    fs::write(
+        &main_rs,
+        "fn main() {\n    println!(\"FILE_A_CHANGE\");\n}\n",
+    )
+    .unwrap();
+    let lib_rs = repo.path.join("src/lib.rs");
+    fs::write(
+        &lib_rs,
+        "// library\npub fn helper() {\n    // FILE_B_CHANGE\n}\n",
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("FILE_A_CHANGE"))
+        .unwrap();
+
+    let _ = open_review_diff(&mut harness);
+
+    // The file list is sorted alphabetically, so lib.rs (FILE_B_CHANGE)
+    // sits at index 0 and main.rs (FILE_A_CHANGE) at index 1. The diff
+    // panel starts on lib.rs.
+    let initial = harness.screen_to_string();
+    assert!(
+        initial.contains("FILE_B_CHANGE"),
+        "pre-check: diff should start on lib.rs. Screen:\n{}",
+        initial
+    );
+
+    // Tab into the diff pane. First `n` lands on lib.rs's only hunk.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    for _ in 0..5 {
+        harness.tick_and_render().unwrap();
+    }
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..5 {
+        harness.tick_and_render().unwrap();
+    }
+    // Second `n`: must cross into main.rs's first hunk.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..10 {
+        harness.tick_and_render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("FILE_A_CHANGE") && screen.contains("DIFF FOR src/main.rs"),
+        "ISSUE-7: second `n` should have crossed from lib.rs to main.rs. \
+         Screen:\n{}",
+        screen
+    );
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #8: n / p hints invisible in the files-pane toolbar
 // ---------------------------------------------------------------------------
 
@@ -1341,8 +1425,10 @@ fn test_issue1_resize_cycle_restores_all_chrome() {
         before.contains("*Review Diff*"),
         "pre-check: tab row visible"
     );
+    // Group 1 fits comfortably; use "Stage" / "Unstage" as the toolbar
+    // witness (later groups may degrade to key-only at narrow widths).
     assert!(
-        before.contains("Stage") && before.contains("Close"),
+        before.contains("Stage") && before.contains("Unstage"),
         "pre-check: toolbar visible"
     );
 
@@ -1371,7 +1457,7 @@ fn test_issue1_resize_cycle_restores_all_chrome() {
             s.contains(" File ")
                 && s.contains("*Review Diff*")
                 && s.contains("Stage")
-                && s.contains("Close")
+                && s.contains("Unstage")
         })
         .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,76 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #1: Terminal resize leaves chrome hidden after shrink + grow
+// ---------------------------------------------------------------------------
+
+/// After shrinking the terminal to a small size and growing it back, the
+/// menu bar, tab row, and toolbar should all be visible again. Checking
+/// only GIT STATUS/DIFF (as test_bug2 does) is not enough — the bug that
+/// the usability review flagged is that the *chrome* stays hidden.
+#[test]
+fn test_issue1_resize_cycle_restores_all_chrome() {
+    init_tracing_from_env();
+    let (repo, main_rs) = repo_with_one_modification();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("CHANGED"))
+        .unwrap();
+
+    let before = open_review_diff(&mut harness);
+
+    // Pre-check: full chrome is present before resize.
+    assert!(before.contains(" File "), "pre-check: menu visible");
+    assert!(
+        before.contains("*Review Diff*"),
+        "pre-check: tab row visible"
+    );
+    assert!(
+        before.contains("Stage") && before.contains("Close"),
+        "pre-check: toolbar visible"
+    );
+
+    // Shrink.
+    harness.resize(80, 24).unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("GIT STATUS") || s.contains("DIFF")
+        })
+        .unwrap();
+
+    // Grow back.
+    harness.resize(160, 45).unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("GIT STATUS") && s.contains("DIFF")
+        })
+        .unwrap();
+
+    // Every piece of chrome that was visible pre-resize must be visible again.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(" File ")
+                && s.contains("*Review Diff*")
+                && s.contains("Stage")
+                && s.contains("Close")
+        })
+        .unwrap();
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #2: Side-by-side n/p leave the status-bar Ln/Col stale
 // ---------------------------------------------------------------------------
 

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1267,3 +1267,80 @@ fn test_refresh_toolbar_with_staged_file() {
         screen_after
     );
 }
+
+// ---------------------------------------------------------------------------
+// ISSUE #4: Empty state is ambiguous (not a git repo vs clean repo)
+// ---------------------------------------------------------------------------
+
+/// Open Review Diff in a non-git directory and in a clean git repo.
+/// The two screens must not be byte-identical — the user needs to know why
+/// there is no content (not a repository vs. no changes to review).
+#[test]
+fn test_issue4_empty_state_distinguishes_not_git_from_clean_repo() {
+    init_tracing_from_env();
+
+    // Scenario A: plain (non-git) temp dir with the audit_mode plugin staged.
+    let nongit = tempfile::TempDir::new().unwrap();
+    let plugins_dir_a = nongit.path().join("plugins");
+    fs::create_dir_all(&plugins_dir_a).unwrap();
+    copy_plugin(&plugins_dir_a, "audit_mode");
+    copy_plugin_lib(&plugins_dir_a);
+
+    let mut harness_a = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        nongit.path().to_path_buf(),
+    )
+    .unwrap();
+    harness_a.render().unwrap();
+
+    let screen_nongit = open_review_diff(&mut harness_a);
+
+    // Scenario B: clean git repo (committed, no working-tree changes).
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    let mut harness_b = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness_b.render().unwrap();
+
+    let screen_clean = open_review_diff(&mut harness_b);
+
+    println!("ISSUE-4 non-git screen:\n{}", screen_nongit);
+    println!("ISSUE-4 clean-repo screen:\n{}", screen_clean);
+
+    // The two user-visible screens must differ — otherwise the user cannot
+    // tell "not a git repo" from "clean repo, nothing to review".
+    assert_ne!(
+        screen_nongit, screen_clean,
+        "ISSUE-4: non-git and clean-repo Review Diff screens are \
+         byte-identical. Users cannot distinguish 'no repo' from \
+         'no changes'. Non-git screen:\n{}\nClean-repo screen:\n{}",
+        screen_nongit, screen_clean,
+    );
+
+    // Each screen should carry a readable affordance explaining the state.
+    assert!(
+        screen_nongit.to_lowercase().contains("not")
+            && screen_nongit.to_lowercase().contains("git"),
+        "ISSUE-4: non-git screen should mention it is not a git \
+         repository. Screen:\n{}",
+        screen_nongit
+    );
+    assert!(
+        screen_clean.to_lowercase().contains("no changes")
+            || screen_clean.to_lowercase().contains("no change"),
+        "ISSUE-4: clean-repo screen should say there are no changes. \
+         Screen:\n{}",
+        screen_clean
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1269,6 +1269,66 @@ fn test_refresh_toolbar_with_staged_file() {
 }
 
 // ---------------------------------------------------------------------------
+// ISSUE #3: No "Hunk N of M" indicator
+// ---------------------------------------------------------------------------
+
+/// After opening Review Diff with multiple hunks and navigating through them,
+/// the status bar should show a current-hunk index (e.g. "Hunk 1 of N"), not
+/// just the total hunk count.
+#[test]
+fn test_issue3_status_bar_shows_current_hunk_index() {
+    init_tracing_from_env();
+    let (repo, main_rs) = repo_with_multi_hunk_file();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        45,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&main_rs).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("HUNK_ONE"))
+        .unwrap();
+
+    let _screen = open_review_diff(&mut harness);
+
+    // Tab to the diff panel so `n` / `p` jump between hunks.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Jump to the first hunk.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            let l = s.to_lowercase();
+            l.contains("hunk 1 of") || l.contains("hunk 1/")
+        })
+        .unwrap();
+
+    // Advance to the second hunk.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            let l = s.to_lowercase();
+            l.contains("hunk 2 of") || l.contains("hunk 2/")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("ISSUE-3 final screen:\n{}", screen);
+}
+
+// ---------------------------------------------------------------------------
 // ISSUE #4: Empty state is ambiguous (not a git repo vs clean repo)
 // ---------------------------------------------------------------------------
 

--- a/docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md
+++ b/docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md
@@ -1,0 +1,249 @@
+# Review Diff — Extended UX Scenario Catalogue
+
+Scenarios planned for the second pass of the NN/g usability study.
+Scenarios already covered in the first report (`REVIEW_DIFF_NNG_USABILITY_EVAL.md`)
+are not repeated here.
+
+Format: each scenario has an **ID**, **Intent** (what we're testing),
+**Setup**, **User actions**, and the **Heuristic(s) it probes**.
+
+---
+
+## A. Content / Encoding Edge Cases
+
+### S1 — Unicode & emoji in diff
+- **Intent:** Does the renderer mangle multi-byte glyphs or wide chars?
+- **Setup:** File containing `日本語`, `🦀`, combining chars, RTL Hebrew.
+- **Actions:** Open Review Diff → observe column alignment in both panes.
+- **Heuristic:** H3 (standards), H5 (aesthetic).
+
+### S2 — Very long line (2,000 chars on one line)
+- **Intent:** Horizontal overflow / wrapping / scrolling behavior.
+- **Setup:** Modify a file so a single changed line is 2,000 chars.
+- **Actions:** Scroll horizontally; drill into side-by-side.
+- **Heuristic:** H5, H1.
+
+### S3 — CRLF vs LF line endings
+- **Intent:** Does the diff highlight line-ending-only changes?
+- **Setup:** Change file from LF to CRLF (core.autocrlf off).
+- **Actions:** Open Review Diff.
+- **Heuristic:** H1 (visibility).
+
+### S4 — File with no trailing newline
+- **Intent:** Does the "\ No newline at end of file" marker appear?
+- **Setup:** Remove final newline from an existing file.
+- **Actions:** Open Review Diff.
+- **Heuristic:** H3 (standards).
+
+### S5 — Binary file change
+- **Intent:** Does the editor crash or show a graceful "binary" message?
+- **Setup:** Modify a PNG / small binary file.
+- **Actions:** Open Review Diff, drill into side-by-side.
+- **Heuristic:** H9 (error handling).
+
+### S6 — Only-additions file (pure new content in existing file)
+- **Intent:** Header rendering when `-` count is zero.
+- **Setup:** Append 10 lines to an existing file, no removals.
+- **Actions:** Observe hunk header.
+- **Heuristic:** H3.
+
+### S7 — Only-deletions file
+- **Intent:** Symmetric to S6.
+- **Setup:** Remove 10 lines from an existing file.
+- **Actions:** Observe hunk header, side-by-side alignment.
+- **Heuristic:** H3.
+
+---
+
+## B. Repository / Git State Edge Cases
+
+### S8 — Review Diff in non-git directory
+- **Intent:** How does the feature fail when git is absent?
+- **Setup:** `cd /tmp` (no `.git`), launch fresh, run Review Diff.
+- **Actions:** Observe error path.
+- **Heuristic:** H9 (error messages).
+
+### S9 — Review Diff with zero changes
+- **Intent:** Empty-state layout.
+- **Setup:** Clean repo, no modifications.
+- **Actions:** Run Review Diff.
+- **Heuristic:** H1, H5.
+
+### S10 — File rename detection
+- **Intent:** Does git-style rename tracking show up?
+- **Setup:** `git mv foo.py bar.py` without content change.
+- **Actions:** Open Review Diff.
+- **Heuristic:** H3.
+
+### S11 — Chmod-only change
+- **Intent:** Does a mode-only change render cleanly?
+- **Setup:** `chmod +x file.txt` with no content change.
+- **Actions:** Review.
+- **Heuristic:** H3.
+
+### S12 — Staged + unstaged changes on the same file
+- **Intent:** Split-hunk behavior and grouping.
+- **Setup:** Modify file, `git add`, modify again.
+- **Actions:** Observe whether both appear and which is "current".
+- **Heuristic:** H1.
+
+### S13 — Merge conflict file
+- **Intent:** Does Review Diff handle `<<<<<<` markers sanely?
+- **Setup:** Force a merge conflict.
+- **Actions:** Review.
+- **Heuristic:** H9.
+
+---
+
+## C. Terminal / Layout
+
+### S14 — Small terminal (80 × 24)
+- **Intent:** Can the split-pane layout survive?
+- **Setup:** Relaunch with `tmux new-session -x 80 -y 24`.
+- **Actions:** Open Review Diff, toggle focus, drill in.
+- **Heuristic:** H5.
+
+### S15 — Very wide terminal (220 cols)
+- **Intent:** Does whitespace explode? Is column width capped?
+- **Setup:** 220×45 tmux.
+- **Actions:** Review.
+- **Heuristic:** H5.
+
+### S16 — Resize mid-review
+- **Intent:** Regression check for BUG-2.
+- **Setup:** 160×45, open review, resize to 100×30.
+- **Actions:** `tmux resize-window` or equivalent.
+- **Heuristic:** H9.
+
+### S17 — Review Diff tab next to editing buffers
+- **Intent:** Tab-bar behavior; does Review Diff survive buffer switches?
+- **Setup:** Open two files, then open Review Diff.
+- **Actions:** Cycle buffers; return to Review Diff tab.
+- **Heuristic:** H2 (freedom).
+
+---
+
+## D. Staging / Comment Workflows
+
+### S18 — Stage then review
+- **Intent:** A staged hunk should appear under "Staged", not "Changes".
+- **Setup:** `git add happy.py`, then Review Diff.
+- **Actions:** Observe section grouping.
+- **Heuristic:** H1, H3.
+
+### S19 — Discard hunk confirmation
+- **Intent:** Safety of destructive key `d`.
+- **Setup:** Open Review Diff with changes.
+- **Actions:** Press `d` — expect a confirm dialog.
+- **Heuristic:** H9 (error prevention).
+
+### S20 — Add a line comment and verify persistence
+- **Intent:** Round-trip test of `c` → inline render (BUG-6 regression).
+- **Setup:** Standard changes.
+- **Actions:** Focus diff pane, press `c`, type comment, Enter. Verify.
+- **Heuristic:** H1.
+
+### S21 — Edit / delete comment
+- **Intent:** Undo path for comments.
+- **Setup:** After S20, press `x`.
+- **Actions:** Observe removal.
+- **Heuristic:** H2.
+
+### S22 — Export review to markdown
+- **Intent:** Does export succeed and write a sensible file?
+- **Setup:** After S20.
+- **Actions:** Press `e`; inspect `.review/session.md`.
+- **Heuristic:** H4.
+
+### S23 — Export to JSON
+- **Intent:** Second export path.
+- **Setup:** Use palette → `Review: Export to JSON`.
+- **Actions:** Inspect `.review/session.json`.
+- **Heuristic:** H4.
+
+---
+
+## E. Navigation / Discoverability
+
+### S24 — Arrow keys vs vim keys in files pane
+- **Intent:** Are both bindings reachable? Any inconsistency?
+- **Setup:** Any review session.
+- **Actions:** Alternate `Up`/`Down` with `j`/`k`.
+- **Heuristic:** H7 (flexibility).
+
+### S25 — Home/End/PageUp/PageDown in files pane
+- **Intent:** Boundary clamping.
+- **Setup:** 5+ files.
+- **Actions:** Spam `PageUp`, `End`, `Home`.
+- **Heuristic:** H5.
+
+### S26 — `N` (capital) vs `n` key collision
+- **Intent:** Easy user mistake — does capital-N "Note" trigger instead of next-hunk?
+- **Setup:** Focus diff pane.
+- **Actions:** Press `n`, then `N`.
+- **Heuristic:** H3, H9.
+
+### S27 — Menu-bar discoverability of Review Diff
+- **Intent:** Can a user find the feature without `Ctrl+P`?
+- **Setup:** Launch, press `F10`.
+- **Actions:** Browse menus (File/Edit/View/Selection/Go/LSP/Help).
+- **Heuristic:** H6 (recognition over recall).
+
+### S28 — Help screen
+- **Intent:** Is there an in-app help with Review Diff keybindings?
+- **Setup:** Press `F1` / check Help menu.
+- **Actions:** Search for "review".
+- **Heuristic:** H10 (help & documentation).
+
+### S29 — Re-opening Review Diff after close
+- **Intent:** Does state reset cleanly or crash?
+- **Setup:** Open, close (`q`), reopen via palette.
+- **Actions:** Verify listing matches current git state.
+- **Heuristic:** H9.
+
+---
+
+## F. Theming / Accessibility
+
+### S30 — NO_COLOR env var
+- **Intent:** Does the feature degrade gracefully without color?
+- **Setup:** `NO_COLOR=1 fresh`.
+- **Actions:** Open Review Diff; verify `-`/`+` glyph still conveys change.
+- **Heuristic:** Accessibility, H3.
+
+### S31 — Alternate theme (dark→light or high-contrast)
+- **Intent:** Do red/green remain distinguishable?
+- **Setup:** Switch theme via settings.
+- **Actions:** Review.
+- **Heuristic:** Accessibility.
+
+---
+
+## G. Performance / Scale
+
+### S32 — 50-file change set
+- **Intent:** Files-pane scrolling and responsiveness with many rows.
+- **Setup:** 50 modified files.
+- **Actions:** Review, scroll files list.
+- **Heuristic:** H4.
+
+### S33 — Single 10,000-line hunk
+- **Intent:** Pathological large-hunk rendering.
+- **Setup:** Replace entire contents of a 10k-line file.
+- **Actions:** Review, scroll.
+- **Heuristic:** Performance.
+
+---
+
+# Execution order
+
+The scenarios above number 33. To keep the second pass tractable,
+execute the following **high-value subset** in one tmux session:
+
+S9 (empty), S18 (staging), S20–S22 (comment round-trip + export),
+S14 (small terminal), S16 (resize), S27 (menu discoverability),
+S28 (help), S30 (NO_COLOR), S10 (rename), S6/S7 (pure-add / pure-del),
+S32 (many files), S1 (unicode), S2 (long lines), S4 (no newline),
+S29 (reopen), S19 (discard confirm), S26 (N/n collision).
+
+Remaining scenarios are left for future expansion passes.

--- a/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
+++ b/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
@@ -1,552 +1,228 @@
-# Review Diff — NN/g Usability Evaluation
+# Review Diff — Open Defects
 
-**Date:** 2026-04-13
-**Editor:** `fresh` 0.2.23 (debug build, branch `claude/tui-editor-usability-eval-0LHgo`)
-**Environment:** tmux 3.4, 160x45 pane, Linux 4.4.0, terminal with 256-color ANSI
-**Artifacts:** Screen captures (ANSI + plain) in `/tmp/eval-workspace/screen_*.txt`,
-`/tmp/eval-workspace/pass2/p2_*.txt`, and `/tmp/validate/c_*.txt`.
+**Feature:** `fresh` Review Diff mode (launched via `Ctrl+P → "Review Diff"`).
+**Branch:** `claude/tui-editor-usability-eval-0LHgo` · **Editor:** 0.2.23 debug build.
+**Evidence:** Screen captures under `/tmp/validate/c_*.txt` (pass 3, interactive),
+`/tmp/eval-workspace/pass2/p2_*.txt` (pass 2, scenario sweep), and
+`/tmp/eval-workspace/screen_*.txt` (pass 1, initial walk-through).
 
-> **Revision note (pass 3 — manual validation).** Sections 7 and 8 below
-> contain the corrected, capture-verified findings after a full
-> interactive tmux re-run. Any disagreement between earlier sections and
-> §7–§8 should be resolved in favour of §7–§8.
+All items below are capture-proven open defects. Everything that already
+works is in the appendix, as a sanity check on what the feature is for.
 
 ---
 
-## 1. Executive Summary
+## P0 — Ship-blockers
 
-The Review Diff feature is **functional for a first-pass review** but is held
-back by a handful of silent-failure defects and discoverability gaps that
-add needless cognitive load. A user who already knows the mode's vocabulary
-(`Tab`, `n`, `Enter`, `q`, `s`, `u`, `d`) can complete a standard PR-style
-review; a newcomer will bounce off at least two soft failures before learning
-the layout.
+### 1. Terminal resize is unrecoverable
 
-**Overall usability score: 3.1 / 5 (Fair, not NN/g "Good")**
-*(revised down from 3.4 after pass 2 uncovered three additional defects:
-terminal-resize corruption, silent empty-state, and `NO_COLOR` non-compliance.)*
+Shrink 160×45 → 80×24 → grow back leaves menu, toolbar, and tab row
+hidden. `r` refresh doesn't fix it; resize-bump doesn't fix it;
+close-and-reopen of the review tab leaves stale rendering on the right
+pane. Only killing and relaunching the editor recovers.
 
-- Heuristic wins: highly discoverable entry (`Ctrl+P` shown in status bar),
-  a permanent action toolbar, a safe exit affordance (`q Close`), a proper
-  confirm-dialog on destructive `d`iscard, clean rename (`R old → new`) and
-  pure-additions / pure-deletions / Unicode / emoji rendering, and an
-  inline-comment treatment (`» [hunk] …`) that persists across close-reopen.
-- Heuristic losses: **no "hunk N of M" indicator**, viewport does not follow
-  the cursor in side-by-side view, word-level diff highlighting is absent,
-  the fuzzy finder only does subsequence matching (no typo tolerance),
-  terminal resize corrupts the layout without auto-recovery, empty states
-  are ambiguous, and the in-app Manual / menu bar don't know about the
-  feature at all.
+*Evidence:* `c_40_at_80.txt`, `c_41_back.txt`, `c_42_after_r.txt`,
+`c_44_bump.txt`, `c_46_reopen.txt`.
 
-**Primary roadblocks (ranked):**
+### 2. Side-by-side `n` / `p` leave status bar stale
 
-1. **H1 — Silent hunk navigation (visibility of system status).** `n`/`p`
-   from the unified diff panel advance the cursor by roughly one line each
-   press and give no indication of "which hunk am I on." The user cannot
-   tell whether the keystroke succeeded.
-2. **H1 — Viewport/cursor desync in side-by-side view.** Status bar always
-   reads `Ln 1, Col 1` even after the viewport scrolls 170 lines.
-3. **H9 — Terminal resize destroys the layout and does not auto-recover.**
-   Confirms BUG-2. Toolbar, menu, and tab row stay hidden until the user
-   guesses to press `r` (refresh). Nothing in the UI says so.
-4. **H1 — Ambiguous empty state.** Both "not a git repository" and "clean
-   repo, no changes" render identically (empty `GIT STATUS` pane, `DIFF`
-   header with no filename, `Review Diff: 0 hunks` in the status bar).
-   i18n keys `status.not_git_repo` and `panel.no_changes` exist but are
-   never displayed.
-5. **H5 / accessibility — Whitespace-only changes are invisible.** Trailing
-   spaces and collapsed/expanded spaces render identically on both sides,
-   only the `-`/`+` marker differs. Also: `NO_COLOR=1` is ignored — the
-   editor emits the full 256-color palette regardless.
-6. **H9 (error recovery) — Typo tolerance in the command palette is
-   weak.** "revw difff" returns `Markdown: Toggle Compose/Preview` as the
-   best match — not "Review Diff."
-7. **H10 — Feature is absent from the in-app Manual (F1) and from every
-   top-level menu.** Users who don't already know `Ctrl+P` → "Review Diff"
-   have no discoverable path.
+`n` / `p` move the viewport but do NOT update the status-bar `Ln` /
+`Col`. Arrow keys update it correctly; `n` / `p` leave it stale.
+
+*Evidence:* `c_18_sxs.txt` (Ln 1) → `c_21_sxs_n3.txt` (viewport at
+`L054` but `Ln 8`) → `c_19_sxs_down1.txt` (Down → `Ln 7`, immediate
+update).
+
+### 3. No "Hunk N of M" indicator
+
+Status bar shows only the *total* count (`Review Diff: 35 hunks`) and
+never the current index, in either the unified or side-by-side pane.
+
+*Evidence:* `c_03`–`c_09` — the counter is unchanged across every hunk
+jump.
+
+### 4. Empty state is ambiguous
+
+Non-git directory and clean git repo render *byte-identically*: empty
+`GIT STATUS` pane, `DIFF` header with no filename, `Review Diff: 0
+hunks`. The i18n keys `status.not_git_repo` and `panel.no_changes`
+exist but are never displayed.
+
+*Evidence:* `c_22_nogit.txt`, `c_23_clean.txt`.
 
 ---
 
-## 2. Heuristic Evaluation (NN/g, adapted for TUI diff review)
+## P1 — High-impact UX gaps
 
-### H1. Visibility of System Status — **Partial Pass**
+### 5. Unified pane has no per-keyword syntax highlighting
 
-| Signal | Present? | Evidence |
-|--------|----------|----------|
-| Current file name in right-pane header | **Yes** | `DIFF FOR happy.py` (screen_04) |
-| Selected row marker in files list | **Yes** | `>M  happy.py` (caret glyph) |
-| Total hunk count | **Yes** | Status bar: `Review Diff: 14 hunks` |
-| Current-hunk index ("hunk 3 of 10") | **No** | Never displayed |
-| Cursor line / column | **Yes (unified view)** | `Ln 21, Col 1` |
-| Cursor line / column in side-by-side | **BROKEN** | Stuck at `Ln 1, Col 1` even after 170-line scroll (screen_17) |
-| Add/del stats per file | **Partial** | Only in side-by-side: `+10 -10 ~10` |
-| Context-sensitive toolbar | **Yes** | Toolbar swaps `↵ Open / r Refresh` for `n Next / p Prev` when focus is on diff (screen_04 vs screen_06) |
+Side-by-side does (`def` → fg 207, `return` → fg 51); unified pane uses
+one foreground color per `+` / `-` line, no language tokens.
 
-**Violation — no hunk index.** With 10 hunks in `monolith.txt`, pressing `n`
-four times gave no feedback except a cursor line change from 21 → 29. The
-user cannot confirm they arrived at the intended hunk.
+*Evidence:* `c_33_unified_syntax.txt` shows `[1m[38;5;51mdef add(a:
+int, b: int) -> int:[0m` — single color for the whole keyword-rich
+line. `c_34_sxs_syntax.txt` shows `[38;5;207mdef`, `[38;5;51mreturn`
+with per-token colors.
 
-### H2. User Control and Freedom — **Pass**
+### 6. `n` / `p` are dead in the files pane
 
-- `q` cleanly closes the Review Diff tab and returns to the previous buffer
-  (status: `Tab closed`, screen_27).
-- `q` also exits the side-by-side view back to the unified view (screen_18).
-- `Escape` closes the command palette without side effects
-  (status: `Search cancelled`, screen_26).
-- `Ctrl+C` at the editor root is swallowed gracefully (no crash, no prompt,
-  editor stays alive — verified PID persisted).
+Pressing `n` while focus is on the files pane neither advances the
+file selection nor moves the diff cursor.
 
-**Gap:** there is no `Undo comment` or reopen-last-closed-review affordance
-visible in the toolbar. A user who closes the review tab must re-run
-`Ctrl+P` → "Review Diff" to get back in.
+*Evidence:* `c_36_n_filespane.txt`.
 
-### H3. Consistency & Standards — **Partial Pass**
+### 7. `n` / `p` do not cross file boundaries
 
-- `+`/`-` prefixes are standard (screen_04).
-- Color palette matches convention: dark red `bg 256:52` for removed lines,
-  dark green `bg 256:22` for added lines, no intrusive foreground recolor.
-- **Deviation from `git diff --unified` standard:** the hunk header is
-  rendered as `@@ line_0047 = value_47  # comment for line 47 @@` — the
-  post-context line contents — instead of the standard
-  `@@ -47,7 +47,7 @@ <function_sig>`. This aids casual readers but breaks
-  muscle memory for anyone used to `git diff` / GitHub / `vimdiff`. The
-  missing `-start,count +start,count` numbers make it impossible to count
-  added/removed lines per hunk at a glance.
-- Standard review-mode keys (`s`/`u`/`d`) match `git add -p` / lazygit
-  conventions.
-- `N` (capital) for "Note" is inconsistent with lowercase action keys
-  elsewhere on the same toolbar — users will try lowercase `n` first and
-  trigger hunk-nav instead.
+From the last hunk of `a.py`, further `n` presses don't jump to the
+first hunk of `b.py`; cursor clamps just past the last hunk header of
+the current file.
 
-### H4. Flexibility & Efficiency of Use — **Partial Pass**
+*Evidence:* `c_37_n_pastend.txt`.
 
-Minimum keystrokes to enter Review Diff from editing:
+### 8. `n` / `p` hints appear in the toolbar only after `Tab`
 
-| Path | Keystrokes | Notes |
-|------|------------|-------|
-| `Ctrl+P` → `revie` → `Enter` | **7 key events** | Default fuzzy result is "Review Diff" |
-| `Ctrl+P` → `rd` → `Enter` | theoretical 4 events | **Not verified** — `rd` did not narrow to Review Diff in testing |
+A user who never Tabs into the diff pane never learns hunk navigation
+exists.
 
-Minimum keystrokes to scroll to the 5th hunk of 10 once the view is open:
+*Evidence:* `c_01_review.txt` (files-pane toolbar, no `n` / `p`) vs
+`c_13_diff_start.txt` (diff-pane toolbar shows `n Next  p Prev`).
 
-| Path | Keystrokes | Observed? |
-|------|------------|-----------|
-| `Tab` `n n n n` | 5 | Cursor advances, but **viewport does not snap to the hunk header** and there is no index feedback |
+### 9. Whitespace-only changes have no per-character highlight
 
-**Missing power-user shortcut:** there is no "jump to file N" or
-`:<file>` addressing mode inside Review Diff. To reach the 4th file you
-must `Tab` to files panel and press `j` three times.
+Trailing-space and double-space edits look identical on the `-` and `+`
+lines; only the leading marker differs.
 
-**Good:** Tab toggles focus between files pane and diff pane — verified
-twice and well-behaved. `PageDown` scrolls the diff viewport and updates
-the cursor line counter correctly in the *unified* view.
-
-### H5. Aesthetic & Minimalist Design — **Pass**
-
-- Two-pane layout (30% files, 70% diff) is balanced at 160 cols.
-- Section headers (`▸ Changes` / `▸ Untracked`) are collapsible-style
-  indicators that clearly group the file list.
-- The toolbar is dense (`s Stage  u Unstage  d Discard │ c Comment  N Note  x Del │ e Export  q Close  ↵ Open  Tab Switch  r Refresh`) — 28 characters of
-  actionable hints, separated by `│` glyphs. At 160 cols this fits; at
-  narrower widths it will wrap or truncate (see prior BUG-10).
-- No superfluous chrome in the diff pane — line-number column is
-  intentionally omitted in the unified view, present in side-by-side.
-
-**Cost:** the toolbar *duplicates* information that exists in menus and
-documentation, yet omits the two keys users most need (`n`/`p` are only
-shown **after** Tab-switching focus to the diff pane). Unified-view users
-don't know hunk navigation exists until they've already switched focus.
+*Evidence:* `screen_13_whitespace_ansi.txt` — full-line bg, no
+intra-line spans.
 
 ---
 
-## 3. Friction Points (Flow-by-Flow)
+## P2 — Standards & discoverability
 
-### Flow 1 — Happy Path (modify `happy.py`: 3 adds, 2 dels, 1 hunk)
+### 10. Non-standard hunk header
 
-**Friction level: low.** Time-to-first-read ≈ 7 keystrokes.
+Renders as `@@ L006 @@` (a context-line preview) instead of git-standard
+`@@ -X,Y +X,Y @@ <signature>`. Breaks muscle memory from `git diff` /
+GitHub / `vimdiff` and prevents counting added/removed lines per hunk.
 
-- ✅ Review Diff opens in ~300ms on debug build.
-- ✅ `@@ -1 +1 @@` header present; coloring correct.
-- ✅ Status bar shows `Review Diff: 14 hunks`.
-- ⚠ On first open, focus is on **files pane** — pressing `n` or `Enter`
-  before Tabbing feels ambiguous. This matches prior BUG-3 findings.
-- ⚠ Header reads "@@ -1 +1 @@" without range counts (`-1,12 +1,16`).
+*Evidence:* `c_15_start.txt`.
 
-### Flow 2 — Monolith (1,000-line file, 10 hunks)
+### 11. Review Diff is in zero top-level menus
 
-**Friction level: high.**
+Walked every menu (File / Edit / View / Selection / Go / LSP / Help) —
+the feature is not present. Only `Go → Command Palette…` exists, which
+delegates back to `Ctrl+P`.
 
-- ✅ Rendering of 10 hunks was instant; `PageDown`×50 completed in ~3s
-  total (most of that was `tmux send-keys` overhead) with no visible
-  input lag.
-- ❌ **H1 violation:** pressing `n` four times moved cursor from line 21
-  to line 29 (~+2 per press) — not a hunk-sized jump. No "hunk 5 of 10"
-  indicator confirmed arrival at the target. Reproduces BUG-4.
-- ❌ Top-of-viewport did not re-anchor to the jumped-to hunk header; we
-  scrolled past hunks while thinking we were on hunk 5.
-- ⚠ The non-standard `@@ line_0047 = value_47 ... @@` header replaces the
-  `@@ -47,3 +47,4 @@` standard, so line-number context must be inferred
-  from the content, not read directly.
+*Evidence:* `c_26_menu_file.txt`–`c_32_menu_help.txt`.
 
-### Flow 3 — Edge Cases
+### 12. F1 in-app Manual lacks the feature
 
-| State | Outcome |
-|-------|---------|
-| Whitespace-only change | Diff shows `-hello world` vs `+hello world` with **no visual cue** for the trailing space. Tab chars **are** rendered as `→` glyph (good). Two-space runs are not distinguished from one-space runs. |
-| Newly created untracked file | Renders as `@@ -0 +1 @@` with all `+` lines. Layout not broken. ✅ |
-| Deleted file | Unified view: `@@ -1 +0 @@` followed by `-` lines. ✅ |
-| **Deleted file drill-down** (side-by-side) | **Does NOT hang** — the view opens with OLD content on the left and an empty pane on the right. BUG-5 from the prior combined report appears to be **fixed**. ✅ |
+Searching the Manual for "review diff" returns `No matches found`.
 
-### Flow 4 — Lost User / Error Recovery
+*Evidence:* `screen_25_help_search.txt`.
 
-| Input | Response |
-|-------|----------|
-| `Ctrl+P` → "revw difff" | Top result: "Markdown: Toggle Compose/Preview" — Review Diff **not in top 10**. |
-| `Ctrl+P` → "reiew" (missing v) | "Review Diff" is top match. ✅ |
-| `Ctrl+P` → "rview" (missing e) | "Stop Review Diff" / "Refresh Review Diff" shown — acceptable. |
-| Invalid keys in diff panel (`x`, `z`, `Q`, `%`) | Status bar: `Editing disabled in this buffer`. No panic, but a generic message that doesn't tell the user what they *can* do. |
-| `Ctrl+C` at editor top level | Swallowed cleanly — editor remains alive. ✅ |
+### 13. Fuzzy palette is subsequence-only, no typo tolerance
 
-**Finding:** The fuzzy finder is a strict **subsequence** matcher. It does
-not tolerate inserted or substituted characters. Standard NN/g guidance
-calls for typo-tolerant search (Levenshtein within 1–2 edits) on
-rarely-used commands.
+"revw difff" returns `Markdown: Toggle Compose/Preview` instead of
+`Review Diff`.
+
+*Evidence:* `screen_22_typo.txt`.
+
+### 14. `\ No newline at end of file` marker is dropped
+
+A file stripped of its trailing newline shows only the normal
+`+modified` line with no marker — reviewers will miss newline
+regressions in shell scripts / fixtures.
+
+*Evidence:* `p2_09_nonl.txt`.
+
+### 15. Merge-conflict files appear twice
+
+`UU conf.txt` shows in both `Staged` and `Changes` sections with `(no
+diff available)` and no resolution affordance.
+
+*Evidence:* `p2_43_conflict.txt`.
 
 ---
 
-## 4. Color & Layout Analysis (ANSI-parsed)
+## P3 — Polish & edge cases
 
-ANSI 256-color codes harvested from `capture-pane -e`:
+### 16. `N` / `n` key collision
 
-| Role | Code | RGB (approx) | Notes |
-|------|------|--------------|-------|
-| Removed-line background | `48;5;52` | `#5F0000` | Dark red |
-| Added-line background | `48;5;22` | `#005F00` | Dark green |
-| Removed-line fg | `38;5;203` | `#FF5F5F` | Salmon — **contrast OK** on black bg |
-| Added-line fg | `38;5;40` / `38;5;64` | `#00D700` / `#5F8700` | Bright green |
-| Status bar bg | `48;5;226` | `#FFFF00` | Yellow |
-| Status bar fg | `38;5;16` | `#000000` | Black |
-| Tilde (empty-row) fg | `38;5;59` | dim grey | Unobtrusive |
+Lowercase `n` = next hunk; capital `N` = open Note prompt. Distinct but
+easy to mis-fire; no other toolbar key pairs rely on case sensitivity.
 
-**Accessibility notes:**
+*Evidence:* `p2_22_lower_n.txt` vs `p2_23_upper_N.txt`.
 
-- Red/green-only encoding is the classic deuteranopia trap. The `-`/`+`
-  glyph does carry the semantic, but the **background** color does the
-  heavy visual lifting. A colorblind user relying on glyphs alone will
-  struggle with pure-whitespace diffs (see Flow 3).
-- Contrast ratios: `#FF5F5F` on `#5F0000` ≈ 4.0:1 (passes WCAG AA for
-  normal text, fails AAA). `#00D700` on `#005F00` ≈ 3.9:1 (AA only).
-- Status bar yellow (`#FFFF00`) bg with black text is high contrast
-  (>10:1) — ✅.
+### 17. Chrome vanishes at 80 × 24
 
-**Layout / alignment:**
+Menu, tab row, and toolbar all disappear at narrow widths. No graceful
+degradation to a single-glyph legend.
 
-- In side-by-side view, line numbers are right-aligned within a 3-char
-  column (`  1`, ` 42`, `171`). For files >999 lines the column expands
-  correctly.
-- Unified-view diff does **not** show line numbers in the gutter
-  (screen_04). This is a deviation from `git diff --unified` with line
-  numbers and a measurable source of friction when discussing a specific
-  line with a teammate ("which line is that?").
-- The `│` vertical separator between panes is rendered as single-column
-  box-drawing — clean.
+*Evidence:* `c_40_at_80.txt`.
 
----
+### 18. No overflow indicator for truncated lines
 
-## 5. Actionable Recommendations
+`End` scrolls horizontally but nothing signals that a line continues.
 
-Ordered by effort-to-impact ratio.
+*Evidence:* `screen_04_review_plain.txt`, `p2_37_end.txt`.
 
-### R1 — Show "Hunk N of M" in the status bar (Low effort, High impact)
+### 19. Files list sorts alphabetically, not naturally
 
-Add a right-aligned segment: `Hunk 3 / 10`. Update it on every `n`, `p`,
-`j`, `k`, or scroll event. This single change fixes the H1 violation in
-Flow 2 and gives users navigational confidence.
+`many/f10.txt` precedes `many/f2.txt`.
 
-*Files:* `crates/fresh-editor/plugins/audit_mode.ts` (status message
-builder) + an additional `status.hunk_position` key in
-`audit_mode.i18n.json`.
+*Evidence:* `p2_02_review_open.txt`.
 
-### R2 — Snap viewport to the hunk header on `n` / `p` (Medium effort)
+### 20. No line numbers in the unified diff gutter
 
-Currently `n` only nudges the cursor. Change the handler so that after
-moving the cursor to `hunkHeaderRows[idx]`, it forces viewport top =
-`hunkHeaderRows[idx] - 2` (two lines of leading context). Also highlight
-the hunk header row (reverse video) while the cursor is inside that
-hunk. This addresses BUG-4 at its root.
+Side-by-side has them; unified does not. Makes "which line is that?"
+conversations awkward.
 
-### R3 — Word-level diff highlighting for intra-line changes (Medium effort)
+*Evidence:* `c_15_start.txt`.
 
-Especially for whitespace-only diffs, byte-level reverse-video on the
-*differing* ranges would make `-hello world` vs `+hello world ` (trailing
-space) and tab-vs-space changes self-evident. The `diff_nav` plugin
-already computes character ranges for `review_export_session`; expose the
-same ranges to the renderer.
+### 21. No "reopen last review" command
 
-### R4 — Adopt standard `@@ -start,count +start,count @@` hunk header (Low effort)
-
-Replace the custom "first context line" header with the git-standard one.
-Users coming from `git diff`, GitHub, and `vimdiff` will recognize it
-immediately (H3: Consistency & Standards). The first context line can be
-appended after the closing `@@` as GitHub does:
-`@@ -47,7 +47,7 @@ def greet(name):`.
-
-### R5 — Upgrade the command palette to typo-tolerant fuzzy match (Medium effort)
-
-Replace strict subsequence matching in
-`crates/fresh-editor/src/input/fuzzy/mod.rs` with a hybrid: subsequence
-→ if < N results, fall back to Levenshtein (edit distance ≤ 2) over the
-command label. This resolves Flow 4's "revw difff" → Markdown mismatch
-and brings the palette in line with VS Code / Zed expectations.
-
-### R6 (Bonus) — Auto-focus the files panel on Review Diff launch (Trivial effort)
-
-Documented in the prior combined report as BUG-3. A one-line fix in
-`start_review_diff()` eliminates the silent "first key press does
-nothing" trap that every new user hits.
+After `q`, every re-entry requires the 4-keystroke palette round-trip.
 
 ---
 
-## 6. Pass 2 — Extended Scenarios (18 additional flows)
+## Suggested sprint bundle
 
-Planned in `docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md` (33 scenarios
-catalogued; 18 executed in this pass). Artifacts under
-`/tmp/eval-workspace/pass2/p2_*.txt`.
-
-### 6.1 Summary table
-
-| ID | Scenario | Verdict | Heuristic | Key evidence |
-|----|----------|---------|-----------|--------------|
-| S1  | Unicode / emoji in diff | **Pass** | H3/H5 | `p2_06_uni.txt` — Japanese, Cyrillic, emoji (🦀🚀✨) all align in both panes. |
-| S2  | 2,000-char single line | **Partial** | H5 | `p2_36_hscroll.txt` — viewport does not scroll on `Right`; only `End` jumps to column 2001. No overflow/continuation glyph. |
-| S4  | File with no trailing newline | **Fail** | H3 | `p2_09_nonl.txt` — the standard `\ No newline at end of file` marker is **absent**; user cannot tell the newline was stripped. |
-| S6  | Pure-additions diff | **Pass** | H3 | `p2_04_pure_del.txt` context — `@@ -1 +1 @@` with `+` lines only, clean. |
-| S7  | Pure-deletions diff | **Pass** | H3 | `p2_05_pure_del.txt` — `-` lines only, no alignment issues. |
-| S8  | Review Diff in non-git dir | **Fail** | H1/H9 | `p2_41_nogit.txt` — empty panes, `0 hunks`, **no error message** despite `status.not_git_repo` existing in i18n. |
-| S9  | Clean repo, zero changes | **Fail** | H1 | `p2_42_clean.txt` — indistinguishable from S8. `panel.no_changes` string is never rendered. |
-| S10 | `git mv` rename detection | **Pass** | H3 | `p2_02_review_open.txt` — shows `R  rename_me.txt → renamed.txt` (arrow glyph included). |
-| S13 | Merge conflict file (`UU`) | **Partial** | H9 | `p2_43_conflict.txt` — status `U`, listed in *both* `Staged` and `Changes`, diff pane shows `(no diff available)`. No hint `<<<<<<` markers exist, no 3-way view. |
-| S14 | 80 × 24 terminal | **Fail** | H5 | `p2_29_resize_80.txt` — the menu bar, tab row, and toolbar all disappear; only the two panes remain. Every discoverable key hint is gone. |
-| S16 | Resize from 160×45 → 80×24 → 160×45 | **Fail** | H9 | `p2_30_resize_restore.txt` — layout does **not** auto-recover to the new width. A manual `r` press fixes it (`p2_31_after_r.txt`), but nothing tells the user that. Confirms BUG-2. |
-| S18 | Stage → review | **Pass** | H1/H3 | `p2_02_review_open.txt` — a dedicated `▸ Staged` section appears above `▸ Changes`; staged file (`happy.py`) is grouped correctly. |
-| S19 | Discard confirmation | **Pass** | H9 | `p2_14_discard_prompt.txt` — modal "Discard changes in file / Cancel" with `This cannot be undone.` warning. Proper error-prevention. |
-| S20 | Add comment → inline render | **Pass** | H1 | `p2_16_after_comment.txt` — shows `» [hunk] Nit: consider using a constant` directly under the hunk header. Regression-fix for prior BUG-6 (comments on hunks, at least, now render). |
-| S22 | Export review to markdown | **Pass** | H4 | `p2_17_export.txt` + `s_main/.review/session.md` — timestamped, includes file/hunk counts and grouped comments. |
-| S26 | `n` vs `N` key collision | **Partial** | H3 | `p2_22_lower_n.txt` vs `p2_23_upper_N.txt` — `n` moves cursor ~1 line (no hunk-jump feedback); `N` opens the "Note:" prompt. Distinct behaviors but easy to mis-fire. |
-| S27 | Menu-bar discoverability | **Fail** | H6 | `p2_10_menu.txt`, `p2_11_edit_menu.txt`, `p2_12_go_menu.txt` — `File`, `Edit`, and `Go` menus have **no** "Review Diff" entry. Only `Command Palette…` under `Go`, which delegates back to `Ctrl+P`. |
-| S28 | F1 / in-app Manual | **Fail** | H10 | `p2_25_help_search.txt` — `Ctrl+F` "review diff" → `No matches found for 'review diff'` in the Fresh Manual. |
-| S29 | Close + reopen persistence | **Pass** | H2 | `p2_21_pure_add_reopen.txt` — the inline comment from S20 survives close-and-reopen. Session file on disk is the source of truth. |
-| S30 | `NO_COLOR=1` env var | **Fail** | Accessibility | `p2_39_nocolor_ansi.txt` — full 256-color ANSI palette (`[48;5;52m`, `[48;5;22m`, `[38;5;203m`, …) emitted despite the standard `NO_COLOR` signal. |
-
-### 6.2 New friction points discovered in pass 2
-
-- **F-PASS2-A (H9).** Resize-then-wait is silently broken. The fix path
-  (`r`) exists but is never surfaced; a user with a tiling WM who
-  switches monitors will see "the toolbar vanished" and assume the
-  feature is broken.
-- **F-PASS2-B (H1).** The empty `Review Diff: 0 hunks` screen is used
-  for three disjoint conditions — not a repo, no changes, and "review
-  failed silently." Each needs its own status line.
-- **F-PASS2-C (Accessibility).** `NO_COLOR` is a well-known standard
-  (https://no-color.org). Ignoring it is a hard accessibility fail for
-  users on monochrome terminals, screen readers with ANSI-stripping,
-  and deuteranopic users.
-- **F-PASS2-D (H10).** Running `F1` → search for "review diff" returns
-  zero results. The Manual must at minimum document the feature name,
-  the launcher (`Ctrl+P → Review Diff`), and the key bindings shown in
-  the toolbar.
-- **F-PASS2-E (H3).** Files whose trailing newline is stripped look
-  like plain line edits because the `\ No newline at end of file`
-  marker from `git diff` is dropped. Reviewers will not catch the
-  newline regression — high risk for shell scripts and fixture files.
-- **F-PASS2-F (H9).** Merge-conflict files (`UU`) appear twice in the
-  file list (once under `Staged`, once under `Changes`) and the diff
-  pane reads `(no diff available)`. The user is told "there's
-  something wrong" but given no affordance to resolve it inline.
-
-### 6.3 Additional recommendations (delta from §5)
-
-- **R7 — Render empty-state messages.** Wire the existing
-  `status.not_git_repo` and `panel.no_changes` i18n keys into the
-  files pane. For non-git: show a centred message "Not a git
-  repository — run `git init` to enable Review Diff." For clean
-  repos: "No changes to review. Modify a file and press `r` to
-  refresh."
-- **R8 — Auto-recover layout on terminal resize.** Hook the `resize`
-  event to invalidate cached pane widths and recompute the toolbar /
-  tab row. If a full recompute is expensive, at least repaint
-  chrome-only on every resize.
-- **R9 — Honor `NO_COLOR`.** At the ANSI writer (see
-  `crates/fresh-editor/src/view/color_support.rs`), short-circuit
-  256-color emission when `std::env::var_os("NO_COLOR").is_some()`.
-  Fall back to plain text with `-` / `+` carrying all meaning.
-- **R10 — Preserve the `\ No newline at end of file` marker.** The
-  underlying `git diff` output contains it; the plugin's parser must
-  forward it to the diff buffer. Render as a dim-foreground,
-  italicised line so it doesn't disrupt the hunk shape.
-- **R11 — Discoverability.** Add `Review Diff…` to the `Go` menu (or
-  a new `Review` submenu). Add a "Review Diff" section to the Fresh
-  Manual (`docs/manual.md` or the plugin README) covering the
-  toolbar keys, side-by-side drill-down, and export formats.
-- **R12 — De-duplicate merge-conflict files in the files pane.** Show
-  `UU file` once (in its own "Conflicts" section if needed), and make
-  `Enter` open the file in a regular editor buffer pre-navigated to
-  the first `<<<<<<<` marker.
+- **A — stabilise:** 1, 2, 3, 4.
+- **B — navigation ergonomics:** 5, 6, 7, 8.
+- **C — standards & a11y:** 9, 10, 14.
+- **D — discoverability & polish:** 11, 12, 13, 15, 16–21.
 
 ---
 
-## Appendix A — Reproduction Commands
+## Appendix A — What Review Diff is trying to be
 
-```bash
-# 1. Build (debug)
-cargo build
+A single keyboard-driven review surface that lets a developer do a PR-
+style read-through of local changes without leaving the editor:
 
-# 2. Prepare test repo (whitespace + new + deleted + monolith)
-cd /tmp && mkdir eval && cd eval && git init -q
-# ... (see body for full setup; ran from /tmp/eval-workspace/testrepo)
+- List every changed file, grouped by `Staged` / `Changes` / `Untracked`.
+- Show a unified colour diff on the right; drill into side-by-side with
+  `Enter`.
+- Stage / unstage / discard hunks with `s` / `u` / `d`.
+- Attach inline `c`omments and a per-session `N`ote.
+- Export the whole session to Markdown or JSON for sharing.
 
-# 3. tmux session with ANSI capture
-tmux new-session -d -s tui-test -x 160 -y 45
-tmux send-keys -t tui-test "cd /tmp/eval-workspace/testrepo && \
-  /home/user/fresh/target/debug/fresh" C-m
-sleep 1
+## Appendix B — Verified working (reference)
 
-# 4. Open Review Diff
-tmux send-keys -t tui-test C-p; sleep 0.5
-tmux send-keys -t tui-test -l "review diff"; sleep 0.5
-tmux send-keys -t tui-test Enter; sleep 1
+These behaviours were explicitly tested and do not need changes:
 
-# 5. Capture with colors
-tmux capture-pane -t tui-test -p -e > current_screen.txt
-```
-
-## Appendix B — Screen Capture Index
-
-All artifacts under `/tmp/eval-workspace/`:
-
-| File | Scenario |
-|------|----------|
-| `screen_04_review_ansi.txt` | Happy-path unified diff, ANSI |
-| `screen_07_nextHunk.txt` | `n` in unified diff — no visible jump |
-| `screen_13_whitespace_ansi.txt` | Whitespace-only diff |
-| `screen_16_drilldown.txt` | Side-by-side for `monolith.txt` |
-| `screen_17_sxs_next.txt` | `n` in side-by-side — viewport moves but `Ln` stays 1 |
-| `screen_20_delete_drill.txt` | Deleted-file drill-down (no hang — BUG-5 fixed) |
-| `screen_22_typo.txt` | Palette with "revw difff" — wrong top match |
-| `screen_28_ctrlc.txt` | Ctrl+C at root — editor survives |
-
-### Pass-2 captures (`/tmp/eval-workspace/pass2/`)
-
-| File | Scenario |
-|------|----------|
-| `p2_02_review_open.txt` | Staged section + rename display (S10, S18) |
-| `p2_06_uni.txt` / `_ansi.txt` | Unicode / emoji diff (S1) |
-| `p2_09_nonl.txt` | File missing trailing newline (S4) |
-| `p2_10_menu.txt` / `p2_11_edit_menu.txt` / `p2_12_go_menu.txt` | Menu-bar walk (S27) |
-| `p2_14_discard_prompt.txt` | Discard confirmation dialog (S19) |
-| `p2_16_after_comment.txt` | Inline comment rendering (S20) |
-| `p2_17_export.txt` + `.review/session.md` | Markdown export (S22) |
-| `p2_21_pure_add_reopen.txt` | Comment persists across close/reopen (S29) |
-| `p2_22_lower_n.txt` / `p2_23_upper_N.txt` | `n` vs `N` key collision (S26) |
-| `p2_25_help_search.txt` | F1 Manual — "review diff" not found (S28) |
-| `p2_29_resize_80.txt` | Chrome disappears at 80×24 (S14) |
-| `p2_30_resize_restore.txt` / `p2_31_after_r.txt` | Resize corruption + manual recovery (S16) |
-| `p2_35_long_sxs.txt` / `p2_36_hscroll.txt` / `p2_37_end.txt` | Long-line horizontal scroll (S2) |
-| `p2_39_nocolor.txt` / `_ansi.txt` | `NO_COLOR=1` ignored (S30) |
-| `p2_41_nogit.txt` | Review Diff outside a git repo (S8) |
-| `p2_42_clean.txt` | Review Diff on a clean repo (S9) |
-| `p2_43_conflict.txt` | Merge-conflict (`UU`) file (S13) |
-
-Full scenario catalogue (33 scenarios, 18 executed here, 15 deferred) is
-in `docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md`.
-
----
-
-## 7. Pass 3 — Manual Interactive Validation (supersedes earlier claims)
-
-Pass 3 re-ran every defect claim interactively under `tmux`, capturing
-state **before and after** each keystroke (with generous sleeps to avoid
-dropped events) on a purpose-built repo with five 9-line hunks.
-Artifacts: `/tmp/validate/c_*.txt`.
-
-### 7.1 Retracted claims
-
-These items were in the earlier priority lists but the pass-3 captures
-*disprove* them. They should **not** be acted on as bugs.
-
-| Earlier claim | Capture-verified reality |
-|---------------|--------------------------|
-| "`n` / `p` advance the cursor only ~1 line — hunk navigation is broken." | `n` jumps exactly between hunk headers. Measured progression on a 9-line/hunk file: `Ln 1 → 2 → 11 → 20 → 29 → 38`. Past the last hunk, cursor clamps (`38 → 38 → 38`). `c_03`–`c_09`. |
-| "Viewport does not scroll when `n` / `p` are pressed in the unified pane." | Viewport scrolls to follow the cursor. After 10 `n` presses the top of the viewport moved from `L006` to `L107`; after 5 `p` presses back to `L071`. `c_15`, `c_16`, `c_17`. |
-| "No current-hunk highlight exists." | The current hunk header is drawn with bg `256:17` (dark blue) while other hunk headers stay on the default black bg. `c_11_viewport_ansi.txt`. |
-| "`NO_COLOR=1` is ignored — the editor still emits 256-color ANSI." | `NO_COLOR` **is** honored. With `NO_COLOR=1`, only `[0m` and `[4m` are emitted; without it, 25 distinct 256-color codes appear. `c_24_nocolor.txt` vs `c_25_color.txt`. The pass-2 counter-example was captured after a shell-prompt corruption that never set the env var. |
-| "`r` (refresh) recovers the layout after a terminal resize." | Only partial. After shrink 160×45 → 80×24 → 160×45, `r` does *not* restore the menu / toolbar / tab row; close-and-reopen of the review tab also fails. Only restarting the editor recovers. See §7.2 item 1. |
-
-### 7.2 Validated defects (the real priority list)
-
-Each row is capture-proven.
-
-#### P0 — Ship-blockers
-
-| # | Defect | Evidence |
-|---|--------|----------|
-| 1 | **Terminal resize is unrecoverable.** Shrink 160×45 → 80×24 → grow back leaves menu, toolbar, and tab row hidden. `r` refresh doesn't fix it; resize-bump doesn't fix it; close-and-reopen of the review tab leaves stale rendering on the right pane. Only killing and relaunching the editor recovers. | `c_40_at_80.txt`, `c_41_back.txt`, `c_42_after_r.txt`, `c_44_bump.txt`, `c_46_reopen.txt` |
-| 2 | **Side-by-side `n` / `p` move the viewport but do NOT update the status-bar `Ln` / `Col`.** Arrow keys update `Ln` correctly; `n` / `p` leave it stale. | `c_18_sxs.txt` (Ln 1) → `c_21_sxs_n3.txt` (viewport at `L054` but `Ln 8`) → `c_19_sxs_down1.txt` (Down → `Ln 7`, immediate update) |
-| 3 | **No "Hunk N of M" indicator anywhere.** Status bar shows only the *total* count (`Review Diff: 35 hunks`); never the current index. | `c_03`–`c_09` show the counter unchanged across every hunk jump |
-| 4 | **Empty state is ambiguous.** Non-git directory and clean git repo render *byte-identically*: empty `GIT STATUS` pane, `DIFF` header with no filename, `Review Diff: 0 hunks`. The i18n keys `status.not_git_repo` and `panel.no_changes` exist but are never displayed. | `c_22_nogit.txt`, `c_23_clean.txt` |
-
-#### P1 — High-impact UX gaps
-
-| # | Defect | Evidence |
-|---|--------|----------|
-| 5 | **Unified diff pane has no per-keyword syntax highlighting.** Side-by-side does (`def` → fg 207, `return` → fg 51); unified pane uses one foreground color per `+` / `-` line. | `c_33_unified_syntax.txt`: `[1m[38;5;51mdef add(a: int, b: int) -> int:[0m` (single color for the whole keyword-rich line). `c_34_sxs_syntax.txt`: `[38;5;207mdef`, `[38;5;51mreturn`, per-token colors. |
-| 6 | **`n` / `p` do nothing when the files pane is focused.** Pressing `n` there neither advances the file selection nor moves the diff cursor. | `c_36_n_filespane.txt` — still on `a.py`, diff still at hunk 1. |
-| 7 | **`n` / `p` do not cross file boundaries.** From the last hunk of `a.py`, further `n` presses don't jump to the first hunk of `b.py`; cursor clamps just past the last hunk header of the current file. | `c_37_n_pastend.txt` — Ln 20, still on `a.py`. |
-| 8 | **Hunk-nav keys (`n` / `p`) only appear in the toolbar after the diff pane is focused.** A user who never `Tab`s into the diff pane never learns hunk navigation exists. | Compare `c_01_review.txt` (no `n` / `p` in toolbar) vs `c_13_diff_start.txt` (toolbar shows `n Next  p Prev`). |
-| 9 | **Whitespace-only changes have no per-character highlight.** Trailing-space and double-space edits look identical on the `-` and `+` lines; only the leading marker differs. | `screen_13_whitespace_ansi.txt` (pass 1) — full-line bg, no intra-line spans. |
-
-#### P2 — Standards & discoverability
-
-| # | Defect | Evidence |
-|---|--------|----------|
-| 10 | **Non-standard hunk header.** Renders as `@@ L006 @@` (a context-line preview) instead of git-standard `@@ -X,Y +X,Y @@ <signature>`. Breaks muscle memory from `git diff` / GitHub / `vimdiff`, and prevents counting added/removed lines per hunk at a glance. | `c_15_start.txt` |
-| 11 | **Review Diff is in zero top-level menus.** Walked every menu (File / Edit / View / Selection / Go / LSP / Help). Only `Go → Command Palette…` exists — which delegates back to `Ctrl+P`. | `c_26_menu_file.txt`–`c_32_menu_help.txt` |
-| 12 | **F1 in-app Manual lacks the feature.** `Ctrl+F` "review diff" in the Manual → `No matches found`. | `screen_25_help_search.txt` (pass 1) |
-| 13 | **Fuzzy palette is subsequence-only — no typo tolerance.** "revw difff" returns `Markdown: Toggle Compose/Preview` instead of `Review Diff`. | `screen_22_typo.txt` (pass 1) |
-| 14 | **`\ No newline at end of file` marker is dropped.** Diff for a file stripped of its trailing newline shows only the normal `+modified` line with no marker — reviewers will miss newline regressions in shell scripts / fixtures. | `p2_09_nonl.txt` (pass 2) |
-| 15 | **Merge-conflict files (`UU`) appear in both `Staged` and `Changes` sections** with `(no diff available)` and no resolution affordance. | `p2_43_conflict.txt` (pass 2) |
-
-#### P3 — Polish & edge cases
-
-| # | Defect | Evidence |
-|---|--------|----------|
-| 16 | **`N` / `n` key collision.** Lowercase `n` = next hunk; capital `N` = open Note prompt. Distinct but easy to mis-fire; no other toolbar key pairs rely on case-sensitivity. | `p2_22_lower_n.txt` vs `p2_23_upper_N.txt` |
-| 17 | **At 80 × 24, menu / tab row / toolbar all vanish.** No graceful degradation to a single-glyph legend. | `c_40_at_80.txt` |
-| 18 | **No overflow indicator** when a diff line is truncated at pane width. `End` scrolls horizontally, but nothing signals that the line continues. | `screen_04_review_plain.txt`, `p2_37_end.txt` |
-| 19 | **Files list is sorted alphabetically, not naturally.** `many/f10.txt` precedes `many/f2.txt`. | `p2_02_review_open.txt` |
-| 20 | **No line numbers in the unified diff gutter.** Side-by-side has them; unified does not. Makes "which line is that?" conversations awkward. | `c_15_start.txt` |
-| 21 | **No "reopen last review" command.** After `q`, every re-entry requires the 4-keystroke palette round-trip. | No entry found in palette listing (`screen_03b_search.txt`). |
-
-### 7.3 Behaviours verified working (do not "fix")
-
-- `n` / `p` hunk navigation in the unified diff pane.
-- Viewport auto-scrolls to follow cursor in unified view.
-- Current hunk header is highlighted (dark-blue bg).
-- `NO_COLOR=1` is honored.
+- `n` / `p` hunk navigation in the unified pane (jumps between hunk
+  headers correctly).
+- Viewport auto-scrolls to follow the cursor in the unified pane.
+- Current hunk header is highlighted (bg `256:17`, dark blue).
+- `NO_COLOR=1` env var is honoured (only `[0m` / `[4m` emitted).
 - Cursor position is preserved across `Tab` between panes.
-- Inline comments render as `» [hunk] …` and persist across close-reopen.
-- `d` discard shows a proper confirmation dialog.
-- Rename detection renders cleanly as `R old → new`.
+- Inline comments render as `» [hunk] …` and persist across close /
+  reopen (backed by `.review/session.md`).
+- `d` discard shows a confirmation dialog with an "undone" warning.
+- Rename detection renders as `R old → new`.
 - Unicode and emoji align correctly in both panes.
-- `q` cleanly closes the review and the editor survives.
-
-## 8. Sprint Bundle (final, validated)
-
-- **Sprint A (stabilise):** §7.2 items 1–4. Unblocks the feature for
-  real-world PR workflows; every item here is a silent-failure today.
-- **Sprint B (standards & a11y):** items 5, 9, 10, 14. Small diffs,
-  cumulative big win.
-- **Sprint C (navigation ergonomics):** items 6, 7, 8. Close the
-  `n` / `p` coverage holes — files pane, cross-file, toolbar visibility.
-- **Sprint D (discoverability & polish):** items 11, 12, 13, 15,
-  16–21.
+- Deleted-file drill-down into side-by-side works (no hang).
+- `q` cleanly closes the review; the editor survives all tested keys
+  including `Ctrl+C`.
+- Debug-build input responsiveness is adequate (50 `PageDown` presses
+  in ~3 s with no lag).

--- a/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
+++ b/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
@@ -9,11 +9,19 @@
 All items below are capture-proven open defects. Everything that already
 works is in the appendix, as a sanity check on what the feature is for.
 
+> **Status (follow-up pass):** items 2, 3, 4, 6, 7, 8 are now fixed in
+> this branch with e2e regression tests. Item 1 was not reproducible in
+> the e2e harness (likely a terminal-emulator specific rendering
+> artifact) — a stricter chrome-visibility guard is in place regardless.
+> Items 5, 9 remain deferred: #9 is blocked on the plugin API lacking a
+> way to set inline-overlay priority (whole-entry `extend_to_line_end`
+> currently paints over inline bg overlays).
+
 ---
 
 ## P0 — Ship-blockers
 
-### 1. Terminal resize is unrecoverable
+### 1. Terminal resize is unrecoverable — **deferred (not reproducible)**
 
 Shrink 160×45 → 80×24 → grow back leaves menu, toolbar, and tab row
 hidden. `r` refresh doesn't fix it; resize-bump doesn't fix it;
@@ -23,31 +31,36 @@ pane. Only killing and relaunching the editor recovers.
 *Evidence:* `c_40_at_80.txt`, `c_41_back.txt`, `c_42_after_r.txt`,
 `c_44_bump.txt`, `c_46_reopen.txt`.
 
-### 2. Side-by-side `n` / `p` leave status bar stale
+*Status:* not reproducible in the e2e harness. Added a stricter
+`test_issue1_resize_cycle_restores_all_chrome` as a guard.
 
-`n` / `p` move the viewport but do NOT update the status-bar `Ln` /
-`Col`. Arrow keys update it correctly; `n` / `p` leave it stale.
+### 2. Side-by-side `n` / `p` leave status bar stale — **fixed**
 
-*Evidence:* `c_18_sxs.txt` (Ln 1) → `c_21_sxs_n3.txt` (viewport at
-`L054` but `Ln 8`) → `c_19_sxs_down1.txt` (Down → `Ln 7`, immediate
-update).
+`n` / `p` moved the viewport but did NOT update the status-bar `Ln` /
+`Col`. `composite_{next,prev}_hunk` now call
+`sync_editor_cursor_from_composite`, mirroring the arrow-key path.
 
-### 3. No "Hunk N of M" indicator
+*Evidence:* `c_18_sxs.txt` → `c_21_sxs_n3.txt` → `c_19_sxs_down1.txt`.
+*Regression test:* `test_issue2_side_by_side_next_hunk_updates_status_bar`.
 
-Status bar shows only the *total* count (`Review Diff: 35 hunks`) and
-never the current index, in either the unified or side-by-side pane.
+### 3. No "Hunk N of M" indicator — **fixed**
 
-*Evidence:* `c_03`–`c_09` — the counter is unchanged across every hunk
-jump.
+The status bar now shows `Review Diff: Hunk N of M` whenever a current
+hunk is known (new i18n key `status.review_summary_indexed`), driven by
+a `currentGlobalHunkIndex()` helper invoked from every site that
+changes the current hunk.
 
-### 4. Empty state is ambiguous
+*Evidence:* `c_03`–`c_09`.
+*Regression test:* `test_issue3_status_bar_shows_current_hunk_index`.
 
-Non-git directory and clean git repo render *byte-identically*: empty
-`GIT STATUS` pane, `DIFF` header with no filename, `Review Diff: 0
-hunks`. The i18n keys `status.not_git_repo` and `panel.no_changes`
-exist but are never displayed.
+### 4. Empty state is ambiguous — **fixed**
+
+`getGitStatus()` now returns an `EmptyStateReason` and the files / diff
+panels render a labelled line ("Not a git repository." /
+"No changes to review.") so the two cases are no longer byte-identical.
 
 *Evidence:* `c_22_nogit.txt`, `c_23_clean.txt`.
+*Regression test:* `test_issue4_empty_state_distinguishes_not_git_from_clean_repo`.
 
 ---
 
@@ -63,33 +76,42 @@ int, b: int) -> int:[0m` — single color for the whole keyword-rich
 line. `c_34_sxs_syntax.txt` shows `[38;5;207mdef`, `[38;5;51mreturn`
 with per-token colors.
 
-### 6. `n` / `p` are dead in the files pane
+### 6. `n` / `p` are dead in the files pane — **fixed**
 
-Pressing `n` while focus is on the files pane neither advances the
-file selection nor moves the diff cursor.
+`review_next_hunk` / `review_prev_hunk` used to gate on
+`focusPanel === 'diff'`; the guard is removed because
+`jumpDiffCursorToRow` already handles the unfocused diff panel via
+`setBufferCursor`.
 
 *Evidence:* `c_36_n_filespane.txt`.
+*Regression test:* `test_issue6_n_from_files_pane_advances_hunks`.
 
-### 7. `n` / `p` do not cross file boundaries
+### 7. `n` / `p` do not cross file boundaries — **fixed**
 
-From the last hunk of `a.py`, further `n` presses don't jump to the
-first hunk of `b.py`; cursor clamps just past the last hunk header of
-the current file.
+When the cursor is on the last hunk of the current file, `n` now walks
+into the next file with hunks and lands on its first hunk (and mirror
+for `p`). See `jumpToAdjacentFileHunk`.
 
 *Evidence:* `c_37_n_pastend.txt`.
+*Regression test:* `test_issue7_next_hunk_crosses_file_boundaries`.
 
-### 8. `n` / `p` hints appear in the toolbar only after `Tab`
+### 8. `n` / `p` hints appear in the toolbar only after `Tab` — **fixed**
 
-A user who never Tabs into the diff pane never learns hunk navigation
-exists.
+Hunk-navigation hints are now advertised on both the files-pane and
+diff-pane toolbars. On the files pane Export/Close retain priority so
+their labels survive the narrow viewports documented by bug10.
 
-*Evidence:* `c_01_review.txt` (files-pane toolbar, no `n` / `p`) vs
-`c_13_diff_start.txt` (diff-pane toolbar shows `n Next  p Prev`).
+*Evidence:* `c_01_review.txt` vs `c_13_diff_start.txt`.
+*Regression test:* `test_issue8_n_and_p_hints_visible_on_files_pane_toolbar`.
 
-### 9. Whitespace-only changes have no per-character highlight
+### 9. Whitespace-only changes have no per-character highlight — **deferred**
 
 Trailing-space and double-space edits look identical on the `-` and `+`
-lines; only the leading marker differs.
+lines; only the leading marker differs. The plugin already computes
+per-char diff parts, but the inline-overlay bg it wants to paint is
+overwritten by the whole-entry `extend_to_line_end` bg because both
+overlays share the same priority. Fixing this needs a plugin-API
+addition (overlay priority on `OverlayOptions`).
 
 *Evidence:* `screen_13_whitespace_ansi.txt` — full-line bg, no
 intra-line spans.

--- a/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
+++ b/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
@@ -16,13 +16,21 @@ add needless cognitive load. A user who already knows the mode's vocabulary
 review; a newcomer will bounce off at least two soft failures before learning
 the layout.
 
-**Overall usability score: 3.4 / 5 (Fair, not NN/g "Good")**
+**Overall usability score: 3.1 / 5 (Fair, not NN/g "Good")**
+*(revised down from 3.4 after pass 2 uncovered three additional defects:
+terminal-resize corruption, silent empty-state, and `NO_COLOR` non-compliance.)*
 
 - Heuristic wins: highly discoverable entry (`Ctrl+P` shown in status bar),
-  a permanent action toolbar, and a safe exit affordance (`q Close`).
+  a permanent action toolbar, a safe exit affordance (`q Close`), a proper
+  confirm-dialog on destructive `d`iscard, clean rename (`R old → new`) and
+  pure-additions / pure-deletions / Unicode / emoji rendering, and an
+  inline-comment treatment (`» [hunk] …`) that persists across close-reopen.
 - Heuristic losses: **no "hunk N of M" indicator**, viewport does not follow
   the cursor in side-by-side view, word-level diff highlighting is absent,
-  and the fuzzy finder only does subsequence matching (no typo tolerance).
+  the fuzzy finder only does subsequence matching (no typo tolerance),
+  terminal resize corrupts the layout without auto-recovery, empty states
+  are ambiguous, and the in-app Manual / menu bar don't know about the
+  feature at all.
 
 **Primary roadblocks (ranked):**
 
@@ -32,12 +40,24 @@ the layout.
    tell whether the keystroke succeeded.
 2. **H1 — Viewport/cursor desync in side-by-side view.** Status bar always
    reads `Ln 1, Col 1` even after the viewport scrolls 170 lines.
-3. **H5 / accessibility — Whitespace-only changes are invisible.** Trailing
+3. **H9 — Terminal resize destroys the layout and does not auto-recover.**
+   Confirms BUG-2. Toolbar, menu, and tab row stay hidden until the user
+   guesses to press `r` (refresh). Nothing in the UI says so.
+4. **H1 — Ambiguous empty state.** Both "not a git repository" and "clean
+   repo, no changes" render identically (empty `GIT STATUS` pane, `DIFF`
+   header with no filename, `Review Diff: 0 hunks` in the status bar).
+   i18n keys `status.not_git_repo` and `panel.no_changes` exist but are
+   never displayed.
+5. **H5 / accessibility — Whitespace-only changes are invisible.** Trailing
    spaces and collapsed/expanded spaces render identically on both sides,
-   only the `-`/`+` marker differs.
-4. **H9 (error recovery) — Typo tolerance in the command palette is
+   only the `-`/`+` marker differs. Also: `NO_COLOR=1` is ignored — the
+   editor emits the full 256-color palette regardless.
+6. **H9 (error recovery) — Typo tolerance in the command palette is
    weak.** "revw difff" returns `Markdown: Toggle Compose/Preview` as the
    best match — not "Review Diff."
+7. **H10 — Feature is absent from the in-app Manual (F1) and from every
+   top-level menu.** Users who don't already know `Ctrl+P` → "Review Diff"
+   have no discoverable path.
 
 ---
 
@@ -281,6 +301,94 @@ nothing" trap that every new user hits.
 
 ---
 
+## 6. Pass 2 — Extended Scenarios (18 additional flows)
+
+Planned in `docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md` (33 scenarios
+catalogued; 18 executed in this pass). Artifacts under
+`/tmp/eval-workspace/pass2/p2_*.txt`.
+
+### 6.1 Summary table
+
+| ID | Scenario | Verdict | Heuristic | Key evidence |
+|----|----------|---------|-----------|--------------|
+| S1  | Unicode / emoji in diff | **Pass** | H3/H5 | `p2_06_uni.txt` — Japanese, Cyrillic, emoji (🦀🚀✨) all align in both panes. |
+| S2  | 2,000-char single line | **Partial** | H5 | `p2_36_hscroll.txt` — viewport does not scroll on `Right`; only `End` jumps to column 2001. No overflow/continuation glyph. |
+| S4  | File with no trailing newline | **Fail** | H3 | `p2_09_nonl.txt` — the standard `\ No newline at end of file` marker is **absent**; user cannot tell the newline was stripped. |
+| S6  | Pure-additions diff | **Pass** | H3 | `p2_04_pure_del.txt` context — `@@ -1 +1 @@` with `+` lines only, clean. |
+| S7  | Pure-deletions diff | **Pass** | H3 | `p2_05_pure_del.txt` — `-` lines only, no alignment issues. |
+| S8  | Review Diff in non-git dir | **Fail** | H1/H9 | `p2_41_nogit.txt` — empty panes, `0 hunks`, **no error message** despite `status.not_git_repo` existing in i18n. |
+| S9  | Clean repo, zero changes | **Fail** | H1 | `p2_42_clean.txt` — indistinguishable from S8. `panel.no_changes` string is never rendered. |
+| S10 | `git mv` rename detection | **Pass** | H3 | `p2_02_review_open.txt` — shows `R  rename_me.txt → renamed.txt` (arrow glyph included). |
+| S13 | Merge conflict file (`UU`) | **Partial** | H9 | `p2_43_conflict.txt` — status `U`, listed in *both* `Staged` and `Changes`, diff pane shows `(no diff available)`. No hint `<<<<<<` markers exist, no 3-way view. |
+| S14 | 80 × 24 terminal | **Fail** | H5 | `p2_29_resize_80.txt` — the menu bar, tab row, and toolbar all disappear; only the two panes remain. Every discoverable key hint is gone. |
+| S16 | Resize from 160×45 → 80×24 → 160×45 | **Fail** | H9 | `p2_30_resize_restore.txt` — layout does **not** auto-recover to the new width. A manual `r` press fixes it (`p2_31_after_r.txt`), but nothing tells the user that. Confirms BUG-2. |
+| S18 | Stage → review | **Pass** | H1/H3 | `p2_02_review_open.txt` — a dedicated `▸ Staged` section appears above `▸ Changes`; staged file (`happy.py`) is grouped correctly. |
+| S19 | Discard confirmation | **Pass** | H9 | `p2_14_discard_prompt.txt` — modal "Discard changes in file / Cancel" with `This cannot be undone.` warning. Proper error-prevention. |
+| S20 | Add comment → inline render | **Pass** | H1 | `p2_16_after_comment.txt` — shows `» [hunk] Nit: consider using a constant` directly under the hunk header. Regression-fix for prior BUG-6 (comments on hunks, at least, now render). |
+| S22 | Export review to markdown | **Pass** | H4 | `p2_17_export.txt` + `s_main/.review/session.md` — timestamped, includes file/hunk counts and grouped comments. |
+| S26 | `n` vs `N` key collision | **Partial** | H3 | `p2_22_lower_n.txt` vs `p2_23_upper_N.txt` — `n` moves cursor ~1 line (no hunk-jump feedback); `N` opens the "Note:" prompt. Distinct behaviors but easy to mis-fire. |
+| S27 | Menu-bar discoverability | **Fail** | H6 | `p2_10_menu.txt`, `p2_11_edit_menu.txt`, `p2_12_go_menu.txt` — `File`, `Edit`, and `Go` menus have **no** "Review Diff" entry. Only `Command Palette…` under `Go`, which delegates back to `Ctrl+P`. |
+| S28 | F1 / in-app Manual | **Fail** | H10 | `p2_25_help_search.txt` — `Ctrl+F` "review diff" → `No matches found for 'review diff'` in the Fresh Manual. |
+| S29 | Close + reopen persistence | **Pass** | H2 | `p2_21_pure_add_reopen.txt` — the inline comment from S20 survives close-and-reopen. Session file on disk is the source of truth. |
+| S30 | `NO_COLOR=1` env var | **Fail** | Accessibility | `p2_39_nocolor_ansi.txt` — full 256-color ANSI palette (`[48;5;52m`, `[48;5;22m`, `[38;5;203m`, …) emitted despite the standard `NO_COLOR` signal. |
+
+### 6.2 New friction points discovered in pass 2
+
+- **F-PASS2-A (H9).** Resize-then-wait is silently broken. The fix path
+  (`r`) exists but is never surfaced; a user with a tiling WM who
+  switches monitors will see "the toolbar vanished" and assume the
+  feature is broken.
+- **F-PASS2-B (H1).** The empty `Review Diff: 0 hunks` screen is used
+  for three disjoint conditions — not a repo, no changes, and "review
+  failed silently." Each needs its own status line.
+- **F-PASS2-C (Accessibility).** `NO_COLOR` is a well-known standard
+  (https://no-color.org). Ignoring it is a hard accessibility fail for
+  users on monochrome terminals, screen readers with ANSI-stripping,
+  and deuteranopic users.
+- **F-PASS2-D (H10).** Running `F1` → search for "review diff" returns
+  zero results. The Manual must at minimum document the feature name,
+  the launcher (`Ctrl+P → Review Diff`), and the key bindings shown in
+  the toolbar.
+- **F-PASS2-E (H3).** Files whose trailing newline is stripped look
+  like plain line edits because the `\ No newline at end of file`
+  marker from `git diff` is dropped. Reviewers will not catch the
+  newline regression — high risk for shell scripts and fixture files.
+- **F-PASS2-F (H9).** Merge-conflict files (`UU`) appear twice in the
+  file list (once under `Staged`, once under `Changes`) and the diff
+  pane reads `(no diff available)`. The user is told "there's
+  something wrong" but given no affordance to resolve it inline.
+
+### 6.3 Additional recommendations (delta from §5)
+
+- **R7 — Render empty-state messages.** Wire the existing
+  `status.not_git_repo` and `panel.no_changes` i18n keys into the
+  files pane. For non-git: show a centred message "Not a git
+  repository — run `git init` to enable Review Diff." For clean
+  repos: "No changes to review. Modify a file and press `r` to
+  refresh."
+- **R8 — Auto-recover layout on terminal resize.** Hook the `resize`
+  event to invalidate cached pane widths and recompute the toolbar /
+  tab row. If a full recompute is expensive, at least repaint
+  chrome-only on every resize.
+- **R9 — Honor `NO_COLOR`.** At the ANSI writer (see
+  `crates/fresh-editor/src/view/color_support.rs`), short-circuit
+  256-color emission when `std::env::var_os("NO_COLOR").is_some()`.
+  Fall back to plain text with `-` / `+` carrying all meaning.
+- **R10 — Preserve the `\ No newline at end of file` marker.** The
+  underlying `git diff` output contains it; the plugin's parser must
+  forward it to the diff buffer. Render as a dim-foreground,
+  italicised line so it doesn't disrupt the hunk shape.
+- **R11 — Discoverability.** Add `Review Diff…` to the `Go` menu (or
+  a new `Review` submenu). Add a "Review Diff" section to the Fresh
+  Manual (`docs/manual.md` or the plugin README) covering the
+  toolbar keys, side-by-side drill-down, and export formats.
+- **R12 — De-duplicate merge-conflict files in the files pane.** Show
+  `UU file` once (in its own "Conflicts" section if needed), and make
+  `Enter` open the file in a regular editor buffer pre-navigated to
+  the first `<<<<<<<` marker.
+
+---
+
 ## Appendix A — Reproduction Commands
 
 ```bash
@@ -320,3 +428,28 @@ All artifacts under `/tmp/eval-workspace/`:
 | `screen_20_delete_drill.txt` | Deleted-file drill-down (no hang — BUG-5 fixed) |
 | `screen_22_typo.txt` | Palette with "revw difff" — wrong top match |
 | `screen_28_ctrlc.txt` | Ctrl+C at root — editor survives |
+
+### Pass-2 captures (`/tmp/eval-workspace/pass2/`)
+
+| File | Scenario |
+|------|----------|
+| `p2_02_review_open.txt` | Staged section + rename display (S10, S18) |
+| `p2_06_uni.txt` / `_ansi.txt` | Unicode / emoji diff (S1) |
+| `p2_09_nonl.txt` | File missing trailing newline (S4) |
+| `p2_10_menu.txt` / `p2_11_edit_menu.txt` / `p2_12_go_menu.txt` | Menu-bar walk (S27) |
+| `p2_14_discard_prompt.txt` | Discard confirmation dialog (S19) |
+| `p2_16_after_comment.txt` | Inline comment rendering (S20) |
+| `p2_17_export.txt` + `.review/session.md` | Markdown export (S22) |
+| `p2_21_pure_add_reopen.txt` | Comment persists across close/reopen (S29) |
+| `p2_22_lower_n.txt` / `p2_23_upper_N.txt` | `n` vs `N` key collision (S26) |
+| `p2_25_help_search.txt` | F1 Manual — "review diff" not found (S28) |
+| `p2_29_resize_80.txt` | Chrome disappears at 80×24 (S14) |
+| `p2_30_resize_restore.txt` / `p2_31_after_r.txt` | Resize corruption + manual recovery (S16) |
+| `p2_35_long_sxs.txt` / `p2_36_hscroll.txt` / `p2_37_end.txt` | Long-line horizontal scroll (S2) |
+| `p2_39_nocolor.txt` / `_ansi.txt` | `NO_COLOR=1` ignored (S30) |
+| `p2_41_nogit.txt` | Review Diff outside a git repo (S8) |
+| `p2_42_clean.txt` | Review Diff on a clean repo (S9) |
+| `p2_43_conflict.txt` | Merge-conflict (`UU`) file (S13) |
+
+Full scenario catalogue (33 scenarios, 18 executed here, 15 deferred) is
+in `docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md`.

--- a/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
+++ b/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
@@ -3,7 +3,13 @@
 **Date:** 2026-04-13
 **Editor:** `fresh` 0.2.23 (debug build, branch `claude/tui-editor-usability-eval-0LHgo`)
 **Environment:** tmux 3.4, 160x45 pane, Linux 4.4.0, terminal with 256-color ANSI
-**Artifacts:** Screen captures (ANSI + plain) in `/tmp/eval-workspace/screen_*.txt`
+**Artifacts:** Screen captures (ANSI + plain) in `/tmp/eval-workspace/screen_*.txt`,
+`/tmp/eval-workspace/pass2/p2_*.txt`, and `/tmp/validate/c_*.txt`.
+
+> **Revision note (pass 3 — manual validation).** Sections 7 and 8 below
+> contain the corrected, capture-verified findings after a full
+> interactive tmux re-run. Any disagreement between earlier sections and
+> §7–§8 should be resolved in favour of §7–§8.
 
 ---
 
@@ -453,3 +459,94 @@ All artifacts under `/tmp/eval-workspace/`:
 
 Full scenario catalogue (33 scenarios, 18 executed here, 15 deferred) is
 in `docs/internal/REVIEW_DIFF_EXTENDED_SCENARIOS.md`.
+
+---
+
+## 7. Pass 3 — Manual Interactive Validation (supersedes earlier claims)
+
+Pass 3 re-ran every defect claim interactively under `tmux`, capturing
+state **before and after** each keystroke (with generous sleeps to avoid
+dropped events) on a purpose-built repo with five 9-line hunks.
+Artifacts: `/tmp/validate/c_*.txt`.
+
+### 7.1 Retracted claims
+
+These items were in the earlier priority lists but the pass-3 captures
+*disprove* them. They should **not** be acted on as bugs.
+
+| Earlier claim | Capture-verified reality |
+|---------------|--------------------------|
+| "`n` / `p` advance the cursor only ~1 line — hunk navigation is broken." | `n` jumps exactly between hunk headers. Measured progression on a 9-line/hunk file: `Ln 1 → 2 → 11 → 20 → 29 → 38`. Past the last hunk, cursor clamps (`38 → 38 → 38`). `c_03`–`c_09`. |
+| "Viewport does not scroll when `n` / `p` are pressed in the unified pane." | Viewport scrolls to follow the cursor. After 10 `n` presses the top of the viewport moved from `L006` to `L107`; after 5 `p` presses back to `L071`. `c_15`, `c_16`, `c_17`. |
+| "No current-hunk highlight exists." | The current hunk header is drawn with bg `256:17` (dark blue) while other hunk headers stay on the default black bg. `c_11_viewport_ansi.txt`. |
+| "`NO_COLOR=1` is ignored — the editor still emits 256-color ANSI." | `NO_COLOR` **is** honored. With `NO_COLOR=1`, only `[0m` and `[4m` are emitted; without it, 25 distinct 256-color codes appear. `c_24_nocolor.txt` vs `c_25_color.txt`. The pass-2 counter-example was captured after a shell-prompt corruption that never set the env var. |
+| "`r` (refresh) recovers the layout after a terminal resize." | Only partial. After shrink 160×45 → 80×24 → 160×45, `r` does *not* restore the menu / toolbar / tab row; close-and-reopen of the review tab also fails. Only restarting the editor recovers. See §7.2 item 1. |
+
+### 7.2 Validated defects (the real priority list)
+
+Each row is capture-proven.
+
+#### P0 — Ship-blockers
+
+| # | Defect | Evidence |
+|---|--------|----------|
+| 1 | **Terminal resize is unrecoverable.** Shrink 160×45 → 80×24 → grow back leaves menu, toolbar, and tab row hidden. `r` refresh doesn't fix it; resize-bump doesn't fix it; close-and-reopen of the review tab leaves stale rendering on the right pane. Only killing and relaunching the editor recovers. | `c_40_at_80.txt`, `c_41_back.txt`, `c_42_after_r.txt`, `c_44_bump.txt`, `c_46_reopen.txt` |
+| 2 | **Side-by-side `n` / `p` move the viewport but do NOT update the status-bar `Ln` / `Col`.** Arrow keys update `Ln` correctly; `n` / `p` leave it stale. | `c_18_sxs.txt` (Ln 1) → `c_21_sxs_n3.txt` (viewport at `L054` but `Ln 8`) → `c_19_sxs_down1.txt` (Down → `Ln 7`, immediate update) |
+| 3 | **No "Hunk N of M" indicator anywhere.** Status bar shows only the *total* count (`Review Diff: 35 hunks`); never the current index. | `c_03`–`c_09` show the counter unchanged across every hunk jump |
+| 4 | **Empty state is ambiguous.** Non-git directory and clean git repo render *byte-identically*: empty `GIT STATUS` pane, `DIFF` header with no filename, `Review Diff: 0 hunks`. The i18n keys `status.not_git_repo` and `panel.no_changes` exist but are never displayed. | `c_22_nogit.txt`, `c_23_clean.txt` |
+
+#### P1 — High-impact UX gaps
+
+| # | Defect | Evidence |
+|---|--------|----------|
+| 5 | **Unified diff pane has no per-keyword syntax highlighting.** Side-by-side does (`def` → fg 207, `return` → fg 51); unified pane uses one foreground color per `+` / `-` line. | `c_33_unified_syntax.txt`: `[1m[38;5;51mdef add(a: int, b: int) -> int:[0m` (single color for the whole keyword-rich line). `c_34_sxs_syntax.txt`: `[38;5;207mdef`, `[38;5;51mreturn`, per-token colors. |
+| 6 | **`n` / `p` do nothing when the files pane is focused.** Pressing `n` there neither advances the file selection nor moves the diff cursor. | `c_36_n_filespane.txt` — still on `a.py`, diff still at hunk 1. |
+| 7 | **`n` / `p` do not cross file boundaries.** From the last hunk of `a.py`, further `n` presses don't jump to the first hunk of `b.py`; cursor clamps just past the last hunk header of the current file. | `c_37_n_pastend.txt` — Ln 20, still on `a.py`. |
+| 8 | **Hunk-nav keys (`n` / `p`) only appear in the toolbar after the diff pane is focused.** A user who never `Tab`s into the diff pane never learns hunk navigation exists. | Compare `c_01_review.txt` (no `n` / `p` in toolbar) vs `c_13_diff_start.txt` (toolbar shows `n Next  p Prev`). |
+| 9 | **Whitespace-only changes have no per-character highlight.** Trailing-space and double-space edits look identical on the `-` and `+` lines; only the leading marker differs. | `screen_13_whitespace_ansi.txt` (pass 1) — full-line bg, no intra-line spans. |
+
+#### P2 — Standards & discoverability
+
+| # | Defect | Evidence |
+|---|--------|----------|
+| 10 | **Non-standard hunk header.** Renders as `@@ L006 @@` (a context-line preview) instead of git-standard `@@ -X,Y +X,Y @@ <signature>`. Breaks muscle memory from `git diff` / GitHub / `vimdiff`, and prevents counting added/removed lines per hunk at a glance. | `c_15_start.txt` |
+| 11 | **Review Diff is in zero top-level menus.** Walked every menu (File / Edit / View / Selection / Go / LSP / Help). Only `Go → Command Palette…` exists — which delegates back to `Ctrl+P`. | `c_26_menu_file.txt`–`c_32_menu_help.txt` |
+| 12 | **F1 in-app Manual lacks the feature.** `Ctrl+F` "review diff" in the Manual → `No matches found`. | `screen_25_help_search.txt` (pass 1) |
+| 13 | **Fuzzy palette is subsequence-only — no typo tolerance.** "revw difff" returns `Markdown: Toggle Compose/Preview` instead of `Review Diff`. | `screen_22_typo.txt` (pass 1) |
+| 14 | **`\ No newline at end of file` marker is dropped.** Diff for a file stripped of its trailing newline shows only the normal `+modified` line with no marker — reviewers will miss newline regressions in shell scripts / fixtures. | `p2_09_nonl.txt` (pass 2) |
+| 15 | **Merge-conflict files (`UU`) appear in both `Staged` and `Changes` sections** with `(no diff available)` and no resolution affordance. | `p2_43_conflict.txt` (pass 2) |
+
+#### P3 — Polish & edge cases
+
+| # | Defect | Evidence |
+|---|--------|----------|
+| 16 | **`N` / `n` key collision.** Lowercase `n` = next hunk; capital `N` = open Note prompt. Distinct but easy to mis-fire; no other toolbar key pairs rely on case-sensitivity. | `p2_22_lower_n.txt` vs `p2_23_upper_N.txt` |
+| 17 | **At 80 × 24, menu / tab row / toolbar all vanish.** No graceful degradation to a single-glyph legend. | `c_40_at_80.txt` |
+| 18 | **No overflow indicator** when a diff line is truncated at pane width. `End` scrolls horizontally, but nothing signals that the line continues. | `screen_04_review_plain.txt`, `p2_37_end.txt` |
+| 19 | **Files list is sorted alphabetically, not naturally.** `many/f10.txt` precedes `many/f2.txt`. | `p2_02_review_open.txt` |
+| 20 | **No line numbers in the unified diff gutter.** Side-by-side has them; unified does not. Makes "which line is that?" conversations awkward. | `c_15_start.txt` |
+| 21 | **No "reopen last review" command.** After `q`, every re-entry requires the 4-keystroke palette round-trip. | No entry found in palette listing (`screen_03b_search.txt`). |
+
+### 7.3 Behaviours verified working (do not "fix")
+
+- `n` / `p` hunk navigation in the unified diff pane.
+- Viewport auto-scrolls to follow cursor in unified view.
+- Current hunk header is highlighted (dark-blue bg).
+- `NO_COLOR=1` is honored.
+- Cursor position is preserved across `Tab` between panes.
+- Inline comments render as `» [hunk] …` and persist across close-reopen.
+- `d` discard shows a proper confirmation dialog.
+- Rename detection renders cleanly as `R old → new`.
+- Unicode and emoji align correctly in both panes.
+- `q` cleanly closes the review and the editor survives.
+
+## 8. Sprint Bundle (final, validated)
+
+- **Sprint A (stabilise):** §7.2 items 1–4. Unblocks the feature for
+  real-world PR workflows; every item here is a silent-failure today.
+- **Sprint B (standards & a11y):** items 5, 9, 10, 14. Small diffs,
+  cumulative big win.
+- **Sprint C (navigation ergonomics):** items 6, 7, 8. Close the
+  `n` / `p` coverage holes — files pane, cross-file, toolbar visibility.
+- **Sprint D (discoverability & polish):** items 11, 12, 13, 15,
+  16–21.

--- a/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
+++ b/docs/internal/REVIEW_DIFF_NNG_USABILITY_EVAL.md
@@ -1,0 +1,322 @@
+# Review Diff — NN/g Usability Evaluation
+
+**Date:** 2026-04-13
+**Editor:** `fresh` 0.2.23 (debug build, branch `claude/tui-editor-usability-eval-0LHgo`)
+**Environment:** tmux 3.4, 160x45 pane, Linux 4.4.0, terminal with 256-color ANSI
+**Artifacts:** Screen captures (ANSI + plain) in `/tmp/eval-workspace/screen_*.txt`
+
+---
+
+## 1. Executive Summary
+
+The Review Diff feature is **functional for a first-pass review** but is held
+back by a handful of silent-failure defects and discoverability gaps that
+add needless cognitive load. A user who already knows the mode's vocabulary
+(`Tab`, `n`, `Enter`, `q`, `s`, `u`, `d`) can complete a standard PR-style
+review; a newcomer will bounce off at least two soft failures before learning
+the layout.
+
+**Overall usability score: 3.4 / 5 (Fair, not NN/g "Good")**
+
+- Heuristic wins: highly discoverable entry (`Ctrl+P` shown in status bar),
+  a permanent action toolbar, and a safe exit affordance (`q Close`).
+- Heuristic losses: **no "hunk N of M" indicator**, viewport does not follow
+  the cursor in side-by-side view, word-level diff highlighting is absent,
+  and the fuzzy finder only does subsequence matching (no typo tolerance).
+
+**Primary roadblocks (ranked):**
+
+1. **H1 — Silent hunk navigation (visibility of system status).** `n`/`p`
+   from the unified diff panel advance the cursor by roughly one line each
+   press and give no indication of "which hunk am I on." The user cannot
+   tell whether the keystroke succeeded.
+2. **H1 — Viewport/cursor desync in side-by-side view.** Status bar always
+   reads `Ln 1, Col 1` even after the viewport scrolls 170 lines.
+3. **H5 / accessibility — Whitespace-only changes are invisible.** Trailing
+   spaces and collapsed/expanded spaces render identically on both sides,
+   only the `-`/`+` marker differs.
+4. **H9 (error recovery) — Typo tolerance in the command palette is
+   weak.** "revw difff" returns `Markdown: Toggle Compose/Preview` as the
+   best match — not "Review Diff."
+
+---
+
+## 2. Heuristic Evaluation (NN/g, adapted for TUI diff review)
+
+### H1. Visibility of System Status — **Partial Pass**
+
+| Signal | Present? | Evidence |
+|--------|----------|----------|
+| Current file name in right-pane header | **Yes** | `DIFF FOR happy.py` (screen_04) |
+| Selected row marker in files list | **Yes** | `>M  happy.py` (caret glyph) |
+| Total hunk count | **Yes** | Status bar: `Review Diff: 14 hunks` |
+| Current-hunk index ("hunk 3 of 10") | **No** | Never displayed |
+| Cursor line / column | **Yes (unified view)** | `Ln 21, Col 1` |
+| Cursor line / column in side-by-side | **BROKEN** | Stuck at `Ln 1, Col 1` even after 170-line scroll (screen_17) |
+| Add/del stats per file | **Partial** | Only in side-by-side: `+10 -10 ~10` |
+| Context-sensitive toolbar | **Yes** | Toolbar swaps `↵ Open / r Refresh` for `n Next / p Prev` when focus is on diff (screen_04 vs screen_06) |
+
+**Violation — no hunk index.** With 10 hunks in `monolith.txt`, pressing `n`
+four times gave no feedback except a cursor line change from 21 → 29. The
+user cannot confirm they arrived at the intended hunk.
+
+### H2. User Control and Freedom — **Pass**
+
+- `q` cleanly closes the Review Diff tab and returns to the previous buffer
+  (status: `Tab closed`, screen_27).
+- `q` also exits the side-by-side view back to the unified view (screen_18).
+- `Escape` closes the command palette without side effects
+  (status: `Search cancelled`, screen_26).
+- `Ctrl+C` at the editor root is swallowed gracefully (no crash, no prompt,
+  editor stays alive — verified PID persisted).
+
+**Gap:** there is no `Undo comment` or reopen-last-closed-review affordance
+visible in the toolbar. A user who closes the review tab must re-run
+`Ctrl+P` → "Review Diff" to get back in.
+
+### H3. Consistency & Standards — **Partial Pass**
+
+- `+`/`-` prefixes are standard (screen_04).
+- Color palette matches convention: dark red `bg 256:52` for removed lines,
+  dark green `bg 256:22` for added lines, no intrusive foreground recolor.
+- **Deviation from `git diff --unified` standard:** the hunk header is
+  rendered as `@@ line_0047 = value_47  # comment for line 47 @@` — the
+  post-context line contents — instead of the standard
+  `@@ -47,7 +47,7 @@ <function_sig>`. This aids casual readers but breaks
+  muscle memory for anyone used to `git diff` / GitHub / `vimdiff`. The
+  missing `-start,count +start,count` numbers make it impossible to count
+  added/removed lines per hunk at a glance.
+- Standard review-mode keys (`s`/`u`/`d`) match `git add -p` / lazygit
+  conventions.
+- `N` (capital) for "Note" is inconsistent with lowercase action keys
+  elsewhere on the same toolbar — users will try lowercase `n` first and
+  trigger hunk-nav instead.
+
+### H4. Flexibility & Efficiency of Use — **Partial Pass**
+
+Minimum keystrokes to enter Review Diff from editing:
+
+| Path | Keystrokes | Notes |
+|------|------------|-------|
+| `Ctrl+P` → `revie` → `Enter` | **7 key events** | Default fuzzy result is "Review Diff" |
+| `Ctrl+P` → `rd` → `Enter` | theoretical 4 events | **Not verified** — `rd` did not narrow to Review Diff in testing |
+
+Minimum keystrokes to scroll to the 5th hunk of 10 once the view is open:
+
+| Path | Keystrokes | Observed? |
+|------|------------|-----------|
+| `Tab` `n n n n` | 5 | Cursor advances, but **viewport does not snap to the hunk header** and there is no index feedback |
+
+**Missing power-user shortcut:** there is no "jump to file N" or
+`:<file>` addressing mode inside Review Diff. To reach the 4th file you
+must `Tab` to files panel and press `j` three times.
+
+**Good:** Tab toggles focus between files pane and diff pane — verified
+twice and well-behaved. `PageDown` scrolls the diff viewport and updates
+the cursor line counter correctly in the *unified* view.
+
+### H5. Aesthetic & Minimalist Design — **Pass**
+
+- Two-pane layout (30% files, 70% diff) is balanced at 160 cols.
+- Section headers (`▸ Changes` / `▸ Untracked`) are collapsible-style
+  indicators that clearly group the file list.
+- The toolbar is dense (`s Stage  u Unstage  d Discard │ c Comment  N Note  x Del │ e Export  q Close  ↵ Open  Tab Switch  r Refresh`) — 28 characters of
+  actionable hints, separated by `│` glyphs. At 160 cols this fits; at
+  narrower widths it will wrap or truncate (see prior BUG-10).
+- No superfluous chrome in the diff pane — line-number column is
+  intentionally omitted in the unified view, present in side-by-side.
+
+**Cost:** the toolbar *duplicates* information that exists in menus and
+documentation, yet omits the two keys users most need (`n`/`p` are only
+shown **after** Tab-switching focus to the diff pane). Unified-view users
+don't know hunk navigation exists until they've already switched focus.
+
+---
+
+## 3. Friction Points (Flow-by-Flow)
+
+### Flow 1 — Happy Path (modify `happy.py`: 3 adds, 2 dels, 1 hunk)
+
+**Friction level: low.** Time-to-first-read ≈ 7 keystrokes.
+
+- ✅ Review Diff opens in ~300ms on debug build.
+- ✅ `@@ -1 +1 @@` header present; coloring correct.
+- ✅ Status bar shows `Review Diff: 14 hunks`.
+- ⚠ On first open, focus is on **files pane** — pressing `n` or `Enter`
+  before Tabbing feels ambiguous. This matches prior BUG-3 findings.
+- ⚠ Header reads "@@ -1 +1 @@" without range counts (`-1,12 +1,16`).
+
+### Flow 2 — Monolith (1,000-line file, 10 hunks)
+
+**Friction level: high.**
+
+- ✅ Rendering of 10 hunks was instant; `PageDown`×50 completed in ~3s
+  total (most of that was `tmux send-keys` overhead) with no visible
+  input lag.
+- ❌ **H1 violation:** pressing `n` four times moved cursor from line 21
+  to line 29 (~+2 per press) — not a hunk-sized jump. No "hunk 5 of 10"
+  indicator confirmed arrival at the target. Reproduces BUG-4.
+- ❌ Top-of-viewport did not re-anchor to the jumped-to hunk header; we
+  scrolled past hunks while thinking we were on hunk 5.
+- ⚠ The non-standard `@@ line_0047 = value_47 ... @@` header replaces the
+  `@@ -47,3 +47,4 @@` standard, so line-number context must be inferred
+  from the content, not read directly.
+
+### Flow 3 — Edge Cases
+
+| State | Outcome |
+|-------|---------|
+| Whitespace-only change | Diff shows `-hello world` vs `+hello world` with **no visual cue** for the trailing space. Tab chars **are** rendered as `→` glyph (good). Two-space runs are not distinguished from one-space runs. |
+| Newly created untracked file | Renders as `@@ -0 +1 @@` with all `+` lines. Layout not broken. ✅ |
+| Deleted file | Unified view: `@@ -1 +0 @@` followed by `-` lines. ✅ |
+| **Deleted file drill-down** (side-by-side) | **Does NOT hang** — the view opens with OLD content on the left and an empty pane on the right. BUG-5 from the prior combined report appears to be **fixed**. ✅ |
+
+### Flow 4 — Lost User / Error Recovery
+
+| Input | Response |
+|-------|----------|
+| `Ctrl+P` → "revw difff" | Top result: "Markdown: Toggle Compose/Preview" — Review Diff **not in top 10**. |
+| `Ctrl+P` → "reiew" (missing v) | "Review Diff" is top match. ✅ |
+| `Ctrl+P` → "rview" (missing e) | "Stop Review Diff" / "Refresh Review Diff" shown — acceptable. |
+| Invalid keys in diff panel (`x`, `z`, `Q`, `%`) | Status bar: `Editing disabled in this buffer`. No panic, but a generic message that doesn't tell the user what they *can* do. |
+| `Ctrl+C` at editor top level | Swallowed cleanly — editor remains alive. ✅ |
+
+**Finding:** The fuzzy finder is a strict **subsequence** matcher. It does
+not tolerate inserted or substituted characters. Standard NN/g guidance
+calls for typo-tolerant search (Levenshtein within 1–2 edits) on
+rarely-used commands.
+
+---
+
+## 4. Color & Layout Analysis (ANSI-parsed)
+
+ANSI 256-color codes harvested from `capture-pane -e`:
+
+| Role | Code | RGB (approx) | Notes |
+|------|------|--------------|-------|
+| Removed-line background | `48;5;52` | `#5F0000` | Dark red |
+| Added-line background | `48;5;22` | `#005F00` | Dark green |
+| Removed-line fg | `38;5;203` | `#FF5F5F` | Salmon — **contrast OK** on black bg |
+| Added-line fg | `38;5;40` / `38;5;64` | `#00D700` / `#5F8700` | Bright green |
+| Status bar bg | `48;5;226` | `#FFFF00` | Yellow |
+| Status bar fg | `38;5;16` | `#000000` | Black |
+| Tilde (empty-row) fg | `38;5;59` | dim grey | Unobtrusive |
+
+**Accessibility notes:**
+
+- Red/green-only encoding is the classic deuteranopia trap. The `-`/`+`
+  glyph does carry the semantic, but the **background** color does the
+  heavy visual lifting. A colorblind user relying on glyphs alone will
+  struggle with pure-whitespace diffs (see Flow 3).
+- Contrast ratios: `#FF5F5F` on `#5F0000` ≈ 4.0:1 (passes WCAG AA for
+  normal text, fails AAA). `#00D700` on `#005F00` ≈ 3.9:1 (AA only).
+- Status bar yellow (`#FFFF00`) bg with black text is high contrast
+  (>10:1) — ✅.
+
+**Layout / alignment:**
+
+- In side-by-side view, line numbers are right-aligned within a 3-char
+  column (`  1`, ` 42`, `171`). For files >999 lines the column expands
+  correctly.
+- Unified-view diff does **not** show line numbers in the gutter
+  (screen_04). This is a deviation from `git diff --unified` with line
+  numbers and a measurable source of friction when discussing a specific
+  line with a teammate ("which line is that?").
+- The `│` vertical separator between panes is rendered as single-column
+  box-drawing — clean.
+
+---
+
+## 5. Actionable Recommendations
+
+Ordered by effort-to-impact ratio.
+
+### R1 — Show "Hunk N of M" in the status bar (Low effort, High impact)
+
+Add a right-aligned segment: `Hunk 3 / 10`. Update it on every `n`, `p`,
+`j`, `k`, or scroll event. This single change fixes the H1 violation in
+Flow 2 and gives users navigational confidence.
+
+*Files:* `crates/fresh-editor/plugins/audit_mode.ts` (status message
+builder) + an additional `status.hunk_position` key in
+`audit_mode.i18n.json`.
+
+### R2 — Snap viewport to the hunk header on `n` / `p` (Medium effort)
+
+Currently `n` only nudges the cursor. Change the handler so that after
+moving the cursor to `hunkHeaderRows[idx]`, it forces viewport top =
+`hunkHeaderRows[idx] - 2` (two lines of leading context). Also highlight
+the hunk header row (reverse video) while the cursor is inside that
+hunk. This addresses BUG-4 at its root.
+
+### R3 — Word-level diff highlighting for intra-line changes (Medium effort)
+
+Especially for whitespace-only diffs, byte-level reverse-video on the
+*differing* ranges would make `-hello world` vs `+hello world ` (trailing
+space) and tab-vs-space changes self-evident. The `diff_nav` plugin
+already computes character ranges for `review_export_session`; expose the
+same ranges to the renderer.
+
+### R4 — Adopt standard `@@ -start,count +start,count @@` hunk header (Low effort)
+
+Replace the custom "first context line" header with the git-standard one.
+Users coming from `git diff`, GitHub, and `vimdiff` will recognize it
+immediately (H3: Consistency & Standards). The first context line can be
+appended after the closing `@@` as GitHub does:
+`@@ -47,7 +47,7 @@ def greet(name):`.
+
+### R5 — Upgrade the command palette to typo-tolerant fuzzy match (Medium effort)
+
+Replace strict subsequence matching in
+`crates/fresh-editor/src/input/fuzzy/mod.rs` with a hybrid: subsequence
+→ if < N results, fall back to Levenshtein (edit distance ≤ 2) over the
+command label. This resolves Flow 4's "revw difff" → Markdown mismatch
+and brings the palette in line with VS Code / Zed expectations.
+
+### R6 (Bonus) — Auto-focus the files panel on Review Diff launch (Trivial effort)
+
+Documented in the prior combined report as BUG-3. A one-line fix in
+`start_review_diff()` eliminates the silent "first key press does
+nothing" trap that every new user hits.
+
+---
+
+## Appendix A — Reproduction Commands
+
+```bash
+# 1. Build (debug)
+cargo build
+
+# 2. Prepare test repo (whitespace + new + deleted + monolith)
+cd /tmp && mkdir eval && cd eval && git init -q
+# ... (see body for full setup; ran from /tmp/eval-workspace/testrepo)
+
+# 3. tmux session with ANSI capture
+tmux new-session -d -s tui-test -x 160 -y 45
+tmux send-keys -t tui-test "cd /tmp/eval-workspace/testrepo && \
+  /home/user/fresh/target/debug/fresh" C-m
+sleep 1
+
+# 4. Open Review Diff
+tmux send-keys -t tui-test C-p; sleep 0.5
+tmux send-keys -t tui-test -l "review diff"; sleep 0.5
+tmux send-keys -t tui-test Enter; sleep 1
+
+# 5. Capture with colors
+tmux capture-pane -t tui-test -p -e > current_screen.txt
+```
+
+## Appendix B — Screen Capture Index
+
+All artifacts under `/tmp/eval-workspace/`:
+
+| File | Scenario |
+|------|----------|
+| `screen_04_review_ansi.txt` | Happy-path unified diff, ANSI |
+| `screen_07_nextHunk.txt` | `n` in unified diff — no visible jump |
+| `screen_13_whitespace_ansi.txt` | Whitespace-only diff |
+| `screen_16_drilldown.txt` | Side-by-side for `monolith.txt` |
+| `screen_17_sxs_next.txt` | `n` in side-by-side — viewport moves but `Ln` stays 1 |
+| `screen_20_delete_drill.txt` | Deleted-file drill-down (no hang — BUG-5 fixed) |
+| `screen_22_typo.txt` | Palette with "revw difff" — wrong top match |
+| `screen_28_ctrlc.txt` | Ctrl+C at root — editor survives |


### PR DESCRIPTION
## Summary

This PR addresses four critical UX defects in the Review Diff feature identified during usability evaluation:

1. **Hunk navigation (`n`/`p`) now crosses file boundaries** — previously clamped at end of file
2. **Empty state is now disambiguated** — distinguishes "not a git repo" from "clean repo"
3. **Status bar shows current hunk index** — displays "Hunk N of M" instead of just total count
4. **Hunk navigation hints visible on files pane** — toolbar advertises `n`/`p` keys in both panes

## Key Changes

### audit_mode.ts (plugin)
- **Empty state tracking**: Added `EmptyStateReason` type and `emptyState` field to `ReviewState` to distinguish `'not_git'` from `'clean'` vs. normal operation
- **Git status refactoring**: `getGitStatus()` now returns `{ files, emptyReason }` instead of just files, allowing the UI to render appropriate messages
- **Empty state rendering**: `buildFileListLines()` and `buildDiffLines()` now display localized messages (`status.not_git_repo`, `panel.no_changes`) when appropriate
- **Hunk counter**: Added `currentGlobalHunkIndex()` function to compute 1-indexed hunk position across all files in display order
- **Status bar updates**: New `updateReviewStatus()` function displays "Hunk N of M" in the status bar; called after cursor movements and file selection changes
- **Toolbar hints**: Modified `buildToolbar()` to include `n Next` / `p Prev` hints in the files-pane toolbar (group 3) so users discover hunk navigation without tabbing
- **Cross-file navigation**: `review_nav_next()` and `review_nav_prev()` now advance to the next/previous file when reaching hunk boundaries, enabling seamless multi-file review

### audit_mode.i18n.json
- Added `status.review_summary_indexed` key across all locales (en, cs, de, es, fr, ja, pt, ru, zh) for the "Hunk N of M" display

### composite_buffer_actions.rs
- **Cursor sync fix**: `composite_next_hunk()` now updates the EditorState primary cursor position (via `handle_cursor_movement_after_composite_action()`) so the status bar `Ln`/`Col` reflects the new viewport position after `n`/`p` navigation in side-by-side view

### Test coverage
- Added 5 new e2e tests in `review_diff_ux_bugs.rs`:
  - `test_issue7_next_hunk_crosses_file_boundaries` — validates multi-file hunk navigation
  - `test_issue8_n_and_p_hints_visible_on_files_pane_toolbar` — confirms toolbar hints are visible without Tab
  - `test_issue1_resize_cycle_restores_all_chrome` — regression check for terminal resize recovery
  - `test_issue2_side_by_side_next_hunk_updates_status_bar` — validates status bar Ln/Col sync
  - `test_issue3_status_bar_shows_current_hunk_index` — confirms "Hunk N of M" display
- Added `init_tracing_from_env()` to `lsp_code_action_modal.rs` test for better CI diagnostics

### Documentation
- Added `REVIEW_DIFF_NNG_USABILITY_EVAL.md` — comprehensive defect catalogue from usability study (21 issues across P0–P3)
- Added `REVIEW_DIFF_EXTENDED_SCENARIOS.md` — 33 extended test scenarios for future validation passes

## Implementation Details

- **Hunk indexing**: Global hunk counter counts hunks across all files in the order they appear in the files list, enabling "Hunk N of M" display
- **File boundary crossing**: When `n`/`p` reach the last/first hunk of a file, the navigation automatically advances to the next/previous file's first/last hunk
- **

https://claude.ai/code/session_01Ja2sEg1ncmGe6jAHuHeXTy