### PR TITLE
Upgrade Rust toolchain from 1.92.0 to 1.95.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,8 @@
           pname = "fresh";
 
           rust-manifest = pkgs.fetchurl {
-            url = "https://static.rust-lang.org/dist/channel-rust-1.92.0.toml";
-            hash = "sha256-sqSWJDUxc+zaz1nBWMAJKTAGBuGWP25GCftIOlCEAtA=";
+            url = "https://static.rust-lang.org/dist/channel-rust-1.95.0.toml";
+            hash = "sha256-gh/xTkxKHL4eiRXzWv8KP7vfjSk61Iq48x47BEDFgfk=";
           };
 
           rustToolchain = inputs.fenix.packages.${system}.fromManifestFile rust-manifest;


### PR DESCRIPTION
## Summary
Updates the Rust toolchain version used in the development environment from 1.92.0 to 1.95.0.

## Changes
- Updated Rust manifest URL from `channel-rust-1.92.0.toml` to `channel-rust-1.95.0.toml`
- Updated manifest hash to reflect the new version's checksum

## Details
This change updates the pinned Rust version in the Nix flake configuration, allowing the project to use the latest stable Rust toolchain (1.95.0) instead of the previous version (1.92.0).

https://claude.ai/code/session_014RPjo3gsCY5xznFs87HYRB