### PR TITLE
fix(markdown-compose): paint table virtual borders with editor.fg

### DIFF
--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -161,11 +161,13 @@ function processTableBorders(
   // Use theme keys (resolved at render time so the borders follow theme
   // changes — same pattern as addOverlay's fg/bg options).
   //
-  //   * fg → editor.line_number_fg (the same dim chrome colour the gutter
-  //     uses, which already exists in every theme)
+  //   * fg → editor.fg (the default document foreground, matching the
+  //     concealed `│` / `─` glyphs inside row text so the virtual
+  //     `┌─┬─┐` / `├─┼─┤` / `└─┴─┘` frame doesn't create a visible seam
+  //     where it meets the in-text borders)
   //   * bg → editor.bg (matches the document background so the borders
   //     blend in rather than carving an opaque slab through the page)
-  const borderOptions = { fg: "editor.line_number_fg", bg: "editor.bg" };
+  const borderOptions = { fg: "editor.fg", bg: "editor.bg" };
 
   for (const line of lines) {
     const ns = `md-tb-${line.line_number}`;


### PR DESCRIPTION
## Summary

In markdown compose mode, table borders came from two rendering paths that disagreed on color:

- **Virtual lines** (`addVirtualLine`) for the top/inter-row/bottom frames (`┌─┬─┐`, `├─┼─┤`, `└─┴─┘`) were styled with `editor.line_number_fg` (a dim chrome color).
- **Concealed source bytes** (`addConceal`) for the `│` / `─` glyphs inside row text had no styling knob, so they fell through to the default `editor.fg`.

The two paths therefore rendered in different colors, producing a visible seam wherever the virtual frame met an in-text border.

## Fix

One-line change in `markdown_compose.ts`: paint the virtual borders with `editor.fg` instead of `editor.line_number_fg`. Both paths now agree, with no plumbing changes on the editor side.

```diff
-  const borderOptions = { fg: "editor.line_number_fg", bg: "editor.bg" };
+  const borderOptions = { fg: "editor.fg", bg: "editor.bg" };
```

## Test plan

- [ ] Open a markdown file with a table in compose mode — verify the `┌─┬─┐` top border, `├─┼─┤` inter-row separators, and `└─┴─┘` bottom border render in the same color as the in-text `│` / `─` glyphs.
- [ ] Existing `markdown_compose` e2e suite still passes.

https://claude.ai/code/session_01HsrdEtXkDwpqLH46sCZPo9