### PR TITLE
feature: Compact / Inline single child directory (#1406)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -134,7 +134,8 @@
         "preview_tabs": true,
         "side": "left",
         "auto_open_on_last_buffer_close": true,
-        "follow_active_buffer": false
+        "follow_active_buffer": false,
+        "compact_directories": true
       }
     },
     "file_browser": {
@@ -958,6 +959,11 @@
           "description": "When the file explorer sidebar is open, automatically expand the\ntree and highlight the file that corresponds to the active buffer\nwhenever you switch tabs. Set to `true` to keep the explorer\nselection in sync with the active tab.\nDefault: false",
           "type": "boolean",
           "default": false
+        },
+        "compact_directories": {
+          "description": "Render single-child directory chains on a single line, e.g.\n`src/main/java/com/example`. Only applies when each intermediate\ndirectory in the chain is expanded and has exactly one visible\nchild that is itself a directory. Mirrors VSCode's\n`explorer.compactFolders`.\nDefault: true",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1396,6 +1396,8 @@ impl Editor {
             .set_show_gitignored(show_gitignored);
         tracing::debug!("Applied show_gitignored={} on init", show_gitignored);
 
+        view.set_compact_directories(self.config.file_explorer.compact_directories);
+
         self.active_window_mut().file_explorer = Some(view);
         self.set_status_message(t!("status.file_explorer_ready").to_string());
 

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -310,8 +310,7 @@ impl Editor {
                 .get_mut(&active_id)
                 .and_then(|w| w.file_explorer.as_mut()),
         ) {
-            let tree = explorer.tree_mut();
-            let result = runtime.block_on(tree.toggle_node(selected_id));
+            let result = runtime.block_on(explorer.toggle_with_chain(selected_id));
 
             let final_name = explorer
                 .tree()

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -192,6 +192,7 @@ impl Editor {
             let patterns = explorer.ignore_patterns_mut();
             patterns.set_show_hidden(self.config.file_explorer.show_hidden);
             patterns.set_show_gitignored(self.config.file_explorer.show_gitignored);
+            explorer.set_compact_directories(self.config.file_explorer.compact_directories);
         }
 
         // On Windows, switch mouse tracking mode when mouse_hover_enabled changes.

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1531,6 +1531,15 @@ pub struct FileExplorerConfig {
     /// Default: false
     #[serde(default = "default_false")]
     pub follow_active_buffer: bool,
+
+    /// Render single-child directory chains on a single line, e.g.
+    /// `src/main/java/com/example`. Only applies when each intermediate
+    /// directory in the chain is expanded and has exactly one visible
+    /// child that is itself a directory. Mirrors VSCode's
+    /// `explorer.compactFolders`.
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub compact_directories: bool,
 }
 
 /// Width configuration for the file explorer.
@@ -1888,6 +1897,7 @@ impl Default for FileExplorerConfig {
             side: default_explorer_side(),
             auto_open_on_last_buffer_close: true,
             follow_active_buffer: false,
+            compact_directories: true,
         }
     }
 }

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -347,6 +347,7 @@ pub struct PartialFileExplorerConfig {
     pub side: Option<crate::config::FileExplorerSide>,
     pub auto_open_on_last_buffer_close: Option<bool>,
     pub follow_active_buffer: Option<bool>,
+    pub compact_directories: Option<bool>,
 }
 
 impl Merge for PartialFileExplorerConfig {
@@ -363,6 +364,8 @@ impl Merge for PartialFileExplorerConfig {
             .merge_from(&other.auto_open_on_last_buffer_close);
         self.follow_active_buffer
             .merge_from(&other.follow_active_buffer);
+        self.compact_directories
+            .merge_from(&other.compact_directories);
     }
 }
 
@@ -770,6 +773,7 @@ impl From<&FileExplorerConfig> for PartialFileExplorerConfig {
             side: Some(cfg.side),
             auto_open_on_last_buffer_close: Some(cfg.auto_open_on_last_buffer_close),
             follow_active_buffer: Some(cfg.follow_active_buffer),
+            compact_directories: Some(cfg.compact_directories),
         }
     }
 }
@@ -792,6 +796,9 @@ impl PartialFileExplorerConfig {
             follow_active_buffer: self
                 .follow_active_buffer
                 .unwrap_or(defaults.follow_active_buffer),
+            compact_directories: self
+                .compact_directories
+                .unwrap_or(defaults.compact_directories),
         }
     }
 }

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -28,6 +28,9 @@ pub struct FileTreeView {
     pub(crate) viewport_height: usize,
     /// Search state for quick navigation
     search: FileExplorerSearch,
+    /// Render single-child directory chains as a single row
+    /// (`foo/bar/baz`). Mirrors VSCode's `explorer.compactFolders`.
+    compact_directories: bool,
 }
 
 /// Sort mode for file tree entries
@@ -55,7 +58,158 @@ impl FileTreeView {
             ignore_patterns: IgnorePatterns::new(),
             viewport_height: 10, // Default, will be updated during rendering
             search: FileExplorerSearch::new(),
+            compact_directories: true,
         }
+    }
+
+    /// Toggle/set the compact-directory rendering mode.
+    pub fn set_compact_directories(&mut self, enabled: bool) {
+        self.compact_directories = enabled;
+    }
+
+    /// Whether compact-directory rendering is enabled.
+    pub fn compact_directories(&self) -> bool {
+        self.compact_directories
+    }
+
+    /// Returns true if `node_id` is a directory whose row gets folded into
+    /// a deeper anchor's row under compact-directory rendering — i.e. it is
+    /// expanded with exactly one visible child that is also a directory.
+    /// Root is never absorbed.
+    fn is_absorbed(&self, node_id: NodeId) -> bool {
+        if !self.compact_directories {
+            return false;
+        }
+        if node_id == self.tree.root_id() {
+            return false;
+        }
+        let node = match self.tree.get_node(node_id) {
+            Some(n) => n,
+            None => return false,
+        };
+        if !node.is_dir() || !node.is_expanded() {
+            return false;
+        }
+        let mut visible_iter = node
+            .children
+            .iter()
+            .copied()
+            .filter(|&c| self.is_node_visible(c));
+        let only_child = match visible_iter.next() {
+            Some(c) => c,
+            None => return false,
+        };
+        if visible_iter.next().is_some() {
+            return false;
+        }
+        match self.tree.get_node(only_child) {
+            Some(child) => child.is_dir(),
+            None => false,
+        }
+    }
+
+    /// Expand `node_id` and then walk down any single-child-directory
+    /// chain, expanding each step so the full chain reveals on a single
+    /// rendered row. No-op when compact mode is off or when the node
+    /// isn't a directory. Stops as soon as a step has zero, multiple, or
+    /// non-directory visible children.
+    pub async fn expand_with_chain(&mut self, node_id: NodeId) -> std::io::Result<()> {
+        // Always perform the first expansion so callers can use this in
+        // place of `tree.expand_node` regardless of compact mode.
+        let needs_initial_expand = self
+            .tree
+            .get_node(node_id)
+            .map(|n| n.is_dir() && !n.is_expanded())
+            .unwrap_or(false);
+        if needs_initial_expand {
+            self.tree.expand_node(node_id).await?;
+        }
+        if !self.compact_directories {
+            return Ok(());
+        }
+        let mut cur = node_id;
+        loop {
+            // Determine the unique visible directory child of `cur`, if
+            // one exists. Limit the immutable borrow to this block so the
+            // subsequent `expand_node` call can take a mutable borrow.
+            let next = {
+                let node = match self.tree.get_node(cur) {
+                    Some(n) => n,
+                    None => return Ok(()),
+                };
+                if !node.is_expanded() {
+                    return Ok(());
+                }
+                let mut visible = node
+                    .children
+                    .iter()
+                    .copied()
+                    .filter(|&c| self.is_node_visible(c));
+                let only = match visible.next() {
+                    Some(c) => c,
+                    None => return Ok(()),
+                };
+                if visible.next().is_some() {
+                    return Ok(());
+                }
+                match self.tree.get_node(only) {
+                    Some(child) if child.is_dir() => only,
+                    _ => return Ok(()),
+                }
+            };
+            let already_expanded = self
+                .tree
+                .get_node(next)
+                .map(|n| n.is_expanded())
+                .unwrap_or(false);
+            if !already_expanded {
+                self.tree.expand_node(next).await?;
+            }
+            cur = next;
+        }
+    }
+
+    /// Toggle expansion on `node_id`. When expanding, also reveals the
+    /// rest of any single-child-directory chain (see `expand_with_chain`).
+    pub async fn toggle_with_chain(&mut self, node_id: NodeId) -> std::io::Result<()> {
+        let was_expanded = self
+            .tree
+            .get_node(node_id)
+            .map(|n| n.is_expanded())
+            .unwrap_or(false);
+        self.tree.toggle_node(node_id).await?;
+        if !was_expanded {
+            self.expand_with_chain(node_id).await?;
+        }
+        Ok(())
+    }
+
+    /// Build the compact-chain prefix for `anchor`: the chain of ancestor
+    /// directories that share its row, ordered outermost-first. Empty when
+    /// compact mode is off or the anchor isn't part of a chain.
+    pub fn compact_chain_for_anchor(&self, anchor: NodeId) -> Vec<NodeId> {
+        if !self.compact_directories {
+            return Vec::new();
+        }
+        let mut prefix = Vec::new();
+        let mut cur = anchor;
+        loop {
+            let cur_node = match self.tree.get_node(cur) {
+                Some(n) => n,
+                None => break,
+            };
+            let parent_id = match cur_node.parent {
+                Some(p) => p,
+                None => break,
+            };
+            if !self.is_absorbed(parent_id) {
+                break;
+            }
+            prefix.push(parent_id);
+            cur = parent_id;
+        }
+        prefix.reverse();
+        prefix
     }
 
     /// Get visible nodes filtered by ignore patterns (hidden files, gitignored, etc.)
@@ -69,13 +223,20 @@ impl FileTreeView {
     }
 
     /// Recursively collect visible nodes, skipping ignored subtrees.
+    /// When compact-directory mode is enabled, intermediate nodes that are
+    /// folded into a deeper anchor's row are also skipped — only the
+    /// anchor (the deepest non-absorbed node in the chain) appears in the
+    /// list, so navigation, indexing, and scrolling all operate on
+    /// rendered rows rather than raw tree nodes.
     fn collect_filtered_visible(&self, id: NodeId, result: &mut Vec<NodeId>) {
         let is_root = id == self.tree.root_id();
         if !is_root && !self.is_node_visible(id) {
             return;
         }
 
-        result.push(id);
+        if !self.is_absorbed(id) {
+            result.push(id);
+        }
 
         if let Some(node) = self.tree.get_node(id) {
             if node.is_expanded() {
@@ -103,14 +264,18 @@ impl FileTreeView {
 
     /// Get currently visible nodes with their indent levels
     ///
-    /// Returns a list of (NodeId, indent_level) tuples for rendering.
+    /// Returns a list of (NodeId, indent_level) tuples for rendering. In
+    /// compact-directory mode, the indent for a chain anchor is the depth
+    /// of the *outermost* directory folded into its row, so the chain
+    /// renders at the same level as it would have without compaction.
     pub fn get_display_nodes(&self) -> Vec<(NodeId, usize)> {
         let visible = self.filtered_visible_nodes();
         visible
             .into_iter()
             .map(|id| {
                 let depth = self.tree.get_depth(id);
-                (id, depth)
+                let chain_len = self.compact_chain_for_anchor(id).len();
+                (id, depth.saturating_sub(chain_len))
             })
             .collect()
     }
@@ -120,9 +285,29 @@ impl FileTreeView {
         self.selected_node
     }
 
-    /// Set the selected node
+    /// Set the selected node. The id is promoted to its chain anchor so
+    /// the cursor always lands on a rendered row in compact mode.
     pub fn set_selected(&mut self, node_id: Option<NodeId>) {
-        self.selected_node = node_id;
+        self.selected_node = node_id.map(|id| self.promote_to_anchor(id));
+    }
+
+    /// Walk down a chain of absorbed directories until reaching the
+    /// non-absorbed anchor. For non-absorbed nodes returns the input.
+    fn promote_to_anchor(&self, node_id: NodeId) -> NodeId {
+        let mut cur = node_id;
+        while self.is_absorbed(cur) {
+            let next = self.tree.get_node(cur).and_then(|node| {
+                node.children
+                    .iter()
+                    .copied()
+                    .find(|&c| self.is_node_visible(c))
+            });
+            match next {
+                Some(c) => cur = c,
+                None => break,
+            }
+        }
+        cur
     }
 
     /// Select the next visible node (clears multi-selection)
@@ -380,7 +565,21 @@ impl FileTreeView {
     pub fn select_parent(&mut self) {
         if let Some(current) = self.selected_node {
             if let Some(node) = self.tree.get_node(current) {
-                if let Some(parent_id) = node.parent {
+                if let Some(mut parent_id) = node.parent {
+                    // In compact mode, the immediate parent may be an
+                    // absorbed directory folded into this same row. Walk
+                    // up until we reach a non-absorbed ancestor so the
+                    // cursor lands on a different visible row.
+                    while self.is_absorbed(parent_id) {
+                        let next = self
+                            .tree
+                            .get_node(parent_id)
+                            .and_then(|n| n.parent);
+                        match next {
+                            Some(p) => parent_id = p,
+                            None => break,
+                        }
+                    }
                     self.selected_node = Some(parent_id);
                 }
             }
@@ -445,7 +644,8 @@ impl FileTreeView {
     /// Navigate to a specific path if it exists in the tree
     pub fn navigate_to_path(&mut self, path: &std::path::Path) {
         if let Some(node) = self.tree.get_node_by_path(path) {
-            self.selected_node = Some(node.id);
+            let id = node.id;
+            self.selected_node = Some(self.promote_to_anchor(id));
             self.update_scroll_for_selection();
         }
     }
@@ -533,7 +733,7 @@ impl FileTreeView {
     /// - There was an error expanding intermediate directories
     pub async fn expand_and_select_file(&mut self, path: &std::path::Path) -> bool {
         if let Some(node_id) = self.tree.expand_to_path(path).await {
-            self.selected_node = Some(node_id);
+            self.selected_node = Some(self.promote_to_anchor(node_id));
             true
         } else {
             false

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -265,19 +265,37 @@ impl FileTreeView {
     /// Get currently visible nodes with their indent levels
     ///
     /// Returns a list of (NodeId, indent_level) tuples for rendering. In
-    /// compact-directory mode, the indent for a chain anchor is the depth
-    /// of the *outermost* directory folded into its row, so the chain
-    /// renders at the same level as it would have without compaction.
+    /// compact-directory mode the indent skips every absorbed ancestor
+    /// in the path so every row sits beneath its visible parent — both
+    /// chain anchors *and* their descendants render at the right level.
     pub fn get_display_nodes(&self) -> Vec<(NodeId, usize)> {
         let visible = self.filtered_visible_nodes();
         visible
             .into_iter()
             .map(|id| {
                 let depth = self.tree.get_depth(id);
-                let chain_len = self.compact_chain_for_anchor(id).len();
-                (id, depth.saturating_sub(chain_len))
+                let absorbed = self.count_absorbed_ancestors(id);
+                (id, depth.saturating_sub(absorbed))
             })
             .collect()
+    }
+
+    /// Count ancestors of `id` whose row is folded into a deeper anchor's
+    /// row under compact mode. Returns 0 when compact mode is off.
+    fn count_absorbed_ancestors(&self, id: NodeId) -> usize {
+        let mut count = 0usize;
+        let mut cur = id;
+        loop {
+            let parent_id = match self.tree.get_node(cur).and_then(|n| n.parent) {
+                Some(p) => p,
+                None => break,
+            };
+            if self.is_absorbed(parent_id) {
+                count += 1;
+            }
+            cur = parent_id;
+        }
+        count
     }
 
     /// Get the currently selected node ID
@@ -571,10 +589,7 @@ impl FileTreeView {
                     // up until we reach a non-absorbed ancestor so the
                     // cursor lands on a different visible row.
                     while self.is_absorbed(parent_id) {
-                        let next = self
-                            .tree
-                            .get_node(parent_id)
-                            .and_then(|n| n.parent);
+                        let next = self.tree.get_node(parent_id).and_then(|n| n.parent);
                         match next {
                             Some(p) => parent_id = p,
                             None => break,
@@ -1160,5 +1175,310 @@ mod tests {
                 .filter_map(|&id| view.tree().get_node(id).map(|n| n.entry.name.clone()))
                 .collect::<Vec<_>>()
         );
+    }
+
+    // ============================================================
+    // Compact-directory tests
+    //
+    // Fixture layout (created by `create_chain_view`):
+    //
+    //     <root>/
+    //       chain/
+    //         a/
+    //           b/
+    //             c/
+    //               leaf.txt
+    //       sibling/
+    //         other.txt
+    //
+    // The `chain → a → b → c` segment is a single-child directory chain.
+    // `c` ends the chain because its only child is a file. `sibling` is
+    // a separate dir at the root level so the root itself has multiple
+    // visible children (and thus is never absorbed).
+    // ============================================================
+
+    async fn create_chain_view() -> (TempDir, FileTreeView) {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        std_fs::create_dir_all(temp_path.join("chain/a/b/c")).unwrap();
+        std_fs::write(temp_path.join("chain/a/b/c/leaf.txt"), "leaf").unwrap();
+        std_fs::create_dir(temp_path.join("sibling")).unwrap();
+        std_fs::write(temp_path.join("sibling/other.txt"), "other").unwrap();
+
+        let backend = Arc::new(StdFileSystem);
+        let manager = Arc::new(FsManager::new(backend));
+        let tree = FileTree::new(temp_path.to_path_buf(), manager)
+            .await
+            .unwrap();
+        let view = FileTreeView::new(tree);
+
+        (temp_dir, view)
+    }
+
+    /// Resolve a node id from a path relative to the tree root.
+    fn id_for(view: &FileTreeView, rel: &str) -> NodeId {
+        let path = view.tree().root_path().join(rel);
+        view.tree()
+            .get_node_by_path(&path)
+            .unwrap_or_else(|| panic!("expected node at {:?}", path))
+            .id
+    }
+
+    fn name_of(view: &FileTreeView, id: NodeId) -> String {
+        view.tree().get_node(id).unwrap().entry.name.clone()
+    }
+
+    #[tokio::test]
+    async fn test_compact_chain_collapses_single_child_dirs() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        // expand_with_chain should drill all the way down to `c` because
+        // every step has exactly one directory child until `c`'s file
+        // child breaks the chain.
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        let c_id = id_for(&view, "chain/a/b/c");
+
+        // The chain anchor for `c` is `[chain, a, b]`, outermost-first.
+        let prefix = view.compact_chain_for_anchor(c_id);
+        let prefix_names: Vec<String> = prefix.iter().map(|&id| name_of(&view, id)).collect();
+        assert_eq!(prefix_names, vec!["chain", "a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn test_compact_display_skips_absorbed_nodes() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        let visible_names: Vec<String> = view
+            .get_display_nodes()
+            .into_iter()
+            .map(|(id, _)| name_of(&view, id))
+            .collect();
+
+        // `chain`, `a`, `b` are folded into `c`'s row and must not appear
+        // as separate rows. `c` is the chain anchor, `leaf.txt` sits
+        // beneath it as its own row, and `sibling` is unaffected.
+        assert!(!visible_names.contains(&"chain".to_string()));
+        assert!(!visible_names.contains(&"a".to_string()));
+        assert!(!visible_names.contains(&"b".to_string()));
+        assert!(visible_names.contains(&"c".to_string()));
+        assert!(visible_names.contains(&"leaf.txt".to_string()));
+        assert!(visible_names.contains(&"sibling".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_compact_indent_preserves_visual_hierarchy() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        let display = view.get_display_nodes();
+        let indent_for = |target: NodeId| {
+            display
+                .iter()
+                .find(|(id, _)| *id == target)
+                .map(|(_, indent)| *indent)
+                .unwrap_or_else(|| panic!("node {target:?} not in display"))
+        };
+
+        let c_id = id_for(&view, "chain/a/b/c");
+        let leaf_id = id_for(&view, "chain/a/b/c/leaf.txt");
+        let sibling_id = id_for(&view, "sibling");
+
+        // `c` renders at indent 1 (the depth of its outermost folded
+        // ancestor `chain`), even though its raw tree depth is 4.
+        assert_eq!(indent_for(c_id), 1);
+        // `leaf.txt` sits one level deeper than its visible parent `c`,
+        // not at its raw depth of 5.
+        assert_eq!(indent_for(leaf_id), 2);
+        // `sibling` is unaffected by the chain on the other branch.
+        assert_eq!(indent_for(sibling_id), 1);
+    }
+
+    #[tokio::test]
+    async fn test_compact_chain_breaks_at_file_or_branch() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        // `c`'s only child is a file (`leaf.txt`), so `c` itself is not
+        // absorbed and renders as a normal row with no further chain.
+        let c_id = id_for(&view, "chain/a/b/c");
+        let visible_names: Vec<String> = view
+            .get_display_nodes()
+            .into_iter()
+            .map(|(id, _)| name_of(&view, id))
+            .collect();
+        assert!(visible_names.contains(&"c".to_string()));
+
+        // `leaf.txt` (file) carries no chain prefix.
+        let leaf_id = id_for(&view, "chain/a/b/c/leaf.txt");
+        assert!(view.compact_chain_for_anchor(leaf_id).is_empty());
+
+        // The root never participates in a chain — even when it has just
+        // one visible child, it stays at the top of the tree on its own
+        // row. Verify by collapsing siblings out of view.
+        // (Here we just assert the principle directly: root is never the
+        // start of a folded prefix for any other anchor.)
+        let prefix_for_c = view.compact_chain_for_anchor(c_id);
+        assert!(!prefix_for_c.contains(&root_id));
+    }
+
+    #[tokio::test]
+    async fn test_compact_disabled_renders_each_node_as_row() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        // Expand the whole chain with compact mode on, then turn it off.
+        // All four directories should now render as separate rows at
+        // their raw depths.
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+        view.set_compact_directories(false);
+
+        let display = view.get_display_nodes();
+        let visible_names: Vec<String> =
+            display.iter().map(|(id, _)| name_of(&view, *id)).collect();
+        assert!(visible_names.contains(&"chain".to_string()));
+        assert!(visible_names.contains(&"a".to_string()));
+        assert!(visible_names.contains(&"b".to_string()));
+        assert!(visible_names.contains(&"c".to_string()));
+
+        // Indents should reflect raw depths since nothing is folded.
+        let indent_for = |target: NodeId| {
+            display
+                .iter()
+                .find(|(id, _)| *id == target)
+                .map(|(_, indent)| *indent)
+                .unwrap()
+        };
+        assert_eq!(indent_for(id_for(&view, "chain")), 1);
+        assert_eq!(indent_for(id_for(&view, "chain/a")), 2);
+        assert_eq!(indent_for(id_for(&view, "chain/a/b")), 3);
+        assert_eq!(indent_for(id_for(&view, "chain/a/b/c")), 4);
+
+        // No chain prefix is ever produced when compact mode is off.
+        assert!(view
+            .compact_chain_for_anchor(id_for(&view, "chain/a/b/c"))
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_expand_with_chain_auto_expands_descendants() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        let chain_id = id_for(&view, "chain");
+        // Pre-condition: `chain` is collapsed.
+        assert!(view.tree().get_node(chain_id).unwrap().is_collapsed());
+
+        view.expand_with_chain(chain_id).await.unwrap();
+
+        // Every dir in the chain (including `c`) should now be expanded
+        // so their tree nodes exist and are reachable. Without
+        // auto-chain-expand the user would have to expand each level
+        // manually before the chain could form visually.
+        for rel in ["chain", "chain/a", "chain/a/b", "chain/a/b/c"] {
+            let id = id_for(&view, rel);
+            assert!(
+                view.tree().get_node(id).unwrap().is_expanded(),
+                "{rel} should be auto-expanded by expand_with_chain"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_toggle_with_chain_collapses_chain_root_only() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        let chain_id = id_for(&view, "chain");
+        // First toggle: expand + auto-reveal chain.
+        view.toggle_with_chain(chain_id).await.unwrap();
+        assert!(view.tree().get_node(chain_id).unwrap().is_expanded());
+
+        // Second toggle: collapse the chain root. `chain` is now
+        // collapsed; its descendants get dropped from the tree (per
+        // `collapse_node`'s own contract) so the chain is fully reset.
+        view.toggle_with_chain(chain_id).await.unwrap();
+        assert!(view.tree().get_node(chain_id).unwrap().is_collapsed());
+    }
+
+    #[tokio::test]
+    async fn test_set_selected_promotes_absorbed_node_to_anchor() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        // `chain` is absorbed into `c`'s row. Selecting `chain` should
+        // land the cursor on `c` so the cursor always sits on a
+        // rendered row.
+        let chain_id = id_for(&view, "chain");
+        let c_id = id_for(&view, "chain/a/b/c");
+        view.set_selected(Some(chain_id));
+        assert_eq!(view.get_selected(), Some(c_id));
+    }
+
+    #[tokio::test]
+    async fn test_select_parent_skips_absorbed_ancestors() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        // Cursor on `leaf.txt` → its raw parent is `c` (visible), so
+        // select_parent lands on `c`.
+        let leaf_id = id_for(&view, "chain/a/b/c/leaf.txt");
+        let c_id = id_for(&view, "chain/a/b/c");
+        view.set_selected(Some(leaf_id));
+        view.select_parent();
+        assert_eq!(view.get_selected(), Some(c_id));
+
+        // From `c`, the immediate parent `b` is absorbed (and so are
+        // `a` and `chain`). select_parent must skip them all and land on
+        // the root, the next non-absorbed ancestor.
+        view.select_parent();
+        assert_eq!(view.get_selected(), Some(root_id));
+    }
+
+    #[tokio::test]
+    async fn test_compact_visible_count_matches_display_rows() {
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+        view.expand_with_chain(id_for(&view, "chain"))
+            .await
+            .unwrap();
+
+        // Rows: root, c (chain anchor), leaf.txt, sibling — 4 in total.
+        // `chain`, `a`, `b` are folded into `c`'s row and don't count.
+        // `sibling` stays collapsed so its file child is not visible.
+        assert_eq!(view.visible_count(), 4);
+        assert_eq!(view.get_display_nodes().len(), 4);
     }
 }

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -181,6 +181,14 @@ impl FileTreeView {
         if !was_expanded {
             self.expand_with_chain(node_id).await?;
         }
+        // The expansion may have folded the cursor's row into a deeper
+        // chain anchor; re-promote so the cursor stays on a rendered row.
+        // Why: select_next/prev locate the cursor by id within
+        // filtered_visible_nodes(); an absorbed cursor is missing from
+        // that list and arrow keys silently no-op.
+        if let Some(sel) = self.selected_node {
+            self.selected_node = Some(self.promote_to_anchor(sel));
+        }
         Ok(())
     }
 
@@ -1422,6 +1430,46 @@ mod tests {
         // `collapse_node`'s own contract) so the chain is fully reset.
         view.toggle_with_chain(chain_id).await.unwrap();
         assert!(view.tree().get_node(chain_id).unwrap().is_collapsed());
+    }
+
+    #[tokio::test]
+    async fn test_toggle_with_chain_keeps_cursor_on_visible_row() {
+        // Regression: pressing Enter on a directory whose subtree folds
+        // into a chain used to leave the cursor on the now-absorbed
+        // directory, so its id was absent from `filtered_visible_nodes()`
+        // and arrow-key navigation silently no-op'd.
+        let (_t, mut view) = create_chain_view().await;
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        let chain_id = id_for(&view, "chain");
+
+        // Cursor sits on `chain` (collapsed → visible) before the user
+        // hits Enter.
+        view.set_selected(Some(chain_id));
+        assert_eq!(view.get_selected(), Some(chain_id));
+
+        // Enter expands the whole chain; `chain`, `a`, `b` become
+        // absorbed and `c` is the chain anchor. The cursor must hop to
+        // `c` so it lands on a rendered row. (The deeper nodes only
+        // exist in the tree after expansion lazily loads them, so look
+        // up `c`'s id afterwards.)
+        view.toggle_with_chain(chain_id).await.unwrap();
+        let c_id = id_for(&view, "chain/a/b/c");
+        assert_eq!(view.get_selected(), Some(c_id));
+
+        // Sanity: the new cursor id is actually present in the visible
+        // rows, so `select_next`/`select_prev` can locate it.
+        let visible: Vec<_> = view
+            .get_display_nodes()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert!(visible.contains(&c_id));
+
+        // And arrow-key navigation still works after the expansion.
+        view.select_next();
+        assert_ne!(view.get_selected(), Some(c_id));
     }
 
     #[tokio::test]

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -251,11 +251,8 @@ impl FileExplorerRenderer {
         // Calculate the left side width for padding calculation
         let indent_width = indent * 2;
         let indicator_width = 2; // "▼ " or "  "
-        // Chain prefix contributes each name plus a "/" separator.
-        let chain_prefix_width: usize = chain_prefix_names
-            .iter()
-            .map(|s| str_width(s) + 1)
-            .sum();
+                                 // Chain prefix contributes each name plus a "/" separator.
+        let chain_prefix_width: usize = chain_prefix_names.iter().map(|s| str_width(s) + 1).sum();
         let name_width = str_width(&node.entry.name);
         let left_side_width = indent_width + indicator_width + chain_prefix_width + name_width;
 

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -239,11 +239,25 @@ impl FileExplorerRenderer {
         // Build the line with indentation and tree structure
         let mut spans = Vec::new();
 
+        // Names of any ancestor directories that compact-mode folded into
+        // this row. Outermost-first; each gets prefixed before the anchor
+        // name and joined by `/`.
+        let chain_prefix_names: Vec<String> = view
+            .compact_chain_for_anchor(node_id)
+            .into_iter()
+            .filter_map(|id| view.tree().get_node(id).map(|n| n.entry.name.clone()))
+            .collect();
+
         // Calculate the left side width for padding calculation
         let indent_width = indent * 2;
         let indicator_width = 2; // "▼ " or "  "
+        // Chain prefix contributes each name plus a "/" separator.
+        let chain_prefix_width: usize = chain_prefix_names
+            .iter()
+            .map(|s| str_width(s) + 1)
+            .sum();
         let name_width = str_width(&node.entry.name);
-        let left_side_width = indent_width + indicator_width + name_width;
+        let left_side_width = indent_width + indicator_width + chain_prefix_width + name_width;
 
         // Indentation
         if indent > 0 {
@@ -293,6 +307,17 @@ impl FileExplorerRenderer {
         } else {
             theme.editor_fg
         };
+
+        // Compact-directory chain prefix: render the folded ancestor names,
+        // each followed by "/", before the anchor name. Use a dimmed
+        // separator so the chain reads as breadcrumbs rather than a flat
+        // path.
+        let chain_segment_style = Style::default().fg(theme.syntax_keyword);
+        let chain_separator_style = Style::default().fg(theme.line_number_fg);
+        for name in &chain_prefix_names {
+            spans.push(Span::styled(name.clone(), chain_segment_style));
+            spans.push(Span::styled("/", chain_separator_style));
+        }
 
         // Render name with match highlighting
         if let Some(fm) = fuzzy_match {

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -1820,7 +1820,13 @@ fn test_folder_shows_modified_indicator_for_unsaved_file() {
 /// Test that nested folder hierarchy shows modified indicator up the tree
 #[test]
 fn test_nested_folder_shows_modified_indicator() {
-    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    // Disable compact-directory rendering so `src` and `components` keep
+    // their own rows; this test asserts on the per-folder modified
+    // indicator propagating up the tree, which the compact-chain
+    // breadcrumb (`src/components` on one row) would otherwise collapse.
+    let mut config = Config::default();
+    config.file_explorer.compact_directories = false;
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
     let project_root = harness.project_dir().unwrap();
 
     // Create a nested folder structure: src/components/Button.js

--- a/crates/fresh-editor/tests/e2e/file_explorer_compact_chain.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer_compact_chain.rs
@@ -1,0 +1,174 @@
+//! E2E regression test for the compact-directory chain feature.
+//!
+//! Repro (manual): with `compact_directories` on (default), pressing Enter
+//! on a directory whose subtree folds into a single-child chain leaves the
+//! cursor pointing at the now-absorbed directory. The selected node id is
+//! no longer in `filtered_visible_nodes()`, so:
+//!   - the rendered cursor indicator (`▌`) disappears entirely;
+//!   - the hardware cursor is no longer placed on the explorer pane;
+//!   - subsequent Down/Up arrow presses silently no-op because
+//!     `select_next/prev` look up the cursor by id within the visible
+//!     list, find nothing, and do nothing.
+//!
+//! This test drives real key events end-to-end and asserts on the
+//! rendered screen output: it expands a chain, verifies the compact
+//! `foo/a/b/c` breadcrumb appears as a single rendered row, verifies the
+//! hardware cursor is still placed on the explorer pane, and verifies
+//! Down arrow actually moves the cursor row down.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+#[test]
+fn test_compact_chain_keeps_cursor_on_visible_row_after_enter() {
+    // Layout (mirrors the unit-test fixture in view::file_tree::view):
+    //
+    //   <root>/
+    //     chain/a/b/c/leaf.txt   ← single-child chain
+    //     sibling/other.txt      ← keeps root from itself becoming a
+    //                              chain anchor
+    //
+    // With compact mode on, expanding `chain` should fold `chain → a → b`
+    // into `c`'s row and render it as a single `chain/a/b/c` breadcrumb.
+    let mut harness = EditorTestHarness::with_temp_project(120, 30).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    fs::create_dir_all(project_root.join("chain/a/b/c")).unwrap();
+    fs::write(project_root.join("chain/a/b/c/leaf.txt"), "leaf").unwrap();
+    fs::create_dir_all(project_root.join("sibling")).unwrap();
+    fs::write(project_root.join("sibling/other.txt"), "other").unwrap();
+
+    // Open the file explorer with the default Ctrl+E binding.
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    // Wait for the root's children to populate. Root auto-expands on
+    // open (its only child is the project root row, which has multiple
+    // visible children — `chain` and `sibling` — so it isn't itself a
+    // chain anchor).
+    harness.wait_for_file_explorer_item("chain").unwrap();
+    harness.wait_for_file_explorer_item("sibling").unwrap();
+
+    // Cursor starts on the project-root row. Press Down to land on the
+    // first child — `chain` (directories sort before `sibling` under the
+    // default Type sort).
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    let _ = harness.editor_mut().process_async_messages();
+    harness.render().unwrap();
+
+    // Sanity: pre-expand the screen shows `chain` as a separate row, no
+    // breadcrumb yet. We're really just checking the test got us to a
+    // pre-expand state where the chain hasn't been folded.
+    let before = harness.screen_to_string();
+    assert!(
+        before.contains("chain"),
+        "expected `chain` row before expansion, got:\n{before}"
+    );
+    assert!(
+        !before.contains("chain/a/b/c"),
+        "did not expect compact breadcrumb before expansion, got:\n{before}"
+    );
+
+    // Press Enter on `chain`. With compact mode on, this expands the
+    // entire `chain → a → b → c` chain in one shot and folds the row
+    // into `c`'s anchor.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Expansion is async — wait for the compact breadcrumb itself to
+    // hit the screen.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("chain/a/b/c"))
+        .unwrap();
+
+    let after_enter = harness.screen_to_string();
+
+    // The compact breadcrumb is rendered as a single row.
+    assert!(
+        after_enter.contains("chain/a/b/c"),
+        "expected compact `chain/a/b/c` breadcrumb after Enter, got:\n{after_enter}"
+    );
+    // None of the absorbed ancestors should remain on a separate row —
+    // i.e. the per-line text `chain` (with no slash) and standalone `a`
+    // / `b` rows are gone. (We check the chained breadcrumb form is
+    // present and the bare-name forms are not their own rows by
+    // searching for tree-indicator + bare-name on a single line.)
+    let absorbed_as_row = |needle: &str| {
+        after_enter.lines().any(|line| {
+            let trimmed = line.trim_start_matches(['│', ' ']);
+            // A row for `chain` would render with the expanded indicator
+            // (`▼ chain`) since it would have to be expanded to lead a
+            // chain. We look for that explicit pattern so we don't get
+            // tricked by the breadcrumb itself (which contains `chain/`).
+            trimmed.starts_with(&format!("▼ {needle} "))
+                || trimmed.starts_with(&format!("▼ {needle}│"))
+                || trimmed == format!("▼ {needle}")
+        })
+    };
+    assert!(
+        !absorbed_as_row("chain"),
+        "absorbed dir `chain` should not render as its own row, got:\n{after_enter}"
+    );
+    assert!(
+        !absorbed_as_row("a"),
+        "absorbed dir `a` should not render as its own row, got:\n{after_enter}"
+    );
+    assert!(
+        !absorbed_as_row("b"),
+        "absorbed dir `b` should not render as its own row, got:\n{after_enter}"
+    );
+
+    // Regression #1: the cursor indicator (`▌`) must be drawn on the
+    // compact breadcrumb row. Before the fix, the cursor sat on an
+    // absorbed node whose id wasn't in the visible list, so the
+    // renderer skipped drawing the indicator entirely (the explorer
+    // only paints `▌` when `get_selected_index()` resolves the cursor
+    // against the visible rows).
+    let breadcrumb_row = after_enter
+        .lines()
+        .find(|line| line.contains("chain/a/b/c"))
+        .unwrap_or_else(|| {
+            panic!("compact breadcrumb row missing from screen:\n{after_enter}")
+        });
+    assert!(
+        breadcrumb_row.contains('▌'),
+        "selected-row indicator `▌` should be drawn on the chain anchor row \
+         after expansion (cursor was promoted from absorbed `chain` to `c`). \
+         Breadcrumb row: {breadcrumb_row:?}\nScreen:\n{after_enter}"
+    );
+
+    // The hardware cursor (used for blinking) is also placed on that
+    // same visible row.
+    let (cursor_x_after, cursor_row_after) = harness.screen_cursor_position();
+    assert!(
+        cursor_row_after >= 1 && cursor_x_after >= 1,
+        "hardware cursor should sit inside the explorer pane after expansion, \
+         got ({cursor_x_after}, {cursor_row_after}). \
+         A cursor at the origin sentinel indicates the renderer never placed \
+         it on a visible explorer row. Screen:\n{after_enter}"
+    );
+
+    // Regression #2: arrow-key navigation must keep working after the
+    // expansion. Down arrow should move the cursor from `c` to
+    // `leaf.txt` (the next visible row). Before the fix, the cursor id
+    // was missing from the visible list, so `select_next` no-op'd and
+    // the cursor row didn't change.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    let _ = harness.editor_mut().process_async_messages();
+    harness.render().unwrap();
+
+    let (_, cursor_row_after_down) = harness.screen_cursor_position();
+    assert_eq!(
+        cursor_row_after_down,
+        cursor_row_after + 1,
+        "Down arrow should advance the cursor one row (chain anchor `c` → `leaf.txt`). \
+         Before fix: the absorbed cursor id meant select_next() couldn't locate the cursor in \
+         the visible list and silently no-op'd. \
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/file_explorer_compact_chain.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer_compact_chain.rs
@@ -131,9 +131,7 @@ fn test_compact_chain_keeps_cursor_on_visible_row_after_enter() {
     let breadcrumb_row = after_enter
         .lines()
         .find(|line| line.contains("chain/a/b/c"))
-        .unwrap_or_else(|| {
-            panic!("compact breadcrumb row missing from screen:\n{after_enter}")
-        });
+        .unwrap_or_else(|| panic!("compact breadcrumb row missing from screen:\n{after_enter}"));
     assert!(
         breadcrumb_row.contains('▌'),
         "selected-row indicator `▌` should be drawn on the chain anchor row \

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -36,6 +36,7 @@ pub mod explorer_menu;
 pub mod external_file_save_as_tab;
 pub mod file_browser;
 pub mod file_explorer;
+pub mod file_explorer_compact_chain;
 pub mod file_permissions;
 pub mod flash;
 pub mod folding;

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1380,9 +1380,10 @@ fn test_settings_file_explorer_width_shows_percent_suffix() {
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
-    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
-    for _ in 0..8 {
+    // Compact Directories, Custom Ignore Patterns, Follow Active Buffer,
+    // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden,
+    // Side, Width.
+    for _ in 0..9 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1428,9 +1429,10 @@ fn test_settings_file_explorer_width_applies_live() {
     }
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
-    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
-    for _ in 0..8 {
+    // Compact Directories, Custom Ignore Patterns, Follow Active Buffer,
+    // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden,
+    // Side, Width.
+    for _ in 0..9 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1538,10 +1540,11 @@ fn test_settings_file_explorer_toggles_propagate_to_runtime() {
     harness.render().unwrap();
 
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
-    // Custom Ignore Patterns, Follow Active Buffer, Preview Tabs,
-    // Respect Gitignore, Show Gitignored, Show Hidden, Side, Width.
+    // Compact Directories, Custom Ignore Patterns, Follow Active Buffer,
+    // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden,
+    // Side, Width.
     // Land on Show Gitignored and toggle.
-    for _ in 0..5 {
+    for _ in 0..6 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness


### PR DESCRIPTION
Easier way to open single child dir tree (eg: Java project com.example.name...)
For more info check : https://github.com/sinelaw/fresh/issues/1406 

Before :
<img width="564" height="272" alt="Screenshot From 2026-05-03 16-54-01" src="https://github.com/user-attachments/assets/a5dac16e-72b1-490d-a33f-550798cb8405" />

After :
<img width="562" height="221" alt="Screenshot From 2026-05-03 16-55-17" src="https://github.com/user-attachments/assets/a6984762-e24d-4850-8bf6-aac6f330347d" />

Settings :
<img width="1178" height="335" alt="Screenshot From 2026-05-03 16-53-18" src="https://github.com/user-attachments/assets/52fccaa4-4f79-495b-8cbd-38f7b921e91e" />


