### PR TITLE
feat(config): add editor.restore_previous_session option (#1404)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -99,6 +99,7 @@
         "auto_save_enabled": false,
         "auto_save_interval_secs": 30,
         "hot_exit": true,
+        "restore_previous_session": true,
         "recovery_enabled": true,
         "auto_recovery_save_interval_secs": 2,
         "auto_revert_poll_interval_ms": 2000,
@@ -618,6 +619,12 @@
         },
         "hot_exit": {
           "description": "Whether to preserve unsaved changes in all buffers (file-backed and\nunnamed) across editor sessions (VS Code \"hot exit\" behavior).\nWhen enabled, modified buffers are backed up on clean exit and their\nunsaved changes are restored on next startup.  Unnamed (scratch)\nbuffers are also persisted (Sublime Text / Notepad++ behavior).\nDefault: true",
+          "type": "boolean",
+          "default": true,
+          "x-section": "Recovery"
+        },
+        "restore_previous_session": {
+          "description": "Whether to auto-open previously opened files (session restore) when\nstarting Fresh in a directory.  When enabled (the default), tabs,\nsplits, cursor positions and the file explorer state are restored\nfrom the last clean exit in the same working directory.  When\ndisabled, Fresh starts with a clean workspace.  The workspace file\non disk is still written on exit, so re-enabling this setting picks\nup whatever state was saved at the most recent clean exit.  The\n`--no-restore` CLI flag is a stronger override: it skips both\nrestoring and saving the workspace.\nDefault: true",
           "type": "boolean",
           "default": true,
           "x-section": "Recovery"

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1124,6 +1124,20 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Recovery"))]
     pub hot_exit: bool,
 
+    /// Whether to auto-open previously opened files (session restore) when
+    /// starting Fresh in a directory.  When enabled (the default), tabs,
+    /// splits, cursor positions and the file explorer state are restored
+    /// from the last clean exit in the same working directory.  When
+    /// disabled, Fresh starts with a clean workspace.  The workspace file
+    /// on disk is still written on exit, so re-enabling this setting picks
+    /// up whatever state was saved at the most recent clean exit.  The
+    /// `--no-restore` CLI flag is a stronger override: it skips both
+    /// restoring and saving the workspace.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Recovery"))]
+    pub restore_previous_session: bool,
+
     // ===== Recovery =====
     /// Whether to enable file recovery (Emacs-style auto-save)
     /// When enabled, buffers are periodically saved to recovery files
@@ -1351,6 +1365,7 @@ impl Default for EditorConfig {
             auto_save_enabled: false,
             auto_save_interval_secs: default_auto_save_interval(),
             hot_exit: true,
+            restore_previous_session: true,
             recovery_enabled: true,
             auto_recovery_save_interval_secs: default_auto_recovery_save_interval(),
             highlight_context_bytes: default_highlight_context_bytes(),

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -795,16 +795,22 @@ fn handle_first_run_setup(
     }
 
     if workspace_enabled {
-        match editor.try_restore_workspace() {
-            Ok(true) => {
-                tracing::info!("Workspace restored successfully");
+        if editor.config().editor.restore_previous_session {
+            match editor.try_restore_workspace() {
+                Ok(true) => {
+                    tracing::info!("Workspace restored successfully");
+                }
+                Ok(false) => {
+                    tracing::debug!("No previous workspace found");
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to restore workspace: {}", e);
+                }
             }
-            Ok(false) => {
-                tracing::debug!("No previous workspace found");
-            }
-            Err(e) => {
-                tracing::warn!("Failed to restore workspace: {}", e);
-            }
+        } else {
+            tracing::info!(
+                "Skipping workspace restore: editor.restore_previous_session is disabled"
+            );
         }
     }
 
@@ -3369,16 +3375,22 @@ fn real_main() -> AnyhowResult<()> {
             tracing::info!("First-run setup complete");
         } else {
             if restore_workspace_on_restart {
-                match editor.try_restore_workspace() {
-                    Ok(true) => {
-                        tracing::info!("Workspace restored successfully");
+                if editor.config().editor.restore_previous_session {
+                    match editor.try_restore_workspace() {
+                        Ok(true) => {
+                            tracing::info!("Workspace restored successfully");
+                        }
+                        Ok(false) => {
+                            tracing::debug!("No previous workspace found");
+                        }
+                        Err(e) => {
+                            tracing::warn!("Failed to restore workspace: {}", e);
+                        }
                     }
-                    Ok(false) => {
-                        tracing::debug!("No previous workspace found");
-                    }
-                    Err(e) => {
-                        tracing::warn!("Failed to restore workspace: {}", e);
-                    }
+                } else {
+                    tracing::info!(
+                        "Skipping workspace restore on restart: editor.restore_previous_session is disabled"
+                    );
                 }
             }
 

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -165,6 +165,7 @@ pub struct PartialEditorConfig {
     pub auto_save_enabled: Option<bool>,
     pub auto_save_interval_secs: Option<u32>,
     pub hot_exit: Option<bool>,
+    pub restore_previous_session: Option<bool>,
     pub highlight_context_bytes: Option<usize>,
     pub mouse_hover_enabled: Option<bool>,
     pub mouse_hover_delay_ms: Option<u64>,
@@ -244,6 +245,8 @@ impl Merge for PartialEditorConfig {
         self.auto_save_interval_secs
             .merge_from(&other.auto_save_interval_secs);
         self.hot_exit.merge_from(&other.hot_exit);
+        self.restore_previous_session
+            .merge_from(&other.restore_previous_session);
         self.highlight_context_bytes
             .merge_from(&other.highlight_context_bytes);
         self.mouse_hover_enabled
@@ -513,6 +516,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             auto_save_enabled: Some(cfg.auto_save_enabled),
             auto_save_interval_secs: Some(cfg.auto_save_interval_secs),
             hot_exit: Some(cfg.hot_exit),
+            restore_previous_session: Some(cfg.restore_previous_session),
             highlight_context_bytes: Some(cfg.highlight_context_bytes),
             mouse_hover_enabled: Some(cfg.mouse_hover_enabled),
             mouse_hover_delay_ms: Some(cfg.mouse_hover_delay_ms),
@@ -611,6 +615,9 @@ impl PartialEditorConfig {
                 .auto_save_interval_secs
                 .unwrap_or(defaults.auto_save_interval_secs),
             hot_exit: self.hot_exit.unwrap_or(defaults.hot_exit),
+            restore_previous_session: self
+                .restore_previous_session
+                .unwrap_or(defaults.restore_previous_session),
             highlight_context_bytes: self
                 .highlight_context_bytes
                 .unwrap_or(defaults.highlight_context_bytes),

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1405,7 +1405,7 @@ impl EditorTestHarness {
         cli_files: &[std::path::PathBuf],
     ) -> anyhow::Result<bool> {
         let mut restored = false;
-        if workspace_enabled {
+        if workspace_enabled && self.editor.config().editor.restore_previous_session {
             restored = self.editor.try_restore_workspace().unwrap_or(false);
         }
 

--- a/crates/fresh-editor/tests/e2e/workspace.rs
+++ b/crates/fresh-editor/tests/e2e/workspace.rs
@@ -233,6 +233,79 @@ fn test_no_session_flag_behavior() {
     }
 }
 
+/// Test that `editor.restore_previous_session = false` disables workspace
+/// restore at startup even when workspace saving is still enabled (issue #1404).
+#[test]
+fn test_restore_previous_session_config_disabled() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file = project_dir.join("persistent.txt");
+    std::fs::write(&file, "This file was open last time").unwrap();
+
+    // First session: open the file and save the workspace so there is
+    // something to restore.
+    {
+        let mut harness = EditorTestHarness::with_config_and_working_dir(
+            80,
+            24,
+            Config::default(),
+            project_dir.clone(),
+        )
+        .unwrap();
+
+        harness.open_file(&file).unwrap();
+        harness.render().unwrap();
+        harness.assert_screen_contains("persistent.txt");
+
+        harness.editor_mut().save_workspace().unwrap();
+    }
+
+    // Second session: start with `restore_previous_session = false` and rely
+    // on the harness `startup` helper (which mirrors the production gate in
+    // main.rs).  The file should NOT be restored.
+    let mut config = Config::default();
+    config.editor.restore_previous_session = false;
+    {
+        let mut harness =
+            EditorTestHarness::with_config_and_working_dir(80, 24, config, project_dir.clone())
+                .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(
+            !restored,
+            "Workspace must not be restored when restore_previous_session is false"
+        );
+
+        harness.render().unwrap();
+        harness.assert_screen_contains("[No Name]");
+        harness.assert_screen_not_contains("persistent.txt");
+    }
+
+    // Third session: re-enable `restore_previous_session` and confirm the
+    // workspace file was still on disk and is now picked up.  This guards
+    // against accidentally skipping the save side when restore is disabled.
+    {
+        let mut harness = EditorTestHarness::with_config_and_working_dir(
+            80,
+            24,
+            Config::default(),
+            project_dir.clone(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(
+            restored,
+            "Workspace should still be on disk and restorable once the config is re-enabled"
+        );
+
+        harness.render().unwrap();
+        harness.assert_screen_contains("persistent.txt");
+    }
+}
+
 /// Test multiple files are all restored
 #[test]
 fn test_session_restores_multiple_files() {


### PR DESCRIPTION
Closes #1404.

## Summary

Users who dislike the auto-opening of previously-opened files on startup had only one escape hatch: the `--no-restore` CLI flag. The issue asks for a config-file knob so the preference is sticky without shell aliases.

This PR adds `editor.restore_previous_session` (bool, default `true`). When set to `false`, Fresh skips `try_restore_workspace()` on first-run setup and on in-process project-switch restarts, but still saves the workspace on exit so the setting can be toggled back on. `--no-restore` remains the stronger override that also skips saving.

## Changes

- New `editor.restore_previous_session` field on `EditorConfig`, default `true`, under the existing `"Recovery"` schema section.
- Matching `PartialEditorConfig` entry, merge logic, and regenerated `plugins/config-schema.json`.
- `main.rs` checks `editor.config().editor.restore_previous_session` before calling `try_restore_workspace()` in both `handle_first_run_setup` and the project-switch restart path.
- Test harness `startup()` helper mirrors the same gate used in `main.rs` so existing workspace e2e tests continue to match production behaviour.
- New e2e test `test_restore_previous_session_config_disabled` exercises the disabled → re-enabled toggle end to end.

## Test plan

- [x] `cargo check --all-targets` passes
- [x] `cargo fmt --check` passes
- [x] `cargo test -p fresh-editor --test e2e_tests e2e::workspace` — all 28 tests pass, including the new one
- [x] Manual tmux validation:
  - Open `fresh file-a.txt file-b.txt`, quit, relaunch `fresh` — both tabs restored (unchanged behaviour).
  - Relaunch `fresh --config no-restore.json` where the config sets `editor.restore_previous_session: false` — starts with only the Dashboard buffer, no previous tabs.
  - Relaunch `fresh --no-restore` — also starts clean (unchanged behaviour).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VWnohJPyt3qH2fGFZvg57E)_