### PR TITLE
vi_mode: expose toggle/enable/disable via exportPluginApi

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -2889,24 +2889,25 @@ editor.on("prompt_confirmed", async (args) => {
 
 let viModeEnabled = false;
 
-function vi_mode_toggle(): void {
-  editor.debug("[vi_mode_toggle] called, viModeEnabled was: " + viModeEnabled);
-  viModeEnabled = !viModeEnabled;
-  editor.debug("[vi_mode_toggle] viModeEnabled now: " + viModeEnabled);
+function enableVi(): void {
+  if (viModeEnabled) return;
+  viModeEnabled = true;
+  switchMode("normal");
+  editor.setStatus(editor.t("status.enabled"));
+}
 
-  if (viModeEnabled) {
-    editor.debug("[vi_mode_toggle] enabling vi mode, calling switchMode('normal')");
-    switchMode("normal");
-    editor.debug("[vi_mode_toggle] switchMode done, setting status");
-    editor.setStatus(editor.t("status.enabled"));
-  } else {
-    editor.debug("[vi_mode_toggle] disabling vi mode");
-    editor.setEditorMode(null);
-    state.mode = "normal";
-    state.pendingOperator = null;
-    editor.setStatus(editor.t("status.disabled"));
-  }
-  editor.debug("[vi_mode_toggle] done");
+function disableVi(): void {
+  if (!viModeEnabled) return;
+  viModeEnabled = false;
+  editor.setEditorMode(null);
+  state.mode = "normal";
+  state.pendingOperator = null;
+  editor.setStatus(editor.t("status.disabled"));
+}
+
+function vi_mode_toggle(): void {
+  if (viModeEnabled) disableVi();
+  else enableVi();
 }
 registerHandler("vi_mode_toggle", vi_mode_toggle);
 
@@ -2916,6 +2917,26 @@ editor.registerCommand(
   "vi_mode_toggle",
   null,  // Always visible - needed to enable vi mode in the first place
 );
+
+export type ViModeApi = {
+  toggle(): void;
+  enable(): void;
+  disable(): void;
+  isEnabled(): boolean;
+};
+
+declare global {
+  interface FreshPluginRegistry {
+    "vi-mode": ViModeApi;
+  }
+}
+
+editor.exportPluginApi("vi-mode", {
+  toggle: vi_mode_toggle,
+  enable: enableVi,
+  disable: disableVi,
+  isEnabled: () => viModeEnabled,
+} satisfies ViModeApi);
 
 // ============================================================================
 // Initialization

--- a/crates/fresh-editor/src/init_script.rs
+++ b/crates/fresh-editor/src/init_script.rs
@@ -49,6 +49,12 @@ const editor = getEditor();
 // Commands:  Ctrl+P -> "init: Reload", "init: Check"
 // CLI:       fresh --cmd init check | fresh --safe | fresh --no-init
 
+// Example: enable vi mode at startup (otherwise off until toggled).
+//
+// editor.on("plugins_loaded", () => {
+//     editor.getPluginApi("vi-mode")?.enable();
+// });
+
 // Example: Add a command to select (mark) from current cursor to target line.
 //
 // registerHandler("select_to_line_handler", async function start_review_range() {


### PR DESCRIPTION
Lets init.ts (or other plugins) flip vi mode programmatically — e.g. editor.getPluginApi("vi-mode")?.enable() in a plugins_loaded handler. The toggle command keeps its existing behavior; enable/disable are idempotent and the toggle dispatches between them.

Fixes https://github.com/sinelaw/fresh/issues/1086