### PR TITLE
Restore hot-exit content even when session restore is disabled

### DIFF
--- a/crates/fresh-editor/src/app/recovery_actions.rs
+++ b/crates/fresh-editor/src/app/recovery_actions.rs
@@ -217,6 +217,150 @@ impl Editor {
         Ok(self.recovery_service.discard_all_recovery()?)
     }
 
+    /// Restore only the hot-exit content from the previous clean exit:
+    /// files with unsaved modifications and unnamed buffers that held
+    /// content.  Called when full session restore is opted out (via
+    /// `--no-restore` or `editor.restore_previous_session = false`) so
+    /// the user does not lose in-progress work just because they asked
+    /// to skip restoring the workspace layout.
+    ///
+    /// Unlike [`Editor::recover_all_buffers`], this path uses
+    /// `load_recovery` and leaves the recovery files in place so the
+    /// current session's hot-exit pipeline keeps owning them (the files
+    /// are cleaned up on the next clean shutdown via
+    /// `end_session_preserving`).
+    ///
+    /// Returns the number of buffers restored.
+    pub fn try_restore_hot_exit_buffers(&mut self) -> AnyhowResult<usize> {
+        use crate::services::recovery::RecoveryResult;
+
+        if !self.config.editor.hot_exit {
+            return Ok(0);
+        }
+
+        let entries = self.recovery_service.list_recoverable()?;
+        if entries.is_empty() {
+            return Ok(0);
+        }
+
+        let mut restored = 0;
+        for entry in entries {
+            match self.recovery_service.load_recovery(&entry) {
+                Ok(RecoveryResult::Recovered {
+                    original_path,
+                    content,
+                }) => {
+                    let text = String::from_utf8_lossy(&content).into_owned();
+                    if let Some(path) = original_path {
+                        match self.open_file(&path) {
+                            Ok(_) => {
+                                {
+                                    let state = self.active_state_mut();
+                                    let total = state.buffer.total_bytes();
+                                    state.buffer.delete(0..total);
+                                    state.buffer.insert(0, &text);
+                                    state.buffer.set_modified(true);
+                                    state.buffer.set_recovery_pending(false);
+                                }
+                                self.active_event_log_mut().clear_saved_position();
+                                restored += 1;
+                                tracing::info!(
+                                    "Hot-exit restore: reopened {} with unsaved changes",
+                                    path.display()
+                                );
+                            }
+                            Err(e) => {
+                                if let Some(confirmation) = e.downcast_ref::<
+                                    crate::model::buffer::LargeFileEncodingConfirmation,
+                                >() {
+                                    self.start_large_file_encoding_confirmation(confirmation);
+                                } else {
+                                    tracing::warn!(
+                                        "Hot-exit restore failed to open {}: {}",
+                                        path.display(),
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        // Unnamed buffer with content — create a fresh
+                        // buffer, drop the recovery ID into metadata so
+                        // future hot-exit saves hit the same file.
+                        let buffer_id = self.new_buffer();
+                        {
+                            let state = self.active_state_mut();
+                            state.buffer.insert(0, &text);
+                            state.buffer.set_modified(true);
+                            state.buffer.set_recovery_pending(false);
+                        }
+                        self.active_event_log_mut().clear_saved_position();
+                        if let Some(meta) = self.buffer_metadata.get_mut(&buffer_id) {
+                            meta.recovery_id = Some(entry.id.clone());
+                        }
+                        restored += 1;
+                        tracing::info!(
+                            "Hot-exit restore: reopened unnamed buffer (recovery_id={})",
+                            entry.id
+                        );
+                    }
+                }
+                Ok(RecoveryResult::RecoveredChunks {
+                    original_path,
+                    chunks,
+                }) => match self.open_file(&original_path) {
+                    Ok(_) => {
+                        {
+                            let state = self.active_state_mut();
+                            for chunk in chunks.into_iter().rev() {
+                                let text = String::from_utf8_lossy(&chunk.content).into_owned();
+                                if chunk.original_len > 0 {
+                                    state
+                                        .buffer
+                                        .delete(chunk.offset..chunk.offset + chunk.original_len);
+                                }
+                                state.buffer.insert(chunk.offset, &text);
+                            }
+                            state.buffer.set_modified(true);
+                            state.buffer.set_recovery_pending(false);
+                        }
+                        self.active_event_log_mut().clear_saved_position();
+                        restored += 1;
+                        tracing::info!(
+                            "Hot-exit restore: reopened {} with chunked changes",
+                            original_path.display()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Hot-exit restore failed to open {}: {}",
+                            original_path.display(),
+                            e
+                        );
+                    }
+                },
+                Ok(RecoveryResult::OriginalFileModified { id, original_path }) => {
+                    tracing::warn!(
+                        "Hot-exit restore skipped {}: original file {} changed on disk",
+                        id,
+                        original_path.display()
+                    );
+                }
+                Ok(RecoveryResult::Corrupted { id, reason }) => {
+                    tracing::warn!("Hot-exit restore skipped {}: corrupted ({})", id, reason);
+                }
+                Ok(RecoveryResult::NotFound { id }) => {
+                    tracing::warn!("Hot-exit restore: recovery file {} missing", id);
+                }
+                Err(e) => {
+                    tracing::warn!("Hot-exit restore: failed to load {}: {}", entry.id, e);
+                }
+            }
+        }
+
+        Ok(restored)
+    }
+
     /// Perform auto-recovery-save for all modified buffers if needed.
     /// Called frequently (every frame); rate-limited by `auto_recovery_save_interval_secs`.
     pub fn auto_recovery_save_dirty_buffers(&mut self) -> AnyhowResult<usize> {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -128,9 +128,17 @@ struct Cli {
     #[arg(long, value_name = "LOG_FILE")]
     event_log: Option<PathBuf>,
 
-    /// Don't restore previous workspace
-    #[arg(long, alias = "no-session")]
+    /// Don't restore previous workspace (only hot-exit content — unsaved
+    /// modified files and unnamed buffers with content — is still restored
+    /// so in-progress work is not lost)
+    #[arg(long, alias = "no-session", conflicts_with = "restore")]
     no_restore: bool,
+
+    /// Force restore of previous workspace, overriding
+    /// `editor.restore_previous_session = false` in the config.  Cannot be
+    /// combined with `--no-restore`.
+    #[arg(long)]
+    restore: bool,
 
     /// Disable upgrade checking and anonymous telemetry
     #[arg(long)]
@@ -192,6 +200,9 @@ struct Args {
     log_file: Option<PathBuf>,
     event_log: Option<PathBuf>,
     no_session: bool,
+    /// Force workspace restore even if `editor.restore_previous_session`
+    /// is disabled in the config.
+    force_restore: bool,
     no_upgrade_check: bool,
     dump_config: bool,
     show_paths: bool,
@@ -441,6 +452,7 @@ impl From<Cli> for Args {
             log_file: cli.log_file,
             event_log: cli.event_log,
             no_session: cli.no_restore,
+            force_restore: cli.restore,
             no_upgrade_check: cli.no_upgrade_check,
             dump_config,
             show_paths,
@@ -794,23 +806,43 @@ fn handle_first_run_setup(
         editor.set_status_log_path(handles.status.path);
     }
 
-    if workspace_enabled {
-        if editor.config().editor.restore_previous_session {
-            match editor.try_restore_workspace() {
-                Ok(true) => {
-                    tracing::info!("Workspace restored successfully");
-                }
-                Ok(false) => {
-                    tracing::debug!("No previous workspace found");
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to restore workspace: {}", e);
-                }
+    let restore_full_session = workspace_enabled
+        && (args.force_restore || editor.config().editor.restore_previous_session);
+
+    if restore_full_session {
+        match editor.try_restore_workspace() {
+            Ok(true) => {
+                tracing::info!("Workspace restored successfully");
             }
+            Ok(false) => {
+                tracing::debug!("No previous workspace found");
+            }
+            Err(e) => {
+                tracing::warn!("Failed to restore workspace: {}", e);
+            }
+        }
+    } else {
+        if !workspace_enabled {
+            tracing::info!("Skipping workspace restore: --no-restore was specified");
         } else {
             tracing::info!(
                 "Skipping workspace restore: editor.restore_previous_session is disabled"
             );
+        }
+        // Session restore opted out, but hot-exit content (unsaved
+        // modified files + unnamed buffers with content) is still
+        // restored so the user does not lose in-progress work.
+        match editor.try_restore_hot_exit_buffers() {
+            Ok(n) if n > 0 => {
+                tracing::info!(
+                    "Restored {} hot-exit buffer(s) despite skipping session restore",
+                    n
+                );
+            }
+            Ok(_) => {}
+            Err(e) => {
+                tracing::warn!("Failed to restore hot-exit buffers: {}", e);
+            }
         }
     }
 
@@ -3383,7 +3415,7 @@ fn real_main() -> AnyhowResult<()> {
             tracing::info!("First-run setup complete");
         } else {
             if restore_workspace_on_restart {
-                if editor.config().editor.restore_previous_session {
+                if args.force_restore || editor.config().editor.restore_previous_session {
                     match editor.try_restore_workspace() {
                         Ok(true) => {
                             tracing::info!("Workspace restored successfully");
@@ -3399,6 +3431,20 @@ fn real_main() -> AnyhowResult<()> {
                     tracing::info!(
                         "Skipping workspace restore on restart: editor.restore_previous_session is disabled"
                     );
+                    // Session restore opted out, but hot-exit content
+                    // for the newly-switched project is still restored.
+                    match editor.try_restore_hot_exit_buffers() {
+                        Ok(n) if n > 0 => {
+                            tracing::info!(
+                                "Restored {} hot-exit buffer(s) on restart despite skipping session restore",
+                                n
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!("Failed to restore hot-exit buffers on restart: {}", e);
+                        }
+                    }
                 }
             }
 

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1404,9 +1404,28 @@ impl EditorTestHarness {
         workspace_enabled: bool,
         cli_files: &[std::path::PathBuf],
     ) -> anyhow::Result<bool> {
+        self.startup_with_force_restore(workspace_enabled, false, cli_files)
+    }
+
+    /// Variant of [`Self::startup`] that can force workspace restore even
+    /// when `editor.restore_previous_session` is disabled — mirrors the
+    /// `--restore` CLI flag in `main.rs`.
+    pub fn startup_with_force_restore(
+        &mut self,
+        workspace_enabled: bool,
+        force_restore: bool,
+        cli_files: &[std::path::PathBuf],
+    ) -> anyhow::Result<bool> {
+        let restore_full_session = workspace_enabled
+            && (force_restore || self.editor.config().editor.restore_previous_session);
         let mut restored = false;
-        if workspace_enabled && self.editor.config().editor.restore_previous_session {
+        if restore_full_session {
             restored = self.editor.try_restore_workspace().unwrap_or(false);
+        } else {
+            // Session restore opted out, but hot-exit content (unsaved
+            // modified files + unnamed buffers with content) is still
+            // restored — matches production behaviour in `main.rs`.
+            let _ = self.editor.try_restore_hot_exit_buffers();
         }
 
         let has_cli_files = !cli_files.is_empty();

--- a/crates/fresh-editor/tests/e2e/workspace.rs
+++ b/crates/fresh-editor/tests/e2e/workspace.rs
@@ -3,9 +3,10 @@
 //! These tests verify the full session save/restore cycle works correctly
 //! by examining rendered screen output rather than internal state.
 
-use crate::common::harness::EditorTestHarness;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
 use fresh::workspace::get_workspace_path;
 use tempfile::TempDir;
 
@@ -2066,4 +2067,280 @@ fn test_user_opened_terminal_still_persists_in_workspace() {
         1,
         "User-opened terminal should still be serialized (no regression)",
     );
+}
+
+// ============================================================================
+// Hot-exit restore when session restore is skipped
+// ============================================================================
+//
+// When the user opts out of full workspace restore (`--no-restore` CLI flag
+// OR `editor.restore_previous_session = false`), hot-exit content — unsaved
+// modified files and unnamed buffers with content — must still be restored
+// so they don't lose in-progress work.  Clean (saved) file tabs that had no
+// unsaved changes are NOT reopened; that's what "don't restore the session"
+// means.
+
+/// Session restore disabled via config still reopens unsaved modified files
+/// with their hot-exit content, but leaves clean tabs closed.
+#[test]
+fn test_hot_exit_restores_dirty_file_when_session_restore_disabled() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let clean_file = project_dir.join("clean.txt");
+    let dirty_file = project_dir.join("dirty.txt");
+    std::fs::write(&clean_file, "clean-on-disk").unwrap();
+    std::fs::write(&dirty_file, "original-on-disk").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open both files, modify one, clean shutdown
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.open_file(&clean_file).unwrap();
+        harness.open_file(&dirty_file).unwrap();
+        harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+        harness.type_text(" UNSAVED").unwrap();
+        harness.render().unwrap();
+        harness.assert_screen_contains("UNSAVED");
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // File on disk stays unchanged (hot-exit doesn't save).
+    assert_eq!(
+        std::fs::read_to_string(&dirty_file).unwrap(),
+        "original-on-disk",
+    );
+
+    // Session 2: restore_previous_session = false.  The workspace file
+    // still lists both tabs, but only the dirty one must be reopened.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+        config.editor.restore_previous_session = false;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(
+            !restored,
+            "Full workspace must not be restored when restore_previous_session is false",
+        );
+
+        harness.render().unwrap();
+        harness.assert_screen_contains("dirty.txt");
+        harness.assert_screen_contains("UNSAVED");
+        harness.assert_screen_not_contains("clean.txt");
+    }
+}
+
+/// `--no-restore` (simulated via `workspace_enabled = false` in the harness)
+/// still restores hot-exit content — the CLI flag is no longer a hammer
+/// that drops unsaved work.
+#[test]
+fn test_hot_exit_restores_dirty_file_when_no_restore_flag() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let dirty_file = project_dir.join("notes.txt");
+    std::fs::write(&dirty_file, "on-disk").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open file, edit, clean shutdown
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.open_file(&dirty_file).unwrap();
+        harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+        harness.type_text(" DRAFT").unwrap();
+        harness.render().unwrap();
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: simulate `--no-restore` — workspace_enabled = false.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.startup(false, &[]).unwrap();
+        harness.render().unwrap();
+
+        // Unsaved edits from the prior session are still available.
+        harness.assert_screen_contains("notes.txt");
+        harness.assert_screen_contains("DRAFT");
+    }
+}
+
+/// Unnamed (scratch) buffers with content are hot-exit state, so they must
+/// also be restored when session restore is skipped.
+#[test]
+fn test_hot_exit_restores_unnamed_buffer_when_session_restore_disabled() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: scratch buffer with content, clean shutdown
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.new_buffer().unwrap();
+        harness.type_text("scratch pad data").unwrap();
+        harness.render().unwrap();
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: restore_previous_session = false.  The scratch buffer
+    // content must still come back.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+        config.editor.restore_previous_session = false;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.startup(true, &[]).unwrap();
+        harness.render().unwrap();
+        harness.assert_screen_contains("scratch pad data");
+    }
+}
+
+/// `--restore` (simulated via `force_restore = true`) overrides
+/// `restore_previous_session = false` and performs a full workspace
+/// restore, reopening clean tabs as well.
+#[test]
+fn test_restore_flag_overrides_disabled_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file = project_dir.join("tracked.txt");
+    std::fs::write(&file, "workspace content").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open file, save workspace, clean shutdown.
+    {
+        let config = Config::default();
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        harness.open_file(&file).unwrap();
+        harness.render().unwrap();
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: config disables restore, but --restore forces it on.
+    {
+        let mut config = Config::default();
+        config.editor.restore_previous_session = false;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        let restored = harness.startup_with_force_restore(true, true, &[]).unwrap();
+        assert!(
+            restored,
+            "--restore must force a full workspace restore even when restore_previous_session is false",
+        );
+
+        harness.render().unwrap();
+        harness.assert_screen_contains("tracked.txt");
+        harness.assert_screen_contains("workspace content");
+    }
 }


### PR DESCRIPTION
## Summary

This change ensures that unsaved work is never lost when users opt out of full workspace restoration. When `--no-restore` is specified or `editor.restore_previous_session = false`, the editor now still restores hot-exit content (unsaved modified files and unnamed buffers with content) while skipping the full session layout restore.

## Key Changes

- **New `try_restore_hot_exit_buffers()` method** in `recovery_actions.rs`: Selectively restores only files with unsaved modifications and unnamed buffers that had content, leaving recovery files in place for the current session's hot-exit pipeline to manage.

- **CLI flag enhancements** in `main.rs`:
  - Added `--restore` flag to force full workspace restore, overriding `editor.restore_previous_session = false`
  - Updated `--no-restore` documentation to clarify that hot-exit content is still restored
  - Made `--restore` and `--no-restore` mutually exclusive

- **Startup logic refactoring** in `main.rs`:
  - Separated full session restore decision from workspace enablement
  - When session restore is skipped, `try_restore_hot_exit_buffers()` is called to preserve in-progress work
  - Applied same logic to both initial startup and project-switch restart scenarios

- **Test harness improvements** in `harness.rs`:
  - Added `startup_with_force_restore()` method to test the `--restore` flag behavior
  - Updated `startup()` to call hot-exit restore when session restore is disabled

- **Comprehensive test coverage** in `workspace.rs`:
  - `test_hot_exit_restores_dirty_file_when_session_restore_disabled`: Verifies dirty files are restored when config disables session restore
  - `test_hot_exit_restores_dirty_file_when_no_restore_flag`: Verifies hot-exit works with `--no-restore` flag
  - `test_hot_exit_restores_unnamed_buffer_when_session_restore_disabled`: Verifies scratch buffers are restored
  - `test_restore_flag_overrides_disabled_config`: Verifies `--restore` forces full session restore

## Implementation Details

- Hot-exit recovery files remain in place after selective restore, allowing the current session's hot-exit pipeline to manage cleanup on the next clean shutdown
- The selective restore respects the same recovery result handling as full recovery (handles corrupted files, modified originals, etc.)
- Unnamed buffers are assigned their recovery ID in metadata so future hot-exit saves target the same recovery file

https://claude.ai/code/session_019j87oUXxyx9nnvz5LcrZXq