### PR TITLE
Fix Review Diff viewport jumping on collapse/expand

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -1579,7 +1579,7 @@ function on_review_mouse_click(data: {
                 else state.collapsedSections.add(cat);
                 applyFolds();
                 const sectionRow = state.sectionHeaderRows[cat];
-                if (sectionRow !== undefined) jumpDiffCursorToRow(sectionRow);
+                if (sectionRow !== undefined) jumpDiffCursorToRow(sectionRow, { recenter: false });
                 return;
             }
         }
@@ -1591,7 +1591,7 @@ function on_review_mouse_click(data: {
                 else state.collapsedFiles.add(key);
                 applyFolds();
                 const headerRow = state.fileHeaderRows[key];
-                if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+                if (headerRow !== undefined) jumpDiffCursorToRow(headerRow, { recenter: false });
                 return;
             }
         }
@@ -1602,7 +1602,7 @@ function on_review_mouse_click(data: {
                 else state.collapsedHunks.add(hunkId);
                 applyFolds();
                 const hunkRow = state.hunkRowByHunkId[hunkId];
-                if (hunkRow !== undefined) jumpDiffCursorToRow(hunkRow);
+                if (hunkRow !== undefined) jumpDiffCursorToRow(hunkRow, { recenter: false });
                 return;
             }
         }
@@ -1812,7 +1812,7 @@ function review_toggle_file_collapse() {
         else state.collapsedSections.add(section);
         applyFolds();
         const sectionRow = state.sectionHeaderRows[section];
-        if (sectionRow !== undefined) jumpDiffCursorToRow(sectionRow);
+        if (sectionRow !== undefined) jumpDiffCursorToRow(sectionRow, { recenter: false });
         return;
     }
 
@@ -1824,7 +1824,7 @@ function review_toggle_file_collapse() {
         else state.collapsedFiles.add(key);
         applyFolds();
         const headerRow = state.fileHeaderRows[key];
-        if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+        if (headerRow !== undefined) jumpDiffCursorToRow(headerRow, { recenter: false });
         return;
     }
 
@@ -1835,7 +1835,7 @@ function review_toggle_file_collapse() {
         else state.collapsedHunks.add(hunk.id);
         applyFolds();
         const hunkRow = state.hunkRowByHunkId[hunk.id];
-        if (hunkRow !== undefined) jumpDiffCursorToRow(hunkRow);
+        if (hunkRow !== undefined) jumpDiffCursorToRow(hunkRow, { recenter: false });
         return;
     }
 
@@ -1848,7 +1848,7 @@ function review_toggle_file_collapse() {
     else state.collapsedFiles.add(key);
     applyFolds();
     const headerRow = state.fileHeaderRows[key];
-    if (headerRow !== undefined) jumpDiffCursorToRow(headerRow);
+    if (headerRow !== undefined) jumpDiffCursorToRow(headerRow, { recenter: false });
 }
 registerHandler("review_toggle_file_collapse", review_toggle_file_collapse);
 
@@ -3147,23 +3147,31 @@ registerHandler("review_drill_down", review_drill_down);
 // --- Hunk navigation for side-by-side diff view ---
 
 /**
- * Move the diff panel's native cursor to the given 1-indexed row, scrolling
- * the viewport so the row is visible.
+ * Move the diff panel's native cursor to the given 1-indexed row.
+ *
+ * `options.recenter` controls whether the viewport is re-centered on the
+ * target row. The default is `true` for user-initiated navigation (next
+ * hunk, jump-to-comment, jump-to-file) — there the caller wants the
+ * target to land at a predictable position in the viewport. Callers
+ * that merely re-anchor the cursor to a nearby header (e.g. after a
+ * collapse/expand toggle) should pass `recenter: false` so the viewport
+ * stays put; `setBufferCursor` still runs `ensure_cursor_visible`, so
+ * the cursor is scrolled into view only when it would otherwise move
+ * off-screen. Without this opt-out every fold toggle re-centers the
+ * cursor's row at ~1/3 from the top of the viewport, which makes the
+ * diff jump around whenever the user is reading anywhere else.
  */
-function jumpDiffCursorToRow(row: number): void {
+function jumpDiffCursorToRow(row: number, options?: { recenter?: boolean }): void {
     const diffId = state.panelBuffers["diff"];
     if (diffId === undefined) return;
     const idx = row - 1;
     if (idx < 0 || idx >= state.diffLineByteOffsets.length) return;
 
-    // Set the cursor by absolute byte offset + scroll the viewport.
-    // Trust setBufferCursor — the previous N × executeAction("move_down")
-    // walk was O(target_row) round-trips into the editor and made
-    // collapsing big diffs visibly slow (thousands of round trips just
-    // to land the cursor on a header).
     const byteOffset = state.diffLineByteOffsets[idx];
     editor.setBufferCursor(diffId, byteOffset);
-    editor.scrollBufferToLine(diffId, idx);
+    if (options?.recenter !== false) {
+        editor.scrollBufferToLine(diffId, idx);
+    }
     state.diffCursorRow = row;
     applyCursorLineOverlay('diff');
     refreshStickyHeader(idx);

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2508,6 +2508,118 @@ fn test_review_diff_collapse_all_and_expand_all() {
     );
 }
 
+/// Regression test for the "Review Diff scroll jumps on collapse/expand"
+/// bug: when the user scrolls the diff cursor via `j` until it sits away
+/// from the re-centering point (roughly the top third of the viewport)
+/// and then presses `Tab` to toggle a fold, the viewport must not jump.
+/// Historically the Tab handler called `editor.scrollBufferToLine` after
+/// every fold toggle, forcing the header row to land at ~1/3 from the top
+/// — which yanked the viewport whenever the cursor was anywhere else.
+#[test]
+fn test_review_diff_tab_preserves_scroll_position() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    setup_audit_mode_plugin(&repo);
+
+    // Baseline commit so the modifications below show up as unstaged hunks.
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    // Add enough tracked files with enough per-file content that the
+    // unified diff comfortably overflows a 40-row viewport.
+    for i in 0..8 {
+        let path = format!("src/mod_{}.rs", i);
+        let content = format!(
+            "fn alpha_{i}() {{\n    let a = {i};\n    let b = a + {i};\n    \
+             println!(\"alpha {i} {{}} {{}}\", a, b);\n}}\n\n\
+             fn beta_{i}() {{\n    let c = {i} * 2;\n    let d = c - 1;\n    \
+             println!(\"beta {i} {{}} {{}}\", c, d);\n}}\n",
+            i = i
+        );
+        repo.create_file(&path, &content);
+    }
+    repo.git_add_all();
+    repo.git_commit("Seed files");
+
+    // Modify every file to produce a multi-hunk diff per file.
+    for i in 0..8 {
+        let path = format!("src/mod_{}.rs", i);
+        let content = format!(
+            "fn alpha_{i}() {{\n    let a = {i} + 100;\n    let b = a + {i} * 3;\n    \
+             let extra = a - b;\n    println!(\"alpha {i} v2 {{}} {{}} {{}}\", a, b, extra);\n}}\n\n\
+             fn beta_{i}() {{\n    let c = {i} * 2 + 5;\n    let d = c - 1;\n    \
+             let more = c + d;\n    println!(\"beta {i} v2 {{}} {{}} {{}}\", c, d, more);\n}}\n",
+            i = i
+        );
+        repo.create_file(&path, &content);
+    }
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    let main_rs_path = repo.path.join("src/main.rs");
+    harness.open_file(&main_rs_path).unwrap();
+    harness.render().unwrap();
+
+    let _ = open_review_diff(&mut harness);
+
+    // Scroll the cursor far down the unified stream using native `j`
+    // motion. `j` delegates to the editor's `move_down`, which moves the
+    // cursor one row at a time and only scrolls the viewport when the
+    // cursor would otherwise step off-screen — so after enough presses
+    // the cursor is pinned near the BOTTOM of the viewport, not at the
+    // ~1/3 mark that `scrollBufferToLine` targets. That mismatch is what
+    // the bug exploits.
+    for _ in 0..100 {
+        harness
+            .send_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.render().unwrap();
+
+    let before = harness.screen_to_string();
+    let top_before = diff_top_anchor(&before);
+
+    // Toggle the fold under the cursor. Without the fix this yanks the
+    // viewport so the cursor row re-centers at ~1/3 from the top, which
+    // changes what's rendered at the top of the diff pane.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let after = harness.screen_to_string();
+    let top_after = diff_top_anchor(&after);
+
+    assert_eq!(
+        top_before, top_after,
+        "Review Diff viewport scrolled unexpectedly after Tab. \
+         Toggling a fold must not re-center the viewport.\n\
+         BEFORE:\n{}\n\nAFTER:\n{}",
+        before, after
+    );
+}
+
+/// Slice the top ~10 rows of the diff content pane out of a rendered
+/// screen string. Used by the scroll-position regression test above.
+/// The layout in tests is: menu bar, tab bar, two toolbar hint rows,
+/// separator, sticky file header, separator, then the diff stream. The
+/// first ~7 rows are chrome that never shifts on a scroll, so we skip
+/// them and compare the first 10 rows of actual diff content.
+fn diff_top_anchor(screen: &str) -> String {
+    screen
+        .lines()
+        .skip(7)
+        .take(10)
+        .map(|l| l.trim_end().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Test that the review diff handles symlinks, type changes (file ↔ symlink),
 /// and mode changes (chmod) without errors.
 /// Git reports type changes as 'T' status and mode changes as 'M'.


### PR DESCRIPTION
## Summary
Fixes a bug where toggling a fold (collapse/expand) in the Review Diff view would unexpectedly re-center the viewport, causing the diff to "jump" when the user was reading elsewhere on the screen.

## Root Cause
The `jumpDiffCursorToRow` function was unconditionally calling `editor.scrollBufferToLine` after every fold toggle, which re-centers the viewport so the target row lands at approximately 1/3 from the top. This aggressive re-centering was appropriate for user-initiated navigation (next hunk, jump-to-comment) but inappropriate when merely re-anchoring the cursor to a nearby header after a collapse/expand operation.

## Changes Made
- **audit_mode.ts**: Modified `jumpDiffCursorToRow` to accept an optional `options` parameter with a `recenter` flag (defaults to `true` for backward compatibility)
  - When `recenter: false`, the function skips the `scrollBufferToLine` call
  - The cursor is still moved via `setBufferCursor`, which runs `ensure_cursor_visible` to scroll the cursor into view only if it would step off-screen
  - Updated all fold toggle handlers (mouse clicks and keyboard) to pass `recenter: false` when re-anchoring the cursor after a collapse/expand
  
- **audit_mode.rs**: Added comprehensive regression test `test_review_diff_tab_preserves_scroll_position` that:
  - Creates a large multi-file diff that overflows the viewport
  - Scrolls the cursor far down using `j` motion (pinning it near the bottom of the viewport)
  - Toggles a fold and verifies the viewport content at the top hasn't changed
  - Includes a helper function `diff_top_anchor` to extract and compare the stable diff content

## Implementation Details
The fix preserves the performance optimization of using `setBufferCursor` with byte offsets (avoiding O(n) round-trips to the editor) while making the re-centering behavior context-aware. Fold toggles now only ensure the cursor stays visible without forcing a specific viewport position.

https://claude.ai/code/session_012oymZnfadqfwF2n8eWU7ip