### PR TITLE
feat(quick-open): live-preview cursor jump when typing `:<N>`

### DIFF
--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -287,6 +287,12 @@ impl Editor {
             return Ok(());
         }
 
+        // A live Quick Open goto-line preview holds a "restore cursor" snapshot
+        // that gets applied on cancel. An editor click is a deliberate new
+        // cursor placement — commit the preview so Esc doesn't rubber-band
+        // the cursor back over the click target.
+        self.quick_open_goto_line_preview = None;
+
         // Focus this split (handles terminal mode exit, tab state, etc.)
         self.focus_split(split_id, buffer_id);
 

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -287,12 +287,6 @@ impl Editor {
             return Ok(());
         }
 
-        // A live Quick Open goto-line preview holds a "restore cursor" snapshot
-        // that gets applied on cancel. An editor click is a deliberate new
-        // cursor placement — commit the preview so Esc doesn't rubber-band
-        // the cursor back over the click target.
-        self.quick_open_goto_line_preview = None;
-
         // Focus this split (handles terminal mode exit, tab state, etc.)
         self.focus_split(split_id, buffer_id);
 

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -676,6 +676,7 @@ impl Editor {
                 histories
             },
             pending_async_prompt_callback: None,
+            quick_open_goto_line_preview: None,
             lsp_progress: std::collections::HashMap::new(),
             lsp_server_statuses: std::collections::HashMap::new(),
             lsp_window_messages: Vec::new(),

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -281,6 +281,22 @@ pub struct DabbrevCycleState {
     pub index: usize,
 }
 
+/// Snapshot of cursor and viewport state used to restore the original position
+/// when a Quick Open goto-line preview is abandoned (cancel, or the user edits
+/// the input so it no longer targets a line).
+#[derive(Debug, Clone)]
+pub(crate) struct GotoLinePreviewSnapshot {
+    pub buffer_id: BufferId,
+    pub split_id: LeafId,
+    pub cursor_id: crate::model::event::CursorId,
+    pub position: usize,
+    pub anchor: Option<usize>,
+    pub sticky_column: usize,
+    pub viewport_top_byte: usize,
+    pub viewport_top_view_line_offset: usize,
+    pub viewport_left_column: usize,
+}
+
 /// The main editor struct - manages multiple buffers, clipboard, and rendering
 pub struct Editor {
     /// All open buffers
@@ -767,6 +783,11 @@ pub struct Editor {
     /// When the prompt is confirmed, the callback is resolved with the input text.
     /// When cancelled, the callback is resolved with null.
     pending_async_prompt_callback: Option<fresh_core::api::JsCallbackId>,
+
+    /// Snapshot of cursor/viewport state saved when a Quick Open goto-line
+    /// preview jump moves the cursor live as the user types ":N". Restored on
+    /// cancel or when the user switches away from the goto-line provider.
+    quick_open_goto_line_preview: Option<GotoLinePreviewSnapshot>,
 
     /// LSP progress tracking (token -> progress info)
     lsp_progress: std::collections::HashMap<String, LspProgressInfo>,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -284,6 +284,13 @@ pub struct DabbrevCycleState {
 /// Snapshot of cursor and viewport state used to restore the original position
 /// when a Quick Open goto-line preview is abandoned (cancel, or the user edits
 /// the input so it no longer targets a line).
+///
+/// `last_jump_position` is the byte offset the most recent preview jump put the
+/// cursor at; the restore path only applies the snapshot when the cursor is
+/// still exactly there. If anything else moved the cursor (mouse click, an
+/// async buffer edit shifting positions via `adjust_for_edit`, …) the snapshot
+/// is considered stale and simply dropped. This is the single staleness check
+/// that replaces per-site invalidation across many call paths.
 #[derive(Debug, Clone)]
 pub(crate) struct GotoLinePreviewSnapshot {
     pub buffer_id: BufferId,
@@ -295,6 +302,7 @@ pub(crate) struct GotoLinePreviewSnapshot {
     pub viewport_top_byte: usize,
     pub viewport_top_view_line_offset: usize,
     pub viewport_left_column: usize,
+    pub last_jump_position: usize,
 }
 
 /// The main editor struct - manages multiple buffers, clipboard, and rendering

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -188,6 +188,11 @@ impl Editor {
             self.apply_event_to_active_buffer(&remove_overlay_event);
         }
         self.hover.set_symbol_range(None);
+
+        // Any focus change (buffer switch, file explorer, menus, …) ends the
+        // Quick Open goto-line preview flow. Drop the snapshot so a later Esc
+        // cannot rubber-band the cursor over state the user has moved past.
+        self.quick_open_goto_line_preview = None;
     }
 
     /// Clear all popups

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -1275,6 +1275,20 @@ impl Editor {
     ) -> PromptResult {
         use crate::input::quick_open::QuickOpenResult;
 
+        // Any live goto-line preview must be resolved before executing the
+        // result: a GotoLine confirm accepts the preview as-is, everything
+        // else (file/buffer/action/etc.) should see the pre-preview state.
+        match &result {
+            QuickOpenResult::GotoLine(_) => {
+                // Commit the preview: discard the saved snapshot without
+                // restoring, since the cursor is already at the target.
+                self.quick_open_goto_line_preview = None;
+            }
+            _ => {
+                self.restore_goto_line_preview_snapshot();
+            }
+        }
+
         match result {
             QuickOpenResult::ExecuteAction(action) => PromptResult::ExecuteAction(action),
             QuickOpenResult::OpenFile { path, line, column } => {

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -141,6 +141,10 @@ impl Editor {
         // Clear status message since hints are now shown in the popup
         self.status_message = None;
 
+        // Clear any stale goto-line preview snapshot (paranoia: should already
+        // be None, but a previous failed prompt could leave one behind).
+        self.quick_open_goto_line_preview = None;
+
         // Start with ">" prefix for command mode by default
         let mut prompt = Prompt::with_suggestions(String::new(), PromptType::QuickOpen, vec![]);
         prompt.input = ">".to_string();
@@ -221,6 +225,107 @@ impl Editor {
                 Some(0)
             };
         }
+
+        // Live preview for the goto-line provider: if the input is ":<N>" for a
+        // valid line N, jump there now so the user sees the target as they type
+        // (matches VSCode's Ctrl+P :<N> behavior). Otherwise, restore the
+        // cursor to its pre-preview position.
+        self.apply_goto_line_preview(input);
+    }
+
+    /// Parse `input` for a live goto-line target and either jump to the target
+    /// (saving the original cursor on the first jump) or restore the saved
+    /// cursor if the input no longer targets a line.
+    fn apply_goto_line_preview(&mut self, input: &str) {
+        let target_line = input
+            .strip_prefix(':')
+            .and_then(|rest| rest.trim().parse::<usize>().ok())
+            .filter(|&n| n > 0);
+
+        if let Some(line) = target_line {
+            self.save_goto_line_preview_snapshot();
+            self.goto_line_col(line, None);
+        } else {
+            self.restore_goto_line_preview_snapshot();
+        }
+    }
+
+    /// Save a snapshot of the active buffer's cursor and viewport so the
+    /// goto-line preview can later restore it. No-op if a snapshot is already
+    /// in place (the saved state should always be the pre-preview one).
+    pub(super) fn save_goto_line_preview_snapshot(&mut self) {
+        if self.quick_open_goto_line_preview.is_some() {
+            return;
+        }
+
+        let buffer_id = self.active_buffer();
+        let split_id = self.split_manager.active_split();
+        let (cursor_id, position, anchor, sticky_column) = {
+            let cursors = self.active_cursors();
+            let primary = cursors.primary();
+            (
+                cursors.primary_id(),
+                primary.position,
+                primary.anchor,
+                primary.sticky_column,
+            )
+        };
+        let (viewport_top_byte, viewport_top_view_line_offset, viewport_left_column) = {
+            let vp = self.active_viewport();
+            (vp.top_byte, vp.top_view_line_offset, vp.left_column)
+        };
+
+        self.quick_open_goto_line_preview = Some(super::GotoLinePreviewSnapshot {
+            buffer_id,
+            split_id,
+            cursor_id,
+            position,
+            anchor,
+            sticky_column,
+            viewport_top_byte,
+            viewport_top_view_line_offset,
+            viewport_left_column,
+        });
+    }
+
+    /// If a goto-line preview snapshot exists, restore the active split's
+    /// cursor and viewport to the saved state and clear the snapshot.
+    pub(super) fn restore_goto_line_preview_snapshot(&mut self) {
+        let Some(snap) = self.quick_open_goto_line_preview.take() else {
+            return;
+        };
+
+        // If the active buffer/split has changed (shouldn't happen during a
+        // quick-open prompt, but be defensive), just drop the snapshot.
+        if self.active_buffer() != snap.buffer_id
+            || self.split_manager.active_split() != snap.split_id
+        {
+            return;
+        }
+
+        let cursors = self.active_cursors();
+        let current = cursors.primary();
+        let event = crate::model::event::Event::MoveCursor {
+            cursor_id: snap.cursor_id,
+            old_position: current.position,
+            new_position: snap.position,
+            old_anchor: current.anchor,
+            new_anchor: snap.anchor,
+            old_sticky_column: current.sticky_column,
+            new_sticky_column: snap.sticky_column,
+        };
+
+        let state = self.buffers.get_mut(&snap.buffer_id).unwrap();
+        let view_state = self.split_view_states.get_mut(&snap.split_id).unwrap();
+        state.apply(&mut view_state.cursors, &event);
+
+        let vp = &mut view_state.viewport;
+        vp.top_byte = snap.viewport_top_byte;
+        vp.top_view_line_offset = snap.viewport_top_view_line_offset;
+        vp.left_column = snap.viewport_left_column;
+        // The cursor we just restored is already consistent with this
+        // viewport; don't let ensure_visible re-scroll on the next render.
+        vp.set_skip_ensure_visible();
     }
 
     /// Cancel search/replace prompts if one is active.
@@ -500,6 +605,9 @@ impl Editor {
                             fp.cancel_loading();
                         }
                     }
+                    // Undo any live goto-line preview so the cursor returns to
+                    // where it was before the prompt was opened.
+                    self.restore_goto_line_preview_snapshot();
                 }
                 _ => {}
             }

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -245,6 +245,12 @@ impl Editor {
         if let Some(line) = target_line {
             self.save_goto_line_preview_snapshot();
             self.goto_line_col(line, None);
+            // Record where the jump landed so restore can detect if the cursor
+            // has since moved (e.g., mouse click, external buffer edit).
+            let new_position = self.active_cursors().primary().position;
+            if let Some(snap) = self.quick_open_goto_line_preview.as_mut() {
+                snap.last_jump_position = new_position;
+            }
         } else {
             self.restore_goto_line_preview_snapshot();
         }
@@ -285,11 +291,21 @@ impl Editor {
             viewport_top_byte,
             viewport_top_view_line_offset,
             viewport_left_column,
+            // Before the first jump the cursor is still at the pre-preview
+            // position; `apply_goto_line_preview` overwrites this with the
+            // jump target immediately after calling `goto_line_col`.
+            last_jump_position: position,
         });
     }
 
     /// If a goto-line preview snapshot exists, restore the active split's
     /// cursor and viewport to the saved state and clear the snapshot.
+    ///
+    /// The snapshot is only applied if the editor is still in exactly the
+    /// state the last preview jump left it in: same active buffer, same split,
+    /// cursor still at `last_jump_position`. Any deviation (user mouse-clicked,
+    /// an async edit shifted the cursor, focus moved elsewhere, …) means the
+    /// pre-preview state is stale and we simply discard the snapshot.
     pub(super) fn restore_goto_line_preview_snapshot(&mut self) {
         let Some(snap) = self.quick_open_goto_line_preview.take() else {
             return;
@@ -305,6 +321,13 @@ impl Editor {
 
         let cursors = self.active_cursors();
         let current = cursors.primary();
+
+        // Cursor no longer where the preview left it → someone else moved it
+        // (mouse click, external edit via `adjust_for_edit`, …). Drop without
+        // restoring to avoid rubber-banding over that deliberate state.
+        if current.position != snap.last_jump_position {
+            return;
+        }
         let event = crate::model::event::Event::MoveCursor {
             cursor_id: snap.cursor_id,
             old_position: current.position,

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -215,6 +215,19 @@ fn test_quick_open_file_path_line_only() {
         .expect("Cursor should jump to Ln 3, Col 1 after Quick Open");
 }
 
+/// Helper: write a fixture file with `n` lines of the form `LINEn\n`.
+///
+/// Tests here use long files so the live-preview jump scrolls the viewport
+/// noticeably, which is observable in the rendered output (per CONTRIBUTING.md:
+/// e2e tests examine rendered output, not internal state).
+fn write_numbered_lines(path: &std::path::Path, n: usize) {
+    let mut s = String::new();
+    for i in 1..=n {
+        s.push_str(&format!("LINE{i}\n"));
+    }
+    fs::write(path, s).unwrap();
+}
+
 /// Quick Open goto-line (":N") should live-preview the jump as the user types,
 /// so the cursor moves to line N before pressing Enter (issue #1253).
 #[test]
@@ -225,37 +238,37 @@ fn test_quick_open_goto_line_live_preview() {
         EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
-    let line1_position = harness.cursor_position();
+    // Baseline: viewport starts at the top, LINE80 is far off-screen.
+    assert!(
+        !harness.screen_to_string().contains("LINE80"),
+        "Baseline viewport should not include line 80"
+    );
 
-    // Open Quick Open, clear the ">" prefix, then type ":3".
+    // Open Quick Open, clear the ">" prefix, then type ":80".
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text(":3").unwrap();
-    harness.render().unwrap();
+    harness.type_text(":80").unwrap();
 
-    // The cursor should already be on line 3 (byte 12, just after "11111\n22222\n")
-    // while the prompt is still open — without ever pressing Enter.
-    let line3_start = "11111\n22222\n".len();
-    assert_ne!(
-        harness.cursor_position(),
-        line1_position,
-        "Cursor should have moved from its starting position"
-    );
-    assert_eq!(
-        harness.cursor_position(),
-        line3_start,
-        "Cursor should live-preview at start of line 3 while typing ':3'"
-    );
+    // Live preview must have scrolled the viewport toward line 80, while the
+    // prompt is still open (no Enter pressed). The suggestion popup overlays
+    // the bottom rows, so line 80 itself may render behind it; check a line
+    // that's guaranteed to be in the visible content area and confirm the
+    // original top-of-file line is gone.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 75 │ LINE75") && !screen.contains("  1 │ LINE1")
+        })
+        .expect("Viewport should scroll toward line 80 during ':80' preview");
 }
 
 /// Extending the live preview to a new number jumps again in the same prompt.
@@ -267,9 +280,8 @@ fn test_quick_open_goto_line_live_preview_updates() {
         EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "11111\n22222\nABCDE12345\n44444\n55555\n66666\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
@@ -281,32 +293,35 @@ fn test_quick_open_goto_line_live_preview_updates() {
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
 
-    // First preview to line 2.
-    harness.type_text(":2").unwrap();
-    harness.render().unwrap();
-    let line2_start = "11111\n".len();
-    assert_eq!(
-        harness.cursor_position(),
-        line2_start,
-        "Cursor should live-preview at start of line 2"
-    );
+    // First preview to line 40 — viewport scrolls so line 35 is visible.
+    harness.type_text(":40").unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 35 │ LINE35") && !screen.contains("  1 │ LINE1")
+        })
+        .expect("Viewport should scroll toward line 40");
 
-    // Change the target to line 5.
+    // Change the target to line 80 — viewport should follow.
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text("5").unwrap();
-    harness.render().unwrap();
-    let line5_start = "11111\n22222\nABCDE12345\n44444\n".len();
-    assert_eq!(
-        harness.cursor_position(),
-        line5_start,
-        "Cursor should live-preview at start of line 5 after updating target"
-    );
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("80").unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 75 │ LINE75") && !screen.contains(" 35 │ LINE35")
+        })
+        .expect("Viewport should follow the updated target to line 80");
 }
 
 /// Canceling the Quick Open prompt (Esc) after a live-preview jump should
-/// restore the cursor to where it was before the prompt was opened.
+/// restore the cursor to where it was before the prompt was opened. Observable
+/// in the rendered output as the viewport scrolling back and the status bar
+/// reporting the original line.
 #[test]
 fn test_quick_open_goto_line_live_preview_cancel_restores() {
     use crossterm::event::{KeyCode, KeyModifiers};
@@ -315,13 +330,11 @@ fn test_quick_open_goto_line_live_preview_cancel_restores() {
         EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
-    let original_position = harness.cursor_position();
 
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
@@ -329,26 +342,24 @@ fn test_quick_open_goto_line_live_preview_cancel_restores() {
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text(":3").unwrap();
-    harness.render().unwrap();
+    harness.type_text(":80").unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 75 │ LINE75") && !screen.contains("  1 │ LINE1")
+        })
+        .expect("Preview should scroll toward line 80");
 
-    let line3_start = "11111\n22222\n".len();
-    assert_eq!(
-        harness.cursor_position(),
-        line3_start,
-        "Cursor should live-preview at start of line 3"
-    );
-
-    // Cancel the prompt.
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
-    harness.render().unwrap();
 
-    // Cursor should be back at its original position.
-    assert_eq!(
-        harness.cursor_position(),
-        original_position,
-        "Cursor should be restored to its pre-preview position after Esc"
-    );
+    // After Esc, the prompt closes and the status bar becomes visible; the
+    // cursor must be back on line 1 and the viewport scrolled back to it.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("Ln 1,") && screen.contains("  1 │ LINE1")
+        })
+        .expect("Esc should restore cursor to pre-preview line 1");
 }
 
 /// Clicking in the editor while a goto-line preview is active should commit
@@ -362,9 +373,8 @@ fn test_quick_open_goto_line_live_preview_mouse_click_commits() {
         EditorTestHarness::with_temp_project_and_config(100, 30, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\nLINE8\nLINE9\nLINE10\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
@@ -375,38 +385,34 @@ fn test_quick_open_goto_line_live_preview_mouse_click_commits() {
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text(":8").unwrap();
-    harness.render().unwrap();
-    let line8_start = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\n".len();
-    assert_eq!(
-        harness.cursor_position(),
-        line8_start,
-        "Preview should have jumped cursor to line 8"
-    );
+    harness.type_text(":80").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(" 78 │ LINE78"))
+        .expect("Preview should scroll so LINE78 is on screen near LINE80");
 
-    // Click in the editor content area. (col=10, row=4 lands on a visible
-    // line near the top of the buffer — past the menu and tab bars.)
-    harness.mouse_click(10, 4).unwrap();
-    let clicked_position = harness.cursor_position();
-    assert_ne!(
-        clicked_position, line8_start,
-        "Mouse click should have moved cursor away from the preview target"
-    );
+    // Locate a visible line's rendered position and click on it. Using a line
+    // different from the preview target proves the click overrides the preview.
+    let (col, row) = harness
+        .find_text_on_screen("LINE78")
+        .expect("LINE78 should be visible while previewing line 80");
+    harness.mouse_click(col, row).unwrap();
 
-    // Press Esc — the pre-preview snapshot must NOT override the click.
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
-    harness.render().unwrap();
-    assert_eq!(
-        harness.cursor_position(),
-        clicked_position,
-        "Cursor should stay where the user clicked; preview snapshot must be committed on click"
-    );
+
+    // The pre-preview snapshot (line 1) must NOT overwrite the click target
+    // (line 78) — status bar must report line 78 after the prompt closes.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 78,"))
+        .expect(
+            "Cursor should stay on the clicked line 78 — pre-preview snapshot must be \
+             dropped on editor click",
+        );
 }
 
-/// A buffer edit that lands before the preview cursor (shifting it forward
-/// via `adjust_for_edit`) invalidates the snapshot: Esc afterwards must NOT
-/// restore, because the pre-preview byte position is meaningless relative to
-/// the edited buffer.
+/// A buffer edit that shifts the cursor via `adjust_for_edit` while the
+/// preview is active invalidates the snapshot: Esc afterwards must NOT restore
+/// the pre-preview byte position, which no longer corresponds to the original
+/// line number.
 #[test]
 fn test_quick_open_goto_line_live_preview_buffer_edit_invalidates() {
     use crossterm::event::{KeyCode, KeyModifiers};
@@ -416,9 +422,8 @@ fn test_quick_open_goto_line_live_preview_buffer_edit_invalidates() {
         EditorTestHarness::with_temp_project_and_config(100, 30, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\nLINE8\nLINE9\nLINE10\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
@@ -429,15 +434,18 @@ fn test_quick_open_goto_line_live_preview_buffer_edit_invalidates() {
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text(":5").unwrap();
-    harness.render().unwrap();
-    let line5_before_edit = "LINE1\nLINE2\nLINE3\nLINE4\n".len();
-    assert_eq!(harness.cursor_position(), line5_before_edit);
+    harness.type_text(":50").unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 45 │ LINE45") && !screen.contains("  1 │ LINE1")
+        })
+        .expect("Preview should scroll toward line 50");
 
-    // External edit (e.g. LSP code action, plugin, format-on-save) inserts
-    // at the start of the buffer. Use a cursor_id that doesn't exist so the
-    // primary cursor only receives `adjust_for_edit` (no end-of-insertion
-    // move) — this models the "async edit came in" scenario.
+    // Simulate an async external edit (LSP code action, plugin, format-on-save)
+    // inserting a single line at the start of the buffer. Use a cursor_id that
+    // doesn't match any cursor so the primary cursor only receives
+    // `adjust_for_edit` (no end-of-insertion jump).
     harness
         .apply_event(Event::Insert {
             position: 0,
@@ -445,19 +453,25 @@ fn test_quick_open_goto_line_live_preview_buffer_edit_invalidates() {
             cursor_id: CursorId(999_999),
         })
         .unwrap();
-    let cursor_after_edit = harness.cursor_position();
-    assert_ne!(
-        cursor_after_edit, line5_before_edit,
-        "Cursor should have shifted via adjust_for_edit after inserting at position 0"
-    );
 
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
-    harness.render().unwrap();
-    assert_eq!(
-        harness.cursor_position(),
-        cursor_after_edit,
-        "Esc must not restore the stale pre-preview snapshot after an external edit shifted the cursor"
-    );
+
+    // Inserting one line before the cursor shifts it via `adjust_for_edit`
+    // from line 50 to physical line 51 of the edited buffer (LINE50 text).
+    // If the restore had fired, the viewport would have snapped back to the
+    // top of the buffer (gutter line "  1 │ PREFIX") and LINE50 would scroll
+    // out of view. Rendered-output evidence that the snapshot was dropped:
+    // the viewport still shows content around the adjusted cursor.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 51 │ LINE50") && !screen.contains("  1 │ PREFIX")
+        })
+        .expect(
+            "Esc must not restore the stale pre-preview snapshot after an external edit \
+             shifted the cursor — expected viewport to stay near line 51 (LINE50), \
+             not snap back to the PREFIX line at the top",
+        );
 }
 
 /// Changing the prefix away from ":" should restore the cursor even without
@@ -470,13 +484,11 @@ fn test_quick_open_goto_line_live_preview_restores_when_prefix_changes() {
         EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
     let project_root = harness.project_dir().unwrap();
 
-    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
     let jump_path = project_root.join("jump.txt");
-    fs::write(&jump_path, content).unwrap();
+    write_numbered_lines(&jump_path, 100);
 
     harness.open_file(&jump_path).unwrap();
     harness.render().unwrap();
-    let original_position = harness.cursor_position();
 
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
@@ -484,16 +496,19 @@ fn test_quick_open_goto_line_live_preview_restores_when_prefix_changes() {
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
-    harness.type_text(":3").unwrap();
-    harness.render().unwrap();
+    harness.type_text(":80").unwrap();
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains(" 75 │ LINE75") && !screen.contains("  1 │ LINE1")
+        })
+        .expect("Preview should scroll toward line 80");
 
-    assert_ne!(
-        harness.cursor_position(),
-        original_position,
-        "Cursor should have moved to line 3 during preview"
-    );
-
-    // Replace ":3" with ">toggle" to switch to the command provider.
+    // Replace ":80" with ">toggle" to switch to the command provider — this
+    // should restore the pre-preview viewport (line 1 visible again).
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
     harness
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
@@ -501,13 +516,15 @@ fn test_quick_open_goto_line_live_preview_restores_when_prefix_changes() {
         .send_key(KeyCode::Backspace, KeyModifiers::NONE)
         .unwrap();
     harness.type_text(">toggle").unwrap();
-    harness.render().unwrap();
-
-    assert_eq!(
-        harness.cursor_position(),
-        original_position,
-        "Cursor should be restored when the goto-line provider is no longer targeted"
-    );
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("  1 │ LINE1") && !screen.contains(" 75 │ LINE75")
+        })
+        .expect(
+            "Switching providers should restore the pre-preview viewport — line 1 visible, \
+             line 75 no longer visible",
+        );
 }
 
 /// Test command palette fuzzy matching

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -351,6 +351,58 @@ fn test_quick_open_goto_line_live_preview_cancel_restores() {
     );
 }
 
+/// Clicking in the editor while a goto-line preview is active should commit
+/// the click as the new cursor position — Esc afterwards must NOT restore
+/// the pre-preview snapshot over the user's click.
+#[test]
+fn test_quick_open_goto_line_live_preview_mouse_click_commits() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 30, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\nLINE8\nLINE9\nLINE10\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(":8").unwrap();
+    harness.render().unwrap();
+    let line8_start = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\n".len();
+    assert_eq!(
+        harness.cursor_position(),
+        line8_start,
+        "Preview should have jumped cursor to line 8"
+    );
+
+    // Click in the editor content area. (col=10, row=4 lands on a visible
+    // line near the top of the buffer — past the menu and tab bars.)
+    harness.mouse_click(10, 4).unwrap();
+    let clicked_position = harness.cursor_position();
+    assert_ne!(
+        clicked_position, line8_start,
+        "Mouse click should have moved cursor away from the preview target"
+    );
+
+    // Press Esc — the pre-preview snapshot must NOT override the click.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        clicked_position,
+        "Cursor should stay where the user clicked; preview snapshot must be committed on click"
+    );
+}
+
 /// Changing the prefix away from ":" should restore the cursor even without
 /// cancelling (so the preview doesn't leak into other providers).
 #[test]

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -215,6 +215,192 @@ fn test_quick_open_file_path_line_only() {
         .expect("Cursor should jump to Ln 3, Col 1 after Quick Open");
 }
 
+/// Quick Open goto-line (":N") should live-preview the jump as the user types,
+/// so the cursor moves to line N before pressing Enter (issue #1253).
+#[test]
+fn test_quick_open_goto_line_live_preview() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+    let line1_position = harness.cursor_position();
+
+    // Open Quick Open, clear the ">" prefix, then type ":3".
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(":3").unwrap();
+    harness.render().unwrap();
+
+    // The cursor should already be on line 3 (byte 12, just after "11111\n22222\n")
+    // while the prompt is still open — without ever pressing Enter.
+    let line3_start = "11111\n22222\n".len();
+    assert_ne!(
+        harness.cursor_position(),
+        line1_position,
+        "Cursor should have moved from its starting position"
+    );
+    assert_eq!(
+        harness.cursor_position(),
+        line3_start,
+        "Cursor should live-preview at start of line 3 while typing ':3'"
+    );
+}
+
+/// Extending the live preview to a new number jumps again in the same prompt.
+#[test]
+fn test_quick_open_goto_line_live_preview_updates() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "11111\n22222\nABCDE12345\n44444\n55555\n66666\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+
+    // First preview to line 2.
+    harness.type_text(":2").unwrap();
+    harness.render().unwrap();
+    let line2_start = "11111\n".len();
+    assert_eq!(
+        harness.cursor_position(),
+        line2_start,
+        "Cursor should live-preview at start of line 2"
+    );
+
+    // Change the target to line 5.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("5").unwrap();
+    harness.render().unwrap();
+    let line5_start = "11111\n22222\nABCDE12345\n44444\n".len();
+    assert_eq!(
+        harness.cursor_position(),
+        line5_start,
+        "Cursor should live-preview at start of line 5 after updating target"
+    );
+}
+
+/// Canceling the Quick Open prompt (Esc) after a live-preview jump should
+/// restore the cursor to where it was before the prompt was opened.
+#[test]
+fn test_quick_open_goto_line_live_preview_cancel_restores() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+    let original_position = harness.cursor_position();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(":3").unwrap();
+    harness.render().unwrap();
+
+    let line3_start = "11111\n22222\n".len();
+    assert_eq!(
+        harness.cursor_position(),
+        line3_start,
+        "Cursor should live-preview at start of line 3"
+    );
+
+    // Cancel the prompt.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Cursor should be back at its original position.
+    assert_eq!(
+        harness.cursor_position(),
+        original_position,
+        "Cursor should be restored to its pre-preview position after Esc"
+    );
+}
+
+/// Changing the prefix away from ":" should restore the cursor even without
+/// cancelling (so the preview doesn't leak into other providers).
+#[test]
+fn test_quick_open_goto_line_live_preview_restores_when_prefix_changes() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 24, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "11111\n22222\nABCDE12345\n44444\n55555\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+    let original_position = harness.cursor_position();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(":3").unwrap();
+    harness.render().unwrap();
+
+    assert_ne!(
+        harness.cursor_position(),
+        original_position,
+        "Cursor should have moved to line 3 during preview"
+    );
+
+    // Replace ":3" with ">toggle" to switch to the command provider.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(">toggle").unwrap();
+    harness.render().unwrap();
+
+    assert_eq!(
+        harness.cursor_position(),
+        original_position,
+        "Cursor should be restored when the goto-line provider is no longer targeted"
+    );
+}
+
 /// Test command palette fuzzy matching
 #[test]
 fn test_command_palette_fuzzy_matching() {

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -403,6 +403,63 @@ fn test_quick_open_goto_line_live_preview_mouse_click_commits() {
     );
 }
 
+/// A buffer edit that lands before the preview cursor (shifting it forward
+/// via `adjust_for_edit`) invalidates the snapshot: Esc afterwards must NOT
+/// restore, because the pre-preview byte position is meaningless relative to
+/// the edited buffer.
+#[test]
+fn test_quick_open_goto_line_live_preview_buffer_edit_invalidates() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    use fresh::model::event::{CursorId, Event};
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config(100, 30, Default::default()).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let content = "LINE1\nLINE2\nLINE3\nLINE4\nLINE5\nLINE6\nLINE7\nLINE8\nLINE9\nLINE10\n";
+    let jump_path = project_root.join("jump.txt");
+    fs::write(&jump_path, content).unwrap();
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text(":5").unwrap();
+    harness.render().unwrap();
+    let line5_before_edit = "LINE1\nLINE2\nLINE3\nLINE4\n".len();
+    assert_eq!(harness.cursor_position(), line5_before_edit);
+
+    // External edit (e.g. LSP code action, plugin, format-on-save) inserts
+    // at the start of the buffer. Use a cursor_id that doesn't exist so the
+    // primary cursor only receives `adjust_for_edit` (no end-of-insertion
+    // move) — this models the "async edit came in" scenario.
+    harness
+        .apply_event(Event::Insert {
+            position: 0,
+            text: "PREFIX\n".to_string(),
+            cursor_id: CursorId(999_999),
+        })
+        .unwrap();
+    let cursor_after_edit = harness.cursor_position();
+    assert_ne!(
+        cursor_after_edit, line5_before_edit,
+        "Cursor should have shifted via adjust_for_edit after inserting at position 0"
+    );
+
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.cursor_position(),
+        cursor_after_edit,
+        "Esc must not restore the stale pre-preview snapshot after an external edit shifted the cursor"
+    );
+}
+
 /// Changing the prefix away from ":" should restore the cursor even without
 /// cancelling (so the preview doesn't leak into other providers).
 #[test]


### PR DESCRIPTION
## Summary

Implements live preview for the Quick Open goto-line provider, matching VSCode's `Ctrl+P` → `:<N>` behavior. As the user types a line number, the editor immediately jumps the cursor to that line so the target is visible before pressing Enter. If the user cancels (Esc) or changes the prefix away from `:` (e.g. starts typing `>command`), the cursor and viewport are restored to the pre-preview state.

Closes #1253.

## Design

- A new `GotoLinePreviewSnapshot` stores the active split's cursor (position, anchor, sticky column) and viewport (top byte, top view-line offset, left column) the first time a preview jump happens during a Quick Open session.
- `update_quick_open_suggestions` parses the current input; if it is `:<N>` for `N > 0`, it saves a snapshot (if one isn't already saved) and calls `goto_line_col(N, None)`. Otherwise, any saved snapshot is restored.
- `cancel_prompt` restores the snapshot for `QuickOpen`, so Esc undoes the preview.
- `execute_quick_open_result` keeps the preview when the user confirms a `GotoLine` result, but restores the pre-preview state first for every other outcome (opening a file, switching buffers, running a command), so the preview never leaks into unrelated actions.

## Test plan

- [x] `cargo check -p fresh-editor --all-targets`
- [x] `cargo fmt --all --check`
- [x] New e2e tests in `tests/e2e/command_palette.rs`:
  - `test_quick_open_goto_line_live_preview` — `:3` previews without Enter.
  - `test_quick_open_goto_line_live_preview_updates` — extending/changing the number re-jumps.
  - `test_quick_open_goto_line_live_preview_cancel_restores` — Esc restores cursor.
  - `test_quick_open_goto_line_live_preview_restores_when_prefix_changes` — switching to `>cmd` restores cursor.
- [x] Manual tmux validation: confirmed preview-while-typing, Esc restore, Enter commit, and switching prefix behaves correctly on a 20-line sample file.

https://claude.ai/code/session_01Bc1t1Sd5DEAKvRPMsXYPhx