### PR TITLE
Capture container userEnvProbe and propagate to docker exec

### DIFF
--- a/crates/fresh-editor/plugins/devcontainer.i18n.json
+++ b/crates/fresh-editor/plugins/devcontainer.i18n.json
@@ -100,7 +100,9 @@
     "ports_panel.no_ports": "No configured or runtime ports to show.",
     "ports_panel.footer": "r: refresh  q/Esc: close",
     "status.ports_panel_opened": "Dev Container Ports panel opened",
-    "status.ports_panel_refreshed": "Dev Container Ports panel refreshed"
+    "status.ports_panel_refreshed": "Dev Container Ports panel refreshed",
+    "popup.attach_action_dismiss_once": "Ignore (once)",
+    "popup.attach_action_dismiss_always": "Ignore (always in this folder)"
   },
   "cs": {
     "cmd.show_info": "Dev Container: Zobrazit info",
@@ -203,7 +205,9 @@
     "ports_panel.no_ports": "Žádné porty k zobrazení.",
     "ports_panel.footer": "r: obnovit  q/Esc: zavřít",
     "status.ports_panel_opened": "Panel přesměrovaných portů otevřen",
-    "status.ports_panel_refreshed": "Panel přesměrovaných portů obnoven"
+    "status.ports_panel_refreshed": "Panel přesměrovaných portů obnoven",
+    "popup.attach_action_dismiss_once": "Ignorovat (tentokrat)",
+    "popup.attach_action_dismiss_always": "Ignorovat (vzdy v teto slozce)"
   },
   "de": {
     "cmd.show_info": "Dev Container: Info anzeigen",
@@ -306,7 +310,9 @@
     "ports_panel.no_ports": "Keine konfigurierten oder aktiven Ports.",
     "ports_panel.footer": "r: aktualisieren  q/Esc: schliessen",
     "status.ports_panel_opened": "Panel fuer weitergeleitete Ports geoeffnet",
-    "status.ports_panel_refreshed": "Panel fuer weitergeleitete Ports aktualisiert"
+    "status.ports_panel_refreshed": "Panel fuer weitergeleitete Ports aktualisiert",
+    "popup.attach_action_dismiss_once": "Ignorieren (einmalig)",
+    "popup.attach_action_dismiss_always": "Ignorieren (immer in diesem Ordner)"
   },
   "es": {
     "cmd.show_info": "Dev Container: Mostrar Info",
@@ -409,7 +415,9 @@
     "ports_panel.no_ports": "No hay puertos configurados ni en ejecucion.",
     "ports_panel.footer": "r: refrescar  q/Esc: cerrar",
     "status.ports_panel_opened": "Panel de puertos reenviados abierto",
-    "status.ports_panel_refreshed": "Panel de puertos reenviados actualizado"
+    "status.ports_panel_refreshed": "Panel de puertos reenviados actualizado",
+    "popup.attach_action_dismiss_once": "Ignorar (una vez)",
+    "popup.attach_action_dismiss_always": "Ignorar (siempre en esta carpeta)"
   },
   "fr": {
     "cmd.show_info": "Dev Container: Afficher les infos",
@@ -512,7 +520,9 @@
     "ports_panel.no_ports": "Aucun port configure ou actif.",
     "ports_panel.footer": "r : actualiser  q/Echap : fermer",
     "status.ports_panel_opened": "Panneau des ports redirigés ouvert",
-    "status.ports_panel_refreshed": "Panneau des ports redirigés actualisé"
+    "status.ports_panel_refreshed": "Panneau des ports redirigés actualisé",
+    "popup.attach_action_dismiss_once": "Ignorer (une fois)",
+    "popup.attach_action_dismiss_always": "Ignorer (toujours dans ce dossier)"
   },
   "ja": {
     "cmd.show_info": "Dev Container: 情報を表示",
@@ -615,7 +625,9 @@
     "ports_panel.no_ports": "表示するポートがありません。",
     "ports_panel.footer": "r: 更新  q/Esc: 閉じる",
     "status.ports_panel_opened": "転送ポートパネルを開きました",
-    "status.ports_panel_refreshed": "転送ポートパネルを更新しました"
+    "status.ports_panel_refreshed": "転送ポートパネルを更新しました",
+    "popup.attach_action_dismiss_once": "無視 (今回のみ)",
+    "popup.attach_action_dismiss_always": "無視 (このフォルダで常に)"
   },
   "ko": {
     "cmd.show_info": "Dev Container: 정보 표시",
@@ -718,7 +730,9 @@
     "ports_panel.no_ports": "표시할 포트가 없습니다.",
     "ports_panel.footer": "r: 새로고침  q/Esc: 닫기",
     "status.ports_panel_opened": "포워딩 포트 패널을 열었습니다",
-    "status.ports_panel_refreshed": "포워딩 포트 패널을 갱신했습니다"
+    "status.ports_panel_refreshed": "포워딩 포트 패널을 갱신했습니다",
+    "popup.attach_action_dismiss_once": "무시 (이번만)",
+    "popup.attach_action_dismiss_always": "무시 (이 폴더에서 항상)"
   },
   "zh-CN": {
     "cmd.show_info": "Dev Container: 显示信息",
@@ -821,7 +835,9 @@
     "ports_panel.no_ports": "没有可显示的端口。",
     "ports_panel.footer": "r: 刷新  q/Esc: 关闭",
     "status.ports_panel_opened": "已打开转发端口面板",
-    "status.ports_panel_refreshed": "已刷新转发端口面板"
+    "status.ports_panel_refreshed": "已刷新转发端口面板",
+    "popup.attach_action_dismiss_once": "忽略 (本次)",
+    "popup.attach_action_dismiss_always": "忽略 (始终在此文件夹)"
   },
   "it": {
     "cmd.show_info": "Dev Container: Mostra info",
@@ -924,7 +940,9 @@
     "ports_panel.no_ports": "Nessuna porta configurata o attiva.",
     "ports_panel.footer": "r: aggiorna  q/Esc: chiudi",
     "status.ports_panel_opened": "Pannello porte inoltrate aperto",
-    "status.ports_panel_refreshed": "Pannello porte inoltrate aggiornato"
+    "status.ports_panel_refreshed": "Pannello porte inoltrate aggiornato",
+    "popup.attach_action_dismiss_once": "Ignora (una volta)",
+    "popup.attach_action_dismiss_always": "Ignora (sempre in questa cartella)"
   },
   "pt-BR": {
     "cmd.show_info": "Dev Container: Mostrar informacoes",
@@ -1027,7 +1045,9 @@
     "ports_panel.no_ports": "Nenhuma porta configurada ou em execução.",
     "ports_panel.footer": "r: atualizar  q/Esc: fechar",
     "status.ports_panel_opened": "Painel de portas encaminhadas aberto",
-    "status.ports_panel_refreshed": "Painel de portas encaminhadas atualizado"
+    "status.ports_panel_refreshed": "Painel de portas encaminhadas atualizado",
+    "popup.attach_action_dismiss_once": "Ignorar (uma vez)",
+    "popup.attach_action_dismiss_always": "Ignorar (sempre nesta pasta)"
   },
   "ru": {
     "cmd.show_info": "Dev Container: Показать информацию",
@@ -1130,7 +1150,9 @@
     "ports_panel.no_ports": "Нет портов для отображения.",
     "ports_panel.footer": "r: обновить  q/Esc: закрыть",
     "status.ports_panel_opened": "Панель перенаправленных портов открыта",
-    "status.ports_panel_refreshed": "Панель перенаправленных портов обновлена"
+    "status.ports_panel_refreshed": "Панель перенаправленных портов обновлена",
+    "popup.attach_action_dismiss_once": "Игнорировать (один раз)",
+    "popup.attach_action_dismiss_always": "Игнорировать (всегда в этой папке)"
   },
   "th": {
     "cmd.show_info": "Dev Container: แสดงข้อมูล",
@@ -1233,7 +1255,9 @@
     "ports_panel.no_ports": "ไม่มีพอร์ตให้แสดง",
     "ports_panel.footer": "r: รีเฟรช  q/Esc: ปิด",
     "status.ports_panel_opened": "เปิดแผงพอร์ตที่ส่งต่อแล้ว",
-    "status.ports_panel_refreshed": "รีเฟรชแผงพอร์ตที่ส่งต่อแล้ว"
+    "status.ports_panel_refreshed": "รีเฟรชแผงพอร์ตที่ส่งต่อแล้ว",
+    "popup.attach_action_dismiss_once": "ละเว้น (ครั้งนี้)",
+    "popup.attach_action_dismiss_always": "ละเว้น (เสมอในโฟลเดอร์นี้)"
   },
   "uk": {
     "cmd.show_info": "Dev Container: Показати інформацію",
@@ -1336,7 +1360,9 @@
     "ports_panel.no_ports": "Немає портів для показу.",
     "ports_panel.footer": "r: оновити  q/Esc: закрити",
     "status.ports_panel_opened": "Панель перенаправлених портів відкрито",
-    "status.ports_panel_refreshed": "Панель перенаправлених портів оновлено"
+    "status.ports_panel_refreshed": "Панель перенаправлених портів оновлено",
+    "popup.attach_action_dismiss_once": "Ігнорувати (один раз)",
+    "popup.attach_action_dismiss_always": "Ігнорувати (завжди в цій папці)"
   },
   "vi": {
     "cmd.show_info": "Dev Container: Hiển thị thông tin",
@@ -1439,6 +1465,8 @@
     "ports_panel.no_ports": "Không có cổng nào để hiển thị.",
     "ports_panel.footer": "r: làm mới  q/Esc: đóng",
     "status.ports_panel_opened": "Đã mở bảng cổng chuyển tiếp",
-    "status.ports_panel_refreshed": "Đã làm mới bảng cổng chuyển tiếp"
+    "status.ports_panel_refreshed": "Đã làm mới bảng cổng chuyển tiếp",
+    "popup.attach_action_dismiss_once": "Bỏ qua (một lần)",
+    "popup.attach_action_dismiss_always": "Bỏ qua (luôn trong thư mục này)"
   }
 }

--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -1962,10 +1962,25 @@ function resolvePanelSplit(): number {
   return active;
 }
 
-/// Drop a virtual buffer into the shared panel slot. Replaces
-/// whatever was in that split (so subsequent Show * commands
-/// cycle the same pane). Returns the new buffer id, or null if
-/// the runtime call failed.
+/// Per-name registry of panel buffers. Keyed by the
+/// `*Dev Container*` / `*Dev Container Logs*` etc. names so
+/// re-running a Show command refreshes its own buffer in place
+/// without destroying the other Show commands' buffers. Lives
+/// in module state — resets on plugin reload, which is fine
+/// since buffer ids change across editor restarts anyway and
+/// the next Show * invocation will (re)create as needed.
+const namedPanelBuffers = new Map<string, number>();
+
+/// Drop a virtual buffer into the shared panel slot.
+///
+/// Per-name dedupe: re-running the same Show command refreshes
+/// the existing same-name buffer in place (`setVirtualBufferContent`)
+/// rather than creating a new one. Different Show commands keep
+/// their own buffers — `Show Container Logs` no longer wipes out
+/// `Show Container Info`'s buffer, so the user can switch back to
+/// it via the tab bar / buffer list.
+///
+/// Returns the new buffer id, or null if the runtime call failed.
 async function openVirtualInPanelSlot(opts: {
   name: string;
   mode: string;
@@ -1977,13 +1992,30 @@ async function openVirtualInPanelSlot(opts: {
   lineWrap?: boolean;
 }): Promise<{ bufferId: number; splitId: number } | null> {
   const splitId = resolvePanelSplit();
-  // If this split currently shows a previously-tracked panel
-  // buffer, drop it from the buffer map after the new one lands
-  // so the tab list doesn't accumulate.
-  const before = editor.listBuffers().filter((b) =>
-    b.splits.some((sid) => sid === splitId)
-    && panelBufferIds.has(b.id),
-  );
+  const liveBuffers = editor.listBuffers();
+
+  // If we already have a same-name buffer (and it's still alive),
+  // refresh its contents and surface it in the panel split rather
+  // than minting a duplicate. This is the per-command-buffer fix:
+  // running `Show Container Logs` twice updates one buffer instead
+  // of stacking two; running it then `Show Container Info` keeps
+  // both alive.
+  const existingId = namedPanelBuffers.get(opts.name);
+  if (existingId !== undefined) {
+    const existing = liveBuffers.find((b) => b.id === existingId);
+    if (existing) {
+      editor.setVirtualBufferContent(
+        existing.id,
+        opts.entries as unknown as Record<string, unknown>[],
+      );
+      editor.focusSplit(splitId);
+      editor.showBuffer(existing.id);
+      panelBufferIds.add(existing.id);
+      return { bufferId: existing.id, splitId };
+    }
+    namedPanelBuffers.delete(opts.name);
+  }
+
   const result = await editor.createVirtualBufferInExistingSplit({
     name: opts.name,
     splitId,
@@ -1992,43 +2024,35 @@ async function openVirtualInPanelSlot(opts: {
     showLineNumbers: opts.showLineNumbers ?? false,
     showCursors: opts.showCursors ?? true,
     editingDisabled: opts.editingDisabled ?? true,
-    lineWrap: opts.lineWrap ?? true,
+    lineWrap: opts.lineWrap ?? false,
     entries: opts.entries,
   });
   if (result === null) return null;
   panelBufferIds.add(result.bufferId);
-  for (const stale of before) {
-    if (stale.id !== result.bufferId) {
-      editor.closeBuffer(stale.id);
-      panelBufferIds.delete(stale.id);
-    }
-  }
+  namedPanelBuffers.set(opts.name, result.bufferId);
   return { bufferId: result.bufferId, splitId };
 }
 
 /// File-backed equivalent for build-log files: focuses the
-/// panel-slot split, opens the file there, closes any stale
-/// build-log buffer that was previously occupying the slot.
+/// panel-slot split and opens the file there. `openFile` is
+/// idempotent by path, so re-running `Show Build Logs` for the
+/// same file just brings the existing buffer to the front; we
+/// don't need our own dedupe layer.
+///
+/// We also turn line-wrap off — build logs are wide structured
+/// output (docker buildx, lifecycle stdout) that's much more
+/// readable scrolled horizontally than soft-wrapped at column 80.
 function openFileInPanelSlot(path: string): void {
   const splitId = resolvePanelSplit();
   editor.focusSplit(splitId);
-  // Buffers currently in the panel split: close them after
-  // openFile so the tab list doesn't grow per invocation.
-  const stale = editor.listBuffers().filter((b) =>
-    b.splits.some((sid) => sid === splitId) && b.path !== path,
-  );
   editor.openFile(path, null, null);
-  for (const b of stale) {
-    // Only auto-close panels we own (build logs / other plugin
-    // outputs) — never the user's own files.
-    const isBuildLog =
-      b.path
-        ?.startsWith(editor.pathJoin(editor.getCwd(), ".fresh-cache", "devcontainer-logs"))
-      ?? false;
-    if (panelBufferIds.has(b.id) || isBuildLog) {
-      editor.closeBuffer(b.id);
-      panelBufferIds.delete(b.id);
-    }
+  // After the file is open, find its buffer id and disable
+  // line wrap. The new-buffer case sets this on first open;
+  // subsequent invocations are no-ops.
+  const opened = editor.listBuffers().find((b) => b.path === path);
+  if (opened) {
+    editor.setLineWrap(opened.id, null, false);
+    panelBufferIds.add(opened.id);
   }
 }
 
@@ -2345,6 +2369,14 @@ function writeAttachDecision(value: AttachDecision): void {
   editor.setGlobalState(attachDecisionKey(), value);
 }
 
+/// In-memory "Ignore (once)" — true after the user picks the
+/// session-only Ignore option in the attach popup. Cleared on
+/// plugin reload, which means the next editor restart asks again.
+/// This is deliberately separate from the persisted "Ignore (always)"
+/// decision (`writeAttachDecision("dismissed")`) so users have a
+/// real choice between "not now" and "stop asking forever".
+let attachDismissedThisSession = false;
+
 /// Breadcrumb written before calling `editor.setAuthority(payload)`
 /// — setAuthority restarts the editor, so there's no clean callback
 /// to hook once the new authority is live. If the post-restart plugin
@@ -2387,7 +2419,8 @@ function showAttachPrompt(): void {
     }),
     actions: [
       { id: "attach", label: editor.t("popup.attach_action_attach") },
-      { id: "dismiss", label: editor.t("popup.attach_action_dismiss") },
+      { id: "dismiss_once", label: editor.t("popup.attach_action_dismiss_once") },
+      { id: "dismiss_always", label: editor.t("popup.attach_action_dismiss_always") },
     ],
   });
 }
@@ -2399,8 +2432,16 @@ function devcontainer_on_attach_popup(data: ActionPopupResultData): void {
     // Fire and forget: runDevcontainerUp's setAuthority call restarts
     // the editor, so nothing after this runs anyway.
     void devcontainer_attach();
-  } else {
+  } else if (data.action_id === "dismiss_always") {
+    // Persistent ignore: write to plugin global state so the next
+    // editor restart in this workspace finds the breadcrumb and
+    // skips the popup entirely.
     writeAttachDecision("dismissed");
+  } else {
+    // `dismiss_once` (or the legacy `dismiss` id from older
+    // popups whose state is replayed mid-session): in-memory flag
+    // only. The next editor restart in this workspace re-asks.
+    attachDismissedThisSession = true;
   }
 }
 registerHandler("devcontainer_on_attach_popup", devcontainer_on_attach_popup);
@@ -2707,11 +2748,15 @@ if (findConfig()) {
       );
       return;
     }
-    // One-shot per-session dismissal: if the user already said "Not
-    // now" in this Editor process, don't re-prompt. On a cold restart
-    // the state is gone and we ask again — that's fine.
+    // Persistent dismissal (`Ignore (always in this directory)`)
+    // OR a successful prior attach — both are recorded in plugin
+    // global state and survive editor restarts. Skip the popup.
     const previousDecision = readAttachDecision();
     if (previousDecision !== null) return;
+    // Session-only dismissal (`Ignore (once)`): in-memory flag,
+    // cleared on plugin reload so the *next* editor restart
+    // re-asks in this workspace.
+    if (attachDismissedThisSession) return;
     showAttachPrompt();
   }
   registerHandler(

--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -934,6 +934,81 @@ async function effectiveLifecycleEnv(): Promise<Record<string, string>> {
   return out;
 }
 
+/// Probe the just-launched container's user-shell env so the docker
+/// authority's spawner can apply it to every `docker exec` (including
+/// the LSP `command_exists` probe and the LSP server spawn itself).
+///
+/// Why pre-restart, not post-restart: `setAuthority` rebuilds the
+/// editor in place; the next plugin instance can't influence the
+/// already-installed authority's spawner without a second restart.
+/// We have one shot, here, while we still hold the host-side spawner
+/// and know which container we're talking to.
+///
+/// Why bash login-interactive: per the dev-container spec, the
+/// default `userEnvProbe` is `loginInteractiveShell`. `bash -lic env`
+/// matches what an attached terminal would see — including PATH
+/// additions from `~/.profile`, `~/.bashrc`, and friends. Custom
+/// `userEnvProbe` settings (`loginShell`, `interactiveShell`, `none`)
+/// are honoured.
+///
+/// Failures (no bash, probe times out, exit non-zero) degrade
+/// gracefully: we return `[]` and the user gets the bare
+/// container-default PATH back — same behaviour as before this fix,
+/// no regression.
+async function captureContainerLoginEnv(
+  result: DevcontainerUpResult,
+): Promise<Array<[string, string]>> {
+  if (!result.containerId) return [];
+  const probe = config?.userEnvProbe ?? "loginInteractiveShell";
+  if (probe === "none") return [];
+
+  const flagMap: Record<string, string[]> = {
+    loginShell: ["-l"],
+    loginInteractiveShell: ["-l", "-i"],
+    interactiveShell: ["-i"],
+  };
+  const flags = flagMap[probe];
+  if (!flags) return [];
+
+  // Compose `docker exec -i [-u USER] [-w WORKSPACE] <id> bash ...`
+  // by hand: at this point the authority hasn't been installed yet,
+  // so `editor.spawnProcess` would route to the host. Use
+  // `spawnHostProcess` and address the container directly via the
+  // host docker CLI.
+  const dockerArgs: string[] = ["exec", "-i"];
+  if (result.remoteUser) {
+    dockerArgs.push("-u", result.remoteUser);
+  }
+  if (result.remoteWorkspaceFolder) {
+    dockerArgs.push("-w", result.remoteWorkspaceFolder);
+  }
+  dockerArgs.push(result.containerId, "bash", ...flags, "-c", "env");
+
+  const probeResult = await editor.spawnHostProcess("docker", dockerArgs);
+  if (probeResult.exit_code !== 0) {
+    editor.debug(
+      `devcontainer: container userEnvProbe (${probe}) failed exit=${probeResult.exit_code}: ${probeResult.stderr.trim()}`,
+    );
+    return [];
+  }
+
+  // Filter to a small allowlist of high-value entries. Forwarding the
+  // entire `env` dump risks shadowing useful container defaults
+  // (`HOSTNAME`, `_`, …) and balloons the `docker exec` arg list.
+  // `PATH` is the one that drives the LSP fix; the others are common
+  // setup the user's shell exports and a non-shell exec wouldn't.
+  const wanted = new Set(["PATH", "HOME", "LANG", "LC_ALL", "SHELL", "USER", "LOGNAME"]);
+  const out: Array<[string, string]> = [];
+  for (const line of probeResult.stdout.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq);
+    if (!wanted.has(key)) continue;
+    out.push([key, line.slice(eq + 1)]);
+  }
+  return out;
+}
+
 /// Wrap `[bin, args]` with an `env K1=V1 K2=V2 bin args...`
 /// invocation when `env` is non-empty. Returns the original pair
 /// when env is empty (no wrapper needed).
@@ -1563,6 +1638,7 @@ function parseDevcontainerUpOutput(stdout: string): DevcontainerUpResult | null 
 
 function buildContainerAuthorityPayload(
   result: DevcontainerUpResult,
+  baseEnv: Array<[string, string]>,
 ): AuthorityPayload | null {
   if (!result.containerId) return null;
   const user = result.remoteUser ?? null;
@@ -1586,6 +1662,7 @@ function buildContainerAuthorityPayload(
       container_id: result.containerId,
       user,
       workspace,
+      env: baseEnv,
     },
     terminal_wrapper: {
       kind: "explicit",
@@ -1785,7 +1862,16 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
     return;
   }
 
-  const payload = buildContainerAuthorityPayload(parsed);
+  // Capture the in-container `userEnvProbe` env BEFORE we hand the
+  // payload to setAuthority. setAuthority restarts the editor; once
+  // the new editor's spawner is wired with the captured PATH, LSP
+  // `command_exists` and `spawn_stdio` see the same binaries the
+  // user's interactive shell sees (e.g. `pylsp` installed by a
+  // `postCreateCommand` into `~/.local/bin`). Per spec, when
+  // `userEnvProbe` is unset the default is `loginInteractiveShell`.
+  const baseEnv = await captureContainerLoginEnv(parsed);
+
+  const payload = buildContainerAuthorityPayload(parsed, baseEnv);
   if (!payload) {
     enterFailedAttach(editor.t("status.rebuild_missing_container_id"));
     return;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -692,6 +692,15 @@ type AuthoritySpawner = {
 	container_id: string;
 	user?: string | null;
 	workspace?: string | null;
+	/**
+	 * Captured `userEnvProbe` env (typically PATH/HOME/LANG/...) applied
+	 * to every `docker exec` the spawner runs. Plugins fill this from a
+	 * one-shot `bash -lic env` against the just-up container so LSP
+	 * `command_exists` and `spawn_stdio` see binaries on shell-only PATH
+	 * entries (e.g. `~/.local/bin`). Optional; empty = use container's
+	 * bare exec env.
+	 */
+	env?: Array<[string, string]>;
 };
 type AuthorityTerminalWrapper = {
 	kind: "host-shell";

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -437,6 +437,17 @@ impl Editor {
         self.warning_log = Some((receiver, path));
     }
 
+    /// Take the warning-log receiver+path out of this editor.
+    ///
+    /// The receiver is single-consumer and lives for the process's
+    /// lifetime; on a destructive editor restart (e.g. authority swap)
+    /// `main.rs` lifts it from the old editor and re-installs it on the
+    /// new one so warnings keep flowing post-restart instead of vanishing
+    /// with the dropped editor.
+    pub fn take_warning_log(&mut self) -> Option<(std::sync::mpsc::Receiver<()>, PathBuf)> {
+        self.warning_log.take()
+    }
+
     /// Set the status message log path
     pub fn set_status_log_path(&mut self, path: PathBuf) {
         self.status_log_path = Some(path);

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3352,9 +3352,7 @@ fn real_main() -> AnyhowResult<()> {
     // "click status bar to view log" action at, and the user sees
     // "status log not available" for every status message after the
     // restart.
-    let status_log_path: Option<PathBuf> = tracing_handles
-        .as_ref()
-        .map(|h| h.status.path.clone());
+    let status_log_path: Option<PathBuf> = tracing_handles.as_ref().map(|h| h.status.path.clone());
 
     // Warning-log channel survives across restarts the same way,
     // except the `Receiver<()>` is single-consumer and can't be
@@ -3363,8 +3361,9 @@ fn real_main() -> AnyhowResult<()> {
     // Seeded here from `tracing_handles` (which then no longer carries
     // the warning slot), and topped up post-iteration via
     // `editor.take_warning_log()`.
-    let mut warning_log_slot: Option<(std::sync::mpsc::Receiver<()>, PathBuf)> =
-        tracing_handles.take().map(|h| (h.warning.receiver, h.warning.path));
+    let mut warning_log_slot: Option<(std::sync::mpsc::Receiver<()>, PathBuf)> = tracing_handles
+        .take()
+        .map(|h| (h.warning.receiver, h.warning.path));
 
     // Main editor loop - supports restarting with a new working directory
     // Returns (loop_result, last_update_result) tuple

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -793,18 +793,15 @@ fn handle_first_run_setup(
     file_locations: &[FileLocation],
     show_file_explorer: bool,
     stdin_stream: &mut Option<StdinStreamState>,
-    tracing_handles: &mut Option<TracingHandles>,
     workspace_enabled: bool,
 ) -> AnyhowResult<()> {
     if let Some(log_path) = &args.event_log {
         tracing::trace!("Event logging enabled: {}", log_path.display());
         editor.enable_event_streaming(log_path)?;
     }
-
-    if let Some(handles) = tracing_handles.take() {
-        editor.set_warning_log(handles.warning.receiver, handles.warning.path);
-        editor.set_status_log_path(handles.status.path);
-    }
+    // The warning-log channel and status-log path used to be wired up
+    // here from `tracing_handles`; that wiring now lives in the main
+    // loop so it survives editor restarts (e.g. devcontainer attach).
 
     let restore_full_session = workspace_enabled
         && (args.force_restore || editor.config().editor.restore_previous_session);
@@ -3349,6 +3346,26 @@ fn real_main() -> AnyhowResult<()> {
     // we consume right before dropping it below.
     let mut current_authority = startup_authority;
 
+    // Status-message log path is just a clone-able path — capture it
+    // once and re-bind to every restarted editor instance. Without
+    // this, the post-`setAuthority` editor has no path to point the
+    // "click status bar to view log" action at, and the user sees
+    // "status log not available" for every status message after the
+    // restart.
+    let status_log_path: Option<PathBuf> = tracing_handles
+        .as_ref()
+        .map(|h| h.status.path.clone());
+
+    // Warning-log channel survives across restarts the same way,
+    // except the `Receiver<()>` is single-consumer and can't be
+    // cloned: lift the whole `(receiver, path)` pair out of the
+    // editor before we drop it, and reinstall it on the next one.
+    // Seeded here from `tracing_handles` (which then no longer carries
+    // the warning slot), and topped up post-iteration via
+    // `editor.take_warning_log()`.
+    let mut warning_log_slot: Option<(std::sync::mpsc::Receiver<()>, PathBuf)> =
+        tracing_handles.take().map(|h| (h.warning.receiver, h.warning.path));
+
     // Main editor loop - supports restarting with a new working directory
     // Returns (loop_result, last_update_result) tuple
     let (result, last_update_result) = loop {
@@ -3400,6 +3417,17 @@ fn real_main() -> AnyhowResult<()> {
             editor.set_gpm_active(true);
         }
 
+        // Re-wire the tracing log paths into every editor instance,
+        // not just the first. Status-bar click → open log, warning
+        // indicator click → open log all break otherwise after the
+        // first authority swap restart.
+        if let Some(p) = status_log_path.as_ref() {
+            editor.set_status_log_path(p.clone());
+        }
+        if let Some((rx, p)) = warning_log_slot.take() {
+            editor.set_warning_log(rx, p);
+        }
+
         if first_run {
             tracing::info!("Running first-run setup...");
             handle_first_run_setup(
@@ -3408,7 +3436,6 @@ fn real_main() -> AnyhowResult<()> {
                 &file_locations,
                 show_file_explorer,
                 &mut stdin_stream,
-                &mut tracing_handles,
                 workspace_enabled,
             )
             .context("Failed first run setup")?;
@@ -3497,6 +3524,10 @@ fn real_main() -> AnyhowResult<()> {
             tracing::info!("Authority transition queued; restarting editor");
             current_authority = new_authority;
         }
+
+        // Pluck the warning-log channel back out of the soon-to-be-
+        // dropped editor so the next iteration can re-bind it.
+        warning_log_slot = editor.take_warning_log();
 
         drop(editor);
 

--- a/crates/fresh-editor/src/server/tests.rs
+++ b/crates/fresh-editor/src/server/tests.rs
@@ -1331,6 +1331,7 @@ mod integration_tests {
                     container_id: "deadbeef".into(),
                     user: Some("vscode".into()),
                     workspace: Some("/workspaces/proj".into()),
+                    env: Vec::new(),
                 },
                 terminal_wrapper: TerminalWrapperSpec::Explicit {
                     command: "docker".into(),
@@ -1491,6 +1492,7 @@ mod integration_tests {
                 container_id: "cafef00d".into(),
                 user: None,
                 workspace: None,
+                env: Vec::new(),
             },
             terminal_wrapper: TerminalWrapperSpec::Explicit {
                 command: "docker".into(),

--- a/crates/fresh-editor/src/services/authority/docker_spawner.rs
+++ b/crates/fresh-editor/src/services/authority/docker_spawner.rs
@@ -80,8 +80,7 @@ impl DockerExecSpawner {
         extra_env: &[(String, String)],
     ) -> Vec<String> {
         let env_capacity = (self.base_env.len() + extra_env.len()) * 2;
-        let mut docker_args: Vec<String> =
-            Vec::with_capacity(args.len() + env_capacity + 8);
+        let mut docker_args: Vec<String> = Vec::with_capacity(args.len() + env_capacity + 8);
         docker_args.push("exec".into());
         if interactive {
             // `-i` keeps stdin open so JSON-RPC clients can write to
@@ -327,7 +326,10 @@ mod tests {
             ],
         );
         let args = sp.build_exec_args("pylsp", &[], None, false, &[]);
-        let abc_pos = args.iter().position(|a| a == "abc").expect("container id present");
+        let abc_pos = args
+            .iter()
+            .position(|a| a == "abc")
+            .expect("container id present");
         let path_pos = args
             .iter()
             .position(|a| a == "PATH=/home/vscode/.local/bin:/usr/bin")
@@ -336,7 +338,10 @@ mod tests {
             .iter()
             .position(|a| a == "LANG=C.UTF-8")
             .expect("LANG env injected");
-        let pylsp_pos = args.iter().position(|a| a == "pylsp").expect("command present");
+        let pylsp_pos = args
+            .iter()
+            .position(|a| a == "pylsp")
+            .expect("command present");
         assert!(path_pos < abc_pos, "PATH must precede container id");
         assert!(lang_pos < abc_pos, "LANG must precede container id");
         assert!(abc_pos < pylsp_pos, "container id must precede command");
@@ -375,7 +380,9 @@ mod tests {
         let sp =
             DockerLongRunningSpawner::new("abc".into(), Some("vscode".into()), Some("/ws".into()));
         let env: Vec<(String, String)> = vec![("RUST_LOG".into(), "debug".into())];
-        let out = sp.inner.build_exec_args("rust-analyzer", &[], None, true, &env);
+        let out = sp
+            .inner
+            .build_exec_args("rust-analyzer", &[], None, true, &env);
         let e_pos = out.iter().position(|a| a == "-e").unwrap();
         let abc_pos = out.iter().position(|a| a == "abc").unwrap();
         let ra_pos = out.iter().position(|a| a == "rust-analyzer").unwrap();

--- a/crates/fresh-editor/src/services/authority/docker_spawner.rs
+++ b/crates/fresh-editor/src/services/authority/docker_spawner.rs
@@ -18,23 +18,46 @@ use crate::services::remote::{
 };
 
 /// Spawn processes inside a long-lived Docker container via `docker exec`.
+///
+/// `base_env` carries env vars that get injected via `docker exec -e
+/// KEY=VAL` on every spawn — the plugin populates this with the
+/// container's `userEnvProbe` capture (notably `PATH`, which differs
+/// between an interactive login shell and a bare `docker exec`). LSP
+/// servers and `command_exists` probes both go through this so
+/// `pylsp` installed by a `postCreateCommand` into `~/.local/bin`
+/// is actually discoverable when the editor goes to spawn it.
 pub(crate) struct DockerExecSpawner {
     container_id: String,
     user: Option<String>,
     workspace: Option<String>,
+    base_env: Vec<(String, String)>,
 }
 
 impl DockerExecSpawner {
-    pub(crate) fn new(
+    pub(crate) fn with_env(
         container_id: String,
         user: Option<String>,
         workspace: Option<String>,
+        base_env: Vec<(String, String)>,
     ) -> Self {
         Self {
             container_id,
             user,
             workspace,
+            base_env,
         }
+    }
+
+    /// Test helper — `with_env` with an empty base env. Production
+    /// always knows whether it has a `userEnvProbe` capture or not, so
+    /// the explicit form is what `from_plugin_payload` calls.
+    #[cfg(test)]
+    pub(crate) fn new(
+        container_id: String,
+        user: Option<String>,
+        workspace: Option<String>,
+    ) -> Self {
+        Self::with_env(container_id, user, workspace, Vec::new())
     }
 }
 
@@ -43,14 +66,22 @@ impl DockerExecSpawner {
     /// `args` inside the container. Shared between the one-shot
     /// `ProcessSpawner` impl and the long-running variant so both
     /// paths honour `-u <user>` / `-w <cwd-or-workspace>` consistently.
+    ///
+    /// `extra_env` is merged after the spawner's own `base_env` (so
+    /// per-call entries override the captured probe). Both flatten to
+    /// `-e KEY=VALUE` flags placed before the container id, matching
+    /// `docker`'s flag-parsing rules.
     fn build_exec_args(
         &self,
         command: &str,
         args: &[String],
         cwd: Option<&Path>,
         interactive: bool,
+        extra_env: &[(String, String)],
     ) -> Vec<String> {
-        let mut docker_args: Vec<String> = Vec::with_capacity(args.len() + 8);
+        let env_capacity = (self.base_env.len() + extra_env.len()) * 2;
+        let mut docker_args: Vec<String> =
+            Vec::with_capacity(args.len() + env_capacity + 8);
         docker_args.push("exec".into());
         if interactive {
             // `-i` keeps stdin open so JSON-RPC clients can write to
@@ -68,6 +99,14 @@ impl DockerExecSpawner {
             docker_args.push("-w".into());
             docker_args.push(dir);
         }
+        for (k, v) in &self.base_env {
+            docker_args.push("-e".into());
+            docker_args.push(format!("{}={}", k, v));
+        }
+        for (k, v) in extra_env {
+            docker_args.push("-e".into());
+            docker_args.push(format!("{}={}", k, v));
+        }
         docker_args.push(self.container_id.clone());
         docker_args.push(command.to_string());
         docker_args.extend(args.iter().cloned());
@@ -84,7 +123,7 @@ impl ProcessSpawner for DockerExecSpawner {
         cwd: Option<String>,
     ) -> Result<SpawnResult, SpawnError> {
         let cwd_path = cwd.as_deref().map(Path::new);
-        let docker_args = self.build_exec_args(&command, &args, cwd_path, false);
+        let docker_args = self.build_exec_args(&command, &args, cwd_path, false, &[]);
 
         let output = Command::new("docker")
             .args(&docker_args)
@@ -120,14 +159,25 @@ pub(crate) struct DockerLongRunningSpawner {
 }
 
 impl DockerLongRunningSpawner {
+    pub(crate) fn with_env(
+        container_id: String,
+        user: Option<String>,
+        workspace: Option<String>,
+        base_env: Vec<(String, String)>,
+    ) -> Self {
+        Self {
+            inner: DockerExecSpawner::with_env(container_id, user, workspace, base_env),
+        }
+    }
+
+    /// Test helper — see [`DockerExecSpawner::new`].
+    #[cfg(test)]
     pub(crate) fn new(
         container_id: String,
         user: Option<String>,
         workspace: Option<String>,
     ) -> Self {
-        Self {
-            inner: DockerExecSpawner::new(container_id, user, workspace),
-        }
+        Self::with_env(container_id, user, workspace, Vec::new())
     }
 }
 
@@ -158,29 +208,12 @@ impl LongRunningSpawner for DockerLongRunningSpawner {
             }
         }
 
-        // `-e KEY=VAL` entries are injected *before* the container id
-        // so `docker exec` applies them to the server process. We use
-        // the same slot as the one-shot path but build a distinct
-        // vector so interactive mode and env flags compose cleanly.
-        let base_args = self.inner.build_exec_args(command, args, cwd, true);
-
-        // `base_args` starts with ["exec", "-i", "-u?", "-w?",
-        // <container>, <command>, <args…>]. Env flags belong between
-        // the flags block and the container id; splice them in by
-        // locating the container id position (first arg that equals
-        // `self.inner.container_id` and isn't a flag value).
-        let mut docker_args: Vec<String> = Vec::with_capacity(base_args.len() + env.len() * 2);
-        let mut inserted_env = false;
-        for arg in base_args {
-            if !inserted_env && arg == self.inner.container_id {
-                for (k, v) in &env {
-                    docker_args.push("-e".into());
-                    docker_args.push(format!("{}={}", k, v));
-                }
-                inserted_env = true;
-            }
-            docker_args.push(arg);
-        }
+        // `-e KEY=VAL` entries (the spawner's captured `userEnvProbe`
+        // base env plus this call's per-spawn `env`) are injected
+        // *before* the container id so `docker exec` applies them to
+        // the server process. `build_exec_args` handles both layers in
+        // one pass.
+        let docker_args = self.inner.build_exec_args(command, args, cwd, true, &env);
 
         let child = Command::new("docker")
             .args(&docker_args)
@@ -199,9 +232,16 @@ impl LongRunningSpawner for DockerLongRunningSpawner {
         // functions, and `$PATH` lookups — the same semantics
         // `which::which` gives on the host, minus `which`'s non-
         // ubiquity inside minimal container images.
+        //
+        // The probe has to see the same `$PATH` the LSP child will see
+        // when it actually spawns; otherwise the editor declines to
+        // launch a server that's perfectly installed (e.g. `pylsp` in
+        // `~/.local/bin`, on PATH for an interactive login shell but
+        // not for the bare exec env). `build_exec_args` includes
+        // `base_env` here for free.
         let probe = format!("command -v {}", shell_quote(command));
         let sh_args = vec!["-c".to_string(), probe];
-        let docker_args = self.inner.build_exec_args("sh", &sh_args, None, false);
+        let docker_args = self.inner.build_exec_args("sh", &sh_args, None, false, &[]);
 
         match Command::new("docker")
             .args(&docker_args)
@@ -243,7 +283,7 @@ mod tests {
             Some("vscode".into()),
             Some("/workspaces/proj".into()),
         );
-        let args = sp.build_exec_args("rust-analyzer", &[], None, false);
+        let args = sp.build_exec_args("rust-analyzer", &[], None, false, &[]);
         // ["exec", "-u", "vscode", "-w", "/workspaces/proj", "abc123", "rust-analyzer"]
         assert_eq!(args[0], "exec");
         assert_eq!(args[1], "-u");
@@ -258,17 +298,73 @@ mod tests {
     #[test]
     fn build_exec_args_interactive_inserts_dash_i() {
         let sp = DockerExecSpawner::new("abc".into(), None, None);
-        let args = sp.build_exec_args("bash", &[], None, true);
+        let args = sp.build_exec_args("bash", &[], None, true, &[]);
         assert_eq!(&args[..3], &["exec", "-i", "abc"]);
     }
 
     #[test]
     fn build_exec_args_cwd_override_wins_over_workspace() {
         let sp = DockerExecSpawner::new("abc".into(), None, Some("/default".into()));
-        let args = sp.build_exec_args("ls", &[], Some(Path::new("/override")), false);
+        let args = sp.build_exec_args("ls", &[], Some(Path::new("/override")), false, &[]);
         // The cwd slot must carry the per-call override, not the default
         let w_pos = args.iter().position(|a| a == "-w").expect("-w present");
         assert_eq!(args[w_pos + 1], "/override");
+    }
+
+    #[test]
+    fn build_exec_args_base_env_lands_before_container_id() {
+        // `userEnvProbe`-captured PATH (and any other env the plugin
+        // hands the spawner constructor) must reach the in-container
+        // command. `docker exec` parses `-e` only before the container
+        // id; anything after is treated as the command/args.
+        let sp = DockerExecSpawner::with_env(
+            "abc".into(),
+            None,
+            None,
+            vec![
+                ("PATH".into(), "/home/vscode/.local/bin:/usr/bin".into()),
+                ("LANG".into(), "C.UTF-8".into()),
+            ],
+        );
+        let args = sp.build_exec_args("pylsp", &[], None, false, &[]);
+        let abc_pos = args.iter().position(|a| a == "abc").expect("container id present");
+        let path_pos = args
+            .iter()
+            .position(|a| a == "PATH=/home/vscode/.local/bin:/usr/bin")
+            .expect("PATH env injected");
+        let lang_pos = args
+            .iter()
+            .position(|a| a == "LANG=C.UTF-8")
+            .expect("LANG env injected");
+        let pylsp_pos = args.iter().position(|a| a == "pylsp").expect("command present");
+        assert!(path_pos < abc_pos, "PATH must precede container id");
+        assert!(lang_pos < abc_pos, "LANG must precede container id");
+        assert!(abc_pos < pylsp_pos, "container id must precede command");
+        // Each env value must be preceded by a `-e` flag.
+        assert_eq!(args[path_pos - 1], "-e");
+        assert_eq!(args[lang_pos - 1], "-e");
+    }
+
+    #[test]
+    fn build_exec_args_extra_env_appended_after_base_env() {
+        // Per-call `env` should compose with the base env so callers
+        // can override individual keys; the call-site env is appended
+        // last, which means later `-e KEY=VAL` wins under `docker exec`'s
+        // last-flag-wins semantics.
+        let sp = DockerExecSpawner::with_env(
+            "abc".into(),
+            None,
+            None,
+            vec![("PATH".into(), "/base".into())],
+        );
+        let extra = vec![("PATH".into(), "/override".into())];
+        let args = sp.build_exec_args("ls", &[], None, false, &extra);
+        let base_idx = args.iter().position(|a| a == "PATH=/base").unwrap();
+        let override_idx = args.iter().position(|a| a == "PATH=/override").unwrap();
+        assert!(
+            base_idx < override_idx,
+            "base env precedes per-call env so the call-site value wins"
+        );
     }
 
     #[test]
@@ -278,21 +374,8 @@ mod tests {
         // the flag block and the container id, not after the command.
         let sp =
             DockerLongRunningSpawner::new("abc".into(), Some("vscode".into()), Some("/ws".into()));
-        let base = sp.inner.build_exec_args("rust-analyzer", &[], None, true);
-        // Simulate the splice the spawner does.
         let env: Vec<(String, String)> = vec![("RUST_LOG".into(), "debug".into())];
-        let mut out: Vec<String> = Vec::with_capacity(base.len() + 2);
-        let mut inserted = false;
-        for a in base {
-            if !inserted && a == "abc" {
-                for (k, v) in &env {
-                    out.push("-e".into());
-                    out.push(format!("{}={}", k, v));
-                }
-                inserted = true;
-            }
-            out.push(a);
-        }
+        let out = sp.inner.build_exec_args("rust-analyzer", &[], None, true, &env);
         let e_pos = out.iter().position(|a| a == "-e").unwrap();
         let abc_pos = out.iter().position(|a| a == "abc").unwrap();
         let ra_pos = out.iter().position(|a| a == "rust-analyzer").unwrap();

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -386,7 +386,10 @@ mod tests {
             serde_json::from_value(json).expect("env field is accepted");
         if let SpawnerSpec::DockerExec { env, .. } = &payload.spawner {
             assert_eq!(env.len(), 2);
-            assert_eq!(env[0], ("PATH".into(), "/home/vscode/.local/bin:/usr/bin".into()));
+            assert_eq!(
+                env[0],
+                ("PATH".into(), "/home/vscode/.local/bin:/usr/bin".into())
+            );
             assert_eq!(env[1], ("LANG".into(), "C.UTF-8".into()));
         } else {
             panic!("expected docker-exec spawner");

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -129,12 +129,26 @@ pub enum SpawnerSpec {
     /// manages the container lifecycle (e.g. via `editor.spawnHostProcess`
     /// to invoke `devcontainer up`) and hands us the container id once it
     /// is ready.
+    ///
+    /// `env` is the captured `userEnvProbe` snapshot from inside the
+    /// container — typically `PATH`, `HOME`, `LANG`, and any vars the
+    /// user's profile exports. It's applied to every `docker exec`
+    /// (one-shot spawns, LSP/long-running, `command_exists` probes)
+    /// so plugins-installed binaries on `~/.local/bin` (or any
+    /// shell-only PATH) actually resolve. Empty when `userEnvProbe`
+    /// is `none` or the probe fails.
     DockerExec {
         container_id: String,
         #[serde(default)]
         user: Option<String>,
         #[serde(default)]
         workspace: Option<String>,
+        /// Captured `userEnvProbe` env. Order is preserved so
+        /// per-call `env` can layer over it deterministically; the
+        /// list of pairs (rather than a HashMap) keeps `docker exec
+        /// -e` ordering explicit.
+        #[serde(default)]
+        env: Vec<(String, String)>,
     },
 }
 
@@ -239,19 +253,22 @@ impl Authority {
                 container_id,
                 user,
                 workspace,
+                env,
             } => (
                 Arc::new(
-                    crate::services::authority::docker_spawner::DockerExecSpawner::new(
+                    crate::services::authority::docker_spawner::DockerExecSpawner::with_env(
                         container_id.clone(),
                         user.clone(),
                         workspace.clone(),
+                        env.clone(),
                     ),
                 ),
                 Arc::new(
-                    crate::services::authority::docker_spawner::DockerLongRunningSpawner::new(
+                    crate::services::authority::docker_spawner::DockerLongRunningSpawner::with_env(
                         container_id,
                         user,
                         workspace,
+                        env,
                     ),
                 ),
             ),
@@ -347,6 +364,54 @@ mod tests {
     }
 
     #[test]
+    fn payload_accepts_docker_exec_env_pairs() {
+        // The captured `userEnvProbe` env carries the in-container
+        // `PATH`/`HOME`/etc. so LSP `command_exists` can find binaries
+        // that live in shell-only PATHs (e.g. `~/.local/bin`).
+        let json = serde_json::json!({
+            "filesystem": { "kind": "local" },
+            "spawner": {
+                "kind": "docker-exec",
+                "container_id": "abc123",
+                "user": "vscode",
+                "workspace": "/workspaces/proj",
+                "env": [
+                    ["PATH", "/home/vscode/.local/bin:/usr/bin"],
+                    ["LANG", "C.UTF-8"]
+                ]
+            },
+            "terminal_wrapper": { "kind": "host-shell" }
+        });
+        let payload: AuthorityPayload =
+            serde_json::from_value(json).expect("env field is accepted");
+        if let SpawnerSpec::DockerExec { env, .. } = &payload.spawner {
+            assert_eq!(env.len(), 2);
+            assert_eq!(env[0], ("PATH".into(), "/home/vscode/.local/bin:/usr/bin".into()));
+            assert_eq!(env[1], ("LANG".into(), "C.UTF-8".into()));
+        } else {
+            panic!("expected docker-exec spawner");
+        }
+        // And the omitted-field form still parses (the field defaults
+        // to empty), so older plugins that don't populate it stay
+        // wire-compatible.
+        let json_no_env = serde_json::json!({
+            "filesystem": { "kind": "local" },
+            "spawner": {
+                "kind": "docker-exec",
+                "container_id": "abc123"
+            },
+            "terminal_wrapper": { "kind": "host-shell" }
+        });
+        let payload2: AuthorityPayload =
+            serde_json::from_value(json_no_env).expect("env is optional");
+        if let SpawnerSpec::DockerExec { env, .. } = payload2.spawner {
+            assert!(env.is_empty());
+        } else {
+            panic!("expected docker-exec spawner");
+        }
+    }
+
+    #[test]
     fn payload_defaults_manages_cwd_to_true_for_explicit_wrapper() {
         // Per the schema, `manages_cwd` is optional in the JSON and
         // defaults to true because re-parented shells almost always
@@ -424,6 +489,7 @@ mod tests {
                 container_id: "abc123".into(),
                 user: Some("vscode".into()),
                 workspace: Some("/workspaces/proj".into()),
+                env: Vec::new(),
             },
             terminal_wrapper: TerminalWrapperSpec::Explicit {
                 command: "docker".into(),

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
@@ -310,9 +310,8 @@ fn user_env_probe_capture_propagates_path_into_subsequent_execs() {
     // container — the plugin's `captureContainerLoginEnv` runs this
     // before handing the payload to `setAuthority`.
     let history_path = state.join("exec_history");
-    let history = fs::read_to_string(&history_path).unwrap_or_else(|e| {
-        panic!("exec_history not found at {history_path:?}: {e}")
-    });
+    let history = fs::read_to_string(&history_path)
+        .unwrap_or_else(|e| panic!("exec_history not found at {history_path:?}: {e}"));
     let probe_lines: Vec<_> = history
         .lines()
         .filter(|l| l.contains("bash -l -i -c env") || l.contains("bash -l -c env"))
@@ -335,8 +334,7 @@ fn user_env_probe_capture_propagates_path_into_subsequent_execs() {
 
     // The post-attach `command -v ls` probe should carry the env
     // captured by the pre-restart `bash -lic env` call.
-    let final_history =
-        fs::read_to_string(&history_path).expect("history readable post-spawn");
+    let final_history = fs::read_to_string(&history_path).expect("history readable post-spawn");
     let cmd_exists_calls: Vec<_> = final_history
         .lines()
         .filter(|l| l.contains("sh -c command -v ls"))
@@ -605,6 +603,119 @@ fn attach_decision_persists_in_plugin_global_state() {
         Some("attached"),
         "attach decision must be \"attached\" after a successful \
          Reopen-in-Container; got {value:?}"
+    );
+}
+
+/// **Follow-up to PR #1704**: the attach prompt used to offer a single
+/// `Ignore` action. User feedback was that they need _two_ separate
+/// dismissals: a session-only "not now" (re-asks next launch) and a
+/// permanent "stop asking" (persisted). Pin the new three-action
+/// shape and the side-effects of each:
+///   - `Ignore (once)` → no plugin global state writes; popup not
+///     re-shown in this session, but next editor launch re-asks.
+///   - `Ignore (always …)` → writes `attach:<cwd> = "dismissed"`
+///     to plugin global state, persisted across launches.
+#[test]
+fn attach_popup_offers_separate_once_and_always_dismiss() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let (_workspace_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_attach_popup(&mut harness);
+
+    // Both new option labels must appear on the rendered popup.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ignore (once)"),
+        "popup must offer session-only dismiss option. Screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("Ignore (always"),
+        "popup must offer permanent dismiss option. Screen:\n{screen}"
+    );
+
+    // Pick "Ignore (once)" — second row in the popup. Down arrow
+    // moves the focus, Enter activates.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+
+    // After "Ignore (once)" the plugin must NOT have written a
+    // persistent dismissal — re-launches should re-ask.
+    let workspace_state = harness.editor().capture_workspace();
+    let dc_state = workspace_state.plugin_global_state.get("devcontainer");
+    let key = format!("attach:{}", workspace.display());
+    let persisted = dc_state.and_then(|m| m.get(&key));
+    assert!(
+        persisted.is_none() || persisted.and_then(|v| v.as_str()) != Some("dismissed"),
+        "Ignore (once) must NOT persist `dismissed` to plugin global state. \
+         Got: {persisted:?}"
+    );
+}
+
+/// **Follow-up to PR #1704**: pin the persistent dismissal path.
+/// Picking `Ignore (always in this folder)` writes `dismissed` to
+/// plugin global state so a subsequent editor launch finds it and
+/// skips the popup.
+#[test]
+fn attach_popup_dismiss_always_persists_decision() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let (_workspace_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_attach_popup(&mut harness);
+
+    // Pick the third row: `Ignore (always in this folder)`.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+
+    let workspace_state = harness.editor().capture_workspace();
+    let dc_state = workspace_state
+        .plugin_global_state
+        .get("devcontainer")
+        .unwrap_or_else(|| {
+            panic!(
+                "Ignore (always …) must write to plugin global state. \
+                 Plugin map: {:?}",
+                workspace_state
+                    .plugin_global_state
+                    .keys()
+                    .collect::<Vec<_>>()
+            )
+        });
+    let key = format!("attach:{}", workspace.display());
+    let value = dc_state.get(&key).unwrap_or_else(|| {
+        panic!(
+            "expected key {key:?} after Ignore (always). Keys present: {:?}",
+            dc_state.keys().collect::<Vec<_>>()
+        )
+    });
+    assert_eq!(
+        value.as_str(),
+        Some("dismissed"),
+        "Ignore (always …) must persist as \"dismissed\"; got {value:?}"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
@@ -241,6 +241,121 @@ fn attach_via_fake_devcontainer_lands_container_authority() {
 /// caller's `_workspace_temp`.
 fn drop_workspace_temp(_workspace: &Path) {}
 
+/// `userEnvProbe` capture is plumbed through to the docker spawner,
+/// so subsequent `docker exec` invocations carry the captured env via
+/// `-e KEY=VAL` flags. Without this, an LSP server installed by a
+/// `postCreateCommand` into a shell-only PATH (e.g. `~/.local/bin`)
+/// fails the editor's `command_exists` probe with "executable not
+/// found in the active authority's PATH".
+///
+/// The fake docker exposes two hooks that make this checkable
+/// without a real container:
+///   - `FAKE_DC_PROBE_RESPONSE`: stdout for any `docker exec ... -c env`,
+///     standing in for what `bash -lic env` would print inside a
+///     real container.
+///   - `<state>/exec_history`: tab-separated record of every `docker
+///     exec` (id, semicolon-joined `-e KEY=VAL` pairs, command).
+///
+/// Test sequence:
+///   1. Workspace + plugin set up; fake `bash -lic env` returns a
+///      known PATH/HOME.
+///   2. Attach via the popup; the plugin's pre-restart probe call
+///      gets recorded in `exec_history` (assertion #1: probe ran).
+///   3. After authority lands, exercise a `docker exec` through the
+///      authority's spawner (LSP `command_exists` is the production
+///      caller; we stand in by spawning a process via the plugin
+///      runtime so the harness doesn't need an LSP wired up).
+///   4. Assertion #2: that exec carries `PATH=...` we set up — the
+///      whole point of the env-plumbing fix.
+#[cfg(unix)]
+#[test]
+fn user_env_probe_capture_propagates_path_into_subsequent_execs() {
+    use crossterm::event::KeyCode;
+
+    let (_workspace_temp, workspace) = set_up_workspace();
+
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+
+    // Pin the env-probe response in the per-test state dir (process
+    // env vars would leak across parallel test bins). The fake docker
+    // shim cats this file when invoked with `... -c env`.
+    let state = harness
+        .fake_devcontainer_state()
+        .expect("fake state present")
+        .to_path_buf();
+    fs::write(
+        state.join("probe_response"),
+        "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin\nHOME=/home/vscode\nLANG=C.UTF-8\n",
+    )
+    .expect("write probe_response");
+
+    harness.tick_and_render().unwrap();
+
+    wait_for_attach_popup(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, crossterm::event::KeyModifiers::NONE)
+        .unwrap();
+
+    let _label = wait_for_container_authority(&mut harness);
+
+    // Read the recorded exec history. The probe call should be in
+    // there: a `bash -l -i -c env` invocation against the just-up
+    // container — the plugin's `captureContainerLoginEnv` runs this
+    // before handing the payload to `setAuthority`.
+    let history_path = state.join("exec_history");
+    let history = fs::read_to_string(&history_path).unwrap_or_else(|e| {
+        panic!("exec_history not found at {history_path:?}: {e}")
+    });
+    let probe_lines: Vec<_> = history
+        .lines()
+        .filter(|l| l.contains("bash -l -i -c env") || l.contains("bash -l -c env"))
+        .collect();
+    assert!(
+        !probe_lines.is_empty(),
+        "plugin must call `bash -lic env` to capture userEnvProbe; \
+         exec_history was:\n{history}"
+    );
+
+    // Now drive a post-attach `docker exec` through the authority's
+    // long-running spawner. The actual production caller is
+    // `LongRunningSpawner::command_exists` (the LSP path probe).
+    // Construct a fresh tokio runtime for the awaiter — the harness
+    // doesn't expose its own and creating one here is cheap.
+    let spawner = harness.editor().authority().long_running_spawner.clone();
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime starts");
+    rt.block_on(async move { spawner.command_exists("ls").await });
+    drop(rt);
+
+    // The post-attach `command -v ls` probe should carry the env
+    // captured by the pre-restart `bash -lic env` call.
+    let final_history =
+        fs::read_to_string(&history_path).expect("history readable post-spawn");
+    let cmd_exists_calls: Vec<_> = final_history
+        .lines()
+        .filter(|l| l.contains("sh -c command -v ls"))
+        .collect();
+    assert!(
+        !cmd_exists_calls.is_empty(),
+        "post-attach command_exists must have run a `command -v` probe; \
+         final history:\n{final_history}"
+    );
+    let last = cmd_exists_calls.last().unwrap();
+    assert!(
+        last.contains("PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin"),
+        "command_exists probe must include the captured PATH; \
+         got line: {last:?}\nfull history:\n{final_history}"
+    );
+
+    drop_workspace_temp(&workspace);
+}
+
 /// Wait until the failed-attach popup has rendered. Title comes from
 /// `popup.failed_attach_title` in the plugin's i18n bundle.
 fn wait_for_failed_attach_popup(harness: &mut EditorTestHarness) {

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_usability_repros.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_usability_repros.rs
@@ -823,6 +823,169 @@ fn show_panels_reuse_single_split_instead_of_stacking() {
     );
 }
 
+/// **Follow-up to PR #1704**: PR #1704 fixed split-stacking by routing
+/// every Show command through one shared panel slot, but it still
+/// _replaced_ each command's buffer with the next command's buffer.
+/// User feedback was: each Show should keep its own buffer so the
+/// user can flip back to the previous command's output via the tab
+/// bar / buffer list, instead of having to re-run the command.
+///
+/// Regression guard: invoke `Show Container Info`, then
+/// `Show Container Logs`, and assert both buffers exist after.
+#[cfg(unix)]
+#[test]
+fn show_panels_keep_per_command_buffers_alive_across_commands() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+    harness.tick_and_render().unwrap();
+    attach_via_fake(&mut harness);
+
+    // Wait for the build log to settle so we don't race the panel
+    // split's first occupant.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("devcontainer-logs/build-"))
+        .unwrap();
+
+    // Show Container Info first.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Dev Container: Show Info").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Dev Container: Show Info"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..40 {
+        harness.tick_and_render().unwrap();
+        std::thread::sleep(Duration::from_millis(25));
+        harness.advance_time(Duration::from_millis(25));
+    }
+
+    // Then Show Container Logs.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .type_text("Dev Container: Show Container Logs")
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("Dev Container: Show Container Logs")
+        })
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..40 {
+        harness.tick_and_render().unwrap();
+        std::thread::sleep(Duration::from_millis(25));
+        harness.advance_time(Duration::from_millis(25));
+    }
+
+    // Both panel buffers must still exist — Show Container Logs
+    // should NOT have closed the Info buffer. The tab bar of the
+    // panel split shows both names when both are open.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("*Dev Container*"),
+        "*Dev Container* (info) buffer must still be visible in \
+         the tab bar after Show Container Logs ran. Screen:\n{screen}"
+    );
+    assert!(
+        screen.contains("*Dev Container Logs*"),
+        "*Dev Container Logs* buffer must be visible in the \
+         tab bar — most recent Show command. Screen:\n{screen}"
+    );
+}
+
+/// **Follow-up to PR #1704**: line wrapping was on by default for
+/// the panel slot's virtual buffers, so logs (containerd build
+/// output, lifecycle command stdout) would soft-wrap at the panel
+/// width and become unreadable. Pin: panel buffers come up with
+/// line wrap disabled.
+#[cfg(unix)]
+#[test]
+fn show_container_logs_buffer_has_line_wrap_disabled() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+    harness.tick_and_render().unwrap();
+    attach_via_fake(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("devcontainer-logs/build-"))
+        .unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .type_text("Dev Container: Show Container Logs")
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("Dev Container: Show Container Logs")
+        })
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..40 {
+        harness.tick_and_render().unwrap();
+        std::thread::sleep(Duration::from_millis(25));
+        harness.advance_time(Duration::from_millis(25));
+    }
+
+    // The panel buffer's line-wrap setting isn't directly
+    // observable through public Rust APIs without adding a new
+    // accessor; use the screen-based proxy. With wrap enabled
+    // the editor draws a wrap-marker glyph at the line break;
+    // with wrap disabled long lines just truncate at the right
+    // edge with no marker. Force a long line into the panel by
+    // running Show Container Logs against fake-docker logs that
+    // contain a >panel-width entry.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("*Dev Container Logs*"),
+        "Show Container Logs must surface its named panel buffer. \
+         Screen:\n{screen}"
+    );
+    // The screen must NOT contain the wrap-marker the editor
+    // draws when soft-wrap is on. Marker is the unicode return
+    // arrow `↵`; absence is the regression guard.
+    let logs_section = screen
+        .lines()
+        .skip_while(|l| !l.contains("*Dev Container Logs*"))
+        .take(10)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !logs_section.contains('\u{21B5}'),
+        "panel logs buffer should default to line-wrap off — \
+         wrap marker '↵' must not appear in the logs body. \
+         Section:\n{logs_section}"
+    );
+}
+
 /// **Critical bug from interactive walkthrough:** when the user
 /// ran a lifecycle command, the captured stdout/stderr were
 /// discarded — only a status line ("postCreateCommand failed

--- a/crates/fresh-editor/tests/e2e/status_bar_message_click.rs
+++ b/crates/fresh-editor/tests/e2e/status_bar_message_click.rs
@@ -114,3 +114,85 @@ fn click_on_plugin_status_message_opens_status_log() -> anyhow::Result<()> {
     );
     Ok(())
 }
+
+/// `set_status_log_path` survives a destructive editor rebuild.
+///
+/// Production drops the old editor and constructs a new one on every
+/// authority swap (devcontainer attach, SSH connect, …). The status
+/// log path used to be wired up only in `handle_first_run_setup`, so
+/// after the swap the new editor had no log path and clicking the
+/// status bar surfaced "Status log not available". `main.rs` now
+/// captures the path once and re-binds it to every editor — this test
+/// pins the bare invariant that re-applying the path on a fresh editor
+/// gets clicks routed back to the log.
+#[test]
+fn status_log_path_can_be_rebound_after_editor_rebuild() -> anyhow::Result<()> {
+    use crate::common::harness::HarnessOptions;
+
+    let temp = tempfile::NamedTempFile::new()?;
+    std::fs::write(temp.path(), "post-restart status log line\n")?;
+    let log_path: PathBuf = temp.path().to_path_buf();
+
+    // First editor: configure the path, then drop it without
+    // touching the channel — simulates the pre-restart editor going
+    // out of scope when `setAuthority` triggers a rebuild.
+    {
+        let mut harness = EditorTestHarness::create(120, 30, HarnessOptions::new())?;
+        harness.editor_mut().set_status_log_path(log_path.clone());
+    }
+
+    // Second editor: brand-new instance, no first-run setup, just
+    // the explicit re-bind that the new main-loop wiring performs.
+    let mut harness = EditorTestHarness::create(120, 30, HarnessOptions::new())?;
+    harness.editor_mut().set_status_log_path(log_path.clone());
+
+    let marker = "post-restart-status-marker";
+    harness.editor_mut().set_status_message(marker.to_string());
+    harness.render()?;
+
+    let (col, row) = harness.find_text_on_screen(marker).ok_or_else(|| {
+        anyhow::anyhow!(
+            "post-restart status marker must be visible; screen:\n{}",
+            harness.screen_to_string()
+        )
+    })?;
+    harness.mouse_click(col, row)?;
+    harness.render()?;
+
+    let content = harness.get_buffer_content().unwrap_or_default();
+    assert!(
+        content.contains("post-restart status log line"),
+        "rebound status log path must open the log buffer; \
+         active buffer content was: {content:?}\nscreen:\n{}",
+        harness.screen_to_string()
+    );
+    Ok(())
+}
+
+/// `take_warning_log` returns the path that was last set, and a
+/// freshly-created editor without `set_warning_log` returns None.
+/// Pins the round-trip used by `main.rs` to forward the warning
+/// channel across editor restarts.
+#[test]
+fn take_warning_log_returns_set_value() -> anyhow::Result<()> {
+    let mut harness = EditorTestHarness::new(80, 24)?;
+    assert!(
+        harness.editor_mut().take_warning_log().is_none(),
+        "new editor has no warning log channel installed"
+    );
+
+    let (_tx, rx) = std::sync::mpsc::channel::<()>();
+    let path = std::path::PathBuf::from("/tmp/fake-warning-log");
+    harness.editor_mut().set_warning_log(rx, path.clone());
+
+    let taken = harness
+        .editor_mut()
+        .take_warning_log()
+        .expect("warning log was set, must be returned by take");
+    assert_eq!(taken.1, path);
+    assert!(
+        harness.editor_mut().take_warning_log().is_none(),
+        "subsequent take returns None — single-consumer semantics"
+    );
+    Ok(())
+}

--- a/scripts/fake-devcontainer/bin/docker
+++ b/scripts/fake-devcontainer/bin/docker
@@ -20,11 +20,19 @@ EOF
 cmd_exec() {
   user=""
   workdir=""
+  exec_env_pairs=()
   while [ $# -gt 0 ]; do
     case "$1" in
       -i|-t|-it|-ti) shift ;;
       -u) user="${2:-}"; shift 2 ;;
       -w) workdir="${2:-}"; shift 2 ;;
+      -e)
+        # `docker exec -e KEY=VAL` — capture for the optional history
+        # log so tests can assert against the env that reached the
+        # container, then export so the child sees it.
+        exec_env_pairs+=("${2:-}")
+        export "${2:-}"
+        shift 2 ;;
       --) shift; break ;;
       -*)
         # Unknown flag — pass through to the child by stopping flag parsing.
@@ -47,12 +55,42 @@ cmd_exec() {
   state="$(fake_state_dir)"
   cdir="$state/containers/$container_id"
 
+  # Record this exec invocation to a per-state history file so tests
+  # can assert on which env vars were forwarded via `-e` and which
+  # commands ran. Each line: `<container_id>\t<env_pair>;<env_pair>...\t<cmd> <args...>`.
+  exec_history_file="$state/exec_history"
+  exec_env_joined="$(IFS=';'; printf '%s' "${exec_env_pairs[*]:-}")"
+  printf '%s\t%s\t%s\n' "$container_id" "$exec_env_joined" "$*" >> "$exec_history_file" 2>/dev/null || true
+
   # Always surface what the editor *requested* via -w, regardless of
   # whether that path exists on the host. Lets tests assert against
   # the in-container path the plugin would have sent (which is what
   # real `docker exec -w` honors), without the fake silently masking
   # a host-vs-container path mismatch.
   export FAKE_DC_REQUESTED_CWD="$workdir"
+
+  # Special-case the `userEnvProbe` exec so tests don't depend on
+  # whatever bash exists on the host (a real `bash -lic env` against
+  # the host can take seconds and emit terminal-mode warnings).
+  # Triggered when the *plain* `bash <flags> -c env` shape arrives —
+  # i.e. the captureContainerLoginEnv probe with no env wrapping.
+  #
+  # Lifecycle-style probes that go through `wrapWithEnv` arrive as
+  # `env KEY=VAL bash <flags> -c env`; those still need to hit a real
+  # bash so `BASH_ENV` etc. get honored (B3 in spec_conformance pins
+  # this). Detect by checking $1 — `bash` means plain probe, anything
+  # else (notably `env`) falls through.
+  if [ $# -ge 2 ] && [ "$1" = "bash" ]; then
+    last_two="${@: -2}"
+    if [ "$last_two" = "-c env" ]; then
+      if [ -f "$state/probe_response" ]; then
+        cat "$state/probe_response"
+      else
+        printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\nHOME=/root\nLANG=C.UTF-8\n'
+      fi
+      exit 0
+    fi
+  fi
 
   if [ -z "$workdir" ] && [ -f "$cdir/workspace" ]; then
     # Treat the recorded host workspace path as the cwd. In real


### PR DESCRIPTION
## Summary

This PR implements environment variable capture from the container's user shell and propagates it to all subsequent `docker exec` invocations. This fixes LSP server discovery for binaries installed in shell-only PATHs (e.g., `~/.local/bin`) by a `postCreateCommand`.

## Key Changes

### Core Environment Capture & Propagation
- **Plugin (`devcontainer.ts`)**: Added `captureContainerLoginEnv()` function that runs `bash -lic env` inside the container before `setAuthority` to capture the user's shell environment (PATH, HOME, LANG, etc.)
- **Plugin**: Modified `buildContainerAuthorityPayload()` to include captured environment in the authority payload
- **Docker Spawner (`docker_spawner.rs`)**: Updated `DockerExecSpawner` and `DockerLongRunningSpawner` to accept and apply `base_env` via `-e KEY=VAL` flags on every `docker exec` invocation
- **Authority (`mod.rs`)**: Extended `SpawnerSpec::DockerExec` to carry the captured environment as a list of key-value pairs

### Panel Buffer Management Improvements
- **Plugin**: Introduced `namedPanelBuffers` registry to deduplicate buffers by command name, allowing users to switch between different Show commands' outputs via the tab bar
- **Plugin**: Changed default line-wrap setting for panel buffers from `true` to `false` to prevent soft-wrapping of wide structured output (docker buildx, lifecycle logs)
- **Plugin**: Refactored `openVirtualInPanelSlot()` to reuse existing same-name buffers instead of creating duplicates

### Attach Popup UX Improvements
- **Plugin**: Split the single "Ignore" action into two separate dismissal options:
  - "Ignore (once)" - session-only, doesn't persist
  - "Ignore (always in this folder)" - persists `dismissed` state to plugin global state
- **i18n**: Added new action labels in all supported languages (en, cs, de, es, fr, ja, ko, pt, ru, zh-cn, zh-tw)

### Editor Restart Resilience
- **Main loop (`main.rs`)**: Moved status-log path and warning-log channel binding outside of `handle_first_run_setup()` so they survive destructive editor rebuilds (e.g., devcontainer attach)
- **Editor accessors**: Added `take_warning_log()` method to extract the warning channel for re-installation on restarted editors

### Testing & Fake Docker Enhancements
- **Fake docker**: Added `-e KEY=VAL` flag parsing and `exec_history` logging to track environment variables passed to container processes
- **Fake docker**: Special-case handling for `userEnvProbe` exec to return configured probe response
- **E2E tests**: Added comprehensive test coverage for environment capture propagation, panel buffer deduplication, and attach popup dismissal options

## Implementation Details

- Environment capture respects the `userEnvProbe` config setting (loginShell, loginInteractiveShell, interactiveShell, none)
- Captured environment is filtered to a safe allowlist (PATH, HOME, LANG, LC_ALL, SHELL, USER, LOGNAME) to avoid shadowing container defaults
- Graceful degradation: if the probe fails, an empty environment is used (same behavior as before the fix)
- Per-call environment variables in spawner methods can override the base captured environment
- Panel buffer deduplication is keyed by buffer name, allowing different Show commands to maintain independent buffers

https://claude.ai/code/session_01TC2Y81WwXNKD9oB3mZNL23