### PR TITLE
feat: Add go to line with selection feature (absolute + relative)

### DIFF
--- a/crates/fresh-editor/plugins/goto_with_selection.i18n.json
+++ b/crates/fresh-editor/plugins/goto_with_selection.i18n.json
@@ -1,0 +1,58 @@
+{
+  "en": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "cs": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "de": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "es": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "fr": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "it": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "ja": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "ko": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "pt-BR": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "ru": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "th": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "uk": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "vi": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  },
+  "zh-CN": {
+    "cmd.goto_line_with_selection": "Go to Line with Selection",
+    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+  }
+}

--- a/crates/fresh-editor/plugins/goto_with_selection.i18n.json
+++ b/crates/fresh-editor/plugins/goto_with_selection.i18n.json
@@ -4,55 +4,55 @@
     "cmd.goto_line_with_selection_desc": "Select from current position to target line"
   },
   "cs": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Jít na řádek s výběrem",
+    "cmd.goto_line_with_selection_desc": "Vybrat od aktuální pozice po cílový řádek"
   },
   "de": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Zur Zeile mit Auswahl",
+    "cmd.goto_line_with_selection_desc": "Von der aktuellen Position zur Zielzeile auswählen"
   },
   "es": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Ir a línea con selección",
+    "cmd.goto_line_with_selection_desc": "Seleccionar desde la posición actual hasta la línea destino"
   },
   "fr": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Aller à la ligne avec sélection",
+    "cmd.goto_line_with_selection_desc": "Sélectionner de la position actuelle jusqu'à la ligne cible"
   },
   "it": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Vai alla riga con selezione",
+    "cmd.goto_line_with_selection_desc": "Seleziona dalla posizione attuale alla riga di destinazione"
   },
   "ja": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "選択付きで移動先へ",
+    "cmd.goto_line_with_selection_desc": "現在位置から移動先行まで選択"
   },
   "ko": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "선택 포함 줄로 이동",
+    "cmd.goto_line_with_selection_desc": "현재 위치에서 대상 줄까지 선택"
   },
   "pt-BR": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Ir para linha com seleção",
+    "cmd.goto_line_with_selection_desc": "Selecionar da posição atual até a linha de destino"
   },
   "ru": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Перейти к строке с выделением",
+    "cmd.goto_line_with_selection_desc": "Выделить от текущей позиции до целевой строки"
   },
   "th": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "ไปยังบรรทัดพร้อมการเลือก",
+    "cmd.goto_line_with_selection_desc": "เลือกจากตำแหน่งปัจจุบันไปยังบรรทัดเป้าหมาย"
   },
   "uk": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Перейти до рядка з виділенням",
+    "cmd.goto_line_with_selection_desc": "Виділити від поточної позиції до цільового рядка"
   },
   "vi": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "Đến dòng với lựa chọn",
+    "cmd.goto_line_with_selection_desc": "Chọn từ vị trí hiện tại đến dòng đích"
   },
   "zh-CN": {
-    "cmd.goto_line_with_selection": "Go to Line with Selection",
-    "cmd.goto_line_with_selection_desc": "Select from current position to target line"
+    "cmd.goto_line_with_selection": "转到行并选中",
+    "cmd.goto_line_with_selection_desc": "从当前位置选中到目标行"
   }
 }

--- a/crates/fresh-editor/plugins/goto_with_selection.ts
+++ b/crates/fresh-editor/plugins/goto_with_selection.ts
@@ -1,0 +1,17 @@
+/// <reference path="./lib/fresh.d.ts" />
+const editor = getEditor();
+
+async function goto_line_with_selection_handler(): Promise<void> {
+  editor.executeActions([
+    { action: "set_mark", count: 1 },
+    { action: "goto_line", count: 1 },
+  ]);
+}
+
+registerHandler("goto_line_with_selection", goto_line_with_selection_handler);
+
+editor.registerCommand(
+  "Go to Line with Selection",
+  "Select from current position to target line",
+  "goto_line_with_selection",
+);

--- a/crates/fresh-editor/plugins/goto_with_selection.ts
+++ b/crates/fresh-editor/plugins/goto_with_selection.ts
@@ -11,7 +11,7 @@ async function goto_line_with_selection_handler(): Promise<void> {
 registerHandler("goto_line_with_selection", goto_line_with_selection_handler);
 
 editor.registerCommand(
-  "Go to Line with Selection",
-  "Select from current position to target line",
+  "%cmd.goto_line_with_selection",
+  "%cmd.goto_line_with_selection_desc",
   "goto_line_with_selection",
 );

--- a/crates/fresh-editor/plugins/tsconfig.json
+++ b/crates/fresh-editor/plugins/tsconfig.json
@@ -48,6 +48,7 @@
     "git_gutter.ts",
     "git_log.ts",
     "gleam-lsp.ts",
+    "goto_with_selection.ts",
     "go-lsp.ts",
     "graphql-lsp.ts",
     "haskell-lsp.ts",

--- a/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
@@ -1,0 +1,335 @@
+//! End-to-end tests for the goto_with_selection plugin
+//!
+//! Tests coverage:
+//! 1. Absolute line numbers mode:
+//!    1.1. Select from line 1 to line 3
+//!    1.2. Select from line 4 to line 2 (reverse selection)
+//! 2. Relative line numbers mode:
+//!    2.1. Start at line 4, select -2 (goes to line 2)
+//!    2.2. Start at line 2, select +2 (goes to line 4)
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use tempfile::TempDir;
+
+/// Helper: write a fixture file with `n` lines of the form `LINE<n>\n`.
+fn write_numbered_lines(path: &std::path::Path, n: usize) {
+    let mut s = String::new();
+    for i in 1..=n {
+        s.push_str(&format!("LINE{i}\n"));
+    }
+    fs::write(path, s).unwrap();
+}
+
+/// Helper to set up test harness with goto_with_selection plugin.
+/// Returns (harness, temp_dir, project_root) - keep temp_dir alive for test duration.
+fn setup_harness_with_plugin(
+    config: fresh::config::Config,
+) -> (EditorTestHarness, TempDir, std::path::PathBuf) {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+
+    // Create plugins directory and copy the plugin
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "goto_with_selection");
+
+    let harness =
+        EditorTestHarness::with_config_and_working_dir(100, 24, config, project_root.clone())
+            .unwrap();
+
+    (harness, temp_dir, project_root)
+}
+
+/// Helper to execute the select_to_line command via command palette
+fn execute_select_to_line(harness: &mut EditorTestHarness, line_number: &str) {
+    // Open command palette
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    // Type the command name
+    harness
+        .type_text("Select from current position to target line")
+        .unwrap();
+    harness.render().unwrap();
+
+    // Confirm command selection
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+
+    // Type the target line number
+    harness.type_text(line_number).unwrap();
+    harness.render().unwrap();
+
+    // Confirm line number
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness.render().unwrap();
+}
+
+/// Test 1.1: Absolute mode - select from line 1 to line 3
+#[test]
+fn test_absolute_select_line_1_to_3() {
+    let (mut harness, _temp, project_root) = setup_harness_with_plugin(Default::default());
+
+    let jump_path = project_root.join("jump.txt");
+    write_numbered_lines(&jump_path, 5);
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    // Execute select_to_line with target line 3
+    execute_select_to_line(&mut harness, "3");
+
+    // Get the selection
+    let cursor = harness.editor().active_cursors().primary();
+    assert!(cursor.anchor.is_some(), "Should have selection anchor");
+    assert!(harness.has_selection(), "Should have active selection");
+
+    // Verify the selected text contains LINE1, LINE2 (LINE3 start is the end position)
+    let selection_range = cursor.selection_range();
+    assert!(selection_range.is_some(), "Should have selection range");
+    let range = selection_range.unwrap();
+    let selected_text = harness
+        .editor_mut()
+        .active_state_mut()
+        .get_text_range(range.start, range.end);
+    assert!(
+        selected_text.contains("LINE1"),
+        "Should contain LINE1, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE2"),
+        "Should contain LINE2, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE3"),
+        "Should not contain LINE3, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE4"),
+        "Should not contain LINE4, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE5"),
+        "Should not contain LINE5, got: '{}'",
+        selected_text
+    );
+}
+
+/// Test 1.2: Absolute mode - select from line 4 to line 2 (reverse)
+#[test]
+fn test_absolute_select_line_4_to_2() {
+    let (mut harness, _temp, project_root) = setup_harness_with_plugin(Default::default());
+
+    let jump_path = project_root.join("jump.txt");
+    write_numbered_lines(&jump_path, 5);
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    // Go to line 4 first using Ctrl+G
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("4").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 4,"))
+        .unwrap();
+
+    // Execute select_to_line with target line 2
+    execute_select_to_line(&mut harness, "2");
+
+    // Get the selection
+    let cursor = harness.editor().active_cursors().primary();
+    assert!(cursor.anchor.is_some(), "Should have selection anchor");
+    assert!(harness.has_selection(), "Should have active selection");
+
+    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is anchor)
+    let selection_range = cursor.selection_range();
+    assert!(selection_range.is_some(), "Should have selection range");
+    let range = selection_range.unwrap();
+    let selected_text = harness
+        .editor_mut()
+        .active_state_mut()
+        .get_text_range(range.start, range.end);
+    assert!(
+        !selected_text.contains("LINE1"),
+        "Should not contain LINE1, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE2"),
+        "Should contain LINE2, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE3"),
+        "Should contain LINE3, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE4"),
+        "Should not contain LINE4, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE5"),
+        "Should not contain LINE5, got: '{}'",
+        selected_text
+    );
+}
+
+/// Test 2.1: Relative mode - at line 4, select -2 (goes to line 2)
+#[test]
+fn test_relative_select_from_line_4_minus_2() {
+    let mut config = fresh::config::Config::default();
+    config.editor.relative_line_numbers = true;
+
+    let (mut harness, _temp, project_root) = setup_harness_with_plugin(config);
+
+    let jump_path = project_root.join("jump.txt");
+    write_numbered_lines(&jump_path, 5);
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    // Go to line 4 first using Ctrl+G
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("4").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 4,"))
+        .unwrap();
+
+    // Execute select_to_line with relative target -2
+    execute_select_to_line(&mut harness, "-2");
+
+    // Get the selection
+    let cursor = harness.editor().active_cursors().primary();
+    assert!(cursor.anchor.is_some(), "Should have selection anchor");
+    assert!(harness.has_selection(), "Should have active selection");
+
+    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is anchor)
+    let selection_range = cursor.selection_range();
+    assert!(selection_range.is_some(), "Should have selection range");
+    let range = selection_range.unwrap();
+    let selected_text = harness
+        .editor_mut()
+        .active_state_mut()
+        .get_text_range(range.start, range.end);
+    assert!(
+        !selected_text.contains("LINE1"),
+        "Should not contain LINE1, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE2"),
+        "Should contain LINE2, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE3"),
+        "Should contain LINE3, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE4"),
+        "Should not contain LINE4, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE5"),
+        "Should not contain LINE5, got: '{}'",
+        selected_text
+    );
+}
+
+/// Test 2.2: Relative mode - at line 2, select +2 (goes to line 4)
+#[test]
+fn test_relative_select_from_line_2_plus_2() {
+    let mut config = fresh::config::Config::default();
+    config.editor.relative_line_numbers = true;
+
+    let (mut harness, _temp, project_root) = setup_harness_with_plugin(config);
+
+    let jump_path = project_root.join("jump.txt");
+    write_numbered_lines(&jump_path, 5);
+
+    harness.open_file(&jump_path).unwrap();
+    harness.render().unwrap();
+
+    // Go to line 2 first using Ctrl+G
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("2").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Ln 2,"))
+        .unwrap();
+
+    // Execute select_to_line with relative target +2
+    execute_select_to_line(&mut harness, "+2");
+
+    // Get the selection
+    let cursor = harness.editor().active_cursors().primary();
+    assert!(cursor.anchor.is_some(), "Should have selection anchor");
+    assert!(harness.has_selection(), "Should have active selection");
+
+    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is end)
+    let selection_range = cursor.selection_range();
+    assert!(selection_range.is_some(), "Should have selection range");
+    let range = selection_range.unwrap();
+    let selected_text = harness
+        .editor_mut()
+        .active_state_mut()
+        .get_text_range(range.start, range.end);
+    assert!(
+        !selected_text.contains("LINE1"),
+        "Should not contain LINE1, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE2"),
+        "Should contain LINE2, got: '{}'",
+        selected_text
+    );
+    assert!(
+        selected_text.contains("LINE3"),
+        "Should contain LINE3, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE4"),
+        "Should not contain LINE4, got: '{}'",
+        selected_text
+    );
+    assert!(
+        !selected_text.contains("LINE5"),
+        "Should not contain LINE5, got: '{}'",
+        selected_text
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
@@ -130,7 +130,7 @@ fn verify_selection_contains_only(harness: &mut EditorTestHarness, expected_line
                 line,
                 screen
             );
-}
+        }
     }
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/goto_with_selection.rs
@@ -76,7 +76,67 @@ fn execute_select_to_line(harness: &mut EditorTestHarness, line_number: &str) {
     harness.render().unwrap();
 }
 
+/// Verifies selection contains ONLY expected lines by: copy selection, select all, paste.
+/// Then checks that the screen shows EXACTLY the expected content (original replaced with selection).
+fn verify_selection_contains_only(harness: &mut EditorTestHarness, expected_lines: &[&str]) {
+    harness.editor_mut().set_clipboard_for_test("".to_string());
+
+    // Copy the selection
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Select all (Ctrl+A)
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Paste (Ctrl+V) - replaces all with copied selection
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Now screen should show ONLY the pasted content
+    let screen = harness.screen_to_string();
+
+    // Check for the Pasted status message
+    assert!(
+        screen.contains("Pasted"),
+        "Should show 'Pasted' status after operation. Screen:\n{}",
+        screen
+    );
+
+    // Verify ALL expected lines are present
+    for line in expected_lines {
+        assert!(
+            screen.contains(line),
+            "Expected '{}' to be visible after copy-all-paste. Screen:\n{}",
+            line,
+            screen
+        );
+    }
+
+    // Verify NO other LINE* content exists (strict)
+    for i in 1..=5 {
+        let line = format!("LINE{}", i);
+        let expected = expected_lines.iter().any(|&e| e == line.as_str());
+        if !expected {
+            assert!(
+                !screen.contains(&line),
+                "Found unexpected '{}' in screen after copy-all-paste. Screen:\n{}",
+                line,
+                screen
+            );
+}
+    }
+}
+
 /// Test 1.1: Absolute mode - select from line 1 to line 3
+///
+/// Verifies the selection command completes and ends at line 3.
 #[test]
 fn test_absolute_select_line_1_to_3() {
     let (mut harness, _temp, project_root) = setup_harness_with_plugin(Default::default());
@@ -90,47 +150,21 @@ fn test_absolute_select_line_1_to_3() {
     // Execute select_to_line with target line 3
     execute_select_to_line(&mut harness, "3");
 
-    // Get the selection
-    let cursor = harness.editor().active_cursors().primary();
-    assert!(cursor.anchor.is_some(), "Should have selection anchor");
-    assert!(harness.has_selection(), "Should have active selection");
+    // Verify status bar shows we're at line 3 (end of selection)
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 3,"),
+        "Status bar should show line 3. Screen:\n{}",
+        screen
+    );
 
-    // Verify the selected text contains LINE1, LINE2 (LINE3 start is the end position)
-    let selection_range = cursor.selection_range();
-    assert!(selection_range.is_some(), "Should have selection range");
-    let range = selection_range.unwrap();
-    let selected_text = harness
-        .editor_mut()
-        .active_state_mut()
-        .get_text_range(range.start, range.end);
-    assert!(
-        selected_text.contains("LINE1"),
-        "Should contain LINE1, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE2"),
-        "Should contain LINE2, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE3"),
-        "Should not contain LINE3, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE4"),
-        "Should not contain LINE4, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE5"),
-        "Should not contain LINE5, got: '{}'",
-        selected_text
-    );
+    // Verify selection contains LINE1 and LINE2 by copy-all-paste
+    verify_selection_contains_only(&mut harness, &["LINE1", "LINE2"]);
 }
 
 /// Test 1.2: Absolute mode - select from line 4 to line 2 (reverse)
+///
+/// Verifies reverse selection (backward) works correctly.
 #[test]
 fn test_absolute_select_line_4_to_2() {
     let (mut harness, _temp, project_root) = setup_harness_with_plugin(Default::default());
@@ -156,47 +190,21 @@ fn test_absolute_select_line_4_to_2() {
     // Execute select_to_line with target line 2
     execute_select_to_line(&mut harness, "2");
 
-    // Get the selection
-    let cursor = harness.editor().active_cursors().primary();
-    assert!(cursor.anchor.is_some(), "Should have selection anchor");
-    assert!(harness.has_selection(), "Should have active selection");
+    // Verify status bar shows we're at line 2 (end of reverse selection)
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 2,"),
+        "Status bar should show line 2. Screen:\n{}",
+        screen
+    );
 
-    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is anchor)
-    let selection_range = cursor.selection_range();
-    assert!(selection_range.is_some(), "Should have selection range");
-    let range = selection_range.unwrap();
-    let selected_text = harness
-        .editor_mut()
-        .active_state_mut()
-        .get_text_range(range.start, range.end);
-    assert!(
-        !selected_text.contains("LINE1"),
-        "Should not contain LINE1, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE2"),
-        "Should contain LINE2, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE3"),
-        "Should contain LINE3, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE4"),
-        "Should not contain LINE4, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE5"),
-        "Should not contain LINE5, got: '{}'",
-        selected_text
-    );
+    // Verify selection contains LINE2 and LINE3 (reverse selection)
+    verify_selection_contains_only(&mut harness, &["LINE2", "LINE3"]);
 }
 
 /// Test 2.1: Relative mode - at line 4, select -2 (goes to line 2)
+///
+/// Verifies relative negative offset works.
 #[test]
 fn test_relative_select_from_line_4_minus_2() {
     let mut config = fresh::config::Config::default();
@@ -225,47 +233,21 @@ fn test_relative_select_from_line_4_minus_2() {
     // Execute select_to_line with relative target -2
     execute_select_to_line(&mut harness, "-2");
 
-    // Get the selection
-    let cursor = harness.editor().active_cursors().primary();
-    assert!(cursor.anchor.is_some(), "Should have selection anchor");
-    assert!(harness.has_selection(), "Should have active selection");
+    // Verify status bar shows we're at line 2 (line 4 + -2 = 2)
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 2,"),
+        "Status bar should show line 2. Screen:\n{}",
+        screen
+    );
 
-    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is anchor)
-    let selection_range = cursor.selection_range();
-    assert!(selection_range.is_some(), "Should have selection range");
-    let range = selection_range.unwrap();
-    let selected_text = harness
-        .editor_mut()
-        .active_state_mut()
-        .get_text_range(range.start, range.end);
-    assert!(
-        !selected_text.contains("LINE1"),
-        "Should not contain LINE1, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE2"),
-        "Should contain LINE2, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE3"),
-        "Should contain LINE3, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE4"),
-        "Should not contain LINE4, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE5"),
-        "Should not contain LINE5, got: '{}'",
-        selected_text
-    );
+    // Verify selection contains LINE2 and LINE3 (relative -2)
+    verify_selection_contains_only(&mut harness, &["LINE2", "LINE3"]);
 }
 
 /// Test 2.2: Relative mode - at line 2, select +2 (goes to line 4)
+///
+/// Verifies relative positive offset works.
 #[test]
 fn test_relative_select_from_line_2_plus_2() {
     let mut config = fresh::config::Config::default();
@@ -294,42 +276,14 @@ fn test_relative_select_from_line_2_plus_2() {
     // Execute select_to_line with relative target +2
     execute_select_to_line(&mut harness, "+2");
 
-    // Get the selection
-    let cursor = harness.editor().active_cursors().primary();
-    assert!(cursor.anchor.is_some(), "Should have selection anchor");
-    assert!(harness.has_selection(), "Should have active selection");
+    // Verify status bar shows we're at line 4 (line 2 + +2 = 4)
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Ln 4,"),
+        "Status bar should show line 4. Screen:\n{}",
+        screen
+    );
 
-    // Verify the selected text contains LINE2, LINE3 (start of LINE4 is end)
-    let selection_range = cursor.selection_range();
-    assert!(selection_range.is_some(), "Should have selection range");
-    let range = selection_range.unwrap();
-    let selected_text = harness
-        .editor_mut()
-        .active_state_mut()
-        .get_text_range(range.start, range.end);
-    assert!(
-        !selected_text.contains("LINE1"),
-        "Should not contain LINE1, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE2"),
-        "Should contain LINE2, got: '{}'",
-        selected_text
-    );
-    assert!(
-        selected_text.contains("LINE3"),
-        "Should contain LINE3, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE4"),
-        "Should not contain LINE4, got: '{}'",
-        selected_text
-    );
-    assert!(
-        !selected_text.contains("LINE5"),
-        "Should not contain LINE5, got: '{}'",
-        selected_text
-    );
+    // Verify selection contains LINE2 and LINE3 (relative +2)
+    verify_selection_contains_only(&mut harness, &["LINE2", "LINE3"]);
 }

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -31,6 +31,7 @@ pub mod diff_cursor;
 pub mod find_file;
 pub mod git;
 pub mod git_log_split_tab_focus;
+pub mod goto_with_selection;
 pub mod gutter;
 pub mod init_script;
 pub mod language_pack;


### PR DESCRIPTION
~This is `go to line with selection` feature for non vim mode (and a follow up for the `go to negative numbers for the relative line numbers mode` feature). We already have `ctrl + g` and `:` in command palette which moves cursor to the line. This PR adds `Got to line with selection` action and `::` (for consistency with `:`) for command palette which will move cursor + make selection from current position to target one.~

Should be useful for those users who won't use vim mode and also I believe in VScode there is such possibility too (probably with plugin, don't quite remember but i used it a lot there).


https://github.com/user-attachments/assets/de25a1bd-a090-42b5-a235-304538b98c63


