### PR TITLE
fix(multi-cursor): use search match for Ctrl-D after substring search

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -684,8 +684,31 @@ impl Editor {
     }
 
     /// Add a cursor at the next occurrence of the selected text
-    /// If no selection, first selects the entire word at cursor position
+    /// If no selection, first selects the entire word at cursor position.
+    ///
+    /// When an active substring search has placed the cursor at a match
+    /// (cursor inside `search_state.matches[i]..matches[i] + match_lengths[i]`),
+    /// the search match is selected instead of the surrounding word.  This
+    /// way subsequent presses look for the search substring rather than the
+    /// whole word, which would skip other substring occurrences (issue #1697).
     pub fn add_cursor_at_next_match(&mut self) {
+        if let Some(range) = self.search_match_at_primary_cursor() {
+            let primary_id = self.active_cursors().primary_id();
+            let primary = self.active_cursors().primary();
+            let event = Event::MoveCursor {
+                cursor_id: primary_id,
+                old_position: primary.position,
+                new_position: range.end,
+                old_anchor: primary.anchor,
+                new_anchor: Some(range.start),
+                old_sticky_column: primary.sticky_column,
+                new_sticky_column: 0,
+            };
+            self.active_event_log_mut().append(event.clone());
+            self.apply_event_to_active_buffer(&event);
+            return;
+        }
+
         let cursors = self.active_cursors().clone();
         let state = self.active_state_mut();
         match add_cursor_at_next_match(state, &cursors) {

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -498,6 +498,30 @@ impl Editor {
         positions
     }
 
+    /// If an active search has placed the cursor inside a match, return that
+    /// match's byte range.  Used by Ctrl-D ("Add cursor at next match") so a
+    /// substring search drives the selection — instead of expanding to the
+    /// whole word — when the user presses Ctrl-D right after searching
+    /// (issue #1697).
+    pub(super) fn search_match_at_primary_cursor(&self) -> Option<std::ops::Range<usize>> {
+        let search_state = self.search_state.as_ref()?;
+        let pos = self.active_cursors().primary().position;
+        // matches is sorted; find the rightmost match start <= pos and check
+        // whether pos falls within [start, start + len).
+        let idx = match search_state.matches.binary_search(&pos) {
+            Ok(i) => i,
+            Err(0) => return None,
+            Err(i) => i - 1,
+        };
+        let start = search_state.matches[idx];
+        let len = *search_state.match_lengths.get(idx)?;
+        if pos < start + len {
+            Some(start..start + len)
+        } else {
+            None
+        }
+    }
+
     /// Find the next match.
     ///
     /// For small files, overlay markers are used as the source of truth

--- a/crates/fresh-editor/tests/e2e/issue_1697_ctrl_d_after_search.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1697_ctrl_d_after_search.rs
@@ -1,0 +1,99 @@
+//! Regression test for <https://github.com/sinelaw/fresh/issues/1697>:
+//!
+//! When the user has performed a substring search (Whole Word OFF, no Regex)
+//! and the cursor is at a search match, pressing Ctrl-D ("Add cursor at next
+//! match") should select just the search match (the substring), not expand
+//! to the surrounding word.  Otherwise, subsequent Ctrl-D presses would look
+//! for the *whole word* and miss other substring occurrences.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use tempfile::TempDir;
+
+/// Helper: open the search prompt, type the query, and commit with Enter so
+/// `search_state` is populated and the cursor jumps to the first match.
+fn run_search(harness: &mut EditorTestHarness, query: &str) {
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(query).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+}
+
+#[test]
+fn test_ctrl_d_after_search_uses_match_not_word() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    // The search query "foo" is a substring of "foobar" but is also its own
+    // word later in the file.  After searching, the cursor lands on the first
+    // match (inside "foobar" at position 0).  Pressing Ctrl-D should select
+    // the 3-byte search match, NOT the whole word "foobar".
+    std::fs::write(&file_path, "foobar foo foo").unwrap();
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().without_empty_plugins_dir())
+            .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    run_search(&mut harness, "foo");
+
+    // After search, cursor should be at the first match (position 0) with no
+    // selection.
+    {
+        let primary = harness.editor().active_cursors().primary();
+        assert_eq!(primary.position, 0, "cursor should be at first match");
+        assert!(
+            primary.anchor.is_none(),
+            "search should not leave a selection on the cursor"
+        );
+    }
+
+    // Press Ctrl-D — should select the search match "foo" (0..3), not the
+    // whole word "foobar" (0..6).
+    harness
+        .send_key(KeyCode::Char('d'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let primary = harness.editor().active_cursors().primary().clone();
+    let selection = primary
+        .selection_range()
+        .expect("Ctrl-D should produce a selection");
+    assert_eq!(
+        selection,
+        0..3,
+        "Ctrl-D after a substring search should select just the search match, \
+         not the surrounding word.  Got selection {:?} with cursor pos {}.",
+        selection,
+        primary.position
+    );
+
+    // Press Ctrl-D again — should add a cursor at the next "foo" substring
+    // (positions 7..10), proving the pattern in use is the substring "foo".
+    harness
+        .send_key(KeyCode::Char('d'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    let count = harness.editor().active_cursors().iter().count();
+    assert_eq!(count, 2, "expected a second cursor after second Ctrl-D");
+
+    let positions: Vec<usize> = harness
+        .editor()
+        .active_cursors()
+        .iter()
+        .map(|(_, c)| c.position)
+        .collect();
+    assert!(
+        positions.contains(&10),
+        "expected new cursor at end of next 'foo' match (position 10); \
+         got positions {:?}",
+        positions
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -64,6 +64,7 @@ pub mod issue_1574_wrapped_down_scroll;
 pub mod issue_1577_unicode_width;
 pub mod issue_1598_shebang_detection;
 pub mod issue_1620_split_terminal_click_panic;
+pub mod issue_1697_ctrl_d_after_search;
 pub mod issue_1718_settings_search_utf8_panic;
 pub mod issue_1790_compose_wrap_highlight;
 pub mod issue_779_after_eof_shade;


### PR DESCRIPTION
Fixes #1697.

## Summary

When the user runs a substring search (Whole Word OFF, no Regex), pressing **Ctrl-D** ("Add cursor at next match") expanded the cursor to the surrounding **word** instead of the **search match**. Subsequent Ctrl-D presses then looked for that whole word and skipped other substring occurrences — exactly the behavior the issue reports.

Example with buffer `foobar foo foo` and search `foo`:
- **Before:** First Ctrl-D selected `foobar` (whole word). Next Ctrl-D found no more `foobar`s and missed the two standalone `foo`s.
- **After:** First Ctrl-D selects the 3-char match `foo` inside `foobar`. Next Ctrl-D adds a cursor at the next `foo`, and so on for all three matches.

## Implementation

`Editor::add_cursor_at_next_match` now first checks whether the primary cursor is sitting inside an active search match (via the new `search_match_at_primary_cursor` helper, which binary-searches the sorted `search_state.matches`). If so, it selects the match range. Otherwise the existing behavior — expand to the whole word, or extend to the next occurrence of an existing selection — runs unchanged.

The helper is `O(log N)` over the match count and reuses `search_state.match_lengths`, so it works for regex searches too even though the issue is specifically about substring search.

## Test plan

- New e2e regression test `issue_1697_ctrl_d_after_search::test_ctrl_d_after_search_uses_match_not_word`:
  - Buffer `foobar foo foo`, search for `foo`, press Ctrl-D — asserts selection is `0..3`, not `0..6`.
  - Press Ctrl-D again — asserts a second cursor is added at the next `foo` substring.
- Verified the test fails on master (selection ends up `0..6`) and passes with the fix.
- Existing `test_ctrl_d_*` and `multicursor`/`selection` e2e suites all still pass — the no-search-active path is untouched.
- Manually validated by driving `fresh /tmp/test_1697.txt` in a tmux session: Ctrl-F → `foo` → Enter → Ctrl-D × 3 produces three cursors, one on each `foo` substring (including the one inside `foobar`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SxJYKHAo8SbcU52cgZSSna)_