### PR TITLE
fix(search): don't hijack query when find_selection_(next|previous) runs on a non-word position

### DIFF
--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -630,22 +630,23 @@ impl Editor {
     /// Otherwise, it starts a new search with the current selection or word under cursor.
     pub(super) fn find_selection_next(&mut self) {
         // If there's already a search active AND cursor is at a match position,
-        // just continue to next match. Otherwise, clear and start fresh.
+        // just continue to next match.
         if let Some(ref search_state) = self.search_state {
             let cursor_pos = self.active_cursors().primary().position;
             if search_state.matches.binary_search(&cursor_pos).is_ok() {
                 self.find_next();
                 return;
             }
-            // Cursor moved away from a match - clear search state
         }
-        self.search_state = None;
 
-        // No active search - start a new one with selection or word under cursor
+        // Try to start a new search from the selection or word under cursor.
         let (search_text, selection_start) = self.get_selection_or_word_for_search_with_pos();
 
         match search_text {
             Some(text) if !text.is_empty() => {
+                // We have a new search term — discard any previous search.
+                self.search_state = None;
+
                 // Record cursor position before search
                 let cursor_before = self.active_cursors().primary().position;
 
@@ -678,7 +679,15 @@ impl Editor {
                 }
             }
             _ => {
-                self.set_status_message(t!("search.no_text").to_string());
+                // No selection or word at the cursor (e.g. cursor sits on a
+                // bracket after `goto_matching_bracket`). Don't synthesize
+                // a query — fall back to navigating the existing search if
+                // there is one (issue #1537).
+                if self.search_state.is_some() {
+                    self.find_next();
+                } else {
+                    self.set_status_message(t!("search.no_text").to_string());
+                }
             }
         }
     }
@@ -690,22 +699,23 @@ impl Editor {
     /// Otherwise, it starts a new search with the current selection or word under cursor.
     pub(super) fn find_selection_previous(&mut self) {
         // If there's already a search active AND cursor is at a match position,
-        // just continue to previous match. Otherwise, clear and start fresh.
+        // just continue to previous match.
         if let Some(ref search_state) = self.search_state {
             let cursor_pos = self.active_cursors().primary().position;
             if search_state.matches.binary_search(&cursor_pos).is_ok() {
                 self.find_previous();
                 return;
             }
-            // Cursor moved away from a match - clear search state
         }
-        self.search_state = None;
 
-        // No active search - start a new one with selection or word under cursor
+        // Try to start a new search from the selection or word under cursor.
         let (search_text, selection_start) = self.get_selection_or_word_for_search_with_pos();
 
         match search_text {
             Some(text) if !text.is_empty() => {
+                // We have a new search term — discard any previous search.
+                self.search_state = None;
+
                 // Record cursor position before search
                 let cursor_before = self.active_cursors().primary().position;
 
@@ -743,7 +753,14 @@ impl Editor {
                 }
             }
             _ => {
-                self.set_status_message(t!("search.no_text").to_string());
+                // No selection or word at the cursor — fall back to
+                // navigating the existing search if there is one
+                // (issue #1537).
+                if self.search_state.is_some() {
+                    self.find_previous();
+                } else {
+                    self.set_status_message(t!("search.no_text").to_string());
+                }
             }
         }
     }
@@ -751,7 +768,9 @@ impl Editor {
     /// Get the text to search for from selection or word under cursor,
     /// along with the start position of that text (for determining if we're at a match).
     fn get_selection_or_word_for_search_with_pos(&mut self) -> (Option<String>, Option<usize>) {
-        use crate::primitives::word_navigation::{find_word_end, find_word_start};
+        use crate::primitives::word_navigation::{
+            find_word_end, find_word_start, is_cursor_on_word_char,
+        };
 
         // First get selection range and cursor position with immutable borrow
         let (selection_range, cursor_pos) = {
@@ -768,9 +787,23 @@ impl Editor {
             }
         }
 
-        // No selection - try to get word under cursor
+        // No selection - try to get word under cursor.
+        //
+        // Only extract a "word under cursor" if the cursor is actually
+        // sitting on a word character. `find_word_start` / `find_word_end`
+        // are designed for word-by-word *navigation* (Ctrl+arrows): when
+        // pointed at a non-word position they intentionally extend across
+        // whitespace/punctuation into the adjacent word. That semantic is
+        // wrong here — for "find selection / word under cursor" we want
+        // either the word at the cursor or nothing. See issue #1537,
+        // where a `goto_matching_bracket` left the cursor on `}` and a
+        // subsequent Ctrl+F3 hijacked the search query into the bracket
+        // plus surrounding words.
         let (word_start, word_end) = {
             let state = self.active_state();
+            if !is_cursor_on_word_char(&state.buffer, cursor_pos) {
+                return (None, None);
+            }
             let word_start = find_word_start(&state.buffer, cursor_pos);
             let word_end = find_word_end(&state.buffer, cursor_pos);
             (word_start, word_end)

--- a/crates/fresh-editor/src/primitives/word_navigation.rs
+++ b/crates/fresh-editor/src/primitives/word_navigation.rs
@@ -174,6 +174,30 @@ pub fn find_completion_word_start(buffer: &Buffer, pos: usize) -> usize {
     start + new_pos
 }
 
+/// Returns true if the grapheme at `pos` is a word character
+/// (alphanumeric or `_`). Position past the end of the buffer returns false.
+///
+/// This is grapheme-aware (handles multi-byte UTF-8 like accented letters)
+/// and is meant for "is the cursor on a word?" checks. Unlike
+/// `find_word_start`/`find_word_end`, it does not extend into adjacent
+/// graphemes — it only looks at the one at `pos`.
+pub fn is_cursor_on_word_char(buffer: &Buffer, pos: usize) -> bool {
+    let buf_len = buffer.len();
+    if pos >= buf_len {
+        return false;
+    }
+    // A UTF-8 grapheme is at most 4 bytes; read enough to decode the first one.
+    const MAX_UTF8_CHAR_LEN: usize = 4;
+    let end = (pos + MAX_UTF8_CHAR_LEN).min(buf_len);
+    let bytes = buffer.slice_bytes(pos..end);
+    let text = String::from_utf8_lossy(&bytes);
+    let next = next_grapheme_boundary(&text, 0);
+    if next == 0 {
+        return false;
+    }
+    get_grapheme_class(&text[..next]) == CharClass::Word
+}
+
 /// Find the start of the word at or before the given position
 ///
 /// Uses grapheme-based classification to correctly handle Unicode characters
@@ -560,6 +584,28 @@ mod tests {
         assert!(!is_word_char(b' '));
         assert!(!is_word_char(b'.'));
         assert!(!is_word_char(b'-'));
+    }
+
+    #[test]
+    fn test_is_cursor_on_word_char() {
+        let buffer = Buffer::from_str_test("hello {world} café");
+        // 'h' of hello
+        assert!(is_cursor_on_word_char(&buffer, 0));
+        // 'o' of hello
+        assert!(is_cursor_on_word_char(&buffer, 4));
+        // space
+        assert!(!is_cursor_on_word_char(&buffer, 5));
+        // '{'
+        assert!(!is_cursor_on_word_char(&buffer, 6));
+        // 'w' of world
+        assert!(is_cursor_on_word_char(&buffer, 7));
+        // '}'
+        assert!(!is_cursor_on_word_char(&buffer, 12));
+        // first byte of multi-byte 'é' in "café"
+        assert!(is_cursor_on_word_char(&buffer, 17));
+        // past the end
+        assert!(!is_cursor_on_word_char(&buffer, buffer.len()));
+        assert!(!is_cursor_on_word_char(&buffer, buffer.len() + 100));
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -155,6 +155,7 @@ pub mod search_center_on_scroll;
 pub mod search_down_stall_after_wrap;
 pub mod search_navigation_after_move;
 pub mod search_replace;
+pub mod search_selection_on_punctuation;
 pub mod search_viewport_stall_after_wrap;
 pub mod select_to_paragraph;
 pub mod selection;

--- a/crates/fresh-editor/tests/e2e/search_selection_on_punctuation.rs
+++ b/crates/fresh-editor/tests/e2e/search_selection_on_punctuation.rs
@@ -1,0 +1,128 @@
+//! Regression test for <https://github.com/sinelaw/fresh/issues/1537>:
+//! after `goto_matching_bracket` (or any cursor jump that lands on a
+//! non-word character), `find_selection_next` / `find_selection_previous`
+//! must not synthesize a search query out of adjacent words by extending
+//! across the bracket/whitespace.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// After Ctrl+F searches for "sub" and the cursor is moved to a
+/// `}` (a non-word character that is not a search match), pressing
+/// Ctrl+F3 (`find_selection_next`) must not replace the active search
+/// query with a multi-line "word" stitched together from the surrounding
+/// text. Either the original "sub" search is kept and we move to the
+/// next "sub", or no new search is started — but we never start a search
+/// for `}` (or for `three\n}\nsub`).
+#[test]
+fn test_find_selection_next_on_punctuation_does_not_hijack_query() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("issue1537.txt");
+    let content = "sub one\nsub two { (\nsub three\n}\nsub four\n";
+    std::fs::write(&file_path, content).unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Search for "sub" so a search_state is active with 4 matches.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("sub").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The lone `}` is at byte offset 30 (line 4, col 1). Move the cursor there.
+    let brace_pos = content.find('}').unwrap();
+    harness
+        .editor_mut()
+        .active_cursors_mut()
+        .primary_mut()
+        .position = brace_pos;
+    harness.render().unwrap();
+    assert_eq!(harness.cursor_position(), brace_pos);
+
+    // Ctrl+F3 — find_selection_next — must not start a search for the
+    // bracket-and-surrounding-words "word".
+    harness
+        .send_key(KeyCode::F(3), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The cursor must land on one of the existing "sub" matches (or stay
+    // put), never on a position whose match contains the closing brace.
+    let cursor = harness.cursor_position();
+    let sub_positions: Vec<usize> = (0..content.len())
+        .filter(|&i| content[i..].starts_with("sub"))
+        .collect();
+    assert!(
+        cursor == brace_pos || sub_positions.contains(&cursor),
+        "After Ctrl+F3 on '}}', cursor moved to {} which is neither the \
+         brace position {} nor any 'sub' match {:?}. The search query \
+         was hijacked by punctuation/whitespace word extension.",
+        cursor,
+        brace_pos,
+        sub_positions
+    );
+}
+
+/// Same as the bracket case, but for whitespace: cursor on a space
+/// between words must not produce a synthesized "word1 word2" query.
+#[test]
+fn test_find_selection_next_on_whitespace_does_not_hijack_query() {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("ws.txt");
+    // "sub" appears on multiple lines so a Ctrl+F search is meaningful.
+    let content = "sub one\nsub two\nsub three\n";
+    std::fs::write(&file_path, content).unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Active search for "sub".
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("sub").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Park the cursor on the space between "sub" and "two" on line 2.
+    let space_pos = "sub one\nsub".len();
+    assert_eq!(&content[space_pos..space_pos + 1], " ");
+    harness
+        .editor_mut()
+        .active_cursors_mut()
+        .primary_mut()
+        .position = space_pos;
+    harness.render().unwrap();
+
+    harness
+        .send_key(KeyCode::F(3), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The buggy behavior synthesizes "sub two" as the search query and
+    // moves to the unique "sub two" match (which happens to start with
+    // "sub"). With the fix, no new query is synthesized — the cursor
+    // continues navigating the existing "sub" search and lands on the
+    // next "sub" (the one on line 3, "sub three").
+    let expected = "sub one\nsub two\n".len();
+    assert_eq!(&content[expected..expected + 3], "sub");
+    assert_eq!(
+        harness.cursor_position(),
+        expected,
+        "Ctrl+F3 on whitespace should not synthesize a query — it should \
+         continue the existing 'sub' search to the next match."
+    );
+}


### PR DESCRIPTION
## Summary

Closes #1537.

After `goto_matching_bracket` left the cursor on a `}`, pressing Ctrl+F3 / Alt+N (`find_selection_next`) would replace the user's existing "sub" search with a synthesized multi-line query like `three\n}\nsub` and land on whatever matched — i.e. the bracket position the user just jumped to. Same for Ctrl+Shift+F3 / Alt+P.

### Root cause

`get_selection_or_word_for_search_with_pos` extracts the "word under cursor" by calling `find_word_start` + `find_word_end`. Those helpers are designed for **word-by-word navigation** (Ctrl+arrows): given a non-word position, they intentionally extend across whitespace/punctuation into the adjacent word. That's correct for navigation but wrong for "what word is at the cursor?" — there is no word at `}`.

### Fix

1. New `is_cursor_on_word_char(buffer, pos)` helper in `word_navigation.rs` — grapheme-aware, returns `true` only when the grapheme at `pos` is alphanumeric or `_`. Unlike the existing helpers, it does not look at adjacent graphemes.
2. `get_selection_or_word_for_search_with_pos` now returns `(None, None)` immediately when the cursor isn't on a word character (and there's no selection).
3. `find_selection_next` / `find_selection_previous` no longer pre-emptively clear the existing `search_state`. When there's no new term to start a fresh search with, fall back to `find_next` / `find_previous` on the existing search instead of dropping it. So Ctrl+F search → goto matching bracket → Ctrl+F3 now keeps navigating "sub", which is what the user wants.

### Tests

- New `tests/e2e/search_selection_on_punctuation.rs` with two regression tests (bracket and whitespace cases) — both fail without the fix and pass with it.
- New unit test for `is_cursor_on_word_char` covering ASCII letters, brackets, whitespace, and a multi-byte UTF-8 grapheme (`é`).
- Existing find_selection / goto_matching_bracket / search_navigation tests all still pass.

## Test plan

- [x] `cargo test -p fresh-editor --lib word_navigation`
- [x] `cargo test -p fresh-editor --test e2e_tests find_selection`
- [x] `cargo test -p fresh-editor --test e2e_tests goto_matching_bracket`
- [x] `cargo test -p fresh-editor --test e2e_tests 'search::'`
- [x] `cargo fmt --all -- --check` and `cargo clippy --all-targets -p fresh-editor`
- [x] Manual repro in tmux: `Ctrl+F sub Enter` → `F3` → arrow to `{` → goto matching bracket → cursor lands on `}` → `Alt+N` now lands on the next "sub" (Match 4 of 4) instead of hijacking the query.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCxhDFT7LWGhns8vU1E4Nv)_