### PR TITLE
feat(keybindings): make completion popup accept/dismiss rebindable

### DIFF
--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -1318,6 +1318,22 @@
       "when": "popup"
     },
     {
+      "comment": "Completion popup context - Tab accepts the selected completion",
+      "key": "Tab",
+      "modifiers": [],
+      "action": "completion_accept",
+      "args": {},
+      "when": "completion"
+    },
+    {
+      "comment": "Completion popup context - Esc dismisses the popup",
+      "key": "Escape",
+      "modifiers": [],
+      "action": "completion_dismiss",
+      "args": {},
+      "when": "completion"
+    },
+    {
       "comment": "Settings context - Navigation and actions",
       "key": "Escape",
       "modifiers": [],

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Přehrát poslední nahrané makro",
   "action.play_macro": "Přehrát makro '%{key}'",
   "action.plugin_action": "Akce pluginu: %{name}",
+  "action.completion_accept": "Přijmout dokončení",
+  "action.completion_dismiss": "Zavřít vyskakovací okno dokončení",
   "action.popup_cancel": "Zrušit vyskakovací okno",
   "action.popup_confirm": "Potvrdit vyskakovací okno",
   "action.popup_page_down": "Vyskakovací okno stránka dolů",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Zuletzt aufgezeichnetes Makro abspielen",
   "action.play_macro": "Makro '%{key}' abspielen",
   "action.plugin_action": "Plugin-Aktion: %{name}",
+  "action.completion_accept": "Vervollständigung annehmen",
+  "action.completion_dismiss": "Vervollständigungs-Popup verwerfen",
   "action.popup_cancel": "Popup abbrechen",
   "action.popup_confirm": "Popup bestätigen",
   "action.popup_page_down": "Popup Seite nach unten",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -128,6 +128,8 @@
   "action.play_last_macro": "Play last recorded macro",
   "action.play_macro": "Play macro '%{key}'",
   "action.plugin_action": "Plugin action: %{name}",
+  "action.completion_accept": "Accept completion",
+  "action.completion_dismiss": "Dismiss completion popup",
   "action.popup_cancel": "Popup cancel",
   "action.popup_confirm": "Popup confirm",
   "action.popup_page_down": "Popup page down",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Reproducir última macro grabada",
   "action.play_macro": "Reproducir macro '%{key}'",
   "action.plugin_action": "Acción de plugin: %{name}",
+  "action.completion_accept": "Aceptar completado",
+  "action.completion_dismiss": "Descartar popup de completado",
   "action.popup_cancel": "Cancelar popup",
   "action.popup_confirm": "Confirmar popup",
   "action.popup_page_down": "Popup página abajo",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Lire la dernière macro enregistrée",
   "action.play_macro": "Lire la macro '%{key}'",
   "action.plugin_action": "Action du plugin : %{name}",
+  "action.completion_accept": "Accepter la complétion",
+  "action.completion_dismiss": "Rejeter la fenêtre de complétion",
   "action.popup_cancel": "Annuler la fenêtre contextuelle",
   "action.popup_confirm": "Confirmer la fenêtre contextuelle",
   "action.popup_page_down": "Fenêtre contextuelle : page suivante",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Riproduci l'ultima macro registrata",
   "action.play_macro": "Riproduci macro '%{key}'",
   "action.plugin_action": "Azione plugin: %{name}",
+  "action.completion_accept": "Accetta completamento",
+  "action.completion_dismiss": "Ignora popup di completamento",
   "action.popup_cancel": "Annulla popup",
   "action.popup_confirm": "Conferma popup",
   "action.popup_page_down": "Pagina giù popup",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "最後に記録したマクロを再生",
   "action.play_macro": "マクロ '%{key}' を再生",
   "action.plugin_action": "プラグインアクション: %{name}",
+  "action.completion_accept": "補完を確定",
+  "action.completion_dismiss": "補完ポップアップを閉じる",
   "action.popup_cancel": "ポップアップをキャンセル",
   "action.popup_confirm": "ポップアップを確定",
   "action.popup_page_down": "ポップアップをページダウン",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "마지막으로 녹화한 매크로 재생",
   "action.play_macro": "매크로 '%{key}' 재생",
   "action.plugin_action": "플러그인 동작: %{name}",
+  "action.completion_accept": "자동 완성 수락",
+  "action.completion_dismiss": "자동 완성 팝업 해제",
   "action.popup_cancel": "팝업 취소",
   "action.popup_confirm": "팝업 확인",
   "action.popup_page_down": "팝업 페이지 아래로",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Reproduzir última macro gravada",
   "action.play_macro": "Reproduzir macro '%{key}'",
   "action.plugin_action": "Ação de plugin: %{name}",
+  "action.completion_accept": "Aceitar conclusão",
+  "action.completion_dismiss": "Dispensar popup de conclusão",
   "action.popup_cancel": "Cancelar popup",
   "action.popup_confirm": "Confirmar popup",
   "action.popup_page_down": "Popup página para baixo",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Воспроизвести последний записанный макрос",
   "action.play_macro": "Воспроизвести макрос '%{key}'",
   "action.plugin_action": "Действие плагина: %{name}",
+  "action.completion_accept": "Принять автодополнение",
+  "action.completion_dismiss": "Закрыть окно автодополнения",
   "action.popup_cancel": "Отмена всплывающего окна",
   "action.popup_confirm": "Подтвердить всплывающее окно",
   "action.popup_page_down": "Всплывающее окно: страница вниз",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "เล่นมาโครที่บันทึกไว้ล่าสุด",
   "action.play_macro": "เล่นมาโคร '%{key}'",
   "action.plugin_action": "การดำเนินการปลั๊กอิน: %{name}",
+  "action.completion_accept": "ยอมรับการเติมคำ",
+  "action.completion_dismiss": "ปิดป๊อปอัพการเติมคำ",
   "action.popup_cancel": "ยกเลิกป๊อปอัพ",
   "action.popup_confirm": "ยืนยันป๊อปอัพ",
   "action.popup_page_down": "ป๊อปอัพลงหนึ่งหน้า",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Відтворити останній записаний макрос",
   "action.play_macro": "Відтворити макрос '%{key}'",
   "action.plugin_action": "Дія плагіна: %{name}",
+  "action.completion_accept": "Прийняти автодоповнення",
+  "action.completion_dismiss": "Закрити спливаюче вікно автодоповнення",
   "action.popup_cancel": "Скасувати спливаюче вікно",
   "action.popup_confirm": "Підтвердити спливаюче вікно",
   "action.popup_page_down": "Спливаюче вікно: сторінка вниз",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "Phát macro đã ghi gần nhất",
   "action.play_macro": "Phát macro '%{key}'",
   "action.plugin_action": "Hành động plugin: %{name}",
+  "action.completion_accept": "Chấp nhận gợi ý hoàn thành",
+  "action.completion_dismiss": "Bỏ qua popup gợi ý hoàn thành",
   "action.popup_cancel": "Hủy popup",
   "action.popup_confirm": "Xác nhận popup",
   "action.popup_page_down": "Popup trang xuống",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -131,6 +131,8 @@
   "action.play_last_macro": "播放上次录制的宏",
   "action.play_macro": "播放宏 '%{key}'",
   "action.plugin_action": "插件操作：%{name}",
+  "action.completion_accept": "接受补全",
+  "action.completion_dismiss": "关闭补全弹窗",
   "action.popup_cancel": "弹窗取消",
   "action.popup_confirm": "弹窗确认",
   "action.popup_page_down": "弹窗向下翻页",

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -20,6 +20,41 @@ impl Editor {
         !matches!(self.key_context, KeyContext::FileExplorer)
     }
 
+    /// Resolve a key event against `KeyContext::Completion` when the topmost
+    /// visible popup is a completion popup. Only `CompletionAccept` and
+    /// `CompletionDismiss` are recognised here — every other key falls
+    /// through to the popup's own handler so type-to-filter, navigation, and
+    /// the "any other key dismisses + passthrough" behaviours stay intact.
+    pub(crate) fn resolve_completion_popup_action(
+        &self,
+        event: &crossterm::event::KeyEvent,
+    ) -> Option<crate::input::keybindings::Action> {
+        use crate::input::keybindings::{Action, KeyContext};
+        use crate::view::popup::PopupKind;
+
+        let topmost_kind = if self.global_popups.is_visible() {
+            self.global_popups.top().map(|p| p.kind)
+        } else if self.active_state().popups.is_visible() {
+            self.active_state().popups.top().map(|p| p.kind)
+        } else {
+            None
+        };
+
+        if topmost_kind != Some(PopupKind::Completion) {
+            return None;
+        }
+
+        match self
+            .keybindings
+            .read()
+            .unwrap()
+            .resolve_in_context_only(event, KeyContext::Completion)
+        {
+            Some(action @ (Action::CompletionAccept | Action::CompletionDismiss)) => Some(action),
+            _ => None,
+        }
+    }
+
     /// Determine the current keybinding context based on UI state
     pub fn get_key_context(&self) -> crate::input::keybindings::KeyContext {
         use crate::input::keybindings::KeyContext;
@@ -1511,6 +1546,15 @@ impl Editor {
                 }
             }
             Action::PopupCancel => {
+                self.handle_popup_cancel();
+            }
+            Action::CompletionAccept => {
+                use super::popup_actions::PopupConfirmResult;
+                if let PopupConfirmResult::EarlyReturn = self.handle_popup_confirm() {
+                    return Ok(());
+                }
+            }
+            Action::CompletionDismiss => {
                 self.handle_popup_cancel();
             }
             Action::InsertChar(c) => {

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -179,6 +179,18 @@ impl Editor {
         // `popups_capture_keys()` predicate so the two paths cannot drift —
         // one source of truth for "is the popup eligible to eat this key?".
         if self.popups_capture_keys() {
+            // Completion popups consult the keybinding resolver in the
+            // `Completion` context first, so accept/dismiss can be remapped
+            // via the keybinding editor. Falls through to the popup's own
+            // handler for everything else (type-to-filter, navigation, etc.).
+            if let Some(action) = self.resolve_completion_popup_action(event) {
+                self.process_deferred_actions(ctx);
+                if let Err(e) = self.handle_action(action) {
+                    tracing::warn!("Completion popup action failed: {}", e);
+                }
+                return Some(InputResult::Consumed);
+            }
+
             // Editor-level (global) popups take precedence over buffer popups
             // so that plugin notifications stay focused even when the active
             // buffer owns its own popup stack.

--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -752,6 +752,7 @@ impl KeybindingEditor {
             ContextFilter::Specific("normal".to_string()),
             ContextFilter::Specific("prompt".to_string()),
             ContextFilter::Specific("popup".to_string()),
+            ContextFilter::Specific("completion".to_string()),
             ContextFilter::Specific("file_explorer".to_string()),
             ContextFilter::Specific("menu".to_string()),
             ContextFilter::Specific("terminal".to_string()),

--- a/crates/fresh-editor/src/app/keybinding_editor/types.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/types.rs
@@ -121,6 +121,7 @@ impl EditBindingState {
             "normal".to_string(),
             "prompt".to_string(),
             "popup".to_string(),
+            "completion".to_string(),
             "file_explorer".to_string(),
             "menu".to_string(),
             "terminal".to_string(),

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -2967,6 +2967,8 @@ pub fn action_to_events(
         | Action::PopupPageDown
         | Action::PopupConfirm
         | Action::PopupCancel
+        | Action::CompletionAccept
+        | Action::CompletionDismiss
         | Action::ToggleFileExplorer
         | Action::ToggleMenuBar
         | Action::ToggleTabBar

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -227,6 +227,10 @@ pub enum KeyContext {
     Prompt,
     /// Popup window is visible
     Popup,
+    /// Completion popup is visible (LSP or non-LSP). Takes precedence over `Popup`
+    /// for `PopupKind::Completion` so accept/dismiss can be bound independently
+    /// of the generic popup keys (Enter/Esc/Up/Down/PageUp/PageDown).
+    Completion,
     /// File explorer has focus
     FileExplorer,
     /// Menu bar is active
@@ -267,6 +271,7 @@ impl KeyContext {
             "global" => Self::Global,
             "prompt" => Self::Prompt,
             "popup" => Self::Popup,
+            "completion" => Self::Completion,
             "fileExplorer" | "file_explorer" => Self::FileExplorer,
             "normal" => Self::Normal,
             "menu" => Self::Menu,
@@ -284,6 +289,7 @@ impl KeyContext {
             Self::Normal => "normal".to_string(),
             Self::Prompt => "prompt".to_string(),
             Self::Popup => "popup".to_string(),
+            Self::Completion => "completion".to_string(),
             Self::FileExplorer => "fileExplorer".to_string(),
             Self::Menu => "menu".to_string(),
             Self::Terminal => "terminal".to_string(),
@@ -543,6 +549,10 @@ pub enum Action {
     PopupPageDown,
     PopupConfirm,
     PopupCancel,
+
+    // Completion popup actions (override generic Popup keys for PopupKind::Completion)
+    CompletionAccept,
+    CompletionDismiss,
 
     // File explorer operations
     ToggleFileExplorer,
@@ -980,6 +990,9 @@ impl Action {
             "popup_page_down" => PopupPageDown,
             "popup_confirm" => PopupConfirm,
             "popup_cancel" => PopupCancel,
+
+            "completion_accept" => CompletionAccept,
+            "completion_dismiss" => CompletionDismiss,
 
             "toggle_file_explorer" => ToggleFileExplorer,
             "toggle_menu_bar" => ToggleMenuBar,
@@ -2264,6 +2277,8 @@ impl KeybindingResolver {
             Action::PopupPageDown => t!("action.popup_page_down"),
             Action::PopupConfirm => t!("action.popup_confirm"),
             Action::PopupCancel => t!("action.popup_cancel"),
+            Action::CompletionAccept => t!("action.completion_accept"),
+            Action::CompletionDismiss => t!("action.completion_dismiss"),
             Action::ToggleFileExplorer => t!("action.toggle_file_explorer"),
             Action::ToggleMenuBar => t!("action.toggle_menu_bar"),
             Action::ToggleTabBar => t!("action.toggle_tab_bar"),

--- a/crates/fresh-editor/src/view/popup/input/completion.rs
+++ b/crates/fresh-editor/src/view/popup/input/completion.rs
@@ -1,9 +1,11 @@
 //! Input handling for completion popups.
 //!
-//! Completion popups support:
+//! Accept and dismiss are resolved upstream against `KeyContext::Completion`
+//! (default: Tab → `completion_accept`, Esc → `completion_dismiss`). The keys
+//! handled here cover the behaviours that do *not* go through the keybinding
+//! system:
 //! - Type-to-filter: typing characters filters the completion list
-//! - Tab: accept the selected completion
-//! - Enter: dismiss the popup and insert newline
+//! - Enter: dismiss the popup and insert newline (passthrough)
 //! - Ctrl+Space: toggle (dismiss) the popup
 //! - Backspace: remove last filter character
 //! - Arrow keys: navigate the list
@@ -19,7 +21,11 @@ pub fn handle_completion_input(
     popup: Option<&mut Popup>,
     ctx: &mut InputContext,
 ) -> InputResult {
-    // Try shared handling first (Esc, PageUp/Down, etc.)
+    // Accept (default: Tab) and dismiss (default: Esc) are resolved upstream
+    // against `KeyContext::Completion` before this handler runs, so we only
+    // see keys that the resolver did not claim.
+
+    // Try shared handling first (Esc fallback, PageUp/Down, etc.)
     match try_handle_shared(event, popup, ctx) {
         SharedHandleResult::Handled(result) => return result,
         SharedHandleResult::NotHandled => {}
@@ -39,12 +45,6 @@ pub fn handle_completion_input(
         KeyCode::Enter => {
             ctx.defer(DeferredAction::ClosePopup);
             InputResult::Ignored
-        }
-
-        // Tab accepts the completion
-        KeyCode::Tab if event.modifiers.is_empty() => {
-            ctx.defer(DeferredAction::ConfirmPopup);
-            InputResult::Consumed
         }
 
         // Arrow navigation (Up/Down navigate the list)
@@ -104,12 +104,6 @@ pub fn handle_completion_input_with_popup(
         KeyCode::Enter => {
             ctx.defer(DeferredAction::ClosePopup);
             InputResult::Ignored
-        }
-
-        // Tab accepts the completion
-        KeyCode::Tab if event.modifiers.is_empty() => {
-            ctx.defer(DeferredAction::ConfirmPopup);
-            InputResult::Consumed
         }
 
         // Arrow navigation (Up/Down navigate the list)


### PR DESCRIPTION
Tab and Esc were hardcoded inside the completion popup input handler, so users couldn't reassign them via the keybinding editor. Add a `Completion` keybinding context with two new actions — `completion_accept` (default Tab) and `completion_dismiss` (default Esc) — that the dispatcher consults when the topmost popup is a `PopupKind::Completion`. Falls through to the existing handler for type-to-filter, navigation, and Enter-passthrough so those behaviours remain unchanged.