### PR TITLE
Fix embedded plugin extraction race and optimize test performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,68 @@ force-frame-pointers = true
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
+
+# Optimize the critical dependencies in the plugin-load path at -O3 even
+# in dev/test builds. These are the only deps where unoptimized code
+# materially slows test wall time:
+#
+#   * oxc_*  — TypeScript→JS transpile + isolated-declarations emit,
+#              dominant cost inside prepare_plugin.
+#   * rquickjs / rquickjs-sys — the JavaScript runtime that runs every
+#              plugin's top-level during plugin_exec.
+#
+# Our own crates still compile at -O0 + debug-info so incremental
+# rebuilds stay fast. We avoid the wildcard `package."*"` form because
+# rebuilding *every* transitive dep at -O3 was prohibitively slow on a
+# cold build.
+[profile.dev.package.oxc_allocator]
+opt-level = 3
+[profile.dev.package.oxc_ast]
+opt-level = 3
+[profile.dev.package.oxc_codegen]
+opt-level = 3
+[profile.dev.package.oxc_diagnostics]
+opt-level = 3
+[profile.dev.package.oxc_isolated_declarations]
+opt-level = 3
+[profile.dev.package.oxc_parser]
+opt-level = 3
+[profile.dev.package.oxc_semantic]
+opt-level = 3
+[profile.dev.package.oxc_span]
+opt-level = 3
+[profile.dev.package.oxc_transformer]
+opt-level = 3
+[profile.dev.package.rquickjs]
+opt-level = 3
+[profile.dev.package.rquickjs-sys]
+opt-level = 3
+[profile.dev.package.rquickjs-serde]
+opt-level = 3
+
+# Mirror the same overrides into the test profile, which `cargo test`
+# and `cargo nextest run` use.
+[profile.test.package.oxc_allocator]
+opt-level = 3
+[profile.test.package.oxc_ast]
+opt-level = 3
+[profile.test.package.oxc_codegen]
+opt-level = 3
+[profile.test.package.oxc_diagnostics]
+opt-level = 3
+[profile.test.package.oxc_isolated_declarations]
+opt-level = 3
+[profile.test.package.oxc_parser]
+opt-level = 3
+[profile.test.package.oxc_semantic]
+opt-level = 3
+[profile.test.package.oxc_span]
+opt-level = 3
+[profile.test.package.oxc_transformer]
+opt-level = 3
+[profile.test.package.rquickjs]
+opt-level = 3
+[profile.test.package.rquickjs-sys]
+opt-level = 3
+[profile.test.package.rquickjs-serde]
+opt-level = 3

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -11,6 +11,57 @@
 // on Editor and most of the types in the module.
 use super::*;
 
+/// Phase-timing helper used when `FRESH_TEST_TIMING=1` is set so test
+/// authors can see where `Editor::with_options` spends its wall clock.
+/// No-op when the env var is unset; printed to stderr otherwise.
+struct InitTimer {
+    label: &'static str,
+    start: std::time::Instant,
+    last: std::time::Instant,
+    enabled: bool,
+}
+
+impl InitTimer {
+    fn start(label: &'static str) -> Self {
+        let enabled = std::env::var("FRESH_TEST_TIMING").is_ok_and(|v| !v.is_empty() && v != "0");
+        let now = std::time::Instant::now();
+        if enabled {
+            eprintln!("[timing] {label}  start");
+        }
+        Self {
+            label,
+            start: now,
+            last: now,
+            enabled,
+        }
+    }
+    fn phase(&mut self, name: &str) {
+        if !self.enabled {
+            return;
+        }
+        let now = std::time::Instant::now();
+        let delta = now.duration_since(self.last);
+        let cumul = now.duration_since(self.start);
+        eprintln!(
+            "[timing]     {name:<30} +{delta:>8.1}ms  (cumul {cumul:.1}ms)",
+            name = name,
+            delta = delta.as_secs_f64() * 1000.0,
+            cumul = cumul.as_secs_f64() * 1000.0,
+        );
+        self.last = now;
+    }
+    fn finish(self) {
+        if !self.enabled {
+            return;
+        }
+        eprintln!(
+            "[timing] {label}  total {total:.1}ms",
+            label = self.label,
+            total = self.start.elapsed().as_secs_f64() * 1000.0,
+        );
+    }
+}
+
 /// Set a value at a dot-separated path inside a JSON object, creating
 /// intermediate maps as needed.
 fn set_dot_path(root: &mut serde_json::Value, path: &str, value: serde_json::Value) {
@@ -209,6 +260,7 @@ impl Editor {
         grammar_registry: Arc<crate::primitives::grammar::GrammarRegistry>,
         defer_plugin_load: bool,
     ) -> AnyhowResult<Self> {
+        let mut t = InitTimer::start("Editor::with_options");
         // Use provided time_source or default to RealTimeSource
         let time_source = time_source.unwrap_or_else(RealTimeSource::shared);
         tracing::info!("Editor::new called with width={}, height={}", width, height);
@@ -221,14 +273,17 @@ impl Editor {
         // This ensures consistent path comparisons throughout the editor
         let working_dir = working_dir.canonicalize().unwrap_or(working_dir);
 
+        t.phase("preamble");
         // Load all themes into registry
         tracing::info!("Loading themes...");
         let theme_loader = crate::view::theme::ThemeLoader::new(dir_context.themes_dir());
+        t.phase("ThemeLoader::new");
         // Scan installed packages (language packs + bundles) before plugin loading.
         // This replaces the JS loadInstalledPackages() — configs, grammars, plugin dirs,
         // and theme dirs are all collected here and applied synchronously.
         let scan_result =
             crate::services::packages::scan_installed_packages(&dir_context.config_dir);
+        t.phase("scan_installed_packages");
 
         // Apply package language configs (user config takes priority via or_insert)
         for (lang_id, lang_config) in &scan_result.language_configs {
@@ -247,6 +302,7 @@ impl Editor {
         }
 
         let theme_registry = Arc::new(theme_loader.load_all(&scan_result.bundle_theme_dirs));
+        t.phase("theme_loader.load_all");
         tracing::info!("Themes loaded");
 
         // Get active theme from registry, falling back to default if not found
@@ -265,7 +321,9 @@ impl Editor {
         // Set terminal cursor color to match theme
         theme.set_terminal_cursor_color();
 
+        t.phase("theme_setup");
         let keybindings = Arc::new(RwLock::new(KeybindingResolver::new(&config)));
+        t.phase("keybindings");
 
         // Create an empty initial buffer
         let mut buffers = HashMap::new();
@@ -300,6 +358,7 @@ impl Editor {
         // Initialize LSP manager with current working directory as root
         let root_uri = types::file_path_to_lsp_uri(&working_dir);
 
+        t.phase("buffer_state");
         // Create Tokio runtime for async I/O (LSP, file watching, git, etc.)
         let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2) // Small pool for I/O tasks
@@ -307,6 +366,7 @@ impl Editor {
             .enable_all()
             .build()
             .ok();
+        t.phase("tokio_runtime");
 
         // Create async bridge for communication
         let async_bridge = AsyncBridge::new();
@@ -354,6 +414,7 @@ impl Editor {
             lsp.set_language_config("typescript".to_string(), deno_config);
         }
 
+        t.phase("lsp_setup");
         // Initialize split manager with the initial buffer
         let split_manager = SplitManager::new(buffer_id);
 
@@ -406,6 +467,7 @@ impl Editor {
         // Build shared theme cache for plugin access
         let theme_cache = Arc::new(RwLock::new(theme_registry.to_json_map()));
 
+        t.phase("split_quickopen_authority");
         // Initialize plugin manager (handles both enabled and disabled cases internally)
         let plugin_manager = PluginManager::new(
             enable_plugins,
@@ -413,6 +475,7 @@ impl Editor {
             dir_context.clone(),
             Arc::clone(&theme_cache),
         );
+        t.phase("PluginManager::new");
 
         // Update the plugin state snapshot with working_dir BEFORE loading plugins
         // This ensures plugins can call getCwd() correctly during initialization
@@ -653,6 +716,7 @@ impl Editor {
             }
         }
 
+        t.phase("plugin_loading");
         // Extract config values before moving config into the struct
         let file_explorer_width = config.file_explorer.width;
         let file_explorer_side = config.file_explorer.side;
@@ -957,6 +1021,7 @@ impl Editor {
             pending_vb_animations: Vec::new(),
         };
 
+        t.phase("editor_struct_assembly");
         // Apply clipboard configuration
         editor.clipboard.apply_config(&editor.config.clipboard);
 
@@ -970,7 +1035,8 @@ impl Editor {
                 );
             }
         }
-
+        t.phase("post_struct_hooks");
+        t.finish();
         Ok(editor)
     }
 

--- a/crates/fresh-editor/src/services/plugins/embedded.rs
+++ b/crates/fresh-editor/src/services/plugins/embedded.rs
@@ -52,7 +52,17 @@ fn get_cache_dir() -> Option<PathBuf> {
     dirs::cache_dir().map(|p| p.join("fresh").join("embedded-plugins"))
 }
 
-/// Extract embedded plugins to the cache directory
+/// Extract embedded plugins to the cache directory.
+///
+/// Concurrency contract: this function is called via a process-local
+/// `OnceLock`, but multiple test processes (e.g. cargo-nextest) may
+/// each call it concurrently against the same on-disk directory. We
+/// publish atomically: extract into a sibling `.pending.<pid>.<nanos>`
+/// directory, write a `.extracted` marker, then `rename` into place.
+/// `rename` over an existing non-empty directory fails on POSIX, so
+/// only one publisher wins; losers fall back to the winner's
+/// directory. Readers gate on the marker file so they never observe a
+/// half-extracted tree.
 fn extract_plugins() -> Result<PathBuf, std::io::Error> {
     let cache_base = get_cache_dir().ok_or_else(|| {
         std::io::Error::new(
@@ -63,35 +73,109 @@ fn extract_plugins() -> Result<PathBuf, std::io::Error> {
 
     let content_hash = PLUGINS_CONTENT_HASH.trim();
     let cache_dir = cache_base.join(content_hash);
+    let marker = cache_dir.join(".extracted");
 
-    // Check if already extracted
-    if cache_dir.exists() && cache_dir.read_dir()?.next().is_some() {
+    if marker.exists() {
         tracing::info!("Using cached embedded plugins from: {:?}", cache_dir);
         return Ok(cache_dir);
     }
 
     tracing::info!("Extracting embedded plugins to: {:?}", cache_dir);
+    std::fs::create_dir_all(&cache_base)?;
 
-    // Clean up old cache versions (move to trash for safety)
-    if cache_base.exists() {
-        for entry in std::fs::read_dir(&cache_base)? {
-            let entry = entry?;
-            if entry.file_name() != content_hash {
-                // Best-effort cleanup of old cache versions; failure is non-fatal.
+    let pid = std::process::id();
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    // tmp_dir name includes the current nanosecond timestamp, so it
+    // can't collide with any prior invocation — no pre-existing dir
+    // to clean up here.
+    let tmp_dir = cache_base.join(format!(".pending.{}.{}", pid, nanos));
+
+    extract_dir_recursive(&EMBEDDED_PLUGINS, &tmp_dir)?;
+    // Marker is written *inside* the temp dir so the rename publishes
+    // the directory and its completeness signal in one atomic step.
+    std::fs::write(tmp_dir.join(".extracted"), b"")?;
+
+    let publish = |tmp_dir: &std::path::Path| std::fs::rename(tmp_dir, &cache_dir);
+
+    let result = match publish(&tmp_dir) {
+        Ok(()) => Ok(cache_dir.clone()),
+        Err(_) if marker.exists() => {
+            // A concurrent publisher won the race; drop our partial work.
+            // tmp_dir has a unique name, so a leak here is unrecoverable
+            // disk noise but never reachable by future readers.
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = std::fs::remove_dir_all(&tmp_dir);
+            Ok(cache_dir.clone())
+        }
+        Err(_) => {
+            // `cache_dir` exists but has no marker — a leftover from
+            // the pre-marker code path that could have written a
+            // half-extracted tree. Sweep it aside and retry once.
+            // Either rename succeeds (cache_dir gone, retry will
+            // publish), fails because cache_dir vanished (another
+            // process beat us — fine, retry will see the publish), or
+            // fails for an OS-level reason (we fall through to the
+            // marker check). All paths converge.
+            let stale = cache_base.join(format!(".stale.{}.{}", pid, nanos));
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = std::fs::rename(&cache_dir, &stale);
+            // Best-effort: if the rename failed, `stale` may not exist
+            // (NotFound) — that's the no-op case. If it succeeded but
+            // remove fails, we leak disk space at a unique-named path
+            // nobody else references.
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = std::fs::remove_dir_all(&stale);
+            match publish(&tmp_dir) {
+                Ok(()) => Ok(cache_dir.clone()),
+                Err(e) => {
+                    // Same as the marker-exists arm above: tmp_dir has
+                    // a unique name, leakage on cleanup failure is
+                    // bounded and unobservable to readers.
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = std::fs::remove_dir_all(&tmp_dir);
+                    if marker.exists() {
+                        Ok(cache_dir.clone())
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
+        }
+    };
+
+    if result.is_ok() {
+        tracing::info!(
+            "Successfully extracted {} embedded plugin files",
+            count_files(&EMBEDDED_PLUGINS)
+        );
+        // Clean up old cache versions (other content hashes) and stale
+        // pending/stale-rename leftovers from prior crashes. Only does
+        // anything once we've successfully committed our extraction.
+        if let Ok(entries) = std::fs::read_dir(&cache_base) {
+            for entry in entries.flatten() {
+                let name_os = entry.file_name();
+                let name = name_os.to_string_lossy();
+                if name == content_hash {
+                    continue;
+                }
+                if name.starts_with(".pending.") || name.starts_with(".stale.") {
+                    // Never trash a tmp dir that another live extractor
+                    // might still own. We can't tell from here, so leave
+                    // those alone — they're cheap and self-clean on the
+                    // next successful publish from that process.
+                    continue;
+                }
+                // Best-effort cleanup of old cache versions.
                 #[allow(clippy::let_underscore_must_use)]
                 let _ = trash::delete(entry.path());
             }
         }
     }
 
-    extract_dir_recursive(&EMBEDDED_PLUGINS, &cache_dir)?;
-
-    tracing::info!(
-        "Successfully extracted {} embedded plugin files",
-        count_files(&EMBEDDED_PLUGINS)
-    );
-
-    Ok(cache_dir)
+    result
 }
 
 /// Recursively extract a directory and its contents

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -809,6 +809,49 @@ impl EditorTestHarness {
         )
     }
 
+    /// Same as [`with_temp_project`] but with TypeScript plugin loading
+    /// disabled. Reserved for tests whose code paths provably do not
+    /// observe plugin behavior — every plugin-loading test boundary is
+    /// ~440 ms of TS transpile + QuickJS evaluation, so the suite-wide
+    /// savings are large.
+    ///
+    /// **Don't reach for this casually.** Disabling plugins removes any
+    /// hooks they install (`editor_initialized`, buffer-changed
+    /// reactions, command registrations). Currently used only by
+    /// scenarios whose contract guarantees no plugin interaction:
+    /// `BufferScenario` (text + caret only, dispatched through core
+    /// `Action`s) and `TraceScenario` (forward + undo trace on the same
+    /// core dispatch). Other scenario runners (Input, Modal, Layout,
+    /// etc.) keep plugins enabled so their tests preserve coverage of
+    /// any plugin-side effect that could reach the asserted state.
+    pub fn with_temp_project_no_plugins(width: u16, height: u16) -> anyhow::Result<Self> {
+        Self::create(
+            width,
+            height,
+            HarnessOptions::new()
+                .with_project_root()
+                .with_empty_plugins_dir(),
+        )
+    }
+
+    /// Same as [`with_temp_project_and_config`] but with plugins
+    /// disabled. See [`with_temp_project_no_plugins`] for when this is
+    /// safe to use.
+    pub fn with_temp_project_and_config_no_plugins(
+        width: u16,
+        height: u16,
+        config: Config,
+    ) -> anyhow::Result<Self> {
+        Self::create(
+            width,
+            height,
+            HarnessOptions::new()
+                .with_project_root()
+                .with_empty_plugins_dir()
+                .with_config(config),
+        )
+    }
+
     /// Create with explicit working directory, using default config.
     pub fn with_working_dir(width: u16, height: u16, working_dir: PathBuf) -> anyhow::Result<Self> {
         let config = Config::default();

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -547,12 +547,14 @@ impl EditorTestHarness {
     /// )?;
     /// ```
     pub fn create(width: u16, height: u16, options: HarnessOptions) -> anyhow::Result<Self> {
+        let mut t = crate::common::timing::Timer::start("harness::create");
         // Create temp directory if we don't have a shared dir_context
         let temp_dir = if options.dir_context.is_none() || options.create_project_root {
             Some(TempDir::new()?)
         } else {
             None
         };
+        t.phase("temp_dir");
 
         // Determine the base path for our temp directory
         let temp_base = temp_dir.as_ref().map(|d| d.path().to_path_buf());
@@ -573,6 +575,7 @@ impl EditorTestHarness {
                 .expect("temp_dir must exist when no working_dir provided")
         };
 
+        t.phase("working_dir_setup");
         // Plugin loading. Historically the harness created an empty
         // `<working_dir>/plugins/` so the editor would scan it and
         // skip the embedded fallback (suppression by directory
@@ -602,6 +605,8 @@ impl EditorTestHarness {
             .unwrap_or(false);
         let enable_plugins_for_editor = true;
 
+        t.phase("plugin_dir_setup");
+
         // Get or create DirectoryContext
         let dir_context = options.dir_context.unwrap_or_else(|| {
             DirectoryContext::for_testing(
@@ -610,6 +615,7 @@ impl EditorTestHarness {
                     .expect("temp_dir must exist when no dir_context provided"),
             )
         });
+        t.phase("dir_context");
 
         // Create TestTimeSource for controllable time in tests
         let test_time_source = Arc::new(TestTimeSource::new());
@@ -668,6 +674,7 @@ impl EditorTestHarness {
         // from this perf fix; flagging here so the next reader knows.
         fresh::i18n::init_with_config(config.locale.as_option());
         config.editor.double_click_time_ms = 10; // Fast double-click for faster tests
+        t.phase("config_and_i18n");
 
         // Create filesystem backend (custom, slow, or default)
         let (filesystem, fs_metrics): (Arc<dyn FileSystem + Send + Sync>, _) =
@@ -682,9 +689,12 @@ impl EditorTestHarness {
                 (Arc::new(StdFileSystem), None)
             };
 
+        t.phase("filesystem");
+
         // Create terminal
         let backend = TestBackend::new(width, height);
         let terminal = Terminal::new(backend)?;
+        t.phase("terminal");
 
         // Create grammar registry if requested (slow, only for tests that need syntax highlighting)
         let grammar_registry = if options.use_full_grammar_registry {
@@ -707,10 +717,13 @@ impl EditorTestHarness {
         // plugin fallback so the bundled set doesn't leak in. This matches
         // the pre-#1722 behavior, where any `working_dir/plugins/` (even
         // empty) suppressed embedded loading.
+        t.phase("grammar_registry");
+
         if working_plugins_populated {
             let target = dir_context.config_dir.join("plugins");
             mirror_plugins_dir(&working_plugins_path, &target)?;
         }
+        t.phase("mirror_plugins");
         // Embedded loads only when the test isn't taking control. The
         // `force_embedded_plugins` escape hatch overrides this for tests
         // that need production plugin-loading semantics (see #1722).
@@ -731,10 +744,13 @@ impl EditorTestHarness {
             enable_embedded_plugins,
         )?;
 
+        t.phase("Editor::for_test");
+
         // Process any pending plugin commands
         editor.process_async_messages();
+        t.phase("process_async_messages");
 
-        Ok(EditorTestHarness {
+        let h = EditorTestHarness {
             editor,
             terminal,
             _temp_dir: temp_dir,
@@ -751,7 +767,9 @@ impl EditorTestHarness {
             vt100_parser: vt100::Parser::new(height, width, 0),
             term_width: width,
             term_height: height,
-        })
+        };
+        t.finish();
+        Ok(h)
     }
 
     // =========================================================================
@@ -962,14 +980,18 @@ impl EditorTestHarness {
 
     /// Open a file in the editor
     pub fn open_file(&mut self, path: &Path) -> anyhow::Result<()> {
+        let mut t = crate::common::timing::Timer::start("harness::open_file");
         self.editor.open_file(path)?;
+        t.phase("editor.open_file");
         self.render()?;
+        t.phase("render");
 
         // Initialize shadow string with the file content (if available)
         // For large files with lazy loading, shadow validation is not supported
         self.shadow_string = self.get_buffer_content().unwrap_or_default();
         self.shadow_cursor = self.cursor_position();
-
+        t.phase("shadow_init");
+        t.finish();
         Ok(())
     }
 

--- a/crates/fresh-editor/tests/common/mod.rs
+++ b/crates/fresh-editor/tests/common/mod.rs
@@ -23,6 +23,9 @@ pub mod scenario;
 pub mod scrollbar;
 #[cfg(test)]
 #[allow(dead_code)]
+pub mod timing;
+#[cfg(test)]
+#[allow(dead_code)]
 pub mod tracing;
 #[cfg(test)]
 #[allow(dead_code)]

--- a/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
@@ -165,6 +165,8 @@ const DEFAULT_FILENAME: &str = "test_buffer.txt";
 /// because it depends on layout state (e.g. viewport scroll), it is
 /// in the wrong domain — use `LayoutScenario` instead.
 pub fn check_buffer_scenario(s: BufferScenario) -> Result<(), ScenarioFailure> {
+    let mut timer =
+        crate::common::timing::Timer::start(format!("buffer_scenario: {}", s.description));
     let term = s.terminal;
     let mut harness = if behavior_is_default(s.behavior) {
         EditorTestHarness::with_temp_project(term.width, term.height)
@@ -177,13 +179,16 @@ pub fn check_buffer_scenario(s: BufferScenario) -> Result<(), ScenarioFailure> {
         EditorTestHarness::with_temp_project_and_config(term.width, term.height, config)
             .expect("EditorTestHarness::with_temp_project_and_config failed")
     };
+    timer.phase("harness_create");
     let filename = s.language.as_deref().unwrap_or(DEFAULT_FILENAME);
     let _fixture = harness
         .load_buffer_from_text_named(filename, &s.initial_text)
         .expect("load_buffer_from_text_named failed");
+    timer.phase("load_buffer");
 
     let api = harness.api_mut();
     api.dispatch_seq(&s.actions);
+    timer.phase("dispatch_actions");
 
     // ── Assert buffer text ──────────────────────────────────────────
     let actual_text = api.buffer_text();
@@ -254,6 +259,10 @@ pub fn check_buffer_scenario(s: BufferScenario) -> Result<(), ScenarioFailure> {
         }
     }
 
+    timer.phase("assertions");
+    drop(harness);
+    timer.phase("harness_drop");
+    timer.finish();
     Ok(())
 }
 

--- a/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
@@ -168,16 +168,21 @@ pub fn check_buffer_scenario(s: BufferScenario) -> Result<(), ScenarioFailure> {
     let mut timer =
         crate::common::timing::Timer::start(format!("buffer_scenario: {}", s.description));
     let term = s.terminal;
+    // BufferScenario observes only buffer text + caret state, dispatched
+    // through core `Action`s exposed by `fresh::test_api`. Plugins can't
+    // reach that observable surface, so we skip plugin loading to save
+    // ~440 ms per test. See `EditorTestHarness::with_temp_project_no_plugins`
+    // for the broader caveat.
     let mut harness = if behavior_is_default(s.behavior) {
-        EditorTestHarness::with_temp_project(term.width, term.height)
-            .expect("EditorTestHarness::with_temp_project failed")
+        EditorTestHarness::with_temp_project_no_plugins(term.width, term.height)
+            .expect("EditorTestHarness::with_temp_project_no_plugins failed")
     } else {
         let mut config = fresh::config::Config::default();
         config.editor.auto_close = s.behavior.auto_close;
         config.editor.auto_indent = s.behavior.auto_indent;
         config.editor.auto_surround = s.behavior.auto_surround;
-        EditorTestHarness::with_temp_project_and_config(term.width, term.height, config)
-            .expect("EditorTestHarness::with_temp_project_and_config failed")
+        EditorTestHarness::with_temp_project_and_config_no_plugins(term.width, term.height, config)
+            .expect("EditorTestHarness::with_temp_project_and_config_no_plugins failed")
     };
     timer.phase("harness_create");
     let filename = s.language.as_deref().unwrap_or(DEFAULT_FILENAME);

--- a/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/buffer_scenario.rs
@@ -185,6 +185,13 @@ pub fn check_buffer_scenario(s: BufferScenario) -> Result<(), ScenarioFailure> {
             .expect("EditorTestHarness::with_temp_project_and_config_no_plugins failed")
     };
     timer.phase("harness_create");
+    // Force the per-harness clipboard into internal-only mode so a
+    // Copy in this scenario can't leak into a parallel test's Paste
+    // through the OS clipboard (arboard/X11/Wayland) and vice versa.
+    // Without this, a flake surfaces: e.g. test A copies " world",
+    // test B copies "universe", test B's Paste sees A's " world"
+    // because they share the process-global SYSTEM_CLIPBOARD.
+    harness.editor_mut().set_clipboard_for_test(String::new());
     let filename = s.language.as_deref().unwrap_or(DEFAULT_FILENAME);
     let _fixture = harness
         .load_buffer_from_text_named(filename, &s.initial_text)

--- a/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
@@ -34,16 +34,21 @@ pub struct TraceScenario {
 }
 
 pub fn check_trace_scenario(s: TraceScenario) -> Result<(), ScenarioFailure> {
+    let mut timer =
+        crate::common::timing::Timer::start(format!("trace_scenario: {}", s.description));
     let mut harness = EditorTestHarness::with_temp_project(80, 24)
         .expect("EditorTestHarness::with_temp_project failed");
+    timer.phase("harness_create");
     let _fixture = harness
         .load_buffer_from_text(&s.initial_text)
         .expect("load_buffer_from_text failed");
+    timer.phase("load_buffer");
 
     let api = harness.api_mut();
 
     // Forward trace.
     api.dispatch_seq(&s.actions);
+    timer.phase("forward_dispatch");
     let after_forward = api.buffer_text();
     if after_forward != s.expected_text {
         return Err(ScenarioFailure::ForwardTraceFailed {
@@ -56,6 +61,7 @@ pub fn check_trace_scenario(s: TraceScenario) -> Result<(), ScenarioFailure> {
     // Reverse trace.
     let undo_actions: Vec<Action> = (0..s.undo_count).map(|_| Action::Undo).collect();
     api.dispatch_seq(&undo_actions);
+    timer.phase("undo_dispatch");
     let after_reverse = api.buffer_text();
     if after_reverse != s.initial_text {
         return Err(ScenarioFailure::ReverseTraceFailed {
@@ -66,6 +72,9 @@ pub fn check_trace_scenario(s: TraceScenario) -> Result<(), ScenarioFailure> {
         });
     }
 
+    drop(harness);
+    timer.phase("harness_drop");
+    timer.finish();
     Ok(())
 }
 

--- a/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
@@ -36,8 +36,12 @@ pub struct TraceScenario {
 pub fn check_trace_scenario(s: TraceScenario) -> Result<(), ScenarioFailure> {
     let mut timer =
         crate::common::timing::Timer::start(format!("trace_scenario: {}", s.description));
-    let mut harness = EditorTestHarness::with_temp_project(80, 24)
-        .expect("EditorTestHarness::with_temp_project failed");
+    // TraceScenario asserts only on buffer text after a forward + undo
+    // trace, both dispatched through core `Action`s. No observable
+    // surface reaches plugin state, so we skip plugin loading. See
+    // `EditorTestHarness::with_temp_project_no_plugins`.
+    let mut harness = EditorTestHarness::with_temp_project_no_plugins(80, 24)
+        .expect("EditorTestHarness::with_temp_project_no_plugins failed");
     timer.phase("harness_create");
     let _fixture = harness
         .load_buffer_from_text(&s.initial_text)

--- a/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
+++ b/crates/fresh-editor/tests/common/scenario/trace_scenario.rs
@@ -42,6 +42,9 @@ pub fn check_trace_scenario(s: TraceScenario) -> Result<(), ScenarioFailure> {
     // `EditorTestHarness::with_temp_project_no_plugins`.
     let mut harness = EditorTestHarness::with_temp_project_no_plugins(80, 24)
         .expect("EditorTestHarness::with_temp_project_no_plugins failed");
+    // See the same call in buffer_scenario.rs: prevents OS-clipboard
+    // bleed across parallel tests that exercise Copy/Paste.
+    harness.editor_mut().set_clipboard_for_test(String::new());
     timer.phase("harness_create");
     let _fixture = harness
         .load_buffer_from_text(&s.initial_text)

--- a/crates/fresh-editor/tests/common/timing.rs
+++ b/crates/fresh-editor/tests/common/timing.rs
@@ -1,0 +1,95 @@
+//! Lightweight phase-timing helper for understanding why semantic tests
+//! are slow.
+//!
+//! Activate by setting `FRESH_TEST_TIMING=1`. When unset, every method
+//! is a no-op and there is no overhead.
+//!
+//! Usage:
+//! ```ignore
+//! let mut t = Timer::start("buffer_scenario: my_test");
+//! // ... do work ...
+//! t.phase("harness_create");
+//! // ... do work ...
+//! t.phase("load_buffer");
+//! // ... do work ...
+//! t.finish();
+//! ```
+//!
+//! Output (one line per phase + summary), printed to stderr:
+//! ```text
+//! [timing] buffer_scenario: my_test  start
+//! [timing]   harness_create        +1480.3ms  (cumul 1480.3ms)
+//! [timing]   load_buffer            +152.7ms  (cumul 1633.0ms)
+//! [timing]   dispatch_actions         +0.4ms  (cumul 1633.4ms)
+//! [timing]   assertions               +1.1ms  (cumul 1634.5ms)
+//! [timing] buffer_scenario: my_test  total 1634.5ms
+//! ```
+
+use std::time::Instant;
+
+pub fn enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED
+        .get_or_init(|| std::env::var("FRESH_TEST_TIMING").is_ok_and(|v| !v.is_empty() && v != "0"))
+}
+
+pub struct Timer {
+    label: String,
+    start: Instant,
+    last: Instant,
+    indent: &'static str,
+}
+
+impl Timer {
+    pub fn start(label: impl Into<String>) -> Self {
+        let label = label.into();
+        let now = Instant::now();
+        if enabled() {
+            eprintln!("[timing] {label}  start");
+        }
+        Self {
+            label,
+            start: now,
+            last: now,
+            indent: "  ",
+        }
+    }
+
+    /// Mark a phase boundary. The reported delta is the time since the
+    /// previous `phase` call (or the timer's start, for the first call).
+    pub fn phase(&mut self, name: &str) {
+        if !enabled() {
+            return;
+        }
+        let now = Instant::now();
+        let delta = now.duration_since(self.last);
+        let cumul = now.duration_since(self.start);
+        eprintln!(
+            "[timing] {indent}{name:<24} +{delta:>8.1}ms  (cumul {cumul:.1}ms)",
+            indent = self.indent,
+            name = name,
+            delta = delta.as_secs_f64() * 1000.0,
+            cumul = cumul.as_secs_f64() * 1000.0,
+        );
+        self.last = now;
+    }
+
+    pub fn finish(self) {
+        if !enabled() {
+            return;
+        }
+        let total = self.start.elapsed();
+        eprintln!(
+            "[timing] {label}  total {total:.1}ms",
+            label = self.label,
+            total = total.as_secs_f64() * 1000.0,
+        );
+    }
+}
+
+/// Convenience: time a single closure and report it as one phase.
+pub fn time_phase<R>(timer: &mut Timer, name: &str, f: impl FnOnce() -> R) -> R {
+    let r = f();
+    timer.phase(name);
+    r
+}

--- a/scripts/stress-extract-race.sh
+++ b/scripts/stress-extract-race.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Stress-test the embedded plugin extraction race fix.
+#
+# What the race looked like (pre-fix): when many test processes start
+# in parallel (cargo nextest), each independently calls `extract_plugins`.
+# The pre-fix code's "is the cache_dir populated?" check returned true
+# the moment process A wrote its first file — process B then started
+# loading plugins from a half-extracted directory and saw failures
+# like:
+#
+#   "Bundling failed for find_references: Cannot resolve import './lib/finder.ts'"
+#   "TypeError: not a function" at clangd_support.ts:N
+#
+# This script wipes the embedded cache and spawns N parallel test
+# processes that all race on extraction. With the fix, every process
+# either publishes its own atomic extraction or falls back to a
+# concurrent winner's, and every test passes.
+#
+# Usage:  scripts/stress-extract-race.sh [N]   (default N=16)
+
+set -u
+
+N="${1:-16}"
+
+cargo test -p fresh-editor --test semantic_tests --no-run 2>&1 | tail -3
+binary=$(find target/debug/deps -maxdepth 1 -name 'semantic_tests-*' -type f -executable -printf '%T@ %p\n' \
+    | sort -nr | head -1 | awk '{print $2}')
+if [[ -z "$binary" || ! -x "$binary" ]]; then
+    echo "Could not locate semantic_tests binary" >&2
+    exit 1
+fi
+echo "Using binary: $binary"
+
+rm -rf "$HOME/.cache/fresh/embedded-plugins" "$HOME/.cache/fresh/plugin-prepare"
+echo "Cache wiped. Spawning $N processes…"
+
+logdir=$(mktemp -d)
+pids=()
+for i in $(seq 1 "$N"); do
+    "$binary" theorem_sort_lines_basic_alphabetical \
+        > "$logdir/run.$i.out" 2>&1 &
+    pids+=("$!")
+done
+
+failures=0
+for pid in "${pids[@]}"; do
+    if ! wait "$pid"; then
+        failures=$((failures + 1))
+    fi
+done
+
+if [[ "$failures" -gt 0 ]]; then
+    echo "FAIL: $failures of $N processes errored. Sample stderr:" >&2
+    for f in "$logdir"/*.out; do
+        if grep -q FAILED "$f"; then
+            echo "── $f ──" >&2
+            tail -20 "$f" >&2
+            break
+        fi
+    done
+    exit 1
+fi
+echo "OK: all $N processes passed."


### PR DESCRIPTION
## Summary

This PR addresses a critical race condition in embedded plugin extraction that occurs when multiple test processes run in parallel (e.g., with cargo-nextest), and adds comprehensive test performance instrumentation to help identify bottlenecks.

## Key Changes

### Plugin Extraction Race Fix
- **Atomic extraction with marker file**: Plugins are now extracted to a temporary `.pending.<pid>.<nanos>` directory, then atomically renamed into place only after writing a `.extracted` marker file. This ensures readers never observe a half-extracted tree.
- **Concurrent publisher handling**: When multiple processes race to extract, only one succeeds via `rename`; losers detect the marker file and fall back to the winner's directory.
- **Stale directory cleanup**: Handles leftover directories from the pre-marker code path by moving them aside before retrying extraction.
- **Improved cleanup logic**: Old cache versions and temporary directories are only cleaned up after a successful extraction, preventing interference with concurrent extractors.

### Test Performance Instrumentation
- **New `Timer` utility** (`tests/common/timing.rs`): Lightweight phase-timing helper activated by `FRESH_TEST_TIMING=1` environment variable. Provides zero overhead when disabled.
- **Harness timing**: Added phase markers throughout `EditorTestHarness::create()` and `open_file()` to identify slow initialization steps.
- **Editor initialization timing**: Added `InitTimer` in `editor_init.rs` to track `Editor::with_options` phases (theme loading, LSP setup, plugin loading, etc.).
- **Scenario timing**: Integrated timing into `BufferScenario` and `TraceScenario` test runners to measure harness creation, buffer loading, and action dispatch.

### Plugin Loading Optimization
- **New no-plugin harness methods**: Added `with_temp_project_no_plugins()` and `with_temp_project_and_config_no_plugins()` to skip plugin loading for tests that don't need it (BufferScenario and TraceScenario).
- **Cargo profile optimization**: Added `-O3` optimization for critical plugin-load dependencies (`oxc_*` and `rquickjs*`) in dev and test profiles, while keeping the main crate at `-O0` for fast incremental rebuilds.

### Test Isolation
- **Clipboard isolation**: Both `BufferScenario` and `TraceScenario` now call `set_clipboard_for_test()` to prevent OS clipboard bleed across parallel tests that exercise Copy/Paste operations.

### Stress Testing
- **New stress test script** (`scripts/stress-extract-race.sh`): Spawns N parallel test processes against a wiped cache to verify the extraction race fix works correctly under concurrent load.

## Implementation Details

The extraction race fix uses a three-phase approach:
1. Extract to a temporary directory with a unique name based on PID and nanosecond timestamp
2. Write a `.extracted` marker file inside the temp directory
3. Atomically rename the entire directory into place

This ensures that the marker file and the complete extraction are published together. On POSIX systems, `rename` over an existing non-empty directory fails, so only one publisher wins. Concurrent processes detect the marker file and reuse the winner's directory, while cleanup of stale directories happens only after successful extraction to avoid race conditions.

The timing instrumentation is designed to be zero-cost when disabled, using `OnceLock` to cache the environment variable check and early-returning from all methods when timing is not enabled.

https://claude.ai/code/session_013a1BvkfyEihrKVKqjwspht