### PR TITLE
fix(flash): make status banner a reliable redraw barrier so e2e tests don't race

### DIFF
--- a/crates/fresh-editor/plugins/flash.ts
+++ b/crates/fresh-editor/plugins/flash.ts
@@ -493,10 +493,19 @@ async function flashJump(): Promise<void> {
   // enough to survive status-bar truncation.  Includes the current
   // pattern so tests (and careful users) can confirm the plugin has
   // accepted each typed key.
+  //
+  // The banner doubles as a synchronization barrier for tests: as long
+  // as setStatus runs AFTER redraw within the same loop iteration, any
+  // observer that sees `Flash[<pattern>]` on screen is guaranteed to
+  // also see the conceals/labels for that same pattern — they were
+  // committed in the redraw immediately before.  Setting the banner
+  // earlier (e.g. in the keypress handler before `continue`) breaks
+  // this invariant: the new banner reaches the screen while the
+  // previous iteration's conceals are still painted, so a renderer
+  // tick in that window shows banner=N with conceals=N-1.
   const setStatusForPattern = (): void => {
     editor.setStatus("Flash[" + state.pattern + "]");
   };
-  setStatusForPattern();
 
   try {
     while (true) {
@@ -522,6 +531,7 @@ async function flashJump(): Promise<void> {
         if (m.label) state.prevLabelByKey.set(matchKey(m), m.label);
       }
       redraw(state.matches, views);
+      setStatusForPattern();
 
       const ev = await editor.getNextKey();
 
@@ -538,7 +548,6 @@ async function flashJump(): Promise<void> {
         if (state.pattern.length > 0) {
           state.pattern = state.pattern.slice(0, -1);
         }
-        setStatusForPattern();
         continue;
       }
 
@@ -551,7 +560,6 @@ async function flashJump(): Promise<void> {
           break;
         }
         state.pattern += ev.key;
-        setStatusForPattern();
         continue;
       }
 


### PR DESCRIPTION
The flash plugin's main loop updated `state.pattern` and the
`Flash[<pattern>]` status banner inside the keypress handler, BEFORE
`continue`ing back to the top of the loop where the next iteration
recomputes labels and redraws conceals.  The banner therefore reached
the screen ahead of the matching conceals — a render tick in that
window showed banner=N with conceals from iteration N-1.

E2E tests (`type_pattern` in tests/e2e/flash.rs) treat the banner as a
synchronization barrier: they `wait_until` the screen contains
`Flash[<pattern>]` before asserting on rendered conceals.  Under load
on slower / Windows CI the renderer would tick between the banner
update and the redraw, the test would observe banner="PID" with
conceals still anchored to "PI", and `flash_label_does_not_eat_space_after_match`
would fail with rendered output like `PIa file lockup` (label `a` on
the `D` cell, where it would land for pattern "PI").

Fix: call `setStatusForPattern()` AFTER `redraw()` within the same loop
iteration, and drop the eager calls inside the keypress handler.  Now
any observer that sees `Flash[<pattern>]` is guaranteed to also see the
conceals/labels for that pattern.  Per CONTRIBUTING rule #3 the test
keeps semantic waiting (no timeouts); the fix makes its existing wait
condition correct rather than introducing one.