### PR TITLE
feat(editor): set terminal window title from active buffer

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -65,6 +65,7 @@
         "show_horizontal_scrollbar": false,
         "show_tilde": true,
         "use_terminal_bg": false,
+        "set_window_title": true,
         "cursor_style": "default",
         "rulers": [],
         "whitespace_show": true,
@@ -397,6 +398,12 @@
           "description": "Use the terminal's default background color instead of the theme's editor background.\nWhen enabled, the editor background inherits from the terminal emulator,\nallowing transparency or custom terminal backgrounds to show through.\nDefault: false",
           "type": "boolean",
           "default": false,
+          "x-section": "Display"
+        },
+        "set_window_title": {
+          "description": "Update the terminal window title (via OSC 2) to reflect the active buffer.\nWhen enabled, Fresh sets the terminal/tab title to \"<file> — Fresh\" as\nyou switch buffers. Harmless on terminals that don't understand the\nescape sequence — they silently ignore it.\nDefault: true",
+          "type": "boolean",
+          "default": true,
           "x-section": "Display"
         },
         "cursor_style": {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -556,6 +556,7 @@ impl Editor {
             restart_with_dir: None,
             status_message: None,
             plugin_status_message: None,
+            last_window_title: None,
             plugin_errors: Vec::new(),
             prompt: None,
             terminal_width: width,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -410,6 +410,11 @@ pub struct Editor {
     /// Plugin-provided status message (displayed alongside the core status)
     plugin_status_message: Option<String>,
 
+    /// Last terminal window title written via OSC 2. Used so we only write
+    /// the escape sequence when the title would actually change, rather
+    /// than on every frame.
+    last_window_title: Option<String>,
+
     /// Accumulated plugin errors (for test assertions)
     /// These are collected when plugin error messages are received
     plugin_errors: Vec<String>,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -574,6 +574,12 @@ impl Editor {
             .get(&self.active_buffer())
             .map(|m| m.display_name.clone())
             .unwrap_or_else(|| "[No Name]".to_string());
+
+        // Reflect the active buffer in the terminal window/tab title. Only
+        // writes when the title actually changes so we don't flood stdout
+        // with OSC sequences every frame.
+        self.update_terminal_title(&display_name);
+
         let status_message = self.status_message.clone();
         let plugin_status_message = self.plugin_status_message.clone();
         let prompt = self.prompt.clone();
@@ -1596,6 +1602,24 @@ impl Editor {
         if let Some(history) = self.prompt_histories.get_mut("search") {
             history.clear();
         }
+    }
+
+    /// Emit an OSC 2 escape sequence to set the host terminal's window/tab
+    /// title based on the active buffer's display name. Deduplicated against
+    /// the last title we wrote so we don't spam stdout every frame.
+    ///
+    /// Gated by `editor.set_window_title` (default on). Terminals that
+    /// don't implement OSC 2 silently drop the sequence.
+    fn update_terminal_title(&mut self, display_name: &str) {
+        if !self.config.editor.set_window_title {
+            return;
+        }
+        let new_title = format!("{} \u{2014} Fresh", display_name);
+        if self.last_window_title.as_deref() == Some(new_title.as_str()) {
+            return;
+        }
+        crate::services::terminal_title::write_terminal_title(&new_title);
+        self.last_window_title = Some(new_title);
     }
 
     /// Save all prompt histories to disk

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -844,6 +844,15 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub use_terminal_bg: bool,
 
+    /// Update the terminal window title (via OSC 2) to reflect the active buffer.
+    /// When enabled, Fresh sets the terminal/tab title to "<file> — Fresh" as
+    /// you switch buffers. Harmless on terminals that don't understand the
+    /// escape sequence — they silently ignore it.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub set_window_title: bool,
+
     /// Cursor style for the terminal cursor.
     /// Options: blinking_block, steady_block, blinking_bar, steady_bar, blinking_underline, steady_underline
     /// Default: blinking_block
@@ -1356,6 +1365,7 @@ impl Default for EditorConfig {
             show_horizontal_scrollbar: false,
             show_tilde: true,
             use_terminal_bg: false,
+            set_window_title: true,
             rulers: Vec::new(),
             whitespace_show: true,
             whitespace_spaces_leading: false,

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -196,6 +196,7 @@ pub struct PartialEditorConfig {
     pub show_horizontal_scrollbar: Option<bool>,
     pub show_tilde: Option<bool>,
     pub use_terminal_bg: Option<bool>,
+    pub set_window_title: Option<bool>,
     pub rulers: Option<Vec<usize>>,
     pub whitespace_show: Option<bool>,
     pub whitespace_spaces_leading: Option<bool>,
@@ -296,6 +297,7 @@ impl Merge for PartialEditorConfig {
             .merge_from(&other.show_horizontal_scrollbar);
         self.show_tilde.merge_from(&other.show_tilde);
         self.use_terminal_bg.merge_from(&other.use_terminal_bg);
+        self.set_window_title.merge_from(&other.set_window_title);
         self.rulers.merge_from(&other.rulers);
         self.whitespace_show.merge_from(&other.whitespace_show);
         self.whitespace_spaces_leading
@@ -538,6 +540,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             show_horizontal_scrollbar: Some(cfg.show_horizontal_scrollbar),
             show_tilde: Some(cfg.show_tilde),
             use_terminal_bg: Some(cfg.use_terminal_bg),
+            set_window_title: Some(cfg.set_window_title),
             rulers: Some(cfg.rulers.clone()),
             whitespace_show: Some(cfg.whitespace_show),
             whitespace_spaces_leading: Some(cfg.whitespace_spaces_leading),
@@ -675,6 +678,7 @@ impl PartialEditorConfig {
                 .unwrap_or(defaults.show_horizontal_scrollbar),
             show_tilde: self.show_tilde.unwrap_or(defaults.show_tilde),
             use_terminal_bg: self.use_terminal_bg.unwrap_or(defaults.use_terminal_bg),
+            set_window_title: self.set_window_title.unwrap_or(defaults.set_window_title),
             rulers: self.rulers.unwrap_or_else(|| defaults.rulers.clone()),
             whitespace_show: self.whitespace_show.unwrap_or(defaults.whitespace_show),
             whitespace_spaces_leading: self

--- a/crates/fresh-editor/src/services/mod.rs
+++ b/crates/fresh-editor/src/services/mod.rs
@@ -25,6 +25,7 @@ pub mod styled_html;
 pub mod telemetry;
 pub mod terminal;
 pub mod terminal_modes;
+pub mod terminal_title;
 pub mod time_source;
 pub mod tracing_setup;
 pub mod warning_log;

--- a/crates/fresh-editor/src/services/terminal_title.rs
+++ b/crates/fresh-editor/src/services/terminal_title.rs
@@ -1,0 +1,87 @@
+//! Set the host terminal's window/tab title.
+//!
+//! Emits an OSC 2 ("Set Window Title") escape sequence on stdout. This is a
+//! terminal-global property that lives outside the alternate screen buffer,
+//! so writing it during rendering is fine and takes effect immediately in
+//! terminals that support it. Terminals that don't understand OSC 2
+//! silently ignore the sequence.
+
+use std::io::{stdout, IsTerminal, Write};
+
+/// Maximum number of bytes to send as a terminal title. Titles longer than
+/// this are truncated. Most terminals cap internally; this guards against
+/// pathological buffer names bloating the output.
+const MAX_TITLE_BYTES: usize = 256;
+
+/// Return a title string safe to embed in an OSC 2 sequence.
+///
+/// Strips ASCII control characters (including ESC and BEL, which would
+/// terminate or break out of the sequence) and truncates to
+/// [`MAX_TITLE_BYTES`] on a UTF-8 character boundary.
+pub fn sanitize_title(title: &str) -> String {
+    let filtered: String = title.chars().filter(|c| !c.is_control()).collect();
+
+    if filtered.len() <= MAX_TITLE_BYTES {
+        return filtered;
+    }
+
+    let mut end = MAX_TITLE_BYTES;
+    while end > 0 && !filtered.is_char_boundary(end) {
+        end -= 1;
+    }
+    filtered[..end].to_string()
+}
+
+/// Write an OSC 2 escape sequence to stdout setting the terminal title.
+///
+/// The title is sanitized before writing. No-op when stdout is not a
+/// terminal (e.g. under cargo test, when piped, when redirected to a
+/// file) — OSC 2 only has meaning for an interactive terminal, and
+/// writing it elsewhere would just leak escape bytes into captured
+/// output.
+///
+/// Best-effort: if stdout is unavailable the error is discarded (the
+/// title is a purely decorative feature and should never disrupt editing).
+pub fn write_terminal_title(title: &str) {
+    if !stdout().is_terminal() {
+        return;
+    }
+    let safe = sanitize_title(title);
+    // OSC 2 ; <title> BEL
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = write!(stdout(), "\x1b]2;{}\x07", safe);
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = stdout().flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_control_characters() {
+        assert_eq!(sanitize_title("hello\x07world"), "helloworld");
+        assert_eq!(sanitize_title("hi\x1b[0m"), "hi[0m");
+        assert_eq!(sanitize_title("line1\nline2"), "line1line2");
+    }
+
+    #[test]
+    fn preserves_ordinary_text() {
+        assert_eq!(sanitize_title("foo/bar.rs — Fresh"), "foo/bar.rs — Fresh");
+    }
+
+    #[test]
+    fn truncates_long_titles_on_char_boundary() {
+        let long = "á".repeat(MAX_TITLE_BYTES); // 2 bytes per char
+        let out = sanitize_title(&long);
+        assert!(out.len() <= MAX_TITLE_BYTES);
+        // Must remain valid UTF-8 — String construction asserts this; also
+        // make sure we didn't slice through a 2-byte sequence.
+        assert!(out.chars().all(|c| c == 'á'));
+    }
+
+    #[test]
+    fn empty_input_yields_empty_output() {
+        assert_eq!(sanitize_title(""), "");
+    }
+}


### PR DESCRIPTION
Closes #1618

## Summary
Emits an OSC 2 ("Set Window Title") escape sequence during `Editor::render`
so the host terminal's window / tab title reflects the currently active
buffer (`<display_name> — Fresh`). Terminals that don't understand the
sequence silently ignore it.

## Design
- New `services/terminal_title` module with `sanitize_title` (strips
  control chars — notably ESC / BEL that would break out of the sequence —
  and truncates to 256 bytes on a UTF‑8 boundary) and `write_terminal_title`
  (emits `\x1b]2;<title>\x07`).
- `write_terminal_title` is a no-op when stdout isn't a terminal
  (`IsTerminal`), so captured output in tests / pipes / CI stays clean.
- `Editor` caches `last_window_title`; `update_terminal_title` only
  writes when the resolved title differs, so we don't spam escapes every
  frame.
- Hooked into `render()` right next to the existing `display_name`
  resolution — same single source of truth used by the tab bar and status
  bar.
- New config flag `editor.set_window_title` (default `true`) with docs
  in the JSON schema. Added to `PartialEditorConfig` + `resolve`.
- Does not clear the title on exit, matching common terminal editors;
  the user's shell prompt will typically overwrite it on the next render.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check -p fresh-editor --all-targets`
- [x] `cargo check -p fresh-editor --all-targets --features gui`
- [x] `cargo test -p fresh-editor --lib` — new unit tests for
      `sanitize_title` (strips control chars, preserves text, char-boundary
      truncation, empty input); all previously passing focused tests
      (`render`, `config`, `partial_config`, `terminal_title`) still pass
      (167 / 167).
- [x] `./scripts/gen_schema.sh` — schemas regenerated.
- [x] Manual end-to-end in tmux (`set-option -g set-titles on`):
  - Launch `fresh test-title.txt` → `tmux display-message -p '#{pane_title}'`
    reports `test-title.txt — Fresh`.
  - Open a second file via `Ctrl+O` → title switches to `another.md — Fresh`.
  - `Ctrl+PgUp` back → title switches back to `test-title.txt — Fresh`.
  - With `.fresh/config.json` `{"editor": {"set_window_title": false}}`
    the pre-existing terminal title is left untouched after launching fresh.

https://claude.ai/code/session_01GHfUgkDEsY4sKnwLUzfEEh