### PR TITLE
Fix diagnostics panel navigation timing issue

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
@@ -207,24 +207,24 @@ fn test_diagnostics_panel_jump_to_correct_line() {
     let panel_screen = harness.screen_to_string();
     eprintln!("[TEST] Panel screen:\n{}", panel_screen);
 
-    // Navigate to the first diagnostic item
-    // Panel layout: line 1=title, line 2=blank, line 3=file header, line 4=first [E] item
-    for _ in 0..10 {
+    // Navigate to the first diagnostic item.
+    // Panel layout: line 1=title, line 2=blank, line 3=file header, line 4=first [E] item.
+    // Press Down exactly 3 times to land on the first item, then wait for the
+    // plugin's async cursor_moved handler to update the status. Don't gate the
+    // Down presses on the screen state: the handler runs in the JS runtime and
+    // the status may not reflect the new cursor position before the next Down,
+    // causing the cursor to overshoot past the items.
+    for _ in 0..3 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
         harness.render().unwrap();
-        let screen = harness.screen_to_string();
-        if screen.contains("Item 1/") {
-            break;
-        }
     }
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Item 1/"))
+        .unwrap();
 
     let on_item = harness.screen_to_string();
     eprintln!("[TEST] On item 1:\n{}", on_item);
-    assert!(
-        on_item.contains("Item 1/"),
-        "Should be on a diagnostic item.\nScreen:\n{}",
-        on_item
-    );
 
     // Press Enter to jump to the diagnostic location (line 0 = display Ln 1)
     harness


### PR DESCRIPTION
## Summary
Fixed a race condition in the diagnostics panel test where the cursor could overshoot past items due to async handler timing. The test was checking screen state after each Down key press, but the plugin's async cursor_moved handler runs in the JS runtime and may not update the status before the next key press.

## Key Changes
- Changed from a loop with conditional break (up to 10 iterations) to exactly 3 Down key presses to reach the first diagnostic item
- Removed the screen state check inside the navigation loop that was causing the race condition
- Added explicit `wait_until()` call after navigation to ensure the async handler has updated the status before assertions
- Simplified the final assertion by removing the redundant check (the wait_until already validates the condition)

## Implementation Details
The fix separates concerns:
1. **Navigation phase**: Send exactly 3 Down presses without waiting for screen updates (the number needed to reach the first item)
2. **Synchronization phase**: Use `wait_until()` to block until the async handler has processed the cursor movement and updated the display
3. **Assertion phase**: Verify the expected state is displayed

This prevents the cursor from overshooting because we no longer gate navigation on intermediate screen states that may not reflect the true cursor position due to async handler delays.

https://claude.ai/code/session_01PwcXASC6cgpW47HGJVUWby