### PR TITLE
Fix compose-mode table truncation rendering off-by-one error

### DIFF
--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -967,6 +967,23 @@ function concealedText(text: string): string {
 const MIN_COL_W = 3;
 
 /**
+ * Return the effective compose width for layout: the configured compose
+ * width clamped to the available viewport width.
+ *
+ * When `config.composeWidth` is explicitly set (e.g. 80) but the editor
+ * content area is smaller (e.g. after the File Explorer sidebar opens),
+ * using the configured value verbatim overflows the viewport. The Rust
+ * render layer already clamps the compose area the same way in
+ * `calculate_compose_layout`; plugin-side computations (table column
+ * allocation, soft-wrap width) need to match.
+ */
+function effectiveComposeWidth(viewportWidth: number): number {
+  const cw = config.composeWidth;
+  if (cw == null) return viewportWidth;
+  return Math.min(cw, viewportWidth);
+}
+
+/**
  * W3C-inspired column width distribution.
  * Constrains columns to fit within `available` width, distributing space
  * proportionally to each column's natural (max) width.
@@ -1320,7 +1337,7 @@ function processLineSoftBreaks(
 
   const viewport = editor.getViewport();
   if (!viewport) return;
-  const width = config.composeWidth ?? viewport.width;
+  const width = effectiveComposeWidth(viewport.width);
 
   // Parse this single line to get block structure
   const blocks = parseMarkdownBlocks(lineContent);
@@ -1544,9 +1561,12 @@ function processTableAlignment(
       mergeWith(widthMap.get(ln)!.maxW);
     }
 
-    // Compute allocated widths constrained to viewport
+    // Compute allocated widths constrained to viewport. Clamp the
+    // configured compose width to the actual viewport — otherwise a
+    // large configured width overflows when the editor area shrinks
+    // (e.g. when the File Explorer sidebar opens).
     const viewport = editor.getViewport();
-    const composeW = config.composeWidth ?? (viewport ? viewport.width : 80);
+    const composeW = effectiveComposeWidth(viewport ? viewport.width : 80);
     const numCols = merged.length;
     const available = composeW - (numCols + 1); // subtract pipe/box-drawing characters
     const allocated = distributeColumnWidths(merged, available);
@@ -1716,7 +1736,7 @@ function onMarkdownViewportChanged(data: {
   // Recompute allocated table column widths for new viewport width
   const bufWidths = getTableWidths(data.buffer_id);
   if (bufWidths) {
-    const composeW = config.composeWidth ?? data.width;
+    const composeW = effectiveComposeWidth(data.width);
     const seen = new Set<string>(); // Track by JSON key to deduplicate shared TableWidthInfo
     for (const [lineNum, info] of bufWidths) {
       const key = info.maxW.join(",");

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -1142,6 +1142,26 @@ function processLineConceals(
         if (lineContent[i] === '|') pipePositions.push(i);
       }
 
+      // Precompute which cells will be truncated. Per-character conceals
+      // that land inside a truncated cell must be suppressed — the cell-
+      // wide truncate conceal already renders the replacement. When both
+      // fire, the per-char conceal at the cell's first byte emits its
+      // replacement, and the cell-wide conceal emits its replacement one
+      // byte later, producing a cell one character wider than allocated.
+      const truncatedCellCharRanges: Array<{start: number; end: number}> = [];
+      if (!cursorStrictlyOnLine && colWidths) {
+        for (let ci = 0; ci < Math.min(cells.length, colWidths.length); ci++) {
+          const cellText = concealedText(cells[ci]);
+          if (cellText.length > colWidths[ci]) {
+            const prevPipe = pipePositions[ci];
+            const nextPipe = pipePositions[ci + 1];
+            if (prevPipe !== undefined && nextPipe !== undefined) {
+              truncatedCellCharRanges.push({ start: prevPipe + 1, end: nextPipe });
+            }
+          }
+        }
+      }
+
       // Track which pipe index we're on (0 = leading pipe)
       let pipeIdx = 0;
       for (let i = 0; i < lineContent.length; i++) {
@@ -1161,11 +1181,15 @@ function processLineConceals(
             const allocatedWidth = colWidths[cellIdx];
 
             if (cellWidth > allocatedWidth) {
-              // Truncate: conceal entire cell content and replace with truncated text
+              // Truncate: conceal entire cell content and replace with truncated text.
+              // Separator rows use box-drawing ─ to match the non-truncated path
+              // (per-char conceals replace source `-` with ─ and pad via pipe replacement).
               const prevPipeCharPos = pipePositions[pipeIdx - 1];
               const cellByteStart = charToByte(lineContent, prevPipeCharPos + 1, byteStart);
               const cellByteEnd = pipeByte;
-              const truncated = cellText.slice(0, allocatedWidth - 1) + '-';
+              const truncated = isSeparator
+                ? '─'.repeat(allocatedWidth)
+                : cellText.slice(0, allocatedWidth - 1) + '-';
               editor.addConceal(bufferId, "md-syntax", cellByteStart, cellByteEnd, truncated);
               truncatedByteRanges.push({start: cellByteStart, end: cellByteEnd});
             } else {
@@ -1188,6 +1212,10 @@ function processLineConceals(
           }
           pipeIdx++;
         } else if (isSeparator && lineContent[i] === '-') {
+          // Skip per-character conceals that land inside a truncated cell;
+          // the cell-wide truncate conceal already handles the rendering.
+          const inTruncated = truncatedCellCharRanges.some(r => i >= r.start && i < r.end);
+          if (inTruncated) continue;
           const db = charToByte(lineContent, i, byteStart);
           editor.addConceal(bufferId, "md-syntax", db, charToByte(lineContent, i + 1, byteStart), "─");
         }

--- a/crates/fresh-editor/tests/e2e/markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose.rs
@@ -4528,3 +4528,133 @@ fn separator_row_fits(screen: &str) -> bool {
     }
     any
 }
+
+/// Regression test: when an explicit compose width is set that's wider
+/// than the available editor area (e.g. compose width 80 in a terminal
+/// where the File Explorer sidebar leaves only ~60 cols for the editor),
+/// the table must clamp its column allocation to the editor area and
+/// not overflow into the sidebar.
+#[test]
+fn test_compose_mode_table_width_clamped_when_sidebar_opens() {
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use crate::common::tracing::init_tracing_from_env;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    init_tracing_from_env();
+
+    let md_content = "\
+# Compose Width Clamp
+
+| ColumnA                          | ColumnB                          | ColumnC                          | ColumnD                          |
+|----------------------------------|----------------------------------|----------------------------------|----------------------------------|
+| alphaaaaaaaaaaaaaaaaaaaaaaaaaaaa | bravooooooooooooooooooooooooooo  | charlieeeeeeeeeeeeeeeeeeeeeeeee  | deltaaaaaaaaaaaaaaaaaaaaaaaaaa   |
+| echooooooooooooooooooooooooooo   | foxtrotttttttttttttttttttttttttt | golffffffffffffffffffffffffffff  | hoteleleleleeeeeeeeeeeeeeeeeeeee |
+";
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("clamp.md");
+    std::fs::write(&md_path, &md_content).unwrap();
+
+    // Terminal just slightly wider than the compose width we'll set (80).
+    // After the sidebar takes ~30 cols, the editor area will be much
+    // narrower than 80 — the plugin must clamp.
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(90, 30, Default::default(), project_root)
+            .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    // Enable compose mode
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("│") && s.contains("─")
+        })
+        .unwrap();
+
+    // Set compose width explicitly to 80
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Set Compose Width").unwrap();
+    harness
+        .wait_for_screen_contains("Set Compose Width")
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    // The prompt comes up pre-filled (e.g. with "None"); clear then type.
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("80").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Let the new compose width settle.
+    let mut prev = String::new();
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            let stable = s == prev;
+            prev = s;
+            stable
+        })
+        .unwrap();
+
+    // Open File Explorer
+    harness.editor_mut().toggle_file_explorer();
+    harness
+        .wait_until_stable(|h| h.editor().file_explorer_visible())
+        .unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    let mut prev = String::new();
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            let stable = s == prev;
+            prev = s;
+            stable
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+
+    // The table must fit on a single line — no separator row should wrap.
+    assert!(
+        separator_row_fits(&screen),
+        "With compose width=80 and the File Explorer sidebar open on a \
+         90-col terminal, the table separator row overflows the editor \
+         content area and wraps. The plugin is using the configured \
+         compose width (80) instead of clamping it to the smaller \
+         editor area.\nScreen:\n{}",
+        screen,
+    );
+}

--- a/crates/fresh-editor/tests/e2e/markdown_compose.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose.rs
@@ -4312,3 +4312,219 @@ fn test_toggle_compose_all_affects_all_buffers() {
         screen
     );
 }
+
+/// Regression test: compose-mode tables must fit within the editor
+/// viewport whether or not the File Explorer sidebar is open.
+///
+/// Bug: when a separator cell (`|---...---|`) was wider than the
+/// allocated column width, the cell-wide truncate conceal and the
+/// per-`-` conceals overlapped — the first `-` of each cell emitted
+/// `─` (from the per-char conceal) AND the cell-wide conceal emitted
+/// its N-char replacement, producing N+1 rendered chars per cell. The
+/// extra characters caused the separator to wrap onto a second line
+/// and visually misalign the table. Opening the sidebar made the
+/// symptom obvious: the smaller viewport forced truncation on a table
+/// that previously fit, exposing the off-by-one.
+#[test]
+fn test_compose_mode_table_width_respects_file_explorer() {
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use crate::common::tracing::init_tracing_from_env;
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    init_tracing_from_env();
+
+    // Table whose natural (un-constrained) width is bigger than the editor
+    // content area once the File Explorer sidebar is open. This forces
+    // `distributeColumnWidths` to shrink columns — but only if the cached
+    // `allocated` widths are recomputed against the new viewport width.
+    //
+    // At 120 col terminal with no sidebar, available = 120-5 = 115, so the
+    // natural widths (~28*4+5 = 117) are re-distributed down slightly.
+    // After the sidebar takes ~34 cols, available drops to ~80, so columns
+    // must get substantially narrower.
+    let md_content = "\
+# Table Width Bug
+
+| ColumnAAAAAAAAAAAAAAAAAAAAAAAAAA | ColumnBBBBBBBBBBBBBBBBBBBBBBBBBB | ColumnCCCCCCCCCCCCCCCCCCCCCCCCCC | ColumnDDDDDDDDDDDDDDDDDDDDDDDDDD |
+|----------------------------------|----------------------------------|----------------------------------|----------------------------------|
+| alphaaaaaaaaaaaaaaaaaaaaaaaaaaaa | bravooooooooooooooooooooooooooo  | charlieeeeeeeeeeeeeeeeeeeeeeeee  | deltaaaaaaaaaaaaaaaaaaaaaaaaaa   |
+| echooooooooooooooooooooooooooo   | foxtrotttttttttttttttttttttttttt | golffffffffffffffffffffffffffff  | hoteleleleleeeeeeeeeeeeeeeeeeeee |
+";
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let md_path = project_root.join("table_width.md");
+    std::fs::write(&md_path, &md_content).unwrap();
+
+    // Use a wide terminal so the unopened-sidebar path has plenty of room.
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, Default::default(), project_root)
+            .unwrap();
+
+    harness.open_file(&md_path).unwrap();
+    harness.render().unwrap();
+
+    // Enable compose mode
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Compose").unwrap();
+    harness.wait_for_screen_contains("Toggle Compose").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // Wait for compose mode to render the table (box-drawing chars visible).
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("│") && s.contains("─")
+        })
+        .unwrap();
+    let mut prev = String::new();
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            let stable = s == prev;
+            prev = s;
+            stable
+        })
+        .unwrap();
+
+    // Capture the table-row span (leftmost→rightmost delimiter column)
+    // before the sidebar is opened. We use the TABLE-ROW signature (row
+    // containing "Column" text + box-drawing pipes), so we don't pick up
+    // sidebar borders.
+    let screen_before = harness.screen_to_string();
+    let (min_before, max_before) = table_column_span_on_content_rows(&screen_before);
+    let width_before = max_before - min_before;
+    assert!(
+        width_before > 60,
+        "Sanity: table should span a meaningful width before the sidebar \
+         is opened; got span {}..{}.\nScreen:\n{}",
+        min_before,
+        max_before,
+        screen_before,
+    );
+
+    // Also: the separator row between header and first data row must fit
+    // on a single line (no wrap). If the separator overflows the editor
+    // content area it will get wrapped, producing a row without both
+    // ├ and ┤ — detect that explicitly.
+    assert!(
+        separator_row_fits(&screen_before),
+        "Separator row doesn't fit on one line BEFORE the sidebar is \
+         opened.\nScreen:\n{}",
+        screen_before,
+    );
+
+    // Open the File Explorer sidebar.
+    harness.editor_mut().toggle_file_explorer();
+    harness
+        .wait_until_stable(|h| h.editor().file_explorer_visible())
+        .unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    // Let compose mode settle again after the viewport change.
+    let mut prev = String::new();
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            let stable = s == prev;
+            prev = s;
+            stable
+        })
+        .unwrap();
+
+    let screen_after = harness.screen_to_string();
+    let (min_after, max_after) = table_column_span_on_content_rows(&screen_after);
+    let width_after = max_after - min_after;
+
+    // After the sidebar opens, the editor content area shrinks. The table
+    // must shrink to fit — natural widths are larger than the new editor
+    // area so `distributeColumnWidths` must re-distribute.
+    assert!(
+        width_after < width_before,
+        "Table width did not shrink when the File Explorer sidebar was \
+         opened. Table span before={}..{} ({}), after={}..{} ({}). The \
+         cached table column widths were not recomputed against the \
+         smaller editor content area.\n\
+         Screen after opening sidebar:\n{}",
+        min_before,
+        max_before,
+        width_before,
+        min_after,
+        max_after,
+        width_after,
+        screen_after,
+    );
+
+    // And the separator must still fit on a single line in the now-
+    // smaller editor area.
+    assert!(
+        separator_row_fits(&screen_after),
+        "Separator row doesn't fit on one line AFTER the sidebar is \
+         opened — it's being rendered wider than the editor content area \
+         and wraps.\nScreen:\n{}",
+        screen_after,
+    );
+}
+
+/// (leftmost, rightmost) column of table delimiters. We use the table's
+/// top/bottom borders (rows containing the table-only glyphs `┬` or `┴`)
+/// — these never appear in the File Explorer pane, whose vertical border
+/// uses only `│` `┌` `┐` `└` `┘` `─`.
+fn table_column_span_on_content_rows(screen: &str) -> (usize, usize) {
+    let mut min_col = usize::MAX;
+    let mut max_col = 0usize;
+    for line in screen.lines() {
+        let is_table_border = line.contains('┬') || line.contains('┴');
+        if !is_table_border {
+            continue;
+        }
+        for (i, c) in line.chars().enumerate() {
+            if matches!(c, '┌' | '┐' | '└' | '┘' | '┬' | '┴') {
+                if i < min_col {
+                    min_col = i;
+                }
+                if i > max_col {
+                    max_col = i;
+                }
+            }
+        }
+    }
+    if min_col == usize::MAX {
+        (0, 0)
+    } else {
+        (min_col, max_col)
+    }
+}
+
+/// True iff every inter-row separator of the table fits on a single
+/// screen line. Each separator row opens with `├`; a well-rendered one
+/// also closes with `┤` on the same line. If the separator overflows the
+/// viewport it gets wrapped onto a second line, and the closing `┤`
+/// appears on the next line — the opening line has `├` but no `┤`.
+fn separator_row_fits(screen: &str) -> bool {
+    let mut any = false;
+    for line in screen.lines() {
+        if line.contains('├') {
+            any = true;
+            if !line.contains('┤') {
+                return false;
+            }
+        }
+    }
+    any
+}

--- a/crates/fresh-editor/tests/e2e/plugins/package_manager.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/package_manager.rs
@@ -621,10 +621,16 @@ fn test_pkg_manager_ui_split_view_and_tab_navigation() {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
 
-    // Wait for package manager UI to appear and loading to complete
-    // (AVAILABLE appears after registry sync finishes)
+    // Wait for package manager UI to appear and loading to complete.
+    // `AVAILABLE` appears once the registry sync finishes, and the footer
+    // panel's help text (which contains "Tab") is populated by the same
+    // updatePkgManagerView() pass — but on slow runners the footer render
+    // can land a frame or two after the list. Wait for both.
     harness
-        .wait_until(|h| h.screen_to_string().contains("AVAILABLE"))
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("AVAILABLE") && s.contains("Tab")
+        })
         .unwrap();
 
     let screen = harness.screen_to_string();


### PR DESCRIPTION
## Summary
Fixes a bug in markdown compose mode where table separator rows would wrap onto multiple lines when the File Explorer sidebar was opened, causing visual misalignment. The issue was caused by overlapping cell-wide and per-character conceals that produced rendered output wider than the allocated column width.

## Changes
- **Precompute truncated cells**: Before applying per-character conceals, identify which cells will be truncated based on their rendered width vs. allocated width.
- **Skip redundant per-char conceals**: When a cell is truncated, suppress the per-character `-` → `─` conceals inside that cell, since the cell-wide truncate conceal already handles the rendering.
- **Fix separator row truncation**: When truncating separator rows (`|---..---|`), use `─` characters to match the visual style of non-truncated separators, rather than mixing truncation styles.
- **Add regression test**: Comprehensive e2e test that verifies table layout remains correct when the File Explorer sidebar is toggled, ensuring column widths are recomputed against the new viewport size.

## Implementation Details
The root cause was that when a separator cell's content exceeded its allocated width:
1. The cell-wide truncate conceal would emit N replacement characters
2. The per-character conceal on the first `-` would emit an additional `─` character
3. This produced N+1 rendered characters, causing the separator to overflow and wrap

The fix prevents this overlap by tracking which character ranges fall within truncated cells and skipping per-character conceals in those ranges. The cell-wide conceal alone then produces the correct width.

https://claude.ai/code/session_0124CQHaoVtRbj8s3Lpqd5we