### PR TITLE
feat(terminal): allow overriding integrated terminal shell via config

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -146,7 +146,8 @@
       "description": "Terminal settings",
       "$ref": "#/$defs/TerminalConfig",
       "default": {
-        "jump_to_end_on_output": true
+        "jump_to_end_on_output": true,
+        "shell": null
       }
     },
     "keybindings": {
@@ -936,8 +937,41 @@
           "description": "When viewing terminal scrollback and new output arrives,\nautomatically jump back to terminal mode (default: true)",
           "type": "boolean",
           "default": true
+        },
+        "shell": {
+          "description": "Override the shell used by the integrated terminal.\n\nWhen unset (the default), Fresh launches the shell named by the\n`$SHELL` environment variable (or the platform default if `$SHELL`\nis empty). Set this to run a different program — for example a\nwrapper script that forces an interactive shell — without having\nto change `$SHELL` for the whole process, which other features\nsuch as `format_on_save` also depend on.\n\nOnly affects local authorities; plugin-provided authorities\n(e.g. `docker exec`) keep their own wrapper.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalShellConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
         }
       }
+    },
+    "TerminalShellConfig": {
+      "description": "Explicit shell command + args for the integrated terminal.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "Executable to launch (e.g. `/usr/bin/fish`, `bash`, or a wrapper\nscript). Resolved via `$PATH` when not absolute.",
+          "type": "string"
+        },
+        "args": {
+          "description": "Arguments passed before any user input.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "required": [
+        "command"
+      ]
     },
     "Keybinding": {
       "description": "Keybinding definition",

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1889,7 +1889,7 @@ impl Editor {
                     Some(working_dir),
                     Some(log_path.clone()),
                     backing_path_for_spawn,
-                    self.authority.terminal_wrapper.clone(),
+                    self.resolved_terminal_wrapper(),
                 ) {
                     Ok(terminal_id) => {
                         // Track log file path

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -24,11 +24,26 @@
 //!   - Performance: O(1) ≈ 1ms
 
 use super::{BufferId, BufferMetadata, Editor};
+use crate::services::authority::TerminalWrapper;
 use crate::services::terminal::TerminalId;
 use crate::state::EditorState;
 use rust_i18n::t;
 
 impl Editor {
+    /// Resolve the terminal wrapper used to spawn a new integrated
+    /// terminal, applying the `terminal.shell` config override on top of
+    /// the authority's wrapper when appropriate.
+    ///
+    /// See `TerminalWrapper::with_user_shell_override` for the override
+    /// rules; this is just the Editor-side wiring that supplies the
+    /// active config.
+    pub(crate) fn resolved_terminal_wrapper(&self) -> TerminalWrapper {
+        self.authority
+            .terminal_wrapper
+            .clone()
+            .with_user_shell_override(self.config.terminal.shell.as_ref())
+    }
+
     /// Open a new terminal in the current split
     pub fn open_terminal(&mut self) {
         // Get the current split dimensions for the terminal size
@@ -65,7 +80,7 @@ impl Editor {
             Some(self.working_dir.clone()),
             Some(log_path.clone()),
             backing_path_for_spawn,
-            self.authority.terminal_wrapper.clone(),
+            self.resolved_terminal_wrapper(),
         ) {
             Ok(terminal_id) => {
                 // Track log file path (use actual ID in case it differs)

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1206,7 +1206,7 @@ impl Editor {
             terminal.cwd.clone(),
             Some(log_path.clone()),
             Some(backing_path.clone()),
-            self.authority.terminal_wrapper.clone(),
+            self.resolved_terminal_wrapper(),
         ) {
             Ok(id) => id,
             Err(e) => {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1695,14 +1695,41 @@ pub struct TerminalConfig {
     /// automatically jump back to terminal mode (default: true)
     #[serde(default = "default_true")]
     pub jump_to_end_on_output: bool,
+
+    /// Override the shell used by the integrated terminal.
+    ///
+    /// When unset (the default), Fresh launches the shell named by the
+    /// `$SHELL` environment variable (or the platform default if `$SHELL`
+    /// is empty). Set this to run a different program — for example a
+    /// wrapper script that forces an interactive shell — without having
+    /// to change `$SHELL` for the whole process, which other features
+    /// such as `format_on_save` also depend on.
+    ///
+    /// Only affects local authorities; plugin-provided authorities
+    /// (e.g. `docker exec`) keep their own wrapper.
+    #[serde(default)]
+    pub shell: Option<TerminalShellConfig>,
 }
 
 impl Default for TerminalConfig {
     fn default() -> Self {
         Self {
             jump_to_end_on_output: true,
+            shell: None,
         }
     }
+}
+
+/// Explicit shell command + args for the integrated terminal.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct TerminalShellConfig {
+    /// Executable to launch (e.g. `/usr/bin/fish`, `bash`, or a wrapper
+    /// script). Resolved via `$PATH` when not absolute.
+    pub command: String,
+
+    /// Arguments passed before any user input.
+    #[serde(default)]
+    pub args: Vec<String>,
 }
 
 /// Warning notification configuration

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -377,12 +377,14 @@ impl Merge for PartialClipboardConfig {
 #[serde(default)]
 pub struct PartialTerminalConfig {
     pub jump_to_end_on_output: Option<bool>,
+    pub shell: Option<crate::config::TerminalShellConfig>,
 }
 
 impl Merge for PartialTerminalConfig {
     fn merge_from(&mut self, other: &Self) {
         self.jump_to_end_on_output
             .merge_from(&other.jump_to_end_on_output);
+        self.shell.merge_from(&other.shell);
     }
 }
 
@@ -775,6 +777,7 @@ impl From<&TerminalConfig> for PartialTerminalConfig {
     fn from(cfg: &TerminalConfig) -> Self {
         Self {
             jump_to_end_on_output: Some(cfg.jump_to_end_on_output),
+            shell: cfg.shell.clone(),
         }
     }
 }
@@ -785,6 +788,7 @@ impl PartialTerminalConfig {
             jump_to_end_on_output: self
                 .jump_to_end_on_output
                 .unwrap_or(defaults.jump_to_end_on_output),
+            shell: self.shell.or_else(|| defaults.shell.clone()),
         }
     }
 }

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -70,6 +70,26 @@ impl TerminalWrapper {
             manages_cwd: false,
         }
     }
+
+    /// Apply the user's `terminal.shell` config override on top of this
+    /// wrapper. The override replaces `command` and `args` only when the
+    /// wrapper leaves cwd management to the terminal manager
+    /// (`manages_cwd == false`) — that is, for the host-shell wrapper.
+    /// Authorities that re-parent the shell (e.g. `docker exec -w …`,
+    /// `ssh …`) pin cwd through their own args and are left untouched so
+    /// the re-parenting stays intact.
+    pub fn with_user_shell_override(
+        mut self,
+        shell: Option<&crate::config::TerminalShellConfig>,
+    ) -> Self {
+        if let Some(shell) = shell {
+            if !self.manages_cwd {
+                self.command = shell.command.clone();
+                self.args = shell.args.clone();
+            }
+        }
+        self
+    }
 }
 
 /// Tagged payload describing how to build an authority from a plugin.
@@ -345,6 +365,55 @@ mod tests {
         let auth = Authority::from_plugin_payload(payload).expect("payload is valid");
         assert!(auth.terminal_wrapper.manages_cwd);
         assert_eq!(auth.display_label, "");
+    }
+
+    #[test]
+    fn user_shell_override_replaces_host_shell_wrapper() {
+        let override_shell = crate::config::TerminalShellConfig {
+            command: "/usr/local/bin/fish".into(),
+            args: vec!["-l".into(), "-i".into()],
+        };
+        let wrapper = TerminalWrapper::host_shell().with_user_shell_override(Some(&override_shell));
+        assert_eq!(wrapper.command, "/usr/local/bin/fish");
+        assert_eq!(wrapper.args, vec!["-l".to_string(), "-i".to_string()]);
+        assert!(!wrapper.manages_cwd);
+    }
+
+    #[test]
+    fn user_shell_override_is_noop_when_wrapper_manages_cwd() {
+        // Docker/SSH-style wrappers set `manages_cwd = true`; replacing
+        // their command would drop the re-parenting args and spawn the
+        // user's shell on the host, defeating the authority.
+        let docker = TerminalWrapper {
+            command: "docker".into(),
+            args: vec![
+                "exec".into(),
+                "-w".into(),
+                "/workspaces/proj".into(),
+                "abc123".into(),
+                "bash".into(),
+            ],
+            manages_cwd: true,
+        };
+        let override_shell = crate::config::TerminalShellConfig {
+            command: "/usr/local/bin/fish".into(),
+            args: vec![],
+        };
+        let wrapper = docker
+            .clone()
+            .with_user_shell_override(Some(&override_shell));
+        assert_eq!(wrapper.command, docker.command);
+        assert_eq!(wrapper.args, docker.args);
+        assert!(wrapper.manages_cwd);
+    }
+
+    #[test]
+    fn user_shell_override_none_leaves_wrapper_unchanged() {
+        let original = TerminalWrapper::host_shell();
+        let wrapper = original.clone().with_user_shell_override(None);
+        assert_eq!(wrapper.command, original.command);
+        assert_eq!(wrapper.args, original.args);
+        assert_eq!(wrapper.manages_cwd, original.manages_cwd);
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -13,6 +13,7 @@
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, TerminalShellConfig};
 use fresh::services::terminal::TerminalState;
 use portable_pty::{native_pty_system, PtySize};
 
@@ -3187,4 +3188,63 @@ fn test_arrow_keys_in_less() {
         .unwrap();
 
     eprintln!("[arrow_keys] test complete");
+}
+
+/// Regression test for issue #1637: `terminal.shell` config overrides the
+/// shell command used by the integrated terminal without having to
+/// change `$SHELL`. Picks a command that is definitely not the user's
+/// login shell — `/bin/cat` — and confirms the spawned terminal handle
+/// reports it back.
+#[test]
+fn test_terminal_shell_config_override() {
+    if native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_err()
+    {
+        eprintln!("Skipping terminal test: PTY not available in this environment");
+        return;
+    }
+
+    let override_cmd = "/bin/cat";
+    if !std::path::Path::new(override_cmd).exists() {
+        eprintln!("Skipping terminal test: {} not available", override_cmd);
+        return;
+    }
+
+    let mut config = Config::default();
+    config.terminal.shell = Some(TerminalShellConfig {
+        command: override_cmd.to_string(),
+        args: Vec::new(),
+    });
+
+    let mut harness = match EditorTestHarness::with_config(80, 24, config) {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    let terminal_buffer = harness.editor().active_buffer_id();
+    let terminal_id = harness
+        .editor()
+        .get_terminal_id(terminal_buffer)
+        .expect("terminal buffer should have a terminal id");
+    let shell = harness
+        .editor()
+        .terminal_manager()
+        .get(terminal_id)
+        .expect("terminal handle should exist")
+        .shell()
+        .to_string();
+
+    assert_eq!(
+        shell, override_cmd,
+        "terminal should spawn with the config-overridden shell"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #1637.

Adds a new `terminal.shell` config option that lets users point the integrated terminal at an explicit command + args without touching `$SHELL`. Changing `$SHELL` affects other features such as `format_on_save`, so users running in containers (or wanting an "interactive-forced" wrapper script for the terminal only) had no clean workaround.

Example config:

```json
{
  "terminal": {
    "shell": {
      "command": "/usr/local/bin/my-interactive-wrapper",
      "args": ["-l"]
    }
  }
}
```

The override is applied in `Editor::resolved_terminal_wrapper` just before every `terminal_manager.spawn(...)`, via a new `TerminalWrapper::with_user_shell_override` helper.

### Scope of the override

`TerminalWrapper::manages_cwd` distinguishes the host-shell wrapper (`false`) from plugin-installed wrappers like `docker exec -w <workspace> … bash -l` (`true`). The override only takes effect when `manages_cwd == false`; re-parented wrappers keep their command + args intact so the authority's cwd/user contract isn't broken.

## Test plan

- [x] Unit tests for `with_user_shell_override` (host-shell replacement, docker-style no-op, `None` no-op).
- [x] E2E test spawning a terminal with `terminal.shell = /bin/cat` and asserting the spawned handle reports it.
- [x] `cargo check --all-targets`, `cargo fmt --check`.
- [x] `./scripts/gen_schema.sh` — `config-schema.json` now documents `terminal.shell`.
- [x] Manual validation in tmux:
  - With override `/bin/cat`: opened terminal, typed text, saw it echoed back (distinctive cat behavior).
  - With override `/bin/sh -c "echo override-with-args; sleep 60"`: saw `override-with-args` print (args honored).
  - Without override: terminal ran `/bin/bash` as before (`echo $0` confirmed).

https://claude.ai/code/session_0165Nh1S6yLFgjxCXo9s8nJ9