### PR TITLE
fix(terminal): strip \\?\ prefix from cwd to clean up PowerShell prompt

### DIFF
--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -22,6 +22,7 @@ use super::term::TerminalState;
 use crate::services::async_bridge::AsyncBridge;
 use crate::services::authority::TerminalWrapper;
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::sync::atomic::AtomicBool;
@@ -206,7 +207,13 @@ impl TerminalManager {
             }
             if !skip_cwd {
                 if let Some(ref dir) = cwd {
-                    cmd.cwd(dir);
+                    // Hand the shell a non-verbatim path. Fresh canonicalizes
+                    // working_dir at startup, which on Windows yields
+                    // `\\?\C:\…`. PowerShell can't infer a drive from a
+                    // verbatim path and falls back to the fully-qualified
+                    // provider form, producing prompts like
+                    // `PS Microsoft.PowerShell.Core\FileSystem::\\?\C:\…>`.
+                    cmd.cwd(strip_verbatim_prefix(dir).as_ref());
                 }
             }
 
@@ -550,6 +557,52 @@ impl Drop for TerminalManager {
     }
 }
 
+/// Convert a Windows verbatim path (`\\?\C:\…` or `\\?\UNC\server\share\…`)
+/// into its non-verbatim equivalent (`C:\…` or `\\server\share\…`).
+///
+/// Returns the input unchanged on non-Windows platforms or for paths that
+/// have no verbatim prefix.
+pub(crate) fn strip_verbatim_prefix(path: &std::path::Path) -> Cow<'_, std::path::Path> {
+    #[cfg(windows)]
+    {
+        use std::path::{Component, Prefix};
+
+        let mut components = path.components();
+        let prefix = match components.next() {
+            Some(Component::Prefix(p)) => p,
+            _ => return Cow::Borrowed(path),
+        };
+
+        let mut rebuilt = std::path::PathBuf::new();
+        match prefix.kind() {
+            Prefix::VerbatimDisk(drive) => {
+                rebuilt.push(format!("{}:\\", drive as char));
+            }
+            Prefix::VerbatimUNC(server, share) => {
+                rebuilt.push(format!(
+                    r"\\{}\{}\",
+                    server.to_string_lossy(),
+                    share.to_string_lossy()
+                ));
+            }
+            _ => return Cow::Borrowed(path),
+        }
+        // Skip the original RootDir (which the rebuilt prefix already includes)
+        // and append the rest of the components.
+        for component in components {
+            if matches!(component, Component::RootDir) {
+                continue;
+            }
+            rebuilt.push(component.as_os_str());
+        }
+        Cow::Owned(rebuilt)
+    }
+    #[cfg(not(windows))]
+    {
+        Cow::Borrowed(path)
+    }
+}
+
 /// Detect the user's shell
 pub fn detect_shell() -> String {
     // Try $SHELL environment variable first
@@ -613,5 +666,48 @@ mod tests {
     fn test_detect_shell() {
         let shell = detect_shell();
         assert!(!shell.is_empty());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn strip_verbatim_prefix_is_noop_on_unix() {
+        use std::path::Path;
+        let p = Path::new("/home/user/project");
+        assert_eq!(strip_verbatim_prefix(p).as_ref(), p);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_removes_verbatim_disk() {
+        use std::path::{Path, PathBuf};
+        let verbatim = PathBuf::from(r"\\?\C:\Users\HP\OneDrive\Desktop\PY'PGMS");
+        let stripped = strip_verbatim_prefix(&verbatim);
+        assert_eq!(
+            stripped.as_ref(),
+            Path::new(r"C:\Users\HP\OneDrive\Desktop\PY'PGMS"),
+            "verbatim disk prefix should be replaced with plain drive form"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_removes_verbatim_unc() {
+        use std::path::{Path, PathBuf};
+        let verbatim = PathBuf::from(r"\\?\UNC\server\share\dir\file");
+        let stripped = strip_verbatim_prefix(&verbatim);
+        assert_eq!(
+            stripped.as_ref(),
+            Path::new(r"\\server\share\dir\file"),
+            "verbatim UNC prefix should be replaced with plain UNC form"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn strip_verbatim_prefix_passes_plain_paths_through() {
+        use std::path::{Path, PathBuf};
+        let plain = PathBuf::from(r"C:\Users\HP\project");
+        let result = strip_verbatim_prefix(&plain);
+        assert_eq!(result.as_ref(), Path::new(r"C:\Users\HP\project"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1771 — PowerShell prompt in the integrated terminal shows a noisy `Microsoft.PowerShell.Core\FileSystem::\\?\C:\…>` prefix on Windows.

## Root cause

`editor_init.rs:222` runs `working_dir.canonicalize()` so internal path comparisons are stable. On Windows that returns the verbatim `\\?\C:\…` form. When that path is then handed to the spawned shell as cwd, PowerShell can't infer a drive from a verbatim path and falls back to the fully-qualified provider form:

```
PS Microsoft.PowerShell.Core\FileSystem::\\?\C:\Users\HP\OneDrive\Desktop\PY'PGMS>
```

Direct PowerShell launches don't show this — their cwd is a normal `C:\…` path that PowerShell maps to its `FileSystem` provider's `C:` drive.

## Change

Strip the verbatim prefix at the spawn site only (`crates/fresh-editor/src/services/terminal/manager.rs`), so internal canonical form is preserved everywhere else (path comparisons, file_uri, etc.).

- Handles `Prefix::VerbatimDisk` (`\\?\C:\…` → `C:\…`) and `Prefix::VerbatimUNC` (`\\?\UNC\server\share\…` → `\\server\share\…`).
- Non-Windows builds get a `Cow::Borrowed` no-op.
- Plain non-verbatim paths pass through unchanged.

The unrelated second complaint in #1771 (trailing whitespace at the right/bottom of the terminal pane) is a separate rendering issue and is left out of this change.

## Test plan

- [x] `cargo check -p fresh-editor` — passes
- [x] `cargo test -p fresh-editor --lib services::terminal::` — 20 passed
- [x] New unit tests cover the no-op (Unix), `VerbatimDisk`, `VerbatimUNC`, and plain-path cases (Windows-only tests are `#[cfg(windows)]`)
- [x] `cargo fmt --check` and `cargo clippy` — no new warnings on touched code
- [ ] Live PowerShell prompt verification on Windows — requires a Windows host; reviewer with Windows access please confirm the prompt now reads `PS C:\Users\…>` instead of `PS Microsoft.PowerShell.Core\FileSystem::\\?\C:\Users\…>`.

https://claude.ai/code/session_016wv1eLMZ7hRR8edDb6Bnmn

---
_Generated by [Claude Code](https://claude.ai/code/session_016wv1eLMZ7hRR8edDb6Bnmn)_