### PR TITLE
fix(popup): never grab keyboard focus when LSP popup auto-shows

### DIFF
--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -1342,6 +1342,14 @@
       "when": "popup"
     },
     {
+      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke)",
+      "key": "t",
+      "modifiers": ["alt"],
+      "action": "popup_focus",
+      "args": {},
+      "when": "global"
+    },
+    {
       "comment": "Completion popup context - Tab accepts the selected completion",
       "key": "Tab",
       "modifiers": [],

--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -1342,12 +1342,19 @@
       "when": "popup"
     },
     {
-      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke)",
+      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke). Bound in normal/fileExplorer rather than global so a user's own alt+t binding in either context wins at the same precedence level — global defaults would shadow the user's normal-context override.",
       "key": "t",
       "modifiers": ["alt"],
       "action": "popup_focus",
       "args": {},
-      "when": "global"
+      "when": "normal"
+    },
+    {
+      "key": "t",
+      "modifiers": ["alt"],
+      "action": "popup_focus",
+      "args": {},
+      "when": "fileExplorer"
     },
     {
       "comment": "Completion popup context - Tab accepts the selected completion",

--- a/crates/fresh-editor/keymaps/emacs.json
+++ b/crates/fresh-editor/keymaps/emacs.json
@@ -133,6 +133,14 @@
       "when": "popup"
     },
     {
+      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke)",
+      "key": "t",
+      "modifiers": ["alt"],
+      "action": "popup_focus",
+      "args": {},
+      "when": "global"
+    },
+    {
       "key": "g",
       "modifiers": ["ctrl"],
       "action": "focus_editor",

--- a/crates/fresh-editor/keymaps/emacs.json
+++ b/crates/fresh-editor/keymaps/emacs.json
@@ -133,12 +133,19 @@
       "when": "popup"
     },
     {
-      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke)",
+      "comment": "Transfer keyboard focus to the topmost popup (LSP popups appear unfocused so they don't swallow the next keystroke). Scoped to non-modal contexts so a user-overridden alt+t in normal/fileExplorer still wins at the same precedence level.",
       "key": "t",
       "modifiers": ["alt"],
       "action": "popup_focus",
       "args": {},
-      "when": "global"
+      "when": "normal"
+    },
+    {
+      "key": "t",
+      "modifiers": ["alt"],
+      "action": "popup_focus",
+      "args": {},
+      "when": "fileExplorer"
     },
     {
       "key": "g",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Vyskakovací okno stránka nahoru",
   "action.popup_select_next": "Vybrat další v okně",
   "action.popup_select_prev": "Vybrat předchozí v okně",
+  "action.popup_focus": "Aktivovat vyskakovací okno",
   "action.prev_buffer": "Předchozí buffer",
   "action.prev_split": "Předchozí rozdělení",
   "action.prompt_accept_suggestion": "Přijmout návrh v příkazovém řádku",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Popup Seite nach oben",
   "action.popup_select_next": "Popup nächstes auswählen",
   "action.popup_select_prev": "Popup vorheriges auswählen",
+  "action.popup_focus": "Popup fokussieren",
   "action.prev_buffer": "Vorheriger Buffer",
   "action.prev_split": "Vorherige Teilung",
   "action.prompt_accept_suggestion": "Eingabe: Vorschlag annehmen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -136,6 +136,7 @@
   "action.popup_page_up": "Popup page up",
   "action.popup_select_next": "Popup select next",
   "action.popup_select_prev": "Popup select previous",
+  "action.popup_focus": "Focus popup",
   "action.prev_buffer": "Previous buffer",
   "action.prev_split": "Previous split",
   "action.prompt_accept_suggestion": "Prompt accept suggestion",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Popup página arriba",
   "action.popup_select_next": "Seleccionar siguiente en popup",
   "action.popup_select_prev": "Seleccionar anterior en popup",
+  "action.popup_focus": "Enfocar popup",
   "action.prev_buffer": "Buffer anterior",
   "action.prev_split": "División anterior",
   "action.prompt_accept_suggestion": "Aceptar sugerencia en prompt",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Fenêtre contextuelle : page précédente",
   "action.popup_select_next": "Fenêtre contextuelle : sélectionner le suivant",
   "action.popup_select_prev": "Fenêtre contextuelle : sélectionner le précédent",
+  "action.popup_focus": "Focaliser la fenêtre contextuelle",
   "action.prev_buffer": "Tampon précédent",
   "action.prev_split": "Division précédente",
   "action.prompt_accept_suggestion": "Invite : accepter la suggestion",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Pagina su popup",
   "action.popup_select_next": "Seleziona prossimo popup",
   "action.popup_select_prev": "Seleziona precedente popup",
+  "action.popup_focus": "Metti a fuoco il popup",
   "action.prev_buffer": "Buffer precedente",
   "action.prev_split": "Divisione precedente",
   "action.prompt_accept_suggestion": "Prompt: accetta suggerimento",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "ポップアップをページアップ",
   "action.popup_select_next": "ポップアップで次を選択",
   "action.popup_select_prev": "ポップアップで前を選択",
+  "action.popup_focus": "ポップアップにフォーカス",
   "action.prev_buffer": "前のバッファ",
   "action.prev_split": "前の分割",
   "action.prompt_accept_suggestion": "プロンプトで候補を受け入れ",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "팝업 페이지 위로",
   "action.popup_select_next": "팝업 다음 선택",
   "action.popup_select_prev": "팝업 이전 선택",
+  "action.popup_focus": "팝업에 포커스",
   "action.prev_buffer": "이전 버퍼",
   "action.prev_split": "이전 분할",
   "action.prompt_accept_suggestion": "프롬프트 제안 수락",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Popup página para cima",
   "action.popup_select_next": "Popup selecionar próximo",
   "action.popup_select_prev": "Popup selecionar anterior",
+  "action.popup_focus": "Focar popup",
   "action.prev_buffer": "Buffer anterior",
   "action.prev_split": "Divisão anterior",
   "action.prompt_accept_suggestion": "Prompt aceitar sugestão",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Всплывающее окно: страница вверх",
   "action.popup_select_next": "Выбрать следующий во всплывающем окне",
   "action.popup_select_prev": "Выбрать предыдущий во всплывающем окне",
+  "action.popup_focus": "Перевести фокус на всплывающее окно",
   "action.prev_buffer": "Предыдущий буфер",
   "action.prev_split": "Предыдущее разделение",
   "action.prompt_accept_suggestion": "Принять предложение в строке ввода",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "ป๊อปอัพขึ้นหนึ่งหน้า",
   "action.popup_select_next": "เลือกถัดไปในป๊อปอัพ",
   "action.popup_select_prev": "เลือกก่อนหน้าในป๊อปอัพ",
+  "action.popup_focus": "โฟกัสที่ป๊อปอัพ",
   "action.prev_buffer": "บัฟเฟอร์ก่อนหน้า",
   "action.prev_split": "การแบ่งก่อนหน้า",
   "action.prompt_accept_suggestion": "ยอมรับข้อเสนอในพรอมต์",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Спливаюче вікно: сторінка вгору",
   "action.popup_select_next": "Спливаюче вікно: вибрати наступний",
   "action.popup_select_prev": "Спливаюче вікно: вибрати попередній",
+  "action.popup_focus": "Перевести фокус на спливаюче вікно",
   "action.prev_buffer": "Попередній буфер",
   "action.prev_split": "Попереднє розділення",
   "action.prompt_accept_suggestion": "Прийняти пропозицію",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "Popup trang lên",
   "action.popup_select_next": "Popup chọn tiếp theo",
   "action.popup_select_prev": "Popup chọn trước đó",
+  "action.popup_focus": "Tập trung vào popup",
   "action.prev_buffer": "Buffer trước đó",
   "action.prev_split": "Chia màn hình trước đó",
   "action.prompt_accept_suggestion": "Chấp nhận gợi ý prompt",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -139,6 +139,7 @@
   "action.popup_page_up": "弹窗向上翻页",
   "action.popup_select_next": "弹窗选择下一个",
   "action.popup_select_prev": "弹窗选择上一个",
+  "action.popup_focus": "聚焦弹窗",
   "action.prev_buffer": "上一个缓冲区",
   "action.prev_split": "上一个分割",
   "action.prompt_accept_suggestion": "提示接受建议",

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -73,11 +73,16 @@ impl Editor {
     /// Whether editor-pane popups (LSP completion, hover, signature help,
     /// global plugin popups, …) should intercept keyboard input.
     ///
-    /// Returns `false` when the user has focus on the file explorer pane:
-    /// popups belong to the editor pane, and the explorer must own its own
-    /// keystrokes — otherwise an LSP completion popup that happened to be
-    /// open would silently swallow Down/Up while the user is browsing the
-    /// tree. Buffer-switch handlers (e.g. `open_file_preview`) clear stale
+    /// Returns `false` when:
+    ///   - the user has focus on the file explorer pane (popups belong
+    ///     to the editor pane, and the explorer must own its own
+    ///     keystrokes), or
+    ///   - the topmost visible popup is unfocused (LSP popups appear
+    ///     unfocused so they don't silently swallow the next keystroke;
+    ///     the user grabs focus explicitly with `popup_focus`,
+    ///     default `Alt+T`).
+    ///
+    /// Buffer-switch handlers (e.g. `open_file_preview`) clear stale
     /// popups so a popup tied to the previous preview doesn't follow the
     /// user across buffers.
     ///
@@ -85,7 +90,65 @@ impl Editor {
     /// and `dispatch_modal_input` (handler routing) so the two cannot drift.
     pub(crate) fn popups_capture_keys(&self) -> bool {
         use crate::input::keybindings::KeyContext;
-        !matches!(self.key_context, KeyContext::FileExplorer)
+        if matches!(self.key_context, KeyContext::FileExplorer) {
+            return false;
+        }
+        self.topmost_popup_focused()
+    }
+
+    /// Whether the topmost visible popup (global stack first, then the
+    /// active buffer's stack) has been marked focused. Returns `false`
+    /// when no popup is visible — the caller is responsible for
+    /// short-circuiting that case.
+    pub(crate) fn topmost_popup_focused(&self) -> bool {
+        if let Some(popup) = self.global_popups.top() {
+            return popup.focused;
+        }
+        if let Some(popup) = self.active_state().popups.top() {
+            return popup.focused;
+        }
+        // No popup → no capture. Returning `false` here is safe because
+        // every caller gates on visibility before reaching this path.
+        false
+    }
+
+    /// When an *unfocused* popup is on screen, resolve the key event
+    /// against `KeyContext::Popup`/`Global` so the user's bound
+    /// `popup_cancel` (default Esc) and `popup_focus` (default Alt+T)
+    /// keys still take effect even though the popup isn't claiming the
+    /// keyboard. Without this, dismissing an LSP auto-prompt with Esc
+    /// would silently fall through to the buffer.
+    ///
+    /// Returns `None` for any other action so type-to-filter, cursor
+    /// motion, etc. continue to drive the buffer.
+    pub(crate) fn resolve_unfocused_popup_action(
+        &self,
+        event: &crossterm::event::KeyEvent,
+    ) -> Option<crate::input::keybindings::Action> {
+        use crate::input::keybindings::{Action, KeyContext};
+
+        let popup_visible =
+            self.global_popups.is_visible() || self.active_state().popups.is_visible();
+        if !popup_visible || self.topmost_popup_focused() {
+            return None;
+        }
+
+        let kb = self.keybindings.read().ok()?;
+        let resolved_popup = kb.resolve_in_context_only(event, KeyContext::Popup);
+        if let Some(action @ Action::PopupCancel) = resolved_popup {
+            return Some(action);
+        }
+        // `popup_focus` lives in the Global context by default so it
+        // works in any UI state; check Global first, then fall through
+        // to Popup for users who scope it explicitly.
+        let resolved_global = kb.resolve_in_context_only(event, KeyContext::Global);
+        if matches!(resolved_global, Some(Action::PopupFocus)) {
+            return resolved_global;
+        }
+        if matches!(resolved_popup, Some(Action::PopupFocus)) {
+            return resolved_popup;
+        }
+        None
     }
 
     /// Resolve a key event against `KeyContext::Completion` when the topmost
@@ -219,8 +282,17 @@ impl Editor {
         let mut context = self.get_key_context();
 
         // Special case: Hover and Signature Help popups should be dismissed on any key press
-        // EXCEPT for Ctrl+C when the popup has a text selection (allow copy first)
-        if matches!(context, crate::input::keybindings::KeyContext::Popup) {
+        // EXCEPT for Ctrl+C when the popup has a text selection (allow copy first).
+        //
+        // Fires for both focused and unfocused popups: an unfocused
+        // hover popup that floats over the buffer must still vanish when
+        // the user starts typing — otherwise it lingers indefinitely
+        // because no key event reaches it. The focused-popup path also
+        // covers the legacy case where a transient popup was given
+        // focus (e.g. via the focus-popup keybinding).
+        let popup_visible_on_screen =
+            self.global_popups.is_visible() || self.active_state().popups.is_visible();
+        if popup_visible_on_screen {
             // Check if the current popup is transient (hover, signature help).
             // Editor-level popups always take precedence over buffer popups
             // when both are visible — they're effectively modal overlays.
@@ -241,13 +313,37 @@ impl Editor {
                     .modifiers
                     .contains(crossterm::event::KeyModifiers::CONTROL);
 
-            if is_transient_popup && !(has_selection && is_copy_key) {
+            // Skip the dismiss when the user is *transferring* focus to
+            // the popup — otherwise pressing the focus-popup key while
+            // a transient popup is on screen would close the popup
+            // before its handler ever sees the focus action.
+            let resolved_action = self
+                .keybindings
+                .read()
+                .ok()
+                .map(|kb| kb.resolve(&key_event, context.clone()));
+            let is_focus_popup_key = matches!(
+                resolved_action,
+                Some(crate::input::keybindings::Action::PopupFocus)
+            );
+
+            if is_transient_popup && !(has_selection && is_copy_key) && !is_focus_popup_key {
                 // Dismiss the popup on any key press (except Ctrl+C with selection)
                 self.hide_popup();
                 tracing::debug!("Dismissed transient popup on key press");
                 // Recalculate context now that popup is gone
                 context = self.get_key_context();
             }
+        }
+
+        // Unfocused popup control: even though an unfocused popup
+        // doesn't claim the keyboard, the user's bound popup-cancel
+        // (default Esc) and popup-focus (default Alt+T) keys must
+        // still affect it. Resolved here, *before* the modal
+        // dispatcher routes the key to the buffer/explorer/etc.
+        if let Some(action) = self.resolve_unfocused_popup_action(&key_event) {
+            self.handle_action(action)?;
+            return Ok(());
         }
 
         // Try hierarchical modal input dispatch first (Settings, Menu, Prompt, Popup)
@@ -1643,6 +1739,9 @@ impl Editor {
             }
             Action::PopupCancel => {
                 self.handle_popup_cancel();
+            }
+            Action::PopupFocus => {
+                self.handle_popup_focus();
             }
             Action::CompletionAccept => {
                 use super::popup_actions::PopupConfirmResult;

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -146,21 +146,33 @@ impl Editor {
         }
 
         let kb = self.keybindings.read().ok()?;
+
+        // `popup_focus` lives in the Normal/FileExplorer context defaults
+        // (not Global) so a user's own binding for the same key in those
+        // contexts wins at the same precedence level. If the resolution
+        // here returns anything other than `PopupFocus`, it's the user's
+        // override — let the normal dispatcher handle it. Don't claim
+        // `popup_cancel` from Normal because Normal's default `Esc`
+        // resolves to `remove_secondary_cursors`, which would shadow the
+        // popup-dismiss intent here.
+        let popup_focus_match = matches!(
+            kb.resolve_in_context_only(event, self.key_context.clone()),
+            Some(Action::PopupFocus),
+        );
+        if popup_focus_match {
+            return Some(Action::PopupFocus);
+        }
+
+        // Fall back to the Popup context for `popup_cancel`. Esc
+        // (the default `popup_cancel` binding) should still dismiss
+        // an unfocused popup even though the popup itself isn't
+        // claiming the keyboard — that matches every other popup-
+        // dismissal affordance in the editor.
         let resolved_popup = kb.resolve_in_context_only(event, KeyContext::Popup);
-        if let Some(action @ Action::PopupCancel) = resolved_popup {
-            return Some(action);
+        match resolved_popup {
+            Some(action @ (Action::PopupCancel | Action::PopupFocus)) => Some(action),
+            _ => None,
         }
-        // `popup_focus` lives in the Global context by default so it
-        // works in any UI state; check Global first, then fall through
-        // to Popup for users who scope it explicitly.
-        let resolved_global = kb.resolve_in_context_only(event, KeyContext::Global);
-        if matches!(resolved_global, Some(Action::PopupFocus)) {
-            return resolved_global;
-        }
-        if matches!(resolved_popup, Some(Action::PopupFocus)) {
-            return resolved_popup;
-        }
-        None
     }
 
     /// Resolve a key event against `KeyContext::Completion` when the topmost

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -133,6 +133,18 @@ impl Editor {
             return None;
         }
 
+        // Higher-priority modal contexts (Settings, Menu, Prompt) own the
+        // keyboard regardless of whether a buffer popup happens to be
+        // visible underneath. Skip the unfocused-popup interception so
+        // pressing Esc in a settings dialog still closes the dialog
+        // rather than reaching past it to dismiss a stale popup.
+        if self.settings_state.as_ref().is_some_and(|s| s.visible)
+            || self.menu_state.active_menu.is_some()
+            || self.is_prompting()
+        {
+            return None;
+        }
+
         let kb = self.keybindings.read().ok()?;
         let resolved_popup = kb.resolve_in_context_only(event, KeyContext::Popup);
         if let Some(action @ Action::PopupCancel) = resolved_popup {

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -171,6 +171,7 @@ impl Editor {
         let popup_data =
             crate::app::popup_actions::build_completion_popup_from_items(all_popup_items, 0);
         let accept_hint = self.completion_accept_key_hint();
+        let focus_hint = self.popup_focus_key_hint();
 
         {
             let buffer_id = self.active_buffer();
@@ -179,6 +180,7 @@ impl Editor {
             let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
             popup_obj.accept_key_hint = accept_hint;
             popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
+            popup_obj.focus_key_hint = focus_hint;
             state.popups.show_or_replace(popup_obj);
         }
 
@@ -642,12 +644,14 @@ impl Editor {
 
         let popup_data = crate::app::popup_actions::build_completion_popup_from_items(items, 0);
         let accept_hint = self.completion_accept_key_hint();
+        let focus_hint = self.popup_focus_key_hint();
 
         let buffer_id = self.active_buffer();
         let state = self.buffers.get_mut(&buffer_id).unwrap();
         let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
         popup_obj.accept_key_hint = accept_hint;
         popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
+        popup_obj.focus_key_hint = focus_hint;
         state.popups.show_or_replace(popup_obj);
     }
 
@@ -1064,6 +1068,7 @@ impl Editor {
         popup.max_height = dynamic_height;
         popup.border_style = Style::default().fg(self.theme.popup_border_fg);
         popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.focus_key_hint = self.popup_focus_key_hint();
 
         // Show the popup
         if let Some(state) = self.buffers.get_mut(&self.active_buffer()) {
@@ -1462,6 +1467,7 @@ impl Editor {
         popup.max_height = 20;
         popup.border_style = Style::default().fg(self.theme.popup_border_fg);
         popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.focus_key_hint = self.popup_focus_key_hint();
 
         // Show the popup
         if let Some(state) = self.buffers.get_mut(&self.active_buffer()) {
@@ -1683,6 +1689,12 @@ impl Editor {
         // `self.pending_code_actions` — the heavy lsp_types payload
         // stays on the Editor to keep the view crate LSP-free.
         popup.resolver = crate::view::popup::PopupResolver::CodeAction;
+        // Code actions are an explicit user invocation (`lsp_code_actions`
+        // command); the user expects to choose immediately, so the popup
+        // grabs focus on creation. Unfocused-by-default behavior applies
+        // only to popups that *appear under the cursor* (completion,
+        // hover, signature help, the LSP-server auto-prompt).
+        popup.focused = true;
 
         // Show the popup, replacing any existing action popup to avoid stacking
         if let Some(state) = self.buffers.get_mut(&self.active_buffer()) {

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -344,6 +344,51 @@ impl Editor {
         Some("Tab".to_string())
     }
 
+    /// Format the keybinding currently bound to `Action::PopupFocus`,
+    /// rendered into popup titles when the popup is unfocused so the
+    /// user can see how to grab the keyboard. Falls back to `Alt+T`
+    /// (the default) when no binding is registered.
+    pub(crate) fn popup_focus_key_hint(&self) -> Option<String> {
+        let kb = self.keybindings.read().ok()?;
+        // The action is meant to fire in any context the user is in
+        // when an unfocused popup is on screen — i.e. Normal,
+        // FileExplorer, Terminal, etc. The keymap registers it under
+        // `KeyContext::Global` so it applies uniformly; look it up
+        // there first, then fall through to `Normal` for users who
+        // override the binding without specifying `when`.
+        kb.get_keybinding_for_action(
+            &crate::input::keybindings::Action::PopupFocus,
+            crate::input::keybindings::KeyContext::Global,
+        )
+        .or_else(|| {
+            kb.get_keybinding_for_action(
+                &crate::input::keybindings::Action::PopupFocus,
+                crate::input::keybindings::KeyContext::Normal,
+            )
+        })
+        .or_else(|| Some("Alt+T".to_string()))
+    }
+
+    /// Mark the topmost visible popup as focused so subsequent key
+    /// events route into the popup's input handler.
+    ///
+    /// Editor-level (global) popups shadow buffer popups for keyboard
+    /// focus, mirroring the priority encoded in `dispatch_modal_input`,
+    /// so we focus whichever popup the user actually sees.
+    ///
+    /// No-op when no popup is visible — the user pressing the
+    /// focus-popup key with nothing to focus shouldn't error or steal
+    /// the keystroke from the buffer.
+    pub fn handle_popup_focus(&mut self) {
+        if let Some(popup) = self.global_popups.top_mut() {
+            popup.focused = true;
+            return;
+        }
+        if let Some(popup) = self.active_state_mut().popups.top_mut() {
+            popup.focused = true;
+        }
+    }
+
     /// Handle typing a character while completion popup is open.
     /// Inserts the character into the buffer and re-filters the completion list.
     pub fn handle_popup_type_char(&mut self, c: char) {

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -350,20 +350,23 @@ impl Editor {
     /// (the default) when no binding is registered.
     pub(crate) fn popup_focus_key_hint(&self) -> Option<String> {
         let kb = self.keybindings.read().ok()?;
-        // The action is meant to fire in any context the user is in
-        // when an unfocused popup is on screen — i.e. Normal,
-        // FileExplorer, Terminal, etc. The keymap registers it under
-        // `KeyContext::Global` so it applies uniformly; look it up
-        // there first, then fall through to `Normal` for users who
-        // override the binding without specifying `when`.
+        // The keymap registers `popup_focus` in the `Normal` and
+        // `FileExplorer` contexts (not `Global`) so a user's own
+        // `alt+t` rebinding in those same contexts wins at the same
+        // precedence level — a Global default would shadow the
+        // override and silently swallow the user's keystroke. Look up
+        // Normal first (the most likely place a user is when the
+        // popup pops up), then fall through to FileExplorer, and
+        // finally to a hard-coded `Alt+T` so the title is never an
+        // empty parenthetical.
         kb.get_keybinding_for_action(
             &crate::input::keybindings::Action::PopupFocus,
-            crate::input::keybindings::KeyContext::Global,
+            crate::input::keybindings::KeyContext::Normal,
         )
         .or_else(|| {
             kb.get_keybinding_for_action(
                 &crate::input::keybindings::Action::PopupFocus,
-                crate::input::keybindings::KeyContext::Normal,
+                crate::input::keybindings::KeyContext::FileExplorer,
             )
         })
         .or_else(|| Some("Alt+T".to_string()))

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -602,6 +602,7 @@ impl Editor {
         use crate::view::popup::{Popup, PopupContent, PopupKind, PopupResolver};
         use ratatui::style::Style;
 
+        let focus_hint = self.popup_focus_key_hint();
         let popup = Popup {
             kind: PopupKind::List,
             title: Some(format!("LSP Servers ({})", language)),
@@ -624,6 +625,11 @@ impl Editor {
             // confirm/cancel routes through handle_lsp_status_action
             // regardless of what other popups are on screen.
             resolver: PopupResolver::LspStatus,
+            // LSP popups appear unfocused so they don't silently swallow
+            // the user's next keystroke; `popup_focus` (default Alt+T)
+            // grabs the keyboard.
+            focused: false,
+            focus_key_hint: focus_hint,
         };
 
         let buffer_id = self.active_buffer();
@@ -876,6 +882,10 @@ impl Editor {
             text_selection: None,
             accept_key_hint: None,
             resolver: PopupResolver::RemoteIndicator,
+            // Explicitly invoked from the status-bar `{remote}` element,
+            // so this popup wants the keyboard immediately.
+            focused: true,
+            focus_key_hint: None,
         };
 
         let buffer_id = self.active_buffer();

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -39,6 +39,10 @@ impl Editor {
 
     /// Show LSP status popup with details about servers active for the current buffer.
     /// Lists each server with its status and provides actions: restart, stop, view log.
+    ///
+    /// User-initiated (status-bar click, `lsp_status` action). The popup
+    /// grabs focus on show because the user explicitly asked for it,
+    /// matching the historical click-to-pick-action affordance.
     pub fn show_lsp_status_popup(&mut self) {
         // Toggle behavior: if the LSP popup is already showing, close it
         // instead of rebuilding and re-showing it.  This lets clicking the
@@ -98,7 +102,7 @@ impl Editor {
             },
         );
 
-        self.build_and_show_lsp_status_popup(&language);
+        self.build_and_show_lsp_status_popup(&language, true);
     }
 
     /// If an auto-start prompt is queued for the active buffer's
@@ -175,7 +179,20 @@ impl Editor {
             }
         }
 
-        self.show_lsp_status_popup();
+        // Auto-prompt on file open: build the popup *unfocused* so it
+        // doesn't silently swallow the user's next keystroke. The user
+        // can grab the keyboard with `popup_focus` (default Alt+T) or
+        // dismiss with Esc. We bypass `show_lsp_status_popup` (which
+        // toggles + grabs focus) and go straight to the builder; the
+        // visibility precondition is already satisfied by the active-
+        // buffer popup-stack check above.
+        let language = self
+            .buffers
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone());
+        if let Some(language) = language {
+            self.build_and_show_lsp_status_popup(&language, false);
+        }
     }
 
     /// Rebuild the LSP-status popup in place if it's currently open.
@@ -202,12 +219,22 @@ impl Editor {
             .get(&self.active_buffer())
             .map(|s| s.language.clone())
             .unwrap_or_else(|| "unknown".to_string());
-        // Replace contents: hide then rebuild.
+        // Replace contents: hide then rebuild. Refresh is triggered by
+        // async progress updates while the popup is already on screen,
+        // so we keep its existing focused state — flipping it back to
+        // unfocused on every progress tick would yank focus away from
+        // a user mid-interaction.
+        let was_focused = self
+            .active_state()
+            .popups
+            .top()
+            .map(|p| p.focused)
+            .unwrap_or(true);
         self.hide_popup();
-        self.build_and_show_lsp_status_popup(&language);
+        self.build_and_show_lsp_status_popup(&language, was_focused);
     }
 
-    fn build_and_show_lsp_status_popup(&mut self, language: &str) {
+    fn build_and_show_lsp_status_popup(&mut self, language: &str, focused: bool) {
         use crate::services::async_bridge::LspServerStatus;
 
         // Build a unified list of all configured servers for this language,
@@ -602,7 +629,11 @@ impl Editor {
         use crate::view::popup::{Popup, PopupContent, PopupKind, PopupResolver};
         use ratatui::style::Style;
 
-        let focus_hint = self.popup_focus_key_hint();
+        let focus_hint = if !focused {
+            self.popup_focus_key_hint()
+        } else {
+            None
+        };
         let popup = Popup {
             kind: PopupKind::List,
             title: Some(format!("LSP Servers ({})", language)),
@@ -625,10 +656,11 @@ impl Editor {
             // confirm/cancel routes through handle_lsp_status_action
             // regardless of what other popups are on screen.
             resolver: PopupResolver::LspStatus,
-            // LSP popups appear unfocused so they don't silently swallow
-            // the user's next keystroke; `popup_focus` (default Alt+T)
-            // grabs the keyboard.
-            focused: false,
+            // Auto-prompt path appears unfocused so an LSP popup that
+            // pops up under the user's cursor does not silently swallow
+            // the next keystroke. User-initiated path (status-bar
+            // click, `lsp_status` action) grabs focus on show.
+            focused,
             focus_key_hint: focus_hint,
         };
 

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -78,6 +78,15 @@ impl Editor {
         let event = Event::ShowPopup { popup };
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
+        // Stamp the freshly-pushed popup with the user's actual
+        // focus-popup keybinding so the title hint reflects the
+        // configured key (default `Alt+T`). The PopupData event itself
+        // doesn't carry this — it's a view-layer concern set after the
+        // converter pushes the Popup onto the active buffer's stack.
+        let hint = self.popup_focus_key_hint();
+        if let Some(top) = self.active_state_mut().popups.top_mut() {
+            top.focus_key_hint = hint;
+        }
     }
 
     /// Show a popup and attach a confirm/cancel resolver to it. The

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -3067,6 +3067,7 @@ pub fn action_to_events(
         | Action::PopupPageDown
         | Action::PopupConfirm
         | Action::PopupCancel
+        | Action::PopupFocus
         | Action::CompletionAccept
         | Action::CompletionDismiss
         | Action::ToggleFileExplorer

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -553,6 +553,11 @@ pub enum Action {
     PopupPageDown,
     PopupConfirm,
     PopupCancel,
+    /// Transfer keyboard focus to the topmost visible popup. LSP popups
+    /// are shown unfocused (so they don't silently swallow keystrokes);
+    /// this action lets the user grab them with the keyboard. Default
+    /// binding is `Alt+T` and is configurable via the keybinding map.
+    PopupFocus,
 
     // Completion popup actions (override generic Popup keys for PopupKind::Completion)
     CompletionAccept,
@@ -996,6 +1001,7 @@ impl Action {
             "popup_page_down" => PopupPageDown,
             "popup_confirm" => PopupConfirm,
             "popup_cancel" => PopupCancel,
+            "popup_focus" => PopupFocus,
 
             "completion_accept" => CompletionAccept,
             "completion_dismiss" => CompletionDismiss,
@@ -2287,6 +2293,7 @@ impl KeybindingResolver {
             Action::PopupPageDown => t!("action.popup_page_down"),
             Action::PopupConfirm => t!("action.popup_confirm"),
             Action::PopupCancel => t!("action.popup_cancel"),
+            Action::PopupFocus => t!("action.popup_focus"),
             Action::CompletionAccept => t!("action.completion_accept"),
             Action::CompletionDismiss => t!("action.completion_dismiss"),
             Action::ToggleFileExplorer => t!("action.toggle_file_explorer"),

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -1080,6 +1080,34 @@ pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
         _ => crate::view::popup::PopupResolver::None,
     };
 
+    // Popups that appear under the user's cursor without an explicit
+    // user gesture default to *unfocused* so the next keystroke drives
+    // the buffer rather than the popup. The user grabs focus with
+    // `popup_focus` (default `Alt+T`). Popups that the user
+    // *explicitly* invokes (completion via Tab, list/action choosers
+    // via plugin commands, …) keep the historical focused-on-show
+    // behavior — type-to-filter and arrow-nav need to "just work"
+    // without an extra keystroke.
+    // Only `PopupKindHint` variants reach this path — Completion, List,
+    // Text. Hover/Action popups are constructed directly in editor code
+    // (`lsp_requests.rs`) and set their own `focused` flag.
+    let focused = match kind {
+        // Completion popups are user-invoked (type-to-trigger / explicit
+        // `lsp_completion`), so type-to-filter and arrow-nav need to
+        // "just work" without the user pressing the focus-popup key.
+        PopupKind::Completion => true,
+        // List popups are typically explicit user invocations (plugin
+        // action popups, status-bar menus). Keep them focused on show.
+        PopupKind::List => true,
+        // Text popups are auto-shown informational overlays —
+        // unfocused so they don't swallow the user's next keystroke.
+        PopupKind::Text => false,
+        // Direct-construction kinds (Hover, Action) are not produced by
+        // `Event::ShowPopup`; default to unfocused if ever reached so
+        // an auto-shown overlay doesn't grab the keyboard by accident.
+        PopupKind::Hover | PopupKind::Action => false,
+    };
+
     Popup {
         kind,
         title: data.title.clone(),
@@ -1096,6 +1124,8 @@ pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
         text_selection: None,
         accept_key_hint: None,
         resolver,
+        focused,
+        focus_key_hint: None,
     }
 }
 

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -262,6 +262,23 @@ pub struct Popup {
     /// Feature-specific resolver for confirm/cancel dispatch. Default
     /// `None` means "no special handling — just dismiss."
     pub resolver: PopupResolver,
+
+    /// Whether the popup currently has keyboard focus.
+    ///
+    /// LSP-spawned popups (completion, hover, signature help, the
+    /// LSP-server status auto-prompt) are created with `focused = false`
+    /// so a popup that pops up under the user's cursor does not silently
+    /// swallow their next keystroke. The user explicitly transfers
+    /// focus to the popup with the `popup_focus` action (default
+    /// binding `Alt+T`); only then do popup-context bindings apply.
+    pub focused: bool,
+
+    /// Pre-rendered key hint for the `popup_focus` action shown in the
+    /// title when `focused == false` (e.g. `"Alt+T"`). `None` falls back
+    /// to a built-in default at render time. Set by the editor when
+    /// constructing the popup so the hint reflects the user's actual
+    /// keybinding for `popup_focus`.
+    pub focus_key_hint: Option<String>,
 }
 
 impl Popup {
@@ -283,6 +300,8 @@ impl Popup {
             text_selection: None,
             accept_key_hint: None,
             resolver: PopupResolver::None,
+            focused: false,
+            focus_key_hint: None,
         }
     }
 
@@ -312,6 +331,8 @@ impl Popup {
             text_selection: None,
             accept_key_hint: None,
             resolver: PopupResolver::None,
+            focused: false,
+            focus_key_hint: None,
         }
     }
 
@@ -333,6 +354,8 @@ impl Popup {
             text_selection: None,
             accept_key_hint: None,
             resolver: PopupResolver::None,
+            focused: false,
+            focus_key_hint: None,
         }
     }
 
@@ -383,6 +406,46 @@ impl Popup {
     pub fn with_resolver(mut self, resolver: PopupResolver) -> Self {
         self.resolver = resolver;
         self
+    }
+
+    /// Mark the popup as keyboard-focused (so popup-context bindings
+    /// route through it). LSP popups stay unfocused on creation; the
+    /// user toggles focus with the `popup_focus` action.
+    pub fn with_focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    /// Pre-render the focus-key hint shown in the popup title when the
+    /// popup is unfocused.
+    pub fn with_focus_key_hint(mut self, hint: String) -> Self {
+        self.focus_key_hint = Some(hint);
+        self
+    }
+
+    /// Compose the title text actually shown on the popup border.
+    ///
+    /// When the popup is unfocused, the focus-key hint (e.g. `"Alt+T"`)
+    /// is appended so the user knows how to grab the popup with the
+    /// keyboard. The hint falls back to a built-in label when no
+    /// `focus_key_hint` is set, so the title never reads as an empty
+    /// parenthetical.
+    pub fn render_title(&self) -> Option<String> {
+        let hint_label = if !self.focused {
+            let hint = self
+                .focus_key_hint
+                .clone()
+                .unwrap_or_else(|| "Alt+T".to_string());
+            Some(format!("[{} to focus]", hint))
+        } else {
+            None
+        };
+        match (&self.title, hint_label) {
+            (Some(title), Some(hint)) => Some(format!("{} {}", title, hint)),
+            (Some(title), None) => Some(title.clone()),
+            (None, Some(hint)) => Some(hint),
+            (None, None) => None,
+        }
     }
 
     /// Get the currently selected item (if this is a list popup)
@@ -954,14 +1017,15 @@ impl Popup {
         // Clear the area behind the popup first to hide underlying text
         frame.render_widget(Clear, area);
 
+        let rendered_title = self.render_title();
         let block = if self.bordered {
             let mut block = Block::default()
                 .borders(Borders::ALL)
                 .border_style(self.border_style)
                 .style(self.background_style);
 
-            if let Some(title) = &self.title {
-                block = block.title(title.as_str());
+            if let Some(title) = rendered_title.as_deref() {
+                block = block.title(title);
             }
 
             block

--- a/crates/fresh-editor/tests/e2e/lsp_popup_focus_keybinding.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_popup_focus_keybinding.rs
@@ -1,0 +1,211 @@
+//! Reproduces the focus-grab regression that surfaces when an LSP popup
+//! pops up over the active buffer: keystrokes used to be silently
+//! swallowed by the popup as soon as it became visible, even if the
+//! user was in the middle of typing or navigating with the cursor. The
+//! LSP auto-prompt that fires on `open_file` is the user-visible
+//! example, but the same focus-routing rule applies to every popup
+//! that pops up *under* the user's cursor without an explicit user
+//! gesture (hover docs, signature help, plugin Text overlays, …).
+//!
+//! The new contract:
+//!   1. Such popups are shown *unfocused*. Subsequent keystrokes drive
+//!      the buffer / explorer / etc., not the popup.
+//!   2. The popup title carries an `[Alt+T to focus]` hint so the user
+//!      knows how to grab it with the keyboard.
+//!   3. Pressing the configured popup-focus key (`Alt+T` by default)
+//!      transfers focus to the popup. The hint disappears once the
+//!      popup has focus.
+//!
+//! Per CONTRIBUTING.md §2 the assertions only inspect rendered screen
+//! output (popup title text + buffer cursor line), never internal
+//! state.
+//!
+//! Same `apply_event(Event::ShowPopup{...})` injection path as
+//! `preview_lsp_popup_focus.rs`. We use `PopupKindHint::Text` here so
+//! the popup is unfocused on show — Completion popups are a separate
+//! beast (user-invoked, type-to-filter requires the popup to be the
+//! keyboard target on show) and are exercised by the dedicated
+//! `lsp_completion_popup_behavior` suite.
+//!
+//! Reproducing the bug on baseline:
+//!   - Without the fix the unfocused-by-default flag does not exist, so
+//!     `[Alt+T to focus]` never appears in the popup title and assertion
+//!     #1 fails immediately.
+//!   - The `popup_focus` action and `Alt+T` global binding don't exist
+//!     either, so assertion #3 (focus transfer dismisses the hint) also
+//!     fails.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::model::event::{Event, PopupContentData, PopupData, PopupKindHint, PopupPositionData};
+
+const FOCUS_HINT: &str = "Alt+T to focus";
+const POPUP_TITLE: &str = "Hover Docs";
+const POPUP_BODY: &str = "auto_shown_overlay_text";
+
+fn setup_buffer_with_lines(line_count: usize) -> EditorTestHarness {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    let body: String = (1..=line_count)
+        .map(|n| format!("line_{:02}\n", n))
+        .collect();
+    harness.type_text(&body).unwrap();
+    // Rewind so Down arrows have somewhere to go.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+}
+
+/// Inject an auto-shown text popup of the same shape an LSP hover/auto-
+/// prompt would build. `PopupKindHint::Text` makes the converter mark
+/// the popup unfocused by default.
+fn show_auto_popup(harness: &mut EditorTestHarness) {
+    harness
+        .apply_event(Event::ShowPopup {
+            popup: PopupData {
+                kind: PopupKindHint::Text,
+                title: Some(POPUP_TITLE.to_string()),
+                description: None,
+                transient: false,
+                content: PopupContentData::Text(vec![POPUP_BODY.to_string()]),
+                position: PopupPositionData::BelowCursor,
+                width: 40,
+                max_height: 6,
+                bordered: true,
+            },
+        })
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// Helper: extract the line of the screen that contains the popup title,
+/// so the assertion error message points right at the bordered title row
+/// rather than dumping the whole frame for every failure.
+fn title_row(harness: &EditorTestHarness) -> Option<String> {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .find(|l| l.contains(POPUP_TITLE))
+        .map(str::to_string)
+}
+
+#[test]
+fn unfocused_popup_advertises_focus_key_in_title() {
+    let mut harness = setup_buffer_with_lines(8);
+
+    show_auto_popup(&mut harness);
+
+    let title_line = title_row(&harness).unwrap_or_else(|| {
+        panic!(
+            "popup title should be visible:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    assert!(
+        title_line.contains(FOCUS_HINT),
+        "Unfocused popup must advertise its focus key in the title; \
+         expected \"{FOCUS_HINT}\" on title row:\n{title_line}",
+    );
+    // Body should still render so this is unambiguously a popup, not
+    // some other widget chrome that happened to contain the title text.
+    assert!(
+        harness.screen_to_string().contains(POPUP_BODY),
+        "popup body should be visible alongside the title hint;\nscreen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+#[test]
+fn arrows_drive_buffer_when_popup_is_unfocused() {
+    let mut harness = setup_buffer_with_lines(8);
+
+    show_auto_popup(&mut harness);
+
+    // Sanity check: cursor is on row 1 of the buffer (after Ctrl+Home).
+    // The status bar reports "Ln 1, Col 1"; we use that as the
+    // pre-condition observable.
+    assert!(
+        harness.screen_to_string().contains("Ln 1"),
+        "precondition: cursor should be on line 1; screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Down arrow with an unfocused popup must drive the buffer cursor.
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 2"),
+        "Down arrow must move the buffer cursor to line 2 when the popup is unfocused; \
+         screen:\n{screen}",
+    );
+}
+
+/// Esc still dismisses an unfocused popup. Without this, the popup
+/// would have to be focused (Alt+T) before the user could close it,
+/// which doesn't match either the LSP-auto-prompt UX or the
+/// `popup_cancel` keybinding contract.
+#[test]
+fn popup_cancel_key_dismisses_unfocused_popup() {
+    let mut harness = setup_buffer_with_lines(8);
+
+    show_auto_popup(&mut harness);
+    assert!(
+        harness.screen_to_string().contains(POPUP_BODY),
+        "precondition: popup must be visible before Esc"
+    );
+
+    harness
+        .send_key(KeyCode::Esc, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains(POPUP_BODY),
+        "Esc on an unfocused popup should dismiss it; popup body still on screen:\n{screen}",
+    );
+    assert!(
+        !screen.contains(POPUP_TITLE),
+        "Esc should also remove the popup title from the screen:\n{screen}",
+    );
+}
+
+#[test]
+fn alt_t_focuses_popup_and_clears_focus_hint() {
+    let mut harness = setup_buffer_with_lines(8);
+
+    show_auto_popup(&mut harness);
+
+    // Sanity precondition: the hint is shown before focusing.
+    let initial_title = title_row(&harness).expect("popup must be visible");
+    assert!(
+        initial_title.contains(FOCUS_HINT),
+        "precondition: focus-key hint must be visible while popup is unfocused;\ntitle row:\n{initial_title}",
+    );
+
+    // Press Alt+T → focus moves to the popup.
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+
+    let title_after = title_row(&harness).unwrap_or_else(|| {
+        panic!(
+            "popup must remain visible after Alt+T;\nscreen:\n{}",
+            harness.screen_to_string()
+        )
+    });
+    assert!(
+        !title_after.contains(FOCUS_HINT),
+        "Once the popup is focused the focus-key hint must disappear from the title;\n\
+         title row:\n{title_after}",
+    );
+    assert!(
+        title_after.contains(POPUP_TITLE),
+        "Popup title text itself should still render after focus transfer;\ntitle row:\n{title_after}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -103,6 +103,7 @@ pub mod lsp_missing_binary_and_dismiss;
 pub mod lsp_multi_semantic_tokens;
 pub mod lsp_no_config;
 pub mod lsp_order;
+pub mod lsp_popup_focus_keybinding;
 pub mod lsp_publish_diagnostics_capability;
 pub mod lsp_server_lifecycle_cleanup;
 pub mod lsp_stop_stale_indicator;


### PR DESCRIPTION
LSP popups that pop up under the user's cursor on file open (the
auto-prompt status popup, hover docs, signature help, plugin Text
overlays, …) used to silently swallow the very next keystroke.
The user could open a file, type a key, and watch the keystroke
disappear into a popup they hadn't acknowledged yet.

Such popups now show *unfocused*: keys flow through to the
buffer/explorer/etc. by default, the popup title carries an
"[Alt+T to focus]" hint, and the user explicitly transfers focus
with a configurable `popup_focus` action (default `Alt+T`,
Global context). Esc still dismisses the popup whether it is
focused or not, matching the existing `popup_cancel` contract.

User-invoked popups (completion via type-trigger, plugin action
choosers, code-action menus, status-bar `{remote}` and LSP-status
menus) keep the historical focused-on-show behavior — type-to-filter
and arrow-nav need to "just work" without an extra keystroke.

https://claude.ai/code/session_01LU52etKGP6ktb9UGk84rSW