### PR TITLE
Fix embedded plugins not loading when project has plugins/ dir

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -94,6 +94,7 @@ impl Editor {
             working_dir,
             filesystem,
             plugins_enabled,
+            true, // enable_embedded_plugins (production: always allow embedded fallback)
             dir_context,
             None,
             color_capability,
@@ -106,8 +107,11 @@ impl Editor {
     /// By default uses empty grammar registry for fast initialization.
     /// Pass `Some(registry)` for tests that need syntax highlighting or shebang detection.
     ///
-    /// `enable_plugins` controls whether plugins (embedded + user) load — pass
-    /// `false` for test isolation (no plugins at all).
+    /// `enable_plugins` controls whether the plugin runtime is active at all.
+    /// `enable_embedded_plugins` separately gates the cargo-binstall embedded
+    /// plugins fallback — tests that pre-populate `<config_dir>/plugins/` and
+    /// want exact control over which plugins load can pass `false` here while
+    /// keeping `enable_plugins = true`.
     #[allow(clippy::too_many_arguments)]
     pub fn for_test(
         config: Config,
@@ -120,6 +124,7 @@ impl Editor {
         time_source: Option<SharedTimeSource>,
         grammar_registry: Option<Arc<crate::primitives::grammar::GrammarRegistry>>,
         enable_plugins: bool,
+        enable_embedded_plugins: bool,
     ) -> AnyhowResult<Self> {
         let mut grammar_registry =
             grammar_registry.unwrap_or_else(crate::primitives::grammar::GrammarRegistry::empty);
@@ -139,6 +144,7 @@ impl Editor {
             working_dir,
             filesystem,
             enable_plugins,
+            enable_embedded_plugins,
             dir_context,
             time_source,
             color_capability,
@@ -161,6 +167,8 @@ impl Editor {
         working_dir: Option<PathBuf>,
         filesystem: Arc<dyn FileSystem + Send + Sync>,
         enable_plugins: bool,
+        #[cfg_attr(not(feature = "embed-plugins"), allow(unused_variables))]
+        enable_embedded_plugins: bool,
         dir_context: DirectoryContext,
         time_source: Option<SharedTimeSource>,
         color_capability: crate::view::color_support::ColorCapability,
@@ -404,9 +412,12 @@ impl Editor {
             // dev workflow come in via the embedded fallback below; user
             // plugins live under `<config_dir>/plugins/`. See issue #1722.
 
-            // If no disk plugins found, try embedded plugins (cargo-binstall builds)
+            // If no disk plugins found, try embedded plugins (cargo-binstall builds).
+            // `enable_embedded_plugins` lets tests opt out so they get exactly
+            // the plugin set they pre-populated under `<config_dir>/plugins/`,
+            // without the bundled set leaking in.
             #[cfg(feature = "embed-plugins")]
-            if plugin_dirs.is_empty() {
+            if enable_embedded_plugins && plugin_dirs.is_empty() {
                 if let Some(embedded_dir) =
                     crate::services::plugins::embedded::get_embedded_plugins_dir()
                 {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -105,6 +105,9 @@ impl Editor {
     ///
     /// By default uses empty grammar registry for fast initialization.
     /// Pass `Some(registry)` for tests that need syntax highlighting or shebang detection.
+    ///
+    /// `enable_plugins` controls whether plugins (embedded + user) load — pass
+    /// `false` for test isolation (no plugins at all).
     #[allow(clippy::too_many_arguments)]
     pub fn for_test(
         config: Config,
@@ -116,6 +119,7 @@ impl Editor {
         filesystem: Arc<dyn FileSystem + Send + Sync>,
         time_source: Option<SharedTimeSource>,
         grammar_registry: Option<Arc<crate::primitives::grammar::GrammarRegistry>>,
+        enable_plugins: bool,
     ) -> AnyhowResult<Self> {
         let mut grammar_registry =
             grammar_registry.unwrap_or_else(crate::primitives::grammar::GrammarRegistry::empty);
@@ -134,7 +138,7 @@ impl Editor {
             height,
             working_dir,
             filesystem,
-            true,
+            enable_plugins,
             dir_context,
             time_source,
             color_capability,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -377,10 +377,10 @@ impl Editor {
 
         // Load TypeScript plugins from multiple directories:
         // 1. Next to the executable (for cargo-dist installations)
-        // 2. In the working directory (for development/local usage)
-        // 3. From embedded plugins (for cargo-binstall, when embed-plugins feature is enabled)
-        // 4. User plugins directory (~/.config/fresh/plugins)
-        // 5. Package manager installed plugins (~/.config/fresh/plugins/packages/*)
+        // 2. From embedded plugins (for cargo-binstall and `cargo run`,
+        //    when embed-plugins feature is enabled)
+        // 3. User plugins directory (~/.config/fresh/plugins)
+        // 4. Package manager installed plugins (~/.config/fresh/plugins/packages/*)
         if plugin_manager.is_active() {
             let mut plugin_dirs: Vec<std::path::PathBuf> = vec![];
 
@@ -394,11 +394,11 @@ impl Editor {
                 }
             }
 
-            // Then check working directory (for development)
-            let working_plugin_dir = working_dir.join("plugins");
-            if working_plugin_dir.exists() && !plugin_dirs.contains(&working_plugin_dir) {
-                plugin_dirs.push(working_plugin_dir);
-            }
+            // No working-directory `plugins/` check: a user project with a
+            // folder named `plugins/` (e.g. a Vite/Rollup project, a Hugo
+            // site) is not a Fresh plugin source. Bundled plugins for the
+            // dev workflow come in via the embedded fallback below; user
+            // plugins live under `<config_dir>/plugins/`. See issue #1722.
 
             // If no disk plugins found, try embedded plugins (cargo-binstall builds)
             #[cfg(feature = "embed-plugins")]

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -574,7 +574,22 @@ impl EditorTestHarness {
         // plugin loading entirely at the editor level when this flag
         // is set. The flag/method names are kept for source-compat
         // with existing tests.
-        let enable_plugins_for_editor = !options.create_empty_plugins_dir;
+        //
+        // Exception: a number of tests use the default
+        // `HarnessOptions::new()` (which leaves `create_empty_plugins_dir`
+        // at `true`) but pre-populate `<working_dir>/plugins/` with their
+        // own fixtures and rely on those plugins loading. Treat any
+        // populated `<working_dir>/plugins/` as an opt-in to plugin
+        // loading regardless of the flag — this matches the pre-#1722
+        // behavior where a populated working-dir plugins folder won out
+        // over the empty-dir trick.
+        let working_plugins_path = working_dir.join("plugins");
+        let working_plugins_populated = working_plugins_path
+            .read_dir()
+            .map(|mut it| it.next().is_some())
+            .unwrap_or(false);
+        let enable_plugins_for_editor =
+            !options.create_empty_plugins_dir || working_plugins_populated;
 
         // Get or create DirectoryContext
         let dir_context = options.dir_context.unwrap_or_else(|| {
@@ -672,19 +687,11 @@ impl EditorTestHarness {
         // plugin fallback so the bundled set doesn't leak in. This matches
         // the pre-#1722 behavior, where any `working_dir/plugins/` (even
         // empty) suppressed embedded loading.
-        let mut user_plugins_supplied = false;
-        if enable_plugins_for_editor {
-            let working_plugins = working_dir.join("plugins");
-            if working_plugins.is_dir() {
-                let mut iter = std::fs::read_dir(&working_plugins)?;
-                if iter.next().is_some() {
-                    let target = dir_context.config_dir.join("plugins");
-                    mirror_plugins_dir(&working_plugins, &target)?;
-                    user_plugins_supplied = true;
-                }
-            }
+        if enable_plugins_for_editor && working_plugins_populated {
+            let target = dir_context.config_dir.join("plugins");
+            mirror_plugins_dir(&working_plugins_path, &target)?;
         }
-        let enable_embedded_plugins = enable_plugins_for_editor && !user_plugins_supplied;
+        let enable_embedded_plugins = enable_plugins_for_editor && !working_plugins_populated;
 
         // Create editor
         let mut editor = Editor::for_test(

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -566,30 +566,34 @@ impl EditorTestHarness {
                 .expect("temp_dir must exist when no working_dir provided")
         };
 
-        // Plugin loading isolation. Historically the harness created an
-        // empty `<working_dir>/plugins/` to suppress embedded plugin
-        // loading via the editor's "if `plugin_dirs.is_empty()`" gate.
-        // The editor no longer scans `<working_dir>/plugins/` (issue
-        // #1722), so we now achieve the same isolation by disabling
-        // plugin loading entirely at the editor level when this flag
-        // is set. The flag/method names are kept for source-compat
-        // with existing tests.
+        // Plugin loading. Historically the harness created an empty
+        // `<working_dir>/plugins/` so the editor would scan it and
+        // skip the embedded fallback (suppression by directory
+        // presence). The editor no longer scans `<working_dir>/plugins/`
+        // (issue #1722), but the harness keeps the directory-presence
+        // contract for tests:
         //
-        // Exception: a number of tests use the default
-        // `HarnessOptions::new()` (which leaves `create_empty_plugins_dir`
-        // at `true`) but pre-populate `<working_dir>/plugins/` with their
-        // own fixtures and rely on those plugins loading. Treat any
-        // populated `<working_dir>/plugins/` as an opt-in to plugin
-        // loading regardless of the flag — this matches the pre-#1722
-        // behavior where a populated working-dir plugins folder won out
-        // over the empty-dir trick.
+        //   * `<working_dir>/plugins/` exists       → user controls the
+        //     plugin set; embedded fallback is off, and any contents
+        //     are mirrored into `<config_dir>/plugins/` (which the
+        //     editor does scan).
+        //   * `<working_dir>/plugins/` doesn't exist → embedded loads
+        //     normally (used by tests that exercise bundled plugins).
+        //
+        // The default `create_empty_plugins_dir = true` continues to
+        // mean "auto-create the dir to opt out of embedded". The plugin
+        // runtime is always active so tests can introspect it via
+        // `plugin_manager().state_snapshot_handle()` etc.
         let working_plugins_path = working_dir.join("plugins");
+        if options.create_empty_plugins_dir && !working_plugins_path.exists() {
+            std::fs::create_dir(&working_plugins_path)?;
+        }
+        let user_controls_plugins = working_plugins_path.is_dir();
         let working_plugins_populated = working_plugins_path
             .read_dir()
             .map(|mut it| it.next().is_some())
             .unwrap_or(false);
-        let enable_plugins_for_editor =
-            !options.create_empty_plugins_dir || working_plugins_populated;
+        let enable_plugins_for_editor = true;
 
         // Get or create DirectoryContext
         let dir_context = options.dir_context.unwrap_or_else(|| {
@@ -687,11 +691,12 @@ impl EditorTestHarness {
         // plugin fallback so the bundled set doesn't leak in. This matches
         // the pre-#1722 behavior, where any `working_dir/plugins/` (even
         // empty) suppressed embedded loading.
-        if enable_plugins_for_editor && working_plugins_populated {
+        if working_plugins_populated {
             let target = dir_context.config_dir.join("plugins");
             mirror_plugins_dir(&working_plugins_path, &target)?;
         }
-        let enable_embedded_plugins = enable_plugins_for_editor && !working_plugins_populated;
+        // Embedded loads only when the test isn't taking control.
+        let enable_embedded_plugins = !user_controls_plugins;
 
         // Create editor
         let mut editor = Editor::for_test(

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -666,13 +666,25 @@ impl EditorTestHarness {
         // `copy_plugin()` against `working_dir/plugins/`; the editor no
         // longer scans that path (issue #1722), so we forward the fixtures
         // here to keep the test API working without touching every caller.
+        //
+        // When the test pre-populated its own plugins, treat that as an
+        // explicit "use exactly these" request and disable the embedded
+        // plugin fallback so the bundled set doesn't leak in. This matches
+        // the pre-#1722 behavior, where any `working_dir/plugins/` (even
+        // empty) suppressed embedded loading.
+        let mut user_plugins_supplied = false;
         if enable_plugins_for_editor {
             let working_plugins = working_dir.join("plugins");
             if working_plugins.is_dir() {
-                let target = dir_context.config_dir.join("plugins");
-                mirror_plugins_dir(&working_plugins, &target)?;
+                let mut iter = std::fs::read_dir(&working_plugins)?;
+                if iter.next().is_some() {
+                    let target = dir_context.config_dir.join("plugins");
+                    mirror_plugins_dir(&working_plugins, &target)?;
+                    user_plugins_supplied = true;
+                }
             }
         }
+        let enable_embedded_plugins = enable_plugins_for_editor && !user_plugins_supplied;
 
         // Create editor
         let mut editor = Editor::for_test(
@@ -686,6 +698,7 @@ impl EditorTestHarness {
             Some(time_source),
             grammar_registry,
             enable_plugins_for_editor,
+            enable_embedded_plugins,
         )?;
 
         // Process any pending plugin commands

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -131,6 +131,26 @@ pub fn copy_plugin_lib(plugins_dir: &Path) {
     }
 }
 
+/// Recursively copy `<src>` into `<dst>`, creating `<dst>` if missing.
+/// Existing files at the destination are overwritten (for re-runs).
+fn mirror_plugins_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if !src.is_dir() {
+        return Ok(());
+    }
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        if src_path.is_dir() {
+            mirror_plugins_dir(&src_path, &dst_path)?;
+        } else {
+            fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
 /// Configuration options for creating an EditorTestHarness.
 ///
 /// Use the builder pattern to configure the harness:
@@ -150,8 +170,15 @@ pub struct HarnessOptions {
     /// Create a "project_root" subdirectory for deterministic paths in snapshots.
     /// When true, `project_dir()` returns this subdirectory path.
     pub create_project_root: bool,
-    /// Create an empty plugins directory to prevent embedded plugin loading.
-    /// Defaults to true for test isolation.
+    /// Disable plugin loading (embedded + user) for test isolation.
+    /// Defaults to true. Set to false (via `without_empty_plugins_dir()`)
+    /// for tests that exercise plugin behavior — they then either pre-
+    /// populate `<working_dir>/plugins/` (which the harness mirrors into
+    /// `<config_dir>/plugins/`) or rely on the embedded plugins fallback.
+    ///
+    /// (Field name kept for source-compat with existing callers; the
+    /// historical "create empty plugins dir" mechanism is gone — see
+    /// issue #1722.)
     pub create_empty_plugins_dir: bool,
     /// Shared DirectoryContext. If None, creates a new one for test isolation.
     pub dir_context: Option<DirectoryContext>,
@@ -175,7 +202,7 @@ pub struct HarnessOptions {
 
 impl HarnessOptions {
     /// Create new options with default settings.
-    /// - `create_empty_plugins_dir`: true (prevents embedded plugin loading)
+    /// - `create_empty_plugins_dir`: true (disables plugin loading for isolation)
     /// - `create_project_root`: false
     pub fn new() -> Self {
         Self {
@@ -210,21 +237,24 @@ impl HarnessOptions {
     /// Use `harness.project_dir()` to get the path.
     pub fn with_project_root(mut self) -> Self {
         self.create_project_root = true;
-        // When using project_root, don't auto-create plugins dir inside it
-        // to avoid breaking tests that check project contents or create their own plugins
+        // Tests using project_root often install their own plugin fixtures
+        // and need plugin loading enabled; opt them out of the no-plugins
+        // default.
         self.create_empty_plugins_dir = false;
         self
     }
 
-    /// Create an empty plugins directory to prevent embedded plugin loading.
-    /// This is enabled by default for test isolation.
+    /// Disable plugin loading for the test (default for isolation). Method
+    /// name kept for source-compat with existing tests.
     pub fn with_empty_plugins_dir(mut self) -> Self {
         self.create_empty_plugins_dir = true;
         self
     }
 
-    /// Don't create an empty plugins directory.
-    /// Embedded plugins may be loaded if no plugins directory exists.
+    /// Enable plugin loading for the test (embedded plugins fire, and any
+    /// fixtures in `<working_dir>/plugins/` are mirrored into the editor's
+    /// scanned `<config_dir>/plugins/`). Method name kept for source-compat
+    /// with existing tests.
     pub fn without_empty_plugins_dir(mut self) -> Self {
         self.create_empty_plugins_dir = false;
         self
@@ -536,13 +566,15 @@ impl EditorTestHarness {
                 .expect("temp_dir must exist when no working_dir provided")
         };
 
-        // Create empty plugins directory if requested
-        if options.create_empty_plugins_dir {
-            let plugins_dir = working_dir.join("plugins");
-            if !plugins_dir.exists() {
-                std::fs::create_dir(&plugins_dir)?;
-            }
-        }
+        // Plugin loading isolation. Historically the harness created an
+        // empty `<working_dir>/plugins/` to suppress embedded plugin
+        // loading via the editor's "if `plugin_dirs.is_empty()`" gate.
+        // The editor no longer scans `<working_dir>/plugins/` (issue
+        // #1722), so we now achieve the same isolation by disabling
+        // plugin loading entirely at the editor level when this flag
+        // is set. The flag/method names are kept for source-compat
+        // with existing tests.
+        let enable_plugins_for_editor = !options.create_empty_plugins_dir;
 
         // Get or create DirectoryContext
         let dir_context = options.dir_context.unwrap_or_else(|| {
@@ -628,6 +660,20 @@ impl EditorTestHarness {
             None // Use empty registry for fast test startup
         };
 
+        // Mirror any plugins the test pre-populated under
+        // `<working_dir>/plugins/` into `<config_dir>/plugins/` (which the
+        // editor scans). Tests historically set up plugin fixtures via
+        // `copy_plugin()` against `working_dir/plugins/`; the editor no
+        // longer scans that path (issue #1722), so we forward the fixtures
+        // here to keep the test API working without touching every caller.
+        if enable_plugins_for_editor {
+            let working_plugins = working_dir.join("plugins");
+            if working_plugins.is_dir() {
+                let target = dir_context.config_dir.join("plugins");
+                mirror_plugins_dir(&working_plugins, &target)?;
+            }
+        }
+
         // Create editor
         let mut editor = Editor::for_test(
             config,
@@ -639,6 +685,7 @@ impl EditorTestHarness {
             filesystem,
             Some(time_source),
             grammar_registry,
+            enable_plugins_for_editor,
         )?;
 
         // Process any pending plugin commands

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -193,6 +193,13 @@ pub struct HarnessOptions {
     /// Defaults to false (uses empty registry for fast test startup).
     /// Set to true only for tests that need syntax highlighting or shebang detection.
     pub use_full_grammar_registry: bool,
+    /// Force the embedded-plugins fallback to fire regardless of whether
+    /// the test created `<working_dir>/plugins/`. The harness's normal
+    /// "directory presence == user controls plugins" rule is for test
+    /// isolation; tests reproducing user-visible plugin behavior (e.g.
+    /// the #1722 regression test) need to override it to match
+    /// production semantics. Defaults to false.
+    pub force_embedded_plugins: bool,
     /// Per-test fake-devcontainer state. Set by [`HarnessOptions::with_fake_devcontainer`];
     /// moved into the harness on `create()` so the lock + tempdir live as long as the test.
     /// Unix-only: the fake CLI is a bash script that doesn't run on Windows.
@@ -215,9 +222,19 @@ impl HarnessOptions {
             filesystem: None,
             preserve_keybinding_map: false,
             use_full_grammar_registry: false,
+            force_embedded_plugins: false,
             #[cfg(unix)]
             fake_devcontainer: None,
         }
+    }
+
+    /// Force the embedded-plugins fallback to fire regardless of test
+    /// fixtures under `<working_dir>/plugins/`. Use only when reproducing
+    /// production plugin-loading behavior in a test (e.g. issue #1722
+    /// regression).
+    pub fn with_forced_embedded_plugins(mut self) -> Self {
+        self.force_embedded_plugins = true;
+        self
     }
 
     /// Set a custom editor configuration.
@@ -695,8 +712,10 @@ impl EditorTestHarness {
             let target = dir_context.config_dir.join("plugins");
             mirror_plugins_dir(&working_plugins_path, &target)?;
         }
-        // Embedded loads only when the test isn't taking control.
-        let enable_embedded_plugins = !user_controls_plugins;
+        // Embedded loads only when the test isn't taking control. The
+        // `force_embedded_plugins` escape hatch overrides this for tests
+        // that need production plugin-loading semantics (see #1722).
+        let enable_embedded_plugins = options.force_embedded_plugins || !user_controls_plugins;
 
         // Create editor
         let mut editor = Editor::for_test(

--- a/crates/fresh-editor/tests/e2e/memory_scroll_leak.rs
+++ b/crates/fresh-editor/tests/e2e/memory_scroll_leak.rs
@@ -159,6 +159,7 @@ fn test_page_down_to_bottom_crossterm_backend_no_memory_explosion() {
         None,  // time source
         None,  // grammar registry
         false, // enable_plugins (memory test doesn't need them)
+        false, // enable_embedded_plugins
     )
     .unwrap();
     editor.process_async_messages();

--- a/crates/fresh-editor/tests/e2e/memory_scroll_leak.rs
+++ b/crates/fresh-editor/tests/e2e/memory_scroll_leak.rs
@@ -156,8 +156,9 @@ fn test_page_down_to_bottom_crossterm_backend_no_memory_explosion() {
         dir_context,
         fresh::view::color_support::ColorCapability::TrueColor,
         filesystem,
-        None, // time source
-        None, // grammar registry
+        None,  // time source
+        None,  // grammar registry
+        false, // enable_plugins (memory test doesn't need them)
     )
     .unwrap();
     editor.process_async_messages();

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -38,6 +38,7 @@ pub mod markdown_source;
 pub mod package_manager;
 pub mod plugin;
 pub mod plugin_keybinding_execution;
+pub mod plugins_dir_in_working_dir;
 pub mod review_diff_ux_bugs;
 pub mod theme_editor;
 pub mod unified_keybindings;

--- a/crates/fresh-editor/tests/e2e/plugins/plugins_dir_in_working_dir.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugins_dir_in_working_dir.rs
@@ -1,0 +1,74 @@
+//! Regression test for https://github.com/sinelaw/fresh/issues/1722
+//!
+//! When a user runs Fresh from a project directory that happens to contain
+//! a folder called `plugins/` (unrelated to Fresh's plugin system), the
+//! embedded bundled plugins (`pkg.ts`, `find_references.ts`, etc.) silently
+//! fail to load. This makes commands like "Package: Packages" disappear
+//! from the command palette and breaks features like "Find References".
+//!
+//! The reproducer from the issue is:
+//! ```shell
+//! mkdir -p lorem/plugins
+//! cd lorem
+//! fresh
+//! ```
+//! Expected: the Package Manager command shows up in the command palette.
+//! Actual: it's missing.
+
+#![cfg(all(feature = "plugins", feature = "embed-plugins"))]
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use tempfile::TempDir;
+
+/// Reproduces issue #1722: an empty `plugins/` directory next to the user's
+/// project must not stop the bundled embedded plugins from loading.
+///
+/// Drives the command palette via keyboard and asserts only on rendered
+/// output: typing a short fragment of the Package Manager command name
+/// must surface the *description* registered by `pkg.ts`
+/// ("Browse and manage installed and available packages"). That string is
+/// only ever rendered as part of the suggestion row and is unique to the
+/// `pkg.ts` plugin's i18n, so its presence on screen proves the embedded
+/// plugin loaded.
+#[test]
+fn test_empty_plugins_dir_in_working_dir_does_not_hide_embedded_plugins() {
+    // Simulate `mkdir -p lorem/plugins; cd lorem; fresh` from the issue.
+    let temp_dir = TempDir::new().unwrap();
+    let working_dir = temp_dir.path().to_path_buf();
+    let user_plugins_dir = working_dir.join("plugins");
+    fs::create_dir_all(&user_plugins_dir).unwrap();
+
+    // `with_config_and_working_dir` calls `.without_empty_plugins_dir()`
+    // internally, so the harness will not overwrite our setup — the empty
+    // `plugins/` folder we just created is what Fresh sees on startup.
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        140,
+        40,
+        Default::default(),
+        working_dir.clone(),
+    )
+    .unwrap();
+
+    // Open the command palette.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    // Type a short fragment that should match the Package Manager command
+    // ("Package: Packages") via the palette's fuzzy match. We deliberately
+    // type *less* than the description we'll assert on, so the assertion
+    // can only succeed by reading text rendered from the suggestion list.
+    harness.type_text("Packages").unwrap();
+
+    // The description string is unique to the `pkg.ts` plugin's i18n. If
+    // embedded plugins didn't load (the bug), this text never appears.
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("Browse and manage installed and available packages")
+        })
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/plugins/plugins_dir_in_working_dir.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugins_dir_in_working_dir.rs
@@ -17,7 +17,7 @@
 
 #![cfg(all(feature = "plugins", feature = "embed-plugins"))]
 
-use crate::common::harness::EditorTestHarness;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::fs;
 use tempfile::TempDir;
@@ -40,14 +40,17 @@ fn test_empty_plugins_dir_in_working_dir_does_not_hide_embedded_plugins() {
     let user_plugins_dir = working_dir.join("plugins");
     fs::create_dir_all(&user_plugins_dir).unwrap();
 
-    // `with_config_and_working_dir` calls `.without_empty_plugins_dir()`
-    // internally, so the harness will not overwrite our setup — the empty
-    // `plugins/` folder we just created is what Fresh sees on startup.
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
+    // The harness's normal "directory presence == user controls plugins"
+    // rule would suppress embedded loading here, masking the bug we want
+    // to verify. `with_forced_embedded_plugins` opts into production
+    // plugin-loading semantics so this test exercises what a real user
+    // would see.
+    let mut harness = EditorTestHarness::create(
         140,
         40,
-        Default::default(),
-        working_dir.clone(),
+        HarnessOptions::new()
+            .with_working_dir(working_dir.clone())
+            .with_forced_embedded_plugins(),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
Fixes issue #1722 where embedded bundled plugins fail to load when the user's project directory contains an unrelated `plugins/` folder. This caused features like the Package Manager command to disappear from the command palette.

## Changes
- **Removed working directory plugin loading**: Deleted the check that loaded plugins from `<working_dir>/plugins/`. A user project with a `plugins/` folder (common in Vite, Rollup, Hugo projects, etc.) is not a Fresh plugin source and was shadowing the embedded plugins.
- **Updated plugin loading order documentation**: Clarified that embedded plugins (via the `embed-plugins` feature) are the fallback for development workflows, while user plugins should be placed in `~/.config/fresh/plugins/`.
- **Added regression test**: Created `plugins_dir_in_working_dir.rs` that reproduces the issue by creating an empty `plugins/` directory in the working directory and verifying that embedded plugins (specifically the Package Manager from `pkg.ts`) still load and function correctly.

## Implementation Details
The fix prioritizes embedded plugins as the intended mechanism for bundled functionality in development builds (cargo-binstall and `cargo run`), while user customizations go to the config directory. This prevents accidental shadowing by unrelated project directories.

https://claude.ai/code/session_01GHiXURrKooaqjzSkVJLR5Q