### PR TITLE
feat(languages): add Templ syntax highlighting (#463)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,6 +1448,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-templ",
  "tree-sitter-typescript",
 ]
 
@@ -5794,6 +5795,16 @@ name = "tree-sitter-rust"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-templ"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86206f76eb2af238a5a7cc53a3d2c750a57a7e7311dc7f86da121264606d8619"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/fresh-editor/src/primitives/highlighter.rs
+++ b/crates/fresh-editor/src/primitives/highlighter.rs
@@ -372,6 +372,9 @@ mod tests {
         let path = std::path::Path::new("test.p");
         assert!(matches!(Language::from_path(path), Some(Language::Pascal)));
 
+        let path = std::path::Path::new("home.templ");
+        assert!(matches!(Language::from_path(path), Some(Language::Templ)));
+
         // Markdown disabled due to tree-sitter version conflict
         // let path = std::path::Path::new("test.md");
         // assert!(matches!(Language::from_path(path), Some(Language::Markdown)));
@@ -395,6 +398,34 @@ mod tests {
         // Keywords like "fn" should be highlighted with the theme's keyword color
         let has_keyword = spans.iter().any(|s| s.color == theme.syntax_keyword);
         assert!(has_keyword, "Should highlight keywords");
+    }
+
+    #[test]
+    fn test_highlighter_templ() {
+        // Reproducer for #463: opening a `.templ` file should produce
+        // highlighted spans (templ is Go + components/HTML/CSS), not
+        // fall back to plain text.
+        let source = "package main\n\
+                      \n\
+                      templ Greet(name string) {\n\
+                      \t<div class=\"hello\">Hello, { name }</div>\n\
+                      }\n";
+        let buffer = Buffer::from_str_test(source);
+        let mut highlighter = Highlighter::new(Language::Templ).unwrap();
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        let spans = highlighter.highlight_viewport(&buffer, 0, buffer.len(), &theme, 100_000);
+
+        assert!(
+            !spans.is_empty(),
+            "Templ file should produce highlighted spans"
+        );
+
+        let has_keyword = spans.iter().any(|s| s.color == theme.syntax_keyword);
+        assert!(
+            has_keyword,
+            "Templ file should highlight at least one keyword (`package` from Go or `templ`)"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -160,6 +160,15 @@ impl IndentCalculator {
                 fresh_languages::tree_sitter_odin::LANGUAGE.into(),
                 include_str!("../../queries/odin/indents.scm"),
             ),
+            Language::Templ => (
+                // Templ extends Go's grammar; Go's indent rules apply to the
+                // Go portions of a templ file. The HTML/CSS portions
+                // currently fall back to copy-current-line indent, which is
+                // good enough as an initial heuristic.
+                "templ",
+                fresh_languages::tree_sitter_templ::LANGUAGE.into(),
+                include_str!("../../queries/go/indents.scm"),
+            ),
         };
 
         // Check if we already have this config

--- a/crates/fresh-editor/src/primitives/reference_highlighter.rs
+++ b/crates/fresh-editor/src/primitives/reference_highlighter.rs
@@ -225,6 +225,7 @@ impl ReferenceHighlighter {
             Language::CSS => fresh_languages::tree_sitter_css::LANGUAGE.into(),
             Language::CSharp => fresh_languages::tree_sitter_c_sharp::LANGUAGE.into(),
             Language::Odin => fresh_languages::tree_sitter_odin::LANGUAGE.into(),
+            Language::Templ => fresh_languages::tree_sitter_templ::LANGUAGE.into(),
         };
 
         // Create parser

--- a/crates/fresh-languages/Cargo.toml
+++ b/crates/fresh-languages/Cargo.toml
@@ -29,11 +29,18 @@ tree-sitter-bash = { version = "0.25.1", optional = true }
 tree-sitter-lua = { version = "0.4.1", optional = true }
 tree-sitter-pascal = { version = "0.10.2", optional = true }
 tree-sitter-odin = { version = "1.3.0", optional = true }
+tree-sitter-templ = { version = "2.2.0", optional = true }
 
 [features]
+# Note: enabling tree-sitter-templ also requires tree-sitter-go because the
+# templ grammar is built on top of Go and we reuse Go's highlight queries
+# for the embedded Go portions of a templ file.
+tree-sitter-templ = ["dep:tree-sitter-templ", "tree-sitter-go"]
+
 all-languages = [
     "tree-sitter-rust", "tree-sitter-python", "tree-sitter-javascript", "tree-sitter-typescript",
     "tree-sitter-html", "tree-sitter-css", "tree-sitter-c", "tree-sitter-cpp", "tree-sitter-go",
     "tree-sitter-json", "tree-sitter-java", "tree-sitter-c-sharp", "tree-sitter-php", "tree-sitter-ruby",
-    "tree-sitter-bash", "tree-sitter-lua", "tree-sitter-pascal", "tree-sitter-odin"
+    "tree-sitter-bash", "tree-sitter-lua", "tree-sitter-pascal", "tree-sitter-odin",
+    "tree-sitter-templ"
 ]

--- a/crates/fresh-languages/queries/templ/highlights.scm
+++ b/crates/fresh-languages/queries/templ/highlights.scm
@@ -1,0 +1,58 @@
+; Vendored from https://github.com/vrischmann/tree-sitter-templ
+; (queries/templ/highlights.scm @ v2.2.0). MIT license.
+;
+; The upstream comment "; inherits: go" is a Helix/Neovim convention to also
+; load the Go grammar's highlights file; we reproduce that effect by
+; concatenating Go's HIGHLIGHTS_QUERY with this file at build time inside
+; `Language::Templ::highlight_config`.
+
+(component_declaration
+  name: (component_identifier) @function)
+
+[
+  (tag_start)
+  (tag_end)
+  (self_closing_tag)
+  (style_tag_start)
+  (style_tag_end)
+  (self_closing_style_tag)
+] @tag
+
+(attribute
+  name: (attribute_name) @tag.attribute)
+
+(attribute
+  value: (quoted_attribute_value) @string)
+
+[
+  (element_text)
+  (style_element_text)
+] @string.special
+
+(css_identifier) @function
+
+(css_property
+  name: (css_property_name) @property)
+
+(css_property
+  value: (css_property_value) @string)
+
+[
+  (expression)
+  (dynamic_class_attribute_value)
+] @function.method
+
+(component_import
+  name: (component_identifier) @function)
+
+(component_render) @function.call
+
+(element_comment) @comment @spell
+
+"@" @operator
+
+[
+  "templ"
+  "css"
+  "script"
+] @keyword

--- a/crates/fresh-languages/src/lib.rs
+++ b/crates/fresh-languages/src/lib.rs
@@ -40,6 +40,8 @@ pub use tree_sitter_python;
 pub use tree_sitter_ruby;
 #[cfg(feature = "tree-sitter-rust")]
 pub use tree_sitter_rust;
+#[cfg(feature = "tree-sitter-templ")]
+pub use tree_sitter_templ;
 #[cfg(feature = "tree-sitter-typescript")]
 pub use tree_sitter_typescript;
 
@@ -170,6 +172,7 @@ pub enum Language {
     Lua,
     Pascal,
     Odin,
+    Templ,
 }
 
 impl Language {
@@ -524,6 +527,32 @@ impl Language {
                 #[cfg(not(feature = "tree-sitter-odin"))]
                 Err("Odin language support not enabled".to_string())
             }
+            Self::Templ => {
+                // The templ grammar extends Go (see vrischmann/tree-sitter-templ),
+                // so combining Go's highlights query with the templ-specific one
+                // gives us reasonable highlighting for both the Go expressions
+                // and the templ-specific component / element / CSS syntax.
+                #[cfg(feature = "tree-sitter-templ")]
+                {
+                    let combined_highlights = format!(
+                        "{}\n{}",
+                        tree_sitter_go::HIGHLIGHTS_QUERY,
+                        TEMPL_HIGHLIGHTS_QUERY,
+                    );
+                    let mut config = HighlightConfiguration::new(
+                        tree_sitter_templ::LANGUAGE.into(),
+                        "templ",
+                        &combined_highlights,
+                        "",
+                        "",
+                    )
+                    .map_err(|e| format!("Failed to create Templ highlight config: {e}"))?;
+                    config.configure(DEFAULT_HIGHLIGHT_CAPTURES);
+                    Ok(config)
+                }
+                #[cfg(not(feature = "tree-sitter-templ"))]
+                Err("Templ language support not enabled".to_string())
+            }
         }
     }
 
@@ -559,6 +588,7 @@ impl Language {
             Language::Lua,
             Language::Pascal,
             Language::Odin,
+            Language::Templ,
         ]
     }
 
@@ -584,6 +614,7 @@ impl Language {
             Self::Lua => "lua",
             Self::Pascal => "pascal",
             Self::Odin => "odin",
+            Self::Templ => "templ",
         }
     }
 
@@ -629,6 +660,7 @@ impl Language {
             Self::Lua => &["lua"],
             Self::Pascal => &["pas", "p"],
             Self::Odin => &["odin"],
+            Self::Templ => &["templ"],
         }
     }
 
@@ -654,6 +686,7 @@ impl Language {
             Self::Lua => "Lua",
             Self::Pascal => "Pascal",
             Self::Odin => "Odin",
+            Self::Templ => "Templ",
         }
     }
 
@@ -680,6 +713,7 @@ impl Language {
             "lua" => Some(Self::Lua),
             "pascal" => Some(Self::Pascal),
             "odin" => Some(Self::Odin),
+            "templ" => Some(Self::Templ),
             _ => None,
         }
     }
@@ -721,6 +755,7 @@ impl Language {
             "lua" => Some(Self::Lua),
             "pascal" => Some(Self::Pascal),
             "odin" => Some(Self::Odin),
+            "templ" => Some(Self::Templ),
             _ => {
                 // Try matching shell variants
                 if name_lower.contains("bash") || name_lower.contains("shell") {
@@ -753,6 +788,19 @@ const DEFAULT_HIGHLIGHT_CAPTURES: &[&str] = &[
     "type",
     "variable",
 ];
+
+/// Templ-specific highlight rules, vendored from the upstream
+/// `tree-sitter-templ` crate's `queries/templ/highlights.scm`. The crate ships
+/// this file but does not re-export it as a public Rust constant, so we keep
+/// our own copy and concatenate it with Go's highlights query (templ extends
+/// the Go grammar) to obtain the final highlight configuration.
+///
+/// Captures that aren't in `DEFAULT_HIGHLIGHT_CAPTURES` (e.g. `@tag`,
+/// `@function.method`) simply go un-styled — the `tree-sitter-highlight`
+/// configurator drops unknown capture names and matches on prefix for the
+/// known ones, so this still produces correct output.
+#[cfg(feature = "tree-sitter-templ")]
+const TEMPL_HIGHLIGHTS_QUERY: &str = include_str!("../queries/templ/highlights.scm");
 
 const TYPESCRIPT_HIGHLIGHT_CAPTURES: &[&str] = &[
     "attribute",
@@ -836,6 +884,23 @@ mod tests {
         // Language::id() must return "csharp" to match the config key
         // used for LSP server lookup and language detection.
         assert_eq!(Language::CSharp.id(), "csharp");
+    }
+
+    #[test]
+    fn test_templ_detected_from_extension() {
+        let path = Path::new("home.templ");
+        assert!(matches!(Language::from_path(path), Some(Language::Templ)));
+    }
+
+    #[test]
+    #[cfg(feature = "tree-sitter-templ")]
+    fn test_templ_highlight_config_builds() {
+        // The combined Go + templ highlights query must parse cleanly against
+        // the templ grammar; otherwise opening a `.templ` file would fall
+        // back to plain text instead of highlighting.
+        Language::Templ
+            .highlight_config()
+            .expect("Templ highlight config should build");
     }
 
     /// Guard: `from_path` and `extensions()` must stay in sync — they used to


### PR DESCRIPTION
## Summary

Closes #463.

`.templ` files currently render as plain unstyled text because no tree-sitter grammar is registered for the language. This PR registers the upstream [`tree-sitter-templ`](https://github.com/vrischmann/tree-sitter-templ) v2.2.0 crate as a new optional dependency on `fresh-languages` and threads a `Language::Templ` variant through the existing language plumbing.

### Approach

The templ grammar is built on top of Go, so the natural way to get useful highlighting is to combine Go's highlight rules with the templ-specific ones (components, element tags, CSS, render expressions, …):

- The grammar comes from `tree_sitter_templ::LANGUAGE`.
- The highlights query is `tree_sitter_go::HIGHLIGHTS_QUERY` + a vendored copy of upstream's `queries/templ/highlights.scm` (the crate ships the file but does not re-export it as a public Rust constant, so we keep our own copy under `crates/fresh-languages/queries/templ/highlights.scm`).
- Indentation reuses Go's `indents.scm` — correct for Go blocks; for HTML/CSS sections inside a component the indent calculator falls back to copy-current-line, which is good enough as an initial heuristic.

A new feature `tree-sitter-templ` is declared explicitly so it pulls in `tree-sitter-go` (we need its `HIGHLIGHTS_QUERY`); both are listed in `all-languages`, which `fresh-editor` already enables.

### Manual validation

Built the binary and opened a sample `.templ` file containing `package`, `import`, a `templ Greet(name string) { … }` component with HTML, a regular Go function, and a `css` block. With the change applied, keywords (`package`, `import`, `templ`, `func`, `return`, `css`), strings, comments, types (`int`, `string`), function names, and `%d` format specifiers all render with the theme's syntax colors instead of as plain grey text.

## Test plan
- [x] `cargo test -p fresh-languages --features all-languages` — new tests `test_templ_detected_from_extension` and `test_templ_highlight_config_builds` pass; existing `test_from_path_matches_extensions` still passes.
- [x] `cargo test -p fresh-editor --lib primitives::highlighter` — new `test_highlighter_templ` passes (verifies a templ buffer produces highlighted spans with at least one keyword styled).
- [x] `cargo test -p fresh-editor --lib primitives::indent` — existing indent tests unaffected.
- [x] `cargo check -p fresh-editor --all-targets` clean; `cargo clippy -p fresh-languages --features all-languages` clean.
- [x] Manual smoke test in tmux on a representative templ file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D41gNRzL86dGkBHQv7A1VE)_