### PR TITLE
refactor(settings): ExplorerWidth supports percent or absolute columns

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -122,7 +122,7 @@
         "show_hidden": false,
         "show_gitignored": false,
         "custom_ignore_patterns": [],
-        "width": 0.30000001192092896,
+        "width": "30%",
         "preview_tabs": true
       }
     },
@@ -874,10 +874,9 @@
           "default": []
         },
         "width": {
-          "description": "Width of file explorer as percentage (0.0 to 1.0)",
-          "type": "number",
-          "format": "float",
-          "default": 0.30000001192092896
+          "description": "File explorer width. Either a percent (`\"30%\"`, 0–100) or an\nabsolute column count (`\"24\"`). Legacy numeric forms are still\naccepted on read: a bare integer is treated as percent, and a\nfractional number in `[0, 1]` is treated as a legacy percent\nfraction (e.g. `0.3` → 30%).",
+          "$ref": "#/$defs/ExplorerWidth",
+          "default": "30%"
         },
         "preview_tabs": {
           "description": "Open files in a \"preview\" (ephemeral) tab on single-click in the\nfile explorer. The preview tab is replaced by the next single-click\ninstead of accumulating tabs. Editing the file, double-clicking\n(or pressing Enter) on it in the explorer, or dragging its tab\npromotes the tab to a permanent tab.\nDefault: true",
@@ -885,6 +884,11 @@
           "default": true
         }
       }
+    },
+    "ExplorerWidth": {
+      "description": "Either a percent like \"30%\" (0–100) or an absolute column count like \"24\".",
+      "type": "string",
+      "pattern": "^(100%|[1-9]?[0-9]%|\\d+)$"
     },
     "FileBrowserConfig": {
       "description": "File browser configuration (for Open File dialog)",

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -578,7 +578,7 @@ impl Editor {
             local_filesystem: Arc::new(crate::model::filesystem::StdFileSystem),
             file_explorer_visible: false,
             file_explorer_sync_in_progress: false,
-            file_explorer_width_percent: file_explorer_width,
+            file_explorer_width,
             pending_file_explorer_show_hidden: None,
             pending_file_explorer_show_gitignored: None,
             menu_bar_visible: show_menu_bar,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -511,9 +511,10 @@ pub struct Editor {
     /// When true, we still render the file explorer area even if file_explorer is temporarily None
     file_explorer_sync_in_progress: bool,
 
-    /// File explorer width as percentage (0.0 to 1.0)
-    /// This is the runtime value that can be modified by dragging the border
-    file_explorer_width_percent: f32,
+    /// File explorer width: either a percent of the terminal width or
+    /// an absolute column count. Runtime value, may be modified by
+    /// dragging the divider (drag preserves the active variant).
+    file_explorer_width: crate::config::ExplorerWidth,
 
     /// Pending show_hidden setting to apply when file explorer is initialized (from session restore)
     pending_file_explorer_show_hidden: Option<bool>,
@@ -1120,13 +1121,12 @@ impl Editor {
 
     /// Calculate the effective width available for tabs.
     ///
-    /// When the file explorer is visible, tabs only get a portion of the terminal width
-    /// based on `file_explorer_width_percent`. This matches the layout calculation in render.rs.
+    /// When the file explorer is visible, tabs only get a portion of the
+    /// terminal width. Matches the layout calculation in render.rs.
     fn effective_tabs_width(&self) -> u16 {
         if self.file_explorer_visible && self.file_explorer.is_some() {
-            // When file explorer is visible, tabs get (1 - explorer_width) of the terminal width
-            let editor_percent = 1.0 - self.file_explorer_width_percent;
-            (self.terminal_width as f32 * editor_percent) as u16
+            let explorer = self.file_explorer_width.to_cols(self.terminal_width);
+            self.terminal_width.saturating_sub(explorer)
         } else {
             self.terminal_width
         }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1594,7 +1594,7 @@ impl Editor {
             {
                 self.mouse_state.dragging_file_explorer = true;
                 self.mouse_state.drag_start_position = Some((col, row));
-                self.mouse_state.drag_start_explorer_width = Some(self.file_explorer_width_percent);
+                self.mouse_state.drag_start_explorer_width = Some(self.file_explorer_width);
                 return Ok(());
             }
         }
@@ -2351,16 +2351,25 @@ impl Editor {
             return Ok(());
         };
 
-        // Calculate the delta in screen space
         let delta = col as i32 - start_col as i32;
         let total_width = self.terminal_width as i32;
 
+        // Drag preserves the variant the user chose. A user editing
+        // columns doesn't want their mode silently flipped to percent
+        // just because they grabbed the divider.
         if total_width > 0 {
-            // Convert screen delta to percentage delta
-            let percent_delta = delta as f32 / total_width as f32;
-            // Clamp the new width between 10% and 50%
-            let new_width = (start_width + percent_delta).clamp(0.1, 0.5);
-            self.file_explorer_width_percent = new_width;
+            use crate::config::ExplorerWidth;
+            self.file_explorer_width = match start_width {
+                ExplorerWidth::Percent(start_pct) => {
+                    let percent_delta = (delta * 100) / total_width;
+                    let new_pct = (start_pct as i32 + percent_delta).clamp(0, 100) as u8;
+                    ExplorerWidth::Percent(new_pct)
+                }
+                ExplorerWidth::Columns(start_cols) => {
+                    let new_cols = (start_cols as i32 + delta).clamp(0, total_width) as u16;
+                    ExplorerWidth::Columns(new_cols)
+                }
+            };
         }
 
         Ok(())

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -171,14 +171,12 @@ impl Editor {
                 self.file_explorer.is_some(),
                 self.file_explorer_sync_in_progress
             );
-            // Convert f32 percentage (0.0-1.0) to u16 percentage (0-100)
-            let explorer_percent = (self.file_explorer_width_percent * 100.0) as u16;
-            let editor_percent = 100 - explorer_percent;
+            let explorer_cols = self.file_explorer_width.to_cols(main_content_area.width);
             let horizontal_chunks = Layout::default()
                 .direction(Direction::Horizontal)
                 .constraints([
-                    Constraint::Percentage(explorer_percent), // File explorer
-                    Constraint::Percentage(editor_percent),   // Editor area
+                    Constraint::Length(explorer_cols), // File explorer
+                    Constraint::Min(0),                // Editor area (remainder)
                 ])
                 .split(main_content_area);
 
@@ -1552,14 +1550,10 @@ impl Editor {
         let file_explorer_should_show = self.file_explorer_visible
             && (self.file_explorer.is_some() || self.file_explorer_sync_in_progress);
         let editor_content_area = if file_explorer_should_show {
-            let explorer_percent = (self.file_explorer_width_percent * 100.0) as u16;
-            let editor_percent = 100 - explorer_percent;
+            let explorer_cols = self.file_explorer_width.to_cols(main_content_area.width);
             let horizontal_chunks = Layout::default()
                 .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Percentage(explorer_percent),
-                    Constraint::Percentage(editor_percent),
-                ])
+                .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
                 .split(main_content_area);
             horizontal_chunks[1]
         } else {

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -423,7 +423,7 @@ impl Editor {
     pub fn resize_visible_terminals(&mut self) {
         // Get the content area excluding file explorer
         let file_explorer_width = if self.file_explorer_visible {
-            (self.terminal_width as f32 * self.file_explorer_width_percent) as u16
+            self.file_explorer_width.to_cols(self.terminal_width)
         } else {
             0
         };

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -797,8 +797,10 @@ pub(super) struct MouseState {
     pub drag_start_ratio: Option<f32>,
     /// Whether we're currently dragging the file explorer border
     pub dragging_file_explorer: bool,
-    /// Initial file explorer width percentage when starting to drag
-    pub drag_start_explorer_width: Option<f32>,
+    /// File explorer width at the moment the drag started. Drag
+    /// preserves the active variant: a drag that begins in `Percent`
+    /// stays in `Percent`, and likewise for `Columns`.
+    pub drag_start_explorer_width: Option<crate::config::ExplorerWidth>,
     /// Current hover target (if any)
     pub hover_target: Option<HoverTarget>,
     /// Whether we're currently doing a text selection drag

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -258,7 +258,7 @@ impl Editor {
             let expanded_dirs = get_expanded_dirs(explorer, &self.working_dir);
             FileExplorerState {
                 visible: self.file_explorer_visible,
-                width_percent: self.file_explorer_width_percent,
+                width: self.file_explorer_width,
                 expanded_dirs,
                 scroll_offset: explorer.get_scroll_offset(),
                 show_hidden: explorer.ignore_patterns().show_hidden(),
@@ -267,7 +267,7 @@ impl Editor {
         } else {
             FileExplorerState {
                 visible: self.file_explorer_visible,
-                width_percent: self.file_explorer_width_percent,
+                width: self.file_explorer_width,
                 expanded_dirs: Vec::new(),
                 scroll_offset: 0,
                 show_hidden: false,
@@ -749,7 +749,7 @@ impl Editor {
 
         // 4. Restore file explorer state
         self.file_explorer_visible = workspace.file_explorer.visible;
-        self.file_explorer_width_percent = workspace.file_explorer.width_percent;
+        self.file_explorer_width = workspace.file_explorer.width;
 
         // Store pending show_hidden and show_gitignored settings (fixes #569)
         // These will be applied when the file explorer is initialized (async)

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1387,9 +1387,13 @@ pub struct FileExplorerConfig {
     #[serde(default)]
     pub custom_ignore_patterns: Vec<String>,
 
-    /// Width of file explorer as percentage (0.0 to 1.0)
+    /// File explorer width. Either a percent (`"30%"`, 0–100) or an
+    /// absolute column count (`"24"`). Legacy numeric forms are still
+    /// accepted on read: a bare integer is treated as percent, and a
+    /// fractional number in `[0, 1]` is treated as a legacy percent
+    /// fraction (e.g. `0.3` → 30%).
     #[serde(default = "default_explorer_width")]
-    pub width: f32,
+    pub width: ExplorerWidth,
 
     /// Open files in a "preview" (ephemeral) tab on single-click in the
     /// file explorer. The preview tab is replaced by the next single-click
@@ -1401,8 +1405,216 @@ pub struct FileExplorerConfig {
     pub preview_tabs: bool,
 }
 
-fn default_explorer_width() -> f32 {
-    0.3 // 30% of screen width
+/// Width configuration for the file explorer.
+///
+/// Two forms are supported:
+///
+/// - `Percent(n)` — relative to the current terminal width. `n` is a
+///   whole-percent value in `0..=100`.
+/// - `Columns(n)` — absolute character columns. `n` is clamped at
+///   render time against the live terminal width so the layout stays
+///   inside the window.
+///
+/// ## Wire formats accepted on deserialize
+///
+/// | JSON form | Parsed as |
+/// |---|---|
+/// | `30` (integer) | `Percent(30)` |
+/// | `0.3` (float in `[0, 1]`) | `Percent(30)` — legacy fraction |
+/// | `1.5`, `30.0` (float outside `[0, 1]`) | `Percent(n)` |
+/// | `"30%"`, `"30 %"` (string with `%`) | `Percent(30)` |
+/// | `"24"` (string, no `%`) | `Columns(24)` |
+///
+/// ## Wire format emitted on serialize
+///
+/// - `Percent(n)` → string `"n%"`
+/// - `Columns(n)` → string `"n"`
+///
+/// This makes `config.json` self-describing: the unit is visible on the
+/// value, and round-trip is stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExplorerWidth {
+    Percent(u8),
+    Columns(u16),
+}
+
+impl ExplorerWidth {
+    /// Default width when none is configured.
+    pub const DEFAULT: Self = Self::Percent(30);
+
+    /// Convert to terminal columns.
+    ///
+    /// `Percent` multiplies `terminal_width` by the percent; `Columns`
+    /// returns the requested count, clamped against `terminal_width`
+    /// so callers never receive a value larger than the window.
+    pub fn to_cols(self, terminal_width: u16) -> u16 {
+        match self {
+            Self::Percent(pct) => ((terminal_width as u32 * pct as u32) / 100) as u16,
+            Self::Columns(cols) => cols.min(terminal_width),
+        }
+    }
+}
+
+impl Default for ExplorerWidth {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl std::fmt::Display for ExplorerWidth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Percent(n) => write!(f, "{}%", n),
+            Self::Columns(n) => write!(f, "{}", n),
+        }
+    }
+}
+
+/// Parse error for `ExplorerWidth` strings.
+#[derive(Debug)]
+pub struct ExplorerWidthParseError(String);
+
+impl std::fmt::Display for ExplorerWidthParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for ExplorerWidthParseError {}
+
+impl std::str::FromStr for ExplorerWidth {
+    type Err = ExplorerWidthParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Err(ExplorerWidthParseError(
+                "explorer width: empty string".into(),
+            ));
+        }
+        if let Some(rest) = s.strip_suffix('%') {
+            let n: u16 = rest.trim().parse().map_err(|_| {
+                ExplorerWidthParseError(format!("explorer width: {:?} is not a valid percent", s))
+            })?;
+            if n > 100 {
+                return Err(ExplorerWidthParseError(format!(
+                    "explorer width: {}% exceeds 100%",
+                    n
+                )));
+            }
+            Ok(Self::Percent(n as u8))
+        } else {
+            let n: u16 = s.parse().map_err(|_| {
+                ExplorerWidthParseError(format!(
+                    "explorer width: {:?} is neither a percent (e.g. \"30%\") nor a column count (e.g. \"24\")",
+                    s
+                ))
+            })?;
+            Ok(Self::Columns(n))
+        }
+    }
+}
+
+impl serde::Serialize for ExplorerWidth {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ExplorerWidth {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(d)?;
+        explorer_width::from_value(&raw)
+    }
+}
+
+impl schemars::JsonSchema for ExplorerWidth {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ExplorerWidth")
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // Declared as string (the canonical written form). Numbers are
+        // still accepted on read via the custom Deserialize impl, for
+        // back-compat with configs saved by older versions.
+        schemars::json_schema!({
+            "type": "string",
+            "pattern": r"^(100%|[1-9]?[0-9]%|\d+)$",
+            "description": "Either a percent like \"30%\" (0–100) or an absolute column count like \"24\".",
+        })
+    }
+}
+
+fn default_explorer_width() -> ExplorerWidth {
+    ExplorerWidth::DEFAULT
+}
+
+/// Public default used by the workspace state deserializer.
+pub fn default_explorer_width_value() -> ExplorerWidth {
+    ExplorerWidth::DEFAULT
+}
+
+/// Shared parsing logic for the custom `Deserialize` impl on
+/// `ExplorerWidth` and for the `Option<ExplorerWidth>` variant used by
+/// `PartialConfig`. Accepts all documented wire formats.
+pub(crate) mod explorer_width {
+    use super::ExplorerWidth;
+    use serde::de::{self, Deserialize, Deserializer};
+    use std::str::FromStr;
+
+    /// `Option<ExplorerWidth>` deserializer for `PartialConfig`.
+    ///
+    /// `null`/absent → `None`. Anything else is parsed by
+    /// [`from_value`] and wrapped in `Some`.
+    pub fn deserialize_optional<'de, D>(d: D) -> Result<Option<ExplorerWidth>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = Option::<serde_json::Value>::deserialize(d)?;
+        match raw {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(v) => from_value(&v).map(Some),
+        }
+    }
+
+    pub(super) fn from_value<E: de::Error>(v: &serde_json::Value) -> Result<ExplorerWidth, E> {
+        match v {
+            serde_json::Value::String(s) => ExplorerWidth::from_str(s).map_err(E::custom),
+            serde_json::Value::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    // Integer number — historical format for percent
+                    // (post-#1118, pre-columns). Keep treating it as
+                    // percent so existing configs stay correct.
+                    if u > 100 {
+                        return Err(E::custom(format!(
+                            "explorer width: {} exceeds 100 (percent). Use \"{}\" for columns.",
+                            u, u
+                        )));
+                    }
+                    Ok(ExplorerWidth::Percent(u as u8))
+                } else if let Some(f) = n.as_f64() {
+                    // Float: legacy fraction in [0, 1] OR explicit percent.
+                    let pct = if (0.0..=1.0).contains(&f) {
+                        f * 100.0
+                    } else {
+                        f
+                    };
+                    if !(0.0..=100.0).contains(&pct) {
+                        return Err(E::custom(format!(
+                            "explorer width: percent {} out of range 0..=100",
+                            pct
+                        )));
+                    }
+                    Ok(ExplorerWidth::Percent(pct.round() as u8))
+                } else {
+                    Err(E::custom("explorer width: unsupported number"))
+                }
+            }
+            _ => Err(E::custom(
+                "explorer width: expected \"30%\", \"24\" (columns), or a number",
+            )),
+        }
+    }
 }
 
 /// Clipboard configuration
@@ -5922,6 +6134,145 @@ impl std::error::Error for ConfigError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_file_explorer_width_default_is_percent_30() {
+        let cfg = FileExplorerConfig::default();
+        assert_eq!(cfg.width, ExplorerWidth::Percent(30));
+    }
+
+    // --- Wire format acceptance ---------------------------------------
+
+    #[test]
+    fn test_width_accepts_legacy_float_fraction() {
+        let cfg: FileExplorerConfig = serde_json::from_str(r#"{"width": 0.3}"#).unwrap();
+        assert_eq!(cfg.width, ExplorerWidth::Percent(30));
+    }
+
+    #[test]
+    fn test_width_accepts_bare_integer_as_percent() {
+        // Historical format from the earlier integer-percent PR.
+        let cfg: FileExplorerConfig = serde_json::from_str(r#"{"width": 42}"#).unwrap();
+        assert_eq!(cfg.width, ExplorerWidth::Percent(42));
+    }
+
+    #[test]
+    fn test_width_accepts_percent_string() {
+        let cfg: FileExplorerConfig = serde_json::from_str(r#"{"width": "75%"}"#).unwrap();
+        assert_eq!(cfg.width, ExplorerWidth::Percent(75));
+        // Tolerate whitespace around the percent.
+        let cfg: FileExplorerConfig = serde_json::from_str(r#"{"width": "42 %"}"#).unwrap();
+        assert_eq!(cfg.width, ExplorerWidth::Percent(42));
+    }
+
+    #[test]
+    fn test_width_accepts_columns_string() {
+        let cfg: FileExplorerConfig = serde_json::from_str(r#"{"width": "24"}"#).unwrap();
+        assert_eq!(cfg.width, ExplorerWidth::Columns(24));
+    }
+
+    #[test]
+    fn test_width_rejects_percent_over_100() {
+        let err = serde_json::from_str::<FileExplorerConfig>(r#"{"width": "150%"}"#)
+            .expect_err("percent > 100 should be rejected");
+        assert!(err.to_string().contains("100"), "{err}");
+    }
+
+    #[test]
+    fn test_width_rejects_integer_over_100() {
+        // Bare integer is interpreted as percent, so >100 is an error.
+        // Users who want 150 columns should write "150".
+        let err = serde_json::from_str::<FileExplorerConfig>(r#"{"width": 150}"#)
+            .expect_err("bare integer > 100 should be rejected as percent");
+        assert!(err.to_string().contains("percent") || err.to_string().contains("100"));
+    }
+
+    #[test]
+    fn test_width_rejects_garbage_string() {
+        serde_json::from_str::<FileExplorerConfig>(r#"{"width": "big"}"#)
+            .expect_err("non-numeric string should be rejected");
+    }
+
+    // --- Write-side format --------------------------------------------
+
+    #[test]
+    fn test_width_serializes_percent_as_string_with_suffix() {
+        let cfg = FileExplorerConfig {
+            width: ExplorerWidth::Percent(30),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(json["width"], serde_json::json!("30%"));
+    }
+
+    #[test]
+    fn test_width_serializes_columns_as_string_without_suffix() {
+        let cfg = FileExplorerConfig {
+            width: ExplorerWidth::Columns(24),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(json["width"], serde_json::json!("24"));
+    }
+
+    #[test]
+    fn test_width_round_trip_both_variants() {
+        for value in [ExplorerWidth::Percent(17), ExplorerWidth::Columns(42)] {
+            let cfg = FileExplorerConfig {
+                width: value,
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&cfg).unwrap();
+            let restored: FileExplorerConfig = serde_json::from_str(&json).unwrap();
+            assert_eq!(restored.width, value, "round trip failed for {:?}", value);
+        }
+    }
+
+    // --- to_cols -------------------------------------------------------
+
+    #[test]
+    fn test_to_cols_percent() {
+        assert_eq!(ExplorerWidth::Percent(30).to_cols(100), 30);
+        assert_eq!(ExplorerWidth::Percent(25).to_cols(120), 30);
+        assert_eq!(ExplorerWidth::Percent(30).to_cols(0), 0);
+        assert_eq!(ExplorerWidth::Percent(100).to_cols(200), 200);
+    }
+
+    #[test]
+    fn test_to_cols_columns_clamps_to_terminal() {
+        assert_eq!(ExplorerWidth::Columns(24).to_cols(100), 24);
+        assert_eq!(ExplorerWidth::Columns(999).to_cols(80), 80);
+        assert_eq!(ExplorerWidth::Columns(0).to_cols(100), 0);
+    }
+
+    // --- load_from_file regression ------------------------------------
+
+    #[test]
+    fn test_load_from_file_accepts_legacy_float_fraction_width() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"file_explorer":{"width":0.25}}"#).unwrap();
+        let cfg = Config::load_from_file(&path).expect("legacy float fraction must still load");
+        assert_eq!(cfg.file_explorer.width, ExplorerWidth::Percent(25));
+    }
+
+    #[test]
+    fn test_load_from_file_accepts_columns_string_width() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"file_explorer":{"width":"42"}}"#).unwrap();
+        let cfg = Config::load_from_file(&path).unwrap();
+        assert_eq!(cfg.file_explorer.width, ExplorerWidth::Columns(42));
+    }
+
+    #[test]
+    fn test_load_from_file_accepts_percent_string_width() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        std::fs::write(&path, r#"{"file_explorer":{"width":"55%"}}"#).unwrap();
+        let cfg = Config::load_from_file(&path).unwrap();
+        assert_eq!(cfg.file_explorer.width, ExplorerWidth::Percent(55));
+    }
 
     #[test]
     fn test_default_config() {

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -321,7 +321,11 @@ pub struct PartialFileExplorerConfig {
     pub show_hidden: Option<bool>,
     pub show_gitignored: Option<bool>,
     pub custom_ignore_patterns: Option<Vec<String>>,
-    pub width: Option<f32>,
+    #[serde(
+        default,
+        deserialize_with = "crate::config::explorer_width::deserialize_optional"
+    )]
+    pub width: Option<crate::config::ExplorerWidth>,
     pub preview_tabs: Option<bool>,
 }
 

--- a/crates/fresh-editor/src/view/controls/text_input/mod.rs
+++ b/crates/fresh-editor/src/view/controls/text_input/mod.rs
@@ -35,6 +35,12 @@ pub struct TextInputState {
     pub focus: FocusState,
     /// If true, validate that value is valid JSON before allowing exit
     pub validate_json: bool,
+    /// "Select-all" affordance: when the input gains focus the whole
+    /// value is conceptually selected, so the next printable keystroke
+    /// replaces it (matching the spinner UX from `NumberInputState`).
+    /// Any cursor movement, deletion, or explicit `insert` cancels the
+    /// flag and the input behaves normally from then on.
+    pub pending_replace_on_type: bool,
 }
 
 impl TextInputState {
@@ -47,7 +53,14 @@ impl TextInputState {
             placeholder: String::new(),
             focus: FocusState::Normal,
             validate_json: false,
+            pending_replace_on_type: false,
         }
+    }
+
+    /// Arm the "next-keystroke-replaces-value" affordance. Call when
+    /// the input first gains focus from a normal/hovered state.
+    pub fn arm_replace_on_type(&mut self) {
+        self.pending_replace_on_type = !self.value.is_empty();
     }
 
     /// Set JSON validation mode
@@ -94,6 +107,7 @@ impl TextInputState {
         if !self.is_enabled() {
             return;
         }
+        self.consume_pending_replace();
         self.value.insert(self.cursor, c);
         self.cursor += c.len_utf8();
     }
@@ -103,6 +117,7 @@ impl TextInputState {
         if !self.is_enabled() {
             return;
         }
+        self.consume_pending_replace();
         self.value.insert_str(self.cursor, s);
         self.cursor += s.len();
     }
@@ -110,6 +125,10 @@ impl TextInputState {
     /// Delete the character before the cursor (backspace)
     pub fn backspace(&mut self) {
         if !self.is_enabled() || self.cursor == 0 {
+            return;
+        }
+        if self.consume_pending_replace() {
+            // The "selected" value is cleared; nothing left to backspace.
             return;
         }
         // Find the previous character boundary
@@ -122,11 +141,27 @@ impl TextInputState {
         self.cursor = prev_boundary;
     }
 
+    /// If a pending replace-on-type is armed, clear the value and the
+    /// flag. Returns whether the pending state was consumed.
+    fn consume_pending_replace(&mut self) -> bool {
+        if self.pending_replace_on_type {
+            self.value.clear();
+            self.cursor = 0;
+            self.pending_replace_on_type = false;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Delete the grapheme cluster at the cursor (delete key)
     ///
     /// Deletes the entire grapheme cluster, handling combining characters properly.
     pub fn delete(&mut self) {
         if !self.is_enabled() || self.cursor >= self.value.len() {
+            return;
+        }
+        if self.consume_pending_replace() {
             return;
         }
         let next_boundary = grapheme::next_grapheme_boundary(&self.value, self.cursor);
@@ -138,6 +173,7 @@ impl TextInputState {
     /// Uses grapheme cluster boundaries for proper handling of combining characters
     /// like Thai diacritics, emoji with modifiers, etc.
     pub fn move_left(&mut self) {
+        self.pending_replace_on_type = false;
         if self.cursor > 0 {
             self.cursor = grapheme::prev_grapheme_boundary(&self.value, self.cursor);
         }
@@ -148,6 +184,7 @@ impl TextInputState {
     /// Uses grapheme cluster boundaries for proper handling of combining characters
     /// like Thai diacritics, emoji with modifiers, etc.
     pub fn move_right(&mut self) {
+        self.pending_replace_on_type = false;
         if self.cursor < self.value.len() {
             self.cursor = grapheme::next_grapheme_boundary(&self.value, self.cursor);
         }
@@ -155,11 +192,13 @@ impl TextInputState {
 
     /// Move cursor to start
     pub fn move_home(&mut self) {
+        self.pending_replace_on_type = false;
         self.cursor = 0;
     }
 
     /// Move cursor to end
     pub fn move_end(&mut self) {
+        self.pending_replace_on_type = false;
         self.cursor = self.value.len();
     }
 
@@ -290,6 +329,44 @@ mod tests {
                 f(frame, area);
             })
             .unwrap();
+    }
+
+    #[test]
+    fn test_arm_replace_on_type_replaces_value_on_first_char() {
+        let mut state = TextInputState::new("Width").with_value("30%");
+        state.arm_replace_on_type();
+        assert!(state.pending_replace_on_type);
+        state.insert('2');
+        assert_eq!(state.value, "2");
+        assert!(!state.pending_replace_on_type);
+        state.insert('4');
+        assert_eq!(state.value, "24");
+    }
+
+    #[test]
+    fn test_arm_replace_on_type_is_cancelled_by_cursor_movement() {
+        let mut state = TextInputState::new("Width").with_value("30%");
+        state.arm_replace_on_type();
+        state.move_left();
+        assert!(!state.pending_replace_on_type);
+        state.insert('x');
+        assert_eq!(state.value, "30x%");
+    }
+
+    #[test]
+    fn test_arm_replace_on_type_skips_when_empty() {
+        let mut state = TextInputState::new("Width");
+        state.arm_replace_on_type();
+        assert!(!state.pending_replace_on_type);
+    }
+
+    #[test]
+    fn test_arm_replace_on_type_backspace_clears_whole_value() {
+        let mut state = TextInputState::new("Width").with_value("30%");
+        state.arm_replace_on_type();
+        state.backspace();
+        assert_eq!(state.value, "");
+        assert!(!state.pending_replace_on_type);
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -1506,8 +1506,18 @@ impl SettingsState {
             }
         }
         if let Some(item) = self.current_item_mut() {
-            if let SettingControl::DualList(ref mut dl) = item.control {
-                dl.editing = true;
+            match item.control {
+                SettingControl::DualList(ref mut dl) => {
+                    dl.editing = true;
+                }
+                SettingControl::Text(ref mut state) => {
+                    // Mirror the spinner's "select-all on enter edit"
+                    // UX: the first printable keystroke replaces the
+                    // current value. Arrow keys or deletion cancel it
+                    // and the input behaves normally from then on.
+                    state.arm_replace_on_type();
+                }
+                _ => {}
             }
         }
     }
@@ -1551,10 +1561,7 @@ impl SettingsState {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
                 SettingControl::TextList(state) => state.insert(c),
-                SettingControl::Text(state) => {
-                    state.value.insert(state.cursor, c);
-                    state.cursor += c.len_utf8();
-                }
+                SettingControl::Text(state) => state.insert(c),
                 SettingControl::Map(state) => {
                     state.new_key_text.insert(state.cursor, c);
                     state.cursor += c.len_utf8();
@@ -1570,16 +1577,7 @@ impl SettingsState {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
                 SettingControl::TextList(state) => state.backspace(),
-                SettingControl::Text(state) => {
-                    if state.cursor > 0 {
-                        let mut char_start = state.cursor - 1;
-                        while char_start > 0 && !state.value.is_char_boundary(char_start) {
-                            char_start -= 1;
-                        }
-                        state.value.remove(char_start);
-                        state.cursor = char_start;
-                    }
-                }
+                SettingControl::Text(state) => state.backspace(),
                 SettingControl::Map(state) => {
                     if state.cursor > 0 {
                         let mut char_start = state.cursor - 1;
@@ -1601,15 +1599,7 @@ impl SettingsState {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
                 SettingControl::TextList(state) => state.move_left(),
-                SettingControl::Text(state) => {
-                    if state.cursor > 0 {
-                        let mut new_pos = state.cursor - 1;
-                        while new_pos > 0 && !state.value.is_char_boundary(new_pos) {
-                            new_pos -= 1;
-                        }
-                        state.cursor = new_pos;
-                    }
-                }
+                SettingControl::Text(state) => state.move_left(),
                 SettingControl::Map(state) => {
                     if state.cursor > 0 {
                         let mut new_pos = state.cursor - 1;
@@ -1630,16 +1620,7 @@ impl SettingsState {
         if let Some(item) = self.current_item_mut() {
             match &mut item.control {
                 SettingControl::TextList(state) => state.move_right(),
-                SettingControl::Text(state) => {
-                    if state.cursor < state.value.len() {
-                        let mut new_pos = state.cursor + 1;
-                        while new_pos < state.value.len() && !state.value.is_char_boundary(new_pos)
-                        {
-                            new_pos += 1;
-                        }
-                        state.cursor = new_pos;
-                    }
-                }
+                SettingControl::Text(state) => state.move_right(),
                 SettingControl::Map(state) => {
                     if state.cursor < state.new_key_text.len() {
                         let mut new_pos = state.cursor + 1;

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -292,8 +292,15 @@ pub struct WorkspaceConfigOverrides {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileExplorerState {
     pub visible: bool,
-    #[serde(default)]
-    pub width_percent: f32,
+    /// File explorer width. See [`crate::config::ExplorerWidth`] for
+    /// the accepted wire formats (percent string, column string, legacy
+    /// numeric forms). The `width_percent` alias preserves read
+    /// compatibility with workspace files written by earlier versions.
+    #[serde(
+        alias = "width_percent",
+        default = "crate::config::default_explorer_width_value"
+    )]
+    pub width: crate::config::ExplorerWidth,
     /// Expanded directories (relative paths)
     #[serde(default)]
     pub expanded_dirs: Vec<PathBuf>,
@@ -312,7 +319,7 @@ impl Default for FileExplorerState {
     fn default() -> Self {
         Self {
             visible: false,
-            width_percent: 0.3,
+            width: crate::config::default_explorer_width_value(),
             expanded_dirs: Vec::new(),
             scroll_offset: 0,
             show_hidden: false,
@@ -1265,10 +1272,10 @@ mod tests {
     }
 
     #[test]
-    fn test_file_explorer_state() {
+    fn test_file_explorer_state_percent_round_trip() {
         let state = FileExplorerState {
             visible: true,
-            width_percent: 0.25,
+            width: crate::config::ExplorerWidth::Percent(25),
             expanded_dirs: vec![
                 PathBuf::from("src"),
                 PathBuf::from("src/app"),
@@ -1283,10 +1290,43 @@ mod tests {
         let restored: FileExplorerState = serde_json::from_str(&json).unwrap();
 
         assert!(restored.visible);
-        assert_eq!(restored.width_percent, 0.25);
+        assert_eq!(restored.width, crate::config::ExplorerWidth::Percent(25));
         assert_eq!(restored.expanded_dirs.len(), 3);
         assert_eq!(restored.scroll_offset, 5);
         assert!(restored.show_hidden);
         assert!(!restored.show_gitignored);
+    }
+
+    #[test]
+    fn test_file_explorer_state_columns_round_trip() {
+        let state = FileExplorerState {
+            visible: true,
+            width: crate::config::ExplorerWidth::Columns(42),
+            expanded_dirs: vec![],
+            scroll_offset: 0,
+            show_hidden: false,
+            show_gitignored: false,
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: FileExplorerState = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.width, crate::config::ExplorerWidth::Columns(42));
+    }
+
+    /// Legacy workspace files named the field `width_percent` and
+    /// stored the value as a float fraction in `0.0..=1.0`. Both must
+    /// still load (via serde `alias` and the `ExplorerWidth`
+    /// deserializer).
+    #[test]
+    fn test_file_explorer_state_legacy_width_percent_alias() {
+        let json = r#"{
+            "visible": true,
+            "width_percent": 0.3,
+            "expanded_dirs": [],
+            "scroll_offset": 0,
+            "show_hidden": false,
+            "show_gitignored": false
+        }"#;
+        let restored: FileExplorerState = serde_json::from_str(json).unwrap();
+        assert_eq!(restored.width, crate::config::ExplorerWidth::Percent(30));
     }
 }

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1268,93 +1268,40 @@ fn test_map_control_add_new_shows_text_input() {
         .unwrap();
 }
 
-/// Test changing File Explorer Width (a percentage/float setting) and saving
+/// Smoke test: the File Explorer Width field renders with the default
+/// 30% displayed as `"30%"` in the settings UI.
 ///
-/// This tests the bug where percentage values were being saved incorrectly:
-/// - Width is stored as float 0.0-1.0 (e.g., 0.3 = 30%)
-/// - UI displays as integer (30)
-/// - Bug: saved as integer (30) instead of float (0.30)
-/// - Result: on reload, 30 * 100 = 3000 displayed
+/// The field is a free-form string now ("30%" or "24" for columns),
+/// so detailed parse/round-trip behavior lives in config unit tests.
 #[test]
-fn test_settings_percentage_value_saves_correctly() {
+fn test_settings_file_explorer_width_shows_percent_suffix() {
     let mut harness = EditorTestHarness::new(100, 40).unwrap();
     harness.render().unwrap();
 
-    // Get initial width (default is 0.3 = 30%)
-    let initial_width = harness.config().file_explorer.width;
-    assert!(
-        (initial_width - 0.3).abs() < 0.01,
-        "Initial width should be ~0.3, got {}",
-        initial_width
+    assert_eq!(
+        harness.config().file_explorer.width,
+        fresh::config::ExplorerWidth::Percent(30),
     );
 
-    // Open settings
     harness.open_settings().unwrap();
 
-    // Navigate to File Explorer category
-    // Categories: General, Clipboard, Editor, File Browser, File Explorer, ...
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Clipboard
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Editor
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // File Browser
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // File Explorer
+    // Navigate to File Explorer category.
+    // Categories in order: General, Clipboard, Editor, File Browser, File Explorer, ...
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
     harness.render().unwrap();
-
-    // Switch to settings panel
+    // Switch to the settings panel.
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
-
-    // Navigate down to find the Width setting.
-    // File Explorer settings (alphabetical): Custom Ignore Patterns,
-    // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden, Width.
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Preview Tabs
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Respect Gitignore
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Show Gitignored
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Show Hidden
-    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap(); // Width
+    // Width is the last field in the alphabetical listing.
+    for _ in 0..5 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
     harness.render().unwrap();
 
-    // Should show Width setting with current value (30 = 0.3 * 100)
     harness.assert_screen_contains("Width");
-    harness.assert_screen_contains("30");
-
-    // Increment the value to 31 (which should become 0.31)
-    harness
-        .send_key(KeyCode::Right, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
-
-    // Should now show 31
-    harness.assert_screen_contains("31");
-
-    // Should show modified indicator
-    harness.assert_screen_contains("modified");
-
-    // Tab to footer (Layer button), then Tab to Save
-    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
-    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap(); // Reset
-    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap(); // Save
-    harness.render().unwrap();
-
-    // Press Enter to save
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
-    harness.render().unwrap();
-
-    // Verify settings is closed
-    assert!(
-        !harness.editor().is_settings_open(),
-        "Settings should be closed after saving"
-    );
-
-    // CRITICAL: Verify the width was saved as a float, not an integer
-    // If the bug exists, width would be 31.0 instead of 0.31
-    let new_width = harness.config().file_explorer.width;
-    assert!(
-        (new_width - 0.31).abs() < 0.01,
-        "Width should be ~0.31 after saving, got {} (bug: value was saved as integer instead of float)",
-        new_width
-    );
+    harness.assert_screen_contains("30%");
 }
 
 /// Test number input editing mode - enter editing, type value, confirm


### PR DESCRIPTION
## Summary

Fixes #1118 and #1213. Also eliminates the "UI accepts absurd values" surface of #1212.

File-explorer width is now a two-variant enum `ExplorerWidth` with one clean wire format and legacy compatibility:

**Canonical forms (written by the editor):**
- `"30%"` — percent of terminal width (0–100)
- `"24"` — absolute column count

**Legacy forms (accepted on read only):**
- `30` (bare integer) → `Percent(30)` — the integer-percent format from the first iteration of this PR
- `0.3` (float in `[0, 1]`) → `Percent(30)` — the original fraction format

## Design

| Layer | Representation |
|---|---|
| Disk | string (`"30%"` or `"24"`), with legacy numeric forms accepted |
| Runtime | `ExplorerWidth` enum |
| Render (`render.rs`, `terminal.rs`, `effective_tabs_width`) | `ExplorerWidth::to_cols(terminal_width) -> u16` |
| Mouse drag | preserves the active variant; no artificial `10..=50` clamp |
| Settings UI | free-form text input via `SettingType::String` |

- One helper (`ExplorerWidth::to_cols`) replaces the scattered `_percent * 100 / terminal_width` math.
- Drag that starts in `Percent` stays in `Percent` (delta in percentage points). Drag that starts in `Columns` stays in `Columns` (delta in columns). A user who configured absolute columns is not silently flipped to percent by grabbing the divider.
- The schema declares the canonical wire format (`type: string` + pattern); the custom `Deserialize` impl transparently accepts all legacy numeric forms.

## UI affordance

Since the field is now a text input rather than a number spinner, replacing the value would have required the user to manually backspace the default. `TextInputState` gains a `pending_replace_on_type` flag: `start_editing` arms it, the next printable keystroke replaces the whole value, and cursor movement / deletion cancels it. Mirrors what the number spinner did before.

## Back-compat

- `FileExplorerConfig::width`: all four wire forms on read; writes the string form.
- `PartialConfig` has a matching `Option<ExplorerWidth>` deserializer so layered config loading stays correct.
- `FileExplorerState::width` (workspace) uses serde `alias = "width_percent"` so older workspace files still load.

## Test plan

- [x] `cargo check -p fresh-editor --all-targets`
- [x] `cargo fmt`
- [x] `cargo test -p fresh-editor --lib` → all 2076 tests pass
- [x] `cargo test -p fresh-editor --test e2e_tests file_explorer` → all 57 tests pass
- [x] Config unit tests: default, legacy fraction, bare integer percent, percent string, whitespace-tolerant percent, columns string, percent>100 rejected, integer>100 rejected, garbage rejected, round-trip for both variants, `to_cols` for both variants, `load_from_file` for every form.
- [x] Workspace-state tests: round-trip for both variants, legacy `width_percent` alias.
- [x] `TextInputState` tests: `pending_replace_on_type` replaces on first char, cancels on cursor move, no-op on empty value, backspace clears the "selected" value.
- [x] **Manual tmux**: UI shows `30%`; edit + type `50%` replaces cleanly; save produces `"width": "50%"`; restart loads it back; edit + type `24` saves `"24"` and the explorer renders at 24 absolute columns; legacy config `{"width": 0.15}` loads as `Percent(15)` (~21 cols of 140); legacy `{"width": "45%"}` loads at 63 cols; Left-arrow after entering edit cancels the replace-on-type affordance.

## Scope

Originally a one-line description fix for #1118; grew into a structural refactor after tracing how the value flows through the editor, and then picked up columns-support (#1213) in the same PR per request. Single coherent change, one canonical unit, one back-compat seam.
