### PR TITLE
Automate winget package publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,4 +568,11 @@ jobs:
     uses: ./.github/workflows/cargo-publish.yml
     secrets: inherit
 
-  # Winget publishing is done manually via scripts/winget-publish.sh
+  # Publish to winget-pkgs
+  publish-winget:
+    needs: [plan, release]
+    if: ${{ needs.plan.outputs.publishing == 'true' && needs.plan.outputs.is_prerelease != 'true' }}
+    uses: ./.github/workflows/winget-publish.yml
+    with:
+      version: ${{ needs.plan.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,41 @@
+# Publish to winget-pkgs after a release is created
+
+name: Publish to winget
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.1.99)'
+        required: true
+        type: string
+
+jobs:
+  publish-winget:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      GH_TOKEN: ${{ secrets.WINGET_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Configure git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Configure gh to use PAT for git auth
+        run: gh auth setup-git
+
+      - name: Publish to winget-pkgs
+        run: ./scripts/winget-publish.py "${VERSION}"


### PR DESCRIPTION
## Summary
This change automates the publishing of releases to the Windows Package Manager (winget-pkgs) repository by integrating it into the release workflow, replacing the previous manual process.

## Key Changes
- **New workflow file** (`.github/workflows/winget-publish.yml`): Created a reusable workflow that handles publishing to winget-pkgs with the following features:
  - Accepts version input via `workflow_call` (for automation) and `workflow_dispatch` (for manual triggers)
  - Sets up Python 3.12 environment
  - Configures git identity for automated commits
  - Uses a Personal Access Token (WINGET_TOKEN) for authentication
  - Executes the existing `scripts/winget-publish.py` script with the version parameter

- **Updated release workflow** (`.github/workflows/release.yml`): Integrated winget publishing as an automated job:
  - Added `publish-winget` job that depends on `plan` and `release` jobs
  - Configured to run only for non-prerelease versions (skips prerelease publishing)
  - Passes the version from the plan job output to the winget workflow
  - Inherits secrets for authentication

## Notable Details
- The automation only triggers for stable releases (excludes prereleases via `is_prerelease != 'true'` condition)
- Leverages the existing `scripts/winget-publish.py` script rather than replacing it
- Uses GitHub's official actions for checkout and Python setup
- Implements proper git configuration for automated commits with the GitHub Actions bot identity

https://claude.ai/code/session_01GTSyj8oSAH5HpNXNgdPfYe