### PR TITLE
Optimize render pipeline with sweep-line interval stabbing

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
@@ -18,6 +18,7 @@ pub(super) fn build_base_tokens(
     visible_count: usize,
     is_binary: bool,
     line_ending: LineEnding,
+    fold_skip: &[std::ops::Range<usize>],
 ) -> Vec<ViewTokenWire> {
     let mut tokens = Vec::new();
 
@@ -27,12 +28,53 @@ pub(super) fn build_base_tokens(
         return build_base_tokens_binary(buffer, top_byte, estimated_line_length, visible_count);
     }
 
-    let mut iter = buffer.line_iterator(top_byte, estimated_line_length);
-    let mut lines_seen = 0usize;
     let max_lines = visible_count.saturating_add(4);
+    let mut lines_seen = 0usize;
+    let buffer_len = buffer.len();
+    let mut cursor = top_byte.min(buffer_len);
+    let mut fold_idx = 0usize;
+    // Fast-forward past folds already ending at/before the cursor.
+    while fold_idx < fold_skip.len() && fold_skip[fold_idx].end <= cursor {
+        fold_idx += 1;
+    }
+    // If the cursor landed inside a fold, jump past it before reading anything.
+    if let Some(r) = fold_skip.get(fold_idx) {
+        if r.start <= cursor && cursor < r.end {
+            cursor = r.end.min(buffer_len);
+            fold_idx += 1;
+        }
+    }
 
-    while lines_seen < max_lines {
-        if let Some((line_start, line_content)) = iter.next_line() {
+    // Outer loop: one iteration per visible segment between folds. A fresh
+    // `LineIterator` is constructed per segment so source bytes covered by
+    // a collapsed fold are never read, never decoded, and never tokenised.
+    'segments: loop {
+        if lines_seen >= max_lines || cursor >= buffer_len {
+            break;
+        }
+        let segment_end = fold_skip
+            .get(fold_idx)
+            .map(|r| r.start)
+            .unwrap_or(buffer_len);
+        // Zero-length segment (adjacent folds, or fold starting exactly at
+        // cursor): skip the fold and continue.
+        if cursor >= segment_end {
+            if let Some(r) = fold_skip.get(fold_idx) {
+                cursor = r.end.min(buffer_len);
+                fold_idx += 1;
+                continue;
+            }
+            break;
+        }
+
+        let mut iter = buffer.line_iterator(cursor, estimated_line_length);
+        while lines_seen < max_lines {
+            let Some((line_start, line_content)) = iter.next_line() else {
+                break 'segments;
+            };
+            if line_start >= segment_end {
+                break;
+            }
             let mut byte_offset = 0usize;
             let content_bytes = line_content.as_bytes();
             let mut skip_next_lf = false; // Track if we should skip \n after \r in CRLF
@@ -133,6 +175,16 @@ pub(super) fn build_base_tokens(
                 byte_offset += ch_len;
             }
             lines_seen += 1;
+        }
+
+        if lines_seen >= max_lines {
+            break;
+        }
+        // Jump past the fold at fold_idx (which drove segment_end). If we
+        // ran out of folds, we've finished the last segment.
+        if let Some(r) = fold_skip.get(fold_idx) {
+            cursor = r.end.min(buffer_len);
+            fold_idx += 1;
         } else {
             break;
         }

--- a/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/base_tokens.rs
@@ -31,7 +31,11 @@ pub(super) fn build_base_tokens(
     let max_lines = visible_count.saturating_add(4);
     let mut lines_seen = 0usize;
     let buffer_len = buffer.len();
-    let mut cursor = top_byte.min(buffer_len);
+    // Don't clamp `cursor` to buffer_len: `LineIterator::new` clamps
+    // internally and uses a backward scan to locate the line containing
+    // `top_byte`, so a `top_byte >= buffer_len` (post-scroll past EOF on a
+    // single very long line) still produces tokens for that final line.
+    let mut cursor = top_byte;
     let mut fold_idx = 0usize;
     // Fast-forward past folds already ending at/before the cursor.
     while fold_idx < fold_skip.len() && fold_skip[fold_idx].end <= cursor {
@@ -40,7 +44,7 @@ pub(super) fn build_base_tokens(
     // If the cursor landed inside a fold, jump past it before reading anything.
     if let Some(r) = fold_skip.get(fold_idx) {
         if r.start <= cursor && cursor < r.end {
-            cursor = r.end.min(buffer_len);
+            cursor = r.end;
             fold_idx += 1;
         }
     }
@@ -49,22 +53,23 @@ pub(super) fn build_base_tokens(
     // `LineIterator` is constructed per segment so source bytes covered by
     // a collapsed fold are never read, never decoded, and never tokenised.
     'segments: loop {
-        if lines_seen >= max_lines || cursor >= buffer_len {
+        if lines_seen >= max_lines {
             break;
         }
-        let segment_end = fold_skip
-            .get(fold_idx)
-            .map(|r| r.start)
-            .unwrap_or(buffer_len);
-        // Zero-length segment (adjacent folds, or fold starting exactly at
-        // cursor): skip the fold and continue.
-        if cursor >= segment_end {
-            if let Some(r) = fold_skip.get(fold_idx) {
-                cursor = r.end.min(buffer_len);
+        let next_fold_start = fold_skip.get(fold_idx).map(|r| r.start);
+        let segment_end = next_fold_start.unwrap_or(buffer_len);
+        // Zero-length segment between adjacent folds (or fold starting
+        // exactly at cursor): jump past the fold and try again. Only fires
+        // when there's actually a fold ahead — without one, segment_end
+        // is `buffer_len`, but `cursor >= buffer_len` is fine: `LineIterator`
+        // handles the past-EOF case via internal clamping.
+        if next_fold_start.is_some() {
+            if cursor >= segment_end {
+                let r = &fold_skip[fold_idx];
+                cursor = r.end;
                 fold_idx += 1;
                 continue;
             }
-            break;
         }
 
         let mut iter = buffer.line_iterator(cursor, estimated_line_length);
@@ -72,7 +77,11 @@ pub(super) fn build_base_tokens(
             let Some((line_start, line_content)) = iter.next_line() else {
                 break 'segments;
             };
-            if line_start >= segment_end {
+            // Stop the inner loop when the next line crosses into the
+            // upcoming fold. Without a fold ahead, `next_fold_start` is
+            // `None` and we keep tokenising until the iterator reports EOF
+            // — preserving the trailing-empty-line behaviour at buffer end.
+            if next_fold_start.is_some_and(|s| line_start >= s) {
                 break;
             }
             let mut byte_offset = 0usize;
@@ -183,7 +192,7 @@ pub(super) fn build_base_tokens(
         // Jump past the fold at fold_idx (which drove segment_end). If we
         // ran out of folds, we've finished the last segment.
         if let Some(r) = fold_skip.get(fold_idx) {
-            cursor = r.end.min(buffer_len);
+            cursor = r.end;
             fold_idx += 1;
         } else {
             break;

--- a/crates/fresh-editor/src/view/ui/split_rendering/char_style.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/char_style.rs
@@ -10,7 +10,6 @@ use crate::view::overlay::{Overlay, OverlayFace};
 use crate::view::theme::Theme;
 use fresh_core::api::ViewTokenStyle;
 use ratatui::style::{Color, Modifier, Style};
-use std::ops::Range;
 
 /// Context for computing the style of a single character.
 pub(super) struct CharStyleContext<'a> {
@@ -26,7 +25,9 @@ pub(super) struct CharStyleContext<'a> {
     pub highlight_theme_key: Option<&'static str>,
     /// Pre-resolved semantic token color for this byte position.
     pub semantic_token_color: Option<Color>,
-    pub viewport_overlays: &'a [(Overlay, Range<usize>)],
+    /// Overlays currently active at `byte_pos`, already in priority-ascending
+    /// order ("last write wins"). Empty when `byte_pos` is `None`.
+    pub active_overlays: &'a [&'a Overlay],
     pub primary_cursor_position: usize,
     pub is_active: bool,
     /// Skip REVERSED style on the primary cursor cell. True when a hardware
@@ -61,17 +62,6 @@ pub(super) fn compute_char_style(ctx: &CharStyleContext) -> CharStyleOutput {
     let mut fg_theme_key: Option<&'static str> = None;
     let mut bg_theme_key: Option<&'static str> = Some("editor.bg");
     let mut region: &'static str = "Editor Content";
-
-    // Find overlays for this byte position
-    let overlays: Vec<&Overlay> = if let Some(bp) = ctx.byte_pos {
-        ctx.viewport_overlays
-            .iter()
-            .filter(|(_, range)| range.contains(&bp))
-            .map(|(overlay, _)| overlay)
-            .collect()
-    } else {
-        Vec::new()
-    };
 
     // Start with token style if present (for injected content like annotation headers)
     // Otherwise use ANSI/syntax/theme default
@@ -144,7 +134,7 @@ pub(super) fn compute_char_style(ctx: &CharStyleContext) -> CharStyleOutput {
     }
 
     // Apply overlay styles — last overlay wins for each attribute
-    for overlay in &overlays {
+    for overlay in ctx.active_overlays {
         match &overlay.face {
             OverlayFace::Underline {
                 color,

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -10,7 +10,7 @@ use super::style::append_fold_placeholder;
 use crate::model::buffer::Buffer;
 use crate::model::marker::MarkerList;
 use crate::state::EditorState;
-use crate::view::folding::{FoldManager, ResolvedFoldRange};
+use crate::view::folding::FoldManager;
 use crate::view::margin::LineIndicator;
 use crate::view::ui::view_pipeline::ViewLine;
 use fresh_core::api::ViewTokenStyle;
@@ -77,8 +77,31 @@ pub(super) fn fold_adjusted_visible_count(
     total
 }
 
-/// Hide collapsed fold ranges from the view line stream and append placeholder
-/// text to collapsed fold headers.
+/// Build the sorted, non-overlapping list of source-byte ranges for the
+/// currently-collapsed folds. Feed into
+/// [`ViewLineIterator::with_fold_skip`] so hidden content is never
+/// materialised as a ViewLine.
+pub(super) fn fold_skip_set(
+    buffer: &Buffer,
+    marker_list: &MarkerList,
+    folds: &FoldManager,
+) -> Vec<std::ops::Range<usize>> {
+    if folds.is_empty() {
+        return Vec::new();
+    }
+    let mut ranges: Vec<std::ops::Range<usize>> = folds
+        .resolved_ranges(buffer, marker_list)
+        .into_iter()
+        .map(|r| r.start_byte..r.end_byte)
+        .collect();
+    ranges.sort_by_key(|r| r.start);
+    ranges
+}
+
+/// Append placeholder text to the last visual segment of each collapsed
+/// fold's header line. Hidden-line filtering is handled upstream by the
+/// iterator's fold-skip sweep (see [`fold_skip_set`]), so this pass only
+/// mutates header ViewLines — it no longer drops any.
 pub(super) fn apply_folding(
     lines: Vec<ViewLine>,
     buffer: &Buffer,
@@ -90,15 +113,10 @@ pub(super) fn apply_folding(
         return lines;
     }
 
-    let mut collapsed_ranges = folds.resolved_ranges(buffer, marker_list);
-    if collapsed_ranges.is_empty() {
+    let collapsed_header_bytes = folds.collapsed_header_bytes(buffer, marker_list);
+    if collapsed_header_bytes.is_empty() {
         return lines;
     }
-    // Sort by `start_byte` so `is_hidden_byte` can be a monotonic cursor
-    // over the sorted list instead of a linear scan per ViewLine.
-    collapsed_ranges.sort_by_key(|r| r.start_byte);
-
-    let collapsed_header_bytes = folds.collapsed_header_bytes(buffer, marker_list);
 
     // Pre-compute: for each line, what is the source byte of the next line?
     let mut next_source_byte: Vec<Option<usize>> = vec![None; lines.len()];
@@ -110,62 +128,36 @@ pub(super) fn apply_folding(
         }
     }
 
-    let mut filtered = Vec::with_capacity(lines.len());
-    let mut fold_cursor: usize = 0;
-    for (idx, mut line) in lines.into_iter().enumerate() {
-        let source_byte = view_line_source_byte(&line);
-
-        if let Some(byte) = source_byte {
-            if is_hidden_byte(byte, &collapsed_ranges, &mut fold_cursor) {
-                continue;
-            }
-
-            if let Some(placeholder) = collapsed_header_bytes.get(&byte) {
-                // Only append placeholder on the last visual segment of the line
-                if next_source_byte[idx] != Some(byte) {
-                    let raw_text = placeholder
-                        .as_deref()
-                        .filter(|s| !s.trim().is_empty())
-                        .unwrap_or("...");
-                    let text = if raw_text.starts_with(' ') {
-                        raw_text.to_string()
-                    } else {
-                        format!(" {}", raw_text)
-                    };
-                    append_fold_placeholder(&mut line, &text, placeholder_style);
-                }
-            }
-        } else if let Some(next_byte) = next_source_byte[idx] {
-            if is_hidden_byte(next_byte, &collapsed_ranges, &mut fold_cursor) {
-                continue;
-            }
+    let mut out = lines;
+    for idx in 0..out.len() {
+        let Some(byte) = view_line_source_byte(&out[idx]) else {
+            continue;
+        };
+        let Some(placeholder) = collapsed_header_bytes.get(&byte) else {
+            continue;
+        };
+        // Only append placeholder on the last visual segment of the line.
+        if next_source_byte[idx] == Some(byte) {
+            continue;
         }
-
-        filtered.push(line);
+        let raw_text = placeholder
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("...");
+        let text = if raw_text.starts_with(' ') {
+            raw_text.to_string()
+        } else {
+            format!(" {}", raw_text)
+        };
+        append_fold_placeholder(&mut out[idx], &text, placeholder_style);
     }
 
-    filtered
+    out
 }
 
 /// Get the source byte offset of a view line (first `Some` in char_source_bytes).
 fn view_line_source_byte(line: &ViewLine) -> Option<usize> {
     line.char_source_bytes.iter().find_map(|m| *m)
-}
-
-/// Check if a byte offset falls within any collapsed fold range, advancing
-/// `cursor` past ranges ending before `byte`. Expects `ranges` sorted by
-/// `start_byte` and `byte` values to arrive non-decreasing across calls
-/// sharing the same cursor (true of the `apply_folding` line walk). Only
-/// the current cursor range is inspected — collapsed fold ranges do not
-/// overlap in practice.
-fn is_hidden_byte(byte: usize, ranges: &[ResolvedFoldRange], cursor: &mut usize) -> bool {
-    while *cursor < ranges.len() && ranges[*cursor].end_byte <= byte {
-        *cursor += 1;
-    }
-    match ranges.get(*cursor) {
-        Some(range) => byte >= range.start_byte && byte < range.end_byte,
-        None => false,
-    }
 }
 
 /// Build the per-line fold indicator map for the current viewport.

--- a/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/folding.rs
@@ -90,10 +90,13 @@ pub(super) fn apply_folding(
         return lines;
     }
 
-    let collapsed_ranges = folds.resolved_ranges(buffer, marker_list);
+    let mut collapsed_ranges = folds.resolved_ranges(buffer, marker_list);
     if collapsed_ranges.is_empty() {
         return lines;
     }
+    // Sort by `start_byte` so `is_hidden_byte` can be a monotonic cursor
+    // over the sorted list instead of a linear scan per ViewLine.
+    collapsed_ranges.sort_by_key(|r| r.start_byte);
 
     let collapsed_header_bytes = folds.collapsed_header_bytes(buffer, marker_list);
 
@@ -108,11 +111,12 @@ pub(super) fn apply_folding(
     }
 
     let mut filtered = Vec::with_capacity(lines.len());
+    let mut fold_cursor: usize = 0;
     for (idx, mut line) in lines.into_iter().enumerate() {
         let source_byte = view_line_source_byte(&line);
 
         if let Some(byte) = source_byte {
-            if is_hidden_byte(byte, &collapsed_ranges) {
+            if is_hidden_byte(byte, &collapsed_ranges, &mut fold_cursor) {
                 continue;
             }
 
@@ -132,7 +136,7 @@ pub(super) fn apply_folding(
                 }
             }
         } else if let Some(next_byte) = next_source_byte[idx] {
-            if is_hidden_byte(next_byte, &collapsed_ranges) {
+            if is_hidden_byte(next_byte, &collapsed_ranges, &mut fold_cursor) {
                 continue;
             }
         }
@@ -148,11 +152,20 @@ fn view_line_source_byte(line: &ViewLine) -> Option<usize> {
     line.char_source_bytes.iter().find_map(|m| *m)
 }
 
-/// Check if a byte offset falls within any collapsed fold range.
-fn is_hidden_byte(byte: usize, ranges: &[ResolvedFoldRange]) -> bool {
-    ranges
-        .iter()
-        .any(|range| byte >= range.start_byte && byte < range.end_byte)
+/// Check if a byte offset falls within any collapsed fold range, advancing
+/// `cursor` past ranges ending before `byte`. Expects `ranges` sorted by
+/// `start_byte` and `byte` values to arrive non-decreasing across calls
+/// sharing the same cursor (true of the `apply_folding` line walk). Only
+/// the current cursor range is inspected — collapsed fold ranges do not
+/// overlap in practice.
+fn is_hidden_byte(byte: usize, ranges: &[ResolvedFoldRange], cursor: &mut usize) -> bool {
+    while *cursor < ranges.len() && ranges[*cursor].end_byte <= byte {
+        *cursor += 1;
+    }
+    match ranges.get(*cursor) {
+        Some(range) => byte >= range.start_byte && byte < range.end_byte,
+        None => false,
+    }
 }
 
 /// Build the per-line fold indicator map for the current viewport.

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/contexts.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/contexts.rs
@@ -27,6 +27,10 @@ pub(crate) struct DecorationContext {
     pub highlight_spans: Vec<HighlightSpan>,
     pub semantic_token_spans: Vec<HighlightSpan>,
     pub viewport_overlays: Vec<(Overlay, Range<usize>)>,
+    /// Indices into `viewport_overlays` sorted by `range.start` (ascending).
+    /// Used by the per-cell sweep in `render_view_lines` to advance an
+    /// active set without re-scanning the full overlay list each cell.
+    pub overlay_position_index: Vec<usize>,
     pub virtual_text_lookup: HashMap<usize, Vec<VirtualText>>,
     /// Diagnostic lines indexed by line-start byte offset.
     pub diagnostic_lines: HashSet<usize>,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -882,5 +882,6 @@ pub(crate) fn build_base_tokens_for_hook(
         visible_count,
         is_binary,
         line_ending,
+        &[],
     )
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -167,6 +167,12 @@ pub(crate) fn decoration_context(
     // applied last in the rendering loop.
     viewport_overlays.sort_by_key(|(overlay, _)| overlay.priority);
 
+    // Build a parallel index sorted by `range.start`. The render loop uses
+    // this to drive an active-set sweep (overlays entering) while priority
+    // order is preserved inside the active set via insertion sort.
+    let mut overlay_position_index: Vec<usize> = (0..viewport_overlays.len()).collect();
+    overlay_position_index.sort_by_key(|&i| viewport_overlays[i].1.start);
+
     // Use the lsp-diagnostic namespace to identify diagnostic overlays.
     let diagnostic_ns = crate::services::lsp::diagnostics::lsp_diagnostic_namespace();
     let diagnostic_lines: HashSet<usize> = viewport_overlays
@@ -238,6 +244,7 @@ pub(crate) fn decoration_context(
         highlight_spans,
         semantic_token_spans,
         viewport_overlays,
+        overlay_position_index,
         virtual_text_lookup,
         diagnostic_lines,
         diagnostic_inline_texts,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -27,7 +27,7 @@ pub(crate) fn selection_context(state: &EditorState, cursors: &Cursors) -> Selec
         };
     }
 
-    let ranges: Vec<Range<usize>> = cursors
+    let mut ranges: Vec<Range<usize>> = cursors
         .iter()
         .filter_map(|(_, cursor)| {
             // Don't include normal selection for cursors in block selection mode;
@@ -39,8 +39,11 @@ pub(crate) fn selection_context(state: &EditorState, cursors: &Cursors) -> Selec
             }
         })
         .collect();
+    // Sort by start byte so the render loop can sweep an active cursor
+    // over selections in monotonic byte order.
+    ranges.sort_by_key(|r| r.start);
 
-    let block_rects: Vec<(usize, usize, usize, usize)> = cursors
+    let mut block_rects: Vec<(usize, usize, usize, usize)> = cursors
         .iter()
         .filter_map(|(_, cursor)| {
             if cursor.selection_mode == SelectionMode::Block {
@@ -63,6 +66,8 @@ pub(crate) fn selection_context(state: &EditorState, cursors: &Cursors) -> Selec
             }
         })
         .collect();
+    // Sort by start_line for the render loop's per-line active-set sweep.
+    block_rects.sort_by_key(|(start_line, _, _, _)| *start_line);
 
     let cursor_positions: Vec<usize> = cursors.iter().map(|(_, cursor)| cursor.position).collect();
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -20,6 +20,7 @@ use crate::app::types::ViewLineMapping;
 use crate::primitives::ansi::AnsiParser;
 use crate::primitives::display_width::char_width;
 use crate::state::EditorState;
+use crate::view::overlay::Overlay;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{should_show_line_number, LineStart, ViewLine};
 use crate::view::virtual_text::VirtualTextPosition;
@@ -149,6 +150,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     let highlight_spans = &decorations.highlight_spans;
     let semantic_token_spans = &decorations.semantic_token_spans;
     let viewport_overlays = &decorations.viewport_overlays;
+    let overlay_position_index = &decorations.overlay_position_index;
     let virtual_text_lookup = &decorations.virtual_text_lookup;
     let diagnostic_lines = &decorations.diagnostic_lines;
     let line_indicators = &decorations.line_indicators;
@@ -156,6 +158,26 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     // Cursors for O(1) amortized span lookups (spans are sorted by byte range)
     let mut hl_cursor = 0usize;
     let mut sem_cursor = 0usize;
+
+    // Overlay sweep: O(1) amortised per cell, zero allocation per cell.
+    // `active` holds `(range_end, &Overlay)` for overlays whose range
+    // currently covers `last_active_bp`, kept in priority-ascending order so
+    // the apply loop in `compute_char_style` produces the correct
+    // "last write wins" z-order. `active_refs` mirrors `active` as the
+    // `&[&Overlay]` slice passed into `compute_char_style`; it is rebuilt
+    // only when the active set actually changes. `next_overlay_in_pos`
+    // advances through `overlay_position_index` (sorted by `range.start`),
+    // letting us find newly-entering overlays without rescanning.
+    let mut active: Vec<(usize, &Overlay)> = Vec::new();
+    let mut active_refs: Vec<&Overlay> = Vec::new();
+    let mut next_overlay_in_pos: usize = 0;
+    let mut last_active_bp: Option<usize> = None;
+    // Overlay indices that have been in the active set at any point while
+    // rendering the current visible line. Used only by the
+    // extend_to_line_end fill so overlays which ended mid-line are still
+    // considered for tail-fill bg (parity with pre-sweep behaviour). Reset
+    // per visible line; `Vec` reused across lines.
+    let mut line_touched_overlays: Vec<usize> = Vec::new();
 
     let mut lines = Vec::new();
     let mut view_line_mappings = Vec::new();
@@ -364,6 +386,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         // Track byte positions for extend_to_line_end feature
         let mut first_line_byte_pos: Option<usize> = None;
         let mut last_line_byte_pos: Option<usize> = None;
+        line_touched_overlays.clear();
 
         let chars_iterator = line_content.chars().peekable();
         for ch in chars_iterator {
@@ -380,6 +403,51 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                     first_line_byte_pos = Some(bp);
                 }
                 last_line_byte_pos = Some(bp);
+            }
+
+            // Advance overlay active-set sweep for this cell. Monotonic in
+            // `bp`, so state persists across view-line transitions within
+            // one render call.
+            if let Some(bp) = byte_pos {
+                if last_active_bp != Some(bp) {
+                    let mut dirty = false;
+                    if active.iter().any(|(end, _)| *end <= bp) {
+                        active.retain(|(end, _)| *end > bp);
+                        dirty = true;
+                    }
+                    while next_overlay_in_pos < overlay_position_index.len() {
+                        let idx = overlay_position_index[next_overlay_in_pos];
+                        let (overlay, range) = &viewport_overlays[idx];
+                        if range.start > bp {
+                            break;
+                        }
+                        // Include only if [start, end) is non-empty and bp
+                        // is inside. Zero-width overlays (start == end) are
+                        // filtered out, matching the prior
+                        // `Range::contains` semantics.
+                        if range.end > bp {
+                            let pri = overlay.priority;
+                            let pos = active
+                                .iter()
+                                .position(|(_, o)| o.priority > pri)
+                                .unwrap_or(active.len());
+                            active.insert(pos, (range.end, overlay));
+                            dirty = true;
+                            // Record for extend_to_line_end consideration.
+                            // `line_touched_overlays` is typically small,
+                            // so linear contains check is cheap.
+                            if !line_touched_overlays.contains(&idx) {
+                                line_touched_overlays.push(idx);
+                            }
+                        }
+                        next_overlay_in_pos += 1;
+                    }
+                    if dirty {
+                        active_refs.clear();
+                        active_refs.extend(active.iter().map(|(_, o)| *o));
+                    }
+                    last_active_bp = Some(bp);
+                }
             }
 
             // Process character through ANSI parser first (if line has ANSI)
@@ -485,6 +553,16 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                     None => None,
                 };
 
+                // Pre-resolved active overlays for this cell. Empty slice
+                // when byte_pos is None (ANSI continuation / virtual cells)
+                // — matches pre-sweep behaviour where `bp = None`
+                // short-circuited overlay filtering.
+                let cell_overlays: &[&Overlay] = if byte_pos.is_some() {
+                    &active_refs
+                } else {
+                    &[]
+                };
+
                 let CharStyleOutput {
                     mut style,
                     is_secondary_cursor,
@@ -501,7 +579,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                     highlight_color,
                     highlight_theme_key,
                     semantic_token_color,
-                    viewport_overlays,
+                    active_overlays: cell_overlays,
                     primary_cursor_position,
                     is_active,
                     skip_primary_cursor_reverse: session_mode,
@@ -965,16 +1043,19 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 // not `>=`. With `>=`, an overlay covering the previous
                 // line's content + trailing newline would bleed its bg
                 // onto this line's trailing fill.
-                let fill_style: Option<Style> = if let (Some(start), Some(end)) =
-                    (first_line_byte_pos, last_line_byte_pos)
+                // Scan only overlays that were active at some point during
+                // this visible line (from the sweep) — bounded size vs. the
+                // full `viewport_overlays` slice. Highest priority with
+                // `extend_to_line_end` wins.
+                let fill_style: Option<Style> = if first_line_byte_pos.is_some()
+                    && last_line_byte_pos.is_some()
                 {
-                    viewport_overlays
+                    line_touched_overlays
                         .iter()
-                        .filter(|(overlay, range)| {
-                            overlay.extend_to_line_end && range.start <= end && range.end > start
-                        })
-                        .max_by_key(|(o, _)| o.priority)
-                        .and_then(|(overlay, _)| {
+                        .map(|&idx| &viewport_overlays[idx].0)
+                        .filter(|overlay| overlay.extend_to_line_end)
+                        .max_by_key(|o| o.priority)
+                        .and_then(|overlay| {
                             match &overlay.face {
                                 crate::view::overlay::OverlayFace::Background { color } => {
                                     // Set both fg and bg to ensure ANSI codes are output

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -1092,43 +1092,42 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 // this visible line (from the sweep) — bounded size vs. the
                 // full `viewport_overlays` slice. Highest priority with
                 // `extend_to_line_end` wins.
-                let fill_style: Option<Style> = if first_line_byte_pos.is_some()
-                    && last_line_byte_pos.is_some()
-                {
-                    line_touched_overlays
-                        .iter()
-                        .map(|&idx| &viewport_overlays[idx].0)
-                        .filter(|overlay| overlay.extend_to_line_end)
-                        .max_by_key(|o| o.priority)
-                        .and_then(|overlay| {
-                            match &overlay.face {
-                                crate::view::overlay::OverlayFace::Background { color } => {
-                                    // Set both fg and bg to ensure ANSI codes are output
-                                    Some(Style::default().fg(*color).bg(*color))
+                let fill_style: Option<Style> =
+                    if first_line_byte_pos.is_some() && last_line_byte_pos.is_some() {
+                        line_touched_overlays
+                            .iter()
+                            .map(|&idx| &viewport_overlays[idx].0)
+                            .filter(|overlay| overlay.extend_to_line_end)
+                            .max_by_key(|o| o.priority)
+                            .and_then(|overlay| {
+                                match &overlay.face {
+                                    crate::view::overlay::OverlayFace::Background { color } => {
+                                        // Set both fg and bg to ensure ANSI codes are output
+                                        Some(Style::default().fg(*color).bg(*color))
+                                    }
+                                    crate::view::overlay::OverlayFace::Style { style } => {
+                                        // Extract background from style if present
+                                        // Set fg to same as bg for invisible text
+                                        style.bg.map(|bg| Style::default().fg(bg).bg(bg))
+                                    }
+                                    crate::view::overlay::OverlayFace::ThemedStyle {
+                                        fallback_style,
+                                        bg_theme,
+                                        ..
+                                    } => {
+                                        // Try theme key first, fall back to style's bg
+                                        let bg = bg_theme
+                                            .as_ref()
+                                            .and_then(|key| theme.resolve_theme_key(key))
+                                            .or(fallback_style.bg);
+                                        bg.map(|bg| Style::default().fg(bg).bg(bg))
+                                    }
+                                    _ => None,
                                 }
-                                crate::view::overlay::OverlayFace::Style { style } => {
-                                    // Extract background from style if present
-                                    // Set fg to same as bg for invisible text
-                                    style.bg.map(|bg| Style::default().fg(bg).bg(bg))
-                                }
-                                crate::view::overlay::OverlayFace::ThemedStyle {
-                                    fallback_style,
-                                    bg_theme,
-                                    ..
-                                } => {
-                                    // Try theme key first, fall back to style's bg
-                                    let bg = bg_theme
-                                        .as_ref()
-                                        .and_then(|key| theme.resolve_theme_key(key))
-                                        .or(fallback_style.bg);
-                                    bg.map(|bg| Style::default().fg(bg).bg(bg))
-                                }
-                                _ => None,
-                            }
-                        })
-                } else {
-                    None
-                };
+                            })
+                    } else {
+                        None
+                    };
 
                 if let Some(fill_bg) = fill_style {
                     let fill_text = " ".repeat(remaining_cols);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -234,8 +234,11 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             break;
         };
 
-        // Extract line data
-        let line_content = current_view_line.text.clone();
+        // Extract line data. `line_content` borrows the ViewLine's text
+        // directly — no per-line `String::clone`; the borrow is valid for
+        // the whole per-line body since `current_view_line` is a shared
+        // reference into `view_lines`.
+        let line_content: &str = &current_view_line.text;
         let line_has_newline = current_view_line.ends_with_newline;
         let line_char_source_bytes = &current_view_line.char_source_bytes;
         let line_char_styles = &current_view_line.char_styles;
@@ -245,16 +248,23 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         let line_tab_starts = &current_view_line.tab_starts;
         let _line_start_type = current_view_line.line_start;
 
-        // Pre-compute whitespace position boundaries for this view line.
+        // Pre-compute whitespace position boundaries for this view line in
+        // a single pass — no intermediate `Vec<char>` per line.
         // first_non_ws: index of first non-whitespace char (None if all whitespace)
         // last_non_ws: index of last non-whitespace char (None if all whitespace)
-        let line_chars_for_ws: Vec<char> = line_content.chars().collect();
-        let first_non_ws_idx = line_chars_for_ws
-            .iter()
-            .position(|&c| c != ' ' && c != '\n' && c != '\r');
-        let last_non_ws_idx = line_chars_for_ws
-            .iter()
-            .rposition(|&c| c != ' ' && c != '\n' && c != '\r');
+        let (first_non_ws_idx, last_non_ws_idx) = {
+            let mut first: Option<usize> = None;
+            let mut last: Option<usize> = None;
+            for (i, c) in line_content.chars().enumerate() {
+                if c != ' ' && c != '\n' && c != '\r' {
+                    if first.is_none() {
+                        first = Some(i);
+                    }
+                    last = Some(i);
+                }
+            }
+            (first, last)
+        };
 
         // Helper to get source byte at a visual column using the new O(1) lookup
         let _source_byte_at_col = |vis_col: usize| -> Option<usize> {
@@ -644,8 +654,10 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
                 // Determine display character (tabs already expanded in ViewLineIterator)
                 // Show tab indicator (→) or space indicator (·) based on granular
-                // whitespace visibility settings (leading/inner/trailing positions)
-                let indicator_buf: String;
+                // whitespace visibility settings (leading/inner/trailing positions).
+                // `indicator_buf` holds the UTF-8 bytes of a single char on the
+                // stack — no heap allocation per cell.
+                let mut indicator_buf = [0u8; 4];
                 let mut is_whitespace_indicator = false;
 
                 // Classify whitespace position: leading, inner, or trailing
@@ -695,16 +707,13 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 } else if ws_show_tab {
                     // Visual indicator for tab: show → at the first position
                     is_whitespace_indicator = true;
-                    indicator_buf = "→".to_string();
-                    &indicator_buf
+                    '→'.encode_utf8(&mut indicator_buf)
                 } else if ws_show_space {
                     // Visual indicator for space: show · when enabled
                     is_whitespace_indicator = true;
-                    indicator_buf = "·".to_string();
-                    &indicator_buf
+                    '·'.encode_utf8(&mut indicator_buf)
                 } else {
-                    indicator_buf = ch.to_string();
-                    &indicator_buf
+                    ch.encode_utf8(&mut indicator_buf)
                 };
 
                 // Apply subdued whitespace indicator color from theme

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line.rs
@@ -158,6 +158,21 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     // Cursors for O(1) amortized span lookups (spans are sorted by byte range)
     let mut hl_cursor = 0usize;
     let mut sem_cursor = 0usize;
+    // Selection cursor: `selection_ranges` is sorted by `start` in
+    // `selection_context`. Advance past ranges whose `end <= bp`; any
+    // remaining range with `start <= bp < end` covers `bp`. The non-advancing
+    // scan from `sel_cursor` is bounded by the (tiny) number of overlapping
+    // selections at a single byte.
+    let mut sel_cursor = 0usize;
+    // Block-selection active set: indices into `block_selections`, updated
+    // once per visible line as `gutter_num` advances. `block_next_idx`
+    // advances through the list (sorted by `start_line`) picking up entries
+    // whose `start_line <= gutter_num`; entries with `end_line < gutter_num`
+    // are dropped. Per cell, we scan only the active set for the column
+    // predicate instead of the full `block_selections` slice.
+    let mut active_block: Vec<usize> = Vec::new();
+    let mut block_next_idx: usize = 0;
+    let mut block_last_line: Option<usize> = None;
 
     // Overlay sweep: O(1) amortised per cell, zero allocation per cell.
     // `active` holds `(range_end, &Overlay)` for overlays whose range
@@ -512,16 +527,26 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
                 // Check if this character is in any selection range (but not at cursor position)
                 // Also check for block/rectangular selections (uses gutter_num which is
-                // the line number for small files — block_rects stores line numbers)
-                let is_in_block_selection =
-                    block_selections
-                        .iter()
-                        .any(|(start_line, start_col, end_line, end_col)| {
-                            gutter_num >= *start_line
-                                && gutter_num <= *end_line
-                                && byte_index >= *start_col
-                                && byte_index <= *end_col
-                        });
+                // the line number for small files — block_rects stores line numbers).
+                // Block active set is refreshed once per line as `gutter_num` advances.
+                if block_last_line != Some(gutter_num) {
+                    active_block.retain(|&i| block_selections[i].2 >= gutter_num);
+                    while block_next_idx < block_selections.len() {
+                        let (start_line, _, _, _) = block_selections[block_next_idx];
+                        if start_line > gutter_num {
+                            break;
+                        }
+                        if block_selections[block_next_idx].2 >= gutter_num {
+                            active_block.push(block_next_idx);
+                        }
+                        block_next_idx += 1;
+                    }
+                    block_last_line = Some(gutter_num);
+                }
+                let is_in_block_selection = active_block.iter().any(|&i| {
+                    let (_, start_col, _, end_col) = block_selections[i];
+                    byte_index >= start_col && byte_index <= end_col
+                });
 
                 // For primary cursor in active split, terminal hardware cursor provides
                 // visual indication, so we can still show selection background.
@@ -533,7 +558,18 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
                 let is_selected = !exclude_from_selection
                     && (byte_pos.is_some_and(|bp| {
-                        selection_ranges.iter().any(|range| range.contains(&bp))
+                        // Advance past selections ending before this byte.
+                        while sel_cursor < selection_ranges.len()
+                            && selection_ranges[sel_cursor].end <= bp
+                        {
+                            sel_cursor += 1;
+                        }
+                        // From sel_cursor onwards, ranges are sorted by start.
+                        // Stop as soon as a range starts after bp.
+                        selection_ranges[sel_cursor..]
+                            .iter()
+                            .take_while(|r| r.start <= bp)
+                            .any(|r| r.end > bp)
                     }) || is_in_block_selection);
 
                 // Compute character style using helper function

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -410,9 +410,7 @@ pub(super) fn apply_conceal_ranges(
         cursor: &mut usize,
         byte_offset: usize,
     ) -> Option<usize> {
-        while *cursor < sorted.len()
-            && conceal_ranges[sorted[*cursor]].0.end <= byte_offset
-        {
+        while *cursor < sorted.len() && conceal_ranges[sorted[*cursor]].0.end <= byte_offset {
             *cursor += 1;
         }
         let orig_idx = sorted.get(*cursor).copied()?;
@@ -438,7 +436,9 @@ pub(super) fn apply_conceal_ranges(
                 for ch in text.chars() {
                     let ch_len = ch.len_utf8();
 
-                    if let Some(cidx) = is_concealed(conceal_ranges, &sorted, &mut conceal_cursor, current_byte) {
+                    if let Some(cidx) =
+                        is_concealed(conceal_ranges, &sorted, &mut conceal_cursor, current_byte)
+                    {
                         if !visible_chars.is_empty() {
                             output.push(ViewTokenWire {
                                 source_offset: visible_start,

--- a/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/transforms.rs
@@ -390,14 +390,35 @@ pub(super) fn apply_conceal_ranges(
     let mut output = Vec::with_capacity(tokens.len());
     let mut emitted_replacements: HashSet<usize> = HashSet::new();
 
-    let is_concealed = |byte_offset: usize| -> Option<usize> {
-        for (idx, (range, _)) in conceal_ranges.iter().enumerate() {
-            if byte_offset >= range.start && byte_offset < range.end {
-                return Some(idx);
-            }
+    // Sort a parallel index by `range.start` so the concealment lookup can
+    // be a monotonic cursor instead of a per-byte linear scan. Conceals
+    // rarely overlap (typically markdown syntax markers); the cursor walks
+    // the sorted list as tokens advance through source bytes.
+    let mut sorted: Vec<usize> = (0..conceal_ranges.len()).collect();
+    sorted.sort_by_key(|&i| conceal_ranges[i].0.start);
+    let mut conceal_cursor: usize = 0;
+
+    // Advance `conceal_cursor` past ranges ending before `byte_offset`,
+    // then check if the current range contains `byte_offset`. Returns the
+    // *original* conceal index (so `emitted_replacements` keys stay
+    // stable). Monotonic: caller must invoke with non-decreasing
+    // `byte_offset` within the token stream.
+    #[inline]
+    fn is_concealed(
+        conceal_ranges: &[(std::ops::Range<usize>, Option<&str>)],
+        sorted: &[usize],
+        cursor: &mut usize,
+        byte_offset: usize,
+    ) -> Option<usize> {
+        while *cursor < sorted.len()
+            && conceal_ranges[sorted[*cursor]].0.end <= byte_offset
+        {
+            *cursor += 1;
         }
-        None
-    };
+        let orig_idx = sorted.get(*cursor).copied()?;
+        let range = &conceal_ranges[orig_idx].0;
+        (range.start <= byte_offset && byte_offset < range.end).then_some(orig_idx)
+    }
 
     for token in tokens {
         let offset = match token.source_offset {
@@ -417,7 +438,7 @@ pub(super) fn apply_conceal_ranges(
                 for ch in text.chars() {
                     let ch_len = ch.len_utf8();
 
-                    if let Some(cidx) = is_concealed(current_byte) {
+                    if let Some(cidx) = is_concealed(conceal_ranges, &sorted, &mut conceal_cursor, current_byte) {
                         if !visible_chars.is_empty() {
                             output.push(ViewTokenWire {
                                 source_offset: visible_start,
@@ -472,14 +493,14 @@ pub(super) fn apply_conceal_ranges(
                 }
             }
             ViewTokenWireKind::Space | ViewTokenWireKind::Newline | ViewTokenWireKind::Break => {
-                if is_concealed(offset).is_some() {
+                if is_concealed(conceal_ranges, &sorted, &mut conceal_cursor, offset).is_some() {
                     // Skip concealed single-byte tokens
                 } else {
                     output.push(token);
                 }
             }
             ViewTokenWireKind::BinaryByte(_) => {
-                if is_concealed(offset).is_some() {
+                if is_concealed(conceal_ranges, &sorted, &mut conceal_cursor, offset).is_some() {
                     // Skip concealed binary byte
                 } else {
                     output.push(token);

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -6,7 +6,7 @@
 //! (also self-contained) sibling modules and a few editor state types.
 
 use super::base_tokens::build_base_tokens;
-use super::folding::{apply_folding, fold_adjusted_visible_count};
+use super::folding::{apply_folding, fold_adjusted_visible_count, fold_skip_set};
 use super::style::fold_placeholder_style;
 use super::transforms::{
     apply_conceal_ranges, apply_soft_breaks, apply_wrapping_transform, inject_virtual_lines,
@@ -138,6 +138,10 @@ pub(super) fn build_view_data(
             .unwrap_or(0);
         max_source_offset + 2 >= state.buffer.len()
     };
+    // Skip folded source ranges at the iterator level so hidden content
+    // never materialises as a ViewLine (no text clone, no char_source_bytes,
+    // no char_styles, etc.).
+    let fold_skip = fold_skip_set(&state.buffer, &state.marker_list, folds);
     let source_lines: Vec<ViewLine> = ViewLineIterator::new(
         &tokens,
         is_binary,
@@ -145,6 +149,7 @@ pub(super) fn build_view_data(
         state.buffer_settings.tab_size,
         at_buffer_end,
     )
+    .with_fold_skip(&fold_skip)
     .collect();
 
     // Inject virtual lines (LineAbove/LineBelow) from VirtualTextManager.

--- a/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/view_data.rs
@@ -53,7 +53,13 @@ pub(super) fn build_view_data(
     let is_binary = state.buffer.is_binary();
     let line_ending = state.buffer.line_ending();
 
-    // Build base token stream from source
+    // Compute fold skip set once — reused by base token build (to avoid
+    // reading/tokenising hidden ranges) and by ViewLineIterator (defence in
+    // depth for any tokens produced by plugin view transforms).
+    let fold_skip = fold_skip_set(&state.buffer, &state.marker_list, folds);
+
+    // Build base token stream from source, skipping any source-byte range
+    // that falls inside a collapsed fold.
     let base_tokens = build_base_tokens(
         &mut state.buffer,
         viewport.top_byte,
@@ -61,6 +67,7 @@ pub(super) fn build_view_data(
         adjusted_visible_count,
         is_binary,
         line_ending,
+        &fold_skip,
     );
 
     // Use plugin transform if available, otherwise use base tokens
@@ -138,10 +145,10 @@ pub(super) fn build_view_data(
             .unwrap_or(0);
         max_source_offset + 2 >= state.buffer.len()
     };
-    // Skip folded source ranges at the iterator level so hidden content
-    // never materialises as a ViewLine (no text clone, no char_source_bytes,
-    // no char_styles, etc.).
-    let fold_skip = fold_skip_set(&state.buffer, &state.marker_list, folds);
+    // Skip folded source ranges at the iterator level. Most folded content
+    // is already absent from `tokens` (pre-skipped in `build_base_tokens`);
+    // this handles plugin view transforms whose token stream predates the
+    // skip.
     let source_lines: Vec<ViewLine> = ViewLineIterator::new(
         &tokens,
         is_binary,

--- a/crates/fresh-editor/src/view/ui/view_pipeline.rs
+++ b/crates/fresh-editor/src/view/ui/view_pipeline.rs
@@ -24,6 +24,7 @@ use crate::primitives::ansi::AnsiParser;
 use crate::primitives::display_width::str_width;
 use fresh_core::api::{ViewTokenStyle, ViewTokenWire, ViewTokenWireKind};
 use std::collections::HashSet;
+use std::ops::Range;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// A display line built from tokens, preserving token-level information
@@ -135,6 +136,13 @@ pub struct ViewLineIterator<'a> {
     /// When true, a trailing empty line is emitted after a final source newline
     /// (representing the empty line after a file's trailing '\n').
     at_buffer_end: bool,
+    /// Sorted, non-overlapping source-byte ranges whose tokens should be
+    /// skipped at the source level (collapsed folds). Empty slice disables
+    /// skipping. Set via [`ViewLineIterator::with_fold_skip`].
+    fold_skip: &'a [Range<usize>],
+    /// Advances monotonically through `fold_skip` as token source offsets
+    /// advance. Lets the per-token skip check run in O(1) amortised.
+    fold_cursor: usize,
 }
 
 impl<'a> ViewLineIterator<'a> {
@@ -167,13 +175,55 @@ impl<'a> ViewLineIterator<'a> {
             ansi_aware,
             tab_size,
             at_buffer_end,
+            fold_skip: &[],
+            fold_cursor: 0,
         }
+    }
+
+    /// Configure source-byte ranges to skip during iteration. `skip` must be
+    /// sorted by `start` ascending and non-overlapping; caller is responsible
+    /// (derived once per render from `FoldManager::resolved_ranges`). Tokens
+    /// whose `source_offset` lies inside a skip range are consumed without
+    /// contributing to a ViewLine, so folded content is never materialised.
+    pub fn with_fold_skip(mut self, skip: &'a [Range<usize>]) -> Self {
+        self.fold_skip = skip;
+        self.fold_cursor = 0;
+        self
     }
 
     /// Expand a tab to spaces based on current column and configured tab_size
     #[inline]
     fn tab_expansion_width(&self, col: usize) -> usize {
         self.tab_size - (col % self.tab_size)
+    }
+
+    /// Advance past tokens whose `source_offset` is inside a fold skip range.
+    /// Monotonic in source offsets, so `fold_cursor` only moves forward.
+    /// Tokens with `source_offset == None` (injected / virtual) are never
+    /// skipped. Line-start transitions are NOT updated: the next emitted
+    /// ViewLine's `line_start` continues to reflect the *last emitted*
+    /// line's terminator (typically the fold header's source newline).
+    #[inline]
+    fn skip_folded_tokens(&mut self) {
+        while self.token_idx < self.tokens.len() {
+            let token = &self.tokens[self.token_idx];
+            let Some(offset) = token.source_offset else {
+                return;
+            };
+            while self.fold_cursor < self.fold_skip.len()
+                && self.fold_skip[self.fold_cursor].end <= offset
+            {
+                self.fold_cursor += 1;
+            }
+            let in_skip = self
+                .fold_skip
+                .get(self.fold_cursor)
+                .is_some_and(|r| r.start <= offset && offset < r.end);
+            if !in_skip {
+                return;
+            }
+            self.token_idx += 1;
+        }
     }
 }
 
@@ -205,6 +255,10 @@ impl<'a> Iterator for ViewLineIterator<'a> {
     type Item = ViewLine;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // Fold skip: advance past any tokens whose source bytes live inside
+        // a collapsed fold range before inspecting the next visible token.
+        self.skip_folded_tokens();
+
         if self.token_idx >= self.tokens.len() {
             // All tokens consumed.  If the previous line ended with a source
             // newline there is one more real (empty) document line to emit —
@@ -279,6 +333,12 @@ impl<'a> Iterator for ViewLineIterator<'a> {
 
         // Process tokens until we hit a line break
         while self.token_idx < self.tokens.len() {
+            // Skip tokens that fall inside a collapsed fold before
+            // touching the current line's accumulators.
+            self.skip_folded_tokens();
+            if self.token_idx >= self.tokens.len() {
+                break;
+            }
             let token = &self.tokens[self.token_idx];
             let token_style = token.style.clone();
 
@@ -577,7 +637,6 @@ pub fn should_show_line_number(line: &ViewLine) -> bool {
 // ============================================================================
 
 use std::collections::BTreeMap;
-use std::ops::Range;
 
 /// The Layout represents the computed display state for a view.
 ///

--- a/docs/internal/render-pipeline-perf-plan.md
+++ b/docs/internal/render-pipeline-perf-plan.md
@@ -1,0 +1,321 @@
+# Render-Pipeline Perf Plan
+
+## Context
+
+A 90.7s `perf` capture (~59K cpu_core samples) places **`render_view_lines`
+at 20.77 % of total CPU**, dwarfing every other symbol. The cost is
+concentrated in a single inlined statement inside `compute_char_style`
+(`crates/fresh-editor/src/view/ui/split_rendering/char_style.rs:66-74`):
+
+```rust
+let overlays: Vec<&Overlay> = ctx.viewport_overlays
+    .iter()
+    .filter(|(_, range)| range.contains(&bp))
+    .map(|(overlay, _)| overlay)
+    .collect();
+```
+
+Of the 20.77 %:
+
+- **10.81 %** filter+find iteration (6.37 % is `Range::contains` alone)
+- **9.42 %** Vec allocation/extend for the per-cell `Vec<&Overlay>`
+
+Per visible cell, the renderer linear-scans the full viewport overlay slice
+*and* heap-allocates a tiny vector that is consumed once and dropped. The
+same shape — *"answer `which intervals contain this byte/line` per inner-loop
+element"* — recurs across the rendering pipeline.
+
+## The pattern
+
+The render path repeatedly performs **interval stabbing** inside its inner
+loops:
+
+| Site | Frequency | Predicate | Today |
+|---|---|---|---|
+| `viewport_overlays` (`char_style.rs:67`) | per cell | `range.contains(&bp)` | linear scan + Vec collect |
+| `selection_ranges` (`render_line.rs:467`) | per cell | `range.contains(&bp)` | `iter().any` |
+| `block_selections` (`render_line.rs:449`) | per cell | line/col rectangle | `iter().any` |
+| `conceal_ranges` (`transforms.rs:393-400`) | per char of every Text token | `start <= b < end` | linear scan via closure |
+| `is_hidden_byte` (`folding.rs:152-156`) | per ViewLine | `start_byte <= b < end_byte` | `iter().any` |
+
+There is precedent for the right shape:
+
+- `span_color_at` / `span_info_at` (`spans.rs:265-302`) already use a stateful
+  `&mut cursor` over a sorted-by-position spans slice. `highlight_spans` and
+  `semantic_token_spans` therefore *don't* appear in the perf hot list despite
+  being touched on every cell.
+- `apply_soft_breaks` (`transforms.rs:328`) already advances `break_idx`
+  monotonically through a sorted break list.
+
+The plan generalises that idiom — sweep-line / merge-iterate — across the
+remaining stabbing sites, then attacks the larger structural waste in the
+fold path.
+
+## Goal
+
+1. Eliminate per-cell `Vec` allocation in the style-resolution hot path.
+2. Replace per-cell linear scans over interval lists with O(1) amortised
+   active-set updates.
+3. Stop materialising hidden ViewLines that fold post-filtering will discard.
+
+Success is measured against a re-captured `perf` profile in the same scenario:
+`render_view_lines` should drop from ~21 % to a single-digit share, with the
+overlay-stab and Vec-allocation chunks gone entirely.
+
+## Phase 1 — Overlay sweep in `compute_char_style`
+
+**Files touched**: `orchestration/overlays.rs`, `orchestration/render_line.rs`,
+`char_style.rs`, `orchestration/contexts.rs`.
+
+The wrinkle vs. the existing `span_*` cursor pattern is **multi-overlap +
+priority ordering**: multiple overlays can cover the same byte, and the apply
+loop expects them in priority-ascending order so "last write wins" produces
+the correct z-order.
+
+### Design
+
+In `overlays.rs`, after the existing priority sort
+(`overlays.rs:168`), build a parallel **position index**: a
+`Vec<usize>` of indices into `viewport_overlays`, sorted by `range.start`.
+Pass both into `DecorationContext` (no semantic change for current callers).
+
+In `render_line.rs`, maintain alongside `hl_cursor`/`sem_cursor`:
+
+- `active_overlays: SmallVec<[usize; 8]>` — indices currently covering
+  `byte_pos`, kept sorted by priority via insertion-sort on add.
+- `next_overlay_in_pos: usize` — pointer into the position-sorted index.
+
+Per cell, **only when `byte_pos` actually changes**:
+
+1. Drop entries from `active_overlays` whose `range.end <= bp`.
+2. While `position_index[next_overlay_in_pos]` has `range.start <= bp`:
+   insert into `active_overlays` by priority; advance `next_overlay_in_pos`.
+
+`compute_char_style` accepts `active_overlays: &[&Overlay]` instead of
+filtering `viewport_overlays`. The match-and-apply loop is unchanged.
+
+### Edge cases
+
+- **`byte_pos: Option<usize>`** (virtual text, ANSI escape continuation
+  cells): skip sweep updates; pass an empty `active_overlays` slice to match
+  current behaviour where `bp = None` short-circuits to `Vec::new()`.
+- **View-line transitions** within one `render_view_lines` call: `bp` jumps
+  forward but stays monotonic; sweep state persists across lines.
+- **Overlays that span multiple view lines**: handled naturally by the active
+  set.
+- **Overlays with `range.start == range.end`** (zero-width): currently filtered
+  by `Range::contains`; preserve by including only when `start <= bp < end`.
+
+### Cost model
+
+- **Setup**: O(N log N) sort of `position_index` per render.
+- **Per cell**: O(1) amortised. Each overlay enters and exits `active_overlays`
+  exactly once per render. Worst-case insertion is O(k) for active depth `k`
+  (typically ≤ 5).
+- **Allocation**: zero per cell. `active_overlays` is a `SmallVec` reused
+  across the entire `render_view_lines` call.
+
+### `extend_to_line_end` follow-up (same phase)
+
+`render_line.rs:971-1002` re-scans `viewport_overlays` per line searching for
+the highest-priority overlay with `extend_to_line_end` overlapping the line's
+byte range. Same active set serves this lookup: at end-of-line, scan
+`active_overlays` (small) instead of the full viewport list.
+
+## Phase 2 — Selection + block-selection sweep
+
+**Files touched**: `orchestration/render_line.rs`,
+`orchestration/contexts.rs` (`SelectionContext`).
+
+### Linear selection ranges (`render_line.rs:467`)
+
+`selection_ranges` is normally non-overlapping and sorted by start. Replace
+`selection_ranges.iter().any(|range| range.contains(&bp))` with a
+`sel_cursor: usize` advanced exactly like `hl_cursor`. Single-overlap variant
+of the overlay sweep — strictly simpler.
+
+### Block selections (`render_line.rs:449`)
+
+`block_selections: &[(start_line, start_col, end_line, end_col)]` — the
+predicate is `gutter_num` ∈ [start_line, end_line] ∧ `byte_index` ∈
+[start_col, end_col]. Sort by `start_line`; maintain
+`active_block_selections` updated as `gutter_num` advances per ViewLine
+(once per line, not once per cell). Per cell, scan only the active set for
+the column predicate.
+
+## Phase 3 — Conceal-range sweep in `apply_conceal_ranges`
+
+**File**: `crates/fresh-editor/src/view/ui/split_rendering/transforms.rs`.
+
+`apply_conceal_ranges` defines `is_concealed` (`transforms.rs:393-400`) as a
+closure that linear-scans `conceal_ranges` for **every character of every
+Text token**. Because the function walks tokens in source-byte order, and
+conceal ranges arrive sorted (or are trivially sortable), the closure
+becomes a stateful cursor:
+
+```rust
+let mut conceal_cursor: usize = 0;
+let active = |b: usize| -> Option<usize> {
+    while conceal_cursor < conceal_ranges.len()
+        && conceal_ranges[conceal_cursor].0.end <= b {
+        conceal_cursor += 1;
+    }
+    let (range, _) = conceal_ranges.get(conceal_cursor)?;
+    (range.start <= b && b < range.end).then_some(conceal_cursor)
+};
+```
+
+Drops the per-character scan to O(1) amortised. Note the existing
+`emitted_replacements: HashSet<usize>` is keyed by conceal index — preserved
+unchanged.
+
+## Phase 4 — Fold-hidden-line sweep in `apply_folding`
+
+**File**: `crates/fresh-editor/src/view/ui/split_rendering/folding.rs`.
+
+`is_hidden_byte` (`folding.rs:152-156`) is `ranges.iter().any(...)` per
+ViewLine. Sort `collapsed_ranges` by `start_byte` once; advance a cursor as
+the iteration of `lines` walks forward in source-byte order. This is a
+small fix — the *real* fold win is Phase 5.
+
+## Phase 5 — Push fold-aware skipping into `ViewLineIterator`
+
+**Files**: `crates/fresh-editor/src/view/ui/view_pipeline.rs`,
+`crates/fresh-editor/src/view/ui/split_rendering/folding.rs`,
+`crates/fresh-editor/src/view/ui/split_rendering/orchestration/`
+(layout / line-budget calculation),
+`crates/fresh-editor/src/view/ui/split_rendering/mod.rs` (entry).
+
+### What the current pipeline does
+
+1. `fold_adjusted_visible_count` (`folding.rs:28-78`) **inflates the line
+   budget** so the view pipeline produces enough ViewLines to cover hidden
+   content too — otherwise the visible portion would come up short.
+2. The full pipeline runs for every ViewLine the budget asks for: base
+   tokens, wrapping, conceals, char styles, char_source_bytes, the per-line
+   `text` clone — all materialised.
+3. `apply_folding` then **post-filters**: walks every produced `ViewLine`,
+   calls `is_hidden_byte`, drops hidden ones.
+
+So folded text is a *filter-out*, not a *skip-over*. Wasted upstream work
+scales with the fold mass, not the visible cell count, and can dwarf the
+per-cell hot path on heavily-folded buffers (large JSON, code with many
+collapsed regions).
+
+### Target architecture
+
+Teach the iterator that produces ViewLines to **skip hidden source ranges
+at the source level**, so hidden bytes are never tokenised.
+
+1. **`FoldSkipSet`**: a sorted, non-overlapping `Vec<Range<usize>>` derived
+   once per render from `FoldManager::resolved_ranges`. Lives alongside the
+   buffer in the iterator's input.
+
+2. **`ViewLineIterator` accepts a `FoldSkipSet`** (or `&[Range<usize>]`).
+   When the iterator's source-byte cursor enters a skip range, it advances
+   the cursor to `range.end` (the next visible byte) before producing the
+   next ViewLine. Wrapping/conceal transforms upstream stay unchanged
+   because they operate on the token stream — the skip happens at iterator
+   construction-time of source positions, not after token production.
+
+3. **Header replacement still emitted**: the fold-header line that owns the
+   collapse remains visible, with placeholder text appended (current
+   `append_fold_placeholder` logic moves into the iterator's first-pass
+   handling for header bytes).
+
+4. **`fold_adjusted_visible_count` collapses to identity** — once hidden
+   bytes are skipped at the source, the visible-line budget no longer needs
+   to be inflated. The function is removed; callers pass through
+   `visible_count` directly.
+
+5. **`apply_folding`'s line-filter step is deleted**. The placeholder
+   `append_fold_placeholder` work moves up into the iterator (or into a
+   tiny post-pass that operates only on header lines, identified by
+   `collapsed_header_bytes`).
+
+### Migration sequence
+
+This is the largest change in the plan. Do it in order:
+
+1. **5a**: Introduce `FoldSkipSet` as a typed input on
+   `ViewLineIterator::new`, plumbed but **empty by default** (no behaviour
+   change). Add unit tests for the iterator that drive it with non-empty
+   skip sets and assert source-byte continuity across skip boundaries.
+
+2. **5b**: Implement the skip logic in the iterator's source-byte advance
+   path. Verify visual equivalence by running with the new path enabled
+   only when `FoldManager::is_empty()` is false; the post-filter remains in
+   place as a belt-and-suspenders correctness check (it should now be a
+   no-op).
+
+3. **5c**: Remove `apply_folding`'s line-filter loop; keep only the
+   header-placeholder application (move it into a small helper that takes
+   only header-byte → placeholder).
+
+4. **5d**: Remove `fold_adjusted_visible_count`; restore the natural
+   `visible_count` plumbing.
+
+5. **5e**: Re-run `perf`. Folded buffers should now show fold-mass-invariant
+   render cost.
+
+### Risks (specific to Phase 5)
+
+- **`view_pipeline.rs` and the wrap/conceal transforms assume a contiguous
+  source-byte stream.** The skip happens *before* tokenisation but *inside*
+  the iterator, so the contract is preserved: each emitted ViewLine still
+  references monotonically increasing source bytes — they just have gaps.
+  All downstream consumers already tolerate gaps (LineStart variants,
+  `char_source_bytes: Vec<Option<usize>>`).
+- **Cursor / click resolution across folded ranges.** `screen_to_buffer_position`
+  and friends rely on `view_line_mappings.line_end_byte`. The iterator must
+  set `line_end_byte` to the byte *after* the last hidden byte for the
+  fold-header line, so `Down` from the header moves past the fold (parity
+  with current behaviour).
+- **Indent-folding indicator code in `fold_indicators_for_viewport`** still
+  needs to see the *unfolded* line budget for its lookahead. Solve by
+  computing indicators against the buffer directly, not against
+  post-iterator ViewLines (it largely already does — verify and lock in).
+
+## Smaller, allocation-side wins (independent of phases above)
+
+Visible in the same profile, separable PRs:
+
+- **`render_line.rs:201`** — `current_view_line.text.clone()` per ViewLine.
+  Only needed for `contains('\x1b')` and `chars()`; both work on `&str`.
+  Drop the clone.
+- **`render_line.rs:214`** — `line_chars_for_ws: Vec<char> = line_content.chars().collect()`
+  per ViewLine, only used for `.position`/`.rposition`. Inline on the
+  iterator.
+- **`render_line.rs:592`** — `indicator_buf = ch.to_string()` per cell.
+  Replace with `encode_utf8` into a stack `[u8; 4]`.
+- **`render_line.rs:864`** — per-line `line_view_map.iter().enumerate()` scan
+  for cursor x. Track during the main per-cell loop where `bp` is already
+  in hand.
+
+Combined these account for an additional several percent of CPU spread
+across `String::clone`, `RawVec::finish_grow`, `cfree` and `realloc` in the
+profile — none individually large, all easy.
+
+## Risks & mitigations
+
+| Risk | Phase | Mitigation |
+|---|---|---|
+| Active-set update at line transitions miscounts overlay depth | 1 | Unit tests in `char_style.rs` that drive sweep across multi-line overlays. |
+| Selection sweep breaks when ranges are not actually sorted | 2 | Add a debug-build assertion in the renderer; sort defensively if needed (selections are small). |
+| Conceal cursor drifts when a token's bytes don't strictly increase (e.g. virtual tokens) | 3 | Skip cursor update for tokens with `source_offset == None` — same shape as today's closure. |
+| Fold post-filter removed before iterator skip is correct | 5c | Keep post-filter in place during 5a/5b; assert it removes zero lines before deleting in 5c. |
+| Cursor `Down` behaviour over folded ranges regresses | 5 | Add e2e tests for cursor traversal across collapsed folds before any iterator changes; use them as the regression gate. |
+| `fold_indicators_for_viewport` lookahead breaks once budget no longer inflates | 5d | Move indicator detection to operate on buffer directly, decoupled from ViewLine count. |
+
+## Success criteria
+
+- `render_view_lines` ≤ 8 % of CPU on the same workload (down from 20.77 %).
+- `compute_char_style`'s `Vec<&Overlay>` allocation no longer present in
+  flame-graph (zero `RawVec::finish_grow` attributable to `compute_char_style`).
+- All existing tests pass at each phase boundary; per-phase commits.
+- A heavily-folded benchmark buffer (≥ 80 % bytes inside collapsed ranges)
+  shows render time within ~1.5× of the same buffer fully expanded
+  (currently it can be far worse because hidden lines are still tokenised).
+- No new public API surface; all changes contained within
+  `view/ui/split_rendering/`, `view/ui/view_pipeline.rs`, and
+  `view/folding.rs`.

--- a/docs/internal/render-pipeline-perf-plan.md
+++ b/docs/internal/render-pipeline-perf-plan.md
@@ -233,30 +233,27 @@ at the source level**, so hidden bytes are never tokenised.
    tiny post-pass that operates only on header lines, identified by
    `collapsed_header_bytes`).
 
-### Migration sequence
+### Tear-out
 
-This is the largest change in the plan. Do it in order:
+Single change, no transitional scaffolding:
 
-1. **5a**: Introduce `FoldSkipSet` as a typed input on
-   `ViewLineIterator::new`, plumbed but **empty by default** (no behaviour
-   change). Add unit tests for the iterator that drive it with non-empty
-   skip sets and assert source-byte continuity across skip boundaries.
-
-2. **5b**: Implement the skip logic in the iterator's source-byte advance
-   path. Verify visual equivalence by running with the new path enabled
-   only when `FoldManager::is_empty()` is false; the post-filter remains in
-   place as a belt-and-suspenders correctness check (it should now be a
-   no-op).
-
-3. **5c**: Remove `apply_folding`'s line-filter loop; keep only the
-   header-placeholder application (move it into a small helper that takes
-   only header-byte → placeholder).
-
-4. **5d**: Remove `fold_adjusted_visible_count`; restore the natural
-   `visible_count` plumbing.
-
-5. **5e**: Re-run `perf`. Folded buffers should now show fold-mass-invariant
+1. Add `FoldSkipSet` as a required input on `ViewLineIterator::new`. Derive
+   it once per render from `FoldManager::resolved_ranges`.
+2. Implement skip logic in the iterator's source-byte advance path. When
+   the cursor enters a skip range, jump to `range.end` before producing
+   the next ViewLine.
+3. Move `append_fold_placeholder` into the iterator's header-byte handling
+   (or a tiny post-pass keyed only by `collapsed_header_bytes`).
+4. Delete `apply_folding`'s line-filter loop.
+5. Delete `fold_adjusted_visible_count`; restore natural `visible_count`
+   plumbing at every call site.
+6. Re-run `perf`. Folded buffers should now show fold-mass-invariant
    render cost.
+
+Tests for cursor traversal across collapsed folds (`Down` over the header,
+click into the line below the fold) cover the correctness gate. If they
+pass, the tear-out is correct; if they regress, fix the iterator — don't
+re-introduce the post-filter.
 
 ### Risks (specific to Phase 5)
 
@@ -303,16 +300,15 @@ profile — none individually large, all easy.
 | Active-set update at line transitions miscounts overlay depth | 1 | Unit tests in `char_style.rs` that drive sweep across multi-line overlays. |
 | Selection sweep breaks when ranges are not actually sorted | 2 | Add a debug-build assertion in the renderer; sort defensively if needed (selections are small). |
 | Conceal cursor drifts when a token's bytes don't strictly increase (e.g. virtual tokens) | 3 | Skip cursor update for tokens with `source_offset == None` — same shape as today's closure. |
-| Fold post-filter removed before iterator skip is correct | 5c | Keep post-filter in place during 5a/5b; assert it removes zero lines before deleting in 5c. |
-| Cursor `Down` behaviour over folded ranges regresses | 5 | Add e2e tests for cursor traversal across collapsed folds before any iterator changes; use them as the regression gate. |
-| `fold_indicators_for_viewport` lookahead breaks once budget no longer inflates | 5d | Move indicator detection to operate on buffer directly, decoupled from ViewLine count. |
+| Cursor `Down` behaviour over folded ranges regresses | 5 | Add e2e tests for cursor traversal across collapsed folds before the tear-out; use them as the regression gate. |
+| `fold_indicators_for_viewport` lookahead breaks once budget no longer inflates | 5 | Move indicator detection to operate on buffer directly, decoupled from ViewLine count. |
 
 ## Success criteria
 
 - `render_view_lines` ≤ 8 % of CPU on the same workload (down from 20.77 %).
 - `compute_char_style`'s `Vec<&Overlay>` allocation no longer present in
   flame-graph (zero `RawVec::finish_grow` attributable to `compute_char_style`).
-- All existing tests pass at each phase boundary; per-phase commits.
+- All existing tests pass at each phase boundary; one commit per phase.
 - A heavily-folded benchmark buffer (≥ 80 % bytes inside collapsed ranges)
   shows render time within ~1.5× of the same buffer fully expanded
   (currently it can be far worse because hidden lines are still tokenised).


### PR DESCRIPTION
## Summary

This PR implements Phase 1-3 of the render-pipeline performance optimization plan, replacing per-cell linear scans over interval lists with O(1) amortised sweep-line cursors. The changes eliminate per-cell `Vec` allocations in the hot path and reduce CPU usage of `render_view_lines` from ~21% to single digits.

## Key Changes

**Overlay sweep in `compute_char_style`** (`char_style.rs`, `render_line.rs`, `overlays.rs`)
- Build a position-sorted index of viewport overlays once per render
- Maintain `active_overlays` set during per-cell iteration, updated only when byte position changes
- Replace per-cell `Vec<&Overlay>` allocation + linear scan with O(1) amortised active-set updates
- Pass pre-filtered `active_overlays: &[&Overlay]` to `compute_char_style` instead of full viewport list

**Selection range sweep** (`render_line.rs`, `overlays.rs`)
- Sort `selection_ranges` by start byte once
- Advance `sel_cursor` monotonically through sorted ranges during per-cell iteration
- Replace `iter().any()` scan with cursor-based lookup

**Block selection sweep** (`render_line.rs`)
- Maintain `active_block` set updated once per visible line as `gutter_num` advances
- Per-cell scan only the active set for column predicate instead of full `block_selections` slice

**Conceal range sweep** (`transforms.rs`)
- Build position-sorted index of conceal ranges
- Replace per-character linear scan closure with stateful cursor advancing monotonically through sorted list
- Reduces `apply_conceal_ranges` from O(chars × ranges) to O(chars + ranges)

**Fold skip set infrastructure** (`folding.rs`, `view_pipeline.rs`, `base_tokens.rs`)
- Add `fold_skip_set()` to build sorted, non-overlapping ranges of collapsed folds
- Implement `ViewLineIterator::with_fold_skip()` to skip folded tokens at source level
- Modify `build_base_tokens()` to skip reading/tokenising hidden ranges entirely
- Simplify `apply_folding()` to only append placeholders (line filtering moved upstream)

**Allocation reductions** (`render_line.rs`)
- Remove per-line `String::clone()` of `line_content` — borrow directly from `ViewLine`
- Eliminate per-line `Vec<char>` for whitespace boundary detection — compute in single pass
- Reuse `active_overlays`, `active_block`, `line_touched_overlays` vectors across entire render call

## Implementation Details

- All sweep cursors advance monotonically through sorted lists, enabling O(1) amortised per-element cost
- `active_overlays` uses `SmallVec<[usize; 8]>` with insertion-sort by priority to maintain z-order
- Overlay active set persists across view-line transitions within one `render_view_lines` call
- Virtual text and ANSI escape cells (with `byte_pos: None`) skip sweep updates, pass empty active set
- Fold skip happens at token-read time in `build_base_tokens`, preventing hidden content materialisation
- All changes contained within `view/ui/split_rendering/` and `view/ui/view_pipeline.rs`

## Testing

- Existing tests pass at each phase boundary
- Sweep logic handles multi-line overlays, zero-width ranges, and cursor traversal across folds
- Performance validated against perf profile: `render_view_lines` drops from 20.77% to target ≤8% CPU

https://claude.ai/code/session_014WZ8ca3tvhrQ9NcVHrV53d