### PR TITLE
Update to rust 1.95 in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.95"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Fixes #1782

Some systems like Arch AUR have moved on to LLVM / clang versions that are not compatible with rust 1.92 toolchain