### PR TITLE
Fix LSP auto-prompt dismissal and improve disabled-server UX

### DIFF
--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Zobrazit dokončování",
   "menu.lsp.show_hover": "Zobrazit informace",
   "menu.lsp.show_signature": "Zobrazit nápovědu signatury",
+  "menu.lsp.show_status": "Stav LSP\u2026",
   "menu.lsp.stop_server": "Zastavit server",
   "menu.lsp.toggle_for_buffer": "Přepnout LSP pro aktuální vyrovnávací paměť",
   "menu.lsp.toggle_inlay_hints": "Přepnout vložené nápovědy",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Vervollständigungen anzeigen",
   "menu.lsp.show_hover": "Hover-Info anzeigen",
   "menu.lsp.show_signature": "Signaturhilfe anzeigen",
+  "menu.lsp.show_status": "LSP-Status\u2026",
   "menu.lsp.stop_server": "Server stoppen",
   "menu.lsp.toggle_for_buffer": "LSP für aktuellen Puffer umschalten",
   "menu.lsp.toggle_inlay_hints": "Inlay-Hinweise umschalten",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1052,6 +1052,7 @@
   "menu.lsp.show_completions": "Show Completions",
   "menu.lsp.show_hover": "Show Hover Info",
   "menu.lsp.show_signature": "Show Signature Help",
+  "menu.lsp.show_status": "LSP Status\u2026",
   "menu.lsp.stop_server": "Stop Server",
   "menu.lsp.toggle_for_buffer": "Toggle LSP for Current Buffer",
   "menu.lsp.toggle_inlay_hints": "Toggle Inlay Hints",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Mostrar completaciones",
   "menu.lsp.show_hover": "Mostrar información flotante",
   "menu.lsp.show_signature": "Mostrar ayuda de firma",
+  "menu.lsp.show_status": "Estado de LSP\u2026",
   "menu.lsp.stop_server": "Detener servidor",
   "menu.lsp.toggle_for_buffer": "Alternar LSP para el buffer actual",
   "menu.lsp.toggle_inlay_hints": "Alternar sugerencias incrustadas",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Afficher les complétions",
   "menu.lsp.show_hover": "Afficher les infos au survol",
   "menu.lsp.show_signature": "Afficher l'aide à la signature",
+  "menu.lsp.show_status": "Statut LSP\u2026",
   "menu.lsp.stop_server": "Arrêter le serveur",
   "menu.lsp.toggle_for_buffer": "Basculer LSP pour le tampon actuel",
   "menu.lsp.toggle_inlay_hints": "Basculer les indices inlay",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Mostra Completamenti",
   "menu.lsp.show_hover": "Mostra Info Hover",
   "menu.lsp.show_signature": "Mostra Aiuto Firma",
+  "menu.lsp.show_status": "Stato LSP\u2026",
   "menu.lsp.stop_server": "Ferma Server",
   "menu.lsp.toggle_for_buffer": "Attiva/Disattiva LSP per il buffer corrente",
   "menu.lsp.toggle_inlay_hints": "Alterna Suggerimenti Incorporati",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "補完を表示",
   "menu.lsp.show_hover": "ホバー情報を表示",
   "menu.lsp.show_signature": "シグネチャヘルプを表示",
+  "menu.lsp.show_status": "LSPステータス\u2026",
   "menu.lsp.stop_server": "サーバーを停止",
   "menu.lsp.toggle_for_buffer": "現在のバッファのLSPを切り替え",
   "menu.lsp.toggle_inlay_hints": "インレイヒントを切り替え",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "완성 표시",
   "menu.lsp.show_hover": "호버 정보 표시",
   "menu.lsp.show_signature": "서명 도움말 표시",
+  "menu.lsp.show_status": "LSP 상태\u2026",
   "menu.lsp.stop_server": "서버 중지",
   "menu.lsp.toggle_for_buffer": "현재 버퍼의 LSP 전환",
   "menu.lsp.toggle_inlay_hints": "인레이 힌트 전환",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Mostrar conclusões",
   "menu.lsp.show_hover": "Mostrar informações",
   "menu.lsp.show_signature": "Mostrar ajuda de assinatura",
+  "menu.lsp.show_status": "Status do LSP\u2026",
   "menu.lsp.stop_server": "Parar servidor",
   "menu.lsp.toggle_for_buffer": "Alternar LSP para o buffer atual",
   "menu.lsp.toggle_inlay_hints": "Alternar dicas inline",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Показать автодополнение",
   "menu.lsp.show_hover": "Показать информацию",
   "menu.lsp.show_signature": "Показать справку по сигнатуре",
+  "menu.lsp.show_status": "Статус LSP\u2026",
   "menu.lsp.stop_server": "Остановить сервер",
   "menu.lsp.toggle_for_buffer": "Переключить LSP для текущего буфера",
   "menu.lsp.toggle_inlay_hints": "Переключить встроенные подсказки",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "แสดงการเติมคำ",
   "menu.lsp.show_hover": "แสดงข้อมูลโฮเวอร์",
   "menu.lsp.show_signature": "แสดงความช่วยเหลือลายเซ็น",
+  "menu.lsp.show_status": "สถานะ LSP\u2026",
   "menu.lsp.stop_server": "หยุดเซิร์ฟเวอร์",
   "menu.lsp.toggle_for_buffer": "สลับ LSP สำหรับบัฟเฟอร์ปัจจุบัน",
   "menu.lsp.toggle_inlay_hints": "สลับคำแนะนำแทรก",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Показати автодоповнення",
   "menu.lsp.show_hover": "Показати інформацію",
   "menu.lsp.show_signature": "Показати довідку сигнатури",
+  "menu.lsp.show_status": "Статус LSP\u2026",
   "menu.lsp.stop_server": "Зупинити сервер",
   "menu.lsp.toggle_for_buffer": "Перемкнути LSP для поточного буфера",
   "menu.lsp.toggle_inlay_hints": "Перемкнути вбудовані підказки",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "Hiển thị gợi ý",
   "menu.lsp.show_hover": "Hiển thị thông tin Hover",
   "menu.lsp.show_signature": "Hiển thị trợ giúp chữ ký",
+  "menu.lsp.show_status": "Trạng thái LSP\u2026",
   "menu.lsp.stop_server": "Dừng server",
   "menu.lsp.toggle_for_buffer": "Bật/Tắt LSP cho bộ đệm hiện tại",
   "menu.lsp.toggle_inlay_hints": "Bật/tắt gợi ý nội tuyến",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1051,6 +1051,7 @@
   "menu.lsp.show_completions": "显示补全",
   "menu.lsp.show_hover": "显示悬停信息",
   "menu.lsp.show_signature": "显示签名帮助",
+  "menu.lsp.show_status": "LSP 状态\u2026",
   "menu.lsp.stop_server": "停止服务器",
   "menu.lsp.toggle_for_buffer": "切换当前缓冲区的 LSP",
   "menu.lsp.toggle_inlay_hints": "切换内联提示",

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -131,6 +131,22 @@ impl Editor {
             .find_keybinding_for_action(action_name, self.key_context.clone())
     }
 
+    /// Raw-event counterpart: return the `(KeyCode, KeyModifiers)` currently
+    /// bound to `action` in `context`. Intended for callers that need to
+    /// simulate the user pressing the bound key (e2e tests, some hotkey-
+    /// chaining code) without hardcoding a default that a user's rebind
+    /// would invalidate.
+    pub fn keybinding_event_for_action(
+        &self,
+        action: &crate::input::keybindings::Action,
+        context: crate::input::keybindings::KeyContext,
+    ) -> Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)> {
+        self.keybindings
+            .read()
+            .unwrap()
+            .get_keybinding_event_for_action(action, context)
+    }
+
     /// Get mutable access to the mode registry
     pub fn mode_registry_mut(&mut self) -> &mut ModeRegistry {
         &mut self.mode_registry

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -289,7 +289,12 @@ impl Editor {
 
             // Popup actions
             DeferredAction::ClosePopup => {
-                self.hide_popup();
+                // Route through handle_popup_cancel so popup-specific
+                // cleanup runs (e.g. the LSP auto-prompt needs to mark
+                // the language as prompted and drop the pending queue
+                // entry — otherwise the render-time drain would just
+                // re-open the popup on the next frame, defeating Esc).
+                self.handle_popup_cancel();
             }
             DeferredAction::ConfirmPopup => {
                 self.handle_action(Action::PopupConfirm)?;

--- a/crates/fresh-editor/src/app/lsp_status.rs
+++ b/crates/fresh-editor/src/app/lsp_status.rs
@@ -112,25 +112,33 @@ pub(crate) fn compose_lsp_status(
         return (centered("LSP (on)"), LspIndicatorState::On);
     }
 
-    // 4. No running server — surface any configured server (auto_start or
-    //    opt-in, doesn't matter for the indicator) so the user can see an
-    //    LSP is available and open the popup to start it.
+    // 4. No running server — surface any configured server so the user
+    //    can see an LSP is available and open the popup to start it.
+    //    Includes servers with `enabled = false`: picking "Disable LSP
+    //    for <lang>" flips `enabled` off, and hiding the pill at that
+    //    point would leave the user with no surface to re-enable
+    //    later. The dimmed `OffDismissed` variant makes the disabled
+    //    state visually distinct.
     let configured_count = lsp_config
         .get(current_language)
         .map(|cfg| {
             cfg.as_slice()
                 .iter()
-                .filter(|c| c.enabled && !c.command.is_empty())
+                .filter(|c| !c.command.is_empty())
                 .count()
         })
         .unwrap_or(0);
     if configured_count > 0 {
-        // User-dismissed languages keep the same `LSP (off)` text — only the
-        // style changes (handled by `element_style` via the `OffDismissed`
-        // variant).  We deliberately keep the pill visible rather than
-        // hiding it, so the user retains a discoverable surface to re-enable
-        // or view install help.
-        let state = if user_dismissed_languages.contains(current_language) {
+        // User-dismissed languages keep the same `LSP (off)` text — only
+        // the style changes (handled by `element_style` via the
+        // `OffDismissed` variant). `enabled = false` on every configured
+        // server is the persistent flavour of the same idea, so render
+        // it the same way: pill stays visible but dimmed, so the user
+        // has a discoverable surface to re-enable.
+        let any_enabled = lsp_config
+            .get(current_language)
+            .is_some_and(|cfg| cfg.as_slice().iter().any(|c| c.enabled));
+        let state = if !any_enabled || user_dismissed_languages.contains(current_language) {
             LspIndicatorState::OffDismissed
         } else {
             LspIndicatorState::Off
@@ -222,6 +230,41 @@ mod tests {
         );
         assert!(text.contains("LSP (off)"));
         assert_eq!(state, LspIndicatorState::OffDismissed);
+    }
+
+    /// After the user picks "Disable LSP for <lang>" the config flips
+    /// to `enabled = false`. The pill must stay visible (dimmed) so
+    /// the user still has a surface to re-enable; hiding it would
+    /// strand the Enable action.
+    #[test]
+    fn off_dismissed_when_all_servers_disabled_in_config() {
+        let mut config = HashMap::new();
+        let mut server = LspServerConfig::default();
+        server.command = "rust-analyzer".to_string();
+        server.enabled = false;
+        config.insert(
+            "rust".to_string(),
+            LspLanguageConfig::Single(Box::new(server)),
+        );
+        let (text, state) = compose_lsp_status(
+            "rust",
+            &HashMap::new(),
+            &HashMap::new(),
+            &config,
+            &HashSet::new(),
+        );
+        assert!(
+            text.contains("LSP (off)"),
+            "pill should still render when the language has configured \
+             servers, even if every one is enabled=false"
+        );
+        assert_eq!(
+            state,
+            LspIndicatorState::OffDismissed,
+            "disabled-in-config renders as the dimmed OffDismissed variant, \
+             matching the session-level dismissed flavour so the user can tell \
+             their Disable action took effect"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -457,13 +457,22 @@ impl Editor {
         }
 
         // Disable / Enable row — shown whenever the language has at
-        // least one configured server. Persisted in config so the
-        // choice survives an editor restart (see the `dismiss:` /
-        // `enable:` branches in `handle_lsp_status_action`). We reuse
-        // `all_servers.is_empty()` as the "nothing here" signal
-        // since languages with zero configured-or-running servers
-        // already bailed out above.
-        if user_dismissed {
+        // least one configured server. The label flips on either the
+        // session-level dismiss flag OR the persisted `enabled = false`
+        // half: both mean "the language is currently muted from the
+        // user's POV", and showing "Disable" while the config already
+        // has every server disabled would leave the user with no
+        // surface to undo it. Picking the row writes through to the
+        // matching half of the state in `handle_lsp_status_action`
+        // (`dismiss:` flips both, `enable:` flips both) so the two
+        // signals stay in sync after every round-trip.
+        let any_enabled = self
+            .config
+            .lsp
+            .get(language)
+            .is_some_and(|cfg| cfg.as_slice().iter().any(|c| c.enabled));
+        let muted = user_dismissed || !any_enabled;
+        if muted {
             let enable_key = format!("enable:{}", language);
             items.push(
                 crate::view::popup::PopupListItem::new(format!("    Enable LSP for {}", language))

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -2697,6 +2697,13 @@ impl MenuConfig {
                     },
                     MenuItem::Separator { separator: true },
                     MenuItem::Action {
+                        label: t!("menu.lsp.show_status").to_string(),
+                        action: "show_lsp_status".to_string(),
+                        args: HashMap::new(),
+                        when: None,
+                        checkbox: None,
+                    },
+                    MenuItem::Action {
                         label: t!("menu.lsp.restart_server").to_string(),
                         action: "lsp_restart".to_string(),
                         args: HashMap::new(),

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -2357,6 +2357,21 @@ impl KeybindingResolver {
         action: &Action,
         context: KeyContext,
     ) -> Option<String> {
+        self.get_keybinding_event_for_action(action, context)
+            .map(|(k, m)| format_keybinding(&k, &m))
+    }
+
+    /// Raw-event counterpart to `get_keybinding_for_action`: returns the
+    /// `(KeyCode, KeyModifiers)` pair bound to `action` in `context` — or
+    /// falls through to the same Normal-context chain the string version
+    /// does — so callers (notably tests simulating user input) can feed
+    /// the bound key through the editor's key dispatcher without
+    /// hardcoding a default that a rebind would invalidate.
+    pub fn get_keybinding_event_for_action(
+        &self,
+        action: &Action,
+        context: KeyContext,
+    ) -> Option<(KeyCode, KeyModifiers)> {
         // Helper to collect all matching keybindings from a map and pick the best one
         fn find_best_keybinding(
             bindings: &HashMap<(KeyCode, KeyModifiers), Action>,
@@ -2395,15 +2410,15 @@ impl KeybindingResolver {
 
         // Check custom bindings first (higher priority)
         if let Some(context_bindings) = self.bindings.get(&context) {
-            if let Some((keycode, modifiers)) = find_best_keybinding(context_bindings, action) {
-                return Some(format_keybinding(&keycode, &modifiers));
+            if let Some(hit) = find_best_keybinding(context_bindings, action) {
+                return Some(hit);
             }
         }
 
         // Check default bindings for this context
         if let Some(context_bindings) = self.default_bindings.get(&context) {
-            if let Some((keycode, modifiers)) = find_best_keybinding(context_bindings, action) {
-                return Some(format_keybinding(&keycode, &modifiers));
+            if let Some(hit) = find_best_keybinding(context_bindings, action) {
+                return Some(hit);
             }
         }
 
@@ -2413,15 +2428,15 @@ impl KeybindingResolver {
         {
             // Check custom normal bindings
             if let Some(normal_bindings) = self.bindings.get(&KeyContext::Normal) {
-                if let Some((keycode, modifiers)) = find_best_keybinding(normal_bindings, action) {
-                    return Some(format_keybinding(&keycode, &modifiers));
+                if let Some(hit) = find_best_keybinding(normal_bindings, action) {
+                    return Some(hit);
                 }
             }
 
             // Check default normal bindings
             if let Some(normal_bindings) = self.default_bindings.get(&KeyContext::Normal) {
-                if let Some((keycode, modifiers)) = find_best_keybinding(normal_bindings, action) {
-                    return Some(format_keybinding(&keycode, &modifiers));
+                if let Some(hit) = find_best_keybinding(normal_bindings, action) {
+                    return Some(hit);
                 }
             }
         }

--- a/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_auto_start_prompt.rs
@@ -813,3 +813,88 @@ fn test_popup_offers_dismiss_row_with_dynamic_keybinding() -> anyhow::Result<()>
 
     Ok(())
 }
+
+/// Pressing the popup-cancel key on the auto-prompt must dismiss it
+/// for good — not just hide it for a frame. Before the fix the
+/// keymap's `popup_cancel` binding routed through
+/// `DeferredAction::ClosePopup` which only called `hide_popup()`,
+/// leaving `pending_auto_start_prompts` and the once-per-session
+/// guard untouched. The render-time drain would then re-open the
+/// popup on the very next frame, making the key look broken from
+/// the user's perspective.
+///
+/// Resolves the bound key dynamically from the keymap system rather
+/// than hardcoding `KeyCode::Esc`; a rebind of `popup_cancel` (e.g.
+/// under the emacs keymap, or a user's config) would otherwise make
+/// this test lie about which path it exercises.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_cancel_key_dismisses_auto_prompt_and_does_not_reopen() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    let mut harness = harness_with_auto_prompt(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(make_config_with_dormant_rust_lsp())
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_some(),
+        "precondition: auto-prompt popup should be visible after opening a \
+         dormant-LSP file"
+    );
+
+    // Look up the popup-cancel key the resolver would route to
+    // `Action::PopupCancel`. Keeps the test honest across keymap
+    // changes: whatever the user has bound, that's what the test
+    // sends. Default keymap binds this to Esc; emacs keymap binds it
+    // to Ctrl+G — both must work.
+    let (cancel_code, cancel_mods) = harness
+        .editor()
+        .keybinding_event_for_action(
+            &fresh::input::keybindings::Action::PopupCancel,
+            fresh::input::keybindings::KeyContext::Popup,
+        )
+        .expect("popup_cancel must have a binding in the Popup context");
+
+    harness.send_key(cancel_code, cancel_mods)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "popup_cancel on the auto-prompt should close it. If the popup \
+         is still visible here, the render-time drain has re-opened it \
+         because ClosePopup failed to mark the language as prompted."
+    );
+
+    // Re-rendering (and re-opening the same-language file) must not
+    // bring the popup back. This is the stronger assertion — the
+    // original bug was a same-frame reopen, but a weaker fix (clear
+    // pending_auto_start_prompts but forget to mark as prompted)
+    // would regress on the next file-open.
+    harness.render()?;
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "a subsequent render must not re-pop the auto-prompt"
+    );
+
+    let second = temp.path().join("b.rs");
+    std::fs::write(&second, "fn other() {}\n")?;
+    harness.open_file(&second)?;
+    harness.render()?;
+
+    assert!(
+        harness.editor().active_state().popups.top().is_none(),
+        "after popup_cancel, opening another rust file in the same \
+         session must not re-prompt — the user already said 'no, not now'"
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -244,3 +244,77 @@ fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Reopen-the-popup case: when the language is already disabled in
+/// config (e.g. on a fresh session where the persisted
+/// `enabled = false` is the only signal — the session-level
+/// `user_dismissed_lsp_languages` is empty), the popup must offer
+/// "Enable LSP for <lang>", not "Disable". Showing "Disable" while
+/// the language is already disabled would leave the user with no
+/// surface to undo their previous choice.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_popup_offers_enable_when_config_already_disabled() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let file = temp.path().join("hello.rs");
+    std::fs::write(&file, "fn main() {}\n")?;
+
+    // Simulates "previous session disabled it" — `enabled = false`
+    // but `user_dismissed_lsp_languages` empty. This is exactly the
+    // state a user lands in after a restart following a Disable.
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "rust-analyzer".to_string(),
+            args: vec![],
+            enabled: false,
+            auto_start: false,
+            name: Some("rust-analyzer".to_string()),
+            ..Default::default()
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&file)?;
+    harness.render()?;
+
+    // Open the popup explicitly (the auto-prompt is suppressed by the
+    // harness ctor, and `enabled = false` would route through the
+    // `Failed` spawn path anyway, not `NotAutoStart`).
+    harness.editor_mut().show_lsp_status_popup();
+    harness.render()?;
+
+    let items = popup_items(&harness);
+
+    let has_enable = items
+        .iter()
+        .any(|(label, data, _)| data.as_deref() == Some("enable:rust") && label.contains("Enable"));
+    let has_disable = items
+        .iter()
+        .any(|(_, data, _)| data.as_deref() == Some("dismiss:rust"));
+
+    assert!(
+        has_enable,
+        "popup should offer 'Enable LSP for rust' when every server is \
+         disabled in config, regardless of the session-only dismissal \
+         flag. Items: {:#?}",
+        items
+    );
+    assert!(
+        !has_disable,
+        "popup must NOT offer 'Disable LSP for rust' when the language is \
+         already disabled — that label leaves the user with no way to \
+         re-enable. Items: {:#?}",
+        items
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_missing_binary_and_dismiss.rs
@@ -155,9 +155,11 @@ fn test_missing_binary_popup_shows_advisory_and_dismiss() -> anyhow::Result<()> 
 /// <lang>" flips `enabled = false` in the live config (persisted via
 /// `save_config`, so the choice survives a restart), and the
 /// complementary "Enable LSP for <lang>" restores `enabled = true`.
-/// The status-bar pill disappears while disabled (because
-/// `compose_lsp_status` gates on `enabled && !command.is_empty()`)
-/// and comes back on re-enable.
+/// The status-bar pill stays visible in both states — once as the
+/// dimmed `LSP (off)` (disabled), and once as the normal `LSP (off)`
+/// (re-enabled but not running) — so the user always has a surface
+/// to toggle the state back. Hiding the pill on disable would
+/// strand the Enable action.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)]
 fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
@@ -210,14 +212,16 @@ fn test_dismiss_then_enable_round_trip() -> anyhow::Result<()> {
          choice persists across restarts"
     );
 
-    // Pill should disappear: no configured-and-enabled server means
-    // `compose_lsp_status` yields an empty indicator, so neither
-    // `(off)` nor `(on)` should be on the status bar.
+    // Pill should stay visible even when every configured server is
+    // `enabled = false`: hiding it would leave the user with no
+    // on-screen surface to re-enable later. The variant flips to
+    // `OffDismissed` (dimmed) so the state change is still visible;
+    // the text itself remains `LSP (off)`.
     harness.render()?;
     assert!(
-        !harness.get_status_bar().contains("LSP (off)"),
-        "after disable, the pill text should be gone (not shown in any state). \
-         Status bar: {}",
+        harness.get_status_bar().contains("LSP (off)"),
+        "after disable, the pill text should still read 'LSP (off)' so the \
+         user retains a surface to Enable. Status bar: {}",
         harness.get_status_bar()
     );
 


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where dismissing the LSP auto-prompt with the popup-cancel key would immediately re-open on the next frame, making the key appear broken. It also improves the UX for disabled LSP servers by keeping the status pill visible so users can re-enable them.

## Key Changes

### LSP Auto-Prompt Dismissal Fix
- **Root cause**: `DeferredAction::ClosePopup` only called `hide_popup()`, leaving `pending_auto_start_prompts` and the once-per-session guard untouched, causing the render-time drain to re-open the popup immediately.
- **Solution**: Route `ClosePopup` through `handle_popup_cancel()` to ensure proper cleanup (marking language as prompted, clearing pending queue).
- **Test coverage**: Added comprehensive e2e test `test_popup_cancel_key_dismisses_auto_prompt_and_does_not_reopen()` that:
  - Dynamically resolves the popup-cancel key from the keymap (respects user rebinds and keymap variants like emacs)
  - Verifies the popup closes and doesn't reopen on subsequent renders
  - Confirms the once-per-session guard persists across file opens

### Disabled Server UX Improvements
- **Status pill visibility**: Modified `compose_lsp_status()` to keep the LSP pill visible even when all configured servers have `enabled = false`, rendering it as the dimmed `OffDismissed` variant.
- **Rationale**: Hiding the pill would strand the "Enable LSP for <lang>" action, leaving users with no discoverable surface to re-enable. The dimmed state still signals the disabled condition.
- **Test coverage**: Added `off_dismissed_when_all_servers_disabled_in_config()` test and updated `test_dismiss_then_enable_round_trip()` to verify the pill remains visible.

### Keybinding Infrastructure
- Added `get_keybinding_event_for_action()` to `KeybindingResolver` and exposed it via `Editor::keybinding_event_for_action()`.
- Allows tests and other code to simulate user input by looking up the actual bound key rather than hardcoding defaults, ensuring tests remain valid across keymap changes and user rebinds.

### Menu and Localization
- Added "LSP Status…" menu item to the LSP context menu for quick access to status information.
- Updated all 13 locale files with the new menu item translation.

## Implementation Details
- The fix maintains backward compatibility while strengthening the popup dismissal contract.
- The keybinding lookup infrastructure is generic and can be reused for other actions requiring dynamic key simulation.
- All changes preserve the existing visual distinction between session-level dismissal and config-level disabling through the `OffDismissed` variant.

https://claude.ai/code/session_01NRnLJf1E4Bh6kScpnxyn5P