### PR TITLE
Treat Shift+Backspace the same as plain Backspace

### DIFF
--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -9,6 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// Terminals vary in how they report certain keys:
 /// - BackTab already encodes Shift+Tab, but some terminals also set SHIFT —
 ///   strip the redundant SHIFT so bindings defined as "BackTab" match.
+/// - Shift+Backspace has no distinct semantics from plain Backspace — strip
+///   the redundant SHIFT so bindings defined as "Backspace" match both.
 /// - Uppercase letters may arrive as `Char('P')` + SHIFT (real Shift press)
 ///   or `Char('A')` without SHIFT (CapsLock on, kitty keyboard protocol).
 ///   In both cases, lowercase the character and preserve the existing
@@ -16,6 +18,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///   while Shift+P still matches the `Shift+P` binding.
 fn normalize_key(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
     if code == KeyCode::BackTab {
+        return (code, modifiers.difference(KeyModifiers::SHIFT));
+    }
+    if code == KeyCode::Backspace {
         return (code, modifiers.difference(KeyModifiers::SHIFT));
     }
     if let KeyCode::Char(c) = code {
@@ -2487,6 +2492,54 @@ mod tests {
         assert_eq!(
             resolver.resolve(&event, KeyContext::Normal),
             Action::InsertChar('a')
+        );
+    }
+
+    #[test]
+    fn test_shift_backspace_matches_backspace() {
+        // Regression test for https://github.com/sinelaw/fresh/issues/1588
+        // Shift+Backspace should resolve to the same action as plain Backspace
+        // in every context where Backspace has a binding.
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+
+        let backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty());
+        let shift_backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::SHIFT);
+
+        // Normal context: backspace deletes backward
+        assert_eq!(
+            resolver.resolve(&backspace, KeyContext::Normal),
+            Action::DeleteBackward,
+            "Backspace should resolve to DeleteBackward in Normal context"
+        );
+        assert_eq!(
+            resolver.resolve(&shift_backspace, KeyContext::Normal),
+            Action::DeleteBackward,
+            "Shift+Backspace should resolve to DeleteBackward (same as Backspace) in Normal context"
+        );
+
+        // Prompt context: prompt_backspace
+        assert_eq!(
+            resolver.resolve(&backspace, KeyContext::Prompt),
+            Action::PromptBackspace,
+            "Backspace should resolve to PromptBackspace in Prompt context"
+        );
+        assert_eq!(
+            resolver.resolve(&shift_backspace, KeyContext::Prompt),
+            Action::PromptBackspace,
+            "Shift+Backspace should resolve to PromptBackspace (same as Backspace) in Prompt context"
+        );
+
+        // FileExplorer context: file_explorer_search_backspace
+        assert_eq!(
+            resolver.resolve(&backspace, KeyContext::FileExplorer),
+            Action::FileExplorerSearchBackspace,
+            "Backspace should resolve to FileExplorerSearchBackspace in FileExplorer context"
+        );
+        assert_eq!(
+            resolver.resolve(&shift_backspace, KeyContext::FileExplorer),
+            Action::FileExplorerSearchBackspace,
+            "Shift+Backspace should resolve to FileExplorerSearchBackspace (same as Backspace) in FileExplorer context"
         );
     }
 

--- a/crates/fresh-editor/src/view/popup/input/completion.rs
+++ b/crates/fresh-editor/src/view/popup/input/completion.rs
@@ -62,8 +62,12 @@ pub fn handle_completion_input(
             InputResult::Consumed
         }
 
-        // Backspace removes last filter character
-        KeyCode::Backspace if event.modifiers.is_empty() => {
+        // Backspace removes last filter character.
+        // Shift+Backspace is treated the same as plain Backspace so an
+        // accidentally-held Shift key doesn't dismiss the popup.
+        KeyCode::Backspace
+            if event.modifiers.is_empty() || event.modifiers == KeyModifiers::SHIFT =>
+        {
             ctx.defer(DeferredAction::PopupBackspace);
             InputResult::Consumed
         }
@@ -127,8 +131,12 @@ pub fn handle_completion_input_with_popup(
             InputResult::Consumed
         }
 
-        // Backspace removes last filter character
-        KeyCode::Backspace if event.modifiers.is_empty() => {
+        // Backspace removes last filter character.
+        // Shift+Backspace is treated the same as plain Backspace so an
+        // accidentally-held Shift key doesn't dismiss the popup.
+        KeyCode::Backspace
+            if event.modifiers.is_empty() || event.modifiers == KeyModifiers::SHIFT =>
+        {
             ctx.defer(DeferredAction::PopupBackspace);
             InputResult::Consumed
         }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -136,6 +136,7 @@ pub mod settings_ruler_keyboard_nav;
 pub mod settings_scrolled_list_click;
 pub mod settings_ui_usability;
 pub mod shell_command;
+pub mod shift_backspace;
 pub mod side_by_side_diff_hunk_nav;
 pub mod side_by_side_diff_scroll;
 pub mod slow_filesystem;

--- a/crates/fresh-editor/tests/e2e/shift_backspace.rs
+++ b/crates/fresh-editor/tests/e2e/shift_backspace.rs
@@ -1,0 +1,37 @@
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Regression test: Shift+Backspace should delete a character backward,
+/// just like plain Backspace.
+///
+/// Users sometimes hold Shift accidentally (e.g. after typing a capital
+/// letter) when pressing Backspace. The editor should treat that identically
+/// to Backspace rather than ignoring the key.
+///
+/// Reproduces: https://github.com/sinelaw/fresh/issues/1588
+#[test]
+fn test_shift_backspace_deletes_character() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Type some text.
+    harness.type_text("hello").unwrap();
+    harness.assert_buffer_content("hello");
+
+    // Shift+Backspace should delete the last character, same as Backspace.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.assert_buffer_content("hell");
+
+    // Pressing plain Backspace should also work.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.assert_buffer_content("hel");
+
+    // Another Shift+Backspace to confirm repeated behavior.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.assert_buffer_content("he");
+}


### PR DESCRIPTION
## Summary
This PR fixes an issue where Shift+Backspace was not recognized as a valid delete action. Users who accidentally hold Shift while pressing Backspace (e.g., after typing a capital letter) will now have the key treated identically to plain Backspace, rather than being ignored.

## Key Changes
- **Keybinding normalization**: Modified `normalize_key()` in `keybindings.rs` to strip the SHIFT modifier from Backspace events, similar to how BackTab is already handled. This ensures Shift+Backspace resolves to the same action as plain Backspace in all contexts (Normal, Prompt, FileExplorer).

- **Completion popup handling**: Updated both `handle_completion_input()` and `handle_completion_input_with_popup()` in `completion.rs` to accept Shift+Backspace as a valid input for removing filter characters, preventing accidental popup dismissal when Shift is held.

- **Test coverage**: Added comprehensive unit tests in `keybindings.rs` to verify Shift+Backspace resolves correctly across all key contexts, and an end-to-end test in `shift_backspace.rs` to confirm the deletion behavior works as expected.

## Implementation Details
The fix follows the existing pattern used for BackTab normalization: terminal inconsistencies mean some keys arrive with redundant modifiers that don't affect their semantics. Backspace with Shift has no distinct meaning from plain Backspace, so the SHIFT modifier is stripped during normalization to ensure consistent keybinding resolution.

Fixes: https://github.com/sinelaw/fresh/issues/1588

https://claude.ai/code/session_01WNoAwYXcmyh2AUGLwdGMH1