### PR TITLE
Add JSONC (JSON with Comments) as a separate language

### DIFF
--- a/crates/fresh-editor/config.example.json
+++ b/crates/fresh-editor/config.example.json
@@ -237,12 +237,43 @@
     },
     "json": {
       "extensions": [
-        "json",
-        "jsonc"
+        "json"
       ],
       "filenames": [],
       "grammar": "json",
       "comment_prefix": null,
+      "auto_indent": true,
+      "highlighter": "auto",
+      "textmate_grammar": null,
+      "show_whitespace_tabs": true,
+      "use_tabs": false
+    },
+    "jsonc": {
+      "extensions": [
+        "jsonc"
+      ],
+      "filenames": [
+        "devcontainer.json",
+        ".devcontainer.json",
+        "tsconfig.json",
+        "tsconfig.*.json",
+        "jsconfig.json",
+        "jsconfig.*.json",
+        ".eslintrc.json",
+        ".babelrc",
+        ".babelrc.json",
+        ".swcrc",
+        ".jshintrc",
+        ".hintrc",
+        "settings.json",
+        "keybindings.json",
+        "tasks.json",
+        "launch.json",
+        "extensions.json",
+        "argv.json"
+      ],
+      "grammar": "jsonc",
+      "comment_prefix": "//",
       "auto_indent": true,
       "highlighter": "auto",
       "textmate_grammar": null,
@@ -460,6 +491,20 @@
       "initialization_options": null
     },
     "json": {
+      "command": "vscode-json-languageserver",
+      "args": [
+        "--stdio"
+      ],
+      "enabled": true,
+      "auto_start": false,
+      "process_limits": {
+        "max_memory_percent": 50,
+        "max_cpu_percent": 90,
+        "enabled": true
+      },
+      "initialization_options": null
+    },
+    "jsonc": {
       "command": "vscode-json-languageserver",
       "args": [
         "--stdio"

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -3442,10 +3442,65 @@ impl Config {
         languages.insert(
             "json".to_string(),
             LanguageConfig {
-                extensions: vec!["json".to_string(), "jsonc".to_string()],
+                extensions: vec!["json".to_string()],
                 filenames: vec![],
                 grammar: "json".to_string(),
                 comment_prefix: None,
+                auto_indent: true,
+                auto_close: None,
+                auto_surround: None,
+                textmate_grammar: None,
+                show_whitespace_tabs: true,
+                line_wrap: None,
+                wrap_column: None,
+                page_view: None,
+                page_width: None,
+                use_tabs: None,
+                tab_size: None,
+                formatter: Some(FormatterConfig {
+                    command: "prettier".to_string(),
+                    args: vec!["--stdin-filepath".to_string(), "$FILE".to_string()],
+                    stdin: true,
+                    timeout_ms: 10000,
+                }),
+                format_on_save: false,
+                on_save: vec![],
+                word_characters: None,
+            },
+        );
+
+        // JSONC — JSON with Comments. Shares the tree-sitter-json parser (via
+        // the `jsonc` grammar alias in `fresh-languages`) but keeps a separate
+        // language id so the `vscode-json-language-server` receives the
+        // correct `languageId` and well-known JSONC filenames like
+        // `devcontainer.json` and `tsconfig.json` route here instead of to
+        // strict JSON.
+        languages.insert(
+            "jsonc".to_string(),
+            LanguageConfig {
+                extensions: vec!["jsonc".to_string()],
+                filenames: vec![
+                    "devcontainer.json".to_string(),
+                    ".devcontainer.json".to_string(),
+                    "tsconfig.json".to_string(),
+                    "tsconfig.*.json".to_string(),
+                    "jsconfig.json".to_string(),
+                    "jsconfig.*.json".to_string(),
+                    ".eslintrc.json".to_string(),
+                    ".babelrc".to_string(),
+                    ".babelrc.json".to_string(),
+                    ".swcrc".to_string(),
+                    ".jshintrc".to_string(),
+                    ".hintrc".to_string(),
+                    "settings.json".to_string(),
+                    "keybindings.json".to_string(),
+                    "tasks.json".to_string(),
+                    "launch.json".to_string(),
+                    "extensions.json".to_string(),
+                    "argv.json".to_string(),
+                ],
+                grammar: "jsonc".to_string(),
+                comment_prefix: Some("//".to_string()),
                 auto_indent: true,
                 auto_close: None,
                 auto_surround: None,
@@ -5233,6 +5288,27 @@ impl Config {
         // vscode-json-language-server (installed via npm install -g vscode-langservers-extracted)
         lsp.insert(
             "json".to_string(),
+            LspLanguageConfig::Multi(vec![LspServerConfig {
+                command: "vscode-json-language-server".to_string(),
+                args: vec!["--stdio".to_string()],
+                enabled: true,
+                auto_start: false,
+                process_limits: ProcessLimits::default(),
+                initialization_options: None,
+                env: Default::default(),
+                language_id_overrides: Default::default(),
+                name: None,
+                only_features: None,
+                except_features: None,
+                root_markers: Default::default(),
+            }]),
+        );
+
+        // Same server handles JSONC — the vscode-json-language-server accepts
+        // the `jsonc` languageId and enables comment/trailing-comma tolerance
+        // plus schema associations for well-known files.
+        lsp.insert(
+            "jsonc".to_string(),
             LspLanguageConfig::Multi(vec![LspServerConfig {
                 command: "vscode-json-language-server".to_string(),
                 args: vec!["--stdio".to_string()],

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -125,6 +125,11 @@ impl IndentCalculator {
                 fresh_languages::tree_sitter_json::LANGUAGE.into(),
                 include_str!("../../queries/json/indents.scm"),
             ),
+            Language::Jsonc => (
+                "jsonc",
+                fresh_languages::tree_sitter_json::LANGUAGE.into(),
+                include_str!("../../queries/json/indents.scm"),
+            ),
             Language::Ruby => (
                 "ruby",
                 fresh_languages::tree_sitter_ruby::LANGUAGE.into(),

--- a/crates/fresh-editor/src/primitives/reference_highlighter.rs
+++ b/crates/fresh-editor/src/primitives/reference_highlighter.rs
@@ -220,6 +220,7 @@ impl ReferenceHighlighter {
             Language::Lua => fresh_languages::tree_sitter_lua::LANGUAGE.into(),
             Language::Pascal => fresh_languages::tree_sitter_pascal::LANGUAGE.into(),
             Language::Json => fresh_languages::tree_sitter_json::LANGUAGE.into(),
+            Language::Jsonc => fresh_languages::tree_sitter_json::LANGUAGE.into(),
             Language::HTML => fresh_languages::tree_sitter_html::LANGUAGE.into(),
             Language::CSS => fresh_languages::tree_sitter_css::LANGUAGE.into(),
             Language::CSharp => fresh_languages::tree_sitter_c_sharp::LANGUAGE.into(),

--- a/crates/fresh-languages/src/lib.rs
+++ b/crates/fresh-languages/src/lib.rs
@@ -161,6 +161,7 @@ pub enum Language {
     Cpp,
     Go,
     Json,
+    Jsonc,
     Java,
     CSharp,
     Php,
@@ -366,6 +367,27 @@ impl Language {
                 #[cfg(not(feature = "tree-sitter-json"))]
                 Err("JSON language support not enabled".to_string())
             }
+            Self::Jsonc => {
+                // JSONC (JSON with Comments) reuses the tree-sitter-json parser.
+                // A dedicated JSONC grammar isn't published as a Rust crate; the
+                // JSON parser recovers past comments and trailing commas well
+                // enough for highlighting, which is the only consumer here.
+                #[cfg(feature = "tree-sitter-json")]
+                {
+                    let mut config = HighlightConfiguration::new(
+                        tree_sitter_json::LANGUAGE.into(),
+                        "jsonc",
+                        tree_sitter_json::HIGHLIGHTS_QUERY,
+                        "",
+                        "",
+                    )
+                    .map_err(|e| format!("Failed to create JSONC highlight config: {e}"))?;
+                    config.configure(DEFAULT_HIGHLIGHT_CAPTURES);
+                    Ok(config)
+                }
+                #[cfg(not(feature = "tree-sitter-json"))]
+                Err("JSONC language support not enabled".to_string())
+            }
             Self::Java => {
                 #[cfg(feature = "tree-sitter-java")]
                 {
@@ -528,6 +550,7 @@ impl Language {
             Language::Cpp,
             Language::Go,
             Language::Json,
+            Language::Jsonc,
             Language::Java,
             Language::CSharp,
             Language::Php,
@@ -552,6 +575,7 @@ impl Language {
             Self::Cpp => "cpp",
             Self::Go => "go",
             Self::Json => "json",
+            Self::Jsonc => "jsonc",
             Self::Java => "java",
             Self::CSharp => "csharp",
             Self::Php => "php",
@@ -596,6 +620,7 @@ impl Language {
             Self::Cpp => &["cpp", "hpp", "cc", "hh", "cxx", "hxx", "cppm", "ixx"],
             Self::Go => &["go"],
             Self::Json => &["json"],
+            Self::Jsonc => &["jsonc"],
             Self::Java => &["java"],
             Self::CSharp => &["cs"],
             Self::Php => &["php"],
@@ -620,6 +645,7 @@ impl Language {
             Self::Cpp => "C++",
             Self::Go => "Go",
             Self::Json => "JSON",
+            Self::Jsonc => "JSON with Comments",
             Self::Java => "Java",
             Self::CSharp => "C#",
             Self::Php => "PHP",
@@ -645,6 +671,7 @@ impl Language {
             "cpp" | "c++" => Some(Self::Cpp),
             "go" => Some(Self::Go),
             "json" => Some(Self::Json),
+            "jsonc" => Some(Self::Jsonc),
             "java" => Some(Self::Java),
             "c_sharp" | "c#" | "csharp" => Some(Self::CSharp),
             "php" => Some(Self::Php),
@@ -686,6 +713,7 @@ impl Language {
             "c++" => Some(Self::Cpp),
             "go" | "golang" => Some(Self::Go),
             "json" => Some(Self::Json),
+            "jsonc" | "json with comments" => Some(Self::Jsonc),
             "java" => Some(Self::Java),
             "c#" => Some(Self::CSharp),
             "php" => Some(Self::Php),


### PR DESCRIPTION
## Summary
This PR introduces JSONC (JSON with Comments) as a distinct language configuration, separate from strict JSON. This allows the editor to properly handle well-known JSONC filenames and provide appropriate language server support with comment tolerance.

## Key Changes
- **Language Configuration**: Split JSON and JSONC into separate language entries
  - JSON now only handles `.json` extension
  - JSONC handles `.jsonc` extension and well-known JSONC filenames (tsconfig.json, jsconfig.json, devcontainer.json, .eslintrc.json, .babelrc, etc.)
  
- **Language Server Support**: Added dedicated LSP configuration for JSONC
  - Both JSON and JSONC use `vscode-json-language-server`
  - Server receives correct `languageId` ("jsonc") to enable comment/trailing-comma tolerance
  - Schema associations work correctly for well-known JSONC files

- **Language Enum**: Added `Language::Jsonc` variant to `fresh-languages`
  - Reuses tree-sitter-json parser (no separate JSONC parser needed)
  - Uses "jsonc" grammar alias for syntax highlighting
  - Properly integrated into language detection and metadata methods

- **Indentation Support**: Added JSONC to indent calculator using shared JSON indentation rules

- **Configuration Examples**: Updated example config to reflect the new JSONC language setup

## Implementation Details
- JSONC reuses the tree-sitter-json parser since a dedicated JSONC parser isn't available as a Rust crate
- The JSON parser handles comments and trailing commas well enough for highlighting purposes
- Comment prefix is set to "//" for JSONC
- Prettier formatter is configured for JSONC with appropriate options

https://claude.ai/code/session_01NvNgp6DchSHmfz9EDoV4oL