### PR TITLE
Add Racket language support with grammar and LSP configuration

### DIFF
--- a/crates/fresh-editor/build.rs
+++ b/crates/fresh-editor/build.rs
@@ -331,6 +331,7 @@ fn generate_syntax_packdump() -> Result<(), Box<dyn std::error::Error>> {
             "src/grammars/autohotkey/AutoHotkey.sublime-syntax",
             "AutoHotkey",
         ),
+        ("src/grammars/racket.sublime-syntax", "Racket"),
     ];
 
     let mut loaded = 0;

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -4389,6 +4389,36 @@ impl Config {
         );
 
         languages.insert(
+            "racket".to_string(),
+            LanguageConfig {
+                extensions: vec![
+                    "rkt".to_string(),
+                    "rktd".to_string(),
+                    "rktl".to_string(),
+                    "scrbl".to_string(),
+                ],
+                filenames: vec![],
+                grammar: "Racket".to_string(),
+                comment_prefix: Some(";".to_string()),
+                auto_indent: true,
+                auto_close: None,
+                auto_surround: None,
+                textmate_grammar: None,
+                show_whitespace_tabs: true,
+                line_wrap: None,
+                wrap_column: None,
+                page_view: None,
+                page_width: None,
+                use_tabs: None,
+                tab_size: None,
+                formatter: None,
+                format_on_save: false,
+                on_save: vec![],
+                word_characters: None,
+            },
+        );
+
+        languages.insert(
             "fsharp".to_string(),
             LanguageConfig {
                 extensions: vec!["fs".to_string(), "fsi".to_string(), "fsx".to_string()],
@@ -6250,6 +6280,26 @@ impl Config {
                 only_features: None,
                 except_features: None,
                 root_markers: Default::default(),
+            }]),
+        );
+
+        // racket-langserver - Racket Language Server
+        // Install via: raco pkg install racket-langserver
+        lsp.insert(
+            "racket".to_string(),
+            LspLanguageConfig::Multi(vec![LspServerConfig {
+                command: "racket-langserver".to_string(),
+                args: vec![],
+                enabled: true,
+                auto_start: false,
+                process_limits: ProcessLimits::default(),
+                initialization_options: None,
+                env: Default::default(),
+                language_id_overrides: Default::default(),
+                name: None,
+                only_features: None,
+                except_features: None,
+                root_markers: vec!["info.rkt".to_string(), ".git".to_string()],
             }]),
         );
 

--- a/crates/fresh-editor/src/grammars/racket.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/racket.sublime-syntax
@@ -1,0 +1,135 @@
+%YAML 1.2
+---
+name: Racket
+file_extensions: [rkt, rktd, rktl, scrbl]
+scope: source.racket
+contexts:
+  main:
+    - include: comments
+    - include: lang_directive
+    - include: strings
+    - include: characters
+    - include: keywords
+    - include: constants
+    - include: numbers
+    - include: quoted
+    - include: function_call
+    - include: punctuation
+  comments:
+    - match: '#\|'
+      push:
+        - meta_scope: comment.block.racket
+        - match: '\|#'
+          pop: true
+    - match: ';.*$'
+      scope: comment.line.semicolon.racket
+    - match: '#;'
+      scope: comment.expression.racket
+  lang_directive:
+    - match: '^(#lang)\s+([^\s]+)'
+      captures:
+        1: keyword.control.directive.racket
+        2: entity.name.namespace.racket
+  strings:
+    - match: '#?"'
+      push:
+        - meta_scope: string.quoted.double.racket
+        - match: '\\(x[0-9A-Fa-f]+|u[0-9A-Fa-f]+|U[0-9A-Fa-f]+|[0-7]{1,3}|.)'
+          scope: constant.character.escape.racket
+        - match: '"'
+          pop: true
+    - match: '#rx#?"'
+      push:
+        - meta_scope: string.regexp.racket
+        - match: '\\.'
+          scope: constant.character.escape.racket
+        - match: '"'
+          pop: true
+    - match: '#px#?"'
+      push:
+        - meta_scope: string.regexp.racket
+        - match: '\\.'
+          scope: constant.character.escape.racket
+        - match: '"'
+          pop: true
+  characters:
+    - match: "#\\\\(space|newline|tab|return|null|nul|backspace|rubout|page|linefeed|vtab|U[0-9A-Fa-f]+|u[0-9A-Fa-f]+|.)"
+      scope: constant.character.racket
+  constants:
+    - match: '#[tT](rue)?\b'
+      scope: constant.language.boolean.true.racket
+    - match: '#[fF](alse)?\b'
+      scope: constant.language.boolean.false.racket
+    - match: '\bnull\b'
+      scope: constant.language.null.racket
+    - match: "'\\(\\s*\\)"
+      scope: constant.language.empty-list.racket
+  numbers:
+    - match: '\b#[eEiI]?#?[bB][+-]?[01]+(/[01]+)?\b'
+      scope: constant.numeric.binary.racket
+    - match: '\b#[eEiI]?#?[oO][+-]?[0-7]+(/[0-7]+)?\b'
+      scope: constant.numeric.octal.racket
+    - match: '\b#[eEiI]?#?[xX][+-]?[0-9a-fA-F]+(/[0-9a-fA-F]+)?\b'
+      scope: constant.numeric.hex.racket
+    - match: '[+-]?\b\d+/\d+\b'
+      scope: constant.numeric.rational.racket
+    - match: '[+-]?\b\d+(\.\d+)?([eE][+-]?\d+)?\b'
+      scope: constant.numeric.racket
+    - match: '[+-](inf|nan)\.[0f]'
+      scope: constant.numeric.special.racket
+  quoted:
+    - match: "'"
+      scope: punctuation.definition.quote.racket
+    - match: '`'
+      scope: punctuation.definition.quasiquote.racket
+    - match: ',@?'
+      scope: punctuation.definition.unquote.racket
+  keywords:
+    # Definition forms
+    - match: '(?<=\(|\[|\{)\s*(define|define-values|define-syntax|define-syntax-rule|define-syntaxes|define-for-syntax|define-struct|define-record-type|define-type|define-signature|define-module|define/contract|define/public|define/private|define/override|define/match|define/generic|struct|struct/contract)\b'
+      captures:
+        1: keyword.declaration.racket
+    # Lambda / function forms
+    - match: '(?<=\(|\[|\{)\s*(lambda|λ|case-lambda|opt-lambda|kw-lambda)\b'
+      captures:
+        1: keyword.declaration.function.racket
+    # Binding forms
+    - match: '(?<=\(|\[|\{)\s*(let|let\*|letrec|letrec\*|let-values|let\*-values|letrec-values|let-syntax|letrec-syntax|let-syntaxes|letrec-syntaxes|let/cc|let/ec|fluid-let|parameterize|with-handlers|with-syntax|with-continuation-mark)\b'
+      captures:
+        1: keyword.control.binding.racket
+    # Control flow
+    - match: '(?<=\(|\[|\{)\s*(if|when|unless|cond|case|match|match\*|match-lambda|match-lambda\*|match-let|match-let\*|match-letrec|match-define|begin|begin0|begin-for-syntax|and|or|not|set!|set!-values|delay|force)\b'
+      captures:
+        1: keyword.control.racket
+    # Iteration
+    - match: '(?<=\(|\[|\{)\s*(for|for/list|for/vector|for/hash|for/hasheq|for/hasheqv|for/and|for/or|for/sum|for/product|for/first|for/last|for/fold|for/foldr|for\*|for\*/list|for\*/vector|for\*/hash|for\*/and|for\*/or|for\*/sum|for\*/product|for\*/first|for\*/last|for\*/fold|do)\b'
+      captures:
+        1: keyword.control.iteration.racket
+    # Module / require / provide
+    - match: '(?<=\(|\[|\{)\s*(module|module\+|module\*|require|provide|all-defined-out|all-from-out|except-out|except-in|prefix-out|prefix-in|rename-out|rename-in|only-in|combine-in|relative-in|submod|planet|file|lib|quote|quasiquote|unquote|unquote-splicing|syntax|quasisyntax|unsyntax|unsyntax-splicing)\b'
+      captures:
+        1: keyword.control.import.racket
+    # Class / object
+    - match: '(?<=\(|\[|\{)\s*(class|class\*|class/c|interface|interface\*|mixin|send|send\*|send/apply|send/keyword-apply|inherit|inherit-field|init|init-field|init-rest|field|public|private|protected|override|augment|abstract|new|make-object|instantiate|is-a\?|implementation\?|interface\?)\b'
+      captures:
+        1: keyword.control.class.racket
+    # Contracts
+    - match: '(?<=\(|\[|\{)\s*(contract|contract-out|recontract-out|->|->\*|->d|->i|case->|case-_>|listof|vectorof|hash/c|cons/c|or/c|and/c|not/c|any/c|none/c|flat-contract|flat-named-contract|symbols|integer-in|real-in|natural-number/c|true/c|false/c|printable/c|between/c|=/c|>=/c|<=/c|>/c|</c|recursive-contract)\b'
+      captures:
+        1: keyword.control.contract.racket
+    # Built-in syntactic forms
+    - match: '(?<=\(|\[|\{)\s*(syntax-rules|syntax-case|syntax-id-rules|syntax-parser|syntax-parse|datum->syntax|syntax->datum|free-identifier=\?|bound-identifier=\?|identifier\?|generate-temporaries|local-expand|expand|eval|namespace-require)\b'
+      captures:
+        1: keyword.control.syntax.racket
+    # Common procedures (variable.function-like highlighting)
+    - match: '(?<=\(|\[|\{)\s*(car|cdr|cons|list|list\*|append|reverse|length|map|for-each|filter|foldl|foldr|apply|null\?|pair\?|list\?|empty\?|number\?|integer\?|rational\?|real\?|complex\?|string\?|symbol\?|boolean\?|procedure\?|char\?|vector\?|hash\?|eq\?|eqv\?|equal\?|=|<|>|<=|>=|\+|-|\*|/|quotient|remainder|modulo|abs|min|max|expt|sqrt|exp|log|sin|cos|tan|asin|acos|atan|floor|ceiling|round|truncate|exact->inexact|inexact->exact|number->string|string->number|string-append|string-length|substring|string-ref|string-upcase|string-downcase|string->list|list->string|string->symbol|symbol->string|read|write|display|newline|printf|format|error|exit)\b'
+      captures:
+        1: support.function.builtin.racket
+  function_call:
+    # Highlight the first symbol after an open paren as a function call
+    - match: '(?<=\(|\[|\{)\s*([A-Za-z\-_!?$%&*+./:<=>?@^_~][A-Za-z0-9\-_!?$%&*+./:<=>?@^_~]*)'
+      captures:
+        1: variable.function.racket
+  punctuation:
+    - match: '[\(\)\[\]\{\}]'
+      scope: punctuation.section.parens.racket

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -232,6 +232,8 @@ pub const HYPRLANG_GRAMMAR: &str = include_str!("../../grammars/hyprlang.sublime
 /// From: https://github.com/SALZKARTOFFEEEL/ahk-sublime-syntax (MIT License)
 pub const AUTOHOTKEY_GRAMMAR: &str =
     include_str!("../../grammars/autohotkey/AutoHotkey.sublime-syntax");
+/// Embedded Racket grammar (syntect doesn't include one)
+pub const RACKET_GRAMMAR: &str = include_str!("../../grammars/racket.sublime-syntax");
 
 /// Registry of all available TextMate grammars.
 ///
@@ -645,6 +647,7 @@ impl GrammarRegistry {
             (ASTRO_GRAMMAR, "Astro"),
             (HYPRLANG_GRAMMAR, "Hyprlang"),
             (AUTOHOTKEY_GRAMMAR, "AutoHotkey"),
+            (RACKET_GRAMMAR, "Racket"),
         ];
 
         for (grammar_str, name) in additional_grammars {
@@ -1543,6 +1546,21 @@ mod tests {
                 should_exist,
                 filename
             );
+        }
+    }
+
+    #[test]
+    fn test_racket_grammar_loaded() {
+        let registry = GrammarRegistry::default();
+        for filename in ["main.rkt", "data.rktd", "info.rktl", "doc.scrbl"] {
+            let result = registry.find_syntax_for_file(Path::new(filename));
+            assert!(
+                result.is_some(),
+                "Racket grammar should be available for {}",
+                filename
+            );
+            let entry = registry.find_by_path(Path::new(filename), None).unwrap();
+            assert_eq!(entry.display_name, "Racket", "for {}", filename);
         }
     }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for the Racket programming language to the Fresh Editor, including syntax highlighting via a custom Sublime Text grammar and Language Server Protocol (LSP) integration.

## Key Changes

- **New Racket Grammar**: Added a complete Sublime Text syntax definition (`racket.sublime-syntax`) with support for:
  - Comments (line, block, and expression forms)
  - String literals (regular, raw regex, and pattern regex)
  - Character literals with escape sequences
  - Numeric literals (binary, octal, hex, rational, floating-point, and special values)
  - Language directives (`#lang`)
  - Comprehensive keyword highlighting for definition forms, lambda expressions, binding forms, control flow, iteration, modules, classes, contracts, and syntax manipulation
  - Built-in procedure highlighting
  - Proper punctuation and quote handling

- **Language Configuration**: Registered Racket in `config.rs` with:
  - File extensions: `.rkt`, `.rktd`, `.rktl`, `.scrbl`
  - Comment prefix: `;`
  - Auto-indentation enabled
  - Whitespace tab visibility enabled

- **LSP Integration**: Configured `racket-langserver` support with:
  - Root markers: `info.rkt` and `.git`
  - Auto-start disabled (manual activation)
  - Standard process limits

- **Grammar Registry**: Integrated the Racket grammar into the grammar registry system with proper test coverage for all supported file extensions

## Implementation Details

The Racket grammar provides sophisticated syntax highlighting for the language's unique features, including proper handling of Racket's distinctive syntax elements like quasiquotes, unquotes, and the lambda symbol (λ). The LSP configuration uses the community-maintained `racket-langserver` package, installable via `raco pkg install racket-langserver`.

https://claude.ai/code/session_01PKXPDraXQ8zBXC4s3jX2cG