### PR TITLE
Fix viewport stall after find-selection wrap on Down arrow

### DIFF
--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -150,6 +150,16 @@ impl Editor {
             }
             view_state.viewport.top_byte = iter.current_position();
             view_state.viewport.top_view_line_offset = 0;
+            // The byte-oriented `ensure_cursor_visible` above may have set
+            // `scrolled_up_in_wrap` so the next `ensure_visible_in_layout`
+            // would fine-tune `top_view_line_offset` to place the cursor
+            // exactly `effective_offset` rows from the top. That hint
+            // matched the byte-oriented routine's chosen `top_byte`; we've
+            // since overridden `top_byte` to a recentered position, so the
+            // pending fine-tune is stale and would shift the viewport away
+            // from the recenter on the very first non-skipped render after
+            // a keypress.
+            view_state.viewport.scrolled_up_in_wrap = false;
             // The next render-time `ensure_visible_in_layout` would otherwise
             // immediately undo this recenter to satisfy its own scroll-margin
             // invariants. Tell it to keep the position we just chose.

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -146,6 +146,7 @@ pub mod scroll_wrapped_reach_last_line;
 pub mod scrolling;
 pub mod search;
 pub mod search_center_on_scroll;
+pub mod search_down_stall_after_wrap;
 pub mod search_navigation_after_move;
 pub mod search_replace;
 pub mod search_viewport_stall_after_wrap;

--- a/crates/fresh-editor/tests/e2e/search_down_stall_after_wrap.rs
+++ b/crates/fresh-editor/tests/e2e/search_down_stall_after_wrap.rs
@@ -1,0 +1,99 @@
+//! E2E test for the Down-arrow viewport-stall bug after find-selection wrap.
+//!
+//! Companion to `search_viewport_stall_after_wrap` (#1689): there the bug
+//! showed up across F3/Alt+N navigation steps. Here it manifests for plain
+//! cursor motion *after* the wrap-around: the wrap-around recenter hands
+//! control back to the editor, the user presses Down to keep reading, but
+//! the viewport stays pinned. The cursor advances off the bottom of the
+//! visible area and stays there for many keypresses before the viewport
+//! finally catches up.
+//!
+//! Repro: file with the word "TARGET" repeated several times, search for
+//! it, cycle through every match (the last Alt+N wraps back to match 1),
+//! then press Down 20 times. The cursor's expected line must be on
+//! screen at the end.
+//!
+//! On a buggy build the viewport stalls around the recentered position
+//! and the line corresponding to "first match line + 20" never enters
+//! the visible area within a reasonable number of presses.
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::path::Path;
+
+const NUM_MATCHES: usize = 5;
+const FIRST_MATCH_LINE: usize = 18;
+const LINE_SPACING: usize = 30;
+const TOTAL_LINES: usize = 200;
+
+fn write_target_file(path: &Path) {
+    let mut content = String::new();
+    for i in 0..TOTAL_LINES {
+        let m = (i.saturating_sub(FIRST_MATCH_LINE)) / LINE_SPACING;
+        let is_match_line =
+            i >= FIRST_MATCH_LINE && m < NUM_MATCHES && i == FIRST_MATCH_LINE + m * LINE_SPACING;
+        if is_match_line {
+            content.push_str(&format!("line {i:03} TARGET here\n"));
+        } else {
+            content.push_str(&format!("line {i:03} filler row\n"));
+        }
+    }
+    std::fs::write(path, &content).unwrap();
+}
+
+/// After Alt+N cycles around to the first match, plain Down presses must
+/// keep the cursor on screen — the viewport must follow.
+#[test]
+fn test_down_after_alt_n_wraparound_keeps_cursor_visible() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    write_target_file(&file_path);
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Open Find prompt and search.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("TARGET").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Cycle through every match, ending with one extra Alt+N that wraps
+    // back to the first match. After this the editor is parked at the
+    // first match again, but the viewport has been recentered around it
+    // and (on the buggy build) is in the state that suppresses the next
+    // few Down-arrow scrolls.
+    for _ in 0..NUM_MATCHES {
+        harness
+            .send_key(KeyCode::Char('n'), KeyModifiers::ALT)
+            .unwrap();
+        harness.process_async_and_render().unwrap();
+    }
+
+    // Press Down 20 times. From the first-match line that's well into the
+    // filler region between matches: cursor should now be at
+    // `FIRST_MATCH_LINE + 20`. The viewport (24 rows tall, ~22 visible
+    // content rows) cannot show both the first match and a line 20 rows
+    // below it, so the viewport must scroll.
+    let down_presses = 20usize;
+    for _ in 0..down_presses {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    let target_line = FIRST_MATCH_LINE + down_presses;
+    let needle = format!("line {target_line:03} filler row");
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(&needle),
+        "After {down_presses} Down presses following Alt+N wrap-around, the cursor's \
+         line ({target_line}, expected text {needle:?}) must be visible — the \
+         viewport stalled instead of following the cursor.\nRendered screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes a viewport stalling bug that occurs when pressing the Down arrow key after a find-selection wrap-around (e.g., after Alt+N cycles back to the first match). The viewport would remain pinned at the recentered position instead of following the cursor, causing the cursor to move off-screen for many keypresses before the viewport finally catches up.

## Changes
- **navigation.rs**: Clear the `scrolled_up_in_wrap` flag after recentering the viewport during find-selection wrap-around. This flag was carrying stale state from the byte-oriented `ensure_cursor_visible` routine into the next render, causing `ensure_visible_in_layout` to apply an outdated fine-tuning adjustment that would undo the recenter position.

- **tests/e2e/search_down_stall_after_wrap.rs**: Add a new E2E test that reproduces the bug by:
  1. Opening a file with multiple "TARGET" matches spaced 30 lines apart
  2. Cycling through all matches with Alt+N (wrapping back to the first)
  3. Pressing Down 20 times
  4. Verifying the cursor's target line is visible on screen

The test ensures the viewport follows cursor motion after wrap-around instead of stalling.

## Implementation Details
The root cause was that `scrolled_up_in_wrap` is set by the byte-oriented `ensure_cursor_visible` routine to hint at a desired `top_view_line_offset` for the next layout pass. When the navigation code overrides `top_byte` to recenter the viewport, this hint becomes stale and causes the subsequent render to shift the viewport away from the intended recenter position. Clearing the flag after recentering ensures the next render respects the new viewport position.

https://claude.ai/code/session_014yzmKx5BCaTrK9PQrEjnLg