### PR TITLE
Fix group tab activation to respect clicked split pane

### DIFF
--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -257,7 +257,7 @@ impl Editor {
                 self.focus_file_explorer();
             }
             if let Some(group_leaf) = return_to_group {
-                self.activate_group_tab(group_leaf);
+                self.activate_group_tab(active_split, group_leaf);
             }
         }
 
@@ -699,7 +699,7 @@ impl Editor {
                 self.set_active_buffer(buffer_id);
             }
             TabTarget::Group(group_leaf_id) => {
-                self.activate_group_tab(group_leaf_id);
+                self.activate_group_tab(active_split, group_leaf_id);
             }
         }
     }

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -433,10 +433,14 @@ impl super::Editor {
         }
     }
 
-    /// Activate a group tab by its Grouped-node LeafId. This sets the
-    /// active tab of the current split so the group's layout becomes visible
-    /// in the split's content area. The active inner leaf receives focus.
-    pub(crate) fn activate_group_tab(&mut self, group_leaf: LeafId) {
+    /// Activate a group tab by its Grouped-node LeafId in the given split.
+    /// Records the group as the split's active tab so the group's layout
+    /// becomes visible in that split's content area, and moves keyboard
+    /// focus to the group's active inner leaf. If `split_id` is not the
+    /// currently active split (e.g. the user clicked a group tab in a
+    /// non-focused pane), focus is transferred to it — tab clicks are
+    /// commitment gestures pointing at the clicked pane.
+    pub(crate) fn activate_group_tab(&mut self, split_id: LeafId, group_leaf: LeafId) {
         // Find the inner active leaf and its buffer from the stored Grouped node.
         let Some(crate::view::split::SplitNode::Grouped {
             active_inner_leaf, ..
@@ -446,20 +450,24 @@ impl super::Editor {
         };
         let inner_leaf = *active_inner_leaf;
 
-        // Set the current split's "effective active target" by recording
-        // the group as the active-tab for this split.
-        let active_split = self.split_manager.active_split();
-        if let Some(vs) = self.split_view_states.get_mut(&active_split) {
-            vs.active_group_tab = Some(group_leaf);
+        // If activating a group tab in a non-focused split, transfer focus
+        // to that split first so subsequent keyboard input routes to the
+        // group's inner panel rather than the previously-active pane. This
+        // mirrors how clicking a buffer tab in another split moves focus.
+        if self.split_manager.active_split() != split_id {
+            self.promote_preview_if_not_in_split(split_id);
+            if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
+                self.key_context = crate::input::keybindings::KeyContext::Normal;
+            }
+            self.split_manager.set_active_split(split_id);
         }
 
-        // Focus the inner leaf's buffer so keyboard input goes there.
-        // NOTE: the inner leaf is NOT in the main split tree — it only
-        // exists inside the stashed Grouped subtree. Focus routing
-        // through focus_split won't work directly.
-        // Instead we set a separate "focused group leaf" marker that the
-        // input router can consult.
-        if let Some(vs) = self.split_view_states.get_mut(&active_split) {
+        // Record the group as the active-tab and focused inner leaf for
+        // this split. The inner leaf is NOT in the main split tree — it
+        // only exists inside the stashed Grouped subtree — so focus is
+        // routed via `focused_group_leaf` rather than `focus_split`.
+        if let Some(vs) = self.split_view_states.get_mut(&split_id) {
+            vs.active_group_tab = Some(group_leaf);
             vs.focused_group_leaf = Some(inner_leaf);
         }
     }

--- a/crates/fresh-editor/src/app/input_helpers.rs
+++ b/crates/fresh-editor/src/app/input_helpers.rs
@@ -49,7 +49,7 @@ impl Editor {
             }
             Some(TabTarget::Group(leaf_id)) => {
                 if self.grouped_subtrees.contains_key(&leaf_id) {
-                    self.activate_group_tab(leaf_id);
+                    self.activate_group_tab(active_split, leaf_id);
                 } else {
                     self.set_status_message(t!("status.previous_tab_closed").to_string());
                 }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2013,10 +2013,11 @@ impl Editor {
                             ));
                         }
                         crate::view::split::TabTarget::Group(group_leaf) => {
-                            // Activate the group tab: set the active leaf to the
-                            // group's preferred inner leaf so this group is
-                            // rendered and its scrollable panel receives focus.
-                            self.activate_group_tab(group_leaf);
+                            // Activate the group tab in the split that owns
+                            // the clicked tab bar — not the currently-focused
+                            // split. The two may differ when the user clicks
+                            // a group tab in a non-focused pane.
+                            self.activate_group_tab(split_id, group_leaf);
                         }
                     }
                     return Ok(());

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_split_tab_focus.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_split_tab_focus.rs
@@ -16,7 +16,7 @@
 //! handler routed the activation through `active_split` instead of the
 //! clicked split.
 
-use crate::common::git_test_helper::{DirGuard, GitTestRepo};
+use crate::common::git_test_helper::GitTestRepo;
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
@@ -51,9 +51,11 @@ fn clicking_group_tab_activates_group_in_the_clicked_split() {
     repo.setup_typical_project();
     repo.setup_git_log_plugin();
 
-    let original_dir = repo.change_to_repo_dir();
-    let _guard = DirGuard::new(original_dir);
-
+    // Deliberately not calling `repo.change_to_repo_dir()` — it mutates
+    // process-global cwd, which is not safe under parallel test execution
+    // (CONTRIBUTING §4). The git_log plugin passes `editor.getCwd()` to
+    // `spawnProcess`, which resolves to the editor's `working_dir` set
+    // below — process cwd is not needed.
     let width = 120u16;
     let height = 40u16;
     let mut harness = EditorTestHarness::with_config_and_working_dir(

--- a/crates/fresh-editor/tests/e2e/plugins/git_log_split_tab_focus.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_log_split_tab_focus.rs
@@ -1,0 +1,150 @@
+//! Regression test: clicking a buffer-group tab (e.g. *Git Log*) in a split
+//! pane must activate the group in THAT pane, not in whichever pane happens
+//! to be focused.
+//!
+//! Reproduction:
+//!   1. open a file
+//!   2. open Git Log via command palette (single split with two tabs:
+//!      hello.txt and *Git Log*)
+//!   3. click the hello.txt tab so the file buffer is the active tab again
+//!   4. run "split horizontal" — this creates a new split BELOW the original
+//!      and the new (bottom) split becomes the active one
+//!   5. click the *Git Log* tab in the TOP pane's tab bar
+//!
+//! Expected: the Git Log view renders in the TOP pane where its tab lives.
+//! Bug: the Git Log view renders in the BOTTOM pane because the tab-click
+//! handler routed the activation through `active_split` instead of the
+//! clicked split.
+
+use crate::common::git_test_helper::{DirGuard, GitTestRepo};
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::time::Duration;
+
+fn advance_past_double_click(harness: &mut EditorTestHarness) {
+    let dc = Duration::from_millis(
+        harness
+            .config()
+            .editor
+            .double_click_time_ms
+            .saturating_mul(2),
+    );
+    harness.advance_time(dc);
+}
+
+/// Find the column where the given text starts in a specific row, counting
+/// chars (not bytes) so wide box-drawing glyphs don't throw off the index.
+fn col_of_text_in_row(harness: &EditorTestHarness, row: u16, needle: &str) -> u16 {
+    let row_text = harness.screen_row_text(row);
+    let needle: Vec<char> = needle.chars().collect();
+    let chars: Vec<char> = row_text.chars().collect();
+    chars
+        .windows(needle.len())
+        .position(|w| w == needle.as_slice())
+        .unwrap_or_else(|| panic!("{:?} not in row {row}: {row_text:?}", needle)) as u16
+}
+
+#[test]
+fn clicking_group_tab_activates_group_in_the_clicked_split() {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    repo.setup_git_log_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let width = 120u16;
+    let height = 40u16;
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        width,
+        height,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    // Open a file so we have a concrete, non-scratch tab to anchor on.
+    harness.open_file(&repo.path.join("src/main.rs")).unwrap();
+    harness.render().unwrap();
+
+    // Trigger Git Log via the command palette. This creates a buffer group
+    // and adds a *Git Log* tab to the current split.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane") && s.contains("Initial commit")
+        })
+        .unwrap();
+
+    // Step 3: click the main.rs tab so the file buffer becomes the active
+    // tab again (clearing the active group). Tabs are on row 1.
+    const TAB_BAR_ROW: u16 = 1;
+    let file_tab_col = col_of_text_in_row(&harness, TAB_BAR_ROW, "main.rs");
+    advance_past_double_click(&mut harness);
+    harness.mouse_click(file_tab_col, TAB_BAR_ROW).unwrap();
+    // Git Log toolbar ("switch pane" hint) is gone because the file tab is
+    // now active in the single split.
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("switch pane"))
+        .unwrap();
+
+    // Step 4: split horizontally via the command palette. This creates a
+    // new split BELOW the original, and the new (bottom) split becomes
+    // the active one. The top split still has both tabs.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("split horiz").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Split pane horiz"))
+        .unwrap();
+
+    // Sanity check: the *Git Log* tab label still lives on the top tab bar
+    // (row 1). It must be there for the next click to target the TOP pane.
+    let git_log_tab_col = col_of_text_in_row(&harness, TAB_BAR_ROW, "Git Log");
+
+    // Step 5: click the *Git Log* tab in the TOP pane's tab bar.
+    advance_past_double_click(&mut harness);
+    harness.mouse_click(git_log_tab_col, TAB_BAR_ROW).unwrap();
+    // Let the group activate and re-render.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("switch pane"))
+        .unwrap();
+
+    // The Git Log's sticky toolbar ("switch pane" hint) must appear in the
+    // TOP half of the screen, NOT the BOTTOM half. Without the fix, the
+    // activation lands on the newly-created (active) bottom split, so the
+    // toolbar shows up below the horizontal separator instead of above it.
+    let screen = harness.screen_to_string();
+    let toolbar_rows: Vec<usize> = screen
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| line.contains("switch pane"))
+        .map(|(row, _)| row)
+        .collect();
+
+    let top_half_end = (height / 2) as usize;
+    assert!(
+        !toolbar_rows.is_empty(),
+        "git log toolbar not rendered at all; screen:\n{screen}"
+    );
+    assert!(
+        toolbar_rows.iter().all(|row| *row < top_half_end),
+        "git log activated in the wrong split: 'switch pane' toolbar \
+         appeared on rows {toolbar_rows:?}, but the clicked *Git Log* tab \
+         lives in the TOP pane (rows < {top_half_end}). Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -13,6 +13,7 @@ pub mod diagnostics_panel_jump;
 pub mod diff_cursor;
 pub mod find_file;
 pub mod git;
+pub mod git_log_split_tab_focus;
 pub mod gutter;
 pub mod init_script;
 pub mod language_pack;


### PR DESCRIPTION
## Summary
Fixed a bug where clicking a buffer-group tab (e.g., *Git Log*) in a non-focused split pane would activate the group in the currently-active split instead of the split containing the clicked tab.

## Key Changes
- **Modified `activate_group_tab()` signature** in `buffer_groups.rs`: Added `split_id` parameter to explicitly specify which split should activate the group, rather than always using the currently-active split.

- **Updated split focus logic**: When activating a group tab in a non-focused split, the method now:
  - Transfers keyboard focus to the clicked split (matching behavior of clicking buffer tabs)
  - Clears file explorer context if active
  - Sets the split as active before recording the group activation

- **Updated all call sites** to pass the correct `split_id`:
  - `mouse_input.rs`: Pass the split containing the clicked tab bar
  - `buffer_close.rs`: Pass the active split when returning to a group after closing buffers
  - `input_helpers.rs`: Pass the active split when navigating tabs via keyboard

- **Added regression test** `git_log_split_tab_focus.rs`: Comprehensive e2e test that reproduces the original bug scenario (opening Git Log, splitting panes, then clicking the Git Log tab in the non-focused pane) and verifies the toolbar appears in the correct pane.

## Implementation Details
The fix treats group tab clicks as commitment gestures pointing at a specific pane, similar to how clicking a regular buffer tab in another split transfers focus to that pane. The group's inner leaf focus is routed through the `focused_group_leaf` marker rather than the main split tree, since grouped subtrees are stashed separately from the active split hierarchy.

https://claude.ai/code/session_01TUzzRxfLCF5Zt56JyWBBbn