### PR TITLE
test(file-explorer): regression coverage for issue #611 (WIP, not reproducing)

### DIFF
--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3471,3 +3471,130 @@ fn test_file_explorer_side_workspace_serialization() {
     // Save the workspace and reload
     harness.editor_mut().save_workspace().unwrap();
 }
+
+/// Reproduces issue #611: when switching files via the file explorer, the
+/// new file's content should be visible without requiring the user to scroll.
+/// The reported symptom is that switching from a file scrolled deep into a
+/// large buffer to a smaller file leaves the editor's content area blank
+/// until the user scrolls slightly.
+#[test]
+fn test_issue_611_explorer_switch_to_smaller_file_shows_content() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 30).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let big_path = project_root.join("big.txt");
+    let small_path = project_root.join("small.txt");
+
+    let mut big_content = String::new();
+    for i in 1..=200 {
+        big_content.push_str(&format!("big line {}\n", i));
+    }
+    fs::write(&big_path, &big_content).unwrap();
+
+    let mut small_content = String::new();
+    for i in 1..=10 {
+        small_content.push_str(&format!("small line {}\n", i));
+    }
+    fs::write(&small_path, &small_content).unwrap();
+
+    // Open big.txt in the editor.
+    harness.editor_mut().open_file(&big_path).unwrap();
+    harness.render().unwrap();
+
+    // Jump deep into big.txt so the viewport's `top_byte` points well past
+    // the entire small.txt — this is the precondition the issue describes.
+    harness.editor_mut().goto_line_col(180, None);
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("big line 180"))
+        .unwrap();
+
+    // Open the file explorer and navigate to small.txt — going through the
+    // explorer's preview path is what the issue specifically calls out.
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer_item("small.txt").unwrap();
+    // Move selection from the root (or big.txt) down until small.txt is
+    // selected. Each Down triggers a preview switch through `open_file_preview`.
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("small line 1"),
+        "After switching to small.txt via the file explorer, its content should \
+         render immediately (not require a manual scroll). Screen:\n{}",
+        screen
+    );
+}
+
+/// Variant of issue #611 where we deliberately put the smaller buffer's view
+/// state into a "scrolled past end" state via a previous deeper visit. If the
+/// editor doesn't sanitize the cached viewport on switch, the smaller buffer
+/// will render blank until the user scrolls.
+#[test]
+fn test_issue_611_explorer_switch_keeps_cached_oob_viewport_invisible() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 30).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    let big_path = project_root.join("big.txt");
+    let small_path = project_root.join("small.txt");
+
+    let mut big_content = String::new();
+    for i in 1..=200 {
+        big_content.push_str(&format!("big line {}\n", i));
+    }
+    fs::write(&big_path, &big_content).unwrap();
+
+    // small.txt starts large — we'll prime its cached scroll position deep
+    // into the buffer, then truncate it on disk so its saved viewport is
+    // out-of-range when we revisit it.
+    let mut large_small = String::new();
+    for i in 1..=200 {
+        large_small.push_str(&format!("small line {}\n", i));
+    }
+    fs::write(&small_path, &large_small).unwrap();
+
+    // Visit small.txt and scroll deep so the split caches a high `top_byte`.
+    harness.editor_mut().open_file(&small_path).unwrap();
+    harness.editor_mut().goto_line_col(180, None);
+    harness.render().unwrap();
+
+    // Now open big.txt and scroll deep too.
+    harness.editor_mut().open_file(&big_path).unwrap();
+    harness.editor_mut().goto_line_col(180, None);
+    harness.render().unwrap();
+
+    // Truncate small.txt on disk so its cached viewport is now well past EOF.
+    let mut tiny_small = String::new();
+    for i in 1..=10 {
+        tiny_small.push_str(&format!("small line {}\n", i));
+    }
+    fs::write(&small_path, &tiny_small).unwrap();
+
+    // Reopen small.txt via the explorer's preview flow.
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer_item("small.txt").unwrap();
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::empty())
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("small line 1"),
+        "After switching to a smaller file via the explorer, its content \
+         should render immediately even when the cached viewport was deeper \
+         than the new file. Screen:\n{}",
+        screen
+    );
+}


### PR DESCRIPTION
**Status: Draft / Work in progress.**

This PR is intentionally a draft because I was unable to reproduce the bug described in #611 in the current codebase. Per the workflow's bailout for "fundamentally unable to reproduce", I'm submitting the artifacts I generated so far for review.

## Issue

[#611](https://github.com/sinelaw/fresh/issues/611) — "when change the file through explorer, sometimes the buffer keep empty until I scroll".

A commenter hypothesized that the editor preserves the previous file's scroll position when switching, so jumping from a deeply-scrolled large file to a smaller file leaves the viewport past EOF, which renders blank until the user scrolls slightly.

## Investigation

I traced the explorer's preview-switch flow:

- `app/click_handlers.rs::handle_file_explorer_click` and `app/file_explorer.rs::file_explorer_preview_selected` both route through
- `app/buffer_management.rs::open_file_preview` →
- `app/file_open_orchestrators.rs::open_file` →
- `app/active_focus.rs::set_active_buffer` → `set_pane_buffer` →
- `view/split.rs::SplitViewState::switch_buffer`

`switch_buffer` creates a fresh `BufferViewState` (with `top_byte=0`) for first-time visits and otherwise restores a previously-saved one; `layout_dirty` is set so the layout is rebuilt. On the surface this is correct.

I built two reproductions targeting the user's described path:

1. **Direct case:** open `big.txt`, jump to line 180, switch to `small.txt` via the explorer's preview keystroke.
2. **Cached out-of-bounds case:** prime `small.txt`'s split-view state with a deep `top_byte`, truncate the file on disk so the cached scroll is past EOF, then re-enter via the explorer.

Both tests **pass** — the editor renders `small line 1` immediately in both scenarios. Manual reproduction in `tmux` (`Ctrl+O` to open big.txt → `Ctrl+G 180 Enter` → `Ctrl+B`/`Ctrl+E` to focus the explorer → `Down` to preview `small.txt`) also showed the file content rendered correctly with no blank-pane state.

## What this PR contains

Two e2e tests in `crates/fresh-editor/tests/e2e/file_explorer.rs`:

- `test_issue_611_explorer_switch_to_smaller_file_shows_content`
- `test_issue_611_explorer_switch_keeps_cached_oob_viewport_invisible`

They pin the user-visible contract that switching files via the file explorer leaves the editor's content area visible without requiring a manual scroll. If anything in the `switch_buffer` / viewport-restoration / layout-invalidation chain regresses, these tests will catch the original symptom.

## Why draft

Per the workflow: when I cannot reproduce a bug, I should stop and submit what I have as a Draft PR. The bug appears to be already fixed (or never reproduced in this configuration), but the issue is still open with the `actionable` label. Reviewers should decide:

- Close #611 as no-longer-reproducible and merge the regression tests as forward coverage, **or**
- Treat the bug as still latent under conditions I haven't covered (specific config, line wrap, plugin interaction, remote FS, etc.) and extend the reproduction.

Happy to adjust based on review.

https://github.com/sinelaw/fresh/issues/611

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMZMDFggUA9UhnPsJ8owef)_