### PR TITLE
fix(keymap/macos): Alt+Right stops at word end (fixes #1288)

### DIFF
--- a/crates/fresh-editor/keymaps/macos.json
+++ b/crates/fresh-editor/keymaps/macos.json
@@ -194,9 +194,10 @@
       "when": "normal"
     },
     {
+      "comment": "Alt+Right -> End of word (macOS Option+Right convention; stops at word end, not past trailing whitespace)",
       "key": "Right",
       "modifiers": ["alt"],
-      "action": "move_word_right",
+      "action": "move_word_end",
       "args": {},
       "when": "normal"
     },
@@ -210,7 +211,7 @@
     {
       "key": "Right",
       "modifiers": ["alt", "shift"],
-      "action": "select_word_right",
+      "action": "select_word_end",
       "args": {},
       "when": "normal"
     },
@@ -225,7 +226,7 @@
     {
       "key": "Right",
       "modifiers": ["ctrl"],
-      "action": "move_word_right",
+      "action": "move_word_end",
       "args": {},
       "when": "normal"
     },
@@ -240,7 +241,7 @@
     {
       "key": "Right",
       "modifiers": ["ctrl", "shift"],
-      "action": "select_word_right",
+      "action": "select_word_end",
       "args": {},
       "when": "normal"
     },

--- a/crates/fresh-editor/tests/e2e/issue_1288_word_select_whitespace.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1288_word_select_whitespace.rs
@@ -1,0 +1,105 @@
+//! Regression test for issue #1288: "Word select includes whitespace"
+//!
+//! On the macOS keymap, pressing Alt+Right (Option+Right) from inside a word
+//! should move the cursor to the END of the current word — not past the
+//! trailing whitespace to the start of the next word. Similarly,
+//! Alt+Shift+Right should select up to the word end only. This matches
+//! the standard macOS convention (TextEdit, VS Code on macOS, etc.).
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+
+fn macos_harness(width: u16, height: u16) -> EditorTestHarness {
+    let config = Config {
+        active_keybinding_map: "macos".into(),
+        ..Default::default()
+    };
+    EditorTestHarness::create(
+        width,
+        height,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_preserved_keybinding_map(),
+    )
+    .unwrap()
+}
+
+/// Alt+Right from within the first word should stop at the end of that word,
+/// not consume trailing whitespace.
+#[test]
+fn test_alt_right_stops_at_word_end() {
+    let mut harness = macos_harness(80, 24);
+    harness.type_text("hello world test").unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+
+    // From start of "hello", Alt+Right should land at end of "hello" (pos 5),
+    // NOT at the start of "world" (pos 6).
+    harness.send_key(KeyCode::Right, KeyModifiers::ALT).unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        5,
+        "Alt+Right from start of 'hello' should stop at end of word (pos 5), \
+         got pos {}",
+        harness.cursor_position()
+    );
+
+    // A second Alt+Right should skip the space and land at end of "world".
+    harness.send_key(KeyCode::Right, KeyModifiers::ALT).unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        11,
+        "Second Alt+Right should stop at end of 'world' (pos 11), got pos {}",
+        harness.cursor_position()
+    );
+}
+
+/// Alt+Shift+Right should extend the selection to the word end, without
+/// including trailing whitespace.
+#[test]
+fn test_alt_shift_right_selects_word_only() {
+    let mut harness = macos_harness(80, 24);
+    harness.type_text("hello world").unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::ALT | KeyModifiers::SHIFT)
+        .unwrap();
+
+    let cursor = harness.editor().active_cursors().primary();
+    let range = cursor
+        .selection_range()
+        .expect("Alt+Shift+Right should create a selection");
+    assert_eq!(
+        (range.start, range.end),
+        (0, 5),
+        "Alt+Shift+Right from start should select exactly 'hello' (0..5), got {range:?}",
+    );
+
+    let selected = harness
+        .editor_mut()
+        .active_state_mut()
+        .get_text_range(range.start, range.end);
+    assert_eq!(
+        selected, "hello",
+        "Selected text should be 'hello' without trailing space, got {selected:?}",
+    );
+}
+
+/// Ctrl+Right on macOS keymap should behave the same as Alt+Right (end of word).
+#[test]
+fn test_ctrl_right_stops_at_word_end_on_macos() {
+    let mut harness = macos_harness(80, 24);
+    harness.type_text("hello world").unwrap();
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::CONTROL)
+        .unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        5,
+        "Ctrl+Right (macOS keymap) from start of 'hello' should stop at pos 5, got {}",
+        harness.cursor_position()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -41,6 +41,7 @@ pub mod hot_exit_flows;
 pub mod indent_dedent;
 pub mod inline_diagnostics;
 pub mod issue_1147_wrapped_line_nav;
+pub mod issue_1288_word_select_whitespace;
 pub mod issue_1502_word_wrap_squished;
 pub mod issue_1566_arrow_selection;
 pub mod issue_1568_session_fold_restore;


### PR DESCRIPTION
## Summary

Closes #1288.

On the macOS keymap, pressing `Alt+Right` (Option+Right) or `Alt+Shift+Right` from inside a word was moving/selecting past the word, consuming the trailing whitespace before stopping at the start of the next word. On macOS the standard convention (TextEdit, VS Code on Mac, native text widgets, …) is to stop exactly at the end of the current word.

## Root cause

`crates/fresh-editor/keymaps/macos.json` bound the arrow-key word-movement shortcuts to the `move_word_right` / `select_word_right` actions, which use `find_word_start_right` (lands at the start of the next word, past whitespace).

## Fix

Rebind these four shortcuts in the macOS keymap to the existing `move_word_end` / `select_word_end` actions, which use `find_word_end_right` (stops at the end of the current word):

- `Alt+Right` → `move_word_end`
- `Alt+Shift+Right` → `select_word_end`
- `Ctrl+Right` → `move_word_end`
- `Ctrl+Shift+Right` → `select_word_end`

`Alt+F` / `Alt+B` (Emacs/readline style) are intentionally left alone, since that convention moves to the next word start.

## Test plan

- [x] Added `crates/fresh-editor/tests/e2e/issue_1288_word_select_whitespace.rs` — three e2e tests that load the `macos` keymap and check `Alt+Right`, `Alt+Shift+Right`, and `Ctrl+Right` land at position 5 for "hello world" instead of position 6.
- [x] Confirmed the tests **fail** on master (reproduces bug: got pos 6, expected 5).
- [x] Confirmed the tests **pass** with this change.
- [x] Ran the existing `selection::` and `ctrl_right` suites (74 tests) — all still pass.
- [x] Manual validation in tmux with the `macos` keymap: `Ctrl+Right` from start of "hello world test" now lands at Col 6 (end of "hello") and a subsequent `Ctrl+Right` lands at Col 12 (end of "world"); `Ctrl+Shift+Right` selects exactly "hello" with no trailing space.
- [x] `cargo fmt` clean, `cargo check --all-targets` clean.