### PR TITLE
fix(hot-exit): scope standalone recovery dir per working_dir (#1550)

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -770,7 +770,7 @@ impl Editor {
             key_context: KeyContext::Normal,
             menu_state: crate::view::ui::MenuState::new(dir_context.themes_dir()),
             menus: crate::config::MenuConfig::translated(),
-            working_dir,
+            working_dir: working_dir.clone(),
             position_history: PositionHistory::new(),
             in_navigation: false,
             next_lsp_request_id: 0,
@@ -887,7 +887,17 @@ impl Editor {
                     enabled: recovery_enabled,
                     ..RecoveryConfig::default()
                 };
-                RecoveryService::with_config_and_dir(recovery_config, dir_context.recovery_dir())
+                // Default to a CWD-scoped recovery directory so each working
+                // directory keeps its own hot-exit recovery files. If this
+                // editor is later promoted to session mode, `set_session_name`
+                // re-creates the service with `RecoveryScope::Session`.
+                // Issue #1550: without per-CWD scoping, opening Fresh in a
+                // second folder would clobber the first folder's unsaved
+                // unnamed buffers on shutdown.
+                let scope = crate::services::recovery::RecoveryScope::Standalone {
+                    working_dir: working_dir.clone(),
+                };
+                RecoveryService::with_scope(recovery_config, &dir_context.recovery_dir(), &scope)
             },
             full_redraw_requested: false,
             suspend_requested: false,

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -925,12 +925,19 @@ impl EditorTestHarness {
             .map(|h| h.state_path.as_path())
     }
 
-    /// Get the recovery directory path for this test harness
-    /// The recovery directory is isolated per-test under the temp directory
+    /// Get the recovery directory path for this test harness.
+    ///
+    /// Returns the *scoped* directory where the editor actually writes
+    /// recovery files. In standalone mode (no `set_session_name`) the path
+    /// is `<base>/default/<encoded_working_dir>/`, so each working directory
+    /// keeps its own recovery files (issue #1550).
     pub fn recovery_dir(&self) -> Option<PathBuf> {
-        self._temp_dir
+        let base = self
+            ._temp_dir
             .as_ref()
-            .map(|d| d.path().join("data").join("recovery"))
+            .map(|d| d.path().join("data").join("recovery"))?;
+        let hash = fresh::workspace::encode_path_for_filename(self.editor.working_dir());
+        Some(base.join("default").join(hash))
     }
 
     /// Take ownership of the temp directory, preventing it from being cleaned up

--- a/crates/fresh-editor/tests/e2e/hot_exit_flows.rs
+++ b/crates/fresh-editor/tests/e2e/hot_exit_flows.rs
@@ -1090,3 +1090,138 @@ fn test_undo_after_hot_exit_recovery_keeps_modified_flag() {
         harness.assert_screen_contains("EDITED");
     }
 }
+
+// =========================================================================
+// Issue #1550 — Hot exit data must not be lost when fresh is also used in
+// another folder.
+//
+// Standalone (non-session) Fresh launches share a single user data dir, but
+// each working directory has its own workspace file. Before the fix, all
+// folders also shared a single flat recovery directory, so when folder B's
+// editor exited it deleted the unnamed-buffer recovery files belonging to
+// folder A. Folder A's saved files were still listed in its workspace, but
+// the unnamed buffer they referenced was gone — exactly the symptom in the
+// bug report.
+//
+// The fix scopes the standalone-mode recovery directory by working_dir
+// (`recovery/default/{cwd_hash}/`), so each folder's exit only touches its
+// own recovery files.
+// =========================================================================
+
+/// After exiting Fresh in folder A and then opening / closing it in folder B,
+/// the unsaved unnamed buffer from folder A must still be restorable.
+#[test]
+fn test_unnamed_buffer_survives_use_in_another_folder() {
+    let temp_dir = TempDir::new().unwrap();
+    let folder_a = temp_dir.path().join("folder_a");
+    let folder_b = temp_dir.path().join("folder_b");
+    std::fs::create_dir(&folder_a).unwrap();
+    std::fs::create_dir(&folder_b).unwrap();
+
+    // Single shared dir context — represents the same user/installation
+    // running Fresh in two different working directories.
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Folder A: full startup → unnamed buffer with content → shutdown.
+    // Calling `startup` is what arms the recovery session lock so that the
+    // matching `shutdown` actually performs the cleanup that historically
+    // deleted other folders' recovery files.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(folder_a.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        harness.startup(true, &[]).unwrap();
+        harness.new_buffer().unwrap();
+        harness.type_text("FOLDER_A_UNSAVED").unwrap();
+        harness.render().unwrap();
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Folder B: same dance with different content. With a global recovery
+    // directory, this shutdown wipes folder A's unnamed-buffer recovery file.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(folder_b.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        harness.startup(true, &[]).unwrap();
+        harness.new_buffer().unwrap();
+        harness.type_text("FOLDER_B_UNSAVED").unwrap();
+        harness.render().unwrap();
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Re-open folder A: the unnamed buffer should still be there with its
+    // unsaved content. Without the per-CWD recovery scope this fails because
+    // folder B's shutdown wiped folder A's recovery files.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(folder_a.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "Folder A workspace should be restored");
+        harness.render().unwrap();
+
+        harness.assert_screen_contains("FOLDER_A_UNSAVED");
+        harness.assert_screen_not_contains("FOLDER_B_UNSAVED");
+    }
+
+    // Sanity-check the symmetric case too: folder B's unnamed buffer must
+    // also still be intact.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            100,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(folder_b.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "Folder B workspace should be restored");
+        harness.render().unwrap();
+
+        harness.assert_screen_contains("FOLDER_B_UNSAVED");
+        harness.assert_screen_not_contains("FOLDER_A_UNSAVED");
+    }
+}


### PR DESCRIPTION
Fixes #1550.

## Summary

In standalone (non-`-a`) mode the recovery service was constructed with the flat `<data>/recovery/` directory shared by every Fresh launch, while workspace files are already per-CWD. The result: opening Fresh in folder B and exiting cleanly would call `end_session_preserving` with **B's** unnamed-buffer IDs and delete every other recovery file in the dir — wiping folder A's unsaved unnamed buffer that A's workspace still referenced. On reopening A, the workspace pointed at a now-missing recovery file and the unsaved buffer silently came back empty.

## Fix

Construct the editor's recovery service with `RecoveryScope::Standalone { working_dir }` (the scope already existed; this is the layout the design doc in `docs/internal/hot-exit-improvements-plan.md` calls for). Each working directory now writes to `<data>/recovery/default/{cwd_hash}/`, so cleanup in one folder can't touch another's recovery files. `RecoveryService::with_scope` already migrates any existing flat-layout files into the active CWD's scoped subdirectory the first time it runs.

Session mode is unchanged: `set_session_name(Some(name))` still re-creates the service with `RecoveryScope::Session { name }` immediately after construction.

## Changes

- `crates/fresh-editor/src/app/editor_init.rs` — switch the recovery service construction to `with_scope` + `RecoveryScope::Standalone { working_dir }`.
- `crates/fresh-editor/tests/common/harness.rs` — `recovery_dir()` now returns the scoped path so existing recovery tests keep inspecting the right directory.
- `crates/fresh-editor/tests/e2e/hot_exit_flows.rs` — new regression test `test_unnamed_buffer_survives_use_in_another_folder` that runs the bug repro end-to-end (folder A → modify → exit → folder B → modify → exit → reopen folder A → assert content). Fails on master, passes with the fix.

## Test plan

- [x] `cargo check --all-targets` (passes)
- [x] `cargo test -p fresh-editor --test e2e_tests hot_exit` — 24 passed
- [x] `cargo test -p fresh-editor --test e2e_tests recovery` — 30 passed
- [x] `cargo test -p fresh-editor --test e2e_tests workspace` — 48 passed
- [x] `cargo test -p fresh-editor --test e2e_tests session` — 48 passed
- [x] New regression test `test_unnamed_buffer_survives_use_in_another_folder` fails without the fix and passes with it
- [x] Manual tmux validation: open Fresh in folder A → unnamed buffer "FOLDER_A_UNSAVED_DRAFT" → Ctrl+Q; open in folder B → unnamed buffer "FOLDER_B_UNSAVED_DRAFT" → Ctrl+Q; reopen folder A → buffer restored ✅; reopen folder B → buffer restored ✅. Recovery dirs on disk: `recovery/default/<encoded_folder_a>/` and `recovery/default/<encoded_folder_b>/`, fully isolated.

https://claude.ai/code/session_01MGdBJTDsLb5PeixENetGoM

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGdBJTDsLb5PeixENetGoM)_