### PR TITLE
fix(prompt): recompute layout after mid-render plugin command dispatch

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -102,8 +102,16 @@ impl Editor {
             }
         }
 
-        // Determine if we need to show search options bar
-        let show_search_options = self.prompt.as_ref().is_some_and(|p| {
+        // Determine if we need to show search options bar.
+        // (Held in mutable bindings because the in-render
+        // `process_commands` block below can dispatch commands —
+        // e.g. `StartPromptAsync`, `SetPromptSuggestions` — that
+        // mutate `self.prompt`. When that happens we recompute these
+        // flags and re-split `main_chunks` so the bottom-row
+        // rendering uses an up-to-date layout. See the
+        // "Recompute layout if mid-render commands changed state"
+        // block below.)
+        let mut show_search_options = self.prompt.as_ref().is_some_and(|p| {
             matches!(
                 p.prompt_type,
                 PromptType::Search
@@ -120,13 +128,13 @@ impl Editor {
         // wrong. Floating-overlay prompts (Live Grep, issue #1796)
         // are exempt because their suggestions live inside the
         // centred frame, not above the bottom row.
-        let prompt_is_overlay = self.prompt.as_ref().is_some_and(|p| p.overlay);
-        let has_suggestions = self
+        let mut prompt_is_overlay = self.prompt.as_ref().is_some_and(|p| p.overlay);
+        let mut has_suggestions = self
             .prompt
             .as_ref()
             .is_some_and(|p| !p.suggestions.is_empty())
             && !prompt_is_overlay;
-        let has_file_browser = self.prompt.as_ref().is_some_and(|p| {
+        let mut has_file_browser = self.prompt.as_ref().is_some_and(|p| {
             matches!(
                 p.prompt_type,
                 PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
@@ -136,34 +144,32 @@ impl Editor {
         // Build main vertical layout: [menu_bar, main_content, status_bar, search_options, prompt_line]
         // Status bar is hidden when suggestions popup is shown
         // Search options bar is shown when in search prompt
-        let constraints = vec![
-            Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }), // Menu bar
-            Constraint::Min(0),                                            // Main content area
-            Constraint::Length(
-                if !self.status_bar_visible || has_suggestions || has_file_browser {
-                    0
-                } else {
-                    1
-                },
-            ), // Status bar (hidden when toggled off or with popups)
-            Constraint::Length(if show_search_options { 1 } else { 0 }),   // Search options bar
-            Constraint::Length(
-                // Prompt line is auto-hidden when no prompt active.
-                // Overlay prompts (Live Grep, issue #1796) host the
-                // input row inside the centred frame, so the
-                // bottom row stays available for editor content
-                // rather than being reserved as dead space.
-                if (self.prompt_line_visible || self.prompt.is_some()) && !prompt_is_overlay {
-                    1
-                } else {
-                    0
-                },
-            ), // Prompt line
-        ];
-
-        let main_chunks = Layout::default()
+        let mut main_chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints(constraints)
+            .constraints(vec![
+                Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }), // Menu bar
+                Constraint::Min(0),                                            // Main content area
+                Constraint::Length(
+                    if !self.status_bar_visible || has_suggestions || has_file_browser {
+                        0
+                    } else {
+                        1
+                    },
+                ), // Status bar (hidden when toggled off or with popups)
+                Constraint::Length(if show_search_options { 1 } else { 0 }),   // Search options bar
+                Constraint::Length(
+                    // Prompt line is auto-hidden when no prompt active.
+                    // Overlay prompts (Live Grep, issue #1796) host the
+                    // input row inside the centred frame, so the
+                    // bottom row stays available for editor content
+                    // rather than being reserved as dead space.
+                    if (self.prompt_line_visible || self.prompt.is_some()) && !prompt_is_overlay {
+                        1
+                    } else {
+                        0
+                    },
+                ), // Prompt line
+            ])
             .split(size);
 
         let menu_bar_area = main_chunks[0];
@@ -400,7 +406,8 @@ impl Editor {
             // at 60fps. The plugin's own refreshLines() call from cursor_moved
             // ensures a follow-up render cycle picks up any missed commands.
             let commands = self.plugin_manager.process_commands();
-            if !commands.is_empty() {
+            let dispatched_any = !commands.is_empty();
+            if dispatched_any {
                 let cmd_names: Vec<String> =
                     commands.iter().map(|c| c.debug_variant_name()).collect();
                 tracing::trace!(count = commands.len(), cmds = ?cmd_names, "process_commands during render");
@@ -413,6 +420,82 @@ impl Editor {
 
             // Flush any deferred grammar rebuilds as a single batch
             self.flush_pending_grammars();
+
+            // Recompute the bottom-row layout if the in-render command
+            // dispatch above mutated state that affects it. Without
+            // this, a `StartPromptAsync` (or similar) processed
+            // mid-render leaves `main_chunks` reflecting the prior
+            // `self.prompt = None` shape — the prompt slot ends up at
+            // (y = size.height, h = 0) and the status bar paints the
+            // bottom row in place of the prompt input. Conservative:
+            // we recompute on *any* dispatched commands rather than
+            // enumerating layout-affecting variants — Layout::split is
+            // cheap, and this avoids a maintenance-burden whitelist
+            // that would silently regress as new `PluginCommand`
+            // variants are added.
+            //
+            // Bounded — single drain + single recompute. We do not
+            // call `process_commands` again, so commands queued by
+            // hooks fired inside the dispatch above wait for the next
+            // render or `editor_tick` (the existing one-frame-late
+            // behaviour the comment above already accepts).
+            //
+            // `main_content_area` (and the file-explorer / split
+            // rendering derived from it earlier in this render) is
+            // intentionally NOT re-derived: those areas were already
+            // painted, and the bottom-row recompute may overwrite a
+            // single row of main content where the new status bar /
+            // prompt now sits. That brief overlap self-corrects on
+            // the next frame, where the layout is built consistently
+            // from the start.
+            if dispatched_any {
+                show_search_options = self.prompt.as_ref().is_some_and(|p| {
+                    matches!(
+                        p.prompt_type,
+                        PromptType::Search
+                            | PromptType::ReplaceSearch
+                            | PromptType::Replace { .. }
+                            | PromptType::QueryReplaceSearch
+                            | PromptType::QueryReplace { .. }
+                    )
+                });
+                prompt_is_overlay = self.prompt.as_ref().is_some_and(|p| p.overlay);
+                has_suggestions = self
+                    .prompt
+                    .as_ref()
+                    .is_some_and(|p| !p.suggestions.is_empty())
+                    && !prompt_is_overlay;
+                has_file_browser = self.prompt.as_ref().is_some_and(|p| {
+                    matches!(
+                        p.prompt_type,
+                        PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
+                    )
+                }) && self.file_open_state.is_some();
+                main_chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints(vec![
+                        Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }),
+                        Constraint::Min(0),
+                        Constraint::Length(
+                            if !self.status_bar_visible || has_suggestions || has_file_browser {
+                                0
+                            } else {
+                                1
+                            },
+                        ),
+                        Constraint::Length(if show_search_options { 1 } else { 0 }),
+                        Constraint::Length(
+                            if (self.prompt_line_visible || self.prompt.is_some())
+                                && !prompt_is_overlay
+                            {
+                                1
+                            } else {
+                                0
+                            },
+                        ),
+                    ])
+                    .split(size);
+            }
         }
 
         // Render editor content (same for both layouts)

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -26,6 +26,13 @@ pub struct PluginManager {
     inner: Option<PluginThreadHandle>,
     #[cfg(not(feature = "plugins"))]
     _phantom: std::marker::PhantomData<()>,
+    /// Test-only side channel: commands pushed via
+    /// [`Self::test_inject_command`] are returned by the next
+    /// `process_commands()` call as if they had come from the plugin
+    /// thread. Always present (zero overhead — empty `Vec`) so
+    /// integration tests in `tests/` can use it without an extra
+    /// feature flag.
+    pending_injected_commands: Vec<super::api::PluginCommand>,
 }
 
 impl PluginManager {
@@ -51,6 +58,7 @@ impl PluginManager {
                     Ok(handle) => {
                         return Self {
                             inner: Some(handle),
+                            pending_injected_commands: Vec::new(),
                         }
                     }
                     Err(e) => {
@@ -62,7 +70,10 @@ impl PluginManager {
             } else {
                 tracing::info!("Plugins disabled via --no-plugins flag");
             }
-            Self { inner: None }
+            Self {
+                inner: None,
+                pending_injected_commands: Vec::new(),
+            }
         }
 
         #[cfg(not(feature = "plugins"))]
@@ -75,12 +86,29 @@ impl PluginManager {
             }
             Self {
                 _phantom: std::marker::PhantomData,
+                pending_injected_commands: Vec::new(),
             }
         }
     }
 
-    /// Check if the plugin system is active (has a running plugin thread).
+    /// Inject a [`PluginCommand`](super::api::PluginCommand) into the
+    /// manager's pending queue as if it had arrived from the plugin
+    /// thread. Returned by the next `process_commands()` call.
+    ///
+    /// Intended for tests that need to deterministically reproduce
+    /// renderer/plugin races (e.g. the mid-render `process_commands`
+    /// path in `Editor::render`) without spinning up the real plugin
+    /// runtime. Production code should not call this.
+    pub fn test_inject_command(&mut self, command: super::api::PluginCommand) {
+        self.pending_injected_commands.push(command);
+    }
+
+    /// Check if the plugin system is active (has a running plugin thread,
+    /// or — in tests — has commands queued via [`Self::test_inject_command`]).
     pub fn is_active(&self) -> bool {
+        if !self.pending_injected_commands.is_empty() {
+            return true;
+        }
         #[cfg(feature = "plugins")]
         {
             self.inner.is_some()
@@ -243,17 +271,18 @@ impl PluginManager {
 
     /// Process pending plugin commands (non-blocking).
     pub fn process_commands(&mut self) -> Vec<super::api::PluginCommand> {
+        // Drain any test-injected commands first so they appear at the
+        // front of the returned batch — matching the order the real
+        // plugin thread would have produced if the inject call were a
+        // genuine plugin response.
+        let mut commands = std::mem::take(&mut self.pending_injected_commands);
         #[cfg(feature = "plugins")]
         {
             if let Some(ref mut manager) = self.inner {
-                return manager.process_commands();
+                commands.extend(manager.process_commands());
             }
-            Vec::new()
         }
-        #[cfg(not(feature = "plugins"))]
-        {
-            Vec::new()
-        }
+        commands
     }
 
     /// Process commands, blocking until `HookCompleted` for the given hook arrives.

--- a/crates/fresh-editor/tests/e2e/prompt.rs
+++ b/crates/fresh-editor/tests/e2e/prompt.rs
@@ -1,5 +1,104 @@
 use crate::common::harness::EditorTestHarness;
 
+/// Regression test for the mid-render plugin command race observed
+/// when invoking the audit_mode plugin's "Review PR Branch" command
+/// from the command palette under auto-hide mode.
+///
+/// `Editor::render` (`crates/fresh-editor/src/app/render.rs:402`) drains
+/// the plugin manager's command queue *after* the layout has been
+/// computed but *before* the prompt/status bar are rendered. Any
+/// plugin command queued just before this render — for example, the
+/// `StartPromptAsync` that `editor.prompt(...)` queues from the
+/// audit_mode handler — gets dispatched at line 402 and sets
+/// `self.prompt = Some(AsyncPrompt)`. The cached `main_chunks` still
+/// reflects the prior `prompt = None` state, so the prompt slot is at
+/// `(y = size.height, h = 0)` (off-screen) and the status bar lands on
+/// the bottom row. The user sees status-bar text where the prompt
+/// input should be.
+///
+/// To reproduce deterministically without spinning up the real plugin
+/// runtime, the test uses `PluginManager::test_inject_command` to
+/// queue a `StartPromptAsync` immediately before a single `render()`
+/// call. The render fires the in-render `process_commands()` call,
+/// which dispatches the injected command mid-render, triggering the
+/// race exactly as the audit_mode flow does.
+///
+/// **Currently fails** — kept ignored so CI stays green while we
+/// decide on the fix shape (simplest: drop the in-render
+/// `process_commands` call; surgical: filter to render-only commands;
+/// defensive: recompute the layout after mid-render command
+/// processing). Remove the `#[ignore]` once the fix lands.
+#[test]
+#[ignore = "expected to fail; reproduces issue #1785-class mid-render plugin race — un-ignore once render.rs:402 fix lands"]
+fn test_mid_render_start_prompt_async_keeps_prompt_visible() {
+    use fresh_core::api::{JsCallbackId, PluginCommand};
+
+    // Match the user-reported environment (200x50 tmux pane, default
+    // auto-hide prompt line).
+    let mut harness = EditorTestHarness::new(200, 50).unwrap();
+    harness.editor_mut().toggle_prompt_line();
+    assert!(!harness.editor().prompt_line_visible());
+
+    // Set a status message so the bottom row's status-bar content is
+    // distinguishable from the editor body. The marker word lets the
+    // assertion below detect any leak unambiguously.
+    harness
+        .editor_mut()
+        .set_status_message("Test status XYZZY-bleed-marker".to_string());
+    harness.render().unwrap();
+
+    // Sanity: with no prompt active and the prompt line auto-hidden,
+    // the status bar lands on the bottom row.
+    let height = harness.buffer().area.height;
+    let bottom_baseline = harness.get_row_text(height - 1);
+    assert!(
+        bottom_baseline.contains("XYZZY-bleed-marker"),
+        "Setup expected status bar on bottom row, got: {:?}",
+        bottom_baseline,
+    );
+
+    // Queue a StartPromptAsync command — this is exactly what the
+    // audit_mode plugin's `editor.prompt(label, initial)` call sends.
+    // The command will be picked up by `Editor::render`'s mid-render
+    // `process_commands()` call.
+    harness
+        .editor_mut()
+        .plugin_manager_mut()
+        .test_inject_command(PluginCommand::StartPromptAsync {
+            label: "Base ref to compare against (default: master): ".to_string(),
+            initial_value: "master".to_string(),
+            callback_id: JsCallbackId(1),
+        });
+
+    // Render once. The render must produce a frame where:
+    //   - the AsyncPrompt's label is on the bottom row, and
+    //   - the bottom row contains no status-bar leftovers.
+    harness.render().unwrap();
+
+    let bottom_row = harness.get_row_text(height - 1);
+    let screen = harness.screen_to_string();
+
+    assert!(
+        bottom_row.contains("Base ref to compare against"),
+        "Expected AsyncPrompt label on bottom row after the injected\n\
+         StartPromptAsync was processed mid-render.\n\
+         Bottom row: {:?}\nFull screen:\n{}",
+        bottom_row,
+        screen,
+    );
+    assert!(
+        !bottom_row.contains("XYZZY-bleed-marker"),
+        "Status-bar text from before the prompt opened leaked through\n\
+         the prompt's row — the layout was computed for prompt=None\n\
+         but the prompt was set Some mid-render, so the prompt slot is\n\
+         at the wrong y/height and the status bar paints the bottom\n\
+         row instead.\n\
+         Bottom row: {:?}\nFull screen:\n{}",
+        bottom_row,
+        screen,
+    );
+}
+
 /// Test that the prompt is rendered correctly
 #[test]
 fn test_prompt_rendering() {

--- a/crates/fresh-editor/tests/e2e/prompt.rs
+++ b/crates/fresh-editor/tests/e2e/prompt.rs
@@ -23,13 +23,7 @@ use crate::common::harness::EditorTestHarness;
 /// which dispatches the injected command mid-render, triggering the
 /// race exactly as the audit_mode flow does.
 ///
-/// **Currently fails** — kept ignored so CI stays green while we
-/// decide on the fix shape (simplest: drop the in-render
-/// `process_commands` call; surgical: filter to render-only commands;
-/// defensive: recompute the layout after mid-render command
-/// processing). Remove the `#[ignore]` once the fix lands.
 #[test]
-#[ignore = "expected to fail; reproduces issue #1785-class mid-render plugin race — un-ignore once render.rs:402 fix lands"]
 fn test_mid_render_start_prompt_async_keeps_prompt_visible() {
     use fresh_core::api::{JsCallbackId, PluginCommand};
 


### PR DESCRIPTION
## Summary

Fixes a mid-render plugin command race in `Editor::render` that produced visible status-bar leakage on the prompt's row when the audit_mode plugin's "Review PR Branch" command was invoked from the command palette under auto-hide mode (`show_prompt_line = false`). Adds harness infrastructure (`PluginManager::test_inject_command`) and a deterministic regression test that reproduces the bug without booting the real plugin runtime.

This PR replaces my earlier #1785 attempt (a `render.rs` clamp on the prompt's render rect), which was reverted because the clamp turned out to be a no-op — the layout's `prompt_chunk` is only ever off-screen because of this race, not because the constraint solver places it there on consistent state.

## Root cause

`Editor::render` (`crates/fresh-editor/src/app/render.rs:402`) drains the plugin manager's command queue *after* the layout has been computed but *before* the prompt/status bar are rendered:

```rust
// Layout computed at line 164 with current self.prompt
let main_chunks = Layout::default()...
// Hooks fire (lines_changed, view_transform_request)
// Line 402: drain *all* plugin commands and dispatch
let commands = self.plugin_manager.process_commands();
for command in commands { self.handle_plugin_command(command); }  // may set self.prompt = Some(...)
// Status bar + prompt rendered using stale main_chunks
```

When the audit_mode plugin's `editor.prompt(label, initial)` queues a `StartPromptAsync` between renders, the next render's mid-render `process_commands()` dispatches it and sets `self.prompt = Some(AsyncPrompt)`. The cached `main_chunks` still reflects `prompt = None`, so:
- `prompt_chunk = (y: size.height, h: 0)` — off-screen, 0 height
- `status_chunk = (y: size.height-1, h: 1)` — gets the bottom row

Status bar paints to the bottom row; prompt paints to a 0-height slot. Confirmed against the real binary's debug log:

```
DBG_RENDER prompt_type=AsyncPrompt sugg_count=0 status_chunk=Rect{y:49,h:1} prompt_chunk=Rect{y:50,h:0}
```

The next frame self-corrects (`status_chunk={y:48,h:1} prompt_chunk={y:49,h:1}`), which is the "shifts up by one row" the user reported.

## Fix

After the mid-render command dispatch, if any commands were processed, recompute the layout-affecting flags (`has_suggestions`, `has_file_browser`, `prompt_is_overlay`, `show_search_options`) and re-split `main_chunks`. The bottom-row render code (status bar, prompt) then paints into the correct slots.

- **Conservative trigger**: "any commands processed" rather than "any layout-affecting command processed". Layout::split is cheap; this avoids a PluginCommand whitelist that would silently regress as new variants are added.
- **Bounded**: single drain + single recompute. No second `process_commands` call, no recursion. Hooks fired by the dispatch handlers above queue their responses for the next render/`editor_tick` — the same one-frame behaviour the existing comment already accepts as imperceptible at 60fps.
- **`main_content_area` intentionally not re-derived**: the file explorer / split rendering already painted to the original `main_content_area`. The bottom-row recompute may overwrite a single row of main content where the new status bar / prompt now sits; that brief overlap self-corrects on the next frame, where the layout is built consistently from the start.

## What this PR adds

1. **`PluginManager::test_inject_command`** (`crates/fresh-editor/src/services/plugins/manager.rs`) — always-present (zero overhead) `pending_injected_commands: Vec<PluginCommand>` queue. `process_commands()` drains it alongside the real plugin thread's commands, and `is_active()` returns true if the queue is non-empty so the in-render `process_commands` block (gated on `is_active`) actually runs in tests with no real plugin runtime.

2. **Regression test** — `test_mid_render_start_prompt_async_keeps_prompt_visible` in `tests/e2e/prompt.rs`:
   - Toggles auto-hide on, sets a status message containing a marker word, asserts the marker lands on the bottom row (sanity).
   - Injects a `StartPromptAsync` and renders once. The render fires the in-render command processing path, dispatches the injected command, and asserts the bottom row shows the prompt's label and contains no status-bar leftovers.
   - Without the fix this asserts-out cleanly with "Status-bar text from before the prompt opened leaked through the prompt's row".

3. **Fix** in `Editor::render` — recompute layout if mid-render command dispatch processed anything.

## Test plan

- [x] `cargo test -p fresh-editor --lib` — 2289 passing
- [x] `cargo test -p fresh-editor --test e2e_tests prompt_` — 75 passing
- [x] `cargo test -p fresh-editor --test e2e_tests popup` — 101 passing
- [x] `cargo test -p fresh-editor --test e2e_tests markdown_compose` — 62 passing
- [x] `cargo test -p fresh-editor --test e2e_tests test_mid_render_start_prompt_async_keeps_prompt_visible` — passes with fix; reverting just the fix portion makes it fail with the expected diagnostic
- [x] `cargo fmt`, `cargo check --all-targets` clean; no new clippy warnings on the changed files
- [x] Manual reproduction in tmux (200×50, default config, README.md, `Ctrl+P` → `Review PR` → Enter) — bottom row now correctly shows `Base ref to compare against (default: master): master` with the status bar one row above; prior to the fix the prompt row showed status-bar text leaking past the prompt's content

https://claude.ai/code/session_017NxQWM8Q3y1HDKoVUWbsfE