### PR TITLE
Add host↔container path translation for LSP URIs in devcontainer

### DIFF
--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -1639,6 +1639,7 @@ function parseDevcontainerUpOutput(stdout: string): DevcontainerUpResult | null 
 function buildContainerAuthorityPayload(
   result: DevcontainerUpResult,
   baseEnv: Array<[string, string]>,
+  hostWorkspace: string | null,
 ): AuthorityPayload | null {
   if (!result.containerId) return null;
   const user = result.remoteUser ?? null;
@@ -1654,6 +1655,20 @@ function buildContainerAuthorityPayload(
   args.push(result.containerId, "bash", "-l");
 
   const shortId = result.containerId.slice(0, 12);
+
+  // Plumb the host↔container workspace mapping through to the
+  // authority. Without this, every LSP URI carrying a workspace path
+  // is mis-translated at the host/container boundary: didOpen sends
+  // host paths to the in-container LSP, and Goto-Definition responses
+  // come back with container paths the editor opens verbatim on the
+  // host. Both roots must be present and absolute for the mapping to
+  // be useful — when either is missing we leave path_translation
+  // unset and accept the (broken) status quo rather than installing a
+  // half-mapping that translates one direction.
+  const path_translation =
+    hostWorkspace && workspace
+      ? { host_root: hostWorkspace, remote_root: workspace }
+      : undefined;
 
   return {
     filesystem: { kind: "local" },
@@ -1671,6 +1686,7 @@ function buildContainerAuthorityPayload(
       manages_cwd: true,
     },
     display_label: "Container:" + shortId,
+    path_translation,
   };
 }
 
@@ -1871,7 +1887,13 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
   // `userEnvProbe` is unset the default is `loginInteractiveShell`.
   const baseEnv = await captureContainerLoginEnv(parsed);
 
-  const payload = buildContainerAuthorityPayload(parsed, baseEnv);
+  // Capture the host workspace path so the authority can translate
+  // LSP URIs at the host↔container boundary. `editor.getCwd()` is
+  // the production host workspace today; we read it just before
+  // setAuthority so the value matches the editor that's about to be
+  // rebuilt.
+  const hostWorkspace = editor.getCwd();
+  const payload = buildContainerAuthorityPayload(parsed, baseEnv, hostWorkspace);
   if (!payload) {
     enterFailedAttach(editor.t("status.rebuild_missing_container_id"));
     return;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -715,6 +715,17 @@ type AuthorityPayload = {
 	spawner: AuthoritySpawner;
 	terminal_wrapper: AuthorityTerminalWrapper;
 	display_label?: string;
+	/**
+	* Optional host↔remote workspace path mapping. The dev-container
+	* authority sets both roots (editor.getCwd() on host;
+	* remoteWorkspaceFolder on container) so LSP URIs translate at the
+	* host/container boundary. Local and SSH authorities omit it.
+	*/
+	path_translation?: PathTranslationSpec;
+};
+type PathTranslationSpec = {
+	host_root: string;
+	remote_root: string;
 };
 type BackgroundProcessResult = {
 	/**

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1416,7 +1416,11 @@ impl Editor {
                     Some(c) => c,
                     None => continue, // Skip buffers that aren't fully loaded
                 };
-                let uri: Option<lsp_types::Uri> = super::types::file_path_to_lsp_uri(&path);
+                let uri: Option<lsp_types::Uri> =
+                    super::types::file_path_to_lsp_uri_with_translation(
+                        &path,
+                        self.authority.path_translation.as_ref(),
+                    );
 
                 if let Some(uri) = uri {
                     let lang_id = state.language.clone();

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -36,10 +36,15 @@ impl Editor {
     ///
     /// This is a common pattern used by diagnostics, inlay hints, and other LSP handlers
     pub(super) fn find_buffer_by_uri(&self, uri: &str) -> Option<BufferId> {
-        let parsed_uri = uri.parse::<lsp_types::Uri>().ok()?;
+        // The incoming URI string came over the LSP wire (e.g. a
+        // `publishDiagnostics` notification), so it's already in the
+        // server's coordinate space. `BufferMetadata.file_uri` is also
+        // wire-side ([`LspUri`]), so a string comparison is the right
+        // primitive here — both sides are translated identically and
+        // we never accidentally compare a host URI to a wire URI.
         self.buffer_metadata
             .iter()
-            .find(|(_, m)| m.file_uri() == Some(&parsed_uri))
+            .find(|(_, m)| m.file_uri().map(|u| u.as_str() == uri).unwrap_or(false))
             .map(|(buffer_id, _)| *buffer_id)
     }
 
@@ -57,7 +62,10 @@ impl Editor {
     /// Callers that need richer per-buffer info (line counts, content, file
     /// paths) can still iterate themselves, but should use the same
     /// `state.language == language` predicate this helper encodes.
-    pub(crate) fn buffers_for_language(&self, language: &str) -> Vec<(BufferId, lsp_types::Uri)> {
+    pub(crate) fn buffers_for_language(
+        &self,
+        language: &str,
+    ) -> Vec<(BufferId, crate::app::types::LspUri)> {
         self.buffers
             .iter()
             .filter_map(|(buffer_id, state)| {
@@ -762,7 +770,9 @@ impl Editor {
             self.next_lsp_request_id += 1;
 
             let last_line = line_count.saturating_sub(1) as u32;
-            if let Err(e) = client.inlay_hints(request_id, uri.clone(), 0, 0, last_line, 10000) {
+            if let Err(e) =
+                client.inlay_hints(request_id, uri.as_uri().clone(), 0, 0, last_line, 10000)
+            {
                 tracing::debug!(
                     "Failed to re-request inlay hints for {}: {}",
                     uri.as_str(),
@@ -820,7 +830,8 @@ impl Editor {
             let request_id = self.next_lsp_request_id;
             self.next_lsp_request_id += 1;
             let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
-            if let Err(e) = client.document_diagnostic(request_id, uri.clone(), previous_result_id)
+            if let Err(e) =
+                client.document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
             {
                 tracing::debug!("Failed to re-pull diagnostics for {}: {}", uri.as_str(), e);
             } else {

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -253,7 +253,10 @@ impl Editor {
                 state.buffer.rename_file_path(new_path.clone());
             }
             if let Some(metadata) = self.buffer_metadata.get_mut(&id) {
-                let file_uri = super::types::file_path_to_lsp_uri(&new_path);
+                let file_uri = super::types::file_path_to_lsp_uri_with_translation(
+                    &new_path,
+                    self.authority.path_translation.as_ref(),
+                );
                 metadata.kind = super::BufferKind::File {
                     path: new_path.clone(),
                     uri: file_uri,

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -253,7 +253,7 @@ impl Editor {
                 state.buffer.rename_file_path(new_path.clone());
             }
             if let Some(metadata) = self.buffer_metadata.get_mut(&id) {
-                let file_uri = super::types::file_path_to_lsp_uri_with_translation(
+                let file_uri = super::types::LspUri::from_host_path(
                     &new_path,
                     self.authority.path_translation.as_ref(),
                 );

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -502,9 +502,12 @@ impl Editor {
         // manager so `force_spawn` can route server processes through
         // the right backend. The editor rebuilds on every authority
         // transition (AUTHORITY_DESIGN.md principle 7), so this is the
-        // single wiring point — no need for a hot-swap API.
+        // single wiring point — no need for a hot-swap API. Path
+        // translation rides along for the same reason — LSP URIs need
+        // to be host↔container-translated under the new authority.
         if let Some(lsp) = self.lsp.as_mut() {
             lsp.set_long_running_spawner(self.authority.long_running_spawner.clone());
+            lsp.set_path_translation(self.authority.path_translation.clone());
         }
         #[cfg(feature = "plugins")]
         {

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -794,7 +794,9 @@ impl Editor {
         let request_id = self.next_lsp_request_id;
         self.next_lsp_request_id += 1;
         let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
-        if let Err(e) = client.document_diagnostic(request_id, uri.clone(), previous_result_id) {
+        if let Err(e) =
+            client.document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
+        {
             tracing::debug!(
                 "Failed to pull diagnostics after edit for {}: {}",
                 uri.as_str(),

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -853,4 +853,226 @@ impl Editor {
         PersistedFileWorkspace::save(&abs_path, file_state);
         tracing::debug!("Saved file state on close for {:?}", abs_path);
     }
+
+    /// Open the file an LSP response URI points at, handling the three
+    /// cases the goto-def / references / workspace-edit handlers all
+    /// have to think about:
+    ///
+    ///   * **on-host file** (the workspace bind mount, or a local
+    ///     authority): host-translate the URI and open the host file
+    ///     normally — exactly what the editor has always done.
+    ///   * **container-only file** (devcontainer attach with the
+    ///     target outside the workspace mount, e.g. a pip-installed
+    ///     `~/.local/.../site-packages/flask/app.py`): fetch the file
+    ///     bytes via the authority's process spawner
+    ///     (`docker exec <id> cat <path>`) and open them as a
+    ///     read-only buffer at the in-container path.
+    ///   * **unreachable** (no file at the host path; container fetch
+    ///     failed or no container authority): return `Err` so the
+    ///     caller can surface a user-visible status message instead
+    ///     of silently opening a phantom buffer.
+    ///
+    /// Cursor placement, focus, and any post-open hook firing are the
+    /// caller's job (this method just resolves "URI → BufferId").
+    pub(crate) fn open_lsp_uri_target(
+        &mut self,
+        uri: &crate::app::types::LspUri,
+    ) -> anyhow::Result<BufferId> {
+        let translation = self.authority.path_translation.clone();
+        let host_path = uri
+            .to_host_path(translation.as_ref())
+            .ok_or_else(|| anyhow::anyhow!("URI is not a file path"))?;
+
+        // Case 1: file is reachable on the host filesystem (either
+        // local authority, or workspace-mounted on a devcontainer).
+        // `open_file` focuses, which is what callers (goto-def,
+        // workspace edits) expect — they want the cursor to land in
+        // the destination buffer afterward.
+        if self.authority.filesystem.exists(&host_path) {
+            return self.open_file(&host_path);
+        }
+
+        // Case 2: container-only fetch. Only meaningful when the
+        // active authority can route a `cat` through to the
+        // container — `path_translation` being set is the proxy for
+        // "this is a container authority". Local + SSH authorities
+        // skip straight to the error case.
+        if translation.is_some() {
+            // The container-side path is the URI's raw path. Calling
+            // `to_host_path` with `None` returns the wire-side path
+            // verbatim (no translation applied) — exactly what we
+            // need for `cat <path>` inside the container.
+            let container_path = uri.to_host_path(None).ok_or_else(|| {
+                anyhow::anyhow!("URI is not a file path (container-side decode failed)")
+            })?;
+            let buffer_id = self.fetch_and_open_container_file(container_path, uri.clone())?;
+            // Match `open_file`'s focus behaviour so the cursor
+            // assertion in callers (goto-def's `MoveCursor` event)
+            // applies to the right buffer.
+            self.set_active_buffer(buffer_id);
+            return Ok(buffer_id);
+        }
+
+        // Case 3: nothing we can open.
+        Err(anyhow::anyhow!(
+            "could not open {}: file not found",
+            host_path.display()
+        ))
+    }
+
+    /// Run `cat <container_path>` through the active authority's
+    /// process spawner and open the result as a read-only buffer
+    /// tagged with the wire URI. Helper for [`Self::open_lsp_uri_target`].
+    ///
+    /// On `cat` exit-code 0 the bytes become the buffer's contents.
+    /// On any error (no tokio runtime, spawner failure, non-zero
+    /// exit) we return `Err` with a message that includes the
+    /// container path and stderr's first line — enough for the
+    /// caller's status-line surface.
+    fn fetch_and_open_container_file(
+        &mut self,
+        container_path: std::path::PathBuf,
+        uri: crate::app::types::LspUri,
+    ) -> anyhow::Result<BufferId> {
+        let runtime = self.tokio_runtime.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "could not open {}: no tokio runtime available for container fetch",
+                container_path.display()
+            )
+        })?;
+
+        let spawner = self.authority.process_spawner.clone();
+        let path_arg = container_path.to_string_lossy().into_owned();
+        let result = runtime
+            .block_on(spawner.spawn("cat".into(), vec![path_arg], None))
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "could not open {} from container: {}",
+                    container_path.display(),
+                    e
+                )
+            })?;
+
+        if result.exit_code != 0 {
+            let first_stderr_line = result
+                .stderr
+                .lines()
+                .next()
+                .unwrap_or("(no error message)")
+                .trim();
+            anyhow::bail!(
+                "could not open {} from container: {}",
+                container_path.display(),
+                first_stderr_line
+            );
+        }
+
+        self.open_container_only_file(container_path, uri, result.stdout.into_bytes())
+    }
+
+    /// Build a buffer from already-fetched container content. The
+    /// buffer's `file_path` is the in-container path (so further LSP
+    /// requests carry the right URI) and the buffer is read-only —
+    /// there is no host writeback path for files that exist only
+    /// inside the container. LSP stays enabled so a follow-up
+    /// goto-def from the fetched buffer works.
+    pub(crate) fn open_container_only_file(
+        &mut self,
+        container_path: std::path::PathBuf,
+        uri: crate::app::types::LspUri,
+        content: Vec<u8>,
+    ) -> anyhow::Result<BufferId> {
+        // Don't double-open. The file_path matches by container path,
+        // since that's what we set after build.
+        let already_open = self
+            .buffers
+            .iter()
+            .find(|(_, state)| state.buffer.file_path() == Some(container_path.as_path()))
+            .map(|(id, _)| *id);
+        if let Some(id) = already_open {
+            return Ok(id);
+        }
+
+        // Build the buffer from the fetched bytes and pin its
+        // file_path to the container path. The host filesystem ref
+        // here is mostly cosmetic — the buffer is read-only so save
+        // never runs through it.
+        let mut buffer = crate::model::buffer::Buffer::from_bytes(
+            content,
+            Arc::clone(&self.authority.filesystem),
+        );
+        buffer.rename_file_path(container_path.clone());
+
+        // Detect language from the container path (the basename's
+        // extension is what matters; the directory tree is
+        // container-side and won't match host-relative globs anyway).
+        let first_line = buffer.first_line_lossy();
+        let detected =
+            crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
+                &container_path,
+                first_line.as_deref(),
+                &self.grammar_registry,
+                &self.config.languages,
+                self.config.default_language.as_deref(),
+            );
+        let mut state = EditorState::from_buffer_with_language(buffer, detected);
+        state.editing_disabled = true;
+
+        // Whitespace / tab settings — same shape as `open_file_no_focus`
+        // so the rendered look is consistent. Container-fetched
+        // buffers should obey the user's editor config like any other
+        // read-only buffer.
+        let mut whitespace =
+            crate::config::WhitespaceVisibility::from_editor_config(&self.config.editor);
+        if let Some(lang_config) = self.config.languages.get(&state.language) {
+            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
+            state.buffer_settings.use_tabs =
+                lang_config.use_tabs.unwrap_or(self.config.editor.use_tabs);
+            state.buffer_settings.tab_size =
+                lang_config.tab_size.unwrap_or(self.config.editor.tab_size);
+        } else {
+            state.buffer_settings.tab_size = self.config.editor.tab_size;
+            state.buffer_settings.use_tabs = self.config.editor.use_tabs;
+        }
+        state.buffer_settings.whitespace = whitespace;
+        state
+            .margins
+            .configure_for_line_numbers(self.config.editor.line_numbers);
+
+        let buffer_id = BufferId(self.next_buffer_id);
+        self.next_buffer_id += 1;
+        self.buffers.insert(buffer_id, state);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+
+        let mut metadata =
+            super::types::BufferMetadata::with_container_file(container_path.clone(), uri);
+        // Notify the LSP servers about the newly opened file so
+        // hover / further goto-def in the fetched buffer works. The
+        // URI we cached is already the wire-form URI, so the LSP
+        // sees the right path.
+        self.notify_lsp_file_opened(&container_path, buffer_id, &mut metadata);
+        self.buffer_metadata.insert(buffer_id, metadata);
+
+        // Wire the buffer into a tab on the preferred split, mirroring
+        // the host-file path. Skip `watch_file` — there's no host
+        // file to inotify, and the spawned-fetch is one-shot.
+        let target_split = self.preferred_split_for_file();
+        let line_wrap = self.resolve_line_wrap_for_buffer(buffer_id);
+        let wrap_column = self.resolve_wrap_column_for_buffer(buffer_id);
+        if let Some(view_state) = self.split_view_states.get_mut(&target_split) {
+            view_state.add_buffer(buffer_id);
+            let buf_state = view_state.ensure_buffer_state(buffer_id);
+            buf_state.apply_config_defaults(
+                self.config.editor.line_numbers,
+                self.config.editor.highlight_current_line,
+                line_wrap,
+                self.config.editor.wrap_indent,
+                wrap_column,
+                self.config.editor.rulers.clone(),
+            );
+        }
+
+        Ok(buffer_id)
+    }
 }

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -301,6 +301,7 @@ impl Editor {
             path.to_path_buf(),
             &display_path,
             &self.working_dir,
+            self.authority.path_translation.as_ref(),
         );
 
         // Mark binary files in metadata and disable LSP
@@ -447,6 +448,7 @@ impl Editor {
             path.to_path_buf(),
             &display_path,
             &self.working_dir,
+            self.authority.path_translation.as_ref(),
         );
         self.buffer_metadata.insert(buffer_id, metadata);
 
@@ -559,6 +561,7 @@ impl Editor {
             path.to_path_buf(),
             &display_path,
             &self.working_dir,
+            self.authority.path_translation.as_ref(),
         );
         self.buffer_metadata.insert(buffer_id, metadata);
 
@@ -707,6 +710,7 @@ impl Editor {
             path.to_path_buf(),
             &display_path,
             &self.working_dir,
+            self.authority.path_translation.as_ref(),
         );
         self.buffer_metadata.insert(buffer_id, metadata);
 

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -1040,7 +1040,10 @@ impl Editor {
     pub(crate) fn notify_lsp_file_changed(&mut self, path: &Path) {
         use crate::services::lsp::manager::LspSpawnResult;
 
-        let Some(lsp_uri) = super::types::file_path_to_lsp_uri(path) else {
+        let Some(lsp_uri) = super::types::file_path_to_lsp_uri_with_translation(
+            path,
+            self.authority.path_translation.as_ref(),
+        ) else {
             return;
         };
 

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -910,9 +910,9 @@ impl Editor {
                 // about the open document.
                 for sh in lsp.get_handles_mut(&language) {
                     tracing::info!("Sending didOpen to LSP '{}' for: {}", sh.name, uri.as_str());
-                    if let Err(e) = sh
-                        .handle
-                        .did_open(uri.clone(), text.clone(), language.clone())
+                    if let Err(e) =
+                        sh.handle
+                            .did_open(uri.as_uri().clone(), text.clone(), language.clone())
                     {
                         tracing::warn!("Failed to send didOpen to LSP '{}': {}", sh.name, e);
                     } else {
@@ -931,10 +931,11 @@ impl Editor {
                 {
                     let request_id = self.next_lsp_request_id;
                     self.next_lsp_request_id += 1;
-                    if let Err(e) =
-                        sh.handle
-                            .document_diagnostic(request_id, uri.clone(), previous_result_id)
-                    {
+                    if let Err(e) = sh.handle.document_diagnostic(
+                        request_id,
+                        uri.as_uri().clone(),
+                        previous_result_id,
+                    ) {
                         tracing::debug!("Failed to request pull diagnostics: {}", e);
                     } else {
                         tracing::info!(
@@ -954,7 +955,7 @@ impl Editor {
 
                         if let Err(e) = sh.handle.inlay_hints(
                             request_id,
-                            uri.clone(),
+                            uri.as_uri().clone(),
                             0,
                             0,
                             last_line,

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -141,7 +141,10 @@ impl Editor {
                 continue; // Skip buffers that aren't fully loaded
             };
 
-            let Some(uri) = super::types::file_path_to_lsp_uri(&buf_path) else {
+            let Some(uri) = super::types::file_path_to_lsp_uri_with_translation(
+                &buf_path,
+                self.authority.path_translation.as_ref(),
+            ) else {
                 continue;
             };
 
@@ -1165,7 +1168,10 @@ impl Editor {
 
                 // Update buffer metadata to point at the temp file, enabling LSP
                 if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
-                    if let Some(uri) = super::types::file_path_to_lsp_uri(&plugin_file) {
+                    if let Some(uri) = super::types::file_path_to_lsp_uri_with_translation(
+                        &plugin_file,
+                        self.authority.path_translation.as_ref(),
+                    ) {
                         metadata.kind = super::types::BufferKind::File {
                             path: plugin_file.clone(),
                             uri: Some(uri),
@@ -1211,7 +1217,10 @@ impl Editor {
                 // Add the plugin workspace folder so tsserver discovers tsconfig.json + fresh.d.ts
                 if let Some(lsp) = &self.lsp {
                     if let Some(handle) = lsp.get_handle("typescript") {
-                        if let Some(uri) = super::types::file_path_to_lsp_uri(&workspace_dir) {
+                        if let Some(uri) = super::types::file_path_to_lsp_uri_with_translation(
+                            &workspace_dir,
+                            self.authority.path_translation.as_ref(),
+                        ) {
                             let name = workspace_dir
                                 .file_name()
                                 .unwrap_or_default()

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -794,7 +794,7 @@ impl Editor {
                             sh.name,
                             language
                         );
-                        if let Err(e) = sh.handle.did_close(uri.clone()) {
+                        if let Err(e) = sh.handle.did_close(uri.as_uri().clone()) {
                             tracing::warn!("Failed to send didClose to '{}': {}", sh.name, e);
                         }
                     }
@@ -927,7 +927,7 @@ impl Editor {
                             sh.name,
                             language
                         );
-                        if let Err(e) = sh.handle.did_close(uri.clone()) {
+                        if let Err(e) = sh.handle.did_close(uri.as_uri().clone()) {
                             tracing::warn!("Failed to send didClose to '{}': {}", sh.name, e);
                         }
                     }
@@ -1062,7 +1062,7 @@ impl Editor {
         };
 
         let handle_id = handle.id();
-        if let Err(e) = handle.did_open(uri.clone(), text, language.to_string()) {
+        if let Err(e) = handle.did_open(uri.as_uri().clone(), text, language.to_string()) {
             tracing::warn!("Failed to send didOpen to LSP: {}", e);
             return;
         }
@@ -1076,7 +1076,9 @@ impl Editor {
         let request_id = self.next_lsp_request_id;
         self.next_lsp_request_id += 1;
         let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
-        if let Err(e) = handle.document_diagnostic(request_id, uri.clone(), previous_result_id) {
+        if let Err(e) =
+            handle.document_diagnostic(request_id, uri.as_uri().clone(), previous_result_id)
+        {
             tracing::warn!("LSP document_diagnostic request failed: {}", e);
         }
 
@@ -1097,7 +1099,9 @@ impl Editor {
 
             let request_id = self.next_lsp_request_id;
             self.next_lsp_request_id += 1;
-            if let Err(e) = handle.inlay_hints(request_id, uri, 0, 0, last_line, last_char) {
+            if let Err(e) =
+                handle.inlay_hints(request_id, uri.as_uri().clone(), 0, 0, last_line, last_char)
+            {
                 tracing::warn!("LSP inlay_hints request failed: {}", e);
             } else {
                 self.pending_inlay_hints_requests.insert(
@@ -1168,7 +1172,7 @@ impl Editor {
 
                 // Update buffer metadata to point at the temp file, enabling LSP
                 if let Some(metadata) = self.buffer_metadata.get_mut(&buffer_id) {
-                    if let Some(uri) = super::types::file_path_to_lsp_uri_with_translation(
+                    if let Some(uri) = super::types::LspUri::from_host_path(
                         &plugin_file,
                         self.authority.path_translation.as_ref(),
                     ) {

--- a/crates/fresh-editor/src/app/lsp_event_notify.rs
+++ b/crates/fresh-editor/src/app/lsp_event_notify.rs
@@ -239,7 +239,10 @@ impl Editor {
             // Broadcast didSave to all handles for this language
             let mut any_sent = false;
             for sh in lsp.get_handles_mut(&language) {
-                if let Err(e) = sh.handle.did_save(uri.clone(), Some(full_text.clone())) {
+                if let Err(e) = sh
+                    .handle
+                    .did_save(uri.as_uri().clone(), Some(full_text.clone()))
+                {
                     tracing::warn!("Failed to send didSave to '{}': {}", sh.name, e);
                 } else {
                     any_sent = true;

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -24,7 +24,7 @@ use crate::view::prompt::{Prompt, PromptType};
 use crate::services::lsp::async_handler::LspHandle;
 use crate::types::LspFeature;
 
-use super::{uri_to_path, Editor, SemanticTokenRangeRequest};
+use super::{Editor, SemanticTokenRangeRequest};
 
 /// Ensure every line in a docstring is separated by a blank line.
 ///
@@ -230,8 +230,14 @@ impl Editor {
         // For now, just jump to the first location
         let location = &locations[0];
 
-        // Convert URI to file path
-        if let Ok(path) = uri_to_path(&location.uri) {
+        // Convert URI to file path. The LSP runs on the other side of
+        // a possible host↔container mount, so apply the active
+        // authority's translation before crossing back into the
+        // editor's host-path-based filesystem layer.
+        if let Ok(path) = super::uri_to_path_with_translation(
+            &location.uri,
+            self.authority.path_translation.as_ref(),
+        ) {
             // Open the file
             let buffer_id = match self.open_file(&path) {
                 Ok(id) => id,
@@ -2199,7 +2205,9 @@ impl Editor {
         // Version check: if the server specifies a version, verify it matches
         // what we sent. A mismatch means the edit was computed against stale content.
         if let Some(expected_version) = text_doc_edit.text_document.version {
-            if let Ok(path) = uri_to_path(&uri) {
+            if let Ok(path) =
+                super::uri_to_path_with_translation(&uri, self.authority.path_translation.as_ref())
+            {
                 if let Some(lsp) = &self.lsp {
                     let language = self
                         .buffers
@@ -2224,7 +2232,9 @@ impl Editor {
             }
         }
 
-        if let Ok(path) = uri_to_path(&uri) {
+        if let Ok(path) =
+            super::uri_to_path_with_translation(&uri, self.authority.path_translation.as_ref())
+        {
             let buffer_id = match self.open_file(&path) {
                 Ok(id) => id,
                 Err(e) => {
@@ -2397,7 +2407,10 @@ impl Editor {
         // Handle changes (map of URI -> Vec<TextEdit>)
         if let Some(changes) = workspace_edit.changes {
             for (uri, edits) in changes {
-                if let Ok(path) = uri_to_path(&uri) {
+                if let Ok(path) = super::uri_to_path_with_translation(
+                    &uri,
+                    self.authority.path_translation.as_ref(),
+                ) {
                     let buffer_id = match self.open_file(&path) {
                         Ok(id) => id,
                         Err(e) => {

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -230,87 +230,86 @@ impl Editor {
         // For now, just jump to the first location
         let location = &locations[0];
 
-        // Convert URI to file path. The LSP runs on the other side of
-        // a possible host↔container mount, so wrap the wire URI in
-        // [`LspUri`] and apply the authority's translation before
-        // crossing back into the editor's host-path-based filesystem
-        // layer.
+        // Resolve the URI to a buffer. `open_lsp_uri_target` handles
+        // all three cases: host file under the workspace mount,
+        // container-only file fetched via `docker exec cat`, and
+        // unreachable (no file at the host path AND container fetch
+        // failed). The last case becomes a user-visible status
+        // message instead of a phantom empty buffer.
         let wire = crate::app::types::LspUri::from_wire(location.uri.clone());
-        if let Ok(path) =
-            super::lsp_uri_to_host_path(&wire, self.authority.path_translation.as_ref())
-        {
-            // Open the file
-            let buffer_id = match self.open_file(&path) {
-                Ok(id) => id,
-                Err(e) => {
-                    // Check if this is a large file encoding confirmation error
-                    if let Some(confirmation) =
-                        e.downcast_ref::<crate::model::buffer::LargeFileEncodingConfirmation>()
-                    {
-                        self.start_large_file_encoding_confirmation(confirmation);
-                    } else {
-                        self.set_status_message(
-                            t!("file.error_opening", error = e.to_string()).to_string(),
-                        );
-                    }
-                    return Ok(());
+        let buffer_id = match self.open_lsp_uri_target(&wire) {
+            Ok(id) => id,
+            Err(e) => {
+                if let Some(confirmation) =
+                    e.downcast_ref::<crate::model::buffer::LargeFileEncodingConfirmation>()
+                {
+                    self.start_large_file_encoding_confirmation(confirmation);
+                } else {
+                    self.set_status_message(
+                        t!("file.error_opening", error = e.to_string()).to_string(),
+                    );
                 }
+                return Ok(());
+            }
+        };
+
+        // Move cursor to the definition position. The buffer's
+        // `file_path` is the *destination* path — the host path on a
+        // bind-mounted file, the container path on a fetched one —
+        // so we read it back for the status message rather than
+        // formatting the original wire URI.
+        let line = location.range.start.line as usize;
+        let character = location.range.start.character as usize;
+        let position = self
+            .buffers
+            .get(&buffer_id)
+            .map(|state| state.buffer.line_col_to_position(line, character));
+
+        if let Some(position) = position {
+            let (cursor_id, old_position, old_anchor, old_sticky_column) = {
+                let cursors = self.active_cursors();
+                let primary = cursors.primary();
+                (
+                    cursors.primary_id(),
+                    primary.position,
+                    primary.anchor,
+                    primary.sticky_column,
+                )
+            };
+            let event = crate::model::event::Event::MoveCursor {
+                cursor_id,
+                old_position,
+                new_position: position,
+                old_anchor,
+                new_anchor: None,
+                old_sticky_column,
+                new_sticky_column: 0,
             };
 
-            // Move cursor to the definition position
-            let line = location.range.start.line as usize;
-            let character = location.range.start.character as usize;
-
-            // Calculate byte position from line and character
-            let position = self
-                .buffers
-                .get(&buffer_id)
-                .map(|state| state.buffer.line_col_to_position(line, character));
-
-            if let Some(position) = position {
-                // Move cursor - read cursor info from split view state
-                let (cursor_id, old_position, old_anchor, old_sticky_column) = {
-                    let cursors = self.active_cursors();
-                    let primary = cursors.primary();
-                    (
-                        cursors.primary_id(),
-                        primary.position,
-                        primary.anchor,
-                        primary.sticky_column,
-                    )
-                };
-                let event = crate::model::event::Event::MoveCursor {
-                    cursor_id,
-                    old_position,
-                    new_position: position,
-                    old_anchor,
-                    new_anchor: None,
-                    old_sticky_column,
-                    new_sticky_column: 0, // Reset sticky column for goto definition
-                };
-
-                let split_id = self.split_manager.active_split();
-                if let Some(state) = self.buffers.get_mut(&buffer_id) {
-                    let cursors = &mut self.split_view_states.get_mut(&split_id).unwrap().cursors;
-                    state.apply(cursors, &event);
-                }
-                // Without this the cursor lands at the definition but the
-                // viewport never scrolls when the target file is already
-                // open (#1689).
-                self.ensure_active_cursor_visible_for_navigation(true);
+            let split_id = self.split_manager.active_split();
+            if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                let cursors = &mut self.split_view_states.get_mut(&split_id).unwrap().cursors;
+                state.apply(cursors, &event);
             }
-
-            self.status_message = Some(
-                t!(
-                    "lsp.jumped_to_definition",
-                    path = path.display().to_string(),
-                    line = line + 1
-                )
-                .to_string(),
-            );
-        } else {
-            self.status_message = Some(t!("lsp.cannot_open_definition").to_string());
+            // Without this the cursor lands at the definition but the
+            // viewport never scrolls when the target file is already
+            // open (#1689).
+            self.ensure_active_cursor_visible_for_navigation(true);
         }
+
+        let display_path = self
+            .buffers
+            .get(&buffer_id)
+            .and_then(|s| s.buffer.file_path().map(|p| p.display().to_string()))
+            .unwrap_or_default();
+        self.status_message = Some(
+            t!(
+                "lsp.jumped_to_definition",
+                path = display_path,
+                line = line + 1
+            )
+            .to_string(),
+        );
 
         Ok(())
     }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -231,13 +231,14 @@ impl Editor {
         let location = &locations[0];
 
         // Convert URI to file path. The LSP runs on the other side of
-        // a possible host↔container mount, so apply the active
-        // authority's translation before crossing back into the
-        // editor's host-path-based filesystem layer.
-        if let Ok(path) = super::uri_to_path_with_translation(
-            &location.uri,
-            self.authority.path_translation.as_ref(),
-        ) {
+        // a possible host↔container mount, so wrap the wire URI in
+        // [`LspUri`] and apply the authority's translation before
+        // crossing back into the editor's host-path-based filesystem
+        // layer.
+        let wire = crate::app::types::LspUri::from_wire(location.uri.clone());
+        if let Ok(path) =
+            super::lsp_uri_to_host_path(&wire, self.authority.path_translation.as_ref())
+        {
             // Open the file
             let buffer_id = match self.open_file(&path) {
                 Ok(id) => id,
@@ -374,7 +375,7 @@ impl Editor {
         f: F,
     ) -> Option<R>
     where
-        F: FnOnce(&LspHandle, &lsp_types::Uri, &str) -> R,
+        F: FnOnce(&LspHandle, &crate::app::types::LspUri, &str) -> R,
     {
         use crate::services::lsp::manager::LspSpawnResult;
 
@@ -415,7 +416,7 @@ impl Editor {
         f: F,
     ) -> Vec<R>
     where
-        F: Fn(&LspHandle, &lsp_types::Uri, &str) -> R,
+        F: Fn(&LspHandle, &crate::app::types::LspUri, &str) -> R,
     {
         use crate::services::lsp::manager::LspSpawnResult;
 
@@ -469,7 +470,7 @@ impl Editor {
         f: F,
     ) -> Vec<R>
     where
-        F: Fn(&LspHandle, &lsp_types::Uri, &str, &str) -> R,
+        F: Fn(&LspHandle, &crate::app::types::LspUri, &str, &str) -> R,
     {
         use crate::services::lsp::manager::LspSpawnResult;
 
@@ -517,7 +518,7 @@ impl Editor {
     fn ensure_did_open_all(
         &mut self,
         buffer_id: BufferId,
-        uri: &lsp_types::Uri,
+        uri: &crate::app::types::LspUri,
         language: &str,
     ) -> Option<()> {
         let lsp = self.lsp.as_mut()?;
@@ -543,7 +544,7 @@ impl Editor {
                 if needs_open.contains(&sh.handle.id()) {
                     if let Err(e) =
                         sh.handle
-                            .did_open(uri.clone(), text.clone(), language.to_string())
+                            .did_open(uri.as_uri().clone(), text.clone(), language.to_string())
                     {
                         tracing::warn!("Failed to send didOpen to '{}': {}", sh.name, e);
                         continue;
@@ -610,8 +611,12 @@ impl Editor {
             |handle, uri, _language| {
                 let idx = counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 let request_id = base_request_id + idx;
-                let result =
-                    handle.completion(request_id, uri.clone(), line as u32, character as u32);
+                let result = handle.completion(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                );
                 if result.is_ok() {
                     tracing::info!(
                         "Requested completion at {}:{}:{} (request_id={})",
@@ -747,7 +752,7 @@ impl Editor {
                 |handle, uri, _language| {
                     let result = handle.goto_definition(
                         request_id,
-                        uri.clone(),
+                        uri.as_uri().clone(),
                         line as u32,
                         character as u32,
                     );
@@ -798,7 +803,12 @@ impl Editor {
         // Use helper to ensure didOpen is sent before the request
         let sent = self
             .with_lsp_for_buffer(buffer_id, LspFeature::Hover, |handle, uri, _language| {
-                let result = handle.hover(request_id, uri.clone(), line as u32, character as u32);
+                let result = handle.hover(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                );
                 if result.is_ok() {
                     tracing::info!(
                         "Requested hover at {}:{}:{} (byte_pos={})",
@@ -849,7 +859,12 @@ impl Editor {
         // Use helper to ensure didOpen is sent before the request
         let sent = self
             .with_lsp_for_buffer(buffer_id, LspFeature::Hover, |handle, uri, _language| {
-                let result = handle.hover(request_id, uri.clone(), line as u32, character as u32);
+                let result = handle.hover(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                );
                 if result.is_ok() {
                     tracing::trace!(
                         "Mouse hover requested at {}:{}:{} (byte_pos={})",
@@ -1342,8 +1357,12 @@ impl Editor {
                 buffer_id,
                 LspFeature::References,
                 |handle, uri, _language| {
-                    let result =
-                        handle.references(request_id, uri.clone(), line as u32, character as u32);
+                    let result = handle.references(
+                        request_id,
+                        uri.as_uri().clone(),
+                        line as u32,
+                        character as u32,
+                    );
                     if result.is_ok() {
                         tracing::info!(
                             "Requested find references at {}:{}:{} (byte_pos={})",
@@ -1386,7 +1405,7 @@ impl Editor {
                 |handle, uri, _language| {
                     let result = handle.signature_help(
                         request_id,
-                        uri.clone(),
+                        uri.as_uri().clone(),
                         line as u32,
                         character as u32,
                     );
@@ -1581,7 +1600,7 @@ impl Editor {
                 let request_id = base_request_id + idx;
                 let result = handle.code_actions(
                     request_id,
-                    uri.clone(),
+                    uri.as_uri().clone(),
                     start_line,
                     start_char,
                     end_line,
@@ -2005,10 +2024,12 @@ impl Editor {
 
         if let Some(lsp) = &mut self.lsp {
             if let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::Format) {
-                if let Err(e) =
-                    sh.handle
-                        .document_formatting(request_id, uri, tab_size, insert_spaces)
-                {
+                if let Err(e) = sh.handle.document_formatting(
+                    request_id,
+                    uri.as_uri().clone(),
+                    tab_size,
+                    insert_spaces,
+                ) {
                     tracing::warn!("Failed to request formatting: {}", e);
                 }
             } else {
@@ -2041,14 +2062,25 @@ impl Editor {
             return Ok(());
         }
 
-        // Convert locations to hook args format
+        // Convert locations to hook args format. Each `loc.uri` is a
+        // wire-side URI from the LSP, so wrap it in [`LspUri`] and run
+        // it through the active authority's translation before
+        // handing a host-path string to the references hook —
+        // otherwise plugins (notably `find_references`) try to open
+        // an in-container path on the host and fail.
+        let translation = self.authority.path_translation.clone();
         let lsp_locations: Vec<crate::services::plugins::hooks::LspLocation> = locations
             .iter()
             .map(|loc| {
-                // Convert URI to file path
+                let wire = crate::app::types::LspUri::from_wire(loc.uri.clone());
+                // Prefer the host-side path (after translation) so
+                // plugin-side file ops resolve. Fall back to the raw
+                // string for non-`file://` URIs so callers can still
+                // see *something*.
                 let file = if loc.uri.scheme().map(|s| s.as_str()) == Some("file") {
-                    // Extract path from file:// URI
-                    loc.uri.path().as_str().to_string()
+                    wire.to_host_path(translation.as_ref())
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| loc.uri.path().as_str().to_string())
                 } else {
                     loc.uri.as_str().to_string()
                 };
@@ -2200,13 +2232,15 @@ impl Editor {
         &mut self,
         text_doc_edit: lsp_types::TextDocumentEdit,
     ) -> AnyhowResult<usize> {
-        let uri = text_doc_edit.text_document.uri;
+        // Wrap the incoming wire URI once; both the version-check
+        // lookup and the file-open below need the host-path form.
+        let uri = crate::app::types::LspUri::from_wire(text_doc_edit.text_document.uri);
 
         // Version check: if the server specifies a version, verify it matches
         // what we sent. A mismatch means the edit was computed against stale content.
         if let Some(expected_version) = text_doc_edit.text_document.version {
             if let Ok(path) =
-                super::uri_to_path_with_translation(&uri, self.authority.path_translation.as_ref())
+                super::lsp_uri_to_host_path(&uri, self.authority.path_translation.as_ref())
             {
                 if let Some(lsp) = &self.lsp {
                     let language = self
@@ -2233,7 +2267,7 @@ impl Editor {
         }
 
         if let Ok(path) =
-            super::uri_to_path_with_translation(&uri, self.authority.path_translation.as_ref())
+            super::lsp_uri_to_host_path(&uri, self.authority.path_translation.as_ref())
         {
             let buffer_id = match self.open_file(&path) {
                 Ok(id) => id,
@@ -2281,9 +2315,19 @@ impl Editor {
 
     /// Apply a resource operation (CreateFile, RenameFile, DeleteFile) from a workspace edit.
     fn apply_resource_operation(&mut self, op: lsp_types::ResourceOp) -> AnyhowResult<()> {
+        // Each URI in a resource operation is wire-side and must be
+        // translated back to the host before we touch the host
+        // filesystem. Wrapping in [`LspUri`] and calling
+        // `to_host_path` is the type-checked path.
+        let translation = self.authority.path_translation.clone();
+        let to_host = |uri: &lsp_types::Uri| -> std::path::PathBuf {
+            crate::app::types::LspUri::from_wire(uri.clone())
+                .to_host_path(translation.as_ref())
+                .unwrap_or_else(|| std::path::PathBuf::from(uri.path().as_str()))
+        };
         match op {
             lsp_types::ResourceOp::Create(create) => {
-                let path = std::path::PathBuf::from(create.uri.path().as_str());
+                let path = to_host(&create.uri);
                 let overwrite = create
                     .options
                     .as_ref()
@@ -2319,8 +2363,8 @@ impl Editor {
                 }
             }
             lsp_types::ResourceOp::Rename(rename) => {
-                let old_path = std::path::PathBuf::from(rename.old_uri.path().as_str());
-                let new_path = std::path::PathBuf::from(rename.new_uri.path().as_str());
+                let old_path = to_host(&rename.old_uri);
+                let new_path = to_host(&rename.new_uri);
                 let overwrite = rename
                     .options
                     .as_ref()
@@ -2354,7 +2398,7 @@ impl Editor {
                 tracing::info!("RenameFile: {:?} -> {:?}", old_path, new_path);
             }
             lsp_types::ResourceOp::Delete(delete) => {
-                let path = std::path::PathBuf::from(delete.uri.path().as_str());
+                let path = to_host(&delete.uri);
                 let recursive = delete
                     .options
                     .as_ref()
@@ -2407,10 +2451,10 @@ impl Editor {
         // Handle changes (map of URI -> Vec<TextEdit>)
         if let Some(changes) = workspace_edit.changes {
             for (uri, edits) in changes {
-                if let Ok(path) = super::uri_to_path_with_translation(
-                    &uri,
-                    self.authority.path_translation.as_ref(),
-                ) {
+                let uri = crate::app::types::LspUri::from_wire(uri);
+                if let Ok(path) =
+                    super::lsp_uri_to_host_path(&uri, self.authority.path_translation.as_ref())
+                {
                     let buffer_id = match self.open_file(&path) {
                         Ok(id) => id,
                         Err(e) => {
@@ -2802,9 +2846,9 @@ impl Editor {
                     .iter()
                     .any(|(_, id)| *id == sh.handle.id())
                 {
-                    if let Err(e) = sh
-                        .handle
-                        .did_open(uri.clone(), text.clone(), language.clone())
+                    if let Err(e) =
+                        sh.handle
+                            .did_open(uri.as_uri().clone(), text.clone(), language.clone())
                     {
                         tracing::warn!(
                             "Failed to send didOpen to '{}' before didChange: {}",
@@ -2838,7 +2882,7 @@ impl Editor {
         let Some(lsp) = self.lsp.as_mut() else { return };
         let mut any_sent = false;
         for sh in lsp.get_handles_mut(&language) {
-            if let Err(e) = sh.handle.did_change(uri.clone(), changes.clone()) {
+            if let Err(e) = sh.handle.did_change(uri.as_uri().clone(), changes.clone()) {
                 tracing::warn!("Failed to send didChange to '{}': {}", sh.name, e);
             } else {
                 any_sent = true;
@@ -2959,10 +3003,12 @@ impl Editor {
 
         if let Some(lsp) = &mut self.lsp {
             if let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::Rename) {
-                if let Err(e) =
-                    sh.handle
-                        .prepare_rename(request_id, uri, line as u32, character as u32)
-                {
+                if let Err(e) = sh.handle.prepare_rename(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                ) {
                     tracing::warn!("Failed to send prepareRename: {}", e);
                 }
             }
@@ -3061,7 +3107,7 @@ impl Editor {
             .with_lsp_for_buffer(buffer_id, LspFeature::Rename, |handle, uri, _language| {
                 let result = handle.rename(
                     request_id,
-                    uri.clone(),
+                    uri.as_uri().clone(),
                     line as u32,
                     character as u32,
                     new_name.clone(),
@@ -3123,8 +3169,14 @@ impl Editor {
                 buffer_id,
                 LspFeature::InlayHints,
                 |handle, uri, _language| {
-                    let result =
-                        handle.inlay_hints(request_id, uri.clone(), 0, 0, last_line, 10000);
+                    let result = handle.inlay_hints(
+                        request_id,
+                        uri.as_uri().clone(),
+                        0,
+                        0,
+                        last_line,
+                        10000,
+                    );
                     if result.is_ok() {
                         tracing::info!(
                             "Requested inlay hints for {} (request_id={})",
@@ -3213,7 +3265,7 @@ impl Editor {
             .map(|s| s.buffer.version())
             .unwrap_or(0);
 
-        match handle.folding_ranges(request_id, uri) {
+        match handle.folding_ranges(request_id, uri.as_uri().clone()) {
             Ok(()) => {
                 self.pending_folding_range_requests.insert(
                     request_id,
@@ -3308,9 +3360,13 @@ impl Editor {
         };
 
         let request_result = if use_delta {
-            handle.semantic_tokens_full_delta(request_id, uri, previous_result_id.unwrap())
+            handle.semantic_tokens_full_delta(
+                request_id,
+                uri.as_uri().clone(),
+                previous_result_id.unwrap(),
+            )
         } else {
-            handle.semantic_tokens_full(request_id, uri)
+            handle.semantic_tokens_full(request_id, uri.as_uri().clone())
         };
 
         match request_result {
@@ -3501,7 +3557,7 @@ impl Editor {
         let request_id = self.next_lsp_request_id;
         self.next_lsp_request_id += 1;
 
-        match handle.semantic_tokens_range(request_id, uri, lsp_range) {
+        match handle.semantic_tokens_range(request_id, uri.as_uri().clone(), lsp_range) {
             Ok(_) => {
                 self.pending_semantic_token_range_requests.insert(
                     request_id,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -214,9 +214,20 @@ pub use self::warning_domains::{
 };
 pub use crate::model::event::BufferId;
 
-/// Helper function to convert lsp_types::Uri to PathBuf
-fn uri_to_path(uri: &lsp_types::Uri) -> Result<PathBuf, String> {
-    fresh_core::file_uri::lsp_uri_to_path(uri).ok_or_else(|| "URI is not a file path".to_string())
+/// Convert an `lsp_types::Uri` from an LSP response to a host-side
+/// `PathBuf`, applying the active authority's remote→host workspace
+/// translation when one is set. The editor's open-file primitives
+/// expect host paths, so every URI that arrives from an LSP server
+/// (Goto-Definition `Location`, references, workspace edits, …) must
+/// be mapped back before it crosses into filesystem-facing code.
+/// Out-of-workspace URIs (system headers, library sources) are
+/// returned unchanged so existing callers' handling stays put.
+fn uri_to_path_with_translation(
+    uri: &lsp_types::Uri,
+    translation: Option<&crate::services::authority::PathTranslation>,
+) -> Result<PathBuf, String> {
+    crate::app::types::lsp_uri_to_host_path_with_translation(uri, translation)
+        .ok_or_else(|| "URI is not a file path".to_string())
 }
 
 /// A pending grammar registration waiting for reload_grammars() to apply

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -214,19 +214,19 @@ pub use self::warning_domains::{
 };
 pub use crate::model::event::BufferId;
 
-/// Convert an `lsp_types::Uri` from an LSP response to a host-side
-/// `PathBuf`, applying the active authority's remote→host workspace
-/// translation when one is set. The editor's open-file primitives
-/// expect host paths, so every URI that arrives from an LSP server
-/// (Goto-Definition `Location`, references, workspace edits, …) must
-/// be mapped back before it crosses into filesystem-facing code.
-/// Out-of-workspace URIs (system headers, library sources) are
-/// returned unchanged so existing callers' handling stays put.
-fn uri_to_path_with_translation(
-    uri: &lsp_types::Uri,
+/// Decode a wire-side LSP URI to a host path. Thin wrapper over
+/// [`LspUri::to_host_path`](crate::app::types::LspUri::to_host_path)
+/// that produces a `Result` for call sites that prefer the
+/// error-string form. Editor code that owns a raw `lsp_types::Uri`
+/// from a third-party type (e.g. `lsp_types::Location.uri`) wraps it
+/// via [`LspUri::from_wire`](crate::app::types::LspUri::from_wire)
+/// and then calls this — that's the only path from a wire URI to a
+/// host `PathBuf`, by construction.
+fn lsp_uri_to_host_path(
+    uri: &crate::app::types::LspUri,
     translation: Option<&crate::services::authority::PathTranslation>,
 ) -> Result<PathBuf, String> {
-    crate::app::types::lsp_uri_to_host_path_with_translation(uri, translation)
+    uri.to_host_path(translation)
         .ok_or_else(|| "URI is not a file path".to_string())
 }
 

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -423,10 +423,11 @@ impl Editor {
                 tracing::info!("Sending didOpen to LSP servers for: {}", uri.as_str());
                 let mut any_opened = false;
                 for sh in lsp.get_handles_mut(language) {
-                    if let Err(e) =
-                        sh.handle
-                            .did_open(uri.clone(), text.clone(), file_language.clone())
-                    {
+                    if let Err(e) = sh.handle.did_open(
+                        uri.as_uri().clone(),
+                        text.clone(),
+                        file_language.clone(),
+                    ) {
                         tracing::warn!("Failed to send didOpen to '{}': {}", sh.name, e);
                     } else {
                         any_opened = true;
@@ -443,9 +444,11 @@ impl Editor {
                         let request_id = self.next_lsp_request_id;
                         self.next_lsp_request_id += 1;
 
-                        if let Err(e) =
-                            handle.document_diagnostic(request_id, uri.clone(), previous_result_id)
-                        {
+                        if let Err(e) = handle.document_diagnostic(
+                            request_id,
+                            uri.as_uri().clone(),
+                            previous_result_id,
+                        ) {
                             tracing::debug!(
                                 "Failed to request pull diagnostics (server may not support): {}",
                                 e
@@ -462,7 +465,7 @@ impl Editor {
 
                             if let Err(e) = handle.inlay_hints(
                                 request_id,
-                                uri.clone(),
+                                uri.as_uri().clone(),
                                 0,
                                 0,
                                 last_line,

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -725,8 +725,12 @@ impl Editor {
                     after_save_len
                 );
 
-                let metadata =
-                    BufferMetadata::with_file(full_path.clone(), &full_path, &self.working_dir);
+                let metadata = BufferMetadata::with_file(
+                    full_path.clone(),
+                    &full_path,
+                    &self.working_dir,
+                    self.authority.path_translation.as_ref(),
+                );
                 self.buffer_metadata.insert(self.active_buffer(), metadata);
 
                 // Auto-detect language if it's currently "text"

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -340,6 +340,44 @@ impl BufferMetadata {
         }
     }
 
+    /// Create metadata for a buffer fetched from inside a container.
+    ///
+    /// Used by `Editor::open_lsp_uri_target` when a Goto-Definition
+    /// (or similar) URI lands on a path that exists only inside the
+    /// container — typically a stdlib / site-packages entry that
+    /// isn't bind-mounted onto the host. The buffer is read-only
+    /// because there's no host-side writeback path; LSP stays enabled
+    /// so further navigation from the fetched buffer (hover, more
+    /// goto-defs) keeps working.
+    ///
+    /// The supplied `uri` is the wire URI the LSP returned (already
+    /// in container-side coordinates) and is cached verbatim — no
+    /// host→remote translation, because the path *is* the remote
+    /// path. The display name is the file name, since the container
+    /// path has nothing to relativize against the host working dir.
+    pub fn with_container_file(container_path: PathBuf, uri: LspUri) -> Self {
+        let display_name = container_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| container_path.to_string_lossy().to_string());
+        Self {
+            kind: BufferKind::File {
+                path: container_path,
+                uri: Some(uri),
+            },
+            display_name,
+            lsp_enabled: true,
+            lsp_disabled_reason: None,
+            read_only: true,
+            binary: false,
+            lsp_opened_with: HashSet::new(),
+            hidden_from_tabs: false,
+            is_preview: false,
+            recovery_id: None,
+        }
+    }
+
     /// Check if a path is a library file (in vendor directories or standard libraries)
     ///
     /// Library files include:

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -1433,7 +1433,15 @@ impl LspUri {
     }
 }
 
-#[cfg(test)]
+// `LspUri` translation algebra works on any platform but the unit-test
+// fixtures use POSIX-shaped paths (the only side that ever exists for a
+// container's interior) and a Linux-style URI without a drive letter.
+// On Windows `lsp_types::Uri::parse(\"file:///workspaces/...\")` returns
+// `None` for lack of a drive letter, which would make these tests fail
+// for reasons unrelated to the algebra they're verifying. Gate to Unix
+// — the cross-platform URI encoding is covered separately by
+// `uri_encoding_tests`.
+#[cfg(all(test, unix))]
 mod lsp_uri_tests {
     use super::*;
     use crate::services::authority::PathTranslation;

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -283,9 +283,20 @@ impl BufferMetadata {
     /// * `canonical_path` - The canonical (symlink-resolved) absolute path to the file
     /// * `display_path` - The user-visible path before canonicalization (for library detection)
     /// * `working_dir` - The canonical working directory for computing relative display name
-    pub fn with_file(canonical_path: PathBuf, display_path: &Path, working_dir: &Path) -> Self {
-        // Compute URI from the absolute path
-        let file_uri = file_path_to_lsp_uri(&canonical_path);
+    /// * `path_translation` - Active authority's host↔remote workspace mapping;
+    ///   used to build the LSP-facing `file_uri` so an in-container LSP sees
+    ///   in-container paths. `None` for local/SSH authorities.
+    pub fn with_file(
+        canonical_path: PathBuf,
+        display_path: &Path,
+        working_dir: &Path,
+        path_translation: Option<&crate::services::authority::PathTranslation>,
+    ) -> Self {
+        // Compute URI from the absolute path. When the active authority
+        // has a host↔remote mapping (devcontainer attach), this is
+        // where the host path gets rewritten into the container path
+        // the LSP server actually understands.
+        let file_uri = file_path_to_lsp_uri_with_translation(&canonical_path, path_translation);
 
         // Compute display name (project-relative when under working_dir, else absolute path).
         // Use canonicalized forms first to handle macOS /var -> /private/var differences.
@@ -1261,6 +1272,44 @@ impl CachedLayout {
 /// Convert a file path to an `lsp_types::Uri`.
 pub fn file_path_to_lsp_uri(path: &Path) -> Option<lsp_types::Uri> {
     fresh_core::file_uri::path_to_lsp_uri(path)
+}
+
+/// Build the LSP-facing URI for a host-side `path`, applying the
+/// authority's host→remote translation when one is set. Used for
+/// every URI that crosses the editor↔LSP boundary outbound (didOpen,
+/// definition, root_uri, …) so a container LSP sees in-container
+/// paths even though the editor caches host paths.
+///
+/// When `translation` is `None` (local + SSH authorities) or the
+/// path doesn't sit under `host_root` (system headers, library
+/// sources), the result is the unchanged host URI — the caller's
+/// handling of out-of-workspace paths is unchanged from the
+/// pre-authority world.
+pub fn file_path_to_lsp_uri_with_translation(
+    path: &Path,
+    translation: Option<&crate::services::authority::PathTranslation>,
+) -> Option<lsp_types::Uri> {
+    let mapped = translation
+        .and_then(|t| t.host_to_remote(path))
+        .unwrap_or_else(|| path.to_path_buf());
+    fresh_core::file_uri::path_to_lsp_uri(&mapped)
+}
+
+/// Inverse of [`file_path_to_lsp_uri_with_translation`]: turn an LSP
+/// URI into a host-side path, applying the authority's remote→host
+/// translation when one is set. Used wherever the editor receives a
+/// URI from the server (Goto-Definition `Location`, references,
+/// workspace edits, …) and needs to open the corresponding host file.
+pub fn lsp_uri_to_host_path_with_translation(
+    uri: &lsp_types::Uri,
+    translation: Option<&crate::services::authority::PathTranslation>,
+) -> Option<PathBuf> {
+    let raw = fresh_core::file_uri::lsp_uri_to_path(uri)?;
+    Some(
+        translation
+            .and_then(|t| t.remote_to_host(&raw))
+            .unwrap_or(raw),
+    )
 }
 
 #[cfg(test)]

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -137,10 +137,13 @@ pub(super) struct InteractiveReplaceState {
 pub enum BufferKind {
     /// A buffer backed by a file on disk
     File {
-        /// Path to the file
+        /// Host-side path to the file. Filesystem APIs and the
+        /// editor's own buffer state always speak in host paths.
         path: PathBuf,
-        /// LSP URI for the file
-        uri: Option<lsp_types::Uri>,
+        /// LSP-facing URI for the file. Already translated for the
+        /// active authority, so handing this to the LSP server is
+        /// always correct. See [`LspUri`] for the why.
+        uri: Option<LspUri>,
     },
     /// A virtual buffer (not backed by a file)
     /// Used for special buffers like *Diagnostics*, *Grep*, etc.
@@ -209,8 +212,14 @@ impl BufferMetadata {
         }
     }
 
-    /// Get the file URI if this is a file-backed buffer
-    pub fn file_uri(&self) -> Option<&lsp_types::Uri> {
+    /// Get the LSP-facing URI if this is a file-backed buffer.
+    ///
+    /// The URI is already translated for the active authority — i.e.
+    /// it carries the in-container path on a devcontainer authority
+    /// and the host path elsewhere. Hand it to the LSP server
+    /// directly; do NOT pass it to filesystem APIs (use
+    /// [`Self::file_path`] for that).
+    pub fn file_uri(&self) -> Option<&LspUri> {
         match &self.kind {
             BufferKind::File { uri, .. } => uri.as_ref(),
             BufferKind::Virtual { .. } => None,
@@ -296,7 +305,7 @@ impl BufferMetadata {
         // has a host↔remote mapping (devcontainer attach), this is
         // where the host path gets rewritten into the container path
         // the LSP server actually understands.
-        let file_uri = file_path_to_lsp_uri_with_translation(&canonical_path, path_translation);
+        let file_uri = LspUri::from_host_path(&canonical_path, path_translation);
 
         // Compute display name (project-relative when under working_dir, else absolute path).
         // Use canonicalized forms first to handle macOS /var -> /private/var differences.
@@ -1274,42 +1283,187 @@ pub fn file_path_to_lsp_uri(path: &Path) -> Option<lsp_types::Uri> {
     fresh_core::file_uri::path_to_lsp_uri(path)
 }
 
-/// Build the LSP-facing URI for a host-side `path`, applying the
-/// authority's host→remote translation when one is set. Used for
-/// every URI that crosses the editor↔LSP boundary outbound (didOpen,
-/// definition, root_uri, …) so a container LSP sees in-container
-/// paths even though the editor caches host paths.
+/// LSP-facing URI: a URI as it appears on the wire to or from a
+/// language server. This is a newtype around `lsp_types::Uri`. The
+/// type-system point is to force every URI that crosses the
+/// editor↔LSP boundary through one of the two checked constructors:
 ///
-/// When `translation` is `None` (local + SSH authorities) or the
-/// path doesn't sit under `host_root` (system headers, library
-/// sources), the result is the unchanged host URI — the caller's
-/// handling of out-of-workspace paths is unchanged from the
-/// pre-authority world.
+///   * [`LspUri::from_host_path`] — given a host path and the active
+///     authority's host↔remote translation, produces an `LspUri` that
+///     carries the in-container path on container authorities (and
+///     the host path everywhere else).
+///   * [`LspUri::from_wire`] — wraps a raw `lsp_types::Uri` that was
+///     received from the LSP server. The wrapped URI is "remote-side"
+///     under a container authority and must be passed back through
+///     [`LspUri::to_host_path`] before any filesystem-facing code
+///     sees it.
+///
+/// Conversely, the only ways to extract a path are:
+///
+///   * [`LspUri::to_host_path`] — applies remote→host translation
+///     symmetrically with `from_host_path`. This is the host-side
+///     `PathBuf` filesystem APIs accept. Untranslated extraction
+///     (`as_uri().path()`) is intentionally not exposed as a method —
+///     callers that genuinely want the wire-side path string read
+///     `as_str()` and document why a host-path interpretation isn't
+///     wanted.
+///
+/// Storing buffer URIs in [`BufferMetadata`] as `LspUri` (not
+/// `lsp_types::Uri`) keeps the cached form already translated for the
+/// active authority, so the dozens of `metadata.file_uri()` call
+/// sites can't accidentally ship a host URI to a container LSP.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LspUri(lsp_types::Uri);
+
+impl LspUri {
+    /// Build an LSP-facing URI from a host path, applying the
+    /// authority's host→remote translation when one is set. Returns
+    /// `None` for relative paths (matches the pre-newtype helper).
+    pub fn from_host_path(
+        path: &Path,
+        translation: Option<&crate::services::authority::PathTranslation>,
+    ) -> Option<Self> {
+        let mapped = translation
+            .and_then(|t| t.host_to_remote(path))
+            .unwrap_or_else(|| path.to_path_buf());
+        fresh_core::file_uri::path_to_lsp_uri(&mapped).map(Self)
+    }
+
+    /// Wrap a raw URI received from the LSP wire. The caller must
+    /// subsequently translate via [`Self::to_host_path`] before
+    /// opening the file or comparing with host paths — that's the
+    /// whole point of having the newtype.
+    pub fn from_wire(uri: lsp_types::Uri) -> Self {
+        Self(uri)
+    }
+
+    /// Borrow the underlying raw URI for serialization to the LSP
+    /// wire (e.g. into JSON-RPC params). Only the LSP transport layer
+    /// should call this; editor-level code never sees a bare
+    /// `lsp_types::Uri`.
+    pub fn as_uri(&self) -> &lsp_types::Uri {
+        &self.0
+    }
+
+    /// String form, for log messages and equality comparisons against
+    /// other URI strings (e.g. when matching a buffer against an
+    /// incoming notification's URI). Does not strip the
+    /// host-vs-container ambiguity — comparisons must be between two
+    /// `LspUri`s, not between a wire URI and a host URI.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Decode this URI to a host path, applying the authority's
+    /// remote→host translation when one is set. Returns `None` for
+    /// non-`file://` URIs.
+    pub fn to_host_path(
+        &self,
+        translation: Option<&crate::services::authority::PathTranslation>,
+    ) -> Option<PathBuf> {
+        let raw = fresh_core::file_uri::lsp_uri_to_path(&self.0)?;
+        Some(
+            translation
+                .and_then(|t| t.remote_to_host(&raw))
+                .unwrap_or(raw),
+        )
+    }
+}
+
+/// Build the LSP-facing URI for a host-side `path`, applying the
+/// authority's host→remote translation when one is set.
+///
+/// Thin shim around [`LspUri::from_host_path`] that returns the
+/// inner [`lsp_types::Uri`] for the few callers (root_uri building
+/// inside `LspManager`, code-action workspace folder hand-off) that
+/// have to feed a raw `Uri` into a third-party API. New code should
+/// prefer `LspUri::from_host_path` directly so the host-vs-LSP side
+/// stays type-checked.
 pub fn file_path_to_lsp_uri_with_translation(
     path: &Path,
     translation: Option<&crate::services::authority::PathTranslation>,
 ) -> Option<lsp_types::Uri> {
-    let mapped = translation
-        .and_then(|t| t.host_to_remote(path))
-        .unwrap_or_else(|| path.to_path_buf());
-    fresh_core::file_uri::path_to_lsp_uri(&mapped)
+    LspUri::from_host_path(path, translation).map(|u| u.into_inner())
 }
 
-/// Inverse of [`file_path_to_lsp_uri_with_translation`]: turn an LSP
-/// URI into a host-side path, applying the authority's remote→host
-/// translation when one is set. Used wherever the editor receives a
-/// URI from the server (Goto-Definition `Location`, references,
-/// workspace edits, …) and needs to open the corresponding host file.
-pub fn lsp_uri_to_host_path_with_translation(
-    uri: &lsp_types::Uri,
-    translation: Option<&crate::services::authority::PathTranslation>,
-) -> Option<PathBuf> {
-    let raw = fresh_core::file_uri::lsp_uri_to_path(uri)?;
-    Some(
-        translation
-            .and_then(|t| t.remote_to_host(&raw))
-            .unwrap_or(raw),
-    )
+impl LspUri {
+    /// Consume `self` and return the raw `lsp_types::Uri`. Reserved
+    /// for the wire layer (LSP transport, lsp_types interop). Editor
+    /// code uses [`Self::as_uri`] when it just needs to borrow.
+    pub fn into_inner(self) -> lsp_types::Uri {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod lsp_uri_tests {
+    use super::*;
+    use crate::services::authority::PathTranslation;
+
+    fn translation() -> PathTranslation {
+        PathTranslation {
+            host_root: PathBuf::from("/tmp/.tmpA1B2"),
+            remote_root: PathBuf::from("/workspaces/proj"),
+        }
+    }
+
+    #[test]
+    fn from_host_path_under_workspace_translates_to_remote_uri() {
+        let host = PathBuf::from("/tmp/.tmpA1B2/src/util.py");
+        let lsp_uri = LspUri::from_host_path(&host, Some(&translation())).expect("absolute path");
+        assert_eq!(lsp_uri.as_str(), "file:///workspaces/proj/src/util.py");
+    }
+
+    #[test]
+    fn from_host_path_outside_workspace_passes_through() {
+        // System headers / library sources sit outside the mounted
+        // workspace; translation returns `None` and the host URI is
+        // shipped to the LSP unchanged. The point of the newtype is
+        // just to make the decision explicit.
+        let host = PathBuf::from("/usr/include/stdio.h");
+        let lsp_uri = LspUri::from_host_path(&host, Some(&translation())).expect("absolute path");
+        assert_eq!(lsp_uri.as_str(), "file:///usr/include/stdio.h");
+    }
+
+    #[test]
+    fn to_host_path_under_remote_root_translates_back() {
+        let wire: lsp_types::Uri = "file:///workspaces/proj/src/util.py".parse().unwrap();
+        let host = LspUri::from_wire(wire)
+            .to_host_path(Some(&translation()))
+            .expect("file:// URI");
+        assert_eq!(host, PathBuf::from("/tmp/.tmpA1B2/src/util.py"));
+    }
+
+    #[test]
+    fn to_host_path_outside_remote_root_passes_through() {
+        let wire: lsp_types::Uri = "file:///usr/include/stdio.h".parse().unwrap();
+        let host = LspUri::from_wire(wire)
+            .to_host_path(Some(&translation()))
+            .expect("file:// URI");
+        assert_eq!(host, PathBuf::from("/usr/include/stdio.h"));
+    }
+
+    #[test]
+    fn round_trip_host_to_wire_to_host_under_workspace() {
+        // The whole point of the symmetry: anything that goes out
+        // through `from_host_path` must come back through
+        // `to_host_path` byte-identical. This is the property the
+        // editor relies on so a buffer's host file_path matches the
+        // path resolved from a server-returned `Location`.
+        let host = PathBuf::from("/tmp/.tmpA1B2/main.py");
+        let lsp_uri = LspUri::from_host_path(&host, Some(&translation())).unwrap();
+        let back = lsp_uri.to_host_path(Some(&translation())).unwrap();
+        assert_eq!(back, host);
+    }
+
+    #[test]
+    fn no_translation_is_identity() {
+        let host = PathBuf::from("/some/host/path/file.rs");
+        let lsp_uri = LspUri::from_host_path(&host, None).unwrap();
+        assert_eq!(lsp_uri.as_str(), "file:///some/host/path/file.rs");
+        let back = lsp_uri.to_host_path(None).unwrap();
+        assert_eq!(back, host);
+    }
 }
 
 #[cfg(test)]

--- a/crates/fresh-editor/src/server/tests.rs
+++ b/crates/fresh-editor/src/server/tests.rs
@@ -1344,6 +1344,7 @@ mod integration_tests {
                     manages_cwd: true,
                 },
                 display_label: "Container:deadbeef".into(),
+                path_translation: None,
             };
             let new_auth = Authority::from_plugin_payload(payload)
                 .map_err(|e| format!("from_plugin_payload: {e}"))?;
@@ -1505,6 +1506,7 @@ mod integration_tests {
                 manages_cwd: true,
             },
             display_label: "Container:cafef00d".into(),
+            path_translation: None,
         };
         let startup_auth =
             Authority::from_plugin_payload(payload).expect("docker payload is valid");

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -29,6 +29,7 @@
 //!   small and additive so we can grow new kinds without breaking the
 //!   plugin contract.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -37,6 +38,55 @@ use crate::model::filesystem::{FileSystem, StdFileSystem};
 use crate::services::remote::{
     LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner, ProcessSpawner,
 };
+
+/// Plugin-supplied form of the host↔remote workspace mapping. Plugins
+/// build this from their own knowledge (e.g. the devcontainer plugin
+/// already has `editor.getCwd()` for the host root and
+/// `result.remoteWorkspaceFolder` for the in-container root). Strings
+/// because the wire format is JSON; paths get parsed in
+/// `Authority::from_plugin_payload`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PathTranslationSpec {
+    pub host_root: String,
+    pub remote_root: String,
+}
+
+/// Symmetric path translation between host and remote workspace
+/// roots. Owned by the active [`Authority`] when the backend lives in
+/// a container (or any other place where the workspace is mounted at a
+/// different path than its on-host location). Local authorities and
+/// SSH leave this field unset.
+///
+/// LSP URIs are the primary consumer: the editor's buffer file paths
+/// are host-side, but the LSP server is on the other side of the
+/// mount and only knows the remote-side path. We translate at the
+/// boundary so the editor can keep using host paths internally and
+/// the LSP keeps seeing the paths it expects.
+#[derive(Debug, Clone)]
+pub struct PathTranslation {
+    pub host_root: PathBuf,
+    pub remote_root: PathBuf,
+}
+
+impl PathTranslation {
+    /// Map a host-side path under `host_root` to its remote-side
+    /// counterpart. Returns `None` for paths outside the workspace
+    /// (e.g. system headers, library sources) — those are passed
+    /// through unchanged so the caller can decide whether to forward
+    /// them as-is or drop them.
+    pub fn host_to_remote(&self, host: &Path) -> Option<PathBuf> {
+        let rel = host.strip_prefix(&self.host_root).ok()?;
+        Some(self.remote_root.join(rel))
+    }
+
+    /// Map a remote-side path under `remote_root` back to its
+    /// host-side counterpart. Same outside-the-workspace caveat as
+    /// [`Self::host_to_remote`].
+    pub fn remote_to_host(&self, remote: &Path) -> Option<PathBuf> {
+        let rel = remote.strip_prefix(&self.remote_root).ok()?;
+        Some(self.host_root.join(rel))
+    }
+}
 
 /// How the integrated terminal is launched under this authority.
 ///
@@ -107,6 +157,13 @@ pub struct AuthorityPayload {
     /// Status-bar / explorer label. Empty = no label rendered.
     #[serde(default)]
     pub display_label: String,
+    /// Optional host↔remote workspace path mapping. Devcontainer-style
+    /// authorities supply both the host workspace path (the editor's
+    /// `cwd` at attach time) and the in-container `remoteWorkspaceFolder`
+    /// so URIs traveling to/from the LSP get translated symmetrically.
+    /// SSH and local authorities leave this unset.
+    #[serde(default)]
+    pub path_translation: Option<PathTranslationSpec>,
 }
 
 /// Filesystem kind chosen by a plugin payload.
@@ -192,6 +249,12 @@ pub struct Authority {
     /// filesystem's `remote_connection_info()` so disconnect annotations
     /// stay in one place.
     pub display_label: String,
+    /// Host↔remote workspace path mapping for backends where the
+    /// workspace is mounted at a different path than its on-host
+    /// location. The dev-container authority populates this so LSP
+    /// URIs translate at the host/container boundary; local and SSH
+    /// authorities leave it `None` and URIs flow through unchanged.
+    pub path_translation: Option<PathTranslation>,
 }
 
 impl Authority {
@@ -205,6 +268,7 @@ impl Authority {
             long_running_spawner: Arc::new(LocalLongRunningSpawner),
             terminal_wrapper: TerminalWrapper::host_shell(),
             display_label: String::new(),
+            path_translation: None,
         }
     }
 
@@ -228,6 +292,7 @@ impl Authority {
             long_running_spawner: Arc::new(LocalLongRunningSpawner),
             terminal_wrapper: TerminalWrapper::host_shell(),
             display_label: String::new(),
+            path_translation: None,
         }
     }
 
@@ -287,12 +352,18 @@ impl Authority {
             },
         };
 
+        let path_translation = payload.path_translation.map(|spec| PathTranslation {
+            host_root: PathBuf::from(spec.host_root),
+            remote_root: PathBuf::from(spec.remote_root),
+        });
+
         Ok(Self {
             filesystem,
             process_spawner,
             long_running_spawner,
             terminal_wrapper,
             display_label: payload.display_label,
+            path_translation,
         })
     }
 }
@@ -328,6 +399,7 @@ mod tests {
             spawner: SpawnerSpec::Local,
             terminal_wrapper: TerminalWrapperSpec::HostShell,
             display_label: String::new(),
+            path_translation: None,
         };
         let auth = Authority::from_plugin_payload(payload).expect("local payload is valid");
         assert!(!auth.terminal_wrapper.command.is_empty());
@@ -510,10 +582,74 @@ mod tests {
                 manages_cwd: true,
             },
             display_label: "Container:abc123".into(),
+            path_translation: None,
         };
         let auth = Authority::from_plugin_payload(payload).expect("docker payload is valid");
         assert_eq!(auth.terminal_wrapper.command, "docker");
         assert!(auth.terminal_wrapper.manages_cwd);
         assert_eq!(auth.display_label, "Container:abc123");
+    }
+
+    #[test]
+    fn path_translation_round_trips_under_workspace() {
+        let pt = PathTranslation {
+            host_root: PathBuf::from("/tmp/.tmpA1B2"),
+            remote_root: PathBuf::from("/workspaces/proj"),
+        };
+        let host = Path::new("/tmp/.tmpA1B2/src/util.py");
+        let remote = pt.host_to_remote(host).expect("host under host_root");
+        assert_eq!(remote, PathBuf::from("/workspaces/proj/src/util.py"));
+        assert_eq!(
+            pt.remote_to_host(&remote)
+                .expect("remote under remote_root"),
+            host.to_path_buf(),
+        );
+    }
+
+    #[test]
+    fn path_translation_returns_none_outside_root() {
+        // Library / system paths sit outside the workspace mapping —
+        // callers decide what to do with them. The translator just
+        // says "not mine".
+        let pt = PathTranslation {
+            host_root: PathBuf::from("/host/proj"),
+            remote_root: PathBuf::from("/workspaces/proj"),
+        };
+        assert!(pt
+            .host_to_remote(Path::new("/usr/include/stdio.h"))
+            .is_none());
+        assert!(pt
+            .remote_to_host(Path::new("/usr/include/stdio.h"))
+            .is_none());
+    }
+
+    #[test]
+    fn from_plugin_payload_with_path_translation_round_trips() {
+        // Plugins (the devcontainer one in particular) supply both
+        // workspace roots so LSP URIs translate at the boundary. The
+        // wire shape uses strings so it survives JSON; the constructed
+        // authority parses them into `PathBuf`.
+        let json = serde_json::json!({
+            "filesystem": { "kind": "local" },
+            "spawner": {
+                "kind": "docker-exec",
+                "container_id": "abc123",
+                "workspace": "/workspaces/proj"
+            },
+            "terminal_wrapper": { "kind": "host-shell" },
+            "path_translation": {
+                "host_root": "/tmp/.tmpA1B2",
+                "remote_root": "/workspaces/proj"
+            }
+        });
+        let payload: AuthorityPayload =
+            serde_json::from_value(json).expect("path_translation is accepted");
+        let auth =
+            Authority::from_plugin_payload(payload).expect("payload with translation is valid");
+        let pt = auth
+            .path_translation
+            .expect("authority carries the translation");
+        assert_eq!(pt.host_root, PathBuf::from("/tmp/.tmpA1B2"));
+        assert_eq!(pt.remote_root, PathBuf::from("/workspaces/proj"));
     }
 }

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -300,6 +300,12 @@ pub struct LspManager {
     /// before any LSP spawn can happen.
     long_running_spawner: Option<std::sync::Arc<dyn crate::services::remote::LongRunningSpawner>>,
 
+    /// Active authority's host↔remote workspace mapping. When set
+    /// (devcontainer attach), [`Self::resolve_root_uri`] applies it to
+    /// the marker-walked workspace root so an in-container LSP sees
+    /// `file:///workspaces/proj` rather than the on-host temp path.
+    path_translation: Option<crate::services::authority::PathTranslation>,
+
     /// Restart attempt timestamps per language (for tracking restart frequency)
     restart_attempts: HashMap<String, Vec<Instant>>,
 
@@ -330,6 +336,7 @@ impl LspManager {
             runtime: None,
             async_bridge: None,
             long_running_spawner: None,
+            path_translation: None,
             restart_attempts: HashMap::new(),
             restart_cooldown: HashSet::new(),
             pending_restarts: HashMap::new(),
@@ -351,6 +358,17 @@ impl LspManager {
         spawner: std::sync::Arc<dyn crate::services::remote::LongRunningSpawner>,
     ) {
         self.long_running_spawner = Some(spawner);
+    }
+
+    /// Install the active authority's host↔remote path mapping. The
+    /// editor calls this from `set_boot_authority` alongside the
+    /// spawner setter so URI translation is in place before any LSP
+    /// spawns under the new authority.
+    pub fn set_path_translation(
+        &mut self,
+        translation: Option<crate::services::authority::PathTranslation>,
+    ) {
+        self.path_translation = translation;
     }
 
     /// Blocking variant of the authority-routed command probe used by
@@ -647,7 +665,10 @@ impl LspManager {
             return Some(uri.clone());
         }
 
-        // 2. Use root_markers to detect workspace root from file path
+        // 2. Use root_markers to detect workspace root from file path.
+        //    Walks the host filesystem; on a container authority that
+        //    yields a host path, which would confuse an in-container
+        //    LSP. Translate before encoding to a URI.
         if let Some(path) = file_path {
             let markers = self
                 .config
@@ -656,7 +677,12 @@ impl LspManager {
                 .map(|c| c.root_markers.as_slice())
                 .unwrap_or(&[]);
             let root = detect_workspace_root(path, markers);
-            if let Some(uri) = path_to_uri(&root) {
+            let mapped = self
+                .path_translation
+                .as_ref()
+                .and_then(|t| t.host_to_remote(&root))
+                .unwrap_or(root);
+            if let Some(uri) = path_to_uri(&mapped) {
                 return Some(uri);
             }
         }

--- a/crates/fresh-editor/tests/e2e/plugins/authority_snapshot.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/authority_snapshot.rs
@@ -35,6 +35,7 @@ fn devcontainer_authority_payload(label: &str) -> AuthorityPayload {
         spawner: SpawnerSpec::Local,
         terminal_wrapper: TerminalWrapperSpec::HostShell,
         display_label: label.to_string(),
+        path_translation: None,
     }
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -192,12 +192,6 @@ fn goto_definition_translates_uris_between_host_and_container() {
     let main_py = workspace.join("main.py");
     let host_util_py = workspace.join("util.py");
 
-    // Pin the in-container workspace path so it diverges from the host
-    // path. Set BEFORE harness creation — the env var is read by the
-    // fake CLI on `up`, and the harness's serialized lock guarantees
-    // we don't race with another test.
-    std::env::set_var("FAKE_DC_REMOTE_WORKSPACE", "/workspaces/proj");
-
     // Configure python's LSP to use the `fake-pylsp` shim. We
     // deliberately use the bare command name (no path) so the lookup
     // goes through PATH inside the fake "container" — the same path
@@ -232,6 +226,12 @@ fn goto_definition_translates_uris_between_host_and_container() {
             .without_empty_plugins_dir(),
     )
     .unwrap();
+
+    // Pin the in-container workspace path so it diverges from the
+    // host path. Set AFTER `with_fake_devcontainer()` acquires its
+    // process-global mutex — setting before would race with parallel
+    // tests' cleanup of the same env var.
+    std::env::set_var("FAKE_DC_REMOTE_WORKSPACE", "/workspaces/proj");
 
     // Pre-state: the fake-lsp uri log must not exist yet (or be
     // empty). The fake-pylsp creates it on first message, so we
@@ -423,5 +423,320 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // Cleanup any per-test env that we set above so neighbouring
     // tests in the same process don't inherit it. The fake-devcontainer
     // mutex serializes us, so no race window.
+    std::env::remove_var("FAKE_DC_REMOTE_WORKSPACE");
+}
+
+/// Common setup for the container-fetched-buffer tests below: planted
+/// workspace, fake-pylsp on PATH, container authority attached, and
+/// `main.py` opened so an LSP handshake has happened. Returns the
+/// per-test state dir so callers can write `fake_lsp_definition_*`
+/// pinning the response, and stash files under `container_fs/`.
+fn arrange_attached_session_with_open_main_py() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    EditorTestHarness,
+    std::path::PathBuf,
+) {
+    let (workspace_temp, workspace) = set_up_workspace();
+    let main_py = workspace.join("main.py");
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "python".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "fake-pylsp".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: vec![".devcontainer".to_string(), ".git".to_string()],
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_config(config)
+            .with_fake_devcontainer()
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+
+    // Set FAKE_DC_REMOTE_WORKSPACE *after* the fake-devcontainer
+    // mutex is held (it's acquired inside `with_fake_devcontainer`).
+    // Setting before would race with parallel tests' cleanup of the
+    // same env var — they could clobber the value between our
+    // `set_var` and the lock acquisition.
+    std::env::set_var("FAKE_DC_REMOTE_WORKSPACE", "/workspaces/proj");
+
+    let state = harness
+        .fake_devcontainer_state()
+        .expect("with_fake_devcontainer was set")
+        .to_path_buf();
+
+    let fake_lsp_bin = fake_lsp_bin_dir();
+    let host_path = std::env::var("PATH").unwrap_or_default();
+    if !host_path
+        .split(':')
+        .any(|p| Path::new(p) == fake_lsp_bin.as_path())
+    {
+        std::env::set_var("PATH", format!("{}:{}", fake_lsp_bin.display(), host_path));
+    }
+    fs::write(
+        state.join("probe_response"),
+        format!(
+            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}\n\
+             HOME=/home/vscode\n\
+             LANG=C.UTF-8\n",
+            fake_lsp_bin.display()
+        ),
+    )
+    .expect("write probe_response");
+
+    harness.tick_and_render().unwrap();
+
+    wait_for_attach_popup(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    let label = wait_for_container_authority(&mut harness);
+    assert!(
+        label.starts_with("Container:"),
+        "expected container authority, got {label:?}"
+    );
+
+    harness.open_file(&main_py).unwrap();
+    bounded_wait(&mut harness, "fake-pylsp initialize", |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("initialize "))
+    });
+    bounded_wait(&mut harness, "fake-pylsp didOpen", |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+    });
+
+    (workspace_temp, workspace, harness, state)
+}
+
+/// Pin a definition target the fake LSP will return for the next
+/// `textDocument/definition` request.
+fn pin_fake_lsp_definition(state: &Path, uri: &str, line: u32, character: u32) {
+    fs::write(state.join("fake_lsp_definition_uri"), format!("{uri}\n"))
+        .expect("write fake_lsp_definition_uri");
+    fs::write(state.join("fake_lsp_definition_line"), format!("{line}\n"))
+        .expect("write fake_lsp_definition_line");
+    fs::write(
+        state.join("fake_lsp_definition_character"),
+        format!("{character}\n"),
+    )
+    .expect("write fake_lsp_definition_character");
+}
+
+/// Stash a file under `<state>/container_fs/<abs_container_path>` so
+/// the fake docker shim's `cat` special-case can serve it. Mirrors
+/// what `docker exec <id> cat <path>` would return for a real
+/// container.
+fn stash_container_file(state: &Path, container_path: &str, content: &str) {
+    let stash = state.join("container_fs").join(
+        container_path
+            .strip_prefix('/')
+            .expect("container_path must be absolute"),
+    );
+    fs::create_dir_all(stash.parent().expect("non-root container path")).unwrap();
+    fs::write(&stash, content).unwrap_or_else(|e| panic!("stash {stash:?}: {e}"));
+}
+
+/// Run cursor down N times, right M times, then trigger Goto-Def.
+fn trigger_goto_definition(harness: &mut EditorTestHarness, down: usize, right: usize) {
+    for _ in 0..down {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    for _ in 0..right {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.process_async_and_render().unwrap();
+    harness
+        .send_key(KeyCode::F(12), KeyModifiers::NONE)
+        .unwrap();
+}
+
+/// Settle the editor: pump async messages a few times to give the
+/// goto-def response + any container-fetch round-trip time to land.
+fn settle(harness: &mut EditorTestHarness) {
+    for _ in 0..40 {
+        harness.process_async_and_render().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        harness.advance_time(std::time::Duration::from_millis(25));
+    }
+}
+
+/// Reproducer: Goto-Definition into a *container-only* file (the
+/// canonical case is jumping into `flask/app.py` from
+/// `~/.local/lib/python3.12/site-packages/`, which only exists inside
+/// the container's Python venv). The translation table doesn't help
+/// here because the path isn't under the workspace mount.
+///
+/// Expected behaviour: the editor fetches the file's contents through
+/// the active authority (`docker exec <id> cat <path>`) and opens the
+/// result as a *read-only* buffer whose path is the in-container path.
+/// Cursor lands at the LSP-reported line/column.
+///
+/// Currently fails because the editor calls `open_file` with the raw
+/// container path, which the host filesystem can't see — the buffer
+/// either errors out or ends up empty at the wrong location.
+#[test]
+fn goto_definition_into_container_only_file_opens_read_only_buffer() {
+    let (_workspace_temp, _workspace, mut harness, state) =
+        arrange_attached_session_with_open_main_py();
+
+    // The container-only file the LSP will point at. Mirrors the
+    // user-reported scenario verbatim (Flask installed into the
+    // vscode user's local site-packages).
+    let container_path = "/home/vscode/.local/lib/python3.12/site-packages/flask/app.py";
+    let container_content = "# flask/app.py — fetched from container\n\
+                             # line 1\n\
+                             # line 2\n\
+                             def some_app_helper():\n\
+                             \treturn 'this content lives only in the container'\n";
+    stash_container_file(&state, container_path, container_content);
+
+    // Pin the LSP response. Line 3 is `def some_app_helper():` in
+    // the stashed content — far from line 0 so we can tell an empty
+    // fallback buffer apart from a real fetch.
+    pin_fake_lsp_definition(&state, &format!("file://{container_path}"), 3, 0);
+
+    // Trigger Goto-Def from main.py line 4 (the `helper()` call).
+    trigger_goto_definition(&mut harness, 4, 6);
+    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("definition "))
+    });
+    settle(&mut harness);
+
+    // ── Container-fetched buffer assertions ──────────────────────
+    // The active buffer's path is the container path verbatim — no
+    // host translation possible because the file isn't under the
+    // workspace mount. The buffer's contents are what we stashed,
+    // proving the fetch went through the docker exec route. The
+    // buffer is read-only because container-only files have no
+    // host-side writeback path. The cursor lands where the LSP
+    // pointed.
+    let active_path: Option<PathBuf> = harness
+        .editor()
+        .active_state()
+        .buffer
+        .file_path()
+        .map(|p| p.to_path_buf());
+    assert_eq!(
+        active_path.as_deref(),
+        Some(Path::new(container_path)),
+        "active buffer path must be the container path; got {active_path:?}"
+    );
+
+    let content = harness
+        .editor()
+        .active_state()
+        .buffer
+        .to_string()
+        .expect("buffer content readable");
+    assert_eq!(
+        content, container_content,
+        "active buffer content must match what `docker exec cat` returned"
+    );
+
+    assert!(
+        harness.editor().is_active_buffer_read_only(),
+        "container-fetched buffers must be read-only (no host-side writeback)"
+    );
+
+    let cursor_pos = harness.cursor_position();
+    let (line, character) = harness
+        .editor()
+        .active_state()
+        .buffer
+        .position_to_lsp_position(cursor_pos);
+    assert_eq!(
+        (line, character),
+        (3, 0),
+        "cursor must land at the LSP-reported line/character. (0,0) \
+         usually means the editor created an empty buffer instead of \
+         fetching the container file."
+    );
+
+    std::env::remove_var("FAKE_DC_REMOTE_WORKSPACE");
+}
+
+/// Reproducer for the failure mode: Goto-Def returns a URI that
+/// resolves to neither a host-visible file nor a container-readable
+/// one (e.g. a stale path the LSP cached, or a typo in a server's
+/// own location math). The editor must surface a user-visible error
+/// instead of silently opening a phantom buffer.
+///
+/// Currently fails because the editor calls `open_file` on the
+/// untranslatable path and either errors silently or opens an empty
+/// buffer.
+#[test]
+fn goto_definition_to_unreachable_uri_surfaces_error_message() {
+    let (_workspace_temp, _workspace, mut harness, state) =
+        arrange_attached_session_with_open_main_py();
+
+    // Path doesn't exist on host; we deliberately *don't* stash it
+    // under `container_fs/`, so the fake docker `cat` falls through
+    // to real `cat` and exits 1.
+    let unreachable = "/this/path/exists/nowhere/ghost.py";
+    pin_fake_lsp_definition(&state, &format!("file://{unreachable}"), 7, 0);
+
+    trigger_goto_definition(&mut harness, 4, 6);
+    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("definition "))
+    });
+    settle(&mut harness);
+
+    // The active buffer must NOT be a phantom at the unreachable
+    // path. The most likely "bad" outcome is the editor opening an
+    // empty buffer at `/this/path/exists/nowhere/ghost.py` (visible
+    // as the active buffer's path matching the unreachable string),
+    // which we explicitly forbid.
+    let active_path: Option<PathBuf> = harness
+        .editor()
+        .active_state()
+        .buffer
+        .file_path()
+        .map(|p| p.to_path_buf());
+    assert_ne!(
+        active_path.as_deref(),
+        Some(Path::new(unreachable)),
+        "Goto-Def into an unreachable URI must NOT open a phantom \
+         buffer at that path. Got: {active_path:?}"
+    );
+
+    // The status line should mention the failure. Observation via
+    // the rendered screen (per CONTRIBUTING §2). The status bar
+    // truncates with `...` once it runs out of room, so we look for
+    // a stable prefix that the renderer will keep — "could not open"
+    // is unambiguous and short enough to fit alongside the
+    // filename / cursor / mode segments at our 160-col harness.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("could not open"),
+        "status line should surface the failure so the user knows the \
+         goto-def didn't navigate. Screen:\n{screen}"
+    );
+
     std::env::remove_var("FAKE_DC_REMOTE_WORKSPACE");
 }

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -662,6 +662,88 @@ fn arrange_attached_session_with_open_main_py() -> (
         "expected container authority, got {label:?}"
     );
 
+    // Fail-fast: the editor will shortly call `command_exists`
+    // through the *active* authority's spawner; if it returns
+    // false, the LSP never starts and `wait_until_with_dumps` will
+    // hang for 180s. Run the exact same probe right here so a
+    // misconfigured PATH / missing exec bit / fake-docker shim bug
+    // surfaces with a clear message instead of a nextest timeout.
+    //
+    // The CI logs from the previous failed run pinpointed this as
+    // the actual stuck point on macOS — the editor's
+    // `command_exists` returned false but we couldn't tell whether
+    // the failure was on the host (file/permissions) or in the
+    // fake-docker → sh → `command -v` chain. Running the probe
+    // directly here narrows it to "this exact authority + this
+    // exact command" so the panic message names the gap.
+    {
+        let spawner = harness.editor().authority().long_running_spawner.clone();
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime for command_exists probe");
+        let exists = rt.block_on(async move { spawner.command_exists("fake-pylsp").await });
+        drop(rt);
+        if !exists {
+            // Surface absolutely everything we know about the
+            // probe so CI logs name the cause: which docker shim
+            // ran, what PATH it received, what the host can see.
+            eprintln!("[infra] command_exists('fake-pylsp') returned false");
+            eprintln!("[infra] host fake_lsp_bin: {}", fake_lsp_bin.display());
+            eprintln!(
+                "[infra] host PATH: {}",
+                std::env::var("PATH").unwrap_or_default()
+            );
+            // Try the SAME probe on the host — if this works, the
+            // problem is the docker shim / -e PATH= round-trip;
+            // if it doesn't, the problem is the file/permissions.
+            let host_probe = std::process::Command::new("sh")
+                .args(["-c", "command -v fake-pylsp"])
+                .output();
+            match host_probe {
+                Ok(out) => eprintln!(
+                    "[infra] host `sh -c 'command -v fake-pylsp'`: status={}, stdout={:?}, stderr={:?}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stdout).trim(),
+                    String::from_utf8_lossy(&out.stderr).trim(),
+                ),
+                Err(e) => eprintln!("[infra] host `sh -c 'command -v fake-pylsp'`: spawn failed: {e}"),
+            }
+            // Run the probe a *second* way — directly invoke the
+            // fake-docker shim from this test process, bypassing
+            // the spawner. Surfaces whether the shim itself is
+            // bypassing the export, or `sh` inside it can't see
+            // PATH, or what.
+            let shim_probe = std::process::Command::new("docker")
+                .args([
+                    "exec",
+                    "-e",
+                    &format!(
+                        "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}",
+                        fake_lsp_bin.display()
+                    ),
+                    "fake-id",
+                    "sh",
+                    "-c",
+                    "echo PATH=$PATH; command -v fake-pylsp; echo exit=$?",
+                ])
+                .output();
+            match shim_probe {
+                Ok(out) => eprintln!(
+                    "[infra] direct fake-docker probe: status={}, stdout={:?}, stderr={:?}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr),
+                ),
+                Err(e) => eprintln!("[infra] direct fake-docker probe: spawn failed: {e}"),
+            }
+            dump_external_state(&state, "command_exists pre-flight");
+            panic!(
+                "infra: command_exists('fake-pylsp') returned false through the \
+                 active authority's spawner. The editor's LSP spawn will fail \
+                 the same way and the test would otherwise hang. See diagnostics above."
+            );
+        }
+        eprintln!("[infra] command_exists('fake-pylsp') OK through authority spawner");
+    }
+
     harness.open_file(&main_py).unwrap();
     wait_until_with_dumps(&mut harness, "fake-pylsp initialize", &state, |_| {
         read_uri_log(&state)

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -41,9 +41,158 @@
 #![cfg(all(unix, feature = "plugins"))]
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// Pre-flight checks that must hold before the test attempts to talk
+/// to the fake LSP. These are cheap, deterministic invariants that
+/// fail loudly with an actionable message instead of letting a
+/// missing `python3` (the fake-pylsp shebang) or a stripped-execute
+/// bit on the script silently degrade into a 180s nextest timeout.
+///
+/// Pattern stolen from the rest of the suite: any infra problem that
+/// is going to make the test pointless should panic *before* the
+/// long wait_untils start, so CI logs show the cause on the line the
+/// test fails.
+fn assert_test_infra() {
+    // 1. python3 must resolve via PATH — that's how the fake-pylsp
+    //    shebang (`#!/usr/bin/env python3`) finds an interpreter.
+    //    On macOS CI both `/usr/bin/python3` (XCode tools) and
+    //    `/usr/local/bin/python3` (Homebrew) usually work; we just
+    //    need *some* python3 that `env` can find.
+    match std::process::Command::new("python3")
+        .arg("--version")
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            eprintln!(
+                "[infra] python3: {}",
+                String::from_utf8_lossy(&out.stdout).trim()
+            );
+        }
+        Ok(out) => panic!(
+            "infra: `python3 --version` exited {}; stderr={:?}. \
+             The fake-pylsp shebang requires python3 on PATH.",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => panic!(
+            "infra: `python3 --version` failed to spawn: {e}. \
+             The fake-pylsp shebang requires python3 on PATH."
+        ),
+    }
+
+    // 2. fake-pylsp must be a real executable file with a Python
+    //    shebang. Git tracks the +x bit (mode 100755), but a careless
+    //    rebase / scripted edit can lose it; catching that here
+    //    surfaces "this is why your LSP never started" instead of
+    //    "the editor hung waiting for an `initialize` reply".
+    let pylsp = fake_lsp_bin_dir().join("fake-pylsp");
+    let meta = match std::fs::metadata(&pylsp) {
+        Ok(m) => m,
+        Err(e) => panic!("infra: fake-pylsp missing at {pylsp:?}: {e}"),
+    };
+    assert!(
+        meta.is_file(),
+        "infra: fake-pylsp at {pylsp:?} is not a regular file"
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode();
+        assert!(
+            mode & 0o111 != 0,
+            "infra: fake-pylsp at {pylsp:?} is not executable (mode={:o}). \
+             `chmod +x` it or check that git preserved the executable bit.",
+            mode
+        );
+    }
+    let first_line = std::fs::read_to_string(&pylsp)
+        .ok()
+        .and_then(|s| s.lines().next().map(str::to_string))
+        .unwrap_or_default();
+    assert!(
+        first_line.starts_with("#!") && first_line.contains("python"),
+        "infra: fake-pylsp shebang should reference python; got {first_line:?}"
+    );
+    eprintln!("[infra] fake-pylsp ready: {pylsp:?} ({first_line})");
+}
+
+/// Dump the test's external state (fake-LSP URI log, fake-docker
+/// exec history, container-fs stash) so a hung test in CI shows what
+/// stage it actually got to. Called periodically from
+/// [`wait_until_with_dumps`] and after every `wait_until` panic.
+fn dump_external_state(state: &Path, label: &str) {
+    eprintln!("=== fake state dump [{label}] ===");
+    eprintln!("--- fake_lsp_uris ---");
+    match fs::read_to_string(state.join("fake_lsp_uris")) {
+        Ok(s) if s.is_empty() => eprintln!("(empty)"),
+        Ok(s) => eprint!("{s}"),
+        Err(e) => eprintln!("(missing: {e})"),
+    }
+    eprintln!("--- exec_history ---");
+    match fs::read_to_string(state.join("exec_history")) {
+        Ok(s) if s.is_empty() => eprintln!("(empty)"),
+        Ok(s) => eprint!("{s}"),
+        Err(e) => eprintln!("(missing: {e})"),
+    }
+    // LSP stderr (if any) goes to a per-PID file under the editor's
+    // log dir. Surface its tail so a Python crash inside fake-pylsp
+    // surfaces in the CI log instead of disappearing into the void.
+    let lsp_log_path = fresh::services::log_dirs::lsp_log_path("python");
+    eprintln!("--- lsp stderr ({}) ---", lsp_log_path.display());
+    match fs::read_to_string(&lsp_log_path) {
+        Ok(s) if s.is_empty() => eprintln!("(empty)"),
+        Ok(s) => {
+            // Cap to last ~4 KB so a chatty server doesn't flood CI.
+            let tail = if s.len() > 4096 {
+                &s[s.len() - 4096..]
+            } else {
+                &s[..]
+            };
+            eprint!("{tail}");
+        }
+        Err(e) => eprintln!("(missing: {e})"),
+    }
+    eprintln!("=== end dump ===");
+}
+
+/// Wrap [`EditorTestHarness::wait_until`] with periodic state dumps.
+/// Same semantic-wait contract — runs forever (CONTRIBUTING §3) and
+/// relies on nextest's outer 180s kill — but every 10 s of waiting
+/// it eprintln's the fake state so a CI log of a TIMEOUT shows the
+/// stage we got stuck at instead of just an empty progress line.
+fn wait_until_with_dumps<F>(harness: &mut EditorTestHarness, label: &str, state: &Path, mut cond: F)
+where
+    F: FnMut(&EditorTestHarness) -> bool,
+{
+    let start = Instant::now();
+    let mut last_dump = start;
+    eprintln!("[wait] start: {label}");
+    loop {
+        harness.tick_and_render().unwrap();
+        if cond(harness) {
+            eprintln!(
+                "[wait] satisfied: {label} (after {:.1}s)",
+                start.elapsed().as_secs_f64()
+            );
+            return;
+        }
+        if last_dump.elapsed() >= Duration::from_secs(10) {
+            eprintln!(
+                "[wait] still waiting on {label} after {:.1}s",
+                start.elapsed().as_secs_f64()
+            );
+            dump_external_state(state, label);
+            last_dump = Instant::now();
+        }
+        std::thread::sleep(Duration::from_millis(50));
+        harness.advance_time(Duration::from_millis(50));
+    }
+}
 
 /// Path to the in-tree `fake-pylsp` bin dir. Tests prepend this to
 /// PATH so `command -v fake-pylsp` resolves both on the host (for the
@@ -296,24 +445,20 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // Wait for the LSP to handshake. The fake-pylsp logs every URI
     // it sees; an `initialize` line is the earliest signal that the
     // server is alive and the editor is talking to it.
-    harness
-        .wait_until(|_| {
-            read_uri_log(&state)
-                .lines()
-                .any(|l| l.starts_with("initialize "))
-        })
-        .unwrap();
+    wait_until_with_dumps(&mut harness, "fake-pylsp initialize", &state, |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("initialize "))
+    });
 
     // Wait for the editor to send `didOpen` for main.py before we
     // ask for a definition — without this the request races the
     // open notification.
-    harness
-        .wait_until(|_| {
-            read_uri_log(&state)
-                .lines()
-                .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
-        })
-        .unwrap();
+    wait_until_with_dumps(&mut harness, "fake-pylsp didOpen main.py", &state, |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+    });
 
     // Move the cursor onto the `helper()` call inside `def main():`.
     // main.py contents:
@@ -345,15 +490,13 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // on the editor having *processed the response*. CI is slower
     // than local; pinning a fixed pump-loop here is what gave us
     // the previous timeout.
-    harness
-        .wait_until(|h| {
-            h.editor()
-                .active_state()
-                .buffer
-                .file_path()
-                .is_some_and(|p| p == host_util_py.as_path())
-        })
-        .unwrap();
+    wait_until_with_dumps(&mut harness, "active buffer == host util.py", &state, |h| {
+        h.editor()
+            .active_state()
+            .buffer
+            .file_path()
+            .is_some_and(|p| p == host_util_py.as_path())
+    });
 
     // ── Direction 1: host → container ────────────────────────────
     // The first `didOpen` URI the LSP saw must be the *container*
@@ -434,6 +577,15 @@ fn arrange_attached_session_with_open_main_py() -> (
     EditorTestHarness,
     std::path::PathBuf,
 ) {
+    // Wire up tracing so RUST_LOG=info / debug from CI surfaces
+    // editor-side LSP events (`Spawning async LSP server`, didOpen
+    // race grace, etc.) alongside our explicit eprintln breadcrumbs.
+    init_tracing_from_env();
+    // Pre-flight invariants: any infra problem fails *here*, before
+    // we burn 180s waiting for a python3 that isn't on PATH or a
+    // script with a stripped exec bit.
+    assert_test_infra();
+
     let (workspace_temp, workspace) = set_up_workspace();
     let main_py = workspace.join("main.py");
 
@@ -511,20 +663,16 @@ fn arrange_attached_session_with_open_main_py() -> (
     );
 
     harness.open_file(&main_py).unwrap();
-    harness
-        .wait_until(|_| {
-            read_uri_log(&state)
-                .lines()
-                .any(|l| l.starts_with("initialize "))
-        })
-        .unwrap();
-    harness
-        .wait_until(|_| {
-            read_uri_log(&state)
-                .lines()
-                .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
-        })
-        .unwrap();
+    wait_until_with_dumps(&mut harness, "fake-pylsp initialize", &state, |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("initialize "))
+    });
+    wait_until_with_dumps(&mut harness, "fake-pylsp didOpen main.py", &state, |_| {
+        read_uri_log(&state)
+            .lines()
+            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+    });
 
     (workspace_temp, workspace, harness, state)
 }
@@ -616,15 +764,18 @@ fn goto_definition_into_container_only_file_opens_read_only_buffer() {
     // buffer's file_path matches the container path. Using
     // `wait_until` instead of a fixed pump-loop means CI's
     // potentially slower docker spawn doesn't push us off a cliff.
-    harness
-        .wait_until(|h| {
+    wait_until_with_dumps(
+        &mut harness,
+        "active buffer == fetched container path",
+        &state,
+        |h| {
             h.editor()
                 .active_state()
                 .buffer
                 .file_path()
                 .is_some_and(|p| p == Path::new(container_path))
-        })
-        .unwrap();
+        },
+    );
 
     // ── Container-fetched buffer assertions ──────────────────────
     // The active buffer's path is the container path verbatim — no
@@ -706,9 +857,9 @@ fn goto_definition_to_unreachable_uri_surfaces_error_message() {
     // container `cat` fails → `Editor::open_lsp_uri_target` returns
     // `Err` → status line set). Waiting on the screen instead of a
     // pump-loop means CI's slower docker spawn doesn't matter.
-    harness
-        .wait_until(|h| h.screen_to_string().contains("could not open"))
-        .unwrap();
+    wait_until_with_dumps(&mut harness, "status line: 'could not open'", &state, |h| {
+        h.screen_to_string().contains("could not open")
+    });
 
     // The active buffer must NOT be a phantom at the unreachable
     // path. The most likely "bad" outcome is the editor opening an

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -1,0 +1,433 @@
+//! Reproducer for the dev-container LSP "Go to Definition" path-translation
+//! bug.
+//!
+//! Background. Container authorities mount the host workspace into the
+//! container at `remoteWorkspaceFolder` — typically not the same string
+//! as the host workspace path. The editor's [`FilesystemSpec::Local`]
+//! doc-comment claims paths "translate 1:1 between host and container",
+//! and that's true for the *bytes* of the prefix once you cross the
+//! mount, but it isn't true for the *path string itself*: a host
+//! workspace at `/tmp/xxx/proj` shows up inside the container at
+//! `/workspaces/proj`. The LSP server runs in the container, so URIs in
+//! its outgoing `textDocument/*` traffic and incoming `Location`
+//! responses use the container-side path. The editor lives on the host,
+//! so its buffer file paths are host-side. There's currently no
+//! translation between the two — that's the bug, and this test pins it.
+//!
+//! What this test does. It drives a real attach via the in-tree fake
+//! devcontainer CLI, configures the Python LSP to point at
+//! [`scripts/fake-lsp/bin/fake-pylsp`] (a bash stub that records every
+//! URI it receives and answers `definition` with a configurable
+//! `Location`), opens a host file, and triggers Go-to-Definition. The
+//! fake LSP is set up to claim the definition lives at
+//! `file:///workspaces/proj/util.py` — a *container* path that doesn't
+//! exist on the host. The test then asserts both translation
+//! directions:
+//!
+//!   * **host → container** (`didOpen` URI must use the container
+//!     path the editor told docker to mount at, not the host path);
+//!   * **container → host** (after the `Location` comes back, the
+//!     active buffer's host path must resolve to `util.py` *on the
+//!     host*, and the cursor must land at the line/character the LSP
+//!     returned).
+//!
+//! The test is expected to fail today because the editor sends host
+//! URIs in `didOpen` and opens the literal container URI from the
+//! definition response. The fix lives in the URI-construction sites
+//! around `app/types.rs:file_path_to_lsp_uri` and the inverse
+//! `app/mod.rs:uri_to_path` — those need to know about the active
+//! authority's host↔container path mapping.
+
+#![cfg(all(unix, feature = "plugins"))]
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Path to the in-tree `fake-pylsp` bin dir. Tests prepend this to
+/// PATH so `command -v fake-pylsp` resolves both on the host (for the
+/// pre-attach phase) and inside the fake "container" (the captured
+/// `userEnvProbe` PATH echoes this dir back through `docker exec
+/// -e PATH=…`).
+fn fake_lsp_bin_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../scripts/fake-lsp/bin")
+        .canonicalize()
+        .expect("scripts/fake-lsp/bin must exist relative to CARGO_MANIFEST_DIR")
+}
+
+/// Set up a workspace that triggers the dev-container popup and is
+/// otherwise minimal. The python LSP config + fake-lsp wiring happens
+/// at the harness layer; this just plants the source files and a
+/// `.devcontainer/devcontainer.json`.
+fn set_up_workspace() -> (tempfile::TempDir, PathBuf) {
+    fresh::i18n::set_locale("en");
+
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().canonicalize().unwrap();
+
+    let dc = workspace.join(".devcontainer");
+    fs::create_dir_all(&dc).unwrap();
+    fs::write(
+        dc.join("devcontainer.json"),
+        r#"{
+            "name": "fake-lsp-go-to-def",
+            "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+            "remoteUser": "vscode",
+            "userEnvProbe": "loginInteractiveShell"
+        }"#,
+    )
+    .unwrap();
+
+    // Distinct contents on each side so an accidental "open the same
+    // file twice" doesn't smuggle a false positive past the cursor
+    // assertion. `util.py` is intentionally long enough to host a
+    // real line 5.
+    fs::write(
+        workspace.join("main.py"),
+        "from util import helper\n\n\ndef main():\n    helper()\n",
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("util.py"),
+        "# util.py — host copy\n\
+         # line 1\n\
+         # line 2\n\
+         # line 3\n\
+         # line 4\n\
+         def helper():\n\
+         \treturn 'host-side definition target'\n",
+    )
+    .unwrap();
+
+    let plugins_dir = workspace.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "devcontainer");
+
+    (temp, workspace)
+}
+
+/// Wait until the devcontainer plugin's "Reopen in Container?" popup
+/// is rendered. Mirrors `devcontainer_attach_e2e::wait_for_attach_popup`
+/// but inlined here so the test file stays self-contained.
+fn wait_for_attach_popup(harness: &mut EditorTestHarness) {
+    bounded_wait(harness, "devcontainer plugin command registration", |h| {
+        let reg = h.editor().command_registry().read().unwrap();
+        reg.get_all().iter().any(|c| c.name == "%cmd.run_lifecycle")
+    });
+    harness.editor().fire_plugins_loaded_hook();
+    bounded_wait(harness, "Reopen in Container popup", |h| {
+        let screen = h.screen_to_string();
+        screen.contains("Dev Container Detected") && screen.contains("Reopen in Container")
+    });
+}
+
+fn bounded_wait<F>(harness: &mut EditorTestHarness, what: &str, mut cond: F)
+where
+    F: FnMut(&EditorTestHarness) -> bool,
+{
+    for _ in 0..200 {
+        harness.tick_and_render().unwrap();
+        if cond(harness) {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        harness.advance_time(std::time::Duration::from_millis(50));
+    }
+    panic!(
+        "bounded_wait timed out: {what} not satisfied in 200 ticks (~10s).\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Promote the plugin-staged authority to active. Same idiom as the
+/// existing devcontainer attach e2e — the harness has no main loop, so
+/// the test does the `take_pending_authority → set_boot_authority`
+/// swap inline.
+fn wait_for_container_authority(harness: &mut EditorTestHarness) -> String {
+    for _ in 0..200 {
+        harness.tick_and_render().unwrap();
+        if let Some(auth) = harness.editor_mut().take_pending_authority() {
+            harness.editor_mut().set_boot_authority(auth);
+            return harness.editor().authority().display_label.clone();
+        }
+        if harness
+            .editor()
+            .authority()
+            .display_label
+            .starts_with("Container:")
+        {
+            return harness.editor().authority().display_label.clone();
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        harness.advance_time(std::time::Duration::from_millis(50));
+    }
+    panic!(
+        "container authority never landed.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+fn read_uri_log(state: &Path) -> String {
+    fs::read_to_string(state.join("fake_lsp_uris")).unwrap_or_default()
+}
+
+/// Reproducer.
+///
+/// Today this test fails because:
+///   * `didOpen` carries `file:///<host>/main.py` rather than
+///     `file:///workspaces/proj/main.py`; and
+///   * the `Location` URI `file:///workspaces/proj/util.py` is opened
+///     verbatim as a host path, so either the open fails or the active
+///     buffer ends up at the wrong host file (and the cursor land
+///     position drifts).
+///
+/// Both directions need to be fixed for Go-to-Definition to work in a
+/// devcontainer. Don't gut one side without exercising the other.
+#[test]
+fn goto_definition_translates_uris_between_host_and_container() {
+    let (_workspace_temp, workspace) = set_up_workspace();
+    let main_py = workspace.join("main.py");
+    let host_util_py = workspace.join("util.py");
+
+    // Pin the in-container workspace path so it diverges from the host
+    // path. Set BEFORE harness creation — the env var is read by the
+    // fake CLI on `up`, and the harness's serialized lock guarantees
+    // we don't race with another test.
+    std::env::set_var("FAKE_DC_REMOTE_WORKSPACE", "/workspaces/proj");
+
+    // Configure python's LSP to use the `fake-pylsp` shim. We
+    // deliberately use the bare command name (no path) so the lookup
+    // goes through PATH inside the fake "container" — the same path
+    // the production code uses via `docker exec sh -c 'command -v
+    // pylsp'`.
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "python".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: "fake-pylsp".to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: vec![".devcontainer".to_string(), ".git".to_string()],
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_config(config)
+            .with_fake_devcontainer()
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+
+    // Pre-state: the fake-lsp uri log must not exist yet (or be
+    // empty). The fake-pylsp creates it on first message, so we
+    // assert the symptom only after triggering Go-to-Definition.
+    let state = harness
+        .fake_devcontainer_state()
+        .expect("with_fake_devcontainer was set")
+        .to_path_buf();
+
+    // Prepend the fake-lsp bin dir to the *host* PATH — the
+    // pre-attach probe (`captureContainerLoginEnv` etc.) and the post-
+    // attach `docker exec` both need to find `fake-pylsp`. With
+    // `FAKE_DC_REMOTE_WORKSPACE=/workspaces/proj` and the host's PATH
+    // injected through the fake docker shim, this is the simplest way
+    // to make the binary reachable from "inside" the container.
+    let fake_lsp_bin = fake_lsp_bin_dir();
+    let host_path = std::env::var("PATH").unwrap_or_default();
+    let already_on_path = host_path
+        .split(':')
+        .any(|p| Path::new(p) == fake_lsp_bin.as_path());
+    if !already_on_path {
+        std::env::set_var(
+            "PATH",
+            format!("{}:{}", fake_lsp_bin.display(), host_path),
+        );
+    }
+
+    // Have `userEnvProbe` echo a PATH that includes the fake-lsp dir
+    // so the in-container `command -v fake-pylsp` probe (and the
+    // subsequent `docker exec -e PATH=… fake-pylsp` spawn) can
+    // resolve the binary. The fake docker reuses the parent process's
+    // env when no `-e` is passed, but the captured probe overrides
+    // PATH on every spawn — so it *must* contain our dir.
+    fs::write(
+        state.join("probe_response"),
+        format!(
+            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}\n\
+             HOME=/home/vscode\n\
+             LANG=C.UTF-8\n",
+            fake_lsp_bin.display()
+        ),
+    )
+    .expect("write probe_response");
+
+    // Pin the definition target the fake LSP returns. The URI uses
+    // the *container* workspace path so the editor (on the host) has
+    // to translate it back. Line 5 col 0 lands on `def helper():` in
+    // util.py — far enough from line 0 that an off-by-N translation
+    // bug shows up clearly.
+    fs::write(
+        state.join("fake_lsp_definition_uri"),
+        "file:///workspaces/proj/util.py\n",
+    )
+    .expect("write fake_lsp_definition_uri");
+    fs::write(state.join("fake_lsp_definition_line"), "5\n")
+        .expect("write fake_lsp_definition_line");
+    fs::write(state.join("fake_lsp_definition_character"), "0\n")
+        .expect("write fake_lsp_definition_character");
+
+    harness.tick_and_render().unwrap();
+
+    // Drive the attach popup → "Reopen in Container" → wait for
+    // authority. After this point, every spawn we drive (including
+    // the LSP) routes through the container authority's
+    // `DockerLongRunningSpawner`.
+    wait_for_attach_popup(&mut harness);
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    let label = wait_for_container_authority(&mut harness);
+    assert!(
+        label.starts_with("Container:"),
+        "expected container authority, got {label:?}"
+    );
+
+    // Open main.py — the LSP autostarts because `auto_start: true`
+    // and the file extension matches the python language config.
+    harness.open_file(&main_py).unwrap();
+
+    // Wait for the LSP to handshake. The fake-pylsp logs every URI
+    // it sees; an `initialize` line is the earliest signal that the
+    // server is alive and the editor is talking to it.
+    bounded_wait(&mut harness, "fake-pylsp initialize", |_| {
+        let log = read_uri_log(&state);
+        log.lines().any(|l| l.starts_with("initialize "))
+    });
+
+    // Wait for the editor to send `didOpen` for main.py before we
+    // ask for a definition — without this the request races the
+    // open notification.
+    bounded_wait(&mut harness, "fake-pylsp didOpen", |_| {
+        let log = read_uri_log(&state);
+        log.lines()
+            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+    });
+
+    // Move the cursor onto the `helper()` call inside `def main():`.
+    // main.py contents:
+    //   line 0: `from util import helper`
+    //   line 1: ``
+    //   line 2: ``
+    //   line 3: `def main():`
+    //   line 4: `    helper()`
+    for _ in 0..4 {
+        harness
+            .send_key(KeyCode::Down, KeyModifiers::NONE)
+            .unwrap();
+    }
+    for _ in 0..6 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.process_async_and_render().unwrap();
+
+    // Trigger Go-to-Definition. F12 is the conventional binding;
+    // mirrors `lsp_goto_definition_readonly.rs`.
+    harness.send_key(KeyCode::F(12), KeyModifiers::NONE).unwrap();
+    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
+        let log = read_uri_log(&state);
+        log.lines().any(|l| l.starts_with("definition "))
+    });
+    // Give the editor time to receive the response and act on it.
+    for _ in 0..40 {
+        harness.process_async_and_render().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        harness.advance_time(std::time::Duration::from_millis(25));
+    }
+
+    // ── Direction 1: host → container ────────────────────────────
+    // The first `didOpen` URI the LSP saw must be the *container*
+    // path (the workspace mounted at `/workspaces/proj`). The host
+    // path leaks in today.
+    let log = read_uri_log(&state);
+    let did_open_lines: Vec<&str> = log
+        .lines()
+        .filter(|l| l.starts_with("didOpen "))
+        .collect();
+    assert!(
+        !did_open_lines.is_empty(),
+        "expected at least one didOpen URI in the fake-lsp log; full log:\n{log}"
+    );
+    let first_did_open = did_open_lines[0];
+    assert!(
+        first_did_open.contains("file:///workspaces/proj/main.py"),
+        "didOpen URI must use the in-container workspace path \
+         `/workspaces/proj/main.py`, but got: {first_did_open:?}.\n\
+         Full uri log:\n{log}\n\
+         (This is the host→container URI translation gap: the editor \
+          tells the LSP about a file at the host path, which the \
+          in-container server can't see.)"
+    );
+    assert!(
+        !first_did_open.contains(workspace.to_str().unwrap()),
+        "didOpen URI must NOT carry the host workspace path; got: \
+         {first_did_open:?}. Full uri log:\n{log}"
+    );
+
+    // ── Direction 2: container → host ────────────────────────────
+    // The fake LSP returned `file:///workspaces/proj/util.py` line 5
+    // col 0. After the editor processes the response, the active
+    // buffer should be the host's `util.py`, and the cursor should
+    // sit at line 5 col 0 — not line 0 (which is what an
+    // open-empty-buffer fallback would give).
+    let active_path: Option<PathBuf> = harness
+        .editor()
+        .active_state()
+        .buffer
+        .file_path()
+        .map(|p| p.to_path_buf());
+    assert_eq!(
+        active_path.as_deref(),
+        Some(host_util_py.as_path()),
+        "after Go-to-Definition the active buffer's host path must be \
+         the host's util.py, not the literal container path returned \
+         by the LSP. Got: {active_path:?}. \
+         (Container→host URI translation gap.)"
+    );
+
+    let cursor_pos = harness.cursor_position();
+    let (line, character) = harness
+        .editor()
+        .active_state()
+        .buffer
+        .position_to_lsp_position(cursor_pos);
+    assert_eq!(
+        (line, character),
+        (5, 0),
+        "after Go-to-Definition the cursor must be at line 5, col 0 \
+         (matching the fake LSP's response). A line:0 col:0 result \
+         usually means the editor opened a fresh empty buffer for \
+         the container URI instead of resolving it to the host file."
+    );
+
+    // Cleanup any per-test env that we set above so neighbouring
+    // tests in the same process don't inherit it. The fake-devcontainer
+    // mutex serializes us, so no race window.
+    std::env::remove_var("FAKE_DC_REMOTE_WORKSPACE");
+}

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -113,41 +113,30 @@ fn set_up_workspace() -> (tempfile::TempDir, PathBuf) {
 /// is rendered. Mirrors `devcontainer_attach_e2e::wait_for_attach_popup`
 /// but inlined here so the test file stays self-contained.
 fn wait_for_attach_popup(harness: &mut EditorTestHarness) {
-    bounded_wait(harness, "devcontainer plugin command registration", |h| {
-        let reg = h.editor().command_registry().read().unwrap();
-        reg.get_all().iter().any(|c| c.name == "%cmd.run_lifecycle")
-    });
+    // Semantic waits, no in-test timeouts (CONTRIBUTING §3). nextest
+    // applies its own outer timeout if anything genuinely hangs.
+    harness
+        .wait_until(|h| {
+            let reg = h.editor().command_registry().read().unwrap();
+            reg.get_all().iter().any(|c| c.name == "%cmd.run_lifecycle")
+        })
+        .unwrap();
     harness.editor().fire_plugins_loaded_hook();
-    bounded_wait(harness, "Reopen in Container popup", |h| {
-        let screen = h.screen_to_string();
-        screen.contains("Dev Container Detected") && screen.contains("Reopen in Container")
-    });
-}
-
-fn bounded_wait<F>(harness: &mut EditorTestHarness, what: &str, mut cond: F)
-where
-    F: FnMut(&EditorTestHarness) -> bool,
-{
-    for _ in 0..200 {
-        harness.tick_and_render().unwrap();
-        if cond(harness) {
-            return;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        harness.advance_time(std::time::Duration::from_millis(50));
-    }
-    panic!(
-        "bounded_wait timed out: {what} not satisfied in 200 ticks (~10s).\nScreen:\n{}",
-        harness.screen_to_string()
-    );
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen.contains("Dev Container Detected") && screen.contains("Reopen in Container")
+        })
+        .unwrap();
 }
 
 /// Promote the plugin-staged authority to active. Same idiom as the
 /// existing devcontainer attach e2e — the harness has no main loop, so
 /// the test does the `take_pending_authority → set_boot_authority`
-/// swap inline.
+/// swap inline. Waits indefinitely (CONTRIBUTING §3); nextest's outer
+/// timeout catches genuine hangs.
 fn wait_for_container_authority(harness: &mut EditorTestHarness) -> String {
-    for _ in 0..200 {
+    loop {
         harness.tick_and_render().unwrap();
         if let Some(auth) = harness.editor_mut().take_pending_authority() {
             harness.editor_mut().set_boot_authority(auth);
@@ -164,10 +153,6 @@ fn wait_for_container_authority(harness: &mut EditorTestHarness) -> String {
         std::thread::sleep(std::time::Duration::from_millis(50));
         harness.advance_time(std::time::Duration::from_millis(50));
     }
-    panic!(
-        "container authority never landed.\nScreen:\n{}",
-        harness.screen_to_string()
-    );
 }
 
 fn read_uri_log(state: &Path) -> String {
@@ -311,19 +296,24 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // Wait for the LSP to handshake. The fake-pylsp logs every URI
     // it sees; an `initialize` line is the earliest signal that the
     // server is alive and the editor is talking to it.
-    bounded_wait(&mut harness, "fake-pylsp initialize", |_| {
-        let log = read_uri_log(&state);
-        log.lines().any(|l| l.starts_with("initialize "))
-    });
+    harness
+        .wait_until(|_| {
+            read_uri_log(&state)
+                .lines()
+                .any(|l| l.starts_with("initialize "))
+        })
+        .unwrap();
 
     // Wait for the editor to send `didOpen` for main.py before we
     // ask for a definition — without this the request races the
     // open notification.
-    bounded_wait(&mut harness, "fake-pylsp didOpen", |_| {
-        let log = read_uri_log(&state);
-        log.lines()
-            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
-    });
+    harness
+        .wait_until(|_| {
+            read_uri_log(&state)
+                .lines()
+                .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+        })
+        .unwrap();
 
     // Move the cursor onto the `helper()` call inside `def main():`.
     // main.py contents:
@@ -347,10 +337,13 @@ fn goto_definition_translates_uris_between_host_and_container() {
     harness
         .send_key(KeyCode::F(12), KeyModifiers::NONE)
         .unwrap();
-    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
-        let log = read_uri_log(&state);
-        log.lines().any(|l| l.starts_with("definition "))
-    });
+    harness
+        .wait_until(|_| {
+            read_uri_log(&state)
+                .lines()
+                .any(|l| l.starts_with("definition "))
+        })
+        .unwrap();
     // Give the editor time to receive the response and act on it.
     for _ in 0..40 {
         harness.process_async_and_render().unwrap();
@@ -514,16 +507,20 @@ fn arrange_attached_session_with_open_main_py() -> (
     );
 
     harness.open_file(&main_py).unwrap();
-    bounded_wait(&mut harness, "fake-pylsp initialize", |_| {
-        read_uri_log(&state)
-            .lines()
-            .any(|l| l.starts_with("initialize "))
-    });
-    bounded_wait(&mut harness, "fake-pylsp didOpen", |_| {
-        read_uri_log(&state)
-            .lines()
-            .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
-    });
+    harness
+        .wait_until(|_| {
+            read_uri_log(&state)
+                .lines()
+                .any(|l| l.starts_with("initialize "))
+        })
+        .unwrap();
+    harness
+        .wait_until(|_| {
+            read_uri_log(&state)
+                .lines()
+                .any(|l| l.starts_with("didOpen ") && l.contains("main.py"))
+        })
+        .unwrap();
 
     (workspace_temp, workspace, harness, state)
 }
@@ -572,16 +569,6 @@ fn trigger_goto_definition(harness: &mut EditorTestHarness, down: usize, right: 
         .unwrap();
 }
 
-/// Settle the editor: pump async messages a few times to give the
-/// goto-def response + any container-fetch round-trip time to land.
-fn settle(harness: &mut EditorTestHarness) {
-    for _ in 0..40 {
-        harness.process_async_and_render().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(25));
-        harness.advance_time(std::time::Duration::from_millis(25));
-    }
-}
-
 /// Reproducer: Goto-Definition into a *container-only* file (the
 /// canonical case is jumping into `flask/app.py` from
 /// `~/.local/lib/python3.12/site-packages/`, which only exists inside
@@ -619,12 +606,21 @@ fn goto_definition_into_container_only_file_opens_read_only_buffer() {
 
     // Trigger Goto-Def from main.py line 4 (the `helper()` call).
     trigger_goto_definition(&mut harness, 4, 6);
-    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
-        read_uri_log(&state)
-            .lines()
-            .any(|l| l.starts_with("definition "))
-    });
-    settle(&mut harness);
+    // Semantic wait: the goto-def response, the container fetch
+    // round-trip (`docker exec cat`), and the buffer creation /
+    // focus / cursor placement all settle by the time the active
+    // buffer's file_path matches the container path. Using
+    // `wait_until` instead of a fixed pump-loop means CI's
+    // potentially slower docker spawn doesn't push us off a cliff.
+    harness
+        .wait_until(|h| {
+            h.editor()
+                .active_state()
+                .buffer
+                .file_path()
+                .is_some_and(|p| p == Path::new(container_path))
+        })
+        .unwrap();
 
     // ── Container-fetched buffer assertions ──────────────────────
     // The active buffer's path is the container path verbatim — no
@@ -700,12 +696,15 @@ fn goto_definition_to_unreachable_uri_surfaces_error_message() {
     pin_fake_lsp_definition(&state, &format!("file://{unreachable}"), 7, 0);
 
     trigger_goto_definition(&mut harness, 4, 6);
-    bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
-        read_uri_log(&state)
-            .lines()
-            .any(|l| l.starts_with("definition "))
-    });
-    settle(&mut harness);
+    // Semantic wait on the rendered failure — the status bar shows
+    // "could not open …" once the editor has fully resolved the
+    // goto-def response (LSP returns Location → host check fails →
+    // container `cat` fails → `Editor::open_lsp_uri_target` returns
+    // `Err` → status line set). Waiting on the screen instead of a
+    // pump-loop means CI's slower docker spawn doesn't matter.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("could not open"))
+        .unwrap();
 
     // The active buffer must NOT be a phantom at the unreachable
     // path. The most likely "bad" outcome is the editor opening an
@@ -723,19 +722,6 @@ fn goto_definition_to_unreachable_uri_surfaces_error_message() {
         Some(Path::new(unreachable)),
         "Goto-Def into an unreachable URI must NOT open a phantom \
          buffer at that path. Got: {active_path:?}"
-    );
-
-    // The status line should mention the failure. Observation via
-    // the rendered screen (per CONTRIBUTING §2). The status bar
-    // truncates with `...` once it runs out of room, so we look for
-    // a stable prefix that the renderer will keep — "could not open"
-    // is unambiguous and short enough to fit alongside the
-    // filename / cursor / mode segments at our 160-col harness.
-    let screen = harness.screen_to_string();
-    assert!(
-        screen.contains("could not open"),
-        "status line should surface the failure so the user knows the \
-         goto-def didn't navigate. Screen:\n{screen}"
     );
 
     std::env::remove_var("FAKE_DC_REMOTE_WORKSPACE");

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -253,10 +253,7 @@ fn goto_definition_translates_uris_between_host_and_container() {
         .split(':')
         .any(|p| Path::new(p) == fake_lsp_bin.as_path());
     if !already_on_path {
-        std::env::set_var(
-            "PATH",
-            format!("{}:{}", fake_lsp_bin.display(), host_path),
-        );
+        std::env::set_var("PATH", format!("{}:{}", fake_lsp_bin.display(), host_path));
     }
 
     // Have `userEnvProbe` echo a PATH that includes the fake-lsp dir
@@ -336,9 +333,7 @@ fn goto_definition_translates_uris_between_host_and_container() {
     //   line 3: `def main():`
     //   line 4: `    helper()`
     for _ in 0..4 {
-        harness
-            .send_key(KeyCode::Down, KeyModifiers::NONE)
-            .unwrap();
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     for _ in 0..6 {
         harness
@@ -349,7 +344,9 @@ fn goto_definition_translates_uris_between_host_and_container() {
 
     // Trigger Go-to-Definition. F12 is the conventional binding;
     // mirrors `lsp_goto_definition_readonly.rs`.
-    harness.send_key(KeyCode::F(12), KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::F(12), KeyModifiers::NONE)
+        .unwrap();
     bounded_wait(&mut harness, "fake-pylsp definition request", |_| {
         let log = read_uri_log(&state);
         log.lines().any(|l| l.starts_with("definition "))
@@ -366,10 +363,7 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // path (the workspace mounted at `/workspaces/proj`). The host
     // path leaks in today.
     let log = read_uri_log(&state);
-    let did_open_lines: Vec<&str> = log
-        .lines()
-        .filter(|l| l.starts_with("didOpen "))
-        .collect();
+    let did_open_lines: Vec<&str> = log.lines().filter(|l| l.starts_with("didOpen ")).collect();
     assert!(
         !did_open_lines.is_empty(),
         "expected at least one didOpen URI in the fake-lsp log; full log:\n{log}"

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -337,19 +337,23 @@ fn goto_definition_translates_uris_between_host_and_container() {
     harness
         .send_key(KeyCode::F(12), KeyModifiers::NONE)
         .unwrap();
+    // Wait until the goto-def round-trip has fully settled — i.e.
+    // the active buffer has switched to util.py. That's a stronger
+    // semantic checkpoint than "fake-pylsp logged the definition
+    // request" because the latter passes as soon as the LSP
+    // *receives* the request, whereas the assertions below depend
+    // on the editor having *processed the response*. CI is slower
+    // than local; pinning a fixed pump-loop here is what gave us
+    // the previous timeout.
     harness
-        .wait_until(|_| {
-            read_uri_log(&state)
-                .lines()
-                .any(|l| l.starts_with("definition "))
+        .wait_until(|h| {
+            h.editor()
+                .active_state()
+                .buffer
+                .file_path()
+                .is_some_and(|p| p == host_util_py.as_path())
         })
         .unwrap();
-    // Give the editor time to receive the response and act on it.
-    for _ in 0..40 {
-        harness.process_async_and_render().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(25));
-        harness.advance_time(std::time::Duration::from_millis(25));
-    }
 
     // ── Direction 1: host → container ────────────────────────────
     // The first `didOpen` URI the LSP saw must be the *container*

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_lsp_definition.rs
@@ -396,10 +396,22 @@ fn goto_definition_translates_uris_between_host_and_container() {
     // resolve the binary. The fake docker reuses the parent process's
     // env when no `-e` is passed, but the captured probe overrides
     // PATH on every spawn — so it *must* contain our dir.
+    // The captured probe PATH gets sent to every subsequent
+    // `docker exec` via `-e PATH=…`, which means it has to be a PATH
+    // a real shell can survive on. Include `/bin` and `/sbin`
+    // explicitly: the fake-docker shim's `exec sh -c "…"` needs to
+    // resolve `sh` itself through this PATH, and on macOS `sh` lives
+    // *only* at `/bin/sh` (Linux usrmerge distros also have
+    // `/usr/bin/sh`, which is why the missing `/bin` only hurt
+    // macOS CI). The fake-docker shim's *default* probe-response
+    // includes `/sbin:/bin` for the same reason; we just have to
+    // remember to do the same when overriding it. Without `/bin`,
+    // `exec sh …` exits 127, `command_exists` returns false, and the
+    // LSP never starts — which is what the previous CI run hung on.
     fs::write(
         state.join("probe_response"),
         format!(
-            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}\n\
+            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:{}\n\
              HOME=/home/vscode\n\
              LANG=C.UTF-8\n",
             fake_lsp_bin.display()
@@ -639,10 +651,22 @@ fn arrange_attached_session_with_open_main_py() -> (
     {
         std::env::set_var("PATH", format!("{}:{}", fake_lsp_bin.display(), host_path));
     }
+    // The captured probe PATH gets sent to every subsequent
+    // `docker exec` via `-e PATH=…`, which means it has to be a PATH
+    // a real shell can survive on. Include `/bin` and `/sbin`
+    // explicitly: the fake-docker shim's `exec sh -c "…"` needs to
+    // resolve `sh` itself through this PATH, and on macOS `sh` lives
+    // *only* at `/bin/sh` (Linux usrmerge distros also have
+    // `/usr/bin/sh`, which is why the missing `/bin` only hurt
+    // macOS CI). The fake-docker shim's *default* probe-response
+    // includes `/sbin:/bin` for the same reason; we just have to
+    // remember to do the same when overriding it. Without `/bin`,
+    // `exec sh …` exits 127, `command_exists` returns false, and the
+    // LSP never starts — which is what the previous CI run hung on.
     fs::write(
         state.join("probe_response"),
         format!(
-            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}\n\
+            "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:{}\n\
              HOME=/home/vscode\n\
              LANG=C.UTF-8\n",
             fake_lsp_bin.display()
@@ -716,7 +740,7 @@ fn arrange_attached_session_with_open_main_py() -> (
                     "exec",
                     "-e",
                     &format!(
-                        "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:{}",
+                        "PATH=/home/vscode/.local/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:{}",
                         fake_lsp_bin.display()
                     ),
                     "fake-id",

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -16,6 +16,8 @@ pub mod dashboard;
 #[cfg(unix)]
 pub mod devcontainer_attach_e2e;
 pub mod devcontainer_failed_attach_popup;
+#[cfg(unix)]
+pub mod devcontainer_lsp_definition;
 pub mod devcontainer_ports_panel;
 pub mod devcontainer_run_lifecycle;
 #[cfg(unix)]

--- a/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
@@ -244,6 +244,7 @@ fn test_remote_indicator_popup_connected_container_offers_show_build_logs() -> a
         spawner: SpawnerSpec::Local,
         terminal_wrapper: TerminalWrapperSpec::HostShell,
         display_label: "Container:deadbeef".to_string(),
+        path_translation: None,
     })?;
     harness.editor_mut().set_boot_authority(authority);
 

--- a/scripts/fake-devcontainer/bin/docker
+++ b/scripts/fake-devcontainer/bin/docker
@@ -92,6 +92,44 @@ cmd_exec() {
     fi
   fi
 
+  # Special-case `cat <abs-path>` (and `cat <abs-path-1> <abs-path-2>`)
+  # so tests can stash "in-container" files at
+  # `<state>/container_fs/<abs-path>` and have the editor's
+  # container-fetch path (`docker exec <id> cat /home/vscode/.../foo.py`)
+  # resolve them without those paths needing to actually exist on the
+  # host. Production `docker exec <id> cat <path>` reads the file
+  # from the container's namespace; this is the simplest faithful
+  # fake. Files not in the stash dir get the real `cat`'s
+  # "no such file" exit code 1, which is also what production gives
+  # for nonexistent paths.
+  if [ $# -ge 2 ] && [ "$1" = "cat" ]; then
+    stash="$state/container_fs"
+    all_found=1
+    for p in "${@:2}"; do
+      case "$p" in
+        /*)
+          if [ ! -f "$stash$p" ]; then
+            all_found=0
+            break
+          fi
+          ;;
+        *)
+          all_found=0
+          break
+          ;;
+      esac
+    done
+    if [ "$all_found" = "1" ]; then
+      for p in "${@:2}"; do
+        cat "$stash$p"
+      done
+      exit 0
+    fi
+    # Fall through to real cat: it will report "No such file" for
+    # the missing path with the standard exit code 1, which the
+    # editor surfaces as "could not read from container".
+  fi
+
   if [ -z "$workdir" ] && [ -f "$cdir/workspace" ]; then
     # Treat the recorded host workspace path as the cwd. In real
     # devcontainers the workspace is bind-mounted to remoteWorkspaceFolder

--- a/scripts/fake-lsp/README.md
+++ b/scripts/fake-lsp/README.md
@@ -1,0 +1,35 @@
+# fake-lsp
+
+Tiny LSP server stubs used by the fresh-editor e2e tests. They speak just
+enough of the LSP wire protocol (Content-Length framing + a handful of
+methods) to drive a single editor flow without needing a real language
+server installed.
+
+## Tools
+
+- `bin/fake-pylsp` — pretends to be `pylsp`. Logs every URI it receives
+  (tagged with the request method) to
+  `<FAKE_DEVCONTAINER_STATE>/fake_lsp_uris`, and answers
+  `textDocument/definition` with a configurable `Location`.
+
+## Pinning the definition target
+
+Tests can pin what the LSP returns for `textDocument/definition` by
+writing the desired values into the per-test state dir before
+triggering the request:
+
+- `fake_lsp_definition_uri`  — full URI (e.g. `file:///workspaces/proj/util.py`)
+- `fake_lsp_definition_line` — 0-based line number (default `5`)
+- `fake_lsp_definition_character` — 0-based column (default `0`)
+
+If the files are absent the defaults above kick in. The same state dir
+is what `scripts/fake-devcontainer/lib/fake-state.sh` uses, so the
+log/config files sit next to `exec_history` and `containers/<id>/`.
+
+## Wiring into a test
+
+The fake LSP runs on the host via the fake docker shim. The shim's
+parent (the test process) sets `PATH` so `command -v fake-pylsp`
+resolves; tests that capture a `userEnvProbe` PATH must include this
+bin dir in the captured value, otherwise the in-container
+`command_exists` probe will report the binary as missing.

--- a/scripts/fake-lsp/bin/fake-pylsp
+++ b/scripts/fake-lsp/bin/fake-pylsp
@@ -1,170 +1,261 @@
-#!/usr/bin/env bash
-# Tiny fake `pylsp` for tests. Reads JSON-RPC framed messages on stdio,
-# logs every received `uri` (with the request method) to
-# `<FAKE_DEVCONTAINER_STATE>/fake_lsp_uris`, and answers the few
-# methods the editor needs to drive Go-to-Definition end-to-end:
-#
-#   - `initialize`              → minimal capabilities
-#   - `textDocument/didOpen`    → notification, no response (logged)
-#   - `textDocument/didChange`  → notification, no response (logged)
-#   - `textDocument/definition` → `Location` whose URI defaults to
-#                                 `file:///workspaces/proj/util.py`
-#                                 line 5, character 0; override by
-#                                 writing the desired URI into
-#                                 `<state>/fake_lsp_definition_uri`
-#                                 before triggering the request.
-#   - `shutdown` / `exit`       → respond null and break
-#
-# Lives in `scripts/fake-lsp/bin/` so tests can prepend that directory
-# to PATH (and to the captured `userEnvProbe` PATH) and have both
-# `command -v fake-pylsp` and the actual spawn resolve via the fake
-# docker shim. See `scripts/fake-lsp/README.md` for the full picture.
-set -u
+#!/usr/bin/env python3
+"""
+Tiny fake `pylsp` for tests.
 
-# Resolve the per-test state dir. Tests using the fake-devcontainer
-# harness already set `FAKE_DEVCONTAINER_STATE`; we reuse that so the
-# uri log lives next to `exec_history` and friends.
-state_dir="${FAKE_DEVCONTAINER_STATE:-${TMPDIR:-/tmp}/fake-lsp-state}"
-mkdir -p "$state_dir" 2>/dev/null || true
-uri_log="$state_dir/fake_lsp_uris"
-def_uri_file="$state_dir/fake_lsp_definition_uri"
-def_line_file="$state_dir/fake_lsp_definition_line"
-def_char_file="$state_dir/fake_lsp_definition_character"
+Speaks just enough of the LSP wire protocol (Content-Length framing
+plus a handful of methods) to let the editor drive Go-to-Definition,
+Find References, and the rest of the request/response surface our e2es
+rely on.
 
-# Read one Content-Length-framed message from stdin into stdout.
-read_message() {
-  local content_length=0 line
-  while IFS= read -r line; do
-    line="${line%$'\r'}"
-    if [ -z "$line" ]; then
-      break
-    fi
-    case "$line" in
-      Content-Length:*)
-        content_length="${line#Content-Length:}"
-        content_length="${content_length// /}"
-        ;;
-    esac
-  done
-  if [ "$content_length" -gt 0 ] 2>/dev/null; then
-    dd bs=1 count="$content_length" 2>/dev/null
-  fi
-}
+Why Python and not bash:
+  * Bash 3.2 (the macOS default `/bin/bash`) lacks `mapfile`/`readarray`
+    and is finicky about negative substring offsets, so a bash script
+    that runs cleanly on Linux can silently die mid-handshake on a
+    macOS CI runner — and the only symptom is that the editor waits
+    forever for a response that never arrives.
+  * Python 3 is universally available on the macOS / Linux / Windows
+    images we target, has reliable buffered I/O, and lets us emit
+    structured progress lines into the URI log so a hung test has
+    actionable diagnostics instead of just "180s timeout".
 
-send_message() {
-  local message="$1"
-  local length=${#message}
-  printf 'Content-Length: %d\r\n\r\n%s' "$length" "$message"
-}
+Behaviour:
+  * Logs every received URI (tagged with method) to
+    `<FAKE_DEVCONTAINER_STATE>/fake_lsp_uris`.
+  * Also logs lifecycle breadcrumbs ("startup", "stdin_eof") to the
+    same file so a CI tail of that file shows where we got stuck.
+  * Answers `textDocument/definition` and `textDocument/references`
+    with a configurable Location. Override per-test by writing the
+    desired values into:
+      - `<state>/fake_lsp_definition_uri`
+      - `<state>/fake_lsp_definition_line`
+      - `<state>/fake_lsp_definition_character`
+    Defaults: `file:///workspaces/proj/util.py`, line 5, char 0.
+"""
+from __future__ import annotations
 
-extract_first_uri() {
-  # First "uri":"..." occurrence in the JSON. Defs/refs requests have
-  # one URI; didOpen has it nested under textDocument; both shapes
-  # share the same first occurrence so this is enough for our needs.
-  printf '%s' "$1" | grep -o '"uri":"[^"]*"' | head -n1 | cut -d'"' -f4
-}
+import json
+import os
+import sys
+from pathlib import Path
 
-extract_method() {
-  printf '%s' "$1" | grep -o '"method":"[^"]*"' | head -n1 | cut -d'"' -f4
-}
+# Per-test scratch dir. The fake-devcontainer harness sets this; if it
+# isn't present we fall back to a tmpdir under TMPDIR so a manual
+# invocation still has somewhere to write the log.
+STATE_DIR = Path(os.environ.get("FAKE_DEVCONTAINER_STATE")
+                 or os.path.join(os.environ.get("TMPDIR", "/tmp"), "fake-lsp-state"))
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+URI_LOG = STATE_DIR / "fake_lsp_uris"
+DEF_URI_FILE = STATE_DIR / "fake_lsp_definition_uri"
+DEF_LINE_FILE = STATE_DIR / "fake_lsp_definition_line"
+DEF_CHAR_FILE = STATE_DIR / "fake_lsp_definition_character"
 
-extract_id() {
-  # Numeric id only — the editor always uses integers.
-  printf '%s' "$1" | grep -oE '"id":[[:space:]]*[0-9]+' | head -n1 | sed -E 's/.*: *([0-9]+).*/\1/'
-}
+DEFAULT_DEF_URI = "file:///workspaces/proj/util.py"
+DEFAULT_DEF_LINE = 5
+DEFAULT_DEF_CHAR = 0
 
-log_uri() {
-  local method="$1" uri="$2"
-  if [ -n "$uri" ]; then
-    printf '%s %s\n' "$method" "$uri" >> "$uri_log" 2>/dev/null || true
-  fi
-}
 
-read_def_target() {
-  local default_uri="file:///workspaces/proj/util.py"
-  local default_line=5
-  local default_char=0
-  local uri line char
-  if [ -f "$def_uri_file" ]; then
-    uri="$(head -n1 "$def_uri_file" 2>/dev/null)"
-  fi
-  : "${uri:=$default_uri}"
-  if [ -f "$def_line_file" ]; then
-    line="$(head -n1 "$def_line_file" 2>/dev/null)"
-  fi
-  : "${line:=$default_line}"
-  if [ -f "$def_char_file" ]; then
-    char="$(head -n1 "$def_char_file" 2>/dev/null)"
-  fi
-  : "${char:=$default_char}"
-  printf '%s\n%s\n%s\n' "$uri" "$line" "$char"
-}
+def log(line: str) -> None:
+    """Append a single line to the URI log. The log doubles as a
+    progress trace for hung tests — CI can dump it to see how far we
+    got."""
+    try:
+        with URI_LOG.open("a") as f:
+            f.write(line + "\n")
+    except OSError:
+        # Logging must never crash the server. If the state dir
+        # vanished mid-test, just keep going.
+        pass
 
-while true; do
-  msg="$(read_message)"
-  [ -z "$msg" ] && break
 
-  method="$(extract_method "$msg")"
-  msg_id="$(extract_id "$msg")"
-  uri="$(extract_first_uri "$msg")"
+def read_def_target() -> tuple[str, int, int]:
+    """Resolve the definition target the editor will pin a Location at.
+    Reads three optional override files, falling back to defaults."""
+    def first_line(path: Path) -> str | None:
+        try:
+            return path.read_text().splitlines()[0]
+        except (OSError, IndexError):
+            return None
 
-  case "$method" in
-    "initialize")
-      log_uri "initialize" "$uri"
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"definitionProvider":true,"hoverProvider":true,"referencesProvider":true}}}'
-      ;;
-    "initialized")
-      # notification, no response
-      ;;
-    "textDocument/didOpen")
-      log_uri "didOpen" "$uri"
-      ;;
-    "textDocument/didChange")
-      log_uri "didChange" "$uri"
-      ;;
-    "textDocument/didSave")
-      log_uri "didSave" "$uri"
-      ;;
-    "textDocument/didClose")
-      log_uri "didClose" "$uri"
-      ;;
-    "textDocument/definition")
-      log_uri "definition" "$uri"
-      # `read -r` triple instead of `mapfile -t` (bash 4+) — macOS
-      # ships bash 3.2 by default and we want this to run there too.
-      def_uri=""; def_line=""; def_char=""
-      { read -r def_uri; read -r def_line; read -r def_char; } < <(read_def_target)
-      end_char=$((def_char + 1))
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"uri":"'"$def_uri"'","range":{"start":{"line":'"$def_line"',"character":'"$def_char"'},"end":{"line":'"$def_line"',"character":'"$end_char"'}}}}'
-      ;;
-    "textDocument/references")
-      log_uri "references" "$uri"
-      # Reuse the configured definition target as a single-element
-      # reference list. Tests pin the *kind* of URI we emit (a wire
-      # URI under the in-container workspace) more than the count, so
-      # one location is enough to exercise the editor-side path
-      # translation.
-      ref_uri=""; ref_line=""; ref_char=""
-      { read -r ref_uri; read -r ref_line; read -r ref_char; } < <(read_def_target)
-      end_char=$((ref_char + 1))
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":[{"uri":"'"$ref_uri"'","range":{"start":{"line":'"$ref_line"',"character":'"$ref_char"'},"end":{"line":'"$ref_line"',"character":'"$end_char"'}}}]}'
-      ;;
-    "textDocument/diagnostic")
-      log_uri "diagnostic" "$uri"
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"kind":"full","items":[]}}'
-      ;;
-    "shutdown")
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
-      ;;
-    "exit")
-      break
-      ;;
-    *)
-      # Unknown method — if it has an id, respond with an empty result
-      # so the editor isn't stuck waiting. Notifications fall through.
-      if [ -n "$msg_id" ]; then
-        send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
-      fi
-      ;;
-  esac
-done
+    uri = first_line(DEF_URI_FILE) or DEFAULT_DEF_URI
+    line_text = first_line(DEF_LINE_FILE)
+    line = int(line_text) if line_text and line_text.strip().isdigit() else DEFAULT_DEF_LINE
+    char_text = first_line(DEF_CHAR_FILE)
+    char = int(char_text) if char_text and char_text.strip().isdigit() else DEFAULT_DEF_CHAR
+    return uri, line, char
+
+
+def read_message() -> dict | None:
+    """Read one Content-Length-framed JSON-RPC message from stdin.
+    Returns the parsed JSON object, or None on clean EOF."""
+    headers: dict[str, str] = {}
+    while True:
+        # `sys.stdin.buffer` for byte-accurate reads — Content-Length
+        # counts bytes, not characters, and decode-on-read could
+        # mis-frame on multibyte payloads.
+        raw = sys.stdin.buffer.readline()
+        if raw == b"":
+            return None  # EOF before any header → graceful shutdown
+        line = raw.decode("ascii", errors="replace").rstrip("\r\n")
+        if line == "":
+            break
+        if ":" in line:
+            key, _, value = line.partition(":")
+            headers[key.strip()] = value.strip()
+
+    length_str = headers.get("Content-Length")
+    if not length_str:
+        return None
+    try:
+        length = int(length_str)
+    except ValueError:
+        return None
+    if length <= 0:
+        return {}
+    body = sys.stdin.buffer.read(length)
+    if len(body) < length:
+        # Truncated — treat as EOF so callers can clean up.
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+
+def send_message(payload: dict) -> None:
+    """Write one Content-Length-framed JSON-RPC message to stdout."""
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+    sys.stdout.buffer.write(header)
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+
+def first_uri(message: dict) -> str:
+    """Pluck a URI we can use as a wait checkpoint. Production LSP
+    messages put it under `textDocument.uri` (notifications/requests),
+    `params.uri` (some workspace ops), or `rootUri` (the `initialize`
+    handshake — the editor identifies the workspace there). Tests
+    wait on log lines like `initialize file://...` so checking each
+    of these slots in turn matches the editor's actual traffic."""
+    params = message.get("params") or {}
+    text_doc = params.get("textDocument") or {}
+    return (
+        text_doc.get("uri")
+        or params.get("uri")
+        or params.get("rootUri")
+        or ""
+    )
+
+
+def handle(message: dict) -> None:
+    method = message.get("method") or ""
+    msg_id = message.get("id")
+    uri = first_uri(message)
+    # Always log a `<method-tail> <uri>` line, even when the URI is
+    # empty — the test harness waits on prefix matches like
+    # `"initialize "` (with trailing space) and a missing URI must
+    # not silently swallow the breadcrumb.
+    short_method = method.rsplit("/", 1)[-1] or method
+    log(f"{short_method} {uri}")
+
+    if method == "initialize":
+        send_message({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "capabilities": {
+                    "textDocumentSync": 1,
+                    "definitionProvider": True,
+                    "hoverProvider": True,
+                    "referencesProvider": True,
+                }
+            },
+        })
+        return
+
+    if method == "initialized":
+        return  # notification, no response
+
+    if method in ("textDocument/didOpen", "textDocument/didChange",
+                  "textDocument/didSave", "textDocument/didClose"):
+        return  # already logged above
+
+    if method == "textDocument/definition":
+        def_uri, def_line, def_char = read_def_target()
+        send_message({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {
+                "uri": def_uri,
+                "range": {
+                    "start": {"line": def_line, "character": def_char},
+                    "end": {"line": def_line, "character": def_char + 1},
+                },
+            },
+        })
+        return
+
+    if method == "textDocument/references":
+        def_uri, def_line, def_char = read_def_target()
+        # Single-element reference list — tests pin the *kind* of URI
+        # we emit (a wire URI under the in-container workspace) more
+        # than the count.
+        send_message({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": [{
+                "uri": def_uri,
+                "range": {
+                    "start": {"line": def_line, "character": def_char},
+                    "end": {"line": def_line, "character": def_char + 1},
+                },
+            }],
+        })
+        return
+
+    if method == "textDocument/diagnostic":
+        send_message({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"kind": "full", "items": []},
+        })
+        return
+
+    if method == "shutdown":
+        send_message({"jsonrpc": "2.0", "id": msg_id, "result": None})
+        return
+
+    if method == "exit":
+        sys.exit(0)
+
+    # Unknown method — keep the editor happy by responding with `null`
+    # if it expects a result. Notifications (no id) just fall through.
+    if msg_id is not None:
+        send_message({"jsonrpc": "2.0", "id": msg_id, "result": None})
+
+
+def main() -> None:
+    log(f"startup pid={os.getpid()} state={STATE_DIR}")
+    while True:
+        try:
+            message = read_message()
+        except KeyboardInterrupt:
+            log("interrupt")
+            return
+        if message is None:
+            log("stdin_eof")
+            return
+        try:
+            handle(message)
+        except BrokenPipeError:
+            log("broken_pipe")
+            return
+        except Exception as exc:  # noqa: BLE001
+            log(f"handler_error {type(exc).__name__}: {exc}")
+            # Keep the loop alive so a single bad message doesn't kill
+            # the whole session.
+            continue
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fake-lsp/bin/fake-pylsp
+++ b/scripts/fake-lsp/bin/fake-pylsp
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Tiny fake `pylsp` for tests. Reads JSON-RPC framed messages on stdio,
+# logs every received `uri` (with the request method) to
+# `<FAKE_DEVCONTAINER_STATE>/fake_lsp_uris`, and answers the few
+# methods the editor needs to drive Go-to-Definition end-to-end:
+#
+#   - `initialize`              → minimal capabilities
+#   - `textDocument/didOpen`    → notification, no response (logged)
+#   - `textDocument/didChange`  → notification, no response (logged)
+#   - `textDocument/definition` → `Location` whose URI defaults to
+#                                 `file:///workspaces/proj/util.py`
+#                                 line 5, character 0; override by
+#                                 writing the desired URI into
+#                                 `<state>/fake_lsp_definition_uri`
+#                                 before triggering the request.
+#   - `shutdown` / `exit`       → respond null and break
+#
+# Lives in `scripts/fake-lsp/bin/` so tests can prepend that directory
+# to PATH (and to the captured `userEnvProbe` PATH) and have both
+# `command -v fake-pylsp` and the actual spawn resolve via the fake
+# docker shim. See `scripts/fake-lsp/README.md` for the full picture.
+set -u
+
+# Resolve the per-test state dir. Tests using the fake-devcontainer
+# harness already set `FAKE_DEVCONTAINER_STATE`; we reuse that so the
+# uri log lives next to `exec_history` and friends.
+state_dir="${FAKE_DEVCONTAINER_STATE:-${TMPDIR:-/tmp}/fake-lsp-state}"
+mkdir -p "$state_dir" 2>/dev/null || true
+uri_log="$state_dir/fake_lsp_uris"
+def_uri_file="$state_dir/fake_lsp_definition_uri"
+def_line_file="$state_dir/fake_lsp_definition_line"
+def_char_file="$state_dir/fake_lsp_definition_character"
+
+# Read one Content-Length-framed message from stdin into stdout.
+read_message() {
+  local content_length=0 line
+  while IFS= read -r line; do
+    line="${line%$'\r'}"
+    if [ -z "$line" ]; then
+      break
+    fi
+    case "$line" in
+      Content-Length:*)
+        content_length="${line#Content-Length:}"
+        content_length="${content_length// /}"
+        ;;
+    esac
+  done
+  if [ "$content_length" -gt 0 ] 2>/dev/null; then
+    dd bs=1 count="$content_length" 2>/dev/null
+  fi
+}
+
+send_message() {
+  local message="$1"
+  local length=${#message}
+  printf 'Content-Length: %d\r\n\r\n%s' "$length" "$message"
+}
+
+extract_first_uri() {
+  # First "uri":"..." occurrence in the JSON. Defs/refs requests have
+  # one URI; didOpen has it nested under textDocument; both shapes
+  # share the same first occurrence so this is enough for our needs.
+  printf '%s' "$1" | grep -o '"uri":"[^"]*"' | head -n1 | cut -d'"' -f4
+}
+
+extract_method() {
+  printf '%s' "$1" | grep -o '"method":"[^"]*"' | head -n1 | cut -d'"' -f4
+}
+
+extract_id() {
+  # Numeric id only — the editor always uses integers.
+  printf '%s' "$1" | grep -oE '"id":[[:space:]]*[0-9]+' | head -n1 | sed -E 's/.*: *([0-9]+).*/\1/'
+}
+
+log_uri() {
+  local method="$1" uri="$2"
+  if [ -n "$uri" ]; then
+    printf '%s %s\n' "$method" "$uri" >> "$uri_log" 2>/dev/null || true
+  fi
+}
+
+read_def_target() {
+  local default_uri="file:///workspaces/proj/util.py"
+  local default_line=5
+  local default_char=0
+  local uri line char
+  if [ -f "$def_uri_file" ]; then
+    uri="$(head -n1 "$def_uri_file" 2>/dev/null)"
+  fi
+  : "${uri:=$default_uri}"
+  if [ -f "$def_line_file" ]; then
+    line="$(head -n1 "$def_line_file" 2>/dev/null)"
+  fi
+  : "${line:=$default_line}"
+  if [ -f "$def_char_file" ]; then
+    char="$(head -n1 "$def_char_file" 2>/dev/null)"
+  fi
+  : "${char:=$default_char}"
+  printf '%s\n%s\n%s\n' "$uri" "$line" "$char"
+}
+
+while true; do
+  msg="$(read_message)"
+  [ -z "$msg" ] && break
+
+  method="$(extract_method "$msg")"
+  msg_id="$(extract_id "$msg")"
+  uri="$(extract_first_uri "$msg")"
+
+  case "$method" in
+    "initialize")
+      log_uri "initialize" "$uri"
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"definitionProvider":true,"hoverProvider":true}}}'
+      ;;
+    "initialized")
+      # notification, no response
+      ;;
+    "textDocument/didOpen")
+      log_uri "didOpen" "$uri"
+      ;;
+    "textDocument/didChange")
+      log_uri "didChange" "$uri"
+      ;;
+    "textDocument/didSave")
+      log_uri "didSave" "$uri"
+      ;;
+    "textDocument/didClose")
+      log_uri "didClose" "$uri"
+      ;;
+    "textDocument/definition")
+      log_uri "definition" "$uri"
+      mapfile -t def < <(read_def_target)
+      def_uri="${def[0]}"
+      def_line="${def[1]}"
+      def_char="${def[2]}"
+      end_char=$((def_char + 1))
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"uri":"'"$def_uri"'","range":{"start":{"line":'"$def_line"',"character":'"$def_char"'},"end":{"line":'"$def_line"',"character":'"$end_char"'}}}}'
+      ;;
+    "textDocument/diagnostic")
+      log_uri "diagnostic" "$uri"
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"kind":"full","items":[]}}'
+      ;;
+    "shutdown")
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+      ;;
+    "exit")
+      break
+      ;;
+    *)
+      # Unknown method — if it has an id, respond with an empty result
+      # so the editor isn't stuck waiting. Notifications fall through.
+      if [ -n "$msg_id" ]; then
+        send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+      fi
+      ;;
+  esac
+done

--- a/scripts/fake-lsp/bin/fake-pylsp
+++ b/scripts/fake-lsp/bin/fake-pylsp
@@ -130,10 +130,10 @@ while true; do
       ;;
     "textDocument/definition")
       log_uri "definition" "$uri"
-      mapfile -t def < <(read_def_target)
-      def_uri="${def[0]}"
-      def_line="${def[1]}"
-      def_char="${def[2]}"
+      # `read -r` triple instead of `mapfile -t` (bash 4+) — macOS
+      # ships bash 3.2 by default and we want this to run there too.
+      def_uri=""; def_line=""; def_char=""
+      { read -r def_uri; read -r def_line; read -r def_char; } < <(read_def_target)
       end_char=$((def_char + 1))
       send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"uri":"'"$def_uri"'","range":{"start":{"line":'"$def_line"',"character":'"$def_char"'},"end":{"line":'"$def_line"',"character":'"$end_char"'}}}}'
       ;;
@@ -142,12 +142,10 @@ while true; do
       # Reuse the configured definition target as a single-element
       # reference list. Tests pin the *kind* of URI we emit (a wire
       # URI under the in-container workspace) more than the count, so
-      # one location is enough to exercise the `LspUri` translation
-      # path on the editor side.
-      mapfile -t def < <(read_def_target)
-      ref_uri="${def[0]}"
-      ref_line="${def[1]}"
-      ref_char="${def[2]}"
+      # one location is enough to exercise the editor-side path
+      # translation.
+      ref_uri=""; ref_line=""; ref_char=""
+      { read -r ref_uri; read -r ref_line; read -r ref_char; } < <(read_def_target)
       end_char=$((ref_char + 1))
       send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":[{"uri":"'"$ref_uri"'","range":{"start":{"line":'"$ref_line"',"character":'"$ref_char"'},"end":{"line":'"$ref_line"',"character":'"$end_char"'}}}]}'
       ;;

--- a/scripts/fake-lsp/bin/fake-pylsp
+++ b/scripts/fake-lsp/bin/fake-pylsp
@@ -111,7 +111,7 @@ while true; do
   case "$method" in
     "initialize")
       log_uri "initialize" "$uri"
-      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"definitionProvider":true,"hoverProvider":true}}}'
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"textDocumentSync":1,"definitionProvider":true,"hoverProvider":true,"referencesProvider":true}}}'
       ;;
     "initialized")
       # notification, no response
@@ -136,6 +136,20 @@ while true; do
       def_char="${def[2]}"
       end_char=$((def_char + 1))
       send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"uri":"'"$def_uri"'","range":{"start":{"line":'"$def_line"',"character":'"$def_char"'},"end":{"line":'"$def_line"',"character":'"$end_char"'}}}}'
+      ;;
+    "textDocument/references")
+      log_uri "references" "$uri"
+      # Reuse the configured definition target as a single-element
+      # reference list. Tests pin the *kind* of URI we emit (a wire
+      # URI under the in-container workspace) more than the count, so
+      # one location is enough to exercise the `LspUri` translation
+      # path on the editor side.
+      mapfile -t def < <(read_def_target)
+      ref_uri="${def[0]}"
+      ref_line="${def[1]}"
+      ref_char="${def[2]}"
+      end_char=$((ref_char + 1))
+      send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":[{"uri":"'"$ref_uri"'","range":{"start":{"line":'"$ref_line"',"character":'"$ref_char"'},"end":{"line":'"$ref_line"',"character":'"$end_char"'}}}]}'
       ;;
     "textDocument/diagnostic")
       log_uri "diagnostic" "$uri"


### PR DESCRIPTION
## Summary

This PR implements bidirectional path translation between host and container workspaces for LSP communication in devcontainer environments. When a devcontainer is attached, the workspace is mounted at a different path inside the container (e.g., `/tmp/xxx/proj` on host → `/workspaces/proj` in container). LSP servers run inside the container and only understand container paths, but the editor caches host paths. This change ensures URIs are correctly translated at both boundaries.

## Key Changes

- **Authority path translation infrastructure** (`services/authority/mod.rs`):
  - Added `PathTranslationSpec` (JSON-serializable) and `PathTranslation` (runtime) types to represent host↔remote workspace mappings
  - Implemented `host_to_remote()` and `remote_to_host()` methods for symmetric path translation
  - Extended `Authority` struct to carry optional `path_translation` field

- **LSP URI translation** (`app/types.rs`):
  - Created `file_path_to_lsp_uri_with_translation()` to apply host→container translation when building URIs for LSP requests (didOpen, definition, etc.)
  - Created `uri_to_path_with_translation()` to apply container→host translation when processing LSP responses
  - Updated `BufferMetadata::with_file()` to accept and use path translation

- **LSP manager integration** (`services/lsp/manager.rs`):
  - Added `path_translation` field to `LspManager`
  - Added `set_path_translation()` method to install the mapping before LSP spawns

- **Editor integration** (`app/mod.rs`, `app/lsp_requests.rs`, `app/lsp_actions.rs`, etc.):
  - Updated all LSP URI construction sites to use `file_path_to_lsp_uri_with_translation()`
  - Updated all LSP URI consumption sites (Goto-Definition, references, etc.) to use `uri_to_path_with_translation()`
  - Ensured path translation is passed through the editor's authority initialization chain

- **Devcontainer plugin** (`plugins/devcontainer.ts`):
  - Extended `buildContainerAuthorityPayload()` to extract and include host workspace path
  - Plumbs `hostWorkspace` and `remoteWorkspaceFolder` into the `path_translation` spec sent to the editor

- **Test infrastructure**:
  - Added comprehensive e2e test (`tests/e2e/plugins/devcontainer_lsp_definition.rs`) that validates both translation directions
  - Created `fake-pylsp` bash stub (`scripts/fake-lsp/bin/fake-pylsp`) that logs URIs and returns configurable definition locations
  - Test verifies didOpen uses container paths and Goto-Definition responses are correctly mapped back to host paths

## Implementation Details

- Path translation is optional and only active when the authority provides both `host_root` and `remote_root`
- Paths outside the workspace root (system headers, library sources) are passed through unchanged
- The translation is applied symmetrically: host paths → container URIs for outbound LSP traffic, container URIs → host paths for inbound responses
- All existing local and SSH authority code paths remain unchanged (translation is `None`)

https://claude.ai/code/session_015ifz1S3UGeMAoAbRkyNiL7