### PR TITLE
Hide hardware cursor when popup overlays it

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -420,6 +420,14 @@ impl Editor {
 
         let is_maximized = self.split_manager.is_maximized();
 
+        // The active split's buffer renderer records where the hardware
+        // cursor *wants* to appear here; we only commit it to the frame at
+        // the very end of this draw pass, after popups have been rendered,
+        // so a popup covering the cursor cell causes the cursor to be
+        // hidden (otherwise the hardware caret would bleed through the
+        // popup).
+        let mut pending_hardware_cursor: Option<(u16, u16)> = None;
+
         let _content_span = tracing::info_span!("render_content").entered();
         let (
             split_areas,
@@ -464,6 +472,7 @@ impl Editor {
             self.config.editor.show_tilde,
             &mut self.cached_layout.cell_theme_map,
             size.width,
+            &mut pending_hardware_cursor,
         );
 
         drop(_content_span);
@@ -1144,11 +1153,67 @@ impl Editor {
             }
         }
 
+        // Commit the active-split hardware cursor (deferred since
+        // `render_content`) unless a popup has been drawn over that cell.
+        // Ratatui draws the hardware caret on top of every cell, so a
+        // popup cannot hide the cursor by painting cells — the only way
+        // to hide it is to leave `Frame::cursor_position` as `None`, which
+        // triggers `Terminal::hide_cursor` at the end of the draw.
+        //
+        // When a prompt is active the prompt renderer already placed the
+        // caret on the prompt line via `frame.set_cursor_position`; don't
+        // override it with the (now-irrelevant) buffer cursor.
+        if let Some((cx, cy)) = pending_hardware_cursor {
+            if self.prompt.is_none() && !self.cursor_obscured_by_overlay(cx, cy) {
+                frame.set_cursor_position((cx, cy));
+            }
+        }
+
         // Convert all colors for terminal capability (256/16 color fallback)
         crate::view::color_support::convert_buffer_colors(
             frame.buffer_mut(),
             self.color_capability,
         );
+    }
+
+    /// Returns true if `(x, y)` falls inside any popup-style overlay that
+    /// was rendered this frame. Used to decide whether the hardware cursor
+    /// should be shown or hidden so it does not bleed through a popup.
+    fn cursor_obscured_by_overlay(&self, x: u16, y: u16) -> bool {
+        let inside = |rect: ratatui::layout::Rect| -> bool {
+            x >= rect.x
+                && x < rect.x.saturating_add(rect.width)
+                && y >= rect.y
+                && y < rect.y.saturating_add(rect.height)
+        };
+
+        if self
+            .cached_layout
+            .popup_areas
+            .iter()
+            .any(|entry| inside(entry.1))
+        {
+            return true;
+        }
+        if self
+            .cached_layout
+            .global_popup_areas
+            .iter()
+            .any(|entry| inside(entry.1))
+        {
+            return true;
+        }
+        if let Some((rect, _, _, _)) = self.cached_layout.suggestions_area {
+            if inside(rect) {
+                return true;
+            }
+        }
+        if let Some(ref fb) = self.file_browser_layout {
+            if inside(fb.popup_area) {
+                return true;
+            }
+        }
+        false
     }
 
     /// Render the Quick Open hints line showing available mode prefixes

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -91,6 +91,7 @@ impl SplitRenderer {
         show_tilde: bool,
         cell_theme_map: &mut Vec<crate::app::types::CellThemeInfo>,
         screen_width: u16,
+        pending_hardware_cursor: &mut Option<(u16, u16)>,
     ) -> (
         Vec<(LeafId, BufferId, Rect, Rect, usize, usize)>,
         HashMap<LeafId, crate::view::ui::tabs::TabLayout>,
@@ -141,6 +142,7 @@ impl SplitRenderer {
             show_tilde,
             cell_theme_map,
             screen_width,
+            pending_hardware_cursor,
         )
     }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -84,6 +84,7 @@ pub(crate) fn render_content(
     show_tilde: bool,
     cell_theme_map: &mut Vec<crate::app::types::CellThemeInfo>,
     screen_width: u16,
+    pending_hardware_cursor: &mut Option<(u16, u16)>,
 ) -> (
     Vec<(LeafId, BufferId, Rect, Rect, usize, usize)>,
     HashMap<LeafId, crate::view::ui::tabs::TabLayout>, // tab layouts per split
@@ -575,6 +576,7 @@ pub(crate) fn render_content(
                 split_show_tilde,
                 cell_theme_map,
                 screen_width,
+                pending_hardware_cursor,
             );
 
             drop(_render_buf_span);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -395,6 +395,7 @@ pub(crate) fn draw_buffer_in_split(
     software_cursor_only: bool,
     rulers: &[usize],
     compose_column_guides: Option<Vec<u16>>,
+    pending_hardware_cursor: &mut Option<(u16, u16)>,
 ) {
     let render_area = layout_output.render_area;
     let effective_editor_bg = layout_output.effective_editor_bg;
@@ -484,7 +485,12 @@ pub(crate) fn draw_buffer_in_split(
     }
 
     if let Some((screen_x, screen_y)) = cursor_screen_pos {
-        frame.set_cursor_position((screen_x, screen_y));
+        // Record the hardware cursor position instead of committing it to
+        // the frame now. `render.rs` decides at the end of the render pass
+        // whether to show the cursor — if a popup later overlays this cell
+        // it suppresses the cursor so the hardware caret does not bleed
+        // through the popup.
+        *pending_hardware_cursor = Some((screen_x, screen_y));
 
         // When software_cursor_only the backend has no hardware cursor, so
         // ensure the cell at the cursor position always has REVERSED style.
@@ -546,6 +552,7 @@ pub(crate) fn render_buffer_in_split(
     show_tilde: bool,
     cell_theme_map: &mut Vec<CellThemeInfo>,
     screen_width: u16,
+    pending_hardware_cursor: &mut Option<(u16, u16)>,
 ) -> Vec<ViewLineMapping> {
     let layout_output = compute_buffer_layout(
         state,
@@ -589,6 +596,7 @@ pub(crate) fn render_buffer_in_split(
         software_cursor_only,
         rulers,
         compose_column_guides,
+        pending_hardware_cursor,
     );
 
     view_line_mappings

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1848,6 +1848,31 @@ impl EditorTestHarness {
         (pos.x, pos.y)
     }
 
+    /// Render and report whether the hardware cursor was shown, and where.
+    ///
+    /// Returns `Some((x, y))` if ratatui's `Terminal::draw` ended the frame
+    /// by calling `show_cursor` + `set_cursor_position` — i.e. the editor
+    /// populated `Frame::cursor_position`. Returns `None` if `hide_cursor`
+    /// was called — i.e. `Frame::cursor_position` was `None`.
+    ///
+    /// Detection uses a sentinel: before `draw`, we move the backend's
+    /// cursor to `(0, 0)`. `Terminal::draw` only updates the backend
+    /// position when the frame asked for the cursor to be shown, so if the
+    /// position stays at the sentinel afterward, the frame hid it. The
+    /// editor never places its hardware cursor at `(0, 0)` (row 0 is the
+    /// menu bar), so the sentinel is unambiguous.
+    pub fn render_observing_cursor(&mut self) -> anyhow::Result<Option<(u16, u16)>> {
+        self.terminal
+            .set_cursor_position(ratatui::layout::Position::new(0, 0))?;
+        self.render()?;
+        let pos = self.terminal.get_cursor_position().unwrap_or_default();
+        if pos.x == 0 && pos.y == 0 {
+            Ok(None)
+        } else {
+            Ok(Some((pos.x, pos.y)))
+        }
+    }
+
     /// Find all visible cursors on screen
     /// Returns a vec of (x, y, character_at_cursor, is_primary)
     /// Primary cursor is detected at hardware cursor position

--- a/crates/fresh-editor/tests/e2e/cursor_under_popup.rs
+++ b/crates/fresh-editor/tests/e2e/cursor_under_popup.rs
@@ -1,0 +1,79 @@
+//! The hardware cursor must not show through a popup.
+//!
+//! Popups are drawn on top of the buffer content, but the ratatui-managed
+//! hardware cursor (`Frame::set_cursor_position`) is rendered by the real
+//! terminal *on top of* every cell — including popup cells. If we leave
+//! the cursor position set when a popup has covered that cell, the user
+//! sees the cursor blink through the popup. The fix is to omit
+//! `Frame::set_cursor_position` for the frame when the cursor would land
+//! inside any popup rect, so `Terminal::draw` calls `hide_cursor`.
+
+use crate::common::harness::EditorTestHarness;
+use fresh::view::popup::{Popup, PopupPosition};
+
+/// A popup placed over the editor cursor must cause the hardware cursor
+/// to be hidden — otherwise the cursor shows through the popup.
+#[test]
+fn hardware_cursor_is_hidden_when_popup_covers_it() {
+    let mut harness = EditorTestHarness::new(80, 30).unwrap();
+
+    // Put something in the buffer so the cursor lives at a known, non-trivial
+    // position (well inside the content area — never at (0, 0)).
+    harness.type_text("hello world").unwrap();
+
+    // Baseline: with no popup, ratatui should render the cursor (Some(..)).
+    let (cx, cy) = harness
+        .render_observing_cursor()
+        .unwrap()
+        .expect("hardware cursor should be visible when no popup is shown");
+
+    // Place a popup so its rect contains (cx, cy).
+    let popup_x = cx.saturating_sub(2);
+    let popup_y = cy.saturating_sub(1);
+    {
+        let editor = harness.editor_mut();
+        let theme = editor.theme().clone();
+        let popup = Popup::text(
+            vec![
+                "I cover the cursor".to_string(),
+                "Line 2 of popup".to_string(),
+                "Line 3 of popup".to_string(),
+            ],
+            &theme,
+        )
+        .with_position(PopupPosition::Fixed {
+            x: popup_x,
+            y: popup_y,
+        })
+        .with_width(40)
+        .with_max_height(10);
+        editor.active_state_mut().popups.show(popup);
+    }
+
+    let cursor_after = harness.render_observing_cursor().unwrap();
+
+    // Sanity: popup actually rendered on top of the buffer cell.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("I cover the cursor"),
+        "popup should be visible on screen, screen was:\n{screen}"
+    );
+
+    // The bug: hardware cursor is still placed at (cx, cy) — which is now
+    // inside the popup — so it shows through. The fix: cursor should be
+    // hidden (None) or moved outside the popup rect.
+    match cursor_after {
+        None => {}
+        Some((hx, hy)) => {
+            let inside_popup =
+                hx >= popup_x && hx < popup_x + 40 && hy >= popup_y && hy < popup_y + 5; // 3 content lines + 2 borders
+            assert!(
+                !inside_popup,
+                "hardware cursor at ({hx}, {hy}) is inside popup rect \
+                 ({popup_x}, {popup_y})..({},{}) — it will show through",
+                popup_x + 40,
+                popup_y + 5,
+            );
+        }
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -21,6 +21,7 @@ pub mod csharp_language_coherence;
 pub mod csi_u_session_input;
 pub mod ctrl_end_wrapped;
 pub mod cursor_style_rendering;
+pub mod cursor_under_popup;
 pub mod dabbrev_completion;
 pub mod document_model;
 pub mod duplicate_line;


### PR DESCRIPTION
## Summary
Fixes a visual bug where the hardware cursor would blink through popup overlays. Ratatui renders the hardware cursor on top of all cells, so popups cannot hide it by painting over cells. The solution is to defer setting the cursor position until after popups are rendered, then suppress it if a popup covers that cell.

## Key Changes
- **Deferred cursor positioning**: Modified `draw_buffer_in_split` to record the desired hardware cursor position in a `pending_hardware_cursor` variable instead of immediately committing it to the frame
- **Overlay detection**: Added `cursor_obscured_by_overlay()` method to check if a cursor position falls within any rendered popup, global popup, suggestions area, or file browser
- **Conditional cursor commit**: At the end of the render pass in `render.rs`, only call `frame.set_cursor_position()` if the cursor is not obscured by an overlay and no prompt is active
- **Test coverage**: Added `hardware_cursor_is_hidden_when_popup_covers_it()` e2e test to verify the cursor is hidden when a popup covers it

## Implementation Details
- The cursor position flows through the render pipeline as a mutable reference: `render_content()` → `SplitRenderer::render()` → `render_buffer_in_split()` → `draw_buffer_in_split()`
- Popup areas are already tracked in `cached_layout` (popup_areas, global_popup_areas, suggestions_area, file_browser_layout), so overlay detection reuses existing data
- The fix respects prompt rendering, which already manages its own cursor position
- Test harness includes new `render_observing_cursor()` method that uses a sentinel position to detect whether the terminal's cursor was actually shown

https://claude.ai/code/session_01Epo7u8DXKeaBae5nsHrgD4