### PR TITLE
Add cancel and build log support for devcontainer attach

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2010,12 +2010,29 @@ pub enum PluginCommand {
     /// (e.g. `devcontainer up`) before installing an authority that
     /// would otherwise route the spawn elsewhere. Behaves like
     /// `SpawnProcess` but always uses `LocalProcessSpawner`.
+    ///
+    /// The TS-side handle exposes `.kill()` on the returned
+    /// `ProcessHandle`, serviced by `KillHostProcess` below — this
+    /// lets callers abort a long-running host spawn (e.g.
+    /// `devcontainer up`) via a user action like "Cancel Startup".
     SpawnHostProcess {
         command: String,
         args: Vec<String>,
         cwd: Option<String>,
         callback_id: JsCallbackId,
     },
+
+    /// Cancel a host-side process previously started via
+    /// `SpawnHostProcess`. `process_id` is the callback id returned
+    /// by `spawnHostProcess` (the TS handle stores it and forwards
+    /// when the caller invokes `.kill()`).
+    ///
+    /// No-op when the id is unknown — the process may have already
+    /// exited, or the caller may hold a stale handle. SIGKILL on
+    /// Unix per `tokio::process::Child::start_kill`; children of the
+    /// killed process may leak (see Q-C2 in
+    /// `DEVCONTAINER_SPEC_GAP_PLAN.md`).
+    KillHostProcess { process_id: u64 },
 }
 
 impl PluginCommand {
@@ -4281,5 +4298,23 @@ mod tests {
         let h = api.state_snapshot_handle();
         assert_eq!(h.read().unwrap().active_buffer_id, BufferId(42));
         assert!(Arc::ptr_eq(&h, &snap));
+    }
+
+    /// `KillHostProcess` survives a round-trip through serde: the
+    /// `process_id` field stays identified by name and the variant
+    /// retains its tag shape. If a future contributor renames the
+    /// field or splits it into a tuple, the plugin-runtime TS side
+    /// (which hand-builds the command JSON for the dispatcher) would
+    /// silently break — this test pins the wire format.
+    #[test]
+    fn plugin_command_kill_host_process_serde_round_trip() {
+        let cmd = PluginCommand::KillHostProcess { process_id: 1234 };
+        let json = serde_json::to_value(&cmd).unwrap();
+        assert_eq!(json["KillHostProcess"]["process_id"], 1234);
+        let decoded: PluginCommand = serde_json::from_value(json).unwrap();
+        match decoded {
+            PluginCommand::KillHostProcess { process_id } => assert_eq!(process_id, 1234),
+            other => panic!("expected KillHostProcess, got {:?}", other),
+        }
     }
 }

--- a/crates/fresh-editor/plugins/devcontainer.i18n.json
+++ b/crates/fresh-editor/plugins/devcontainer.i18n.json
@@ -72,7 +72,16 @@
     "indicator.error_initialize": "initializeCommand failed",
     "status.rebuild_parse_failed": "could not parse devcontainer up output",
     "status.rebuild_missing_container_id": "missing containerId",
-    "indicator.error_restart_recovery": "attach did not complete"
+    "indicator.error_restart_recovery": "attach did not complete",
+    "status.build_log_prepare_failed": "Could not prepare build log file",
+    "status.no_build_log": "No dev container build log yet",
+    "status.build_log_missing": "Build log file is missing or unreadable",
+    "status.cancel_nothing_in_flight": "No dev container attach is in progress",
+    "status.attach_cancelled": "Dev container attach cancelled",
+    "cmd.show_build_logs": "Dev Container: Show Build Logs",
+    "cmd.show_build_logs_desc": "Open the most recent devcontainer up build log",
+    "cmd.cancel_attach": "Dev Container: Cancel Startup",
+    "cmd.cancel_attach_desc": "Abort an in-flight dev container attach"
   },
   "cs": {
     "cmd.show_info": "Dev Container: Zobrazit info",
@@ -147,7 +156,16 @@
     "indicator.error_initialize": "initializeCommand selhal",
     "status.rebuild_parse_failed": "nelze zpracovat výstup devcontainer up",
     "status.rebuild_missing_container_id": "chybí containerId",
-    "indicator.error_restart_recovery": "připojení nebylo dokončeno"
+    "indicator.error_restart_recovery": "připojení nebylo dokončeno",
+    "status.build_log_prepare_failed": "Nelze připravit soubor s protokolem sestavení",
+    "status.no_build_log": "Žádný protokol sestavení dev containeru zatím není",
+    "status.build_log_missing": "Soubor s protokolem sestavení chybí nebo je nečitelný",
+    "status.cancel_nothing_in_flight": "Neprobíhá žádné připojování dev containeru",
+    "status.attach_cancelled": "Připojování dev containeru zrušeno",
+    "cmd.show_build_logs": "Dev Container: Zobrazit protokol sestavení",
+    "cmd.show_build_logs_desc": "Otevřít protokol posledního devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Zrušit spouštění",
+    "cmd.cancel_attach_desc": "Přerušit probíhající připojování dev containeru"
   },
   "de": {
     "cmd.show_info": "Dev Container: Info anzeigen",
@@ -222,7 +240,16 @@
     "indicator.error_initialize": "initializeCommand fehlgeschlagen",
     "status.rebuild_parse_failed": "Ausgabe von devcontainer up konnte nicht analysiert werden",
     "status.rebuild_missing_container_id": "containerId fehlt",
-    "indicator.error_restart_recovery": "Anhängen nicht abgeschlossen"
+    "indicator.error_restart_recovery": "Anhängen nicht abgeschlossen",
+    "status.build_log_prepare_failed": "Build-Protokolldatei konnte nicht vorbereitet werden",
+    "status.no_build_log": "Noch kein Dev Container Build-Protokoll vorhanden",
+    "status.build_log_missing": "Build-Protokolldatei fehlt oder ist nicht lesbar",
+    "status.cancel_nothing_in_flight": "Kein Dev Container-Anhang läuft gerade",
+    "status.attach_cancelled": "Dev Container-Anhang abgebrochen",
+    "cmd.show_build_logs": "Dev Container: Build-Protokolle anzeigen",
+    "cmd.show_build_logs_desc": "Öffnet das letzte devcontainer up Build-Protokoll",
+    "cmd.cancel_attach": "Dev Container: Start abbrechen",
+    "cmd.cancel_attach_desc": "Bricht einen laufenden Dev Container-Anhang ab"
   },
   "es": {
     "cmd.show_info": "Dev Container: Mostrar Info",
@@ -297,7 +324,16 @@
     "indicator.error_initialize": "initializeCommand falló",
     "status.rebuild_parse_failed": "no se pudo analizar la salida de devcontainer up",
     "status.rebuild_missing_container_id": "falta containerId",
-    "indicator.error_restart_recovery": "la conexión no se completó"
+    "indicator.error_restart_recovery": "la conexión no se completó",
+    "status.build_log_prepare_failed": "No se pudo preparar el archivo de registro de compilación",
+    "status.no_build_log": "Aún no hay registro de compilación del dev container",
+    "status.build_log_missing": "El archivo de registro de compilación falta o es ilegible",
+    "status.cancel_nothing_in_flight": "No hay ninguna conexión de dev container en curso",
+    "status.attach_cancelled": "Conexión de dev container cancelada",
+    "cmd.show_build_logs": "Dev Container: Mostrar registros de compilación",
+    "cmd.show_build_logs_desc": "Abre el registro del último devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Cancelar inicio",
+    "cmd.cancel_attach_desc": "Aborta una conexión de dev container en curso"
   },
   "fr": {
     "cmd.show_info": "Dev Container: Afficher les infos",
@@ -372,7 +408,16 @@
     "indicator.error_initialize": "initializeCommand a échoué",
     "status.rebuild_parse_failed": "impossible d'analyser la sortie de devcontainer up",
     "status.rebuild_missing_container_id": "containerId manquant",
-    "indicator.error_restart_recovery": "l'attachement n'a pas abouti"
+    "indicator.error_restart_recovery": "l'attachement n'a pas abouti",
+    "status.build_log_prepare_failed": "Impossible de préparer le fichier journal de compilation",
+    "status.no_build_log": "Aucun journal de compilation de dev container",
+    "status.build_log_missing": "Fichier journal de compilation manquant ou illisible",
+    "status.cancel_nothing_in_flight": "Aucun rattachement de dev container en cours",
+    "status.attach_cancelled": "Rattachement de dev container annulé",
+    "cmd.show_build_logs": "Dev Container : Afficher les journaux de compilation",
+    "cmd.show_build_logs_desc": "Ouvrir le dernier journal de devcontainer up",
+    "cmd.cancel_attach": "Dev Container : Annuler le démarrage",
+    "cmd.cancel_attach_desc": "Interrompt un rattachement de dev container en cours"
   },
   "ja": {
     "cmd.show_info": "Dev Container: 情報を表示",
@@ -447,7 +492,16 @@
     "indicator.error_initialize": "initializeCommand が失敗しました",
     "status.rebuild_parse_failed": "devcontainer up の出力を解析できませんでした",
     "status.rebuild_missing_container_id": "containerId がありません",
-    "indicator.error_restart_recovery": "アタッチが完了しませんでした"
+    "indicator.error_restart_recovery": "アタッチが完了しませんでした",
+    "status.build_log_prepare_failed": "ビルドログファイルを準備できませんでした",
+    "status.no_build_log": "Dev Container のビルドログがまだありません",
+    "status.build_log_missing": "ビルドログファイルが見つからないか読み取れません",
+    "status.cancel_nothing_in_flight": "進行中の Dev Container のアタッチはありません",
+    "status.attach_cancelled": "Dev Container のアタッチをキャンセルしました",
+    "cmd.show_build_logs": "Dev Container: ビルドログを表示",
+    "cmd.show_build_logs_desc": "最新の devcontainer up のビルドログを開く",
+    "cmd.cancel_attach": "Dev Container: 起動をキャンセル",
+    "cmd.cancel_attach_desc": "進行中の Dev Container のアタッチを中断する"
   },
   "ko": {
     "cmd.show_info": "Dev Container: 정보 표시",
@@ -522,7 +576,16 @@
     "indicator.error_initialize": "initializeCommand 실패",
     "status.rebuild_parse_failed": "devcontainer up 출력을 파싱할 수 없음",
     "status.rebuild_missing_container_id": "containerId 누락",
-    "indicator.error_restart_recovery": "연결이 완료되지 않음"
+    "indicator.error_restart_recovery": "연결이 완료되지 않음",
+    "status.build_log_prepare_failed": "빌드 로그 파일을 준비할 수 없습니다",
+    "status.no_build_log": "아직 Dev Container 빌드 로그가 없습니다",
+    "status.build_log_missing": "빌드 로그 파일이 없거나 읽을 수 없습니다",
+    "status.cancel_nothing_in_flight": "진행 중인 Dev Container 연결이 없습니다",
+    "status.attach_cancelled": "Dev Container 연결이 취소되었습니다",
+    "cmd.show_build_logs": "Dev Container: 빌드 로그 보기",
+    "cmd.show_build_logs_desc": "최근 devcontainer up의 빌드 로그를 엽니다",
+    "cmd.cancel_attach": "Dev Container: 시작 취소",
+    "cmd.cancel_attach_desc": "진행 중인 Dev Container 연결을 중단합니다"
   },
   "zh-CN": {
     "cmd.show_info": "Dev Container: 显示信息",
@@ -597,7 +660,16 @@
     "indicator.error_initialize": "initializeCommand 失败",
     "status.rebuild_parse_failed": "无法解析 devcontainer up 的输出",
     "status.rebuild_missing_container_id": "缺少 containerId",
-    "indicator.error_restart_recovery": "附加未完成"
+    "indicator.error_restart_recovery": "附加未完成",
+    "status.build_log_prepare_failed": "无法准备构建日志文件",
+    "status.no_build_log": "尚无 Dev Container 构建日志",
+    "status.build_log_missing": "构建日志文件缺失或无法读取",
+    "status.cancel_nothing_in_flight": "当前没有进行中的 Dev Container 连接",
+    "status.attach_cancelled": "已取消 Dev Container 连接",
+    "cmd.show_build_logs": "Dev Container: 显示构建日志",
+    "cmd.show_build_logs_desc": "打开最近一次 devcontainer up 的构建日志",
+    "cmd.cancel_attach": "Dev Container: 取消启动",
+    "cmd.cancel_attach_desc": "中止进行中的 Dev Container 连接"
   },
   "it": {
     "cmd.show_info": "Dev Container: Mostra info",
@@ -672,7 +744,16 @@
     "indicator.error_initialize": "initializeCommand fallito",
     "status.rebuild_parse_failed": "impossibile analizzare l'output di devcontainer up",
     "status.rebuild_missing_container_id": "containerId mancante",
-    "indicator.error_restart_recovery": "collegamento non completato"
+    "indicator.error_restart_recovery": "collegamento non completato",
+    "status.build_log_prepare_failed": "Impossibile preparare il file di log della build",
+    "status.no_build_log": "Nessun log di build del dev container disponibile",
+    "status.build_log_missing": "File di log della build mancante o illeggibile",
+    "status.cancel_nothing_in_flight": "Nessun collegamento al dev container in corso",
+    "status.attach_cancelled": "Collegamento al dev container annullato",
+    "cmd.show_build_logs": "Dev Container: Mostra log di build",
+    "cmd.show_build_logs_desc": "Apre il log dell'ultimo devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Annulla avvio",
+    "cmd.cancel_attach_desc": "Interrompe un collegamento al dev container in corso"
   },
   "pt-BR": {
     "cmd.show_info": "Dev Container: Mostrar informacoes",
@@ -747,7 +828,16 @@
     "indicator.error_initialize": "initializeCommand falhou",
     "status.rebuild_parse_failed": "não foi possível analisar a saída do devcontainer up",
     "status.rebuild_missing_container_id": "containerId ausente",
-    "indicator.error_restart_recovery": "conexão não concluída"
+    "indicator.error_restart_recovery": "conexão não concluída",
+    "status.build_log_prepare_failed": "Não foi possível preparar o arquivo de log de build",
+    "status.no_build_log": "Ainda não há log de build do dev container",
+    "status.build_log_missing": "Arquivo de log de build ausente ou ilegível",
+    "status.cancel_nothing_in_flight": "Nenhuma conexão de dev container em andamento",
+    "status.attach_cancelled": "Conexão de dev container cancelada",
+    "cmd.show_build_logs": "Dev Container: Mostrar logs de build",
+    "cmd.show_build_logs_desc": "Abre o log do último devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Cancelar inicialização",
+    "cmd.cancel_attach_desc": "Aborta uma conexão de dev container em andamento"
   },
   "ru": {
     "cmd.show_info": "Dev Container: Показать информацию",
@@ -822,7 +912,16 @@
     "indicator.error_initialize": "initializeCommand завершился с ошибкой",
     "status.rebuild_parse_failed": "не удалось разобрать вывод devcontainer up",
     "status.rebuild_missing_container_id": "отсутствует containerId",
-    "indicator.error_restart_recovery": "подключение не завершилось"
+    "indicator.error_restart_recovery": "подключение не завершилось",
+    "status.build_log_prepare_failed": "Не удалось подготовить файл журнала сборки",
+    "status.no_build_log": "Журнал сборки dev container пока отсутствует",
+    "status.build_log_missing": "Файл журнала сборки отсутствует или не читается",
+    "status.cancel_nothing_in_flight": "Нет выполняемого подключения dev container",
+    "status.attach_cancelled": "Подключение dev container отменено",
+    "cmd.show_build_logs": "Dev Container: Показать журнал сборки",
+    "cmd.show_build_logs_desc": "Открывает журнал последнего devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Отменить запуск",
+    "cmd.cancel_attach_desc": "Прерывает выполняющееся подключение dev container"
   },
   "th": {
     "cmd.show_info": "Dev Container: แสดงข้อมูล",
@@ -897,7 +996,16 @@
     "indicator.error_initialize": "initializeCommand ล้มเหลว",
     "status.rebuild_parse_failed": "ไม่สามารถแยกวิเคราะห์เอาต์พุตของ devcontainer up",
     "status.rebuild_missing_container_id": "ขาด containerId",
-    "indicator.error_restart_recovery": "การเชื่อมต่อไม่สำเร็จ"
+    "indicator.error_restart_recovery": "การเชื่อมต่อไม่สำเร็จ",
+    "status.build_log_prepare_failed": "ไม่สามารถเตรียมไฟล์บันทึกการสร้าง",
+    "status.no_build_log": "ยังไม่มีบันทึกการสร้าง Dev Container",
+    "status.build_log_missing": "ไฟล์บันทึกการสร้างหายไปหรืออ่านไม่ได้",
+    "status.cancel_nothing_in_flight": "ไม่มีการเชื่อมต่อ Dev Container ที่กำลังดำเนินการ",
+    "status.attach_cancelled": "ยกเลิกการเชื่อมต่อ Dev Container แล้ว",
+    "cmd.show_build_logs": "Dev Container: แสดงบันทึกการสร้าง",
+    "cmd.show_build_logs_desc": "เปิดบันทึกการสร้าง devcontainer up ล่าสุด",
+    "cmd.cancel_attach": "Dev Container: ยกเลิกการเริ่มต้น",
+    "cmd.cancel_attach_desc": "ยกเลิกการเชื่อมต่อ Dev Container ที่กำลังดำเนินการ"
   },
   "uk": {
     "cmd.show_info": "Dev Container: Показати інформацію",
@@ -972,7 +1080,16 @@
     "indicator.error_initialize": "initializeCommand завершився з помилкою",
     "status.rebuild_parse_failed": "не вдалося розібрати вивід devcontainer up",
     "status.rebuild_missing_container_id": "відсутній containerId",
-    "indicator.error_restart_recovery": "підключення не завершилося"
+    "indicator.error_restart_recovery": "підключення не завершилося",
+    "status.build_log_prepare_failed": "Не вдалося підготувати файл журналу збирання",
+    "status.no_build_log": "Журнал збирання dev container ще відсутній",
+    "status.build_log_missing": "Файл журналу збирання відсутній або не читається",
+    "status.cancel_nothing_in_flight": "Немає поточного підключення dev container",
+    "status.attach_cancelled": "Підключення dev container скасовано",
+    "cmd.show_build_logs": "Dev Container: Показати журнал збирання",
+    "cmd.show_build_logs_desc": "Відкриває журнал останнього devcontainer up",
+    "cmd.cancel_attach": "Dev Container: Скасувати запуск",
+    "cmd.cancel_attach_desc": "Перериває поточне підключення dev container"
   },
   "vi": {
     "cmd.show_info": "Dev Container: Hiển thị thông tin",
@@ -1047,6 +1164,15 @@
     "indicator.error_initialize": "initializeCommand thất bại",
     "status.rebuild_parse_failed": "không thể phân tích đầu ra của devcontainer up",
     "status.rebuild_missing_container_id": "thiếu containerId",
-    "indicator.error_restart_recovery": "gắn kết không hoàn tất"
+    "indicator.error_restart_recovery": "gắn kết không hoàn tất",
+    "status.build_log_prepare_failed": "Không thể chuẩn bị tệp nhật ký xây dựng",
+    "status.no_build_log": "Chưa có nhật ký xây dựng dev container",
+    "status.build_log_missing": "Tệp nhật ký xây dựng bị thiếu hoặc không đọc được",
+    "status.cancel_nothing_in_flight": "Không có kết nối dev container đang chạy",
+    "status.attach_cancelled": "Đã hủy kết nối dev container",
+    "cmd.show_build_logs": "Dev Container: Hiện nhật ký xây dựng",
+    "cmd.show_build_logs_desc": "Mở nhật ký devcontainer up gần nhất",
+    "cmd.cancel_attach": "Dev Container: Hủy khởi động",
+    "cmd.cancel_attach_desc": "Hủy kết nối dev container đang chạy"
   }
 }

--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -87,6 +87,17 @@ let infoPanelSplitId: number | null = null;
 let infoPanelOpen = false;
 let cachedContent = "";
 
+// The in-flight `devcontainer up` handle (set before we await, cleared
+// on exit). `devcontainer_cancel_attach` forwards `.kill()` to this.
+// null when no attach is running.
+let attachInFlight: ProcessHandle<SpawnResult> | null = null;
+
+// Set by `devcontainer_cancel_attach` right before it kills the
+// in-flight handle; read by `runDevcontainerUp` so the non-zero exit
+// coming out of the kill doesn't also trigger a FailedAttach — the
+// cancel already set the indicator back to Local.
+let attachCancelled = false;
+
 // Focus state for info panel buttons (Tab navigation like pkg.ts)
 type InfoFocusTarget = { type: "button"; index: number };
 
@@ -1040,10 +1051,79 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
     label: editor.t("indicator.phase_build"),
   });
   editor.setStatus(editor.t("status.rebuilding"));
-  const args = ["up", "--workspace-folder", cwd, ...extraArgs];
-  const result = await editor.spawnHostProcess("devcontainer", args);
+
+  // Redirect `devcontainer up`'s stderr into a workspace-scoped log
+  // file; let stdout flow back through the existing pipe so we parse
+  // the success JSON from `result.stdout` as before. This mirrors
+  // the CLI's stream contract: stdout = machine-readable result;
+  // stderr = human-readable progress / errors. The log file holds
+  // exactly the "progress/errors" half.
+  //
+  // Rationale for the file:
+  //   - "Show Build Logs" is just `openFile(path)` — no new API.
+  //   - Fresh's auto-revert (2s poll) streams lines into the buffer
+  //     as they arrive; user sees live progress without special
+  //     plumbing.
+  //   - Path is under the workspace, so bind-mount coincidence keeps
+  //     it reachable post-attach (container auth sees the same file).
+  //   - `.fresh-cache/.gitignore = *` self-ignores the cache dir
+  //     without forcing users to touch their own `.gitignore`.
+  const logPath = await prepareBuildLogFile(cwd);
+  if (!logPath) {
+    const errText = editor.t("status.build_log_prepare_failed");
+    editor.setStatus(editor.t("status.rebuild_failed", { error: errText }));
+    editor.setRemoteIndicatorState({
+      kind: "failed_attach",
+      error: errText,
+    });
+    return;
+  }
+  rememberLastBuildLogPath(logPath);
+  // Open the log immediately so auto-revert will poll it and the
+  // user sees lines stream in. Non-fatal if openFile fails — the
+  // build continues either way.
+  editor.openFile(logPath, null, null);
+
+  // `sh -c 'exec devcontainer "$@" 2> "$LOG"' sh <log> <args...>` —
+  // positional-arg form so the log path and cwd never get
+  // string-interpolated into the script body. $1 is the log path;
+  // `shift` drops it; `$@` is the devcontainer invocation.
+  const shellScript = 'LOG="$1"; shift; exec devcontainer "$@" 2> "$LOG"';
+  const args = [
+    "-c",
+    shellScript,
+    "sh",
+    logPath,
+    "up",
+    "--workspace-folder",
+    cwd,
+    ...extraArgs,
+  ];
+  const handle = editor.spawnHostProcess("sh", args);
+  attachInFlight = handle;
+  attachCancelled = false;
+  let result: SpawnResult;
+  try {
+    result = await handle;
+  } finally {
+    attachInFlight = null;
+  }
+
+  // Cancel path: `devcontainer_cancel_attach` set `attachCancelled`
+  // and flipped the indicator back to Local already. The non-zero
+  // exit coming out of `Child::start_kill()` is not an error.
+  if (attachCancelled) {
+    attachCancelled = false;
+    return;
+  }
+
   if (result.exit_code !== 0) {
-    const errText = result.stderr.trim() || "unknown";
+    // On failure the log file holds the stderr trace — surface its
+    // last non-empty line as a human-readable status blurb. This
+    // is purely cosmetic; exit_code drove the branch.
+    const logText = editor.readFile(logPath) ?? "";
+    const errText = extractLastNonEmptyLine(logText)
+      ?? `exit ${result.exit_code}`;
     editor.setStatus(editor.t("status.rebuild_failed", { error: errText }));
     editor.setRemoteIndicatorState({
       kind: "failed_attach",
@@ -1086,6 +1166,60 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
   editor.setAuthority(payload);
 }
 
+// Lay out `.fresh-cache/devcontainer-logs/<timestamp>.log` under the
+// workspace. Returns the log path on success, null on failure
+// (mkdir denied, etc.). The directory carries its own
+// `.gitignore = *` so the cache never leaks into a commit without
+// the user touching their top-level `.gitignore`.
+async function prepareBuildLogFile(cwd: string): Promise<string | null> {
+  const cacheDir = `${cwd}/.fresh-cache`;
+  const logDir = `${cacheDir}/devcontainer-logs`;
+  const mkRes = await editor.spawnHostProcess("mkdir", ["-p", logDir]);
+  if (mkRes.exit_code !== 0) {
+    editor.debug(
+      `devcontainer: mkdir -p ${logDir} failed: ${mkRes.stderr.trim()}`,
+    );
+    return null;
+  }
+  const cacheIgnore = `${cacheDir}/.gitignore`;
+  if (editor.readFile(cacheIgnore) === null) {
+    // writeFile failure is non-fatal — worst case the user sees
+    // `.fresh-cache/` in `git status` once.
+    editor.writeFile(cacheIgnore, "*\n");
+  }
+  // `toISOString()` → "2026-04-21T12:34:56.789Z"; strip the ms+Z
+  // and swap separators that are awkward in filenames on some
+  // platforms.
+  const ts = new Date()
+    .toISOString()
+    .replace(/\.\d+Z$/, "")
+    .replace(/:/g, "-")
+    .replace("T", "_");
+  return `${logDir}/build-${ts}.log`;
+}
+
+function lastBuildLogKey(): string {
+  return "last-build-log:" + editor.getCwd();
+}
+
+function rememberLastBuildLogPath(path: string): void {
+  editor.setGlobalState(lastBuildLogKey(), path);
+}
+
+function readLastBuildLogPath(): string | null {
+  const raw = editor.getGlobalState(lastBuildLogKey()) as unknown;
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+function extractLastNonEmptyLine(text: string): string | null {
+  const lines = text.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (t.length > 0) return t;
+  }
+  return null;
+}
+
 async function devcontainer_attach(): Promise<void> {
   if (!config) {
     editor.setStatus(editor.t("status.no_config"));
@@ -1124,6 +1258,49 @@ async function devcontainer_detach(): Promise<void> {
   editor.clearAuthority();
 }
 registerHandler("devcontainer_detach", devcontainer_detach);
+
+/// Abort an in-flight attach by killing the `devcontainer up` host
+/// spawn. No-op when nothing is in flight. The indicator is flipped
+/// back to Local immediately — cancel is a user-initiated revert,
+/// not a failure, so we don't go through FailedAttach.
+async function devcontainer_cancel_attach(): Promise<void> {
+  const handle = attachInFlight;
+  if (!handle) {
+    editor.setStatus(editor.t("status.cancel_nothing_in_flight"));
+    return;
+  }
+  // Order matters: set the flag before kill() so the awaiting
+  // runDevcontainerUp sees `attachCancelled = true` when the
+  // terminal event arrives, and takes the silent-return path
+  // instead of painting FailedAttach on top of the Local we're
+  // about to install.
+  attachCancelled = true;
+  editor.setRemoteIndicatorState({ kind: "local" });
+  editor.setStatus(editor.t("status.attach_cancelled"));
+  // `.kill()` returns a Promise<boolean> from the TS wrapper — we
+  // don't need the boolean; the kill is fire-and-forget.
+  void handle.kill();
+}
+registerHandler("devcontainer_cancel_attach", devcontainer_cancel_attach);
+
+/// Open the build log from the most recent `devcontainer up` in a
+/// buffer. The path was remembered across restarts via
+/// `setGlobalState`, so this works both during Connecting (log is
+/// still being appended — Fresh's auto-revert shows live updates)
+/// and after a FailedAttach / successful attach.
+async function devcontainer_show_build_logs(): Promise<void> {
+  const path = readLastBuildLogPath();
+  if (!path) {
+    editor.setStatus(editor.t("status.no_build_log"));
+    return;
+  }
+  if (editor.readFile(path) === null) {
+    editor.setStatus(editor.t("status.build_log_missing"));
+    return;
+  }
+  editor.openFile(path, null, null);
+}
+registerHandler("devcontainer_show_build_logs", devcontainer_show_build_logs);
 
 /// Show a one-shot snapshot of the attached container's stdout/stderr
 /// via `docker logs --tail 1000 <id>`. The log is rendered into a
@@ -1404,6 +1581,18 @@ function registerCommands(): void {
     "%cmd.show_logs",
     "%cmd.show_logs_desc",
     "devcontainer_show_logs",
+    null,
+  );
+  editor.registerCommand(
+    "%cmd.show_build_logs",
+    "%cmd.show_build_logs_desc",
+    "devcontainer_show_build_logs",
+    null,
+  );
+  editor.registerCommand(
+    "%cmd.cancel_attach",
+    "%cmd.cancel_attach_desc",
+    "devcontainer_cancel_attach",
     null,
   );
 }

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -528,6 +528,14 @@ impl Editor {
                     stderr,
                     exit_code,
                 } => {
+                    // Drop any host-process kill handle tied to this
+                    // id. The spawn task has exited (that's what this
+                    // event means) so the handle is stale; a late
+                    // `KillHostProcess` from the plugin should be a
+                    // silent no-op rather than a dangling send. For
+                    // non-host-process spawns the key won't be in
+                    // the map and the remove is a no-op.
+                    self.host_process_handles.remove(&process_id);
                     self.handle_plugin_process_output(
                         fresh_core::api::JsCallbackId::from(process_id),
                         stdout,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -660,6 +660,7 @@ impl Editor {
             next_buffer_group_id: 0,
             grouped_subtrees: HashMap::new(),
             background_process_handles: HashMap::new(),
+            host_process_handles: HashMap::new(),
             prompt_histories: {
                 // Load prompt histories from disk if available
                 let mut histories = HashMap::new();

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -752,6 +752,13 @@ pub struct Editor {
     /// Maps process_id to abort handle
     background_process_handles: HashMap<u64, tokio::task::AbortHandle>,
 
+    /// Cancellation senders for host-side processes spawned via
+    /// `spawnHostProcess`. Firing the sender (or dropping it) triggers
+    /// an in-task `child.start_kill()` so the process is reaped, not
+    /// just orphaned. Entries are removed when the spawn task sends
+    /// its terminal `PluginProcessOutput`.
+    host_process_handles: HashMap<u64, tokio::sync::oneshot::Sender<()>>,
+
     /// Prompt histories keyed by prompt type name (e.g., "search", "replace", "goto_line", "plugin:custom_name")
     /// This provides a generic history system that works for all prompt types including plugin prompts.
     prompt_histories: HashMap<String, crate::input::input_history::InputHistory>,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -2625,3 +2625,121 @@ impl Editor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Focused tests for the SpawnHostProcess kill mechanism.
+    //!
+    //! These don't exercise the full `handle_plugin_command` dispatcher
+    //! (which would require scaffolding an Editor with a real tokio
+    //! runtime and async_bridge); they replicate the inner
+    //! `tokio::select!` pattern directly on a real subprocess. A
+    //! regression in the select arms or in the kill-then-wait
+    //! sequencing would reproduce here.
+    //!
+    //! The dispatcher-level integration coverage comes from the e2e
+    //! attach-cancel test in `tests/e2e/` — this unit test is the
+    //! lower-level pin.
+    use tokio::io::{AsyncReadExt, BufReader};
+    use tokio::process::Command as TokioCommand;
+    use tokio::time::{timeout, Duration};
+
+    /// A long-sleep child that runs `tokio::select! { wait | kill_rx }`
+    /// terminates when the kill channel fires, and the terminal exit
+    /// code reflects signal termination (non-zero / None).
+    ///
+    /// Spawns `sleep` directly rather than through `sh -c` so SIGKILL
+    /// reaches the process whose pipe our reader futures hold —
+    /// `sh -c sleep` leaks the sleep child on SIGKILL (Q-C2), the
+    /// pipe stays open, and the reader future hangs. That's a
+    /// deliberate known limitation of start_kill; this test
+    /// exercises the clean path.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn kill_via_oneshot_terminates_long_running_child() {
+        let mut cmd = TokioCommand::new("sleep");
+        cmd.args(["30"]);
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().expect("spawn sh -c sleep 30");
+        let pid = child.id().expect("child has a pid");
+
+        let (kill_tx, mut kill_rx) = tokio::sync::oneshot::channel::<()>();
+        let stdout_pipe = child.stdout.take();
+        let stderr_pipe = child.stderr.take();
+
+        let stdout_fut = async {
+            let mut buf = String::new();
+            if let Some(s) = stdout_pipe {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = BufReader::new(s).read_to_string(&mut buf).await;
+            }
+            buf
+        };
+        let stderr_fut = async {
+            let mut buf = String::new();
+            if let Some(s) = stderr_pipe {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = BufReader::new(s).read_to_string(&mut buf).await;
+            }
+            buf
+        };
+        let wait_fut = async {
+            tokio::select! {
+                status = child.wait() => {
+                    status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1)
+                }
+                _ = &mut kill_rx => {
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = child.start_kill();
+                    child
+                        .wait()
+                        .await
+                        .map(|s| s.code().unwrap_or(-1))
+                        .unwrap_or(-1)
+                }
+            }
+        };
+
+        // Give the shell a moment to install itself — firing kill
+        // against an not-yet-existent child is still valid (SIGKILL
+        // to a zombie is a no-op) but we want to actually exercise
+        // the running-child path.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        kill_tx.send(()).expect("kill channel send");
+
+        let result = timeout(Duration::from_secs(5), async {
+            tokio::join!(stdout_fut, stderr_fut, wait_fut)
+        })
+        .await;
+
+        let (_stdout, _stderr, exit_code) = result.expect(
+            "kill path must resolve within 5s — if this times out the \
+             select! arm order or kill-then-wait logic is broken",
+        );
+        // On Unix, `Child::start_kill()` is SIGKILL. The exit status's
+        // `code()` is `None` for signal-terminated processes, and our
+        // dispatcher's `.unwrap_or(-1)` surfaces that as -1.
+        assert_eq!(
+            exit_code, -1,
+            "SIGKILL on a running child should yield no exit code \
+             (surfaced as -1 by the dispatcher)"
+        );
+
+        // Sanity: the child must be gone. `kill -0 <pid>` returns 0
+        // iff the process still exists / is being reaped; we expect
+        // non-zero (No such process) after our wait(). This rules out
+        // a zombie / leaked child that would indicate we skipped the
+        // wait() on the kill path.
+        let still_alive = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(
+            !still_alive,
+            "process {pid} must be reaped after wait() — a still-\
+             alive check means the kill path leaked the child"
+        );
+    }
+}

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -822,40 +822,126 @@ impl Editor {
                 // they want is even built. Uses the same callback shape
                 // as `SpawnProcess` so the plugin-facing API is
                 // symmetric.
+                //
+                // Kill handle: we store a oneshot sender in
+                // `host_process_handles` keyed by the callback id. A
+                // `KillHostProcess` dispatch sends on it; the spawn
+                // task's `tokio::select!` then start_kill()s the
+                // child. This lets a plugin cancel a long-running
+                // spawn (e.g. "Cancel Startup" on the Remote
+                // Indicator popup during `devcontainer up`).
                 if let (Some(runtime), Some(bridge)) = (&self.tokio_runtime, &self.async_bridge) {
+                    use tokio::io::{AsyncReadExt, BufReader};
+                    use tokio::process::Command as TokioCommand;
+
                     let effective_cwd = cwd.or_else(|| {
                         std::env::current_dir()
                             .map(|p| p.to_string_lossy().to_string())
                             .ok()
                     });
                     let sender = bridge.sender();
-                    let host_spawner: std::sync::Arc<dyn crate::services::remote::ProcessSpawner> =
-                        std::sync::Arc::new(crate::services::remote::LocalProcessSpawner);
+                    let process_id = callback_id.as_u64();
+
+                    let (kill_tx, mut kill_rx) = tokio::sync::oneshot::channel::<()>();
+                    self.host_process_handles.insert(process_id, kill_tx);
 
                     runtime.spawn(async move {
-                        #[allow(clippy::let_underscore_must_use)]
-                        match host_spawner.spawn(command, args, effective_cwd).await {
-                            Ok(result) => {
-                                let _ = sender.send(AsyncMessage::PluginProcessOutput {
-                                    process_id: callback_id.as_u64(),
-                                    stdout: result.stdout,
-                                    stderr: result.stderr,
-                                    exit_code: result.exit_code,
-                                });
-                            }
+                        let mut cmd = TokioCommand::new(&command);
+                        cmd.args(&args);
+                        cmd.stdout(std::process::Stdio::piped());
+                        cmd.stderr(std::process::Stdio::piped());
+                        if let Some(ref dir) = effective_cwd {
+                            cmd.current_dir(dir);
+                        }
+                        let mut child = match cmd.spawn() {
+                            Ok(c) => c,
                             Err(e) => {
+                                #[allow(clippy::let_underscore_must_use)]
                                 let _ = sender.send(AsyncMessage::PluginProcessOutput {
-                                    process_id: callback_id.as_u64(),
+                                    process_id,
                                     stdout: String::new(),
                                     stderr: e.to_string(),
                                     exit_code: -1,
                                 });
+                                return;
                             }
-                        }
+                        };
+
+                        // Take the pipes out of the Child so the
+                        // reader tasks own them; then `child.wait()`
+                        // has exclusive mutable access for the
+                        // kill-or-exit select. Matches the
+                        // fresh-plugin-runtime process.rs pattern.
+                        let stdout_pipe = child.stdout.take();
+                        let stderr_pipe = child.stderr.take();
+
+                        let stdout_fut = async {
+                            let mut buf = String::new();
+                            if let Some(s) = stdout_pipe {
+                                #[allow(clippy::let_underscore_must_use)]
+                                let _ = BufReader::new(s).read_to_string(&mut buf).await;
+                            }
+                            buf
+                        };
+                        let stderr_fut = async {
+                            let mut buf = String::new();
+                            if let Some(s) = stderr_pipe {
+                                #[allow(clippy::let_underscore_must_use)]
+                                let _ = BufReader::new(s).read_to_string(&mut buf).await;
+                            }
+                            buf
+                        };
+                        let wait_fut = async {
+                            tokio::select! {
+                                status = child.wait() => {
+                                    status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1)
+                                }
+                                _ = &mut kill_rx => {
+                                    // Best-effort SIGKILL + reap.
+                                    // Children of the killed
+                                    // process may leak (Q-C2).
+                                    #[allow(clippy::let_underscore_must_use)]
+                                    let _ = child.start_kill();
+                                    child
+                                        .wait()
+                                        .await
+                                        .map(|s| s.code().unwrap_or(-1))
+                                        .unwrap_or(-1)
+                                }
+                            }
+                        };
+                        let (stdout, stderr, exit_code) =
+                            tokio::join!(stdout_fut, stderr_fut, wait_fut);
+
+                        #[allow(clippy::let_underscore_must_use)]
+                        let _ = sender.send(AsyncMessage::PluginProcessOutput {
+                            process_id,
+                            stdout,
+                            stderr,
+                            exit_code,
+                        });
                     });
                 } else {
                     self.plugin_manager
                         .reject_callback(callback_id, "Async runtime not available".to_string());
+                }
+            }
+
+            PluginCommand::KillHostProcess { process_id } => {
+                // Removing from the map gives us the oneshot sender.
+                // Firing it signals the spawn task to `start_kill()`
+                // the child and reap. Unknown ids are intentionally
+                // silent — the process may have exited on its own
+                // and its cleanup already drained the slot.
+                if let Some(tx) = self.host_process_handles.remove(&process_id) {
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = tx.send(());
+                    tracing::debug!("KillHostProcess: sent kill for process_id={}", process_id);
+                } else {
+                    tracing::debug!(
+                        "KillHostProcess: unknown process_id={} (already exited?)",
+                        process_id
+                    );
                 }
             }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -2717,29 +2717,49 @@ mod tests {
             "kill path must resolve within 5s — if this times out the \
              select! arm order or kill-then-wait logic is broken",
         );
-        // On Unix, `Child::start_kill()` is SIGKILL. The exit status's
-        // `code()` is `None` for signal-terminated processes, and our
-        // dispatcher's `.unwrap_or(-1)` surfaces that as -1.
-        assert_eq!(
-            exit_code, -1,
-            "SIGKILL on a running child should yield no exit code \
-             (surfaced as -1 by the dispatcher)"
+        // The cross-platform invariant is "the child did not complete
+        // its 30s sleep" — i.e. the exit code is non-success. Platform
+        // specifics:
+        //   - Unix: `start_kill()` sends SIGKILL; `ExitStatus::code()`
+        //     returns None for signal-terminated processes, which our
+        //     dispatcher maps to -1 via `.unwrap_or(-1)`.
+        //   - Windows: `start_kill()` calls `TerminateProcess(..., 1)`;
+        //     `code()` returns `Some(1)`, mapped to 1 by the same
+        //     `.unwrap_or(-1)`.
+        // A successful 30s sleep would yield 0 — that's the
+        // regression case we're guarding against.
+        assert_ne!(
+            exit_code, 0,
+            "killed child must exit non-success (got 0 — did the \
+             kill arm fire too late, or did sleep somehow complete?)"
         );
 
-        // Sanity: the child must be gone. `kill -0 <pid>` returns 0
-        // iff the process still exists / is being reaped; we expect
-        // non-zero (No such process) after our wait(). This rules out
-        // a zombie / leaked child that would indicate we skipped the
-        // wait() on the kill path.
-        let still_alive = std::process::Command::new("kill")
-            .args(["-0", &pid.to_string()])
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        assert!(
-            !still_alive,
-            "process {pid} must be reaped after wait() — a still-\
-             alive check means the kill path leaked the child"
-        );
+        // Sanity: on Unix the child must be gone. `kill -0 <pid>`
+        // returns 0 iff the process still exists; we expect non-zero
+        // (No such process) after wait(). This catches a zombie /
+        // leaked child that would indicate we skipped the wait() on
+        // the kill path. Skipped on Windows — `kill` isn't available
+        // and `tasklist` output parsing is more noise than signal
+        // for this one-shot check; the wait() having returned is
+        // already evidence of reap there.
+        #[cfg(unix)]
+        {
+            let still_alive = std::process::Command::new("kill")
+                .args(["-0", &pid.to_string()])
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false);
+            assert!(
+                !still_alive,
+                "process {pid} must be reaped after wait() — a still-\
+                 alive check means the kill path leaked the child"
+            );
+        }
+        #[cfg(not(unix))]
+        {
+            // Touch `pid` so the unused-variable lint doesn't fire on
+            // non-Unix builds.
+            let _ = pid;
+        }
     }
 }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -703,16 +703,13 @@ impl Editor {
                         .map(|s| format!(" — {}", s))
                         .unwrap_or_default();
                     title = format!("Remote: Connecting{}", suffix);
-                    // Phase C lands Cancel Startup; Phase D lands
-                    // streaming logs. Until both exist, the rows
-                    // render disabled so users can see the surface
-                    // exists without clicking into a broken action.
                     items.push(
-                        PopupListItem::new("    Cancel Startup (coming soon)".to_string())
-                            .disabled(),
+                        PopupListItem::new("    Cancel Startup".to_string())
+                            .with_data("plugin:devcontainer_cancel_attach".to_string()),
                     );
                     items.push(
-                        PopupListItem::new("    Show Logs (coming soon)".to_string()).disabled(),
+                        PopupListItem::new("    Show Logs".to_string())
+                            .with_data("plugin:devcontainer_show_build_logs".to_string()),
                     );
                 }
                 RemoteIndicatorOverride::FailedAttach { error } => {
@@ -730,8 +727,8 @@ impl Editor {
                             .with_data("clear_override".to_string()),
                     );
                     items.push(
-                        PopupListItem::new("    Show Build Logs (coming soon)".to_string())
-                            .disabled(),
+                        PopupListItem::new("    Show Build Logs".to_string())
+                            .with_data("plugin:devcontainer_show_build_logs".to_string()),
                     );
                 }
                 _ => {

--- a/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
@@ -32,6 +32,26 @@ fn popup_item_texts(harness: &EditorTestHarness) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Pair of (label, data, disabled) for each row — lets a test assert
+/// both "row is visible" and "row dispatches the right action and is
+/// not disabled." Prevents regressions where a row quietly loses its
+/// action (reverted to a `.disabled()` stub).
+fn popup_item_rows(harness: &EditorTestHarness) -> Vec<(String, Option<String>, bool)> {
+    harness
+        .editor()
+        .active_state()
+        .popups
+        .top()
+        .map(|p| match &p.content {
+            fresh::view::popup::PopupContent::List { items, .. } => items
+                .iter()
+                .map(|i| (i.text.clone(), i.data.clone(), i.disabled))
+                .collect(),
+            _ => Vec::new(),
+        })
+        .unwrap_or_default()
+}
+
 #[test]
 fn test_remote_indicator_popup_local_with_devcontainer_offers_reopen() -> anyhow::Result<()> {
     let temp = tempfile::tempdir()?;
@@ -112,23 +132,37 @@ fn test_remote_indicator_popup_connecting_offers_cancel_and_logs() -> anyhow::Re
     harness.editor_mut().show_remote_indicator_popup();
     harness.render()?;
 
-    let items = popup_item_texts(&harness);
-    assert!(
-        items.iter().any(|t| t.contains("Cancel Startup")),
-        "Connecting popup should offer a Cancel Startup row. Items: {:#?}",
-        items
+    let rows = popup_item_rows(&harness);
+    let cancel = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Cancel Startup"))
+        .unwrap_or_else(|| panic!("Connecting popup lacks a Cancel Startup row. Rows: {rows:#?}"));
+    assert_eq!(
+        cancel.1.as_deref(),
+        Some("plugin:devcontainer_cancel_attach"),
+        "Cancel Startup must dispatch the plugin cancel handler. Row: {cancel:?}"
     );
     assert!(
-        items
+        !cancel.2,
+        "Cancel Startup must not be disabled. Row: {cancel:?}"
+    );
+
+    let logs = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Show Logs") && !t.contains("Container"))
+        .unwrap_or_else(|| panic!("Connecting popup lacks a Show Logs row. Rows: {rows:#?}"));
+    assert_eq!(
+        logs.1.as_deref(),
+        Some("plugin:devcontainer_show_build_logs"),
+        "Show Logs must dispatch the plugin show-build-logs handler. Row: {logs:?}"
+    );
+    assert!(!logs.2, "Show Logs must not be disabled. Row: {logs:?}");
+
+    assert!(
+        !rows
             .iter()
-            .any(|t| t.contains("Show Logs") && !t.contains("Container")),
-        "Connecting popup should offer a Show Logs row. Items: {:#?}",
-        items
-    );
-    assert!(
-        !items.iter().any(|t| t.contains("Reopen in Container")),
-        "Connecting popup must not dispatch a second attach. Items: {:#?}",
-        items
+            .any(|(t, _, _)| t.contains("Reopen in Container")),
+        "Connecting popup must not dispatch a second attach. Rows: {rows:#?}"
     );
     Ok(())
 }
@@ -149,22 +183,37 @@ fn test_remote_indicator_popup_failed_attach_offers_retry() -> anyhow::Result<()
     harness.editor_mut().show_remote_indicator_popup();
     harness.render()?;
 
-    let items = popup_item_texts(&harness);
-    assert!(
-        items.iter().any(|t| t.contains("Retry")),
-        "FailedAttach popup should offer a Retry row. Items: {:#?}",
-        items
+    let rows = popup_item_rows(&harness);
+    let retry = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Retry"))
+        .unwrap_or_else(|| panic!("FailedAttach popup lacks a Retry row. Rows: {rows:#?}"));
+    assert_eq!(retry.1.as_deref(), Some("plugin:devcontainer_retry_attach"));
+    assert!(!retry.2);
+
+    let reopen = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Reopen Locally"))
+        .unwrap_or_else(|| {
+            panic!("FailedAttach popup lacks a Reopen Locally row. Rows: {rows:#?}")
+        });
+    assert_eq!(reopen.1.as_deref(), Some("clear_override"));
+    assert!(!reopen.2);
+
+    let logs = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Show Build Logs"))
+        .unwrap_or_else(|| {
+            panic!("FailedAttach popup lacks a Show Build Logs row. Rows: {rows:#?}")
+        });
+    assert_eq!(
+        logs.1.as_deref(),
+        Some("plugin:devcontainer_show_build_logs"),
+        "Show Build Logs must dispatch the plugin show-build-logs handler. Row: {logs:?}"
     );
     assert!(
-        items.iter().any(|t| t.contains("Reopen Locally")),
-        "FailedAttach popup should offer a Reopen Locally row. Items: {:#?}",
-        items
-    );
-    assert!(
-        items.iter().any(|t| t.contains("Show Build Logs")),
-        "FailedAttach popup should offer a Show Build Logs row (stub until Phase D). \
-         Items: {:#?}",
-        items
+        !logs.2,
+        "Show Build Logs must not be disabled. Row: {logs:?}"
     );
     Ok(())
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3924,6 +3924,22 @@ impl JsEditorApi {
         id
     }
 
+    /// Cancel a host-side process started via `spawnHostProcess`.
+    /// `process_id` is the callback id the JS wrapper stashed on the
+    /// handle. Returns `false` only when the command channel is dead
+    /// (editor tearing down). Unknown ids no-op on the editor side —
+    /// see `PluginCommand::KillHostProcess` in fresh-core/api.rs.
+    ///
+    /// Exposed on the JS side as `editor._killHostProcess`; the
+    /// public API is `handle.kill()` from the `spawnHostProcess`
+    /// wrapper.
+    #[plugin_api(js_name = "_killHostProcess")]
+    pub fn kill_host_process(&self, process_id: u64) -> bool {
+        self.command_sender
+            .send(PluginCommand::KillHostProcess { process_id })
+            .is_ok()
+    }
+
     /// Install a new authority via an opaque payload.
     ///
     /// The payload is a JS object describing filesystem + spawner +
@@ -4978,7 +4994,36 @@ impl QuickJsBackend {
 
                 // Apply wrappers to async functions on editor
                 editor.spawnProcess = _wrapAsyncThenable("_spawnProcessStart", "spawnProcess");
-                editor.spawnHostProcess = _wrapAsyncThenable("_spawnHostProcessStart", "spawnHostProcess");
+                // spawnHostProcess gets a bespoke wrapper (instead of
+                // `_wrapAsyncThenable`) because its `ProcessHandle`
+                // exposes a real `kill()` that forwards to
+                // `_killHostProcess`. Generic wrap has no hook for
+                // that.
+                editor.spawnHostProcess = function(command, args, cwd) {
+                    if (typeof editor._spawnHostProcessStart !== 'function') {
+                        throw new Error('editor.spawnHostProcess is not implemented (missing _spawnHostProcessStart)');
+                    }
+                    const callbackId = editor._spawnHostProcessStart(command, args || [], cwd || "");
+                    const resultPromise = new Promise(function(resolve, reject) {
+                        globalThis._pendingCallbacks.set(callbackId, { resolve: resolve, reject: reject });
+                    });
+                    return {
+                        processId: callbackId,
+                        get result() { return resultPromise; },
+                        then: function(f, r) { return resultPromise.then(f, r); },
+                        catch: function(r) { return resultPromise.catch(r); },
+                        kill: function() {
+                            // Returns true when the kill was enqueued
+                            // (the process may have already exited; in
+                            // that case the dispatcher silently
+                            // drops it). Matches the
+                            // `ProcessHandle.kill(): Promise<boolean>`
+                            // type signature by wrapping the sync
+                            // boolean in a Promise.
+                            return Promise.resolve(editor._killHostProcess(callbackId));
+                        }
+                    };
+                };
                 editor.delay = _wrapAsync("_delayStart", "delay");
                 editor.createVirtualBuffer = _wrapAsync("_createVirtualBufferStart", "createVirtualBuffer");
                 editor.createVirtualBufferInSplit = _wrapAsync("_createVirtualBufferInSplitStart", "createVirtualBufferInSplit");


### PR DESCRIPTION
## Summary
This PR implements the ability to cancel an in-flight `devcontainer up` process and view its build logs, addressing user experience gaps during container startup. Users can now abort long-running container builds via a "Cancel Startup" action and review build progress/errors through a persistent log file.

## Key Changes

### Host Process Cancellation Infrastructure
- **Editor Core (`plugin_dispatch.rs`)**: Refactored `SpawnHostProcess` to use direct `tokio::process::Command` instead of `LocalProcessSpawner`, enabling real-time stdout/stderr capture and process cancellation via `tokio::select!` with a oneshot channel
- **New `KillHostProcess` command**: Added plugin command to cancel host processes by process_id; unknown ids silently no-op (process may have already exited)
- **Process handle tracking (`mod.rs`)**: Added `host_process_handles` HashMap to store kill-signal senders keyed by process_id
- **Cleanup on exit (`async_dispatch.rs`)**: Removes stale kill handles when processes complete

### Build Log Persistence
- **Log file management (`devcontainer.ts`)**: 
  - `prepareBuildLogFile()` creates `.fresh-cache/devcontainer-logs/` with auto-gitignore
  - Redirects `devcontainer up` stderr to a timestamped log file via shell wrapper
  - Opens log immediately so Fresh's auto-revert polls and streams live updates
- **Log retrieval**: `readLastBuildLogPath()` / `rememberLastBuildLogPath()` persist the most recent log path across restarts via global state
- **Error extraction**: `extractLastNonEmptyLine()` surfaces the last non-empty log line as a human-readable status on failure

### Plugin API & UI
- **JS wrapper (`quickjs_backend.rs`)**: Added `_killHostProcess()` API and bespoke `spawnHostProcess` wrapper that returns a `ProcessHandle` with `.kill()` method
- **Commands**: Registered `devcontainer_cancel_attach` and `devcontainer_show_build_logs` handlers
- **Remote indicator popup (`popup_dialogs.rs`)**: 
  - "Cancel Startup" now active (not disabled) during Connecting state
  - "Show Build Logs" available in both Connecting and FailedAttach states
- **Cancellation semantics**: Sets `attachCancelled` flag before kill to prevent FailedAttach overlay when user cancels

### Testing & Localization
- **Unit test (`plugin_dispatch.rs`)**: `kill_via_oneshot_terminates_long_running_child()` validates the select! pattern and process reaping on SIGKILL
- **E2E test updates (`remote_indicator_popup.rs`)**: Enhanced assertions to verify action dispatch data and enabled state
- **i18n**: Added 12 new strings across all supported languages for cancel/log UI and status messages

## Notable Implementation Details
- **Process reaping**: Pipes are extracted from `Child` before the kill-or-wait select to ensure exclusive mutable access and proper cleanup
- **Shell wrapper**: Uses positional args (`sh -c 'LOG="$1"; shift; exec devcontainer "$@" 2> "$LOG"'`) to avoid string interpolation of paths
- **Silent failures**: Unknown process_ids in `KillHostProcess` are intentionally silent (debug-logged) since processes may exit naturally
- **Known limitation (Q-C2)**: Children of killed processes may leak when using `start_kill()` on shell-wrapped commands; documented in spec gap plan

https://claude.ai/code/session_01D7aTZU2ipaJzKKt9RVXRDx