### PR TITLE
Fix search/replace bugs: undo, stale matches, duplication, corruption

### DIFF
--- a/crates/fresh-editor/plugins/search_replace.i18n.json
+++ b/crates/fresh-editor/plugins/search_replace.i18n.json
@@ -36,7 +36,9 @@
     "panel.replace_all_btn": "Replace All (Alt+Ret)",
     "panel.type_pattern": "Type a search pattern above",
     "panel.matches_count": "Matches (%{count} in %{files} files)",
-    "panel.matches_title": "Matches"
+    "panel.matches_title": "Matches",
+    "prompt.confirm_replace": "Replace %{count} match(es) in %{files} file(s)? Undo only covers files still open in this session. Press Enter to confirm, Esc to cancel.",
+    "status.replace_cancelled": "Replacement cancelled"
   },
   "cs": {
     "cmd.search_replace": "Hledat a nahradit v projektu",

--- a/crates/fresh-editor/plugins/search_replace.i18n.json
+++ b/crates/fresh-editor/plugins/search_replace.i18n.json
@@ -77,7 +77,9 @@
     "panel.replace_all_btn": "Nahradit vše (Alt+Ret)",
     "panel.type_pattern": "Zadejte vyhledávací vzor",
     "panel.matches_count": "Shody (%{count} v %{files} souborech)",
-    "panel.matches_title": "Shody"
+    "panel.matches_title": "Shody",
+    "prompt.confirm_replace": "Nahradit %{count} výskyt(ů) v %{files} souboru(ech)? Vrátit zpět lze jen soubory otevřené v této relaci. Enter potvrdí, Esc zruší.",
+    "status.replace_cancelled": "Nahrazení zrušeno"
   },
   "de": {
     "cmd.search_replace": "Suchen und Ersetzen im Projekt",
@@ -116,7 +118,9 @@
     "panel.replace_all_btn": "Alle ersetzen (Alt+Ret)",
     "panel.type_pattern": "Suchmuster oben eingeben",
     "panel.matches_count": "Treffer (%{count} in %{files} Dateien)",
-    "panel.matches_title": "Treffer"
+    "panel.matches_title": "Treffer",
+    "prompt.confirm_replace": "%{count} Treffer in %{files} Datei(en) ersetzen? Rückgängig wirkt nur auf Dateien, die in dieser Sitzung geöffnet sind. Enter bestätigt, Esc bricht ab.",
+    "status.replace_cancelled": "Ersetzen abgebrochen"
   },
   "es": {
     "cmd.search_replace": "Buscar y Reemplazar en Proyecto",
@@ -155,7 +159,9 @@
     "panel.replace_all_btn": "Reemplazar todo (Alt+Ret)",
     "panel.type_pattern": "Escriba un patrón de búsqueda",
     "panel.matches_count": "Coincidencias (%{count} en %{files} archivos)",
-    "panel.matches_title": "Coincidencias"
+    "panel.matches_title": "Coincidencias",
+    "prompt.confirm_replace": "¿Reemplazar %{count} coincidencia(s) en %{files} archivo(s)? Deshacer solo cubre los archivos abiertos en esta sesión. Intro confirma, Esc cancela.",
+    "status.replace_cancelled": "Reemplazo cancelado"
   },
   "fr": {
     "cmd.search_replace": "Rechercher et Remplacer dans le Projet",
@@ -194,7 +200,9 @@
     "panel.replace_all_btn": "Tout remplacer (Alt+Ret)",
     "panel.type_pattern": "Saisissez un motif de recherche",
     "panel.matches_count": "Correspondances (%{count} dans %{files} fichiers)",
-    "panel.matches_title": "Correspondances"
+    "panel.matches_title": "Correspondances",
+    "prompt.confirm_replace": "Remplacer %{count} correspondance(s) dans %{files} fichier(s) ? L'annulation ne concerne que les fichiers ouverts dans cette session. Entrée confirme, Échap annule.",
+    "status.replace_cancelled": "Remplacement annulé"
   },
   "it": {
     "cmd.search_replace": "Cerca e sostituisci nel progetto",
@@ -233,7 +241,9 @@
     "panel.replace_all_btn": "Sostituisci tutto (Alt+Ret)",
     "panel.type_pattern": "Digita un modello di ricerca",
     "panel.matches_count": "Corrispondenze (%{count} in %{files} file)",
-    "panel.matches_title": "Corrispondenze"
+    "panel.matches_title": "Corrispondenze",
+    "prompt.confirm_replace": "Sostituire %{count} corrispondenza/e in %{files} file? L'annulla copre solo i file aperti in questa sessione. Invio conferma, Esc annulla.",
+    "status.replace_cancelled": "Sostituzione annullata"
   },
   "ja": {
     "cmd.search_replace": "プロジェクト内で検索と置換",
@@ -272,7 +282,9 @@
     "panel.replace_all_btn": "すべて置換 (Alt+Ret)",
     "panel.type_pattern": "検索パターンを入力してください",
     "panel.matches_count": "一致 (%{files}ファイル中%{count}件)",
-    "panel.matches_title": "一致"
+    "panel.matches_title": "一致",
+    "prompt.confirm_replace": "%{files} 個のファイルで %{count} 件の一致を置換しますか？元に戻せるのはこのセッションで開いているファイルのみです。Enterで確認、Escでキャンセル。",
+    "status.replace_cancelled": "置換がキャンセルされました"
   },
   "ko": {
     "cmd.search_replace": "프로젝트에서 검색 및 바꾸기",
@@ -311,7 +323,9 @@
     "panel.replace_all_btn": "모두 바꾸기 (Alt+Ret)",
     "panel.type_pattern": "검색 패턴을 입력하세요",
     "panel.matches_count": "일치 (%{files}개 파일에서 %{count}개)",
-    "panel.matches_title": "일치"
+    "panel.matches_title": "일치",
+    "prompt.confirm_replace": "%{files}개 파일에서 %{count}개 일치를 바꾸시겠습니까? 실행 취소는 이 세션에서 열려 있는 파일에만 적용됩니다. Enter 확인, Esc 취소.",
+    "status.replace_cancelled": "바꾸기가 취소됨"
   },
   "pt-BR": {
     "cmd.search_replace": "Pesquisar e Substituir no Projeto",
@@ -350,7 +364,9 @@
     "panel.replace_all_btn": "Substituir tudo (Alt+Ret)",
     "panel.type_pattern": "Digite um padrão de pesquisa",
     "panel.matches_count": "Correspondências (%{count} em %{files} arquivos)",
-    "panel.matches_title": "Correspondências"
+    "panel.matches_title": "Correspondências",
+    "prompt.confirm_replace": "Substituir %{count} ocorrência(s) em %{files} arquivo(s)? Desfazer só cobre arquivos abertos nesta sessão. Enter confirma, Esc cancela.",
+    "status.replace_cancelled": "Substituição cancelada"
   },
   "ru": {
     "cmd.search_replace": "Поиск и замена в проекте",
@@ -389,7 +405,9 @@
     "panel.replace_all_btn": "Заменить все (Alt+Ret)",
     "panel.type_pattern": "Введите шаблон поиска",
     "panel.matches_count": "Совпадения (%{count} в %{files} файлах)",
-    "panel.matches_title": "Совпадения"
+    "panel.matches_title": "Совпадения",
+    "prompt.confirm_replace": "Заменить %{count} совпадений в %{files} файлах? Отмена применяется только к файлам, открытым в этом сеансе. Enter — подтвердить, Esc — отменить.",
+    "status.replace_cancelled": "Замена отменена"
   },
   "th": {
     "cmd.search_replace": "ค้นหาและแทนที่ในโปรเจกต์",
@@ -428,7 +446,9 @@
     "panel.replace_all_btn": "แทนที่ทั้งหมด (Alt+Ret)",
     "panel.type_pattern": "พิมพ์รูปแบบการค้นหา",
     "panel.matches_count": "รายการที่ตรงกัน (%{count} ใน %{files} ไฟล์)",
-    "panel.matches_title": "รายการที่ตรงกัน"
+    "panel.matches_title": "รายการที่ตรงกัน",
+    "prompt.confirm_replace": "แทนที่ %{count} รายการใน %{files} ไฟล์? เลิกทำครอบคลุมเฉพาะไฟล์ที่เปิดอยู่ในเซสชันนี้เท่านั้น กด Enter เพื่อยืนยัน, Esc เพื่อยกเลิก",
+    "status.replace_cancelled": "ยกเลิกการแทนที่"
   },
   "uk": {
     "cmd.search_replace": "Пошук та заміна в проекті",
@@ -467,7 +487,9 @@
     "panel.replace_all_btn": "Замінити все (Alt+Ret)",
     "panel.type_pattern": "Введіть шаблон пошуку",
     "panel.matches_count": "Збіги (%{count} у %{files} файлах)",
-    "panel.matches_title": "Збіги"
+    "panel.matches_title": "Збіги",
+    "prompt.confirm_replace": "Замінити %{count} збіг(ів) у %{files} файл(ах)? Скасування охоплює лише файли, відкриті в цьому сеансі. Enter — підтвердити, Esc — скасувати.",
+    "status.replace_cancelled": "Заміну скасовано"
   },
   "vi": {
     "cmd.search_replace": "Tìm và Thay thế trong Dự án",
@@ -506,7 +528,9 @@
     "panel.replace_all_btn": "Thay thế tất cả (Alt+Ret)",
     "panel.type_pattern": "Nhập mẫu tìm kiếm",
     "panel.matches_count": "Kết quả (%{count} trong %{files} tệp)",
-    "panel.matches_title": "Kết quả"
+    "panel.matches_title": "Kết quả",
+    "prompt.confirm_replace": "Thay thế %{count} kết quả trong %{files} tệp? Hoàn tác chỉ áp dụng cho các tệp đang mở trong phiên này. Enter để xác nhận, Esc để hủy.",
+    "status.replace_cancelled": "Đã hủy thay thế"
   },
   "zh-CN": {
     "cmd.search_replace": "在项目中搜索和替换",
@@ -545,6 +569,8 @@
     "panel.replace_all_btn": "全部替换 (Alt+Ret)",
     "panel.type_pattern": "请输入搜索模式",
     "panel.matches_count": "匹配 (%{files} 个文件中 %{count} 个)",
-    "panel.matches_title": "匹配"
+    "panel.matches_title": "匹配",
+    "prompt.confirm_replace": "在 %{files} 个文件中替换 %{count} 处匹配？撤销仅适用于本次会话中打开的文件。按 Enter 确认，Esc 取消。",
+    "status.replace_cancelled": "替换已取消"
   }
 }

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -1161,8 +1161,15 @@ async function doReplaceAll(): Promise<void> {
   editor.setStatus(editor.t("status.replacing", { count: String(selected.length) }));
   const statusMsg = await executeReplacements(selected);
   editor.setStatus(statusMsg);
-  await rerunSearchQuiet();
+  // Clear stale results before re-searching: the byte offsets in
+  // `panel.searchResults` now point at positions in the pre-replacement
+  // file and must never be re-used (see bug #4 — a second Alt+Enter would
+  // otherwise corrupt files by writing into moved offsets).  We also drop
+  // `busy` so rerunSearchQuiet doesn't bail out on its own guard.
+  panel.searchResults = [];
+  panel.fileGroups = [];
   panel.busy = false;
+  await rerunSearchQuiet();
   updatePanelContent();
 }
 
@@ -1189,8 +1196,11 @@ async function doReplaceScoped(): Promise<void> {
   editor.setStatus(editor.t("status.replacing", { count: String(toReplace.length) }));
   const statusMsg = await executeReplacements(toReplace);
   editor.setStatus(statusMsg);
-  await rerunSearchQuiet();
+  // See doReplaceAll — clear stale offsets and drop busy before re-searching.
+  panel.searchResults = [];
+  panel.fileGroups = [];
   panel.busy = false;
+  await rerunSearchQuiet();
   updatePanelContent();
 }
 

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -1157,6 +1157,20 @@ async function doReplaceAll(): Promise<void> {
     editor.setStatus(editor.t("status.no_items_selected"));
     return;
   }
+  // Confirm before applying.  Replacements write to disk immediately; Undo
+  // only covers files that remain open in this session (see bug #1 report).
+  const fileCount = new Set(selected.map(r => r.match.file)).size;
+  const confirmed = await editor.prompt(
+    editor.t("prompt.confirm_replace", {
+      count: String(selected.length),
+      files: String(fileCount),
+    }),
+    "",
+  );
+  if (confirmed === null) {
+    editor.setStatus(editor.t("status.replace_cancelled"));
+    return;
+  }
   panel.busy = true;
   editor.setStatus(editor.t("status.replacing", { count: String(selected.length) }));
   const statusMsg = await executeReplacements(selected);
@@ -1189,6 +1203,19 @@ async function doReplaceScoped(): Promise<void> {
 
   if (toReplace.length === 0) {
     editor.setStatus(editor.t("status.no_selected"));
+    return;
+  }
+
+  const fileCount = new Set(toReplace.map(r => r.match.file)).size;
+  const confirmed = await editor.prompt(
+    editor.t("prompt.confirm_replace", {
+      count: String(toReplace.length),
+      files: String(fileCount),
+    }),
+    "",
+  );
+  if (confirmed === null) {
+    editor.setStatus(editor.t("status.replace_cancelled"));
     return;
   }
 

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -1279,6 +1279,19 @@ function onSearchReplacePromptCancelled(args: { prompt_type: string }): boolean 
 registerHandler("onSearchReplacePromptCancelled", onSearchReplacePromptCancelled);
 editor.on("prompt_cancelled", "onSearchReplacePromptCancelled");
 
+// If the panel's virtual buffer is closed externally (via the × button,
+// the Close Buffer/Close Tab commands, or anything else), reset the
+// plugin's internal state so the next invocation of `openPanel` creates
+// a fresh buffer/split instead of trying to update a buffer that no
+// longer exists (which silently no-ops and leaves the user with no UI).
+function onSearchReplaceBufferClosed(args: { buffer_id: number }): void {
+  if (panel && args.buffer_id === panel.resultsBufferId) {
+    panel = null;
+  }
+}
+registerHandler("onSearchReplaceBufferClosed", onSearchReplaceBufferClosed);
+editor.on("buffer_closed", "onSearchReplaceBufferClosed");
+
 editor.registerCommand(
   "%cmd.search_replace",
   "%cmd.search_replace_desc",

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -2519,7 +2519,9 @@ impl Editor {
     /// the user closes them all together by closing the group tab.
     pub fn close_tab(&mut self) {
         // If the active split has a group tab active, close the whole group
-        // rather than just the focused panel buffer.
+        // rather than just the focused panel buffer — only the Close-Tab
+        // command (or keybinding) can express "close the group I'm viewing",
+        // so this prelude stays here rather than in `close_tab_in_split`.
         let active_split = self.split_manager.active_split();
         if let Some(group_leaf_id) = self
             .split_view_states
@@ -2531,125 +2533,21 @@ impl Editor {
             return;
         }
 
+        // Delegate to `close_tab_in_split` so the Close-Buffer command,
+        // Alt+W, and the mouse × button all run the same code path —
+        // there should be no difference in behavior between them.
         let buffer_id = self.active_buffer();
-
-        // Count how many splits have this buffer in their open_buffers
-        let buffer_in_other_splits = self
-            .split_view_states
-            .iter()
-            .filter(|(&split_id, view_state)| {
-                split_id != active_split && view_state.has_buffer(buffer_id)
-            })
-            .count();
-
-        // Get current split's open buffers
-        let current_split_tabs = self
-            .split_view_states
-            .get(&active_split)
-            .map(|vs| vs.buffer_tab_ids_vec())
-            .unwrap_or_default();
-
-        // If this is the only tab in this split and there are no other splits with this buffer,
-        // this is the last viewport - behave like close_buffer
-        let is_last_viewport = buffer_in_other_splits == 0;
-
-        if is_last_viewport {
-            // If this is the only buffer in this split AND there are other splits,
-            // close the split instead of the buffer (don't create an empty replacement)
-            let has_other_splits = self.split_manager.root().count_leaves() > 1;
-            if current_split_tabs.len() <= 1 && has_other_splits {
-                // Check for unsaved changes first
-                if self.active_state().buffer.is_modified() {
-                    let name = self.get_buffer_display_name(buffer_id);
-                    let save_key = t!("prompt.key.save").to_string();
-                    let discard_key = t!("prompt.key.discard").to_string();
-                    let cancel_key = t!("prompt.key.cancel").to_string();
-                    self.start_prompt(
-                        t!(
-                            "prompt.buffer_modified",
-                            name = name,
-                            save_key = save_key,
-                            discard_key = discard_key,
-                            cancel_key = cancel_key
-                        )
-                        .to_string(),
-                        PromptType::ConfirmCloseBuffer { buffer_id },
-                    );
-                    return;
-                }
-                // Close the buffer first, then the split
-                if let Err(e) = self.close_buffer(buffer_id) {
-                    tracing::warn!("Failed to close buffer: {}", e);
-                }
-                self.close_active_split();
-                return;
-            }
-
-            // Last viewport of this buffer - close the buffer entirely
-            if self.active_state().buffer.is_modified() {
-                // Buffer has unsaved changes - prompt for confirmation
-                let name = self.get_buffer_display_name(buffer_id);
-                let save_key = t!("prompt.key.save").to_string();
-                let discard_key = t!("prompt.key.discard").to_string();
-                let cancel_key = t!("prompt.key.cancel").to_string();
-                self.start_prompt(
-                    t!(
-                        "prompt.buffer_modified",
-                        name = name,
-                        save_key = save_key,
-                        discard_key = discard_key,
-                        cancel_key = cancel_key
-                    )
-                    .to_string(),
-                    PromptType::ConfirmCloseBuffer { buffer_id },
-                );
-            } else if let Err(e) = self.close_buffer(buffer_id) {
-                self.set_status_message(t!("file.cannot_close", error = e.to_string()).to_string());
-            } else {
-                self.set_status_message(t!("buffer.tab_closed").to_string());
-            }
-        } else {
-            // There are other viewports of this buffer - just remove from current split's tabs
-            if current_split_tabs.len() <= 1 {
-                // This is the only tab in this split - close the split
-                // If we're closing a terminal buffer while in terminal mode, exit terminal mode
-                if self.terminal_mode && self.is_terminal_buffer(buffer_id) {
-                    self.terminal_mode = false;
-                    self.key_context = crate::input::keybindings::KeyContext::Normal;
-                }
-                self.close_active_split();
-                return;
-            }
-
-            // Find replacement buffer for this split
-            let current_idx = current_split_tabs
-                .iter()
-                .position(|&id| id == buffer_id)
-                .unwrap_or(0);
-            let replacement_idx = if current_idx > 0 { current_idx - 1 } else { 1 };
-            let replacement_buffer = current_split_tabs[replacement_idx];
-
-            // If we're closing a terminal buffer while in terminal mode, exit terminal mode
-            if self.terminal_mode && self.is_terminal_buffer(buffer_id) {
-                self.terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
-            }
-
-            // Remove buffer from this split's tabs
-            if let Some(view_state) = self.split_view_states.get_mut(&active_split) {
-                view_state.remove_buffer(buffer_id);
-            }
-
-            // Update the split to show the replacement buffer
-            self.split_manager
-                .set_split_buffer(active_split, replacement_buffer);
-
-            self.set_status_message(t!("buffer.tab_closed").to_string());
-        }
+        self.close_tab_in_split(buffer_id, active_split);
     }
 
     /// Close a specific tab (buffer) in a specific split.
-    /// Used by mouse click handler on tab close button.
+    ///
+    /// This is the single shared implementation used by:
+    ///   * the mouse × button on a tab,
+    ///   * the Close Buffer command (via `close_tab`),
+    ///   * the Close Tab command and the `Alt+W` keybinding (via `close_tab`).
+    ///
+    /// All three paths should behave identically; keep new logic here.
     /// Returns true if the tab was closed without needing a prompt.
     pub fn close_tab_in_split(&mut self, buffer_id: BufferId, split_id: LeafId) -> bool {
         // If closing a terminal buffer while in terminal mode, exit terminal mode
@@ -2696,6 +2594,26 @@ impl Editor {
                     );
                     return false;
                 }
+            }
+            // If this is the only tab in this split AND there are other
+            // splits, close the split rather than swap it to a fallback
+            // buffer.  Mirrors `close_tab()` so mouse-click close and
+            // Close Buffer/Close Tab commands behave the same — without
+            // this, the × button leaves a leftover split showing some
+            // unrelated buffer (observed with the Search/Replace panel).
+            let has_other_splits = self.split_manager.root().count_leaves() > 1;
+            if split_tabs.len() <= 1 && has_other_splits {
+                self.handle_close_split(split_id.into());
+                // handle_close_split also disposes the buffer-less split;
+                // buffer lifetime cleanup happens via its own path.
+                if let Err(e) = self.close_buffer(buffer_id) {
+                    tracing::debug!(
+                        "close_tab_in_split: buffer cleanup after split close failed: {}",
+                        e
+                    );
+                }
+                self.set_status_message(t!("buffer.tab_closed").to_string());
+                return true;
             }
             if let Err(e) = self.close_buffer(buffer_id) {
                 self.set_status_message(t!("file.cannot_close", error = e.to_string()).to_string());

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -6473,6 +6473,13 @@ impl Editor {
                     }
                 }
 
+                // Capture the source split before creating the buffer —
+                // `create_virtual_buffer` unconditionally adds the new buffer
+                // as a tab to the currently active split, which is the wrong
+                // thing for a panel that lives in its own dedicated split
+                // (it would show up as a tab in BOTH splits — see bug #3).
+                let source_split_before_create = self.split_manager.active_split();
+
                 // Create the virtual buffer first
                 let buffer_id = self.create_virtual_buffer(name.clone(), mode.clone(), read_only);
                 tracing::info!(
@@ -6519,6 +6526,18 @@ impl Editor {
                     .split_active_positioned(split_dir, buffer_id, ratio, before)
                 {
                     Ok(new_split_id) => {
+                        // The buffer now lives in its own split, so drop its
+                        // tab from the source split (see bug #3).  Only do
+                        // this when the new split actually differs from the
+                        // source split — otherwise we'd leave no split
+                        // displaying the buffer.
+                        if new_split_id != source_split_before_create {
+                            if let Some(source_view_state) =
+                                self.split_view_states.get_mut(&source_split_before_create)
+                            {
+                                source_view_state.remove_buffer(buffer_id);
+                            }
+                        }
                         // Create independent view state for the new split with the buffer in tabs
                         let mut view_state = SplitViewState::with_buffer(
                             self.terminal_width,

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2444,6 +2444,18 @@ impl Editor {
                     if let Some(meta) = self.buffer_metadata.get_mut(&bid) {
                         meta.hidden_from_tabs = true;
                     }
+                    // `open_file_no_focus` unconditionally attaches the new
+                    // buffer as a tab to the preferred split.  When we're
+                    // running as a side effect of the Search/Replace panel,
+                    // the preferred split may be the panel's split (or any
+                    // normal split), which then carries a phantom tab for
+                    // this "hidden" buffer.  Close-Buffer on the panel would
+                    // then fall through to that tab instead of closing the
+                    // whole split.  Strip the buffer from every split's tab
+                    // list so only the panel split holds the panel buffer.
+                    for view_state in self.split_view_states.values_mut() {
+                        view_state.remove_buffer(bid);
+                    }
                     bid
                 }
                 Err(e) => {

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2495,6 +2495,7 @@ impl Editor {
         // via the standard event log machinery.  Project replace has no
         // meaningful cursor positions to restore on undo, so we pass empty
         // cursor lists.
+        let mut saved_path: Option<std::path::PathBuf> = None;
         let bulk_edit_event = if let Some(state) = self.buffers.get_mut(&buffer_id) {
             let old_snapshot = state.buffer.snapshot_buffer_state();
             let displaced_markers = state.capture_displaced_markers_bulk(&edits_owned);
@@ -2526,7 +2527,12 @@ impl Editor {
 
             let new_snapshot = state.buffer.snapshot_buffer_state();
 
-            // Save the buffer via the FileSystem trait
+            // Save the buffer via the FileSystem trait.  Capture the path
+            // into the outer `saved_path` so we can refresh the watched
+            // mtime after dropping the &mut self borrow on `state` —
+            // otherwise the auto-revert poller sees the new mtime, treats
+            // it as an external change, and reverts the buffer from disk,
+            // wiping the event log we're about to append (see bug #1).
             if let Some(path) = state.buffer.file_path().map(|p| p.to_path_buf()) {
                 if let Err(e) = state.buffer.save_to_file(&path) {
                     self.plugin_manager.reject_callback(
@@ -2535,6 +2541,7 @@ impl Editor {
                     );
                     return;
                 }
+                saved_path = Some(path);
             }
 
             Some(Event::BulkEdit {
@@ -2553,6 +2560,15 @@ impl Editor {
         } else {
             None
         };
+
+        // Refresh the watched mtime for the just-saved file so the
+        // auto-revert poller does NOT treat our own save as an external
+        // change.  Without this, `handle_file_changed` → `revert_buffer_by_id`
+        // would run and reset the event log we're about to append to,
+        // making the replace silently un-undoable (bug #1).
+        if let Some(ref path) = saved_path {
+            self.watch_file(path);
+        }
 
         // Record the BulkEdit on the buffer's event log so Undo can revert it.
         if let Some(event) = bulk_edit_event {

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2469,9 +2469,62 @@ impl Editor {
 
         let replacements = edits.len();
 
-        if let Some(state) = self.buffers.get_mut(&buffer_id) {
-            // Apply all edits as a single bulk operation (single undo action)
+        // Owned tuples for helpers that don't take references.
+        let edits_owned: Vec<(usize, usize, String)> = sorted_matches
+            .iter()
+            .map(|&(offset, len)| (offset, len, replacement.clone()))
+            .collect();
+        // Merged edit-lengths list for marker/margin replay on undo/redo.
+        // Mirrors the merging logic in `apply_events_as_bulk_edit`.
+        let edit_lengths: Vec<(usize, usize, usize)> = {
+            let mut lengths: Vec<(usize, usize, usize)> = Vec::new();
+            for (pos, del_len, text) in &edits_owned {
+                if let Some(last) = lengths.last_mut() {
+                    if last.0 == *pos {
+                        last.1 += del_len;
+                        last.2 += text.len();
+                        continue;
+                    }
+                }
+                lengths.push((*pos, *del_len, text.len()));
+            }
+            lengths
+        };
+
+        // Apply edits and capture pre/post snapshots so the replace is undoable
+        // via the standard event log machinery.  Project replace has no
+        // meaningful cursor positions to restore on undo, so we pass empty
+        // cursor lists.
+        let bulk_edit_event = if let Some(state) = self.buffers.get_mut(&buffer_id) {
+            let old_snapshot = state.buffer.snapshot_buffer_state();
+            let displaced_markers = state.capture_displaced_markers_bulk(&edits_owned);
+
+            // Apply all edits as a single bulk operation
             state.buffer.apply_bulk_edits(&edits);
+
+            // Adjust markers and margins to track the edits, matching the
+            // logic used by interactive multi-cursor edits.
+            for &(pos, del_len, ins_len) in &edit_lengths {
+                if del_len > 0 && ins_len > 0 {
+                    if ins_len > del_len {
+                        state.marker_list.adjust_for_insert(pos, ins_len - del_len);
+                        state.margins.adjust_for_insert(pos, ins_len - del_len);
+                    } else if del_len > ins_len {
+                        state.marker_list.adjust_for_delete(pos, del_len - ins_len);
+                        state.margins.adjust_for_delete(pos, del_len - ins_len);
+                    }
+                } else if del_len > 0 {
+                    state.marker_list.adjust_for_delete(pos, del_len);
+                    state.margins.adjust_for_delete(pos, del_len);
+                } else if ins_len > 0 {
+                    state.marker_list.adjust_for_insert(pos, ins_len);
+                    state.margins.adjust_for_insert(pos, ins_len);
+                }
+            }
+
+            state.highlighter.invalidate_all();
+
+            let new_snapshot = state.buffer.snapshot_buffer_state();
 
             // Save the buffer via the FileSystem trait
             if let Some(path) = state.buffer.file_path().map(|p| p.to_path_buf()) {
@@ -2482,6 +2535,48 @@ impl Editor {
                     );
                     return;
                 }
+            }
+
+            Some(Event::BulkEdit {
+                old_snapshot: Some(old_snapshot),
+                new_snapshot: Some(new_snapshot),
+                old_cursors: Vec::new(),
+                new_cursors: Vec::new(),
+                description: format!(
+                    "Project replace ({} replacement{})",
+                    replacements,
+                    if replacements == 1 { "" } else { "s" }
+                ),
+                edits: edit_lengths,
+                displaced_markers,
+            })
+        } else {
+            None
+        };
+
+        // Record the BulkEdit on the buffer's event log so Undo can revert it.
+        if let Some(event) = bulk_edit_event {
+            if let Some(event_log) = self.event_logs.get_mut(&buffer_id) {
+                event_log.append(event);
+            }
+            self.invalidate_layouts_for_buffer(buffer_id);
+
+            // Notify LSP with full document content (bulk edits collapse
+            // incremental ranges).
+            let full_content_change = self
+                .buffers
+                .get(&buffer_id)
+                .and_then(|s| s.buffer.to_string())
+                .map(|text| {
+                    vec![lsp_types::TextDocumentContentChangeEvent {
+                        range: None,
+                        range_length: None,
+                        text,
+                    }]
+                })
+                .unwrap_or_default();
+            if !full_content_change.is_empty() {
+                self.send_lsp_changes_for_buffer(buffer_id, full_content_change);
             }
         }
 

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2586,6 +2586,15 @@ impl Editor {
         if let Some(event) = bulk_edit_event {
             if let Some(event_log) = self.event_logs.get_mut(&buffer_id) {
                 event_log.append(event);
+                // The file on disk is now in the post-replace state, so mark
+                // this position as "saved".  Otherwise `saved_at_index` would
+                // stay at its pre-replace value and undo (which moves
+                // `current_index` backwards) would land on the old saved
+                // position and `update_modified_from_event_log` would clear
+                // the modified flag — leaving the user with a reverted buffer
+                // that looks clean even though disk still has the XYZ
+                // content.  We want the tab to show `a.txt*` after undo.
+                event_log.mark_saved();
             }
             self.invalidate_layouts_for_buffer(buffer_id);
 

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1722,12 +1722,46 @@ fn serialize_split_node(
     terminal_indices: &HashMap<TerminalId, usize>,
     split_labels: &HashMap<SplitId, String>,
 ) -> SerializedSplitNode {
+    serialize_split_node_pruned(
+        node,
+        buffer_metadata,
+        working_dir,
+        terminal_buffers,
+        terminal_indices,
+        split_labels,
+    )
+    .unwrap_or_else(|| {
+        // Entire tree was virtual buffers — nothing to persist.  Fall back to
+        // an empty [No Name] leaf so the restored workspace is still valid.
+        SerializedSplitNode::Leaf {
+            file_path: None,
+            split_id: 0,
+            label: None,
+            unnamed_recovery_id: None,
+        }
+    })
+}
+
+/// Like `serialize_split_node` but returns `None` for subtrees that only
+/// contain transient virtual buffers (e.g. `*Search/Replace*` panels).
+/// Virtual buffers can't be rebuilt from disk, so persisting their split
+/// would leave an empty or mis-attributed pane on restore (see bug #5).
+/// When one child of a Split prunes away, the surviving child is hoisted in
+/// place of the whole Split node.
+fn serialize_split_node_pruned(
+    node: &SplitNode,
+    buffer_metadata: &HashMap<BufferId, super::types::BufferMetadata>,
+    working_dir: &Path,
+    terminal_buffers: &HashMap<BufferId, TerminalId>,
+    terminal_indices: &HashMap<TerminalId, usize>,
+    split_labels: &HashMap<SplitId, String>,
+) -> Option<SerializedSplitNode> {
     match node {
         SplitNode::Grouped { layout, .. } => {
             // Grouped nodes are rebuilt by plugins on load; serialize just
             // the inner layout so the split tree structure is preserved
             // without the group wrapper.
-            serialize_split_node(
+            serialize_split_node_pruned(
                 layout,
                 buffer_metadata,
                 working_dir,
@@ -1745,15 +1779,23 @@ fn serialize_split_node(
 
             if let Some(terminal_id) = terminal_buffers.get(buffer_id) {
                 if let Some(index) = terminal_indices.get(terminal_id) {
-                    return SerializedSplitNode::Terminal {
+                    return Some(SerializedSplitNode::Terminal {
                         terminal_index: *index,
                         split_id: raw_split_id.0,
                         label,
-                    };
+                    });
                 }
             }
 
             let meta = buffer_metadata.get(buffer_id);
+
+            // Virtual buffers (e.g. the *Search/Replace* panel) have no
+            // persistent identity — drop them and let the parent Split node
+            // collapse to the sibling.
+            if meta.map(|m| m.is_virtual()).unwrap_or(false) {
+                return None;
+            }
+
             let file_path = meta.and_then(|m| m.file_path()).and_then(|abs_path| {
                 if abs_path.as_os_str().is_empty() {
                     None // unnamed buffer
@@ -1773,12 +1815,12 @@ fn serialize_split_node(
                 None
             };
 
-            SerializedSplitNode::Leaf {
+            Some(SerializedSplitNode::Leaf {
                 file_path,
                 split_id: raw_split_id.0,
                 label,
                 unnamed_recovery_id,
-            }
+            })
         }
         SplitNode::Split {
             direction,
@@ -1789,29 +1831,37 @@ fn serialize_split_node(
             ..
         } => {
             let raw_split_id: SplitId = (*split_id).into();
-            SerializedSplitNode::Split {
-                direction: match direction {
-                    SplitDirection::Horizontal => SerializedSplitDirection::Horizontal,
-                    SplitDirection::Vertical => SerializedSplitDirection::Vertical,
-                },
-                first: Box::new(serialize_split_node(
-                    first,
-                    buffer_metadata,
-                    working_dir,
-                    terminal_buffers,
-                    terminal_indices,
-                    split_labels,
-                )),
-                second: Box::new(serialize_split_node(
-                    second,
-                    buffer_metadata,
-                    working_dir,
-                    terminal_buffers,
-                    terminal_indices,
-                    split_labels,
-                )),
-                ratio: *ratio,
-                split_id: raw_split_id.0,
+            let first = serialize_split_node_pruned(
+                first,
+                buffer_metadata,
+                working_dir,
+                terminal_buffers,
+                terminal_indices,
+                split_labels,
+            );
+            let second = serialize_split_node_pruned(
+                second,
+                buffer_metadata,
+                working_dir,
+                terminal_buffers,
+                terminal_indices,
+                split_labels,
+            );
+            match (first, second) {
+                (Some(f), Some(s)) => Some(SerializedSplitNode::Split {
+                    direction: match direction {
+                        SplitDirection::Horizontal => SerializedSplitDirection::Horizontal,
+                        SplitDirection::Vertical => SerializedSplitDirection::Vertical,
+                    },
+                    first: Box::new(f),
+                    second: Box::new(s),
+                    ratio: *ratio,
+                    split_id: raw_split_id.0,
+                }),
+                // One side was a virtual-buffer-only subtree — collapse to
+                // the surviving sibling.
+                (Some(only), None) | (None, Some(only)) => Some(only),
+                (None, None) => None,
             }
         }
     }

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -750,6 +750,85 @@ fn test_search_replace_split_not_restored_across_restart() {
     }
 }
 
+/// Regression: closing the *Search/Replace* panel via the `Close Buffer`
+/// command after a project-wide replace used to leave a stray split behind
+/// showing one of the auto-opened hidden buffers (b.txt, c.txt) instead of
+/// closing the panel's split entirely.  The replace opens each modified
+/// file via `open_file_no_focus`, which unconditionally attaches the new
+/// buffer as a tab to the preferred split — leaving phantom tabs behind.
+/// Close-Buffer would then fall through to a hidden file tab instead of
+/// closing the split.
+#[test]
+fn test_search_replace_close_buffer_after_replace_closes_split() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+    confirm_replace_all(&mut harness);
+
+    // Invoke Close Buffer via the command palette while focus is still on
+    // the *Search/Replace* buffer.  This must close the whole panel split —
+    // not swap the split to a hidden buffer that was auto-opened by the
+    // replace.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Close Buffer").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Close the current buffer"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // After Close Buffer: only the original alpha.txt tab should remain.
+    // No *Search/Replace* tab, no duplicate alpha.txt in a leftover split,
+    // no beta.txt / gamma.txt tabs from the auto-opened hidden buffers.
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    let alpha_tab_count = screen.matches("alpha.txt ×").count();
+    assert_eq!(
+        alpha_tab_count, 1,
+        "alpha.txt should appear as exactly one tab after closing the panel.\n\
+         Screen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains("beta.txt ×"),
+        "beta.txt (auto-opened hidden buffer) must not end up as a tab.\n\
+         Screen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains("gamma.txt ×"),
+        "gamma.txt must not end up as a tab.\nScreen:\n{}",
+        screen
+    );
+}
+
 /// Bug 3 (upstream): opening the search/replace panel used to create the
 /// virtual buffer in the *current* split's tab bar AND in a new split,
 /// leaving `*Search/Replace*` visible twice on screen.  Assert it appears

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -636,3 +636,85 @@ fn test_search_replace_multiple_matches_same_line() {
     );
     eprintln!("[DEBUG {}] test PASSED", elapsed());
 }
+
+/// Bug 4 (upstream): pressing Alt+Enter a second time should not re-apply
+/// the replacement using stale byte offsets from the pre-replacement search,
+/// which would corrupt the file (e.g. "XYZ world" → "hhXYZrld").
+///
+/// After a successful replace, the panel must refresh its match list before
+/// honoring another Alt+Enter.  A second Alt+Enter must leave the file
+/// byte-for-byte identical to the state after the first Alt+Enter.
+#[test]
+fn test_search_replace_second_alt_enter_does_not_corrupt_files() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    // Use a replacement shorter than the pattern to make byte-offset drift
+    // observable: "hello" → "XYZ" shrinks the file by 2 bytes per match, so
+    // replaying the original offsets would clobber innocent bytes.
+    fs::write(
+        project_root.join("corrupt.txt"),
+        "hello world\nhello there\nthis is a hello test\nfinal hello line\n",
+    )
+    .unwrap();
+
+    let start_file = project_root.join("corrupt.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+
+    // Wait for search results and focus to stabilize.
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+
+    // First Alt+Enter — replace all.
+    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Replaced"))
+        .unwrap();
+
+    let after_first = fs::read_to_string(project_root.join("corrupt.txt")).unwrap();
+    assert_eq!(
+        after_first, "XYZ world\nXYZ there\nthis is a XYZ test\nfinal XYZ line\n",
+        "First Alt+Enter should produce clean replacements. Got:\n{}",
+        after_first
+    );
+
+    // Let the panel settle (rerunSearchQuiet should have cleared the list
+    // since "hello" no longer exists in the file).
+    harness
+        .wait_until_stable(|h| !h.screen_to_string().contains("Replacing"))
+        .unwrap();
+
+    // Second Alt+Enter — with a correctly-refreshed match list there are no
+    // remaining matches, so this must be a no-op on disk.
+    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
+
+    // Give any async replace work a chance to finish.  We can't key off
+    // "Replaced" here because a correct implementation will NOT produce that
+    // status a second time — so wait for the screen to stabilize instead.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    let after_second = fs::read_to_string(project_root.join("corrupt.txt")).unwrap();
+    assert_eq!(
+        after_second, after_first,
+        "Second Alt+Enter must not modify the file further (no stale offsets). \
+         After first: {:?}\nAfter second: {:?}",
+        after_first, after_second
+    );
+}

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -652,6 +652,42 @@ fn test_search_replace_multiple_matches_same_line() {
     eprintln!("[DEBUG {}] test PASSED", elapsed());
 }
 
+/// Bug 3 (upstream): opening the search/replace panel used to create the
+/// virtual buffer in the *current* split's tab bar AND in a new split,
+/// leaving `*Search/Replace*` visible twice on screen.  Assert it appears
+/// exactly once.
+#[test]
+fn test_search_replace_panel_not_duplicated_in_tabs() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    // Count only tab-bar occurrences (label followed by the close × or
+    // end-of-tab spacing).  Tabs render as `*Search/Replace* ×`; the
+    // bottom status bar shows `*Search/Replace* [RO]` which we ignore.
+    let tab_occurrences = screen.matches("*Search/Replace* ×").count();
+    assert_eq!(
+        tab_occurrences, 1,
+        "The *Search/Replace* buffer should have exactly one tab on screen \
+         (in its own split), not duplicated as a tab in the source split.\n\
+         Screen:\n{}",
+        screen
+    );
+}
+
 /// Bug 1 (upstream) companion: pressing Alt+Enter opens a confirmation
 /// prompt explaining that the replace is not restore-safe.  Cancelling the
 /// prompt must leave the file unchanged.

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -89,6 +89,22 @@ fn enter_search_and_replace(harness: &mut EditorTestHarness, search: &str, repla
     harness.render().unwrap();
 }
 
+/// Trigger Replace All (Alt+Enter), accept the confirmation prompt, and wait
+/// for the "Replaced" status. Used by every test that exercises a successful
+/// replacement — the confirmation prompt was added to guard against the
+/// accidental-replace-you-can't-undo case described in bug #1.
+fn confirm_replace_all(harness: &mut EditorTestHarness) {
+    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Replaced"))
+        .unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -367,13 +383,8 @@ fn test_search_replace_executes_replacement() {
         })
         .unwrap();
 
-    // Press Alt+Enter to execute Replace All
-    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-
-    // Wait for the status message confirming replacement
-    harness
-        .wait_until(|h| h.screen_to_string().contains("Replaced"))
-        .unwrap();
+    // Press Alt+Enter to execute Replace All (confirms via prompt).
+    confirm_replace_all(&mut harness);
 
     // Verify files were modified on disk
     let alpha = fs::read_to_string(project_root.join("alpha.txt")).unwrap();
@@ -440,12 +451,8 @@ fn test_search_replace_delete_pattern() {
         })
         .unwrap();
 
-    // Alt+Enter to execute Replace All
-    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-
-    harness
-        .wait_until(|h| h.screen_to_string().contains("Replaced"))
-        .unwrap();
+    // Alt+Enter to execute Replace All (confirms via prompt).
+    confirm_replace_all(&mut harness);
 
     let content = fs::read_to_string(project_root.join("target.txt")).unwrap();
     assert_eq!(
@@ -598,10 +605,18 @@ fn test_search_replace_multiple_matches_same_line() {
         harness.screen_to_string()
     );
 
-    // Alt+Enter to execute Replace All
+    // Alt+Enter to execute Replace All (confirms via prompt).
     eprintln!("[DEBUG {}] pressing Alt+Enter to Replace All", elapsed());
     harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-    eprintln!("[DEBUG {}] Alt+Enter sent", elapsed());
+    harness.wait_for_prompt().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    eprintln!(
+        "[DEBUG {}] Alt+Enter sent and confirmation accepted",
+        elapsed()
+    );
 
     eprintln!("[DEBUG {}] waiting for 'Replaced' confirmation", elapsed());
     {
@@ -635,6 +650,141 @@ fn test_search_replace_multiple_matches_same_line() {
         content
     );
     eprintln!("[DEBUG {}] test PASSED", elapsed());
+}
+
+/// Bug 1 (upstream) companion: pressing Alt+Enter opens a confirmation
+/// prompt explaining that the replace is not restore-safe.  Cancelling the
+/// prompt must leave the file unchanged.
+#[test]
+fn test_search_replace_confirmation_prompt_cancel_leaves_files_untouched() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    let original = "hello world\nhello again\n";
+    fs::write(project_root.join("cancel.txt"), original).unwrap();
+
+    let start_file = project_root.join("cancel.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+
+    // Trigger Replace All — expect the confirmation prompt to open.
+    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    // Prompt text should warn about the undo caveat.
+    let prompt_screen = harness.screen_to_string();
+    assert!(
+        prompt_screen.contains("Undo only covers"),
+        "Confirmation prompt should warn about undo scope.  Screen:\n{}",
+        prompt_screen
+    );
+
+    // Cancel the prompt with Escape.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Replacement cancelled"))
+        .unwrap();
+
+    // File must be unchanged on disk.
+    let after = fs::read_to_string(project_root.join("cancel.txt")).unwrap();
+    assert_eq!(
+        after, original,
+        "File must be unchanged after cancelling the confirmation prompt."
+    );
+}
+
+/// Bug 1 (upstream): after a project-wide replace, the `Undo` command must
+/// actually revert the in-memory buffer for the currently-focused file.
+/// Previously replaceInFile bypassed the event log, so Ctrl+Z / the Undo
+/// command was a no-op and users couldn't recover from a mistaken replace.
+#[test]
+fn test_search_replace_is_undoable_via_command_palette() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    fs::write(
+        project_root.join("undo.txt"),
+        "hello world\nhello there\nfinal hello line\n",
+    )
+    .unwrap();
+
+    let start_file = project_root.join("undo.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+
+    confirm_replace_all(&mut harness);
+
+    // Close the panel so focus returns to undo.txt.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+
+    // Sanity: the focused buffer shows the replaced text.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("XYZ world"))
+        .unwrap();
+
+    // Invoke `Undo` via the command palette (avoids any terminal Ctrl+Z/SUSP
+    // ambiguity and tests the command, not the keybinding).
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Undo").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Undo the last edit"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Buffer must revert to the pre-replace content.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("hello world")
+                && s.contains("hello there")
+                && s.contains("final hello line")
+                && !s.contains("XYZ world")
+        })
+        .unwrap();
 }
 
 /// Bug 2 (upstream): after a successful replace, the match tree must be
@@ -682,10 +832,7 @@ fn test_search_replace_refreshes_match_list_after_replace() {
     );
 
     // Execute replacement.
-    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-    harness
-        .wait_until(|h| h.screen_to_string().contains("Replaced"))
-        .unwrap();
+    confirm_replace_all(&mut harness);
 
     // After the replacement settles, the match tree must no longer display
     // stale "hello" rows — the file has no "hello" left, so the list should
@@ -754,11 +901,8 @@ fn test_search_replace_second_alt_enter_does_not_corrupt_files() {
         })
         .unwrap();
 
-    // First Alt+Enter — replace all.
-    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
-    harness
-        .wait_until(|h| h.screen_to_string().contains("Replaced"))
-        .unwrap();
+    // First Alt+Enter — replace all (confirms via prompt).
+    confirm_replace_all(&mut harness);
 
     let after_first = fs::read_to_string(project_root.join("corrupt.txt")).unwrap();
     assert_eq!(

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -1,8 +1,10 @@
 //! E2E tests for the Search & Replace plugin (multi-file project-wide search/replace)
 
-use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
 use std::fs;
 
 /// Set up a project directory with the search_replace plugin.
@@ -650,6 +652,102 @@ fn test_search_replace_multiple_matches_same_line() {
         content
     );
     eprintln!("[DEBUG {}] test PASSED", elapsed());
+}
+
+/// Bug 5 (upstream): the search/replace split must not persist across an
+/// editor restart.  The `*Search/Replace*` panel is a transient virtual
+/// buffer — the workspace serializer previously remembered the split
+/// shape and, since the virtual buffer itself can't be rebuilt from
+/// disk, the restored split silently showed "some random file" (usually
+/// whichever file was active in the main pane).
+///
+/// Verify by restarting the harness with a shared `DirectoryContext` and
+/// asserting that the only visible file content after restore appears
+/// exactly once — i.e. exactly one split, no orphan duplicate.
+#[test]
+fn test_search_replace_split_not_restored_across_restart() {
+    init_tracing_from_env();
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project_root");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let plugins_dir = project_dir.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "search_replace");
+
+    // Use a distinctive content so we can count how many splits show it.
+    let file = project_dir.join("persist.txt");
+    fs::write(
+        &file,
+        "UNIQUEMARKERPERSIST alpha\nUNIQUEMARKERPERSIST beta\n",
+    )
+    .unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open file, open the Search/Replace panel, then shutdown.
+    {
+        let mut harness = EditorTestHarness::create(
+            160,
+            40,
+            HarnessOptions::new()
+                .with_config(Config::default())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        harness.open_file(&file).unwrap();
+        harness.render().unwrap();
+
+        open_search_replace_via_palette(&mut harness);
+        harness
+            .wait_until(|h| h.screen_to_string().contains("Search:"))
+            .unwrap();
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: restore.  The *Search/Replace* virtual buffer is gone, so
+    // if the split were restored it would end up showing the main file as
+    // a duplicate.  Assert we have exactly one split for persist.txt.
+    {
+        let mut harness = EditorTestHarness::create(
+            160,
+            40,
+            HarnessOptions::new()
+                .with_config(Config::default())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "Workspace should have restored");
+        harness.render().unwrap();
+
+        let screen = harness.screen_to_string();
+        // The search/replace panel must not come back.
+        assert!(
+            !screen.contains("*Search/Replace*"),
+            "*Search/Replace* panel should not be restored after restart.\n\
+             Screen:\n{}",
+            screen
+        );
+        // The file content should appear exactly once — not duplicated as
+        // an orphan "random file" split left behind by the stale layout.
+        let marker_occurrences = screen.matches("UNIQUEMARKERPERSIST alpha").count();
+        assert_eq!(
+            marker_occurrences, 1,
+            "persist.txt content should appear once (single split), not \
+             duplicated by a leftover split from the replaced panel.\n\
+             Screen:\n{}",
+            screen
+        );
+    }
 }
 
 /// Bug 3 (upstream): opening the search/replace panel used to create the

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -845,6 +845,166 @@ fn test_search_replace_confirmation_prompt_cancel_leaves_files_untouched() {
     );
 }
 
+/// Bug 1 (upstream) — full manual reproduction: after the replace saves
+/// the file, the auto-revert poller sees a fresh mtime and, if it runs
+/// before the user presses Undo, calls `revert_buffer_by_id` which
+/// resets the event log.  Undo then finds nothing to revert.
+///
+/// We trigger this path deterministically by invoking `handle_file_changed`
+/// explicitly — the production equivalent of the polling tick firing
+/// after the save.  Without the mtime refresh in `handle_replace_in_buffer`
+/// this wipes the BulkEdit and the assertion below fails.
+#[test]
+fn test_search_replace_undo_survives_auto_revert_poll() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    let file = project_root.join("auto_revert.txt");
+    fs::write(&file, "hello one\nhello two\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+    confirm_replace_all(&mut harness);
+
+    // Simulate the auto-revert poller tick firing after our save —
+    // equivalent to the `file_mod_times` mismatch that production sees
+    // when `save_to_file` is followed by a polling cycle.
+    harness
+        .editor_mut()
+        .handle_file_changed(file.to_str().unwrap());
+    harness.render().unwrap();
+
+    // Close the panel.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("XYZ one"))
+        .unwrap();
+
+    // Undo via the command palette.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Undo").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Undo the last edit"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("hello one") && s.contains("hello two") && !s.contains("XYZ one")
+        })
+        .unwrap();
+}
+
+/// Bug 1 (upstream) variant: with multiple files already open before the
+/// replace, the `Undo` command must still revert the currently-focused
+/// buffer after a project-wide replace.
+#[test]
+fn test_search_replace_is_undoable_with_multiple_open_buffers() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    fs::write(project_root.join("multi_a.txt"), "hello A1\nhello A2\n").unwrap();
+    fs::write(
+        project_root.join("multi_b.txt"),
+        "hello B1\nhello B2\nhello B3\n",
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+
+    // Open both files; multi_b.txt is active at the end of this setup.
+    harness
+        .open_file(&project_root.join("multi_a.txt"))
+        .unwrap();
+    harness
+        .open_file(&project_root.join("multi_b.txt"))
+        .unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+    confirm_replace_all(&mut harness);
+
+    // Close the panel; focus returns to multi_b.txt (the previously active
+    // file buffer in the source split).
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+
+    // Sanity: multi_b.txt buffer shows the replaced text.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("XYZ B1"))
+        .unwrap();
+
+    // Invoke Undo via the command palette.  Active buffer at this point is
+    // multi_b.txt — its event log must carry the BulkEdit so Undo reverts.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Undo").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Undo the last edit"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // multi_b.txt buffer reverts; multi_a.txt was touched by the replace
+    // but user hasn't focused it yet — its event log should still have the
+    // BulkEdit so focusing it and undoing would revert it too.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("hello B1")
+                && s.contains("hello B2")
+                && s.contains("hello B3")
+                && !s.contains("XYZ B1")
+        })
+        .unwrap();
+}
+
 /// Bug 1 (upstream): after a project-wide replace, the `Undo` command must
 /// actually revert the in-memory buffer for the currently-focused file.
 /// Previously replaceInFile bypassed the event log, so Ctrl+Z / the Undo

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -637,6 +637,80 @@ fn test_search_replace_multiple_matches_same_line() {
     eprintln!("[DEBUG {}] test PASSED", elapsed());
 }
 
+/// Bug 2 (upstream): after a successful replace, the match tree must be
+/// refreshed.  It previously kept displaying the pre-replacement matches
+/// (e.g. still showed "hello" rows after replacing hello→XYZ), hiding what
+/// actually changed and feeding the repeat-replace corruption (bug 4).
+#[test]
+fn test_search_replace_refreshes_match_list_after_replace() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    fs::write(
+        project_root.join("refresh.txt"),
+        "hello world\nhello again\nhello there\n",
+    )
+    .unwrap();
+
+    let start_file = project_root.join("refresh.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+
+    // Pre-condition: the match tree shows the pre-replacement context.
+    let before = harness.screen_to_string();
+    assert!(
+        before.contains("hello world"),
+        "Expected pre-replacement match context on screen. Got:\n{}",
+        before
+    );
+
+    // Execute replacement.
+    harness.send_key(KeyCode::Enter, KeyModifiers::ALT).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Replaced"))
+        .unwrap();
+
+    // After the replacement settles, the match tree must no longer display
+    // stale "hello" rows — the file has no "hello" left, so the list should
+    // either be empty ("No matches") or show fresh post-replace state.
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            // Tree has refreshed: stale match-row context is gone.
+            !s.contains("hello world") && !s.contains("hello again") && !s.contains("hello there")
+        })
+        .unwrap();
+
+    let after = harness.screen_to_string();
+    assert!(
+        !after.contains("hello world"),
+        "Match list must not display stale 'hello world' row after replacement.\n{}",
+        after
+    );
+    assert!(
+        !after.contains("hello again"),
+        "Match list must not display stale 'hello again' row after replacement.\n{}",
+        after
+    );
+}
+
 /// Bug 4 (upstream): pressing Alt+Enter a second time should not re-apply
 /// the replacement using stale byte offsets from the pre-replacement search,
 /// which would corrupt the file (e.g. "XYZ world" → "hhXYZrld").

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -750,6 +750,105 @@ fn test_search_replace_split_not_restored_across_restart() {
     }
 }
 
+/// Regression: closing the *Search/Replace* panel via the tab × button
+/// (mouse click) used to leave a stray split behind showing a duplicate
+/// of the original buffer, while the `Close Buffer` command closed the
+/// split cleanly.  Both close paths should behave the same.
+#[test]
+fn test_search_replace_tab_x_button_closes_whole_split() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Find the panel's buffer id and split id, then invoke the same code
+    // path the mouse × handler uses.
+    let (panel_buffer, panel_split) = {
+        let editor = harness.editor();
+        let split_id = editor.effective_active_split();
+        let buffer_id = editor.active_buffer();
+        (buffer_id, split_id)
+    };
+    harness
+        .editor_mut()
+        .close_tab_in_split(panel_buffer, panel_split);
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("*Search/Replace*"),
+        "Panel should be gone after × close.\nScreen:\n{}",
+        screen
+    );
+    let alpha_tab_count = screen.matches("alpha.txt ×").count();
+    assert_eq!(
+        alpha_tab_count, 1,
+        "alpha.txt should appear as exactly one tab after × close — no \
+         leftover split with a duplicate alpha.txt pane.\nScreen:\n{}",
+        screen
+    );
+}
+
+/// Regression: opening the panel, closing it via Escape, then immediately
+/// reopening it used to fail silently — the plugin state held a stale
+/// reference to the now-dead virtual buffer and `updatePanelContent` noop'd.
+/// After the fix (a `buffer_closed` hook resets plugin state), reopen
+/// creates a fresh panel.
+#[test]
+fn test_search_replace_reopen_after_close_works() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    // Open panel once.
+    open_search_replace_via_palette(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Close via Escape (plugin's own close path).
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+
+    // Reopen — panel must be visible again.
+    open_search_replace_via_palette(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+    assert!(
+        harness.screen_to_string().contains("*Search/Replace*"),
+        "Panel should reopen after having been closed."
+    );
+}
+
 /// Regression: closing the *Search/Replace* panel via the `Close Buffer`
 /// command after a project-wide replace used to leave a stray split behind
 /// showing one of the auto-opened hidden buffers (b.txt, c.txt) instead of

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -750,6 +750,95 @@ fn test_search_replace_split_not_restored_across_restart() {
     }
 }
 
+/// Regression: after a project-wide replace + undo, the buffer now
+/// differs from disk (undo only touches in-memory state), so the tab
+/// must show the modified indicator (`*`).  Previously the event log's
+/// `saved_at_index` was left at its pre-replace value, and undo moved
+/// `current_index` back to match, making `update_modified_from_event_log`
+/// clear the modified flag even though disk still had the XYZ content.
+#[test]
+fn test_search_replace_undo_marks_buffer_as_modified() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+
+    fs::write(project_root.join("dirty.txt"), "hello one\nhello two\n").unwrap();
+
+    let start_file = project_root.join("dirty.txt");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "hello", "XYZ");
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("matches") && s.contains("[v]")
+        })
+        .unwrap();
+    confirm_replace_all(&mut harness);
+
+    // Close the panel; focus returns to dirty.txt.  Right after the
+    // replace the tab should NOT be dirty — buffer matches disk.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("*Search/Replace*"))
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("XYZ one"))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("dirty.txt*"),
+        "Right after replace, dirty.txt buffer should match disk (no `*`).\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Undo.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Undo").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Undo the last edit"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Buffer reverted.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("hello one") && s.contains("hello two") && !s.contains("XYZ one")
+        })
+        .unwrap();
+
+    // Disk still has XYZ (undo didn't touch disk).
+    let on_disk = fs::read_to_string(project_root.join("dirty.txt")).unwrap();
+    assert_eq!(
+        on_disk, "XYZ one\nXYZ two\n",
+        "Undo must not modify disk — it only reverts the in-memory buffer."
+    );
+
+    // Tab must show the modified marker because buffer != disk.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("dirty.txt*") || screen.contains("dirty.txt [+]"),
+        "After undo, dirty.txt should be marked modified (buffer != disk).\n\
+         Screen:\n{}",
+        screen
+    );
+}
+
 /// Regression: closing the *Search/Replace* panel via the tab × button
 /// (mouse click) used to leave a stray split behind showing a duplicate
 /// of the original buffer, while the `Close Buffer` command closed the

--- a/docs/internal/project-search-replace-bug-reproduction.md
+++ b/docs/internal/project-search-replace-bug-reproduction.md
@@ -1,0 +1,252 @@
+# Project Search/Replace — Reproduction Report
+
+**Date:** 2026-04-15
+**Branch:** `claude/fix-search-replace-bugs-rmhHU`
+**Build:** `cargo build --bin fresh` (debug, no `--release`)
+**Harness:** manual tmux (`send-keys` / `capture-pane`) against `/tmp/srtest`
+**Upstream bug list:** https://github.com/mandolyte/fresh-ideas-testing/blob/main/Project-search-replace.md
+
+## Test fixture
+
+```
+/tmp/srtest/
+├── .git/                 (initialized, one commit)
+├── a.txt                 "hello world\nhello there\nthis is a hello test\nfinal hello line\n"
+├── b.txt                 "hello from b\nanother hello\nno match here\nhello hello hello\n"
+└── sub/
+    └── c.txt             "nested hello\nhello nested\n"
+```
+
+Total: 11 occurrences of `hello` across 3 files.
+
+## Summary table
+
+| # | Bug (from doc)                                    | Reproduced?                                  |
+|---|---------------------------------------------------|----------------------------------------------|
+| 1 | Ctrl+Z does not undo project replacements         | ✅ Confirmed — bug is in the `undo` command itself, not key handling |
+| 2 | Match list not refreshed after replacement        | ✅ Confirmed                                 |
+| 3 | Panel duplication                                 | ✅ Confirmed                                 |
+| 4 | `Alt+Ret` repeats replacement on stale matches    | ✅ Confirmed — worse than documented (produces file corruption) |
+| 5 | Split panel persists after restart w/ random file | ✅ Confirmed                                 |
+| 6 | Buffer content mixup after restart                | ⚠️ Partially — split/tab serialization is broken; literal "wrong content under right label" not observed |
+
+Additional issues discovered while reproducing (`A`–`D`) are at the bottom.
+
+---
+
+## Bug 1 — `Undo` does not revert project replacements
+
+**Severity:** High. Data loss if user relies on undo after a mistaken project-wide replace.
+
+**Observed:** The `Undo` command (whether triggered via `Ctrl+Z` key or via command palette) has no effect on changes made by project search/replace. Both the in-memory buffer and the file on disk remain in the post-replace state.
+
+### Reproduction
+
+Prerequisites: run `stty susp undef` before launching fresh, otherwise `Ctrl+Z` is swallowed by the shell as SIGTSTP (see issue D below).
+
+1. `cd /tmp/srtest && /home/user/fresh/target/debug/fresh --no-restore a.txt`
+2. `Ctrl+P`, type `Search and Replace in Project`, `Enter`
+3. `Alt+]` (focus the panel — required, see issue A)
+4. Type `hello`, `Enter`, type `XYZ`, `Enter`
+5. `Alt+Enter` — status bar: `Replaced 11 occurrences in 3 files`. Verify on disk: `cat a.txt` → `XYZ world / XYZ there / this is a XYZ test / final XYZ line`.
+6. `Escape`, `Escape` to close the panel.
+7. `Alt+[` to focus the main split (`a.txt`).
+8. `Ctrl+P`, type `Undo`, `Enter`.
+
+**Expected:** `a.txt` reverts to `hello world / …`.
+**Actual:** `a.txt` remains `XYZ world / …`, in buffer and on disk. Repeated `Undo` invocations also no-op.
+
+### Likely root cause
+
+`doReplaceAll` in `crates/fresh-editor/plugins/search_replace.ts` writes through `editor.replaceInFile(filePath, matches, panel.replaceText)`, which bypasses per-buffer undo-stack entries. See `doReplaceAll` (~line 799) and the backend path in `crates/fresh-editor/src/app/plugin_commands.rs`.
+
+---
+
+## Bug 2 — Match list is not refreshed after replacement
+
+**Severity:** Medium. User cannot tell what has actually been modified; amplifies Bug 4.
+
+**Observed:** After `Alt+Enter`, files are updated but the panel still lists the pre-replacement matches with the old context strings.
+
+### Reproduction
+
+1. `cd /tmp/srtest && /home/user/fresh/target/debug/fresh --no-restore a.txt`
+2. `Ctrl+P`, `Search and Replace in Project`, `Enter`, `Alt+]`.
+3. `hello`, `Enter`, `HI`, `Enter`. Panel shows `(11 matches / 3 files)` listing, e.g. `a.txt:1 - hello world`.
+4. `Alt+Enter`. Status bar: `Replaced 11 occurrences in 3 files`. Verify: `cat a.txt` shows `HI …`.
+5. Look at the panel.
+
+**Expected:** Match list clears (or re-runs search and shows new matches for `hello` = 0).
+**Actual:** Panel still reads `(11 matches / 3 files)` with stale entries `a.txt:1 - hello world`, `b.txt:4 - hello hello hello`, etc.
+
+### Likely root cause
+
+No post-replace refresh. `doReplaceAll` does not call `rerunSearch()`/`rerunSearchQuiet()` after writing files, so `panel.searchResults` and `panel.fileGroups` remain stale.
+
+---
+
+## Bug 3 — Panel duplication
+
+**Severity:** Medium. Confusing layout; contributes to the persistence/focus bugs.
+
+**Observed:** Invoking the feature creates `*Search/Replace*` in two places at once — as a **tab in the currently focused split** and as a **new split** with the actual panel UI.
+
+### Reproduction
+
+1. `cd /tmp/srtest && /home/user/fresh/target/debug/fresh --no-restore .`
+2. `Ctrl+P`, `Search and Replace in Project`, `Enter`.
+3. Inspect the tab bar and splits.
+
+**Observed pane layout (captured):**
+
+```
+File Explorer  | [No Name] ×   *Search/Replace* ×
+               |    ...
+               |    ────────────────────────
+               | *Search/Replace* ×
+               | Search: []  Replace: []
+               | [ ] Case  [ ] Regex  [ ] Whole  [Replace All]
+               | ─── Matches ───
+               |  Type a search pattern above
+```
+
+Note `*Search/Replace*` appears twice: once as a tab next to `[No Name]` and once as its own split.
+
+---
+
+## Bug 4 — `Alt+Ret` repeats replacement on stale matches (file corruption)
+
+**Severity:** Critical. Silent file corruption with no warning and no undo.
+
+**Observed:** Pressing `Alt+Enter` a second time uses the **original** byte offsets stored in `panel.searchResults` against the now-modified file content, writing garbled text.
+
+### Reproduction
+
+1. `cd /tmp/srtest && git checkout .` (reset fixture)
+2. Launch fresh, open panel, search `hello`, replace `XYZ`, run the search, `Alt+Enter` — file becomes:
+   ```
+   XYZ world
+   XYZ there
+   this is a XYZ test
+   final XYZ line
+   ```
+3. Press `Alt+Enter` again (no intermediate actions — panel still shows the stale match list from Bug 2).
+4. `cat /tmp/srtest/a.txt`.
+
+**Expected:** Either a warning/no-op (no `hello` in files anymore) or the replace re-runs a fresh search and does nothing.
+**Actual observed output:**
+
+```
+hhXYZ world
+hXYZ there
+this is a hXYZ tesHIal HI line
+hXYZ
+```
+
+The second replace took the byte offsets recorded for `hello` (offsets 0, 12, 24, … in the *original* a.txt), looked up 5 bytes at each offset (whatever happens to be there in the modified file), and replaced them with `XYZ`. Result: garbage.
+
+### Likely root cause
+
+Replace path iterates `panel.searchResults` (a `SearchResult[]` captured at search time) and uses each result's `byte_offset` / `length` without verifying that the bytes at those offsets still match the search pattern. See `doReplaceAll` around `search_replace.ts:799` and the server-side `editor.replaceInFile` handler.
+
+### Mitigation ideas
+
+- Re-run the search (or a per-file byte-check) immediately before applying replacements.
+- Disable the `[Replace All]` action and clear `panel.searchResults` after a successful replace.
+- Validate that the bytes at each stored offset still equal the original match before overwriting.
+
+---
+
+## Bug 5 — Split persists across restart, but with a "random" file
+
+**Severity:** Medium. User reopens the editor and finds a stray split showing the wrong buffer.
+
+**Observed:** Workspace serialization preserves the split that held `*Search/Replace*`, but since the virtual buffer is not restorable, the restored split ends up showing whichever file happened to be active in the neighboring split.
+
+### Reproduction
+
+1. `cd /tmp/srtest && /home/user/fresh/target/debug/fresh a.txt` (no `--no-restore`).
+2. `Ctrl+P`, `Search and Replace in Project`, `Enter`. Confirm bottom split shows the panel.
+3. `Ctrl+Q` to quit cleanly (saves workspace).
+4. Relaunch: `/home/user/fresh/target/debug/fresh` (no arguments).
+
+**Expected:** Either no stray split, or the `*Search/Replace*` panel is reopened.
+**Actual:** Two vertical splits appear; the bottom split that previously held `*Search/Replace*` now shows `a.txt` (the last active file). Repeating the quit/restart cycle accumulates further copies of this split.
+
+---
+
+## Bug 6 — Tab restoration for the search/replace split is broken (partial)
+
+**Severity:** Medium. Related to Bug 5; the workspace save/restore round-trip loses the virtual panel but keeps its neighbors.
+
+**Observed:** When extra file tabs are opened next to `*Search/Replace*` in the same split, the panel tab is silently dropped on restart and only the file tabs remain.
+
+### Reproduction
+
+1. Launch fresh with session restore on (`fresh .`).
+2. `Ctrl+P`, `Search and Replace in Project`, `Enter`. Bottom split now has `*Search/Replace*`.
+3. `Ctrl+P`, type `b.txt`, `Enter` to open `b.txt` — it attaches as a second tab in the same bottom split: `*Search/Replace* ×   b.txt ×`.
+4. `Ctrl+Q` to quit.
+5. Relaunch with session restore.
+
+**Expected:** Either both tabs restored, or only the real file tab restored with no stale splits.
+**Actual:** The `*Search/Replace*` tab is gone, `b.txt` tab remains with correct content, and — combined with Bug 5 — the split stacking accumulates on subsequent quit/relaunch cycles (I ended with four vertical splits across two sessions: `a.txt` ×3 and `b.txt` ×1).
+
+The "wrong content under the right label" symptom described in the original doc was not observed in this session, but the underlying serializer clearly mishandles virtual buffers, so it is plausible that a different tab order produces mismatched labels.
+
+---
+
+## Additional issues discovered while reproducing
+
+### A — Focus does not land on the search field after opening the panel
+
+**Observed:** Immediately after `Ctrl+P → Search and Replace in Project → Enter`, keystrokes leak into whichever pane was previously focused.
+
+**Symptoms seen:**
+
+- Typing `hello` when the file explorer had focus inserted `/hello` into the explorer's filter field (title bar shows `/hello`).
+- Typing `hello` when `a.txt` had focus inserted `h` into `a.txt` (buffer became `hhello world`) before focus caught up, leaving the search box with `ello`.
+
+**Workaround:** always press `Alt+]` (next_split) after opening the panel to move focus onto the search field.
+
+### B — Typing in the search field does NOT auto-run the search
+
+**Observed:** `insertCharAtCursor` in `search_replace.ts` (line 193) updates `panel.searchPattern` and redraws, but does not call `rerunSearchDebounced()`. Same for `search_replace_backspace` / `search_replace_delete`.
+
+**Evidence:** Ran with `--log-file /tmp/fresh.log`; `handle_grep_project_streaming` does not fire while typing. The "No matches found" label shown next to a populated search box is a placeholder (`searchPattern && !results` branch in the renderer), not a search result.
+
+**Actual flow required:**
+
+1. Type pattern → no search.
+2. `Enter` → moves focus from search field to replace field.
+3. Type replacement (can be empty).
+4. `Enter` → runs the search.
+
+### C — `Escape` does not always close the panel
+
+Escape in the wrong sub-pane (e.g. in the split that duplicates the panel as a tab) only closes one instance or the file-explorer filter. Repeated Escape presses are needed, and order matters.
+
+### D — `Ctrl+Z` is caught by the shell, not by fresh
+
+Fresh does not disable the terminal's `VSUSP` character (default `^Z`), so pressing `Ctrl+Z` inside the editor sends SIGTSTP and stops the process (`[1]+ Stopped fresh`). A real terminal user would likely see the same behavior. Worked around in testing with `stty susp undef` before launching.
+
+---
+
+## Code hotspots
+
+| Concern | File | Notes |
+|---|---|---|
+| Replace path / stale offsets / no undo push | `crates/fresh-editor/plugins/search_replace.ts` — `doReplaceAll` (~L799) | Uses cached `panel.searchResults`; does not validate offsets, does not refresh, does not record undo. |
+| No search-on-type | `crates/fresh-editor/plugins/search_replace.ts` — `insertCharAtCursor` (L193), `mode_text_input` (L203) | Neither calls `rerunSearchDebounced()`. |
+| Backend grep (seems fine) | `crates/fresh-editor/src/app/plugin_commands.rs:2112` `handle_grep_project_streaming` | Streams results correctly; log confirms 11 matches found. |
+| Panel open duplicates | `crates/fresh-editor/plugins/search_replace.ts` — `openPanel` (~L694) | Creates split AND registers tab in existing split. |
+| Workspace serialization of virtual buffers | (grep for `*Search/Replace*` save paths) | Loses the panel on restart while keeping the split shape. |
+| Key-binding / TTY SUSP | `crates/fresh-editor/keymaps/default.json` (`Ctrl+Z`→`undo`), terminal setup in `fresh-winterm` | Raw mode does not clear `VSUSP`. |
+
+## Environment
+
+- OS: Linux 4.4.0 (gvisor sandbox), shell `bash`, TTY via `tmux` 240×60.
+- Rust toolchain as declared in `rust-toolchain.toml`.
+- Build command: `cargo build --bin fresh` (debug profile).
+- Launch: `/home/user/fresh/target/debug/fresh --log-file /tmp/fresh.log [--no-restore] <args>`.
+- Logging: `--log-file` writes the full `tracing` output; `handle_grep_project_streaming` logs each search.


### PR DESCRIPTION
## Summary

This PR fixes five critical bugs in the project search/replace feature that caused data loss, file corruption, and confusing UI behavior. The fixes ensure replacements are undoable, match lists refresh after replacement, the panel doesn't duplicate, stale byte offsets aren't reused, and virtual buffers don't persist across restarts.

## Key Changes

**Bug #1 — Replacements not undoable:**
- Modified `replace_in_file` in `plugin_commands.rs` to record a `BulkEdit` event on the buffer's event log instead of bypassing it
- Captures pre/post snapshots and displaced markers so `Undo` can revert project-wide replacements
- Properly adjusts markers and margins to track the bulk edits

**Bug #2 — Stale match list after replacement:**
- Clear `panel.searchResults` and `panel.fileGroups` in `doReplaceAll()` before re-running the search
- Prevents the panel from displaying pre-replacement matches with outdated context strings

**Bug #3 — Panel duplication in tabs:**
- Capture the active split before creating the virtual buffer in `create_virtual_buffer_and_split`
- Only create the split if the buffer wasn't already added as a tab to the current split
- Ensures `*Search/Replace*` appears in exactly one location

**Bug #4 — File corruption from stale byte offsets:**
- Clear `panel.searchResults` immediately after replacement (before re-running search)
- Prevents a second `Alt+Enter` from reusing pre-replacement byte offsets against modified file content
- Fixes silent file corruption that occurred when offsets drifted after replacements

**Bug #5 — Virtual buffer split persists across restart:**
- Implement `serialize_split_node_pruned()` in `workspace.rs` to filter out virtual buffers during serialization
- Virtual buffers (like `*Search/Replace*`) are dropped from the workspace save; surviving siblings are hoisted in place
- Prevents orphaned splits from appearing on restore with random file content

**Additional improvements:**
- Add confirmation prompt before executing replacements (warns about undo scope limitations)
- Add comprehensive E2E tests covering all five bugs plus edge cases
- Add reproduction documentation with detailed steps and root cause analysis
- Update i18n strings for confirmation prompt and cancellation status

## Implementation Details

- The `serialize_split_node_pruned()` function returns `Option<SerializedSplitNode>` to allow pruning of virtual-buffer-only subtrees
- When both children of a Split prune away, the entire Split is dropped and replaced by a fallback `[No Name]` leaf
- Bulk edit event recording mirrors the logic used by interactive multi-cursor edits for consistency
- Confirmation prompt uses `editor.prompt()` with localized text explaining the undo limitation

https://claude.ai/code/session_01Jsa8ZH4WjcezKnb4SCyGbr