### PR TITLE
Fix tab drag regression and refactor type aliases

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3545,6 +3545,7 @@ fn default_plugin_provider_priority() -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn test_plugin_api_creation() {
@@ -4174,13 +4175,15 @@ mod tests {
     // mutants replace the body with `Ok(())` / `()`, i.e. the side effect
     // disappears. One assertion per method ties the side effect down.
 
-    fn mk_api() -> (
+    type MkApi = (
         PluginApi,
         std::sync::mpsc::Receiver<PluginCommand>,
         Arc<RwLock<HookRegistry>>,
         Arc<RwLock<CommandRegistry>>,
         Arc<RwLock<EditorStateSnapshot>>,
-    ) {
+    );
+
+    fn mk_api() -> MkApi {
         let hooks = Arc::new(RwLock::new(HookRegistry::new()));
         let commands = Arc::new(RwLock::new(CommandRegistry::new()));
         let (tx, rx) = std::sync::mpsc::channel();
@@ -4266,7 +4269,7 @@ mod tests {
                 PathBuf::from("/tmp/x.rs"), Some(4), Some(8)
             ),
             PluginCommand::OpenFileAtLocation { path, line, column }
-                if path == PathBuf::from("/tmp/x.rs")
+                if path == Path::new("/tmp/x.rs")
                     && line == Some(4)
                     && column == Some(8)
         );
@@ -4278,7 +4281,7 @@ mod tests {
             ),
             PluginCommand::OpenFileInSplit { split_id, path, line, column }
                 if split_id == 2
-                    && path == PathBuf::from("/tmp/y.rs")
+                    && path == Path::new("/tmp/y.rs")
                     && line == Some(5)
                     && column.is_none()
         );

--- a/crates/fresh-core/src/file_uri.rs
+++ b/crates/fresh-core/src/file_uri.rs
@@ -131,10 +131,8 @@ pub fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
     // Must start with file:// (accept file:/// and file://localhost/)
     let path_str = if let Some(rest) = uri.strip_prefix("file:///") {
         rest
-    } else if let Some(rest) = uri.strip_prefix("file://localhost/") {
-        rest
     } else {
-        return None;
+        uri.strip_prefix("file://localhost/")?
     };
 
     let decoded = percent_decode(path_str);

--- a/crates/fresh-editor/src/app/tab_drag.rs
+++ b/crates/fresh-editor/src/app/tab_drag.rs
@@ -299,9 +299,19 @@ impl Editor {
             }
         }
 
-        // Focus the target split and switch to the dropped buffer
-        self.split_manager
-            .set_split_buffer(target_split_id, buffer_id);
+        // Focus the target split and switch to the dropped buffer.
+        //
+        // Use `set_pane_buffer` (not raw `set_split_buffer`) so the target
+        // split's `SplitViewState` gets a `keyed_states` entry for the
+        // dropped buffer. Without this, dragging a tab into a split that
+        // never hosted that buffer (e.g. a search-replace results tab
+        // dragged out of the utility dock onto another split) leaves the
+        // target SVS missing the entry. `set_active_buffer` below would
+        // then early-return because the split tree already reports
+        // `buffer_id` as active, so it never reaches `set_pane_buffer`
+        // either — and the next keystroke panics in
+        // `apply_event_to_state` on `keyed_states.get_mut(...).unwrap()`.
+        self.set_pane_buffer(target_split_id, buffer_id);
         self.split_manager.set_active_split(target_split_id);
         self.set_active_buffer(buffer_id);
 

--- a/crates/fresh-editor/tests/e2e/tab_drag.rs
+++ b/crates/fresh-editor/tests/e2e/tab_drag.rs
@@ -793,3 +793,115 @@ fn test_drag_right_split_to_left_border_switches_order() {
         );
     }
 }
+
+/// Regression test: dragging a tab onto a split whose `keyed_states` does not
+/// already contain that buffer must add the entry, otherwise the next
+/// keystroke panics in `apply_event_to_state` on an `Option::unwrap()`
+/// against the missing per-buffer state.
+///
+/// To trigger the missing-keyed-state condition we first split off a tab
+/// onto a fresh split (which initializes its `SplitViewState` via
+/// `with_buffer`, populating `keyed_states` with only that one buffer),
+/// then drag a different tab onto the new split's tab bar. Typing a
+/// character afterwards used to panic — see the bug reproduced when
+/// dragging the search-replace tab out of the utility dock.
+#[test]
+fn test_drag_tab_to_fresh_split_then_type_does_not_panic() {
+    let (mut harness, _temp_dir, _files) = setup_multi_file_harness();
+
+    // Step 1: drag the first tab to the right edge to create a new split.
+    // The new split is initialized via `SplitViewState::with_buffer`,
+    // so its `keyed_states` contains only the dragged buffer.
+    let tabs = get_all_tabs(&harness);
+    assert!(tabs.len() >= 2, "Need at least two tabs to set up the test");
+    let first_tab = &tabs[0];
+    let split_areas = harness.editor().get_split_areas().to_vec();
+    let (_, _, content_rect, _, _, _) = split_areas[0];
+    let right_edge_col = content_rect.x + content_rect.width - 2;
+    let content_center_row = content_rect.y + content_rect.height / 2;
+
+    let dragged_first = first_tab.buffer_id;
+    harness
+        .mouse_drag(
+            first_tab.center_col(),
+            first_tab.tab_row,
+            right_edge_col,
+            content_center_row,
+        )
+        .unwrap();
+    assert_eq!(harness.editor().get_split_count(), 2);
+
+    // Step 2: identify the new (right) split and pick a tab in the
+    // remaining (left) split that is *not* present in the new split's
+    // `keyed_states`.
+    let new_active_split = harness.editor().get_active_split();
+    assert_eq!(
+        harness.editor().get_split_buffer(new_active_split.into()),
+        Some(dragged_first)
+    );
+
+    // Advance time so the next mouse_down isn't treated as a double-click
+    // of the first drag's mouse_down (the tab centers can collide).
+    harness.advance_time(std::time::Duration::from_millis(1000));
+    harness.render().unwrap();
+    let tabs = get_all_tabs(&harness);
+    let other_tab = tabs
+        .iter()
+        .find(|t| t.split_id != new_active_split && t.buffer_id != dragged_first)
+        .expect("expected a tab in the source split with a different buffer");
+    let other_buffer = other_tab.buffer_id;
+    let source_split_id = other_tab.split_id;
+    // Avoid landing on the exact same coordinate as the first drag's
+    // mouse_down (which would trigger the multi-click detector and
+    // suppress the drag init); offset slightly within the tab area.
+    let other_center = other_tab.center_col().saturating_add(2);
+    let other_row = other_tab.tab_row;
+
+    // Find the new split's tab bar position to use as the drop target.
+    let target_tab = tabs
+        .iter()
+        .find(|t| t.split_id == new_active_split)
+        .expect("new split should have at least one tab");
+    let target_center = target_tab.center_col();
+    let target_row = target_tab.tab_row;
+
+    // Sanity-check the drop zone before the drag so we know the test is
+    // actually exercising `move_tab_to_split` (TabBar drop zone) rather
+    // than some adjacent edge zone.
+    let drop_zone = harness
+        .editor()
+        .compute_drop_zone(target_center, target_row, source_split_id);
+    assert!(
+        matches!(drop_zone, Some(TabDropZone::TabBar(sid, _)) if sid == new_active_split),
+        "Expected TabBar drop zone over new split's tab bar, got {:?}",
+        drop_zone
+    );
+
+    // Step 3: drag the other tab onto the new split's tab bar.
+    harness
+        .mouse_drag(other_center, other_row, target_center, target_row)
+        .unwrap();
+
+    // Sanity: the buffer landed in the new split's tab list.
+    let target_tabs = harness.editor().get_split_tabs(new_active_split);
+    assert!(
+        target_tabs.contains(&other_buffer),
+        "Dragged buffer should appear in the new split's tabs (got {:?})",
+        target_tabs
+    );
+
+    // Step 4: type a character. Without the fix, this panics in
+    // `apply_event_to_state` because the new split's `keyed_states`
+    // never got an entry for the dropped buffer.
+    harness.type_text("Z").unwrap();
+    harness.render().unwrap();
+
+    // Observe the rendered screen: the typed 'Z' should be visible
+    // somewhere in the new split's content area.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains('Z'),
+        "Typed character 'Z' should render after drag-and-type. Screen:\n{}",
+        screen
+    );
+}

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -108,6 +108,12 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{mpsc, Arc, RwLock};
 
+/// Plugin-API exports map shared across every `JsEditorApi` /
+/// `QuickJsBackend` instance on a single runtime. Maps an export name to
+/// `(exporter plugin name, persistent JS object)`.
+type PluginApiExports =
+    Rc<RefCell<HashMap<String, (String, rquickjs::Persistent<rquickjs::Object<'static>>)>>>;
+
 /// Recursively copy a directory and all its contents.
 fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(dst)?;
@@ -757,8 +763,7 @@ pub struct JsEditorApi {
     /// persistent JS Object). Shared across every plugin context on the
     /// same Runtime so init.ts can reach another plugin's typed API.
     #[qjs(skip_trace)]
-    plugin_api_exports:
-        Rc<RefCell<HashMap<String, (String, rquickjs::Persistent<rquickjs::Object<'static>>)>>>,
+    plugin_api_exports: PluginApiExports,
     pub plugin_name: String,
 }
 
@@ -4731,8 +4736,7 @@ pub struct QuickJsBackend {
     /// Plugin-configuration plane (design M3): name → (exporter, persistent
     /// JS Object). Shared across every JsEditorApi instance on this
     /// Runtime.
-    plugin_api_exports:
-        Rc<RefCell<HashMap<String, (String, rquickjs::Persistent<rquickjs::Object<'static>>)>>>,
+    plugin_api_exports: PluginApiExports,
 }
 
 impl Drop for QuickJsBackend {


### PR DESCRIPTION
## Summary
This PR fixes a critical regression where dragging a tab onto a split that doesn't already contain that buffer would cause a panic on the next keystroke. It also includes refactoring improvements and test coverage.

## Key Changes

### Bug Fix: Tab Drag Panic (tab_drag.rs)
- **Root cause**: When dragging a tab to a fresh split (e.g., search-replace results from utility dock), the target split's `SplitViewState` was initialized with only the dragged buffer in `keyed_states`. If a different buffer was then dragged onto that split, the new buffer's entry was never added to `keyed_states`, causing a panic in `apply_event_to_state` on the next keystroke.
- **Solution**: Changed `move_tab_to_split` to call `set_pane_buffer` instead of raw `set_split_buffer`. This ensures the target split's `keyed_states` gets an entry for the dropped buffer, even if the split tree already reports it as active.
- **Test**: Added comprehensive regression test `test_drag_tab_to_fresh_split_then_type_does_not_panic` that reproduces the exact scenario and verifies the fix.

### Refactoring: Type Alias Extraction (quickjs_backend.rs)
- Extracted the complex `Rc<RefCell<HashMap<String, (String, rquickjs::Persistent<rquickjs::Object<'static>>)>>>` type into a named type alias `PluginApiExports` for improved readability and maintainability.
- Applied the alias to both `JsEditorApi` and `QuickJsBackend` struct definitions.

### Code Quality Improvements (api.rs)
- Added missing `use std::path::Path` import.
- Extracted the return type of `mk_api()` test helper into a named type alias `MkApi` for clarity.
- Updated test assertions to use `Path::new()` instead of `PathBuf::from()` for more idiomatic path comparisons.

### Simplification (file_uri.rs)
- Simplified `file_uri_to_path` logic by combining the two `strip_prefix` branches into a single expression using the `?` operator, reducing nesting and improving readability.

https://claude.ai/code/session_01Ju5PSMAUuuBERF9J25jEJb