### PR TITLE
Force module mode in isolated declarations and refresh plugins.d.ts on InitEdit

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1255,14 +1255,27 @@ impl Editor {
                 // then open it in the editor so users can edit + reload.
                 let config_dir = self.dir_context.config_dir.clone();
                 match crate::init_script::ensure_starter(&config_dir) {
-                    Ok(path) => match self.open_file(&path) {
-                        Ok(_) => {
-                            self.set_status_message(format!("init.ts: {}", path.display()));
+                    Ok(path) => {
+                        // Regenerate `types/plugins.d.ts` from the live plugin
+                        // set. It's written once at editor startup, but any
+                        // plugin loaded/reloaded/unloaded since then would
+                        // leave the aggregate stale (or missing, in builds
+                        // where the plugins feature was off at boot but the
+                        // user has since enabled a plugin). The user's
+                        // tsconfig.json lists this file in `files`, so a
+                        // stale copy is exactly when `getPluginApi("foo")`
+                        // loses its typed overload.
+                        let declarations = self.plugin_manager.plugin_declarations();
+                        crate::init_script::write_plugin_declarations(&config_dir, &declarations);
+                        match self.open_file(&path) {
+                            Ok(_) => {
+                                self.set_status_message(format!("init.ts: {}", path.display()));
+                            }
+                            Err(e) => {
+                                self.set_status_message(format!("init.ts: open failed: {e}"));
+                            }
                         }
-                        Err(e) => {
-                            self.set_status_message(format!("init.ts: open failed: {e}"));
-                        }
-                    },
+                    }
                     Err(e) => {
                         self.set_status_message(format!("init.ts: create failed: {e}"));
                     }

--- a/crates/fresh-editor/tests/e2e/plugins/init_script.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/init_script.rs
@@ -363,6 +363,41 @@ fn init_edit_creates_starter_template_when_missing() {
 }
 
 #[test]
+fn init_edit_refreshes_plugins_d_ts() {
+    // The user's tsconfig.json lists `types/plugins.d.ts` in `files`, so
+    // it must exist by the time the LSP picks up init.ts or the typed
+    // `getPluginApi("foo")` overload stays untyped. Startup writes the
+    // file once; the InitEdit action re-runs that write so plugins
+    // loaded/unloaded since boot are reflected before the user opens
+    // init.ts, and so a user who deleted the file gets it back.
+    use fresh::input::keybindings::Action;
+
+    let (mut harness, _tmp, config_dir) = harness_with_scratch_config_dir();
+    let plugins_dts = config_dir.join("types").join("plugins.d.ts");
+
+    // Delete whatever the harness may have written at boot so we can
+    // assert that InitEdit itself re-creates the file.
+    if plugins_dts.exists() {
+        fs::remove_file(&plugins_dts).unwrap();
+    }
+
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::InitEdit);
+    harness.editor_mut().process_async_messages();
+
+    assert!(
+        plugins_dts.exists(),
+        "InitEdit must write types/plugins.d.ts so the user's tsconfig.json resolves"
+    );
+    let body = std::fs::read_to_string(&plugins_dts).unwrap();
+    assert!(
+        body.contains("AUTO-GENERATED"),
+        "plugins.d.ts should carry the fresh autogen header: {body:?}"
+    );
+}
+
+#[test]
 fn init_check_action_reports_ok_on_a_clean_file() {
     use fresh::input::keybindings::Action;
 

--- a/crates/fresh-parser-js/src/lib.rs
+++ b/crates/fresh-parser-js/src/lib.rs
@@ -73,6 +73,18 @@ pub fn transpile_typescript(source: &str, filename: &str) -> Result<String> {
 /// downstream plugins and to the user's `init.ts` without manual
 /// `.d.ts` maintenance.
 ///
+/// The source is forced into **module** mode before the transform runs:
+/// isolated-declarations only hides non-exported symbols when the input
+/// AST has at least one `ImportDeclaration`/`ExportDeclaration`. For a
+/// plain-script input it instead emits a `declare` for every top-level
+/// declaration, leaking internal interfaces, constants, and function
+/// signatures into the aggregate `plugins.d.ts`. Many Fresh plugins
+/// have no `import`/`export` statement (they're top-level calls on the
+/// ambient `editor` global), so we append the canonical empty-export
+/// marker `export {};` when the source doesn't already have module
+/// syntax. `SourceType::with_module(true)` on the parser alone is not
+/// enough — the transform looks at the AST, not the parser flag.
+///
 /// Returns the generated `.d.ts` source as a string. Non-fatal
 /// diagnostics from the isolated-declarations pass are surfaced in
 /// the error path when they render an empty emit unusable; benign
@@ -80,9 +92,19 @@ pub fn transpile_typescript(source: &str, filename: &str) -> Result<String> {
 /// are tolerated and the caller simply gets a partial emit.
 pub fn emit_isolated_declarations(source: &str, filename: &str) -> Result<String> {
     let allocator = Allocator::default();
-    let source_type = SourceType::from_path(filename).unwrap_or_default();
+    let source_type = SourceType::from_path(filename)
+        .unwrap_or_default()
+        .with_module(true);
 
-    let parser_ret = Parser::new(&allocator, source, source_type).parse();
+    let module_marked;
+    let effective_source: &str = if has_es_module_syntax(source) {
+        source
+    } else {
+        module_marked = format!("{source}\nexport {{}};\n");
+        &module_marked
+    };
+
+    let parser_ret = Parser::new(&allocator, effective_source, source_type).parse();
     if !parser_ret.errors.is_empty() {
         let errors: Vec<String> = parser_ret.errors.iter().map(|e| e.to_string()).collect();
         return Err(anyhow!(
@@ -827,6 +849,58 @@ fn declaration_to_statement(decl: Declaration<'_>) -> Statement<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn emit_isolated_declarations_script_hides_internals() {
+        // Script-style plugin: no `import`, no `export`. Before we forced
+        // module mode, isolated-declarations treated every top-level
+        // declaration as publicly visible and leaked `interface Internal`,
+        // `declare const internal`, `declare function internal()` into
+        // the emit. Module mode keeps the output empty for a file with
+        // no exports.
+        let source = r#"
+            interface Internal { x: number; }
+            const internalConst: Internal = { x: 1 };
+            function internalFn(): void {}
+        "#;
+        let dts = emit_isolated_declarations(source, "script_plugin.ts").unwrap();
+        assert!(
+            !dts.contains("Internal"),
+            "non-exported interface leaked into .d.ts: {dts}"
+        );
+        assert!(
+            !dts.contains("internalConst"),
+            "non-exported const leaked into .d.ts: {dts}"
+        );
+        assert!(
+            !dts.contains("internalFn"),
+            "non-exported function leaked into .d.ts: {dts}"
+        );
+    }
+
+    #[test]
+    fn emit_isolated_declarations_keeps_exports_and_registry_augmentation() {
+        // A plugin that has no `import`/`export` statements in the
+        // value plane but does augment `FreshPluginRegistry` still has
+        // to land its `declare global` block in the emit — that's what
+        // makes `editor.getPluginApi("foo")` typed in init.ts.
+        let source = r#"
+            export type FooApi = { doThing(): void };
+            declare global {
+                interface FreshPluginRegistry {
+                    foo: FooApi;
+                }
+            }
+            const internal = 42;
+        "#;
+        let dts = emit_isolated_declarations(source, "foo.ts").unwrap();
+        assert!(dts.contains("FooApi"), "exported type missing: {dts}");
+        assert!(
+            dts.contains("FreshPluginRegistry"),
+            "registry augmentation missing: {dts}"
+        );
+        assert!(!dts.contains("internal"), "internal const leaked: {dts}");
+    }
 
     #[test]
     fn test_transpile_basic_typescript() {


### PR DESCRIPTION
## Summary
This PR fixes two related issues with Fresh plugin type generation:

1. **Isolated declarations now forces module mode** to prevent internal symbols from leaking into the aggregate `plugins.d.ts` file for script-style plugins that have no `import`/`export` statements.

2. **InitEdit action now regenerates `plugins.d.ts`** to ensure the file stays in sync when plugins are loaded, reloaded, or unloaded after editor startup.

## Key Changes

### Parser: Force Module Mode for Isolated Declarations
- Modified `emit_isolated_declarations()` to set `with_module(true)` on the `SourceType` to ensure the isolated-declarations transform treats the input as a module
- Added logic to append `export {};` to script-style plugin sources that lack ES module syntax, forcing the AST into module mode where isolated-declarations properly hides non-exported symbols
- Added comprehensive documentation explaining why this is necessary (isolated-declarations only hides internals when the AST contains import/export declarations)
- Added two new tests:
  - `emit_isolated_declarations_script_hides_internals`: Verifies that internal interfaces, constants, and functions don't leak into the `.d.ts` output for script-style plugins
  - `emit_isolated_declarations_keeps_exports_and_registry_augmentation`: Ensures exported types and `declare global` blocks are preserved while internal symbols remain hidden

### Editor: Refresh plugins.d.ts on InitEdit
- Modified the `InitEdit` action handler to regenerate `types/plugins.d.ts` from the current plugin set before opening `init.ts`
- This ensures the file is always in sync with loaded/unloaded plugins and recovers the file if it was deleted
- Added e2e test `init_edit_refreshes_plugins_d_ts` to verify the file is created/refreshed by the InitEdit action

## Implementation Details
- The `module_marked` variable uses a local binding to ensure the appended `export {};` string lives long enough for the parser
- The regeneration happens before opening the file so users see the updated types immediately
- The solution respects the user's `tsconfig.json` which lists `types/plugins.d.ts` in `files`, making the file critical for type resolution

https://claude.ai/code/session_01LkrVgJawDLdzVk22FzUMfT