### PR TITLE
Fix flaky git command palette tests on slow CI runners

### DIFF
--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -18,10 +18,12 @@ fn trigger_git_grep(harness: &mut EditorTestHarness) {
         .unwrap();
     harness.wait_for_prompt().unwrap();
     harness.type_text("Git Grep").unwrap();
+    // Wait for the command to appear in the palette before pressing Enter,
+    // otherwise Enter races with async palette filtering on slow CI runners.
+    harness.wait_for_screen_contains("Git Grep").unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
 }
 
 /// Helper to trigger git find file via command palette
@@ -661,7 +663,9 @@ fn test_git_commands_via_command_palette() {
 
     // Type to filter to git commands (note: no colon in command name)
     harness.type_text("Git Grep").unwrap();
-    harness.render().unwrap();
+    // Wait for the filtered item before pressing Enter to avoid a race with
+    // async palette filtering on slow CI runners.
+    harness.wait_for_screen_contains("Git Grep").unwrap();
 
     // Confirm
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -24,6 +24,9 @@ fn trigger_git_grep(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
+    // Wait for the grep prompt to be visible before returning so callers can
+    // type their query immediately without racing the async plugin mount.
+    harness.wait_for_screen_contains("Git grep: ").unwrap();
 }
 
 /// Helper to trigger git find file via command palette
@@ -63,12 +66,6 @@ fn test_git_grep_shows_results() {
 
     // Trigger git grep
     trigger_git_grep(&mut harness);
-
-    // Wait for the grep prompt to appear. Eager `assert_screen_contains`
-    // races the JS plugin's prompt mount on slow CI runners (notably
-    // Windows): the palette closes on Enter but the grep prompt isn't
-    // rendered yet by the time the assertion runs.
-    harness.wait_for_screen_contains("Git grep: ").unwrap();
 
     // Type search query
     harness.type_text("config").unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -244,11 +244,11 @@ fn test_git_grep_confirm_jumps_to_location() {
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
 
-    // Give it time to open the file
-    harness.sleep(std::time::Duration::from_millis(200));
-    harness.render().unwrap();
+    // Wait for the grep prompt to close (file open is async)
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("Git grep:"))
+        .unwrap();
 
     let screen = harness.screen_to_string();
     println!("After confirming grep result:\n{screen}");
@@ -949,12 +949,13 @@ fn trigger_git_log(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_prompt().unwrap();
     harness.type_text("Git Log").unwrap();
+    harness.wait_for_screen_contains("Git Log").unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_screen_contains("switch pane").unwrap();
 }
 
 /// Test git log opens and shows commits
@@ -1183,11 +1184,11 @@ fn test_git_log_close() {
     harness
         .send_key(KeyCode::Char('q'), KeyModifiers::NONE)
         .unwrap();
-    harness.process_async_and_render().unwrap();
 
-    // Git log should be closed
-    harness.sleep(std::time::Duration::from_millis(100));
-    harness.render().unwrap();
+    // Wait for git log to actually close (buffer group teardown is async)
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("switch pane"))
+        .unwrap();
 
     let screen_after = harness.screen_to_string();
     println!("After closing:\n{screen_after}");
@@ -1555,12 +1556,13 @@ fn trigger_git_blame(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_prompt().unwrap();
     harness.type_text("Git Blame").unwrap();
+    harness.wait_for_screen_contains("Git Blame").unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
+    harness.wait_for_screen_contains("──").unwrap();
 }
 
 /// Test git blame opens and shows blame blocks with headers


### PR DESCRIPTION
## Summary
Replace `harness.render()` calls with `harness.wait_for_screen_contains()` in git command palette tests to eliminate race conditions on slow CI runners.

## Key Changes
- In `trigger_git_grep()`: Added explicit wait for "Git Grep" to appear in the command palette before pressing Enter, replacing the `render()` call that didn't guarantee the async filtering had completed
- In `test_git_commands_via_command_palette()`: Applied the same fix to wait for the filtered item before confirming the selection
- Removed unnecessary `render()` calls that didn't provide synchronization guarantees

## Implementation Details
The issue was that `render()` only refreshes the UI without waiting for async operations to complete. On slow CI runners, the command palette's async filtering could still be in progress when Enter was pressed, causing the test to fail. By using `wait_for_screen_contains()`, we ensure the filtered command is actually visible before proceeding, providing proper synchronization for the async palette filtering operation.

https://claude.ai/code/session_0125jtRgRCz9gaBN33sdMJmC