### PR TITLE
fix(git_log): support j/k navigation in git-log file-view buffers

### DIFF
--- a/crates/fresh-editor/plugins/git_log.i18n.json
+++ b/crates/fresh-editor/plugins/git_log.i18n.json
@@ -32,9 +32,7 @@
     "status.move_to_diff": "Move cursor to a diff line",
 
     "panel.commits_header": "Commits:",
-    "panel.no_commits": "  No commits found",
-    "panel.log_footer": "%{count} commits | Up/Down/j/k: navigate | RET: show | y: yank hash | r: refresh | q: quit",
-    "panel.detail_footer": "Up/Down/j/k: navigate | RET: open file at line | q: back to log"
+    "panel.no_commits": "  No commits found"
   },
   "cs": {
     "cmd.git_log": "Git Log",
@@ -69,9 +67,7 @@
     "status.move_to_diff": "Presunte kurzor na radek diffu",
 
     "panel.commits_header": "Commity:",
-    "panel.no_commits": "  Zadne commity nenalezeny",
-    "panel.log_footer": "%{count} commitu | Nahoru/Dolu/j/k: navigace | RET: zobrazit | y: kopirovat hash | r: obnovit | q: ukoncit",
-    "panel.detail_footer": "Nahoru/Dolu/j/k: navigace | RET: otevrit soubor na radku | q: zpet do logu"
+    "panel.no_commits": "  Zadne commity nenalezeny"
   },
   "de": {
     "cmd.git_log": "Git-Protokoll",
@@ -106,9 +102,7 @@
     "status.move_to_diff": "Cursor auf eine Diff-Zeile bewegen",
 
     "panel.commits_header": "Commits:",
-    "panel.no_commits": "  Keine Commits gefunden",
-    "panel.log_footer": "%{count} Commits | Auf/Ab/j/k: navigieren | RET: anzeigen | y: Hash kopieren | r: aktualisieren | q: beenden",
-    "panel.detail_footer": "Auf/Ab/j/k: navigieren | RET: Datei bei Zeile oeffnen | q: zurueck zum Protokoll"
+    "panel.no_commits": "  Keine Commits gefunden"
   },
   "es": {
     "cmd.git_log": "Registro Git",
@@ -143,9 +137,7 @@
     "status.move_to_diff": "Mueve el cursor a una linea de diff",
 
     "panel.commits_header": "Commits:",
-    "panel.no_commits": "  No se encontraron commits",
-    "panel.log_footer": "%{count} commits | Arriba/Abajo/j/k: navegar | RET: mostrar | y: copiar hash | r: actualizar | q: salir",
-    "panel.detail_footer": "Arriba/Abajo/j/k: navegar | RET: abrir archivo en linea | q: volver al registro"
+    "panel.no_commits": "  No se encontraron commits"
   },
   "fr": {
     "cmd.git_log": "Journal Git",
@@ -180,9 +172,7 @@
     "status.move_to_diff": "Deplacez le curseur sur une ligne de diff",
 
     "panel.commits_header": "Commits:",
-    "panel.no_commits": "  Aucun commit trouve",
-    "panel.log_footer": "%{count} commits | Haut/Bas/j/k: naviguer | RET: afficher | y: copier hash | r: actualiser | q: quitter",
-    "panel.detail_footer": "Haut/Bas/j/k: naviguer | RET: ouvrir fichier a la ligne | q: retour au journal"
+    "panel.no_commits": "  Aucun commit trouve"
   },
   "it": {
     "cmd.git_log": "Git Log",
@@ -215,9 +205,7 @@
     "status.move_to_diff_with_context": "Sposta il cursore su una riga di diff con contesto file",
     "status.move_to_diff": "Sposta il cursore su una riga di diff",
     "panel.commits_header": "Commit:",
-    "panel.no_commits": "  Nessun commit trovato",
-    "panel.log_footer": "%{count} commit | Su/Giù/j/k: naviga | RET: mostra | y: copia hash | r: aggiorna | q: esci",
-    "panel.detail_footer": "Su/Giù/j/k: naviga | RET: apri file alla riga | q: torna al log"
+    "panel.no_commits": "  Nessun commit trovato"
   },
   "ja": {
     "cmd.git_log": "Gitログ",
@@ -252,9 +240,7 @@
     "status.move_to_diff": "カーソルを差分行に移動してください",
 
     "panel.commits_header": "コミット:",
-    "panel.no_commits": "  コミットが見つかりません",
-    "panel.log_footer": "%{count}件のコミット | 上/下/j/k: 移動 | RET: 表示 | y: ハッシュをコピー | r: 更新 | q: 終了",
-    "panel.detail_footer": "上/下/j/k: 移動 | RET: ファイルを行で開く | q: ログに戻る"
+    "panel.no_commits": "  コミットが見つかりません"
   },
   "ko": {
     "cmd.git_log": "Git 로그",
@@ -289,9 +275,7 @@
     "status.move_to_diff": "커서를 diff 줄로 이동하세요",
 
     "panel.commits_header": "커밋:",
-    "panel.no_commits": "  커밋을 찾을 수 없습니다",
-    "panel.log_footer": "%{count}개 커밋 | 위/아래/j/k: 탐색 | RET: 표시 | y: 해시 복사 | r: 새로고침 | q: 종료",
-    "panel.detail_footer": "위/아래/j/k: 탐색 | RET: 해당 줄에서 파일 열기 | q: 로그로 돌아가기"
+    "panel.no_commits": "  커밋을 찾을 수 없습니다"
   },
   "pt-BR": {
     "cmd.git_log": "Git Log",
@@ -326,9 +310,7 @@
     "status.move_to_diff": "Mova o cursor para uma linha de diff",
 
     "panel.commits_header": "Commits:",
-    "panel.no_commits": "  Nenhum commit encontrado",
-    "panel.log_footer": "%{count} commits | Cima/Baixo/j/k: navegar | RET: mostrar | y: copiar hash | r: atualizar | q: sair",
-    "panel.detail_footer": "Cima/Baixo/j/k: navegar | RET: abrir arquivo na linha | q: voltar ao log"
+    "panel.no_commits": "  Nenhum commit encontrado"
   },
   "ru": {
     "cmd.git_log": "Git Log",
@@ -363,9 +345,7 @@
     "status.move_to_diff": "Peremesstite kursor na stroku diff",
 
     "panel.commits_header": "Kommity:",
-    "panel.no_commits": "  Kommity ne naydeny",
-    "panel.log_footer": "%{count} kommitov | Vverkh/Vniz/j/k: navigatsiya | RET: pokazat' | y: kopirovat' khesh | r: obnovit' | q: vyyti",
-    "panel.detail_footer": "Vverkh/Vniz/j/k: navigatsiya | RET: otkryt' fayl na stroke | q: nazad k logu"
+    "panel.no_commits": "  Kommity ne naydeny"
   },
   "th": {
     "cmd.git_log": "Git Log",
@@ -400,9 +380,7 @@
     "status.move_to_diff": "เลื่อนเคอร์เซอร์ไปที่บรรทัด diff",
 
     "panel.commits_header": "คอมมิต:",
-    "panel.no_commits": "  ไม่พบคอมมิต",
-    "panel.log_footer": "%{count} คอมมิต | ขึ้น/ลง/j/k: นำทาง | RET: แสดง | y: คัดลอกแฮช | r: รีเฟรช | q: ออก",
-    "panel.detail_footer": "ขึ้น/ลง/j/k: นำทาง | RET: เปิดไฟล์ที่บรรทัด | q: กลับไปที่ log"
+    "panel.no_commits": "  ไม่พบคอมมิต"
   },
   "uk": {
     "cmd.git_log": "Git Log",
@@ -437,9 +415,7 @@
     "status.move_to_diff": "Peremistit' kursor na ryadok diff",
 
     "panel.commits_header": "Komity:",
-    "panel.no_commits": "  Komity ne znaydeno",
-    "panel.log_footer": "%{count} komitiv | Vhoru/Vnyz/j/k: navihatsiya | RET: pokazaty | y: kopiyuvaty khesh | r: onovyty | q: vyyty",
-    "panel.detail_footer": "Vhoru/Vnyz/j/k: navihatsiya | RET: vidkryty fayl na ryadku | q: nazad do lohu"
+    "panel.no_commits": "  Komity ne znaydeno"
   },
   "vi": {
     "cmd.git_log": "Git Log",
@@ -474,9 +450,7 @@
     "status.move_to_diff": "Di chuyển con trỏ đến dòng diff",
 
     "panel.commits_header": "Commit:",
-    "panel.no_commits": "  Không tìm thấy commit",
-    "panel.log_footer": "%{count} commit | Lên/Xuống/j/k: điều hướng | RET: hiển thị | y: sao chép hash | r: làm mới | q: thoát",
-    "panel.detail_footer": "Lên/Xuống/j/k: điều hướng | RET: mở tệp tại dòng | q: quay lại log"
+    "panel.no_commits": "  Không tìm thấy commit"
   },
   "zh-CN": {
     "cmd.git_log": "Git日志",
@@ -511,8 +485,6 @@
     "status.move_to_diff": "请将光标移动到差异行",
 
     "panel.commits_header": "提交:",
-    "panel.no_commits": "  未找到提交",
-    "panel.log_footer": "%{count}个提交 | 上/下/j/k: 导航 | RET: 显示 | y: 复制哈希 | r: 刷新 | q: 退出",
-    "panel.detail_footer": "上/下/j/k: 导航 | RET: 在行处打开文件 | q: 返回日志"
+    "panel.no_commits": "  未找到提交"
   }
 }

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -686,13 +686,23 @@ async function git_log_detail_open_file(): Promise<void> {
 registerHandler("git_log_detail_open_file", git_log_detail_open_file);
 
 // File-view mode so `q` closes the tab and returns to the group.
+//
+// j/k alias Up/Down as in the main git-log mode, and we inherit Normal
+// bindings so arrows, PageUp/Down, Home/End, Ctrl+C copy, etc. still work
+// in this read-only buffer — without `inheritNormalBindings`, unbound keys
+// in a read-only mode fall through to the edit actions and trip the
+// `editing_disabled` status message (see #566).
 editor.defineMode(
   "git-log-file-view",
   [
+    ["k", "move_up"],
+    ["j", "move_down"],
     ["q", "git_log_file_view_close"],
     ["Escape", "git_log_file_view_close"],
   ],
-  true
+  true, // read-only
+  false, // allow_text_input
+  true, // inherit Normal-context bindings for unbound keys
 );
 
 function git_log_file_view_close(): void {

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -2499,9 +2499,7 @@ fn test_git_log_file_view_jk_navigation() {
         .unwrap();
 
     // Tab into the detail panel so Enter-on-a-diff-line opens the file-view.
-    harness
-        .send_key(KeyCode::Tab, KeyModifiers::NONE)
-        .unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     harness.process_async_and_render().unwrap();
 
     // Wait for the commit diff to render in the detail panel.

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -2456,3 +2456,168 @@ fn test_git_blame_original_buffer_not_decorated() {
         "Original file should NOT have blame headers after closing blame"
     );
 }
+
+/// Regression test for https://github.com/sinelaw/fresh/issues/566.
+///
+/// The git-log-related read-only buffers advertise `j/k: navigate` in their
+/// footer hints. Pressing j/k used to fall through to the editing actions
+/// and trip the `Editing disabled in this buffer` status message instead of
+/// moving the cursor. The main log and detail panels already bind j/k
+/// explicitly; this test covers the file-view buffer (opened from the detail
+/// panel's `Enter on a diff line` path), which previously did not.
+#[test]
+fn test_git_log_file_view_jk_navigation() {
+    let repo = GitTestRepo::new();
+
+    // A file with several lines so j/k have somewhere to move to.
+    let multiline = "line one\nline two\nline three\nline four\nline five\n";
+    repo.create_file("notes.txt", multiline);
+    repo.git_add(&["notes.txt"]);
+    repo.git_commit("Add notes.txt");
+
+    repo.setup_git_log_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    trigger_git_log(&mut harness);
+
+    // Wait for git log to load and show the commit.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("switch pane") && screen.contains("Add notes.txt")
+        })
+        .unwrap();
+
+    // Tab into the detail panel so Enter-on-a-diff-line opens the file-view.
+    harness
+        .send_key(KeyCode::Tab, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Wait for the commit diff to render in the detail panel.
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("Author:") && screen.contains("+line one")
+        })
+        .unwrap();
+
+    // The file-view buffer is active when the status bar's leading "current
+    // buffer" field is `*<hash>:notes.txt* [RO]`. Matching on the status bar
+    // rather than the one-shot "(read-only) | Target: line N" ready message
+    // avoids a race: the ready message is later overwritten by any status
+    // the next key produces, but the buffer's name / [RO] indicator stays.
+    let file_view_active = |h: &EditorTestHarness| {
+        h.screen_to_string()
+            .lines()
+            .any(|l| l.contains(":notes.txt*") && l.contains("[RO]") && l.contains("Ln "))
+    };
+
+    // Walk the cursor down the detail panel, trying Enter each time until
+    // the file-view actually opens. The detail panel only accepts Enter on
+    // diff lines that have file context; other rows keep the detail panel
+    // focused and surface "Move cursor to a diff line with file context"
+    // in the status bar. Opening the file-view spawns `git show` under the
+    // hood, so we poll briefly after each Enter for the async result.
+    for _ in 0..40 {
+        harness
+            .send_key(KeyCode::Enter, KeyModifiers::NONE)
+            .unwrap();
+        for _ in 0..20 {
+            harness.process_async_and_render().unwrap();
+            if file_view_active(&harness) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+        if file_view_active(&harness) {
+            break;
+        }
+        harness
+            .send_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .unwrap();
+        harness.process_async_and_render().unwrap();
+    }
+    assert!(
+        file_view_active(&harness),
+        "Did not reach a diff line that opens the file-view. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Record the file-view's starting line so we can assert that j moves
+    // the cursor forward without caring exactly which diff line the walk
+    // above landed on. The pre-fix behaviour for this buffer was: j/k ran
+    // no action, left the cursor where it was, and set the status to
+    // "Editing disabled in this buffer". The assertions below cover both
+    // halves: cursor motion AND the absence of that status message.
+    let start_line: usize = {
+        let screen = harness.screen_to_string();
+        parse_ln(&screen).unwrap_or_else(|| {
+            panic!("Could not parse 'Ln <N>' from file-view status. Screen:\n{screen}")
+        })
+    };
+    assert!(
+        !harness
+            .screen_to_string()
+            .to_lowercase()
+            .contains("editing disabled"),
+        "'Editing disabled' should not appear before pressing j. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Press j — cursor should advance and the editing-disabled message must
+    // not fire (the core #566 regression check).
+    harness
+        .send_key(KeyCode::Char('j'), KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+    let after_j = {
+        let screen = harness.screen_to_string();
+        assert!(
+            !screen.to_lowercase().contains("editing disabled"),
+            "j should move the cursor in git-log-file-view, not trigger 'Editing disabled'. Screen:\n{screen}"
+        );
+        parse_ln(&screen)
+            .unwrap_or_else(|| panic!("Could not parse line after j. Screen:\n{screen}"))
+    };
+    assert!(
+        after_j > start_line,
+        "Expected cursor to advance after pressing j (start_line={start_line}, after_j={after_j})"
+    );
+
+    // Press k — the critical check is again the absence of the
+    // "Editing disabled" status. (Cursor motion on k in a virtual
+    // buffer is covered by the main git-log mode tests; the regression
+    // we're guarding here is specifically the status-message path.)
+    harness
+        .send_key(KeyCode::Char('k'), KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+    {
+        let screen = harness.screen_to_string();
+        assert!(
+            !screen.to_lowercase().contains("editing disabled"),
+            "k should not trigger 'Editing disabled' in git-log-file-view. Screen:\n{screen}"
+        );
+    }
+}
+
+/// Extract the line number from a status-bar fragment of the form "Ln N, Col M".
+/// Uses `rfind` so it picks the status bar at the bottom of the screen rather
+/// than any earlier occurrence (e.g. "| Ln" in help text).
+fn parse_ln(screen: &str) -> Option<usize> {
+    let idx = screen.rfind("Ln ")?;
+    let rest = &screen[idx + 3..];
+    let end = rest.find(',')?;
+    rest[..end].trim().parse().ok()
+}


### PR DESCRIPTION
Fixes #566.

## Summary

The git-log file-view buffer (opened from a diff line in the detail panel) advertised `j/k: navigate` in its status hints, but pressing j or k fell through to edit actions and surfaced `Editing disabled in this buffer` instead of moving the cursor.

The main log and detail panels already bind j/k explicitly; this change extends the same treatment to the file-view mode, and cleans up a pair of stale i18n footer strings that referenced a pre-refactor hint bar.

## Changes

- **`git_log.ts`** — Bind `j`/`k` to `move_down`/`move_up` in the `git-log-file-view` mode, and pass `inheritNormalBindings: true` so arrows, PageUp/Down, Home/End, Ctrl+C copy still work without having to re-bind each one. Also added a short comment explaining the read-only-mode fallthrough that motivated the fix.
- **`git_log.i18n.json`** — Remove `panel.log_footer` and `panel.detail_footer` across all 14 locales. They haven't been rendered anywhere since the toolbar refactor and advertised j/k navigation that didn't work.
- **`tests/e2e/plugins/git.rs`** — New `test_git_log_file_view_jk_navigation` regression test: walks the detail panel until Enter opens a file-view, then asserts that j moves the cursor forward and neither j nor k produces the "Editing disabled" status message.

## Test plan

- [x] `cargo test -p fresh-editor --test e2e_tests test_git_log` — all 11 git_log e2e tests pass, including the new regression test
- [x] `cargo test -p fresh-editor --test test_plugin_i18n_completeness` — i18n key-parity checks pass after dropping the dead strings
- [x] Manual validation in a tmux session with a rebuilt `fresh` binary: opening the git log, tabbing to the detail panel, pressing Enter on a `+` diff line, then j/j/k — cursor moves, no "Editing disabled" status

https://claude.ai/code/session_01KGKQ6yEMMtkASqAfioRRSE