### PR TITLE
Force render on active animations in editor server loop

### DIFF
--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -463,6 +463,17 @@ impl EditorServer {
                 if editor.check_mouse_hover_timer() {
                     needs_render = true;
                 }
+
+                // Active animations force a render every FRAME_DURATION so
+                // the slide settles on its own. Without this the loop only
+                // ticks when an external event (input, resize, async
+                // message) flips `needs_render`, so under tmux a buffer
+                // switch paints its first frame and then freezes mid-slide
+                // until the user nudges the terminal. Mirrors the direct
+                // (non-server) loop in `main.rs`.
+                if editor.animations.is_active() {
+                    needs_render = true;
+                }
             }
 
             // Render and broadcast if needed


### PR DESCRIPTION
## Summary
Added a check to force rendering when animations are active in the editor server's main loop, ensuring smooth animation playback regardless of external events.

## Key Changes
- Added `editor.animations.is_active()` check in the editor server's event loop to set `needs_render = true` when animations are running
- This ensures animations render every `FRAME_DURATION` and complete smoothly, rather than freezing mid-animation when waiting for external events (input, resize, async messages)
- Aligns the server-based animation behavior with the direct loop implementation in `main.rs`

## Implementation Details
The fix addresses a specific issue where buffer switches under tmux would paint their first animation frame and then freeze until user interaction. By continuously triggering renders during active animations, the animation loop can settle naturally without requiring external events to drive the render cycle.

https://claude.ai/code/session_01Nh4uds2kyC6bge9gurwSnk