### PR TITLE
fix(config): clamp file-explorer width to match mouse-drag range

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -874,9 +874,11 @@
           "default": []
         },
         "width": {
-          "description": "Width of file explorer as percentage (0.0 to 1.0)",
+          "description": "Width of file explorer as a fraction of the terminal width (0.1 to 0.5,\ni.e. 10% to 50%). Matches the range enforced by mouse-drag resizing.",
           "type": "number",
           "format": "float",
+          "minimum": 0.1,
+          "maximum": 0.5,
           "default": 0.30000001192092896
         },
         "preview_tabs": {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -477,8 +477,11 @@ impl Editor {
             }
         }
 
-        // Extract config values before moving config into the struct
-        let file_explorer_width = config.file_explorer.width;
+        // Extract config values before moving config into the struct.
+        // Clamp file-explorer width to the same range enforced by mouse-drag
+        // resizing (see `handle_file_explorer_border_drag`), so pre-existing
+        // out-of-range values in saved configs don't produce an unusable UI.
+        let file_explorer_width = config.file_explorer.width.clamp(0.1, 0.5);
         let recovery_enabled = config.editor.recovery_enabled;
         let check_for_updates = config.check_for_updates;
         let show_menu_bar = config.editor.show_menu_bar;

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1387,8 +1387,10 @@ pub struct FileExplorerConfig {
     #[serde(default)]
     pub custom_ignore_patterns: Vec<String>,
 
-    /// Width of file explorer as percentage (0.0 to 1.0)
+    /// Width of file explorer as a fraction of the terminal width (0.1 to 0.5,
+    /// i.e. 10% to 50%). Matches the range enforced by mouse-drag resizing.
     #[serde(default = "default_explorer_width")]
+    #[schemars(range(min = 0.1, max = 0.5))]
     pub width: f32,
 
     /// Open files in a "preview" (ephemeral) tab on single-click in the

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1357,6 +1357,78 @@ fn test_settings_percentage_value_saves_correctly() {
     );
 }
 
+/// Regression test for #1212: settings should reject File Explorer width
+/// values below the minimum enforced by mouse-drag resizing (0.1 == 10%),
+/// so users can't produce an unusable sidebar by typing e.g. 2.
+#[test]
+fn test_settings_file_explorer_width_clamps_to_minimum() {
+    let mut harness = EditorTestHarness::new(100, 40).unwrap();
+    harness.render().unwrap();
+
+    // Open settings and search for the File Explorer Width setting.
+    harness.open_settings().unwrap();
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    for c in "file explorer width".chars() {
+        harness
+            .send_key(KeyCode::Char(c), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The default value is 30 (0.3 * 100 as a percentage).
+    harness.assert_screen_contains("30");
+
+    // Enter editing mode, clear the value, and type an out-of-range value.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    for c in "2".chars() {
+        harness
+            .send_key(KeyCode::Char(c), KeyModifiers::NONE)
+            .unwrap();
+    }
+    // Confirm - value should be clamped to the minimum (10).
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("10");
+    harness.assert_screen_not_contains(" 2 ");
+
+    // Save the change and verify the stored float is 0.1.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        !harness.editor().is_settings_open(),
+        "Settings should be closed after saving"
+    );
+
+    let new_width = harness.config().file_explorer.width;
+    assert!(
+        (new_width - 0.1).abs() < 0.01,
+        "Width should be clamped to 0.1 (minimum), got {}",
+        new_width
+    );
+}
+
 /// Test number input editing mode - enter editing, type value, confirm
 #[test]
 fn test_number_input_enter_editing_mode() {


### PR DESCRIPTION
Closes #1212.

## Summary

The File Explorer `width` setting accepted any float, so typing a very small / negative value in the Settings UI or editing the config file directly produced an unusable or invisible sidebar — even though mouse-drag resizing already clamped to `0.1..=0.5` (10% to 50%).

## Changes

- **Schema bounds**: Annotate `FileExplorerConfig::width` with `#[schemars(range(min = 0.1, max = 0.5))]`. The generated JSON schema now carries explicit `minimum` / `maximum`, which the Settings UI's `NumberInputState` already honours on confirm/edit via `with_min`/`with_max` (values are clamped when the user presses Enter).
- **Docs**: Update the doc comment (also surfaced as the setting description) from the misleading "0.0 to 1.0" to "0.1 to 0.5, i.e. 10% to 50%", and explicitly note the match with mouse-drag resizing — also addresses the documentation half of the related issue.
- **Defensive runtime clamp**: Apply `.clamp(0.1, 0.5)` on editor init so that existing saved configs with out-of-range values don't produce a broken UI after upgrade.
- **Regenerated** `plugins/config-schema.json`.

The config file on disk is left untouched; only the runtime value is clamped. Users can still see their saved value in Settings, and any edit there will be bounded.

## Test plan

- [x] `cargo check --all-targets` passes
- [x] `cargo fmt --check` passes
- [x] New e2e regression test `test_settings_file_explorer_width_clamps_to_minimum` passes (types `2` in Settings → clamps to `10` → saves as `0.1`)
- [x] Existing `test_settings_percentage_value_saves_correctly` still passes
- [x] Manual validation in tmux: launched fresh with `width: 0.02` in config → sidebar renders at 10% of terminal width, not 2%

https://claude.ai/code/session_01E3DAGDKwoVagzWjBwJ92a9