### PR TITLE
fix(encoding): stop CJK mojibake when a UTF-8 codepoint straddles the 8 KB detection window (#1635)

### DIFF
--- a/crates/fresh-editor/src/model/encoding.rs
+++ b/crates/fresh-editor/src/model/encoding.rs
@@ -1141,4 +1141,39 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_detect_utf8_cjk_across_internal_8kb_boundary() {
+        // Regression for #1635: when callers pass the full file bytes with
+        // `truncated=false`, the detector still internally clamps the sample
+        // to the first 8 KB. If a multi-byte UTF-8 sequence straddles that
+        // internal 8192-byte cutoff, the strict UTF-8 check fails and the
+        // CJK continuation bytes get misclassified by the fallback path
+        // (often as Windows-1250/1251/1252), garbling the whole file.
+        //
+        // The full buffer IS valid UTF-8, so detection must return UTF-8.
+
+        // Build padding that is pure ASCII and leaves exactly one byte of
+        // room inside the first 8 KB before we write a 3-byte CJK codepoint.
+        // "项" = [0xE9, 0xA1, 0xB9] — the first byte sits at offset 8191,
+        // the remaining two bytes spill past the internal 8192-byte sample.
+        let mut buffer = Vec::with_capacity(16 * 1024);
+        buffer.resize(8 * 1024 - 1, b'a');
+        // CJK text that crosses the boundary and continues after it.
+        buffer.extend_from_slice("项目设置项目设置项目设置".as_bytes());
+
+        assert!(buffer.len() > 8 * 1024);
+        assert!(std::str::from_utf8(&buffer).is_ok());
+
+        // The caller (load_small_file) passes the full content with
+        // `truncated=false` because no truncation occurred at the call site.
+        // Detection must still return UTF-8.
+        let detected = detect_encoding_or_binary(&buffer, false).0;
+        assert_eq!(
+            detected,
+            Encoding::Utf8,
+            "Valid UTF-8 CJK content must be detected as UTF-8 even when a \
+             multi-byte sequence straddles the detector's internal 8 KB sample boundary"
+        );
+    }
 }

--- a/crates/fresh-editor/src/model/encoding.rs
+++ b/crates/fresh-editor/src/model/encoding.rs
@@ -255,6 +255,13 @@ pub fn detect_encoding_or_binary(bytes: &[u8], truncated: bool) -> (Encoding, bo
     let check_len = bytes.len().min(8 * 1024);
     let sample = &bytes[..check_len];
 
+    // The caller's `truncated` flag says whether the bytes they passed were
+    // already cut from a larger stream. The detector additionally clamps the
+    // sample to 8 KB internally, which is its own source of truncation — a
+    // multi-byte UTF-8 sequence straddling that cutoff would otherwise fail
+    // strict validation even though the full buffer is valid UTF-8 (#1635).
+    let sample_truncated = truncated || check_len < bytes.len();
+
     // 1. Check for BOM (Byte Order Mark) - highest priority, definitely text
     if sample.starts_with(&[0xEF, 0xBB, 0xBF]) {
         return (Encoding::Utf8Bom, false);
@@ -292,7 +299,7 @@ pub fn detect_encoding_or_binary(bytes: &[u8], truncated: bool) -> (Encoding, bo
     // truncation artifact). Without truncation, require exact validity — a
     // trailing 0xE9 in a short file is a Latin-1 'é', not a truncated codepoint.
     let is_valid_utf8 = utf8_valid_len == sample.len()
-        || (truncated && utf8_valid_len > 0 && utf8_valid_len >= sample.len() - 3);
+        || (sample_truncated && utf8_valid_len > 0 && utf8_valid_len >= sample.len() - 3);
     if is_valid_utf8 {
         let valid_sample = &sample[..utf8_valid_len];
         // Check if it's pure ASCII (subset of UTF-8)
@@ -301,7 +308,11 @@ pub fn detect_encoding_or_binary(bytes: &[u8], truncated: bool) -> (Encoding, bo
         if has_binary_control {
             return (Encoding::Utf8, true);
         }
-        if valid_sample.iter().all(|&b| b < 128) {
+        // If the tolerance branch accepted a trailing incomplete multi-byte
+        // sequence, the file is not pure ASCII — the byte at `utf8_valid_len`
+        // is a UTF-8 lead byte. Classify as UTF-8 in that case.
+        let has_non_ascii_tail = utf8_valid_len < sample.len();
+        if !has_non_ascii_tail && valid_sample.iter().all(|&b| b < 128) {
             return (Encoding::Ascii, false);
         }
         return (Encoding::Utf8, false);

--- a/crates/fresh-editor/tests/e2e/encoding.rs
+++ b/crates/fresh-editor/tests/e2e/encoding.rs
@@ -2408,3 +2408,54 @@ fn test_latin1_trailing_accent_not_misdetected_as_utf8() {
         buffer_content
     );
 }
+
+/// Regression test for #1635: UTF-8 CJK files whose size exceeds the 8 KB
+/// encoding-detection sample must not be mis-decoded as a legacy encoding
+/// when a multi-byte sequence straddles the 8192-byte boundary.
+#[test]
+fn test_utf8_cjk_file_larger_than_8kb_displays_correctly() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("cjk_over_8kb.txt");
+
+    // Build a valid UTF-8 file whose first non-ASCII multi-byte character
+    // straddles the detector's internal 8 KB sampling boundary. Pad with
+    // ASCII 'a' until we've written exactly 8191 bytes, then emit CJK
+    // content — the second and third bytes of the first CJK codepoint
+    // sit at file offsets 8192 and 8193.
+    let mut content = Vec::with_capacity(16 * 1024);
+    content.resize(8 * 1024 - 1, b'a');
+    let cjk = "项目设置 的 CJK 内容 项目设置";
+    content.extend_from_slice(cjk.as_bytes());
+    content.push(b'\n');
+
+    assert!(content.len() > 8 * 1024);
+    assert!(std::str::from_utf8(&content).is_ok());
+    std::fs::write(&file_path, &content).unwrap();
+
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // If detection misfires and picks a legacy encoding, the buffer will
+    // contain mojibake instead of the original CJK characters.
+    let buffer_content = harness.get_buffer_content().unwrap();
+    for ch in ['项', '目', '设', '置'] {
+        assert!(
+            buffer_content.contains(ch),
+            "CJK character {:?} should survive load. Buffer preview: {:?}",
+            ch,
+            &buffer_content[..buffer_content.len().min(200)]
+        );
+    }
+
+    // Status bar should not advertise a legacy encoding for this UTF-8 file.
+    let screen = harness.screen_to_string();
+    for legacy in ["Windows-1252", "Windows-1250", "Windows-1251"] {
+        assert!(
+            !screen.contains(legacy),
+            "UTF-8 CJK file must not be detected as {}. Screen: {:?}",
+            legacy,
+            screen
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1635. UTF-8 files containing CJK characters were displayed as mojibake when the file exceeded ~8 KB. Root cause: `detect_encoding_or_binary` clamps its sample to the first 8192 bytes internally, but the existing 3-byte "trailing incomplete UTF-8 sequence" tolerance only engaged when the *caller* set `truncated=true`. For files loaded via `load_small_file`, the full buffer is passed with `truncated=false`, so a multi-byte codepoint straddling the 8192-byte boundary made strict UTF-8 validation fail and chardetng chose a legacy encoding (typically Windows-1252), garbling the whole buffer.

## Fix

- Treat the detector's own 8 KB clamp as truncation: `sample_truncated = truncated || check_len < bytes.len()`.
- Use `sample_truncated` for the existing incomplete-trailing-sequence tolerance.
- When that tolerance fires, the byte past `utf8_valid_len` is a UTF-8 lead byte, so the file is not pure ASCII — classify as UTF-8 rather than ASCII in that branch.

The fix is surgical: only two lines of logic change in the hot path, plus the small ASCII/UTF-8 disambiguation guard.

## Tests

Split into the test-first / fix-second commit pattern per CONTRIBUTING.md:

1. `test(encoding): reproduce CJK mojibake at 8 KB sample boundary` — adds
   - unit test `test_detect_utf8_cjk_across_internal_8kb_boundary` in `crates/fresh-editor/src/model/encoding.rs`
   - e2e test `test_utf8_cjk_file_larger_than_8kb_displays_correctly` in `crates/fresh-editor/tests/e2e/encoding.rs`
2. `fix(encoding): treat internal 8 KB sample clamp as truncation` — makes both tests pass.

All 46 encoding unit tests and 37 e2e encoding tests pass after the fix.

## Manual validation

Built the `fresh` binary and opened an 8469-byte UTF-8 file (`'a' × 8191` + `项目设置 / 项目设置 / …` + trailing CJK lines) in a tmux session. Before the fix the status bar showed `Windows-1252` with garbled glyphs; after the fix the status bar shows `UTF-8` and all `项目设置` occurrences render correctly.

## Test plan

- [x] `cargo test -p fresh-editor --lib 'model::encoding'`
- [x] `cargo test -p fresh-editor --test e2e_tests 'e2e::encoding::'`
- [x] `cargo check --all-targets`
- [x] `cargo fmt --all --check`
- [x] Manual tmux validation opening a CJK file larger than 8 KB with a codepoint crossing offset 8192

https://claude.ai/code/session_01371hvxNtApVax7QafZjk9m