### PR TITLE
feat(explorer): preview selected file on keyboard up/down (#1570)

### DIFF
--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -226,6 +226,7 @@ impl Editor {
             explorer.select_prev_match();
             explorer.update_scroll_for_selection();
         }
+        self.file_explorer_preview_selected();
     }
 
     pub fn file_explorer_navigate_down(&mut self) {
@@ -233,6 +234,7 @@ impl Editor {
             explorer.select_next_match();
             explorer.update_scroll_for_selection();
         }
+        self.file_explorer_preview_selected();
     }
 
     pub fn file_explorer_page_up(&mut self) {
@@ -240,12 +242,46 @@ impl Editor {
             explorer.select_page_up();
             explorer.update_scroll_for_selection();
         }
+        self.file_explorer_preview_selected();
     }
 
     pub fn file_explorer_page_down(&mut self) {
         if let Some(explorer) = &mut self.file_explorer {
             explorer.select_page_down();
             explorer.update_scroll_for_selection();
+        }
+        self.file_explorer_preview_selected();
+    }
+
+    /// Open the currently selected file in preview mode, mirroring the
+    /// single-click flow in `handle_file_explorer_click`. No-op if the
+    /// selection is a directory, preview-tabs are disabled, or the open
+    /// would surface an interactive prompt (e.g. large-file encoding
+    /// confirmation) — the user can still commit with Enter to get the
+    /// full error flow. Keeps focus on the file explorer so further
+    /// keyboard navigation continues to update the preview.
+    fn file_explorer_preview_selected(&mut self) {
+        // Avoid turning every arrow press into a permanent tab when the
+        // user has opted out of preview tabs.
+        if !self.config.file_explorer.preview_tabs {
+            return;
+        }
+
+        let path = match self
+            .file_explorer
+            .as_ref()
+            .and_then(|explorer| explorer.get_selected_entry())
+        {
+            Some(entry) if !entry.is_dir() => entry.path.clone(),
+            _ => return,
+        };
+
+        if let Err(e) = self.open_file_preview(&path) {
+            tracing::debug!(
+                "file_explorer_preview_selected: skipping preview for {:?}: {}",
+                path,
+                e
+            );
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/crash_repro.rs
+++ b/crates/fresh-editor/tests/e2e/crash_repro.rs
@@ -104,16 +104,29 @@ fn test_issue_562_delete_folder_crash_scroll_offset() {
     let screen_after_collapse = harness.screen_to_string();
     println!("Screen after collapse:\n{}", screen_after_collapse);
 
-    // Verify the folder is now collapsed (should not show file_000 anymore)
+    // The collapse invariant is about what's rendered in the explorer
+    // pane, not the rest of the screen. Keyboard nav in the explorer
+    // now also drives the preview tab, so "file_000.txt" will appear
+    // in the tab bar / status bar as the currently-previewed buffer
+    // — that has nothing to do with whether the folder is collapsed.
+    let explorer_rows: String = screen_after_collapse
+        .lines()
+        .filter(|line| line.starts_with('│'))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // Verify the folder is now collapsed (explorer pane should not show file_000)
     assert!(
-        !screen_after_collapse.contains("file_000"),
-        "Folder should be collapsed, file_000 should not be visible"
+        !explorer_rows.contains("file_000"),
+        "Folder should be collapsed, file_000 should not be visible in explorer pane:\n{}",
+        explorer_rows
     );
 
     // Verify big_folder is still visible (just collapsed)
     assert!(
-        screen_after_collapse.contains("big_folder"),
-        "big_folder should still be visible after collapse"
+        explorer_rows.contains("big_folder"),
+        "big_folder should still be visible after collapse:\n{}",
+        explorer_rows
     );
 
     // Continue rendering to ensure stability

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -1094,18 +1094,18 @@ fn test_scroll_allows_cursor_to_top() {
     // The test: when we press Up, the cursor should move WITHIN the viewport
     // for (viewport_height - 1) times before the view scrolls.
 
-    // Track which files are visible to detect scrolling
+    // Track which files are visible to detect scrolling. Only scan rows
+    // that start with the explorer's left border so the tab bar and
+    // status bar (which reflect the current preview buffer and would
+    // change with every cursor move) don't leak into the viewport check.
     let get_visible_files = |screen: &str| -> Vec<String> {
         screen
             .lines()
+            .filter(|line| line.starts_with('│'))
             .filter_map(|line| {
-                // Look for lines with file names (fileXX.txt pattern)
-                if line.contains("file") && line.contains(".txt") {
-                    // Extract the file number
-                    for word in line.split_whitespace() {
-                        if word.starts_with("file") && word.ends_with(".txt") {
-                            return Some(word.to_string());
-                        }
+                for word in line.split_whitespace() {
+                    if word.starts_with("file") && word.ends_with(".txt") {
+                        return Some(word.to_string());
                     }
                 }
                 None

--- a/crates/fresh-editor/tests/e2e/preview_tabs.rs
+++ b/crates/fresh-editor/tests/e2e/preview_tabs.rs
@@ -359,3 +359,91 @@ fn preview_tab_renders_with_translated_suffix() {
         "rendered tab bar should contain the translated preview suffix; got:\n{row}"
     );
 }
+
+/// Keyboard up/down navigation in the file explorer should follow the
+/// same single-click semantics: the selected file opens in preview mode
+/// and subsequent arrow presses replace it (issue #1570).
+#[test]
+fn keyboard_navigation_previews_selected_file() {
+    let mut harness = setup_with_explorer(&["alpha.txt", "beta.txt"]);
+
+    // Selection starts on the root. Down moves to the first child.
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let row = tab_bar(&harness);
+    assert!(
+        row.contains("alpha.txt") && row.contains("(preview)"),
+        "down arrow should open the selected file in preview mode; got:\n{row}"
+    );
+
+    // Second Down moves to beta.txt; preview must replace alpha.txt.
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let row = tab_bar(&harness);
+    assert!(
+        row.contains("beta.txt") && row.contains("(preview)"),
+        "second down arrow should preview beta.txt; got:\n{row}"
+    );
+    assert!(
+        !row.contains("alpha.txt"),
+        "alpha.txt preview should have been replaced; got:\n{row}"
+    );
+
+    // Up returns to alpha.txt; preview replaces beta.txt.
+    harness
+        .send_key(KeyCode::Up, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let row = tab_bar(&harness);
+    assert!(
+        row.contains("alpha.txt") && row.contains("(preview)"),
+        "up arrow should preview alpha.txt again; got:\n{row}"
+    );
+    assert!(
+        !row.contains("beta.txt"),
+        "beta.txt preview should have been replaced; got:\n{row}"
+    );
+}
+
+/// With preview_tabs disabled, keyboard navigation must NOT open any
+/// buffer — otherwise every arrow press would accumulate permanent
+/// tabs.
+#[test]
+fn keyboard_navigation_skips_preview_when_disabled() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project = harness.project_dir().unwrap();
+    fs::write(project.join("alpha.txt"), "alpha.txt\n").unwrap();
+    fs::write(project.join("beta.txt"), "beta.txt\n").unwrap();
+
+    harness.editor_mut().config_mut().file_explorer.preview_tabs = false;
+
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("alpha.txt").unwrap();
+    harness.wait_for_file_explorer_item("beta.txt").unwrap();
+
+    let initial_tab_bar = tab_bar(&harness);
+
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let row = tab_bar(&harness);
+    assert_eq!(
+        row, initial_tab_bar,
+        "with preview_tabs disabled, keyboard nav must not alter the tab bar; got:\n{row}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1570.

When navigating the file explorer with the arrow/page keys, the preview tab now updates to show the currently selected file — mirroring the single-click flow. Previously only mouse clicks drove the preview, so keyboard-only users had to press Enter (which commits the tab) to inspect a file.

## Design

Added a private helper `file_explorer_preview_selected()` on `Editor` that:
- Skips when `file_explorer.preview_tabs` is disabled (otherwise every arrow press would spam permanent tabs).
- Grabs the selected entry; skips directories.
- Calls the existing `open_file_preview()` — which already handles all the preview-tab invariants (dedup, split anchoring, replacing the prior preview, LSP lifecycle).
- Swallows non-fatal errors so preview is opportunistic and doesn't break navigation on e.g. an `.ignored`-gated path.

The helper is invoked at the end of the four existing navigation methods: `file_explorer_navigate_up`, `file_explorer_navigate_down`, `file_explorer_page_up`, `file_explorer_page_down`. Focus stays on the explorer.

## Test plan

- [x] Added e2e tests in `tests/e2e/preview_tabs.rs`:
  - `keyboard_navigation_previews_selected_file`: down/down/up sequence replaces the preview tab each time.
  - `keyboard_navigation_skips_preview_when_disabled`: no tab-bar churn when `preview_tabs` is off.
- [x] Updated `test_scroll_allows_cursor_to_top` in `tests/e2e/file_explorer.rs` to only scan explorer-pane rows (the tab bar and status bar now react to cursor moves and would otherwise shadow the viewport check).
- [x] Ran full `file_explorer` + `preview_tabs` e2e suites: 77 passed, 0 failed, 5 pre-existing ignored.
- [x] Manual validation in tmux: started `fresh` in a 4-file project, arrowed up/down and saw the tab bar flip between `alpha.txt (preview)` → `delta.txt (preview)` → `beta.txt (preview)` with matching buffer contents. Pressing Enter on the previewed tab correctly promotes it (drops the `(preview)` suffix).

https://claude.ai/code/session_01S88zjG5CZEiNio8cXHxMnT

---
_Generated by [Claude Code](https://claude.ai/code/session_01S88zjG5CZEiNio8cXHxMnT)_