### PR TITLE
fix(windows): hide transient console windows from spawned subprocesses

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2774,6 +2774,7 @@ impl Editor {
 
     /// Get git diff stats for a file (insertions/deletions)
     fn get_git_diff_stats(&self, path: &std::path::Path) -> Option<String> {
+        use crate::services::process_hidden::HideWindow;
         use std::process::Command;
 
         // Run git diff --numstat for the file
@@ -2781,6 +2782,7 @@ impl Editor {
             .args(["diff", "--numstat", "--"])
             .arg(path)
             .current_dir(&self.working_dir)
+            .hide_window()
             .output()
             .ok()?;
 
@@ -2814,6 +2816,7 @@ impl Editor {
             .args(["diff", "--numstat", "--cached", "--"])
             .arg(path)
             .current_dir(&self.working_dir)
+            .hide_window()
             .output()
             .ok()?;
 
@@ -2847,6 +2850,7 @@ impl Editor {
         &self,
         dir_path: &std::path::Path,
     ) -> Option<Vec<std::path::PathBuf>> {
+        use crate::services::process_hidden::HideWindow;
         use std::process::Command;
 
         // Resolve symlinks to get the actual directory path
@@ -2859,6 +2863,7 @@ impl Editor {
             .args(["status", "--porcelain", "--"])
             .arg(&resolved_path)
             .current_dir(&self.working_dir)
+            .hide_window()
             .output()
             .ok()?;
 

--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 use super::Editor;
 use crate::config::{FormatterConfig, OnSaveAction};
 use crate::model::event::Event;
+use crate::services::process_hidden::HideWindow;
 use rust_i18n::t;
 
 /// Result of running a formatter or on-save action
@@ -189,7 +190,8 @@ impl Editor {
         cmd.args(["-c", &full_command])
             .current_dir(&project_root)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            .hide_window();
 
         if formatter.stdin {
             cmd.stdin(Stdio::piped());
@@ -373,7 +375,8 @@ impl Editor {
         cmd.args(["-c", &full_command])
             .current_dir(&working_dir)
             .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
+            .stderr(Stdio::piped())
+            .hide_window();
 
         if action.stdin {
             cmd.stdin(Stdio::piped());
@@ -587,6 +590,7 @@ fn command_exists(command: &str) -> bool {
             .arg(command)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
+            .hide_window()
             .status()
             .map(|s| s.success())
             .unwrap_or(false)

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1677,10 +1677,12 @@ impl Editor {
             self.host_process_handles.insert(process_id, kill_tx);
 
             runtime.spawn(async move {
+                use crate::services::process_hidden::HideWindow;
                 let mut cmd = TokioCommand::new(&command);
                 cmd.args(&args);
                 cmd.stdout(std::process::Stdio::piped());
                 cmd.stderr(std::process::Stdio::piped());
+                cmd.hide_window();
                 if let Some(ref dir) = effective_cwd {
                     cmd.current_dir(dir);
                 }
@@ -1784,11 +1786,13 @@ impl Editor {
             // Receiver may be dropped if editor is shutting down
             #[allow(clippy::let_underscore_must_use)]
             let handle = runtime.spawn(async move {
+                use crate::services::process_hidden::HideWindow;
                 let mut child = match TokioCommand::new(&command)
                     .args(&args)
                     .current_dir(&effective_cwd)
                     .stdout(std::process::Stdio::piped())
                     .stderr(std::process::Stdio::piped())
+                    .hide_window()
                     .spawn()
                 {
                     Ok(child) => child,

--- a/crates/fresh-editor/src/app/shell_command.rs
+++ b/crates/fresh-editor/src/app/shell_command.rs
@@ -9,6 +9,7 @@ use std::process::{Command, Stdio};
 
 use super::Editor;
 use crate::model::event::Event;
+use crate::services::process_hidden::HideWindow;
 use crate::view::prompt::PromptType;
 use rust_i18n::t;
 
@@ -40,6 +41,7 @@ impl Editor {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .hide_window()
             .spawn()
             .map_err(|e| format!("Failed to spawn shell: {}", e))?;
 
@@ -261,6 +263,7 @@ impl Editor {
         let shell = detect_shell();
         let mut child = Command::new(&shell)
             .args(["-c", command])
+            .hide_window()
             .spawn()
             .map_err(|e| anyhow::anyhow!("Failed to spawn shell: {}", e))?;
 

--- a/crates/fresh-editor/src/model/filesystem.rs
+++ b/crates/fresh-editor/src/model/filesystem.rs
@@ -1239,6 +1239,7 @@ impl FileSystem for StdFileSystem {
         uid: u32,
         gid: u32,
     ) -> io::Result<()> {
+        use crate::services::process_hidden::HideWindow;
         use std::process::{Command, Stdio};
 
         // Write data via sudo tee
@@ -1247,6 +1248,7 @@ impl FileSystem for StdFileSystem {
             .stdin(Stdio::piped())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
+            .hide_window()
             .spawn()
             .map_err(|e| io::Error::other(format!("failed to spawn sudo: {}", e)))?;
 
@@ -1267,6 +1269,7 @@ impl FileSystem for StdFileSystem {
         // Set permissions via sudo chmod
         let status = Command::new("sudo")
             .args(["chmod", &format!("{:o}", mode), &path.to_string_lossy()])
+            .hide_window()
             .status()?;
         if !status.success() {
             return Err(io::Error::other("sudo chmod failed"));
@@ -1279,6 +1282,7 @@ impl FileSystem for StdFileSystem {
                 &format!("{}:{}", uid, gid),
                 &path.to_string_lossy(),
             ])
+            .hide_window()
             .status()?;
         if !status.success() {
             return Err(io::Error::other("sudo chown failed"));

--- a/crates/fresh-editor/src/services/authority/docker_spawner.rs
+++ b/crates/fresh-editor/src/services/authority/docker_spawner.rs
@@ -13,6 +13,7 @@ use std::process::Stdio;
 use async_trait::async_trait;
 use tokio::process::Command;
 
+use crate::services::process_hidden::HideWindow;
 use crate::services::remote::{
     LongRunningSpawner, ProcessSpawner, SpawnError, SpawnResult, StdioChild,
 };
@@ -128,6 +129,7 @@ impl ProcessSpawner for DockerExecSpawner {
             .args(&docker_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .hide_window()
             .output()
             .await
             .map_err(|e| SpawnError::Process(e.to_string()))?;
@@ -219,6 +221,7 @@ impl LongRunningSpawner for DockerLongRunningSpawner {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .hide_window()
             .kill_on_drop(true)
             .spawn()
             .map_err(|e| SpawnError::Process(e.to_string()))?;
@@ -246,6 +249,7 @@ impl LongRunningSpawner for DockerLongRunningSpawner {
             .args(&docker_args)
             .stdout(Stdio::null())
             .stderr(Stdio::null())
+            .hide_window()
             .status()
             .await
         {

--- a/crates/fresh-editor/src/services/mod.rs
+++ b/crates/fresh-editor/src/services/mod.rs
@@ -15,6 +15,7 @@ pub mod log_dirs;
 pub mod lsp;
 pub mod packages;
 pub mod plugins;
+pub mod process_hidden;
 pub mod process_limits;
 pub mod recovery;
 pub mod release_checker;

--- a/crates/fresh-editor/src/services/process_hidden.rs
+++ b/crates/fresh-editor/src/services/process_hidden.rs
@@ -1,0 +1,38 @@
+//! Suppress the transient console window that Windows opens for
+//! console-subsystem children spawned from a GUI parent (git, ssh,
+//! docker, formatters, plugin processes, …). Setting `CREATE_NO_WINDOW`
+//! at spawn time prevents the brief black flash.
+//!
+//! No-op on non-Windows targets.
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub trait HideWindow {
+    /// Mark the command so its child does not get a visible console
+    /// window on Windows. No-op elsewhere.
+    fn hide_window(&mut self) -> &mut Self;
+}
+
+impl HideWindow for std::process::Command {
+    #[cfg(windows)]
+    fn hide_window(&mut self) -> &mut Self {
+        use std::os::windows::process::CommandExt;
+        self.creation_flags(CREATE_NO_WINDOW)
+    }
+    #[cfg(not(windows))]
+    fn hide_window(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl HideWindow for tokio::process::Command {
+    #[cfg(windows)]
+    fn hide_window(&mut self) -> &mut Self {
+        self.creation_flags(CREATE_NO_WINDOW)
+    }
+    #[cfg(not(windows))]
+    fn hide_window(&mut self) -> &mut Self {
+        self
+    }
+}

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -2,6 +2,7 @@
 //!
 //! Handles spawning SSH process and bootstrapping the Python agent.
 
+use crate::services::process_hidden::HideWindow;
 use crate::services::remote::channel::AgentChannel;
 use crate::services::remote::protocol::AgentResponse;
 use crate::services::remote::AGENT_SOURCE;
@@ -124,6 +125,7 @@ impl SshConnection {
         cmd.stdout(Stdio::piped());
         // Inherit stderr so SSH can prompt for password on the terminal
         cmd.stderr(Stdio::inherit());
+        cmd.hide_window();
 
         let mut child = cmd.spawn()?;
 
@@ -422,6 +424,7 @@ async fn establish_ssh_transport(
     cmd.stdin(Stdio::piped());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::null()); // No terminal for reconnection
+    cmd.hide_window();
 
     let mut child = cmd.spawn()?;
 
@@ -490,6 +493,7 @@ pub async fn spawn_local_agent() -> Result<std::sync::Arc<AgentChannel>, SshErro
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .hide_window()
         .spawn()?;
 
     let stdin = child
@@ -536,6 +540,7 @@ pub async fn spawn_local_agent_with_capacity(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .hide_window()
         .spawn()?;
 
     let stdin = child
@@ -591,6 +596,7 @@ pub async fn spawn_local_agent_transport() -> Result<
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
+        .hide_window()
         .spawn()?;
 
     let stdin = child

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -15,6 +15,7 @@
 //!   through this so an authority pointing at a container runs the server
 //!   inside the container (via `docker exec -i`) instead of on the host.
 
+use crate::services::process_hidden::HideWindow;
 use crate::services::process_limits::PostSpawnAction;
 use crate::services::remote::channel::{AgentChannel, ChannelError};
 use crate::services::remote::protocol::{decode_base64, exec_params};
@@ -75,6 +76,7 @@ impl ProcessSpawner for LocalProcessSpawner {
     ) -> Result<SpawnResult, SpawnError> {
         let mut cmd = tokio::process::Command::new(&command);
         cmd.args(&args);
+        cmd.hide_window();
 
         if let Some(ref dir) = cwd {
             cmd.current_dir(dir);
@@ -329,6 +331,7 @@ impl LongRunningSpawner for LocalLongRunningSpawner {
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
+            .hide_window()
             .kill_on_drop(true);
         if let Some(dir) = cwd {
             cmd.current_dir(dir);

--- a/crates/fresh-plugin-runtime/src/process.rs
+++ b/crates/fresh-plugin-runtime/src/process.rs
@@ -46,6 +46,12 @@ pub async fn spawn_plugin_process(
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
 
+    // On Windows, suppress the transient console window that the OS
+    // would otherwise flash for a console-subsystem child spawned from
+    // the GUI editor. CREATE_NO_WINDOW = 0x0800_0000.
+    #[cfg(windows)]
+    cmd.creation_flags(0x0800_0000);
+
     // Set working directory if provided
     if let Some(ref dir) = cwd {
         cmd.current_dir(dir);


### PR DESCRIPTION
When the GUI editor spawns a console-subsystem child on Windows (git,
ssh, docker, formatters, plugin processes, etc.), the OS would briefly
flash a black console window. Setting CREATE_NO_WINDOW in the child's
creation flags suppresses it. Adds a HideWindow extension trait for
both std and tokio Command types and applies it at every production
spawn site; no-op on non-Windows.

https://claude.ai/code/session_01UCsZsVgLQVXffdAxtd5G2L