### PR TITLE
feat(search): center match vertically when Find Next must scroll

### DIFF
--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -164,6 +164,10 @@ impl Editor {
     /// Move the primary cursor to `position`, clear its selection anchor,
     /// update the cached line number (used by the status bar), and scroll
     /// the active split so the cursor is visible.
+    ///
+    /// If the match was off-screen and required a scroll, the viewport is
+    /// vertically centered on the match to provide surrounding context
+    /// (issue #1251). Matches already visible are not re-scrolled.
     fn move_cursor_to_match(&mut self, position: usize) {
         let active_split = self.split_manager.active_split();
         let active_buffer = self.active_buffer();
@@ -175,7 +179,23 @@ impl Editor {
                 state.primary_cursor_line_number =
                     crate::model::buffer::LineNumber::Absolute(pos.line);
             }
+            let top_byte_before = view_state.viewport.top_byte;
             view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
+            if view_state.viewport.top_byte != top_byte_before {
+                // We had to scroll: recenter the match vertically so the user
+                // sees context above and below the match.
+                let viewport_height = view_state.viewport.visible_line_count();
+                let target_rows_from_top = viewport_height / 2;
+                let mut iter = state.buffer.line_iterator(position, 80);
+                for _ in 0..target_rows_from_top {
+                    if iter.prev().is_none() {
+                        break;
+                    }
+                }
+                view_state.viewport.top_byte = iter.current_position();
+                view_state.viewport.top_view_line_offset = 0;
+                view_state.viewport.set_skip_ensure_visible();
+            }
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -126,6 +126,7 @@ pub mod save_nonexistent_directory;
 pub mod scroll_clearing;
 pub mod scrolling;
 pub mod search;
+pub mod search_center_on_scroll;
 pub mod search_navigation_after_move;
 pub mod search_replace;
 pub mod select_to_paragraph;

--- a/crates/fresh-editor/tests/e2e/search_center_on_scroll.rs
+++ b/crates/fresh-editor/tests/e2e/search_center_on_scroll.rs
@@ -1,0 +1,110 @@
+//! E2E tests for vertical centering of search matches when Find Next must scroll.
+//!
+//! Covers <https://github.com/sinelaw/fresh/issues/1251>:
+//! When Find Next navigates to a match that is off-screen, the viewport is
+//! scrolled so the match is vertically centered — providing surrounding
+//! context above and below. Matches that were already visible are not
+//! re-scrolled.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// When Find Next jumps to a match far below the viewport, the viewport
+/// should end up with the match vertically centered.
+#[test]
+fn test_find_next_centers_match_when_scrolling() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+
+    let mut content = String::new();
+    for i in 0..100 {
+        if i == 2 || i == 60 {
+            content.push_str(&format!("line {} NEEDLE here\n", i));
+        } else {
+            content.push_str(&format!("line {} filler text\n", i));
+        }
+    }
+    std::fs::write(&file_path, &content).unwrap();
+
+    let viewport_rows: u16 = 24;
+    let mut harness = EditorTestHarness::new(100, viewport_rows).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("NEEDLE").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Move to the next match (line 60, off-screen below).
+    harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The viewport height available for content is less than the terminal
+    // height (status bar, search panel, etc.).  Use the editor's own reported
+    // viewport height and top line to verify centering.
+    let viewport_height = harness.viewport_height();
+    let top_line = harness.top_line_number();
+
+    // The match is on line 60 (0-indexed).  Centering places the match
+    // roughly at viewport_height / 2 rows from the top.
+    let expected_top_line = 60usize.saturating_sub(viewport_height / 2);
+    assert_eq!(
+        top_line, expected_top_line,
+        "Find Next should center the match vertically when scrolling; \
+         viewport_height={}, expected_top_line={}, got top_line={}",
+        viewport_height, expected_top_line, top_line
+    );
+}
+
+/// When the next match is already fully visible in the viewport, Find Next
+/// should not scroll or recenter — that would be surprising and discard
+/// the user's reading context.
+#[test]
+fn test_find_next_does_not_recenter_visible_match() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+
+    let mut content = String::new();
+    for i in 0..40 {
+        if i == 2 || i == 5 {
+            content.push_str(&format!("line {} NEEDLE here\n", i));
+        } else {
+            content.push_str(&format!("line {} filler text\n", i));
+        }
+    }
+    std::fs::write(&file_path, &content).unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("NEEDLE").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    let top_line_before = harness.top_line_number();
+
+    // Both matches are within the initial viewport, so Find Next should not scroll.
+    harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+    harness.process_async_and_render().unwrap();
+
+    let top_line_after = harness.top_line_number();
+    assert_eq!(
+        top_line_before, top_line_after,
+        "Find Next should not scroll when the next match is already visible"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1251.

When Find Next / Find Previous navigates to a match that lies outside the current viewport, scroll so the match sits in the vertical center instead of placing it just barely inside the scroll margin. This gives users context above and below the match without having to follow up with Ctrl+Up/Down to see surrounding lines.

Matches that are already fully visible are **not** re-scrolled, preserving the user's reading context — only the "had to scroll anyway" case is changed.

### Implementation

`move_cursor_to_match` in `crates/fresh-editor/src/app/search_ops.rs` now records `viewport.top_byte` before the existing `ensure_cursor_visible` call. If the call ended up scrolling (top_byte changed), the viewport is repositioned so the match line lands at `viewport_height / 2` rows from the top, mirroring the existing recenter / scroll-to-line-center logic. `set_skip_ensure_visible()` is set so the next render frame doesn't undo the scroll.

This single hook covers all entry points that move the cursor to a match: initial search confirmation, F3/Shift-F3, Alt+N/P, find-selection-next/previous, and the large-file / overlay-based search paths.

## Test plan

- [x] `cargo test -p fresh-editor --test e2e_tests e2e::search::` — all 43 search tests pass
- [x] `cargo test -p fresh-editor --test e2e_tests -- e2e::search_navigation_after_move:: e2e::search_replace::` — all 29 tests pass
- [x] New e2e tests in `crates/fresh-editor/tests/e2e/search_center_on_scroll.rs`:
  - `test_find_next_centers_match_when_scrolling` — verifies viewport top lands at `match_line - viewport_height/2` when scrolling is required
  - `test_find_next_does_not_recenter_visible_match` — verifies no scroll occurs when the next match is already visible
- [x] Manual validation in tmux: open a 100-line file with NEEDLE on lines 2 and 60, Ctrl+F NEEDLE Enter, then F3 — match on line 60 lands centered in the pane.
