### PR TITLE
Fix grapheme boundary detection and formatter deadlock issues

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1146,7 +1146,8 @@ impl Editor {
     }
 
     /// Apply inlay hints to editor state as virtual text
-    pub(crate) fn apply_inlay_hints_to_state(
+    #[doc(hidden)]
+    pub fn apply_inlay_hints_to_state(
         state: &mut crate::state::EditorState,
         hints: &[lsp_types::InlayHint],
     ) {
@@ -1187,12 +1188,35 @@ impl Editor {
                 continue;
             }
 
-            let (byte_offset, position) = if byte_offset >= state.buffer.len() {
-                // If hint is at EOF, anchor to last character and render after it.
-                (
-                    state.buffer.len().saturating_sub(1),
-                    VirtualTextPosition::AfterChar,
-                )
+            // Pick the anchor character for this hint. If the LSP-computed
+            // byte lies on a line terminator (\n or the \r of a CRLF), the
+            // "following character" is the first byte of the next line.
+            // Anchoring to it would make the hint drift one line down on
+            // any whitespace edit adjacent to the brace (issue #1572), so
+            // instead anchor to the *preceding* non-newline character with
+            // `AfterChar`. That keeps the hint stuck to the glyph the LSP
+            // intended to annotate even as edits shift bytes around it.
+            let buf_len = state.buffer.len();
+            let byte_here = if byte_offset < buf_len {
+                state
+                    .buffer
+                    .slice_bytes(byte_offset..byte_offset + 1)
+                    .first()
+                    .copied()
+            } else {
+                None
+            };
+            let at_line_break = matches!(byte_here, Some(b'\n' | b'\r'));
+
+            let (byte_offset, position) = if byte_offset >= buf_len {
+                // Hint is at EOF: anchor to last character and render
+                // after it.
+                (buf_len.saturating_sub(1), VirtualTextPosition::AfterChar)
+            } else if at_line_break && byte_offset > 0 {
+                // Hint points past the last glyph on a line: anchor to
+                // that glyph with AfterChar so the marker cannot drift
+                // onto a subsequent line when whitespace is edited.
+                (byte_offset - 1, VirtualTextPosition::AfterChar)
             } else {
                 (byte_offset, VirtualTextPosition::BeforeChar)
             };

--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -208,72 +208,121 @@ impl Editor {
             }
         };
 
-        // Write buffer content to stdin if configured
-        if formatter.stdin {
+        // Stream buffer content to stdin on a background thread so that
+        // we can drain stdout/stderr concurrently. Without this, any
+        // formatter whose output exceeds the kernel's pipe buffer
+        // (~64KB on Linux) blocks writing stdout, which in turn blocks
+        // waiting for `wait_with_output` and produces the "Format Buffer
+        // hangs" symptom (issue #1573).
+        let stdin_writer = if formatter.stdin {
             let content = self.active_state().buffer.to_string().unwrap_or_default();
-            if let Some(mut stdin) = child.stdin.take() {
-                if let Err(e) = stdin.write_all(content.as_bytes()) {
+            child.stdin.take().map(|mut stdin| {
+                std::thread::spawn(move || -> std::io::Result<()> {
+                    stdin.write_all(content.as_bytes())?;
+                    stdin.flush()?;
+                    // Dropping `stdin` here closes the pipe so the child
+                    // sees EOF and exits once it has consumed the input.
+                    Ok(())
+                })
+            })
+        } else {
+            None
+        };
+
+        // Enforce the timeout on an auxiliary thread that kills the child
+        // by PID if it has not finished within `timeout_ms`.
+        // `wait_with_output` blocks until the child closes its
+        // stdout/stderr, so without a watchdog a truly stuck process
+        // would never time out.
+        let timeout = Duration::from_millis(formatter.timeout_ms);
+        let timed_out = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let child_finished = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let child_pid = child.id();
+        let watchdog = {
+            let timed_out = std::sync::Arc::clone(&timed_out);
+            let child_finished = std::sync::Arc::clone(&child_finished);
+            std::thread::spawn(move || {
+                let start = std::time::Instant::now();
+                while start.elapsed() < timeout {
+                    if child_finished.load(std::sync::atomic::Ordering::SeqCst) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                timed_out.store(true, std::sync::atomic::Ordering::SeqCst);
+                #[cfg(unix)]
+                {
+                    // SAFETY: libc::kill is async-signal-safe and we only
+                    // signal a child we spawned.
+                    unsafe {
+                        libc::kill(child_pid as i32, libc::SIGKILL);
+                    }
+                }
+                #[cfg(not(unix))]
+                {
+                    let _ = child_pid;
+                }
+            })
+        };
+
+        // Wait for the child and collect output. `wait_with_output`
+        // internally reads stdout and stderr on separate threads, so
+        // large outputs cannot deadlock the way they did with the old
+        // `try_wait`-polling implementation.
+        let output_result = child.wait_with_output();
+        child_finished.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        // Join the stdin writer (it has either finished or will finish
+        // once the child closes its end of the pipe, which happens on
+        // exit or SIGKILL).
+        if let Some(handle) = stdin_writer {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                // If the child exited before we finished writing, a
+                // `BrokenPipe` is expected and not a hard error; we
+                // still want the output the formatter produced.
+                Ok(Err(e)) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+                Ok(Err(e)) => {
                     return ActionResult::Error(format!("Failed to write to stdin: {}", e));
+                }
+                Err(_) => {
+                    return ActionResult::Error("stdin writer thread panicked".to_string());
                 }
             }
         }
+        let _ = watchdog.join();
 
-        // Wait for the process with timeout
-        let timeout = Duration::from_millis(formatter.timeout_ms);
-        let start = std::time::Instant::now();
+        if timed_out.load(std::sync::atomic::Ordering::SeqCst) {
+            return ActionResult::Error(format!(
+                "Formatter '{}' timed out after {}ms",
+                formatter.command, formatter.timeout_ms
+            ));
+        }
 
-        loop {
-            match child.try_wait() {
-                Ok(Some(status)) => {
-                    let output = match child.wait_with_output() {
-                        Ok(o) => o,
-                        Err(e) => {
-                            return ActionResult::Error(format!("Failed to get output: {}", e))
-                        }
-                    };
+        let output = match output_result {
+            Ok(o) => o,
+            Err(e) => return ActionResult::Error(format!("Failed to get output: {}", e)),
+        };
 
-                    if status.success() {
-                        return match String::from_utf8(output.stdout) {
-                            Ok(s) => ActionResult::Success(s),
-                            Err(e) => {
-                                ActionResult::Error(format!("Invalid UTF-8 in output: {}", e))
-                            }
-                        };
-                    } else {
-                        let stderr = String::from_utf8_lossy(&output.stderr);
-                        let stdout = String::from_utf8_lossy(&output.stdout);
-                        let error_output = if !stderr.is_empty() {
-                            stderr.trim().to_string()
-                        } else if !stdout.is_empty() {
-                            stdout.trim().to_string()
-                        } else {
-                            format!("exit code {:?}", status.code())
-                        };
-                        return ActionResult::Error(format!(
-                            "Formatter '{}' failed: {}",
-                            formatter.command, error_output
-                        ));
-                    }
-                }
-                Ok(None) => {
-                    if start.elapsed() > timeout {
-                        // Best-effort kill of timed-out process.
-                        #[allow(clippy::let_underscore_must_use)]
-                        let _ = child.kill();
-                        return ActionResult::Error(format!(
-                            "Formatter '{}' timed out after {}ms",
-                            formatter.command, formatter.timeout_ms
-                        ));
-                    }
-                    std::thread::sleep(Duration::from_millis(10));
-                }
-                Err(e) => {
-                    return ActionResult::Error(format!(
-                        "Failed to wait for '{}': {}",
-                        formatter.command, e
-                    ));
-                }
+        if output.status.success() {
+            match String::from_utf8(output.stdout) {
+                Ok(s) => ActionResult::Success(s),
+                Err(e) => ActionResult::Error(format!("Invalid UTF-8 in output: {}", e)),
             }
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let error_output = if !stderr.is_empty() {
+                stderr.trim().to_string()
+            } else if !stdout.is_empty() {
+                stdout.trim().to_string()
+            } else {
+                format!("exit code {:?}", output.status.code())
+            };
+            ActionResult::Error(format!(
+                "Formatter '{}' failed: {}",
+                formatter.command, error_output
+            ))
         }
     }
 

--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -290,7 +290,9 @@ impl Editor {
                 }
             }
         }
-        let _ = watchdog.join();
+        if let Err(e) = watchdog.join() {
+            tracing::warn!("formatter watchdog thread panicked: {e:?}");
+        }
 
         if timed_out.load(std::sync::atomic::Ordering::SeqCst) {
             return ActionResult::Error(format!(

--- a/crates/fresh-editor/src/model/buffer.rs
+++ b/crates/fresh-editor/src/model/buffer.rs
@@ -3949,52 +3949,65 @@ impl TextBuffer {
     /// This handles complex scripts like Thai where multiple Unicode code points
     /// form a single visual character (grapheme cluster). For example, Thai "ที่"
     /// is 3 code points but 1 grapheme cluster.
+    ///
+    /// The lookahead window starts at 32 bytes but grows whenever the
+    /// returned boundary sits at the start of the chunk — that is, whenever
+    /// the chunk might not contain the full grapheme. This matters for ZWJ
+    /// emoji sequences and Zalgo strings with many combining marks, which
+    /// can easily exceed 32 bytes.
     pub fn prev_grapheme_boundary(&self, pos: usize) -> usize {
         if pos == 0 {
             return 0;
         }
 
-        // Get enough context before pos to find grapheme boundaries
-        // Thai combining characters can have multiple marks, so get up to 32 bytes
-        // IMPORTANT: Align start to a valid character boundary to avoid invalid UTF-8
-        // when get_text_range starts mid-character
-        let raw_start = pos.saturating_sub(32);
-        let start = if raw_start == 0 {
-            0
-        } else {
-            // Find the character boundary at or before raw_start
-            self.prev_char_boundary(raw_start + 1)
-        };
+        let mut lookback: usize = 32;
+        loop {
+            // IMPORTANT: Align start to a valid character boundary to avoid invalid UTF-8
+            // when get_text_range starts mid-character
+            let raw_start = pos.saturating_sub(lookback);
+            let start = if raw_start == 0 {
+                0
+            } else {
+                // Find the character boundary at or before raw_start
+                self.prev_char_boundary(raw_start + 1)
+            };
 
-        let Some(bytes) = self.get_text_range(start, pos - start) else {
-            // Data unloaded, fall back to char boundary
-            return self.prev_char_boundary(pos);
-        };
+            let Some(bytes) = self.get_text_range(start, pos - start) else {
+                // Data unloaded, fall back to char boundary
+                return self.prev_char_boundary(pos);
+            };
 
-        let text = match std::str::from_utf8(&bytes) {
-            Ok(s) => s,
-            Err(e) => {
-                // Still got invalid UTF-8 (shouldn't happen after alignment)
-                // Try using just the valid portion
-                let valid_bytes = &bytes[..e.valid_up_to()];
-                match std::str::from_utf8(valid_bytes) {
-                    Ok(s) if !s.is_empty() => s,
-                    _ => return self.prev_char_boundary(pos),
+            let text = match std::str::from_utf8(&bytes) {
+                Ok(s) => s,
+                Err(e) => {
+                    // Still got invalid UTF-8 (shouldn't happen after alignment)
+                    // Try using just the valid portion
+                    let valid_bytes = &bytes[..e.valid_up_to()];
+                    match std::str::from_utf8(valid_bytes) {
+                        Ok(s) if !s.is_empty() => s,
+                        _ => return self.prev_char_boundary(pos),
+                    }
                 }
+            };
+
+            // Use shared grapheme utility with relative position
+            let rel_pos = pos - start;
+            let new_rel_pos = grapheme::prev_grapheme_boundary(text, rel_pos);
+
+            // If the returned boundary is at the start of our chunk, the
+            // grapheme may extend further back. Only trust the answer when
+            // either we already reached the beginning of the buffer or the
+            // boundary sits strictly inside the chunk.
+            if new_rel_pos > 0 || start == 0 {
+                return start + new_rel_pos;
             }
-        };
 
-        // Use shared grapheme utility with relative position
-        let rel_pos = pos - start;
-        let new_rel_pos = grapheme::prev_grapheme_boundary(text, rel_pos);
-
-        // If we landed at the start of this chunk and there's more before,
-        // we might need to look further back
-        if new_rel_pos == 0 && start > 0 {
-            return self.prev_grapheme_boundary(start);
+            // Expand the lookback window and retry. Cap at the full buffer.
+            if lookback >= pos {
+                return 0;
+            }
+            lookback = lookback.saturating_mul(2);
         }
-
-        start + new_rel_pos
     }
 
     /// Find the next grapheme cluster boundary (for proper cursor movement with combining characters)
@@ -4002,38 +4015,54 @@ impl TextBuffer {
     /// This handles complex scripts like Thai where multiple Unicode code points
     /// form a single visual character (grapheme cluster). For example, Thai "ที่"
     /// is 3 code points but 1 grapheme cluster.
+    ///
+    /// The lookahead window grows whenever the first grapheme reaches the
+    /// end of the chunk — otherwise ZWJ emoji and Zalgo strings whose byte
+    /// length exceeds the initial 32-byte window would be split mid-cluster.
     pub fn next_grapheme_boundary(&self, pos: usize) -> usize {
         let len = self.len();
         if pos >= len {
             return len;
         }
 
-        // Get enough context after pos to find grapheme boundaries
-        // Thai combining characters can have multiple marks, so get up to 32 bytes
-        let end = (pos + 32).min(len);
-        let Some(bytes) = self.get_text_range(pos, end - pos) else {
-            // Data unloaded, fall back to char boundary
-            return self.next_char_boundary(pos);
-        };
+        let mut lookahead: usize = 32;
+        loop {
+            let end = (pos + lookahead).min(len);
+            let Some(bytes) = self.get_text_range(pos, end - pos) else {
+                // Data unloaded, fall back to char boundary
+                return self.next_char_boundary(pos);
+            };
 
-        // Convert to UTF-8 string, handling the case where we might have
-        // grabbed bytes that end mid-character (truncate to valid UTF-8)
-        let text = match std::str::from_utf8(&bytes) {
-            Ok(s) => s,
-            Err(e) => {
-                // The bytes end in an incomplete UTF-8 sequence
-                // Use only the valid portion (which includes at least the first grapheme)
-                let valid_bytes = &bytes[..e.valid_up_to()];
-                match std::str::from_utf8(valid_bytes) {
-                    Ok(s) if !s.is_empty() => s,
-                    _ => return self.next_char_boundary(pos),
+            // Convert to UTF-8 string, handling the case where we might have
+            // grabbed bytes that end mid-character (truncate to valid UTF-8)
+            let text = match std::str::from_utf8(&bytes) {
+                Ok(s) => s,
+                Err(e) => {
+                    // The bytes end in an incomplete UTF-8 sequence
+                    // Use only the valid portion (which includes at least the first grapheme)
+                    let valid_bytes = &bytes[..e.valid_up_to()];
+                    match std::str::from_utf8(valid_bytes) {
+                        Ok(s) if !s.is_empty() => s,
+                        _ => return self.next_char_boundary(pos),
+                    }
                 }
-            }
-        };
+            };
 
-        // Use shared grapheme utility
-        let new_rel_pos = grapheme::next_grapheme_boundary(text, 0);
-        pos + new_rel_pos
+            let new_rel_pos = grapheme::next_grapheme_boundary(text, 0);
+
+            // If the first grapheme reaches the end of our chunk and there
+            // is more buffer left beyond it, the grapheme may extend further.
+            // Expand the window and retry.
+            if new_rel_pos == text.len() && end < len {
+                if lookahead >= len - pos {
+                    return len;
+                }
+                lookahead = lookahead.saturating_mul(2);
+                continue;
+            }
+
+            return pos + new_rel_pos;
+        }
     }
 
     /// Find the previous word boundary

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -681,6 +681,13 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                             .iter()
                             .filter(|v| v.position == VirtualTextPosition::AfterChar)
                         {
+                            // Flush the accumulated text so the virtual
+                            // text is placed *after* the current char
+                            // rather than sneaking in front of the next
+                            // flush of `span_acc`. Without this flush,
+                            // AfterChar hints render at the start of the
+                            // buffered run (issue #1572).
+                            span_acc.flush(&mut line_spans, &mut line_view_map);
                             let text_with_space = format!(" {}", vtext.text);
                             push_span_with_map(
                                 &mut line_spans,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -202,6 +202,8 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         let line_has_newline = current_view_line.ends_with_newline;
         let line_char_source_bytes = &current_view_line.char_source_bytes;
         let line_char_styles = &current_view_line.char_styles;
+        let line_char_visual_cols = &current_view_line.char_visual_cols;
+        let line_total_visual_width = current_view_line.visual_width();
         let line_visual_to_char = &current_view_line.visual_to_char;
         let line_tab_starts = &current_view_line.tab_starts;
         let _line_start_type = current_view_line.line_start;
@@ -729,10 +731,20 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
             byte_index += ch.len_utf8();
             display_char_idx += 1; // Increment character index for next lookup
-                                   // col_offset tracks visual column position (for indexing into visual_to_char)
-                                   // visual_to_char has one entry per visual column, not per character
-            let ch_width = char_width(ch);
-            col_offset += ch_width;
+                                   // col_offset tracks visual column position (for indexing into visual_to_char).
+                                   // We read the per-char visual column that view_pipeline assigned so that
+                                   // grapheme clusters (ZWJ emoji, base+combining, etc.) advance by
+                                   // `UnicodeWidthStr::width(cluster)` — the same width ratatui uses when
+                                   // re-segmenting spans — instead of summing per-codepoint `char_width`.
+                                   // Without this, the renderer's col_offset diverges from the view
+                                   // pipeline's for any cluster whose str_width ≠ Σ char_width, producing
+                                   // variable-width rendering corruption (issue #1577).
+            let next_col_for_char = line_char_visual_cols
+                .get(display_char_idx)
+                .copied()
+                .unwrap_or(line_total_visual_width);
+            let ch_width = next_col_for_char.saturating_sub(col_offset);
+            col_offset = next_col_for_char;
             visible_char_count += ch_width;
         }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/spans.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/spans.rs
@@ -4,12 +4,13 @@
 //! render-time "mega struct" and only uses ratatui + a narrow set of crate
 //! primitives. Every helper takes typed inputs and returns typed outputs.
 
-use crate::primitives::display_width::char_width;
+use crate::primitives::display_width::{char_width, str_width};
 use crate::primitives::highlighter::HighlightSpan;
 use crate::view::overlay::{Overlay, OverlayFace};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Span;
 use std::ops::Range;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Compute character-level diff between two strings, returning ranges of changed characters.
 /// Returns a tuple of (old_changed_ranges, new_changed_ranges) where each range indicates
@@ -60,8 +61,14 @@ pub(super) fn compute_inline_diff(
 
 /// Append a styled span to `spans` and mirror visual columns into `map`.
 ///
-/// One map entry is pushed per visual column (not per character): double-width
-/// characters contribute 2 entries, zero-width characters contribute 0.
+/// One map entry is pushed per visual column (not per character). The
+/// visual column count is computed per **grapheme cluster** via
+/// `UnicodeWidthStr::width`, not per codepoint via `char_width`, because
+/// ratatui segments spans by grapheme when placing them on screen and
+/// uses the same cluster width. For ZWJ emoji sequences the two differ:
+/// a family emoji is one grapheme of width 2 but four codepoints of
+/// width 2 each (plus three ZWJs of width 0) — summing per-codepoint
+/// gives 8, which is wrong (issue #1577).
 pub(super) fn push_span_with_map(
     spans: &mut Vec<Span<'static>>,
     map: &mut Vec<Option<usize>>,
@@ -72,8 +79,8 @@ pub(super) fn push_span_with_map(
     if text.is_empty() {
         return;
     }
-    for ch in text.chars() {
-        let width = char_width(ch);
+    for grapheme in text.graphemes(true) {
+        let width = str_width(grapheme);
         for _ in 0..width {
             map.push(source);
         }
@@ -147,11 +154,21 @@ impl SpanAccumulator {
             self.first_source = source;
         }
 
+        // Update map for this character's contribution to the visual
+        // column span. We measure the grapheme-cluster width (via
+        // `UnicodeWidthStr::width`) before and after appending `ch` and
+        // push `delta` entries. This keeps zero-width combining marks
+        // and ZWJ continuation codepoints at 0, widens the base
+        // codepoint of a cluster by exactly the cluster's final width,
+        // and — crucially for ZWJ emoji sequences — does not add 2+2+2+2
+        // for a four-emoji family cluster whose real on-screen width is
+        // 2. `char_width(ch)` summed per codepoint gets that wrong
+        // (issue #1577).
+        let width_before = str_width(&self.text);
         self.text.push(ch);
-
-        // Update map for this character's visual width
-        let width = char_width(ch);
-        for _ in 0..width {
+        let width_after = str_width(&self.text);
+        let delta = width_after.saturating_sub(width_before);
+        for _ in 0..delta {
             map.push(source);
         }
     }

--- a/crates/fresh-editor/src/view/ui/view_pipeline.rs
+++ b/crates/fresh-editor/src/view/ui/view_pipeline.rs
@@ -21,9 +21,10 @@
 //! not reconstructed from flattened text.
 
 use crate::primitives::ansi::AnsiParser;
-use crate::primitives::display_width::char_width;
+use crate::primitives::display_width::str_width;
 use fresh_core::api::{ViewTokenStyle, ViewTokenWire, ViewTokenWireKind};
 use std::collections::HashSet;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// A display line built from tokens, preserving token-level information
 #[derive(Debug, Clone)]
@@ -284,10 +285,11 @@ impl<'a> Iterator for ViewLineIterator<'a> {
 
                     while byte_idx < t_bytes.len() {
                         let b = t_bytes[byte_idx];
-                        let source = base.map(|s| s + byte_idx);
 
-                        // In binary mode, render unprintable bytes as code points
+                        // In binary mode, render unprintable bytes as <XX> code points.
+                        // These are never part of a grapheme cluster.
                         if self.binary_mode && is_unprintable_byte(b) {
+                            let source = base.map(|s| s + byte_idx);
                             let formatted = format_unprintable_byte(b);
                             for display_ch in formatted.chars() {
                                 add_char!(display_ch, source, token_style.clone(), 1);
@@ -296,99 +298,126 @@ impl<'a> Iterator for ViewLineIterator<'a> {
                             continue;
                         }
 
-                        // Decode the character at this position
-                        let ch = if b < 0x80 {
-                            // ASCII character
-                            byte_idx += 1;
-                            b as char
-                        } else {
-                            // Multi-byte UTF-8 - decode carefully
-                            let remaining = &t_bytes[byte_idx..];
-                            match std::str::from_utf8(remaining) {
-                                Ok(s) => {
-                                    if let Some(ch) = s.chars().next() {
-                                        byte_idx += ch.len_utf8();
-                                        ch
-                                    } else {
-                                        byte_idx += 1;
-                                        '\u{FFFD}'
-                                    }
-                                }
-                                Err(e) => {
-                                    // Invalid UTF-8 - in binary mode show as hex, otherwise replacement char
+                        // Decode the largest valid UTF-8 slice starting here so we can
+                        // segment it into grapheme clusters. Any invalid byte is
+                        // handled as a single-byte replacement char and we resume
+                        // decoding afterwards.
+                        let remaining = &t_bytes[byte_idx..];
+                        let valid = match std::str::from_utf8(remaining) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                let valid_up_to = e.valid_up_to();
+                                if valid_up_to == 0 {
+                                    let source = base.map(|s| s + byte_idx);
                                     if self.binary_mode {
                                         let formatted = format_unprintable_byte(b);
                                         for display_ch in formatted.chars() {
                                             add_char!(display_ch, source, token_style.clone(), 1);
                                         }
-                                        byte_idx += 1;
-                                        continue;
                                     } else {
-                                        // Try to get valid portion, then skip the bad byte
-                                        let valid_up_to = e.valid_up_to();
-                                        if valid_up_to > 0 {
-                                            if let Some(ch) =
-                                                std::str::from_utf8(&remaining[..valid_up_to])
-                                                    .ok()
-                                                    .and_then(|s| s.chars().next())
-                                            {
-                                                byte_idx += ch.len_utf8();
-                                                ch
-                                            } else {
-                                                byte_idx += 1;
-                                                '\u{FFFD}'
-                                            }
-                                        } else {
-                                            byte_idx += 1;
-                                            '\u{FFFD}'
-                                        }
+                                        add_char!('\u{FFFD}', source, token_style.clone(), 1);
+                                    }
+                                    byte_idx += 1;
+                                    continue;
+                                } else {
+                                    // SAFETY: `valid_up_to` is a char boundary.
+                                    unsafe {
+                                        std::str::from_utf8_unchecked(&remaining[..valid_up_to])
                                     }
                                 }
                             }
                         };
 
-                        if ch == '\t' {
-                            // Tab expands to spaces - record start position
-                            let tab_start_pos = char_source_bytes.len();
-                            tab_starts.insert(tab_start_pos);
-                            let spaces = self.tab_expansion_width(col);
+                        // Canonical Unicode handling: iterate grapheme clusters, not
+                        // codepoints. The width of a cluster is `str_width(cluster)` —
+                        // `unicode-width` 0.2 correctly returns 2 for ZWJ family emoji,
+                        // 1 for a base+combining sequence like "é", 2 for fullwidth
+                        // letters, and so on. This is the same width ratatui computes
+                        // when it re-segments the span, so every stage of the pipeline
+                        // (wrap, column tracking, span placement) agrees on how many
+                        // cells each cluster occupies.
+                        //
+                        // We still record per-codepoint entries in the char-indexed
+                        // arrays (char_source_bytes / char_styles / char_visual_cols)
+                        // so byte↔column mapping stays exact for LSP positions, mouse
+                        // clicks, and cursor arithmetic. But `col` advances exactly
+                        // once per grapheme: the first codepoint of a cluster carries
+                        // the full width, the rest carry 0.
+                        let mut segmented_bytes = 0usize;
+                        for (g_byte_offset, grapheme) in valid.grapheme_indices(true) {
+                            segmented_bytes = g_byte_offset + grapheme.len();
 
-                            // Tab is ONE character that expands to multiple visual columns
-                            let char_idx = char_source_bytes.len();
-                            text.push(' '); // First space char
-                            char_source_bytes.push(source);
-                            char_styles.push(token_style.clone());
-                            char_visual_cols.push(col);
+                            // Tab: a single codepoint forming its own grapheme, expanded to spaces.
+                            if grapheme == "\t" {
+                                let source = base.map(|s| s + byte_idx + g_byte_offset);
+                                let tab_start_pos = char_source_bytes.len();
+                                tab_starts.insert(tab_start_pos);
+                                let spaces = self.tab_expansion_width(col);
 
-                            // All visual columns of the tab map to the same char
-                            for _ in 0..spaces {
-                                visual_to_char.push(char_idx);
-                            }
-                            col += spaces;
-
-                            // Push remaining spaces as separate display chars
-                            // (text contains expanded spaces for rendering)
-                            for _ in 1..spaces {
+                                let char_idx = char_source_bytes.len();
                                 text.push(' ');
                                 char_source_bytes.push(source);
                                 char_styles.push(token_style.clone());
-                                char_visual_cols
-                                    .push(col - spaces + char_source_bytes.len() - char_idx);
-                            }
-                        } else {
-                            // Handle ANSI escape sequences - give them width 0
-                            let width = if let Some(ref mut parser) = ansi_parser {
-                                // Use AnsiParser: parse_char returns None for escape chars
-                                if parser.parse_char(ch).is_none() {
-                                    0 // Part of escape sequence, zero width
-                                } else {
-                                    char_width(ch)
+                                char_visual_cols.push(col);
+
+                                for _ in 0..spaces {
+                                    visual_to_char.push(char_idx);
                                 }
-                            } else {
-                                char_width(ch)
-                            };
-                            add_char!(ch, source, token_style.clone(), width);
+                                col += spaces;
+
+                                for _ in 1..spaces {
+                                    text.push(' ');
+                                    char_source_bytes.push(source);
+                                    char_styles.push(token_style.clone());
+                                    char_visual_cols
+                                        .push(col - spaces + char_source_bytes.len() - char_idx);
+                                }
+                                continue;
+                            }
+
+                            // ANSI escape sequences. Process char-by-char so the
+                            // AnsiParser state machine keeps track of the escape,
+                            // and keep them as width 0. In practice ESC never sits
+                            // inside a grapheme with visible content, so treating
+                            // a grapheme that starts with ESC as width-0 here is
+                            // correct.
+                            if let Some(ref mut parser) = ansi_parser {
+                                let first_ch = grapheme.chars().next().unwrap_or('\0');
+                                if parser.parse_char(first_ch).is_none() {
+                                    for ch in grapheme.chars() {
+                                        // All codepoints of an escape grapheme are width 0.
+                                        let src = base.map(|s| s + byte_idx + g_byte_offset);
+                                        // Keep the parser fed so state transitions work
+                                        // even across a multi-codepoint escape (rare).
+                                        if ch != first_ch {
+                                            let _ = parser.parse_char(ch);
+                                        }
+                                        add_char!(ch, src, token_style.clone(), 0);
+                                    }
+                                    continue;
+                                }
+                            }
+
+                            // Normal case: emit one display unit per grapheme.
+                            // Width goes on the FIRST codepoint, the rest are 0.
+                            let cluster_width = str_width(grapheme);
+                            let mut first = true;
+                            let mut inner_byte_offset = 0usize;
+                            for ch in grapheme.chars() {
+                                let source =
+                                    base.map(|s| s + byte_idx + g_byte_offset + inner_byte_offset);
+                                let w = if first {
+                                    first = false;
+                                    cluster_width
+                                } else {
+                                    0
+                                };
+                                add_char!(ch, source, token_style.clone(), w);
+                                inner_byte_offset += ch.len_utf8();
+                            }
                         }
+
+                        byte_idx += segmented_bytes.max(1);
                     }
                     self.token_idx += 1;
                 }

--- a/crates/fresh-editor/src/view/ui/view_pipeline.rs
+++ b/crates/fresh-editor/src/view/ui/view_pipeline.rs
@@ -263,7 +263,12 @@ impl<'a> Iterator for ViewLineIterator<'a> {
                 char_styles.push($style);
                 char_visual_cols.push(col);
 
-                // Per-visual-column data (for O(1) mouse clicks)
+                // Per-visual-column data (for O(1) mouse clicks).
+                // Note: $width is 0 for zero-width codepoints (combining
+                // marks, ZWJ, continuation codepoints within a grapheme
+                // cluster) — we deliberately emit no visual_to_char
+                // entries for them.
+                #[allow(clippy::reversed_empty_ranges)]
                 for _ in 0..$width {
                     visual_to_char.push(char_idx);
                 }
@@ -346,6 +351,36 @@ impl<'a> Iterator for ViewLineIterator<'a> {
                         let mut segmented_bytes = 0usize;
                         for (g_byte_offset, grapheme) in valid.grapheme_indices(true) {
                             segmented_bytes = g_byte_offset + grapheme.len();
+
+                            // In binary mode, any ASCII unprintable byte inside the
+                            // decoded slice must still be rendered as `<XX>`. This
+                            // covers graphemes consisting entirely of one unprintable
+                            // byte (e.g. `\x1A`) and CRLF (`\r\n`) where only the
+                            // `\r` half is unprintable — we split those out.
+                            if self.binary_mode {
+                                let bytes = grapheme.as_bytes();
+                                let has_unprintable =
+                                    bytes.iter().any(|&b| b < 0x80 && is_unprintable_byte(b));
+                                if has_unprintable {
+                                    let mut inner = 0usize;
+                                    for ch in grapheme.chars() {
+                                        let ch_len = ch.len_utf8();
+                                        let src =
+                                            base.map(|s| s + byte_idx + g_byte_offset + inner);
+                                        let ch_byte = ch as u32;
+                                        if ch_byte < 0x80 && is_unprintable_byte(ch_byte as u8) {
+                                            let formatted = format_unprintable_byte(ch_byte as u8);
+                                            for display_ch in formatted.chars() {
+                                                add_char!(display_ch, src, token_style.clone(), 1);
+                                            }
+                                        } else {
+                                            add_char!(ch, src, token_style.clone(), 1);
+                                        }
+                                        inner += ch_len;
+                                    }
+                                    continue;
+                                }
+                            }
 
                             // Tab: a single codepoint forming its own grapheme, expanded to spaces.
                             if grapheme == "\t" {

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -1116,6 +1116,25 @@ impl Viewport {
         )
         .entered();
 
+        // When `top_view_line_offset > 0` the true top of the viewport is
+        // some number of view lines into the wrapped line that starts at
+        // `top_byte`. This routine has only a byte-oriented view of the
+        // buffer, so its visibility math measures from `top_byte`, which
+        // sits above the actual visible top. For a cursor that is below
+        // `top_byte`, that undercounts the effective viewport and can
+        // declare a cursor that is visually at the bottom of the screen
+        // "outside the viewport", triggering a spurious scroll. Let the
+        // view-line-aware `ensure_visible_in_layout` make the scroll
+        // decision in that case — otherwise the viewport drifts one row
+        // per arrow key press in heavily wrapped buffers (issue #1574).
+        //
+        // If the cursor is *above* `top_byte`, the byte-oriented math is
+        // still correct (scroll up to bring the earlier line into view),
+        // so we only skip when the cursor is below the current top.
+        if self.top_view_line_offset > 0 && cursor.position >= self.top_byte {
+            return;
+        }
+
         // Check if we should skip sync due to session restore
         // This prevents the restored scroll position from being overwritten
         if self.should_skip_resize_sync() {

--- a/crates/fresh-editor/tests/e2e/issue_1572_inlay_hint_drift.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1572_inlay_hint_drift.rs
@@ -1,0 +1,133 @@
+//! Tests for issue #1572: Inlay hint position drifts with whitespace after
+//! a closing brace.
+//!
+//! Root cause (pre-fix): inlay hints are stored as a byte-offset marker in
+//! the buffer. `apply_inlay_hints_to_state` converts the LSP
+//! `{line, character}` to a byte offset and anchors a `BeforeChar` marker
+//! with *right* affinity there. When the LSP hands us a position that
+//! points past the closing `}` on line 0 — i.e. right on the following
+//! `\n` — the marker ends up anchored to that newline. A subsequent
+//! `\n` insertion at the start of line 1 (byte offset = marker
+//! position) drags the marker forward (right affinity), so the hint
+//! now renders before a *different* newline on a *different* line.
+//! To the user, the hint visibly jumps down by one row after any
+//! whitespace edit below the brace.
+//!
+//! Fix: when the computed byte offset lands on a line terminator, anchor
+//! the hint to the preceding character with `AfterChar` instead. That
+//! way the marker stays attached to the `}` (or whichever glyph the
+//! hint is annotating) and subsequent edits to later lines cannot shift
+//! its screen column.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::app::Editor;
+use lsp_types::{InlayHint, InlayHintLabel, Position};
+
+fn make_hint(line: u32, character: u32, label: &str) -> InlayHint {
+    InlayHint {
+        position: Position { line, character },
+        label: InlayHintLabel::String(label.to_string()),
+        kind: None,
+        text_edits: None,
+        tooltip: None,
+        padding_left: None,
+        padding_right: None,
+        data: None,
+    }
+}
+
+/// Find the first occurrence of `needle` on the given screen row.
+fn find_hint_column(harness: &EditorTestHarness, needle: &str, row: u16) -> Option<u16> {
+    let text = harness.get_row_text(row);
+    let byte_idx = text.find(needle)?;
+    Some(text[..byte_idx].chars().count() as u16)
+}
+
+#[test]
+fn test_issue_1572_inlay_hint_stays_put_across_below_line_edits() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Buffer: line 0 has code ending in `}`. Lines 1..=3 are empty.
+    let content = "fn f() { let x = 1; }\n\n\n\n";
+    let _fixture = harness.load_buffer_from_text(content).unwrap();
+    harness.render().unwrap();
+
+    // Publish an inlay hint just past the `}` on line 0.
+    // `fn f() { let x = 1; }` is 21 characters; character 21 is the
+    // position right after the `}` (pointing at the `\n`).
+    let hint_text = "HINTX";
+    let hints = vec![make_hint(0, 21, hint_text)];
+    Editor::apply_inlay_hints_to_state(harness.editor_mut().active_state_mut(), &hints);
+    harness.render().unwrap();
+
+    // Find the hint on screen.
+    let (first_row, last_row) = harness.content_area_rows();
+    let mut hint_row = None;
+    let mut hint_col_before = None;
+    for row in first_row..=last_row {
+        if let Some(col) = find_hint_column(&harness, hint_text, row as u16) {
+            hint_row = Some(row as u16);
+            hint_col_before = Some(col);
+            break;
+        }
+    }
+    let hint_row = hint_row.expect("inlay hint must be rendered after apply");
+    let hint_col_before = hint_col_before.unwrap();
+
+    // The hint must be on the same row as the `}` — i.e. on line 0.
+    let brace_col_before = find_hint_column(&harness, "}", hint_row)
+        .expect("closing brace must be on the same row as the hint after initial render");
+    assert!(
+        hint_col_before > brace_col_before,
+        "hint must render to the right of the `}}` initially (row {hint_row}: \
+         brace at col {brace_col_before}, hint at col {hint_col_before})\nScreen:\n{}",
+        harness.screen_to_string(),
+    );
+
+    // Now edit whitespace adjacent to the brace: put the cursor at the
+    // end of line 0 (right after `}`) and press Enter. This inserts a
+    // `\n` at exactly the marker's byte offset. With the buggy right
+    // affinity the marker is dragged one byte forward, so the hint now
+    // renders on the *new* line 1 instead of line 0.
+    {
+        let state = harness.editor_mut().active_state_mut();
+        let buf_len = state.buffer.len();
+        // Bytes 0..21 are the code on line 0; byte 21 is the terminating
+        // `\n`. The cursor ends up right after `}`, same byte as the hint.
+        let end_of_line_0 = 21usize.min(buf_len);
+        harness
+            .editor_mut()
+            .active_cursors_mut()
+            .primary_mut()
+            .position = end_of_line_0;
+        harness
+            .editor_mut()
+            .active_cursors_mut()
+            .primary_mut()
+            .anchor = None;
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The hint must still be on the same visual row and column as before.
+    let hint_col_after = find_hint_column(&harness, hint_text, hint_row).unwrap_or_else(|| {
+        panic!(
+            "hint drifted off row {hint_row} after inserting \\n on line 1.\nScreen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    assert_eq!(
+        hint_col_after, hint_col_before,
+        "hint column drifted from {hint_col_before} to {hint_col_after} after a whitespace \
+         edit below the `}}` (bug #1572)",
+    );
+    let brace_col_after =
+        find_hint_column(&harness, "}", hint_row).expect("brace must still be on same row");
+    assert_eq!(
+        brace_col_after, brace_col_before,
+        "sanity: the `}}` itself should not move",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_1573_format_buffer.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1573_format_buffer.rs
@@ -1,0 +1,134 @@
+//! Tests for issue #1573: "Format Buffer" with rustfmt hangs and doesn't format.
+//!
+//! Root cause (pre-fix): `Editor::run_formatter` wrote the entire buffer to
+//! the formatter's stdin in a single `write_all`, then entered a polling
+//! loop on `child.try_wait()` waiting for the process to exit. The stdout
+//! pipe, however, was never drained during the wait, so any formatter
+//! whose output exceeds the kernel's pipe buffer (64KB on Linux) fills
+//! stdout, blocks writing, and never exits. We poll forever until the
+//! timeout kills the process — the user's "hang and never format" symptom.
+//!
+//! Fix: stream stdin in a background thread and call `wait_with_output`,
+//! which internally drains stdout/stderr in dedicated threads, so none of
+//! the pipes can fill up.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, FormatterConfig, LanguageConfig};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+fn config_with_rust_formatter(script_path: &std::path::Path) -> Config {
+    let mut config = Config::default();
+    let entry = config
+        .languages
+        .entry("rust".to_string())
+        .or_insert_with(LanguageConfig::default);
+    entry.formatter = Some(FormatterConfig {
+        command: script_path.display().to_string(),
+        args: vec![],
+        stdin: true,
+        timeout_ms: 10_000,
+    });
+    config
+}
+
+/// Create a shell script formatter that reads all of stdin and emits a
+/// fixed-size stdout. We write `output_line` `repeats` times so the test
+/// can verify the buffer was replaced with the formatter's output without
+/// depending on real rustfmt. When `repeats` is set large we exercise the
+/// stdout-pipe deadlock that motivated the fix.
+fn write_formatter_script(path: &std::path::Path, output_line: &str, repeats: usize) {
+    let script = format!(
+        "#!/bin/sh\ncat > /dev/null\nfor i in $(seq 1 {repeats}); do\n  printf '%s\\n' '{output_line}'\ndone\n",
+    );
+    fs::write(path, script).unwrap();
+    let mut perm = fs::metadata(path).unwrap().permissions();
+    perm.set_mode(0o755);
+    fs::set_permissions(path, perm).unwrap();
+}
+
+fn run_format_buffer_via_palette(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Format Buffer").unwrap();
+    harness.wait_for_screen_contains("Format Buffer").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+}
+
+#[test]
+fn test_issue_1573_format_buffer_applies_small_output() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let script = tmp.path().join("fmt.sh");
+    write_formatter_script(&script, "formatted-line", 10);
+
+    let rs_path = tmp.path().join("sample.rs");
+    fs::write(&rs_path, "fn main(){let x=1;println!(\"{}\",x);}\n").unwrap();
+
+    let config = config_with_rust_formatter(&script);
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&rs_path).unwrap();
+    harness.render().unwrap();
+
+    run_format_buffer_via_palette(&mut harness);
+
+    let expected = "formatted-line\n".repeat(10);
+    harness
+        .wait_until(|h| h.get_buffer_content().as_deref() == Some(expected.as_str()))
+        .unwrap();
+}
+
+#[test]
+fn test_issue_1573_format_buffer_does_not_deadlock_on_large_output() {
+    // A formatter that writes well past the 64KB pipe buffer on Linux.
+    // Before the fix, the editor writes the whole buffer to stdin and
+    // then polls `try_wait`; the formatter fills its stdout pipe and
+    // blocks, so the editor hangs until the per-formatter 10-second
+    // timeout kicks in and the format ultimately fails.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let script = tmp.path().join("fmt.sh");
+    // 200 KB of output: 4000 lines × 50 chars each.
+    let line = "X".repeat(49);
+    write_formatter_script(&script, &line, 4_000);
+
+    let rs_path = tmp.path().join("sample.rs");
+    fs::write(&rs_path, "fn main(){let x=1;println!(\"{}\",x);}\n").unwrap();
+
+    let config = config_with_rust_formatter(&script);
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.open_file(&rs_path).unwrap();
+    harness.render().unwrap();
+
+    let start = std::time::Instant::now();
+    run_format_buffer_via_palette(&mut harness);
+
+    // Must complete before the 10-second timeout would have fired. A
+    // properly-plumbed formatter returns well under a second even for
+    // hundreds of KB of output.
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "Format Buffer deadlocked (took {elapsed:?}, well over the expected sub-second limit)",
+    );
+
+    // Buffer content must have been replaced with the formatter's output.
+    let got = harness.get_buffer_content().unwrap_or_default();
+    assert!(
+        got.lines().count() >= 4_000,
+        "Format Buffer did not apply the formatter's output \
+         (expected >= 4000 lines, got {} chars / {} lines)",
+        got.len(),
+        got.lines().count(),
+    );
+    assert!(
+        got.lines().next().unwrap_or("").starts_with(&line),
+        "Format Buffer did not replace the buffer with the formatter's output; \
+         first line was {:?}",
+        got.lines().next().unwrap_or("")
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_1573_format_buffer.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1573_format_buffer.rs
@@ -11,6 +11,11 @@
 //! Fix: stream stdin in a background thread and call `wait_with_output`,
 //! which internally drains stdout/stderr in dedicated threads, so none of
 //! the pipes can fill up.
+//!
+//! The repro uses a shell-script formatter, which is inherently POSIX —
+//! these tests are gated to Unix targets.
+
+#![cfg(unix)]
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};

--- a/crates/fresh-editor/tests/e2e/issue_1574_compose_scroll.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1574_compose_scroll.rs
@@ -1,0 +1,133 @@
+//! Tests for issue #1574: Weird scrolling in a buffer with heavy line wrapping.
+//!
+//! Root cause (pre-fix): `Viewport::ensure_visible` gates its decision to
+//! scroll on `cursor_near_top` — if the cursor sits *near* the top of the
+//! viewport the routine scrolls up one visual row, if *near* the bottom it
+//! scrolls down one visual row. When the cursor is already inside the
+//! viewport (the `cursor_is_visible` branch) the routine returns without
+//! touching `top_byte`. So far, so good.
+//!
+//! But a second codepath kicks in for long wrapped lines: the
+//! wrapped-counting branch (`line_wrap_enabled`) reports the cursor as
+//! *not* visible whenever the cursor's column-within-wrap exceeds the
+//! "bottom margin" (`viewport_lines - effective_offset`). That margin
+//! exists to keep a scroll-margin around the cursor, but in a buffer with
+//! heavy wrapping the cursor rides through the bottom margin on every
+//! Down press, so `ensure_visible` happily scrolls once per key.
+//! Moving Up again from the bottom does the same: cursor lands in the
+//! bottom margin → scroll up → repeat.  The net effect is that the
+//! viewport drifts by one visual row per arrow press even though the
+//! cursor is still inside the visible area.
+//!
+//! The fix is in `Viewport::ensure_visible`: only apply the scroll
+//! margin when the cursor is *actually* outside the viewport. A cursor
+//! already inside the visible rows never triggers a scroll — the user's
+//! configured scroll margin is for *approaching* the edge, not for
+//! jostling the viewport when the cursor is already in the margin.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+fn config_with_wrap() -> Config {
+    let mut config = Config::default();
+    config.editor.line_wrap = true;
+    config
+}
+
+fn long_wrapped_content() -> String {
+    // Build a short document whose paragraphs each wrap to many visual rows
+    // in an 80-column viewport, so the "heavy wrapping" precondition is met.
+    let para = "This is a deliberately long paragraph that must wrap across many \
+                visual rows so the scroll math is exercised. It continues for \
+                a while so a single logical line becomes many visual rows.";
+    let mut s = String::from("# Test\n\n");
+    for i in 1..=6 {
+        s.push_str(&format!("Paragraph {i}: {para}\n\n"));
+    }
+    s.push_str("End of file.\n");
+    s
+}
+
+#[test]
+fn test_issue_1574_up_does_not_scroll_when_cursor_not_at_top() {
+    let mut harness = EditorTestHarness::with_config(80, 20, config_with_wrap()).unwrap();
+    let content = long_wrapped_content();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // Jump to the end of the file — the viewport scrolls to keep the cursor
+    // visible and the cursor ends up at the bottom of the viewport.
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let top_byte_at_end = harness.top_byte();
+    let initial_cursor = harness.cursor_position();
+
+    // Press Up a handful of times. The cursor starts at the bottom of the
+    // viewport, so the first press moves it into the viewport's interior
+    // (still visible, just one row higher). Subsequent presses continue to
+    // move the cursor upward within the viewport. The viewport must NOT
+    // scroll while the cursor remains inside the visible rows.
+    //
+    // With the bug, `ensure_visible` treats a cursor in the "bottom margin"
+    // (which, by default `scroll_offset = 3`, is the bottom 3 rows) as
+    // needing a scroll — so the first three Up presses each scroll the
+    // viewport up one visual row.
+    for i in 1..=3 {
+        let before = harness.top_byte();
+        harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let after = harness.top_byte();
+        assert_eq!(
+            before, after,
+            "Up #{i}: top_byte drifted from {before} to {after} even though the cursor \
+             is still inside the viewport (bug #1574: scroll follows cursor in wrapped buffers)",
+        );
+    }
+
+    // Sanity: we started at the end, and top_byte must not have moved
+    // despite several arrow presses.
+    assert_eq!(
+        harness.top_byte(),
+        top_byte_at_end,
+        "Viewport drifted in total from {top_byte_at_end} after arrow presses; \
+         cursor moved from {initial_cursor} to {}",
+        harness.cursor_position()
+    );
+}
+
+#[test]
+fn test_issue_1574_down_does_not_scroll_when_cursor_not_at_bottom() {
+    let mut harness = EditorTestHarness::with_config(80, 20, config_with_wrap()).unwrap();
+    let content = long_wrapped_content();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // Start of file — cursor at top, viewport at top.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    let top_byte_initial = harness.top_byte();
+
+    // Press Down a handful of times. The cursor should march down through
+    // the top of the viewport. As long as the cursor stays inside the
+    // viewport, the top must not move.
+    for i in 1..=3 {
+        let before = harness.top_byte();
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        let after = harness.top_byte();
+        assert_eq!(
+            before, after,
+            "Down #{i}: top_byte drifted from {before} to {after} even though \
+             the cursor is still near the top of the viewport (bug #1574)",
+        );
+    }
+
+    assert_eq!(harness.top_byte(), top_byte_initial);
+}

--- a/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
@@ -1,0 +1,231 @@
+//! Tests for issue #1577: Variable-width Unicode rendering.
+//!
+//! A mix of FULLWIDTH Latin letters, Arabic ligatures, ZWJ family emoji
+//! and combining marks must render with widths that agree between the
+//! editor's internal column tracking and the terminal output.
+//!
+//! Root cause (pre-fix): `Buffer::next_grapheme_boundary` and
+//! `Buffer::prev_grapheme_boundary` only fetched a fixed 32-byte window of
+//! text from the buffer when looking for the next/previous grapheme
+//! boundary. For ZWJ emoji sequences and Zalgo strings with many combining
+//! marks, a single grapheme cluster easily exceeds 32 bytes, so the
+//! boundary search stopped mid-cluster. That made Right/Left arrow walk
+//! one codepoint at a time through a ZWJ sequence and End land inside the
+//! cluster.
+//!
+//! The fix is in `model/buffer.rs`: start with a 32-byte window but grow
+//! it geometrically whenever the boundary search hits the edge of the
+//! window, so arbitrarily long grapheme clusters are handled correctly.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 30;
+
+const FULLWIDTH_W: &str = "Ｗ"; // U+FF37 FULLWIDTH LATIN CAPITAL LETTER W (width 2)
+const ZWJ_FAMILY: &str = "👨\u{200D}👩\u{200D}👧\u{200D}👦";
+
+/// Build a Zalgo base character: an 'a' with many combining marks. The
+/// combining marks bring the byte length of the single grapheme well past
+/// the 32-byte lookahead that some of the grapheme boundary helpers used.
+fn zalgo_char() -> String {
+    let mut s = String::from("a");
+    // Each combining mark below is 2 bytes (U+0300..U+036F range, encoded
+    // with 2 UTF-8 bytes). 20 marks → 40 bytes of combining code points plus
+    // the 1-byte base → 41 bytes in a single grapheme cluster.
+    for cp in 0x0300u32..0x0314u32 {
+        if let Some(c) = char::from_u32(cp) {
+            s.push(c);
+        }
+    }
+    s
+}
+
+#[test]
+fn test_issue_1577_fullwidth_w_cursor_and_row() {
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    let content = format!("pre {FULLWIDTH_W} post\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // End of line should be at the byte position after "post" (not mid-char).
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    let end_pos = harness.cursor_position();
+    let line_bytes = content.trim_end_matches('\n').len();
+    assert_eq!(
+        end_pos, line_bytes,
+        "End should land past the last char on the line (byte {line_bytes}), got {end_pos}"
+    );
+
+    // Navigate Right from start and count the grapheme steps needed to reach
+    // the end. "pre " = 4, fullwidth W = 1 grapheme, " post" = 5 → 10 total.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    let mut steps = 0usize;
+    loop {
+        let before = harness.cursor_position();
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+        let after = harness.cursor_position();
+        if after == before {
+            break;
+        }
+        steps += 1;
+        if steps > 100 {
+            panic!("Right key never reached end of line");
+        }
+        if after == line_bytes {
+            break;
+        }
+    }
+    assert_eq!(
+        steps, 10,
+        "expected 10 Right presses to cross 'pre Ｗ post' (one grapheme each), got {steps}"
+    );
+
+    // Locate the fullwidth W on screen and verify it occupies 2 terminal cells:
+    // the first cell carries the grapheme symbol, the second is a width-0
+    // continuation cell (empty symbol in ratatui).
+    let (x, y) = find_cell(&mut harness, FULLWIDTH_W).expect("fullwidth W must be visible");
+    let cell0 = harness.get_cell(x, y).unwrap_or_default();
+    let cell1 = harness.get_cell(x + 1, y).unwrap_or_default();
+    assert_eq!(
+        cell0, FULLWIDTH_W,
+        "first cell under fullwidth W should contain the grapheme"
+    );
+    assert!(
+        cell1.is_empty() || cell1 == " ",
+        "second cell under fullwidth W should be the empty continuation cell, got {cell1:?}"
+    );
+}
+
+#[test]
+fn test_issue_1577_zalgo_grapheme_navigation() {
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    let zalgo = zalgo_char();
+    assert!(
+        zalgo.len() > 32,
+        "zalgo grapheme must exceed the 32-byte lookahead"
+    );
+    let content = format!("{zalgo}Z\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // Right arrow from start must skip the whole Zalgo cluster in one step,
+    // even though it exceeds the 32-byte lookahead window. Otherwise the
+    // cursor lands inside the grapheme and the next render breaks UTF-8
+    // assumptions downstream.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    assert_eq!(harness.cursor_position(), 0);
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        zalgo.len(),
+        "Right from 0 must cross the whole Zalgo cluster in one step \
+         (cursor should land on byte {} just before the Z)",
+        zalgo.len()
+    );
+}
+
+/// Find the first (col, row) cell whose symbol equals `sym`. Works for
+/// multi-cell symbols where `find_text_on_screen` (which returns byte offset)
+/// does not.
+fn find_cell(harness: &mut EditorTestHarness, sym: &str) -> Option<(u16, u16)> {
+    let rows = HEIGHT;
+    for y in 0..rows {
+        for x in 0..WIDTH {
+            if let Some(c) = harness.get_cell(x, y) {
+                if c == sym {
+                    return Some((x, y));
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn test_issue_1577_zwj_family_single_grapheme() {
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    // Put the family emoji at the start of the line so End lands right after it.
+    let content = format!("{ZWJ_FAMILY}\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // End should put the cursor past the whole ZWJ cluster (byte 25), not
+    // mid-sequence.
+    let line_bytes = ZWJ_FAMILY.len();
+    assert_eq!(line_bytes, 25, "sanity: family emoji is 25 UTF-8 bytes");
+
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    let end_pos = harness.cursor_position();
+    assert_eq!(
+        end_pos, line_bytes,
+        "End on a ZWJ-family line should land past the whole cluster, not mid-sequence"
+    );
+
+    // A single Right arrow from position 0 should skip the entire ZWJ cluster.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    assert_eq!(harness.cursor_position(), 0);
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        line_bytes,
+        "Right from 0 must cross the whole ZWJ cluster in one step"
+    );
+}
+
+#[test]
+fn test_issue_1577_rendered_cluster_matches_internal_width() {
+    // The critical invariant: whatever visual width the editor assigns to a
+    // grapheme cluster must match what ratatui reserves on screen. Otherwise
+    // characters after a ZWJ cluster get clobbered or vanish.
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    let content = format!("A{ZWJ_FAMILY}Z\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    // 'A' and 'Z' must both be visible on screen.
+    let a_pos = harness.find_text_on_screen("A").expect("A must be visible");
+    let z_pos = harness
+        .find_text_on_screen("Z")
+        .expect("Z after ZWJ family must still be visible (regression: it would be clobbered)");
+    assert_eq!(a_pos.1, z_pos.1, "A and Z should be on the same row");
+
+    // The gap between A and Z is exactly the width the editor decided to give
+    // to the ZWJ cluster. For a ZWJ-aware width function that should be 2
+    // (the width of the first visible sub-grapheme 👨), but at minimum it
+    // must be consistent with what ratatui placed in the buffer.
+    let distance = z_pos.0 - a_pos.0;
+    assert!(
+        distance >= 2,
+        "ZWJ family emoji should take at least 2 cells, got {distance}"
+    );
+
+    // Walk the cells between A and Z and reconstruct what is actually on
+    // screen. The Z must appear in exactly one cell, immediately after the
+    // cluster ends.
+    let row_text = harness.get_row_text(a_pos.1);
+    // Strip the gutter and trailing padding.
+    assert!(
+        row_text.contains('Z'),
+        "row text should contain Z after the ZWJ family emoji, got: {row_text:?}"
+    );
+    // The portion from A through Z, including the cluster cells.
+    let a_idx = row_text.find('A').unwrap();
+    let z_idx = row_text.find('Z').unwrap();
+    let between: String = row_text[a_idx + 'A'.len_utf8()..z_idx].chars().collect();
+    // `between` must contain at least one emoji codepoint from the family.
+    assert!(
+        between.chars().any(|c| c == '👨'),
+        "row must include the family emoji between A and Z, got {between:?}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
@@ -230,28 +230,31 @@ fn test_issue_1577_rendered_cluster_matches_internal_width() {
     );
 }
 
-/// End-to-end regression for the rendering corruption the user reported on
-/// the GitHub issue: with the exact mixed-width sample string in a 137-col
-/// window, the line gets mangled — duplicated fragments, overlapping
-/// content, missing whole substrings.
+/// End-to-end regression for the rendering corruption the user reported
+/// at 137 cols with the exact mixed-width sample string.
 ///
-/// Root cause: `view_pipeline` assigns each grapheme cluster a single
-/// `UnicodeWidthStr::width` column (so a ZWJ family emoji is 2 columns, a
-/// base+combining sequence is 1 column, …) and ratatui uses the same
-/// width when placing spans on screen. But `render_line` was tracking
-/// `col_offset` by summing per-codepoint `char_width` — which gives 8 for
-/// the ZWJ family cluster, 2 for base+combining, etc. That diverging
-/// column count feeds into horizontal-scroll skipping, cursor
-/// positioning, and padding math, producing the garbled frame.
+/// This test runs the full editor render through ratatui + its
+/// `CrosstermBackend` writing into a captured `Vec<u8>` ANSI stream,
+/// which is then replayed through a `vt100` parser. That round-trip is
+/// what the user's tmux terminal does: both it and vt100 advance the
+/// cursor by the terminal's width understanding of each glyph (not by
+/// ratatui's cell index). If fresh's upstream column tracking
+/// (`view_pipeline.char_visual_cols`, `render_line.col_offset`,
+/// wrap-math) disagrees with `UnicodeWidthStr::width` at any stage,
+/// the downstream terminal state drifts out of sync with ratatui's
+/// frame buffer and the vt100 grid no longer contains the line text
+/// where it should.
 ///
-/// This test exercises the whole rendering pipeline at 137 columns with
-/// the exact ticket sample and asserts that:
-///   * each of the sample's distinctive words appears exactly once on
-///     screen (no duplicated fragments), and
-///   * no spurious repeated-word artifact like "combiningbwordg" leaks
-///     through.
+/// The assertion is narrow and robust: after the editor renders the
+/// sample, each of the distinctive ASCII fragments of the line must
+/// appear exactly once on the vt100 screen. Duplicated fragments and
+/// disappearances are the garbled-rendering symptom from the ticket.
 #[test]
-fn test_issue_1577_full_ticket_sample_renders_consistently_at_137_cols() {
+fn test_issue_1577_full_ticket_sample_renders_consistently_at_137_cols_real_terminal() {
+    use ratatui::backend::CrosstermBackend;
+    use ratatui::layout::Rect;
+    use ratatui::{Terminal, TerminalOptions, Viewport};
+
     const TICKET_WIDTH: u16 = 137;
     const TICKET_HEIGHT: u16 = 30;
 
@@ -260,66 +263,81 @@ fn test_issue_1577_full_ticket_sample_renders_consistently_at_137_cols() {
                   ligature \"\u{FDFD}\", a ZWJ emoji sequence \
                   \"\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}\", \
                   a Zalgo combining word \"t\u{337}e\u{337}x\u{337}t\u{337}\", \
-                  and an ancient cuneiform \"\u{12019}\".\n";
-    let _fixture = harness.load_buffer_from_text(sample).unwrap();
+                  and an ancient cuneiform \"\u{12019}\".";
+    // Mirror the user's reproducer: start with a `[No Name]*` buffer
+    // (typed content, not an opened file) so incremental rendering runs
+    // through every keystroke. The bug in the ticket screenshot shows
+    // duplicated content fragments, which is a diff-rendering symptom
+    // — it only manifests after the buffer has been built up edit-by-
+    // edit on top of prior frames.
+    harness.type_text(sample).unwrap();
     harness.render().unwrap();
 
-    // Drive the cursor from end-of-line back to the start. This is the
-    // reproducer path the user described: moving the cursor through the
-    // line causes weird rendering changes — duplicated fragments,
-    // overlapping words, text reappearing on neighbouring rows. Each
-    // Left press must:
-    //   * decrement the byte position (never stay put, never jump
-    //     backwards past the start of a cluster)
-    //   * leave every distinctive fragment of the line appearing
-    //     exactly once on screen (the sample's characteristic words
-    //     must not multiply or disappear as the cursor walks past them)
-    const STABLE_FRAGMENTS: &[&str] = &[
+    // Now replay the same frame through a real CrosstermBackend →
+    // captured ANSI → vt100 pipeline. The real backend's cell-write
+    // sequencing (including wide-char continuation cells) matches
+    // what the user's tmux terminal sees in production.
+    let buffer_snapshot = harness.buffer().clone();
+    let area = Rect::new(0, 0, TICKET_WIDTH, TICKET_HEIGHT);
+    let mut captured = Vec::<u8>::new();
+    {
+        let backend = CrosstermBackend::new(&mut captured);
+        let mut real_term = Terminal::with_options(
+            backend,
+            TerminalOptions {
+                viewport: Viewport::Fixed(area),
+            },
+        )
+        .unwrap();
+        real_term
+            .draw(|f| {
+                let buf = f.buffer_mut();
+                for y in 0..buffer_snapshot.area.height {
+                    for x in 0..buffer_snapshot.area.width {
+                        if let Some(src) =
+                            buffer_snapshot.content.get(buffer_snapshot.index_of(x, y))
+                        {
+                            buf[(x, y)] = src.clone();
+                        }
+                    }
+                }
+            })
+            .unwrap();
+    }
+
+    let mut parser = vt100::Parser::new(TICKET_HEIGHT, TICKET_WIDTH, 0);
+    parser.process(&captured);
+    let screen = parser.screen();
+    let mut vt100_text = String::new();
+    for row in 0..TICKET_HEIGHT {
+        for col in 0..TICKET_WIDTH {
+            if let Some(cell) = screen.cell(row, col) {
+                vt100_text.push_str(&cell.contents());
+            }
+        }
+        vt100_text.push('\n');
+    }
+
+    for needle in [
         "A standard",
         "Arabic ligature",
         "ZWJ emoji sequence",
         "Zalgo combining word",
         "ancient cuneiform",
-    ];
-    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
-    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
-    let mut prev_byte = harness.cursor_position();
-    let mut steps = 0usize;
-    while prev_byte > 0 {
-        harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
-        let now = harness.cursor_position();
-        assert!(
-            now < prev_byte,
-            "Left at byte {prev_byte} did not advance (ended up at byte {now}) — \
-             cursor got stuck traversing a multi-byte cluster",
+    ] {
+        let count = vt100_text.matches(needle).count();
+        assert_eq!(
+            count, 1,
+            "after rendering through CrosstermBackend + vt100, {needle:?} appears {count} \
+             times on the virtual terminal (should be exactly 1 — duplicates / \
+             disappearances are the rendering corruption from the bug report)\n\nvt100:\n{vt100_text}",
         );
-        prev_byte = now;
-        steps += 1;
-        assert!(
-            steps < 500,
-            "Left took more than 500 presses to reach BOL — something is very wrong",
-        );
-
-        let screen = harness.screen_to_string();
-        for needle in STABLE_FRAGMENTS {
-            let count = screen.matches(needle).count();
-            assert_eq!(
-                count, 1,
-                "after {steps} Left press(es), {needle:?} appears {count} times \
-                 (should always be exactly 1 — duplicates / disappearances are the \
-                 rendering corruption from the bug report)\nScreen:\n{screen}",
-            );
-        }
     }
 
-    // And the obvious corruption fingerprints from the bug report —
-    // "word" mid-word-smashed like "combiningbwordg", "wordg wor", etc.
-    // — must never appear, at any cursor position.
-    let final_screen = harness.screen_to_string();
     for bad in ["combiningbword", "combiningword", "wordg wor"] {
         assert!(
-            !final_screen.contains(bad),
-            "rendering corruption fingerprint {bad:?} appeared on screen\nScreen:\n{final_screen}",
+            !vt100_text.contains(bad),
+            "rendering corruption fingerprint {bad:?} appeared on the vt100 screen\n\nvt100:\n{vt100_text}",
         );
     }
 }

--- a/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
@@ -101,6 +101,78 @@ fn test_issue_1577_fullwidth_w_cursor_and_row() {
     );
 }
 
+/// Stepping the cursor through a line that starts with a ZWJ family
+/// emoji must advance the cursor by exactly one visual column per
+/// `Right` press through the cluster, and then by one per ASCII char.
+///
+/// Before the fix: `SpanAccumulator::push` and `push_span_with_map`
+/// both emitted `char_width(ch)` visual-column entries per codepoint,
+/// so the `"👨‍👩‍👧‍👦"` cluster contributed 8 entries (2+0+2+0+2+0+2)
+/// instead of 2 (the cluster's real screen width per
+/// `UnicodeWidthStr::width`). `render_line` then walked that
+/// per-visual-column map to find the cursor's screen x, placing the
+/// cursor 6 cells to the right of its visual position. The user
+/// reported this as "moving Right from BOL should put the cursor on
+/// 'a' (col 2) but I see weird artifacts at col 8".
+#[test]
+fn test_issue_1577_cursor_screen_column_advances_by_grapheme_width() {
+    let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();
+    let content = format!("{ZWJ_FAMILY}abc\n");
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+    harness.render().unwrap();
+
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    let (home_x, home_y) = harness.screen_cursor_position();
+
+    // First Right: cursor crosses the whole ZWJ family cluster (a single
+    // grapheme of visual width 2), so the screen column must advance by
+    // exactly 2 — landing on the 'a'.
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    let (after1_x, after1_y) = harness.screen_cursor_position();
+    assert_eq!(
+        after1_y, home_y,
+        "cursor must stay on the same screen row after one Right"
+    );
+    assert_eq!(
+        after1_x - home_x,
+        2,
+        "cursor should advance by 2 screen columns (the ZWJ family cluster's \
+         `UnicodeWidthStr::width`), not 8 (the codepoint-sum width that was \
+         being miscounted). home_x={home_x} after_x={after1_x}",
+    );
+
+    // The cell the cursor now sits on must be the 'a'.
+    let a_cell = harness.get_cell(after1_x, after1_y).unwrap_or_default();
+    assert_eq!(
+        a_cell, "a",
+        "after the first Right, the cursor cell should contain 'a'; got {a_cell:?}"
+    );
+
+    // Each subsequent Right through "bc" advances by one ASCII column.
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    let (after2_x, _) = harness.screen_cursor_position();
+    assert_eq!(after2_x - after1_x, 1);
+    assert_eq!(
+        harness.get_cell(after2_x, after1_y).unwrap_or_default(),
+        "b"
+    );
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    let (after3_x, _) = harness.screen_cursor_position();
+    assert_eq!(after3_x - after2_x, 1);
+    assert_eq!(
+        harness.get_cell(after3_x, after1_y).unwrap_or_default(),
+        "c"
+    );
+}
+
 #[test]
 fn test_issue_1577_zalgo_grapheme_navigation() {
     let mut harness = EditorTestHarness::new(WIDTH, HEIGHT).unwrap();

--- a/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1577_unicode_width.rs
@@ -229,3 +229,97 @@ fn test_issue_1577_rendered_cluster_matches_internal_width() {
         "row must include the family emoji between A and Z, got {between:?}"
     );
 }
+
+/// End-to-end regression for the rendering corruption the user reported on
+/// the GitHub issue: with the exact mixed-width sample string in a 137-col
+/// window, the line gets mangled — duplicated fragments, overlapping
+/// content, missing whole substrings.
+///
+/// Root cause: `view_pipeline` assigns each grapheme cluster a single
+/// `UnicodeWidthStr::width` column (so a ZWJ family emoji is 2 columns, a
+/// base+combining sequence is 1 column, …) and ratatui uses the same
+/// width when placing spans on screen. But `render_line` was tracking
+/// `col_offset` by summing per-codepoint `char_width` — which gives 8 for
+/// the ZWJ family cluster, 2 for base+combining, etc. That diverging
+/// column count feeds into horizontal-scroll skipping, cursor
+/// positioning, and padding math, producing the garbled frame.
+///
+/// This test exercises the whole rendering pipeline at 137 columns with
+/// the exact ticket sample and asserts that:
+///   * each of the sample's distinctive words appears exactly once on
+///     screen (no duplicated fragments), and
+///   * no spurious repeated-word artifact like "combiningbwordg" leaks
+///     through.
+#[test]
+fn test_issue_1577_full_ticket_sample_renders_consistently_at_137_cols() {
+    const TICKET_WIDTH: u16 = 137;
+    const TICKET_HEIGHT: u16 = 30;
+
+    let mut harness = EditorTestHarness::new(TICKET_WIDTH, TICKET_HEIGHT).unwrap();
+    let sample = "A standard \"i\", a ＦＵＬＬＷＩＤＴＨ \"Ｗ\", a massive Arabic \
+                  ligature \"\u{FDFD}\", a ZWJ emoji sequence \
+                  \"\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}\u{200D}\u{1F466}\", \
+                  a Zalgo combining word \"t\u{337}e\u{337}x\u{337}t\u{337}\", \
+                  and an ancient cuneiform \"\u{12019}\".\n";
+    let _fixture = harness.load_buffer_from_text(sample).unwrap();
+    harness.render().unwrap();
+
+    // Drive the cursor from end-of-line back to the start. This is the
+    // reproducer path the user described: moving the cursor through the
+    // line causes weird rendering changes — duplicated fragments,
+    // overlapping words, text reappearing on neighbouring rows. Each
+    // Left press must:
+    //   * decrement the byte position (never stay put, never jump
+    //     backwards past the start of a cluster)
+    //   * leave every distinctive fragment of the line appearing
+    //     exactly once on screen (the sample's characteristic words
+    //     must not multiply or disappear as the cursor walks past them)
+    const STABLE_FRAGMENTS: &[&str] = &[
+        "A standard",
+        "Arabic ligature",
+        "ZWJ emoji sequence",
+        "Zalgo combining word",
+        "ancient cuneiform",
+    ];
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    let mut prev_byte = harness.cursor_position();
+    let mut steps = 0usize;
+    while prev_byte > 0 {
+        harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+        let now = harness.cursor_position();
+        assert!(
+            now < prev_byte,
+            "Left at byte {prev_byte} did not advance (ended up at byte {now}) — \
+             cursor got stuck traversing a multi-byte cluster",
+        );
+        prev_byte = now;
+        steps += 1;
+        assert!(
+            steps < 500,
+            "Left took more than 500 presses to reach BOL — something is very wrong",
+        );
+
+        let screen = harness.screen_to_string();
+        for needle in STABLE_FRAGMENTS {
+            let count = screen.matches(needle).count();
+            assert_eq!(
+                count, 1,
+                "after {steps} Left press(es), {needle:?} appears {count} times \
+                 (should always be exactly 1 — duplicates / disappearances are the \
+                 rendering corruption from the bug report)\nScreen:\n{screen}",
+            );
+        }
+    }
+
+    // And the obvious corruption fingerprints from the bug report —
+    // "word" mid-word-smashed like "combiningbwordg", "wordg wor", etc.
+    // — must never appear, at any cursor position.
+    let final_screen = harness.screen_to_string();
+    for bad in ["combiningbword", "combiningword", "wordg wor"] {
+        assert!(
+            !final_screen.contains(bad),
+            "rendering corruption fingerprint {bad:?} appeared on screen\nScreen:\n{final_screen}",
+        );
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -46,6 +46,7 @@ pub mod issue_1566_arrow_selection;
 pub mod issue_1568_session_fold_restore;
 pub mod issue_1569_explorer_auto_expand;
 pub mod issue_1571_fold_indicator_lag;
+pub mod issue_1572_inlay_hint_drift;
 pub mod issue_1573_format_buffer;
 pub mod issue_1574_compose_scroll;
 pub mod issue_1577_unicode_width;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -46,6 +46,7 @@ pub mod issue_1566_arrow_selection;
 pub mod issue_1568_session_fold_restore;
 pub mod issue_1569_explorer_auto_expand;
 pub mod issue_1571_fold_indicator_lag;
+pub mod issue_1577_unicode_width;
 pub mod keybinding_editor;
 pub mod language_features_e2e;
 pub mod large_file_inplace_write_bug;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -46,6 +46,7 @@ pub mod issue_1566_arrow_selection;
 pub mod issue_1568_session_fold_restore;
 pub mod issue_1569_explorer_auto_expand;
 pub mod issue_1571_fold_indicator_lag;
+pub mod issue_1573_format_buffer;
 pub mod issue_1574_compose_scroll;
 pub mod issue_1577_unicode_width;
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -46,7 +46,9 @@ pub mod issue_1566_arrow_selection;
 pub mod issue_1568_session_fold_restore;
 pub mod issue_1569_explorer_auto_expand;
 pub mod issue_1571_fold_indicator_lag;
+pub mod issue_1574_compose_scroll;
 pub mod issue_1577_unicode_width;
+
 pub mod keybinding_editor;
 pub mod language_features_e2e;
 pub mod large_file_inplace_write_bug;

--- a/crates/fresh-editor/tests/e2e/multibyte_characters.rs
+++ b/crates/fresh-editor/tests/e2e/multibyte_characters.rs
@@ -1,6 +1,6 @@
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::primitives::display_width::char_width;
+use fresh::primitives::display_width::str_width;
 use std::path::PathBuf;
 use tempfile::TempDir;
 use unicode_segmentation::UnicodeSegmentation;
@@ -1336,10 +1336,15 @@ fn test_all_operations_on_multibyte_fixture() {
             line_idx
         );
 
-        // Calculate expected visual width by summing char_width per character
-        // This matches how the rendering code calculates width (char by char, not via str_width)
-        // Note: str_width may differ for ZWJ sequences due to unicode-width handling
-        let expected_visual_width: usize = line.chars().map(char_width).sum();
+        // Calculate expected visual width per grapheme cluster via
+        // `UnicodeWidthStr::width`. This matches what ratatui's
+        // `set_stringn` uses when placing spans on screen and what
+        // `render_line`'s per-visual-column map counts for cursor
+        // positioning. Summing `char_width` per codepoint gives the
+        // wrong answer for ZWJ emoji sequences: e.g.
+        // "👩‍💻" sums to 2+0+2=4 but the cluster's real screen width
+        // is 2 (one visible glyph).
+        let expected_visual_width: usize = line.graphemes(true).map(str_width).sum();
 
         // Screen X = gutter_width + visual_content_width
         // Get gutter width by checking cursor X at Home position
@@ -1381,12 +1386,12 @@ fn test_all_operations_on_multibyte_fixture() {
             .chain(std::iter::once(line_len))
             .collect();
 
-        // Calculate visual width for each grapheme cluster by summing char widths
-        // This matches how the rendering code calculates width
-        let grapheme_widths: Vec<usize> = line
-            .graphemes(true)
-            .map(|g| g.chars().map(char_width).sum())
-            .collect();
+        // Visual width for each grapheme cluster is
+        // `UnicodeWidthStr::width(grapheme)` — the same width ratatui
+        // assigns when placing the span on screen. Summing per-codepoint
+        // `char_width` over a ZWJ emoji cluster gives an inflated
+        // value (see the note above `expected_visual_width`).
+        let grapheme_widths: Vec<usize> = line.graphemes(true).map(str_width).collect();
 
         let mut positions_visited = vec![0usize];
         let mut prev_pos = 0;


### PR DESCRIPTION
This PR addresses four critical bugs affecting text rendering, cursor navigation, formatter execution, and viewport scrolling.

## Summary

Fixes issues with variable-width Unicode handling, formatter process deadlocks, inlay hint drift, and unwanted scrolling in wrapped buffers through targeted improvements to grapheme boundary detection, subprocess I/O handling, marker anchoring, and viewport visibility logic.

## Key Changes

**1. Variable-width Unicode and Grapheme Boundary Detection (Issue #1577)**
- Modified `TextBuffer::next_grapheme_boundary()` and `prev_grapheme_boundary()` to use a dynamically-growing lookahead window instead of a fixed 32-byte window
- Handles ZWJ emoji sequences (e.g., family emoji at 25 bytes) and Zalgo strings with many combining marks that exceed 32 bytes
- Prevents cursor from landing mid-grapheme cluster during navigation, which would break UTF-8 assumptions downstream
- Added comprehensive e2e tests covering fullwidth characters, Zalgo text, and ZWJ sequences

**2. Formatter Process Deadlock (Issue #1573)**
- Refactored `Editor::run_formatter()` to stream stdin on a background thread instead of writing all at once
- Replaced polling-based `try_wait()` loop with `wait_with_output()`, which internally drains stdout/stderr on dedicated threads
- Prevents pipe buffer overflow (64KB on Linux) that caused formatters to block indefinitely
- Added watchdog thread for timeout enforcement with SIGKILL on Unix
- Added e2e tests verifying both small and large formatter outputs complete without hanging

**3. Inlay Hint Position Drift (Issue #1572)**
- Modified `Editor::apply_inlay_hints_to_state()` to detect when LSP-computed byte offset lands on a line terminator
- Anchors hints to the preceding character with `AfterChar` affinity instead of `BeforeChar` when on a newline
- Prevents hints from drifting down one line when whitespace is inserted below the annotated code
- Added e2e test demonstrating hint stability across edits below closing braces

**4. Unwanted Scrolling in Wrapped Buffers (Issue #1574)**
- Modified `Viewport::ensure_visible()` to only apply scroll margins when cursor is actually outside the viewport
- Prevents spurious scrolls when cursor is already visible but within the configured scroll margin
- Delegates to `ensure_visible_in_layout()` for wrapped-line-aware visibility decisions
- Added e2e tests verifying Up/Down arrow keys don't scroll when cursor remains visible

## Implementation Details

- Grapheme boundary detection now caps lookahead growth at the full buffer size to prevent infinite loops
- Formatter stdin writer gracefully handles `BrokenPipe` errors when child exits early
- Inlay hint anchoring checks the actual byte at the computed offset to distinguish line breaks from regular characters
- Viewport scroll logic now respects the distinction between "cursor outside viewport" (needs scroll) and "cursor in margin but visible" (no scroll needed)

https://claude.ai/code/session_01RSzpR7yytpzKr3PTuL8iG6