### PR TITLE
fix(theme): make sections optional, add `extends` inheritance + luminance auto-infer (#1281)

### DIFF
--- a/crates/fresh-editor/plugins/schemas/theme.schema.json
+++ b/crates/fresh-editor/plugins/schemas/theme.schema.json
@@ -1,12 +1,19 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ThemeFile",
-  "description": "Serializable theme definition (matches JSON structure)\n\nThe five color sections (`editor`, `ui`, `search`, `diagnostic`, `syntax`)\nare all optional. Every leaf field within each section already has a\n`#[serde(default = \"…\")]` fallback, so a theme JSON only needs to specify\nthe colors it cares about. This matches the minimal example shipped in\n`docs/features/themes.md` and unblocks user-authored themes that override\njust `editor`/`syntax` (issue #1281).",
+  "description": "Serializable theme definition (matches JSON structure)\n\nThe five color sections (`editor`, `ui`, `search`, `diagnostic`, `syntax`)\nare all optional. Every leaf field within each section already has a\n`#[serde(default = \"…\")]` fallback, so a theme JSON only needs to specify\nthe colors it cares about. This matches the minimal example shipped in\n`docs/features/themes.md` and unblocks user-authored themes that override\njust `editor`/`syntax` (issue #1281).\n\n**Inheritance**: when a theme omits whole sections, the unset fields are\nresolved against a *base* theme rather than against the per-field hardcoded\nfallback. The base is chosen in this order:\n\n1. Explicit `extends` field (`\"builtin://light\"`, `\"dark\"`, etc.).\n2. If `editor.bg` is provided, the relative-luminance of that color picks\n   `builtin://light` or `builtin://dark` automatically — so a user theme\n   that sets a cream background gets light UI chrome without any extra\n   configuration.\n3. Otherwise, fall through to the per-field hardcoded defaults.\n\nOnly built-in themes are valid `extends` targets in this version. Chained\ninheritance across user themes is intentionally out of scope here.",
   "type": "object",
   "properties": {
     "name": {
       "description": "Theme name",
       "type": "string"
+    },
+    "extends": {
+      "description": "Optional base theme to inherit from. Accepts `\"builtin://NAME\"` or a\nbare built-in name (e.g. `\"dark\"`, `\"light\"`, `\"high-contrast\"`).\nWhen set, every field this theme does not specify is taken from the\nbase; explicit fields override the base. See [`ThemeFile`] for the\nfull inheritance resolution order.",
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "editor": {
       "description": "Editor area colors",

--- a/crates/fresh-editor/plugins/schemas/theme.schema.json
+++ b/crates/fresh-editor/plugins/schemas/theme.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ThemeFile",
-  "description": "Serializable theme definition (matches JSON structure)",
+  "description": "Serializable theme definition (matches JSON structure)\n\nThe five color sections (`editor`, `ui`, `search`, `diagnostic`, `syntax`)\nare all optional. Every leaf field within each section already has a\n`#[serde(default = \"…\")]` fallback, so a theme JSON only needs to specify\nthe colors it cares about. This matches the minimal example shipped in\n`docs/features/themes.md` and unblocks user-authored themes that override\njust `editor`/`syntax` (issue #1281).",
   "type": "object",
   "properties": {
     "name": {
@@ -10,32 +10,420 @@
     },
     "editor": {
       "description": "Editor area colors",
-      "$ref": "#/$defs/EditorColors"
+      "$ref": "#/$defs/EditorColors",
+      "default": {
+        "bg": [
+          30,
+          30,
+          30
+        ],
+        "fg": [
+          212,
+          212,
+          212
+        ],
+        "cursor": [
+          255,
+          255,
+          255
+        ],
+        "inactive_cursor": "DarkGray",
+        "selection_bg": [
+          38,
+          79,
+          120
+        ],
+        "current_line_bg": [
+          40,
+          40,
+          40
+        ],
+        "line_number_fg": [
+          100,
+          100,
+          100
+        ],
+        "line_number_bg": [
+          30,
+          30,
+          30
+        ],
+        "diff_add_bg": [
+          35,
+          60,
+          35
+        ],
+        "diff_remove_bg": [
+          70,
+          35,
+          35
+        ],
+        "diff_add_highlight_bg": null,
+        "diff_remove_highlight_bg": null,
+        "diff_modify_bg": [
+          40,
+          38,
+          30
+        ],
+        "ruler_bg": [
+          50,
+          50,
+          50
+        ],
+        "whitespace_indicator_fg": [
+          70,
+          70,
+          70
+        ],
+        "after_eof_bg": null
+      }
     },
     "ui": {
       "description": "UI element colors (tabs, menus, status bar, etc.)",
-      "$ref": "#/$defs/UiColors"
+      "$ref": "#/$defs/UiColors",
+      "default": {
+        "tab_active_fg": "Yellow",
+        "tab_active_bg": "Blue",
+        "tab_inactive_fg": "White",
+        "tab_inactive_bg": "DarkGray",
+        "tab_separator_bg": "Black",
+        "tab_close_hover_fg": [
+          255,
+          100,
+          100
+        ],
+        "tab_hover_bg": [
+          70,
+          70,
+          75
+        ],
+        "menu_bg": [
+          60,
+          60,
+          65
+        ],
+        "menu_fg": [
+          220,
+          220,
+          220
+        ],
+        "menu_active_bg": [
+          60,
+          60,
+          60
+        ],
+        "menu_active_fg": [
+          255,
+          255,
+          255
+        ],
+        "menu_dropdown_bg": [
+          50,
+          50,
+          50
+        ],
+        "menu_dropdown_fg": [
+          220,
+          220,
+          220
+        ],
+        "menu_highlight_bg": [
+          70,
+          130,
+          180
+        ],
+        "menu_highlight_fg": [
+          255,
+          255,
+          255
+        ],
+        "menu_border_fg": [
+          100,
+          100,
+          100
+        ],
+        "menu_separator_fg": [
+          80,
+          80,
+          80
+        ],
+        "menu_hover_bg": [
+          55,
+          55,
+          55
+        ],
+        "menu_hover_fg": [
+          255,
+          255,
+          255
+        ],
+        "menu_disabled_fg": [
+          100,
+          100,
+          100
+        ],
+        "menu_disabled_bg": [
+          50,
+          50,
+          50
+        ],
+        "status_bar_fg": "White",
+        "status_bar_bg": "DarkGray",
+        "status_palette_fg": null,
+        "status_palette_bg": null,
+        "status_lsp_on_fg": null,
+        "status_lsp_on_bg": null,
+        "prompt_fg": "White",
+        "prompt_bg": "Black",
+        "prompt_selection_fg": "White",
+        "prompt_selection_bg": [
+          58,
+          79,
+          120
+        ],
+        "popup_border_fg": "Gray",
+        "popup_bg": [
+          30,
+          30,
+          30
+        ],
+        "popup_selection_bg": [
+          58,
+          79,
+          120
+        ],
+        "popup_selection_fg": [
+          255,
+          255,
+          255
+        ],
+        "popup_text_fg": "White",
+        "suggestion_bg": [
+          30,
+          30,
+          30
+        ],
+        "suggestion_selected_bg": [
+          58,
+          79,
+          120
+        ],
+        "help_bg": "Black",
+        "help_fg": "White",
+        "help_key_fg": "Cyan",
+        "help_separator_fg": "DarkGray",
+        "help_indicator_fg": "Red",
+        "help_indicator_bg": "Black",
+        "inline_code_bg": "DarkGray",
+        "split_separator_fg": [
+          100,
+          100,
+          100
+        ],
+        "split_separator_hover_fg": [
+          100,
+          149,
+          237
+        ],
+        "scrollbar_track_fg": "DarkGray",
+        "scrollbar_thumb_fg": "Gray",
+        "scrollbar_track_hover_fg": "Gray",
+        "scrollbar_thumb_hover_fg": "White",
+        "compose_margin_bg": [
+          18,
+          18,
+          18
+        ],
+        "semantic_highlight_bg": [
+          60,
+          60,
+          80
+        ],
+        "terminal_bg": "Default",
+        "terminal_fg": "Default",
+        "status_warning_indicator_bg": [
+          181,
+          137,
+          0
+        ],
+        "status_warning_indicator_fg": [
+          0,
+          0,
+          0
+        ],
+        "status_error_indicator_bg": [
+          220,
+          50,
+          47
+        ],
+        "status_error_indicator_fg": [
+          255,
+          255,
+          255
+        ],
+        "status_warning_indicator_hover_bg": [
+          211,
+          167,
+          30
+        ],
+        "status_warning_indicator_hover_fg": [
+          0,
+          0,
+          0
+        ],
+        "status_error_indicator_hover_bg": [
+          250,
+          80,
+          77
+        ],
+        "status_error_indicator_hover_fg": [
+          255,
+          255,
+          255
+        ],
+        "tab_drop_zone_bg": [
+          70,
+          130,
+          180
+        ],
+        "tab_drop_zone_border": [
+          100,
+          149,
+          237
+        ],
+        "settings_selected_bg": [
+          60,
+          60,
+          70
+        ],
+        "settings_selected_fg": [
+          255,
+          255,
+          255
+        ],
+        "file_status_added_fg": null,
+        "file_status_modified_fg": null,
+        "file_status_deleted_fg": null,
+        "file_status_renamed_fg": null,
+        "file_status_untracked_fg": null,
+        "file_status_conflicted_fg": null
+      }
     },
     "search": {
       "description": "Search result highlighting colors",
-      "$ref": "#/$defs/SearchColors"
+      "$ref": "#/$defs/SearchColors",
+      "default": {
+        "match_bg": [
+          100,
+          100,
+          20
+        ],
+        "match_fg": [
+          255,
+          255,
+          255
+        ],
+        "label_bg": [
+          199,
+          78,
+          189
+        ],
+        "label_fg": [
+          255,
+          255,
+          255
+        ]
+      }
     },
     "diagnostic": {
       "description": "LSP diagnostic colors (errors, warnings, etc.)",
-      "$ref": "#/$defs/DiagnosticColors"
+      "$ref": "#/$defs/DiagnosticColors",
+      "default": {
+        "error_fg": "Red",
+        "error_bg": [
+          60,
+          20,
+          20
+        ],
+        "warning_fg": "Yellow",
+        "warning_bg": [
+          60,
+          50,
+          0
+        ],
+        "info_fg": "Blue",
+        "info_bg": [
+          0,
+          30,
+          60
+        ],
+        "hint_fg": "Gray",
+        "hint_bg": [
+          30,
+          30,
+          30
+        ]
+      }
     },
     "syntax": {
       "description": "Syntax highlighting colors",
-      "$ref": "#/$defs/SyntaxColors"
+      "$ref": "#/$defs/SyntaxColors",
+      "default": {
+        "keyword": [
+          86,
+          156,
+          214
+        ],
+        "string": [
+          206,
+          145,
+          120
+        ],
+        "comment": [
+          106,
+          153,
+          85
+        ],
+        "function": [
+          220,
+          220,
+          170
+        ],
+        "type": [
+          78,
+          201,
+          176
+        ],
+        "variable": [
+          156,
+          220,
+          254
+        ],
+        "constant": [
+          79,
+          193,
+          255
+        ],
+        "operator": [
+          212,
+          212,
+          212
+        ],
+        "punctuation_bracket": [
+          212,
+          212,
+          212
+        ],
+        "punctuation_delimiter": [
+          212,
+          212,
+          212
+        ]
+      }
     }
   },
   "required": [
-    "name",
-    "editor",
-    "ui",
-    "search",
-    "diagnostic",
-    "syntax"
+    "name"
   ],
   "$defs": {
     "EditorColors": {

--- a/crates/fresh-editor/plugins/theme_editor.ts
+++ b/crates/fresh-editor/plugins/theme_editor.ts
@@ -258,8 +258,12 @@ function loadThemeSections(): ThemeSection[] {
   const sectionOrder = ["editor", "ui", "search", "diagnostic", "syntax"];
 
   for (const [sectionName, sectionSchema] of Object.entries(properties)) {
-    // Skip "name" field - it's not a color section
-    if (sectionName === "name") continue;
+    // Skip top-level fields that aren't color sections: `name` is the
+    // theme's identity and `extends` is the inheritance pointer (a string,
+    // not a section). Without this check, the plugin would emit
+    // `"extends": {}` when serializing back out, which fails to round-trip
+    // as a `ThemeFile`.
+    if (sectionName === "name" || sectionName === "extends") continue;
 
     const sectionObj = sectionSchema as Record<string, unknown>;
     const sectionDesc = (sectionObj.description as string) || "";

--- a/crates/fresh-editor/src/view/theme/loader.rs
+++ b/crates/fresh-editor/src/view/theme/loader.rs
@@ -443,9 +443,7 @@ impl ThemeLoader {
                         let theme_path = pkg_dir.join(file);
                         if theme_path.exists() {
                             if let Ok(content) = std::fs::read_to_string(&theme_path) {
-                                if let Ok(theme_file) = serde_json::from_str::<ThemeFile>(&content)
-                                {
-                                    let theme: Theme = theme_file.into();
+                                if let Ok(theme) = Theme::from_json(&content) {
                                     let normalized_name = normalize_theme_name(name);
                                     let info = if let Some(ref repo) = repository {
                                         ThemeInfo::with_key(
@@ -516,8 +514,8 @@ impl ThemeLoader {
                 self.scan_directory(&path, &new_pack, repository, themes, theme_list);
             } else if path.extension().is_some_and(|ext| ext == "json") {
                 if let Ok(content) = std::fs::read_to_string(&path) {
-                    if let Ok(theme_file) = serde_json::from_str::<ThemeFile>(&content) {
-                        let name = normalize_theme_name(&theme_file.name);
+                    if let Ok(theme) = Theme::from_json(&content) {
+                        let name = normalize_theme_name(&theme.name);
                         let info = if let Some(repo) = repository {
                             ThemeInfo::with_key(&name, pack, format!("{}#{}", repo, name))
                         } else if pack.starts_with("user") {
@@ -532,7 +530,6 @@ impl ThemeLoader {
                             continue;
                         }
 
-                        let theme: Theme = theme_file.into();
                         themes.insert(info.key.clone(), theme);
                         theme_list.push(info);
                     }

--- a/crates/fresh-editor/src/view/theme/types.rs
+++ b/crates/fresh-editor/src/view/theme/types.rs
@@ -245,20 +245,66 @@ impl From<Color> for ColorDef {
 }
 
 /// Serializable theme definition (matches JSON structure)
+///
+/// The five color sections (`editor`, `ui`, `search`, `diagnostic`, `syntax`)
+/// are all optional. Every leaf field within each section already has a
+/// `#[serde(default = "…")]` fallback, so a theme JSON only needs to specify
+/// the colors it cares about. This matches the minimal example shipped in
+/// `docs/features/themes.md` and unblocks user-authored themes that override
+/// just `editor`/`syntax` (issue #1281).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ThemeFile {
     /// Theme name
     pub name: String,
     /// Editor area colors
+    #[serde(default = "default_editor_colors")]
     pub editor: EditorColors,
     /// UI element colors (tabs, menus, status bar, etc.)
+    #[serde(default = "default_ui_colors")]
     pub ui: UiColors,
     /// Search result highlighting colors
+    #[serde(default = "default_search_colors")]
     pub search: SearchColors,
     /// LSP diagnostic colors (errors, warnings, etc.)
+    #[serde(default = "default_diagnostic_colors")]
     pub diagnostic: DiagnosticColors,
     /// Syntax highlighting colors
+    #[serde(default = "default_syntax_colors")]
     pub syntax: SyntaxColors,
+}
+
+// Per-section defaults piggyback on the field-level `#[serde(default = "…")]`
+// already declared on every leaf — deserializing an empty object materializes
+// an all-defaults section without us having to restate every field here, and
+// keeps the section default in lock-step with its field defaults.
+fn default_section<T: serde::de::DeserializeOwned>(section: &'static str) -> T {
+    serde_json::from_str("{}").unwrap_or_else(|e| {
+        panic!(
+            "theme section `{}` must be default-constructible from `{{}}` \
+             (every field needs `#[serde(default = ...)]`): {}",
+            section, e
+        )
+    })
+}
+
+fn default_editor_colors() -> EditorColors {
+    default_section("editor")
+}
+
+fn default_ui_colors() -> UiColors {
+    default_section("ui")
+}
+
+fn default_search_colors() -> SearchColors {
+    default_section("search")
+}
+
+fn default_diagnostic_colors() -> DiagnosticColors {
+    default_section("diagnostic")
+}
+
+fn default_syntax_colors() -> SyntaxColors {
+    default_section("syntax")
 }
 
 /// Editor area colors
@@ -1741,6 +1787,70 @@ mod tests {
         let json = r#"{"name":"test","editor":{},"ui":{},"search":{},"diagnostic":{},"syntax":{}}"#;
         let theme = Theme::from_json(json).expect("Should parse minimal theme");
         assert_eq!(theme.name, "test");
+    }
+
+    /// Regression test for #1281: a user theme that follows the minimal example
+    /// in `docs/features/themes.md` (only `name`, `editor`, `syntax` — no `ui`,
+    /// `search`, or `diagnostic` sections) must load successfully. Before the
+    /// fix, `serde_json::from_str::<ThemeFile>` errored with `missing field
+    /// `ui``, the loader silently dropped the theme, and the user saw
+    /// "Failed to load theme" in the status bar.
+    #[test]
+    fn test_minimal_user_theme_from_issue_1281_loads() {
+        // Verbatim from https://github.com/sinelaw/fresh/issues/1281
+        let json = r#"{
+  "name": "gruvbox-light-orange",
+  "editor": {
+    "bg": [251, 241, 199],
+    "fg": [60, 56, 54],
+    "cursor": [254, 128, 25],
+    "selection_bg": [213, 196, 161]
+  },
+  "syntax": {
+    "keyword": [175, 58, 3],
+    "string": [152, 151, 26],
+    "comment": [146, 131, 116]
+  }
+}"#;
+        let theme = Theme::from_json(json)
+            .expect("Theme from issue #1281 should parse without `ui`/`search`/`diagnostic`");
+        assert_eq!(theme.name, "gruvbox-light-orange");
+
+        // Explicit fields land where expected.
+        assert_eq!(theme.editor_bg, Color::Rgb(251, 241, 199));
+        assert_eq!(theme.editor_fg, Color::Rgb(60, 56, 54));
+        assert_eq!(theme.cursor, Color::Rgb(254, 128, 25));
+        assert_eq!(theme.selection_bg, Color::Rgb(213, 196, 161));
+        assert_eq!(theme.syntax_keyword, Color::Rgb(175, 58, 3));
+        assert_eq!(theme.syntax_string, Color::Rgb(152, 151, 26));
+        assert_eq!(theme.syntax_comment, Color::Rgb(146, 131, 116));
+
+        // A theme that omits `ui`/`search`/`diagnostic` should still produce
+        // a usable `Theme` — the missing sections fall back to per-field
+        // defaults, so colors that the editor reads from those sections are
+        // populated rather than left in an undefined state.
+        assert_eq!(
+            theme.resolve_theme_key("diagnostic.error_fg"),
+            Some(theme.diagnostic_error_fg)
+        );
+        assert_eq!(
+            theme.resolve_theme_key("ui.status_bar_fg"),
+            Some(theme.status_bar_fg)
+        );
+    }
+
+    /// `name` remains the only truly required top-level field. A theme JSON
+    /// missing `name` should still be rejected with a clear error so users
+    /// don't end up with an unidentifiable theme in the registry.
+    #[test]
+    fn test_theme_without_name_still_errors() {
+        let json = r#"{ "editor": {} }"#;
+        let err = Theme::from_json(json).expect_err("missing `name` must be an error");
+        assert!(
+            err.contains("name"),
+            "error should mention the missing `name` field, got: {}",
+            err
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/theme/types.rs
+++ b/crates/fresh-editor/src/view/theme/types.rs
@@ -252,10 +252,31 @@ impl From<Color> for ColorDef {
 /// the colors it cares about. This matches the minimal example shipped in
 /// `docs/features/themes.md` and unblocks user-authored themes that override
 /// just `editor`/`syntax` (issue #1281).
+///
+/// **Inheritance**: when a theme omits whole sections, the unset fields are
+/// resolved against a *base* theme rather than against the per-field hardcoded
+/// fallback. The base is chosen in this order:
+///
+/// 1. Explicit `extends` field (`"builtin://light"`, `"dark"`, etc.).
+/// 2. If `editor.bg` is provided, the relative-luminance of that color picks
+///    `builtin://light` or `builtin://dark` automatically — so a user theme
+///    that sets a cream background gets light UI chrome without any extra
+///    configuration.
+/// 3. Otherwise, fall through to the per-field hardcoded defaults.
+///
+/// Only built-in themes are valid `extends` targets in this version. Chained
+/// inheritance across user themes is intentionally out of scope here.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ThemeFile {
     /// Theme name
     pub name: String,
+    /// Optional base theme to inherit from. Accepts `"builtin://NAME"` or a
+    /// bare built-in name (e.g. `"dark"`, `"light"`, `"high-contrast"`).
+    /// When set, every field this theme does not specify is taken from the
+    /// base; explicit fields override the base. See [`ThemeFile`] for the
+    /// full inheritance resolution order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extends: Option<String>,
     /// Editor area colors
     #[serde(default = "default_editor_colors")]
     pub editor: EditorColors,
@@ -1345,6 +1366,9 @@ impl From<Theme> for ThemeFile {
     fn from(theme: Theme) -> Self {
         Self {
             name: theme.name,
+            // A round-tripped `Theme` is already fully resolved — no further
+            // inheritance is needed when serializing back out.
+            extends: None,
             editor: EditorColors {
                 bg: theme.editor_bg.into(),
                 fg: theme.editor_fg.into(),
@@ -1470,6 +1494,87 @@ impl From<Theme> for ThemeFile {
     }
 }
 
+/// Resolve the base theme that a parsed `ThemeFile` should be layered on top of.
+///
+/// See [`ThemeFile`] for the resolution order. Returns an error only when
+/// `extends` references a base that does not exist; the no-info-at-all case
+/// quietly falls through to the per-field hardcoded defaults so a theme of
+/// `{"name": "x"}` keeps working.
+fn resolve_base_theme(theme_file: &ThemeFile, raw: &serde_json::Value) -> Result<Theme, String> {
+    // 1. Explicit `extends`.
+    if let Some(extends) = theme_file.extends.as_deref() {
+        let name = extends.strip_prefix("builtin://").unwrap_or(extends);
+        return Theme::load_builtin(name).ok_or_else(|| {
+            let available: Vec<&str> = BUILTIN_THEMES.iter().map(|t| t.name).collect();
+            format!(
+                "theme `extends: {:?}` does not match any built-in theme. \
+                 Available: {}. \
+                 Inheriting from other user themes is not yet supported.",
+                extends,
+                available.join(", ")
+            )
+        });
+    }
+
+    // 2. Auto-infer from explicit `editor.bg` luminance. We deliberately read
+    //    the *raw* JSON here instead of `theme_file.editor.bg` — the typed
+    //    struct fills in a default for `bg` even when the user didn't write
+    //    one, and inferring a base from a default we ourselves invented would
+    //    be circular.
+    if let Some(bg) = raw
+        .get("editor")
+        .and_then(|e| e.get("bg"))
+        .cloned()
+        .and_then(|v| serde_json::from_value::<ColorDef>(v).ok())
+    {
+        let color: Color = bg.into();
+        if let Some((r, g, b)) = color_to_rgb(color) {
+            let lum = relative_luminance(r, g, b);
+            let base_name = if lum > 0.5 { THEME_LIGHT } else { THEME_DARK };
+            if let Some(base) = Theme::load_builtin(base_name) {
+                return Ok(base);
+            }
+        }
+    }
+
+    // 3. Fallback: per-field hardcoded defaults via the existing typed path.
+    Ok(theme_file.clone().into())
+}
+
+/// Compute sRGB relative luminance (ITU-R BT.709) for an RGB triple in 0..=255.
+/// Used for picking a light vs dark base when the user didn't ask for one.
+fn relative_luminance(r: u8, g: u8, b: u8) -> f64 {
+    0.2126 * (r as f64 / 255.0) + 0.7152 * (g as f64 / 255.0) + 0.0722 * (b as f64 / 255.0)
+}
+
+/// Walk the user-supplied JSON and overlay every explicitly-set leaf onto the
+/// base theme. Reuses [`Theme::resolve_theme_key_mut`] so the override surface
+/// is exactly the surface the rest of the editor already knows how to address;
+/// unknown keys are silently ignored, matching `override_colors` semantics.
+fn apply_theme_overrides(theme: &mut Theme, theme_file: &ThemeFile, raw: &serde_json::Value) {
+    // Name always comes from the user file — that's the theme's identity.
+    theme.name = theme_file.name.clone();
+
+    for section in ["editor", "ui", "search", "diagnostic", "syntax"] {
+        let Some(obj) = raw.get(section).and_then(|v| v.as_object()) else {
+            continue;
+        };
+        for (field, value) in obj {
+            // Optional `Option<ColorDef>` fields encode `null` as JSON null.
+            // Treat that as "no override," not "set to default."
+            if value.is_null() {
+                continue;
+            }
+            let key = format!("{}.{}", section, field);
+            if let Ok(color_def) = serde_json::from_value::<ColorDef>(value.clone()) {
+                if let Some(slot) = theme.resolve_theme_key_mut(&key) {
+                    *slot = color_def.into();
+                }
+            }
+        }
+    }
+}
+
 impl Theme {
     /// Returns `true` when the theme has a light background.
     ///
@@ -1477,15 +1582,9 @@ impl Theme {
     /// A threshold of 0.5 separates dark from light; for `Color::Reset` or
     /// unresolvable colors, falls back to `false` (dark).
     pub fn is_light(&self) -> bool {
-        if let Some((r, g, b)) = color_to_rgb(self.editor_bg) {
-            // sRGB relative luminance (ITU-R BT.709)
-            let lum = 0.2126 * (r as f64 / 255.0)
-                + 0.7152 * (g as f64 / 255.0)
-                + 0.0722 * (b as f64 / 255.0);
-            lum > 0.5
-        } else {
-            false
-        }
+        color_to_rgb(self.editor_bg)
+            .map(|(r, g, b)| relative_luminance(r, g, b) > 0.5)
+            .unwrap_or(false)
     }
 
     /// Load a builtin theme by name (no I/O, uses embedded JSON).
@@ -1498,10 +1597,27 @@ impl Theme {
     }
 
     /// Parse theme from JSON string (no I/O).
+    ///
+    /// Supports the inheritance model documented on [`ThemeFile`]: an explicit
+    /// `extends` chooses the base; otherwise the relative luminance of an
+    /// explicit `editor.bg` picks `builtin://light` vs `builtin://dark`;
+    /// otherwise the per-field hardcoded defaults apply. Every leaf the user
+    /// JSON specifies overrides the corresponding field on the base — the
+    /// override walk uses the same `resolve_theme_key_mut` machinery as
+    /// `override_colors`, so the supported set of keys stays in lock-step.
     pub fn from_json(json: &str) -> Result<Self, String> {
-        let theme_file: ThemeFile =
+        // Dual-parse: the typed `ThemeFile` validates the schema and gives us
+        // `name` / `extends` cheaply; the raw `Value` tells us *which* fields
+        // the user actually specified, which we cannot recover from the typed
+        // struct because every field has a serde default.
+        let raw: serde_json::Value =
             serde_json::from_str(json).map_err(|e| format!("Failed to parse theme JSON: {}", e))?;
-        Ok(theme_file.into())
+        let theme_file: ThemeFile = serde_json::from_value(raw.clone())
+            .map_err(|e| format!("Failed to parse theme: {}", e))?;
+
+        let mut theme = resolve_base_theme(&theme_file, &raw)?;
+        apply_theme_overrides(&mut theme, &theme_file, &raw);
+        Ok(theme)
     }
 
     /// Resolve a theme key to a Color.
@@ -1795,6 +1911,11 @@ mod tests {
     /// fix, `serde_json::from_str::<ThemeFile>` errored with `missing field
     /// `ui``, the loader silently dropped the theme, and the user saw
     /// "Failed to load theme" in the status bar.
+    ///
+    /// Beyond loading, this also pins the auto-inheritance behavior: with a
+    /// cream `editor.bg`, the unspecified UI/diagnostic colors must come from
+    /// `builtin://light` (so the theme reads coherently end-to-end), not from
+    /// the dark-flavored hardcoded fallbacks.
     #[test]
     fn test_minimal_user_theme_from_issue_1281_loads() {
         // Verbatim from https://github.com/sinelaw/fresh/issues/1281
@@ -1825,18 +1946,100 @@ mod tests {
         assert_eq!(theme.syntax_string, Color::Rgb(152, 151, 26));
         assert_eq!(theme.syntax_comment, Color::Rgb(146, 131, 116));
 
-        // A theme that omits `ui`/`search`/`diagnostic` should still produce
-        // a usable `Theme` — the missing sections fall back to per-field
-        // defaults, so colors that the editor reads from those sections are
-        // populated rather than left in an undefined state.
+        // Auto-inheritance: cream bg → `builtin://light` is the base. The
+        // unspecified UI/diagnostic colors should match the light builtin's
+        // values — not the dark-flavored hardcoded fallbacks.
+        let light = Theme::load_builtin(THEME_LIGHT).expect("light builtin");
         assert_eq!(
-            theme.resolve_theme_key("diagnostic.error_fg"),
-            Some(theme.diagnostic_error_fg)
+            theme.status_bar_fg, light.status_bar_fg,
+            "ui.status_bar_fg should inherit from builtin://light when bg is bright"
         );
         assert_eq!(
-            theme.resolve_theme_key("ui.status_bar_fg"),
-            Some(theme.status_bar_fg)
+            theme.diagnostic_error_fg, light.diagnostic_error_fg,
+            "diagnostic.error_fg should inherit from builtin://light when bg is bright"
         );
+        assert_eq!(
+            theme.menu_bg, light.menu_bg,
+            "ui.menu_bg should inherit from builtin://light when bg is bright"
+        );
+    }
+
+    /// A user theme with an explicit `extends` must inherit from that base —
+    /// even when auto-inference would have picked something different.
+    #[test]
+    fn test_extends_explicit_builtin_wins_over_auto_infer() {
+        // `editor.bg` is dark (would auto-infer `dark`), but `extends` asks
+        // for `light`. The explicit choice must win.
+        let json = r#"{
+            "name": "explicit-light",
+            "extends": "builtin://light",
+            "editor": { "bg": [0, 0, 0] }
+        }"#;
+        let theme = Theme::from_json(json).expect("extends should resolve");
+        let light = Theme::load_builtin(THEME_LIGHT).expect("light builtin");
+
+        // Override applied.
+        assert_eq!(theme.editor_bg, Color::Rgb(0, 0, 0));
+        // Unspecified fields come from the explicit base, not from auto-infer.
+        assert_eq!(theme.menu_bg, light.menu_bg);
+        assert_eq!(theme.tab_active_bg, light.tab_active_bg);
+        assert_eq!(theme.diagnostic_warning_fg, light.diagnostic_warning_fg);
+    }
+
+    /// Bare-name `extends` (e.g. `"dark"`) is the legacy form accepted by the
+    /// rest of the registry (`ThemeRegistry::resolve_key`), so we accept it
+    /// here too — being strict about a `builtin://` prefix would just be a
+    /// papercut for users hand-writing a theme JSON.
+    #[test]
+    fn test_extends_bare_builtin_name_works() {
+        let json = r#"{ "name": "x", "extends": "high-contrast" }"#;
+        let theme = Theme::from_json(json).expect("bare-name extends should resolve");
+        let hc = Theme::load_builtin("high-contrast").expect("hc builtin");
+        assert_eq!(theme.menu_bg, hc.menu_bg);
+    }
+
+    /// An unknown `extends` target must produce a clear error that names what
+    /// went wrong and lists the valid alternatives — anything less leaves the
+    /// user staring at the same opaque "Failed to load theme" message that
+    /// motivated #1281 in the first place.
+    #[test]
+    fn test_extends_unknown_builtin_errors_with_helpful_message() {
+        let json = r#"{ "name": "x", "extends": "builtin://no-such-theme" }"#;
+        let err = Theme::from_json(json).expect_err("unknown extends must error");
+        assert!(
+            err.contains("no-such-theme"),
+            "error should quote the bad value, got: {}",
+            err
+        );
+        assert!(
+            err.contains("dark") && err.contains("light"),
+            "error should list available builtins, got: {}",
+            err
+        );
+    }
+
+    /// Auto-inference picks `dark` for a clearly-dark `editor.bg`. Mirrors
+    /// the light path tested in the #1281 regression so both branches stay
+    /// honest.
+    #[test]
+    fn test_auto_infer_dark_base_from_dark_bg() {
+        let json = r#"{ "name": "x", "editor": { "bg": [20, 20, 30] } }"#;
+        let theme = Theme::from_json(json).expect("should parse");
+        let dark = Theme::load_builtin(THEME_DARK).expect("dark builtin");
+        assert_eq!(theme.menu_bg, dark.menu_bg);
+        assert_eq!(theme.diagnostic_error_fg, dark.diagnostic_error_fg);
+    }
+
+    /// With neither `extends` nor an explicit `editor.bg`, there's nothing to
+    /// infer from — the theme should still load and use the per-field
+    /// hardcoded defaults rather than failing or picking an arbitrary builtin.
+    #[test]
+    fn test_no_inheritance_signal_uses_hardcoded_defaults() {
+        let json = r#"{ "name": "x" }"#;
+        let theme = Theme::from_json(json).expect("should parse");
+        // The hardcoded `default_editor_bg` is `Rgb(30, 30, 30)`. Pin that so
+        // a future change to the default prompts a deliberate test update.
+        assert_eq!(theme.editor_bg, Color::Rgb(30, 30, 30));
     }
 
     /// `name` remains the only truly required top-level field. A theme JSON
@@ -1851,6 +2054,31 @@ mod tests {
             "error should mention the missing `name` field, got: {}",
             err
         );
+    }
+
+    /// Overriding a single nested field on top of an explicit `extends` must
+    /// only touch that field — every sibling stays at the base's value. This
+    /// is the surgical-tweak workflow ("I love `dark` but want a different
+    /// cursor color"), and the override walk must not bleed into other fields.
+    #[test]
+    fn test_extends_overrides_compose_field_by_field() {
+        let json = r#"{
+            "name": "dark-with-pink-cursor",
+            "extends": "builtin://dark",
+            "editor": { "cursor": [255, 105, 180] }
+        }"#;
+        let theme = Theme::from_json(json).expect("should parse");
+        let dark = Theme::load_builtin(THEME_DARK).expect("dark builtin");
+
+        // Cursor was overridden.
+        assert_eq!(theme.cursor, Color::Rgb(255, 105, 180));
+        // Every other editor field comes from the base verbatim.
+        assert_eq!(theme.editor_bg, dark.editor_bg);
+        assert_eq!(theme.editor_fg, dark.editor_fg);
+        assert_eq!(theme.selection_bg, dark.selection_bg);
+        // And so do the other sections.
+        assert_eq!(theme.menu_bg, dark.menu_bg);
+        assert_eq!(theme.syntax_keyword, dark.syntax_keyword);
     }
 
     #[test]

--- a/crates/fresh-editor/tests/test_theme_schema_i18n.rs
+++ b/crates/fresh-editor/tests/test_theme_schema_i18n.rs
@@ -22,8 +22,13 @@ fn parse_schema_i18n_keys(
     };
 
     for (section_name, section_schema) in properties {
-        // Skip "name" field - it's not a color section
-        if section_name == "name" {
+        // Skip top-level fields that aren't color sections: `name` is the
+        // theme's identity and `extends` is the inheritance pointer (a string,
+        // not a section). The TypeScript theme-editor plugin
+        // (`plugins/theme_editor.ts::loadThemeSections`) uses the same skip
+        // list — they must stay in lock-step or the plugin will save
+        // `"extends": {}` and the round-trip test breaks.
+        if section_name == "name" || section_name == "extends" {
             continue;
         }
 

--- a/docs/features/themes.md
+++ b/docs/features/themes.md
@@ -89,6 +89,43 @@ Themes are stored as JSON files. You can also edit them directly at `~/.config/f
 
 Colors are specified as `[R, G, B]` arrays with values from 0-255.
 
+Only `name` is required. Any section or field you omit is filled in from a
+**base theme** (see [Inheritance](#inheritance) below), so a partial theme
+only needs to spell out the colors that differ from its base.
+
+## Inheritance
+
+A theme can build on top of another theme instead of restating every color.
+Any field you don't set is taken from the base; the fields you do set
+override the base.
+
+```jsonc
+{
+  "name": "my-light-tweak",
+  "extends": "builtin://light",        // pick the base
+  "editor": { "cursor": [255, 105, 180] }  // change one thing
+}
+```
+
+`extends` accepts a built-in name in either form: `"builtin://light"` or
+just `"light"`. The available built-ins are `dark`, `light`, and
+`high-contrast` (plus any others shipped in your install — see the
+**Select Theme** menu for the full list). Inheriting from another *user*
+theme is not supported in this version.
+
+If `extends` is omitted, Fresh tries to pick a sensible base for you:
+
+- If your theme sets `editor.bg`, Fresh looks at the relative luminance of
+  that color and picks `builtin://light` for bright backgrounds and
+  `builtin://dark` for dim ones. So a custom theme that only sets a cream
+  background gets light-flavored UI chrome automatically.
+- If your theme doesn't set `editor.bg` either, every unset field falls
+  back to a per-field hardcoded default.
+
+This means the partial example at the top of this section works without
+needing to spell out every UI/diagnostic color — Fresh fills the rest in
+from the matching built-in.
+
 ## Inspecting Theme Colors
 
 Use "Inspect Theme at Cursor" from the command palette to see which theme colors apply at the cursor position. You can also `Ctrl+Right-Click` on any text to see theme info in a popup.


### PR DESCRIPTION
## Summary

Fixes #1281, plus a layered design fix for the failure mode that #1281
exposed.

The strict bug — `serde_json::from_str::<ThemeFile>` rejecting any theme
that omitted `ui`/`search`/`diagnostic` — is fixed by promoting those
sections to `#[serde(default = "…")]`. But that alone leaves users in a
worse spot: a partial light theme would now *load*, only to render with
dark UI chrome because the per-field hardcoded fallbacks all lean dark.
The verbatim "gruvbox-light-orange" from the issue would have rendered
with cream editor body and dark menus, popups, and status bar.

So this PR also gives `ThemeFile` a real inheritance model — the same
shape every other modern editor (VSCode, Helix, Sublime, Zed) uses:

1. **Explicit `extends`** (`"builtin://light"` or bare `"light"`) chooses
   the base; the user's overrides layer on top.
2. **Luminance auto-inference**: with no `extends`, an explicit
   `editor.bg` picks `builtin://light` for bright backgrounds and
   `builtin://dark` for dim ones. So #1281's verbatim JSON now produces
   a coherent light theme without any extra config from the user.
3. **Hardcoded defaults** (back-compat) when neither signal is present.

Inheriting from another *user* theme is intentionally out of scope —
it adds dependency-graph and cycle-detection problems that deserve
their own design pass. `builtin://NAME` only, with a clear error
listing the available bases when the target isn't a built-in.

## Design notes

- `Theme::from_json` dual-parses: the typed `ThemeFile` for schema
  validation and `name`/`extends`, plus the raw `serde_json::Value` to
  recover *which* fields the user actually wrote. The typed struct alone
  can't tell us — every field has a serde default, so user-set vs
  default is indistinguishable after the first parse.
- The override walk uses `Theme::resolve_theme_key_mut`, so the
  override surface is exactly the surface the rest of the editor already
  addresses. No parallel switch statement to keep in sync; the existing
  `resolve_theme_key_mut_matches_resolve_theme_key_domain` test pins the
  read/write resolvers in lock-step.
- The loader now goes through `Theme::from_json` for user/package
  themes. Built-ins keep the direct `ThemeFile`-from-JSON fast path —
  they're complete by construction and don't need the resolution
  machinery.
- `Option<ColorDef>` fields encode `null` as JSON null. The override walk
  treats null as "no override" (skip), not "set to default", which keeps
  inheritance composing intuitively.

## What changed

| File | Change |
|---|---|
| `crates/fresh-editor/src/view/theme/types.rs` | `ThemeFile`: optional sections + new `extends` field. New `Theme::from_json` with `resolve_base_theme` + `apply_theme_overrides` helpers. Six new inheritance tests; the #1281 regression test now also pins inheritance from `builtin://light`. |
| `crates/fresh-editor/src/view/theme/loader.rs` | User/package theme paths route through `Theme::from_json` so they pick up the resolution model. |
| `crates/fresh-editor/plugins/theme_editor.ts` | Skip `extends` alongside `name` when enumerating color sections from the schema. Without this, the plugin emitted `"extends": {}` on save and broke `ThemeFile` round-trip. |
| `crates/fresh-editor/plugins/schemas/theme.schema.json` | Regenerated via `./scripts/gen_schema.sh`: `extends` added, sections moved off `required` (only `name` remains required). |
| `docs/features/themes.md` | New "Inheritance" section documenting `extends` and the auto-inference rule. The minimal example gets an explanatory line. |

## Test plan

- [x] `cargo test -p fresh-editor --lib` — 2259/2259 pass, including:
  - 32 theme tests (was 26 before this PR).
  - 6 new inheritance tests: explicit `extends`, bare-name `extends`,
    unknown-target error message, light/dark auto-infer, no-signal
    fallback, surgical field overrides on top of a base.
  - The existing `test_minimal_user_theme_from_issue_1281_loads`
    extended to assert UI/diagnostic colors come from `builtin://light`.
- [x] `cargo test -p fresh-editor --test e2e_tests theme` — 59/59
  pass, including the previously-failing
  `test_save_builtin_theme_produces_valid_file` and
  `test_issue_1180_save_theme_creates_themes_directory` (the plugin
  fix).
- [x] `cargo fmt --check`, `cargo clippy --lib --tests --no-deps` clean.
- [x] `tsc --noEmit` on `plugins/tsconfig.json` clean.
- [x] Manual tmux validation against a fresh `~/.config/fresh/themes/`:
  1. **Verbatim #1281 JSON** — loads, renders with cream editor body
     *and* light UI chrome (menus, popups, status bar). Shows as
     `(current)` in `Ctrl+P → Select Theme`.
  2. **`{ "extends": "builtin://dark", "editor": { "cursor": pink } }`** —
     loads, dark UI inherited from base, only the cursor color changes.
     Status bar dark, popups dark, etc. Confirms surgical override
     composition on a real base.
- [x] Schema regeneration touches only `theme.schema.json`
  (config + package schemas unchanged).

## Out of scope (deliberate)

Two follow-ups I'd recommend filing as separate issues:

- **Inheriting from other user themes** (`extends: "my-base.json"`).
  Needs a load-order resolver and cycle detection; nontrivial enough
  to warrant its own design.
- **Terminal-defaults for the no-info-at-all case** — the `{"name":"x"}`
  fallback today returns hardcoded VSCode-Dark-ish RGB values. Switching
  the container fields to `Color::Reset` (vim-like terminal-default
  rendering) is orthogonal to inheritance and touches every default
  function plus snapshot-style tests. Worth doing, but separately.