### PR TITLE
feat(file-explorer): add follow_active_buffer config option

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -133,7 +133,8 @@
         "width": "30%",
         "preview_tabs": true,
         "side": "left",
-        "auto_open_on_last_buffer_close": true
+        "auto_open_on_last_buffer_close": true,
+        "follow_active_buffer": false
       }
     },
     "file_browser": {
@@ -952,6 +953,11 @@
           "description": "Automatically focus the file explorer when the last buffer is\nclosed. Set to `false` for a \"blank workspace\" workflow where\nnothing opens automatically and the user explicitly invokes the\nfile explorer (e.g. via keybinding or command palette).\nDefault: true",
           "type": "boolean",
           "default": true
+        },
+        "follow_active_buffer": {
+          "description": "When the file explorer sidebar is open, automatically expand the\ntree and highlight the file that corresponds to the active buffer\nwhenever you switch tabs. Set to `true` to keep the explorer\nselection in sync with the active tab.\nDefault: false",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -121,6 +121,7 @@ impl Editor {
         self.ensure_active_tab_visible(active_split, buffer_id, self.effective_tabs_width());
 
         if self.file_explorer_visible
+            && self.config.file_explorer.follow_active_buffer
             && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
         {
             self.sync_file_explorer_to_active_file();

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -120,8 +120,11 @@ impl Editor {
         // Ensure the newly active tab is visible
         self.ensure_active_tab_visible(active_split, buffer_id, self.effective_tabs_width());
 
-        // Note: We don't sync file explorer here to avoid flicker during tab switches.
-        // File explorer syncs when explicitly focused via focus_file_explorer().
+        if self.file_explorer_visible
+            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
+        {
+            self.sync_file_explorer_to_active_file();
+        }
 
         // Update plugin state snapshot BEFORE firing the hook so that
         // the handler sees the new active buffer, not the old one.

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1523,6 +1523,14 @@ pub struct FileExplorerConfig {
     /// Default: true
     #[serde(default = "default_true")]
     pub auto_open_on_last_buffer_close: bool,
+
+    /// When the file explorer sidebar is open, automatically expand the
+    /// tree and highlight the file that corresponds to the active buffer
+    /// whenever you switch tabs. Set to `true` to keep the explorer
+    /// selection in sync with the active tab.
+    /// Default: false
+    #[serde(default = "default_false")]
+    pub follow_active_buffer: bool,
 }
 
 /// Width configuration for the file explorer.
@@ -1879,6 +1887,7 @@ impl Default for FileExplorerConfig {
             preview_tabs: true,
             side: default_explorer_side(),
             auto_open_on_last_buffer_close: true,
+            follow_active_buffer: false,
         }
     }
 }

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -346,6 +346,7 @@ pub struct PartialFileExplorerConfig {
     pub preview_tabs: Option<bool>,
     pub side: Option<crate::config::FileExplorerSide>,
     pub auto_open_on_last_buffer_close: Option<bool>,
+    pub follow_active_buffer: Option<bool>,
 }
 
 impl Merge for PartialFileExplorerConfig {
@@ -360,6 +361,8 @@ impl Merge for PartialFileExplorerConfig {
         self.side.merge_from(&other.side);
         self.auto_open_on_last_buffer_close
             .merge_from(&other.auto_open_on_last_buffer_close);
+        self.follow_active_buffer
+            .merge_from(&other.follow_active_buffer);
     }
 }
 
@@ -766,6 +769,7 @@ impl From<&FileExplorerConfig> for PartialFileExplorerConfig {
             preview_tabs: Some(cfg.preview_tabs),
             side: Some(cfg.side),
             auto_open_on_last_buffer_close: Some(cfg.auto_open_on_last_buffer_close),
+            follow_active_buffer: Some(cfg.follow_active_buffer),
         }
     }
 }
@@ -785,6 +789,9 @@ impl PartialFileExplorerConfig {
             auto_open_on_last_buffer_close: self
                 .auto_open_on_last_buffer_close
                 .unwrap_or(defaults.auto_open_on_last_buffer_close),
+            follow_active_buffer: self
+                .follow_active_buffer
+                .unwrap_or(defaults.follow_active_buffer),
         }
     }
 }

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -1,6 +1,7 @@
 use crate::common::git_test_helper::GitTestRepo;
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
 use std::fs;
 
 /// Test file explorer toggle
@@ -3744,4 +3745,76 @@ fn test_file_explorer_duplicate_refreshes_git_decorations() {
                 .any(|line| line.contains("alpha copy.txt") && line.contains('U'))
         })
         .unwrap();
+}
+
+/// Test that with `file_explorer.follow_active_buffer = true`, switching tabs
+/// re-syncs the file explorer to the newly active buffer's path — visibly
+/// expanding the directory containing that file.
+///
+/// Two files live in different subdirectories; both directories are
+/// initially collapsed. Opening file_b (after file_a was opened in-place
+/// over the empty buffer) syncs the explorer, expanding dir_b. Then
+/// `prev_buffer` switches the active tab back to file_a — with the sync
+/// hook in place, dir_a expands and file_a.txt becomes visible in the
+/// tree. Without the hook, dir_a stays collapsed and the wait times out.
+#[test]
+fn test_follow_active_buffer_syncs_explorer_on_tab_switch() {
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = true;
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    fs::create_dir_all(project_root.join("dir_a")).unwrap();
+    fs::create_dir_all(project_root.join("dir_b")).unwrap();
+    fs::write(project_root.join("dir_a/file_a.txt"), "content a").unwrap();
+    fs::write(project_root.join("dir_b/file_b.txt"), "content b").unwrap();
+
+    // Open the explorer but keep focus in the editor so the sync hook is
+    // eligible (it is gated on `key_context != FileExplorer`).
+    harness.editor_mut().toggle_file_explorer();
+    harness.editor_mut().focus_editor();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    // Opening file_a replaces the initial `[No Name]` buffer in place, so
+    // `set_active_buffer` is a no-op and no sync fires. Opening file_b
+    // creates a new buffer; the sync triggered by that switch expands
+    // dir_b, leaving dir_a still collapsed.
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_a/file_a.txt"))
+        .unwrap();
+    harness
+        .editor_mut()
+        .open_file(&project_root.join("dir_b/file_b.txt"))
+        .unwrap();
+    harness
+        .wait_until(|h| explorer_tree_contains(h, "file_b.txt"))
+        .unwrap();
+    assert!(
+        !explorer_tree_contains(&harness, "file_a.txt"),
+        "Precondition: dir_a should still be collapsed (file_a.txt not in \
+         the tree) before the tab switch.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Switch the active tab back to file_a. With the sync hook in place,
+    // the explorer expands dir_a and file_a.txt becomes visible in the
+    // tree. Without it, dir_a stays collapsed and this wait times out.
+    harness.editor_mut().prev_buffer();
+    harness
+        .wait_until(|h| explorer_tree_contains(h, "file_a.txt"))
+        .unwrap();
+}
+
+/// Returns `true` when `name` appears on a screen line that also contains a
+/// tree connector, matching the existing `wait_for_file_explorer_item`
+/// heuristic. Reads only rendered output.
+fn explorer_tree_contains(harness: &EditorTestHarness, name: &str) -> bool {
+    harness
+        .screen_to_string()
+        .lines()
+        .any(|line| line.contains(name) && line.contains('│'))
 }

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1380,9 +1380,9 @@ fn test_settings_file_explorer_width_shows_percent_suffix() {
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Preview Tabs, Respect Gitignore, Show Gitignored,
-    // Show Hidden, Side, Width.
-    for _ in 0..7 {
+    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
+    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
+    for _ in 0..8 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1428,9 +1428,9 @@ fn test_settings_file_explorer_width_applies_live() {
     }
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Preview Tabs, Respect Gitignore, Show Gitignored,
-    // Show Hidden, Side, Width.
-    for _ in 0..7 {
+    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
+    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
+    for _ in 0..8 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1538,9 +1538,10 @@ fn test_settings_file_explorer_toggles_propagate_to_runtime() {
     harness.render().unwrap();
 
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Preview Tabs, Respect Gitignore, Show Gitignored,
-    // Show Hidden, Side, Width. Land on Show Gitignored and toggle.
-    for _ in 0..4 {
+    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
+    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
+    // Land on Show Gitignored and toggle.
+    for _ in 0..5 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Adds `file_explorer.follow_active_buffer` (default: `false`) so users can opt in to automatic file explorer sync on tab switch.

When enabled, switching tabs expands the tree and highlights the file corresponding to the newly active buffer — without stealing keyboard focus from the editor.

**Usage** (`~/.config/fresh/config.json`):
```json
{
  "file_explorer": {
    "follow_active_buffer": true
  }
}
```

**How it works:**

`sync_file_explorer_to_active_file()` already existed and handled exactly this expand-and-select logic. It was just never called on tab switch. The only addition is calling it from `set_active_buffer` when the explorer is visible, the new setting is enabled, and the user isn't actively navigating inside the explorer panel (`key_context != FileExplorer`).

The `file_explorer_sync_in_progress` guard inside `sync_file_explorer_to_active_file()` prevents re-entrant async tasks on rapid tab switching.

**Changes:**
- `config.rs` — `follow_active_buffer: bool` field on `FileExplorerConfig` (default `false`)
- `partial_config.rs` — corresponding `Option<bool>` in `PartialFileExplorerConfig`, wired into `merge_from`, `From`, and `resolve`
- `active_focus.rs` — call `sync_file_explorer_to_active_file()` in `set_active_buffer` when the new setting is `true`

</details>