### PR TITLE
Wrap mutable editor state in Arc for CoW-safe plugin snapshots

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -750,22 +750,47 @@ pub struct EditorStateSnapshot {
     pub clipboard: String,
     /// Editor's working directory (for file operations and spawning processes)
     pub working_dir: PathBuf,
-    /// LSP diagnostics per file URI
-    /// Maps file URI string to Vec of diagnostics for that file
+    /// LSP diagnostics per file URI.
+    /// Maps file URI string to Vec of diagnostics for that file.
+    ///
+    /// Wrapped in `Arc` so snapshot refresh is a refcount bump rather than
+    /// a deep clone. The editor only mutates its own map through
+    /// `Arc::make_mut`, which CoW-clones while this snapshot still holds
+    /// a reference — a reader can never observe an in-place mutation.
+    ///
+    /// `#[serde(skip)]`: serde out-of-the-box can't serialize `Arc<T>`
+    /// (behind the `rc` cargo feature we don't enable). We never serialize
+    /// the snapshot as a whole — plugin readers pull out these Arcs and
+    /// serialize the *inner* value directly (e.g. `get_all_diagnostics`).
+    #[serde(skip)]
     #[ts(type = "any")]
-    pub diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
-    /// LSP folding ranges per file URI
-    /// Maps file URI string to Vec of folding ranges for that file
+    pub diagnostics: Arc<HashMap<String, Vec<lsp_types::Diagnostic>>>,
+    /// LSP folding ranges per file URI.
+    /// Maps file URI string to Vec of folding ranges for that file.
+    /// Arc-wrapped for the same CoW invariant as `diagnostics`; see that
+    /// field for why this is `#[serde(skip)]`.
+    #[serde(skip)]
     #[ts(type = "any")]
-    pub folding_ranges: HashMap<String, Vec<lsp_types::FoldingRange>>,
-    /// Runtime config as serde_json::Value (merged user config + defaults)
-    /// This is the runtime config, not just the user's config file
+    pub folding_ranges: Arc<HashMap<String, Vec<lsp_types::FoldingRange>>>,
+    /// Runtime config as serde_json::Value (merged user config + defaults).
+    /// This is the runtime config, not just the user's config file.
+    ///
+    /// Wrapped in `Arc` so the snapshot update is a refcount bump. The
+    /// editor reserializes its source `Config` only when the underlying
+    /// `Arc<Config>` pointer has moved (i.e., after a real mutation), and
+    /// swaps the whole `Arc<Value>` atomically — callers never see a
+    /// partially-updated blob. `#[serde(skip)]` for the same reason as
+    /// `diagnostics`.
+    #[serde(skip)]
     #[ts(type = "any")]
-    pub config: serde_json::Value,
-    /// User config as serde_json::Value (only what's in the user's config file)
-    /// Fields not present here are using default values
+    pub config: Arc<serde_json::Value>,
+    /// User config as serde_json::Value (only what's in the user's config file).
+    /// Fields not present here are using default values.
+    /// Arc-wrapped; swapped as a whole when the user's file is reloaded.
+    /// `#[serde(skip)]` for the same reason as `diagnostics`.
+    #[serde(skip)]
     #[ts(type = "any")]
-    pub user_config: serde_json::Value,
+    pub user_config: Arc<serde_json::Value>,
     /// Available grammars with provenance info, updated when grammar registry changes
     #[ts(type = "GrammarInfo[]")]
     pub available_grammars: Vec<GrammarInfoSnapshot>,
@@ -816,10 +841,10 @@ impl EditorStateSnapshot {
             selected_text: None,
             clipboard: String::new(),
             working_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            diagnostics: HashMap::new(),
-            folding_ranges: HashMap::new(),
-            config: serde_json::Value::Null,
-            user_config: serde_json::Value::Null,
+            diagnostics: Arc::new(HashMap::new()),
+            folding_ranges: Arc::new(HashMap::new()),
+            config: Arc::new(serde_json::Value::Null),
+            user_config: Arc::new(serde_json::Value::Null),
             available_grammars: Vec::new(),
             editor_mode: None,
             plugin_view_states: HashMap::new(),

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1129,11 +1129,16 @@ interface EditorAPI {
 	*/
 	getTempDir(): string;
 	/**
-	* Get current config as JS object
+	* Get current config as JS object.
+	* 
+	* The snapshot holds an `Arc<serde_json::Value>` that was serialized
+	* on the editor side the last time the underlying `Arc<Config>`
+	* changed. Cloning the Arc inside the read lock is a refcount bump;
+	* the actual walk into the JS runtime happens outside the lock.
 	*/
 	getConfig(): unknown;
 	/**
-	* Get user config as JS object
+	* Get user config as JS object. Same Arc-clone pattern as `get_config`.
 	*/
 	getUserConfig(): unknown;
 	/**

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -111,9 +111,9 @@ impl Editor {
 
         // Update the merged view
         if merged.is_empty() {
-            self.stored_diagnostics.remove(uri);
+            self.stored_diagnostics_mut().remove(uri);
         } else {
-            self.stored_diagnostics
+            self.stored_diagnostics_mut()
                 .insert(uri.to_string(), merged.clone());
         }
 
@@ -366,9 +366,9 @@ impl Editor {
         }
 
         if ranges.is_empty() {
-            self.stored_folding_ranges.remove(&uri);
+            self.stored_folding_ranges_mut().remove(&uri);
         } else {
-            self.stored_folding_ranges.insert(uri.clone(), ranges);
+            self.stored_folding_ranges_mut().insert(uri.clone(), ranges);
         }
 
         if let Some(state) = self.buffers.get_mut(&request.buffer_id) {

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -24,11 +24,47 @@ impl Editor {
     }
 
     /// Get a mutable reference to the config.
-    /// Intended for tests and in-process settings UIs that update the
-    /// live editor configuration. Not all config fields take effect
-    /// immediately — some are read only at startup or on buffer open.
+    ///
+    /// Routes through `Arc::make_mut`: if the plugin state snapshot (or any
+    /// other reader) still holds an `Arc` to the current value, this
+    /// CoW-clones so existing readers observe a stable value and the next
+    /// snapshot refresh sees a new pointer. `Arc<T>` has no `DerefMut`, so
+    /// the only way to mutate through `self.config` is via this accessor —
+    /// there is no code path that can silently leave a reader with stale
+    /// data.
     pub fn config_mut(&mut self) -> &mut Config {
-        &mut self.config
+        Arc::make_mut(&mut self.config)
+    }
+
+    /// Replace the config wholesale. Used by the "reload config" path and
+    /// by tests that want to swap in a freshly-parsed file. Constructs a
+    /// fresh `Arc`, so any snapshot that still holds the old value sees
+    /// the pointer move and will reserialize on the next refresh.
+    pub fn set_config(&mut self, new_config: Config) {
+        self.config = Arc::new(new_config);
+    }
+
+    /// Replace the cached raw user config. Like `set_config`, constructs
+    /// a fresh `Arc` so the plugin snapshot notices the change.
+    pub(crate) fn set_user_config_raw(&mut self, value: serde_json::Value) {
+        self.user_config_raw = Arc::new(value);
+    }
+
+    /// Mutable access to the merged diagnostics map. Routes through
+    /// `Arc::make_mut`, which CoW-clones while the plugin snapshot still
+    /// holds the old map — readers never observe an in-place mutation.
+    pub(crate) fn stored_diagnostics_mut(
+        &mut self,
+    ) -> &mut HashMap<String, Vec<lsp_types::Diagnostic>> {
+        Arc::make_mut(&mut self.stored_diagnostics)
+    }
+
+    /// Mutable access to the folding-ranges map. CoW-clones through
+    /// `Arc::make_mut` for the same reason as `stored_diagnostics_mut`.
+    pub(crate) fn stored_folding_ranges_mut(
+        &mut self,
+    ) -> &mut HashMap<String, Vec<lsp_types::FoldingRange>> {
+        Arc::make_mut(&mut self.stored_folding_ranges)
     }
 
     /// Get a reference to the key translator (for input calibration)

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -477,9 +477,8 @@ impl Editor {
         // via `config_mut()`) can leave `config_cached_json` referring to
         // stale memory.
         let config_arc = Arc::new(config);
-        let config_cached_json = Arc::new(
-            serde_json::to_value(&*config_arc).unwrap_or(serde_json::Value::Null),
-        );
+        let config_cached_json =
+            Arc::new(serde_json::to_value(&*config_arc).unwrap_or(serde_json::Value::Null));
         let config_snapshot_anchor = Arc::clone(&config_arc);
 
         let mut editor = Editor {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -470,12 +470,26 @@ impl Editor {
         // Cache raw user config at startup (to avoid re-reading file every frame)
         let user_config_raw = Config::read_user_config_raw(&working_dir);
 
+        // Wrap config in Arc and pre-seed the snapshot mirror + JSON cache.
+        // Doing this at construction means the strong count of the live
+        // `config` Arc starts at 2 and stays there: every `Arc::make_mut`
+        // call on `config` is forced to CoW, so no mutation path (direct or
+        // via `config_mut()`) can leave `config_cached_json` referring to
+        // stale memory.
+        let config_arc = Arc::new(config);
+        let config_cached_json = Arc::new(
+            serde_json::to_value(&*config_arc).unwrap_or(serde_json::Value::Null),
+        );
+        let config_snapshot_anchor = Arc::clone(&config_arc);
+
         let mut editor = Editor {
             buffers,
             event_logs,
             next_buffer_id: 2,
-            config,
-            user_config_raw,
+            config: config_arc,
+            config_snapshot_anchor,
+            config_cached_json,
+            user_config_raw: Arc::new(user_config_raw),
             dir_context: dir_context.clone(),
             grammar_registry,
             pending_grammars: scan_result
@@ -625,8 +639,8 @@ impl Editor {
             scheduled_inlay_hints_request: None,
             stored_push_diagnostics: HashMap::new(),
             stored_pull_diagnostics: HashMap::new(),
-            stored_diagnostics: HashMap::new(),
-            stored_folding_ranges: HashMap::new(),
+            stored_diagnostics: Arc::new(HashMap::new()),
+            stored_folding_ranges: Arc::new(HashMap::new()),
             event_broadcaster: crate::model::control_event::EventBroadcaster::default(),
             bookmarks: bookmarks::BookmarkState::default(),
             search_case_sensitive: true,

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -797,7 +797,7 @@ impl Editor {
         self.set_status_message(msg.to_string());
 
         // Persist to config so the setting survives across sessions
-        self.config.file_explorer.show_hidden = show_hidden;
+        self.config_mut().file_explorer.show_hidden = show_hidden;
         self.persist_config_change(
             "/file_explorer/show_hidden",
             serde_json::Value::Bool(show_hidden),
@@ -820,7 +820,7 @@ impl Editor {
         self.set_status_message(msg.to_string());
 
         // Persist to config so the setting survives across sessions
-        self.config.file_explorer.show_gitignored = show_gitignored;
+        self.config_mut().file_explorer.show_gitignored = show_gitignored;
         self.persist_config_change(
             "/file_explorer/show_gitignored",
             serde_json::Value::Bool(show_gitignored),

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -532,7 +532,8 @@ impl Editor {
                 self.start_quick_open();
             }
             Action::ToggleLineWrap => {
-                self.config.editor.line_wrap = !self.config.editor.line_wrap;
+                let new_value = !self.config.editor.line_wrap;
+                self.config_mut().editor.line_wrap = new_value;
 
                 // Update all viewports to reflect the new line wrap setting,
                 // respecting per-language overrides
@@ -559,8 +560,8 @@ impl Editor {
                 self.set_status_message(t!("view.line_wrap_state", state = state).to_string());
             }
             Action::ToggleCurrentLineHighlight => {
-                self.config.editor.highlight_current_line =
-                    !self.config.editor.highlight_current_line;
+                let new_value = !self.config.editor.highlight_current_line;
+                self.config_mut().editor.highlight_current_line = new_value;
 
                 // Update all splits
                 let leaf_ids: Vec<_> = self.split_view_states.keys().copied().collect();
@@ -925,7 +926,7 @@ impl Editor {
 
                 if is_builtin || is_user_defined {
                     // Update the active keybinding map in config
-                    self.config.active_keybinding_map = map_name.clone().into();
+                    self.config_mut().active_keybinding_map = map_name.clone().into();
 
                     // Reload the keybinding resolver with the new map
                     *self.keybindings.write().unwrap() =

--- a/crates/fresh-editor/src/app/keybinding_editor_actions.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor_actions.rs
@@ -64,7 +64,7 @@ impl Editor {
 
         // Remove deleted custom bindings from config
         for remove in editor.get_pending_removes() {
-            self.config.keybindings.retain(|kb| {
+            self.config_mut().keybindings.retain(|kb| {
                 !(kb.action == remove.action
                     && kb.key == remove.key
                     && kb.modifiers == remove.modifiers
@@ -75,7 +75,7 @@ impl Editor {
         // Add new custom bindings
         let new_bindings = editor.get_custom_bindings();
         for binding in new_bindings {
-            self.config.keybindings.push(binding);
+            self.config_mut().keybindings.push(binding);
         }
 
         // Rebuild the keybinding resolver

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -819,11 +819,11 @@ impl Editor {
             .map(|u| u.as_str().to_string());
 
         if let Some(uri_str) = uri {
-            self.stored_diagnostics.remove(&uri_str);
+            self.stored_diagnostics_mut().remove(&uri_str);
             self.stored_push_diagnostics.remove(&uri_str);
             self.stored_pull_diagnostics.remove(&uri_str);
             self.diagnostic_result_ids.remove(&uri_str);
-            self.stored_folding_ranges.remove(&uri_str);
+            self.stored_folding_ranges_mut().remove(&uri_str);
         }
 
         // Cancel scheduled diagnostic pull if it targets this buffer

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -303,11 +303,51 @@ pub struct Editor {
     /// Next buffer ID to assign
     next_buffer_id: usize,
 
-    /// Configuration
-    config: Config,
+    /// Configuration.
+    ///
+    /// Stored as `Arc<Config>` so that mutations go through `Arc::make_mut`
+    /// (via `config_mut()`), which clone-on-writes when any other holder
+    /// references the same value. `Arc<T>` has no `DerefMut`, so direct
+    /// field assignment through `self.config` is a compile error — every
+    /// mutation must route through the CoW-aware accessor.
+    ///
+    /// **Freshness invariant**: `config_snapshot_anchor` below is set to
+    /// `Arc::clone(&self.config)` on every plugin-snapshot refresh. That
+    /// guarantees the first `Arc::make_mut(&mut self.config)` after each
+    /// refresh *always* CoW-clones (strong count ≥ 2), so `self.config`
+    /// moves to a new pointer and stops being `ptr_eq` with the anchor.
+    /// Subsequent mutations in the same refresh cycle may mutate the new
+    /// pointer in place, but the anchor still points at the *pre-refresh*
+    /// value — so the next refresh's `ptr_eq(self.config, anchor)` check
+    /// still detects that serialization is out of date. In no scenario
+    /// can `config_cached_json` go stale relative to `*self.config`.
+    config: Arc<Config>,
 
-    /// Cached raw user config (for plugins, avoids re-reading file on every frame)
-    user_config_raw: serde_json::Value,
+    /// Clone of `config` captured at the last plugin-snapshot refresh.
+    /// The only writer is `update_plugin_state_snapshot` (see
+    /// `plugin_dispatch.rs`), which keeps it in lock-step with
+    /// `config_cached_json`. Two roles:
+    ///
+    /// 1. Forces the first post-refresh `Arc::make_mut` on `self.config`
+    ///    to CoW, so any mutation produces a new pointer distinguishable
+    ///    by `Arc::ptr_eq` from the anchor.
+    /// 2. Acts as the cache key for `config_cached_json`:
+    ///    `Arc::ptr_eq(&self.config, &self.config_snapshot_anchor)` is
+    ///    true iff the cached JSON is still valid.
+    config_snapshot_anchor: Arc<Config>,
+
+    /// Serialized JSON of `*self.config` as of the last time
+    /// `ptr_eq(&self.config, &self.config_snapshot_anchor)` was false.
+    /// This is the value the plugin snapshot hands to `getConfig()`.
+    /// Recomputed only when the config pointer actually moves, so idle
+    /// ticks do zero serialization work.
+    config_cached_json: Arc<serde_json::Value>,
+
+    /// Cached raw user config (for plugins, avoids re-reading file on every frame).
+    /// Wrapped in `Arc` so the plugin snapshot refresh is a refcount bump
+    /// and mutation is funneled through `set_user_config_raw()`, which
+    /// replaces the whole `Arc`.
+    user_config_raw: Arc<serde_json::Value>,
 
     /// Directory context for editor state paths
     dir_context: DirectoryContext,
@@ -749,12 +789,15 @@ pub struct Editor {
     /// Stored LSP diagnostics per URI (pull model - native RA diagnostics)
     stored_pull_diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
 
-    /// Merged view of push + pull diagnostics per URI (for plugin access)
-    stored_diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
+    /// Merged view of push + pull diagnostics per URI (for plugin access).
+    /// `Arc` wrapper: snapshot refresh is a refcount bump, and mutation is
+    /// forced through `Arc::make_mut` which CoW-clones while the snapshot
+    /// still references the previous map.
+    stored_diagnostics: Arc<HashMap<String, Vec<lsp_types::Diagnostic>>>,
 
     /// Stored LSP folding ranges per URI
     /// Maps file URI string to Vec of folding ranges for that file
-    stored_folding_ranges: HashMap<String, Vec<lsp_types::FoldingRange>>,
+    stored_folding_ranges: Arc<HashMap<String, Vec<lsp_types::FoldingRange>>>,
 
     /// Event broadcaster for control events (observable by external systems)
     event_broadcaster: crate::model::control_event::EventBroadcaster,

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1730,7 +1730,9 @@ impl Editor {
             }),
             ..Default::default()
         };
-        self.config.languages.insert(language.clone(), lang_config);
+        self.config_mut()
+            .languages
+            .insert(language.clone(), lang_config);
         tracing::info!("Language config registered for '{}'", language);
     }
 
@@ -1766,7 +1768,7 @@ impl Editor {
             lsp.set_language_config(language.clone(), lsp_config.clone());
         }
         // Also update runtime config
-        self.config.lsp.insert(
+        self.config_mut().lsp.insert(
             language.clone(),
             crate::types::LspLanguageConfig::Multi(vec![lsp_config]),
         );
@@ -1822,7 +1824,11 @@ impl Editor {
                 ..
             } in &additional
             {
-                let lang_config = self.config.languages.entry(language.clone()).or_default();
+                let lang_config = self
+                    .config_mut()
+                    .languages
+                    .entry(language.clone())
+                    .or_default();
                 for ext in extensions {
                     if !lang_config.extensions.contains(ext) {
                         lang_config.extensions.push(ext.clone());
@@ -1923,7 +1929,11 @@ impl Editor {
             ..
         } in &additional
         {
-            let lang_config = self.config.languages.entry(language.clone()).or_default();
+            let lang_config = self
+                .config_mut()
+                .languages
+                .entry(language.clone())
+                .or_default();
             for ext in extensions {
                 if !lang_config.extensions.contains(ext) {
                     lang_config.extensions.push(ext.clone());

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -232,8 +232,7 @@ impl Editor {
             // config mutation), this branch is skipped entirely and the
             // snapshot update is a refcount bump.
             if !Arc::ptr_eq(&self.config, &self.config_snapshot_anchor) {
-                let json = serde_json::to_value(&*self.config)
-                    .unwrap_or(serde_json::Value::Null);
+                let json = serde_json::to_value(&*self.config).unwrap_or(serde_json::Value::Null);
                 self.config_cached_json = Arc::new(json);
                 self.config_snapshot_anchor = Arc::clone(&self.config);
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -217,18 +217,32 @@ impl Editor {
             // Update working directory (for spawning processes in correct directory)
             snapshot.working_dir = self.working_dir.clone();
 
-            // Update LSP diagnostics
-            snapshot.diagnostics = self.stored_diagnostics.clone();
+            // Update LSP diagnostics: Arc refcount bump; no clone.
+            snapshot.diagnostics = Arc::clone(&self.stored_diagnostics);
 
-            // Update LSP folding ranges
-            snapshot.folding_ranges = self.stored_folding_ranges.clone();
+            // Update LSP folding ranges: Arc refcount bump; no clone.
+            snapshot.folding_ranges = Arc::clone(&self.stored_folding_ranges);
 
-            // Update config (serialize the runtime config for plugins)
-            snapshot.config = serde_json::to_value(&self.config).unwrap_or(serde_json::Value::Null);
+            // Update config. Reserialize only when the underlying
+            // `Arc<Config>` pointer has actually moved since the last
+            // refresh — `Arc::ptr_eq` vs `config_snapshot_anchor` is a
+            // sound cache key because the anchor keeps `self.config`'s
+            // strong count at ≥ 2, forcing every `Arc::make_mut` on the
+            // editor side to CoW into a new allocation. On idle (no
+            // config mutation), this branch is skipped entirely and the
+            // snapshot update is a refcount bump.
+            if !Arc::ptr_eq(&self.config, &self.config_snapshot_anchor) {
+                let json = serde_json::to_value(&*self.config)
+                    .unwrap_or(serde_json::Value::Null);
+                self.config_cached_json = Arc::new(json);
+                self.config_snapshot_anchor = Arc::clone(&self.config);
+            }
+            snapshot.config = Arc::clone(&self.config_cached_json);
 
-            // Update user config (cached raw file contents, not merged with defaults)
-            // This allows plugins to distinguish between user-set and default values
-            snapshot.user_config = self.user_config_raw.clone();
+            // Update user config (cached raw file contents, not merged with defaults).
+            // This allows plugins to distinguish between user-set and default values.
+            // Arc refcount bump; no clone.
+            snapshot.user_config = Arc::clone(&self.user_config_raw);
 
             // Update editor mode (for vi mode and other modal editing)
             snapshot.editor_mode = self.editor_mode.clone();
@@ -1463,7 +1477,7 @@ impl Editor {
                 }
 
                 // 2. Update the config to disable the language
-                if let Some(lsp_configs) = self.config.lsp.get_mut(&language) {
+                if let Some(lsp_configs) = self.config_mut().lsp.get_mut(&language) {
                     for c in lsp_configs.as_mut_slice() {
                         c.enabled = false;
                         c.auto_start = false;

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -671,11 +671,12 @@ impl Editor {
                     }
                 }
                 // Persist to user config
-                self.config.editor.rulers = self
+                let new_rulers = self
                     .split_view_states
                     .get(&active_split)
                     .map(|vs| vs.rulers.clone())
                     .unwrap_or_default();
+                self.config_mut().editor.rulers = new_rulers;
                 self.save_rulers_to_config();
                 self.set_status_message(t!("rulers.added", column = col).to_string());
             }
@@ -697,11 +698,12 @@ impl Editor {
                 view_state.rulers.retain(|&r| r != col);
             }
             // Persist to user config
-            self.config.editor.rulers = self
+            let new_rulers = self
                 .split_view_states
                 .get(&active_split)
                 .map(|vs| vs.rulers.clone())
                 .unwrap_or_default();
+            self.config_mut().editor.rulers = new_rulers;
             self.save_rulers_to_config();
             self.set_status_message(t!("rulers.removed", column = col).to_string());
         }
@@ -1158,7 +1160,7 @@ impl Editor {
         }
 
         // Update config: disable auto_start for the stopped server(s)
-        if let Some(lsp_configs) = self.config.lsp.get_mut(language) {
+        if let Some(lsp_configs) = self.config_mut().lsp.get_mut(language) {
             for c in lsp_configs.as_mut_slice() {
                 if let Some(name) = server_name {
                     // Only disable auto_start for the specific server

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -96,10 +96,10 @@ impl Editor {
         };
 
         // Apply the new config
-        self.config = new_config.clone();
+        self.set_config(new_config.clone());
 
         // Refresh cached raw user config for plugins
-        self.user_config_raw = Config::read_user_config_raw(&self.working_dir);
+        self.set_user_config_raw(Config::read_user_config_raw(&self.working_dir));
 
         // Apply runtime changes
         if old_theme != self.config.theme {

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -414,7 +414,7 @@ impl Editor {
                     .resolve_key(key_or_name)
                     .unwrap_or(key_or_name)
                     .to_string();
-                self.config.theme = resolved.into();
+                self.config_mut().theme = resolved.into();
 
                 // Persist to config file
                 self.save_theme_to_config();
@@ -600,7 +600,7 @@ impl Editor {
 
         if is_builtin || is_user_defined {
             // Update the active keybinding map in config
-            self.config.active_keybinding_map = map_name.to_string().into();
+            self.config_mut().active_keybinding_map = map_name.to_string().into();
 
             // Reload the keybinding resolver with the new map
             *self.keybindings.write().unwrap() =
@@ -685,7 +685,7 @@ impl Editor {
 
         if let Some(style) = CursorStyle::parse(style_name) {
             // Update the config in memory
-            self.config.editor.cursor_style = style;
+            self.config_mut().editor.cursor_style = style;
 
             // Apply the cursor style to the terminal
             if self.session_mode {
@@ -843,7 +843,7 @@ impl Editor {
             crate::i18n::set_locale(locale_name);
 
             // Update the config in memory
-            self.config.locale = crate::config::LocaleName(Some(locale_name.to_string()));
+            self.config_mut().locale = crate::config::LocaleName(Some(locale_name.to_string()));
 
             // Regenerate menus with the new locale
             self.menus = crate::config::MenuConfig::translated();

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -669,7 +669,7 @@ impl Editor {
 
     /// Set terminal jump_to_end_on_output config option (for testing)
     pub fn set_terminal_jump_to_end_on_output(&mut self, value: bool) {
-        self.config.terminal.jump_to_end_on_output = value;
+        self.config_mut().terminal.jump_to_end_on_output = value;
     }
 
     /// Get read-only access to the terminal manager (for testing)

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -124,7 +124,8 @@ impl Editor {
 
     /// Toggle vertical scrollbar visibility
     pub fn toggle_vertical_scrollbar(&mut self) {
-        self.config.editor.show_vertical_scrollbar = !self.config.editor.show_vertical_scrollbar;
+        let new_value = !self.config.editor.show_vertical_scrollbar;
+        self.config_mut().editor.show_vertical_scrollbar = new_value;
         let status = if self.config.editor.show_vertical_scrollbar {
             t!("toggle.vertical_scrollbar_shown")
         } else {
@@ -135,8 +136,8 @@ impl Editor {
 
     /// Toggle horizontal scrollbar visibility
     pub fn toggle_horizontal_scrollbar(&mut self) {
-        self.config.editor.show_horizontal_scrollbar =
-            !self.config.editor.show_horizontal_scrollbar;
+        let new_value = !self.config.editor.show_horizontal_scrollbar;
+        self.config_mut().editor.show_horizontal_scrollbar = new_value;
         let status = if self.config.editor.show_horizontal_scrollbar {
             t!("toggle.horizontal_scrollbar_shown")
         } else {
@@ -220,7 +221,8 @@ impl Editor {
     /// On Windows, this also switches the mouse tracking mode: mode 1003
     /// (all motion) when enabled, mode 1002 (cell motion) when disabled.
     pub fn toggle_mouse_hover(&mut self) {
-        self.config.editor.mouse_hover_enabled = !self.config.editor.mouse_hover_enabled;
+        let new_value = !self.config.editor.mouse_hover_enabled;
+        self.config_mut().editor.mouse_hover_enabled = new_value;
 
         if self.config.editor.mouse_hover_enabled {
             self.set_status_message(t!("toggle.mouse_hover_enabled").to_string());
@@ -261,7 +263,8 @@ impl Editor {
 
     /// Toggle inlay hints visibility
     pub fn toggle_inlay_hints(&mut self) {
-        self.config.editor.enable_inlay_hints = !self.config.editor.enable_inlay_hints;
+        let new_value = !self.config.editor.enable_inlay_hints;
+        self.config_mut().editor.enable_inlay_hints = new_value;
 
         if self.config.editor.enable_inlay_hints {
             // Re-request inlay hints for the active buffer
@@ -344,10 +347,13 @@ impl Editor {
     /// Uses the layered config system to properly merge with defaults.
     pub fn reload_config(&mut self) {
         let old_theme = self.config.theme.clone();
-        self.config = Config::load_with_layers(&self.dir_context, &self.working_dir);
+        self.set_config(Config::load_with_layers(
+            &self.dir_context,
+            &self.working_dir,
+        ));
 
         // Refresh cached raw user config for plugins
-        self.user_config_raw = Config::read_user_config_raw(&self.working_dir);
+        self.set_user_config_raw(Config::read_user_config_raw(&self.working_dir));
 
         // Apply theme change if needed
         if old_theme != self.config.theme {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -678,19 +678,19 @@ impl Editor {
 
         // 1. Apply config overrides
         if let Some(line_numbers) = workspace.config_overrides.line_numbers {
-            self.config.editor.line_numbers = line_numbers;
+            self.config_mut().editor.line_numbers = line_numbers;
         }
         if let Some(relative_line_numbers) = workspace.config_overrides.relative_line_numbers {
-            self.config.editor.relative_line_numbers = relative_line_numbers;
+            self.config_mut().editor.relative_line_numbers = relative_line_numbers;
         }
         if let Some(line_wrap) = workspace.config_overrides.line_wrap {
-            self.config.editor.line_wrap = line_wrap;
+            self.config_mut().editor.line_wrap = line_wrap;
         }
         if let Some(syntax_highlighting) = workspace.config_overrides.syntax_highlighting {
-            self.config.editor.syntax_highlighting = syntax_highlighting;
+            self.config_mut().editor.syntax_highlighting = syntax_highlighting;
         }
         if let Some(enable_inlay_hints) = workspace.config_overrides.enable_inlay_hints {
-            self.config.editor.enable_inlay_hints = enable_inlay_hints;
+            self.config_mut().editor.enable_inlay_hints = enable_inlay_hints;
         }
         if let Some(mouse_enabled) = workspace.config_overrides.mouse_enabled {
             self.mouse_enabled = mouse_enabled;

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -446,7 +446,24 @@ impl EditorTestHarness {
         config.check_for_updates = false; // Disable update checking in tests
 
         // Initialize i18n with the config's locale before creating the editor
-        // This ensures menu defaults are created with the correct translations
+        // This ensures menu defaults are created with the correct translations.
+        //
+        // TODO(flakiness): this mutates a *process-global* locale
+        // (`rust_i18n::set_locale`). Cargo runs all test functions in one
+        // process in parallel, so harness-created tests can race each other:
+        // a German-locale harness can flip the global to `de` while an
+        // unrelated test is asserting on English UI strings, producing
+        // intermittent failures like
+        // `e2e::locale::test_default_locale_shows_english_search_options`
+        // when the full suite is run in parallel. (The tests in
+        // `tests/e2e/locale.rs` use a module-local mutex, which serializes
+        // them against each other but not against the rest of the suite.)
+        //
+        // Pre-exists this branch; see master for identical parallel-run
+        // failures. A robust fix means either moving rust_i18n locale into
+        // a thread-local, or holding a *global* (process-wide) test lock
+        // around every harness-driven render. Not worth the scope creep
+        // from this perf fix; flagging here so the next reader knows.
         fresh::i18n::init_with_config(config.locale.as_option());
         config.editor.double_click_time_ms = 10; // Fast double-click for faster tests
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1639,27 +1639,32 @@ impl JsEditorApi {
 
     // === Config ===
 
-    /// Get current config as JS object
+    /// Get current config as JS object.
+    ///
+    /// The snapshot holds an `Arc<serde_json::Value>` that was serialized
+    /// on the editor side the last time the underlying `Arc<Config>`
+    /// changed. Cloning the Arc inside the read lock is a refcount bump;
+    /// the actual walk into the JS runtime happens outside the lock.
     pub fn get_config<'js>(&self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<Value<'js>> {
-        let config: serde_json::Value = self
+        let config = self
             .state_snapshot
             .read()
-            .map(|s| s.config.clone())
-            .unwrap_or_else(|_| serde_json::json!({}));
+            .map(|s| std::sync::Arc::clone(&s.config))
+            .unwrap_or_else(|_| std::sync::Arc::new(serde_json::json!({})));
 
-        rquickjs_serde::to_value(ctx, &config)
+        rquickjs_serde::to_value(ctx, &*config)
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
-    /// Get user config as JS object
+    /// Get user config as JS object. Same Arc-clone pattern as `get_config`.
     pub fn get_user_config<'js>(&self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<Value<'js>> {
-        let config: serde_json::Value = self
+        let config = self
             .state_snapshot
             .read()
-            .map(|s| s.user_config.clone())
-            .unwrap_or_else(|_| serde_json::json!({}));
+            .map(|s| std::sync::Arc::clone(&s.user_config))
+            .unwrap_or_else(|_| std::sync::Arc::new(serde_json::json!({})));
 
-        rquickjs_serde::to_value(ctx, &config)
+        rquickjs_serde::to_value(ctx, &*config)
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
@@ -3295,7 +3300,7 @@ impl JsEditorApi {
         let diagnostics = if let Ok(s) = self.state_snapshot.read() {
             // Convert to JsDiagnostic format for JS
             let mut result: Vec<JsDiagnostic> = Vec::new();
-            for (uri, diags) in &s.diagnostics {
+            for (uri, diags) in s.diagnostics.iter() {
                 for diag in diags {
                     result.push(JsDiagnostic {
                         uri: uri.clone(),


### PR DESCRIPTION
## Summary

Refactor the editor's mutable state to use `Arc<T>` wrappers with copy-on-write semantics, ensuring that plugin state snapshots never observe stale data when the editor mutates configuration, diagnostics, or folding ranges.

## Key Changes

- **Config management**: Wrap `Config` in `Arc<Config>` and introduce `config_snapshot_anchor` and `config_cached_json` to implement a cache-key pattern. The snapshot anchor keeps the strong count ≥ 2, forcing every `Arc::make_mut` call to CoW-clone. Config serialization is cached and only recomputed when the underlying pointer moves (i.e., after a real mutation).

- **Accessor methods**: Add `config_mut()` to route all mutations through `Arc::make_mut`, and add `set_config()` and `set_user_config_raw()` for wholesale replacement. This ensures no code path can silently leave a reader with stale data.

- **Diagnostics and folding ranges**: Wrap `stored_diagnostics` and `stored_folding_ranges` in `Arc<HashMap<...>>` and provide `stored_diagnostics_mut()` and `stored_folding_ranges_mut()` accessors that CoW-clone while the snapshot still holds the old map.

- **User config**: Wrap `user_config_raw` in `Arc<serde_json::Value>` and replace it wholesale via `set_user_config_raw()` rather than mutating in place.

- **Plugin snapshot refresh**: Update `update_plugin_state_snapshot` to use `Arc::clone()` for refcount bumps instead of deep clones. Config serialization is skipped on idle frames (when `Arc::ptr_eq` detects no pointer movement).

- **Plugin API**: Update `get_config()` and `get_user_config()` in the QuickJS backend to clone the `Arc` inside the read lock, then dereference outside the lock.

- **Call sites**: Update all direct mutations of `self.config`, `self.stored_diagnostics`, and `self.stored_folding_ranges` to use the new accessor methods.

## Implementation Details

The freshness invariant ensures that `config_snapshot_anchor` is always set to `Arc::clone(&self.config)` after each snapshot refresh. This keeps the strong count at ≥ 2, so the first `Arc::make_mut` after a refresh always CoW-clones into a new allocation. Subsequent mutations in the same refresh cycle may mutate the new pointer in place, but the anchor still points at the pre-refresh value, so the next refresh's `ptr_eq` check still detects that serialization is out of date.

On idle frames (no config mutation), the snapshot update is a refcount bump with zero serialization work.

https://claude.ai/code/session_011Q83Lcsq2kg96BQVwWCWwJ