### PR TITLE
Fix gitignore patterns to not hide parent directories

### DIFF
--- a/crates/fresh-editor/src/view/file_tree/ignore.rs
+++ b/crates/fresh-editor/src/view/file_tree/ignore.rs
@@ -174,7 +174,9 @@ impl IgnorePatterns {
         // Find the most specific .gitignore (deepest directory)
         // that could apply to this path
         for (gitignore_dir, gitignore) in &self.gitignores {
-            if path.starts_with(gitignore_dir) {
+            // A .gitignore at dir X governs entries *inside* X, not X itself —
+            // otherwise a `*` pattern would hide the directory it lives in.
+            if path.starts_with(gitignore_dir) && path != gitignore_dir.as_path() {
                 let relative_path = path.strip_prefix(gitignore_dir).unwrap_or(path);
                 let matched = gitignore.matched(relative_path, is_dir);
 

--- a/crates/fresh-editor/src/view/file_tree/view.rs
+++ b/crates/fresh-editor/src/view/file_tree/view.rs
@@ -904,4 +904,61 @@ mod tests {
         view.set_sort_mode(SortMode::Modified);
         assert_eq!(view.get_sort_mode(), SortMode::Modified);
     }
+
+    /// Reproducer: expanding a directory whose only contents are gitignored
+    /// (e.g. a build artifact dir whose own .gitignore is `*`) must not make
+    /// the directory itself disappear from the tree.
+    #[tokio::test]
+    async fn test_expanded_dir_with_all_children_filtered_stays_visible() {
+        let temp_dir = TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+
+        let build_dir = temp_path.join("build");
+        std_fs::create_dir(&build_dir).unwrap();
+        std_fs::create_dir(build_dir.join("export")).unwrap();
+        std_fs::write(build_dir.join("metadata"), b"").unwrap();
+        std_fs::write(build_dir.join(".gitignore"), b"*\n").unwrap();
+
+        let backend = Arc::new(StdFileSystem);
+        let manager = Arc::new(FsManager::new(backend));
+        let tree = FileTree::new(temp_path.to_path_buf(), manager)
+            .await
+            .unwrap();
+        let mut view = FileTreeView::new(tree);
+
+        let root_id = view.tree().root_id();
+        view.tree_mut().expand_node(root_id).await.unwrap();
+
+        let build_id = view
+            .tree()
+            .get_node(root_id)
+            .unwrap()
+            .children
+            .iter()
+            .copied()
+            .find(|&id| {
+                view.tree()
+                    .get_node(id)
+                    .map(|n| n.entry.name == "build")
+                    .unwrap_or(false)
+            })
+            .expect("build/ child not found");
+
+        view.tree_mut().expand_node(build_id).await.unwrap();
+        view.load_gitignore_from_bytes(&build_dir, b"*\n", None);
+
+        let visible: Vec<NodeId> = view
+            .get_display_nodes()
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert!(
+            visible.contains(&build_id),
+            "expanded build/ row vanished after its children were all filtered (visible={:?})",
+            visible
+                .iter()
+                .filter_map(|&id| view.tree().get_node(id).map(|n| n.entry.name.clone()))
+                .collect::<Vec<_>>()
+        );
+    }
 }


### PR DESCRIPTION
## Summary
Fixed a bug where directories with gitignore patterns that match all their contents (e.g., `*`) would disappear from the file tree when expanded. The issue was that gitignore rules were being applied to the directory itself, when they should only apply to entries *inside* the directory.

## Key Changes
- **ignore.rs**: Modified the gitignore matching logic to exclude the directory containing the `.gitignore` file from pattern matching. A `.gitignore` at directory X now only governs entries inside X, not X itself.
- **view.rs**: Added a regression test `test_expanded_dir_with_all_children_filtered_stays_visible()` that verifies an expanded directory remains visible in the tree even when all its children are filtered by gitignore patterns.

## Implementation Details
The fix adds a simple path equality check: when evaluating whether a `.gitignore` applies to a path, we now ensure `path != gitignore_dir.as_path()`. This prevents the directory containing the `.gitignore` from being hidden by its own rules, which is the correct behavior according to how gitignore semantics work.

The test case reproduces the specific scenario: a `build/` directory with a `.gitignore` containing `*` that filters out all children, but the directory itself should remain visible in the tree.

https://claude.ai/code/session_01Hu1aMS1Te6KqofGLCVDTKA