### PR TITLE
refactor(plugin-runtime): extract request_id() and deduplicate response dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,6 +1491,7 @@ dependencies = [
  "oxc_span",
  "rquickjs",
  "rquickjs-serde",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -278,6 +278,23 @@ pub enum PluginResponse {
     },
 }
 
+impl PluginResponse {
+    pub fn request_id(&self) -> u64 {
+        match self {
+            Self::VirtualBufferCreated { request_id, .. }
+            | Self::TerminalCreated { request_id, .. }
+            | Self::LspRequest { request_id, .. }
+            | Self::HighlightsComputed { request_id, .. }
+            | Self::BufferText { request_id, .. }
+            | Self::LineStartPosition { request_id, .. }
+            | Self::LineEndPosition { request_id, .. }
+            | Self::BufferLineCount { request_id, .. }
+            | Self::CompositeBufferCreated { request_id, .. }
+            | Self::SplitByLabel { request_id, .. } => *request_id,
+        }
+    }
+}
+
 /// Messages sent from async plugin tasks to the synchronous main loop
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]

--- a/crates/fresh-plugin-runtime/Cargo.toml
+++ b/crates/fresh-plugin-runtime/Cargo.toml
@@ -11,6 +11,7 @@ description = "JavaScript plugin runtime for Fresh editor"
 [dependencies]
 rquickjs.workspace = true
 rquickjs-serde.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 jsonc-parser.workspace = true
 tokio.workspace = true

--- a/crates/fresh-plugin-runtime/src/thread.rs
+++ b/crates/fresh-plugin-runtime/src/thread.rs
@@ -12,7 +12,7 @@
 use crate::backend::quickjs_backend::{AsyncResourceOwners, PendingResponses, TsPluginInfo};
 use crate::backend::QuickJsBackend;
 use anyhow::{anyhow, Result};
-use fresh_core::api::{EditorStateSnapshot, PluginCommand};
+use fresh_core::api::{EditorStateSnapshot, JsCallbackId, PluginCommand};
 use fresh_core::hooks::HookArgs;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -350,7 +350,7 @@ impl PluginThreadHandle {
         }
 
         // If not found, it must be a JS callback
-        use fresh_core::api::{JsCallbackId, PluginResponse};
+        use fresh_core::api::PluginResponse;
 
         match response {
             PluginResponse::VirtualBufferCreated {
@@ -379,8 +379,7 @@ impl PluginThreadHandle {
                 }
             },
             PluginResponse::HighlightsComputed { request_id, spans } => {
-                let result = serde_json::to_string(&spans).unwrap_or_else(|_| "[]".to_string());
-                self.resolve_callback(JsCallbackId(request_id), result);
+                self.resolve_json_callback(request_id, &spans, "[]");
             }
             PluginResponse::BufferText { request_id, text } => match text {
                 Ok(content) => {
@@ -409,24 +408,16 @@ impl PluginThreadHandle {
                 request_id,
                 position,
             } => {
-                // Return the position as a number or null
-                let result =
-                    serde_json::to_string(&position).unwrap_or_else(|_| "null".to_string());
-                self.resolve_callback(JsCallbackId(request_id), result);
+                self.resolve_json_callback(request_id, position, "null");
             }
             PluginResponse::LineEndPosition {
                 request_id,
                 position,
             } => {
-                // Return the position as a number or null
-                let result =
-                    serde_json::to_string(&position).unwrap_or_else(|_| "null".to_string());
-                self.resolve_callback(JsCallbackId(request_id), result);
+                self.resolve_json_callback(request_id, position, "null");
             }
             PluginResponse::BufferLineCount { request_id, count } => {
-                // Return the count as a number or null
-                let result = serde_json::to_string(&count).unwrap_or_else(|_| "null".to_string());
-                self.resolve_callback(JsCallbackId(request_id), result);
+                self.resolve_json_callback(request_id, count, "null");
             }
             PluginResponse::TerminalCreated {
                 request_id,
@@ -447,11 +438,16 @@ impl PluginThreadHandle {
                 request_id,
                 split_id,
             } => {
-                let result = serde_json::to_string(&split_id.map(|s| s.0))
-                    .unwrap_or_else(|_| "null".to_string());
-                self.resolve_callback(JsCallbackId(request_id), result);
+                self.resolve_json_callback(request_id, split_id.map(|s| s.0), "null");
             }
         }
+    }
+
+    /// Serialize `value` to JSON and resolve a JS callback with the result.
+    /// Uses `fallback` as the JSON string if serialization fails.
+    fn resolve_json_callback(&self, request_id: u64, value: impl serde::Serialize, fallback: &str) {
+        let result = serde_json::to_string(&value).unwrap_or_else(|_| fallback.to_string());
+        self.resolve_callback(JsCallbackId(request_id), result);
     }
 
     /// Look up the plugin that owns a request_id and send a TrackAsyncResource
@@ -826,19 +822,7 @@ fn respond_to_pending(
     pending_responses: &PendingResponses,
     response: fresh_core::api::PluginResponse,
 ) -> bool {
-    let request_id = match &response {
-        fresh_core::api::PluginResponse::VirtualBufferCreated { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::LspRequest { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::HighlightsComputed { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::BufferText { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::CompositeBufferCreated { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::LineStartPosition { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::LineEndPosition { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::BufferLineCount { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::TerminalCreated { request_id, .. } => *request_id,
-        fresh_core::api::PluginResponse::SplitByLabel { request_id, .. } => *request_id,
-    };
-
+    let request_id = response.request_id();
     let sender = {
         let mut pending = pending_responses.lock().unwrap();
         pending.remove(&request_id)


### PR DESCRIPTION
## Summary

**File targeted:** `crates/fresh-plugin-runtime/src/thread.rs` (1803 lines)

**The offense — "Copy-Paste Specialist" + redundant field-extraction match:**

1. `respond_to_pending` contained a 10-arm exhaustive `match` whose sole purpose was extracting the `request_id` field that is present in *every* `PluginResponse` variant. Any new variant added to the enum immediately breaks compilation here, even though the logic is always the same.

2. `deliver_response` repeated the same `serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string())` + `resolve_callback` pattern verbatim across five arms (`HighlightsComputed`, `LineStartPosition`, `LineEndPosition`, `BufferLineCount`, `SplitByLabel`).

## Changes

- **`fresh-core/src/api.rs`** — add `PluginResponse::request_id() -> u64`: a single method that consolidates the field extraction. New variants automatically satisfy the exhaustiveness check here rather than silently adding an 11th arm elsewhere.

- **`fresh-plugin-runtime/src/thread.rs`**
  - `respond_to_pending`: 10-arm match → 1 method call (`response.request_id()`)
  - Add private `resolve_json_callback(request_id, value: impl Serialize, fallback)` helper
  - Replace the five copy-pasted serialize-then-callback blocks with calls to the helper

- **`fresh-plugin-runtime/Cargo.toml`** — declare `serde` as a direct dependency (was already present transitively; explicit declaration is required to use `impl serde::Serialize` as a bound)

## Test plan

- [ ] CI compilation passes (no logic was changed, only structure)
- [ ] Existing plugin-runtime tests (`respond_to_pending_sends_lsp_response`, `respond_to_pending_handles_virtual_buffer_created`) continue to pass
- [ ] `cargo clippy` clean on the two modified crates

https://claude.ai/code/session_01D7ameYysy9gz4eBvB6tfhE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7ameYysy9gz4eBvB6tfhE)_