### PR TITLE
test(git_log): de-flake open-file-after-close via cursor-position anchors

### DIFF
--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -239,6 +239,13 @@ struct ActiveEffect {
 pub struct AnimationRunner {
     next_id: u64,
     active: Vec<ActiveEffect>,
+    /// Cumulative count of effects accepted by either `start` or
+    /// `start_with_id`. Monotonic; increments before the effect is
+    /// pushed so a sample taken any time after the call sees the
+    /// post-increment value. Tests sample this around the action under
+    /// test to detect that an effect was kicked off without having to
+    /// catch the transient `is_active()` window between polling ticks.
+    total_started: u64,
     /// Full snapshot of the buffer at the end of the previous render
     /// pass. Ratatui's swap_buffers resets the "current" buffer, so at
     /// the start of the next draw `frame.buffer_mut()` is blank — not
@@ -258,6 +265,7 @@ impl AnimationRunner {
         Self {
             next_id: 1,
             active: Vec::new(),
+            total_started: 0,
             last_frame: None,
         }
     }
@@ -295,6 +303,7 @@ impl AnimationRunner {
                     delay,
                 } => (Box::new(SlideIn::new(from, duration)), delay, duration),
             };
+        self.total_started += 1;
         self.active.push(ActiveEffect {
             id,
             area,
@@ -360,6 +369,15 @@ impl AnimationRunner {
         self.active
             .iter()
             .any(|e| e.status == EffectStatus::Running)
+    }
+
+    /// Cumulative number of effects accepted by either `start` or
+    /// `start_with_id`, since this runner was constructed. Monotonic —
+    /// never decreases. Tests use this to detect that an effect was
+    /// kicked off without having to catch the transient `is_active()`
+    /// window between two polling ticks.
+    pub fn total_started(&self) -> u64 {
+        self.total_started
     }
 
     pub fn next_deadline(&self) -> Option<Instant> {

--- a/crates/fresh-editor/tests/e2e/animation.rs
+++ b/crates/fresh-editor/tests/e2e/animation.rs
@@ -13,10 +13,12 @@ use std::fs;
 /// Cycling to the next tab fires a slide-in effect over the active
 /// split's content area. We don't assert the direction of the slide
 /// from the rendered frame (direction is a runner-internal decision
-/// encoded in the effect's `from` edge); instead we wait for
-/// `animations.is_active()` to flip true, which proves the Editor
-/// actually kicked the animation off. Then we wait for it to settle
-/// and verify the post-animation frame shows the new active buffer.
+/// encoded in the effect's `from` edge); instead we sample the
+/// monotonic `total_started()` counter before/after the action, which
+/// proves the Editor actually kicked the animation off without
+/// requiring the polling loop to catch the transient `is_active()`
+/// window — under heavy CI load a single 50 ms `wait_until` tick can
+/// straddle the entire 260 ms animation, missing the flip.
 ///
 /// Animations are off by default in the test harness (see the comment
 /// in common/harness.rs); this test opts them back on via an explicit
@@ -40,18 +42,21 @@ fn next_buffer_kicks_off_a_slide_animation() {
     harness
         .wait_until(|h| h.screen_to_string().contains("BRAVO_BUFFER_CONTENT"))
         .unwrap();
-
-    // Baseline: no animation in flight at steady state.
-    assert!(!harness.editor().animations.is_active());
+    // Baseline: any open-time animation has settled.
+    harness
+        .wait_until(|h| !h.editor().animations.is_active())
+        .unwrap();
+    let baseline = harness.editor().animations.total_started();
 
     // Switch to the previous tab. The Editor should start a
     // horizontal slide (prev → from the left).
     harness.editor_mut().prev_buffer();
 
-    // is_active flips true within a couple of ticks; wait for it
-    // semantically rather than polling on a timer.
+    // The runner increments `total_started` on `start()`; the count is
+    // monotonic so this catches the kick-off even if the animation has
+    // already finished by the time we poll.
     harness
-        .wait_until(|h| h.editor().animations.is_active())
+        .wait_until(|h| h.editor().animations.total_started() > baseline)
         .unwrap();
 
     // Settle, then confirm the alpha buffer is now the active one.
@@ -138,12 +143,16 @@ fn tab_switch_from_group_to_file_animates() {
     harness
         .wait_until(|h| !h.editor().animations.is_active())
         .unwrap();
+    let baseline = harness.editor().animations.total_started();
 
     // Cycle to the previous tab: group → file. Before the fix,
-    // is_active stayed false forever and this wait never returned.
+    // total_started never incremented and the wait never returned.
+    // We use the monotonic counter rather than `is_active()` so a
+    // single delayed wait_until tick under load can't straddle the
+    // 260 ms animation and miss its `true` window entirely.
     harness.editor_mut().prev_buffer();
     harness
-        .wait_until(|h| h.editor().animations.is_active())
+        .wait_until(|h| h.editor().animations.total_started() > baseline)
         .unwrap();
 
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
@@ -131,9 +131,11 @@ fn dashboard_bringup_animation_settles_and_renders() {
     // animate_virtual_buffer (e.g. if the viewport_changed trigger
     // silently breaks) — the test would otherwise pass trivially
     // because a never-started animation looks identical to a
-    // finished one.
+    // finished one. Sample the monotonic counter rather than the
+    // transient `is_active()` so a slow-polling iteration on a busy
+    // CI box can't straddle the entire animation window.
     harness
-        .wait_until(|h| h.editor().animations.is_active())
+        .wait_until(|h| h.editor().animations.total_started() > 0)
         .unwrap();
 
     // Now settle the bringup animation: the runner flips is_active to

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -1430,25 +1430,52 @@ fn test_git_log_open_file_works_after_closing_previous_file_view() {
         .unwrap();
 
     // Focus the detail panel (Tab from log) and land on a diff line.
+    //
+    // Detail-buffer line layout for a single-file two-commit show with
+    // `--stat --patch` (the `---` after the commit message is a stat
+    // separator emitted by git, not a diff header):
+    //
+    //   Ln 1   <short>  <subject>      (detail-title;       no `file` prop)
+    //   Ln 2   commit <hash>           (detail-commit-line; no `file` prop)
+    //   Ln 3   Author: …               (detail-meta;        no `file` prop)
+    //   Ln 4   Date:   …               (detail-meta;        no `file` prop)
+    //   Ln 5   <blank>
+    //   Ln 6       <commit message>
+    //   Ln 7   ---                     (git stat separator)
+    //   Ln 8    src/main.rs | 2 +-     (stat)
+    //   Ln 9    1 file changed, …      (stat)
+    //   Ln 10  <blank>
+    //   Ln 11  diff --git a/…  b/…     (detail-diff-header; HAS `file`)
+    //   Ln 12  index …                 (detail-diff-header; no `file`)
+    //   Ln 13  --- a/src/main.rs       (detail-diff-header; no `file`)
+    //   Ln 14  +++ b/src/main.rs       (detail-diff-header; HAS `file`)
+    //   Ln 15  @@ -1,3 +1,3 @@         (detail-hunk-header; HAS `file`)
+    //   Ln 16   fn main() {            (detail-context;     HAS `file`)
+    //
+    // Ln 11 is the first content-bearing diff line; Lns 12–13 lack the
+    // `file` property and would silently trigger the move-to-diff-with-context
+    // fallback in the plugin. So the test must land *exactly* on Ln 11 (and
+    // later Ln 16) before pressing Enter.
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
-    // Move down enough to be on an actual diff line (past the commit header).
     for _ in 0..10 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
+    // Semantic anchor: the focused-panel chrome prints `Ln N, Col M`, so
+    // wait for the cursor to actually land at Ln 11 before Enter rather
+    // than relying on the move pipeline being fully drained per-keypress.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 11, Col 1"))
+        .unwrap();
     // First Enter: open file-view of src/main.rs @ HEAD.
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    // Wait for the file-view virtual buffer to actually open. The earlier
-    // `contains("println!(\"second\");")` condition was racy: the detail
-    // panel already contains `+    println!("second");` from the diff, so
-    // the wait returned before `createVirtualBuffer` finished and before
-    // focus moved into the file-view mode. The subsequent `q` then hit
-    // the detail panel's `git-log` mode, which binds `q` to `git_log_q`
-    // (closes the whole buffer group), wrecking the rest of the test.
-    // The `*<hash>:src/main.rs*` tab title is only produced by
+    // Wait for the file-view virtual buffer to actually open. The
+    // `*<hash>:src/main.rs*` tab title is only produced by
     // `createVirtualBuffer` in git_log.ts and cannot be matched by the
-    // diff, so it's the safe completion signal.
+    // diff, so it's the safe completion signal. The move-cursor status
+    // is also accepted so the assertion below can fail loudly if Enter
+    // somehow misses the file-bearing line despite the pre-Enter wait.
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
@@ -1456,6 +1483,13 @@ fn test_git_log_open_file_works_after_closing_previous_file_view() {
                 || s.contains("Move cursor to a diff line with file context")
         })
         .unwrap();
+    {
+        let s = harness.screen_to_string();
+        assert!(
+            !s.contains("Move cursor to a diff line with file context"),
+            "BUG: first Enter at Ln 11 fell back to move-cursor status:\n{s}",
+        );
+    }
 
     // Close the file-view (q) and go back to the detail panel.
     harness
@@ -1465,24 +1499,21 @@ fn test_git_log_open_file_works_after_closing_previous_file_view() {
         .wait_until(|h| h.screen_to_string().contains("+    println!(\"second\");"))
         .unwrap();
 
-    // Nudge the detail cursor and press Enter again. Before the fix,
-    // the second Enter reported "Move cursor to a diff line with file context".
+    // Nudge the detail cursor down to Ln 16 (` fn main() {`, a context
+    // diff line that has `file` set) and press Enter again. Before the
+    // fix the second Enter reported "Move cursor to a diff line with
+    // file context".
     for _ in 0..5 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 16, Col 1"))
+        .unwrap();
+    harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
 
-    // Semantic wait: the second Enter either succeeds (a fresh file-view
-    // virtual buffer `*<hash>:src/main.rs*` appears as a tab — that name is
-    // only produced by `createVirtualBuffer` in git_log.ts, so it cannot be
-    // matched by the still-visible detail panel) or the plugin falls back
-    // to the move-cursor status (the bug we're guarding against). The
-    // assert below distinguishes the two. Using `wait_until_stable` here
-    // was racy: the detail panel already contains "+    println!(\"second\")",
-    // so the condition matched before the Enter was processed, and the
-    // stability phase looped forever on an oscillating status-bar cell.
+    // Same accept-and-assert pattern as the first Enter.
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();


### PR DESCRIPTION
The test sent N Down keys then Enter and trusted the cursor would land
exactly on the diff-content line. The wait_until between Enter and the
subsequent q was permissive — it accepted *either* the new file-view
tab `:src/main.rs*` OR the plugin's "Move cursor to a diff line with
file context" status. So a one-line cursor drift would silently take
the second branch, q would then fall through to git-log mode (q ↦
git_log_q ↦ git_log_close), the whole group would be torn down, and
the next wait_until for the diff text would hang until the 180 s
nextest timeout.

Make the cursor position the explicit setup invariant:

  * After the 10 Downs, wait_until the focused-panel chrome shows
    `Ln 11, Col 1` before pressing Enter. Same for the post-q 5 Downs
    against `Ln 16, Col 1`. Both readouts come from the active
    SplitViewState's footer, so the wait observes rendered output (no
    inspectors).

  * Keep both branches in the post-Enter wait but assert immediately
    if "Move cursor…" is present, both for the first AND second Enter.
    With the pre-Enter cursor anchor in place this should never fire,
    but if some future regression *does* land us off the file-bearing
    line the test fails fast with the actual screen instead of timing
    out in an unrelated wait.

Confirmed via tmux + send-keys + capture-pane that:

  * `git show --stat --patch` emits an undocumented `---` separator
    between the commit message and the stat block (now spelled out in
    a comment alongside the full per-line layout); without that the
    mental count was off by one.

  * Ln 11 = `diff --git a/src/main.rs b/src/main.rs` is the *only*
    file-bearing line in the Ln 11–13 neighborhood — Ln 12 (`index
    …`) and Ln 13 (`--- a/…`) both lack the `file` text-property and
    map straight to the move-to-diff-with-context fallback.

30/30 local repeats pass with the new test; the previous version
landed off-line often enough to surface in CI.