### PR TITLE
feat: file explorer side option

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -128,7 +128,8 @@
         "show_gitignored": false,
         "custom_ignore_patterns": [],
         "width": "30%",
-        "preview_tabs": true
+        "preview_tabs": true,
+        "side": "left"
       }
     },
     "file_browser": {
@@ -918,6 +919,11 @@
           "description": "Open files in a \"preview\" (ephemeral) tab on single-click in the\nfile explorer. The preview tab is replaced by the next single-click\ninstead of accumulating tabs. Editing the file, double-clicking\n(or pressing Enter) on it in the explorer, or dragging its tab\npromotes the tab to a permanent tab.\nDefault: true",
           "type": "boolean",
           "default": true
+        },
+        "side": {
+          "description": "Which side of the screen to show the file explorer on.\nDefault: left",
+          "$ref": "#/$defs/FileExplorerSide",
+          "default": "left"
         }
       }
     },
@@ -925,6 +931,14 @@
       "description": "Either a percent like \"30%\" (0–100) or an absolute column count like \"24\".",
       "type": "string",
       "pattern": "^(100%|[1-9]?[0-9]%|\\d+)$"
+    },
+    "FileExplorerSide": {
+      "description": "Side placement for the file explorer panel.",
+      "type": "string",
+      "enum": [
+        "left",
+        "right"
+      ]
     },
     "FileBrowserConfig": {
       "description": "File browser configuration (for Open File dialog)",

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -504,6 +504,7 @@ impl Editor {
 
         // Extract config values before moving config into the struct
         let file_explorer_width = config.file_explorer.width;
+        let file_explorer_side = config.file_explorer.side;
         let recovery_enabled = config.editor.recovery_enabled;
         let check_for_updates = config.check_for_updates;
         let show_menu_bar = config.editor.show_menu_bar;
@@ -606,6 +607,7 @@ impl Editor {
             file_explorer_visible: false,
             file_explorer_sync_in_progress: false,
             file_explorer_width,
+            file_explorer_side,
             pending_file_explorer_show_hidden: None,
             pending_file_explorer_show_gitignored: None,
             menu_bar_visible: show_menu_bar,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -568,6 +568,9 @@ pub struct Editor {
     /// dragging the divider (drag preserves the active variant).
     file_explorer_width: crate::config::ExplorerWidth,
 
+    /// File explorer side placement (left or right)
+    file_explorer_side: crate::config::FileExplorerSide,
+
     /// Pending show_hidden setting to apply when file explorer is initialized (from session restore)
     pending_file_explorer_show_hidden: Option<bool>,
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1,5 +1,6 @@
 use super::lsp_status::compose_lsp_status;
 use super::*;
+use crate::config::FileExplorerSide;
 
 impl Editor {
     /// Render the editor to the terminal
@@ -171,23 +172,34 @@ impl Editor {
             && (self.file_explorer.is_some() || self.file_explorer_sync_in_progress);
 
         if file_explorer_should_show {
-            // Split horizontally: [file_explorer | editor]
+            // Split horizontally based on side placement
             tracing::trace!(
-                "render: file explorer layout active (present={}, sync_in_progress={})",
+                "render: file explorer layout active (present={}, sync_in_progress={}, side={:?})",
                 self.file_explorer.is_some(),
-                self.file_explorer_sync_in_progress
+                self.file_explorer_sync_in_progress,
+                self.file_explorer_side
             );
             let explorer_cols = self.file_explorer_width.to_cols(main_content_area.width);
-            let horizontal_chunks = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([
-                    Constraint::Length(explorer_cols), // File explorer
-                    Constraint::Min(0),                // Editor area (remainder)
-                ])
-                .split(main_content_area);
 
-            self.cached_layout.file_explorer_area = Some(horizontal_chunks[0]);
-            editor_content_area = horizontal_chunks[1];
+            let (explorer_area, editor_area) = match self.file_explorer_side {
+                FileExplorerSide::Left => {
+                    let chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
+                        .split(main_content_area);
+                    (chunks[0], chunks[1])
+                }
+                FileExplorerSide::Right => {
+                    let chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Min(0), Constraint::Length(explorer_cols)])
+                        .split(main_content_area);
+                    (chunks[1], chunks[0])
+                }
+            };
+
+            self.cached_layout.file_explorer_area = Some(explorer_area);
+            editor_content_area = editor_area;
 
             // Get connection string before mutable borrow of file_explorer.
             let remote_connection = self.connection_display_string();
@@ -223,7 +235,7 @@ impl Editor {
                 FileExplorerRenderer::render(
                     explorer,
                     frame,
-                    horizontal_chunks[0],
+                    explorer_area,
                     is_focused,
                     &files_with_unsaved_changes,
                     &self.file_explorer_decoration_cache,

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -170,6 +170,7 @@ impl Editor {
         // Propagate file-explorer settings to live runtime state (IgnorePatterns
         // and width are shadows of config, not read live on each render).
         self.file_explorer_width = self.config.file_explorer.width;
+        self.file_explorer_side = self.config.file_explorer.side;
         if let Some(ref mut explorer) = self.file_explorer {
             let patterns = explorer.ignore_patterns_mut();
             patterns.set_show_hidden(self.config.file_explorer.show_hidden);

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -259,6 +259,7 @@ impl Editor {
             FileExplorerState {
                 visible: self.file_explorer_visible,
                 width: self.file_explorer_width,
+                side: self.file_explorer_side,
                 expanded_dirs,
                 scroll_offset: explorer.get_scroll_offset(),
                 show_hidden: explorer.ignore_patterns().show_hidden(),
@@ -268,6 +269,7 @@ impl Editor {
             FileExplorerState {
                 visible: self.file_explorer_visible,
                 width: self.file_explorer_width,
+                side: self.file_explorer_side,
                 expanded_dirs: Vec::new(),
                 scroll_offset: 0,
                 show_hidden: false,
@@ -760,6 +762,7 @@ impl Editor {
         // 4. Restore file explorer state
         self.file_explorer_visible = workspace.file_explorer.visible;
         self.file_explorer_width = workspace.file_explorer.width;
+        self.file_explorer_side = workspace.file_explorer.side;
 
         // Store pending show_hidden and show_gitignored settings (fixes #569)
         // These will be applied when the file explorer is initialized (async)

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1430,6 +1430,15 @@ impl Default for EditorConfig {
     }
 }
 
+/// Side placement for the file explorer panel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FileExplorerSide {
+    #[default]
+    Left,
+    Right,
+}
+
 /// File explorer configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FileExplorerConfig {
@@ -1465,6 +1474,11 @@ pub struct FileExplorerConfig {
     /// Default: true
     #[serde(default = "default_true")]
     pub preview_tabs: bool,
+
+    /// Which side of the screen to show the file explorer on.
+    /// Default: left
+    #[serde(default = "default_explorer_side")]
+    pub side: FileExplorerSide,
 }
 
 /// Width configuration for the file explorer.
@@ -1619,6 +1633,10 @@ impl schemars::JsonSchema for ExplorerWidth {
 
 fn default_explorer_width() -> ExplorerWidth {
     ExplorerWidth::DEFAULT
+}
+
+fn default_explorer_side() -> FileExplorerSide {
+    FileExplorerSide::default()
 }
 
 /// Public default used by the workspace state deserializer.
@@ -1815,6 +1833,7 @@ impl Default for FileExplorerConfig {
             custom_ignore_patterns: Vec::new(),
             width: default_explorer_width(),
             preview_tabs: true,
+            side: default_explorer_side(),
         }
     }
 }

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -335,6 +335,7 @@ pub struct PartialFileExplorerConfig {
     )]
     pub width: Option<crate::config::ExplorerWidth>,
     pub preview_tabs: Option<bool>,
+    pub side: Option<crate::config::FileExplorerSide>,
 }
 
 impl Merge for PartialFileExplorerConfig {
@@ -346,6 +347,7 @@ impl Merge for PartialFileExplorerConfig {
             .merge_from(&other.custom_ignore_patterns);
         self.width.merge_from(&other.width);
         self.preview_tabs.merge_from(&other.preview_tabs);
+        self.side.merge_from(&other.side);
     }
 }
 
@@ -734,6 +736,7 @@ impl From<&FileExplorerConfig> for PartialFileExplorerConfig {
             custom_ignore_patterns: Some(cfg.custom_ignore_patterns.clone()),
             width: Some(cfg.width),
             preview_tabs: Some(cfg.preview_tabs),
+            side: Some(cfg.side),
         }
     }
 }
@@ -749,6 +752,7 @@ impl PartialFileExplorerConfig {
                 .unwrap_or_else(|| defaults.custom_ignore_patterns.clone()),
             width: self.width.unwrap_or(defaults.width),
             preview_tabs: self.preview_tabs.unwrap_or(defaults.preview_tabs),
+            side: self.side.unwrap_or(defaults.side),
         }
     }
 }

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -301,6 +301,9 @@ pub struct FileExplorerState {
         default = "crate::config::default_explorer_width_value"
     )]
     pub width: crate::config::ExplorerWidth,
+    /// File explorer side placement
+    #[serde(default)]
+    pub side: crate::config::FileExplorerSide,
     /// Expanded directories (relative paths)
     #[serde(default)]
     pub expanded_dirs: Vec<PathBuf>,
@@ -320,6 +323,7 @@ impl Default for FileExplorerState {
         Self {
             visible: false,
             width: crate::config::default_explorer_width_value(),
+            side: crate::config::FileExplorerSide::Left,
             expanded_dirs: Vec::new(),
             scroll_offset: 0,
             show_hidden: false,
@@ -1276,6 +1280,7 @@ mod tests {
         let state = FileExplorerState {
             visible: true,
             width: crate::config::ExplorerWidth::Percent(25),
+            side: crate::config::FileExplorerSide::Left,
             expanded_dirs: vec![
                 PathBuf::from("src"),
                 PathBuf::from("src/app"),
@@ -1302,6 +1307,7 @@ mod tests {
         let state = FileExplorerState {
             visible: true,
             width: crate::config::ExplorerWidth::Columns(42),
+            side: crate::config::FileExplorerSide::Left,
             expanded_dirs: vec![],
             scroll_offset: 0,
             show_hidden: false,

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3450,7 +3450,9 @@ fn test_file_explorer_side_workspace_serialization() {
     let mut config = Config::default();
     config.file_explorer.side = FileExplorerSide::Right;
 
-    let mut harness = EditorTestHarness::with_config_and_working_dir(120, 40, config, project_dir.clone()).unwrap();
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, config, project_dir.clone())
+            .unwrap();
 
     // Show file explorer
     harness.editor_mut().toggle_file_explorer();

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3379,3 +3379,93 @@ fn test_file_explorer_minimum_render_width_is_5_cols() {
         harness.screen_to_string()
     );
 }
+
+/// Test that FileExplorerSide::Left renders explorer on the left (default behavior)
+#[test]
+fn test_file_explorer_side_left() {
+    use fresh::config::{Config, ExplorerWidth, FileExplorerSide};
+
+    let mut config = Config::default();
+    config.file_explorer.side = FileExplorerSide::Left;
+    config.file_explorer.width = ExplorerWidth::Columns(30); // Fixed width for predictable test
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    fs::write(project_root.join("test.txt"), "test").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.render().unwrap();
+
+    let border_col = find_explorer_border_col(&harness);
+
+    // File explorer should be on the left side (~30% of 120 = ~36 cols is default width)
+    // Border should be around column 35-40 (well before the middle of screen at 60)
+    assert!(
+        border_col < 60,
+        "File explorer should be on the left side (border at col {}). Screen:\n{}",
+        border_col,
+        harness.screen_to_string()
+    );
+}
+
+/// Test that FileExplorerSide::Right renders explorer on the right side
+#[test]
+fn test_file_explorer_side_right() {
+    use fresh::config::{Config, ExplorerWidth, FileExplorerSide};
+
+    let mut config = Config::default();
+    config.file_explorer.side = FileExplorerSide::Right;
+    config.file_explorer.width = ExplorerWidth::Columns(30); // Fixed width for predictable test
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    fs::write(project_root.join("test.txt"), "test").unwrap();
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.render().unwrap();
+
+    let border_col = find_explorer_border_col(&harness);
+
+    // File explorer should be on the right side (terminal width 120, so right side starts around col 80)
+    assert!(
+        border_col > 60,
+        "File explorer should be on the right side (border at col {}). Screen:\n{}",
+        border_col,
+        harness.screen_to_string()
+    );
+}
+
+/// Test that workspace serialization correctly persists file explorer side
+#[test]
+fn test_file_explorer_side_workspace_serialization() {
+    use fresh::config::{Config, FileExplorerSide};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let project_dir = temp_dir.path().to_path_buf();
+    fs::write(project_dir.join("file.txt"), "content").unwrap();
+
+    // Create config with side set to Right
+    let mut config = Config::default();
+    config.file_explorer.side = FileExplorerSide::Right;
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(120, 40, config, project_dir.clone()).unwrap();
+
+    // Show file explorer
+    harness.editor_mut().toggle_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.render().unwrap();
+
+    // Verify it's on the right
+    let border_col = find_explorer_border_col(&harness);
+    assert!(
+        border_col > 60,
+        "File explorer should be on right side (border at col {}). Screen:\n{}",
+        border_col,
+        harness.screen_to_string()
+    );
+
+    // Save the workspace and reload
+    harness.editor_mut().save_workspace().unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1340,7 +1340,7 @@ fn test_settings_file_explorer_width_applies_live() {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
-    for _ in 0..5 {
+    for _ in 0..6 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1350,6 +1350,8 @@ fn test_settings_file_explorer_width_applies_live() {
     // confirm, then save settings with Ctrl+S. The text input arms
     // replace-on-type when editing starts, so the first printable key
     // clears "30%" automatically — no separate select-all is needed.
+    // Note: Added FileExplorerSide field, so Width is now at position 6 (0-indexed)
+    // instead of 5 in the alphabetical listing.
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();


### PR DESCRIPTION
<img width="1856" height="934" alt="screenshot-2026-04-27_09-34-15" src="https://github.com/user-attachments/assets/15899dba-d86d-4a7a-b883-53d79424a53e" />
<img width="1860" height="943" alt="screenshot-2026-04-27_09-34-40" src="https://github.com/user-attachments/assets/92f2be86-6049-4bfa-81e8-f839d2e9b5db" />

## Summary
- Add `FileExplorerSide` enum (`left`/`right`) to config
- Add `side` field to `FileExplorerConfig` (defaults to `left` for backward compatibility)
- Update render logic to conditionally swap horizontal split based on side config  
- Update workspace serialization to persist side preference
- Add e2e tests for side placement
