### PR TITLE
fix(file-open): scroll dialog using actual viewport height (#245)

### DIFF
--- a/crates/fresh-editor/src/app/file_open.rs
+++ b/crates/fresh-editor/src/app/file_open.rs
@@ -81,6 +81,12 @@ pub struct FileOpenState {
     /// Scroll offset for file list
     pub scroll_offset: usize,
 
+    /// Number of file rows visible in the viewport, as reported by the
+    /// renderer on the previous frame. Used by selection actions to clamp
+    /// `scroll_offset` to the actual viewport instead of a fixed default —
+    /// the renderer is the only place that knows the real viewport height.
+    pub last_visible_rows: usize,
+
     /// Which section is currently active
     pub active_section: FileOpenSection,
 
@@ -124,6 +130,7 @@ impl FileOpenState {
             sort_ascending: true,
             selected_index: None,
             scroll_offset: 0,
+            last_visible_rows: 0,
             active_section: FileOpenSection::Files,
             filter: String::new(),
             shortcuts,
@@ -548,30 +555,39 @@ impl FileOpenState {
         }
     }
 
-    /// Ensure selected item is visible in viewport
+    /// Ensure selected item is visible in viewport, using the most recent
+    /// viewport height reported by the renderer. Called from input handlers,
+    /// where the actual viewport height isn't known directly.
     fn ensure_selected_visible(&mut self) {
-        let Some(idx) = self.selected_index else {
-            return;
-        };
-        // This will be called with actual visible_rows from renderer
-        // For now, use a reasonable default
-        let visible_rows = 15;
-        if idx < self.scroll_offset {
-            self.scroll_offset = idx;
-        } else if idx >= self.scroll_offset + visible_rows {
-            self.scroll_offset = idx.saturating_sub(visible_rows - 1);
-        }
+        self.clamp_scroll_to_selection();
     }
 
-    /// Update scroll offset based on visible rows
+    /// Reconcile `scroll_offset` with the actual viewport height. The
+    /// renderer calls this once per frame; selection actions call
+    /// `ensure_selected_visible` which uses the cached value.
     pub fn update_scroll_for_visible_rows(&mut self, visible_rows: usize) {
-        let Some(idx) = self.selected_index else {
+        self.last_visible_rows = visible_rows;
+        self.clamp_scroll_to_selection();
+    }
+
+    /// Clamp `scroll_offset` so the selection stays within the viewport
+    /// `[scroll_offset, scroll_offset + last_visible_rows)`, and so that we
+    /// never scroll past the last entry.
+    fn clamp_scroll_to_selection(&mut self) {
+        let visible_rows = self.last_visible_rows;
+        if visible_rows == 0 {
             return;
-        };
-        if idx < self.scroll_offset {
-            self.scroll_offset = idx;
-        } else if idx >= self.scroll_offset + visible_rows {
-            self.scroll_offset = idx.saturating_sub(visible_rows - 1);
+        }
+        if let Some(idx) = self.selected_index {
+            if idx < self.scroll_offset {
+                self.scroll_offset = idx;
+            } else if idx >= self.scroll_offset + visible_rows {
+                self.scroll_offset = idx + 1 - visible_rows;
+            }
+        }
+        let max_offset = self.entries.len().saturating_sub(visible_rows);
+        if self.scroll_offset > max_offset {
+            self.scroll_offset = max_offset;
         }
     }
 
@@ -847,6 +863,83 @@ mod tests {
 
         state.select_last();
         assert_eq!(state.selected_index, Some(2));
+    }
+
+    /// Regression test for #245: when the terminal is small enough that the
+    /// file list shows fewer than the previous hardcoded 15 rows, moving the
+    /// selection past the bottom of the viewport must scroll the list so the
+    /// selected entry stays visible.
+    #[test]
+    fn test_scroll_follows_selection_in_small_viewport() {
+        let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
+        state.set_entries(
+            (0..10)
+                .map(|i| make_entry(&format!("f{i}"), false))
+                .collect(),
+        );
+
+        // Renderer reports a 3-row viewport (very small terminal).
+        state.update_scroll_for_visible_rows(3);
+        assert_eq!(state.scroll_offset, 0);
+
+        // Walk down to index 4. Selection must remain inside [scroll_offset, scroll_offset + 3).
+        for _ in 0..5 {
+            state.select_next();
+        }
+        assert_eq!(state.selected_index, Some(4));
+        let idx = state.selected_index.unwrap();
+        assert!(
+            idx >= state.scroll_offset && idx < state.scroll_offset + 3,
+            "selected idx {idx} not in viewport [{}, {})",
+            state.scroll_offset,
+            state.scroll_offset + 3
+        );
+
+        // Jumping to the last entry must also keep it on screen.
+        state.select_last();
+        let idx = state.selected_index.unwrap();
+        assert_eq!(idx, 9);
+        assert!(
+            idx >= state.scroll_offset && idx < state.scroll_offset + 3,
+            "select_last left idx {idx} outside viewport [{}, {})",
+            state.scroll_offset,
+            state.scroll_offset + 3
+        );
+
+        // Moving back up shrinks the offset so we don't leave a blank tail.
+        state.select_first();
+        assert_eq!(state.selected_index, Some(0));
+        assert_eq!(state.scroll_offset, 0);
+    }
+
+    /// When the viewport shrinks (terminal resize), the next renderer pass
+    /// must re-clamp `scroll_offset` so the selection stays visible.
+    #[test]
+    fn test_scroll_reclamped_on_viewport_shrink() {
+        let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
+        state.set_entries(
+            (0..20)
+                .map(|i| make_entry(&format!("f{i}"), false))
+                .collect(),
+        );
+
+        state.update_scroll_for_visible_rows(15);
+        for _ in 0..15 {
+            state.select_next();
+        }
+        // Selection at idx 14 fits in a 15-row viewport with offset 0.
+        assert_eq!(state.selected_index, Some(14));
+        assert_eq!(state.scroll_offset, 0);
+
+        // Terminal shrinks to 4 rows; the next render reports the new height.
+        state.update_scroll_for_visible_rows(4);
+        let idx = state.selected_index.unwrap();
+        assert!(
+            idx >= state.scroll_offset && idx < state.scroll_offset + 4,
+            "selected idx {idx} not in shrunk viewport [{}, {})",
+            state.scroll_offset,
+            state.scroll_offset + 4
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1433,7 +1433,7 @@ impl Editor {
             prompt.prompt_type,
             PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
         ) {
-            let Some(file_open_state) = &self.file_open_state else {
+            let Some(file_open_state) = &mut self.file_open_state else {
                 return;
             };
             let max_height = prompt_area.y.saturating_sub(1).min(20);

--- a/crates/fresh-editor/src/view/ui/file_browser.rs
+++ b/crates/fresh-editor/src/view/ui/file_browser.rs
@@ -38,7 +38,7 @@ impl FileBrowserRenderer {
     pub fn render(
         frame: &mut Frame,
         area: Rect,
-        state: &FileOpenState,
+        state: &mut FileOpenState,
         theme: &crate::view::theme::Theme,
         hover_target: &Option<crate::app::HoverTarget>,
         keybindings: Option<&crate::input::keybindings::KeybindingResolver>,
@@ -490,13 +490,16 @@ impl FileBrowserRenderer {
     fn render_file_list(
         frame: &mut Frame,
         area: Rect,
-        state: &FileOpenState,
+        state: &mut FileOpenState,
         theme: &crate::view::theme::Theme,
         hover_target: &Option<crate::app::HoverTarget>,
     ) -> usize {
         use crate::app::HoverTarget;
 
         let visible_rows = area.height as usize;
+        // Sync scroll/selection with the actual viewport before drawing —
+        // input handlers had to guess the height; only the renderer knows it.
+        state.update_scroll_for_visible_rows(visible_rows);
         let width = area.width as usize;
 
         // Column widths (matching header)


### PR DESCRIPTION
Fixes #245.

## Problem

When the terminal is very small, the Open File dialog (Ctrl+O) doesn't scroll properly: pressing Down past the last visible entry keeps `scroll_offset` at 0, so the selection cursor walks off the bottom of the visible list.

Root cause: `FileOpenState::ensure_selected_visible()` (called by every selection action — `select_next`, `select_prev`, `page_down`, `page_up`, `select_last`, `apply_filter`) computed the scroll window using a hardcoded `visible_rows = 15`, even though the renderer already knew the real viewport height as `area.height as usize`. The state had a `update_scroll_for_visible_rows()` method intended for the renderer to call, but nothing called it.

## Fix

- Cache the viewport height in `FileOpenState::last_visible_rows`, treated as the single source of truth for both selection actions and the renderer.
- Have `FileBrowserRenderer::render` (now `&mut FileOpenState`) call `state.update_scroll_for_visible_rows(visible_rows)` once per frame, before producing the visible entry slice.
- Replace the duplicated scroll logic with one private `clamp_scroll_to_selection()` used by both `ensure_selected_visible` (input handlers, uses cached value) and `update_scroll_for_visible_rows` (renderer, supplies fresh value). Also clamps `scroll_offset` to `entries.len() - visible_rows`, so a viewport that grew via terminal resize doesn't leave a blank tail.

## Tests

`crates/fresh-editor/src/app/file_open.rs`:

- `test_scroll_follows_selection_in_small_viewport` — asserts that after walking the selection past a 3-row viewport, the selection remains inside `[scroll_offset, scroll_offset + 3)`. Fails on the hardcoded-15 behavior with `selected idx 4 not in viewport [0, 3)`.
- `test_scroll_reclamped_on_viewport_shrink` — asserts that when the renderer reports a smaller viewport (terminal resize), the next render reconciles `scroll_offset` so the selection stays visible.

All 26 existing `e2e::file_browser` tests still pass.

## Manual Validation

Built `fresh` and ran inside an 80x12 tmux pane (`/tmp/fresh-245` populated with 30 files):

- `Ctrl+O` opens the dialog with ~5 visible rows.
- Pressing `Down` 25 times scrolls the list and keeps the highlighted entry visible at the bottom (`file24` shown highlighted, list shows `file20..file24`).
- Pressing `Up` 30 times scrolls back; selection lands on `../` with the list showing `../, file01..file04`.
- Resizing the pane to 80x25 redraws the dialog with more entries visible, no glitches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bj3KPiz6RNF4nGu1cnA47Z)_