### PR TITLE
fix(file-explorer): gitignored dotfiles respect gitignore toggle (#1388)

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1191,11 +1191,12 @@ impl Editor {
         let root_path = view.tree().get_node(root_id).map(|n| n.entry.path.clone());
 
         if let Some(root_path) = root_path {
-            if let Err(e) = view.load_gitignore_for_dir(&root_path) {
-                tracing::warn!("Failed to load root .gitignore from {:?}: {}", root_path, e);
-            } else {
-                tracing::debug!("Loaded root .gitignore from {:?}", root_path);
-            }
+            crate::app::file_operations::load_gitignore_via_fs(
+                self.authority.filesystem.as_ref(),
+                &mut view,
+                &root_path,
+            );
+            tracing::debug!("Loaded root .gitignore from {:?}", root_path);
         }
 
         // Apply show_hidden / show_gitignored settings.

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -314,13 +314,11 @@ impl Editor {
                             .map(|n| (n.entry.path.clone(), n.entry.is_symlink()));
 
                         if let Some((dir_path, is_symlink)) = node_info {
-                            if let Err(e) = explorer.load_gitignore_for_dir(&dir_path) {
-                                tracing::warn!(
-                                    "Failed to load .gitignore from {:?}: {}",
-                                    dir_path,
-                                    e
-                                );
-                            }
+                            crate::app::file_operations::load_gitignore_via_fs(
+                                self.authority.filesystem.as_ref(),
+                                explorer,
+                                &dir_path,
+                            );
 
                             // If a symlink directory was just expanded, we need to rebuild
                             // the decoration cache so decorations under the canonical target

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -9,6 +9,8 @@
 //! - Save conflict detection
 
 use crate::model::buffer::SudoSaveRequired;
+use crate::model::filesystem::FileSystem;
+use crate::view::file_tree::FileTreeView;
 use crate::view::prompt::PromptType;
 use std::path::{Path, PathBuf};
 
@@ -133,9 +135,11 @@ impl Editor {
         // Otherwise the tree keeps filtering by the old rules until restart.
         if let Some(ref p) = path {
             if p.file_name().and_then(|n| n.to_str()) == Some(".gitignore") {
-                if let (Some(parent), Some(explorer)) = (p.parent(), self.file_explorer.as_mut()) {
-                    if let Err(e) = explorer.load_gitignore_for_dir(parent) {
-                        tracing::warn!("Failed to reload .gitignore after save: {}", e);
+                if let Some(parent) = p.parent() {
+                    let parent = parent.to_path_buf();
+                    let fs = self.authority.filesystem.clone();
+                    if let Some(explorer) = self.file_explorer.as_mut() {
+                        load_gitignore_via_fs(fs.as_ref(), explorer, &parent);
                     }
                 }
             }
@@ -551,12 +555,10 @@ impl Editor {
         // Re-stat every loaded .gitignore and reload/drop as needed, so
         // external edits (git pull, sed, another editor) and deletions take
         // effect without a restart. In-editor saves already reload eagerly
-        // via finalize_save_buffer. This is sync I/O on a handful of small
-        // files — we don't need the bg thread for it.
-        if let Some(ref mut explorer) = self.file_explorer {
-            if explorer.ignore_patterns_mut().sync_gitignores_from_disk() {
-                any_refreshed = true;
-            }
+        // via finalize_save_buffer. Sync I/O here — a handful of small files
+        // and all access goes through the filesystem authority.
+        if self.sync_gitignores_from_disk() {
+            any_refreshed = true;
         }
 
         // If a previous dir-poll is still in flight, don't stack another.
@@ -641,7 +643,7 @@ impl Editor {
         )>,
         git_index_mtime: Option<(PathBuf, std::time::SystemTime)>,
     ) -> bool {
-        let mut dirs_to_refresh = Vec::new();
+        let mut dirs_to_refresh: Vec<(crate::view::file_tree::NodeId, PathBuf)> = Vec::new();
 
         for (node_id, path, mtime_opt) in results {
             let Some(current_mtime) = mtime_opt else {
@@ -651,7 +653,7 @@ impl Editor {
             if let Some(&stored_mtime) = self.dir_mod_times.get(&path) {
                 if current_mtime != stored_mtime {
                     self.dir_mod_times.insert(path.clone(), current_mtime);
-                    dirs_to_refresh.push(node_id);
+                    dirs_to_refresh.push((node_id, path.clone()));
                     tracing::debug!("Directory changed: {:?}", path);
                 }
             } else {
@@ -683,17 +685,56 @@ impl Editor {
             return false;
         }
 
-        // Refresh each changed directory
+        // Refresh each changed directory and (re)load its .gitignore. A new
+        // .gitignore file inside an expanded dir bumps the dir's mtime so we
+        // land here; refresh_node re-lists entries but doesn't parse rules —
+        // load_gitignore_via_fs handles the rules side. Idempotent when the
+        // dir has no .gitignore.
+        let refreshed_dirs: Vec<PathBuf> = dirs_to_refresh.iter().map(|(_, p)| p.clone()).collect();
         if let (Some(runtime), Some(explorer)) = (&self.tokio_runtime, &mut self.file_explorer) {
-            for node_id in dirs_to_refresh {
+            for (node_id, _) in dirs_to_refresh {
                 let tree = explorer.tree_mut();
                 if let Err(e) = runtime.block_on(tree.refresh_node(node_id)) {
                     tracing::warn!("Failed to refresh directory: {}", e);
                 }
             }
         }
+        let fs = self.authority.filesystem.clone();
+        if let Some(explorer) = self.file_explorer.as_mut() {
+            for dir in refreshed_dirs {
+                load_gitignore_via_fs(fs.as_ref(), explorer, &dir);
+            }
+        }
 
         true
+    }
+
+    /// Re-stat every loaded .gitignore via the filesystem authority and
+    /// reload or drop as needed. Returns true if anything changed.
+    fn sync_gitignores_from_disk(&mut self) -> bool {
+        let fs = self.authority.filesystem.clone();
+        let Some(explorer) = self.file_explorer.as_mut() else {
+            return false;
+        };
+        let dirs = explorer.ignore_patterns().loaded_gitignore_dirs();
+        let mut changed = false;
+        for dir in dirs {
+            let gitignore_path = dir.join(".gitignore");
+            match fs.metadata(&gitignore_path) {
+                Err(_) => {
+                    explorer.ignore_patterns_mut().remove_gitignore(&dir);
+                    changed = true;
+                }
+                Ok(meta) => {
+                    let stored = explorer.ignore_patterns().stored_gitignore_mtime(&dir);
+                    if stored != meta.modified {
+                        load_gitignore_via_fs(fs.as_ref(), explorer, &dir);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        changed
     }
 
     /// Resolve the path to `.git/index` via `git rev-parse --git-dir`.
@@ -1246,4 +1287,24 @@ impl Editor {
             _ => None,
         }
     }
+}
+
+/// Stat and read `dir/.gitignore` via the filesystem authority and install
+/// the result on `explorer`. No-op (with a warn-level log on unexpected
+/// errors) when the file doesn't exist. Shared by the init, expand, save,
+/// and poll paths so everything routes through the same authority.
+pub(crate) fn load_gitignore_via_fs(fs: &dyn FileSystem, explorer: &mut FileTreeView, dir: &Path) {
+    let gitignore_path = dir.join(".gitignore");
+    let meta = match fs.metadata(&gitignore_path) {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+    let bytes = match fs.read_file(&gitignore_path) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("Failed to read {:?}: {}", gitignore_path, e);
+            return;
+        }
+    };
+    explorer.load_gitignore_from_bytes(dir, &bytes, meta.modified);
 }

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -524,6 +524,7 @@ impl Editor {
 
         // Check for results from a previous background poll
         let mut any_refreshed = false;
+        let mut dir_poll_pending = false;
         if let Some(ref rx) = self.pending_dir_poll_rx {
             match rx.try_recv() {
                 Ok((dir_results, git_index_mtime)) => {
@@ -531,7 +532,7 @@ impl Editor {
                     any_refreshed = self.process_dir_poll_results(dir_results, git_index_mtime);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {
-                    return false;
+                    dir_poll_pending = true;
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                     self.pending_dir_poll_rx = None;
@@ -546,6 +547,22 @@ impl Editor {
             return any_refreshed;
         }
         self.last_file_tree_poll = self.time_source.now();
+
+        // Re-stat every loaded .gitignore and reload/drop as needed, so
+        // external edits (git pull, sed, another editor) and deletions take
+        // effect without a restart. In-editor saves already reload eagerly
+        // via finalize_save_buffer. This is sync I/O on a handful of small
+        // files — we don't need the bg thread for it.
+        if let Some(ref mut explorer) = self.file_explorer {
+            if explorer.ignore_patterns_mut().sync_gitignores_from_disk() {
+                any_refreshed = true;
+            }
+        }
+
+        // If a previous dir-poll is still in flight, don't stack another.
+        if dir_poll_pending {
+            return any_refreshed;
+        }
 
         // Resolve the git index path once (first poll only). This uses the
         // ProcessSpawner which may block briefly on the first call, but only

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -129,6 +129,18 @@ impl Editor {
             }
         }
 
+        // Reload .gitignore in the file explorer when the user saves one.
+        // Otherwise the tree keeps filtering by the old rules until restart.
+        if let Some(ref p) = path {
+            if p.file_name().and_then(|n| n.to_str()) == Some(".gitignore") {
+                if let (Some(parent), Some(explorer)) = (p.parent(), self.file_explorer.as_mut()) {
+                    if let Err(e) = explorer.load_gitignore_for_dir(parent) {
+                        tracing::warn!("Failed to reload .gitignore after save: {}", e);
+                    }
+                }
+            }
+        }
+
         // Notify LSP of save
         self.notify_lsp_save_buffer(buffer_id);
 

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -167,10 +167,14 @@ impl Editor {
         self.status_bar_visible = self.config.editor.show_status_bar;
         self.prompt_line_visible = self.config.editor.show_prompt_line;
 
-        // Re-sync the cached file-explorer width from config so a Settings UI
-        // change resizes the panel without a restart. (Drag updates the cache
-        // directly; config edits only update `self.config`.)
+        // Propagate file-explorer settings to live runtime state (IgnorePatterns
+        // and width are shadows of config, not read live on each render).
         self.file_explorer_width = self.config.file_explorer.width;
+        if let Some(ref mut explorer) = self.file_explorer {
+            let patterns = explorer.ignore_patterns_mut();
+            patterns.set_show_hidden(self.config.file_explorer.show_hidden);
+            patterns.set_show_gitignored(self.config.file_explorer.show_gitignored);
+        }
 
         // On Windows, switch mouse tracking mode when mouse_hover_enabled changes.
         // Mode 1003 (all motion) is used for hover; mode 1002 (cell motion) otherwise.

--- a/crates/fresh-editor/src/view/file_tree/ignore.rs
+++ b/crates/fresh-editor/src/view/file_tree/ignore.rs
@@ -63,75 +63,56 @@ impl IgnorePatterns {
         }
     }
 
-    /// Load .gitignore file from a directory
+    /// Install a gitignore for `dir` from already-read bytes.
     ///
-    /// This should be called when expanding a directory to load its .gitignore
-    pub fn load_gitignore(&mut self, dir: &Path) -> std::io::Result<()> {
-        let gitignore_path = dir.join(".gitignore");
-
-        if !gitignore_path.exists() {
-            return Ok(()); // No .gitignore, nothing to load
-        }
-
+    /// I/O lives in the caller (the editor's filesystem authority), keeping
+    /// this module pure so it works uniformly over local and remote trees.
+    /// Pass `mtime` so the poll can later detect external changes.
+    pub fn load_gitignore_from_bytes(
+        &mut self,
+        dir: &Path,
+        contents: &[u8],
+        mtime: Option<SystemTime>,
+    ) {
         let mut builder = GitignoreBuilder::new(dir);
-        builder.add(&gitignore_path);
+        let source = dir.join(".gitignore");
+        for line in contents.split(|&b| b == b'\n') {
+            let line = std::str::from_utf8(line).unwrap_or("");
+            if let Err(e) = builder.add_line(Some(source.clone()), line) {
+                tracing::warn!("Malformed .gitignore line in {:?}: {}", source, e);
+            }
+        }
 
         match builder.build() {
             Ok(gitignore) => {
-                let mtime = std::fs::metadata(&gitignore_path)
-                    .ok()
-                    .and_then(|m| m.modified().ok());
-                // Remove any existing gitignore for this directory
                 self.gitignores.retain(|(path, _)| path != dir);
-                // Add new gitignore
                 self.gitignores.push((dir.to_path_buf(), gitignore));
                 if let Some(mtime) = mtime {
                     self.gitignore_mtimes.insert(dir.to_path_buf(), mtime);
+                } else {
+                    self.gitignore_mtimes.remove(dir);
                 }
-                Ok(())
             }
             Err(e) => {
-                tracing::warn!("Failed to load .gitignore from {:?}: {}", gitignore_path, e);
-                Ok(()) // Don't fail if .gitignore is malformed
+                tracing::warn!("Failed to build .gitignore for {:?}: {}", dir, e);
             }
         }
     }
 
-    /// Re-check every currently-loaded `.gitignore` on disk, reloading those
-    /// whose mtime has changed and dropping those that have been deleted.
-    ///
-    /// Returns `true` if anything changed (so the caller knows to re-render).
-    pub fn sync_gitignores_from_disk(&mut self) -> bool {
-        let dirs: Vec<PathBuf> = self.gitignores.iter().map(|(d, _)| d.clone()).collect();
-        let mut changed = false;
+    /// Drop any loaded gitignore for `dir`.
+    pub fn remove_gitignore(&mut self, dir: &Path) {
+        self.gitignores.retain(|(d, _)| d != dir);
+        self.gitignore_mtimes.remove(dir);
+    }
 
-        for dir in dirs {
-            let gitignore_path = dir.join(".gitignore");
-            let current_mtime = std::fs::metadata(&gitignore_path)
-                .ok()
-                .and_then(|m| m.modified().ok());
+    /// Dirs for which a gitignore is currently loaded.
+    pub fn loaded_gitignore_dirs(&self) -> Vec<PathBuf> {
+        self.gitignores.iter().map(|(d, _)| d.clone()).collect()
+    }
 
-            match current_mtime {
-                None => {
-                    // File vanished — drop the entry.
-                    self.gitignores.retain(|(d, _)| d != &dir);
-                    self.gitignore_mtimes.remove(&dir);
-                    changed = true;
-                }
-                Some(mtime) => {
-                    let stored = self.gitignore_mtimes.get(&dir).copied();
-                    if stored != Some(mtime) {
-                        // Content changed — reload. load_gitignore overwrites
-                        // the entry and stores the new mtime.
-                        if self.load_gitignore(&dir).is_ok() {
-                            changed = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        changed
+    /// Mtime recorded when the gitignore for `dir` was last loaded.
+    pub fn stored_gitignore_mtime(&self, dir: &Path) -> Option<SystemTime> {
+        self.gitignore_mtimes.get(dir).copied()
     }
 
     /// Add a custom glob pattern to ignore
@@ -302,9 +283,6 @@ fn is_hidden_name(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::io::Write;
-    use tempfile::TempDir;
 
     #[test]
     fn test_hidden_file_detection() {
@@ -355,22 +333,14 @@ mod tests {
     }
 
     #[test]
-    fn test_gitignore_loading() -> std::io::Result<()> {
-        let temp_dir = TempDir::new()?;
-        let gitignore_path = temp_dir.path().join(".gitignore");
-
-        let mut file = fs::File::create(&gitignore_path)?;
-        writeln!(file, "*.log")?;
-        writeln!(file, "build/")?;
-        writeln!(file, "# Comment")?;
-        writeln!(file, "!important.log")?;
-
+    fn test_gitignore_loading() {
         let mut patterns = IgnorePatterns::new();
-        patterns.load_gitignore(temp_dir.path())?;
-
+        patterns.load_gitignore_from_bytes(
+            Path::new("/foo"),
+            b"*.log\nbuild/\n# Comment\n!important.log\n",
+            None,
+        );
         assert_eq!(patterns.gitignore_count(), 1);
-
-        Ok(())
     }
 
     #[test]
@@ -402,72 +372,55 @@ mod tests {
     }
 
     #[test]
-    fn test_hidden_gitignored_respects_gitignore_filter() -> std::io::Result<()> {
+    fn test_hidden_gitignored_respects_gitignore_filter() {
         // Regression test for #1388: a file that is both hidden (starts with '.')
         // and matched by .gitignore must stay hidden when `show_gitignored` is
         // false, even if `show_hidden` is true. Hidden ≠ gitignored, and the
         // user's choice to hide gitignored files should take precedence.
-        let temp_dir = TempDir::new()?;
-        let mut gitignore = fs::File::create(temp_dir.path().join(".gitignore"))?;
-        writeln!(gitignore, ".DS_Store")?;
-        drop(gitignore);
-
+        let root = Path::new("/repo");
         let mut patterns = IgnorePatterns::new();
-        patterns.load_gitignore(temp_dir.path())?;
+        patterns.load_gitignore_from_bytes(root, b".DS_Store\n", None);
         patterns.set_show_hidden(true);
         patterns.set_show_gitignored(false);
 
-        let ds_store = temp_dir.path().join(".DS_Store");
+        let ds_store = root.join(".DS_Store");
         assert!(
             patterns.is_ignored(&ds_store, false),
             ".DS_Store is gitignored; should be hidden despite show_hidden=true"
         );
 
         // A hidden file NOT in .gitignore should still be shown.
-        let gitignore_file = temp_dir.path().join(".gitignore");
+        let gitignore_file = root.join(".gitignore");
         assert!(
             !patterns.is_ignored(&gitignore_file, false),
             ".gitignore is hidden but not gitignored; should be visible \
              when show_hidden=true"
         );
 
-        // Conversely, when show_gitignored is true, the file reappears even
-        // if show_hidden is false (gitignored filter is independent).
+        // With show_hidden=false, the hidden filter hides .DS_Store on its own
+        // regardless of the gitignore filter state.
         patterns.set_show_hidden(false);
         patterns.set_show_gitignored(true);
         assert!(
             patterns.is_ignored(&ds_store, false),
-            ".DS_Store is still hidden, should respect show_hidden=false"
+            "show_hidden=false still hides .DS_Store (hidden filter)"
         );
 
         // Both filters disabled → fully visible.
         patterns.set_show_hidden(true);
         patterns.set_show_gitignored(true);
         assert!(!patterns.is_ignored(&ds_store, false));
-
-        Ok(())
     }
 
     #[test]
-    fn test_multiple_gitignores() -> std::io::Result<()> {
-        let temp_root = TempDir::new()?;
-        let sub_dir = temp_root.path().join("subdir");
-        fs::create_dir(&sub_dir)?;
-
-        // Root .gitignore
-        let mut root_gitignore = fs::File::create(temp_root.path().join(".gitignore"))?;
-        writeln!(root_gitignore, "*.tmp")?;
-
-        // Subdir .gitignore
-        let mut sub_gitignore = fs::File::create(sub_dir.join(".gitignore"))?;
-        writeln!(sub_gitignore, "*.bak")?;
+    fn test_multiple_gitignores() {
+        let root = Path::new("/repo");
+        let sub = root.join("subdir");
 
         let mut patterns = IgnorePatterns::new();
-        patterns.load_gitignore(temp_root.path())?;
-        patterns.load_gitignore(&sub_dir)?;
+        patterns.load_gitignore_from_bytes(root, b"*.tmp\n", None);
+        patterns.load_gitignore_from_bytes(&sub, b"*.bak\n", None);
 
         assert_eq!(patterns.gitignore_count(), 2);
-
-        Ok(())
     }
 }

--- a/crates/fresh-editor/src/view/file_tree/ignore.rs
+++ b/crates/fresh-editor/src/view/file_tree/ignore.rs
@@ -9,7 +9,9 @@
 //! compatible with git's ignore rules.
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 /// Status of a file/directory with respect to ignore patterns
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +33,10 @@ pub struct IgnorePatterns {
     /// Key: directory path, Value: gitignore rules for that directory
     gitignores: Vec<(PathBuf, Gitignore)>,
 
+    /// Mtime of each loaded .gitignore at load time. Used to detect
+    /// external edits and deletions during the file-tree poll.
+    gitignore_mtimes: HashMap<PathBuf, SystemTime>,
+
     /// Custom glob patterns to ignore
     custom_patterns: Vec<String>,
 
@@ -49,6 +55,7 @@ impl IgnorePatterns {
     pub fn new() -> Self {
         Self {
             gitignores: Vec::new(),
+            gitignore_mtimes: HashMap::new(),
             custom_patterns: Vec::new(),
             show_hidden: false,
             show_gitignored: false,
@@ -71,10 +78,16 @@ impl IgnorePatterns {
 
         match builder.build() {
             Ok(gitignore) => {
+                let mtime = std::fs::metadata(&gitignore_path)
+                    .ok()
+                    .and_then(|m| m.modified().ok());
                 // Remove any existing gitignore for this directory
                 self.gitignores.retain(|(path, _)| path != dir);
                 // Add new gitignore
                 self.gitignores.push((dir.to_path_buf(), gitignore));
+                if let Some(mtime) = mtime {
+                    self.gitignore_mtimes.insert(dir.to_path_buf(), mtime);
+                }
                 Ok(())
             }
             Err(e) => {
@@ -82,6 +95,43 @@ impl IgnorePatterns {
                 Ok(()) // Don't fail if .gitignore is malformed
             }
         }
+    }
+
+    /// Re-check every currently-loaded `.gitignore` on disk, reloading those
+    /// whose mtime has changed and dropping those that have been deleted.
+    ///
+    /// Returns `true` if anything changed (so the caller knows to re-render).
+    pub fn sync_gitignores_from_disk(&mut self) -> bool {
+        let dirs: Vec<PathBuf> = self.gitignores.iter().map(|(d, _)| d.clone()).collect();
+        let mut changed = false;
+
+        for dir in dirs {
+            let gitignore_path = dir.join(".gitignore");
+            let current_mtime = std::fs::metadata(&gitignore_path)
+                .ok()
+                .and_then(|m| m.modified().ok());
+
+            match current_mtime {
+                None => {
+                    // File vanished — drop the entry.
+                    self.gitignores.retain(|(d, _)| d != &dir);
+                    self.gitignore_mtimes.remove(&dir);
+                    changed = true;
+                }
+                Some(mtime) => {
+                    let stored = self.gitignore_mtimes.get(&dir).copied();
+                    if stored != Some(mtime) {
+                        // Content changed — reload. load_gitignore overwrites
+                        // the entry and stores the new mtime.
+                        if self.load_gitignore(&dir).is_ok() {
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        changed
     }
 
     /// Add a custom glob pattern to ignore
@@ -222,6 +272,7 @@ impl IgnorePatterns {
     /// Clear all gitignore rules
     pub fn clear_gitignores(&mut self) {
         self.gitignores.clear();
+        self.gitignore_mtimes.clear();
     }
 
     /// Clear all custom patterns

--- a/crates/fresh-editor/src/view/file_tree/ignore.rs
+++ b/crates/fresh-editor/src/view/file_tree/ignore.rs
@@ -100,29 +100,29 @@ impl IgnorePatterns {
 
     /// Check if a path should be ignored
     ///
-    /// Returns true if the file should be hidden from the tree
+    /// Each filter (hidden / custom / gitignored) is evaluated independently:
+    /// a file is hidden from the tree if *any* enabled filter matches it. This
+    /// way a file that is both hidden and gitignored still disappears when
+    /// gitignored files are hidden, even if hidden files are shown.
     pub fn is_ignored(&self, path: &Path, is_dir: bool) -> bool {
-        let status = self.get_status(path, is_dir);
-
-        match status {
-            IgnoreStatus::Visible => false,
-            IgnoreStatus::GitIgnored => !self.show_gitignored,
-            IgnoreStatus::Hidden => !self.show_hidden,
-            IgnoreStatus::CustomIgnored => !self.show_custom_ignored,
+        if !self.show_hidden && is_hidden_name(path) {
+            return true;
         }
+        if !self.show_custom_ignored && self.matches_custom_pattern(path) {
+            return true;
+        }
+        if !self.show_gitignored && self.matches_gitignore(path, is_dir) {
+            return true;
+        }
+        false
     }
 
     /// Get the ignore status of a path
     ///
     /// This is useful for rendering (e.g., gray out ignored files)
     pub fn get_status(&self, path: &Path, is_dir: bool) -> IgnoreStatus {
-        // Check if hidden (starts with .)
-        if let Some(name) = path.file_name() {
-            if let Some(name_str) = name.to_str() {
-                if name_str.starts_with('.') && name_str != ".." && name_str != "." {
-                    return IgnoreStatus::Hidden;
-                }
-            }
+        if is_hidden_name(path) {
+            return IgnoreStatus::Hidden;
         }
 
         // Check custom patterns
@@ -241,6 +241,13 @@ impl Default for IgnorePatterns {
     }
 }
 
+fn is_hidden_name(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.starts_with('.') && n != "." && n != "..")
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -341,6 +348,53 @@ mod tests {
 
         patterns.set_show_gitignored(false);
         assert!(!patterns.show_gitignored());
+    }
+
+    #[test]
+    fn test_hidden_gitignored_respects_gitignore_filter() -> std::io::Result<()> {
+        // Regression test for #1388: a file that is both hidden (starts with '.')
+        // and matched by .gitignore must stay hidden when `show_gitignored` is
+        // false, even if `show_hidden` is true. Hidden ≠ gitignored, and the
+        // user's choice to hide gitignored files should take precedence.
+        let temp_dir = TempDir::new()?;
+        let mut gitignore = fs::File::create(temp_dir.path().join(".gitignore"))?;
+        writeln!(gitignore, ".DS_Store")?;
+        drop(gitignore);
+
+        let mut patterns = IgnorePatterns::new();
+        patterns.load_gitignore(temp_dir.path())?;
+        patterns.set_show_hidden(true);
+        patterns.set_show_gitignored(false);
+
+        let ds_store = temp_dir.path().join(".DS_Store");
+        assert!(
+            patterns.is_ignored(&ds_store, false),
+            ".DS_Store is gitignored; should be hidden despite show_hidden=true"
+        );
+
+        // A hidden file NOT in .gitignore should still be shown.
+        let gitignore_file = temp_dir.path().join(".gitignore");
+        assert!(
+            !patterns.is_ignored(&gitignore_file, false),
+            ".gitignore is hidden but not gitignored; should be visible \
+             when show_hidden=true"
+        );
+
+        // Conversely, when show_gitignored is true, the file reappears even
+        // if show_hidden is false (gitignored filter is independent).
+        patterns.set_show_hidden(false);
+        patterns.set_show_gitignored(true);
+        assert!(
+            patterns.is_ignored(&ds_store, false),
+            ".DS_Store is still hidden, should respect show_hidden=false"
+        );
+
+        // Both filters disabled → fully visible.
+        patterns.set_show_hidden(true);
+        patterns.set_show_gitignored(true);
+        assert!(!patterns.is_ignored(&ds_store, false));
+
+        Ok(())
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -369,11 +369,16 @@ impl FileTreeView {
         }
     }
 
-    /// Load .gitignore for a directory
-    ///
-    /// This should be called when expanding a directory to load its .gitignore
-    pub fn load_gitignore_for_dir(&mut self, dir_path: &std::path::Path) -> std::io::Result<()> {
-        self.ignore_patterns.load_gitignore(dir_path)
+    /// Install a gitignore for `dir_path` from already-read bytes. Caller
+    /// performs the I/O via the editor's filesystem authority.
+    pub fn load_gitignore_from_bytes(
+        &mut self,
+        dir_path: &std::path::Path,
+        contents: &[u8],
+        mtime: Option<std::time::SystemTime>,
+    ) {
+        self.ignore_patterns
+            .load_gitignore_from_bytes(dir_path, contents, mtime);
     }
 
     /// Expand all parent directories and select the given file path

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3013,6 +3013,71 @@ fn test_external_gitignore_edit_and_delete_reload_via_poll() {
     );
 }
 
+/// Creating a .gitignore externally in an already-expanded directory must
+/// be picked up by the poll: the dir's mtime bumps, refresh_node re-lists,
+/// and the rules for that dir get loaded for the first time.
+#[test]
+fn test_externally_creating_gitignore_loads_rules_via_poll() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    fs::write(project_root.join("foo.txt"), "").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.render().unwrap();
+
+    // Sanity: no gitignore loaded at start.
+    assert_eq!(
+        harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .loaded_gitignore_dirs()
+            .len(),
+        0
+    );
+
+    // Prime the dir-mtime store so the later change is detected as a
+    // difference, not as a first-sighting. Two ticks: spawn + receive.
+    harness.advance_time(std::time::Duration::from_secs(5));
+    harness.editor_mut().poll_file_tree_changes();
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    harness.advance_time(std::time::Duration::from_secs(5));
+    harness.editor_mut().poll_file_tree_changes();
+
+    // Externally create a .gitignore that matches foo.txt. Sleep past 1s
+    // filesystem mtime granularity so the parent dir's mtime is distinguishable.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    fs::write(project_root.join(".gitignore"), "foo.txt\n").unwrap();
+
+    // First tick spawns the bg dir-poll; subsequent ticks process its
+    // results (where refresh_node + reload-gitignore runs). Advance time
+    // past the poll interval on every iteration so the guard lets us in.
+    let foo = project_root.join("foo.txt");
+    let mut picked_up = false;
+    for _ in 0..50 {
+        harness.advance_time(std::time::Duration::from_secs(5));
+        harness.editor_mut().poll_file_tree_changes();
+        if harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&foo, false)
+        {
+            picked_up = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    assert!(
+        picked_up,
+        "new .gitignore should be loaded via dir-mtime poll + refresh path"
+    );
+}
+
 /// Helper: find the right border column of the file explorer on screen.
 ///
 /// Scans for the box-drawing corner characters that ratatui's `Block` draws

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2950,6 +2950,69 @@ fn test_saving_nested_gitignore_reloads_for_that_dir() {
     );
 }
 
+/// External edits to a .gitignore must be picked up by the file-tree poll,
+/// and deleting a .gitignore must drop its rules.
+#[test]
+fn test_external_gitignore_edit_and_delete_reload_via_poll() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let gitignore_path = project_root.join(".gitignore");
+    fs::write(&gitignore_path, "foo.txt\n").unwrap();
+    fs::write(project_root.join("foo.txt"), "").unwrap();
+    fs::write(project_root.join("bar.txt"), "").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.render().unwrap();
+
+    let check = |h: &EditorTestHarness, name: &str| {
+        h.editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&project_root.join(name), false)
+    };
+    assert!(
+        check(&harness, "foo.txt"),
+        "initial: foo.txt should be gitignored"
+    );
+    assert!(
+        !check(&harness, "bar.txt"),
+        "initial: bar.txt should not be gitignored"
+    );
+
+    // Sleep past typical 1s mtime granularity so the edit produces a distinct
+    // mtime. External write + poll tick.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    fs::write(&gitignore_path, "bar.txt\n").unwrap();
+    harness.advance_time(std::time::Duration::from_secs(5));
+    harness.editor_mut().poll_file_tree_changes();
+
+    assert!(
+        !check(&harness, "foo.txt"),
+        "after external edit: foo.txt should be visible"
+    );
+    assert!(
+        check(&harness, "bar.txt"),
+        "after external edit: bar.txt should be gitignored"
+    );
+
+    // Delete .gitignore — the dropped entry should no longer filter anything.
+    fs::remove_file(&gitignore_path).unwrap();
+    harness.advance_time(std::time::Duration::from_secs(5));
+    harness.editor_mut().poll_file_tree_changes();
+
+    assert!(
+        !check(&harness, "foo.txt"),
+        "after delete: foo.txt should be visible"
+    );
+    assert!(
+        !check(&harness, "bar.txt"),
+        "after delete: bar.txt should be visible"
+    );
+}
+
 /// Helper: find the right border column of the file explorer on screen.
 ///
 /// Scans for the box-drawing corner characters that ratatui's `Block` draws

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2776,6 +2776,58 @@ fn test_dotfiles_hidden_by_default_and_toggle_controls_visibility() {
     );
 }
 
+/// Regression test for https://github.com/sinelaw/fresh/issues/1388:
+/// A file that is both a dotfile and matched by .gitignore should stay hidden
+/// while "Show Gitignored Files" is off, even if "Show Hidden Files" is on.
+/// Previously the explorer classified such files as Hidden first and only
+/// consulted the hidden-files toggle, letting gitignored dotfiles slip in.
+#[test]
+fn test_hidden_gitignored_file_respects_gitignore_toggle() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    fs::write(project_root.join(".gitignore"), ".DS_Store\n").unwrap();
+    fs::write(project_root.join(".DS_Store"), "macos junk").unwrap();
+    fs::write(project_root.join("visible_file.txt"), "visible").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness
+        .wait_for_file_explorer_item("visible_file.txt")
+        .unwrap();
+
+    // Turn on "Show hidden files". "Show gitignored files" stays off.
+    harness.editor_mut().file_explorer_toggle_hidden();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(".gitignore"),
+        ".gitignore is hidden but not gitignored; should be visible with \
+         show_hidden=true.\nScreen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains(".DS_Store"),
+        ".DS_Store is gitignored AND hidden; it should stay out of the \
+         explorer while 'Show Gitignored Files' is off, regardless of \
+         'Show Hidden Files'.\nScreen:\n{}",
+        screen
+    );
+
+    // Turning on "Show gitignored files" reveals the file.
+    harness.editor_mut().file_explorer_toggle_gitignored();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(".DS_Store"),
+        ".DS_Store should be visible when both 'Show Hidden Files' and \
+         'Show Gitignored Files' are on.\nScreen:\n{}",
+        screen
+    );
+}
+
 /// Helper: find the right border column of the file explorer on screen.
 ///
 /// Scans for the box-drawing corner characters that ratatui's `Block` draws

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2828,6 +2828,128 @@ fn test_hidden_gitignored_file_respects_gitignore_toggle() {
     );
 }
 
+/// Editing .gitignore in the editor and saving must reload the patterns
+/// so the file explorer picks up the new rules without a restart.
+#[test]
+fn test_saving_gitignore_reloads_ignore_patterns() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    // Start with a .gitignore that does NOT match .target_file.
+    let gitignore_path = project_root.join(".gitignore");
+    fs::write(&gitignore_path, "other_pattern\n").unwrap();
+    fs::write(project_root.join(".target_file"), "content").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+
+    // Show hidden so .target_file would be visible on the hidden-filter side.
+    harness.editor_mut().file_explorer_toggle_hidden();
+    harness.wait_for_file_explorer_item(".target_file").unwrap();
+    assert!(
+        !harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&project_root.join(".target_file"), false),
+        "pre-save: .target_file should be visible (not yet gitignored)"
+    );
+
+    // Open .gitignore, append `.target_file`, save.
+    harness.editor_mut().open_file(&gitignore_path).unwrap();
+    harness.editor_mut().focus_editor();
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text(".target_file\n").unwrap();
+    harness.editor_mut().save().unwrap();
+    harness.render().unwrap();
+
+    // Sanity: the on-disk file really has the new rule.
+    let disk = fs::read_to_string(&gitignore_path).unwrap();
+    assert!(
+        disk.contains(".target_file"),
+        "pre-check: .gitignore on disk must contain .target_file after save. Got:\n{}",
+        disk
+    );
+
+    // After save, the new rule should be live — no restart, no manual refresh.
+    assert!(
+        harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&project_root.join(".target_file"), false),
+        "post-save: .target_file should be filtered out by the reloaded .gitignore. \
+         On-disk .gitignore:\n{}",
+        disk
+    );
+}
+
+/// Nested .gitignore — editing a per-directory .gitignore must reload patterns
+/// for that specific directory (not just the root).
+#[test]
+fn test_saving_nested_gitignore_reloads_for_that_dir() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    let subdir = project_root.join("subdir");
+    fs::create_dir(&subdir).unwrap();
+
+    let nested_gitignore = subdir.join(".gitignore");
+    fs::write(&nested_gitignore, "\n").unwrap();
+    fs::write(subdir.join(".target_file"), "content").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.editor_mut().file_explorer_toggle_hidden();
+    harness.render().unwrap();
+
+    // Before: subdir/.target_file is not matched by any loaded gitignore.
+    assert!(
+        !harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&subdir.join(".target_file"), false),
+        "pre-save: nested .target_file should not be filtered yet"
+    );
+
+    // Edit the nested .gitignore.
+    harness.editor_mut().open_file(&nested_gitignore).unwrap();
+    harness.editor_mut().focus_editor();
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text(".target_file\n").unwrap();
+    harness.editor_mut().save().unwrap();
+    harness.render().unwrap();
+
+    // Reloaded — the subdir-scoped rule is live.
+    assert!(
+        harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&subdir.join(".target_file"), false),
+        "post-save: nested .target_file should be filtered by the reloaded per-dir .gitignore"
+    );
+    // And it doesn't leak upward: a sibling file at the root is not affected.
+    fs::write(project_root.join(".target_file"), "content").unwrap();
+    assert!(
+        !harness
+            .editor()
+            .file_explorer()
+            .unwrap()
+            .ignore_patterns()
+            .is_ignored(&project_root.join(".target_file"), false),
+        "a nested .gitignore rule must not filter a same-named file at the project root"
+    );
+}
+
 /// Helper: find the right border column of the file explorer on screen.
 ///
 /// Scans for the box-drawing corner characters that ratatui's `Block` draws

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -2833,7 +2833,9 @@ fn test_hidden_gitignored_file_respects_gitignore_toggle() {
 #[test]
 fn test_saving_gitignore_reloads_ignore_patterns() {
     let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
-    let project_root = harness.project_dir().unwrap();
+    // Canonicalize so path comparisons match the tree's internal form on
+    // macOS (tempdirs live under /var/folders → /private/var/folders).
+    let project_root = harness.project_dir().unwrap().canonicalize().unwrap();
 
     // Start with a .gitignore that does NOT match .target_file.
     let gitignore_path = project_root.join(".gitignore");
@@ -2893,7 +2895,7 @@ fn test_saving_gitignore_reloads_ignore_patterns() {
 #[test]
 fn test_saving_nested_gitignore_reloads_for_that_dir() {
     let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
-    let project_root = harness.project_dir().unwrap();
+    let project_root = harness.project_dir().unwrap().canonicalize().unwrap();
     let subdir = project_root.join("subdir");
     fs::create_dir(&subdir).unwrap();
 
@@ -2955,7 +2957,7 @@ fn test_saving_nested_gitignore_reloads_for_that_dir() {
 #[test]
 fn test_external_gitignore_edit_and_delete_reload_via_poll() {
     let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
-    let project_root = harness.project_dir().unwrap();
+    let project_root = harness.project_dir().unwrap().canonicalize().unwrap();
 
     let gitignore_path = project_root.join(".gitignore");
     fs::write(&gitignore_path, "foo.txt\n").unwrap();
@@ -3019,7 +3021,7 @@ fn test_external_gitignore_edit_and_delete_reload_via_poll() {
 #[test]
 fn test_externally_creating_gitignore_loads_rules_via_poll() {
     let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
-    let project_root = harness.project_dir().unwrap();
+    let project_root = harness.project_dir().unwrap().canonicalize().unwrap();
 
     fs::write(project_root.join("foo.txt"), "").unwrap();
 

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1413,6 +1413,87 @@ fn find_settings_explorer_border_col(harness: &EditorTestHarness) -> u16 {
     );
 }
 
+/// Regression: toggling File Explorer → Show Hidden in the Settings UI and
+/// saving must update the live file explorer's IgnorePatterns, not just the
+/// config on disk. Width must also be propagated to the live explorer width.
+#[test]
+fn test_settings_file_explorer_toggles_propagate_to_runtime() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+
+    // Sanity: both toggles start off.
+    assert!(!harness
+        .editor()
+        .file_explorer()
+        .unwrap()
+        .ignore_patterns()
+        .show_hidden());
+    assert!(!harness
+        .editor()
+        .file_explorer()
+        .unwrap()
+        .ignore_patterns()
+        .show_gitignored());
+
+    harness.open_settings().unwrap();
+
+    // Navigate to File Explorer category. Order (from test_settings_percentage):
+    // General, Clipboard, Editor, File Browser, File Explorer.
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // File Explorer items (alphabetical): Custom Ignore Patterns, Preview Tabs,
+    // Respect Gitignore, Show Gitignored, Show Hidden, Width.
+    // Land on Show Gitignored and toggle.
+    for _ in 0..3 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Move to Show Hidden and toggle.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Tab to footer then navigate to Save (index 2) and press Enter.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap(); // Reset
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap(); // Save
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        !harness.editor().is_settings_open(),
+        "Settings should be closed after saving"
+    );
+
+    // Config persisted.
+    assert!(harness.config().file_explorer.show_hidden);
+    assert!(harness.config().file_explorer.show_gitignored);
+
+    // Live IgnorePatterns updated — the bug was that only the config changed
+    // and the running explorer kept its old state until next restart.
+    let patterns = harness.editor().file_explorer().unwrap().ignore_patterns();
+    assert!(
+        patterns.show_hidden(),
+        "live IgnorePatterns.show_hidden was not propagated from Settings save"
+    );
+    assert!(
+        patterns.show_gitignored(),
+        "live IgnorePatterns.show_gitignored was not propagated from Settings save"
+    );
+}
+
 /// Test number input editing mode - enter editing, type value, confirm
 #[test]
 fn test_number_input_enter_editing_mode() {


### PR DESCRIPTION
## Summary

Fixes #1388. A file that is both a dotfile and matched by `.gitignore` (e.g. `.DS_Store` with `.DS_Store` in `.gitignore`) is currently shown in the File Explorer whenever "Show Hidden Files" is on, even if "Show Gitignored Files" is off. That contradicts the user's filter setting.

Root cause: `IgnorePatterns::is_ignored` routed through `get_status`, which returns the first matching classification (hidden wins). A hidden-and-gitignored path was only ever gated by `show_hidden`; `show_gitignored` was never consulted.

Fix: evaluate each filter independently in `is_ignored` — a file is hidden from the tree if **any** enabled filter matches it. Extract the dotfile test into a small helper so both methods stay consistent.

## Test plan

- [x] `cargo test -p fresh-editor --lib view::file_tree::ignore` (7/7 pass, including new `test_hidden_gitignored_respects_gitignore_filter`)
- [x] `cargo test -p fresh-editor --test e2e_tests file_explorer` (58/58 pass, including new `test_hidden_gitignored_file_respects_gitignore_toggle`)
- [x] `cargo check --all-targets -p fresh-editor`
- [x] `cargo fmt --check`
- [x] Manual validation in tmux against a real repro (`/tmp` repo with `.gitignore` = `.DS_Store\n` + a `.DS_Store` file): with Show Hidden on and Show Gitignored off, `.DS_Store` no longer appears; toggling Show Gitignored on brings it back.
