### PR TITLE
Fix Settings text input focus and cursor visibility

### DIFF
--- a/crates/fresh-editor/src/view/controls/text_input/mod.rs
+++ b/crates/fresh-editor/src/view/controls/text_input/mod.rs
@@ -33,6 +33,11 @@ pub struct TextInputState {
     pub placeholder: String,
     /// Focus state
     pub focus: FocusState,
+    /// If true, the user is actively editing (Enter was pressed). When
+    /// the control is merely selected/highlighted via navigation this
+    /// stays `false`, which suppresses the cursor block so the caret
+    /// only appears once the user asks to type.
+    pub editing: bool,
     /// If true, validate that value is valid JSON before allowing exit
     pub validate_json: bool,
     /// "Select-all" affordance: when the input gains focus the whole
@@ -52,6 +57,7 @@ impl TextInputState {
             label: label.into(),
             placeholder: String::new(),
             focus: FocusState::Normal,
+            editing: false,
             validate_json: false,
             pending_replace_on_type: false,
         }
@@ -261,7 +267,11 @@ impl TextInputColors {
             border: theme.line_number_fg,
             placeholder: theme.line_number_fg,
             cursor: theme.cursor,
-            focused: theme.selection_bg,
+            // Use a fg-family colour for the focused/editing accent so
+            // the label and bracket highlighting remain readable against
+            // dark row backgrounds. `selection_bg` is a background colour
+            // and renders as dark-on-dark on high-contrast themes.
+            focused: theme.settings_selected_fg,
             disabled: theme.line_number_fg,
         }
     }
@@ -276,7 +286,7 @@ impl TextInputColors {
             border: theme.line_number_fg,
             placeholder: theme.line_number_fg,
             cursor: theme.cursor,
-            focused: theme.selection_bg,
+            focused: theme.settings_selected_fg,
             disabled: theme.line_number_fg,
         }
     }

--- a/crates/fresh-editor/src/view/controls/text_input/render.rs
+++ b/crates/fresh-editor/src/view/controls/text_input/render.rs
@@ -54,16 +54,26 @@ pub fn render_text_input_aligned(
         return TextInputLayout::default();
     }
 
+    // Distinguish three visual states for the label and brackets:
+    //   - Normal / selected-but-not-editing → normal label; muted border.
+    //     (The row's selection-highlight background already indicates
+    //     keyboard focus; the input box stays visually calm.)
+    //   - Focused + editing → normal label; brackets picked out in the
+    //     accent colour to show this is where typing goes.
+    //   - Hovered → accent-coloured brackets as a hover affordance.
+    //   - Disabled → everything dimmed.
     let (label_color, text_color, border_color, placeholder_color) = match state.focus {
         FocusState::Normal => (colors.label, colors.text, colors.border, colors.placeholder),
-        FocusState::Focused => (
-            colors.focused,
-            colors.text,
-            colors.focused,
-            colors.placeholder,
-        ),
+        FocusState::Focused => {
+            let border = if state.editing {
+                colors.focused
+            } else {
+                colors.border
+            };
+            (colors.label, colors.text, border, colors.placeholder)
+        }
         FocusState::Hovered => (
-            colors.focused,
+            colors.label,
             colors.text,
             colors.focused,
             colors.placeholder,
@@ -146,7 +156,7 @@ pub fn render_text_input_aligned(
     let input_start = area.x + final_label_width;
     let input_area = Rect::new(input_start, area.y, actual_field_width + 2, 1);
 
-    let cursor_pos = if state.focus == FocusState::Focused && !is_placeholder {
+    let cursor_pos = if state.focus == FocusState::Focused && state.editing && !is_placeholder {
         // Calculate cursor visual position within the visible area
         let cursor_visual_in_field = cursor_visual_pos.saturating_sub(scroll_visual_offset);
         let cursor_x = input_start + 1 + cursor_visual_in_field as u16;

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -827,8 +827,8 @@ impl EntryDialogState {
             }
             match &mut item.control {
                 SettingControl::Text(state) => {
-                    // TextInputState uses focus state, cursor is already at end from with_value
                     state.cursor = state.value.len();
+                    state.editing = true;
                     self.editing_text = true;
                 }
                 SettingControl::TextList(state) => {
@@ -852,8 +852,10 @@ impl EntryDialogState {
     /// Stop text editing mode
     pub fn stop_editing(&mut self) {
         if let Some(item) = self.current_item_mut() {
-            if let SettingControl::Number(state) = &mut item.control {
-                state.cancel_editing();
+            match &mut item.control {
+                SettingControl::Number(state) => state.cancel_editing(),
+                SettingControl::Text(state) => state.editing = false,
+                _ => {}
             }
         }
         self.editing_text = false;

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -299,7 +299,15 @@ impl SettingsState {
                 SettingControl::Toggle(ref mut state) => state.focus = focus_state,
                 SettingControl::Number(ref mut state) => state.focus = focus_state,
                 SettingControl::Dropdown(ref mut state) => state.focus = focus_state,
-                SettingControl::Text(ref mut state) => state.focus = focus_state,
+                SettingControl::Text(ref mut state) => {
+                    state.focus = focus_state;
+                    // Leaving a text input via navigation also exits
+                    // edit mode, so the cursor never lingers on a row
+                    // the user is no longer looking at.
+                    if !focused {
+                        state.editing = false;
+                    }
+                }
                 SettingControl::Json(_) | SettingControl::Complex { .. } => {} // These don't have focus state
             }
         }
@@ -1511,6 +1519,7 @@ impl SettingsState {
                     dl.editing = true;
                 }
                 SettingControl::Text(ref mut state) => {
+                    state.editing = true;
                     // Mirror the spinner's "select-all on enter edit"
                     // UX: the first printable keystroke replaces the
                     // current value. Arrow keys or deletion cancel it
@@ -1526,8 +1535,14 @@ impl SettingsState {
     pub fn stop_editing(&mut self) {
         self.editing_text = false;
         if let Some(item) = self.current_item_mut() {
-            if let SettingControl::DualList(ref mut dl) = item.control {
-                dl.editing = false;
+            match item.control {
+                SettingControl::DualList(ref mut dl) => {
+                    dl.editing = false;
+                }
+                SettingControl::Text(ref mut state) => {
+                    state.editing = false;
+                }
+                _ => {}
             }
         }
     }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -151,6 +151,7 @@ pub mod settings_paste;
 pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
 pub mod settings_scrolled_list_click;
+pub mod settings_text_input_focus;
 pub mod settings_ui_usability;
 pub mod shell_command;
 pub mod shift_backspace;

--- a/crates/fresh-editor/tests/e2e/settings_text_input_focus.rs
+++ b/crates/fresh-editor/tests/e2e/settings_text_input_focus.rs
@@ -1,0 +1,214 @@
+//! E2E tests for Settings UI text input focus/edit visuals.
+//!
+//! Reproduces two bugs seen when navigating to a text field (e.g. Terminal ->
+//! Command) in the Settings UI:
+//!
+//! 1. The current item's label text uses `theme.selection_bg` as its
+//!    foreground colour, which renders as dark-on-dark (unreadable) on the
+//!    high-contrast theme (and is semantically wrong on any theme — a
+//!    background colour has no reason to be used as a foreground).
+//! 2. The text-input cursor (a reversed-video cell inside the brackets)
+//!    is rendered as soon as the row is navigated-to, before the user
+//!    has actually entered edit mode by pressing Enter. There is thus no
+//!    visual indication that a second keypress is needed to start typing.
+//!
+//! The fix introduces an explicit `editing` flag on `TextInputState`:
+//! * the cursor is only drawn when `editing == true`;
+//! * in the selected-but-not-editing state the row's highlight background
+//!   provides the "you are here" cue, while the label/brackets retain
+//!   readable foreground colours.
+//!
+//! These tests verify both behaviours and would have caught the regression.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use ratatui::style::Modifier;
+
+/// Navigate to Terminal -> Command via the settings search.
+fn open_terminal_command(harness: &mut EditorTestHarness) {
+    harness.open_settings().unwrap();
+
+    // Filter to the Terminal category via search.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("terminal command").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Command");
+
+    // Walk up then down looking for the focus indicator on the Command
+    // label row (search may have dropped focus on a different item).
+    for _ in 0..30 {
+        if find_command_row(harness).is_some() {
+            return;
+        }
+        harness.send_key(KeyCode::Up, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    for _ in 0..30 {
+        if find_command_row(harness).is_some() {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+    }
+    panic!(
+        "Could not focus the Terminal -> Command row. Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Return the (row_index, line) where the focus indicator ">" sits on the
+/// `Command` text-input label. Walks the row by character to accommodate
+/// multibyte box-drawing characters.
+fn find_command_row(harness: &EditorTestHarness) -> Option<(u16, String)> {
+    let height = harness.buffer().area.height;
+    for y in 0..height {
+        let line = harness.get_row_text(y);
+        let chars: Vec<char> = line.chars().collect();
+        // Find "Command" followed (on same line) by '['.
+        let needle: Vec<char> = "Command".chars().collect();
+        let Some(cmd_col) = (0..chars.len().saturating_sub(needle.len() - 1))
+            .find(|&i| chars[i..i + needle.len()] == needle[..])
+        else {
+            continue;
+        };
+        if !chars[cmd_col..].contains(&'[') {
+            continue;
+        }
+        // Focus indicator ">" sits a few cells before the label.
+        if let Some(arrow_col) = chars[..cmd_col].iter().rposition(|&c| c == '>') {
+            if cmd_col - arrow_col <= 6 {
+                return Some((y, line));
+            }
+        }
+    }
+    None
+}
+
+/// Locate the x-coordinate of the opening `[` of the text input on the
+/// Command row. Walks the row character-by-character because the screen
+/// contains multibyte box-drawing characters (`│` is 3 bytes / 1 column).
+fn find_bracket_open(harness: &EditorTestHarness, row: u16) -> Option<u16> {
+    let line = harness.get_row_text(row);
+    let chars: Vec<char> = line.chars().collect();
+    let needle = "Command";
+    let needle_chars: Vec<char> = needle.chars().collect();
+    // Find "Command" by character column.
+    let mut label_col: Option<usize> = None;
+    for start in 0..chars.len().saturating_sub(needle_chars.len() - 1) {
+        if chars[start..start + needle_chars.len()] == needle_chars[..] {
+            label_col = Some(start);
+            break;
+        }
+    }
+    let label_col = label_col?;
+    let bracket_offset = chars[label_col..].iter().position(|&c| c == '[')?;
+    Some((label_col + bracket_offset) as u16)
+}
+
+/// Return true if any cell in [x..x+width) on the given row has the
+/// REVERSED modifier — which is how the text-input cursor is drawn.
+fn has_cursor_cell(harness: &EditorTestHarness, x: u16, y: u16, width: u16) -> bool {
+    for dx in 0..width {
+        if let Some(style) = harness.get_cell_style(x + dx, y) {
+            if style.add_modifier.contains(Modifier::REVERSED) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Bug: the cursor (REVERSED cell) is rendered as soon as the text input
+/// is navigated to, before the user has pressed Enter to enter edit mode.
+/// The cursor should only appear once the user has explicitly started
+/// editing.
+#[test]
+fn test_command_cursor_hidden_until_editing() {
+    let mut harness = EditorTestHarness::new(140, 40).unwrap();
+    harness.render().unwrap();
+    open_terminal_command(&mut harness);
+
+    let (row, _line) = find_command_row(&harness).expect("Command row not focused");
+    let bracket_x = find_bracket_open(&harness, row).expect("Expected '[' on Command row");
+
+    // When the row is merely selected (not in edit mode) we should not
+    // render a cursor inside the brackets.
+    assert!(
+        !has_cursor_cell(&harness, bracket_x, row, 30),
+        "BUG: Settings UI renders a REVERSED cursor cell inside the Command \
+         input even before the user has pressed Enter to start editing. \
+         This makes it impossible to tell whether the field is highlighted \
+         for navigation or actively being edited.\nRow: {}\nScreen:\n{}",
+        harness.get_row_text(row),
+        harness.screen_to_string()
+    );
+
+    // Enter edit mode — now the cursor SHOULD be visible.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let (row, _line) = find_command_row(&harness).expect("Command row still focused");
+    let bracket_x = find_bracket_open(&harness, row).expect("Expected '[' on Command row");
+
+    assert!(
+        has_cursor_cell(&harness, bracket_x, row, 30),
+        "After pressing Enter the Command text input should show a cursor \
+         inside the brackets.\nRow: {}\nScreen:\n{}",
+        harness.get_row_text(row),
+        harness.screen_to_string()
+    );
+}
+
+/// Bug: the Command label foreground uses `theme.selection_bg`, which is a
+/// dark colour (RGB 50,60,90 in high-contrast). On the dark row-highlight
+/// background it renders as unreadable dark-on-dark.
+///
+/// The fix must use a readable colour (e.g. `settings_selected_fg`) for the
+/// focused label. This test guards against the specific regression by
+/// asserting the foreground colour is not `theme.selection_bg`.
+#[test]
+fn test_command_label_not_selection_bg_color() {
+    use ratatui::style::Color;
+
+    let mut harness = EditorTestHarness::new(140, 40).unwrap();
+    harness.render().unwrap();
+    open_terminal_command(&mut harness);
+
+    let (row, _line) = find_command_row(&harness).expect("Command row not focused");
+    // The row text may contain multibyte box-drawing chars; locate the
+    // "Command" column via char iteration.
+    let row_text = harness.get_row_text(row);
+    let chars: Vec<char> = row_text.chars().collect();
+    let needle: Vec<char> = "Command".chars().collect();
+    let label_col = (0..chars.len().saturating_sub(needle.len() - 1))
+        .find(|&i| chars[i..i + needle.len()] == needle[..])
+        .expect("Command label should be present") as u16;
+
+    // Grab the foreground colour of the first cell of the label.
+    let style = harness
+        .get_cell_style(label_col, row)
+        .expect("label cell should have a style");
+    let fg = style.fg.expect("label should have an fg colour");
+
+    // High-contrast theme's selection_bg is dark blue.
+    let forbidden = Color::Rgb(50, 60, 90);
+    assert_ne!(
+        fg,
+        forbidden,
+        "BUG: focused Settings text-input label is rendered with \
+         theme.selection_bg ({:?}) as its foreground colour, which is dark-on-dark \
+         and unreadable in the high-contrast theme. It must use a readable \
+         foreground (e.g. settings_selected_fg / editor_fg).\nRow: {}\nScreen:\n{}",
+        forbidden,
+        harness.get_row_text(row),
+        harness.screen_to_string()
+    );
+}


### PR DESCRIPTION
## Summary
Fixes two visual bugs in the Settings UI when navigating to text input fields:
1. The cursor was rendered before entering edit mode, making it impossible to distinguish between selected and actively-editing states
2. The focused label used `theme.selection_bg` as foreground color, causing dark-on-dark text on high-contrast themes

## Changes
- **Added `editing` flag to `TextInputState`**: Distinguishes between "selected via navigation" and "actively editing" states. The cursor is now only rendered when `editing == true`.
- **Updated text input rendering logic**: 
  - When focused but not editing, the label uses normal color and borders are muted (the row's selection highlight provides the "you are here" cue)
  - When focused and editing, brackets are highlighted in the accent color to show where typing goes
  - Cursor only appears after user presses Enter to enter edit mode
- **Fixed label color for focused state**: Changed from `theme.selection_bg` (a background color) to `theme.settings_selected_fg` for readable foreground text
- **Updated state management**: 
  - `SettingsState` now sets `editing = true` when Enter is pressed on a text input
  - `editing` is reset to `false` when navigating away or calling `stop_editing()`
  - Applied same pattern to `EntryDialogState` for consistency
- **Added comprehensive E2E tests**: New test file verifies both the cursor visibility behavior and label color readability

## Implementation Details
The fix maintains visual hierarchy by using the row's selection background as the primary focus indicator, while reserving the accent color (`settings_selected_fg`) for the input brackets only when actively editing. This provides clear visual feedback about the interaction state without relying on background colors for foreground text.

https://claude.ai/code/session_01MhAT1B5iUXw5iacRr3rgwe