### PR TITLE
Add sequence numbers to buffer group focus status for reliable testing

### DIFF
--- a/crates/fresh-editor/tests/e2e/buffer_groups.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_groups.rs
@@ -53,10 +53,28 @@ fn open_test_bg(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
+/// Extract the monotonic `seq=N` value that the plugin appends to its
+/// focus status line. Returns `None` if no such status is on screen.
+fn parse_which_seq(harness: &EditorTestHarness) -> Option<u64> {
+    let s = harness.screen_to_string();
+    let idx = s.rfind("TestBG: FOCUS=")?;
+    let tail = &s[idx..];
+    let seq_idx = tail.find("seq=")?;
+    let after = &tail[seq_idx + "seq=".len()..];
+    let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+    digits.parse().ok()
+}
+
 /// Run the "TestBG: Which" command and return the reported focus via
 /// the status bar — one of "LEFT", "RIGHT", "OTHER", or `None` if the
 /// command wasn't executed / status not updated.
+///
+/// The plugin tags each status with a monotonic `seq=N`. We record the
+/// highest seq already on screen and wait for a strictly higher one,
+/// so we never read a stale status left over from a previous invocation.
 fn run_which(harness: &mut EditorTestHarness) -> Option<&'static str> {
+    let prev_seq = parse_which_seq(harness).unwrap_or(0);
+
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
@@ -69,14 +87,16 @@ fn run_which(harness: &mut EditorTestHarness) -> Option<&'static str> {
     harness.render().unwrap();
 
     harness
-        .wait_until(|h| h.screen_to_string().contains("TestBG: FOCUS="))
+        .wait_until(|h| parse_which_seq(h).is_some_and(|s| s > prev_seq))
         .unwrap();
     let s = harness.screen_to_string();
-    if s.contains("TestBG: FOCUS=LEFT") {
+    let idx = s.rfind("TestBG: FOCUS=")?;
+    let tail = &s[idx..];
+    if tail.starts_with("TestBG: FOCUS=LEFT") {
         Some("LEFT")
-    } else if s.contains("TestBG: FOCUS=RIGHT") {
+    } else if tail.starts_with("TestBG: FOCUS=RIGHT") {
         Some("RIGHT")
-    } else if s.contains("TestBG: FOCUS=OTHER") {
+    } else if tail.starts_with("TestBG: FOCUS=OTHER") {
         Some("OTHER")
     } else {
         None

--- a/crates/fresh-editor/tests/plugins/test_buffer_groups.ts
+++ b/crates/fresh-editor/tests/plugins/test_buffer_groups.ts
@@ -59,16 +59,25 @@ registerHandler("tbg_create", tbg_create);
 /**
  * Report which panel's buffer is the currently active buffer via the status
  * message. The test reads the status bar to assert focus routing.
+ *
+ * Each call includes a monotonic `seq=N` suffix so tests can distinguish a
+ * freshly-computed result from a stale one left over from a previous call;
+ * without this, `wait_until(contains "TestBG: FOCUS=")` would return
+ * immediately on the old status line before the new invocation has run.
  */
+let whichSeq = 0;
 function tbg_which(): void {
+  whichSeq++;
   const activeId = editor.getActiveBufferId();
+  let focus: string;
   if (activeId === state.panels["left"]) {
-    editor.setStatus("TestBG: FOCUS=LEFT");
+    focus = "LEFT";
   } else if (activeId === state.panels["right"]) {
-    editor.setStatus("TestBG: FOCUS=RIGHT");
+    focus = "RIGHT";
   } else {
-    editor.setStatus(`TestBG: FOCUS=OTHER(${activeId})`);
+    focus = `OTHER(${activeId})`;
   }
+  editor.setStatus(`TestBG: FOCUS=${focus} seq=${whichSeq}`);
 }
 registerHandler("tbg_which", tbg_which);
 


### PR DESCRIPTION
## Summary
This PR improves the reliability of buffer group focus tests by adding monotonic sequence numbers to the plugin's status messages. This allows tests to distinguish freshly-computed results from stale status lines left over from previous invocations.

## Key Changes
- **Plugin (TypeScript)**: Modified `tbg_which()` to append a monotonic `seq=N` suffix to status messages, incrementing on each call
- **Test (Rust)**: 
  - Added `parse_which_seq()` helper function to extract the sequence number from the status line
  - Updated `run_which()` to record the previous sequence number before executing the command
  - Changed the wait condition from a simple string contains check to waiting for a strictly higher sequence number
  - Refactored focus detection to use `starts_with()` on the tail of the status string for more precise matching

## Implementation Details
The sequence number approach solves a race condition where `wait_until(contains "TestBG: FOCUS=")` would return immediately if an old status line from a previous invocation was still on screen. By requiring a strictly higher sequence number, the test now guarantees it's reading the result of the current command invocation, not a stale result from before.

https://claude.ai/code/session_019hAGArDRG9w8eQbBMiRTmW