### PR TITLE
Make action popups editor-level to persist across buffer switches

### DIFF
--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -1063,29 +1063,36 @@ if (findConfig()) {
 
   editor.debug("Dev Container plugin initialized: " + name);
 
-  // Skip the attach prompt whenever a non-local authority is already
-  // installed. This covers the (common) case of the post-attach
-  // restart reloading the plugin with the container authority in
-  // effect — the user already said yes, don't ask again. We look at
-  // the authority label rather than plugin global state because state
-  // is per-Editor and is wiped by the restart; the label survives
-  // because it lives on the fresh Editor's authority.
-  const authorityLabel = editor.getAuthorityLabel();
-  const alreadyAttached = authorityLabel.length > 0;
-
-  if (!alreadyAttached) {
+  // Decide whether to surface the attach prompt AFTER main.rs installs
+  // the boot authority. When the plugin's top-level body runs, the
+  // editor is still being constructed and `authority.display_label` is
+  // whatever the default Authority carried during Editor construction —
+  // which is empty even on the post-attach restart, because the real
+  // container authority is only installed via `set_boot_authority`
+  // (called right before `plugins_loaded` fires). Deferring to this
+  // hook means `getAuthorityLabel()` reads the freshly-refreshed
+  // snapshot and we don't re-prompt a user who already attached.
+  function devcontainer_maybe_show_attach_prompt(): void {
+    const authorityLabel = editor.getAuthorityLabel();
+    const alreadyAttached = authorityLabel.length > 0;
+    if (alreadyAttached) {
+      editor.debug(
+        "Dev Container plugin: authority '" + authorityLabel + "' already installed, skipping attach prompt",
+      );
+      return;
+    }
     // One-shot per-session dismissal: if the user already said "Not
     // now" in this Editor process, don't re-prompt. On a cold restart
     // the state is gone and we ask again — that's fine.
     const previousDecision = readAttachDecision();
-    if (previousDecision === null) {
-      showAttachPrompt();
-    }
-  } else {
-    editor.debug(
-      "Dev Container plugin: authority '" + authorityLabel + "' already installed, skipping attach prompt",
-    );
+    if (previousDecision !== null) return;
+    showAttachPrompt();
   }
+  registerHandler(
+    "devcontainer_maybe_show_attach_prompt",
+    devcontainer_maybe_show_attach_prompt,
+  );
+  editor.on("plugins_loaded", "devcontainer_maybe_show_attach_prompt");
 } else {
   editor.debug("Dev Container plugin: no devcontainer.json found");
 }

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -479,8 +479,16 @@ impl Editor {
     /// only, where the editor is still being set up and there is no
     /// user-visible state to preserve. Do not call this from the event
     /// loop — use `install_authority` for that.
+    ///
+    /// Also refreshes the plugin state snapshot so hooks that fire after
+    /// this call (notably `plugins_loaded`, fired by `main.rs` right
+    /// after `set_boot_authority`) see the real `authority_label` instead
+    /// of the empty string the temporary `Authority::local()` carried
+    /// during construction.
     pub fn set_boot_authority(&mut self, authority: crate::services::authority::Authority) {
         self.authority = authority;
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
     }
 
     /// Read-only access to the active authority.

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -752,7 +752,7 @@ impl Editor {
             search_scan: search_scan::SearchScan::default(),
             search_overlay_top_byte: None,
             review_hunks: Vec::new(),
-            active_action_popup: None,
+            active_action_popup: Vec::new(),
             global_popups: crate::view::popup::PopupManager::new(),
             composite_buffers: HashMap::new(),
             composite_view_states: HashMap::new(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -753,6 +753,7 @@ impl Editor {
             search_overlay_top_byte: None,
             review_hunks: Vec::new(),
             active_action_popup: None,
+            global_popups: crate::view::popup::PopupManager::new(),
             composite_buffers: HashMap::new(),
             composite_view_states: HashMap::new(),
         };

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -687,8 +687,6 @@ impl Editor {
             #[cfg(feature = "plugins")]
             plugin_render_requested: false,
             chord_state: Vec::new(),
-            pending_lsp_confirmation: None,
-            pending_lsp_status_popup: None,
             user_dismissed_lsp_languages: std::collections::HashSet::new(),
             auto_start_prompted_languages: std::collections::HashSet::new(),
             pending_auto_start_prompts: std::collections::HashSet::new(),
@@ -752,7 +750,6 @@ impl Editor {
             search_scan: search_scan::SearchScan::default(),
             search_overlay_top_byte: None,
             review_hunks: Vec::new(),
-            active_action_popup: Vec::new(),
             global_popups: crate::view::popup::PopupManager::new(),
             composite_buffers: HashMap::new(),
             composite_view_states: HashMap::new(),

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -13,7 +13,7 @@ impl Editor {
             KeyContext::Menu
         } else if self.is_prompting() {
             KeyContext::Prompt
-        } else if self.active_state().popups.is_visible() {
+        } else if self.global_popups.is_visible() || self.active_state().popups.is_visible() {
             KeyContext::Popup
         } else if self.is_composite_buffer(self.active_buffer()) {
             KeyContext::CompositeBuffer
@@ -80,9 +80,14 @@ impl Editor {
         // Special case: Hover and Signature Help popups should be dismissed on any key press
         // EXCEPT for Ctrl+C when the popup has a text selection (allow copy first)
         if matches!(context, crate::input::keybindings::KeyContext::Popup) {
-            // Check if the current popup is transient (hover, signature help)
+            // Check if the current popup is transient (hover, signature help).
+            // Editor-level popups always take precedence over buffer popups
+            // when both are visible — they're effectively modal overlays.
             let (is_transient_popup, has_selection) = {
-                let popup = self.active_state().popups.top();
+                let popup = self
+                    .global_popups
+                    .top()
+                    .or_else(|| self.active_state().popups.top());
                 (
                     popup.is_some_and(|p| p.transient),
                     popup.is_some_and(|p| p.has_selection()),
@@ -442,9 +447,13 @@ impl Editor {
                 }
             },
             Action::Copy => {
-                // Check if there's an active popup with text selection
-                let state = self.active_state();
-                if let Some(popup) = state.popups.top() {
+                // Check if there's an active popup with text selection.
+                // Editor-level popups take precedence over buffer popups.
+                let popup = self
+                    .global_popups
+                    .top()
+                    .or_else(|| self.active_state().popups.top());
+                if let Some(popup) = popup {
                     if popup.has_selection() {
                         if let Some(text) = popup.get_selected_text() {
                             self.clipboard.copy(text);

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -22,6 +22,7 @@ impl Editor {
     pub fn dispatch_terminal_input(&mut self, event: &KeyEvent) -> Option<InputResult> {
         // Skip if we're in a prompt/popup (those need to handle keys normally)
         let in_modal = self.is_prompting()
+            || self.global_popups.is_visible()
             || self.active_state().popups.is_visible()
             || self.menu_state.active_menu.is_some()
             || self.settings_state.as_ref().is_some_and(|s| s.visible)
@@ -170,6 +171,20 @@ impl Editor {
                     return Some(result);
                 }
             }
+        }
+
+        // Editor-level (global) popups take precedence over buffer popups so
+        // that plugin notifications stay focused even when the active buffer
+        // owns its own popup stack.
+        if self.global_popups.is_visible() {
+            let result = self.global_popups.dispatch_input(event, &mut ctx);
+            self.process_deferred_actions(ctx);
+            if result != InputResult::Ignored {
+                return Some(result);
+            }
+            // Re-check visibility — the dispatch may have queued a ClosePopup
+            // that the deferred-action processor has now fired.
+            return None;
         }
 
         // Popup is next

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -193,6 +193,7 @@ impl Editor {
             // Convert PopupData to Popup and use show_or_replace to avoid stacking
             let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
             popup_obj.accept_key_hint = accept_hint;
+            popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
             state.popups.show_or_replace(popup_obj);
         }
 
@@ -647,6 +648,7 @@ impl Editor {
         let state = self.buffers.get_mut(&buffer_id).unwrap();
         let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
         popup_obj.accept_key_hint = accept_hint;
+        popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
         state.popups.show_or_replace(popup_obj);
     }
 
@@ -1720,6 +1722,10 @@ impl Editor {
         popup.max_height = 15;
         popup.border_style = Style::default().fg(self.theme.popup_border_fg);
         popup.background_style = Style::default().bg(self.theme.popup_bg);
+        // Confirm reads the selected row's `data` as an index into
+        // `self.pending_code_actions` — the heavy lsp_types payload
+        // stays on the Editor to keep the view crate LSP-free.
+        popup.resolver = crate::view::popup::PopupResolver::CodeAction;
 
         // Show the popup, replacing any existing action popup to avoid stacking
         if let Some(state) = self.buffers.get_mut(&self.active_buffer()) {

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1029,9 +1029,12 @@ pub struct Editor {
     /// Hunks for the Review Diff tool
     review_hunks: Vec<fresh_core::api::ReviewHunk>,
 
-    /// Active action popup (for plugin showActionPopup API)
-    /// Stores (popup_id, Vec<(action_id, action_label)>)
-    active_action_popup: Option<(String, Vec<(String, String)>)>,
+    /// Stack of active plugin action popups, parallel to `global_popups`:
+    /// each entry is `(popup_id, actions)` for the popup at the same index
+    /// in the global stack. Replaces the old single-slot tracking so two
+    /// plugins firing showActionPopup concurrently each get their own
+    /// `action_popup_result` callback when their popup is resolved.
+    active_action_popup: Vec<(String, Vec<(String, String)>)>,
 
     /// Editor-level popups that float above any buffer regardless of which
     /// one is active. Plugin notifications (showActionPopup) live here so a

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1033,6 +1033,12 @@ pub struct Editor {
     /// Stores (popup_id, Vec<(action_id, action_label)>)
     active_action_popup: Option<(String, Vec<(String, String)>)>,
 
+    /// Editor-level popups that float above any buffer regardless of which
+    /// one is active. Plugin notifications (showActionPopup) live here so a
+    /// switch to a virtual buffer (Dashboard, diagnostics panel, …) doesn't
+    /// hide them mid-decision.
+    pub(crate) global_popups: crate::view::popup::PopupManager,
+
     /// Composite buffers (separate from regular buffers)
     /// These display multiple source buffers in a single tab
     composite_buffers: HashMap<BufferId, crate::model::composite_buffer::CompositeBuffer>,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -828,15 +828,12 @@ pub struct Editor {
     /// Stores the keys pressed so far in a chord sequence
     chord_state: Vec<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)>,
 
-    /// Pending LSP confirmation - language name awaiting user confirmation
-    /// When Some, a confirmation popup is shown asking user to approve LSP spawn
-    pending_lsp_confirmation: Option<String>,
-
-    /// Pending LSP status popup - when true, the active popup is an LSP status
-    /// details popup with server actions (restart/stop/view log).
-    /// Contains the list of (action_key, label) pairs for the popup items.
-    pending_lsp_status_popup: Option<Vec<(String, String)>>,
-
+    // (Historical `pending_lsp_confirmation` and `pending_lsp_status_popup`
+    // fields moved onto `Popup::resolver` — each popup carries its own
+    // "how do I confirm?" identity, so `handle_popup_confirm` dispatches
+    // by matching the focused popup's resolver instead of racing through
+    // a precedence cascade of side-channel `Option`s that a second
+    // simultaneously-open popup could steal.)
     /// Languages the user has interactively dismissed from the LSP popup.
     ///
     /// Separate from `LspServerConfig::enabled` (which is the persisted
@@ -1029,17 +1026,13 @@ pub struct Editor {
     /// Hunks for the Review Diff tool
     review_hunks: Vec<fresh_core::api::ReviewHunk>,
 
-    /// Stack of active plugin action popups, parallel to `global_popups`:
-    /// each entry is `(popup_id, actions)` for the popup at the same index
-    /// in the global stack. Replaces the old single-slot tracking so two
-    /// plugins firing showActionPopup concurrently each get their own
-    /// `action_popup_result` callback when their popup is resolved.
-    active_action_popup: Vec<(String, Vec<(String, String)>)>,
-
     /// Editor-level popups that float above any buffer regardless of which
     /// one is active. Plugin notifications (showActionPopup) live here so a
     /// switch to a virtual buffer (Dashboard, diagnostics panel, …) doesn't
     /// hide them mid-decision.
+    ///
+    /// Each plugin popup carries its `popup_id` inside its
+    /// `PopupResolver::PluginAction` — no parallel side-channel stack.
     pub(crate) global_popups: crate::view::popup::PopupManager,
 
     /// Composite buffers (separate from regular buffers)

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -731,6 +731,17 @@ impl Editor {
 
     /// Check if mouse position is over any popup (including non-transient ones like completion)
     fn is_mouse_over_any_popup(&self, col: u16, row: u16) -> bool {
+        // Editor-level popup overlays absorb every click within their outer
+        // rect so the buffer below doesn't receive a stray cursor placement.
+        for (_, popup_area, _, _, _) in &self.cached_layout.global_popup_areas {
+            if col >= popup_area.x
+                && col < popup_area.x + popup_area.width
+                && row >= popup_area.y
+                && row < popup_area.y + popup_area.height
+            {
+                return true;
+            }
+        }
         let layouts = popup_areas_to_layout_info(&self.cached_layout.popup_areas);
         let hit_tester = PopupHitTester::new(&layouts, &self.active_state().popups);
         hit_tester.is_over_popup(col, row)
@@ -1432,6 +1443,39 @@ impl Editor {
                 popup.scroll_by(delta);
             }
             return Ok(());
+        }
+
+        // Editor-level popups overlay buffer popups, so handle their clicks
+        // first. Mirrors the buffer-popup loop below: close-button →
+        // PopupCancel, list item → select + PopupConfirm.
+        for (popup_idx, popup_rect, inner_rect, scroll_offset, num_items) in
+            self.cached_layout.global_popup_areas.clone().iter().rev()
+        {
+            if popup_rect.width >= 5 {
+                let cb_x = popup_rect.x + popup_rect.width - 4;
+                if row == popup_rect.y && col >= cb_x && col < cb_x + 3 {
+                    return self.handle_action(Action::PopupCancel);
+                }
+            }
+            if col >= inner_rect.x
+                && col < inner_rect.x + inner_rect.width
+                && row >= inner_rect.y
+                && row < inner_rect.y + inner_rect.height
+                && *num_items > 0
+            {
+                let relative_row = (row - inner_rect.y) as usize;
+                let item_idx = scroll_offset + relative_row;
+                if item_idx < *num_items {
+                    if let Some(popup) = self.global_popups.get_mut(*popup_idx) {
+                        if let crate::view::popup::PopupContent::List { items: _, selected } =
+                            &mut popup.content
+                        {
+                            *selected = item_idx;
+                        }
+                    }
+                    return self.handle_action(Action::PopupConfirm);
+                }
+            }
         }
 
         // Check if click is on the popup's close-button overlay ("[×]")

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1543,7 +1543,7 @@ impl Editor {
                 self.active_action_popup = Some((popup_id.clone(), action_ids));
 
                 // Create popup with message + action list
-                let popup = crate::model::event::PopupData {
+                let popup_data = crate::model::event::PopupData {
                     kind: crate::model::event::PopupKindHint::List,
                     title: Some(title),
                     description: Some(message),
@@ -1555,7 +1555,13 @@ impl Editor {
                     bordered: true,
                 };
 
-                self.show_popup(popup);
+                // Action popups are buffer-independent notifications; route
+                // them to the editor-level popup stack so they remain visible
+                // (and dismissible) regardless of which buffer is focused —
+                // including virtual buffers like the Dashboard that own the
+                // whole split.
+                let popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+                self.global_popups.show(popup_obj);
                 tracing::info!(
                     "Action popup shown: id={}, active_action_popup={:?}",
                     popup_id,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1537,14 +1537,11 @@ impl Editor {
                     })
                     .collect();
 
-                // Push tracking onto the stack parallel to `global_popups`.
-                // A second plugin calling showActionPopup while the first is
-                // still up gets a new entry, not a clobbered one, so each
-                // popup fires its own `action_popup_result` on dismiss.
-                let action_ids: Vec<(String, String)> =
-                    actions.into_iter().map(|a| (a.id, a.label)).collect();
-                self.active_action_popup
-                    .push((popup_id.clone(), action_ids));
+                // The popup_id lives on the popup itself via its
+                // `PopupResolver::PluginAction` — no side-channel stack.
+                // Drop the incoming `actions` vec; its ids are already
+                // encoded as each list item's `data` field below.
+                drop(actions);
 
                 // Create popup with message + action list
                 let popup_data = crate::model::event::PopupData {
@@ -1564,12 +1561,19 @@ impl Editor {
                 // (and dismissible) regardless of which buffer is focused —
                 // including virtual buffers like the Dashboard that own the
                 // whole split.
-                let popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+                //
+                // The resolver carries the popup_id so confirm/cancel fires
+                // `action_popup_result` for exactly THIS popup, even when
+                // multiple plugin popups are stacked concurrently.
+                let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+                popup_obj.resolver = crate::view::popup::PopupResolver::PluginAction {
+                    popup_id: popup_id.clone(),
+                };
                 self.global_popups.show(popup_obj);
                 tracing::info!(
                     "Action popup shown: id={}, stack_depth={}",
                     popup_id,
-                    self.active_action_popup.len()
+                    self.global_popups.all().len()
                 );
             }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1537,10 +1537,14 @@ impl Editor {
                     })
                     .collect();
 
-                // Store action info for when popup is confirmed/cancelled
+                // Push tracking onto the stack parallel to `global_popups`.
+                // A second plugin calling showActionPopup while the first is
+                // still up gets a new entry, not a clobbered one, so each
+                // popup fires its own `action_popup_result` on dismiss.
                 let action_ids: Vec<(String, String)> =
                     actions.into_iter().map(|a| (a.id, a.label)).collect();
-                self.active_action_popup = Some((popup_id.clone(), action_ids));
+                self.active_action_popup
+                    .push((popup_id.clone(), action_ids));
 
                 // Create popup with message + action list
                 let popup_data = crate::model::event::PopupData {
@@ -1563,9 +1567,9 @@ impl Editor {
                 let popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
                 self.global_popups.show(popup_obj);
                 tracing::info!(
-                    "Action popup shown: id={}, active_action_popup={:?}",
+                    "Action popup shown: id={}, stack_depth={}",
                     popup_id,
-                    self.active_action_popup.as_ref().map(|(id, _)| id)
+                    self.active_action_popup.len()
                 );
             }
 

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -19,121 +19,128 @@ pub enum PopupConfirmResult {
 impl Editor {
     /// Handle PopupConfirm action.
     ///
-    /// Returns `PopupConfirmResult` indicating what the caller should do next.
+    /// Dispatches by reading the currently-focused popup's `PopupResolver`
+    /// — the popup itself carries its own "how do I confirm?" identity.
+    /// This eliminates the old side-channel cascade where `pending_X:
+    /// Option<...>` flags competed for precedence: two popups coexisting
+    /// (e.g. plugin action popup on the global stack + LSP auto-prompt
+    /// on the buffer stack) would race on whose flag the cascade hit
+    /// first, and the wrong branch would claim the key.
+    ///
+    /// Global popups shadow buffer popups for keyboard focus (see
+    /// `input_dispatch::dispatch_modal_input`), so the confirm path
+    /// picks the same popup: global first, then the active buffer.
     pub fn handle_popup_confirm(&mut self) -> PopupConfirmResult {
-        // Check if this is an LSP status details popup
-        if self.pending_lsp_status_popup.is_some() {
-            let action_key = self
-                .active_state()
-                .popups
-                .top()
-                .and_then(|p| p.selected_item())
-                .and_then(|item| item.data.clone());
+        use crate::view::popup::PopupResolver;
 
-            self.hide_popup();
-            self.pending_lsp_status_popup = None;
-            // User picked a row → they've seen and handled the
-            // prompt, so end the auto-prompt cycle for this
-            // language. Mirrors the same cleanup in
-            // `handle_popup_cancel` for the Esc path.
-            let active = self.active_buffer();
-            if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
-                self.pending_auto_start_prompts.remove(&language);
-                self.auto_start_prompted_languages.insert(language);
-            }
+        // Clone the top popup's resolver so we can `match` on it without
+        // keeping a borrow on `self.global_popups` / `self.buffers`
+        // while the handler mutates the editor.
+        let resolver = if self.global_popups.is_visible() {
+            self.global_popups.top().map(|p| p.resolver.clone())
+        } else {
+            self.active_state().popups.top().map(|p| p.resolver.clone())
+        };
 
-            if let Some(key) = action_key {
-                self.handle_lsp_status_action(&key);
-            }
-            return PopupConfirmResult::EarlyReturn;
-        }
-
-        // Check if this is an action popup (from plugin showActionPopup).
-        // Action popups live on the editor-level (global) stack so they show
-        // over any buffer; the `active_action_popup` stack runs parallel to
-        // `global_popups`, so the *top* entry corresponds to the *top*
-        // popup. Pop both together here.
-        if !self.active_action_popup.is_empty() {
-            let action_id = self
-                .global_popups
-                .top()
-                .or_else(|| self.active_state().popups.top())
-                .and_then(|p| p.selected_item())
-                .and_then(|item| item.data.clone())
-                .unwrap_or_else(|| "dismissed".to_string());
-
-            self.hide_popup();
-            let (popup_id, _actions) = self
-                .active_action_popup
-                .pop()
-                .expect("non-empty checked above");
-
-            // Fire the ActionPopupResult hook
-            self.plugin_manager.run_hook(
-                "action_popup_result",
-                crate::services::plugins::hooks::HookArgs::ActionPopupResult {
-                    popup_id,
-                    action_id,
-                },
-            );
-
-            return PopupConfirmResult::EarlyReturn;
-        }
-
-        // Check if this is a code action popup
-        if self.pending_code_actions.is_some() {
-            let selected_index = self
-                .active_state()
-                .popups
-                .top()
-                .and_then(|p| p.selected_item())
-                .and_then(|item| item.data.as_ref())
-                .and_then(|data| data.parse::<usize>().ok());
-
-            self.hide_popup();
-            if let Some(index) = selected_index {
-                self.execute_code_action(index);
-            }
-            self.pending_code_actions = None;
-            return PopupConfirmResult::EarlyReturn;
-        }
-
-        // Check if this is an LSP confirmation popup
-        if self.pending_lsp_confirmation.is_some() {
-            let action = self
-                .active_state()
-                .popups
-                .top()
-                .and_then(|p| p.selected_item())
-                .and_then(|item| item.data.clone());
-            if let Some(action) = action {
+        match resolver {
+            Some(PopupResolver::PluginAction { popup_id }) => {
+                let action_id = self
+                    .global_popups
+                    .top()
+                    .or_else(|| self.active_state().popups.top())
+                    .and_then(|p| p.selected_item())
+                    .and_then(|item| item.data.clone())
+                    .unwrap_or_else(|| "dismissed".to_string());
                 self.hide_popup();
-                self.handle_lsp_confirmation_response(&action);
-                return PopupConfirmResult::EarlyReturn;
-            }
-        }
-
-        // If it's a completion popup, insert the selected item
-        let completion_info = self
-            .active_state()
-            .popups
-            .top()
-            .filter(|p| p.kind == crate::view::popup::PopupKind::Completion)
-            .and_then(|p| p.selected_item())
-            .map(|item| (item.text.clone(), item.data.clone()));
-
-        // Perform the completion if we have text
-        if let Some((label, insert_text)) = completion_info {
-            if let Some(text) = insert_text {
-                self.insert_completion_text(text);
+                self.plugin_manager.run_hook(
+                    "action_popup_result",
+                    crate::services::plugins::hooks::HookArgs::ActionPopupResult {
+                        popup_id,
+                        action_id,
+                    },
+                );
+                PopupConfirmResult::EarlyReturn
             }
 
-            // Apply additional_text_edits (e.g., auto-imports) from the matching CompletionItem
-            self.apply_completion_additional_edits(&label);
-        }
+            Some(PopupResolver::LspStatus) => {
+                let action_key = self
+                    .active_state()
+                    .popups
+                    .top()
+                    .and_then(|p| p.selected_item())
+                    .and_then(|item| item.data.clone());
+                self.hide_popup();
+                // User picked a row → end the auto-prompt cycle for
+                // this language.
+                let active = self.active_buffer();
+                if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
+                    self.pending_auto_start_prompts.remove(&language);
+                    self.auto_start_prompted_languages.insert(language);
+                }
+                if let Some(key) = action_key {
+                    self.handle_lsp_status_action(&key);
+                }
+                PopupConfirmResult::EarlyReturn
+            }
 
-        self.hide_popup();
-        PopupConfirmResult::Done
+            Some(PopupResolver::CodeAction) => {
+                let selected_index = self
+                    .active_state()
+                    .popups
+                    .top()
+                    .and_then(|p| p.selected_item())
+                    .and_then(|item| item.data.as_ref())
+                    .and_then(|data| data.parse::<usize>().ok());
+                self.hide_popup();
+                if let Some(index) = selected_index {
+                    self.execute_code_action(index);
+                }
+                self.pending_code_actions = None;
+                PopupConfirmResult::EarlyReturn
+            }
+
+            Some(PopupResolver::LspConfirm { language }) => {
+                let action = self
+                    .active_state()
+                    .popups
+                    .top()
+                    .and_then(|p| p.selected_item())
+                    .and_then(|item| item.data.clone());
+                if let Some(action) = action {
+                    self.hide_popup();
+                    self.handle_lsp_confirmation_response(&language, &action);
+                    PopupConfirmResult::EarlyReturn
+                } else {
+                    self.hide_popup();
+                    PopupConfirmResult::EarlyReturn
+                }
+            }
+
+            Some(PopupResolver::Completion) => {
+                // Grab the selected item's label + insert-text before we
+                // mutate the popup stack — insert_completion_text edits
+                // the buffer, which invalidates the borrow.
+                let completion_info = self
+                    .active_state()
+                    .popups
+                    .top()
+                    .and_then(|p| p.selected_item())
+                    .map(|item| (item.text.clone(), item.data.clone()));
+                if let Some((label, insert_text)) = completion_info {
+                    if let Some(text) = insert_text {
+                        self.insert_completion_text(text);
+                    }
+                    self.apply_completion_additional_edits(&label);
+                }
+                self.hide_popup();
+                PopupConfirmResult::Done
+            }
+
+            Some(PopupResolver::None) | None => {
+                self.hide_popup();
+                PopupConfirmResult::Done
+            }
+        }
     }
 
     /// Insert completion text, replacing the word prefix at cursor.
@@ -249,62 +256,67 @@ impl Editor {
     }
 
     /// Handle PopupCancel action.
+    ///
+    /// Mirrors `handle_popup_confirm`: dispatch on the focused popup's
+    /// `PopupResolver`. Each flavour does its own cleanup; no
+    /// precedence between unrelated popup types.
     pub fn handle_popup_cancel(&mut self) {
-        tracing::info!(
-            "handle_popup_cancel: action_popup_stack_depth={}",
-            self.active_action_popup.len()
-        );
+        use crate::view::popup::PopupResolver;
 
-        // Check if this is an LSP status details popup
-        if self.pending_lsp_status_popup.take().is_some() {
-            // The user has now seen the prompt and dismissed it —
-            // end the auto-prompt cycle for the active buffer's
-            // language so re-focusing another file of the same
-            // language doesn't re-pop it.
-            let active = self.active_buffer();
-            if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
-                self.pending_auto_start_prompts.remove(&language);
-                self.auto_start_prompted_languages.insert(language);
+        let resolver = if self.global_popups.is_visible() {
+            self.global_popups.top().map(|p| p.resolver.clone())
+        } else {
+            self.active_state().popups.top().map(|p| p.resolver.clone())
+        };
+
+        match resolver {
+            Some(PopupResolver::PluginAction { popup_id }) => {
+                tracing::info!(
+                    "handle_popup_cancel: dismissing action popup id={}",
+                    popup_id
+                );
+                self.hide_popup();
+                self.plugin_manager.run_hook(
+                    "action_popup_result",
+                    crate::services::plugins::hooks::HookArgs::ActionPopupResult {
+                        popup_id,
+                        action_id: "dismissed".to_string(),
+                    },
+                );
             }
-            self.hide_popup();
-            return;
-        }
 
-        // Check if this is an action popup (from plugin showActionPopup).
-        // Pop the top entry of the parallel tracking stack together with the
-        // popup itself so a deeper queued popup (if any) surfaces next.
-        if let Some((popup_id, _actions)) = self.active_action_popup.pop() {
-            tracing::info!(
-                "handle_popup_cancel: dismissing action popup id={}",
-                popup_id
-            );
-            self.hide_popup();
+            Some(PopupResolver::LspStatus) => {
+                // End the auto-prompt cycle for the active buffer's
+                // language so re-focusing another file of the same
+                // language doesn't re-pop it.
+                let active = self.active_buffer();
+                if let Some(language) = self.buffers.get(&active).map(|s| s.language.clone()) {
+                    self.pending_auto_start_prompts.remove(&language);
+                    self.auto_start_prompted_languages.insert(language);
+                }
+                self.hide_popup();
+            }
 
-            // Fire the ActionPopupResult hook with "dismissed"
-            self.plugin_manager.run_hook(
-                "action_popup_result",
-                crate::services::plugins::hooks::HookArgs::ActionPopupResult {
-                    popup_id,
-                    action_id: "dismissed".to_string(),
-                },
-            );
-            tracing::info!("handle_popup_cancel: action_popup_result hook fired");
-            return;
-        }
+            Some(PopupResolver::CodeAction) => {
+                self.pending_code_actions = None;
+                self.hide_popup();
+            }
 
-        if self.pending_code_actions.is_some() {
-            self.pending_code_actions = None;
-            self.hide_popup();
-            return;
-        }
+            Some(PopupResolver::LspConfirm { language: _ }) => {
+                self.set_status_message(t!("lsp.startup_cancelled_msg").to_string());
+                self.hide_popup();
+            }
 
-        if self.pending_lsp_confirmation.is_some() {
-            self.pending_lsp_confirmation = None;
-            self.set_status_message(t!("lsp.startup_cancelled_msg").to_string());
+            Some(PopupResolver::Completion) => {
+                self.hide_popup();
+                self.completion_items = None;
+            }
+
+            Some(PopupResolver::None) | None => {
+                self.hide_popup();
+                self.completion_items = None;
+            }
         }
-        self.hide_popup();
-        // Clear completion items when popup is closed
-        self.completion_items = None;
     }
 
     /// Get the formatted key hint for the completion accept action (e.g. "Tab").
@@ -458,6 +470,7 @@ impl Editor {
         let state = self.buffers.get_mut(&buffer_id).unwrap();
         let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
         popup_obj.accept_key_hint = accept_hint;
+        popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
         state.popups.show_or_replace(popup_obj);
     }
 }

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -50,10 +50,10 @@ impl Editor {
 
         // Check if this is an action popup (from plugin showActionPopup).
         // Action popups live on the editor-level (global) stack so they show
-        // over any buffer; read the selection from there first, falling back
-        // to the active buffer's stack for legacy callers.
-        if let Some((popup_id, _actions)) = &self.active_action_popup {
-            let popup_id = popup_id.clone();
+        // over any buffer; the `active_action_popup` stack runs parallel to
+        // `global_popups`, so the *top* entry corresponds to the *top*
+        // popup. Pop both together here.
+        if !self.active_action_popup.is_empty() {
             let action_id = self
                 .global_popups
                 .top()
@@ -63,7 +63,10 @@ impl Editor {
                 .unwrap_or_else(|| "dismissed".to_string());
 
             self.hide_popup();
-            self.active_action_popup = None;
+            let (popup_id, _actions) = self
+                .active_action_popup
+                .pop()
+                .expect("non-empty checked above");
 
             // Fire the ActionPopupResult hook
             self.plugin_manager.run_hook(
@@ -248,8 +251,8 @@ impl Editor {
     /// Handle PopupCancel action.
     pub fn handle_popup_cancel(&mut self) {
         tracing::info!(
-            "handle_popup_cancel: active_action_popup={:?}",
-            self.active_action_popup.as_ref().map(|(id, _)| id)
+            "handle_popup_cancel: action_popup_stack_depth={}",
+            self.active_action_popup.len()
         );
 
         // Check if this is an LSP status details popup
@@ -267,8 +270,10 @@ impl Editor {
             return;
         }
 
-        // Check if this is an action popup (from plugin showActionPopup)
-        if let Some((popup_id, _actions)) = self.active_action_popup.take() {
+        // Check if this is an action popup (from plugin showActionPopup).
+        // Pop the top entry of the parallel tracking stack together with the
+        // popup itself so a deeper queued popup (if any) surfaces next.
+        if let Some((popup_id, _actions)) = self.active_action_popup.pop() {
             tracing::info!(
                 "handle_popup_cancel: dismissing action popup id={}",
                 popup_id

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -48,13 +48,16 @@ impl Editor {
             return PopupConfirmResult::EarlyReturn;
         }
 
-        // Check if this is an action popup (from plugin showActionPopup)
+        // Check if this is an action popup (from plugin showActionPopup).
+        // Action popups live on the editor-level (global) stack so they show
+        // over any buffer; read the selection from there first, falling back
+        // to the active buffer's stack for legacy callers.
         if let Some((popup_id, _actions)) = &self.active_action_popup {
             let popup_id = popup_id.clone();
             let action_id = self
-                .active_state()
-                .popups
+                .global_popups
                 .top()
+                .or_else(|| self.active_state().popups.top())
                 .and_then(|p| p.selected_item())
                 .and_then(|item| item.data.clone())
                 .unwrap_or_else(|| "dismissed".to_string());

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -19,10 +19,7 @@ use super::Editor;
 /// buffers without affecting unrelated popups (completion, hover,
 /// etc.) that might be on top.
 fn is_lsp_status_popup(popup: &crate::view::popup::Popup) -> bool {
-    popup
-        .title
-        .as_deref()
-        .is_some_and(|t| t.starts_with("LSP Servers ("))
+    matches!(popup.resolver, crate::view::popup::PopupResolver::LspStatus)
 }
 
 impl Editor {
@@ -47,9 +44,13 @@ impl Editor {
         // instead of rebuilding and re-showing it.  This lets clicking the
         // status-bar LSP indicator a second time dismiss the popup, matching
         // the common affordance for status-bar menus.
-        if self.pending_lsp_status_popup.is_some() {
+        if self
+            .active_state()
+            .popups
+            .top()
+            .is_some_and(is_lsp_status_popup)
+        {
             self.hide_popup();
-            self.pending_lsp_status_popup = None;
             return;
         }
 
@@ -151,12 +152,11 @@ impl Editor {
             return;
         }
 
-        // Pop any orphan LSP status popup off *other* buffers so
-        // the user doesn't find a stale prompt when they later
-        // visit those tabs. `show_lsp_status_popup` also toggles
-        // off whatever is currently tracked in
-        // `pending_lsp_status_popup`, so reset that marker first
-        // — otherwise the call below would close instead of show.
+        // Pop any orphan LSP status popup off *other* buffers so the
+        // user doesn't find a stale prompt when they later visit those
+        // tabs. Each buffer's popup carries its own `LspStatus`
+        // resolver, so we can identify orphan LSP status popups by
+        // resolver value without a side-channel marker.
         let active_id = active;
         for (id, state) in self.buffers.iter_mut() {
             if *id == active_id {
@@ -166,7 +166,6 @@ impl Editor {
                 state.popups.hide();
             }
         }
-        self.pending_lsp_status_popup = None;
 
         self.show_lsp_status_popup();
     }
@@ -179,7 +178,15 @@ impl Editor {
     /// would freeze on the snapshot taken at open time while the status-bar
     /// spinner keeps moving, making them look disconnected.
     pub fn refresh_lsp_status_popup_if_open(&mut self) {
-        if self.pending_lsp_status_popup.is_none() {
+        // Only rebuild if the active buffer's top popup IS an LSP
+        // status popup — otherwise we'd spuriously build one on top of
+        // unrelated state.
+        if !self
+            .active_state()
+            .popups
+            .top()
+            .is_some_and(is_lsp_status_popup)
+        {
             return;
         }
         let language = self
@@ -187,14 +194,8 @@ impl Editor {
             .get(&self.active_buffer())
             .map(|s| s.language.clone())
             .unwrap_or_else(|| "unknown".to_string());
-        // Replace contents: hide then rebuild.  hide_popup() clears
-        // pending_lsp_status_popup via handle_popup_cancel pathways, but
-        // here we're calling it directly without routing through a cancel,
-        // so stash and restore the marker so the rebuild sees "already
-        // open" and doesn't fall through the toggle branch.
-        let was_pending = self.pending_lsp_status_popup.take();
+        // Replace contents: hide then rebuild.
         self.hide_popup();
-        drop(was_pending);
         self.build_and_show_lsp_status_popup(&language);
     }
 
@@ -527,9 +528,13 @@ impl Editor {
                 .with_data(cancel_key.clone()),
         );
         action_keys.push((cancel_key, format!("Dismiss ({})", cancel_binding)));
-
-        // Store action keys for handling confirmation
-        self.pending_lsp_status_popup = Some(action_keys);
+        // `action_keys` is no longer kept on the editor — each list
+        // item already carries its action key in its `data` field, and
+        // the `LspStatus` resolver on the popup tells confirm how to
+        // interpret that data. The local binding is retained only to
+        // keep the existing construction logic unchanged; it falls out
+        // of scope with the rest.
+        let _ = action_keys;
 
         // Pin the popup width up-front, using the *worst-case* widths for
         // any row that varies at runtime (the progress line).  This keeps
@@ -574,7 +579,7 @@ impl Editor {
             )
             .unwrap_or(crate::view::popup::PopupPosition::BottomRight);
 
-        use crate::view::popup::{Popup, PopupContent, PopupKind};
+        use crate::view::popup::{Popup, PopupContent, PopupKind, PopupResolver};
         use ratatui::style::Style;
 
         let popup = Popup {
@@ -595,6 +600,10 @@ impl Editor {
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
+            // This is the LSP status / auto-prompt popup — mark it so
+            // confirm/cancel routes through handle_lsp_status_action
+            // regardless of what other popups are on screen.
+            resolver: PopupResolver::LspStatus,
         };
 
         let buffer_id = self.active_buffer();

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -82,6 +82,23 @@ impl Editor {
 
     /// Hide the topmost popup
     pub fn hide_popup(&mut self) {
+        // Editor-level popups take precedence: dismiss them first if any are
+        // visible. This avoids leaking a popup-stack pop event into the
+        // active buffer's event log when the popup we're closing is global.
+        if self.global_popups.is_visible() {
+            self.global_popups.hide();
+
+            // Clear hover symbol highlight if present (kept for parity with
+            // the buffer-popup branch even though global popups don't use it
+            // today — cheap no-op when nothing is set).
+            if let Some(handle) = self.hover.take_symbol_overlay() {
+                let remove_overlay_event = crate::model::event::Event::RemoveOverlay { handle };
+                self.apply_event_to_active_buffer(&remove_overlay_event);
+            }
+            self.hover.set_symbol_range(None);
+            return;
+        }
+
         let event = Event::HidePopup;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
@@ -103,6 +120,8 @@ impl Editor {
     /// Dismiss transient popups if present
     /// These popups should be dismissed on scroll or other user actions
     pub(super) fn dismiss_transient_popups(&mut self) {
+        // Action popups are persistent by design — only buffer-level transient
+        // popups (Hover, Signature Help) get auto-dismissed here.
         let is_transient_popup = self
             .active_state()
             .popups
@@ -118,6 +137,10 @@ impl Editor {
     /// Scroll any popup content by delta lines
     /// Positive delta scrolls down, negative scrolls up
     pub(super) fn scroll_popup(&mut self, delta: i32) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.scroll_by(delta);
+            return;
+        }
         if let Some(popup) = self.active_state_mut().popups.top_mut() {
             popup.scroll_by(delta);
             tracing::debug!(
@@ -447,6 +470,10 @@ impl Editor {
 
     /// Navigate popup selection (next item)
     pub fn popup_select_next(&mut self) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.select_next();
+            return;
+        }
         let event = Event::PopupSelectNext;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
@@ -454,6 +481,10 @@ impl Editor {
 
     /// Navigate popup selection (previous item)
     pub fn popup_select_prev(&mut self) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.select_prev();
+            return;
+        }
         let event = Event::PopupSelectPrev;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
@@ -461,6 +492,10 @@ impl Editor {
 
     /// Navigate popup (page down)
     pub fn popup_page_down(&mut self) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.page_down();
+            return;
+        }
         let event = Event::PopupPageDown;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
@@ -468,6 +503,10 @@ impl Editor {
 
     /// Navigate popup (page up)
     pub fn popup_page_up(&mut self) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.page_up();
+            return;
+        }
         let event = Event::PopupPageUp;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -80,6 +80,21 @@ impl Editor {
         self.apply_event_to_active_buffer(&event);
     }
 
+    /// Show a popup and attach a confirm/cancel resolver to it. The
+    /// `PopupData` event doesn't carry the resolver (it's a view-layer
+    /// concern that doesn't need event-log replay); we set it on the
+    /// resulting `Popup` immediately after `show_popup` pushes it.
+    pub fn show_popup_with_resolver(
+        &mut self,
+        popup: crate::model::event::PopupData,
+        resolver: crate::view::popup::PopupResolver,
+    ) {
+        self.show_popup(popup);
+        if let Some(top) = self.active_state_mut().popups.top_mut() {
+            top.resolver = resolver;
+        }
+    }
+
     /// Hide the topmost popup
     pub fn hide_popup(&mut self) {
         // Editor-level popups take precedence: dismiss them first if any are
@@ -193,9 +208,6 @@ impl Editor {
             PopupContentData, PopupData, PopupKindHint, PopupListItemData, PopupPositionData,
         };
 
-        // Store the pending confirmation
-        self.pending_lsp_confirmation = Some(language.to_string());
-
         // Get the server command for display
         let server_info = if let Some(lsp) = &self.lsp {
             if let Some(config) = lsp.get_config(language) {
@@ -245,7 +257,15 @@ impl Editor {
             bordered: true,
         };
 
-        self.show_popup(popup);
+        // The language travels with the popup via its resolver so
+        // confirm time reads it from the popup itself — no side-channel
+        // Editor field needed, and no coupling between popups.
+        self.show_popup_with_resolver(
+            popup,
+            crate::view::popup::PopupResolver::LspConfirm {
+                language: language.to_string(),
+            },
+        );
     }
 
     /// Handle the LSP confirmation popup response
@@ -254,11 +274,11 @@ impl Editor {
     /// confirmation popup. It processes the response and starts the LSP
     /// server if approved.
     ///
-    /// Returns true if a response was handled, false if there was no pending confirmation.
-    pub fn handle_lsp_confirmation_response(&mut self, action: &str) -> bool {
-        let Some(language) = self.pending_lsp_confirmation.take() else {
-            return false;
-        };
+    /// `language` is read from the confirming popup's `PopupResolver`
+    /// (no side-channel), so `handle_popup_confirm`'s resolver match
+    /// can call us directly with what it destructured out of the popup.
+    pub fn handle_lsp_confirmation_response(&mut self, language: &str, action: &str) -> bool {
+        let language = language.to_string();
 
         // Get file path from active buffer for workspace root detection
         let file_path = self
@@ -463,9 +483,21 @@ impl Editor {
         }
     }
 
-    /// Check if there's a pending LSP confirmation
+    /// Check if the topmost visible popup is the LSP confirmation
+    /// popup. Used by callers that need to know "is an LSP confirm
+    /// prompt currently in front of the user?" — e.g. the file-open
+    /// queue waits on this instead of racing past the prompt.
     pub fn has_pending_lsp_confirmation(&self) -> bool {
-        self.pending_lsp_confirmation.is_some()
+        use crate::view::popup::PopupResolver;
+        let matches_lsp_confirm = |p: &crate::view::popup::Popup| -> bool {
+            matches!(p.resolver, PopupResolver::LspConfirm { .. })
+        };
+        self.global_popups.top().is_some_and(matches_lsp_confirm)
+            || self
+                .active_state()
+                .popups
+                .top()
+                .is_some_and(matches_lsp_confirm)
     }
 
     /// Navigate popup selection (next item)

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -976,41 +976,43 @@ impl Editor {
         // virtual buffers (Dashboard, diagnostics) that own the whole split.
         // These don't need cursor-relative positioning — they all use absolute
         // positions like BottomRight or Centered.
-        if self.global_popups.is_visible() {
-            self.cached_layout.global_popup_areas.clear();
-            for (popup_idx, popup) in self.global_popups.all().iter().enumerate() {
-                let popup_area = popup.calculate_area(size, None);
-                let desc_height = popup.description_height();
-                let inner_area = if popup.bordered {
-                    ratatui::layout::Rect {
-                        x: popup_area.x + 1,
-                        y: popup_area.y + 1 + desc_height,
-                        width: popup_area.width.saturating_sub(2),
-                        height: popup_area.height.saturating_sub(2 + desc_height),
-                    }
-                } else {
-                    ratatui::layout::Rect {
-                        x: popup_area.x,
-                        y: popup_area.y + desc_height,
-                        width: popup_area.width,
-                        height: popup_area.height.saturating_sub(desc_height),
-                    }
-                };
-                let num_items = match &popup.content {
-                    crate::view::popup::PopupContent::List { items, .. } => items.len(),
-                    _ => 0,
-                };
-                self.cached_layout.global_popup_areas.push((
-                    popup_idx,
-                    popup_area,
-                    inner_area,
-                    popup.scroll_offset,
-                    num_items,
-                ));
-                popup.render_with_hover(frame, popup_area, &theme_clone, hover_target.as_ref());
-            }
-        } else {
-            self.cached_layout.global_popup_areas.clear();
+        //
+        // Queue semantics: concurrent action popups stack in `global_popups`,
+        // but only the top one renders & receives input. Deeper popups
+        // surface as the top is resolved — the alternative (drawing all at
+        // the same BottomRight slot) makes them illegible.
+        self.cached_layout.global_popup_areas.clear();
+        if let Some(popup) = self.global_popups.top() {
+            let top_idx = self.global_popups.all().len() - 1;
+            let popup_area = popup.calculate_area(size, None);
+            let desc_height = popup.description_height();
+            let inner_area = if popup.bordered {
+                ratatui::layout::Rect {
+                    x: popup_area.x + 1,
+                    y: popup_area.y + 1 + desc_height,
+                    width: popup_area.width.saturating_sub(2),
+                    height: popup_area.height.saturating_sub(2 + desc_height),
+                }
+            } else {
+                ratatui::layout::Rect {
+                    x: popup_area.x,
+                    y: popup_area.y + desc_height,
+                    width: popup_area.width,
+                    height: popup_area.height.saturating_sub(desc_height),
+                }
+            };
+            let num_items = match &popup.content {
+                crate::view::popup::PopupContent::List { items, .. } => items.len(),
+                _ => 0,
+            };
+            self.cached_layout.global_popup_areas.push((
+                top_idx,
+                popup_area,
+                inner_area,
+                popup.scroll_offset,
+                num_items,
+            ));
+            popup.render_with_hover(frame, popup_area, &theme_clone, hover_target.as_ref());
         }
 
         // Render menu bar last so dropdown appears on top of all other content

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -971,6 +971,48 @@ impl Editor {
             }
         }
 
+        // Render editor-level popups (e.g. plugin action popups) on top of any
+        // buffer content so they stay visible across buffer switches and over
+        // virtual buffers (Dashboard, diagnostics) that own the whole split.
+        // These don't need cursor-relative positioning — they all use absolute
+        // positions like BottomRight or Centered.
+        if self.global_popups.is_visible() {
+            self.cached_layout.global_popup_areas.clear();
+            for (popup_idx, popup) in self.global_popups.all().iter().enumerate() {
+                let popup_area = popup.calculate_area(size, None);
+                let desc_height = popup.description_height();
+                let inner_area = if popup.bordered {
+                    ratatui::layout::Rect {
+                        x: popup_area.x + 1,
+                        y: popup_area.y + 1 + desc_height,
+                        width: popup_area.width.saturating_sub(2),
+                        height: popup_area.height.saturating_sub(2 + desc_height),
+                    }
+                } else {
+                    ratatui::layout::Rect {
+                        x: popup_area.x,
+                        y: popup_area.y + desc_height,
+                        width: popup_area.width,
+                        height: popup_area.height.saturating_sub(desc_height),
+                    }
+                };
+                let num_items = match &popup.content {
+                    crate::view::popup::PopupContent::List { items, .. } => items.len(),
+                    _ => 0,
+                };
+                self.cached_layout.global_popup_areas.push((
+                    popup_idx,
+                    popup_area,
+                    inner_area,
+                    popup.scroll_offset,
+                    num_items,
+                ));
+                popup.render_with_hover(frame, popup_area, &theme_clone, hover_target.as_ref());
+            }
+        } else {
+            self.cached_layout.global_popup_areas.clear();
+        }
+
         // Render menu bar last so dropdown appears on top of all other content
         // Update menu context with current editor state
         self.update_menu_context();

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -913,6 +913,11 @@ pub(crate) struct CachedLayout {
     /// Popup areas for mouse hit testing
     /// scrollbar_rect is Some if popup has a scrollbar
     pub popup_areas: Vec<PopupAreaLayout>,
+    /// Editor-level popup areas (e.g. plugin action popups) for mouse hit
+    /// testing. Stored separately from buffer popups because they're owned by
+    /// `Editor.global_popups` rather than the active buffer's state.
+    /// Fields: (popup_index, rect, inner_rect, scroll_offset, num_items)
+    pub global_popup_areas: Vec<(usize, Rect, Rect, usize, usize)>,
     /// Suggestions area for mouse hit testing
     /// (inner_rect, scroll_start_idx, visible_count, total_count)
     pub suggestions_area: Option<(Rect, usize, usize, usize)>,

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -1076,6 +1076,17 @@ pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
         crate::model::event::PopupKindHint::Text => PopupKind::Text,
     };
 
+    // Kind-implied resolver default: a popup whose kind is
+    // `Completion` always confirms by inserting the selected
+    // completion, regardless of who built it. Other kinds need an
+    // explicit resolver (LSP confirm, plugin action, LSP status, code
+    // action) because the same `List` kind is used for all four, so we
+    // can't infer which feature owns the popup from its kind alone.
+    let resolver = match kind {
+        PopupKind::Completion => crate::view::popup::PopupResolver::Completion,
+        _ => crate::view::popup::PopupResolver::None,
+    };
+
     Popup {
         kind,
         title: data.title.clone(),
@@ -1091,6 +1102,7 @@ pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
         scroll_offset: 0,
         text_selection: None,
         accept_key_hint: None,
+        resolver,
     }
 }
 

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -68,6 +68,40 @@ pub enum PopupKind {
     Text,
 }
 
+/// How `handle_popup_confirm` / `handle_popup_cancel` should resolve the
+/// popup. Each variant names the feature that owns this popup — adding a
+/// new popup flavour is "add a variant + a confirm/cancel branch," with
+/// zero precedence ordering to maintain between unrelated features.
+///
+/// Stored on the `Popup` itself so the confirm dispatcher inspects the
+/// *currently focused* popup (global or buffer) and routes by value. No
+/// out-of-band `Option` on the Editor can silently claim an Enter
+/// belonging to a different popup.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum PopupResolver {
+    /// Generic popup with no feature-specific confirm/cancel logic —
+    /// confirm/cancel simply dismiss the popup.
+    #[default]
+    None,
+    /// LSP completion popup. Confirm inserts the selected item's text.
+    Completion,
+    /// "Start LSP server?" confirmation. Confirm dispatches the selected
+    /// row's `data` (e.g. "allow_once") through
+    /// `handle_lsp_confirmation_response`.
+    LspConfirm { language: String },
+    /// LSP server-status / auto-prompt popup. Confirm dispatches the
+    /// selected row's `data` through `handle_lsp_status_action`.
+    LspStatus,
+    /// LSP code-action chooser. Selected row's `data` is the index into
+    /// `Editor::pending_code_actions` (heavy `lsp_types` payload stays
+    /// there to keep the view crate free of LSP types).
+    CodeAction,
+    /// Plugin-requested action popup (`editor.showActionPopup`). Confirm
+    /// fires `action_popup_result` with this popup's id and the selected
+    /// row's `data` as the action id.
+    PluginAction { popup_id: String },
+}
+
 /// Content of a popup window
 #[derive(Debug, Clone, PartialEq)]
 pub enum PopupContent {
@@ -219,6 +253,10 @@ pub struct Popup {
 
     /// Key hint shown right-aligned on the selected item (e.g. "(Tab)")
     pub accept_key_hint: Option<String>,
+
+    /// Feature-specific resolver for confirm/cancel dispatch. Default
+    /// `None` means "no special handling — just dismiss."
+    pub resolver: PopupResolver,
 }
 
 impl Popup {
@@ -239,6 +277,7 @@ impl Popup {
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
+            resolver: PopupResolver::None,
         }
     }
 
@@ -267,6 +306,7 @@ impl Popup {
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
+            resolver: PopupResolver::None,
         }
     }
 
@@ -287,6 +327,7 @@ impl Popup {
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
+            resolver: PopupResolver::None,
         }
     }
 
@@ -329,6 +370,13 @@ impl Popup {
     /// Set border style
     pub fn with_border_style(mut self, style: Style) -> Self {
         self.border_style = style;
+        self
+    }
+
+    /// Attach the confirm/cancel resolver so this popup dispatches to
+    /// the right handler regardless of what other popups are on screen.
+    pub fn with_resolver(mut self, resolver: PopupResolver) -> Self {
+        self.resolver = resolver;
         self
     }
 

--- a/crates/fresh-editor/tests/e2e/action_popup_global.rs
+++ b/crates/fresh-editor/tests/e2e/action_popup_global.rs
@@ -1,0 +1,196 @@
+//! E2E tests for plugin action popups (`editor.showActionPopup`).
+//!
+//! Action popups carry buffer-independent decisions (e.g. the
+//! devcontainer plugin's "attach now?" prompt). They must remain visible
+//! and actionable while the user is on _any_ buffer — including virtual
+//! buffers like the Dashboard that own the whole split.
+//!
+//! Regression: the popup used to be attached to the active buffer's popup
+//! stack at the moment showActionPopup ran, and would vanish as soon as a
+//! plugin (e.g. the dashboard) made a different buffer active.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::services::plugins::api::{ActionPopupAction, PluginCommand};
+
+fn show_devcontainer_attach_popup(harness: &mut EditorTestHarness) {
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::ShowActionPopup {
+            popup_id: "devcontainer-attach".to_string(),
+            title: "Dev Container detected".to_string(),
+            message: "Attach to dev container 'test-container'?".to_string(),
+            actions: vec![
+                ActionPopupAction {
+                    id: "attach".to_string(),
+                    label: "Attach".to_string(),
+                },
+                ActionPopupAction {
+                    id: "dismiss".to_string(),
+                    label: "Not now".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+}
+
+/// The popup should render over a virtual buffer that owns the whole
+/// split (Dashboard pattern), not just over file buffers. This is the
+/// regression: previously the popup was scoped to the buffer that was
+/// active at show-time, so a buffer switch hid it.
+#[test]
+fn action_popup_renders_over_virtual_buffer() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Create a virtual buffer mimicking the Dashboard plugin: a tab that
+    // a plugin opens to fill the whole split before the popup appears.
+    let dashboard_buffer = harness.editor_mut().create_virtual_buffer(
+        "Dashboard".to_string(),
+        "dashboard".to_string(),
+        true,
+    );
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            dashboard_buffer,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                "── Dashboard ──\n  weather: sunny\n  git: clean\n",
+            )],
+        )
+        .unwrap();
+    harness.editor_mut().switch_buffer(dashboard_buffer);
+    harness.render().unwrap();
+
+    // The dashboard text should be on screen before the popup is shown,
+    // confirming the virtual buffer is the active split's content.
+    let before = harness.screen_to_string();
+    assert!(
+        before.contains("Dashboard"),
+        "Pre-popup screen should show the dashboard buffer. Screen:\n{}",
+        before
+    );
+
+    // Now a plugin (e.g. devcontainer) shows its action popup. The
+    // dashboard buffer is still active.
+    show_devcontainer_attach_popup(&mut harness);
+    harness.render().unwrap();
+
+    // The popup body must be visible on screen even though the active
+    // buffer is the virtual dashboard.
+    let after = harness.screen_to_string();
+    assert!(
+        after.contains("Attach"),
+        "Action popup should render over the dashboard. Screen:\n{}",
+        after
+    );
+    assert!(
+        after.contains("Not now"),
+        "Action popup's dismiss action should be visible. Screen:\n{}",
+        after
+    );
+    assert!(
+        after.contains("Dev Container detected") || after.contains("Dev Container"),
+        "Action popup title should be visible. Screen:\n{}",
+        after
+    );
+}
+
+/// Esc on a global action popup must dismiss it without falling through
+/// to the buffer below.
+#[test]
+fn action_popup_dismisses_on_escape() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    let dashboard_buffer = harness.editor_mut().create_virtual_buffer(
+        "Dashboard".to_string(),
+        "dashboard".to_string(),
+        true,
+    );
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            dashboard_buffer,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                "── Dashboard ──\n",
+            )],
+        )
+        .unwrap();
+    harness.editor_mut().switch_buffer(dashboard_buffer);
+    harness.render().unwrap();
+
+    show_devcontainer_attach_popup(&mut harness);
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("Attach"),
+        "Sanity: popup is up before Esc."
+    );
+
+    // Esc should route to the global popup, not the buffer.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+
+    let after_esc = harness.screen_to_string();
+    assert!(
+        !after_esc.contains("Attach") && !after_esc.contains("Not now"),
+        "Esc should dismiss the global action popup. Screen:\n{}",
+        after_esc
+    );
+}
+
+/// Switching to a different buffer after the popup is shown must NOT
+/// hide it — the popup is editor-level, not buffer-local.
+#[test]
+fn action_popup_persists_across_buffer_switch() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Start on a file-style buffer.
+    let scratch = harness.editor_mut().create_virtual_buffer(
+        "scratch".to_string(),
+        "text".to_string(),
+        false,
+    );
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            scratch,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                "scratch buffer\n",
+            )],
+        )
+        .unwrap();
+    harness.editor_mut().switch_buffer(scratch);
+    harness.render().unwrap();
+
+    // Show the popup while `scratch` is active.
+    show_devcontainer_attach_popup(&mut harness);
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("Attach"),
+        "Sanity: popup visible on the scratch buffer."
+    );
+
+    // Open a Dashboard-style virtual buffer and switch to it. With the old
+    // buffer-scoped popup the popup would be lost here.
+    let dashboard = harness.editor_mut().create_virtual_buffer(
+        "Dashboard".to_string(),
+        "dashboard".to_string(),
+        true,
+    );
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            dashboard,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                "── Dashboard ──\n",
+            )],
+        )
+        .unwrap();
+    harness.editor_mut().switch_buffer(dashboard);
+    harness.render().unwrap();
+
+    let after_switch = harness.screen_to_string();
+    assert!(
+        after_switch.contains("Attach"),
+        "Action popup must survive a buffer switch. Screen:\n{}",
+        after_switch
+    );
+}

--- a/crates/fresh-editor/tests/e2e/action_popup_global.rs
+++ b/crates/fresh-editor/tests/e2e/action_popup_global.rs
@@ -195,6 +195,31 @@ fn action_popup_persists_across_buffer_switch() {
     );
 }
 
+fn show_devcontainer_attach_popup_named(
+    harness: &mut EditorTestHarness,
+    popup_id: &str,
+    container_name: &str,
+) {
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::ShowActionPopup {
+            popup_id: popup_id.to_string(),
+            title: "Dev Container detected".to_string(),
+            message: format!("Attach to '{}'?", container_name),
+            actions: vec![
+                ActionPopupAction {
+                    id: "attach".to_string(),
+                    label: "Attach".to_string(),
+                },
+                ActionPopupAction {
+                    id: "dismiss".to_string(),
+                    label: "Not now".to_string(),
+                },
+            ],
+        })
+        .unwrap();
+}
+
 fn show_generic_popup(
     harness: &mut EditorTestHarness,
     popup_id: &str,
@@ -339,5 +364,155 @@ fn action_popups_queue_confirms_preserve_per_popup_identity() {
         !after_second_confirm.contains("First popup body"),
         "Both popups must be resolved. Screen:\n{}",
         after_second_confirm
+    );
+}
+
+/// Regression for "user reports Attach stopped attaching when an LSP
+/// auto-prompt is also on screen":
+///
+///   1. Open a file in a project that has devcontainer.json AND LSP
+///      configured-but-dormant for the file's language. The LSP
+///      auto-prompt shows (buffer stack); the devcontainer plugin
+///      shows its Attach popup (global stack) concurrently.
+///   2. User presses Enter on the devcontainer popup to pick "Attach".
+///   3. Pre-fix: `handle_popup_confirm`'s cascade checked
+///      `pending_lsp_status_popup.is_some()` first, read the
+///      *selected LSP popup row's* data, dismissed the devcontainer
+///      popup without firing `action_popup_result`, and surfaced the
+///      LSP popup underneath — so "Attach" never ran.
+///   4. Post-fix: the confirm path inspects the focused popup's
+///      `PopupResolver`; global popup's `PluginAction` variant is
+///      matched first, fires the hook with the right action id, and
+///      leaves the LSP popup untouched underneath.
+///
+/// The test installs a small plugin that captures every
+/// `action_popup_result` call via the status bar so we can assert the
+/// hook ran with the right arguments.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn action_popup_attach_fires_hook_even_when_lsp_auto_prompt_is_open() {
+    use crate::common::harness::{copy_plugin_lib, HarnessOptions};
+    use std::fs;
+
+    // Plugin: registers a showActionPopup caller (the "devcontainer
+    // mock") + listens for action_popup_result and writes the outcome
+    // to the status bar.
+    let temp = tempfile::tempdir().unwrap();
+    let project_root = temp.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+
+    // Plugin just needs to observe the action_popup_result hook — we
+    // show the popup itself by handing Rust a `PluginCommand`, which
+    // exercises the same dispatch code path as a JS-side
+    // `editor.showActionPopup(...)`.
+    let plugin = r#"
+const editor = getEditor();
+
+globalThis.devmock_on_result = function(data: { popup_id: string; action_id: string }): void {
+    editor.setStatus("result: " + data.popup_id + "/" + data.action_id);
+};
+editor.on("action_popup_result", "devmock_on_result");
+"#;
+    fs::write(plugins_dir.join("devmock.ts"), plugin).unwrap();
+
+    // Source file — .rs so the LSP auto-prompt's language match fires.
+    let file = project_root.join("src.rs");
+    fs::write(&file, "fn main() {}\n").unwrap();
+
+    // Config with a dormant rust LSP (enabled, auto_start = false) so
+    // opening src.rs queues the auto-prompt.
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "rust-analyzer".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: false,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("rust-analyzer".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(project_root.clone()),
+    )
+    .unwrap();
+    // The harness disables LSP auto-prompt by default to keep unrelated
+    // tests clean. This test specifically exercises the collision with
+    // the auto-prompt, so re-enable it for this editor.
+    harness.editor_mut().set_lsp_auto_prompt_enabled(true);
+
+    // Open the file — LSP auto-prompt will show on the buffer popup
+    // stack on the next render.
+    harness.open_file(&file).unwrap();
+    harness.render().unwrap();
+    // Sanity: the LSP popup surfaced.
+    assert!(
+        harness.screen_to_string().contains("rust-analyzer"),
+        "LSP auto-prompt should be visible after opening src.rs. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Trigger the devcontainer-mock action popup on top of it. From
+    // here on both popups coexist: LSP on buffer stack, plugin action
+    // on global stack.
+    show_devcontainer_attach_popup_named(&mut harness, "devcontainer-attach", "mock-container");
+    harness.render().unwrap();
+    let with_both = harness.screen_to_string();
+    assert!(
+        with_both.contains("Attach") && with_both.contains("mock-container"),
+        "Devcontainer-mock popup should be on screen. Screen:\n{}",
+        with_both
+    );
+
+    // Enter on the global (devcontainer) popup. Default selection is
+    // "Attach" (index 0). The hook must fire with action_id=attach —
+    // that's the signal the plugin's attach routine ran.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Bounded wait: the plugin thread processes the hook
+    // asynchronously, so poll a fixed number of tick+render cycles.
+    // When the cascade bug is in effect, the hook never fires and the
+    // assertion below trips with a concrete failure instead of
+    // hanging the test runner.
+    for _ in 0..50 {
+        harness.tick_and_render().unwrap();
+        if harness
+            .screen_to_string()
+            .contains("result: devcontainer-attach/")
+        {
+            break;
+        }
+    }
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("result: devcontainer-attach/attach"),
+        "Pressing Enter on the devcontainer popup must fire \
+         action_popup_result with action_id=attach, even while an LSP \
+         auto-prompt is also on screen. Got status line: looking for \
+         'result: devcontainer-attach/attach' in:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains("result: devcontainer-attach/dismissed"),
+        "Enter must not fire a 'dismissed' result — that would mean the \
+         popup was swallowed by an unrelated confirm branch. Screen:\n{}",
+        screen
     );
 }

--- a/crates/fresh-editor/tests/e2e/action_popup_global.rs
+++ b/crates/fresh-editor/tests/e2e/action_popup_global.rs
@@ -194,3 +194,150 @@ fn action_popup_persists_across_buffer_switch() {
         after_switch
     );
 }
+
+fn show_generic_popup(
+    harness: &mut EditorTestHarness,
+    popup_id: &str,
+    title: &str,
+    body: &str,
+    actions: Vec<(&str, &str)>,
+) {
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::ShowActionPopup {
+            popup_id: popup_id.to_string(),
+            title: title.to_string(),
+            message: body.to_string(),
+            actions: actions
+                .into_iter()
+                .map(|(id, label)| ActionPopupAction {
+                    id: id.to_string(),
+                    label: label.to_string(),
+                })
+                .collect(),
+        })
+        .unwrap();
+}
+
+/// Two popups pushed concurrently (e.g. two plugins both deciding the
+/// session needs attention) must queue LIFO: only the top is interactive,
+/// dismissing it surfaces the next, and each one fires its own
+/// `action_popup_result` hook instead of the second clobbering the first's
+/// tracking.
+#[test]
+fn action_popups_queue_and_each_resolves_independently() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // First plugin pops up an attach prompt.
+    show_generic_popup(
+        &mut harness,
+        "devcontainer-attach",
+        "Attach?",
+        "Attach to 'alpha'?",
+        vec![("attach", "Attach alpha"), ("dismiss", "Not now alpha")],
+    );
+    // Second plugin pops up right after — e.g. a different plugin's warning.
+    show_generic_popup(
+        &mut harness,
+        "pkg-install",
+        "Install?",
+        "Install bravo package?",
+        vec![("yes", "Install bravo"), ("no", "Skip bravo")],
+    );
+    harness.render().unwrap();
+
+    // Only the second (top-of-stack) popup is visible. The first is queued
+    // underneath and re-surfaces when the top is dismissed.
+    let frame1 = harness.screen_to_string();
+    assert!(
+        frame1.contains("Install bravo"),
+        "Top-of-stack popup must render. Screen:\n{}",
+        frame1
+    );
+    assert!(
+        !frame1.contains("Attach alpha"),
+        "Queued popup must not leak through underneath. Screen:\n{}",
+        frame1
+    );
+
+    // Esc dismisses the top (fires action_popup_result for 'pkg-install').
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Now the first popup (`devcontainer-attach`) takes its place.
+    let frame2 = harness.screen_to_string();
+    assert!(
+        frame2.contains("Attach alpha"),
+        "Queued popup must surface after the top is dismissed. Screen:\n{}",
+        frame2
+    );
+    assert!(
+        !frame2.contains("Install bravo"),
+        "Dismissed popup must not be re-drawn. Screen:\n{}",
+        frame2
+    );
+
+    // Dismiss the remaining popup too.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let frame3 = harness.screen_to_string();
+    assert!(
+        !frame3.contains("Attach alpha") && !frame3.contains("Install bravo"),
+        "Both popups must be gone after two Esc presses. Screen:\n{}",
+        frame3
+    );
+}
+
+/// Same as above, but each popup is confirmed via Enter rather than Esc,
+/// exercising the confirm path's parallel-stack pop.
+#[test]
+fn action_popups_queue_confirms_preserve_per_popup_identity() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    show_generic_popup(
+        &mut harness,
+        "first",
+        "First?",
+        "First popup body",
+        vec![("ok", "OK first"), ("cancel", "Cancel first")],
+    );
+    show_generic_popup(
+        &mut harness,
+        "second",
+        "Second?",
+        "Second popup body",
+        vec![("ok", "OK second"), ("cancel", "Cancel second")],
+    );
+    harness.render().unwrap();
+
+    // Enter on the top popup ('second') — default selection is index 0 'OK'.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let after_first_confirm = harness.screen_to_string();
+    assert!(
+        !after_first_confirm.contains("Second popup body"),
+        "Top popup must be gone after Enter. Screen:\n{}",
+        after_first_confirm
+    );
+    assert!(
+        after_first_confirm.contains("First popup body"),
+        "Queued popup must surface after top is confirmed. Screen:\n{}",
+        after_first_confirm
+    );
+
+    // Enter again — this time on the first popup.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    let after_second_confirm = harness.screen_to_string();
+    assert!(
+        !after_second_confirm.contains("First popup body"),
+        "Both popups must be resolved. Screen:\n{}",
+        after_second_confirm
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -1,3 +1,4 @@
+pub mod action_popup_global;
 pub mod altgr_shift;
 pub mod ansi_cursor;
 pub mod auto_indent;

--- a/crates/fresh-editor/tests/e2e/plugins/authority_snapshot.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/authority_snapshot.rs
@@ -1,0 +1,111 @@
+//! Regression test for the devcontainer-restart re-prompt bug.
+//!
+//! Repro: after the user picks "Attach" in the devcontainer popup, the
+//! plugin calls `setAuthority`, which triggers the editor-restart flow.
+//! `main.rs` constructs a fresh `Editor` (with `Authority::local()` and
+//! empty `display_label`), then calls `set_boot_authority(real)` and
+//! finally fires the `plugins_loaded` hook so plugins can finish
+//! initializing.
+//!
+//! The devcontainer plugin's "am I already attached?" check reads
+//! `editor.getAuthorityLabel()`, which is served from the plugin state
+//! snapshot. Before the fix, `set_boot_authority` didn't refresh that
+//! snapshot, so the plugin saw the stale empty label that the
+//! `Authority::local()` construction-time default seeded, and re-showed
+//! the attach popup — even though the status bar correctly reflected the
+//! new container authority.
+//!
+//! This test pins the invariant the plugin relies on: **after
+//! `set_boot_authority`, a read from the plugin state snapshot returns
+//! the real authority's `display_label`, not the construction-time
+//! default.** That's sufficient — the JS plugin end of the flow is
+//! straightforward string propagation.
+
+use crate::common::harness::EditorTestHarness;
+use fresh::services::authority::{
+    Authority, AuthorityPayload, FilesystemSpec, SpawnerSpec, TerminalWrapperSpec,
+};
+
+fn devcontainer_authority_payload(label: &str) -> AuthorityPayload {
+    // Filesystem/spawner kinds match the minimal local-fs + host-spawner
+    // combination so the harness doesn't need docker; what matters for
+    // the snapshot propagation test is the `display_label` round-trip.
+    AuthorityPayload {
+        filesystem: FilesystemSpec::Local,
+        spawner: SpawnerSpec::Local,
+        terminal_wrapper: TerminalWrapperSpec::HostShell,
+        display_label: label.to_string(),
+    }
+}
+
+/// Directly observes the plugin state snapshot the plugin runtime reads
+/// from. A failing assertion here means `editor.getAuthorityLabel()`
+/// returns "" from JS — which is what makes the devcontainer popup come
+/// back after restart.
+#[test]
+fn set_boot_authority_refreshes_plugin_state_snapshot() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Sanity: a freshly-constructed Editor has `Authority::local()` with
+    // an empty label, and that is what the snapshot carries.
+    let snapshot_handle = harness
+        .editor()
+        .plugin_manager()
+        .state_snapshot_handle()
+        .expect("plugins enabled in the default test harness");
+    let initial = snapshot_handle.read().unwrap().authority_label.clone();
+    assert_eq!(
+        initial, "",
+        "Construction seeds an empty authority_label in the plugin snapshot"
+    );
+
+    // Install the container authority the same way main.rs does after
+    // editor construction during the post-attach restart.
+    let authority =
+        Authority::from_plugin_payload(devcontainer_authority_payload("Container:deadbeef"))
+            .unwrap();
+    harness.editor_mut().set_boot_authority(authority);
+
+    // The plugin state snapshot must now reflect the container
+    // authority. Before the fix this stayed empty and the devcontainer
+    // plugin's `getAuthorityLabel()` check on `plugins_loaded` still
+    // read "", re-triggering the attach popup.
+    let after = snapshot_handle.read().unwrap().authority_label.clone();
+    assert_eq!(
+        after, "Container:deadbeef",
+        "set_boot_authority must refresh the plugin state snapshot so \
+         `plugins_loaded` hook handlers read the installed label"
+    );
+}
+
+/// Guard the other side of the same invariant: after `clear_authority`
+/// (the `devcontainer_detach` path) flows through, the snapshot returns
+/// to the empty label so "am I already attached?" goes back to "no".
+#[test]
+fn set_boot_authority_back_to_local_clears_plugin_state_snapshot_label() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    let snapshot_handle = harness
+        .editor()
+        .plugin_manager()
+        .state_snapshot_handle()
+        .expect("plugins enabled in the default test harness");
+
+    // Swap to a container authority, then back to local. Each transition
+    // must push through the snapshot, otherwise the plugin's decision
+    // will lag by one restart.
+    let container =
+        Authority::from_plugin_payload(devcontainer_authority_payload("Container:feedface"))
+            .unwrap();
+    harness.editor_mut().set_boot_authority(container);
+    assert_eq!(
+        snapshot_handle.read().unwrap().authority_label,
+        "Container:feedface"
+    );
+
+    harness.editor_mut().set_boot_authority(Authority::local());
+    assert_eq!(
+        snapshot_handle.read().unwrap().authority_label,
+        "",
+        "Swapping back to local must clear the label in the snapshot"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -2,6 +2,7 @@
 //! These tests are only compiled when the "plugins" feature is enabled.
 
 pub mod audit_mode;
+pub mod authority_snapshot;
 pub mod command_keybinding_editor;
 pub mod diagnostics_panel_bugs;
 pub mod diagnostics_panel_jump;


### PR DESCRIPTION
## Summary
This change fixes a regression where plugin action popups (e.g., devcontainer "attach now?" prompts) would disappear when switching to a different buffer. Action popups are now managed at the editor level rather than being attached to individual buffers, ensuring they remain visible and actionable regardless of which buffer is active.

## Key Changes

- **Added editor-level popup stack**: Introduced `global_popups: PopupManager` to the `Editor` struct to manage popups that should persist across buffer switches
- **Routing action popups to global stack**: Modified `handle_plugin_command` to route `ShowActionPopup` commands to the global popup stack instead of the active buffer's stack
- **Input handling precedence**: Updated input dispatch to check global popups first before buffer-level popups, ensuring action popups take precedence and receive keyboard events
- **Rendering on top**: Modified the render pipeline to draw global popups last (on top of all buffer content), including proper layout caching for mouse hit testing
- **Mouse input handling**: Extended mouse input handling to recognize clicks on global popup areas, including close buttons and list items
- **Popup navigation**: Updated popup navigation methods (`popup_select_next`, `popup_select_prev`, `scroll_popup`, etc.) to operate on global popups when visible
- **Popup dismissal**: Modified `hide_popup` to prioritize closing global popups first, preventing event log pollution
- **Comprehensive E2E tests**: Added three regression tests covering:
  - Rendering over virtual buffers (Dashboard pattern)
  - Dismissal via Escape key without fallthrough
  - Persistence across buffer switches

## Implementation Details

- Global popups use absolute positioning (e.g., `BottomRight`, `Centered`) and don't require cursor-relative positioning
- The global popup stack is checked before buffer-level popups in all input/rendering paths to maintain proper modal behavior
- Layout information for global popups is cached separately (`global_popup_areas`) for efficient mouse hit testing
- Action popups remain persistent by design and are not auto-dismissed on scroll like transient popups (Hover, Signature Help)

https://claude.ai/code/session_01Hh63pFLEf3NR7V7PeXQSMY