### PR TITLE
Fix viewport stall after search wrap-around (issue #1689)

### DIFF
--- a/crates/fresh-editor/src/app/bookmark_actions.rs
+++ b/crates/fresh-editor/src/app/bookmark_actions.rs
@@ -60,6 +60,10 @@ impl Editor {
 
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
+        // Bookmarks can point anywhere in the file; the viewport must scroll
+        // to follow the jump even when the bookmark target is in the same
+        // buffer that's already visible (#1689).
+        self.ensure_active_cursor_visible_for_navigation(true);
         self.set_status_message(t!("bookmark.jumped", key = key).to_string());
     }
 

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -752,6 +752,10 @@ impl Editor {
                 let state = self.buffers.get_mut(&target_buffer).unwrap();
                 let view_state = self.split_view_states.get_mut(&split_id).unwrap();
                 state.apply(&mut view_state.cursors, &event);
+                // Position-history entries can land anywhere in the buffer;
+                // the viewport must scroll to the restored cursor or the user
+                // sees the same page after Ctrl+- / Ctrl+= (#1689).
+                self.ensure_active_cursor_visible_for_navigation(true);
             }
         }
 
@@ -792,6 +796,10 @@ impl Editor {
                 let state = self.buffers.get_mut(&target_buffer).unwrap();
                 let view_state = self.split_view_states.get_mut(&split_id).unwrap();
                 state.apply(&mut view_state.cursors, &event);
+                // Position-history entries can land anywhere in the buffer;
+                // the viewport must scroll to the restored cursor or the user
+                // sees the same page after Ctrl+- / Ctrl+= (#1689).
+                self.ensure_active_cursor_visible_for_navigation(true);
             }
         }
 

--- a/crates/fresh-editor/src/app/diagnostic_jumps.rs
+++ b/crates/fresh-editor/src/app/diagnostic_jumps.rs
@@ -63,6 +63,9 @@ impl Editor {
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);
+            // Diagnostics can be on any line; the viewport must scroll so the
+            // user actually sees the error after pressing F8 (#1689).
+            self.ensure_active_cursor_visible_for_navigation(true);
 
             // Show diagnostic message in status bar
             let state = self.active_state();
@@ -131,6 +134,9 @@ impl Editor {
             };
             self.active_event_log_mut().append(event.clone());
             self.apply_event_to_active_buffer(&event);
+            // Diagnostics can be on any line; the viewport must scroll so the
+            // user actually sees the error after pressing F8 (#1689).
+            self.ensure_active_cursor_visible_for_navigation(true);
 
             // Show diagnostic message in status bar
             let state = self.active_state();

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -760,8 +760,12 @@ impl Editor {
             None => return,
         };
 
-        // Apply cursor position and viewport (scroll) state to SplitViewState
-        if let Some(view_state) = self.split_view_states.get_mut(&split_id) {
+        // Apply cursor position and viewport (scroll) state to SplitViewState.
+        // Field-disjoint borrows: `split_view_states` and `buffers` are
+        // separate fields, so we can hold mut borrows on both at once.
+        let view_state_opt = self.split_view_states.get_mut(&split_id);
+        let buffer_state_opt = self.buffers.get_mut(&buffer_id);
+        if let (Some(view_state), Some(buffer_state)) = (view_state_opt, buffer_state_opt) {
             if let Some(buf_state) = view_state.keyed_states.get_mut(&buffer_id) {
                 let cursor_pos = file_state.cursor.position.min(max_pos);
                 buf_state.cursors.primary_mut().position = cursor_pos;
@@ -770,6 +774,13 @@ impl Editor {
             }
             view_state.viewport.top_byte = file_state.scroll.top_byte;
             view_state.viewport.left_column = file_state.scroll.left_column;
+            // Saved cursor and saved viewport are written from independent
+            // fields and may be out of sync (e.g. cursor moved off-screen
+            // before save). Reconcile so the restored view always shows the
+            // cursor — without this, arrow keys in wrap mode can't bring the
+            // viewport back because of the `top_view_line_offset > 0` early
+            // return in `viewport.rs::ensure_visible` (#1689 follow-up).
+            super::navigation::reconcile_restored_buffer_view(view_state, &mut buffer_state.buffer);
         }
     }
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -287,6 +287,10 @@ impl Editor {
                     let cursors = &mut self.split_view_states.get_mut(&split_id).unwrap().cursors;
                     state.apply(cursors, &event);
                 }
+                // Without this the cursor lands at the definition but the
+                // viewport never scrolls when the target file is already
+                // open (#1689).
+                self.ensure_active_cursor_visible_for_navigation(true);
             }
 
             self.status_message = Some(

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -47,6 +47,7 @@ mod macros;
 mod menu_actions;
 mod menu_context;
 mod mouse_input;
+mod navigation;
 mod on_save_actions;
 mod path_utils;
 mod plugin_commands;

--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -1,0 +1,175 @@
+//! Cursor-jump primitives that guarantee viewport visibility.
+//!
+//! All "navigate the cursor to a byte offset" flows — search next/prev,
+//! LSP go-to-definition, jump-to-line, diagnostic jumps, plugin
+//! `scrollBufferToLine`, etc. — should funnel through this module instead
+//! of mutating `cursors` and calling `ensure_cursor_visible` directly.
+//!
+//! The lower-level [`view::split::BufferViewState::ensure_cursor_visible`]
+//! has several short-circuit paths (the `skip_ensure_visible` flag set by
+//! prior scroll actions, the `top_view_line_offset > 0` early-return for
+//! wrapped buffers, `skip_resize_sync`) that can leave a freshly-set cursor
+//! stranded outside the viewport. That class of bug — "status bar updates
+//! but the page never moves" — is why every navigation primitive here ends
+//! with a *post-condition check*: if the cursor is still off-screen when
+//! the call returns, we force a hard recenter (issue #1689).
+//!
+//! Use [`Editor::ensure_active_cursor_visible_for_navigation`] right after
+//! any explicit cursor mutation that represents a user-visible jump. Use
+//! [`Editor::jump_active_cursor_to`] when the call site can also delegate
+//! the cursor mutation itself.
+//!
+//! Edits (typing, paste, indent, …) should keep using the existing
+//! `ensure_cursor_visible` path — they want the "don't undo a deliberate
+//! scroll" behavior of the skip flag.
+
+use crate::model::buffer::LineNumber;
+
+use super::Editor;
+
+/// Whether the active cursor should be vertically recentered when a jump
+/// causes the viewport to scroll, and whether the selection anchor should
+/// be reset.
+#[derive(Clone, Copy, Debug)]
+pub struct JumpOptions {
+    /// If `true`, drop the selection anchor (the jump becomes a plain move).
+    /// Set to `false` to extend the selection from the previous anchor.
+    pub clear_anchor: bool,
+    /// If the jump caused the viewport to scroll *or* the post-condition
+    /// safety net had to fire, recenter the cursor vertically. This is the
+    /// behavior search/LSP/error navigation want — a cold landing spot
+    /// should show context above and below.
+    pub recenter_on_scroll: bool,
+}
+
+impl Default for JumpOptions {
+    fn default() -> Self {
+        Self {
+            clear_anchor: true,
+            recenter_on_scroll: true,
+        }
+    }
+}
+
+impl JumpOptions {
+    /// Convenience: defaults for navigation jumps (clear anchor, recenter).
+    pub fn navigation() -> Self {
+        Self::default()
+    }
+}
+
+impl Editor {
+    /// Move the active cursor to `position` and guarantee that position is
+    /// rendered in the active viewport.
+    ///
+    /// This is the canonical "jump the cursor somewhere" entry point. It
+    /// performs a direct cursor mutation (no `MoveCursor` event, no undo
+    /// entry, no `cursor_moved` plugin hook) and then funnels through
+    /// [`Editor::ensure_active_cursor_visible_for_navigation`] for the
+    /// visibility invariant.
+    ///
+    /// Callers that need a `MoveCursor` event (undo + plugin hooks) should
+    /// build the event themselves and call
+    /// [`Editor::ensure_active_cursor_visible_for_navigation`] afterwards.
+    pub fn jump_active_cursor_to(&mut self, position: usize, opts: JumpOptions) {
+        let active_split = self.split_manager.active_split();
+        let active_buffer = self.active_buffer();
+        if let Some(view_state) = self.split_view_states.get_mut(&active_split) {
+            view_state.cursors.primary_mut().position = position;
+            if opts.clear_anchor {
+                view_state.cursors.primary_mut().anchor = None;
+            }
+            if let Some(state) = self.buffers.get_mut(&active_buffer) {
+                if let Some(pos) = state.buffer.offset_to_position(position) {
+                    state.primary_cursor_line_number = LineNumber::Absolute(pos.line);
+                }
+            }
+        }
+        self.ensure_active_cursor_visible_for_navigation(opts.recenter_on_scroll);
+    }
+
+    /// Guarantee the active cursor is visible in the active viewport.
+    ///
+    /// Call this immediately after any cursor mutation that represents a
+    /// programmatic jump (search match, goto-definition, jump-to-line,
+    /// next-error, plugin scroll-to-position). It:
+    ///
+    /// 1. Clears `skip_ensure_visible` so a stale prior scroll does not
+    ///    suppress this one.
+    /// 2. Calls the lower-level `ensure_cursor_visible`.
+    /// 3. **Verifies** the cursor's line is now within the viewport's line
+    ///    range. If it isn't (the lower-level routine short-circuited, or
+    ///    `view_lines`-aware logic disagreed with byte-line math), forces a
+    ///    hard recenter so the cursor lands roughly mid-viewport.
+    /// 4. If the visible range moved at all and `recenter_on_scroll` is
+    ///    set, recenters for context.
+    ///
+    /// Step 3 is the safety net that makes "cursor moves but viewport
+    /// stalls" (#1689) impossible to reproduce regardless of what the
+    /// lower-level scroll machinery decides to do.
+    pub fn ensure_active_cursor_visible_for_navigation(&mut self, recenter_on_scroll: bool) {
+        let active_split = self.split_manager.active_split();
+        let active_buffer = self.active_buffer();
+
+        let Some(view_state) = self.split_view_states.get_mut(&active_split) else {
+            return;
+        };
+        let Some(state) = self.buffers.get_mut(&active_buffer) else {
+            return;
+        };
+
+        // 1. Clear stale skip flag — a prior recenter (or scroll action) may
+        // have set it, but this navigation step is *new user intent* and must
+        // not be silently suppressed.
+        view_state.viewport.clear_skip_ensure_visible();
+
+        let cursor_pos = view_state.cursors.primary().position;
+        let top_byte_before = view_state.viewport.top_byte;
+
+        // 2. Best-effort scroll via the existing line-aware routine.
+        view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
+
+        let scrolled = view_state.viewport.top_byte != top_byte_before;
+
+        // 3. Post-condition check — derive line numbers (cheap, exact for
+        // non-large files; estimated for large files) and confirm the cursor
+        // line lies within the viewport's line range. If it doesn't, the
+        // lower-level routine bailed out for one of its skip-paths and we
+        // must force a recenter.
+        let cursor_visible = is_cursor_line_visible(view_state, &state.buffer, cursor_pos);
+
+        let needs_recenter = !cursor_visible || (scrolled && recenter_on_scroll);
+        if needs_recenter {
+            let viewport_height = view_state.viewport.visible_line_count();
+            let target_rows_from_top = viewport_height / 2;
+            let mut iter = state.buffer.line_iterator(cursor_pos, 80);
+            for _ in 0..target_rows_from_top {
+                if iter.prev().is_none() {
+                    break;
+                }
+            }
+            view_state.viewport.top_byte = iter.current_position();
+            view_state.viewport.top_view_line_offset = 0;
+            // The next render-time `ensure_visible_in_layout` would otherwise
+            // immediately undo this recenter to satisfy its own scroll-margin
+            // invariants. Tell it to keep the position we just chose.
+            view_state.viewport.set_skip_ensure_visible();
+        }
+    }
+}
+
+/// Approximate visibility check using line numbers. False negatives only —
+/// if we say "not visible" when it actually is, the helper recenters
+/// unnecessarily but still leaves the cursor on screen, which is
+/// observably indistinguishable from the no-op case.
+fn is_cursor_line_visible(
+    view_state: &crate::view::split::BufferViewState,
+    buffer: &crate::model::buffer::Buffer,
+    cursor_pos: usize,
+) -> bool {
+    let viewport = &view_state.viewport;
+    let top_line = buffer.get_line_number(viewport.top_byte);
+    let cursor_line = buffer.get_line_number(cursor_pos);
+    let viewport_height = viewport.visible_line_count();
+    cursor_line >= top_line && cursor_line < top_line.saturating_add(viewport_height)
+}

--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -173,3 +173,45 @@ fn is_cursor_line_visible(
     let viewport_height = viewport.visible_line_count();
     cursor_line >= top_line && cursor_line < top_line.saturating_add(viewport_height)
 }
+
+/// Reconcile a freshly-restored `(buf_state.viewport, buf_state.cursors)` pair
+/// so the cursor is guaranteed visible.
+///
+/// Session/workspace restore re-applies the previously-saved viewport
+/// `top_byte` (and `top_view_line_offset` in wrap mode) and the previously-
+/// saved cursor position independently. If those two were *already* out of
+/// sync at save time — for example because the cursor moved off-screen via a
+/// prior bug or via plugin scroll-to-position — the restore re-creates an
+/// off-screen cursor that arrow keys can't escape (the wrap-mode early
+/// return in `viewport.rs::ensure_visible` kicks in for any cursor whose
+/// byte position is `>= viewport.top_byte`, which is true for *all* cursors
+/// below the viewport top — so naive Up/Down can never bring the viewport
+/// back to the cursor).
+///
+/// Call this on each restored buffer's state right after writing the
+/// scroll/cursor fields. If the cursor's line is already visible inside the
+/// restored viewport this is a no-op — we keep the user's saved scroll
+/// position for free. If not, recenter so the cursor lands mid-viewport
+/// (#1689 follow-up).
+pub(crate) fn reconcile_restored_buffer_view(
+    buf_state: &mut crate::view::split::BufferViewState,
+    buffer: &mut crate::model::buffer::Buffer,
+) {
+    let cursor_pos = buf_state.cursors.primary().position;
+    if is_cursor_line_visible(buf_state, buffer, cursor_pos) {
+        return;
+    }
+    let viewport_height = buf_state.viewport.visible_line_count();
+    let target_rows_from_top = viewport_height / 2;
+    let mut iter = buffer.line_iterator(cursor_pos, 80);
+    for _ in 0..target_rows_from_top {
+        if iter.prev().is_none() {
+            break;
+        }
+    }
+    buf_state.viewport.top_byte = iter.current_position();
+    buf_state.viewport.top_view_line_offset = 0;
+    // Restore code already calls set_skip_resize_sync; we don't need to also
+    // pin against ensure_visible because the next render will see the cursor
+    // is already inside the viewport range we just chose.
+}

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -989,18 +989,13 @@ impl Editor {
         // state.primary_cursor_line_number which was set before the jump.
         state.primary_cursor_line_number = crate::model::buffer::LineNumber::Absolute(target_line);
 
-        // Update cursors (now in SplitViewState)
-        let cursors = self.active_cursors_mut();
-        cursors.primary_mut().position = clamped_position;
-        cursors.primary_mut().anchor = None;
-
-        // Ensure the position is visible in the active split's viewport
-        let active_split = self.split_manager.active_split();
-        let active_buffer = self.active_buffer();
-        if let Some(view_state) = self.split_view_states.get_mut(&active_split) {
-            let state = self.buffers.get_mut(&active_buffer).unwrap();
-            view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
-        }
+        // Funnel through the navigation primitive so the cursor is guaranteed
+        // visible in the viewport (#1689 — without this, jump_to_line_column
+        // could land off-screen if a prior scroll set skip_ensure_visible).
+        self.jump_active_cursor_to(
+            clamped_position,
+            super::navigation::JumpOptions::navigation(),
+        );
     }
 
     /// Handle OpenFileAtLocation command

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -165,38 +165,14 @@ impl Editor {
     /// update the cached line number (used by the status bar), and scroll
     /// the active split so the cursor is visible.
     ///
-    /// If the match was off-screen and required a scroll, the viewport is
+    /// Delegates to [`Editor::jump_active_cursor_to`] so the viewport
+    /// invariant (cursor must end up visible) is enforced uniformly with
+    /// every other navigation flow (LSP goto-def, jump-to-line, etc.). If
+    /// the match was off-screen and required a scroll, the viewport is
     /// vertically centered on the match to provide surrounding context
-    /// (issue #1251). Matches already visible are not re-scrolled.
+    /// (issue #1251); matches already visible are not re-scrolled.
     fn move_cursor_to_match(&mut self, position: usize) {
-        let active_split = self.split_manager.active_split();
-        let active_buffer = self.active_buffer();
-        if let Some(view_state) = self.split_view_states.get_mut(&active_split) {
-            view_state.cursors.primary_mut().position = position;
-            view_state.cursors.primary_mut().anchor = None;
-            let state = self.buffers.get_mut(&active_buffer).unwrap();
-            if let Some(pos) = state.buffer.offset_to_position(position) {
-                state.primary_cursor_line_number =
-                    crate::model::buffer::LineNumber::Absolute(pos.line);
-            }
-            let top_byte_before = view_state.viewport.top_byte;
-            view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
-            if view_state.viewport.top_byte != top_byte_before {
-                // We had to scroll: recenter the match vertically so the user
-                // sees context above and below the match.
-                let viewport_height = view_state.viewport.visible_line_count();
-                let target_rows_from_top = viewport_height / 2;
-                let mut iter = state.buffer.line_iterator(position, 80);
-                for _ in 0..target_rows_from_top {
-                    if iter.prev().is_none() {
-                        break;
-                    }
-                }
-                view_state.viewport.top_byte = iter.current_position();
-                view_state.viewport.top_view_line_offset = 0;
-                view_state.viewport.set_skip_ensure_visible();
-            }
-        }
+        self.jump_active_cursor_to(position, super::navigation::JumpOptions::navigation());
     }
 
     pub(super) fn perform_search(&mut self, query: &str) {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1602,6 +1602,17 @@ impl Editor {
             buf_state.viewport.left_column = file_state.scroll.left_column;
             buf_state.viewport.set_skip_resize_sync();
 
+            // Saved cursor and saved viewport are independent fields; if they
+            // were already out of sync at save time (cursor moved off-screen
+            // before the user closed) the restore re-creates an off-screen
+            // cursor that arrow keys can't escape (the wrap-mode early return
+            // in `viewport.rs::ensure_visible` no-ops for any cursor whose
+            // byte position is `>= viewport.top_byte`). Reconcile so the
+            // restored view always shows the cursor (#1689 follow-up).
+            if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                super::navigation::reconcile_restored_buffer_view(buf_state, &mut state.buffer);
+            }
+
             // Restore per-buffer view mode and compose width
             buf_state.view_mode = match file_state.view_mode {
                 SerializedViewMode::Source => ViewMode::Source,

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -1331,8 +1331,26 @@ impl Viewport {
         // If the cursor is *above* `top_byte`, the byte-oriented math is
         // still correct (scroll up to bring the earlier line into view),
         // so we only skip when the cursor is below the current top.
+        //
+        // BUT: only defer when the cursor is plausibly inside (or just past)
+        // the visible area. If the cursor is far below `top_byte` — say more
+        // than two viewport heights of source lines away — the byte-math
+        // undercount cannot account for the disagreement, and
+        // `ensure_visible_in_layout` won't help either because its
+        // `view_lines` slice only covers the rendered window. Falling
+        // through here lets us perform a real scroll so cursor jumps
+        // (programmatic scroll, plugin cursor-set, restored-state with stale
+        // cursor) end up on screen instead of stranding the cursor far below
+        // a frozen viewport (#1689 follow-up).
         if self.top_view_line_offset > 0 && cursor.position >= self.top_byte {
-            return;
+            let top_line = buffer.get_line_number(self.top_byte);
+            let cursor_line = buffer.get_line_number(cursor.position);
+            let viewport_height = self.visible_line_count().max(1);
+            if cursor_line < top_line.saturating_add(viewport_height.saturating_mul(2)) {
+                return;
+            }
+            // Cursor is far below — fall through and let the byte-oriented
+            // scroll path bring the viewport down.
         }
 
         // Check if we should skip sync due to session restore

--- a/crates/fresh-editor/src/view/viewport.rs
+++ b/crates/fresh-editor/src/view/viewport.rs
@@ -2225,4 +2225,132 @@ mod tests {
             vp.left_column
         );
     }
+
+    /// Regression for #1689 follow-up: in wrap mode with
+    /// `top_view_line_offset > 0`, the early-return at the top of
+    /// `ensure_visible` used to fire for *any* cursor below `top_byte`,
+    /// stranding cursors that were many lines below the viewport. Verify
+    /// the early-return now defers to a real scroll when the cursor is
+    /// far below (more than 2x viewport height in source lines).
+    #[test]
+    fn test_ensure_visible_far_below_top_with_wrap_offset_does_scroll() {
+        // 200 lines so we have plenty of room for "far below".
+        let mut content = String::new();
+        for i in 0..200 {
+            content.push_str(&format!("line_{i}\n"));
+        }
+        let mut buffer = Buffer::from_str_test(&content);
+
+        let mut vp = Viewport::new(80, 10); // 10 visible lines
+        vp.line_wrap_enabled = true;
+
+        // Park top_byte at line 5 and inject a non-zero wrap offset to
+        // trigger the wrap-mode early-return. (Real users hit this state
+        // via the wrap-aware scroll-up path, but we set it manually here.)
+        let mut iter = buffer.line_iterator(0, 80);
+        let mut line_5_byte = 0;
+        for i in 0..5 {
+            if let Some((line_start, _)) = iter.next_line() {
+                if i == 4 {
+                    line_5_byte = line_start;
+                    break;
+                }
+            }
+        }
+        vp.top_byte = line_5_byte;
+        vp.top_view_line_offset = 2; // > 0 → triggers the early-return path
+
+        let top_before = vp.top_byte;
+
+        // Move cursor to line 100 — way below `top_byte` (10*2=20 viewport
+        // heights of 1 source line each, so cursor at line 100 is well
+        // beyond `top_line + 2*viewport_height`).
+        let mut iter = buffer.line_iterator(0, 80);
+        let mut line_100_byte = 0;
+        for i in 0..100 {
+            if let Some((line_start, _)) = iter.next_line() {
+                if i == 99 {
+                    line_100_byte = line_start;
+                    break;
+                }
+            }
+        }
+        let cursor = Cursor::new(line_100_byte);
+
+        vp.ensure_visible(&mut buffer, &cursor, &[]);
+
+        assert_ne!(
+            vp.top_byte, top_before,
+            "ensure_visible must scroll when the cursor is far below the viewport \
+             top, even in wrap mode with `top_view_line_offset > 0`. Pre-fix this \
+             early-returned at the top of `ensure_visible` and the viewport stalled."
+        );
+
+        // Cursor should now be inside the viewport's source-line range.
+        let new_top_line = buffer.get_line_number(vp.top_byte);
+        let cursor_line = buffer.get_line_number(line_100_byte);
+        let viewport_height = vp.visible_line_count();
+        assert!(
+            cursor_line >= new_top_line && cursor_line < new_top_line + viewport_height,
+            "After scrolling, cursor line {cursor_line} should be inside viewport \
+             line range [{new_top_line}, {})",
+            new_top_line + viewport_height
+        );
+    }
+
+    /// Companion case: in the SAME wrap-mode + `top_view_line_offset > 0`
+    /// state, a cursor that's only slightly below the viewport top must
+    /// still trigger the early-return so we don't undo the wrap-aware
+    /// scroll machinery that was added for #1574. The fix's heuristic is
+    /// "skip when cursor is within 2x viewport-height of top".
+    #[test]
+    fn test_ensure_visible_close_below_top_with_wrap_offset_still_skips() {
+        let mut content = String::new();
+        for i in 0..50 {
+            content.push_str(&format!("line_{i}\n"));
+        }
+        let mut buffer = Buffer::from_str_test(&content);
+
+        let mut vp = Viewport::new(80, 10);
+        vp.line_wrap_enabled = true;
+
+        let mut iter = buffer.line_iterator(0, 80);
+        let mut line_5_byte = 0;
+        for i in 0..5 {
+            if let Some((line_start, _)) = iter.next_line() {
+                if i == 4 {
+                    line_5_byte = line_start;
+                    break;
+                }
+            }
+        }
+        vp.top_byte = line_5_byte;
+        vp.top_view_line_offset = 2;
+
+        let top_before = vp.top_byte;
+
+        // Cursor at line 8 — only 3 lines below top, well within 2x
+        // viewport height (=20). Should hit the early-return: viewport
+        // unchanged, deferred to render-time `ensure_visible_in_layout`.
+        let mut iter = buffer.line_iterator(0, 80);
+        let mut line_8_byte = 0;
+        for i in 0..8 {
+            if let Some((line_start, _)) = iter.next_line() {
+                if i == 7 {
+                    line_8_byte = line_start;
+                    break;
+                }
+            }
+        }
+        let cursor = Cursor::new(line_8_byte);
+
+        vp.ensure_visible(&mut buffer, &cursor, &[]);
+
+        assert_eq!(
+            vp.top_byte, top_before,
+            "Cursor close below top in wrap mode must still defer to \
+             ensure_visible_in_layout (the #1574 invariant). Got top_byte={}, expected {}",
+            vp.top_byte, top_before
+        );
+    }
 }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -141,6 +141,7 @@ pub mod search;
 pub mod search_center_on_scroll;
 pub mod search_navigation_after_move;
 pub mod search_replace;
+pub mod search_viewport_stall_after_wrap;
 pub mod select_to_paragraph;
 pub mod selection;
 pub mod server_session_lifecycle;

--- a/crates/fresh-editor/tests/e2e/search_viewport_stall_after_wrap.rs
+++ b/crates/fresh-editor/tests/e2e/search_viewport_stall_after_wrap.rs
@@ -1,0 +1,125 @@
+//! E2E test for the viewport-stall-after-wrap bug in Find Next.
+//!
+//! Reproduces <https://github.com/sinelaw/fresh/issues/1689>:
+//! When cycling through matches with F3, the viewport scrolls correctly on
+//! the first pass but stalls after the first wrap-around. The cursor keeps
+//! moving to subsequent matches (status bar updates), but the viewport no
+//! longer scrolls to follow it, so matches in other parts of the file end
+//! up completely off-screen.
+//!
+//! Shape of the bug-inducing input: several match clusters, each cluster
+//! small enough to fit in one viewport but clusters separated by enough
+//! lines that no two clusters are ever visible together. This mirrors the
+//! real-world repro in `plugins/lib/fresh.d.ts` searching for `getPluginApi`
+//! (7 matches in 3 clusters at lines 75/90/93, 957/972, 1920/1926).
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::path::Path;
+
+/// Build a buffer with 7 "NEEDLE" matches in 3 clusters: lines 5/6/7, 55/56,
+/// 105/106. Clusters are >40 lines apart so they can never share a 24-row
+/// viewport.
+const MATCH_LINES: &[usize] = &[5, 6, 7, 55, 56, 105, 106];
+
+fn write_clustered_needle_file(path: &Path) {
+    let mut content = String::new();
+    for i in 0..200 {
+        if MATCH_LINES.contains(&i) {
+            content.push_str(&format!("line {i} NEEDLE here\n"));
+        } else {
+            content.push_str(&format!("line {i} filler text\n"));
+        }
+    }
+    std::fs::write(path, &content).unwrap();
+}
+
+/// Drive the search prompt, returning a harness parked on the first match.
+fn harness_searched_for_needle() -> (EditorTestHarness, tempfile::TempDir) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    write_clustered_needle_file(&file_path);
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("NEEDLE").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    (harness, temp_dir)
+}
+
+#[test]
+fn test_find_next_viewport_does_not_stall_after_wrap() {
+    let (mut harness, _temp_dir) = harness_searched_for_needle();
+
+    // Find Next order: initial lands on match 1 (line 5).
+    // Each F3 press then advances through match 2, 3, 4, 5, 6, 7, wrap to 1,
+    // 2, 3, 4 … keeping one-to-one with MATCH_LINES cycled.
+    //
+    // After 10 F3 presses we should be on match 4 again (line 55) — this is
+    // in cluster B, far from cluster A. That means *on this press* the
+    // viewport must have scrolled; the cursor sits at line 55 which is
+    // outside any viewport that was showing cluster A.
+    //
+    // The bug stalls the viewport around cluster A after the first wrap
+    // (press #7). Thereafter every F3 moves the cursor but not the
+    // viewport — so `line 55` is never rendered.
+    let presses = 10usize;
+    for _ in 0..presses {
+        harness.send_key(KeyCode::F(3), KeyModifiers::NONE).unwrap();
+        harness.process_async_and_render().unwrap();
+    }
+
+    // Sequence after `presses` F3s starting from match 1:
+    //   idx = presses % 7  (0-indexed match index)
+    // 10 % 7 = 3, which is MATCH_LINES[3] = 55.
+    let expected_match_line = MATCH_LINES[presses % MATCH_LINES.len()];
+    assert_eq!(
+        expected_match_line, 55,
+        "sanity: after 10 F3 presses the cursor should be on the line-55 match"
+    );
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&format!("line {expected_match_line} NEEDLE here")),
+        "After {presses} F3 presses the current match (line {expected_match_line}) \
+         must be visible on screen, but the viewport stalled on an earlier cluster. \
+         Rendered screen:\n{screen}"
+    );
+}
+
+/// Same viewport-stall manifests via Alt+N (`find_selection_next`) once a
+/// search is active — Alt+N delegates to `find_next` when the cursor is on
+/// a match, so any fix to `move_cursor_to_match` must keep this path healthy
+/// too.
+#[test]
+fn test_find_selection_next_viewport_does_not_stall_after_wrap() {
+    let (mut harness, _temp_dir) = harness_searched_for_needle();
+
+    let presses = 10usize;
+    for _ in 0..presses {
+        harness
+            .send_key(KeyCode::Char('n'), KeyModifiers::ALT)
+            .unwrap();
+        harness.process_async_and_render().unwrap();
+    }
+
+    let expected_match_line = MATCH_LINES[presses % MATCH_LINES.len()];
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&format!("line {expected_match_line} NEEDLE here")),
+        "After {presses} Alt+N presses the current match (line {expected_match_line}) \
+         must be visible on screen, but the viewport stalled on an earlier cluster. \
+         Rendered screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug where the viewport would stall and fail to scroll after the first wrap-around in search operations (Find Next, Find Selection Next), even though the cursor continued to move to subsequent matches. This resulted in matches becoming off-screen while the status bar updated normally.

## Root Cause

The lower-level `ensure_cursor_visible` routine has several short-circuit paths (stale `skip_ensure_visible` flag, wrapped buffer logic, etc.) that could leave a freshly-set cursor stranded outside the viewport. Individual navigation flows (search, LSP, diagnostics, etc.) were calling this routine directly without verifying the post-condition that the cursor actually ended up visible.

## Key Changes

- **New navigation module** (`crates/fresh-editor/src/app/navigation.rs`):
  - Introduces `JumpOptions` struct to control anchor clearing and recenter behavior
  - Implements `Editor::jump_active_cursor_to()` — the canonical cursor-jump entry point that mutates the cursor and guarantees visibility
  - Implements `Editor::ensure_active_cursor_visible_for_navigation()` — a post-condition safety net that:
    1. Clears stale `skip_ensure_visible` flags
    2. Calls the lower-level `ensure_cursor_visible`
    3. **Verifies** the cursor line is within the viewport's line range
    4. Forces a hard recenter if the cursor is still off-screen or if scrolling occurred with `recenter_on_scroll` enabled
  - Includes `is_cursor_line_visible()` helper for approximate visibility checks

- **Updated search operations** (`search_ops.rs`):
  - `move_cursor_to_match()` now delegates to `jump_active_cursor_to()` instead of manually managing cursor updates and scroll logic
  - Simplifies the implementation while guaranteeing the viewport invariant

- **Updated plugin commands** (`plugin_commands.rs`):
  - `jump_to_line_column()` now uses `jump_active_cursor_to()` to ensure the jumped-to position is visible

- **Updated navigation flows**:
  - `diagnostic_jumps.rs`: Added `ensure_active_cursor_visible_for_navigation()` call after diagnostic jumps
  - `bookmark_actions.rs`: Added visibility guarantee after bookmark navigation
  - `lsp_requests.rs`: Added visibility guarantee after go-to-definition
  - `buffer_close.rs`: Added visibility guarantee when restoring position history (Ctrl+- / Ctrl+=)

- **Comprehensive E2E test** (`tests/e2e/search_viewport_stall_after_wrap.rs`):
  - Reproduces the original bug with a file containing 7 matches in 3 clusters separated by >40 lines
  - Verifies that after 10 Find Next presses (including wrap-around), the current match remains visible on screen
  - Tests both F3 (Find Next) and Alt+N (Find Selection Next) paths

## Implementation Details

The safety net in `ensure_active_cursor_visible_for_navigation()` uses line-number-based visibility checks (cheap and exact for non-large files, estimated for large files) rather than byte-offset comparisons, since the lower-level scroll machinery may disagree with byte-line math. False negatives (saying "not visible" when it actually is) only trigger unnecessary recenters, which is observably indistinguishable from the no-op case.

Edits (typing, paste, indent, etc.) continue using the existing `ensure_cursor_visible` path to preserve the "don't undo a deliberate scroll" behavior of the skip flag.

https://claude.ai/code/session_01QRK5uPai7JsJ5Z4cqLNbWA