### PR TITLE
Add shebang/first-line detection for extensionless files

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -556,9 +556,11 @@ impl Editor {
 
                     for (buf_id, path) in buffers_to_update {
                         if let Some(state) = self.buffers.get_mut(&buf_id) {
+                            let first_line = state.buffer.first_line_lossy();
                             let detected =
                                 crate::primitives::detected_language::DetectedLanguage::from_path(
                                     &path,
+                                    first_line.as_deref(),
                                     &self.grammar_registry,
                                     &self.config.languages,
                                 );

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -224,9 +224,11 @@ impl Editor {
                 self.config.editor.large_file_threshold_bytes as usize,
                 Arc::clone(&self.filesystem),
             )?;
+            let first_line = buffer.first_line_lossy();
             let detected =
                 crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
                     &display_path,
+                    first_line.as_deref(),
                     &self.grammar_registry,
                     &self.config.languages,
                     self.config.default_language.as_deref(),
@@ -422,9 +424,11 @@ impl Editor {
             self.config.editor.large_file_threshold_bytes as usize,
             Arc::clone(&self.local_filesystem),
         )?;
+        let first_line = buffer.first_line_lossy();
         let detected =
             crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
                 &display_path,
+                first_line.as_deref(),
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),
@@ -525,11 +529,13 @@ impl Editor {
                 estimated_line_length: self.config.editor.estimated_line_length,
             },
         )?;
+        let first_line = buffer.first_line_lossy();
         // Create editor state with the buffer
         // Use display_path for language detection (glob patterns match user-visible paths)
         let detected =
             crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
                 &display_path,
+                first_line.as_deref(),
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),
@@ -670,11 +676,13 @@ impl Editor {
             path,
             Arc::clone(&self.filesystem),
         )?;
+        let first_line = buffer.first_line_lossy();
         // Create editor state with the buffer
         // Use display_path for language detection (glob patterns match user-visible paths)
         let detected =
             crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
                 &display_path,
+                first_line.as_deref(),
                 &self.grammar_registry,
                 &self.config.languages,
                 self.config.default_language.as_deref(),

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -97,9 +97,11 @@ impl Editor {
         if let Some(ref p) = path {
             if let Some(state) = self.buffers.get_mut(&buffer_id) {
                 if state.language == "text" {
+                    let first_line = state.buffer.first_line_lossy();
                     let detected =
                         crate::primitives::detected_language::DetectedLanguage::from_path(
                             p,
+                            first_line.as_deref(),
                             &self.grammar_registry,
                             &self.config.languages,
                         );

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -1052,9 +1052,11 @@ impl Editor {
 
                 // Set buffer language to TypeScript so LSP requests use the right handle
                 if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                    let first_line = state.buffer.first_line_lossy();
                     let detected =
                         crate::primitives::detected_language::DetectedLanguage::from_path(
                             &plugin_file,
+                            first_line.as_deref(),
                             &self.grammar_registry,
                             &self.config.languages,
                         );

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -559,9 +559,11 @@ impl Editor {
                 let mut new_language = String::new();
                 if let Some(state) = self.buffers.get_mut(&self.active_buffer()) {
                     if state.language == "text" {
+                        let first_line = state.buffer.first_line_lossy();
                         let detected =
                             crate::primitives::detected_language::DetectedLanguage::from_path(
                                 &full_path,
+                                first_line.as_deref(),
                                 &self.grammar_registry,
                                 &self.config.languages,
                             );

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -2363,6 +2363,17 @@ impl TextBuffer {
         self.format.set_default_encoding(encoding);
     }
 
+    /// Get the first line of the buffer as a lossy UTF-8 string, suitable
+    /// for shebang / first-line grammar detection. Returns `None` for an
+    /// empty buffer. Non-UTF-8 bytes are replaced with U+FFFD.
+    pub fn first_line_lossy(&self) -> Option<String> {
+        let bytes = self.get_line(0)?;
+        if bytes.is_empty() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
     /// Get text for a specific line
     pub fn get_line(&self, line: usize) -> Option<Vec<u8>> {
         let (start, end) = self.piece_tree.line_range(line, &self.buffers)?;

--- a/crates/fresh-editor/src/primitives/detected_language.rs
+++ b/crates/fresh-editor/src/primitives/detected_language.rs
@@ -51,13 +51,21 @@ impl DetectedLanguage {
     /// 2. Glob pattern match in user config
     /// 3. Extension match in user config
     /// 4. Built-in detection (catalog lookup)
-    /// 5. Fallback config (if set and no other match found)
+    /// 5. Shebang / first-line regex against `first_line` (catalog lookup)
+    /// 6. Fallback config (if set and no other match found)
+    ///
+    /// `first_line` is the literal first line of the file (including any
+    /// trailing newline). The caller — which has already loaded the buffer
+    /// via the `FileSystem` trait — supplies it so the registry never does
+    /// its own I/O. Pass `None` when there is no content to inspect (e.g.,
+    /// virtual buffers, unsaved files).
     pub fn from_path(
         path: &Path,
+        first_line: Option<&str>,
         registry: &GrammarRegistry,
         languages: &HashMap<String, LanguageConfig>,
     ) -> Self {
-        Self::from_path_with_fallback(path, registry, languages, None)
+        Self::from_path_with_fallback(path, first_line, registry, languages, None)
     }
 
     /// Like `from_path`, but also accepts an optional default language name
@@ -65,6 +73,7 @@ impl DetectedLanguage {
     /// The `default_language` must reference a key in the `languages` map.
     pub fn from_path_with_fallback(
         path: &Path,
+        first_line: Option<&str>,
         registry: &GrammarRegistry,
         languages: &HashMap<String, LanguageConfig>,
         default_language: Option<&str>,
@@ -82,7 +91,7 @@ impl DetectedLanguage {
             d
         };
 
-        if let Some(entry) = registry.find_by_path(path) {
+        if let Some(entry) = registry.find_by_path(path, first_line) {
             return override_name(Self::from_entry(entry, registry));
         }
 
@@ -147,7 +156,7 @@ impl DetectedLanguage {
             cleaned
         };
         registry
-            .find_by_path(Path::new(filename))
+            .find_by_path(Path::new(filename), None)
             .map(|entry| Self::from_entry(entry, registry))
             .unwrap_or_else(Self::plain_text)
     }

--- a/crates/fresh-editor/src/primitives/grammar/loader.rs
+++ b/crates/fresh-editor/src/primitives/grammar/loader.rs
@@ -917,7 +917,9 @@ mod tests {
         registry.apply_language_config(&languages);
 
         // Custom filename resolves to bash via the catalog.
-        let entry = registry.find_by_path(Path::new("CUSTOMBUILD")).unwrap();
+        let entry = registry
+            .find_by_path(Path::new("CUSTOMBUILD"), None)
+            .unwrap();
         assert!(
             entry.display_name.to_lowercase().contains("bash")
                 || entry.display_name.to_lowercase().contains("shell"),
@@ -926,7 +928,9 @@ mod tests {
         );
 
         // Custom extension resolves to bash via the catalog.
-        let entry = registry.find_by_path(Path::new("script.myext")).unwrap();
+        let entry = registry
+            .find_by_path(Path::new("script.myext"), None)
+            .unwrap();
         assert!(
             entry.display_name.to_lowercase().contains("bash")
                 || entry.display_name.to_lowercase().contains("shell"),

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -662,26 +662,15 @@ impl GrammarRegistry {
 
     /// Find syntax for a file by path/extension/filename.
     ///
-    /// Checks in order:
-    /// 1. User-configured grammar extensions (by scope)
-    /// 2. By extension (includes built-in + embedded grammars)
-    /// 3. By filename (custom dotfile mappings like .zshrc)
-    /// 4. By filename via syntect (handles Makefile, .bashrc, etc.)
+    /// Purely metadata-based — does not read the file. For first-line
+    /// (shebang) fallback, use [`find_by_path`] with a `first_line` argument
+    /// and resolve the returned entry's syntect index.
     pub fn find_syntax_for_file(&self, path: &Path) -> Option<&SyntaxReference> {
-        if let Some(entry) = self.find_by_path(path) {
-            // Return the syntect grammar if one is attached; otherwise bail.
-            // We must NOT fall through to syntect's own detection here — the
-            // catalog match (e.g. a user-declared "fish" or tree-sitter-only
-            // TypeScript) is authoritative, and syntect might misclassify
-            // `.fish` as bash via its built-in heuristics.
-            return entry
-                .engines
-                .syntect
-                .map(|i| &self.syntax_set.syntaxes()[i]);
-        }
-        // No catalog match — try syntect's file detection (first-line /
-        // Makefile-style filenames that aren't in filename_scopes).
-        self.syntax_set.find_syntax_for_file(path).ok().flatten()
+        let entry = self.find_by_path(path, None)?;
+        entry
+            .engines
+            .syntect
+            .map(|i| &self.syntax_set.syntaxes()[i])
     }
 
     /// Find syntax by name, with alias resolution.
@@ -1084,16 +1073,27 @@ impl GrammarRegistry {
             .map(|&idx| &self.catalog[idx])
     }
 
-    /// Look up a grammar entry by file path.
+    /// Look up a grammar entry by file path, with optional first-line content
+    /// for shebang / `first_line_match` detection.
     ///
     /// Resolution order:
     /// 1. Exact filename (config-declared filenames and filename_scopes live here)
     /// 2. Glob patterns from user config (e.g. "*.conf", "/etc/**/rc.*")
     /// 3. File extension
+    /// 4. Shebang / first-line regex match on `first_line` if supplied
     ///
     /// Globs take priority over extension so a user rule like `*.conf → bash`
-    /// wins over any built-in extension match on `.conf`.
-    pub fn find_by_path(&self, path: &Path) -> Option<&GrammarEntry> {
+    /// wins over any built-in extension match on `.conf`. The first-line
+    /// fallback (#4) is last so catalog matches stay authoritative — syntect
+    /// might otherwise misclassify `.fish` as bash via its first-line
+    /// regexes.
+    ///
+    /// The first-line fallback is pure: it runs syntect's
+    /// `find_syntax_by_first_line` regex cache against the caller-supplied
+    /// string. The registry never touches the filesystem — the caller (who
+    /// already loaded the buffer via the `FileSystem` trait) must extract
+    /// the first line and pass it in.
+    pub fn find_by_path(&self, path: &Path, first_line: Option<&str>) -> Option<&GrammarEntry> {
         let filename = path.file_name().and_then(|n| n.to_str());
         let path_str = path.to_str().unwrap_or("");
 
@@ -1120,9 +1120,18 @@ impl GrammarRegistry {
         }
 
         if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            return self.find_by_extension(ext);
+            if let Some(entry) = self.find_by_extension(ext) {
+                return Some(entry);
+            }
         }
-        None
+
+        // Last resort: shebang / first-line regex match against the
+        // caller-supplied content. Map the matched syntect grammar back to a
+        // catalog entry by name — every syntect syntax has a catalog entry,
+        // so this round-trip preserves tree-sitter attachment.
+        let line = first_line?;
+        let syntax = self.syntax_set.find_syntax_by_first_line(line)?;
+        self.find_by_name(&syntax.name)
     }
 
     /// Look up a grammar entry by file extension (case-insensitive, without dot).
@@ -1623,15 +1632,17 @@ mod tests {
         registry.apply_language_config(&languages);
 
         assert!(
-            registry.find_by_path(Path::new("nftables.conf")).is_some(),
+            registry
+                .find_by_path(Path::new("nftables.conf"), None)
+                .is_some(),
             "*.conf should match nftables.conf"
         );
         assert!(
-            registry.find_by_path(Path::new("lfrc")).is_some(),
+            registry.find_by_path(Path::new("lfrc"), None).is_some(),
             "*rc should match lfrc"
         );
         // Unrelated file shouldn't panic.
-        let _ = registry.find_by_path(Path::new("randomfile"));
+        let _ = registry.find_by_path(Path::new("randomfile"), None);
     }
 
     #[test]
@@ -1665,16 +1676,18 @@ mod tests {
         registry.apply_language_config(&languages);
 
         assert!(
-            registry.find_by_path(Path::new("/etc/rc.conf")).is_some(),
+            registry
+                .find_by_path(Path::new("/etc/rc.conf"), None)
+                .is_some(),
             "/etc/**/rc.* should match /etc/rc.conf"
         );
         assert!(
             registry
-                .find_by_path(Path::new("/etc/init/rc.local"))
+                .find_by_path(Path::new("/etc/init/rc.local"), None)
                 .is_some(),
             "/etc/**/rc.* should match /etc/init/rc.local"
         );
-        let _ = registry.find_by_path(Path::new("/var/rc.conf"));
+        let _ = registry.find_by_path(Path::new("/var/rc.conf"), None);
     }
 
     #[test]
@@ -1737,7 +1750,7 @@ mod tests {
         registry.apply_language_config(&languages);
 
         // "lfrc" should match the exact rule (python), not the glob (bash)
-        let entry = registry.find_by_path(Path::new("lfrc")).unwrap();
+        let entry = registry.find_by_path(Path::new("lfrc"), None).unwrap();
         assert!(
             entry.display_name.to_lowercase().contains("python"),
             "exact match should win over glob, got: {}",
@@ -1930,7 +1943,7 @@ mod tests {
     fn test_catalog_find_by_path_and_extension() {
         let registry = GrammarRegistry::default();
         let ts = registry
-            .find_by_path(Path::new("foo.ts"))
+            .find_by_path(Path::new("foo.ts"), None)
             .expect("foo.ts should resolve");
         assert_eq!(ts.display_name, "TypeScript");
         let rs = registry.find_by_extension("rs").expect("rs should resolve");
@@ -1998,7 +2011,9 @@ mod tests {
         // Sanity: config applied.
         assert!(registry.find_by_extension("myconf").is_some());
         assert!(
-            registry.find_by_path(Path::new("foo.myconf")).is_some(),
+            registry
+                .find_by_path(Path::new("foo.myconf"), None)
+                .is_some(),
             "glob should match before register_alias"
         );
 
@@ -2010,7 +2025,9 @@ mod tests {
             "config extension must survive register_alias"
         );
         assert!(
-            registry.find_by_path(Path::new("foo.myconf")).is_some(),
+            registry
+                .find_by_path(Path::new("foo.myconf"), None)
+                .is_some(),
             "glob must survive register_alias"
         );
     }
@@ -2096,7 +2113,7 @@ mod tests {
             ("GNUmakefile", "makefile"),
         ] {
             let entry = registry
-                .find_by_path(Path::new(filename))
+                .find_by_path(Path::new(filename), None)
                 .unwrap_or_else(|| panic!("{} must resolve via catalog", filename));
             assert!(
                 entry.display_name.to_lowercase().contains(expected_substr),
@@ -2116,7 +2133,7 @@ mod tests {
     fn test_jsx_resolves_to_javascript() {
         let registry = GrammarRegistry::default();
         let entry = registry
-            .find_by_path(Path::new("foo.jsx"))
+            .find_by_path(Path::new("foo.jsx"), None)
             .expect("foo.jsx must resolve");
         assert_eq!(entry.display_name, "JavaScript");
     }
@@ -2135,7 +2152,9 @@ mod tests {
         );
         registry.apply_language_config(&languages);
         assert!(registry.find_by_extension("myext").is_some());
-        assert!(registry.find_by_path(Path::new("foo.myglob")).is_some());
+        assert!(registry
+            .find_by_path(Path::new("foo.myglob"), None)
+            .is_some());
 
         // Force a rebuild — the catalog gets wiped and re-populated from
         // syntect / tree-sitter, but user config must come back on top.
@@ -2145,7 +2164,9 @@ mod tests {
             "rebuild_catalog must replay applied user config"
         );
         assert!(
-            registry.find_by_path(Path::new("foo.myglob")).is_some(),
+            registry
+                .find_by_path(Path::new("foo.myglob"), None)
+                .is_some(),
             "rebuild_catalog must replay user globs"
         );
     }

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1056,8 +1056,10 @@ impl HighlightEngine {
     /// Thin wrapper around `from_entry` that resolves the path via the catalog.
     /// User-config-declared filename/extension mappings are honoured as long as
     /// `GrammarRegistry::apply_language_config` has been called on the registry.
-    pub fn for_file(path: &Path, registry: &GrammarRegistry) -> Self {
-        if let Some(entry) = registry.find_by_path(path) {
+    /// `first_line` is used for shebang / first-line regex fallback — pass
+    /// `None` when no content is available.
+    pub fn for_file(path: &Path, first_line: Option<&str>, registry: &GrammarRegistry) -> Self {
+        if let Some(entry) = registry.find_by_path(path, first_line) {
             return Self::from_entry(entry, registry);
         }
         Self::None
@@ -1343,25 +1345,25 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // Languages with TextMate grammars use TextMate for highlighting
-        let engine = HighlightEngine::for_file(Path::new("test.rs"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.rs"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         // Tree-sitter language should still be detected for other features
         assert!(engine.language().is_some());
 
-        let engine = HighlightEngine::for_file(Path::new("test.py"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.py"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.language().is_some());
 
-        let engine = HighlightEngine::for_file(Path::new("test.js"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.js"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.language().is_some());
 
         // TypeScript falls back to tree-sitter (syntect doesn't include TS by default)
-        let engine = HighlightEngine::for_file(Path::new("test.ts"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.ts"), None, &registry);
         assert_eq!(engine.backend_name(), "tree-sitter");
         assert!(engine.language().is_some());
 
-        let engine = HighlightEngine::for_file(Path::new("test.tsx"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.tsx"), None, &registry);
         assert_eq!(engine.backend_name(), "tree-sitter");
         assert!(engine.language().is_some());
     }
@@ -1379,7 +1381,7 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // Unknown extension
-        let engine = HighlightEngine::for_file(Path::new("test.unknown_xyz_123"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("test.unknown_xyz_123"), None, &registry);
         // Might be none or might find something via syntect
         // Just verify it doesn't panic
         let _ = engine.backend_name();
@@ -1398,7 +1400,7 @@ mod tests {
         let registry =
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
-        let mut engine = HighlightEngine::for_file(Path::new("test.rs"), &registry);
+        let mut engine = HighlightEngine::for_file(Path::new("test.rs"), None, &registry);
 
         // Create empty buffer
         let buffer = Buffer::from_str("", 0, test_fs());
@@ -1422,7 +1424,7 @@ mod tests {
         let registry =
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
-        let mut engine = HighlightEngine::for_file(Path::new("test.java"), &registry);
+        let mut engine = HighlightEngine::for_file(Path::new("test.java"), None, &registry);
 
         // Create CRLF content with keywords on each line
         // Each "public" keyword should be highlighted at byte positions:
@@ -1490,7 +1492,7 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // git-rebase-todo files should use the Git Rebase Todo grammar
-        let engine = HighlightEngine::for_file(Path::new("git-rebase-todo"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("git-rebase-todo"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
     }
@@ -1501,12 +1503,12 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // COMMIT_EDITMSG should use the Git Commit Message grammar
-        let engine = HighlightEngine::for_file(Path::new("COMMIT_EDITMSG"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("COMMIT_EDITMSG"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
 
         // MERGE_MSG should also work
-        let engine = HighlightEngine::for_file(Path::new("MERGE_MSG"), &registry);
+        let engine = HighlightEngine::for_file(Path::new("MERGE_MSG"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
     }
@@ -1517,12 +1519,12 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // .gitignore should use the Gitignore grammar
-        let engine = HighlightEngine::for_file(Path::new(".gitignore"), &registry);
+        let engine = HighlightEngine::for_file(Path::new(".gitignore"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
 
         // .dockerignore should also work
-        let engine = HighlightEngine::for_file(Path::new(".dockerignore"), &registry);
+        let engine = HighlightEngine::for_file(Path::new(".dockerignore"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
     }
@@ -1533,12 +1535,12 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // .gitconfig should use the Git Config grammar
-        let engine = HighlightEngine::for_file(Path::new(".gitconfig"), &registry);
+        let engine = HighlightEngine::for_file(Path::new(".gitconfig"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
 
         // .gitmodules should also work
-        let engine = HighlightEngine::for_file(Path::new(".gitmodules"), &registry);
+        let engine = HighlightEngine::for_file(Path::new(".gitmodules"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
     }
@@ -1549,7 +1551,7 @@ mod tests {
             GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
 
         // .gitattributes should use the Git Attributes grammar
-        let engine = HighlightEngine::for_file(Path::new(".gitattributes"), &registry);
+        let engine = HighlightEngine::for_file(Path::new(".gitattributes"), None, &registry);
         assert_eq!(engine.backend_name(), "textmate");
         assert!(engine.has_highlighting());
     }

--- a/crates/fresh-editor/src/primitives/textmate_engine.rs
+++ b/crates/fresh-editor/src/primitives/textmate_engine.rs
@@ -67,11 +67,14 @@ impl TextMateEngine {
         }
     }
 
-    /// Create a TextMate engine for a file path
+    /// Create a TextMate engine for a file path.
+    ///
+    /// Purely metadata-based: resolves the grammar by filename/extension via
+    /// the catalog. Shebang / first-line detection is not applied here —
+    /// callers with buffer content should go through
+    /// `DetectedLanguage::from_path`, which handles that fallback.
     pub fn for_file(path: &Path, registry: &GrammarRegistry) -> Option<Self> {
         let syntax_set = registry.syntax_set_arc();
-
-        // Find syntax by file extension
         let syntax = registry.find_syntax_for_file(path)?;
 
         // Find the index of this syntax in the set

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -355,8 +355,9 @@ impl EditorState {
         fs: Arc<dyn FileSystem + Send + Sync>,
     ) -> anyhow::Result<Self> {
         let buffer = Buffer::load_from_file(path, large_file_threshold, fs)?;
+        let first_line = buffer.first_line_lossy();
         let detected = registry
-            .find_by_path(path)
+            .find_by_path(path, first_line.as_deref())
             .map(|entry| DetectedLanguage::from_entry(entry, registry))
             .unwrap_or_else(DetectedLanguage::plain_text);
         let mut state = Self::new_from_buffer(buffer);
@@ -381,7 +382,9 @@ impl EditorState {
         fs: Arc<dyn FileSystem + Send + Sync>,
     ) -> anyhow::Result<Self> {
         let buffer = Buffer::load_from_file(path, large_file_threshold, fs)?;
-        let detected = DetectedLanguage::from_path(path, registry, languages);
+        let first_line = buffer.first_line_lossy();
+        let detected =
+            DetectedLanguage::from_path(path, first_line.as_deref(), registry, languages);
         let mut state = Self::new_from_buffer(buffer);
         state.apply_language(detected);
         Ok(state)

--- a/crates/fresh-editor/tests/e2e/issue_1598_shebang_detection.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1598_shebang_detection.rs
@@ -1,0 +1,55 @@
+//! Reproduction for issue #1598: no syntax highlighting if file extension is
+//! missing with version 0.2.24.
+//!
+//! Reported by @mabod: a file named `test` (no extension) with a shebang
+//! `#!/usr/bin/zsh` at the top is not detected as a shell script in
+//! 0.2.24, even though it worked in 0.2.23.
+//!
+//! Opening such a file should detect a shell language (bash/zsh/shell) from
+//! the shebang, not fall back to plain `text`.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn test_extensionless_file_with_zsh_shebang_is_detected_as_shell() {
+    let temp_dir = TempDir::new().unwrap();
+    let working_dir = temp_dir.path().to_path_buf();
+
+    // Exactly the file from the issue: no extension, `#!/usr/bin/zsh` shebang.
+    let test_file = working_dir.join("test");
+    fs::write(
+        &test_file,
+        "#!/usr/bin/zsh\n\nexport MY_ZSH=\"$0\"\nexport MY_ZSH_VERSION=2.8\n",
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new()
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry()
+            .with_working_dir(working_dir.clone()),
+    )
+    .unwrap();
+
+    harness.open_file(&test_file).unwrap();
+
+    let language = harness.editor().active_state().language.clone();
+    let display_name = harness.editor().active_state().display_name.clone();
+
+    eprintln!(
+        "Detected language={:?} display_name={:?}",
+        language, display_name
+    );
+
+    assert_ne!(
+        language, "text",
+        "extensionless file with `#!/usr/bin/zsh` shebang should be detected \
+         as a shell language via shebang, not fall back to plain text \
+         (display_name was {:?})",
+        display_name
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -51,6 +51,7 @@ pub mod issue_1573_format_buffer;
 pub mod issue_1574_compose_scroll;
 pub mod issue_1574_wrapped_down_scroll;
 pub mod issue_1577_unicode_width;
+pub mod issue_1598_shebang_detection;
 
 pub mod keybinding_editor;
 pub mod language_features_e2e;

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -5076,9 +5076,11 @@ impl Editor {
 
                     for (buf_id, path) in buffers_to_update {
                         if let Some(state) = self.buffers.get_mut(&buf_id) {
+                            let first_line = state.buffer.first_line_lossy();
                             let detected =
                                 crate::primitives::detected_language::DetectedLanguage::from_path(
                                     &path,
+                                    first_line.as_deref(),
                                     &self.grammar_registry,
                                     &self.config.languages,
                                 );


### PR DESCRIPTION
## Summary
Restore shebang-based syntax detection for files without extensions, fixing a regression where extensionless files (e.g., `test` with `#!/usr/bin/zsh`) were incorrectly falling back to plain text instead of being detected as shell scripts.

## Key Changes

- **Extended `GrammarRegistry::find_by_path`** to accept an optional `first_line` parameter for shebang/first-line regex matching. This is now the fourth resolution step after exact filename, glob patterns, and extension matching.

- **Simplified `find_syntax_for_file`** to be purely metadata-based (no filesystem access), delegating shebang fallback to callers via `find_by_path` with the `first_line` argument.

- **Added `TextBuffer::first_line_lossy`** helper to extract the first line of a buffer as lossy UTF-8, suitable for shebang detection without requiring filesystem I/O.

- **Updated all call sites** to pass the first line when available:
  - `HighlightEngine::for_file` now accepts `first_line: Option<&str>`
  - `DetectedLanguage::from_path` and `from_path_with_fallback` now accept `first_line: Option<&str>`
  - File open orchestrators and state initialization extract and pass the first line from loaded buffers
  - All test cases updated to pass `None` for the new parameter

- **Added regression test** (`issue_1598_shebang_detection.rs`) verifying that extensionless files with shebangs are correctly detected as shell languages.

## Implementation Details

The shebang fallback is intentionally last in the resolution order so catalog matches (user config + built-in) remain authoritative. This prevents syntect's first-line regexes from misclassifying files like `.fish` as bash.

The first-line detection is pure: it runs syntect's `find_syntax_by_first_line` regex cache against caller-supplied content. The registry never touches the filesystem — callers that have already loaded the buffer via the `FileSystem` trait extract and pass the first line.

https://claude.ai/code/session_01TPYyL9Eq7qJfuzwE8g3nzE