### PR TITLE
ci(winget): inject PAT into git URLs for push auth

### DIFF
--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -34,8 +34,9 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Configure gh to use PAT for git auth
-        run: gh auth setup-git
+      - name: Configure git credentials for github.com
+        run: |
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Publish to winget-pkgs
         run: ./scripts/winget-publish.py "${VERSION}"


### PR DESCRIPTION
gh auth setup-git doesn't reliably register a credential helper when only GH_TOKEN env is set (no interactive gh auth login), so git push to the winget-pkgs fork was failing with exit 128. Use a global url.insteadOf rewrite to embed the token in github.com HTTPS URLs.