### PR TITLE
Refine cursor-jump animation trigger logic for split panes

### DIFF
--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1165,13 +1165,14 @@ pub struct Editor {
     /// while animations are running.
     pub animations: crate::view::animation::AnimationRunner,
 
-    /// Hardware-cursor screen position from the previous render pass, used
-    /// to detect "jumps" (search, goto-line, click, goto-definition, focus
+    /// Hardware-cursor screen position from the previous render pass, paired
+    /// with the active split that owned the cursor at that time. Used to
+    /// detect "jumps" (search, goto-line, click, goto-definition, focus
     /// change between splits, tab/buffer switch, etc.) and animate the
     /// cursor moving from its old screen position to its new one. Cross-
-    /// pane and cross-buffer jumps animate too — the trail just paints
-    /// over whatever cells lie along the straight line.
-    pub(crate) previous_cursor_screen_pos: Option<(u16, u16)>,
+    /// pane jumps animate unconditionally; same-pane jumps animate only
+    /// when the cursor moved more than two rows.
+    pub(crate) previous_cursor_screen_pos: Option<((u16, u16), LeafId)>,
     /// ID of the most recent cursor-jump animation, kept so successive jumps
     /// cancel the prior one instead of stacking trail effects.
     pub(crate) cursor_jump_animation: Option<crate::view::animation::AnimationId>,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1170,8 +1170,8 @@ pub struct Editor {
     /// detect "jumps" (search, goto-line, click, goto-definition, focus
     /// change between splits, tab/buffer switch, etc.) and animate the
     /// cursor moving from its old screen position to its new one. Cross-
-    /// pane jumps animate unconditionally; same-pane jumps animate only
-    /// when the cursor moved more than two rows.
+    /// pane jumps animate unconditionally; same-pane jumps animate when
+    /// the cursor moved more than two rows or at least ten columns.
     pub(crate) previous_cursor_screen_pos: Option<((u16, u16), LeafId)>,
     /// ID of the most recent cursor-jump animation, kept so successive jumps
     /// cancel the prior one instead of stacking trail effects.

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -493,13 +493,11 @@ impl Editor {
         drop(_content_span);
 
         // Cursor-jump animation: compare the cursor's screen position to
-        // the prior frame and, if the user moved it non-incrementally
-        // (search match, goto-line, click, goto-definition, focus change
-        // between split panes, tab switch, etc.), kick off a short trail
-        // effect from the old to the new screen cell. The trail crosses
-        // pane separators when the jump is across splits — that's the
-        // intended "follow the focus" cue.
-        self.maybe_start_cursor_jump_animation(pending_hardware_cursor);
+        // the prior frame and animate either when the cursor crossed split
+        // panes or moved more than two rows within the same pane. The
+        // trail crosses pane separators when the jump is across splits —
+        // that's the intended "follow the focus" cue.
+        self.maybe_start_cursor_jump_animation(pending_hardware_cursor, active_split);
 
         // Detect viewport changes and fire hooks
         // Compare against previous frame's viewport state (stored in self.previous_viewports)
@@ -1241,13 +1239,17 @@ impl Editor {
     /// (small `dx`/`dy`) must NOT trigger the animation, but search jumps,
     /// goto-line/definition, and pane switches (which always cross several
     /// rows or many columns) must.
-    fn maybe_start_cursor_jump_animation(&mut self, current_pos: Option<(u16, u16)>) {
+    fn maybe_start_cursor_jump_animation(
+        &mut self,
+        current_pos: Option<(u16, u16)>,
+        active_split: crate::model::event::LeafId,
+    ) {
         // Honour the global animations toggle. Tests default to
         // `animations = false` so single-tick `render()` calls observe the
         // settled buffer instead of a mid-flight trail; users can also
         // disable animations entirely from config.
         if !self.config.editor.animations {
-            self.previous_cursor_screen_pos = current_pos;
+            self.previous_cursor_screen_pos = current_pos.map(|p| (p, active_split));
             return;
         }
 
@@ -1259,25 +1261,26 @@ impl Editor {
             return;
         };
 
-        let prev_pos = self.previous_cursor_screen_pos;
+        let prev_entry = self.previous_cursor_screen_pos;
         // Update tracking unconditionally for the next frame.
-        self.previous_cursor_screen_pos = Some(current);
+        self.previous_cursor_screen_pos = Some((current, active_split));
 
-        let Some(prev) = prev_pos else {
+        let Some((prev, prev_split)) = prev_entry else {
             return;
         };
-        if prev == current {
+        if prev == current && prev_split == active_split {
             return;
         }
 
         let dx = (current.0 as i32 - prev.0 as i32).abs();
         let dy = (current.1 as i32 - prev.1 as i32).abs();
-        // Heuristic: animate only when the move is clearly non-incremental.
-        // Typing / arrow keys produce |dx|<=1 and |dy|<=1; word-jump and
-        // home/end on short lines produce small dx; we want to skip those
-        // and animate jumps that visibly cross the screen.
-        let is_jump = dy >= 3 || dx >= 10;
-        if !is_jump {
+        // Animate only when the cursor crossed split panes, or when it
+        // moved more than two rows within the same pane. Small horizontal
+        // moves and short vertical hops (typing, arrow keys, word-jump,
+        // home/end on short lines) are intentionally skipped.
+        let crossed_panes = prev_split != active_split;
+        let row_jump = dy > 2;
+        if !crossed_panes && !row_jump {
             return;
         }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1274,13 +1274,15 @@ impl Editor {
 
         let dx = (current.0 as i32 - prev.0 as i32).abs();
         let dy = (current.1 as i32 - prev.1 as i32).abs();
-        // Animate only when the cursor crossed split panes, or when it
-        // moved more than two rows within the same pane. Small horizontal
-        // moves and short vertical hops (typing, arrow keys, word-jump,
-        // home/end on short lines) are intentionally skipped.
+        // Animate when the cursor crossed split panes, or when it made a
+        // non-incremental move within the same pane: more than two rows
+        // vertically, or at least ten columns horizontally. Small hops
+        // (typing, arrow keys, word-jump, home/end on short lines) are
+        // intentionally skipped.
         let crossed_panes = prev_split != active_split;
         let row_jump = dy > 2;
-        if !crossed_panes && !row_jump {
+        let col_jump = dx >= 10;
+        if !crossed_panes && !row_jump && !col_jump {
             return;
         }
 


### PR DESCRIPTION
## Summary
This PR refines the cursor-jump animation logic to properly account for split pane context. The animation now tracks both the cursor's screen position and which split pane owned the cursor, enabling more intelligent decisions about when to animate.

## Key Changes
- **Track active split with cursor position**: Modified `previous_cursor_screen_pos` to store both the screen coordinates `(u16, u16)` and the `LeafId` of the active split pane, changing the type from `Option<(u16, u16)>` to `Option<((u16, u16), LeafId)>`

- **Updated animation trigger logic**: Refined the heuristic for when to animate cursor jumps:
  - **Always animate** when the cursor crosses between split panes (regardless of distance)
  - **Animate within same pane** only for non-incremental moves: more than 2 rows vertically OR at least 10 columns horizontally
  - This replaces the previous threshold of `dy >= 3 || dx >= 10` with clearer semantics

- **Pass active split context**: Updated `maybe_start_cursor_jump_animation()` to accept the `active_split` parameter, allowing it to determine whether a cursor movement crossed pane boundaries

- **Improved documentation**: Updated comments to clarify the new behavior and distinguish between cross-pane jumps (always animated) and same-pane jumps (animated only for significant moves)

## Implementation Details
The change makes the animation behavior more predictable by explicitly handling the split-pane case. Cross-pane cursor movements (which represent focus changes between splits) now always trigger the animation as a visual "follow the focus" cue, while same-pane movements use a stricter threshold to avoid animating minor cursor movements like typing or arrow-key navigation.

https://claude.ai/code/session_01Tn3LrEoW3ddGSNEotpvEr4