### PR TITLE
test(diagnostics): disable animations in multiline-scroll test

### DIFF
--- a/crates/fresh-editor/tests/e2e/inline_diagnostics.rs
+++ b/crates/fresh-editor/tests/e2e/inline_diagnostics.rs
@@ -176,6 +176,10 @@ fn test_current_line_highlight_extends_through_inline_diagnostic() {
 fn test_multiline_diagnostic_highlight_visible_when_partially_scrolled() {
     let mut config = fresh::config::Config::default();
     config.editor.line_numbers = false;
+    // Ctrl+Home and the post-scroll cursor reposition both cross the
+    // cursor-jump threshold (dy >= 3); without this, the trail can paint
+    // cells with blended cursor/bg colors and race the assertion below.
+    config.editor.animations = false;
 
     // Use a small viewport so we can scroll easily
     // Height 10: menu bar (1) + tab bar (1) + content (6) + status (1) + prompt (1)


### PR DESCRIPTION
The harness only auto-disables `editor.animations` for tests that don't
pass an explicit Config (harness.rs:638-642); this test passes its own
Config, so animations stayed on (default true). Both Ctrl+Home (jumps
from line 20 to line 1) and the post-scroll cursor reposition cross the
cursor-jump threshold (dy >= 3 || dx >= 10), and `CursorJump` paints a
short fading trail along the path using `Instant::now()` for elapsed
time. Under CI load the wall-clock between the scroll-triggered render
and the next render can leave the animation mid-flight, painting cell
(0, 2) with a blended color (e.g. cursor (255,255,255) toward bg
(0,0,0) ≈ Rgb(109,109,109)) and racing the overlay-color assertion.

Disabling animations matches the harness's own rationale ("tests that
drive the UI via single render() calls and then inspect the screen
would see mid-slide frames instead of the settled result") and the
CONTRIBUTING guidance against time-sensitive tests.