### PR TITLE
Add TextArea widget for multi-line text input

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1426,6 +1426,63 @@ pub enum WidgetSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },
+    /// Multi-line text input. The host owns value + cursor as
+    /// instance state (mirrors `TextInput`), plus a vertical scroll
+    /// offset that auto-clamps to keep the cursor's line visible
+    /// within `rows` visible rows.
+    ///
+    /// Smart-key dispatch differs from `TextInput`: `Enter` inserts
+    /// a newline at the cursor (rather than advancing focus), so
+    /// the multi-line shape is the natural one. Plugins that want
+    /// `Enter` to submit can intercept the key in their own mode
+    /// binding and call `panel.command(focusAdvance(1))` instead.
+    /// `Up`/`Down` move the cursor between lines (clamped to each
+    /// line's column count); `Home`/`End` jump within the current
+    /// line; `Left`/`Right`/`Backspace`/`Delete` and printable text
+    /// behave exactly as in `TextInput`.
+    ///
+    /// The widget renders `rows` lines tall, padded with blanks
+    /// when `value` is shorter, with `field_width` columns wide
+    /// when set (`0` = use the panel's natural width). When
+    /// unfocused and empty, `placeholder` is rendered in the first
+    /// row only.
+    TextArea {
+        /// Initial text. Spec value is used at first render only;
+        /// instance state takes over thereafter (matching
+        /// `TextInput`'s host-owned value model).
+        #[serde(default)]
+        value: String,
+        /// Initial byte-offset cursor. Negative ⇒ "no cursor"; the
+        /// host clamps to `[0, value.len()]`.
+        #[serde(default = "default_cursor_byte")]
+        cursor_byte: i32,
+        /// Visual focus flag (initial-only — instance state takes
+        /// over once the panel has any tabbable widgets, see
+        /// `focus_key` semantics).
+        #[serde(default)]
+        focused: bool,
+        /// Optional label rendered on its own row above the
+        /// editing region (`Label:` followed by the multi-line
+        /// box). Empty = omitted.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        label: String,
+        /// Placeholder text shown on the first row when the value
+        /// is empty and the field is unfocused.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        placeholder: Option<String>,
+        /// Number of visible rows of editing region. Plugin
+        /// computes from its viewport; `0` falls back to a small
+        /// default (3) at render time.
+        #[serde(default)]
+        rows: u32,
+        /// Visible column width inside the editing region. `0`
+        /// (default) = grow with the longest visible line up to
+        /// the panel width.
+        #[serde(default)]
+        field_width: u32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key: Option<String>,
+    },
     /// Imperative-virtual-buffer escape hatch. The plugin supplies
     /// `TextPropertyEntry[]` exactly as it would for
     /// `setVirtualBufferContent`; the host inlines those entries into
@@ -1491,18 +1548,19 @@ pub enum WidgetAction {
     ///
     /// Dispatch table:
     ///
-    /// | Key                                   | TextInput   | Toggle / Button | List       | Tree                | (no focus) |
-    /// |---------------------------------------|-------------|-----------------|------------|---------------------|------------|
-    /// | `Tab`                                 | focus +1    | focus +1        | focus +1   | focus +1            | no-op      |
-    /// | `Shift+Tab`                           | focus -1    | focus -1        | focus -1   | focus -1            | no-op      |
-    /// | `Backspace` / `Delete` / `Home` / `End` | text-edit | no-op           | no-op      | no-op               | no-op      |
-    /// | `Left`                                | text-edit   | no-op           | no-op      | collapse / parent   | no-op      |
-    /// | `Right`                               | text-edit   | no-op           | no-op      | expand              | no-op      |
-    /// | `Up`                                  | no-op       | no-op           | select -1  | select -1 (visible) | no-op      |
-    /// | `Down`                                | no-op       | no-op           | select +1  | select +1 (visible) | no-op      |
-    /// | `Enter`                               | focus +1    | activate        | activate   | activate            | no-op      |
-    /// | `Space`                               | char " "    | activate        | activate   | activate            | no-op      |
-    /// | (anything else)                       | no-op       | no-op           | no-op      | no-op               | no-op      |
+    /// | Key                                   | TextInput   | TextArea          | Toggle / Button | List       | Tree                | (no focus) |
+    /// |---------------------------------------|-------------|-------------------|-----------------|------------|---------------------|------------|
+    /// | `Tab`                                 | focus +1    | focus +1          | focus +1        | focus +1   | focus +1            | no-op      |
+    /// | `Shift+Tab`                           | focus -1    | focus -1          | focus -1        | focus -1   | focus -1            | no-op      |
+    /// | `Backspace` / `Delete`                | text-edit   | text-edit         | no-op           | no-op      | no-op               | no-op      |
+    /// | `Home` / `End`                        | text-edit   | line-start / -end | no-op           | no-op      | no-op               | no-op      |
+    /// | `Left`                                | text-edit   | text-edit         | no-op           | no-op      | collapse / parent   | no-op      |
+    /// | `Right`                               | text-edit   | text-edit         | no-op           | no-op      | expand              | no-op      |
+    /// | `Up`                                  | no-op       | line up           | no-op           | select -1  | select -1 (visible) | no-op      |
+    /// | `Down`                                | no-op       | line down         | no-op           | select +1  | select +1 (visible) | no-op      |
+    /// | `Enter`                               | focus +1    | insert `\n`       | activate        | activate   | activate            | no-op      |
+    /// | `Space`                               | char " "    | char " "          | activate        | activate   | activate            | no-op      |
+    /// | (anything else)                       | no-op       | no-op             | no-op           | no-op      | no-op               | no-op      |
     ///
     /// "no-op" still returns successfully — plugins can rely on the
     /// command not erroring when the focused widget can't handle the

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -838,6 +838,49 @@ type WidgetSpec = {
 	fieldWidth: number;
 	key?: string | null;
 } | {
+	"kind": "textArea";
+	/**
+	* Initial text. Spec value is used at first render only;
+	* instance state takes over thereafter (matching
+	* `TextInput`'s host-owned value model).
+	*/
+	value: string;
+	/**
+	* Initial byte-offset cursor. Negative ⇒ "no cursor"; the
+	* host clamps to `[0, value.len()]`.
+	*/
+	cursorByte: number;
+	/**
+	* Visual focus flag (initial-only — instance state takes
+	* over once the panel has any tabbable widgets, see
+	* `focus_key` semantics).
+	*/
+	focused: boolean;
+	/**
+	* Optional label rendered on its own row above the
+	* editing region (`Label:` followed by the multi-line
+	* box). Empty = omitted.
+	*/
+	label?: string;
+	/**
+	* Placeholder text shown on the first row when the value
+	* is empty and the field is unfocused.
+	*/
+	placeholder?: string | null;
+	/**
+	* Number of visible rows of editing region. Plugin
+	* computes from its viewport; `0` falls back to a small
+	* default (3) at render time.
+	*/
+	rows: number;
+	/**
+	* Visible column width inside the editing region. `0`
+	* (default) = grow with the longest visible line up to
+	* the panel width.
+	*/
+	fieldWidth: number;
+	key?: string | null;
+} | {
 	"kind": "raw";
 	entries: Array<TextPropertyEntry>;
 	key?: string | null;

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -219,6 +219,55 @@ export function tree(options: {
   };
 }
 
+/** Multi-line text input, rendered as a fixed-height block of
+ * `rows` rows. The host owns the value, cursor, and vertical scroll
+ * as instance state — same pattern as `textInput`, lifted to a
+ * 2-D buffer.
+ *
+ * **Smart-key dispatch differs from `textInput`**:
+ * `Enter` inserts a newline (instead of advancing focus);
+ * `Up`/`Down` move between lines; `Home`/`End` jump within the
+ * current line; `Left`/`Right`/`Backspace`/`Delete` and printable
+ * chars work as in `textInput`. Plugins that want `Enter` to
+ * submit can intercept the key in their own mode binding and call
+ * `panel.command(focusAdvance(1))` instead — this default is
+ * non-breaking because the smart-key dispatch is opt-in.
+ *
+ * `rows` controls visible height (default 3 if omitted).
+ * `fieldWidth` controls visible column width inside the editing
+ * region; `0` (default) uses the panel width. Long lines
+ * tail-truncate with `…`; short lines pad with trailing spaces so
+ * the focused-bg block keeps a rectangular shape.
+ *
+ * `key` is required for any TextArea that should preserve its
+ * value, cursor, and scroll across re-renders. */
+export function textArea(
+  options: {
+    value?: string;
+    cursorByte?: number;
+    focused?: boolean;
+    label?: string;
+    placeholder?: string;
+    /** Visible rows of editing area; default 3. */
+    rows?: number;
+    /** Visible column width; `0` = use panel width. */
+    fieldWidth?: number;
+    key?: string;
+  } = {},
+): WidgetSpec {
+  return {
+    kind: "textArea",
+    value: options.value ?? "",
+    cursorByte: options.cursorByte ?? -1,
+    focused: options.focused ?? false,
+    label: options.label ?? "",
+    placeholder: options.placeholder,
+    rows: options.rows ?? 3,
+    fieldWidth: options.fieldWidth ?? 0,
+    key: options.key,
+  };
+}
+
 /** Single-line text input, rendered as `[value]` (or
  * `Label: [value]` if `label` is provided). The host drives the
  * actual hardware cursor at `cursorByte` when focused — no painted

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -23,6 +23,15 @@ use crate::view::split::SplitViewState;
 
 use super::Editor;
 
+/// Discriminator for the two text-bearing widget kinds. Used by the
+/// printable-char dispatcher (`handle_widget_text_input_char`) to
+/// route a key into TextInput or TextArea instance state.
+#[derive(Debug, Clone, Copy)]
+enum TextWidgetKind {
+    TextInput,
+    TextArea,
+}
+
 /// Returns the byte offset of the start (want_end=false) or end (want_end=true)
 /// of `line` (0-indexed) within `content`. Returns `None` when `line` is out of
 /// range. The "end" position is the byte index of the terminating `\n`; for the
@@ -3367,19 +3376,43 @@ impl Editor {
                 value,
                 cursor_byte,
             } => {
-                // TextInput value+cursor live in instance state.
+                // Value+cursor live in instance state for both
+                // TextInput and TextArea; route to the right state
+                // variant based on the spec.
                 if let Some(panel) = self.widget_registry.get_mut(panel_id) {
                     let cb = match cursor_byte {
                         Some(c) if c >= 0 => (c as u32).min(value.len() as u32),
                         _ => value.len() as u32,
                     };
-                    panel.instance_states.insert(
-                        widget_key,
-                        crate::widgets::WidgetInstanceState::TextInput {
+                    let widget_kind = crate::widgets::find_widget_by_key(&panel.spec, &widget_key)
+                        .map(|w| match w {
+                            fresh_core::api::WidgetSpec::TextArea { .. } => "textArea",
+                            _ => "textInput",
+                        })
+                        .unwrap_or("textInput");
+                    let new_state = match widget_kind {
+                        "textArea" => {
+                            // Preserve scroll across the mutation;
+                            // the renderer re-clamps it on re-render.
+                            let scroll_row = match panel.instance_states.get(&widget_key) {
+                                Some(crate::widgets::WidgetInstanceState::TextArea {
+                                    scroll_row,
+                                    ..
+                                }) => *scroll_row,
+                                _ => 0,
+                            };
+                            crate::widgets::WidgetInstanceState::TextArea {
+                                value,
+                                cursor_byte: cb,
+                                scroll_row,
+                            }
+                        }
+                        _ => crate::widgets::WidgetInstanceState::TextInput {
                             value,
                             cursor_byte: cb,
                         },
-                    );
+                    };
+                    panel.instance_states.insert(widget_key, new_state);
                 }
             }
             WidgetMutation::SetChecked {
@@ -3510,6 +3543,9 @@ impl Editor {
                     Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                         self.handle_widget_tree_select_move(panel_id, delta);
                     }
+                    Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                        self.handle_widget_text_area_key(panel_id, key);
+                    }
                     _ => {}
                 }
             }
@@ -3517,16 +3553,23 @@ impl Editor {
                 Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
                     self.handle_widget_text_input_key(panel_id, key);
                 }
+                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_area_key(panel_id, key);
+                }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                     self.handle_widget_tree_lateral(panel_id, key == "Right");
                 }
                 _ => {}
             },
-            "Backspace" | "Delete" | "Home" | "End" => {
-                if matches!(widget, Some(fresh_core::api::WidgetSpec::TextInput { .. })) {
+            "Backspace" | "Delete" | "Home" | "End" => match widget {
+                Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
                     self.handle_widget_text_input_key(panel_id, key);
                 }
-            }
+                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_area_key(panel_id, key);
+                }
+                _ => {}
+            },
             "Enter" => match widget {
                 Some(fresh_core::api::WidgetSpec::Button { .. })
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {
@@ -3546,6 +3589,13 @@ impl Editor {
                     // dispatching it through the smart-key router.
                     self.handle_widget_focus_advance(panel_id, 1);
                 }
+                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    // Multi-line input: Enter inserts a newline at
+                    // the cursor. Plugins that want Enter to submit
+                    // can intercept it before dispatching through
+                    // the smart-key router.
+                    self.handle_widget_text_area_key(panel_id, "Enter");
+                }
                 _ => {}
             },
             "Space" => match widget {
@@ -3555,6 +3605,9 @@ impl Editor {
                 }
                 Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
                     self.handle_widget_text_input_char(panel_id, " ");
+                }
+                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_area_char(panel_id, " ");
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
                     self.fire_list_activate(panel_id, &focus_key);
@@ -4123,6 +4176,16 @@ impl Editor {
         if text.is_empty() {
             return;
         }
+        // Route to TextArea when that's what's focused — same call
+        // shape, multi-line writer.
+        if let Some(kind) = self.focused_text_widget_kind(panel_id) {
+            match kind {
+                TextWidgetKind::TextArea => {
+                    return self.handle_widget_text_area_char(panel_id, text);
+                }
+                TextWidgetKind::TextInput => {}
+            }
+        }
         let (focus_key, value, cur) = match self.read_focused_text_input(panel_id) {
             Some(t) => t,
             None => return,
@@ -4133,6 +4196,126 @@ impl Editor {
         new_value.push_str(&value[cur..]);
         let new_cursor = cur + text.len();
         self.write_focused_text_input(panel_id, &focus_key, new_value, new_cursor);
+    }
+
+    /// Apply a non-printable editing key to the focused TextArea —
+    /// `Backspace`, `Delete`, `Left`, `Right`, `Home`, `End`, `Up`,
+    /// `Down`, or `Enter`. Updates instance state and fires
+    /// `widget_event { event_type: "change", payload: { value,
+    /// cursorByte } }`.
+    fn handle_widget_text_area_key(&mut self, panel_id: u64, key: &str) {
+        let (focus_key, value, cur) = match self.read_focused_text_area(panel_id) {
+            Some(t) => t,
+            None => return,
+        };
+        let (new_value, new_cursor) = crate::widgets::apply_text_area_key(&value, cur, key);
+        if new_value == value && new_cursor == cur {
+            return;
+        }
+        self.write_focused_text_area(panel_id, &focus_key, new_value, new_cursor);
+    }
+
+    /// Insert printable text at the focused TextArea's cursor.
+    fn handle_widget_text_area_char(&mut self, panel_id: u64, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        let (focus_key, value, cur) = match self.read_focused_text_area(panel_id) {
+            Some(t) => t,
+            None => return,
+        };
+        let mut new_value = String::with_capacity(value.len() + text.len());
+        new_value.push_str(&value[..cur]);
+        new_value.push_str(text);
+        new_value.push_str(&value[cur..]);
+        let new_cursor = cur + text.len();
+        self.write_focused_text_area(panel_id, &focus_key, new_value, new_cursor);
+    }
+
+    fn read_focused_text_area(&self, panel_id: u64) -> Option<(String, String, usize)> {
+        let panel = self.widget_registry.get(panel_id)?;
+        let focus_key = panel.focus_key.clone();
+        if focus_key.is_empty() {
+            return None;
+        }
+        if let Some(crate::widgets::WidgetInstanceState::TextArea {
+            value, cursor_byte, ..
+        }) = panel.instance_states.get(&focus_key)
+        {
+            return Some((focus_key, value.clone(), *cursor_byte as usize));
+        }
+        let widget = crate::widgets::find_widget_by_key(&panel.spec, &focus_key)?;
+        match widget {
+            fresh_core::api::WidgetSpec::TextArea {
+                value, cursor_byte, ..
+            } => {
+                let cur = if *cursor_byte < 0 {
+                    value.len()
+                } else {
+                    (*cursor_byte as usize).min(value.len())
+                };
+                Some((focus_key, value.clone(), cur))
+            }
+            _ => None,
+        }
+    }
+
+    fn write_focused_text_area(
+        &mut self,
+        panel_id: u64,
+        focus_key: &str,
+        new_value: String,
+        new_cursor: usize,
+    ) {
+        if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+            // Preserve scroll_row across the mutation; the renderer
+            // re-clamps it on the next render.
+            let scroll_row = match panel.instance_states.get(focus_key) {
+                Some(crate::widgets::WidgetInstanceState::TextArea { scroll_row, .. }) => {
+                    *scroll_row
+                }
+                _ => 0,
+            };
+            panel.instance_states.insert(
+                focus_key.to_string(),
+                crate::widgets::WidgetInstanceState::TextArea {
+                    value: new_value.clone(),
+                    cursor_byte: new_cursor as u32,
+                    scroll_row,
+                },
+            );
+        }
+        self.rerender_widget_panel(panel_id);
+        if self.plugin_manager.has_hook_handlers("widget_event") {
+            self.plugin_manager.run_hook(
+                "widget_event",
+                fresh_core::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key: focus_key.to_string(),
+                    event_type: "change".into(),
+                    payload: serde_json::json!({
+                        "value": new_value,
+                        "cursorByte": new_cursor as i64,
+                    }),
+                },
+            );
+        }
+    }
+
+    /// Inspect the panel's focused widget kind among the text-bearing
+    /// kinds (TextInput / TextArea). Used by the printable-char
+    /// dispatcher to route between them.
+    fn focused_text_widget_kind(&self, panel_id: u64) -> Option<TextWidgetKind> {
+        let panel = self.widget_registry.get(panel_id)?;
+        let focus_key = panel.focus_key.clone();
+        if focus_key.is_empty() {
+            return None;
+        }
+        match crate::widgets::find_widget_by_key(&panel.spec, &focus_key)? {
+            fresh_core::api::WidgetSpec::TextInput { .. } => Some(TextWidgetKind::TextInput),
+            fresh_core::api::WidgetSpec::TextArea { .. } => Some(TextWidgetKind::TextArea),
+            _ => None,
+        }
     }
 
     fn handle_unmount_widget_panel(&mut self, panel_id: u64) {

--- a/crates/fresh-editor/src/widgets/actions.rs
+++ b/crates/fresh-editor/src/widgets/actions.rs
@@ -31,6 +31,7 @@ pub fn find_widget_by_key<'a>(spec: &'a WidgetSpec, target: &str) -> Option<&'a 
         WidgetSpec::Toggle { key: Some(k), .. }
         | WidgetSpec::Button { key: Some(k), .. }
         | WidgetSpec::TextInput { key: Some(k), .. }
+        | WidgetSpec::TextArea { key: Some(k), .. }
         | WidgetSpec::List { key: Some(k), .. }
         | WidgetSpec::Tree { key: Some(k), .. }
             if k == target =>
@@ -108,6 +109,124 @@ pub fn apply_text_input_key(value: &str, cursor: usize, key: &str) -> (String, u
         "End" => (value.to_string(), value.len()),
         _ => (value.to_string(), cursor),
     }
+}
+
+/// Apply a non-printable editing key to a multi-line `(value,
+/// cursor)` pair, returning `(new_value, new_cursor)`. `cursor` is
+/// a UTF-8 byte offset clamped to `[0, value.len()]`.
+///
+/// Recognised keys: `"Backspace"`, `"Delete"`, `"Left"`, `"Right"`,
+/// `"Home"`, `"End"`, `"Up"`, `"Down"`, `"Enter"`. Any other key
+/// string is a no-op.
+///
+/// Compared to `apply_text_input_key`:
+/// * `"Home"`/`"End"` jump to the start/end of the *current line*
+///   (the line containing `cursor`), not the whole buffer.
+/// * `"Up"`/`"Down"` move between lines, preserving the byte column
+///   within the line where possible (clamped to each target line's
+///   length).
+/// * `"Enter"` inserts a `'\n'` at the cursor — TextArea's defining
+///   behaviour, separate from the smart-key dispatch path which also
+///   funnels Enter here when the focused widget is a TextArea.
+///
+/// `Left`/`Right`/`Backspace`/`Delete` are unchanged from
+/// `TextInput` semantics and respect UTF-8 char boundaries (an
+/// embedded `\n` is just another char that gets crossed by these
+/// keys).
+pub fn apply_text_area_key(value: &str, cursor: usize, key: &str) -> (String, usize) {
+    let cursor = cursor.min(value.len());
+    match key {
+        "Backspace" | "Delete" | "Left" | "Right" => apply_text_input_key(value, cursor, key),
+        "Home" => (value.to_string(), line_start(value, cursor)),
+        "End" => (value.to_string(), line_end(value, cursor)),
+        "Up" => {
+            let (line_start, col) = line_start_and_col(value, cursor);
+            if line_start == 0 {
+                // No previous line — clamp to start.
+                return (value.to_string(), 0);
+            }
+            // Previous line spans [prev_start, line_start - 1]; the
+            // newline at byte `line_start - 1` separates the two.
+            let prev_end = line_start - 1;
+            let prev_start = line_start_at(value, prev_end);
+            let prev_len = prev_end - prev_start;
+            let new_col = col.min(prev_len);
+            let new_cursor = clamp_to_char_boundary(value, prev_start + new_col);
+            (value.to_string(), new_cursor)
+        }
+        "Down" => {
+            let (line_start, col) = line_start_and_col(value, cursor);
+            let cur_line_end = line_end_at(value, line_start);
+            if cur_line_end >= value.len() {
+                // No next line — clamp to end.
+                return (value.to_string(), value.len());
+            }
+            let next_start = cur_line_end + 1;
+            let next_end = line_end_at(value, next_start);
+            let next_len = next_end - next_start;
+            let new_col = col.min(next_len);
+            let new_cursor = clamp_to_char_boundary(value, next_start + new_col);
+            (value.to_string(), new_cursor)
+        }
+        "Enter" => {
+            let mut new_value = String::with_capacity(value.len() + 1);
+            new_value.push_str(&value[..cursor]);
+            new_value.push('\n');
+            new_value.push_str(&value[cursor..]);
+            (new_value, cursor + 1)
+        }
+        _ => (value.to_string(), cursor),
+    }
+}
+
+/// Byte index of the start of the line containing `cursor`. The
+/// "start of a line" is either byte 0 or one byte past the most
+/// recent `\n`.
+fn line_start(value: &str, cursor: usize) -> usize {
+    line_start_at(value, cursor)
+}
+
+/// Byte index of the end of the line containing `cursor` — the
+/// position of the next `\n`, or `value.len()` if there is none
+/// after `cursor`.
+fn line_end(value: &str, cursor: usize) -> usize {
+    line_end_at(value, cursor)
+}
+
+fn line_start_at(value: &str, byte: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut i = byte;
+    while i > 0 && bytes[i - 1] != b'\n' {
+        i -= 1;
+    }
+    i
+}
+
+fn line_end_at(value: &str, byte: usize) -> usize {
+    let bytes = value.as_bytes();
+    let mut i = byte;
+    while i < bytes.len() && bytes[i] != b'\n' {
+        i += 1;
+    }
+    i
+}
+
+/// Returns `(line_start, col_in_bytes)` for `cursor`. `col_in_bytes`
+/// is `cursor - line_start`.
+fn line_start_and_col(value: &str, cursor: usize) -> (usize, usize) {
+    let s = line_start_at(value, cursor);
+    (s, cursor - s)
+}
+
+/// Snap `byte` down to the nearest UTF-8 char boundary at or before
+/// it. Used when projecting an Up/Down byte-column into a line that
+/// might split a multi-byte char at the target column.
+fn clamp_to_char_boundary(value: &str, byte: usize) -> usize {
+    let mut i = byte.min(value.len());
+    while i > 0 && !value.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
 }
 
 /// In-place mutate a `Toggle`'s `checked` field by walking the
@@ -465,6 +584,111 @@ mod tests {
             }
             _ => unreachable!(),
         }
+    }
+
+    // ---- TextArea key tests --------------------------------------------
+
+    #[test]
+    fn text_area_enter_inserts_newline_at_cursor() {
+        let (v, c) = apply_text_area_key("hello", 2, "Enter");
+        assert_eq!(v, "he\nllo");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn text_area_enter_at_end_appends_newline() {
+        let (v, c) = apply_text_area_key("ab", 2, "Enter");
+        assert_eq!(v, "ab\n");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn text_area_left_right_share_text_input_semantics() {
+        assert_eq!(apply_text_area_key("abc", 2, "Left"), ("abc".into(), 1));
+        assert_eq!(apply_text_area_key("abc", 1, "Right"), ("abc".into(), 2));
+    }
+
+    #[test]
+    fn text_area_backspace_can_delete_a_newline() {
+        // Cursor right after the `\n` between line 0 and 1.
+        let (v, c) = apply_text_area_key("ab\ncd", 3, "Backspace");
+        assert_eq!(v, "abcd");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn text_area_home_jumps_to_line_start_not_buffer_start() {
+        // Cursor is on line 1 (after "\n"). Home → byte 3 (line 1's
+        // start), not byte 0.
+        let (v, c) = apply_text_area_key("ab\ncd", 4, "Home");
+        assert_eq!(v, "ab\ncd");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn text_area_end_jumps_to_line_end_not_buffer_end() {
+        // Cursor at start of line 0. End → byte 2 (line 0's end),
+        // not the value's full length.
+        let (v, c) = apply_text_area_key("ab\ncd", 0, "End");
+        assert_eq!(v, "ab\ncd");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn text_area_up_moves_to_previous_line_preserving_column() {
+        // "abcd\nef" — cursor at byte 7 (col 2 on line 1, after 'f').
+        // Up → byte 2 (col 2 on line 0).
+        let (v, c) = apply_text_area_key("abcd\nef", 7, "Up");
+        assert_eq!(v, "abcd\nef");
+        assert_eq!(c, 2);
+    }
+
+    #[test]
+    fn text_area_up_clamps_column_to_short_target_line() {
+        // "ab\nxyz" — cursor at byte 6 (col 3 on line 1).
+        // Up → end of line 0 (byte 2), since col 3 exceeds line 0's
+        // length 2.
+        let (v, c) = apply_text_area_key("ab\nxyz", 6, "Up");
+        assert_eq!(c, 2);
+        assert_eq!(v, "ab\nxyz");
+    }
+
+    #[test]
+    fn text_area_up_at_top_line_clamps_to_buffer_start() {
+        let (_, c) = apply_text_area_key("abc\ndef", 2, "Up");
+        assert_eq!(c, 0);
+    }
+
+    #[test]
+    fn text_area_down_moves_to_next_line_preserving_column() {
+        // "abcd\nefgh" — cursor at byte 2 (col 2 on line 0).
+        // Down → byte 7 (col 2 on line 1, which starts at byte 5).
+        let (_, c) = apply_text_area_key("abcd\nefgh", 2, "Down");
+        assert_eq!(c, 7);
+    }
+
+    #[test]
+    fn text_area_down_at_last_line_clamps_to_buffer_end() {
+        let (v, c) = apply_text_area_key("abc\ndef", 5, "Down");
+        assert_eq!(v, "abc\ndef");
+        assert_eq!(c, 7);
+    }
+
+    #[test]
+    fn text_area_unknown_key_is_noop() {
+        assert_eq!(apply_text_area_key("abc", 1, "Wat"), ("abc".into(), 1));
+    }
+
+    #[test]
+    fn text_area_up_clamps_to_char_boundary() {
+        // Two-byte char `é` at start of line 1. Cursor at line 1,
+        // byte 1 (start of the second `\xa9` byte of `é`). Up
+        // shouldn't land mid-multibyte-char on line 0 either.
+        // Use "aé\nbé" — line 0 = "aé" (3 bytes), line 1 = "bé"
+        // (3 bytes). Cursor at byte 5 (mid-line 1 between 'b' and
+        // 'é'). Up → col 1 on line 0, byte 1 (between 'a' and 'é').
+        let (_, c) = apply_text_area_key("aé\nbé", 5, "Up");
+        assert_eq!(c, 1);
     }
 
     #[test]

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -19,8 +19,8 @@ mod registry;
 mod render;
 
 pub use actions::{
-    apply_text_input_key, find_widget_by_key, set_list_items_in_spec, set_toggle_checked_in_spec,
-    set_tree_nodes_in_spec, tree_parent_index,
+    apply_text_area_key, apply_text_input_key, find_widget_by_key, set_list_items_in_spec,
+    set_toggle_checked_in_spec, set_tree_nodes_in_spec, tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
 pub use render::{render_spec, FocusCursor, RenderOutput};

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -79,6 +79,19 @@ pub enum WidgetInstanceState {
     /// `WidgetCommand` mutations because the host doesn't read
     /// from the spec for value at all once instance state exists.
     TextInput { value: String, cursor_byte: u32 },
+    /// `TextArea` instance state: host-owned multi-line value,
+    /// cursor byte offset within `value`, and vertical scroll
+    /// offset (the index of the first visible line). Same
+    /// host-owned semantics as `TextInput` — once instance state
+    /// exists, the spec's `value` / `cursor_byte` are ignored.
+    /// `scroll_row` auto-clamps each render to keep the cursor's
+    /// line within the visible window; plugins never compute
+    /// scroll math.
+    TextArea {
+        value: String,
+        cursor_byte: u32,
+        scroll_row: u32,
+    },
     /// `Tree` instance state: host-owned scroll offset, selected
     /// index, and the set of expanded item keys. All three become
     /// authoritative after first render — the spec's

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -175,6 +175,7 @@ fn collect_tabbable(spec: &WidgetSpec, out: &mut Vec<String>) {
         WidgetSpec::Toggle { key: Some(k), .. }
         | WidgetSpec::Button { key: Some(k), .. }
         | WidgetSpec::TextInput { key: Some(k), .. }
+        | WidgetSpec::TextArea { key: Some(k), .. }
         | WidgetSpec::List { key: Some(k), .. }
         | WidgetSpec::Tree { key: Some(k), .. }
             if !k.is_empty() =>
@@ -825,6 +826,85 @@ fn render_collected(
             ensure_trailing_newline(&mut entry);
             entries.push(entry);
         }
+        WidgetSpec::TextArea {
+            value,
+            cursor_byte,
+            focused,
+            label,
+            placeholder,
+            rows,
+            field_width,
+            key,
+        } => {
+            let is_focused = match key.as_deref() {
+                Some(k) if !k.is_empty() => k == focus_key,
+                _ => *focused,
+            };
+            // Host-owned value/cursor + scroll, mirroring TextInput.
+            // First render seeds from the spec; subsequent renders
+            // read the previous instance state and ignore the spec's
+            // value / cursor_byte.
+            let (effective_value, effective_cursor_byte, prev_scroll) = match key
+                .as_deref()
+                .filter(|k| !k.is_empty())
+                .and_then(|k| prev.get(k))
+            {
+                Some(WidgetInstanceState::TextArea {
+                    value,
+                    cursor_byte,
+                    scroll_row,
+                }) => (value.clone(), *cursor_byte as i32, *scroll_row),
+                _ => (value.clone(), *cursor_byte, 0),
+            };
+            // Default rows to a small value when the plugin omits
+            // it — keeps the editing region from collapsing.
+            let visible_rows = if *rows == 0 { 3 } else { *rows };
+            let rendered = render_text_area(
+                &effective_value,
+                effective_cursor_byte,
+                is_focused,
+                label,
+                placeholder.as_deref(),
+                visible_rows,
+                *field_width,
+                prev_scroll,
+                panel_width,
+            );
+            // Persist instance state for next render. Cursor is
+            // clamped into [0, value.len()]; scroll_row is the
+            // renderer's auto-clamped value (cursor's line stays in
+            // view).
+            if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
+                let cb = effective_cursor_byte
+                    .max(0)
+                    .min(effective_value.len() as i32) as u32;
+                next_state.insert(
+                    k.to_string(),
+                    WidgetInstanceState::TextArea {
+                        value: effective_value.clone(),
+                        cursor_byte: cb,
+                        scroll_row: rendered.scroll_row,
+                    },
+                );
+            }
+            // Publish cursor for the hardware-cursor driver. The
+            // renderer's `cursor_buffer_row` is relative to the
+            // first rendered entry of this widget (label adds a
+            // row), and `cursor_byte_in_entry` is the byte within
+            // that row's text.
+            if let (Some(buffer_row), Some(byte_in_row)) =
+                (rendered.cursor_buffer_row, rendered.cursor_byte_in_row)
+            {
+                focus_cursor = Some(FocusCursor {
+                    buffer_row,
+                    byte_in_row: byte_in_row as u32,
+                });
+            }
+            for mut e in rendered.entries {
+                ensure_trailing_newline(&mut e);
+                entries.push(e);
+            }
+        }
         WidgetSpec::Raw {
             entries: raw_entries,
             ..
@@ -1294,6 +1374,231 @@ pub fn render_text_input(
             inline_overlays: overlays,
         },
         cursor_byte_in_entry,
+    }
+}
+
+/// Output of `render_text_area`. One entry per visible row of the
+/// editing region, plus optionally one preceding label row.
+pub struct RenderedTextArea {
+    /// The label row (if any) followed by `visible_rows` rows of
+    /// editing content. Empty `value` lines are rendered as blank
+    /// padded rows so the widget always occupies its full visual
+    /// height.
+    pub entries: Vec<TextPropertyEntry>,
+    /// Auto-clamped scroll row (first visible line of `value`)
+    /// after this render. Persisted into instance state by the
+    /// caller.
+    pub scroll_row: u32,
+    /// Buffer row (within `entries`) where the host should drop
+    /// the hardware cursor when focused. `None` when unfocused or
+    /// when `value` is empty and the placeholder is showing.
+    pub cursor_buffer_row: Option<u32>,
+    /// Byte offset within the cursor's row text where the cursor
+    /// lands. Pairs with `cursor_buffer_row`.
+    pub cursor_byte_in_row: Option<usize>,
+}
+
+/// Render a multi-line `TextArea`.
+///
+/// Layout:
+/// * If `label` is non-empty, one `Label:` row precedes the editing
+///   region.
+/// * Then exactly `visible_rows` rows of editing content. Lines of
+///   `value` between `[scroll_row, scroll_row + visible_rows)` are
+///   rendered; rows beyond the value are blanks (padded so the
+///   editing region's input-bg block keeps its rectangular shape).
+/// * The editing region uses `field_width` columns when set; `0`
+///   means "use up to `panel_width`". Long lines are truncated with
+///   `…` at the right when they exceed the field width — this is
+///   different from `TextInput`'s head-truncation, because the
+///   cursor is no longer pinned to end-of-value (it can be
+///   anywhere within multi-line content).
+/// * When focused, every visible content row gets the
+///   `ui.prompt_bg` overlay extended to the field width so the
+///   editing region reads as a single block.
+/// * Placeholder: shown on the *first* row only when unfocused and
+///   `value` is empty.
+///
+/// Cursor: returns the visible row index (relative to `entries`)
+/// and byte offset within that row's text. The auto-clamp policy:
+/// keep the cursor's line in view by adjusting `scroll_row` when
+/// the cursor's line falls outside `[scroll_row, scroll_row +
+/// visible_rows)`.
+#[allow(clippy::too_many_arguments)]
+pub fn render_text_area(
+    value: &str,
+    cursor_byte: i32,
+    focused: bool,
+    label: &str,
+    placeholder: Option<&str>,
+    visible_rows: u32,
+    field_width: u32,
+    prev_scroll: u32,
+    panel_width: u32,
+) -> RenderedTextArea {
+    // Resolve effective field width: caller's value if set, else
+    // `panel_width` (or a small default if the panel is unsized).
+    let target_width: usize = if field_width > 0 {
+        field_width as usize
+    } else if panel_width != u32::MAX && panel_width > 0 {
+        panel_width as usize
+    } else {
+        40
+    };
+
+    // Split value into lines (without the `\n`). Empty value still
+    // produces one (empty) line — matching how a single-line
+    // editor would treat an empty buffer.
+    let mut lines: Vec<&str> = value.split('\n').collect();
+    if lines.is_empty() {
+        lines.push("");
+    }
+
+    // Cursor → (line_index, byte_in_line). When `cursor_byte` is
+    // negative (no cursor), we still compute a line for scroll
+    // bookkeeping but don't emit a focus_cursor.
+    let raw_cursor_byte = if cursor_byte < 0 {
+        value.len()
+    } else {
+        (cursor_byte as usize).min(value.len())
+    };
+    let (cursor_line, cursor_col) = byte_to_line_col(value, raw_cursor_byte);
+
+    // Auto-clamp scroll: keep cursor's line in [scroll_row,
+    // scroll_row + visible_rows). On first render, prev_scroll == 0.
+    let visible_rows_usize = visible_rows.max(1) as usize;
+    let mut scroll_row = prev_scroll as usize;
+    if cursor_line < scroll_row {
+        scroll_row = cursor_line;
+    } else if cursor_line >= scroll_row + visible_rows_usize {
+        scroll_row = cursor_line + 1 - visible_rows_usize;
+    }
+    // Don't scroll past the last line.
+    let max_scroll = lines.len().saturating_sub(visible_rows_usize);
+    if scroll_row > max_scroll {
+        scroll_row = max_scroll;
+    }
+
+    let show_placeholder =
+        !focused && value.is_empty() && placeholder.is_some() && !placeholder.unwrap().is_empty();
+
+    let mut entries: Vec<TextPropertyEntry> = Vec::new();
+    let mut cursor_buffer_row: Option<u32> = None;
+    let mut cursor_byte_in_row: Option<usize> = None;
+
+    if !label.is_empty() {
+        let mut text = String::with_capacity(label.len() + 2);
+        text.push_str(label);
+        text.push(':');
+        entries.push(TextPropertyEntry {
+            text,
+            properties: Default::default(),
+            style: None,
+            inline_overlays: Vec::new(),
+        });
+    }
+    let label_offset: u32 = entries.len() as u32;
+
+    for row_in_view in 0..visible_rows_usize {
+        let line_idx = scroll_row + row_in_view;
+        let mut row_text;
+        let mut overlays: Vec<InlineOverlay> = Vec::new();
+
+        if line_idx < lines.len() {
+            row_text = pad_or_truncate_line(lines[line_idx], target_width);
+        } else {
+            row_text = " ".repeat(target_width);
+        }
+
+        // Placeholder shows on the first row only.
+        if show_placeholder && row_in_view == 0 {
+            let ph = placeholder.unwrap();
+            row_text = pad_or_truncate_line(ph, target_width);
+            overlays.push(InlineOverlay {
+                start: 0,
+                end: row_text.len(),
+                style: OverlayOptions {
+                    fg: Some(OverlayColorSpec::theme_key(KEY_PLACEHOLDER_FG)),
+                    ..Default::default()
+                },
+                properties: Default::default(),
+            });
+        }
+
+        // Focused-bg covers the full row width — the editing
+        // region reads as a single block.
+        if focused {
+            overlays.push(InlineOverlay {
+                start: 0,
+                end: row_text.len(),
+                style: OverlayOptions {
+                    bg: Some(OverlayColorSpec::theme_key(KEY_INPUT_BG)),
+                    ..Default::default()
+                },
+                properties: Default::default(),
+            });
+        }
+
+        // Drop the cursor on this row if it matches.
+        if focused && line_idx == cursor_line && cursor_byte >= 0 {
+            // The cursor's byte column on its line. If the line was
+            // truncated, the cursor may have shifted past the
+            // visible region — clamp to the last visible byte so
+            // the hardware cursor stays in the row.
+            let col_in_line = cursor_col.min(row_text.len());
+            cursor_buffer_row = Some(label_offset + row_in_view as u32);
+            cursor_byte_in_row = Some(col_in_line);
+        }
+
+        entries.push(TextPropertyEntry {
+            text: row_text,
+            properties: Default::default(),
+            style: None,
+            inline_overlays: overlays,
+        });
+    }
+
+    RenderedTextArea {
+        entries,
+        scroll_row: scroll_row as u32,
+        cursor_buffer_row,
+        cursor_byte_in_row,
+    }
+}
+
+/// Translate a byte offset in `value` to (line_index, byte_in_line).
+fn byte_to_line_col(value: &str, byte: usize) -> (usize, usize) {
+    let byte = byte.min(value.len());
+    let mut line = 0usize;
+    let mut line_start = 0usize;
+    for (i, &b) in value.as_bytes().iter().enumerate().take(byte) {
+        if b == b'\n' {
+            line += 1;
+            line_start = i + 1;
+        }
+    }
+    (line, byte - line_start)
+}
+
+/// Pad `line` with trailing spaces to `target` chars, or
+/// tail-truncate with `…` if it overflows. Operates on chars to keep
+/// the visual width predictable for ASCII; multibyte chars count as
+/// one char each (terminal column width != char count for CJK, but
+/// that's an acceptable v1 limitation matching `TextInput`).
+fn pad_or_truncate_line(line: &str, target: usize) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    if chars.len() <= target {
+        let mut out = line.to_string();
+        let pad = target - chars.len();
+        for _ in 0..pad {
+            out.push(' ');
+        }
+        out
+    } else {
+        let keep = target.saturating_sub(1);
+        let mut out: String = chars.iter().take(keep).collect();
+        out.push('…');
+        out
     }
 }
 
@@ -2592,5 +2897,201 @@ mod tests {
         let mut tabbable = Vec::new();
         collect_tabbable(&spec, &mut tabbable);
         assert_eq!(tabbable, vec!["toggle", "tree"]);
+    }
+
+    // -------------------------------------------------------------
+    // TextArea
+    // -------------------------------------------------------------
+
+    fn make_text_area(
+        value: &str,
+        cursor_byte: i32,
+        focused: bool,
+        rows: u32,
+        field_width: u32,
+        key: Option<&str>,
+    ) -> WidgetSpec {
+        WidgetSpec::TextArea {
+            value: value.into(),
+            cursor_byte,
+            focused,
+            label: String::new(),
+            placeholder: None,
+            rows,
+            field_width,
+            key: key.map(|s| s.into()),
+        }
+    }
+
+    #[test]
+    fn text_area_renders_visible_rows_count() {
+        // Single line value, but rows=3 → 3 entries (line + 2
+        // blanks).
+        let spec = make_text_area("hi", -1, false, 3, 10, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "", 80);
+        assert_eq!(out.entries.len(), 3);
+    }
+
+    #[test]
+    fn text_area_pads_short_lines_to_field_width() {
+        let spec = make_text_area("hi", -1, false, 1, 6, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "", 80);
+        // First (only visible) row: "hi" padded to 6 chars → "hi    \n"
+        let first = &out.entries[0];
+        assert_eq!(first.text, "hi    \n");
+    }
+
+    #[test]
+    fn text_area_truncates_long_line_with_ellipsis() {
+        let spec = make_text_area("abcdefghi", -1, false, 1, 5, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "", 80);
+        // 9 chars trimmed to 5 → "abcd…\n".
+        assert_eq!(out.entries[0].text, "abcd…\n");
+    }
+
+    #[test]
+    fn text_area_focused_adds_input_bg_overlay_per_row() {
+        let spec = make_text_area("a\nb", -1, true, 3, 4, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "ta", 80);
+        for entry in &out.entries {
+            let has_bg = entry.inline_overlays.iter().any(|o| {
+                o.style
+                    .bg
+                    .as_ref()
+                    .and_then(|c| c.as_theme_key())
+                    .map(|k| k == "ui.prompt_bg")
+                    .unwrap_or(false)
+            });
+            assert!(has_bg, "every focused row gets input-bg");
+        }
+    }
+
+    #[test]
+    fn text_area_publishes_focus_cursor_at_value_position() {
+        // value="ab\ncd", cursor at byte 4 (col 1 on line 1, char
+        // 'd' position).
+        let spec = make_text_area("ab\ncd", 4, true, 3, 6, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "ta", 80);
+        let fc = out.focus_cursor.expect("focused → cursor published");
+        // Line 1 is the second visible row → buffer_row 1.
+        assert_eq!(fc.buffer_row, 1);
+        // Col 1 on the rendered row.
+        assert_eq!(fc.byte_in_row, 1);
+    }
+
+    #[test]
+    fn text_area_label_offsets_cursor_buffer_row() {
+        // With a label, the editing region starts on row 1, so a
+        // cursor on line 0 of the value lands on row 1 of the
+        // buffer.
+        let spec = WidgetSpec::TextArea {
+            value: "hi".into(),
+            cursor_byte: 1,
+            focused: true,
+            label: "Note".into(),
+            placeholder: None,
+            rows: 2,
+            field_width: 6,
+            key: Some("ta".into()),
+        };
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "ta", 80);
+        // entries[0] is the label row, entries[1..] are content.
+        assert!(out.entries[0].text.starts_with("Note:"));
+        let fc = out.focus_cursor.unwrap();
+        assert_eq!(fc.buffer_row, 1);
+    }
+
+    #[test]
+    fn text_area_persists_value_and_cursor_in_instance_state() {
+        let spec = make_text_area("abc", 2, true, 2, 8, Some("ta"));
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "ta", 80);
+        match out.instance_states.get("ta") {
+            Some(WidgetInstanceState::TextArea {
+                value, cursor_byte, ..
+            }) => {
+                assert_eq!(value, "abc");
+                assert_eq!(*cursor_byte, 2);
+            }
+            other => panic!("expected TextArea instance state, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn text_area_instance_state_overrides_spec_value() {
+        // Plugin's spec says "old" but instance state has "new" —
+        // the renderer reads from instance state.
+        let spec = make_text_area("old", 0, true, 2, 8, Some("ta"));
+        let mut prev = HashMap::new();
+        prev.insert(
+            "ta".into(),
+            WidgetInstanceState::TextArea {
+                value: "new".into(),
+                cursor_byte: 3,
+                scroll_row: 0,
+            },
+        );
+        let out = render_spec(&spec, &prev, "ta", 80);
+        // The first row should now read "new" (not "old").
+        assert!(out.entries[0].text.starts_with("new"));
+    }
+
+    #[test]
+    fn text_area_scroll_clamps_to_keep_cursor_visible() {
+        // 5-line value, rows=2. Cursor on line 4 (last). On first
+        // render the renderer should auto-scroll so line 4 is
+        // visible.
+        let spec = make_text_area("a\nb\nc\nd\ne", 8, true, 2, 4, Some("ta"));
+        // byte 8 is on the 5th line (line index 4).
+        let prev = HashMap::new();
+        let out = render_spec(&spec, &prev, "ta", 80);
+        match out.instance_states.get("ta") {
+            Some(WidgetInstanceState::TextArea { scroll_row, .. }) => {
+                assert_eq!(*scroll_row, 3, "scroll so lines 3..5 are visible");
+            }
+            _ => panic!("expected TextArea instance state"),
+        }
+    }
+
+    #[test]
+    fn text_area_unfocused_empty_shows_placeholder_in_first_row() {
+        // Test the renderer directly (focused=false). Host-owned
+        // focus would otherwise auto-focus the only tabbable
+        // widget — see `text_area_publishes_focus_cursor_at_value_position`
+        // for the focused path.
+        let r = render_text_area("", -1, false, "", Some("write here"), 2, 12, 0, 80);
+        assert!(r.entries[0].text.starts_with("write here"));
+        // Placeholder uses the muted-fg overlay.
+        let fg = r.entries[0]
+            .inline_overlays
+            .iter()
+            .find_map(|o| o.style.fg.as_ref())
+            .and_then(|c| c.as_theme_key());
+        assert_eq!(fg, Some("ui.menu_disabled_fg"));
+    }
+
+    #[test]
+    fn text_area_tabbable_keys_include_text_area_with_key() {
+        let spec = WidgetSpec::Col {
+            children: vec![
+                WidgetSpec::Toggle {
+                    checked: false,
+                    label: "T".into(),
+                    focused: false,
+                    key: Some("toggle".into()),
+                },
+                make_text_area("", -1, false, 3, 10, Some("note")),
+            ],
+            key: None,
+        };
+        let mut tabbable = Vec::new();
+        collect_tabbable(&spec, &mut tabbable);
+        assert_eq!(tabbable, vec!["toggle", "note"]);
     }
 }

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -58,7 +58,7 @@ clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
 
 | Type | Notes |
 |---|---|
-| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `List`, `Spacer`, `Raw`. |
+| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `TextArea`, `List`, `Tree`, `Spacer`, `Raw`. |
 | `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` | Shapes referenced by the spec / IPC. |
 | `PluginCommand::MountWidgetPanel`, `UpdateWidgetPanel`, `UnmountWidgetPanel` | Spec lifecycle. |
 | `PluginCommand::WidgetCommand { panel_id, action }` | Routes a `WidgetAction` (key dispatch / focus / activate / select-move / text-input). |
@@ -78,7 +78,7 @@ clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
 
 | File | Exports |
 |---|---|
-| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `list`, `spacer`, `flexSpacer`, `raw`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `unmount`. |
+| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree`, `treeNode`, `spacer`, `flexSpacer`, `raw`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `unmount`. |
 | `index.ts` | Re-exports the above. |
 | `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` types. `widget_event` hook. |
 
@@ -120,17 +120,24 @@ per-spec `theme` override map yet.
 
 In rough decreasing user impact:
 
-1. **`Tree` widget.** Search_replace's match list is a tree (file ▶
-   matches) flattened to a `List` today; users lost click-to-expand
-   and Right-arrow-to-expand. Many other plugins want the same shape
-   (`audit_mode.ts`, file-explorer, find_references).
-2. **Targeted spec subtree replacement (`WidgetMutation::SetSpec`).**
-   The fast-path mutators handle the field-level cases; replacing one
-   subtree (e.g. swapping a toolbar's children) still needs a full
-   `updateWidgetPanel`.
-3. **`Tabs` / `Group` widget.** `git_log.ts` toolbar, settings
-   categories.
-4. **`TextArea` widget.** Multi-line input. Composer plugins.
+1. ~~**`Tree` widget.**~~ Shipped. `search_replace.ts` migrated to
+   `tree(...)` with host-owned expansion + scroll + selection.
+2. ~~**Targeted spec subtree replacement (`WidgetMutation::SetSpec`).**~~
+   Skipped. The reconciler already preserves instance state across
+   a full `panel.set(spec)` re-emit, so a SetSpec fast path is a
+   pure IPC-byte optimization with no UX consequence; revisit only
+   if profiling on a large-spec panel shows it matters.
+3. ~~**`Tabs` / `Group` widget.**~~ Skipped — no in-tree consumer.
+   `git_log.ts`'s "tab" toolbar is a strip of action buttons
+   (Tab/RET/y/r/q), not a UI tab switcher; the buffer-group panes
+   are managed by the editor's panel manager outside the widget
+   runtime. Revisit when a real consumer appears.
+4. ~~**`TextArea` widget.**~~ Shipped. Multi-line input with
+   host-owned value, cursor, and vertical scroll; `Enter` inserts
+   a newline (form-style "Enter submits" remains the `TextInput`
+   default), `Up`/`Down` walk lines preserving column,
+   `Home`/`End` jump within the current line. Smart-key dispatch
+   table extended in `WidgetAction::Key` doc.
 5. **`Prompt` / `Layer` / Compositor (§7 in this doc).** The big
    architectural piece. Today `Popup`, `Prompt`, `showActionPopup`,
    hover tooltips, completion popups all live in separate


### PR DESCRIPTION
## Summary
Implements a new `TextArea` widget variant that provides multi-line text editing capabilities, complementing the existing single-line `TextInput` widget. The widget follows the same host-owned instance state pattern as `TextInput` but extends it to handle vertical scrolling and line-based cursor movement.

## Key Changes

### Core Widget Implementation
- **New `TextArea` variant** in `WidgetSpec` enum with fields for value, cursor position, focus state, label, placeholder, visible rows, field width, and key
- **Instance state tracking** via new `WidgetInstanceState::TextArea` variant that persists value, cursor byte offset, and scroll row across renders
- **Rendering logic** in `render_text_area()` function that:
  - Splits multi-line content into visible rows with auto-scrolling to keep cursor in view
  - Pads short lines and tail-truncates long lines with `…` to maintain rectangular editing region
  - Applies focused background overlay across all visible rows
  - Handles placeholder display on first row when empty and unfocused
  - Publishes hardware cursor position relative to rendered entries

### Key Handling
- **New `apply_text_area_key()` function** in `actions.rs` that handles:
  - `Up`/`Down` for line navigation with column preservation (clamped to target line length)
  - `Home`/`End` for line-relative (not buffer-relative) jumps
  - `Enter` to insert newlines at cursor position
  - `Left`/`Right`/`Backspace`/`Delete` with shared `TextInput` semantics
  - UTF-8 char boundary safety for multi-byte characters
- **Smart-key dispatch routing** in `plugin_dispatch.rs` that routes keys and printable text to `TextArea` handlers
- **Enter key behavior** differs from `TextInput`: inserts newline instead of advancing focus (plugins can intercept to change this)

### Plugin API
- **TypeScript builder function** `textArea()` in `widgets.ts` with sensible defaults
- **Type definitions** in `fresh.d.ts` for full IDE support
- **Documentation** in design doc reflecting new widget variant

### Testing
- Comprehensive test suite covering:
  - Row rendering and padding/truncation
  - Focused background overlays
  - Cursor positioning and focus cursor publication
  - Instance state persistence and override behavior
  - Scroll clamping to keep cursor visible
  - Placeholder display logic
  - Tabbable key collection
  - All key handling scenarios (Up/Down column preservation, line-relative Home/End, newline insertion, UTF-8 safety)

## Notable Implementation Details
- **Scroll auto-clamping**: Renderer automatically adjusts scroll position to keep cursor's line visible within the `visible_rows` range
- **Column preservation on Up/Down**: When moving between lines of different lengths, the cursor attempts to maintain its byte column, clamping to the target line's length
- **Placeholder-only-on-first-row**: Placeholder text only appears on the first visible row, not repeated across empty lines
- **Rectangular editing region**: Focused background extends to full field width on every visible row, creating a cohesive block appearance
- **Host-owned state model**: Mirrors `TextInput` pattern where spec value is used only at first render; subsequent renders read from instance state

https://claude.ai/code/session_01FGmQQg82u93Y6EzGFk3ECV