### PR TITLE
Fix flaky test by waiting for async diff buffer rebuild

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -3733,15 +3733,15 @@ fn test_review_diff_n_auto_expands_collapsed_file() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
-
-    let after_n = harness.screen_to_string();
-    assert!(
-        after_n.contains("HUNK_A") || after_n.contains("HUNK_B"),
-        "After `n`, the previously-collapsed file's hunk content should be \
-         revealed. Screen:\n{}",
-        after_n
-    );
+    // The plugin's `review_next_hunk` handler rebuilds the diff buffer
+    // asynchronously via `updateMagitDisplay`; wait for the expansion to
+    // land on screen rather than assuming a single render flushes it.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("HUNK_A") || s.contains("HUNK_B")
+        })
+        .unwrap();
 }
 
 /// The sticky panel sits between the toolbar and the diff stream.


### PR DESCRIPTION
## Summary
Fixed a flaky test in `test_review_diff_n_auto_expands_collapsed_file` that was making incorrect assumptions about when the diff buffer expansion would be visible on screen.

## Key Changes
- Replaced a single `render()` call followed by immediate assertion with a `wait_until()` polling loop
- The test now properly waits for the plugin's asynchronous `review_next_hunk` handler to complete its diff buffer rebuild via `updateMagitDisplay`
- Updated the assertion logic to check for hunk content (`HUNK_A` or `HUNK_B`) within the polling loop rather than after a single render

## Implementation Details
The original test assumed that calling `render()` once would be sufficient to see the expanded file content after pressing 'n'. However, the plugin rebuilds the diff buffer asynchronously, so the expansion may not be visible immediately. The fix uses `wait_until()` to poll the screen state until the expected hunk content appears, making the test more robust and less prone to timing-related failures.

https://claude.ai/code/session_01Gcx3uRkzE2KNwLkUz1jvbq