### PR TITLE
Docs: clarify dashboard widgets, init.ts commands, and devcontainer features

### DIFF
--- a/docs/blog/fresh-0.3.0/index.md
+++ b/docs/blog/fresh-0.3.0/index.md
@@ -21,7 +21,7 @@ See the [Startup Script guide](/configuration/init) for the full picture.
 
 ## Dashboard
 
-A built-in TUI dashboard replaces the default `[No Name]` buffer with weather info, git status + repo URL, a "vs master" commits-ahead/behind row, open GitHub PRs for the current repo, and disk usage for common mounts. Enable it via `plugins.dashboard.enabled` in `config.json` or the Settings UI. Third-party plugins and your `init.ts` can contribute custom sections through the `registerSection()` API — see the [Dashboard feature page](/features/dashboard).
+A built-in TUI dashboard replaces the default `[No Name]` buffer with git status + repo URL, a "vs master" commits-ahead/behind row, and disk usage for common mounts. Optional weather and GitHub-PR widgets ship in the box and can be wired up from `init.ts` since they hit the network. Enable the plugin via `plugins.dashboard.enabled` in `config.json` or the Settings UI. Third-party plugins and your `init.ts` can contribute custom sections through the `registerSection()` API — see the [Dashboard feature page](/features/dashboard).
 
 <div class="showcase-demo">
   <img src="./dashboard/showcase.gif" alt="Dashboard demo" />

--- a/docs/configuration/init.md
+++ b/docs/configuration/init.md
@@ -72,10 +72,11 @@ if (editor.getEnv("FRESH_PROFILE") === "writing") {
 
 ## Editing and reloading
 
-- **`init: Edit`** from the command palette opens (or creates) `~/.config/fresh/init.ts` with a starter template. The same command also writes `types/fresh.d.ts` and a `tsconfig.json` so LSP gives you completions against the real plugin API.
-- **`init: Reload`** re-runs the file without restarting Fresh.
-- **`init: Check`** type-checks without running.
+- **`init: Edit init.ts`** from the command palette opens (or creates) `~/.config/fresh/init.ts` with a starter template. The same command also refreshes `types/fresh.d.ts`, writes `types/plugins.d.ts` (so `editor.getPluginApi("dashboard")` and friends are typed), and creates a `tsconfig.json` on first run.
+- **`init: Reload init.ts`** re-runs the file without restarting Fresh.
+- **`init: Check init.ts`** runs a syntax check (oxc parser) and reports parse errors. It does not run a full TypeScript type-check.
 - **`fresh --no-init`** (alias `--safe`) skips loading for a single launch — useful if the file errors out.
+- **Crash fuse:** if `init.ts` fails to evaluate three times in a row within five minutes, the next launch auto-skips it until you fix or remove the file. A successful evaluation clears the counter.
 
 The full API surface is the same as plugins — see the [Plugin API reference](/plugins/api/).
 

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -1,8 +1,10 @@
 # Dashboard
 
-> **Activation:** `plugins.dashboard.enabled` in `config.json`, or in the Settings UI under **Plugins → dashboard**. No palette command.
+> **Activation:** `plugins.dashboard.enabled` in `config.json`, or in the Settings UI under **Plugins → dashboard**.
+>
+> **Palette:** `Show Dashboard` (available once the plugin is enabled).
 
-Fresh includes a built-in TUI dashboard plugin that replaces the default `[No Name]` buffer you see after `fresh` with no arguments. It shows weather info, git status and repo URL, a "vs master" row (commits ahead/behind), recent GitHub PRs for the current repo, and disk usage for common mounts.
+Fresh includes a built-in TUI dashboard plugin that replaces the default `[No Name]` buffer you see after `fresh` with no arguments. By default it shows git status and repo URL, a "vs master" row (commits ahead/behind), and disk usage for common mounts. Weather and recent GitHub PRs are bundled but opt-in — see [Built-in opt-in widgets](#built-in-opt-in-widgets) below.
 
 ## Enabling
 
@@ -16,13 +18,28 @@ The dashboard is off by default. Turn it on from the Settings UI (**Open Setting
 }
 ```
 
+Once enabled, the dashboard auto-opens at startup and after the last buffer is closed. To keep the plugin loaded but skip those ambient open paths — leaving `Show Dashboard` as the only entry point — set `plugins.dashboard.auto-open` to `false`. The default is `true`.
+
 ## Tips
 
 - The dashboard only renders in buffers that have no file attached, so opening any file replaces it — you don't need to close it manually.
-- Weather and GitHub widgets need network access; if either is unreachable, the section is quietly hidden rather than blocking the rest of the dashboard.
 - `git` must be on `PATH` for the git and "vs master" rows to populate.
-- The GitHub section shows open PRs for the *current repo* (detected from the `origin` remote). Outside a GitHub clone, it renders a short explanatory message instead.
 - **Keyboard navigation** — `Tab` / `Down` / `j` step to the next clickable row, `Shift+Tab` / `Up` / `k` step back, `Enter` activates. Mouse clicks still work.
+
+## Built-in opt-in widgets
+
+`weather` and `github` ship with the plugin but aren't registered by default — both hit the network on every refresh, so opting in is explicit. Their refresh handlers live on the plugin API as `builtinHandlers`; pass either to `registerSection` from your [`init.ts`](../configuration/init.md):
+
+```ts
+editor.on("plugins_loaded", () => {
+  const dash = editor.getPluginApi("dashboard");
+  if (!dash) return;
+  dash.registerSection("weather", dash.builtinHandlers.weather);
+  dash.registerSection("github", dash.builtinHandlers.github);
+});
+```
+
+The GitHub section shows open PRs for the *current repo* (detected from the `origin` remote). Outside a GitHub clone, it renders a short explanatory message instead. If either widget can't reach its endpoint, the section surfaces a one-line error rather than blocking the rest of the dashboard.
 
 ## Adding Your Own Sections
 
@@ -44,7 +61,7 @@ editor.on("plugins_loaded", () => {
 });
 ```
 
-The `ctx` parameter exposes `kv`, `text`, `newline`, and `error` primitives. Colors are symbolic (`"muted"`, `"accent"`, `"ok"`, `"warn"`, `"err"`, `"value"`), so sections pick up theme changes automatically. `onClick` is routed through the editor's mouse-click dispatcher and works even in terminals that strip OSC-8 hyperlinks.
+The `ctx` parameter exposes `kv`, `text`, `newline`, and `error` primitives. Colors are symbolic (`"muted"`, `"accent"`, `"value"`, `"number"`, `"ok"`, `"warn"`, `"err"`, `"branch"`), so sections pick up theme changes automatically. `onClick` is routed through the editor's mouse-click dispatcher and works even in terminals that strip OSC-8 hyperlinks.
 
 `registerSection` returns a function you can call to remove that one section later; `dash.clearAllSections()` drops every section a plugin has registered. Call these when your plugin unloads so hot-reload doesn't leave stale rows.
 

--- a/docs/features/devcontainer.md
+++ b/docs/features/devcontainer.md
@@ -1,6 +1,6 @@
 # Devcontainers
 
-> **Palette:** `Dev Container: Attach`, `Dev Container: Detach`, `Dev Container: Rebuild`, `Dev Container: Create Config`, `Dev Container: Show Info`, `Dev Container: Show Ports`, `Dev Container: Show Logs`, `Dev Container: Show Features`, `Dev Container: Open Config`, `Dev Container: Run Lifecycle Command`. A proactive popup also appears on launch for projects with a `.devcontainer/devcontainer.json`.
+> **Palette:** `Dev Container: Attach`, `Dev Container: Detach`, `Dev Container: Rebuild`, `Dev Container: Cancel Startup`, `Dev Container: Create Config`, `Dev Container: Show Info`, `Dev Container: Show Ports`, `Dev Container: Show Forwarded Ports`, `Dev Container: Show Logs`, `Dev Container: Show Build Logs`, `Dev Container: Show Features`, `Dev Container: Open Config`, `Dev Container: Run Lifecycle Command`. A proactive popup also appears on launch for projects with a `.devcontainer/devcontainer.json`.
 
 Fresh detects projects that ship a `.devcontainer/devcontainer.json` and prompts to **Attach** or **Rebuild** the container. When attached, the embedded terminal runs *inside* the container, and filesystem and process operations target the container instead of your host — including LSP servers, which Fresh spawns through the container so you don't need a host toolchain.
 
@@ -20,7 +20,7 @@ If a project doesn't have a `.devcontainer/devcontainer.json` yet, run **Dev Con
 
 Open a project that contains `.devcontainer/devcontainer.json`. Run **Dev Container: Attach** from the command palette (`Ctrl+P`). The first attach runs the devcontainer `initializeCommand` (if any) on the host, then builds and starts the container; subsequent attaches reuse it. **Dev Container: Rebuild** forces a full rebuild — reach for it after changing the Dockerfile or `devcontainer.json`.
 
-During build or attach, the **build log** streams into a workspace split. If an attach fails, a recovery popup offers **Retry**, **Show Logs**, or **Detach**; subsequent launches don't re-prompt. The status-bar **{remote}** indicator tracks the lifecycle — `Connecting`, `Connected`, or `FailedAttach` — and clicking it opens a context-aware menu.
+During build or attach, the **build log** streams into a workspace split. If an attach fails, a recovery popup offers **Retry**, **Show Build Logs**, or **Reopen Locally** (Esc dismisses without changing authority). The launch-time attach prompt itself is one-shot per workspace: once you choose Attach or Dismiss, reopening the same project doesn't re-prompt. The status-bar **{remote}** indicator tracks the lifecycle — `Connecting`, `Connected`, or `FailedAttach` — and clicking it opens a context-aware menu.
 
 While attached:
 


### PR DESCRIPTION
This PR updates documentation across several feature pages and guides to reflect recent changes and clarify existing functionality.

**Key changes:**

- **Dashboard plugin:** Restructured documentation to clarify that weather and GitHub widgets are opt-in and require explicit registration via `init.ts`. Added a new "Built-in opt-in widgets" section with code examples showing how to register them. Updated the feature description to reflect that only git status, "vs master" row, and disk usage are enabled by default. Added documentation for the `plugins.dashboard.auto-open` config option and the `Show Dashboard` palette command.

- **Init.ts configuration:** Updated command palette command names to be more descriptive (`init: Edit init.ts`, `init: Reload init.ts`, `init: Check init.ts`). Clarified that `init: Check` performs syntax checking via oxc parser rather than full TypeScript type-checking. Added documentation for the "crash fuse" feature that auto-skips `init.ts` after three consecutive failures within five minutes. Noted that the `init: Edit` command now generates `types/plugins.d.ts` for proper typing of plugin APIs.

- **Devcontainer feature:** Updated palette command list to include new commands (`Dev Container: Cancel Startup`, `Dev Container: Show Forwarded Ports`, `Dev Container: Show Build Logs`). Clarified the attach failure recovery flow, noting that the recovery popup now offers "Show Build Logs" and "Reopen Locally" options, and that the launch-time attach prompt is one-shot per workspace.

- **Blog post (0.3.0):** Updated dashboard description to clarify the opt-in nature of weather and GitHub widgets and that they require `init.ts` configuration.

- **Color palette reference:** Expanded the list of symbolic color names available in dashboard sections to include `"number"` and `"branch"`.

These changes improve clarity around plugin configuration, initialization, and feature discovery without modifying any source code behavior.

https://claude.ai/code/session_019puRSPYLWiAQXbSCzYttR9