### PR TITLE
Add keyboard navigation to dashboard with focus highlight

### DIFF
--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -191,6 +191,21 @@ let fetchToken = 0; // bumped each open; late fetches from a prior open no-op.
 let nextSectionId = 1;
 const registeredSections: RegisteredSection[] = [];
 
+// Ordered list of focusable clickable targets on the currently-painted
+// frame. Rebuilt every paint() from `currentRowActions`. One entry per
+// row that carries at least one action — when a row holds multiple
+// ranges (e.g. PR rows with both #num and title clickable), the highlight
+// spans the union and the activation dispatches the first range's action
+// so Enter matches the leftmost click target on that row.
+type ClickTarget = {
+    bufferRow: number; // absolute buffer row (after topPad)
+    colStart: number; // visual col (inclusive)
+    colEnd: number; // visual col (exclusive)
+    action: ClickAction;
+};
+let clickableTargets: ClickTarget[] = [];
+let focusedIndex = 0;
+
 // ── Drawing primitives ─────────────────────────────────────────────────
 
 function utf8Len(s: string): number {
@@ -612,6 +627,23 @@ let lastPaintedH = -1;
 // the click handler can gate on buffer_col too. Rebuilt every paint.
 let currentRowActions: Map<number, ClickActionRange[]> = new Map();
 
+// Map a visual column (counted from the start of the line) to a UTF-8
+// byte offset inside `text`. Used to translate the visual col ranges
+// stored in ClickTarget into the byte-offset range an InlineOverlay
+// needs. Walks chars with visualWidth/utf8Len so frame glyphs like
+// `│` (3 bytes, 1 col) and future wide chars stay aligned.
+function visualColToByteOffset(text: string, visualCol: number): number {
+    if (visualCol <= 0) return 0;
+    let col = 0;
+    let bytes = 0;
+    for (const ch of text) {
+        if (col >= visualCol) return bytes;
+        col += visualWidth(ch);
+        bytes += utf8Len(ch);
+    }
+    return bytes;
+}
+
 function paint(dims?: { width: number; height: number }) {
     if (dashboardBufferId === null) return;
     const bufferId = dashboardBufferId;
@@ -647,6 +679,65 @@ function paint(dims?: { width: number; height: number }) {
         abs.set(row + topPad, ranges);
     }
     currentRowActions = abs;
+
+    // Rebuild the ordered focus targets in visual row order. A row with
+    // multiple ranges collapses into a single target whose highlight
+    // spans the union of its ranges; Enter dispatches the first range's
+    // action, matching the leftmost click target on that row.
+    const targets: ClickTarget[] = [];
+    const sortedRows = [...abs.keys()].sort((a, b) => a - b);
+    for (const row of sortedRows) {
+        const ranges = abs.get(row)!;
+        if (ranges.length === 0) continue;
+        let minCol = ranges[0].colStart;
+        let maxCol = ranges[0].colEnd;
+        for (const r of ranges) {
+            if (r.colStart < minCol) minCol = r.colStart;
+            if (r.colEnd > maxCol) maxCol = r.colEnd;
+        }
+        targets.push({
+            bufferRow: row,
+            colStart: minCol,
+            colEnd: maxCol,
+            action: ranges[0].action,
+        });
+    }
+    clickableTargets = targets;
+    if (targets.length === 0) {
+        focusedIndex = 0;
+    } else if (focusedIndex < 0 || focusedIndex >= targets.length) {
+        focusedIndex =
+            ((focusedIndex % targets.length) + targets.length) % targets.length;
+    }
+
+    // Paint the focus highlight by mutating the entry for the focused
+    // row: translate its visual col range into a byte range and push an
+    // inline overlay on top of whatever foreground/underline spans the
+    // frame renderer already added. Using `editor.selection_bg` keeps
+    // the highlight theme-aware — it follows theme switches for free
+    // and matches other selection-style highlights elsewhere in the UI.
+    if (targets.length > 0) {
+        const focus = targets[focusedIndex];
+        const entry = entries[focus.bufferRow];
+        if (entry) {
+            const lineText = entry.text.endsWith("\n")
+                ? entry.text.slice(0, -1)
+                : entry.text;
+            const byteStart = visualColToByteOffset(lineText, focus.colStart);
+            const byteEnd = visualColToByteOffset(lineText, focus.colEnd);
+            if (byteEnd > byteStart) {
+                const overlays: InlineOverlay[] = entry.inlineOverlays
+                    ? [...entry.inlineOverlays]
+                    : [];
+                overlays.push({
+                    start: byteStart,
+                    end: byteEnd,
+                    style: { bg: "editor.selection_bg" },
+                });
+                entry.inlineOverlays = overlays;
+            }
+        }
+    }
 
     editor.setVirtualBufferContent(bufferId, entries);
     lastPaintedW = width;
@@ -1337,6 +1428,7 @@ async function openDashboard() {
 
     const res = await editor.createVirtualBuffer({
         name: "Dashboard",
+        mode: "dashboard",
         readOnly: true,
         showLineNumbers: false,
         showCursors: false,
@@ -1344,6 +1436,7 @@ async function openDashboard() {
     });
     dashboardBufferId = res.bufferId;
     dashboardOpening = false;
+    focusedIndex = 0;
 
     // Re-check: while we were awaiting createVirtualBuffer, a real
     // file may have landed — e.g. a CLI file from `fresh my_file`
@@ -1462,6 +1555,49 @@ registerHandler(
         paint({ width: data.width, height: data.height });
     },
 );
+// Keyboard navigation. The dashboard buffer is `showCursors: false` +
+// `editingDisabled: true`, so there's no native cursor to drive
+// selection — we track focus ourselves via `focusedIndex` and repaint
+// to move the highlight. Wraparound in both directions so the user
+// can't walk off either end of the clickable list.
+function moveFocus(delta: number) {
+    if (clickableTargets.length === 0) return;
+    focusedIndex =
+        (focusedIndex + delta + clickableTargets.length) %
+        clickableTargets.length;
+    paint();
+}
+registerHandler("dashboardFocusNext", () => moveFocus(1));
+registerHandler("dashboardFocusPrev", () => moveFocus(-1));
+registerHandler("dashboardActivate", () => {
+    if (clickableTargets.length === 0) return;
+    const target = clickableTargets[focusedIndex];
+    if (!target) return;
+    dispatchClickAction(target.action);
+});
+
+// Mode bindings mirror the standard "list with selectable rows"
+// idiom: Tab / Down / j step forward, BackTab / Up / k step back,
+// Return activates. `inheritNormalBindings: false` because every
+// useful key on a read-only, no-cursor buffer is either bound above
+// or intentionally inert (we don't want j/k falling through to cursor
+// movement commands that would silently do nothing here).
+editor.defineMode(
+    "dashboard",
+    [
+        ["Tab", "dashboardFocusNext"],
+        ["Down", "dashboardFocusNext"],
+        ["j", "dashboardFocusNext"],
+        ["BackTab", "dashboardFocusPrev"],
+        ["Up", "dashboardFocusPrev"],
+        ["k", "dashboardFocusPrev"],
+        ["Return", "dashboardActivate"],
+    ],
+    true, // read-only
+    false, // allow_text_input
+    false, // don't inherit Normal bindings — no cursor to move
+);
+
 // Dispatch clicks on rows that carry an action. We don't trust the
 // terminal to honor OSC-8 hyperlinks on the `url` span — many strip
 // them silently — so every clickable element also registers a

--- a/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
@@ -6,6 +6,7 @@
 //! dormant (it should) or not.
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 use std::fs;
 use std::path::PathBuf;
@@ -189,3 +190,185 @@ if (dash) {
 // If we ever need a regression test, the right level is a pure-Rust
 // unit test of the range-lookup logic (once the dashboard exposes a
 // testable seam for it), not a full-stack mouse dispatch.
+
+// ── Keyboard navigation ────────────────────────────────────────────────
+//
+// The dashboard is a `showCursors: false`, `editingDisabled: true`
+// virtual buffer, so there is no native cursor — navigation is driven
+// by a custom mode with Tab/BackTab, Up/Down, j/k stepping through
+// clickable rows and Return dispatching the focused row's action.
+// Focus is rendered as a `selection_bg` inline overlay on the focused
+// row's content range.
+//
+// This test avoids the cross-async-plugin-callback chain that made the
+// earlier mouse-click tests flaky: it only observes the render side,
+// not an onClick effect, and it uses semantic `wait_until` to collapse
+// the keypress → mode dispatch → paint → render path without fixed
+// timers.
+
+/// Drop a sidecar that registers a section with three clickable rows
+/// carrying distinctive text ("ALPHA", "BETA", "GAMMA"). Each row's
+/// onClick is a no-op — we only care about the highlight moving, not
+/// the click firing, to stay on the render-chain side of the async
+/// boundary the removed mouse-click tests stumbled over.
+fn write_nav_sidecar(plugins_dir: &std::path::Path) {
+    let sidecar = r#"/// <reference path="./lib/fresh.d.ts" />
+/// @depends-on dashboard
+const editor = getEditor();
+
+type Ctx = {
+    kv: (label: string, value: string, color?: string) => void;
+    text: (s: string, opts?: { color?: string; bold?: boolean; url?: string; onClick?: () => void }) => void;
+    newline: () => void;
+    error: (message: string) => void;
+};
+
+const dash = editor.getPluginApi("dashboard") as
+    | { registerSection: (name: string, refresh: (ctx: Ctx) => Promise<void>) => () => void }
+    | null;
+
+if (dash) {
+    dash.registerSection("nav", async (ctx) => {
+        for (const label of ["ALPHA", "BETA", "GAMMA"]) {
+            ctx.text("    ", { color: "muted" });
+            ctx.text(label, { color: "accent", onClick: () => {} });
+            ctx.newline();
+        }
+    });
+}
+"#;
+    fs::write(plugins_dir.join("sidecar.ts"), sidecar).unwrap();
+}
+
+/// Background color of the cell immediately under the `A` in `label`
+/// on the rendered screen. Used to compare "is this row highlighted?"
+/// across keypresses. Returns None if the text isn't on screen yet.
+fn label_bg(h: &EditorTestHarness, label: &str) -> Option<ratatui::style::Color> {
+    let (col, row) = h.find_text_on_screen(label)?;
+    h.get_cell_style(col, row)
+        .map(|s| s.bg.unwrap_or(ratatui::style::Color::Reset))
+}
+
+/// True when the bg at `label`'s first cell differs from the bg at the
+/// same row's `│` frame border — the border never carries the focus
+/// highlight, so a within-row bg mismatch is a theme-independent way
+/// to detect that the row is the focused one. Avoids comparing against
+/// a hard-coded selection color that would change per theme.
+fn is_label_highlighted(h: &EditorTestHarness, label: &str) -> bool {
+    let Some((col, row)) = h.find_text_on_screen(label) else {
+        return false;
+    };
+    let label_bg = h
+        .get_cell_style(col, row)
+        .and_then(|s| s.bg)
+        .unwrap_or(ratatui::style::Color::Reset);
+    // The left frame border on the dashboard sits at column 0 visibility
+    // after leftPad spaces — scan leftward from the label until we hit
+    // the border glyph `│` and sample its bg there.
+    for x in (0..col).rev() {
+        let pos = h.buffer().index_of(x, row);
+        if let Some(cell) = h.buffer().content.get(pos) {
+            if cell.symbol() == "│" {
+                let border_bg = cell.style().bg.unwrap_or(ratatui::style::Color::Reset);
+                return label_bg != border_bg;
+            }
+        }
+    }
+    false
+}
+
+/// End-to-end check that keyboard navigation moves the focus highlight
+/// between clickable rows. Uses the sidecar section above so the test
+/// is independent of whether the working directory happens to be a
+/// git repo (the built-in git/github sections render different rows
+/// depending on that, which would otherwise shift the expected
+/// highlight position between local and CI runs).
+#[test]
+fn keyboard_navigation_moves_focus_highlight() {
+    let (_harness_unused, _tmp, plugins_dir) = harness_with_dashboard_plugin_and_plugins_dir();
+    write_nav_sidecar(&plugins_dir);
+
+    // Rebuild the harness so the plugin scanner picks up the sidecar —
+    // `harness_with_dashboard_plugin_and_plugins_dir` already scanned
+    // once when it constructed the first harness.
+    drop(_harness_unused);
+    let working_dir = plugins_dir.parent().unwrap().to_path_buf();
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, Config::default(), working_dir)
+            .expect("harness");
+
+    harness.editor_mut().fire_ready_hook();
+
+    // Wait for all three sidecar rows to land — the custom section's
+    // refresh is async, and until it resolves there are no clickable
+    // targets in our section to navigate through.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("ALPHA") && s.contains("BETA") && s.contains("GAMMA")
+        })
+        .unwrap();
+
+    // Initial focus: the plugin starts with focusedIndex = 0, and the
+    // first target in document order is ALPHA. BETA and GAMMA should
+    // not be highlighted.
+    harness
+        .wait_until(|h| {
+            is_label_highlighted(h, "ALPHA")
+                && !is_label_highlighted(h, "BETA")
+                && !is_label_highlighted(h, "GAMMA")
+        })
+        .unwrap();
+    let alpha_highlighted_bg = label_bg(&harness, "ALPHA").expect("alpha bg");
+
+    // Tab moves forward: highlight should land on BETA.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| is_label_highlighted(h, "BETA") && !is_label_highlighted(h, "ALPHA"))
+        .unwrap();
+    // The theme-colored highlight bg we recorded on ALPHA should now
+    // appear on BETA — same style, different row.
+    assert_eq!(
+        label_bg(&harness, "BETA"),
+        Some(alpha_highlighted_bg),
+        "Tab should move the same highlight style from ALPHA to BETA"
+    );
+
+    // `j` (vi-style) also moves forward.
+    harness
+        .send_key(KeyCode::Char('j'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| is_label_highlighted(h, "GAMMA") && !is_label_highlighted(h, "BETA"))
+        .unwrap();
+
+    // BackTab steps backward — highlight returns to BETA.
+    harness
+        .send_key(KeyCode::BackTab, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| is_label_highlighted(h, "BETA") && !is_label_highlighted(h, "GAMMA"))
+        .unwrap();
+
+    // `k` also moves backward.
+    harness
+        .send_key(KeyCode::Char('k'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| is_label_highlighted(h, "ALPHA") && !is_label_highlighted(h, "BETA"))
+        .unwrap();
+
+    // Wraparound: one more `k` from the first target should land on
+    // the last clickable target overall (which may live in a built-in
+    // section, not necessarily GAMMA). We just assert ALPHA is no
+    // longer highlighted — the wrap direction is covered by the fact
+    // that we didn't run off the end and crash.
+    harness
+        .send_key(KeyCode::Char('k'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| !is_label_highlighted(h, "ALPHA"))
+        .unwrap();
+
+    harness.assert_no_plugin_errors();
+}


### PR DESCRIPTION
## Summary
Implements keyboard-driven navigation for the dashboard plugin, allowing users to move focus between clickable rows using Tab/BackTab, arrow keys, and vi-style j/k bindings, with visual feedback via a theme-aware selection highlight.

## Key Changes

- **Focus tracking**: Added `clickableTargets` array and `focusedIndex` to track the currently focused clickable row in document order
- **Visual highlight**: Implemented focus rendering as an inline overlay using `editor.selection_bg` that spans the union of all clickable ranges on a focused row
- **Keyboard handlers**: Added three new handlers (`dashboardFocusNext`, `dashboardFocusPrev`, `dashboardActivate`) with wraparound navigation in both directions
- **Dashboard mode**: Defined a new "dashboard" mode with bindings for Tab/Down/j (forward), BackTab/Up/k (backward), and Return (activate), with `inheritNormalBindings: false` to prevent unintended fallthrough
- **Helper utilities**: 
  - `visualColToByteOffset()` converts visual column positions to UTF-8 byte offsets for inline overlay positioning
  - Collapse multi-range rows into single targets where Enter dispatches the leftmost action
- **Comprehensive test**: Added `keyboard_navigation_moves_focus_highlight()` e2e test that validates focus movement across three test rows, verifying highlight movement and wraparound behavior using render-side observation rather than async click callbacks

## Implementation Details

- Focus highlight uses the same `selection_bg` styling as other UI selections, making it theme-aware and automatically responsive to theme changes
- The test avoids the async plugin callback flakiness of earlier mouse-click tests by observing only the render chain and using `wait_until` semantics
- Row highlighting is theme-independent: the test detects focus by comparing the row's background against the frame border's background, which never carries the highlight
- Wraparound uses modulo arithmetic to handle both forward and backward navigation seamlessly

https://claude.ai/code/session_01KaeGt1RvoyYE3ocLRigkVg