### PR TITLE
feat(clipboard): column-mode paste when cursor count matches line count

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -520,6 +520,10 @@ impl Editor {
     /// - Line ending normalization (CRLF/CR → buffer's format)
     /// - Single cursor paste
     /// - Multi-cursor paste (pastes at each cursor)
+    /// - Column-mode paste: when the cursor count equals the number of
+    ///   clipboard lines, each cursor receives a distinct line (matches
+    ///   VSCode/Notepad++ behavior, see issue #1057). This makes a
+    ///   block-selected copy/paste round-trip preserve its rectangular shape.
     /// - Selection replacement (deletes selection before inserting)
     /// - Atomic undo (single undo step for entire operation)
     /// - Routing to prompt if one is open
@@ -546,16 +550,6 @@ impl Editor {
             return;
         }
 
-        // Convert to buffer's line ending format
-        let buffer_line_ending = self.active_state().buffer.line_ending();
-        let paste_text = match buffer_line_ending {
-            crate::model::buffer::LineEnding::LF => normalized,
-            crate::model::buffer::LineEnding::CRLF => normalized.replace('\n', "\r\n"),
-            crate::model::buffer::LineEnding::CR => normalized.replace('\n', "\r"),
-        };
-
-        let mut events = Vec::new();
-
         // Collect cursor info sorted in reverse order by position
         let mut cursor_data: Vec<_> = self
             .active_cursors()
@@ -571,6 +565,26 @@ impl Editor {
             .collect();
         cursor_data.sort_by_key(|(_, _, pos)| std::cmp::Reverse(*pos));
 
+        // Decide whether to distribute one clipboard line per cursor
+        // (column-mode paste). We split on LF (after normalization above) and
+        // ignore a single trailing empty entry from a trailing newline so that
+        // "a\nb\nc" and "a\nb\nc\n" both yield 3 lines.
+        let mut lines_for_distribution: Vec<&str> = normalized.split('\n').collect();
+        if lines_for_distribution.len() > 1 && lines_for_distribution.last() == Some(&"") {
+            lines_for_distribution.pop();
+        }
+        let use_column_paste = cursor_data.len() > 1
+            && lines_for_distribution.len() > 1
+            && lines_for_distribution.len() == cursor_data.len();
+
+        // Convert to buffer's line ending format (only used in non-column mode;
+        // a single column-paste line never contains an embedded newline).
+        let paste_text_full = match self.active_state().buffer.line_ending() {
+            crate::model::buffer::LineEnding::LF => normalized.clone(),
+            crate::model::buffer::LineEnding::CRLF => normalized.replace('\n', "\r\n"),
+            crate::model::buffer::LineEnding::CR => normalized.replace('\n', "\r"),
+        };
+
         // Get deleted text for each selection
         let cursor_data_with_text: Vec<_> = {
             let state = self.active_state_mut();
@@ -585,8 +599,18 @@ impl Editor {
                 .collect()
         };
 
-        // Build events for each cursor
-        for (cursor_id, selection, insert_position, deleted_text) in cursor_data_with_text {
+        // Build events for each cursor.
+        //
+        // cursor_data_with_text is sorted by position DESCENDING (so events
+        // applied in vector order don't invalidate earlier offsets). For column
+        // paste we want the topmost cursor (smallest position) to receive the
+        // first clipboard line, so we index into `lines_for_distribution` from
+        // the back when iterating.
+        let total = cursor_data_with_text.len();
+        let mut events = Vec::new();
+        for (i, (cursor_id, selection, insert_position, deleted_text)) in
+            cursor_data_with_text.into_iter().enumerate()
+        {
             if let (Some(range), Some(text)) = (selection, deleted_text) {
                 events.push(Event::Delete {
                     range,
@@ -594,9 +618,14 @@ impl Editor {
                     cursor_id,
                 });
             }
+            let text = if use_column_paste {
+                lines_for_distribution[total - 1 - i].to_string()
+            } else {
+                paste_text_full.clone()
+            };
             events.push(Event::Insert {
                 position: insert_position,
-                text: paste_text.clone(),
+                text,
                 cursor_id,
             });
         }

--- a/crates/fresh-editor/tests/e2e/paste.rs
+++ b/crates/fresh-editor/tests/e2e/paste.rs
@@ -839,3 +839,166 @@ fn test_paste_crlf_into_prompt() {
     // Prompt should contain the text (newlines may be shown differently in prompt)
     harness.assert_screen_contains("line1");
 }
+
+// ============================================================================
+// Column-mode paste tests (issue #1057)
+//
+// When the cursor count matches the number of clipboard lines, each cursor
+// receives a distinct line — matching VSCode/Notepad++ behavior. This makes a
+// block-selected copy/paste round-trip preserve its rectangular shape.
+// ============================================================================
+
+/// When the number of clipboard lines matches the cursor count, each cursor
+/// receives one line in top-to-bottom order.
+#[test]
+fn test_paste_distributes_lines_when_cursor_count_matches() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("aaa\nbbb\nccc").unwrap();
+    harness.assert_buffer_content("aaa\nbbb\nccc");
+
+    // Place a cursor at the end of each line.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+    harness.editor_mut().add_cursor_below();
+    harness.editor_mut().add_cursor_below();
+    assert_eq!(harness.editor().active_cursors().count(), 3);
+
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("X\nYY\nZZZ".to_string());
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+
+    // First cursor receives "X", second "YY", third "ZZZ".
+    harness.assert_buffer_content("aaaX\nbbbYY\ncccZZZ");
+}
+
+/// A trailing newline in the clipboard is dropped before deciding whether to
+/// distribute, so "X\nY\n" with 2 cursors still distributes one line per
+/// cursor.
+#[test]
+fn test_paste_column_mode_ignores_trailing_newline() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("aaa\nbbb").unwrap();
+    harness.assert_buffer_content("aaa\nbbb");
+
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.editor_mut().add_cursor_below();
+    assert_eq!(harness.editor().active_cursors().count(), 2);
+
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("X\nY\n".to_string());
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("Xaaa\nYbbb");
+}
+
+/// When cursor count and clipboard line count don't match, fall back to
+/// pasting the full multi-line text at every cursor.
+#[test]
+fn test_paste_pastes_full_text_when_cursor_count_does_not_match() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("aaa\nbbb").unwrap();
+    harness.assert_buffer_content("aaa\nbbb");
+
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.editor_mut().add_cursor_below();
+    assert_eq!(harness.editor().active_cursors().count(), 2);
+
+    // 2 cursors but 3 clipboard lines → fall back to inserting the whole
+    // multi-line text at each cursor.
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("X\nY\nZ".to_string());
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X\nY\nZaaa\nX\nY\nZbbb");
+}
+
+/// Round-trip: copying a block selection and pasting it at a multi-cursor
+/// preserves the rectangular shape (the headline scenario from issue #1057).
+#[test]
+fn test_block_selection_copy_paste_roundtrip() {
+    use fresh::input::keybindings::Action;
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Six lines we'll later treat as two side-by-side columns.
+    harness
+        .type_text("Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6")
+        .unwrap();
+
+    // Select "Line 4", "Line 5", "Line 6" as a block: cursor is currently at
+    // end of "Line 6"; extend block selection up two lines, then left across
+    // each line's contents.
+    for _ in 0..2 {
+        harness
+            .editor_mut()
+            .dispatch_action_for_tests(Action::BlockSelectUp);
+    }
+    for _ in 0.."Line 6".len() {
+        harness
+            .editor_mut()
+            .dispatch_action_for_tests(Action::BlockSelectLeft);
+    }
+    harness.render().unwrap();
+
+    // Copy the block.
+    harness.editor_mut().copy_selection();
+    let copied = harness.editor().clipboard_content_for_test();
+    assert_eq!(copied, "Line 4\nLine 5\nLine 6");
+
+    // Move to start of "Line 1" and place a cursor at the start of each
+    // of the three target lines.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.editor_mut().add_cursor_below();
+    harness.editor_mut().add_cursor_below();
+    assert_eq!(harness.editor().active_cursors().count(), 3);
+
+    // Paste: each cursor should receive its own line of the copied block.
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+
+    harness
+        .assert_buffer_content("Line 4Line 1\nLine 5Line 2\nLine 6Line 3\nLine 4\nLine 5\nLine 6");
+}
+
+/// Column-mode paste must remain atomic for undo: a single Ctrl+Z reverts
+/// every per-cursor insertion.
+#[test]
+fn test_paste_column_mode_undo_is_atomic() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    harness.type_text("aaa\nbbb\nccc").unwrap();
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.editor_mut().add_cursor_below();
+    harness.editor_mut().add_cursor_below();
+
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("X\nY\nZ".to_string());
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+    harness.assert_buffer_content("Xaaa\nYbbb\nZccc");
+
+    harness
+        .send_key(KeyCode::Char('z'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_buffer_content("aaa\nbbb\nccc");
+}


### PR DESCRIPTION
## Summary

Closes #1057.

When a user has N cursors and the clipboard holds N lines, pasting now distributes one line per cursor (top‑to‑bottom) instead of inserting the full multi‑line text at every cursor. This is the column‑mode paste expected by users coming from VSCode / Notepad++, and it makes a block‑selected copy/paste round‑trip preserve its rectangular shape.

### Behavior

- **N cursors + N clipboard lines** → each cursor receives one line in order. A trailing newline in the clipboard is treated as a separator (so `"a\nb\n"` with 2 cursors still distributes).
- **Any other shape** (single cursor, mismatched count) → existing behavior: full pasted text inserted at every cursor.
- Block selection already converts to a multi‑cursor before editing actions, so a copy/paste round‑trip of a rectangular region works without any caller changes.
- Atomicity, selection replacement, and CRLF/CR normalization are unchanged — they sit in the same code path.

### Manual validation

Reproduced the canonical scenario from the issue in a tmux session against the built binary:

```
Line 1            Line 4Line 1
Line 2            Line 5Line 2
Line 3   →        Line 6Line 3
Line 4            Line 4
Line 5            Line 5
Line 6            Line 6
```

Steps: block‑select `Line 4..Line 6` (Alt+Shift+Down/Right), Ctrl+C, Ctrl+Home, Ctrl+Alt+Down twice to add 2 cursors, Ctrl+V. Single‑cursor paste of the same clipboard still inserts the multi‑line text at one location.

## Test plan

- [x] `cargo test -p fresh-editor --test e2e_tests -- paste::` — all 31 paste tests pass, including 5 new ones:
  - `test_paste_distributes_lines_when_cursor_count_matches`
  - `test_paste_column_mode_ignores_trailing_newline`
  - `test_paste_pastes_full_text_when_cursor_count_does_not_match`
  - `test_block_selection_copy_paste_roundtrip`
  - `test_paste_column_mode_undo_is_atomic`
- [x] `cargo test -p fresh-editor --test semantic_tests -- block_selection` — existing block‑selection tests still pass
- [x] `cargo fmt`, `cargo check --all-targets`, `cargo clippy -p fresh-editor --all-targets` (no new warnings introduced)
- [x] Manual tmux validation of the issue's scenario against the built binary

https://claude.ai/code/session_011sHbDUb87kSSSgMKrURnAw

---
_Generated by [Claude Code](https://claude.ai/code/session_011sHbDUb87kSSSgMKrURnAw)_