### PR TITLE
Auto-prompt LSP status popup for dormant servers

### DIFF
--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -266,6 +266,17 @@ impl Editor {
         !self.lsp_progress.is_empty()
     }
 
+    /// Toggle the LSP auto-prompt popup on this editor instance.
+    ///
+    /// See `app::lsp_auto_prompt` for the full rationale. In short:
+    /// tests default this to `false` to stop the popup from
+    /// swallowing keystrokes in scenarios that don't exercise LSP;
+    /// tests that DO exercise it re-enable on the specific harness
+    /// they care about.
+    pub fn set_lsp_auto_prompt_enabled(&mut self, enabled: bool) {
+        self.lsp_auto_prompt_enabled = enabled;
+    }
+
     /// Get the current LSP progress info (if any)
     pub fn get_lsp_progress(&self) -> Vec<(String, String, Option<String>)> {
         self.lsp_progress

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -657,6 +657,7 @@ impl Editor {
             user_dismissed_lsp_languages: std::collections::HashSet::new(),
             auto_start_prompted_languages: std::collections::HashSet::new(),
             pending_auto_start_prompts: std::collections::HashSet::new(),
+            lsp_auto_prompt_enabled: super::lsp_auto_prompt::default_enabled(),
             pending_close_buffer: None,
             auto_revert_enabled: true,
             last_auto_revert_poll: time_source.now(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -656,6 +656,7 @@ impl Editor {
             pending_lsp_status_popup: None,
             user_dismissed_lsp_languages: std::collections::HashSet::new(),
             auto_start_prompted_languages: std::collections::HashSet::new(),
+            pending_auto_start_prompts: std::collections::HashSet::new(),
             pending_close_buffer: None,
             auto_revert_enabled: true,
             last_auto_revert_poll: time_source.now(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -655,6 +655,7 @@ impl Editor {
             pending_lsp_confirmation: None,
             pending_lsp_status_popup: None,
             user_dismissed_lsp_languages: std::collections::HashSet::new(),
+            auto_start_prompted_languages: std::collections::HashSet::new(),
             pending_close_buffer: None,
             auto_revert_enabled: true,
             last_auto_revert_poll: time_source.now(),

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -875,8 +875,13 @@ impl Editor {
                 // the prompt this session or dismissed the pill —
                 // both mean "please don't re-pop this."  The
                 // persisted `auto_start = true` flag is what
-                // silences the prompt across sessions.
-                if !self.auto_start_prompted_languages.contains(&language)
+                // silences the prompt across sessions. Also skip
+                // when the process-wide toggle is off — e2e tests
+                // set this via `set_lsp_auto_prompt_enabled(false)`
+                // in their ctor so the popup doesn't steal
+                // keystrokes from unrelated scenarios.
+                if self.lsp_auto_prompt_enabled
+                    && !self.auto_start_prompted_languages.contains(&language)
                     && !self.is_lsp_language_user_dismissed(&language)
                 {
                     self.pending_auto_start_prompts.insert(language);

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -860,20 +860,26 @@ impl Editor {
                     "LSP for {} not auto-starting (auto_start=false). Use command palette to start manually.",
                     language
                 );
-                // Surface the LSP popup once per language per session so
-                // the user can discover the dormant server (otherwise
-                // the only visible signal is a muted `LSP (off)` pill
-                // at the bottom-right, which is easy to miss). Skip if
-                // the user has already been prompted for this language
-                // this session, or has dismissed the pill entirely —
-                // both mean "please don't re-pop this on every file
-                // open." The persisted `auto_start=true` flag is what
+                // Queue an auto-prompt for this language so the user
+                // can discover the dormant server (otherwise the only
+                // visible signal is a muted `LSP (off)` pill, which is
+                // easy to miss). We intentionally don't show the popup
+                // inline here — session restore typically opens many
+                // files of the same language back-to-back, and the
+                // buffer active at *this* instant isn't necessarily
+                // the one the user lands on. Draining happens on
+                // render, which guarantees the popup attaches to
+                // whichever buffer the user is actually looking at.
+                //
+                // Skip queueing entirely when the user already got
+                // the prompt this session or dismissed the pill —
+                // both mean "please don't re-pop this."  The
+                // persisted `auto_start = true` flag is what
                 // silences the prompt across sessions.
                 if !self.auto_start_prompted_languages.contains(&language)
                     && !self.is_lsp_language_user_dismissed(&language)
                 {
-                    self.auto_start_prompted_languages.insert(language.clone());
-                    self.show_lsp_status_popup();
+                    self.pending_auto_start_prompts.insert(language);
                 }
             }
             LspSpawnResult::NotConfigured => {

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -860,6 +860,21 @@ impl Editor {
                     "LSP for {} not auto-starting (auto_start=false). Use command palette to start manually.",
                     language
                 );
+                // Surface the LSP popup once per language per session so
+                // the user can discover the dormant server (otherwise
+                // the only visible signal is a muted `LSP (off)` pill
+                // at the bottom-right, which is easy to miss). Skip if
+                // the user has already been prompted for this language
+                // this session, or has dismissed the pill entirely —
+                // both mean "please don't re-pop this on every file
+                // open." The persisted `auto_start=true` flag is what
+                // silences the prompt across sessions.
+                if !self.auto_start_prompted_languages.contains(&language)
+                    && !self.is_lsp_language_user_dismissed(&language)
+                {
+                    self.auto_start_prompted_languages.insert(language.clone());
+                    self.show_lsp_status_popup();
+                }
             }
             LspSpawnResult::NotConfigured => {
                 tracing::debug!("No LSP server configured for language: {}", language);

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -381,7 +381,16 @@ impl Editor {
     /// - `enable:<language>` — restore a dismissed language's pill
     /// - `autostart:<language>/<server_name>` — flip auto_start=true for
     ///   the named server in config, save, and start it now
+    /// - `cancel_popup` — no-op here; the row exists purely so the
+    ///   user has an on-screen "Dismiss" affordance (close is handled
+    ///   upstream in `handle_popup_confirm` before this is called)
     pub fn handle_lsp_status_action(&mut self, action_key: &str) {
+        if action_key == "cancel_popup" {
+            // Popup is already closed by `handle_popup_confirm`; the
+            // row only exists to give the user an on-screen surface
+            // that documents the Esc shortcut. Nothing to do here.
+            return;
+        }
         if let Some(target) = action_key.strip_prefix("autostart:") {
             // Persist `auto_start = true` in config so the server
             // starts automatically on future file opens, then kick it

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -379,8 +379,51 @@ impl Editor {
     /// - `log:<language>` — open the LSP log file for the language
     /// - `dismiss:<language>` — hide the pill for this language (dim style)
     /// - `enable:<language>` — restore a dismissed language's pill
+    /// - `autostart:<language>/<server_name>` — flip auto_start=true for
+    ///   the named server in config, save, and start it now
     pub fn handle_lsp_status_action(&mut self, action_key: &str) {
-        if let Some(language) = action_key.strip_prefix("start:") {
+        if let Some(target) = action_key.strip_prefix("autostart:") {
+            // Persist `auto_start = true` in config so the server
+            // starts automatically on future file opens, then kick it
+            // off right away for the current session. Mirrors the
+            // persisting half of the stop-server prompt path (see
+            // `handle_stop_lsp_server` which sets auto_start=false).
+            if let Some((language, server_name)) = target.split_once('/') {
+                if let Some(lsp_configs) = self.config_mut().lsp.get_mut(language) {
+                    for c in lsp_configs.as_mut_slice() {
+                        if c.display_name() == server_name {
+                            c.auto_start = true;
+                        }
+                    }
+                    if let Err(e) = self.save_config() {
+                        tracing::warn!(
+                            "Failed to save config after enabling LSP auto-start: {}",
+                            e
+                        );
+                    } else {
+                        let config_path = self.dir_context.config_path();
+                        self.emit_event(
+                            "config_changed",
+                            serde_json::json!({
+                                "path": config_path.to_string_lossy(),
+                            }),
+                        );
+                    }
+                }
+
+                // Start the server now so the user doesn't have to
+                // re-open the file to see LSP features come alive.
+                let file_path = self
+                    .buffer_metadata
+                    .get(&self.active_buffer())
+                    .and_then(|meta| meta.file_path().cloned());
+                if let Some(lsp) = self.lsp.as_mut() {
+                    let (_, message) = lsp.manual_restart(language, file_path.as_deref());
+                    self.status_message = Some(message);
+                }
+                self.reopen_buffers_for_language(language);
+            }
+        } else if let Some(language) = action_key.strip_prefix("start:") {
             // Start/restart LSP for this language (same as the "Start/Restart LSP" command)
             let file_path = self
                 .buffer_metadata

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -496,14 +496,72 @@ impl Editor {
                 self.status_message = Some(format!("No log file found for {}", language));
             }
         } else if let Some(language) = action_key.strip_prefix("dismiss:") {
-            self.dismiss_lsp_language(language);
-            self.status_message = Some(format!(
-                "LSP pill dimmed for {}. Click it to re-enable.",
-                language
-            ));
+            // Persist `enabled = false` for every configured server
+            // under this language so the decision survives a restart
+            // — the old behaviour (just marking the language
+            // dismissed in-memory) meant the next editor session
+            // re-prompted the user. We keep the session-level
+            // `user_dismissed_lsp_languages` flag updated too so
+            // anything that still reads it (dimmed pill style, the
+            // popup's Enable/Disable toggle) stays consistent with
+            // the persisted state until the in-memory cache next
+            // re-reads config.
+            let lang = language.to_string();
+            self.dismiss_lsp_language(&lang);
+            let mut changed = false;
+            if let Some(lsp_configs) = self.config_mut().lsp.get_mut(&lang) {
+                for c in lsp_configs.as_mut_slice() {
+                    if c.enabled {
+                        c.enabled = false;
+                        changed = true;
+                    }
+                }
+            }
+            if changed {
+                if let Err(e) = self.save_config() {
+                    tracing::warn!("Failed to save config after disabling LSP: {}", e);
+                } else {
+                    let config_path = self.dir_context.config_path();
+                    self.emit_event(
+                        "config_changed",
+                        serde_json::json!({
+                            "path": config_path.to_string_lossy(),
+                        }),
+                    );
+                }
+            }
+            self.status_message = Some(format!("LSP disabled for {}.", lang));
         } else if let Some(language) = action_key.strip_prefix("enable:") {
-            self.undismiss_lsp_language(language);
-            self.status_message = Some(format!("LSP pill restored for {}.", language));
+            // Symmetric re-enable: flip `enabled = true` on every
+            // configured server for this language and persist. The
+            // popup's "Enable LSP for <lang>" row is the inverse of
+            // the disable action, so it must undo both halves —
+            // session dismissal and the on-disk flag.
+            let lang = language.to_string();
+            self.undismiss_lsp_language(&lang);
+            let mut changed = false;
+            if let Some(lsp_configs) = self.config_mut().lsp.get_mut(&lang) {
+                for c in lsp_configs.as_mut_slice() {
+                    if !c.enabled {
+                        c.enabled = true;
+                        changed = true;
+                    }
+                }
+            }
+            if changed {
+                if let Err(e) = self.save_config() {
+                    tracing::warn!("Failed to save config after enabling LSP: {}", e);
+                } else {
+                    let config_path = self.dir_context.config_path();
+                    self.emit_event(
+                        "config_changed",
+                        serde_json::json!({
+                            "path": config_path.to_string_lossy(),
+                        }),
+                    );
+                }
+            }
+            self.status_message = Some(format!("LSP enabled for {}.", lang));
         }
     }
 

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -798,6 +798,29 @@ impl Editor {
             self.clear_diagnostics_for_server(name);
         }
 
+        // Clear any in-flight `$/progress` entries for this language
+        // if the language has no surviving handles. The dead server
+        // will never send the matching `end` notifications, so
+        // without this cleanup `compose_lsp_status` would keep
+        // winning the spinner branch over `(off)` — the indicator
+        // would stay stuck on a rotating braille glyph that doesn't
+        // actually rotate (no async events fire to re-render).
+        //
+        // We defer the check to after the shutdown so handle
+        // enumeration reflects the new state. Keyed by language
+        // because `LspProgressInfo` doesn't carry a server name —
+        // safe: if any handle for the language survives, progress
+        // on that language is still the surviving server's business
+        // and we leave it alone.
+        let any_handle_left = self
+            .lsp
+            .as_ref()
+            .is_some_and(|lsp| lsp.has_handles(language));
+        if !any_handle_left {
+            self.lsp_progress
+                .retain(|_, info| info.language != language);
+        }
+
         true
     }
 

--- a/crates/fresh-editor/src/app/lsp_auto_prompt.rs
+++ b/crates/fresh-editor/src/app/lsp_auto_prompt.rs
@@ -1,0 +1,40 @@
+//! Per-process default for the "auto-prompt on first open" LSP popup.
+//!
+//! Normally the editor surfaces the LSP status popup the first time
+//! the user opens a file for a language that has an `enabled +
+//! auto_start = false` server configured (see
+//! `notify_lsp_file_opened` in `file_operations.rs`). That behaviour
+//! is great for users but actively hostile to e2e tests: the popup
+//! is shown on the first render after `open_file`, and from that
+//! point on any `send_key` call targets the popup's input handler
+//! rather than the buffer. Hundreds of tests that happen to open
+//! `.rs` files (or any language with a default LSP config) suddenly
+//! see their keystrokes swallowed.
+//!
+//! The default here is read once per `Editor` in its constructor
+//! and stored as a per-editor flag — so parallel tests can't race
+//! each other's toggles. The test-harness ctor flips the default to
+//! `false`; tests that specifically exercise the auto-prompt pass
+//! `HarnessOptions::with_lsp_auto_prompt(true)` to override on
+//! their own editor instance.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Process-wide default read by `Editor::new` at construction time.
+/// Real editor sessions leave this at its initial `true`; tests
+/// flip it to `false` in their ctor (see `tests/common/harness.rs`).
+static DEFAULT_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Snapshot the current default. Called once per Editor so each
+/// editor instance is born with a stable flag that can't be
+/// changed under it by a concurrently-running test.
+pub fn default_enabled() -> bool {
+    DEFAULT_ENABLED.load(Ordering::Relaxed)
+}
+
+/// Override the process-wide default. Expected to be called from
+/// the test-harness ctor (before any `Editor` is constructed) or
+/// from per-test setup when the default needs flipping.
+pub fn set_default_enabled(enabled: bool) {
+    DEFAULT_ENABLED.store(enabled, Ordering::Relaxed);
+}

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -38,6 +38,7 @@ mod keybinding_editor_actions;
 mod lifecycle;
 mod line_scan;
 mod lsp_actions;
+pub mod lsp_auto_prompt;
 mod lsp_event_notify;
 mod lsp_requests;
 mod lsp_status;
@@ -855,6 +856,15 @@ pub struct Editor {
     /// active buffer ends up being a later one. Once drained, the
     /// language moves to `auto_start_prompted_languages`.
     pending_auto_start_prompts: std::collections::HashSet<String>,
+
+    /// Per-editor flag gating the LSP auto-prompt. Real sessions
+    /// default this to `true` (see `lsp_auto_prompt::default_enabled`);
+    /// test infrastructure flips the default to `false` in its ctor
+    /// to keep the popup from stealing keystrokes from scenarios
+    /// that don't care about LSP. Snapshotted at construction so
+    /// parallel tests running in the same process don't race on a
+    /// shared atomic.
+    lsp_auto_prompt_enabled: bool,
 
     /// Pending close buffer - buffer to close after SaveFileAs completes
     /// Used when closing a modified buffer that needs to be saved first

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -840,6 +840,13 @@ pub struct Editor {
     /// survive editor restarts.
     user_dismissed_lsp_languages: std::collections::HashSet<String>,
 
+    /// Languages for which the auto-start prompt has already been
+    /// surfaced this session, so subsequent opens of files in the same
+    /// language don't keep re-popping the popup. Cleared only by
+    /// editor restart — the persisted `auto_start=true` flag is what
+    /// silences the prompt across sessions.
+    auto_start_prompted_languages: std::collections::HashSet<String>,
+
     /// Pending close buffer - buffer to close after SaveFileAs completes
     /// Used when closing a modified buffer that needs to be saved first
     pending_close_buffer: Option<BufferId>,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -847,6 +847,15 @@ pub struct Editor {
     /// silences the prompt across sessions.
     auto_start_prompted_languages: std::collections::HashSet<String>,
 
+    /// Languages for which an auto-start prompt is queued, waiting
+    /// for a buffer of that language to become active. The popup is
+    /// shown lazily on render so it attaches to the currently-focused
+    /// buffer — this keeps the prompt visible when a session restore
+    /// opens several files of the same language back-to-back and the
+    /// active buffer ends up being a later one. Once drained, the
+    /// language moves to `auto_start_prompted_languages`.
+    pending_auto_start_prompts: std::collections::HashSet<String>,
+
     /// Pending close buffer - buffer to close after SaveFileAs completes
     /// Used when closing a modified buffer that needs to be saved first
     pending_close_buffer: Option<BufferId>,

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -32,6 +32,15 @@ impl Editor {
 
             self.hide_popup();
             self.pending_lsp_status_popup = None;
+            // User picked a row → they've seen and handled the
+            // prompt, so end the auto-prompt cycle for this
+            // language. Mirrors the same cleanup in
+            // `handle_popup_cancel` for the Esc path.
+            let active = self.active_buffer();
+            if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
+                self.pending_auto_start_prompts.remove(&language);
+                self.auto_start_prompted_languages.insert(language);
+            }
 
             if let Some(key) = action_key {
                 self.handle_lsp_status_action(&key);
@@ -242,6 +251,15 @@ impl Editor {
 
         // Check if this is an LSP status details popup
         if self.pending_lsp_status_popup.take().is_some() {
+            // The user has now seen the prompt and dismissed it —
+            // end the auto-prompt cycle for the active buffer's
+            // language so re-focusing another file of the same
+            // language doesn't re-pop it.
+            let active = self.active_buffer();
+            if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
+                self.pending_auto_start_prompts.remove(&language);
+                self.auto_start_prompted_languages.insert(language);
+            }
             self.hide_popup();
             return;
         }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -479,9 +479,9 @@ impl Editor {
             action_keys.push((dismiss_key, format!("Disable LSP for {}", language)));
         }
 
-        // View log action (always, at the end) — grayed out and
-        // non-actionable when no log file exists yet for this language
-        // (e.g. the server was never started, or has been rotated away).
+        // View log action — grayed out and non-actionable when no
+        // log file exists yet for this language (e.g. the server was
+        // never started, or has been rotated away).
         let log_path = crate::services::log_dirs::lsp_log_path(language);
         let log_exists = log_path.exists();
         let log_key = format!("log:{}", language);
@@ -493,6 +493,31 @@ impl Editor {
             log_item = log_item.disabled();
         }
         items.push(log_item);
+
+        // Trailing Dismiss row — gives users an on-screen way out of
+        // the popup without having to know that Esc works. The key
+        // label is looked up from the keybinding resolver so a
+        // rebound PopupCancel stays visible in the row label
+        // ("Dismiss (Q)", etc.). Falls back to "Esc" as the usual
+        // default if the resolver has no binding at all (unusual,
+        // but we don't want an empty parenthetical).
+        let cancel_binding = self
+            .keybindings
+            .read()
+            .ok()
+            .and_then(|kb| {
+                kb.get_keybinding_for_action(
+                    &crate::input::keybindings::Action::PopupCancel,
+                    crate::input::keybindings::KeyContext::Popup,
+                )
+            })
+            .unwrap_or_else(|| "Esc".to_string());
+        let cancel_key = "cancel_popup".to_string();
+        items.push(
+            crate::view::popup::PopupListItem::new(format!("    Dismiss ({})", cancel_binding))
+                .with_data(cancel_key.clone()),
+        );
+        action_keys.push((cancel_key, format!("Dismiss ({})", cancel_binding)));
 
         // Store action keys for handling confirmation
         self.pending_lsp_status_popup = Some(action_keys);

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -13,6 +13,18 @@ use crate::app::warning_domains::WarningDomain;
 
 use super::Editor;
 
+/// True when `popup` is the LSP status popup (as built by
+/// `build_and_show_lsp_status_popup`). Used by the auto-prompt
+/// drain to find and clean up orphan prompts on non-active
+/// buffers without affecting unrelated popups (completion, hover,
+/// etc.) that might be on top.
+fn is_lsp_status_popup(popup: &crate::view::popup::Popup) -> bool {
+    popup
+        .title
+        .as_deref()
+        .is_some_and(|t| t.starts_with("LSP Servers ("))
+}
+
 impl Editor {
     /// Show warnings by opening the warning log file directly
     ///
@@ -78,6 +90,85 @@ impl Editor {
         );
 
         self.build_and_show_lsp_status_popup(&language);
+    }
+
+    /// If an auto-start prompt is queued for the active buffer's
+    /// language, show it now. Called from the render path so the
+    /// popup always attaches to the buffer the user is actually
+    /// looking at — even across a session restore that opens
+    /// several files of the same language in succession and flips
+    /// the active buffer mid-sequence.
+    ///
+    /// The language stays in `pending_auto_start_prompts` after a
+    /// draw: if focus moves to a different buffer of the same
+    /// language before the user has dismissed the popup, we'll
+    /// pop the orphan from the old buffer's stack and re-attach
+    /// the popup to the new active buffer on the next render. The
+    /// user-side lifecycle — pick an action, or press Esc — is
+    /// what flips the language into
+    /// `auto_start_prompted_languages` and ends the prompt cycle
+    /// (see `handle_lsp_status_action` and `handle_popup_cancel`).
+    ///
+    /// Short-circuits aggressively so the steady-state cost on
+    /// every render is a single `HashSet::is_empty` check.
+    pub(crate) fn drain_pending_lsp_prompt_for_active_buffer(&mut self) {
+        if self.pending_auto_start_prompts.is_empty() {
+            return;
+        }
+        let active = self.active_buffer();
+        let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) else {
+            return;
+        };
+        if !self.pending_auto_start_prompts.contains(&language) {
+            return;
+        }
+        // Recheck the dismissal guard at show time — it may have
+        // flipped between file-open and render.
+        if self.is_lsp_language_user_dismissed(&language) {
+            self.pending_auto_start_prompts.remove(&language);
+            return;
+        }
+        // If the active buffer's top popup is already the LSP
+        // status popup, nothing to do — the previous render landed
+        // it here and the user is presumably looking at it.
+        if self
+            .buffers
+            .get(&active)
+            .and_then(|s| s.popups.top())
+            .is_some_and(is_lsp_status_popup)
+        {
+            return;
+        }
+        // If some OTHER popup owns the active buffer's top (e.g.
+        // a completion popup), don't stomp on it — wait for a
+        // future frame when the user has dismissed it.
+        if self
+            .buffers
+            .get(&active)
+            .and_then(|s| s.popups.top())
+            .is_some()
+        {
+            return;
+        }
+
+        // Pop any orphan LSP status popup off *other* buffers so
+        // the user doesn't find a stale prompt when they later
+        // visit those tabs. `show_lsp_status_popup` also toggles
+        // off whatever is currently tracked in
+        // `pending_lsp_status_popup`, so reset that marker first
+        // — otherwise the call below would close instead of show.
+        let active_id = active;
+        for (id, state) in self.buffers.iter_mut() {
+            if *id == active_id {
+                continue;
+            }
+            if state.popups.top().is_some_and(is_lsp_status_popup) {
+                state.popups.hide();
+            }
+        }
+        self.pending_lsp_status_popup = None;
+
+        self.show_lsp_status_popup();
     }
 
     /// Rebuild the LSP-status popup in place if it's currently open.

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -155,6 +155,23 @@ impl Editor {
                     .collect()
             })
             .unwrap_or_default();
+        // Per-server auto_start flag map (display_name → auto_start).
+        // Used to decide whether to offer an "Enable auto-start for X"
+        // row alongside the "Start X" action — relevant only when the
+        // server is enabled but dormant and the user hasn't opted into
+        // auto-start yet.
+        let auto_start_by_server: std::collections::HashMap<String, bool> = self
+            .config
+            .lsp
+            .get(language)
+            .map(|cfg| {
+                cfg.as_slice()
+                    .iter()
+                    .filter(|c| !c.command.is_empty())
+                    .map(|c| (c.display_name(), c.auto_start))
+                    .collect()
+            })
+            .unwrap_or_default();
         let user_dismissed = self.is_lsp_language_user_dismissed(language);
 
         if configured_servers.is_empty() && running_statuses.is_empty() {
@@ -293,14 +310,55 @@ impl Editor {
                     .disabled(),
                 );
             } else {
-                // Start
+                // Two sibling rows for a dormant server:
+                //
+                //   "Start <name> once"          — just for this session,
+                //                                  config stays auto_start=false
+                //   "Start <name> automatically" — persists auto_start=true
+                //                                  AND starts the server now
+                //
+                // The "once" label is only needed (vs. just "Start") when
+                // the "automatically" sibling is also present (i.e. when
+                // auto_start is currently false) — otherwise there's
+                // nothing to disambiguate it from.
+                let is_manual = !auto_start_by_server.get(name).copied().unwrap_or(true);
+                let start_label = if is_manual {
+                    format!("    Start {} once", name)
+                } else {
+                    format!("    Start {}", name)
+                };
+                let start_action_label = if is_manual {
+                    format!("Start {} once", name)
+                } else {
+                    format!("Start {}", name)
+                };
                 let start_key = format!("start:{}", language);
                 if !action_keys.iter().any(|(k, _)| k == &start_key) {
                     items.push(
-                        crate::view::popup::PopupListItem::new(format!("    Start {}", name))
+                        crate::view::popup::PopupListItem::new(start_label)
                             .with_data(start_key.clone()),
                     );
-                    action_keys.push((start_key, format!("Start {}", name)));
+                    action_keys.push((start_key, start_action_label));
+                }
+
+                // "Start automatically": per-server, offered only when
+                // the server is dormant with `auto_start = false`.
+                // Persists auto_start=true AND starts the server now so
+                // users don't have to re-open the file. Skipped when
+                // the flag is already true (the normal "Start" row above
+                // is enough) or when the binary is missing (covered by
+                // the disabled advisory branch — persisting auto-start
+                // for a missing binary would just fail on every open).
+                if is_manual {
+                    let autostart_key = format!("autostart:{}/{}", language, name);
+                    items.push(
+                        crate::view::popup::PopupListItem::new(format!(
+                            "    Start {} automatically",
+                            name
+                        ))
+                        .with_data(autostart_key.clone()),
+                    );
+                    action_keys.push((autostart_key, format!("Start {} automatically", name)));
                 }
             }
         }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -401,18 +401,40 @@ impl Editor {
                     .disabled(),
                 );
             } else {
-                // Two sibling rows for a dormant server:
+                // Two sibling rows for a dormant server, in the
+                // order the user most likely wants:
                 //
-                //   "Start <name> once"          — just for this session,
-                //                                  config stays auto_start=false
-                //   "Start <name> automatically" — persists auto_start=true
-                //                                  AND starts the server now
+                //   "Start <name> (always)" — persist auto_start=true
+                //                              AND start the server now.
+                //                              Listed first because
+                //                              persistent-start is the
+                //                              common case, so pre-
+                //                              selecting it lets the
+                //                              user press Enter and
+                //                              move on.
+                //   "Start <name> once"     — start for this session,
+                //                              config stays auto_start=false.
                 //
-                // The "once" label is only needed (vs. just "Start") when
-                // the "automatically" sibling is also present (i.e. when
-                // auto_start is currently false) — otherwise there's
-                // nothing to disambiguate it from.
+                // The "once" suffix is only needed (vs. just "Start")
+                // when the "(always)" sibling is also present — i.e.
+                // when auto_start is currently false. Otherwise there
+                // is nothing to disambiguate it from.
                 let is_manual = !auto_start_by_server.get(name).copied().unwrap_or(true);
+
+                // "(always)" row — first, so it's the default.
+                if is_manual {
+                    let autostart_key = format!("autostart:{}/{}", language, name);
+                    items.push(
+                        crate::view::popup::PopupListItem::new(format!(
+                            "    Start {} (always)",
+                            name
+                        ))
+                        .with_data(autostart_key.clone()),
+                    );
+                    action_keys.push((autostart_key, format!("Start {} (always)", name)));
+                }
+
+                // "once" / plain Start row.
                 let start_label = if is_manual {
                     format!("    Start {} once", name)
                 } else {
@@ -430,26 +452,6 @@ impl Editor {
                             .with_data(start_key.clone()),
                     );
                     action_keys.push((start_key, start_action_label));
-                }
-
-                // "Start automatically": per-server, offered only when
-                // the server is dormant with `auto_start = false`.
-                // Persists auto_start=true AND starts the server now so
-                // users don't have to re-open the file. Skipped when
-                // the flag is already true (the normal "Start" row above
-                // is enough) or when the binary is missing (covered by
-                // the disabled advisory branch — persisting auto-start
-                // for a missing binary would just fail on every open).
-                if is_manual {
-                    let autostart_key = format!("autostart:{}/{}", language, name);
-                    items.push(
-                        crate::view::popup::PopupListItem::new(format!(
-                            "    Start {} automatically",
-                            name
-                        ))
-                        .with_data(autostart_key.clone()),
-                    );
-                    action_keys.push((autostart_key, format!("Start {} automatically", name)));
                 }
             }
         }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -456,30 +456,25 @@ impl Editor {
             }
         }
 
-        // Dismiss / Enable row — shown whenever the language has at
-        // least one configured server.  Gives the user a surface to
-        // mute the pill (dim style) and, later, to restore it.  We
-        // reuse `all_servers.is_empty()` as the "nothing here" signal
+        // Disable / Enable row — shown whenever the language has at
+        // least one configured server. Persisted in config so the
+        // choice survives an editor restart (see the `dismiss:` /
+        // `enable:` branches in `handle_lsp_status_action`). We reuse
+        // `all_servers.is_empty()` as the "nothing here" signal
         // since languages with zero configured-or-running servers
         // already bailed out above.
         if user_dismissed {
             let enable_key = format!("enable:{}", language);
             items.push(
-                crate::view::popup::PopupListItem::new(format!(
-                    "    Enable LSP pill for {}",
-                    language
-                ))
-                .with_data(enable_key.clone()),
+                crate::view::popup::PopupListItem::new(format!("    Enable LSP for {}", language))
+                    .with_data(enable_key.clone()),
             );
             action_keys.push((enable_key, format!("Enable LSP for {}", language)));
         } else {
             let dismiss_key = format!("dismiss:{}", language);
             items.push(
-                crate::view::popup::PopupListItem::new(format!(
-                    "    Disable LSP pill for {}",
-                    language
-                ))
-                .with_data(dismiss_key.clone()),
+                crate::view::popup::PopupListItem::new(format!("    Disable LSP for {}", language))
+                    .with_data(dismiss_key.clone()),
             );
             action_keys.push((dismiss_key, format!("Disable LSP for {}", language)));
         }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -14,6 +14,13 @@ impl Editor {
         // Reset per-cell theme key map for this frame
         self.cached_layout.reset_cell_theme_map();
 
+        // Attach any queued LSP auto-start prompt to the currently
+        // active buffer. Done here (rather than at file-open) so the
+        // popup follows the user's focus through a session restore
+        // that opens several files of the same language in
+        // succession. No-op when nothing is queued.
+        self.drain_pending_lsp_prompt_for_active_buffer();
+
         // For scroll sync groups, we need to update the active split's viewport position BEFORE
         // calling sync_scroll_groups, so that the sync reads the correct position.
         // Otherwise, cursor movements like 'G' (go to end) won't sync properly because

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -12,6 +12,16 @@ fn init_test_environment() {
     // Install signal handlers for debugging hangs (dumps JS + Rust stack traces on Ctrl+C)
     fresh::services::signal_handler::install_signal_handlers();
 
+    // Disable the LSP auto-prompt popup across the suite. When enabled,
+    // the popup shows on the first render after `open_file` for any
+    // language with a default-configured LSP, and the popup's input
+    // handler then swallows every subsequent `send_key` call — which
+    // breaks hundreds of tests that happen to open `.rs`/`.py`/etc
+    // files without intending to exercise LSP. Tests that specifically
+    // assert on the auto-prompt re-enable it per-editor via
+    // `harness.editor_mut().set_lsp_auto_prompt_enabled(true)`.
+    fresh::app::lsp_auto_prompt::set_default_enabled(false);
+
     // Enable panicking on JS errors so plugin bugs surface immediately in tests
     #[cfg(feature = "plugins")]
     fresh_plugin_runtime::backend::set_panic_on_js_errors(true);

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -20,6 +20,21 @@
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 
+/// Build a harness and flip the auto-prompt flag ON for it — the
+/// test-harness ctor disables auto-prompt process-wide so unrelated
+/// tests don't get popup keystroke interception. Tests in this file
+/// specifically assert on the auto-prompt, so they re-enable it on
+/// their own editor instance.
+fn harness_with_auto_prompt(
+    width: u16,
+    height: u16,
+    options: HarnessOptions,
+) -> anyhow::Result<EditorTestHarness> {
+    let mut harness = EditorTestHarness::create(width, height, options)?;
+    harness.editor_mut().set_lsp_auto_prompt_enabled(true);
+    Ok(harness)
+}
+
 fn make_config_with_dormant_rust_lsp() -> fresh::config::Config {
     let mut config = fresh::config::Config::default();
     config.lsp.insert(
@@ -70,7 +85,7 @@ fn test_popup_auto_shows_on_open_for_dormant_lsp() -> anyhow::Result<()> {
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -117,7 +132,7 @@ fn test_popup_offers_start_always_action() -> anyhow::Result<()> {
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -207,7 +222,7 @@ fn test_popup_preselects_start_always() -> anyhow::Result<()> {
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -252,7 +267,7 @@ fn test_enable_autostart_action_sets_flag_in_config() -> anyhow::Result<()> {
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -379,7 +394,7 @@ done
         }]),
     );
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -436,7 +451,7 @@ fn test_popup_does_not_auto_show_when_auto_start_true() -> anyhow::Result<()> {
         }]),
     );
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -469,7 +484,7 @@ fn test_auto_prompt_respects_user_dismissal() -> anyhow::Result<()> {
     std::fs::write(&first, "fn main() {}\n")?;
     std::fs::write(&second, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -533,7 +548,7 @@ fn test_auto_prompt_follows_active_buffer_on_session_restore() -> anyhow::Result
     std::fs::write(&first, "fn main() {}\n")?;
     std::fs::write(&second, "fn other() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -602,7 +617,7 @@ fn test_disable_action_persists_enabled_false() -> anyhow::Result<()> {
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()
@@ -721,7 +736,7 @@ fn test_popup_offers_dismiss_row_with_dynamic_keybinding() -> anyhow::Result<()>
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
 
-    let mut harness = EditorTestHarness::create(
+    let mut harness = harness_with_auto_prompt(
         120,
         30,
         HarnessOptions::new()

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -8,9 +8,12 @@
 //! behaviour that the LSP status popup auto-shows on first file open
 //! for such languages, and that the popup offers the pair of actions:
 //!
-//!   * "Start <server> once"          — start now, config unchanged
-//!   * "Start <server> automatically" — persist `auto_start = true`
-//!                                       AND start now
+//!   * "Start <server> (always)" — persist `auto_start = true` AND
+//!                                  start now. Listed first and
+//!                                  pre-selected, because
+//!                                  persistent-start is what most
+//!                                  users want.
+//!   * "Start <server> once"     — start now, config unchanged.
 //!
 //! named as siblings so the difference ("just this session" vs.
 //! "and every future session") is legible at a glance.
@@ -98,14 +101,18 @@ fn test_popup_auto_shows_on_open_for_dormant_lsp() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The auto-shown popup must offer BOTH a "Start <server> once" row
-/// (session-only) and a "Start <server> automatically" row (persists
-/// `auto_start = true`), so the user can pick between one-off and
-/// persistent behaviour directly from the prompt, without editing the
-/// on-disk config by hand.
+/// The auto-shown popup must offer BOTH a "Start <server> (always)"
+/// row (persists `auto_start = true`) and a "Start <server> once" row
+/// (session-only), so the user can pick between persistent and one-off
+/// behaviour directly from the prompt without editing the on-disk
+/// config by hand.
+///
+/// Order matters: "(always)" is listed first so it's the default
+/// selection — the common case is "yes, I want this server from now
+/// on", which should be achievable with Enter alone.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
-fn test_popup_offers_start_automatically_action() -> anyhow::Result<()> {
+fn test_popup_offers_start_always_action() -> anyhow::Result<()> {
     let temp = tempfile::tempdir()?;
     let file = temp.path().join("hello.rs");
     std::fs::write(&file, "fn main() {}\n")?;
@@ -123,27 +130,27 @@ fn test_popup_offers_start_automatically_action() -> anyhow::Result<()> {
 
     let items = popup_items(&harness);
 
-    // "Start <server> automatically" — persistent sibling.
-    let autostart_row = items
+    // "Start <server> (always)" — persistent sibling.
+    let always_row = items
         .iter()
         .find(|(_, data, _)| data.as_deref() == Some("autostart:rust/rust-analyzer"))
         .unwrap_or_else(|| {
             panic!(
-                "popup should offer a 'Start rust-analyzer automatically' action with \
+                "popup should offer a 'Start rust-analyzer (always)' action with \
                  data 'autostart:rust/rust-analyzer'. Items: {:#?}",
                 items
             )
         });
-    let (auto_label, _, auto_disabled) = autostart_row;
+    let (always_label, _, always_disabled) = always_row;
     assert!(
-        !auto_disabled,
-        "the Start-automatically row must be actionable (not disabled). Label: {:?}",
-        auto_label
+        !always_disabled,
+        "the Start (always) row must be actionable (not disabled). Label: {:?}",
+        always_label
     );
     assert!(
-        auto_label.contains("Start rust-analyzer automatically"),
-        "row label must read 'Start <server> automatically'. Label: {:?}",
-        auto_label
+        always_label.contains("Start rust-analyzer (always)"),
+        "row label must read 'Start <server> (always)'. Label: {:?}",
+        always_label
     );
 
     // "Start <server> once" — session-only sibling.
@@ -161,8 +168,74 @@ fn test_popup_offers_start_automatically_action() -> anyhow::Result<()> {
     assert!(
         once_label.contains("Start rust-analyzer once"),
         "row label must read 'Start <server> once' to distinguish it from the \
-         automatically sibling. Label: {:?}",
+         (always) sibling. Label: {:?}",
         once_label
+    );
+
+    // Order + default selection: "(always)" must come before "once"
+    // in the popup, so the pre-selected row (the first actionable
+    // item) is the persistent one.
+    let always_idx = items
+        .iter()
+        .position(|(_, data, _)| data.as_deref() == Some("autostart:rust/rust-analyzer"))
+        .expect("always row present");
+    let once_idx = items
+        .iter()
+        .position(|(_, data, _)| data.as_deref() == Some("start:rust"))
+        .expect("once row present");
+    assert!(
+        always_idx < once_idx,
+        "'(always)' should come before 'once' so Enter picks the persistent \
+         option. always_idx={}, once_idx={}, items={:#?}",
+        always_idx,
+        once_idx,
+        items
+    );
+
+    Ok(())
+}
+
+/// The popup's default selection lands on the "(always)" row so the
+/// user can just press Enter — separate from position ordering (a
+/// popup could in theory list "(always)" first but pre-select a
+/// later row). Verified by checking the popup's `selected` index
+/// matches the "(always)" row.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_preselects_start_always() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    let popup = harness
+        .editor()
+        .active_state()
+        .popups
+        .top()
+        .expect("popup should be visible");
+    let (items, selected) = match &popup.content {
+        fresh::view::popup::PopupContent::List { items, selected } => (items, *selected),
+        _ => panic!("expected a List popup"),
+    };
+    let selected_item = items.get(selected).expect("selected index in range");
+    assert_eq!(
+        selected_item.data.as_deref(),
+        Some("autostart:rust/rust-analyzer"),
+        "default selection should be the '(always)' row so Enter kicks off \
+         persistent-start. Selected row: {:?}, all items: {:#?}",
+        selected_item,
+        items
     );
 
     Ok(())

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -1,0 +1,434 @@
+//! E2E tests: auto-prompt when opening a file for a language with a
+//! configured LSP server that's enabled but `auto_start = false`.
+//!
+//! When a user has configured an LSP server for a language but left
+//! `auto_start = false`, opening a matching file used to produce a
+//! silent `LSP (off)` pill and nothing else — the user could easily
+//! miss that a server is one command away. These tests pin the
+//! behaviour that the LSP status popup auto-shows on first file open
+//! for such languages, and that the popup offers the pair of actions:
+//!
+//!   * "Start <server> once"          — start now, config unchanged
+//!   * "Start <server> automatically" — persist `auto_start = true`
+//!                                       AND start now
+//!
+//! named as siblings so the difference ("just this session" vs.
+//! "and every future session") is legible at a glance.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+
+fn make_config_with_dormant_rust_lsp() -> fresh::config::Config {
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "rust-analyzer".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: false,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("rust-analyzer".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+    config
+}
+
+/// Collect the currently-visible popup's list item text lines, in order.
+fn popup_items(harness: &EditorTestHarness) -> Vec<(String, Option<String>, bool)> {
+    harness
+        .editor()
+        .active_state()
+        .popups
+        .top()
+        .map(|p| match &p.content {
+            fresh::view::popup::PopupContent::List { items, .. } => items
+                .iter()
+                .map(|i| (i.text.clone(), i.data.clone(), i.disabled))
+                .collect(),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default()
+}
+
+/// Opening a file whose language has a configured, enabled, but
+/// `auto_start = false` LSP server MUST auto-show the LSP status popup
+/// on first open. Without this prompt the user sees a silent `LSP
+/// (off)` pill and may not notice that a server is one action away.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_auto_shows_on_open_for_dormant_lsp() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    // The auto-shown popup is the same List popup used by the
+    // status-bar click path (the existing LSP status popup), so its
+    // items match the shape that `popup_items` knows how to decode.
+    let items = popup_items(&harness);
+    assert!(
+        !items.is_empty(),
+        "LSP status popup should auto-show when opening a file whose language has \
+         an enabled-but-auto_start=false server. Got no visible list popup."
+    );
+    // Sanity: popup's header row mentions our configured server, so
+    // we're looking at an LSP popup and not some unrelated prompt.
+    assert!(
+        items.iter().any(|(t, _, _)| t.contains("rust-analyzer")),
+        "popup should list the configured server rust-analyzer. Items: {:#?}",
+        items
+    );
+
+    Ok(())
+}
+
+/// The auto-shown popup must offer BOTH a "Start <server> once" row
+/// (session-only) and a "Start <server> automatically" row (persists
+/// `auto_start = true`), so the user can pick between one-off and
+/// persistent behaviour directly from the prompt, without editing the
+/// on-disk config by hand.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_offers_start_automatically_action() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    let items = popup_items(&harness);
+
+    // "Start <server> automatically" — persistent sibling.
+    let autostart_row = items
+        .iter()
+        .find(|(_, data, _)| data.as_deref() == Some("autostart:rust/rust-analyzer"))
+        .unwrap_or_else(|| {
+            panic!(
+                "popup should offer a 'Start rust-analyzer automatically' action with \
+                 data 'autostart:rust/rust-analyzer'. Items: {:#?}",
+                items
+            )
+        });
+    let (auto_label, _, auto_disabled) = autostart_row;
+    assert!(
+        !auto_disabled,
+        "the Start-automatically row must be actionable (not disabled). Label: {:?}",
+        auto_label
+    );
+    assert!(
+        auto_label.contains("Start rust-analyzer automatically"),
+        "row label must read 'Start <server> automatically'. Label: {:?}",
+        auto_label
+    );
+
+    // "Start <server> once" — session-only sibling.
+    let once_row = items
+        .iter()
+        .find(|(_, data, _)| data.as_deref() == Some("start:rust"))
+        .unwrap_or_else(|| {
+            panic!(
+                "popup must also offer a 'start:rust' row. Items: {:#?}",
+                items
+            )
+        });
+    let (once_label, _, once_disabled) = once_row;
+    assert!(!once_disabled, "the 'Start once' row must be actionable");
+    assert!(
+        once_label.contains("Start rust-analyzer once"),
+        "row label must read 'Start <server> once' to distinguish it from the \
+         automatically sibling. Label: {:?}",
+        once_label
+    );
+
+    Ok(())
+}
+
+/// Invoking "Start <server> automatically" must persist
+/// `auto_start = true` in the live config so the server starts
+/// automatically on subsequent opens (and, by extension, gets saved to
+/// disk via the same save_config path used by other LSP popup actions).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_enable_autostart_action_sets_flag_in_config() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    // Precondition: auto_start is false.
+    let before = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].auto_start)
+        .expect("rust config must be present");
+    assert!(!before, "precondition: auto_start must start false");
+
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("autostart:rust/rust-analyzer");
+
+    let after = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].auto_start)
+        .expect("rust config must still be present");
+    assert!(
+        after,
+        "after invoking the autostart action, config must have auto_start=true"
+    );
+
+    Ok(())
+}
+
+/// Invoking "Start <server> automatically" must do BOTH things it
+/// advertises: persist `auto_start = true` AND start the server now,
+/// so LSP features come alive in the current buffer without the user
+/// having to re-open the file or toggle it by hand.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_enable_autostart_action_also_spawns_server() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+
+    // Minimal fake LSP: writes a PID to the log on spawn, replies
+    // to the initialize handshake, and idles. The log file's
+    // existence is the witness that the server actually started.
+    let script_path = temp.path().join("fake_autostart_lsp.sh");
+    let script = r##"#!/bin/bash
+LOG_FILE="$1"
+echo "$$" >> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"positionEncoding":"utf-16","textDocumentSync":{"openClose":true,"change":2,"save":{}}}}}'
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+        *)
+            if [ -n "$method" ] && [ -n "$msg_id" ]; then
+                send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            fi
+            ;;
+    esac
+done
+"##;
+    std::fs::write(&script_path, script)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms)?;
+    }
+
+    let spawn_log = temp.path().join("spawn.log");
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![spawn_log.to_string_lossy().to_string()],
+            enabled: true,
+            auto_start: false,
+            name: Some("rust-analyzer".to_string()),
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    // Precondition: the auto-prompt popup is open (that's the path
+    // under test); server has NOT spawned yet because auto_start=false.
+    assert!(
+        !spawn_log.exists(),
+        "precondition: server must not have spawned before action"
+    );
+
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("autostart:rust/rust-analyzer");
+
+    // Semantic wait: spawn log exists iff the server process started.
+    harness.wait_until(|_| spawn_log.exists())?;
+
+    Ok(())
+}
+
+/// If the configured LSP already has `auto_start = true`, no prompt is
+/// needed — the server starts (or tries to) automatically, so auto-
+/// popping the popup would be a distraction. This is the negative
+/// control: opening a file for an `auto_start=true` server must NOT
+/// auto-show the LSP popup.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_does_not_auto_show_when_auto_start_true() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            // Point at a missing binary so nothing actually spawns and
+            // the test stays hermetic. The field under test is the
+            // prompt-or-not decision, which keys off `auto_start`, not
+            // binary availability.
+            command: "this-binary-definitely-does-not-exist-xyz999".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            name: Some("rust-analyzer".to_string()),
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "no auto-prompt should appear when auto_start=true is already configured"
+    );
+
+    Ok(())
+}
+
+/// When the user has dismissed the LSP pill for this language (via the
+/// popup's "Disable LSP pill for …" action), the auto-prompt must
+/// respect that dismissal and stay silent on subsequent file opens —
+/// otherwise the mute surface would be useless, since the popup would
+/// re-pop every time the user opens another file of the same language.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_auto_prompt_respects_user_dismissal() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let first = temp.path().join("a.rs");
+    let second = temp.path().join("b.rs");
+    std::fs::write(&first, "fn main() {}\n")?;
+    std::fs::write(&second, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&first)?;
+    harness.render()?;
+
+    // First open: popup shows.
+    assert!(
+        harness.editor().active_state().popups.top().is_some(),
+        "first open should auto-show the prompt"
+    );
+
+    // User dismisses the pill and closes the popup.
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("dismiss:rust");
+    harness.editor_mut().hide_popup();
+    harness.render()?;
+
+    // Second file of the same language — no re-prompt.
+    harness.open_file(&second)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "after the user dismissed the LSP pill for rust, opening another rust file \
+         must not re-pop the prompt"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -698,3 +698,103 @@ fn test_disable_action_persists_enabled_false() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// The popup must expose its own "Dismiss" affordance as a selectable
+/// row — not rely on the user to know Esc closes it — and the row
+/// label must advertise the current keybinding so the UI stays
+/// truthful when the user has rebound things.
+///
+/// Specifically:
+///   1. A row with data `cancel_popup` is present, actionable, and
+///      sits at the end of the popup (after all the server-specific
+///      and language-level actions).
+///   2. The row label reads "Dismiss (<key>)" where <key> is the
+///      currently-bound key for `Action::PopupCancel` in the Popup
+///      key context — looked up via the keybinding resolver, not
+///      hardcoded. On a stock keymap that's "Esc".
+///   3. Invoking the row (via `handle_popup_confirm`, the same path
+///      the Enter key goes through) closes the popup.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_offers_dismiss_row_with_dynamic_keybinding() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    let items = popup_items(&harness);
+
+    // (1) Row present, actionable, and last.
+    let dismiss_idx = items
+        .iter()
+        .position(|(_, data, _)| data.as_deref() == Some("cancel_popup"))
+        .unwrap_or_else(|| {
+            panic!(
+                "popup should offer a 'cancel_popup' row so users can dismiss \
+                 via selection, not only via Esc. Items: {:#?}",
+                items
+            )
+        });
+    let (label, _, disabled) = &items[dismiss_idx];
+    assert!(
+        !disabled,
+        "the Dismiss row must be actionable. Label: {:?}",
+        label
+    );
+    assert_eq!(
+        dismiss_idx,
+        items.len() - 1,
+        "Dismiss should be the LAST row — it's a fallback out, not a \
+         server-specific action. Items: {:#?}",
+        items
+    );
+
+    // (2) Label mentions Dismiss + the bound key looked up dynamically
+    //     from the keymap system. On the default keymap PopupCancel is
+    //     bound to Esc, which is what `format_keybinding` stringifies
+    //     for `KeyCode::Esc`.
+    assert!(
+        label.contains("Dismiss"),
+        "label should mention 'Dismiss'. Label: {:?}",
+        label
+    );
+    assert!(
+        label.contains("Esc"),
+        "label should include the dynamically-resolved keybinding for \
+         Action::PopupCancel (default: Esc). Hardcoding 'Esc' here is a \
+         smell, but the test pins the default; a keymap change would \
+         flip the label and this assertion would guide the update. \
+         Label: {:?}",
+        label
+    );
+
+    // (3) Invoking the row closes the popup. `show_lsp_status_popup`
+    //     toggles based on `pending_lsp_status_popup`, so after
+    //     confirm the popup should be gone.
+    harness
+        .editor_mut()
+        .active_state_mut()
+        .popups
+        .top_mut()
+        .expect("popup visible")
+        .select_index(dismiss_idx);
+    harness.editor_mut().handle_popup_confirm();
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "selecting the Dismiss row should close the popup"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -578,3 +578,123 @@ fn test_auto_prompt_follows_active_buffer_on_session_restore() -> anyhow::Result
 
     Ok(())
 }
+
+/// Picking "Disable LSP for <lang>" in the auto-prompt popup must do
+/// two user-visible things:
+///
+///   1. The row label drops the word "pill" — from the user's
+///      perspective they're disabling the LSP, not some pill widget.
+///   2. It flips `enabled = false` in the persisted config. The
+///      old behaviour (`user_dismissed_lsp_languages`, a session-
+///      scoped HashSet) didn't survive a restart, so the user got
+///      re-prompted the next time they opened the editor and
+///      rightly concluded the "Disable" action didn't actually do
+///      what it said.
+///
+/// After invoking the action, the in-memory config (which is what
+/// `save_config` writes to disk) must have `enabled = false` on the
+/// rust LSP entry — and the auto-prompt path must therefore stay
+/// silent on subsequent file opens.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_disable_action_persists_enabled_false() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    // Precondition: the popup is up and its disable row exists —
+    // asserted in `test_popup_auto_shows_on_open_for_dormant_lsp`
+    // and `test_popup_offers_start_always_action`. Here we focus on
+    // the label + side-effect of the disable row.
+
+    // 1. Label: the visible row should NOT mention "pill".
+    let items = popup_items(&harness);
+    let disable_row = items
+        .iter()
+        .find(|(_, data, _)| data.as_deref() == Some("dismiss:rust"))
+        .unwrap_or_else(|| {
+            panic!(
+                "popup should offer a 'dismiss:rust' action. Items: {:#?}",
+                items
+            )
+        });
+    let (disable_label, _, _) = disable_row;
+    assert!(
+        !disable_label.contains("pill"),
+        "row label shouldn't expose the internal 'pill' noun. Label: {:?}",
+        disable_label
+    );
+    assert!(
+        disable_label.contains("Disable LSP for rust"),
+        "row label should read 'Disable LSP for <lang>'. Label: {:?}",
+        disable_label
+    );
+
+    // Precondition for (2): the config currently has enabled=true.
+    assert!(
+        harness
+            .editor()
+            .config()
+            .lsp
+            .get("rust")
+            .map(|cfg| cfg.as_slice()[0].enabled)
+            .unwrap(),
+        "precondition: rust LSP should start as enabled=true"
+    );
+
+    harness
+        .editor_mut()
+        .handle_lsp_status_action("dismiss:rust");
+
+    // 2a. The action flipped enabled=false in the live config (the
+    //     same config `save_config` serializes to disk).
+    let enabled_after = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].enabled)
+        .expect("rust config must still be present");
+    assert!(
+        !enabled_after,
+        "BUG: 'Disable LSP for rust' must set enabled=false in the config \
+         so the change survives an editor restart. The old session-only \
+         `user_dismissed_lsp_languages` HashSet meant the next session \
+         re-prompted the user, contradicting the action's label."
+    );
+
+    // 2b. Effect: subsequent file opens in this same session no
+    //     longer pop the auto-prompt, because enabled=false takes
+    //     the spawn flow down the `Failed` path rather than
+    //     `NotAutoStart`. (A second harness + fresh config-reload
+    //     would assert the cross-restart half, but touching the
+    //     disk layer is disproportionate here; the config-state
+    //     assertion above already pins the invariant that gets
+    //     serialized.)
+    harness.editor_mut().hide_popup();
+    harness.render()?;
+
+    let second = temp.path().join("b.rs");
+    std::fs::write(&second, "fn main() {}\n")?;
+    harness.open_file(&second)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "after 'Disable LSP for rust', opening another rust file must not \
+         re-pop the auto-prompt"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -432,3 +432,76 @@ fn test_auto_prompt_respects_user_dismissal() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Regression: when a session (re)opens multiple buffers of the same
+/// language back-to-back — the common shape of a session restore —
+/// the auto-prompt must end up on whichever buffer the user is
+/// looking at, not stuck on the first one that happened to be active
+/// when the prompt fired.
+///
+/// Today the prompt fires inside `notify_lsp_file_opened` and the
+/// popup attaches to `active_buffer()` at that instant. The
+/// once-per-session guard then suppresses subsequent fires for the
+/// same language, so if the active buffer flips after the first open
+/// (as it does when a later file is opened and takes focus) the popup
+/// is orphaned on a background buffer and the user sees nothing.
+///
+/// The test opens two `.rs` files in sequence — the second one wins
+/// focus, so if you imagine this as a session restore, the user lands
+/// on `b.rs`. The active buffer at that point must have the prompt;
+/// otherwise the auto-prompt is effectively invisible for anyone
+/// with more than one buffer open.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_auto_prompt_follows_active_buffer_on_session_restore() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let first = temp.path().join("a.rs");
+    let second = temp.path().join("b.rs");
+    std::fs::write(&first, "fn main() {}\n")?;
+    std::fs::write(&second, "fn other() {}\n")?;
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    // Simulate a session restore that reopens two rust buffers in a
+    // row. Each call's `notify_lsp_file_opened` runs with that file
+    // already the active buffer — but only the first open will fire
+    // the prompt (per the once-per-session guard), and it attaches
+    // the popup to `a.rs`. The second open flips active → `b.rs`.
+    harness.open_file(&first)?;
+    harness.render()?;
+    harness.open_file(&second)?;
+    harness.render()?;
+
+    // Sanity: the last opened file is what the user is looking at.
+    // Asserted via the rendered tab bar rather than internal state
+    // so the test speaks the user's language ("what's on my
+    // screen") — not the editor's.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("b.rs"),
+        "precondition: active tab should be b.rs. Screen:\n{}",
+        screen
+    );
+
+    // The user is on `b.rs` with a dormant rust LSP. The auto-prompt
+    // must be visible here — not stuck on `a.rs` in the background.
+    // `active_state().popups.top()` returns the popup stack for the
+    // currently-visible buffer only, so a `None` here means the
+    // popup exists elsewhere (or not at all) and the user sees
+    // nothing.
+    assert!(
+        harness.editor().active_state().popups.top().is_some(),
+        "auto-prompt should be visible on whichever rust buffer is currently \
+         active, not orphaned on a background buffer the user may never visit. \
+         Screen:\n{}",
+        screen
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -81,6 +81,9 @@ fn test_missing_binary_popup_shows_advisory_and_dismiss() -> anyhow::Result<()> 
             .with_config(make_config_with_missing_rust_lsp())
             .with_working_dir(temp.path().to_path_buf()),
     )?;
+    // Opt this test into the LSP auto-prompt; the harness ctor
+    // disables it by default for the rest of the suite.
+    harness.editor_mut().set_lsp_auto_prompt_enabled(true);
 
     harness.open_file(&file)?;
 
@@ -169,6 +172,9 @@ fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
             .with_config(make_config_with_missing_rust_lsp())
             .with_working_dir(temp.path().to_path_buf()),
     )?;
+    // Opt this test into the LSP auto-prompt; the harness ctor
+    // disables it by default for the rest of the suite.
+    harness.editor_mut().set_lsp_auto_prompt_enabled(true);
 
     harness.open_file(&file)?;
     harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -89,8 +89,10 @@ fn test_missing_binary_popup_shows_advisory_and_dismiss() -> anyhow::Result<()> 
     // because the real issue is upstream.
     harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
 
-    // Open the popup the same way the status-bar click handler would.
-    harness.editor_mut().show_lsp_status_popup();
+    // The LSP auto-prompt already opens the popup on the first
+    // file open for a language with enabled+auto_start=false
+    // configured, so we don't need to invoke show_lsp_status_popup
+    // ourselves — doing so would toggle the popup closed.
 
     let items = popup_items(&harness);
     assert!(!items.is_empty(), "LSP status popup should have items");
@@ -139,17 +141,20 @@ fn test_missing_binary_popup_shows_advisory_and_dismiss() -> anyhow::Result<()> 
     });
     assert!(
         dismiss_row.is_some(),
-        "expected a 'Disable LSP pill for rust' row. Items: {:#?}",
+        "expected a 'Disable LSP for rust' row. Items: {:#?}",
         items
     );
 
     Ok(())
 }
 
-/// Dismissing a language transitions the indicator to the muted
-/// `OffDismissed` variant and surfaces an "Enable LSP pill for …"
-/// action in the popup. Re-enabling restores the yellow `Off` variant
-/// and the original "Disable …" action.
+/// Disable → Enable round-trips through the popup: "Disable LSP for
+/// <lang>" flips `enabled = false` in the live config (persisted via
+/// `save_config`, so the choice survives a restart), and the
+/// complementary "Enable LSP for <lang>" restores `enabled = true`.
+/// The status-bar pill disappears while disabled (because
+/// `compose_lsp_status` gates on `enabled && !command.is_empty()`)
+/// and comes back on re-enable.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
@@ -168,66 +173,64 @@ fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
     harness.open_file(&file)?;
     harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
 
-    // Precondition: not dismissed.
+    // Precondition: enabled=true in config.
+    let enabled_initial = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].enabled)
+        .expect("rust config present");
     assert!(
-        !harness.editor().is_lsp_language_user_dismissed("rust"),
-        "precondition: should not be dismissed"
+        enabled_initial,
+        "precondition: rust LSP should start enabled=true"
     );
 
-    // Dismiss directly through the action handler — this is what the
-    // popup dispatches when the user picks the "Disable LSP pill" row.
+    // Disable via the action handler — the path the popup dispatches
+    // when the user picks the "Disable LSP for rust" row.
     harness
         .editor_mut()
         .handle_lsp_status_action("dismiss:rust");
+    let enabled_after_disable = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].enabled)
+        .unwrap();
     assert!(
-        harness.editor().is_lsp_language_user_dismissed("rust"),
-        "after dismiss, language should be marked dismissed"
+        !enabled_after_disable,
+        "Disable LSP for rust must flip enabled=false in config so the \
+         choice persists across restarts"
     );
 
-    // Text of the pill stays `LSP (off)` — only the style changes,
-    // which is carried by `LspIndicatorState::OffDismissed` inside the
-    // render path (not observable from plain text).
-    let _ = harness.render();
+    // Pill should disappear: no configured-and-enabled server means
+    // `compose_lsp_status` yields an empty indicator, so neither
+    // `(off)` nor `(on)` should be on the status bar.
+    harness.render()?;
     assert!(
-        harness.get_status_bar().contains("LSP (off)"),
-        "text does not change on dismiss. status bar: {}",
+        !harness.get_status_bar().contains("LSP (off)"),
+        "after disable, the pill text should be gone (not shown in any state). \
+         Status bar: {}",
         harness.get_status_bar()
     );
 
-    // Re-enable round-trips cleanly.
+    // Re-enable via the symmetric action.
     harness.editor_mut().handle_lsp_status_action("enable:rust");
+    let enabled_after_reenable = harness
+        .editor()
+        .config()
+        .lsp
+        .get("rust")
+        .map(|cfg| cfg.as_slice()[0].enabled)
+        .unwrap();
     assert!(
-        !harness.editor().is_lsp_language_user_dismissed("rust"),
-        "after enable, language should no longer be dismissed"
+        enabled_after_reenable,
+        "Enable LSP for rust must flip enabled=true in config"
     );
 
-    // Open the popup and confirm the action row text flipped back to
-    // the "Disable" form.
-    harness.editor_mut().show_lsp_status_popup();
-    let items = popup_items(&harness);
-    assert!(
-        items
-            .iter()
-            .any(|(_, data, _)| data.as_deref() == Some("dismiss:rust")),
-        "re-enabled state should show the Disable action again. Items: {:#?}",
-        items
-    );
-
-    // Dismiss once more and verify the popup now offers Enable.
-    // `show_lsp_status_popup` toggles, so call it to close first.
-    harness.editor_mut().show_lsp_status_popup();
-    harness
-        .editor_mut()
-        .handle_lsp_status_action("dismiss:rust");
-    harness.editor_mut().show_lsp_status_popup();
-    let items = popup_items(&harness);
-    assert!(
-        items
-            .iter()
-            .any(|(_, data, _)| data.as_deref() == Some("enable:rust")),
-        "dismissed state should offer Enable action. Items: {:#?}",
-        items
-    );
+    // Pill should come back.
+    harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
 
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/lsp_stop_stale_indicator.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_stop_stale_indicator.rs
@@ -178,3 +178,180 @@ fn test_stop_lsp_server_clears_stale_on_indicator() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Fake LSP that, on `initialize`, fires a `$/progress begin`
+/// notification that never gets a corresponding `end`. This puts the
+/// editor's `lsp_progress` map into the "active work for this
+/// language" state, which drives the status-bar spinner. Used by the
+/// test below to reproduce the user-reported "spinner stuck after
+/// stop" bug.
+fn create_progress_stuck_server_script(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = r##"#!/bin/bash
+LOG_FILE="${1:-/tmp/progress_stuck_log.txt}"
+> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+    echo "RECV: $method id=$msg_id" >> "$LOG_FILE"
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"positionEncoding":"utf-16","textDocumentSync":{"openClose":true,"change":2,"save":{}},"workDoneProgress":true}}}'
+            ;;
+        "initialized")
+            # Fire a progress-begin that we intentionally never end —
+            # the server is about to be stopped and we want to prove
+            # the editor clears progress state on its side rather
+            # than waiting for an `end` that'll never arrive.
+            send_message '{"jsonrpc":"2.0","method":"$/progress","params":{"token":"stuck-1","value":{"kind":"begin","title":"indexing"}}}'
+            echo "SENT: progress begin" >> "$LOG_FILE"
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+        "exit") break ;;
+        *)
+            if [ -n "$method" ] && [ -n "$msg_id" ]; then
+                send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            fi
+            ;;
+    esac
+done
+"##;
+
+    let script_path = dir.join("fake_progress_stuck_server.sh");
+    std::fs::write(&script_path, script).expect("failed to write fake server");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).unwrap();
+    }
+
+    script_path
+}
+
+/// After `Stop LSP Server` the status-bar indicator must stop
+/// showing the progress spinner, even when the server had open
+/// `$/progress` work in flight — the server is dead and will never
+/// send an `end` notification, so the editor has to clear its own
+/// progress bookkeeping when it stops the server.
+///
+/// Bug (user-reported): stopping an LSP that had emitted a
+/// `$/progress begin` leaves `lsp_progress` populated; the spinner
+/// branch in `compose_lsp_status` wins over the "(off)" branch and
+/// the pill stays stuck on the rotating braille char. Worse, the
+/// spinner stops re-rendering on its own (no async progress events
+/// arrive any more), so it only advances when some unrelated event
+/// — mouse hover, keypress — re-renders the frame. From the user's
+/// perspective the indicator is frozen yet twitchy.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_stop_lsp_server_clears_stale_progress_spinner() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let script_path = create_progress_stuck_server_script(temp_dir.path());
+    let log_file = temp_dir.path().join("progress_stuck.log");
+    let test_file = temp_dir.path().join("hello.rs");
+    std::fs::write(&test_file, "fn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![log_file.to_string_lossy().to_string()],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("progress-stuck".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait until the spinner branch wins, i.e. the editor has
+    // received a `$/progress begin` and `lsp_progress` is populated
+    // for `rust`. `has_active_lsp_progress` on the editor is the
+    // authoritative view into that map; we use it as the readiness
+    // signal rather than scraping spinner glyphs out of the screen.
+    harness.wait_until(|h| h.editor().has_active_lsp_progress())?;
+
+    // Sanity: the visible indicator is in spinner mode, not "(on)"
+    // or "(off)". The spinner's exact glyph rotates with wall-clock,
+    // so the stable signal is the ABSENCE of both paren'd states.
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("LSP (on)") && !screen.contains("LSP (off)"),
+        "pre-condition: indicator should be in spinner state (no paren'd \
+         label) while progress is active. Screen:\n{}",
+        screen
+    );
+
+    // Stop via the same prompt path the command palette uses.
+    harness.editor_mut().handle_stop_lsp_server("rust");
+    harness.render()?;
+
+    // After stop: progress state should be cleared on our side
+    // (the server can't send `end` — it's dead) and the indicator
+    // should read the configured-but-not-running "LSP (off)".
+    let screen = harness.screen_to_string();
+    assert!(
+        !harness.editor().has_active_lsp_progress(),
+        "BUG: `lsp_progress` still has entries for the stopped server. \
+         That keeps the spinner branch in `compose_lsp_status` live \
+         forever, since the `end` notification is never coming. \
+         Screen:\n{}",
+        screen
+    );
+    assert!(
+        screen.contains("LSP (off)"),
+        "After stop, the indicator should be 'LSP (off)'. Stuck spinner \
+         means `compose_lsp_status` took the progress branch instead. \
+         Screen:\n{}",
+        screen
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -65,6 +65,7 @@ pub mod line_wrapping;
 pub mod live_grep;
 pub mod locale;
 pub mod lsp;
+pub mod lsp_auto_start_prompt;
 pub mod lsp_autostart_selective;
 pub mod lsp_bulk_edit_undo_desync;
 pub mod lsp_code_action_modal;


### PR DESCRIPTION
## Summary

Add an auto-prompt feature that surfaces the LSP status popup when opening a file for a language with a configured, enabled LSP server that has `auto_start = false`. This helps users discover dormant servers that would otherwise only show a silent `LSP (off)` pill.

## Key Changes

- **New test suite** (`lsp_auto_start_prompt.rs`): Comprehensive E2E tests covering:
  - Auto-popup behavior on first file open for dormant servers
  - Dual action buttons: "Start once" (session-only) and "Start automatically" (persists config)
  - Config persistence when enabling auto-start
  - Server spawning immediately after enabling auto-start
  - Negative control: no popup when `auto_start = true` already
  - Dismissal respect: popup doesn't re-appear after user dismisses the pill

- **Popup dialog enhancement** (`popup_dialogs.rs`):
  - Track per-server `auto_start` flags to determine which actions to offer
  - Add "Start <server> automatically" row alongside "Start <server> once" when server is dormant (`auto_start = false`)
  - Differentiate labels with "once" suffix to clarify session-only vs. persistent behavior

- **LSP action handler** (`lsp_actions.rs`):
  - New `autostart:<language>/<server_name>` action to enable auto-start in config
  - Persist the flag change to disk and emit config change event
  - Immediately spawn the server so LSP features activate without requiring file re-open

- **File operations** (`file_operations.rs`):
  - Auto-show LSP status popup when opening files for dormant servers
  - Track prompted languages per session to avoid re-popping on every file open
  - Respect user dismissals (don't re-prompt if pill was muted)

- **Editor state** (`mod.rs`, `editor_init.rs`):
  - Add `auto_start_prompted_languages` set to track which languages have been prompted this session
  - Initialize the set during editor creation

## Implementation Details

The prompt respects user intent at multiple levels:
- **Per-session**: Only prompts once per language per session (tracked in `auto_start_prompted_languages`)
- **Persistent**: Respects user dismissals via the existing `user_dismissed_lsp_languages` set
- **Across sessions**: Once `auto_start = true` is persisted, the prompt never appears again

The dual-action design lets users choose between one-off activation ("Start once") and persistent enablement ("Start automatically") directly from the prompt, eliminating the need to manually edit config files.

https://claude.ai/code/session_01W8HGR4eeuLC98eA5sUW9zt