### PR TITLE
Add section removal APIs to dashboard plugin

### DIFF
--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -150,10 +150,17 @@ export type SectionRefresh = (ctx: DashboardContext) => Promise<void>;
 /**
  * Public surface of the bundled `dashboard` plugin, reachable through
  * `editor.getPluginApi("dashboard")`. Third-party plugins and user
- * init.ts can contribute their own rows via `registerSection`.
+ * init.ts can contribute their own rows via `registerSection`, and can
+ * tear them down again via `removeSection` / `clearAllSections`.
  */
 export type DashboardApi = {
     registerSection(name: string, refresh: SectionRefresh): () => void;
+    /** Remove every registered section whose name matches `name`.
+     *  Returns true if at least one section was removed. */
+    removeSection(name: string): boolean;
+    /** Remove every registered section, including the bundled
+     *  built-ins (weather, git, github, disk). */
+    clearAllSections(): void;
 };
 
 declare global {
@@ -349,6 +356,32 @@ function registerSection(name: string, refresh: SectionRefresh): () => void {
             paint();
         }
     };
+}
+
+// Remove every registered section whose name matches `name`. Returns
+// true if at least one section was removed. Names are compared verbatim
+// — no case folding or trimming — matching the name passed to
+// `registerSection`. In-flight refreshes for removed sections resolve
+// onto detached entry objects and no longer influence what's rendered.
+function removeSection(name: string): boolean {
+    let removed = false;
+    for (let i = registeredSections.length - 1; i >= 0; i--) {
+        if (registeredSections[i].name === name) {
+            registeredSections.splice(i, 1);
+            removed = true;
+        }
+    }
+    if (removed) paint();
+    return removed;
+}
+
+// Clear every registered section, including the bundled built-ins.
+// The dashboard frame is still drawn — only the section body between
+// header and footer is empty until something registers a new section.
+function clearAllSections(): void {
+    if (registeredSections.length === 0) return;
+    registeredSections.length = 0;
+    paint();
 }
 
 async function refreshSection(entry: RegisteredSection, myToken: number) {
@@ -1479,10 +1512,11 @@ registerSection("git", gitRefresh);
 registerSection("github", githubRefresh);
 registerSection("disk", diskRefresh);
 
-// Expose the section-registration entry point to other plugins and
-// to user init.ts. The API is intentionally small: a single
-// `registerSection(name, refresh)` that returns an unregister
-// callback. The refresh callback receives a `DashboardContext` with
+// Expose the section-management entry points to other plugins and to
+// user init.ts. `registerSection(name, refresh)` adds a section and
+// returns an unregister callback; `removeSection(name)` tears sections
+// down by name; `clearAllSections()` removes every section, built-ins
+// included. The refresh callback receives a `DashboardContext` with
 // `kv`, `text`, `newline`, and `error` primitives — see the init.ts
 // starter template for an end-to-end example.
 editor.exportPluginApi("dashboard", {
@@ -1494,6 +1528,15 @@ editor.exportPluginApi("dashboard", {
             throw new Error("dashboard.registerSection: refresh must be a function");
         }
         return registerSection(name, refresh);
+    },
+    removeSection(name: string): boolean {
+        if (typeof name !== "string" || name.length === 0) {
+            throw new Error("dashboard.removeSection: name must be a non-empty string");
+        }
+        return removeSection(name);
+    },
+    clearAllSections(): void {
+        clearAllSections();
     },
 });
 


### PR DESCRIPTION
## Summary
Extends the dashboard plugin's public API with two new methods for managing registered sections: `removeSection()` to remove sections by name, and `clearAllSections()` to remove all sections including built-ins.

## Key Changes
- Added `removeSection(name: string): boolean` to the `DashboardApi` type, allowing removal of sections by name with a boolean return indicating if any were removed
- Added `clearAllSections(): void` to the `DashboardApi` type, allowing complete clearing of all registered sections
- Implemented `removeSection()` function that:
  - Iterates backwards through registered sections to safely remove matching entries
  - Compares names verbatim (no case folding or trimming)
  - Triggers a repaint if any sections were removed
  - Returns true if at least one section was removed
- Implemented `clearAllSections()` function that:
  - Clears all registered sections including bundled built-ins (weather, git, github, disk)
  - Preserves the dashboard frame while emptying the section body
  - Triggers a repaint only if sections existed
- Exported both new methods through the plugin API with input validation for `removeSection()`
- Updated documentation comments to reflect the expanded API surface

## Implementation Details
- In-flight refreshes for removed sections resolve onto detached entry objects and no longer influence rendering
- `removeSection()` validates that the name parameter is a non-empty string before processing
- Both functions call `paint()` to update the UI after modifications
- The implementation maintains backward compatibility with existing `registerSection()` functionality

https://claude.ai/code/session_01SqfUjYFeJPPZG9sudLYo9L