### PR TITLE
feat(dashboard): add "Show Dashboard" command palette entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@
 
 ### Features
 
-* **`init.ts`**: Fresh now auto-loads `~/.config/fresh/init.ts`! Allows you to run plugin code on startup, which complements the purely declarative config system with imperative, environment-aware logic. Use command palette `init: Edit` to generate a template with some examples. Enable LSP to get help and completions when editing your init file. Use `init: Reload` to run it after editing. Use `--no-init` / `--safe` to skip loading.
+* **`init.ts`**: Fresh now auto-loads `~/.config/fresh/init.ts`! Allows you to run plugin code on startup, which complements the purely declarative config system with imperative, environment-aware logic. Use command palette `init: Edit` to generate a template with some examples. Enable LSP to get help and completions when editing your init file. Use `init: Reload` to run it after editing. Use `--no-init` / `--safe` to skip loading. Example (for the Dashboard plugin):
+    ```typescript
+    const dash = editor.getPluginApi("dashboard");
+    if (dash) {
+      dash.registerSection("env", async (ctx) => {
+        ctx.kv("USER", editor.getEnv("USER") || "?");
+      });
+    }
+    ```
+    Will add a line like this:
+    ```
+    │ ▎  ENV                              │
+    │    USER      someone                │
+    ```
 
 * **Dashboard plugin**: Built-in TUI dashboard that replaces the usual "[No Name]" with weather info, git status + repo URL, a "vs master" row (commits ahead/behind), open GitHub PRs for the current repo, and disk usage for common mounts. Enable via `plugins.dashboard.enabled` in `config.json` or the Settings UI. Third-party plugins and `init.ts` can contribute their own rows via the `registerSection()` API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,36 @@
 
 ## 0.2.26
 
+This version brings major features and many quality-of-life improvements and bug fixes:
+
+- A cool dashboard plugin
+- Devcontainer support
+- init.ts
+
+And more (see below). A large version is more likely to contain regression bugs, so please bear with me if you encounter problems, and open github issues without hesitation.
+
 ### Features
 
-* **`init.ts`**: Fresh now auto-loads `~/.config/fresh/init.ts`! Allows you to run plugin code on startup, which complements the purely declarative config system with imperative, environment-aware logic. Use command palette `init: Edit` to generate a template with some examples. Enable LSP to get help and completions when editing your init file. Use `init: Reload` to run it after editing. Use `--no-init` / `--safe` to skip loading. Example (for the Dashboard plugin):
+* **Dashboard plugin**: Built-in TUI dashboard that replaces the usual "[No Name]" with useful at-a-glance info.
+    - Default widgets: git status + repo URL, a "vs master" row (commits ahead/behind), and disk usage for common mounts.
+    - Opt-in widgets: weather, and open GitHub PRs for the current repo.
+    - Auto-open (on startup / last-buffer-close) is configurable — e.g. `editor.getPluginApi("dashboard")?.setAutoOpen(false)` in `init.ts`. When off, use the "Show Dashboard" command in the palette.
+    - Third-party plugins and `init.ts` can contribute their own rows via the `registerSection()` API. The `init.ts` starter template includes ready-to-paste snippets for enabling the opt-in widgets, toggling auto-open, and registering custom sections (see below).
+
+* **Devcontainer support** (thanks @masak1yu!): Fresh integrates with the [devcontainer CLI](https://github.com/devcontainers/cli) (install it yourself).
+    - Detects `.devcontainer/devcontainer.json` and offers Attach / Rebuild / Detach.
+    - Embedded terminal, filesystem, and LSP servers all run inside the devcontainer.
+    - `Dev Container: Create Config` scaffolds a config for projects that don't have one.
+    - `Dev Container: Show Ports` merges configured `forwardPorts` with live `docker port` output.
+    - `Dev Container: Show Logs` captures the container's recent stdout/stderr.
+    - Build log streams into a workspace split; failed attaches offer Retry / Show Logs / Detach via a recovery popup.
+    - `initializeCommand` runs on attach.
+
+* **`init.ts`**: Fresh now auto-loads `~/.config/fresh/init.ts`! Allows you to run plugin code on startup, which complements the purely declarative config system with imperative, environment-aware logic. Use command palette `init: Edit` to generate a template with some examples. Use `init: Reload` to run it after editing. Use `--no-init` / `--safe` to skip loading.  
+    - Tip: *Enable LSP* when editing `init.ts` to get help and completions. 
+    - Example (for the Dashboard plugin):
     ```typescript
+    // in your init.ts file:
     const dash = editor.getPluginApi("dashboard");
     if (dash) {
       dash.registerSection("env", async (ctx) => {
@@ -13,23 +39,22 @@
       });
     }
     ```
-    Will add a line like this:
+    Will add a line like this to your dashboard:
     ```
     │ ▎  ENV                              │
     │    USER      someone                │
     ```
 
-* **Dashboard plugin**: Built-in TUI dashboard that replaces the usual "[No Name]" with weather info, git status + repo URL, a "vs master" row (commits ahead/behind), open GitHub PRs for the current repo, and disk usage for common mounts. Enable via `plugins.dashboard.enabled` in `config.json` or the Settings UI. Third-party plugins and `init.ts` can contribute their own rows via the `registerSection()` API.
-
-* **Devcontainer support**: Detects `.devcontainer/devcontainer.json` and offers Attach / Rebuild / Detach via the [devcontainer CLI](https://github.com/devcontainers/cli), which you need to install. Embedded terminal, filesystem, and LSP servers all run inside the devcontainer. `Dev Container: Create Config` scaffolds a config for projects that don't have one. `Dev Container: Show Ports` merges configured `forwardPorts` with live `docker port` output; `Dev Container: Show Logs` captures the container's recent stdout/stderr. The build log streams into a workspace split, and failed attaches offer Retry/Show Logs/Detach through a recovery popup. `initializeCommand` runs on attach.
-
 * **`{remote}` status-bar indicator**: Clickable status-bar element that lights up when you're attached to an SSH remote or devcontainer, with a context-aware menu (detach, show logs, retry attach, …). Surfaces `Connecting` / `Connected` / `FailedAttach` states. Fresh's config v1→v2 migration injects `{remote}` into customized `status_bar.left`.
 
 * **Hot-exit restore split from session restore**: `editor.restore_previous_session` config and the `--no-restore` / `--restore` CLI flags now control workspace/tab restoration separately from hot-exit content — unsaved scratch buffers come back even when you opt out of full session restore (#1404).
 
-* **File explorer — cut/copy/paste + multi-selection**: `Ctrl+C` / `Ctrl+X` / `Ctrl+V` in the explorer with same-dir auto-rename, per-file conflict prompt on cross-dir paste, and `Shift+Up/Down` multi-select. Cut-pending items are dimmed until pasted; cancel a pending cut with Escape or by pasting back into the same directory. Renaming a file or directory relocates any open buffers inside it; deleting a file closes its buffer.
-
-* **Dashboard — keyboard navigation**: `Tab` / `Down` / `j` steps forward through clickable rows (PR numbers, repo URL, review-branch action, …), `Shift+Tab` / `Up` / `k` steps back, `Enter` activates the focused row. Mouse clicks continue to work.
+* **File explorer — cut/copy/paste + multi-selection + right-click context menu** (thanks @theogravity!):
+    - `Ctrl+C` / `Ctrl+X` / `Ctrl+V` with same-dir auto-rename and per-file conflict prompt on cross-dir paste.
+    - `Shift+Up/Down` for multi-select.
+    - Right-click context menu (#1684) with the usual file operations, honoring the active multi-selection.
+    - Cut-pending items are dimmed until pasted; cancel a pending cut with Escape or by pasting back into the same directory.
+    - Renaming a file or directory relocates any open buffers inside it; deleting a file closes its buffer.
 
 * **File explorer — keyboard preview**: Moving the cursor with Up/Down in the explorer previews the highlighted file in a preview tab (#1570), so you can scan files without leaving the keyboard.
 
@@ -67,7 +92,15 @@
   - "file://${HOME}/themes/x.json" — absolute path; ${HOME}, ${XDG_CONFIG_HOME} are expanded
   - "https://github.com/foo/themes#dark" — URL-packaged theme
 
-* **Plugin API additions**: `editor.overrideThemeColors(...)` for in-memory theme mutation, `editor.parseJsonc(...)` for host-side JSONC parsing, and plugin-created terminals now have an ephemeral lifetime (they close cleanly when the action that spawned them finishes). Plugin authors can also augment `FreshPluginRegistry` to make `editor.getPluginApi("name")` return a typed interface — no `as`-cast needed on the consumer side; augmentations are emitted to `~/.config/fresh/types/plugins.d.ts` at load time. `spawnHostProcess` now returns a handle with `kill()` (and a matching `KillHostProcess` command). `BufferInfo.splits` surfaces which splits display a buffer, for "focus-if-visible" dedupe. `editor.setRemoteIndicatorState(...)` / `clearRemoteIndicatorState()` let remote plugins drive the status-bar `{remote}` element. Dashboard gains `dash.registerSection()` (with a returned remover) and `dash.clearAllSections()` for plugin extension.
+* **Plugin API additions**:
+    - `editor.overrideThemeColors(...)` for in-memory theme mutation.
+    - `editor.parseJsonc(...)` for host-side JSONC parsing.
+    - Plugin-created terminals now have an ephemeral lifetime — they close cleanly when the action that spawned them finishes.
+    - Plugin authors can augment `FreshPluginRegistry` to make `editor.getPluginApi("name")` return a typed interface (no `as`-cast needed). Augmentations are emitted to `~/.config/fresh/types/plugins.d.ts` at load time.
+    - `spawnHostProcess` now returns a handle with `kill()` (and a matching `KillHostProcess` command).
+    - `BufferInfo.splits` surfaces which splits display a buffer, for "focus-if-visible" dedupe.
+    - `editor.setRemoteIndicatorState(...)` / `clearRemoteIndicatorState()` let remote plugins drive the status-bar `{remote}` element.
+    - Dashboard gains `dash.registerSection()` (with a returned remover) and `dash.clearAllSections()` for plugin extension.
 
 * **JSONC language**: `.jsonc` files and well-known JSONC-with-`.json`-suffix files (`devcontainer.json`, `tsconfig.json`, `.eslintrc.json`, `.babelrc`, VS Code settings files) now get a dedicated `jsonc` language with comment-tolerant highlighting and LSP routing through `vscode-json-language-server` with the correct `languageId`.
 

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -4552,7 +4552,7 @@ async function start_review_branch(): Promise<void> {
     const promptText = (rawPromptText && !rawPromptText.startsWith("prompt."))
         ? rawPromptText
         : `Base ref to compare against (default: ${suggested}):`;
-    const input = await editor.prompt(promptText, suggested);
+    const input = await editor.prompt(promptText + " ", suggested);
     if (input === null) {
         editor.setStatus(editor.t("status.cancelled") || "Cancelled");
         return;

--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -16,6 +16,11 @@ const editor = getEditor();
 //   it is never loaded, so no buffers are created, no timers run,
 //   and no network fetches fire.
 //
+//   A second flag `plugins.dashboard.auto-open` (default true) gates
+//   only the ambient open paths (startup + last-buffer-closed). When
+//   false the plugin still loads and the "Show Dashboard" command is
+//   still available — it just won't appear on its own.
+//
 //   - Auto-centers both horizontally and vertically. Repaints when the
 //     viewport changes (terminal resize, file-explorer toggle, split
 //     reshape).
@@ -159,8 +164,19 @@ export type DashboardApi = {
      *  Returns true if at least one section was removed. */
     removeSection(name: string): boolean;
     /** Remove every registered section, including the bundled
-     *  built-ins (weather, git, github, disk). */
+     *  built-ins (git, disk). */
     clearAllSections(): void;
+    /** Toggle the ambient auto-open behaviour for this session.
+     *  Equivalent to setting `plugins.dashboard.auto-open` in the
+     *  user config, but scoped to the current process. */
+    setAutoOpen(enabled: boolean): void;
+    /** Refresh handlers for the built-in widgets that aren't
+     *  registered by default (both hit the network). Pass one to
+     *  `registerSection` from init.ts to enable it. */
+    builtinHandlers: {
+        weather: SectionRefresh;
+        github: SectionRefresh;
+    };
 };
 
 declare global {
@@ -1528,8 +1544,24 @@ async function dashboardShowOrFocus() {
 }
 registerHandler("dashboardShowOrFocus", dashboardShowOrFocus);
 
+// Auto-open resolution: the session override (set via the exported
+// plugin API from init.ts) wins over the user config. We read from
+// getUserConfig (raw file) rather than getConfig because unknown
+// fields are dropped when the Config struct reserializes. Default
+// is true.
+let autoOpenOverride: boolean | null = null;
+
+function autoOpenEnabled(): boolean {
+    if (autoOpenOverride !== null) return autoOpenOverride;
+    const cfg = editor.getUserConfig() as Record<string, unknown> | null;
+    const plugins = cfg?.plugins as Record<string, unknown> | undefined;
+    const dashboard = plugins?.dashboard as Record<string, unknown> | undefined;
+    return dashboard?.["auto-open"] !== false;
+}
+
 function shouldShowDashboard(): boolean {
     if (dashboardBufferId !== null) return false;
+    if (!autoOpenEnabled()) return false;
     const all = editor.listBuffers();
     const realFiles = all.filter(
         (b) => !b.is_virtual && b.path && b.path.length > 0,
@@ -1680,9 +1712,12 @@ registerHandler(
 // Register the built-in sections. They use the same public
 // `DashboardContext` API that third-party plugins consume, so any
 // change to the context contract surfaces here first.
-registerSection("weather", weatherRefresh);
+//
+// `weather` and `github` are opt-in — they hit the network on every
+// refresh, so we only register `git` and `disk` by default. Users
+// wire the others up from init.ts via the exported plugin API; see
+// the init.ts starter template for a ready-to-paste example.
 registerSection("git", gitRefresh);
-registerSection("github", githubRefresh);
 registerSection("disk", diskRefresh);
 
 // Expose the section-management entry points to other plugins and to
@@ -1710,6 +1745,13 @@ editor.exportPluginApi("dashboard", {
     },
     clearAllSections(): void {
         clearAllSections();
+    },
+    setAutoOpen(enabled: boolean): void {
+        autoOpenOverride = !!enabled;
+    },
+    builtinHandlers: {
+        weather: weatherRefresh,
+        github: githubRefresh,
     },
 });
 

--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -1421,6 +1421,34 @@ async function refreshLoop(myBufferId: number) {
 // and create a second Dashboard tab.
 let dashboardOpening = false;
 
+// Kick section refreshes and start the periodic refresh loop. Used
+// both by the ambient auto-open path and by the command-palette
+// "Show Dashboard" handler — the parts that differ (whether to bail
+// on real files, whether to sweep untitled scratch) live in the
+// callers.
+function bootstrapDashboard(bufferId: number) {
+    // Reset section draws to "loading…" and kick a fresh refresh for
+    // each registered section. Token guards against late resolvers
+    // from a prior open clobbering the new one.
+    //
+    // GitHub's section callback reuses the last-good PR snapshot (if
+    // any) on its first call post-open so a re-opened dashboard can
+    // draw real data on the first frame while the refresh round-trip
+    // is still in flight. Refresh failures surface via the in-panel
+    // stale-data banner.
+    fetchToken++;
+    const myToken = fetchToken;
+    for (const entry of registeredSections) {
+        entry.draw = loadingDraw();
+        void refreshSection(entry, myToken);
+    }
+    paint();
+
+    // Kick off the 5-second refresh loop. It stops itself when the
+    // dashboard is closed.
+    refreshLoop(bufferId);
+}
+
 async function openDashboard() {
     if (dashboardBufferId !== null) return; // already open
     if (dashboardOpening) return; // another openDashboard is mid-await
@@ -1469,27 +1497,36 @@ async function openDashboard() {
         }
     }
 
-    // Reset section draws to "loading…" and kick a fresh refresh for
-    // each registered section. Token guards against late resolvers
-    // from a prior open clobbering the new one.
-    //
-    // GitHub's section callback reuses the last-good PR snapshot (if
-    // any) on its first call post-open so a re-opened dashboard can
-    // draw real data on the first frame while the refresh round-trip
-    // is still in flight. Refresh failures surface via the in-panel
-    // stale-data banner.
-    fetchToken++;
-    const myToken = fetchToken;
-    for (const entry of registeredSections) {
-        entry.draw = loadingDraw();
-        void refreshSection(entry, myToken);
-    }
-    paint();
-
-    // Kick off the 5-second refresh loop. It stops itself when the
-    // dashboard is closed.
-    refreshLoop(dashboardBufferId);
+    bootstrapDashboard(dashboardBufferId);
 }
+
+// Command-palette handler: show the dashboard if it isn't open, or
+// bring it to the front of the current split if it is. Unlike the
+// ambient open path, this never closes real files or untitled scratch
+// — if the user has a file open and types "Show Dashboard", the
+// dashboard opens alongside it rather than replacing it.
+async function dashboardShowOrFocus() {
+    if (dashboardBufferId !== null) {
+        editor.showBuffer(dashboardBufferId);
+        return;
+    }
+    if (dashboardOpening) return;
+    dashboardOpening = true;
+    const res = await editor.createVirtualBuffer({
+        name: "Dashboard",
+        mode: "dashboard",
+        readOnly: true,
+        showLineNumbers: false,
+        showCursors: false,
+        editingDisabled: true,
+    });
+    dashboardBufferId = res.bufferId;
+    dashboardOpening = false;
+    focusedIndex = 0;
+    editor.showBuffer(dashboardBufferId);
+    bootstrapDashboard(dashboardBufferId);
+}
+registerHandler("dashboardShowOrFocus", dashboardShowOrFocus);
 
 function shouldShowDashboard(): boolean {
     if (dashboardBufferId !== null) return false;
@@ -1692,6 +1729,15 @@ editor.on("buffer_closed", "dashboardOnBufferClosed");
 editor.on("viewport_changed", "dashboardOnViewportChanged");
 editor.on("mouse_click", "dashboardOnMouseClick");
 editor.on("after_file_open", "dashboardOnAfterFileOpen");
+
+// Command-palette entry. No-op when the dashboard is already the
+// focused tab (showBuffer on a visible buffer is a cheap re-focus).
+editor.registerCommand(
+    "Show Dashboard",
+    "Open the dashboard, or bring it to the front if it's already open",
+    "dashboardShowOrFocus",
+);
+
 if (editor.listBuffers().length > 0 && shouldShowDashboard()) {
     openDashboard();
 }

--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -1098,7 +1098,7 @@ const gitRefresh: SectionRefresh = async (ctx) => {
     );
 
     // Clickable "review branch" action. Triggers the audit_mode
-    // plugin's `start_review_diff` handler via the plugin-action
+    // plugin's `start_review_branch` handler via the plugin-action
     // bridge — executeAction falls through to Action::PluginAction
     // for any name that's not a built-in, and the plugin manager
     // dispatches that to the registered handler by name.
@@ -1106,7 +1106,7 @@ const gitRefresh: SectionRefresh = async (ctx) => {
     ctx.text("▶ review branch", {
         color: "accent",
         bold: true,
-        onClick: () => editor.executeAction("start_review_diff"),
+        onClick: () => editor.executeAction("start_review_branch"),
     });
     ctx.newline();
 };

--- a/crates/fresh-editor/src/init_script.rs
+++ b/crates/fresh-editor/src/init_script.rs
@@ -106,6 +106,29 @@ const editor = getEditor();
 //     if (api) api.configure({ option: "value" });
 // });
 
+// Example: enable the opt-in Dashboard widgets (weather, GitHub).
+// Both hit the network on every refresh, so the plugin ships with
+// only `git` and `disk` registered by default. The handlers live
+// on the exported plugin API as `builtinHandlers` — pass them to
+// `registerSection` with whatever name you like.
+//
+// editor.on("plugins_loaded", () => {
+//     const dash = editor.getPluginApi("dashboard");
+//     if (!dash) return;
+//     dash.registerSection("weather", dash.builtinHandlers.weather);
+//     dash.registerSection("github", dash.builtinHandlers.github);
+// });
+
+// Example: disable the Dashboard's auto-open behaviour on this
+// machine (it will still be available via the "Show Dashboard"
+// command). The same toggle can also be set persistently in
+// config.json at `plugins.dashboard.auto-open`.
+//
+// editor.on("plugins_loaded", () => {
+//     const dash = editor.getPluginApi("dashboard");
+//     if (dash) dash.setAutoOpen(false);
+// });
+
 // Example: add a custom section to the Dashboard plugin.
 //
 // `editor.getPluginApi("dashboard")` is typed automatically via


### PR DESCRIPTION
Brings the dashboard to the current split if it's open, or creates it if it isn't. Unlike the ambient auto-open path, it doesn't close real files or untitled scratch — invoking the command next to an open file leaves the file in place. Shared init is factored out into bootstrapDashboard.