### PR TITLE
feat(title): include project name in terminal window title

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2555,7 +2555,8 @@ impl Editor {
     }
 
     /// Emit an OSC 2 escape sequence to set the host terminal's window/tab
-    /// title based on the active buffer's display name. Deduplicated against
+    /// title based on the active buffer's display name and the project name
+    /// (the working directory's last path component). Deduplicated against
     /// the last title we wrote so we don't spam stdout every frame.
     ///
     /// Gated by `editor.set_window_title` (default on). Terminals that
@@ -2564,7 +2565,9 @@ impl Editor {
         if !self.config.editor.set_window_title {
             return;
         }
-        let new_title = format!("{} \u{2014} Fresh", display_name);
+        let project_name = self.working_dir.file_name().and_then(|s| s.to_str());
+        let new_title =
+            crate::services::terminal_title::build_window_title(display_name, project_name);
         if self.last_window_title.as_deref() == Some(new_title.as_str()) {
             return;
         }

--- a/crates/fresh-editor/src/services/terminal_title.rs
+++ b/crates/fresh-editor/src/services/terminal_title.rs
@@ -32,6 +32,26 @@ pub fn sanitize_title(title: &str) -> String {
     filtered[..end].to_string()
 }
 
+/// Build a terminal window title from the active buffer's display name and
+/// the optional project name (typically the working directory's last
+/// component). Including the project name disambiguates files when several
+/// Fresh sessions are open across different projects.
+///
+/// Format:
+/// - With project: `<display_name> — <project_name> — Fresh`
+/// - Without project: `<display_name> — Fresh`
+///
+/// An empty `project_name` is treated the same as `None`, so callers can pass
+/// the result of `Path::file_name().and_then(OsStr::to_str)` directly.
+pub fn build_window_title(display_name: &str, project_name: Option<&str>) -> String {
+    match project_name {
+        Some(p) if !p.is_empty() => {
+            format!("{} \u{2014} {} \u{2014} Fresh", display_name, p)
+        }
+        _ => format!("{} \u{2014} Fresh", display_name),
+    }
+}
+
 /// Write an OSC 2 escape sequence to stdout setting the terminal title.
 ///
 /// The title is sanitized before writing. No-op when stdout is not a
@@ -83,5 +103,37 @@ mod tests {
     #[test]
     fn empty_input_yields_empty_output() {
         assert_eq!(sanitize_title(""), "");
+    }
+
+    #[test]
+    fn title_includes_project_when_provided() {
+        assert_eq!(
+            build_window_title("foo/bar.rs", Some("my-project")),
+            "foo/bar.rs \u{2014} my-project \u{2014} Fresh"
+        );
+    }
+
+    #[test]
+    fn title_omits_project_when_none() {
+        assert_eq!(
+            build_window_title("foo/bar.rs", None),
+            "foo/bar.rs \u{2014} Fresh"
+        );
+    }
+
+    #[test]
+    fn title_omits_project_when_empty_string() {
+        assert_eq!(
+            build_window_title("foo/bar.rs", Some("")),
+            "foo/bar.rs \u{2014} Fresh"
+        );
+    }
+
+    #[test]
+    fn title_handles_virtual_buffer_names() {
+        assert_eq!(
+            build_window_title("[No Name]", Some("my-project")),
+            "[No Name] \u{2014} my-project \u{2014} Fresh"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #1793.

Extends the OSC 2 title set in #1618 to include the project name (the working directory's last path component), so users can distinguish Fresh sessions that have buffers with the same name across different projects.

**Format change:**

| Before | After |
|--------|-------|
| `foo/bar.rs — Fresh` | `foo/bar.rs — my-project — Fresh` |
| `[No Name] — Fresh` | `[No Name] — my-project — Fresh` |

When the working directory has no `file_name` (e.g. filesystem root), the title falls back to the original `<display_name> — Fresh` format.

I went with `<file> — <project> — Fresh` (the VS Code convention) rather than prepending `<project>/<file>` because it composes correctly when `display_name` is already an absolute path (file outside the working dir) or a virtual buffer like `[No Name]`.

## Implementation

- Extracted a pure `build_window_title(display_name, project_name)` function in `services/terminal_title.rs` so the title-building logic is unit-testable independent of `EditorState` and stdout.
- `update_terminal_title` (in `app/render.rs`) now passes `working_dir.file_name()` to it.
- Existing dedup against `last_window_title` and the `editor.set_window_title` config gate are unchanged.

## Test plan

- [x] Unit tests in `services/terminal_title.rs` cover: project provided, project `None`, project empty string, virtual buffer name with project. All pass under `cargo test -p fresh-editor --lib services::terminal_title` (8 passed).
- [x] `cargo check -p fresh-editor --all-targets` passes.
- [x] Manual validation in tmux: opened `fresh sample.txt` from `/tmp/freshtest-myproject`, captured the raw OSC 2 sequence via `tmux pipe-pane`, and confirmed the bytes are `\x1b]2;sample.txt — freshtest-myproject — Fresh\x07`. Also confirmed the dashboard / `[No Name]` paths emit `[No Name] — freshtest-myproject — Fresh`.

https://claude.ai/code/session_01LKEujAQDWJfg9hNVjRhghg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKEujAQDWJfg9hNVjRhghg)_