### PR TITLE
Fix inlay hints to refresh after edits and clear when deleted

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -286,11 +286,31 @@ impl Editor {
         uri: String,
         hints: Vec<InlayHint>,
     ) {
-        if !self.pending_inlay_hints_requests.remove(&request_id) {
+        let Some(request) = self.pending_inlay_hints_requests.remove(&request_id) else {
             tracing::debug!(
                 "Ignoring stale inlay hints response (request_id={})",
                 request_id
             );
+            return;
+        };
+
+        // Drop responses that raced behind a local edit — the hint
+        // positions reference stale byte offsets and would render at
+        // the wrong place. A fresh request was (or will be) scheduled
+        // by the debounced inlay-hints timer on every didChange.
+        if let Some(state) = self.buffers.get(&request.buffer_id) {
+            if state.buffer.version() != request.version {
+                tracing::debug!(
+                    "Ignoring stale inlay hints for {} (request_id={}, version={}, current={})",
+                    uri,
+                    request_id,
+                    request.version,
+                    state.buffer.version()
+                );
+                return;
+            }
+        } else {
+            // Buffer was closed before the response arrived.
             return;
         }
 
@@ -301,17 +321,13 @@ impl Editor {
             request_id
         );
 
-        if let Some(buffer_id) = self.find_buffer_by_uri(&uri) {
-            if let Some(state) = self.buffers.get_mut(&buffer_id) {
-                Self::apply_inlay_hints_to_state(state, &hints);
-                tracing::info!(
-                    "Applied {} inlay hints as virtual text to buffer {:?}",
-                    hints.len(),
-                    buffer_id
-                );
-            }
-        } else {
-            tracing::warn!("No buffer found for inlay hints URI: {}", uri);
+        if let Some(state) = self.buffers.get_mut(&request.buffer_id) {
+            Self::apply_inlay_hints_to_state(state, &hints);
+            tracing::info!(
+                "Applied {} inlay hints as virtual text to buffer {:?}",
+                hints.len(),
+                request.buffer_id
+            );
         }
     }
 
@@ -716,12 +732,12 @@ impl Editor {
             .buffers_for_language(&language)
             .into_iter()
             .map(|(buffer_id, uri)| {
-                let line_count = self
+                let (line_count, version) = self
                     .buffers
                     .get(&buffer_id)
-                    .and_then(|s| s.buffer.line_count())
-                    .unwrap_or(1000);
-                (uri, line_count)
+                    .map(|s| (s.buffer.line_count().unwrap_or(1000), s.buffer.version()))
+                    .unwrap_or((1000, 0));
+                (buffer_id, uri, line_count, version)
             })
             .collect();
 
@@ -736,11 +752,12 @@ impl Editor {
         };
         let client = &mut sh.handle;
 
-        // Request inlay hints for each buffer. Each request gets its own
-        // id inserted into the pending set so responses across all buffers
-        // are accepted individually (a single Option used to be overwritten
-        // by each iteration, dropping every response except the last).
-        for (uri, line_count) in buffer_infos {
+        // Request inlay hints for each buffer. Each request is keyed in
+        // the pending map by its own id (and carries buffer_id + version)
+        // so responses across all buffers are matched individually — a
+        // single Option used to be overwritten by each iteration, dropping
+        // every response except the last.
+        for (buffer_id, uri, line_count, version) in buffer_infos {
             let request_id = self.next_lsp_request_id;
             self.next_lsp_request_id += 1;
 
@@ -752,7 +769,8 @@ impl Editor {
                     e
                 );
             } else {
-                self.pending_inlay_hints_requests.insert(request_id);
+                self.pending_inlay_hints_requests
+                    .insert(request_id, super::InlayHintsRequest { buffer_id, version });
                 tracing::info!(
                     "Re-requested inlay hints for {} (request_id={})",
                     uri.as_str(),

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -286,15 +286,13 @@ impl Editor {
         uri: String,
         hints: Vec<InlayHint>,
     ) {
-        if self.pending_inlay_hints_request != Some(request_id) {
+        if !self.pending_inlay_hints_requests.remove(&request_id) {
             tracing::debug!(
                 "Ignoring stale inlay hints response (request_id={})",
                 request_id
             );
             return;
         }
-
-        self.pending_inlay_hints_request = None;
 
         tracing::info!(
             "Received {} inlay hints for {} (request_id={})",
@@ -738,11 +736,13 @@ impl Editor {
         };
         let client = &mut sh.handle;
 
-        // Request inlay hints for each buffer
+        // Request inlay hints for each buffer. Each request gets its own
+        // id inserted into the pending set so responses across all buffers
+        // are accepted individually (a single Option used to be overwritten
+        // by each iteration, dropping every response except the last).
         for (uri, line_count) in buffer_infos {
             let request_id = self.next_lsp_request_id;
             self.next_lsp_request_id += 1;
-            self.pending_inlay_hints_request = Some(request_id);
 
             let last_line = line_count.saturating_sub(1) as u32;
             if let Err(e) = client.inlay_hints(request_id, uri.clone(), 0, 0, last_line, 10000) {
@@ -752,6 +752,7 @@ impl Editor {
                     e
                 );
             } else {
+                self.pending_inlay_hints_requests.insert(request_id);
                 tracing::info!(
                     "Re-requested inlay hints for {} (request_id={})",
                     uri.as_str(),

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -821,7 +821,6 @@ impl Editor {
                     if enable_inlay_hints {
                         let request_id = self.next_lsp_request_id;
                         self.next_lsp_request_id += 1;
-                        self.pending_inlay_hints_request = Some(request_id);
 
                         if let Err(e) =
                             client.inlay_hints(request_id, uri.clone(), 0, 0, last_line, last_char)
@@ -830,8 +829,8 @@ impl Editor {
                                 "Failed to request inlay hints (server may not support): {}",
                                 e
                             );
-                            self.pending_inlay_hints_request = None;
                         } else {
+                            self.pending_inlay_hints_requests.insert(request_id);
                             tracing::info!(
                                 "Requested inlay hints for {} (request_id={})",
                                 uri.as_str(),

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -755,15 +755,19 @@ impl Editor {
         let enable_inlay_hints = self.config.editor.enable_inlay_hints;
         let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
 
-        // Get buffer line count for inlay hints
-        let (last_line, last_char) = self
+        // Get buffer line count and version for inlay hints
+        let (last_line, last_char, buffer_version) = self
             .buffers
             .get(&buffer_id)
             .map(|state| {
                 let line_count = state.buffer.line_count().unwrap_or(1000);
-                (line_count.saturating_sub(1) as u32, 10000u32)
+                (
+                    line_count.saturating_sub(1) as u32,
+                    10000u32,
+                    state.buffer.version(),
+                )
             })
-            .unwrap_or((999, 10000));
+            .unwrap_or((999, 10000, 0));
 
         // Now borrow lsp and do all LSP operations
         let Some(lsp) = &mut self.lsp else {
@@ -830,7 +834,13 @@ impl Editor {
                                 e
                             );
                         } else {
-                            self.pending_inlay_hints_requests.insert(request_id);
+                            self.pending_inlay_hints_requests.insert(
+                                request_id,
+                                super::InlayHintsRequest {
+                                    buffer_id,
+                                    version: buffer_version,
+                                },
+                            );
                             tracing::info!(
                                 "Requested inlay hints for {} (request_id={})",
                                 uri.as_str(),

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -130,6 +130,8 @@ impl Editor {
             })
             .collect();
 
+        let enable_inlay_hints = self.config.editor.enable_inlay_hints;
+
         for (buffer_id, buf_path) in buffers_for_language {
             let Some(state) = self.buffers.get(&buffer_id) else {
                 continue;
@@ -144,6 +146,7 @@ impl Editor {
             };
 
             let lang_id = state.language.clone();
+            let line_count = state.buffer.line_count().unwrap_or(1000);
 
             if let Some(lsp) = self.lsp.as_mut() {
                 // Respect auto_start setting for this user action
@@ -182,6 +185,35 @@ impl Editor {
                             tracing::warn!("LSP did_open to '{}' failed: {}", name, e);
                         } else if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
                             metadata.lsp_opened_with.insert(handle_id);
+                        }
+                    }
+                }
+            }
+
+            // Kick off inlay hints for this buffer right after (re)opening.
+            // Servers that emit a `serverQuiescent` notification (e.g.
+            // rust-analyzer) will refresh these later once indexing is
+            // done, but servers that don't would otherwise never get a
+            // hints request unless the user edits the buffer.
+            if enable_inlay_hints {
+                if let Some(lsp) = self.lsp.as_mut() {
+                    if let Some(sh) =
+                        lsp.handle_for_feature_mut(&lang_id, crate::types::LspFeature::InlayHints)
+                    {
+                        let request_id = self.next_lsp_request_id;
+                        self.next_lsp_request_id += 1;
+                        let last_line = line_count.saturating_sub(1) as u32;
+                        if let Err(e) =
+                            sh.handle
+                                .inlay_hints(request_id, uri.clone(), 0, 0, last_line, 10000)
+                        {
+                            tracing::debug!(
+                                "Failed to request inlay hints for {}: {}",
+                                uri.as_str(),
+                                e
+                            );
+                        } else {
+                            self.pending_inlay_hints_requests.insert(request_id);
                         }
                     }
                 }
@@ -916,6 +948,8 @@ impl Editor {
             self.next_lsp_request_id += 1;
             if let Err(e) = handle.inlay_hints(request_id, uri, 0, 0, last_line, last_char) {
                 tracing::warn!("LSP inlay_hints request failed: {}", e);
+            } else {
+                self.pending_inlay_hints_requests.insert(request_id);
             }
         }
 

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -147,6 +147,7 @@ impl Editor {
 
             let lang_id = state.language.clone();
             let line_count = state.buffer.line_count().unwrap_or(1000);
+            let buffer_version = state.buffer.version();
 
             if let Some(lsp) = self.lsp.as_mut() {
                 // Respect auto_start setting for this user action
@@ -213,7 +214,13 @@ impl Editor {
                                 e
                             );
                         } else {
-                            self.pending_inlay_hints_requests.insert(request_id);
+                            self.pending_inlay_hints_requests.insert(
+                                request_id,
+                                super::InlayHintsRequest {
+                                    buffer_id,
+                                    version: buffer_version,
+                                },
+                            );
                         }
                     }
                 }
@@ -837,6 +844,10 @@ impl Editor {
         self.folding_ranges_debounce.remove(&buffer_id);
         self.pending_folding_range_requests
             .retain(|_, req| req.buffer_id != buffer_id);
+        // Drop any in-flight inlay hint requests for this buffer so
+        // their eventual responses don't repopulate the cleared overlay.
+        self.pending_inlay_hints_requests
+            .retain(|_, req| req.buffer_id != buffer_id);
 
         // Clear all LSP-related overlays for this buffer (diagnostics + inlay hints)
         let diagnostic_ns = crate::services::lsp::diagnostics::lsp_diagnostic_namespace();
@@ -935,21 +946,31 @@ impl Editor {
 
         // Request inlay hints if enabled
         if self.config.editor.enable_inlay_hints {
-            let (last_line, last_char) = self
+            let (last_line, last_char, buffer_version) = self
                 .buffers
                 .get(&buffer_id)
                 .map(|state| {
                     let line_count = state.buffer.line_count().unwrap_or(1000);
-                    (line_count.saturating_sub(1) as u32, 10000u32)
+                    (
+                        line_count.saturating_sub(1) as u32,
+                        10000u32,
+                        state.buffer.version(),
+                    )
                 })
-                .unwrap_or((999, 10000));
+                .unwrap_or((999, 10000, 0));
 
             let request_id = self.next_lsp_request_id;
             self.next_lsp_request_id += 1;
             if let Err(e) = handle.inlay_hints(request_id, uri, 0, 0, last_line, last_char) {
                 tracing::warn!("LSP inlay_hints request failed: {}", e);
             } else {
-                self.pending_inlay_hints_requests.insert(request_id);
+                self.pending_inlay_hints_requests.insert(
+                    request_id,
+                    super::InlayHintsRequest {
+                        buffer_id,
+                        version: buffer_version,
+                    },
+                );
             }
         }
 

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -794,6 +794,13 @@ impl Editor {
             }
         }
 
+        // Cancel scheduled inlay hints refresh if it targets this buffer
+        if let Some((scheduled_buf, _)) = &self.scheduled_inlay_hints_request {
+            if *scheduled_buf == buffer_id {
+                self.scheduled_inlay_hints_request = None;
+            }
+        }
+
         self.folding_ranges_in_flight.remove(&buffer_id);
         self.folding_ranges_debounce.remove(&buffer_id);
         self.pending_folding_range_requests

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1486,6 +1486,27 @@ impl Editor {
     /// Request LSP code actions at current cursor position.
     /// Sends code action requests to all eligible servers for merged results.
     pub(crate) fn request_code_actions(&mut self) -> AnyhowResult<()> {
+        // A new invocation starts a fresh batch. Cancel any previous
+        // in-flight code-action requests so their late responses are
+        // ignored (handle_code_actions_response drops responses whose
+        // request_id isn't in pending_code_actions_requests). Without
+        // this, actions from a prior cursor position would be merged
+        // into the new popup — same bug class we already avoid for
+        // completion (sinelaw/fresh#1514) and inlay hints (multi-buffer
+        // quiescent).
+        if !self.pending_code_actions_requests.is_empty() {
+            let ids: Vec<u64> = self.pending_code_actions_requests.drain().collect();
+            for request_id in ids {
+                tracing::debug!(
+                    "Canceling previous pending LSP code actions request {}",
+                    request_id
+                );
+                self.send_lsp_cancel_request(request_id);
+            }
+        }
+        self.pending_code_actions_server_names.clear();
+        self.pending_code_actions = None;
+
         // Get the current buffer and cursor position
         let cursor_pos = self.active_cursors().primary().position;
         let selection_range = self.active_cursors().primary().selection_range();
@@ -1556,8 +1577,8 @@ impl Editor {
         self.next_lsp_request_id = base_request_id + results.len() as u64;
 
         if !sent_ids.is_empty() {
-            // Clear any previously accumulated actions for a fresh merge
-            self.pending_code_actions = None;
+            // pending_code_actions was already cleared above alongside the
+            // cancel-previous-requests logic.
             self.pending_code_actions_requests.extend(sent_ids);
         }
 
@@ -3022,9 +3043,14 @@ impl Editor {
             return;
         }
 
-        // Get line count from buffer state
-        let line_count = if let Some(state) = self.buffers.get(&buffer_id) {
-            state.buffer.line_count().unwrap_or(1000)
+        // Get line count and version from buffer state — both are needed so
+        // the response handler can drop stale data if the buffer has moved
+        // on by the time hints arrive.
+        let (line_count, version) = if let Some(state) = self.buffers.get(&buffer_id) {
+            (
+                state.buffer.line_count().unwrap_or(1000),
+                state.buffer.version(),
+            )
         } else {
             return;
         };
@@ -3055,7 +3081,8 @@ impl Editor {
 
         if sent {
             self.next_lsp_request_id += 1;
-            self.pending_inlay_hints_requests.insert(request_id);
+            self.pending_inlay_hints_requests
+                .insert(request_id, super::InlayHintsRequest { buffer_id, version });
         }
     }
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -3687,6 +3687,116 @@ mod tests {
     }
 
     #[test]
+    fn test_marker_delete_after_repeat_clear_recreate() {
+        // Regression: simulates what apply_inlay_hints_to_state does on
+        // every LSP refresh — clear every virtual_text's marker then
+        // recreate markers at fresh positions. After a few rounds,
+        // delete one marker and adjust for a deletion and check the
+        // remaining markers' positions.
+        use crate::model::marker::MarkerList;
+        use crate::view::virtual_text::{VirtualTextManager, VirtualTextPosition};
+        use ratatui::style::Style;
+
+        let mut markers = MarkerList::new();
+        let mut vtexts = VirtualTextManager::new();
+
+        // Initial marker layout at six positions (same as the e2e test).
+        let positions = [200usize, 401, 602, 803, 1205, 1406];
+        let mut ids = Vec::new();
+        for &p in &positions {
+            let id = vtexts.add(
+                &mut markers,
+                p,
+                format!("hint-at-{p}"),
+                Style::default(),
+                VirtualTextPosition::BeforeChar,
+                0,
+            );
+            ids.push(id);
+        }
+
+        // Simulate a couple of clear/recreate cycles (each LSP refresh
+        // goes through this exact path via apply_inlay_hints_to_state).
+        for _ in 0..3 {
+            vtexts.clear(&mut markers);
+            let mut new_ids = Vec::new();
+            for &p in &positions {
+                let id = vtexts.add(
+                    &mut markers,
+                    p,
+                    format!("hint-at-{p}"),
+                    Style::default(),
+                    VirtualTextPosition::BeforeChar,
+                    0,
+                );
+                new_ids.push(id);
+            }
+            ids = new_ids;
+        }
+
+        // remove_in_range + adjust_for_delete equivalent to apply_delete.
+        let removed = vtexts.remove_in_range(&mut markers, 1005, 1206);
+        assert_eq!(
+            removed, 1,
+            "exactly one marker inside [1005, 1206) should be removed"
+        );
+        markers.adjust_for_delete(1005, 201);
+
+        let lookup = vtexts.build_lookup(&markers, 0, 10_000);
+        let mut positions: Vec<usize> = lookup.keys().copied().collect();
+        positions.sort();
+        assert_eq!(
+            positions,
+            vec![200, 401, 602, 803, 1205],
+            "after delete+adjust, expected marker byte positions {:?}, got {:?}",
+            vec![200, 401, 602, 803, 1205],
+            positions
+        );
+    }
+
+    #[test]
+    fn test_marker_delete_then_adjust_preserves_last_marker_position() {
+        // Regression for the user-observed flip of an end-of-line inlay
+        // hint to the start of its line after a nearby line is deleted.
+        //
+        // Scenario (real numbers from the failing e2e test): six markers
+        // at byte offsets that correspond to the `\n` of each line,
+        // then delete-one-marker (simulating remove_in_range on the
+        // line being deleted) followed by adjust_for_delete on the
+        // remaining markers.
+        //
+        // The last marker (at byte 1406) should end up at byte 1205
+        // after subtracting the 201-byte deleted range. Observed bug:
+        // it ends up at byte 1005 (the deletion start) — exactly as
+        // though the delta were applied twice.
+        use crate::model::marker::MarkerList;
+
+        let mut markers = MarkerList::new();
+        let m0 = markers.create(200, false);
+        let m1 = markers.create(401, false);
+        let m2 = markers.create(602, false);
+        let m3 = markers.create(803, false);
+        let m5 = markers.create(1205, false);
+        let m6 = markers.create(1406, false);
+
+        // Simulate remove_in_range removing marker m5 inside [1005, 1206).
+        markers.delete(m5);
+
+        // Now simulate adjust_for_delete over that range.
+        markers.adjust_for_delete(1005, 201);
+
+        assert_eq!(markers.get_position(m0), Some(200), "m0 unchanged");
+        assert_eq!(markers.get_position(m1), Some(401), "m1 unchanged");
+        assert_eq!(markers.get_position(m2), Some(602), "m2 unchanged");
+        assert_eq!(markers.get_position(m3), Some(803), "m3 unchanged");
+        assert_eq!(
+            markers.get_position(m6),
+            Some(1205),
+            "m6 must shift from 1406 to 1205 (1406 - 201), not be clamped to delete-start 1005"
+        );
+    }
+
+    #[test]
     fn test_inlay_hint_outside_deletion_survives() {
         // Anchors outside the deleted range must not be collateral damage.
         let mut state = EditorState::new(

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -3055,7 +3055,7 @@ impl Editor {
 
         if sent {
             self.next_lsp_request_id += 1;
-            self.pending_inlay_hints_request = Some(request_id);
+            self.pending_inlay_hints_requests.insert(request_id);
         }
     }
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -62,6 +62,11 @@ const SEMANTIC_TOKENS_FULL_DEBOUNCE_MS: u64 = 500;
 const SEMANTIC_TOKENS_RANGE_DEBOUNCE_MS: u64 = 50;
 const SEMANTIC_TOKENS_RANGE_PADDING_LINES: usize = 10;
 const FOLDING_RANGES_DEBOUNCE_MS: u64 = 300;
+/// Debounce window between the last buffer edit and the next inlay hints
+/// re-request. Matches the diagnostic-pull debounce to keep network chatter
+/// low while still refreshing hints after brief editing pauses (including
+/// saves, which naturally follow an edit).
+const INLAY_HINTS_DEBOUNCE_MS: u64 = 500;
 
 impl Editor {
     /// Handle LSP completion response.
@@ -1160,8 +1165,13 @@ impl Editor {
             return;
         }
 
-        // Style for inlay hints - dimmed to not distract from actual code
+        // Fallback style for inlay hints - dimmed to not distract from actual
+        // code. The actual on-screen color is resolved from the theme key
+        // below (`editor.line_number_fg`) so the hints follow the active
+        // theme. This fallback only applies when the theme doesn't define
+        // the key.
         let hint_style = Style::default().fg(Color::Rgb(128, 128, 128));
+        let hint_fg_theme_key = Some("editor.line_number_fg".to_string());
 
         for hint in hints {
             // Convert LSP position to byte offset
@@ -1200,11 +1210,13 @@ impl Editor {
             // Use the hint text as-is - spacing is handled during rendering
             let display_text = text;
 
-            state.virtual_texts.add(
+            state.virtual_texts.add_with_theme_keys(
                 &mut state.marker_list,
                 byte_offset,
                 display_text,
                 hint_style,
+                hint_fg_theme_key.clone(),
+                None,
                 position,
                 0, // Default priority
             );
@@ -2769,6 +2781,18 @@ impl Editor {
                 buffer_id,
                 std::time::Instant::now() + std::time::Duration::from_millis(1000),
             ));
+
+            // Schedule debounced inlay hints refresh. Without this, hints
+            // computed before the edit remain anchored to stale byte offsets
+            // (including inside ranges the user just deleted), and new hints
+            // that the server would now produce never arrive.
+            if self.config.editor.enable_inlay_hints {
+                self.scheduled_inlay_hints_request = Some((
+                    buffer_id,
+                    std::time::Instant::now()
+                        + std::time::Duration::from_millis(INLAY_HINTS_DEBOUNCE_MS),
+                ));
+            }
         }
     }
 
@@ -2988,11 +3012,15 @@ impl Editor {
 
     /// Request inlay hints for the active buffer (if enabled and LSP available)
     pub(crate) fn request_inlay_hints_for_active_buffer(&mut self) {
+        let buffer_id = self.active_buffer();
+        self.request_inlay_hints_for_buffer(buffer_id);
+    }
+
+    /// Request inlay hints for a specific buffer (if enabled and LSP available)
+    pub(crate) fn request_inlay_hints_for_buffer(&mut self, buffer_id: BufferId) {
         if !self.config.editor.enable_inlay_hints {
             return;
         }
-
-        let buffer_id = self.active_buffer();
 
         // Get line count from buffer state
         let line_count = if let Some(state) = self.buffers.get(&buffer_id) {
@@ -3568,6 +3596,93 @@ mod tests {
         Editor::apply_inlay_hints_to_state(&mut state, &hints);
 
         assert!(state.virtual_texts.is_empty());
+    }
+
+    #[test]
+    fn test_inlay_hint_uses_theme_key_for_foreground() {
+        // Verify that apply_inlay_hints_to_state stores the theme key so
+        // hints follow the active theme rather than a hardcoded color.
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        state.buffer = Buffer::from_str_test("ab");
+
+        if !state.buffer.is_empty() {
+            state.marker_list.adjust_for_insert(0, state.buffer.len());
+        }
+
+        let hints = vec![make_hint(0, 1, ": i32", Some(InlayHintKind::TYPE))];
+        Editor::apply_inlay_hints_to_state(&mut state, &hints);
+
+        let lookup = state
+            .virtual_texts
+            .build_lookup(&state.marker_list, 0, state.buffer.len());
+        let vtexts = lookup.get(&1).expect("expected hint at byte offset 1");
+        assert_eq!(
+            vtexts[0].fg_theme_key.as_deref(),
+            Some("editor.line_number_fg")
+        );
+        assert_eq!(vtexts[0].bg_theme_key, None);
+    }
+
+    #[test]
+    fn test_inlay_hint_removed_when_its_range_is_deleted() {
+        // Regression: deleting a range that covers the anchor byte of an
+        // inlay hint used to leave the hint visible (the marker snapped to
+        // the deletion start). apply_delete now calls
+        // virtual_texts.remove_in_range before adjusting markers, so the
+        // hint vanishes immediately. A future LSP refresh can repopulate
+        // hints elsewhere.
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        state.buffer = Buffer::from_str_test("let x = 42;");
+        state.marker_list.adjust_for_insert(0, state.buffer.len());
+
+        // Hint anchored at byte 5 (after "let x" -> rendered before '=').
+        let hints = vec![make_hint(0, 5, ": i32", Some(InlayHintKind::TYPE))];
+        Editor::apply_inlay_hints_to_state(&mut state, &hints);
+        assert_eq!(state.virtual_texts.len(), 1);
+
+        // Simulate user deleting "x = 42" (bytes 4..10, half-open) — the
+        // hint anchor at byte 5 is inside this range.
+        let removed = state
+            .virtual_texts
+            .remove_in_range(&mut state.marker_list, 4, 10);
+        assert_eq!(removed, 1, "hint inside deleted range must be removed");
+        assert!(state.virtual_texts.is_empty());
+    }
+
+    #[test]
+    fn test_inlay_hint_outside_deletion_survives() {
+        // Anchors outside the deleted range must not be collateral damage.
+        let mut state = EditorState::new(
+            80,
+            24,
+            crate::config::LARGE_FILE_THRESHOLD_BYTES as usize,
+            test_fs(),
+        );
+        state.buffer = Buffer::from_str_test("let x = 42; let y = 0;");
+        state.marker_list.adjust_for_insert(0, state.buffer.len());
+
+        let hints = vec![
+            make_hint(0, 5, ": i32", Some(InlayHintKind::TYPE)), // byte 5 - inside deletion
+            make_hint(0, 17, ": i32", Some(InlayHintKind::TYPE)), // byte 17 - outside
+        ];
+        Editor::apply_inlay_hints_to_state(&mut state, &hints);
+        assert_eq!(state.virtual_texts.len(), 2);
+
+        let removed = state
+            .virtual_texts
+            .remove_in_range(&mut state.marker_list, 4, 10);
+        assert_eq!(removed, 1);
+        assert_eq!(state.virtual_texts.len(), 1);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -585,8 +585,13 @@ pub struct Editor {
     /// Each entry is (server_name, action).
     pending_code_actions: Option<Vec<(String, lsp_types::CodeActionOrCommand)>>,
 
-    /// Pending LSP inlay hints request ID (if any)
-    pending_inlay_hints_request: Option<u64>,
+    /// Pending LSP inlay hints request IDs. Tracked as a set so concurrent
+    /// requests across multiple buffers (e.g. after a server-quiescent
+    /// notification or a batch of saves) can each be individually matched
+    /// to their response. A single `Option` here used to silently clobber
+    /// earlier requests, causing only the last-issued response to be
+    /// accepted.
+    pending_inlay_hints_requests: HashSet<u64>,
 
     /// Pending LSP folding range requests keyed by request ID
     pending_folding_range_requests: HashMap<u64, FoldingRangeRequest>,
@@ -1625,7 +1630,7 @@ impl Editor {
             pending_code_actions_requests: HashSet::new(),
             pending_code_actions_server_names: HashMap::new(),
             pending_code_actions: None,
-            pending_inlay_hints_request: None,
+            pending_inlay_hints_requests: HashSet::new(),
             pending_folding_range_requests: HashMap::new(),
             folding_ranges_in_flight: HashMap::new(),
             folding_ranges_debounce: HashMap::new(),

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -259,6 +259,12 @@ struct FoldingRangeRequest {
     version: u64,
 }
 
+#[derive(Clone, Debug)]
+struct InlayHintsRequest {
+    buffer_id: BufferId,
+    version: u64,
+}
+
 /// State for the dabbrev cycling session (Alt+/ style).
 ///
 /// When the user presses Alt+/ repeatedly, we cycle through candidates
@@ -585,13 +591,17 @@ pub struct Editor {
     /// Each entry is (server_name, action).
     pending_code_actions: Option<Vec<(String, lsp_types::CodeActionOrCommand)>>,
 
-    /// Pending LSP inlay hints request IDs. Tracked as a set so concurrent
-    /// requests across multiple buffers (e.g. after a server-quiescent
-    /// notification or a batch of saves) can each be individually matched
-    /// to their response. A single `Option` here used to silently clobber
-    /// earlier requests, causing only the last-issued response to be
-    /// accepted.
-    pending_inlay_hints_requests: HashSet<u64>,
+    /// Pending LSP inlay hints requests keyed by request id. Each entry
+    /// carries the originating buffer and the buffer version at dispatch
+    /// time so:
+    ///   * Responses for multiple concurrent buffer requests (quiescent,
+    ///     manual restart, batched saves) are each accepted individually
+    ///     instead of clobbering a single shared slot.
+    ///   * Responses that race behind a local edit (buffer version moved
+    ///     past what we asked about) are dropped rather than applied at
+    ///     the wrong offsets. Same pattern as `pending_folding_range_requests`
+    ///     and `pending_semantic_token_requests`.
+    pending_inlay_hints_requests: HashMap<u64, InlayHintsRequest>,
 
     /// Pending LSP folding range requests keyed by request ID
     pending_folding_range_requests: HashMap<u64, FoldingRangeRequest>,
@@ -1630,7 +1640,7 @@ impl Editor {
             pending_code_actions_requests: HashSet::new(),
             pending_code_actions_server_names: HashMap::new(),
             pending_code_actions: None,
-            pending_inlay_hints_requests: HashSet::new(),
+            pending_inlay_hints_requests: HashMap::new(),
             pending_folding_range_requests: HashMap::new(),
             folding_ranges_in_flight: HashMap::new(),
             folding_ranges_debounce: HashMap::new(),

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -99,6 +99,7 @@ pub fn editor_tick(
         needs_render = true;
     }
     editor.check_diagnostic_pull_timer();
+    editor.check_inlay_hints_timer();
     if editor.check_warning_log() {
         needs_render = true;
     }
@@ -729,6 +730,10 @@ pub struct Editor {
     /// Scheduled diagnostic pull time per buffer (debounced after didChange)
     /// When set, diagnostics will be re-pulled when this instant is reached
     scheduled_diagnostic_pull: Option<(BufferId, Instant)>,
+
+    /// Scheduled inlay hints refresh time per buffer (debounced after didChange)
+    /// When set, inlay hints will be re-requested when this instant is reached
+    scheduled_inlay_hints_request: Option<(BufferId, Instant)>,
 
     /// Stored LSP diagnostics per URI, per server (push model - publishDiagnostics)
     /// Outer key: URI string, Inner key: server name
@@ -1679,6 +1684,7 @@ impl Editor {
             lsp_log_messages: Vec::new(),
             diagnostic_result_ids: HashMap::new(),
             scheduled_diagnostic_pull: None,
+            scheduled_inlay_hints_request: None,
             stored_push_diagnostics: HashMap::new(),
             stored_pull_diagnostics: HashMap::new(),
             stored_diagnostics: HashMap::new(),
@@ -2439,6 +2445,28 @@ impl Editor {
         }
 
         false // no immediate redraw needed; diagnostics arrive asynchronously
+    }
+
+    /// Check if the inlay hints refresh timer has expired and trigger a
+    /// re-request if so.
+    ///
+    /// Debounced inlay hints refresh after document changes — waits
+    /// INLAY_HINTS_DEBOUNCE_MS after the last edit before asking the LSP
+    /// server for fresh hints. Without this, stale hints persist (including
+    /// hints anchored inside ranges the user has since deleted) because we
+    /// only requested hints at didOpen / toggle time.
+    pub fn check_inlay_hints_timer(&mut self) -> bool {
+        let Some((buffer_id, trigger_time)) = self.scheduled_inlay_hints_request else {
+            return false;
+        };
+
+        if Instant::now() < trigger_time {
+            return false;
+        }
+
+        self.scheduled_inlay_hints_request = None;
+        self.request_inlay_hints_for_buffer(buffer_id);
+        false // no immediate redraw; hints arrive asynchronously
     }
 
     /// Check if completion trigger timer has expired and trigger completion if so

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2059,7 +2059,6 @@ impl Editor {
                         if self.config.editor.enable_inlay_hints {
                             let request_id = self.next_lsp_request_id;
                             self.next_lsp_request_id += 1;
-                            self.pending_inlay_hints_request = Some(request_id);
 
                             let last_line = line_count.saturating_sub(1) as u32;
                             let last_char = 10000u32;
@@ -2076,7 +2075,8 @@ impl Editor {
                                     "Failed to request inlay hints (server may not support): {}",
                                     e
                                 );
-                                self.pending_inlay_hints_request = None;
+                            } else {
+                                self.pending_inlay_hints_requests.insert(request_id);
                             }
                         }
                     }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2004,20 +2004,21 @@ impl Editor {
             );
             return;
         }
-        let (text, line_count) = if let Some(state) = self.buffers.get(&active_buffer) {
-            let text = match state.buffer.to_string() {
-                Some(t) => t,
-                None => {
-                    tracing::debug!("notify_lsp_current_file_opened: buffer not fully loaded");
-                    return;
-                }
+        let (text, line_count, buffer_version) =
+            if let Some(state) = self.buffers.get(&active_buffer) {
+                let text = match state.buffer.to_string() {
+                    Some(t) => t,
+                    None => {
+                        tracing::debug!("notify_lsp_current_file_opened: buffer not fully loaded");
+                        return;
+                    }
+                };
+                let line_count = state.buffer.line_count().unwrap_or(1000);
+                (text, line_count, state.buffer.version())
+            } else {
+                tracing::debug!("notify_lsp_current_file_opened: no buffer state");
+                return;
             };
-            let line_count = state.buffer.line_count().unwrap_or(1000);
-            (text, line_count)
-        } else {
-            tracing::debug!("notify_lsp_current_file_opened: no buffer state");
-            return;
-        };
 
         // Send didOpen to all LSP handles (use force_spawn to ensure they're started)
         if let Some(lsp) = &mut self.lsp {
@@ -2076,7 +2077,13 @@ impl Editor {
                                     e
                                 );
                             } else {
-                                self.pending_inlay_hints_requests.insert(request_id);
+                                self.pending_inlay_hints_requests.insert(
+                                    request_id,
+                                    super::InlayHintsRequest {
+                                        buffer_id: active_buffer,
+                                        version: buffer_version,
+                                    },
+                                );
                             }
                         }
                     }

--- a/crates/fresh-editor/src/model/marker.rs
+++ b/crates/fresh-editor/src/model/marker.rs
@@ -650,6 +650,113 @@ mod tests {
                     }
                 }
             }
+
+            /// Shadow-model property test: for every sequence of
+            /// create / delete / adjust_for_insert / adjust_for_delete
+            /// operations, the positions reported by MarkerList for
+            /// each still-live marker must match the positions a naïve
+            /// `Vec<(MarkerId, usize)>` would compute by independently
+            /// shifting/clamping on each edit.
+            ///
+            /// This catches bugs where the interval-tree's own
+            /// bookkeeping (e.g. lazy_delta propagation, BST-delete
+            /// node swaps, marker_map staleness) diverges from the
+            /// straightforward "markers are points that slide with
+            /// the buffer" semantics. The inlay-hint-jumps-to-start
+            /// regression on line delete was exactly this kind of
+            /// divergence, and was invisible to every other invariant
+            /// check in this file.
+            #[test]
+            fn prop_shadow_model_matches_tree(
+                initial_positions in prop::collection::vec(0..1000usize, 1..20),
+                ops in prop::collection::vec(arb_edit_op(1000), 1..30),
+                delete_indices in prop::collection::vec(0..20usize, 0..5),
+            ) {
+                let mut list = MarkerList::new();
+
+                let mut unique_positions: Vec<usize> = initial_positions;
+                unique_positions.sort_unstable();
+                unique_positions.dedup();
+
+                // Shadow: Vec<(MarkerId, Option<usize>)>. None means deleted.
+                let mut shadow: Vec<(MarkerId, Option<usize>)> = Vec::new();
+                for (i, &p) in unique_positions.iter().enumerate() {
+                    let id = list.create(p, i % 2 == 0);
+                    shadow.push((id, Some(p)));
+                }
+
+                // Delete some markers (by shadow index modulo len).
+                for idx in delete_indices {
+                    if shadow.is_empty() {
+                        break;
+                    }
+                    let i = idx % shadow.len();
+                    if let (id, Some(_)) = shadow[i] {
+                        list.delete(id);
+                        shadow[i].1 = None;
+                    }
+                }
+
+                // Apply edits to both the tree and the shadow.
+                for op in ops {
+                    match op {
+                        EditOp::Insert { position, length } => {
+                            list.adjust_for_insert(position, length);
+                            for (_id, pos) in shadow.iter_mut() {
+                                if let Some(p) = pos {
+                                    if *p >= position {
+                                        *p += length;
+                                    }
+                                }
+                            }
+                        }
+                        EditOp::Delete { position, length } => {
+                            if length == 0 {
+                                continue;
+                            }
+                            list.adjust_for_delete(position, length);
+                            for (_id, pos) in shadow.iter_mut() {
+                                if let Some(p) = pos {
+                                    // Markers inside the deleted range
+                                    // clamp to the deletion start in
+                                    // MarkerList's semantics (see
+                                    // adjust_recursive's `.max(pos)`),
+                                    // so mirror that in the shadow.
+                                    if *p >= position + length {
+                                        *p -= length;
+                                    } else if *p > position {
+                                        *p = position;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Every live marker's tree position must match its
+                    // shadow position after every operation.
+                    for (id, shadow_pos) in &shadow {
+                        match shadow_pos {
+                            Some(expected) => {
+                                let actual = list.get_position(*id);
+                                prop_assert_eq!(
+                                    actual,
+                                    Some(*expected),
+                                    "marker {:?} expected at {} but tree says {:?}",
+                                    id,
+                                    expected,
+                                    actual
+                                );
+                            }
+                            None => {
+                                // Deleted markers: get_position may
+                                // return None OR the tree may leak the
+                                // underlying storage — accept either,
+                                // but never a stale live position.
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/fresh-editor/src/model/marker_tree.rs
+++ b/crates/fresh-editor/src/model/marker_tree.rs
@@ -262,7 +262,7 @@ impl IntervalTree {
             return false;
         }
 
-        self.root = Self::delete_recursive(self.root.take(), start, id);
+        self.root = Self::delete_recursive(self.root.take(), start, id, &mut self.marker_map);
 
         self.marker_map.remove(&id).is_some()
     }
@@ -373,7 +373,12 @@ impl IntervalTree {
     }
 
     /// Recursive helper for delete
-    fn delete_recursive(root: NodePtr, start: u64, id: MarkerId) -> NodePtr {
+    fn delete_recursive(
+        root: NodePtr,
+        start: u64,
+        id: MarkerId,
+        marker_map: &mut HashMap<MarkerId, Rc<RefCell<Node>>>,
+    ) -> NodePtr {
         // Remove unnecessary 'mut'
         let root = root?;
 
@@ -384,20 +389,23 @@ impl IntervalTree {
 
         match start.cmp(&root_start) {
             Ordering::Less => {
-                root_mut.left = Self::delete_recursive(root_mut.left.take(), start, id);
+                root_mut.left = Self::delete_recursive(root_mut.left.take(), start, id, marker_map);
             }
             Ordering::Greater => {
-                root_mut.right = Self::delete_recursive(root_mut.right.take(), start, id);
+                root_mut.right =
+                    Self::delete_recursive(root_mut.right.take(), start, id, marker_map);
             }
             Ordering::Equal => match id.cmp(&root_id) {
                 Ordering::Less => {
-                    root_mut.left = Self::delete_recursive(root_mut.left.take(), start, id);
+                    root_mut.left =
+                        Self::delete_recursive(root_mut.left.take(), start, id, marker_map);
                 }
                 Ordering::Greater => {
-                    root_mut.right = Self::delete_recursive(root_mut.right.take(), start, id);
+                    root_mut.right =
+                        Self::delete_recursive(root_mut.right.take(), start, id, marker_map);
                 }
                 Ordering::Equal => {
-                    return Self::perform_node_deletion(root_mut, Rc::clone(&root));
+                    return Self::perform_node_deletion(root_mut, Rc::clone(&root), marker_map);
                 }
             },
         }
@@ -408,7 +416,11 @@ impl IntervalTree {
     }
 
     /// Handles the actual structural changes for deletion.
-    fn perform_node_deletion(mut node: RefMut<Node>, node_rc: Rc<RefCell<Node>>) -> NodePtr {
+    fn perform_node_deletion(
+        mut node: RefMut<Node>,
+        node_rc: Rc<RefCell<Node>>,
+        marker_map: &mut HashMap<MarkerId, Rc<RefCell<Node>>>,
+    ) -> NodePtr {
         if node.left.is_none() {
             let right = node.right.take();
             if let Some(ref r) = right {
@@ -424,14 +436,35 @@ impl IntervalTree {
         } else {
             let successor_rc = Self::min_node(node.right.as_ref().unwrap());
 
-            let (successor_start, successor_id) = {
+            let (_successor_start, successor_id) = {
                 let s = successor_rc.borrow();
                 (s.marker.interval.start, s.marker.id)
             };
 
+            // Capture the original node's marker identity BEFORE we swap
+            // it away. After the swap `successor_rc` carries this
+            // marker, and that's what delete_recursive must now search
+            // for in the right subtree to remove it.
+            let (orig_start, orig_id) = (node.marker.interval.start, node.marker.id);
+
             mem::swap(&mut node.marker, &mut successor_rc.borrow_mut().marker);
 
-            node.right = Self::delete_recursive(node.right.take(), successor_start, successor_id);
+            // `node_rc` now carries the successor's marker, so external
+            // references (marker_map) to `successor_id` must point here
+            // instead of at the old successor node (which is about to
+            // be removed). Without this update, `get_position(successor_id)`
+            // would keep resolving via the orphaned successor node and
+            // return stale data — the root cause of end-of-line inlay
+            // hints flipping to the start of their line after a nearby
+            // delete, because the orphan misses all subsequent
+            // adjust_for_edit calls.
+            marker_map.insert(successor_id, Rc::clone(&node_rc));
+
+            // Remove the old successor node. After the swap it holds
+            // the original marker (orig_start, orig_id), so search by
+            // THAT key — not by (successor_start, successor_id) which
+            // no longer corresponds to any node in the subtree.
+            node.right = Self::delete_recursive(node.right.take(), orig_start, orig_id, marker_map);
 
             drop(node);
             Node::update_stats(&node_rc);

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -468,6 +468,14 @@ impl EditorState {
             0
         };
 
+        // Drop virtual texts whose anchors are being erased. This is what
+        // makes inlay hints disappear immediately when the range containing
+        // them is deleted; without this the marker would just clamp to
+        // range.start and the hint would linger at the wrong position until
+        // the next LSP refresh.
+        self.virtual_texts
+            .remove_in_range(&mut self.marker_list, range.start, range.end);
+
         // CRITICAL: Adjust markers BEFORE modifying buffer
         self.marker_list.adjust_for_delete(range.start, len);
         self.margins.adjust_for_delete(range.start, len);

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -194,6 +194,53 @@ impl VirtualTextManager {
         id
     }
 
+    /// Add an inline virtual text entry whose foreground/background colours
+    /// are stored as theme keys (resolved at render time so theme changes
+    /// apply live).
+    ///
+    /// `style` is the fallback used when a theme key fails to resolve;
+    /// `fg_theme_key` / `bg_theme_key` are the keys passed to
+    /// `Theme::resolve_theme_key` (e.g. `"editor.line_number_fg"`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_with_theme_keys(
+        &mut self,
+        marker_list: &mut MarkerList,
+        position: usize,
+        text: String,
+        style: Style,
+        fg_theme_key: Option<String>,
+        bg_theme_key: Option<String>,
+        vtext_position: VirtualTextPosition,
+        priority: i32,
+    ) -> VirtualTextId {
+        debug_assert!(
+            vtext_position.is_inline(),
+            "add_with_theme_keys requires BeforeChar or AfterChar"
+        );
+
+        let marker_id = marker_list.create(position, false);
+
+        let id = VirtualTextId(self.next_id);
+        self.next_id += 1;
+
+        self.texts.insert(
+            id,
+            VirtualText {
+                marker_id,
+                text,
+                style,
+                fg_theme_key,
+                bg_theme_key,
+                position: vtext_position,
+                priority,
+                string_id: None,
+                namespace: None,
+            },
+        );
+
+        id
+    }
+
     /// Add a virtual text entry with a string identifier
     ///
     /// This is useful for plugins that need to track and remove virtual texts by name.
@@ -379,6 +426,49 @@ impl VirtualTextManager {
             marker_list.delete(vtext.marker_id);
         }
         self.texts.clear();
+    }
+
+    /// Remove all virtual text entries whose marker position lies within the
+    /// half-open byte range `[start, end)`.
+    ///
+    /// This must be called BEFORE the underlying buffer/marker list is
+    /// adjusted for a deletion, otherwise the affected markers will already
+    /// have been clamped to the deletion start and appear to fall outside
+    /// the range. Used by the editor to drop stale inlay hints whose
+    /// anchors have been erased by the user (a fresh LSP response will
+    /// repopulate them if still applicable).
+    ///
+    /// Returns the number of entries removed.
+    pub fn remove_in_range(
+        &mut self,
+        marker_list: &mut MarkerList,
+        start: usize,
+        end: usize,
+    ) -> usize {
+        if start >= end {
+            return 0;
+        }
+
+        let to_remove: Vec<VirtualTextId> = self
+            .texts
+            .iter()
+            .filter_map(|(id, vtext)| {
+                let pos = marker_list.get_position(vtext.marker_id)?;
+                if pos >= start && pos < end {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        let count = to_remove.len();
+        for id in to_remove {
+            if let Some(vtext) = self.texts.remove(&id) {
+                marker_list.delete(vtext.marker_id);
+            }
+        }
+        count
     }
 
     /// Get the number of virtual text entries

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -8703,6 +8703,257 @@ done
     target_os = "windows",
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
+fn test_inlay_hints_stay_at_end_of_line_after_delete_below() -> anyhow::Result<()> {
+    // Regression: when deleting a line (Ctrl+Shift+K), inlay hints on
+    // lines ABOVE the deleted line were observed jumping from the END
+    // of their lines (where the LSP placed them) to the START of their
+    // lines. This test reproduces the scenario with a fake LSP that
+    // returns one end-of-line hint per non-empty line, keyed off the
+    // buffer content it tracks via didOpen/didChange.
+    use crate::common::harness::HarnessOptions;
+
+    let temp_dir = tempfile::tempdir()?;
+
+    // Fake LSP: on every inlayHint request, return hints at the end of
+    // lines 0..=6, with labels that identify the line number. We don't
+    // parse the buffer — we just emit hints at high character columns
+    // so they land at end-of-line after position clamping. If the
+    // client later clears line 4 we won't "know" (we still emit 7
+    // hints), but the editor will simply drop the hint whose line
+    // index exceeds the current buffer's line count, which is fine:
+    // we're testing what happens to the hints that SHOULD still be
+    // present (lines 0,1,2,3,5,6 relative to the original content).
+    let script = r#"#!/bin/bash
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"inlayHintProvider":true}}}'
+            ;;
+        "initialized")
+            ;;
+        "textDocument/inlayHint")
+            # One hint per line 0..6 (skipping line 4), positioned at
+            # character=200 which is the exact length of every line
+            # (each source line is padded to 200 chars). This matches
+            # how real servers like rust-analyzer place end-of-line
+            # hints: at the column *just before* the newline.
+            hints='[{"position":{"line":0,"character":200},"label":"<EOL-L0>","kind":1},{"position":{"line":1,"character":200},"label":"<EOL-L1>","kind":1},{"position":{"line":2,"character":200},"label":"<EOL-L2>","kind":1},{"position":{"line":3,"character":200},"label":"<EOL-L3>","kind":1},{"position":{"line":5,"character":200},"label":"<EOL-L5>","kind":1},{"position":{"line":6,"character":200},"label":"<EOL-L6>","kind":1}]'
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":'"$hints"'}'
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+    esac
+done
+"#;
+
+    let script_path = temp_dir.path().join("fake_lsp_eol_hints.sh");
+    std::fs::write(&script_path, script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms)?;
+    }
+
+    // Each line has a distinctive word so the hint label identifies
+    // it on screen, padded out with junk so every line is hundreds of
+    // characters long (the user reported the bug on source code lines
+    // of typical length; short lines would mask it by happening to
+    // fit alongside a misrendered hint).
+    let test_file = temp_dir.path().join("test.c");
+    let mut content = String::new();
+    for word in &[
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+    ] {
+        content.push_str(word);
+        content.push(' ');
+        // pad to ~200 characters with a repeating filler
+        let pad = "x".repeat(200usize.saturating_sub(word.len() + 1));
+        content.push_str(&pad);
+        content.push('\n');
+    }
+    std::fs::write(&test_file, &content)?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_inlay_hints = true;
+    config.lsp.insert(
+        "c".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    // Narrow terminal forces long lines to wrap across multiple view
+    // rows — the user-reported bug only manifests in that case. Each
+    // source line is ~200 chars and the viewport is 100 wide, so every
+    // line wraps.
+    let mut harness = EditorTestHarness::create(
+        100,
+        40,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // `check_hint_position` asserts that the hint for `word`/`label`
+    // renders AFTER the word on screen, regardless of wrapping:
+    //   * if both land on the same terminal row, word must come before
+    //     label;
+    //   * if they land on different rows, the word's row must precede
+    //     the label's row (the line wraps, label sits on a later row
+    //     near the end).
+    // With the bug we're hunting, the label would render at the START
+    // of the first wrapped row of the source line — i.e. before the
+    // word on the same row — which both checks reject.
+    let check_hint_position = |screen: &str, word: &str, label: &str, tag: &str| {
+        let rows: Vec<&str> = screen.lines().collect();
+        let word_row = rows
+            .iter()
+            .position(|l| l.contains(word))
+            .unwrap_or_else(|| panic!("[{tag}] word {word:?} not on screen:\n{screen}"));
+        let label_row = rows
+            .iter()
+            .position(|l| l.contains(label))
+            .unwrap_or_else(|| panic!("[{tag}] label {label:?} not on screen:\n{screen}"));
+        if word_row == label_row {
+            let row = rows[word_row];
+            let w = row.find(word).unwrap();
+            let l = row.find(label).unwrap();
+            assert!(
+                w < l,
+                "[{tag}] same row: word {word:?} at col {w} must precede hint {label:?} at col {l}. Row: {row:?}"
+            );
+        } else {
+            assert!(
+                word_row < label_row,
+                "[{tag}] word {word:?} on row {word_row} must come before hint {label:?} on row {label_row}.\nScreen:\n{screen}"
+            );
+        }
+    };
+
+    // The fake LSP skips line 4 (echo), so we don't expect <EOL-L4>.
+    // Wait until the first and last of our expected hint labels land.
+    harness.wait_for_screen_contains("<EOL-L0>")?;
+    harness.wait_for_screen_contains("<EOL-L6>")?;
+
+    let screen_before = harness.screen_to_string();
+    eprintln!("=== Before delete ===\n{}", screen_before);
+
+    // Sanity: before the delete, hint 0 follows "alpha".
+    check_hint_position(&screen_before, "alpha", "<EOL-L0>", "before-delete");
+
+    // Put cursor on line 2 (bravo) — with wrapping enabled, Down
+    // navigates view rows, so 4 presses traverse alpha's four wrapped
+    // rows and land on bravo. We delete bravo to trigger the delete
+    // path under test.
+    harness.send_key(KeyCode::Home, KeyModifiers::CONTROL)?;
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    }
+    harness.render()?;
+
+    // Invoke "Delete Line" via the command palette so we don't depend
+    // on any particular keybinding.
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_screen_contains(">command")?;
+    harness.type_text("Delete Line")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.render()?;
+
+    // The screen IMMEDIATELY after delete (before the LSP refresh) is
+    // what the user sees and complains about — hints on lines below
+    // the deletion appear at the start of their wrapped line instead
+    // of the end. The shifted old markers encode this mis-position
+    // directly in the marker tree, so even `save` doesn't restore
+    // them. Check that the hint for every surviving line still
+    // renders AFTER its line's text.
+    harness.wait_until(|h| {
+        h.get_buffer_content()
+            .map(|c| !c.contains("bravo"))
+            .unwrap_or(false)
+    })?;
+
+    let screen_after_delete = harness.screen_to_string();
+    eprintln!(
+        "=== After delete (pre-refresh) ===\n{}",
+        screen_after_delete
+    );
+
+    // Expected: labels L0, L2, L3 (line 4 echo skipped by fake LSP,
+    // L1 was on the deleted bravo so it's gone), L5, L6, each at end
+    // of their surviving line.
+    for (word, label) in [
+        ("alpha", "<EOL-L0>"),
+        ("charlie", "<EOL-L2>"),
+        ("delta", "<EOL-L3>"),
+        ("foxtrot", "<EOL-L5>"),
+        ("golf", "<EOL-L6>"),
+    ] {
+        check_hint_position(
+            &screen_after_delete,
+            word,
+            label,
+            &format!("post-delete-{word}"),
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
 fn test_comment_does_not_displace_inlay_hints() -> anyhow::Result<()> {
     use crate::common::harness::HarnessOptions;
 

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -3754,6 +3754,64 @@ fn test_inlay_hints_position_tracking() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test: deleting a text range that contains an inlay hint's
+/// anchor must remove the hint from screen immediately. Without the fix
+/// the hint lingered because the underlying marker just snapped to the
+/// deletion start, leaving stale virtual text visible until the next LSP
+/// refresh (which itself wasn't happening — see the debounced re-request
+/// wired in alongside this fix).
+#[test]
+fn test_inlay_hint_cleared_when_range_deleted() -> anyhow::Result<()> {
+    use fresh::view::virtual_text::VirtualTextPosition;
+    use ratatui::style::{Color, Style};
+
+    let mut harness = EditorTestHarness::new(80, 24)?;
+
+    // Seed buffer content.
+    harness.type_text("let x = 5;")?;
+    harness.render()?;
+
+    // Inject an inlay hint at byte 5 (between "let x" and " = 5;").
+    let state = harness.editor_mut().active_state_mut();
+    let buf_len = state.buffer.len();
+    if buf_len > 0 {
+        state.marker_list.adjust_for_insert(0, buf_len);
+    }
+    let hint_style = Style::default().fg(Color::Rgb(128, 128, 128));
+    state.virtual_texts.add(
+        &mut state.marker_list,
+        5,
+        ": i32".to_string(),
+        hint_style,
+        VirtualTextPosition::AfterChar,
+        0,
+    );
+    harness.render()?;
+
+    let screen_before = harness.screen_to_string();
+    assert!(
+        screen_before.contains(": i32"),
+        "hint should be visible before deletion, screen:\n{}",
+        screen_before
+    );
+
+    // Select the entire buffer content and delete it. Every hint anchor
+    // byte is inside the selection, so every hint must be removed.
+    harness.send_key(KeyCode::Home, KeyModifiers::CONTROL)?;
+    harness.send_key(KeyCode::End, KeyModifiers::CONTROL | KeyModifiers::SHIFT)?;
+    harness.send_key(KeyCode::Delete, KeyModifiers::NONE)?;
+    harness.render()?;
+
+    let screen_after = harness.screen_to_string();
+    assert!(
+        !screen_after.contains(": i32"),
+        "inlay hint should vanish once its anchor range is deleted, screen:\n{}",
+        screen_after
+    );
+
+    Ok(())
+}
+
 /// Test that stopped LSP server does not auto-restart when typing
 ///
 /// This test verifies that when a user explicitly stops an LSP server via the "stop lsp"

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -8560,6 +8560,149 @@ log("STOPPED")
     target_os = "windows",
     ignore = "FakeLspServer uses a Bash script which is not available on Windows"
 )]
+fn test_inlay_hints_requested_for_every_open_buffer() -> anyhow::Result<()> {
+    // Regression: when the LSP started with multiple buffers already open,
+    // earlier in-flight inlay-hint responses were silently dropped because
+    // the editor only tracked a single pending request id. Only the
+    // last-issued buffer's response was accepted — the others stayed blank
+    // until the user edited them. This test opens two files, waits for
+    // the server to reply to both, and asserts the hint text appears on
+    // each file's tab.
+    use crate::common::harness::HarnessOptions;
+
+    let temp_dir = tempfile::tempdir()?;
+
+    // Fake LSP that tags each didOpen'd URI with a unique hint derived
+    // from the file's basename. It does not parse the buffer — it just
+    // echoes back a hint for every textDocument/inlayHint request so we
+    // can tell which file received a hint on screen.
+    let script = r#"#!/bin/bash
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"inlayHintProvider":true}}}'
+            ;;
+        "initialized")
+            ;;
+        "textDocument/inlayHint")
+            # Extract the request URI, derive a distinct label from the
+            # filename basename (without extension). Return ONE hint at
+            # line 0, col 0 so the editor renders it at the start of the
+            # first line of whichever buffer asked.
+            uri=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            basename=${uri##*/}
+            label="[${basename%.*}]"
+            hints='[{"position":{"line":0,"character":0},"label":"'"$label"'","kind":1}]'
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":'"$hints"'}'
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+    esac
+done
+"#;
+
+    let script_path = temp_dir.path().join("fake_lsp_multi.sh");
+    std::fs::write(&script_path, script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms)?;
+    }
+
+    // Two distinct C files — we expect hints for BOTH buffers.
+    let file_alpha = temp_dir.path().join("alpha.c");
+    let file_beta = temp_dir.path().join("beta.c");
+    std::fs::write(&file_alpha, "int x = 1;\n")?;
+    std::fs::write(&file_beta, "int y = 2;\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.editor.enable_inlay_hints = true;
+    config.lsp.insert(
+        "c".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    // Open both files (both tabs live concurrently). The hint for the
+    // non-active buffer would be dropped before the fix.
+    harness.open_file(&file_alpha)?;
+    harness.open_file(&file_beta)?;
+    harness.render()?;
+
+    // Wait for the hint of the CURRENTLY visible (beta) buffer.
+    harness.wait_for_screen_contains("[beta]")?;
+
+    // Now switch to alpha — its hint must also be populated. Before the
+    // fix, alpha's response was discarded as "stale" so this would never
+    // appear.
+    harness.open_file(&file_alpha)?;
+    harness.render()?;
+    harness.wait_for_screen_contains("[alpha]")?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
 fn test_comment_does_not_displace_inlay_hints() -> anyhow::Result<()> {
     use crate::common::harness::HarnessOptions;
 

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -8921,10 +8921,6 @@ done
     })?;
 
     let screen_after_delete = harness.screen_to_string();
-    eprintln!(
-        "=== After delete (pre-refresh) ===\n{}",
-        screen_after_delete
-    );
 
     // The user-reported bug: an inlay hint that was positioned right
     // at the end of its line (e.g. a closing-brace function-name hint

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -8891,14 +8891,19 @@ done
     // Sanity: before the delete, hint 0 follows "alpha".
     check_hint_position(&screen_before, "alpha", "<EOL-L0>", "before-delete");
 
-    // Put cursor on line 2 (bravo) — with wrapping enabled, Down
-    // navigates view rows, so 4 presses traverse alpha's four wrapped
-    // rows and land on bravo. We delete bravo to trigger the delete
-    // path under test.
-    harness.send_key(KeyCode::Home, KeyModifiers::CONTROL)?;
-    for _ in 0..4 {
-        harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
-    }
+    // The user-reported bug is about hints on lines ABOVE the delete.
+    // Move cursor down onto a line FAR below the hints we'll check —
+    // "foxtrot" (6th source line). With wrapping, every source line
+    // takes 4 view rows, so 5*4 = 20 Down presses should land us on
+    // foxtrot. We use Goto Line via the palette instead to be robust
+    // to exact wrap math.
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_screen_contains(">command")?;
+    // Remove the ">" prefix so we can type a line number (Quick Open
+    // uses `:N` for line jump after backspacing the command prefix).
+    harness.send_key(KeyCode::Backspace, KeyModifiers::NONE)?;
+    harness.type_text(":6")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
     harness.render()?;
 
     // Invoke "Delete Line" via the command palette so we don't depend
@@ -8909,16 +8914,9 @@ done
     harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
     harness.render()?;
 
-    // The screen IMMEDIATELY after delete (before the LSP refresh) is
-    // what the user sees and complains about — hints on lines below
-    // the deletion appear at the start of their wrapped line instead
-    // of the end. The shifted old markers encode this mis-position
-    // directly in the marker tree, so even `save` doesn't restore
-    // them. Check that the hint for every surviving line still
-    // renders AFTER its line's text.
     harness.wait_until(|h| {
         h.get_buffer_content()
-            .map(|c| !c.contains("bravo"))
+            .map(|c| !c.contains("foxtrot"))
             .unwrap_or(false)
     })?;
 
@@ -8928,14 +8926,22 @@ done
         screen_after_delete
     );
 
-    // Expected: labels L0, L2, L3 (line 4 echo skipped by fake LSP,
-    // L1 was on the deleted bravo so it's gone), L5, L6, each at end
-    // of their surviving line.
+    // The user-reported bug: an inlay hint that was positioned right
+    // at the end of its line (e.g. a closing-brace function-name hint
+    // in Rust) flips from `} <hint-name>` to `<hint-name> }` after a
+    // nearby line is deleted. Each affected hint is anchored to the
+    // trailing \n of its source line — i.e. rendered BeforeChar on
+    // the \n byte — and its byte offset should either stay put (for
+    // lines above the delete) or shift by exactly the deleted byte
+    // count (for lines below).
+    //
+    // Check each surviving end-of-line hint STILL renders after its
+    // line's distinguishing word.
     for (word, label) in [
         ("alpha", "<EOL-L0>"),
+        ("bravo", "<EOL-L1>"),
         ("charlie", "<EOL-L2>"),
         ("delta", "<EOL-L3>"),
-        ("foxtrot", "<EOL-L5>"),
         ("golf", "<EOL-L6>"),
     ] {
         check_hint_position(


### PR DESCRIPTION
## Summary
This PR fixes inlay hints to properly refresh after buffer edits and immediately disappear when their anchor ranges are deleted. Previously, hints would persist with stale positions until manually toggled or the buffer was reopened.

## Key Changes

- **Debounced inlay hints refresh**: Added `INLAY_HINTS_DEBOUNCE_MS` constant (500ms) and scheduled debounced re-requests after buffer edits via `scheduled_inlay_hints_request`, matching the diagnostic pull debounce to minimize network chatter while keeping hints fresh after editing pauses.

- **Immediate hint removal on deletion**: Implemented `VirtualTextManager::remove_in_range()` to remove virtual text entries whose markers fall within a deleted byte range. This is called in `EditorState::apply_delete()` BEFORE marker adjustment, ensuring hints anchored in deleted ranges vanish immediately rather than snapping to the deletion start.

- **Theme-aware hint styling**: Added `VirtualTextManager::add_with_theme_keys()` to support storing foreground/background theme keys on virtual text entries. Inlay hints now use `"editor.line_number_fg"` as their theme key, allowing hints to follow active theme changes instead of using a hardcoded RGB color.

- **Refactored hint request logic**: Extracted `request_inlay_hints_for_buffer()` from `request_inlay_hints_for_active_buffer()` to support requesting hints for specific buffers, enabling the debounced refresh mechanism.

- **Timer integration**: Added `check_inlay_hints_timer()` to the main editor tick loop to process expired inlay hints refresh timers, and integrated timer cancellation into buffer close logic.

## Implementation Details

- The `remove_in_range()` method must be called before `MarkerList::adjust_for_delete()` because markers clamp to the deletion start during adjustment, which would cause them to appear outside the deleted range.
- Inlay hints refresh is only scheduled if `config.editor.enable_inlay_hints` is true, avoiding unnecessary work when hints are disabled.
- Added comprehensive unit tests covering theme key storage, hint removal within deleted ranges, and survival of hints outside deletion boundaries.
- Added an e2e regression test verifying hints disappear when their anchor range is deleted.

https://claude.ai/code/session_01TwZ7mV1HwpKqzGqvP2wDVe