### PR TITLE
Fix UTF-8 panic when truncating strings with non-ASCII characters

### DIFF
--- a/crates/fresh-editor/src/app/shell_command.rs
+++ b/crates/fresh-editor/src/app/shell_command.rs
@@ -318,11 +318,52 @@ fn detect_shell() -> String {
 }
 
 /// Truncate a command string for display purposes.
+///
+/// Counts characters (not bytes) so non-ASCII commands like
+/// `echo こんにちは` don't byte-slice through the middle of a multi-byte
+/// UTF-8 sequence and panic.
 fn truncate_command(command: &str, max_len: usize) -> String {
     let trimmed = command.trim();
-    if trimmed.len() <= max_len {
+    if trimmed.chars().count() <= max_len {
         trimmed.to_string()
     } else {
-        format!("{}...", &trimmed[..max_len - 3])
+        let keep = max_len.saturating_sub(3);
+        let kept: String = trimmed.chars().take(keep).collect();
+        format!("{}...", kept)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_command;
+
+    #[test]
+    fn truncate_command_ascii_fits() {
+        assert_eq!(truncate_command("echo hi", 30), "echo hi");
+    }
+
+    #[test]
+    fn truncate_command_ascii_truncates() {
+        assert_eq!(truncate_command("echo hello world", 10), "echo he...");
+    }
+
+    #[test]
+    fn truncate_command_multibyte_does_not_panic() {
+        // Regression: byte-slicing this command at `max_len - 3 = 7` lands
+        // inside the 3-byte UTF-8 sequence for 'こ' and previously panicked
+        // (same class as #1718). Now `keep = 7` characters are kept.
+        let cmd = "echo こんにちは世界";
+        let out = truncate_command(cmd, 10);
+        assert_eq!(out, "echo こん...");
+    }
+
+    #[test]
+    fn truncate_command_emoji_does_not_panic() {
+        // Regression: emoji is 4 UTF-8 bytes per code point; byte slicing
+        // at any byte index that isn't a multiple of 4 (mod the leading
+        // ASCII run) would panic.
+        let cmd = "echo 😀😀😀😀😀😀";
+        let out = truncate_command(cmd, 8);
+        assert_eq!(out, "echo ...");
     }
 }

--- a/crates/fresh-editor/src/view/controls/map_input/render.rs
+++ b/crates/fresh-editor/src/view/controls/map_input/render.rs
@@ -61,10 +61,17 @@ pub fn render_map(
 
         // Value preview using display_field if available
         let value_preview = state.get_display_value(value);
-        // Truncate if too long
+        // Truncate if too long. Counts characters (not bytes) so that a
+        // preview value containing non-ASCII (e.g. quoted strings with
+        // emoji or CJK) doesn't byte-slice through a multi-byte UTF-8
+        // sequence and panic — same class as #1718.
         let max_preview_len = 30;
-        let value_preview = if value_preview.len() > max_preview_len {
-            format!("{}...", &value_preview[..max_preview_len - 3])
+        let value_preview = if value_preview.chars().count() > max_preview_len {
+            let kept: String = value_preview
+                .chars()
+                .take(max_preview_len.saturating_sub(3))
+                .collect();
+            format!("{}...", kept)
         } else {
             value_preview
         };
@@ -224,7 +231,11 @@ pub fn render_map(
     }
 }
 
-/// Format a JSON value as a short preview string
+/// Format a JSON value as a short preview string.
+///
+/// Counts characters (not bytes) when truncating so that a JSON string
+/// containing non-ASCII (e.g. CJK, emoji) doesn't byte-slice through a
+/// multi-byte UTF-8 sequence and panic — same class as #1718.
 pub(super) fn format_value_preview(value: &serde_json::Value, max_len: usize) -> String {
     let s = match value {
         serde_json::Value::Null => "null".to_string(),
@@ -234,9 +245,43 @@ pub(super) fn format_value_preview(value: &serde_json::Value, max_len: usize) ->
         serde_json::Value::Array(arr) => format!("[{} items]", arr.len()),
         serde_json::Value::Object(obj) => format!("{{{} fields}}", obj.len()),
     };
-    if s.len() > max_len {
-        format!("{}...", &s[..max_len - 3])
+    if s.chars().count() > max_len {
+        let kept: String = s.chars().take(max_len.saturating_sub(3)).collect();
+        format!("{}...", kept)
     } else {
         s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_value_preview;
+    use serde_json::json;
+
+    #[test]
+    fn format_value_preview_ascii_truncates() {
+        let v = json!("hello world this is a long string");
+        let out = format_value_preview(&v, 10);
+        assert_eq!(out, "\"hello ...");
+    }
+
+    #[test]
+    fn format_value_preview_multibyte_does_not_panic() {
+        // Regression: byte-slicing a JSON string at `max_len - 3` would
+        // land inside the 3-byte UTF-8 sequence for `こ` and panic — same
+        // class as #1718.
+        let v = json!("こんにちは世界これはテストです");
+        let out = format_value_preview(&v, 10);
+        // Must not panic; output must be valid UTF-8.
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 10);
+    }
+
+    #[test]
+    fn format_value_preview_emoji_does_not_panic() {
+        let v = json!("📦📦📦📦📦📦📦📦📦📦");
+        let out = format_value_preview(&v, 5);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 5);
     }
 }

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -106,6 +106,19 @@ fn byte_to_char_idx(s: &str, byte_offset: usize) -> usize {
         .count()
 }
 
+/// Truncate `s` to at most `max_chars` characters, appending `"..."` if it
+/// was actually shortened. Counts characters (not bytes) so non-ASCII
+/// inputs (CJK descriptions, emoji, etc.) don't byte-slice through a
+/// multi-byte UTF-8 sequence and panic — same class as #1718.
+fn truncate_chars_with_ellipsis(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let kept: String = s.chars().take(max_chars.saturating_sub(3)).collect();
+        format!("{}...", kept)
+    }
+}
+
 /// Render the settings modal
 pub fn render_settings(
     frame: &mut Frame,
@@ -1673,14 +1686,11 @@ fn render_map_partial(
             Style::default()
         };
 
-        // Get display value
+        // Get display value. `truncate_chars_with_ellipsis` counts
+        // characters (not bytes) so a localized / CJK preview value
+        // doesn't panic on truncation (same class as #1718).
         let value_preview = state.get_display_value(value);
-        let max_preview_len = 20;
-        let value_preview = if value_preview.len() > max_preview_len {
-            format!("{}...", &value_preview[..max_preview_len - 3])
-        } else {
-            value_preview
-        };
+        let value_preview = truncate_chars_with_ellipsis(&value_preview, 20);
 
         let display_key: String = key.chars().take(key_width as usize).collect();
         let mut spans = vec![
@@ -2682,17 +2692,14 @@ fn render_search_result_item(
         Rect::new(area.x, area.y + 1, area.width, 1),
     );
 
-    // Third line: Description (if any)
+    // Third line: Description (if any). Counts characters (not bytes)
+    // when checking and truncating: descriptions can be localized (e.g.
+    // CJK translations) and a byte-based slice could land inside a
+    // multi-byte UTF-8 sequence and panic — same class as #1718.
     if let Some(ref desc) = display_desc {
         let desc_style = Style::default().fg(theme.line_number_fg);
         let max_chars = (area.width as usize).saturating_sub(2);
-        let truncated_desc = if desc.chars().count() > max_chars {
-            let limit = (area.width as usize).saturating_sub(5);
-            let end = desc.floor_char_boundary(limit);
-            format!("  {}...", &desc[..end])
-        } else {
-            format!("  {}", desc)
-        };
+        let truncated_desc = format!("  {}", truncate_chars_with_ellipsis(desc, max_chars));
         frame.render_widget(
             Paragraph::new(truncated_desc).style(desc_style),
             Rect::new(area.x, area.y + 2, area.width, 1),
@@ -2803,17 +2810,17 @@ fn render_confirm_dialog(
     );
     y += 2;
 
-    // List changes
+    // List changes. Character-based truncation here (rather than byte
+    // truncation) keeps CJK / emoji change descriptions from byte-slicing
+    // through a multi-byte UTF-8 sequence and panicking — same class as
+    // #1718.
     let change_style = Style::default().fg(theme.popup_text_fg);
     for change in changes
         .iter()
         .take((dialog_height as usize).saturating_sub(7))
     {
-        let truncated = if change.len() > inner.width as usize - 2 {
-            format!("• {}...", &change[..inner.width as usize - 5])
-        } else {
-            format!("• {}", change)
-        };
+        let max_chars = (inner.width as usize).saturating_sub(2);
+        let truncated = format!("• {}", truncate_chars_with_ellipsis(change, max_chars));
         frame.render_widget(
             Paragraph::new(truncated).style(change_style),
             Rect::new(inner.x, y, inner.width, 1),
@@ -2924,17 +2931,17 @@ fn render_reset_dialog(frame: &mut Frame, parent_area: Rect, state: &SettingsSta
     );
     y += 2;
 
-    // List changes
+    // List changes. Character-based truncation here (rather than byte
+    // truncation) keeps CJK / emoji change descriptions from byte-slicing
+    // through a multi-byte UTF-8 sequence and panicking — same class as
+    // #1718.
     let change_style = Style::default().fg(theme.popup_text_fg);
     for change in changes
         .iter()
         .take((dialog_height as usize).saturating_sub(7))
     {
-        let truncated = if change.len() > inner.width as usize - 2 {
-            format!("• {}...", &change[..inner.width as usize - 5])
-        } else {
-            format!("• {}", change)
-        };
+        let max_chars = (inner.width as usize).saturating_sub(2);
+        let truncated = format!("• {}", truncate_chars_with_ellipsis(change, max_chars));
         frame.render_widget(
             Paragraph::new(truncated).style(change_style),
             Rect::new(inner.x, y, inner.width, 1),
@@ -3493,6 +3500,34 @@ fn render_help_overlay(frame: &mut Frame, parent_area: Rect, theme: &Theme) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_chars_with_ellipsis_ascii_fits() {
+        assert_eq!(truncate_chars_with_ellipsis("hi", 10), "hi");
+    }
+
+    #[test]
+    fn truncate_chars_with_ellipsis_ascii_truncates() {
+        assert_eq!(truncate_chars_with_ellipsis("hello world!", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_chars_with_ellipsis_multibyte_does_not_panic() {
+        // Regression: byte-slicing this string at `max - 3` would land
+        // inside the 3-byte UTF-8 sequence for `こ` and panic — same class
+        // as #1718.
+        let out = truncate_chars_with_ellipsis("こんにちは世界からのテスト", 8);
+        assert!(out.ends_with("..."));
+        // 5 kept chars + 3 ellipsis chars = 8 total chars.
+        assert_eq!(out.chars().count(), 8);
+    }
+
+    #[test]
+    fn truncate_chars_with_ellipsis_emoji_does_not_panic() {
+        let out = truncate_chars_with_ellipsis("📦📦📦📦📦📦📦📦", 5);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 5);
+    }
 
     // Basic compile test - actual rendering tests would need a test backend
     #[test]

--- a/crates/fresh-editor/src/view/ui/file_browser.rs
+++ b/crates/fresh-editor/src/view/ui/file_browser.rs
@@ -419,11 +419,7 @@ impl FileBrowserRenderer {
         } else {
             header_style
         };
-        let name_display = if name_header.len() < name_col_width {
-            format!("{:<width$}", name_header, width = name_col_width)
-        } else {
-            name_header[..name_col_width].to_string()
-        };
+        let name_display = fit_header_to_col_width(&name_header, name_col_width);
         spans.push(Span::styled(name_display, name_style));
 
         // Size column
@@ -653,6 +649,20 @@ impl FileBrowserRenderer {
     }
 }
 
+/// Pad or truncate a header string so it occupies exactly `col_width`
+/// character positions. Counts characters (not bytes) so headers
+/// containing the sort arrow `▲`/`▼` (3 UTF-8 bytes each) or localized
+/// labels from `t!()` don't byte-slice through a multi-byte sequence and
+/// panic — same class as #1718.
+fn fit_header_to_col_width(header: &str, col_width: usize) -> String {
+    let chars = header.chars().count();
+    if chars < col_width {
+        format!("{:<width$}", header, width = col_width)
+    } else {
+        header.chars().take(col_width).collect()
+    }
+}
+
 /// Layout information for mouse hit testing
 #[derive(Debug, Clone)]
 pub struct FileBrowserLayout {
@@ -828,5 +838,42 @@ impl FileBrowserLayout {
         let detect_encoding_end = detect_encoding_start + 28;
 
         x >= detect_encoding_start && x < detect_encoding_end
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fit_header_to_col_width;
+
+    #[test]
+    fn fit_header_pads_when_short() {
+        assert_eq!(fit_header_to_col_width("Name", 8), "Name    ");
+    }
+
+    #[test]
+    fn fit_header_truncates_ascii() {
+        assert_eq!(fit_header_to_col_width("Filename▲", 4), "File");
+    }
+
+    #[test]
+    fn fit_header_truncates_with_sort_arrow_does_not_panic() {
+        // Regression: header ` Name ▲` is 9 bytes (`▲` = 3 bytes) but
+        // 7 characters. Under the old byte-based code, col_width=7 would
+        // byte-slice at index 7 — inside the 3-byte UTF-8 sequence for
+        // `▲` — and panic the editor (same class as #1718). Now the
+        // header is truncated by character count.
+        let out = fit_header_to_col_width(" Name ▲", 7);
+        assert_eq!(out, " Name ▲");
+        assert_eq!(out.chars().count(), 7);
+    }
+
+    #[test]
+    fn fit_header_truncates_localized_does_not_panic() {
+        // Localized header (e.g. Japanese) where every label char is
+        // 3 UTF-8 bytes. Old byte-based truncation at col_width=4 would
+        // panic mid-character; character-based truncation keeps 4 chars.
+        let out = fit_header_to_col_width(" 名前 ▲", 4);
+        assert!(out.is_char_boundary(out.len()));
+        assert_eq!(out.chars().count(), 4);
     }
 }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -412,9 +412,13 @@ pub fn truncate_path(path: &Path, max_len: usize) -> TruncatedPath {
     let available_for_suffix = max_len.saturating_sub(prefix.len() + ellipsis_len);
 
     if available_for_suffix < 5 || components.len() <= 1 {
-        // Not enough space or only one component, just truncate the end
+        // Not enough space or only one component, just truncate the end.
+        // Walk back to a char boundary so paths with non-ASCII components
+        // (e.g. `/home/ユーザー/project`) don't byte-slice through a
+        // multi-byte UTF-8 sequence and panic (same class as #1718).
         let truncated_path = if path_str.len() > max_len.saturating_sub(3) {
-            format!("{}...", &path_str[..max_len.saturating_sub(3)])
+            let cut = path_str.floor_char_boundary(max_len.saturating_sub(3));
+            format!("{}...", &path_str[..cut])
         } else {
             path_str.to_string()
         };
@@ -451,11 +455,14 @@ pub fn truncate_path(path: &Path, max_len: usize) -> TruncatedPath {
     }
 
     let suffix = if suffix_parts.is_empty() {
-        // Can't fit any suffix components, truncate the last component
+        // Can't fit any suffix components, truncate the last component.
+        // floor_char_boundary keeps the slice on a valid UTF-8 boundary
+        // when `last` contains non-ASCII characters.
         let last = components.last().unwrap_or(&"");
         let truncate_to = available_for_suffix.saturating_sub(4); // "/.." and some chars
         if truncate_to > 0 && last.len() > truncate_to {
-            format!("/{}...", &last[..truncate_to])
+            let cut = last.floor_char_boundary(truncate_to);
+            format!("/{}...", &last[..cut])
         } else {
             format!("/{}", last)
         }
@@ -1670,6 +1677,34 @@ mod tests {
 
         assert!(!result.truncated);
         assert_eq!(result.suffix, "/");
+    }
+
+    #[test]
+    fn test_truncate_path_multibyte_single_component_does_not_panic() {
+        // Routes into the "truncate the end" branch (line 414): the prefix
+        // alone exceeds max_len, so available_for_suffix becomes 0. Before
+        // the fix, byte-slicing `path_str` at `max_len - 3 = 2` lands
+        // inside the 3-byte UTF-8 sequence for `ユ` and panicked the
+        // editor — same class as #1718.
+        let path = PathBuf::from("/ユーザーのプロジェクト名前/file");
+        let result = truncate_path(&path, 5);
+        let display = result.to_string_plain();
+        assert!(display.is_char_boundary(display.len()));
+        assert!(display.ends_with("..."));
+    }
+
+    #[test]
+    fn test_truncate_path_multibyte_last_component_does_not_panic() {
+        // Routes into the "truncate the last component" branch (line 453):
+        // available_for_suffix is large enough to enter the suffix-build
+        // loop, but the only remaining component doesn't fit, so we fall
+        // back to truncating it. Before the fix, byte-slicing the
+        // non-ASCII component at `truncate_to = 1` lands inside the 3-byte
+        // UTF-8 sequence for `ユ` and panicked.
+        let path = PathBuf::from("/a/ユーザーのプロジェクト名前");
+        let result = truncate_path(&path, 13);
+        let display = result.to_string_plain();
+        assert!(display.is_char_boundary(display.len()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR fixes a class of panics that occur when truncating strings containing non-ASCII characters (CJK, emoji, etc.) by switching from byte-based to character-based truncation throughout the codebase. The issue arises when byte-slicing lands in the middle of a multi-byte UTF-8 sequence.

## Key Changes

- **New helper functions for safe truncation:**
  - `truncate_chars_with_ellipsis()` in `settings/render.rs` - centralizes character-based truncation with ellipsis
  - `fit_header_to_col_width()` in `file_browser.rs` - safely pads or truncates headers by character count
  - Updated `truncate_command()` in `shell_command.rs` to use character-based logic
  - Updated `format_value_preview()` in `map_input/render.rs` to use character-based logic
  - Updated `truncate_path()` in `status_bar.rs` to use `floor_char_boundary()` for safe UTF-8 slicing

- **Replaced byte-based truncation with character-based:**
  - Settings modal value preview truncation
  - Search result description truncation
  - Confirm/reset dialog change list truncation
  - Map input value preview truncation
  - File browser header truncation
  - Status bar path truncation
  - Shell command display truncation

- **Added comprehensive test coverage:**
  - Tests for ASCII strings that fit and need truncation
  - Regression tests for multi-byte UTF-8 sequences (CJK characters)
  - Regression tests for emoji (4-byte UTF-8 sequences)
  - All tests verify no panics occur and output remains valid UTF-8

## Implementation Details

The fix uses Rust's `str::chars()` iterator to count and slice by Unicode scalar values rather than bytes. For cases where we need to slice at a specific byte position (like in `truncate_path()`), we use `str::floor_char_boundary()` to safely walk back to the nearest valid UTF-8 boundary.

All changes are backward compatible and maintain the same visual truncation behavior while preventing panics on non-ASCII input.

https://claude.ai/code/session_01Ljd17QuymxTtJxpajwbgRZ