### PR TITLE
fix(terminal): resync hidden terminal PTY size on tab reveal (#1795)

### DIFF
--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -107,6 +107,16 @@ impl Editor {
             self.sync_terminal_to_buffer(buffer_id);
         }
 
+        // Window resize events only resize terminals that are currently the
+        // active tab in their split (see `resize_visible_terminals`). A
+        // terminal hidden behind another tab when the host was resized never
+        // sees the new size, so its PTY child keeps reporting stale
+        // dimensions when the user switches back. Re-running the visible
+        // resize here picks up the now-revealed terminal. Issue #1795.
+        if self.is_terminal_buffer(buffer_id) {
+            self.resize_visible_terminals();
+        }
+
         // Ensure the newly active tab is visible
         self.ensure_active_tab_visible(active_split, buffer_id, self.effective_tabs_width());
 

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -3252,3 +3252,76 @@ fn test_terminal_shell_config_override() {
         "terminal should spawn with the config-overridden shell"
     );
 }
+
+/// Regression: a terminal hidden behind another tab during a window resize
+/// should pick up the new dimensions when the user switches back to it,
+/// rather than keeping the stale pre-resize PTY size.  Issue #1795.
+#[test]
+fn test_hidden_terminal_resyncs_pty_size_when_revealed() {
+    let mut harness = harness_or_return!(120, 35);
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+
+    let terminal_buffer = harness.editor().active_buffer_id();
+    let terminal_id = harness
+        .editor()
+        .get_terminal_id(terminal_buffer)
+        .expect("terminal buffer should have a terminal id");
+    let (cols_before, rows_before) = harness
+        .editor()
+        .terminal_manager()
+        .get(terminal_id)
+        .expect("terminal handle should exist")
+        .size();
+
+    // Move the terminal off-screen by switching to a fresh empty buffer in the
+    // same split.  The terminal is now hidden behind the new tab.
+    harness.new_buffer().unwrap();
+    let other_buffer = harness.editor().active_buffer_id();
+    assert_ne!(other_buffer, terminal_buffer);
+    assert!(!harness.editor().is_terminal_buffer(other_buffer));
+
+    // Shrink the host terminal while the PTY is hidden.  Without the fix,
+    // `resize_visible_terminals` skips the hidden buffer and the PTY keeps
+    // its original geometry.
+    harness.resize(80, 25).unwrap();
+
+    // Sanity: the PTY child still reports the original (stale) dimensions.
+    let (cols_hidden, rows_hidden) = harness
+        .editor()
+        .terminal_manager()
+        .get(terminal_id)
+        .expect("terminal handle should exist")
+        .size();
+    assert_eq!(
+        (cols_hidden, rows_hidden),
+        (cols_before, rows_before),
+        "hidden terminal should not have been resized while off-screen"
+    );
+
+    // Bring the terminal tab back to the front; the PTY size should now
+    // reflect the smaller window.
+    harness.editor_mut().switch_buffer(terminal_buffer);
+    harness.render().unwrap();
+
+    let (cols_after, rows_after) = harness
+        .editor()
+        .terminal_manager()
+        .get(terminal_id)
+        .expect("terminal handle should exist")
+        .size();
+
+    assert!(
+        cols_after < cols_before,
+        "expected PTY cols to shrink after reveal: before={}, after={}",
+        cols_before,
+        cols_after
+    );
+    assert!(
+        rows_after < rows_before,
+        "expected PTY rows to shrink after reveal: before={}, after={}",
+        rows_before,
+        rows_after
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1795. A terminal buffer that was hidden behind another tab while the host
window was resized kept reporting its pre-resize PTY dimensions even after the
user switched back to it (`$COLUMNS` / `stty size` stuck at the old values).

`resize_visible_terminals` only resizes the active tab's terminal in each split
(it iterates `get_visible_buffers`, which yields one buffer per leaf), so a
hidden terminal never gets a new `TIOCSWINSZ` and its child keeps the stale
geometry. Window-resize handlers therefore couldn't reach it.

This change calls `resize_visible_terminals` from `set_active_buffer` whenever
the newly active buffer is a terminal. The call is a no-op when the PTY already
matches its split's content area (`TerminalHandle::resize` short-circuits on
equal dimensions), so it doesn't add work on unrelated tab switches.

## Repro / validation

Manual repro in tmux (matches the steps in the issue):

1. Launch fresh in a 120×35 pane, open a Terminal — `echo $COLUMNS` reports `118`, `stty size` `31 118`.
2. Switch to another tab (Ctrl+PageUp).
3. `tmux resize-window -x 80 -y 25`.
4. Switch back (Ctrl+PageDown). `echo $COLUMNS` now reports `78`, `stty size` `21 78`.

Without the fix, step 4 still showed `118` / `31 118`.

## Test plan

- [x] New e2e regression `terminal::test_hidden_terminal_resyncs_pty_size_when_revealed` fails on `master` (PTY stays at the original cols) and passes with the fix.
- [x] Full `terminal::` e2e suite green (50 passed).
- [x] Full `terminal_resize::` e2e suite green (2 passed).
- [x] All buffer/workspace e2e tests green (191 passed).
- [x] `cargo check --all-targets`, `cargo clippy -p fresh-editor --tests`, `cargo fmt --check` clean.
- [x] Manual tmux validation reproduces the bug on master and is fixed on this branch.

https://claude.ai/code/session_01Wmk8JrA44oAoGcJYWC1HkE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wmk8JrA44oAoGcJYWC1HkE)_