### PR TITLE
fix(menu-bar): persist Toggle Menu Bar globally, not per-workspace

### DIFF
--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -57,15 +57,22 @@ impl Editor {
         }
     }
 
-    /// Toggle menu bar visibility
+    /// Toggle menu bar visibility.
+    ///
+    /// `editor.show_menu_bar` is a global preference, so the toggle updates the
+    /// runtime config and persists the change to the user config layer (same
+    /// pattern as the file-explorer toggles). See issue #1156.
     pub fn toggle_menu_bar(&mut self) {
-        self.menu_bar_visible = !self.menu_bar_visible;
+        let new_value = !self.menu_bar_visible;
+        self.config_mut().editor.show_menu_bar = new_value;
+        self.menu_bar_visible = new_value;
         // When explicitly toggling, clear auto-show state
         self.menu_bar_auto_shown = false;
         // Close any open menu when hiding the menu bar
         if !self.menu_bar_visible {
             self.menu_state.close_menu();
         }
+        self.persist_config_change("/editor/show_menu_bar", serde_json::Value::Bool(new_value));
         let status = if self.menu_bar_visible {
             t!("toggle.menu_bar_shown")
         } else {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -277,7 +277,10 @@ impl Editor {
             }
         };
 
-        // Capture config overrides (only store deviations from defaults)
+        // Capture config overrides (only store deviations from defaults).
+        // `menu_bar_hidden` is intentionally left unset: menu bar visibility
+        // is a global preference (`editor.show_menu_bar`), not a per-workspace
+        // override. See issue #1156.
         let config_overrides = WorkspaceConfigOverrides {
             line_numbers: Some(self.config.editor.line_numbers),
             relative_line_numbers: Some(self.config.editor.relative_line_numbers),
@@ -285,7 +288,7 @@ impl Editor {
             syntax_highlighting: Some(self.config.editor.syntax_highlighting),
             enable_inlay_hints: Some(self.config.editor.enable_inlay_hints),
             mouse_enabled: Some(self.mouse_enabled),
-            menu_bar_hidden: Some(!self.menu_bar_visible),
+            menu_bar_hidden: None,
         };
 
         // Capture histories using the items() accessor from the prompt_histories HashMap
@@ -779,9 +782,10 @@ impl Editor {
         if let Some(mouse_enabled) = overrides.mouse_enabled {
             self.mouse_enabled = mouse_enabled;
         }
-        if let Some(menu_bar_hidden) = overrides.menu_bar_hidden {
-            self.menu_bar_visible = !menu_bar_hidden;
-        }
+        // `overrides.menu_bar_hidden` is a legacy field — kept for serde
+        // compatibility with workspaces written by older builds, but no
+        // longer applied: menu bar visibility is now a global preference.
+        // See issue #1156.
     }
 
     fn restore_search_options(&mut self, opts: &SearchOptions) {

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -285,6 +285,11 @@ pub struct WorkspaceConfigOverrides {
     pub enable_inlay_hints: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mouse_enabled: Option<bool>,
+    /// Legacy: menu bar visibility was once stored as a per-workspace
+    /// override here. It is now a global preference (`editor.show_menu_bar`),
+    /// so this field is no longer written and is ignored on restore. Kept
+    /// only for serde compatibility with workspaces saved by older builds.
+    /// See issue #1156.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub menu_bar_hidden: Option<bool>,
 }

--- a/crates/fresh-editor/tests/e2e/toggle_bars.rs
+++ b/crates/fresh-editor/tests/e2e/toggle_bars.rs
@@ -1,6 +1,8 @@
-use crate::common::harness::{layout, EditorTestHarness};
+use crate::common::harness::{layout, EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use tempfile::TempDir;
 
 /// Test that the tab bar is visible by default
 #[test]
@@ -513,4 +515,115 @@ fn test_toggle_prompt_line_via_command_palette() {
     // Prompt line should be visible again
     harness.assert_screen_contains("Prompt line shown");
     assert!(harness.editor().prompt_line_visible());
+}
+
+/// Regression test for issue #1156: toggling the menu bar via the View menu /
+/// command palette should persist to the global user config so the change is
+/// truly global (every workspace picks it up on next launch), not a per-
+/// workspace override.
+#[test]
+fn test_toggle_menu_bar_persists_to_global_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: open the editor and toggle the menu bar off via the runtime
+    // action (same code path used by the View menu and the "Toggle Menu Bar"
+    // command-palette entry).
+    {
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(Config::default())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.render().unwrap();
+
+        // Sanity: the global default is "show menu bar" = true.
+        assert!(harness.editor().config().editor.show_menu_bar);
+
+        harness.editor_mut().toggle_menu_bar();
+
+        // After toggling, the runtime config must reflect the new value.
+        assert!(
+            !harness.editor().config().editor.show_menu_bar,
+            "toggle_menu_bar should update show_menu_bar in the global config"
+        );
+    }
+
+    // Session 2: a different working directory using the same user config
+    // dir. Loading the config layers from disk must reflect the persisted
+    // change — otherwise the toggle was per-workspace, not global.
+    let other_project = temp_dir.path().join("other_project");
+    std::fs::create_dir(&other_project).unwrap();
+    let loaded = Config::load_with_layers(&dir_context, &other_project);
+    assert!(
+        !loaded.editor.show_menu_bar,
+        "Toggle should persist to user config so unrelated workspaces inherit it"
+    );
+}
+
+/// Regression test for issue #1156: a stale `menu_bar_hidden` workspace
+/// override from an older Fresh release must not silently win over the
+/// current global `editor.show_menu_bar` setting. The setting is global,
+/// so the override is treated as legacy and ignored on restore.
+#[test]
+fn test_workspace_override_does_not_shadow_global_show_menu_bar() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: hide the menu bar (toggle persists to global user config)
+    // and save the workspace. Older builds also wrote a per-workspace
+    // `menu_bar_hidden=true` override here.
+    {
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(Config::default())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.render().unwrap();
+        harness.editor_mut().toggle_menu_bar();
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: the user re-enables the menu bar globally before reopening
+    // (e.g. via the Settings UI on a different machine, or by editing the
+    // config file). Now reopen the same workspace — the global setting
+    // must win.
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new()
+            .with_config({
+                let mut c = Config::default();
+                c.editor.show_menu_bar = true;
+                c
+            })
+            .with_working_dir(project_dir.clone())
+            .with_shared_dir_context(dir_context.clone())
+            .without_empty_plugins_dir(),
+    )
+    .unwrap();
+    harness.editor_mut().try_restore_workspace().unwrap();
+    harness.render().unwrap();
+
+    let menu_bar_row = harness.get_screen_row(0);
+    assert!(
+        menu_bar_row.contains("File"),
+        "Global show_menu_bar=true must take precedence over a stale \
+         workspace override. Got row 0: {:?}",
+        menu_bar_row
+    );
 }


### PR DESCRIPTION
Closes #1156.

## Summary

`editor.show_menu_bar` was advertised as a global preference, but the View menu / command-palette **Toggle Menu Bar** action only mutated the runtime flag and never touched the config. Worse, `WorkspaceConfigOverrides` then captured the runtime value and restored it on workspace load, so each workspace silently shadowed any global change the user made via Settings. Net effect: the toggle behaved per-workspace and could never be set globally without a restart — exactly the user complaint in #1156.

The fix mirrors the existing file-explorer toggle pattern:

- `toggle_menu_bar` now updates `config.editor.show_menu_bar` and calls `persist_config_change("/editor/show_menu_bar", …)`, so the change is written to the user config layer immediately.
- `WorkspaceConfigOverrides::menu_bar_hidden` is no longer written and is ignored on restore. The field is kept (with a doc comment marking it legacy) so workspace files saved by older builds still deserialize cleanly.

## Test plan

Two regression tests added in `crates/fresh-editor/tests/e2e/toggle_bars.rs`:

- [x] `test_toggle_menu_bar_persists_to_global_config` — toggle once, reload the config from disk in an unrelated working dir and confirm `show_menu_bar=false` came along.
- [x] `test_workspace_override_does_not_shadow_global_show_menu_bar` — save a workspace while the menu bar is hidden, then reopen with `show_menu_bar=true` in config and confirm the menu bar is rendered (the legacy override must not win).

Both fail on master and pass with the change.

- [x] `cargo fmt --check`
- [x] `cargo clippy -p fresh-editor --all-targets` (no new warnings)
- [x] `cargo check --all-targets`
- [x] `cargo test -p fresh-editor --test e2e_tests -- toggle_bars:: menu_bar:: workspace::` (all green)

## Manual validation

Ran the freshly built binary in tmux against two separate project dirs sharing the same `XDG_CONFIG_HOME`:

1. Open in `projectA` → `Ctrl+P` → "Toggle Menu Bar" → menu bar disappears.
2. Inspect the user config: `show_menu_bar` is now `false` on disk.
3. Quit, reopen in `projectB` → menu bar is hidden (global setting honored).
4. Toggle it back on → config flips to `true`.

https://claude.ai/code/session_01YJJwtjkhJ43ApVfEdxVhqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01YJJwtjkhJ43ApVfEdxVhqe)_