### PR TITLE
Add segment-based row building and text normalization to TextPropertyEntry

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3265,6 +3265,10 @@ pub struct JsTextPropertyEntry {
     #[serde(default)]
     #[ts(optional)]
     pub truncate_to_chars: Option<u32>,
+    /// See `TextPropertyEntry::segments`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub segments: Option<Vec<crate::text_property::StyledSegment>>,
 }
 
 /// Directory entry returned by readDir

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3257,6 +3257,14 @@ pub struct JsTextPropertyEntry {
     #[serde(default)]
     #[ts(optional)]
     pub inline_overlays: Option<Vec<crate::text_property::InlineOverlay>>,
+    /// See `TextPropertyEntry::pad_to_chars`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub pad_to_chars: Option<u32>,
+    /// See `TextPropertyEntry::truncate_to_chars`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub truncate_to_chars: Option<u32>,
 }
 
 /// Directory entry returned by readDir

--- a/crates/fresh-core/src/text_property.rs
+++ b/crates/fresh-core/src/text_property.rs
@@ -114,12 +114,40 @@ pub struct InlineOverlay {
     pub unit: OffsetUnit,
 }
 
+/// One styled segment of a `TextPropertyEntry` built via the
+/// `segments` field. Plugins use segments to describe row content
+/// structurally — a sequence of (text, optional style, optional
+/// nested overlays) — instead of pre-rendering the text and
+/// computing byte/char offsets for overlays themselves. The host
+/// concatenates segment text and emits the corresponding overlays
+/// during `normalize_widths`.
+#[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub struct StyledSegment {
+    /// Verbatim text for this segment.
+    pub text: String,
+    /// When set, the host emits an `InlineOverlay` covering this
+    /// segment's text in the final entry.
+    #[ts(type = "Partial<OverlayOptions>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<OverlayOptions>,
+    /// Additional overlays inside this segment. Offsets are in
+    /// the overlay's own `unit`, relative to the segment's start
+    /// (NOT the final entry text); the host shifts them by the
+    /// segment's position during concatenation.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub overlays: Vec<InlineOverlay>,
+}
+
 /// An entry with text and its properties
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export, rename_all = "camelCase")]
 pub struct TextPropertyEntry {
-    /// The text content
+    /// The text content. When `segments` is non-empty `text` is
+    /// rebuilt from concatenating segment text during
+    /// `normalize_widths` and any value supplied here is replaced.
     pub text: String,
     /// Properties for this text
     #[ts(type = "Record<string, any>")]
@@ -131,6 +159,13 @@ pub struct TextPropertyEntry {
     /// Optional sub-range styling within this entry
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inline_overlays: Vec<InlineOverlay>,
+    /// Optional segment list. When non-empty the host concatenates
+    /// segment text into `text` and pushes one `InlineOverlay`
+    /// (in `Char` units) per styled segment plus the segment's
+    /// nested `overlays` shifted by its position. Resolved before
+    /// truncate/pad/char-byte conversion in `normalize_widths`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub segments: Vec<StyledSegment>,
     /// Pad `text` with spaces to this many display columns
     /// (Unicode codepoints). No-op when `text` already has at
     /// least this many codepoints. Applied before overlays are
@@ -154,20 +189,62 @@ impl TextPropertyEntry {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         }
     }
 
-    /// Apply `truncate_to_chars`, then `pad_to_chars`, then convert
-    /// any `unit: Char` overlays to byte offsets against the
-    /// resulting `text`. Idempotent: an entry with neither
-    /// pad/truncate hints nor char-unit overlays is left untouched.
+    /// Resolve `segments` (if any) into `text` plus inline overlays,
+    /// then apply `truncate_to_chars`, then `pad_to_chars`, then
+    /// convert any `unit: Char` overlays to byte offsets against the
+    /// resulting `text`. Idempotent: an entry with no segments,
+    /// pad/truncate hints, or char-unit overlays is left untouched.
     ///
     /// Truncation rounds the byte cut to a UTF-8 codepoint boundary.
     /// Char-offset overlays beyond the resulting codepoint count are
     /// clamped to that count.
     pub fn normalize_widths(&mut self) {
+        if !self.segments.is_empty() {
+            // Segments are authoritative: replace any pre-existing
+            // `text`. Per-segment style becomes a Char-unit overlay
+            // covering the segment; nested overlays shift by the
+            // segment's start in their declared unit.
+            let segments = std::mem::take(&mut self.segments);
+            self.text.clear();
+            let mut char_cursor: usize = 0;
+            let mut byte_cursor: usize = 0;
+            for seg in segments {
+                let seg_chars = seg.text.chars().count();
+                let seg_bytes = seg.text.len();
+                if let Some(style) = seg.style {
+                    self.inline_overlays.push(InlineOverlay {
+                        start: char_cursor,
+                        end: char_cursor + seg_chars,
+                        style,
+                        properties: HashMap::new(),
+                        unit: OffsetUnit::Char,
+                    });
+                }
+                for mut o in seg.overlays {
+                    match o.unit {
+                        OffsetUnit::Char => {
+                            o.start += char_cursor;
+                            o.end += char_cursor;
+                        }
+                        OffsetUnit::Byte => {
+                            o.start += byte_cursor;
+                            o.end += byte_cursor;
+                        }
+                    }
+                    self.inline_overlays.push(o);
+                }
+                self.text.push_str(&seg.text);
+                char_cursor += seg_chars;
+                byte_cursor += seg_bytes;
+            }
+        }
+
         if let Some(max_chars) = self.truncate_to_chars {
             let max = max_chars as usize;
             let cur = self.text.chars().count();
@@ -254,6 +331,18 @@ impl TextPropertyEntry {
             style,
             properties: HashMap::new(),
             unit: OffsetUnit::Byte,
+        });
+        self
+    }
+
+    /// Push a styled segment. After `normalize_widths` runs, the
+    /// segment becomes part of `text` plus a Char-unit
+    /// `InlineOverlay` covering it (when `style` is set).
+    pub fn with_segment(mut self, text: impl Into<String>, style: Option<OverlayOptions>) -> Self {
+        self.segments.push(StyledSegment {
+            text: text.into(),
+            style,
+            overlays: Vec::new(),
         });
         self
     }
@@ -411,5 +500,144 @@ mod normalize_tests {
         assert_eq!(o.start, 1);
         assert_eq!(o.end, 4);
         assert_eq!(o.unit, OffsetUnit::Byte);
+    }
+
+    fn styled(text: &str, fg_marker_bold: bool) -> StyledSegment {
+        StyledSegment {
+            text: text.to_string(),
+            style: if fg_marker_bold {
+                Some(OverlayOptions {
+                    bold: true,
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
+            overlays: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn segments_concatenate_into_text() {
+        let mut e = entry("ignored");
+        e.segments = vec![
+            styled("hello", false),
+            styled(" ", false),
+            styled("world", false),
+        ];
+        e.normalize_widths();
+        assert_eq!(e.text, "hello world");
+        assert!(e.segments.is_empty(), "segments consumed");
+    }
+
+    #[test]
+    fn styled_segments_emit_char_unit_overlays_for_styled_segments_only() {
+        let mut e = entry("");
+        e.segments = vec![
+            styled("AB", false),
+            styled("CD", true), // bold
+            styled("EF", false),
+            styled("GH", true), // bold
+        ];
+        e.normalize_widths();
+        // After char→byte conversion (all ASCII so identity).
+        assert_eq!(e.text, "ABCDEFGH");
+        let bold: Vec<_> = e.inline_overlays.iter().filter(|o| o.style.bold).collect();
+        assert_eq!(bold.len(), 2);
+        assert_eq!((bold[0].start, bold[0].end), (2, 4));
+        assert_eq!((bold[1].start, bold[1].end), (6, 8));
+    }
+
+    #[test]
+    fn styled_segments_with_multibyte_text_emit_correct_byte_overlays() {
+        // "éé" + "x" + "éé" = chars [0..2, 2..3, 3..5], bytes [0..4, 4..5, 5..9].
+        let mut e = entry("");
+        e.segments = vec![styled("éé", false), styled("x", true), styled("éé", false)];
+        e.normalize_widths();
+        assert_eq!(e.text, "ééxéé");
+        let bold = e
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("styled middle segment");
+        assert_eq!((bold.start, bold.end), (4, 5));
+        assert_eq!(&e.text[bold.start..bold.end], "x");
+    }
+
+    #[test]
+    fn segment_nested_overlays_shift_by_segment_position_in_their_unit() {
+        let mut e = entry("");
+        e.segments = vec![
+            StyledSegment {
+                text: "abc".to_string(),
+                style: None,
+                overlays: vec![],
+            },
+            StyledSegment {
+                text: "éé".to_string(),
+                style: None,
+                overlays: vec![InlineOverlay {
+                    start: 1,
+                    end: 2,
+                    style: OverlayOptions {
+                        bold: true,
+                        ..Default::default()
+                    },
+                    properties: HashMap::new(),
+                    unit: OffsetUnit::Char,
+                }],
+            },
+        ];
+        e.normalize_widths();
+        // "abcéé" — segment2 starts at char 3, byte 3.
+        // Nested overlay [1..2] in segment2 → entry chars [4..5].
+        // Char→byte conversion: char 4 = byte 5, char 5 = byte 7.
+        let bold = e
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("nested overlay");
+        assert_eq!(&e.text[bold.start..bold.end], "é");
+    }
+
+    #[test]
+    fn segments_then_pad_works() {
+        let mut e = entry("");
+        e.segments = vec![styled("ab", true)];
+        e.pad_to_chars = Some(5);
+        e.normalize_widths();
+        assert_eq!(e.text, "ab   ");
+        let bold = e
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("segment overlay");
+        assert_eq!((bold.start, bold.end), (0, 2));
+    }
+
+    #[test]
+    fn segments_then_truncate_clamps_overlapping_overlay() {
+        let mut e = entry("");
+        e.segments = vec![styled("abcdefghij", true)];
+        e.truncate_to_chars = Some(5);
+        e.normalize_widths();
+        // Truncated to "ab..." (budget>3).
+        assert_eq!(e.text, "ab...");
+        let bold = e
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("segment overlay");
+        // Bold overlay covered chars [0..10] originally; clamped to
+        // the new text length (5 codepoints / 5 bytes ASCII).
+        assert_eq!(bold.end, e.text.len());
+    }
+
+    #[test]
+    fn segments_replace_pre_existing_text() {
+        let mut e = entry("should be discarded");
+        e.segments = vec![styled("only this", false)];
+        e.normalize_widths();
+        assert_eq!(e.text, "only this");
     }
 }

--- a/crates/fresh-core/src/text_property.rs
+++ b/crates/fresh-core/src/text_property.rs
@@ -68,14 +68,39 @@ impl TextProperty {
     }
 }
 
+/// Unit for `InlineOverlay` `start` / `end` offsets.
+///
+/// Plugins emitting overlays for text whose byte/codepoint counts
+/// match (pure ASCII) can stay on the `Byte` default and avoid
+/// per-overlay UTF-8 arithmetic. Plugins working with text that
+/// may contain multi-byte characters can emit offsets in `Char`
+/// units and let the host convert them to byte offsets at
+/// consumption time — which is free in Rust against the entry's
+/// final text.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ts_rs::TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub enum OffsetUnit {
+    /// UTF-8 byte offsets within the entry's text. Default.
+    #[default]
+    Byte,
+    /// Unicode codepoint (scalar value) offsets within the entry's
+    /// text. Converted to byte offsets at consumption time.
+    Char,
+}
+
+fn is_byte_unit(u: &OffsetUnit) -> bool {
+    matches!(u, OffsetUnit::Byte)
+}
+
 /// An inline overlay specifying styling for a sub-range within a text entry
 #[derive(Debug, Clone, Serialize, Deserialize, ts_rs::TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export, rename_all = "camelCase")]
 pub struct InlineOverlay {
-    /// Start byte offset within the entry's text
+    /// Start offset within the entry's text. See `unit`.
     pub start: usize,
-    /// End byte offset within the entry's text (exclusive)
+    /// End offset within the entry's text (exclusive). See `unit`.
     pub end: usize,
     /// Styling options for this range
     #[ts(type = "Partial<OverlayOptions>")]
@@ -84,6 +109,9 @@ pub struct InlineOverlay {
     #[ts(type = "Record<string, any>")]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub properties: HashMap<String, serde_json::Value>,
+    /// Unit for `start` / `end`. Defaults to `byte`.
+    #[serde(default, skip_serializing_if = "is_byte_unit")]
+    pub unit: OffsetUnit,
 }
 
 /// An entry with text and its properties
@@ -103,6 +131,19 @@ pub struct TextPropertyEntry {
     /// Optional sub-range styling within this entry
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub inline_overlays: Vec<InlineOverlay>,
+    /// Pad `text` with spaces to this many display columns
+    /// (Unicode codepoints). No-op when `text` already has at
+    /// least this many codepoints. Applied before overlays are
+    /// resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pad_to_chars: Option<u32>,
+    /// Truncate `text` to at most this many display columns
+    /// (Unicode codepoints). When the budget is greater than
+    /// 3 the truncated tail is replaced with `...`; when it is
+    /// 3 or less the text is cut at exactly the budget. Applied
+    /// before overlays are resolved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_to_chars: Option<u32>,
 }
 
 impl TextPropertyEntry {
@@ -113,6 +154,77 @@ impl TextPropertyEntry {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            pad_to_chars: None,
+            truncate_to_chars: None,
+        }
+    }
+
+    /// Apply `truncate_to_chars`, then `pad_to_chars`, then convert
+    /// any `unit: Char` overlays to byte offsets against the
+    /// resulting `text`. Idempotent: an entry with neither
+    /// pad/truncate hints nor char-unit overlays is left untouched.
+    ///
+    /// Truncation rounds the byte cut to a UTF-8 codepoint boundary.
+    /// Char-offset overlays beyond the resulting codepoint count are
+    /// clamped to that count.
+    pub fn normalize_widths(&mut self) {
+        if let Some(max_chars) = self.truncate_to_chars {
+            let max = max_chars as usize;
+            let cur = self.text.chars().count();
+            if cur > max {
+                if max <= 3 {
+                    let cut_byte = self
+                        .text
+                        .char_indices()
+                        .nth(max)
+                        .map(|(b, _)| b)
+                        .unwrap_or(self.text.len());
+                    self.text.truncate(cut_byte);
+                } else {
+                    let keep = max - 3;
+                    let cut_byte = self
+                        .text
+                        .char_indices()
+                        .nth(keep)
+                        .map(|(b, _)| b)
+                        .unwrap_or(self.text.len());
+                    self.text.truncate(cut_byte);
+                    self.text.push_str("...");
+                }
+            }
+        }
+
+        if let Some(min_chars) = self.pad_to_chars {
+            let cur = self.text.chars().count();
+            let target = min_chars as usize;
+            if target > cur {
+                let pad = target - cur;
+                self.text.reserve(pad);
+                for _ in 0..pad {
+                    self.text.push(' ');
+                }
+            }
+        }
+
+        let needs_conversion = self
+            .inline_overlays
+            .iter()
+            .any(|o| matches!(o.unit, OffsetUnit::Char));
+        if needs_conversion {
+            // Build a codepoint-index → byte-index lookup over the
+            // final text. One pass; subsequent overlay lookups are
+            // O(1) into the table.
+            let mut char_to_byte: Vec<usize> = self.text.char_indices().map(|(b, _)| b).collect();
+            char_to_byte.push(self.text.len());
+            for o in &mut self.inline_overlays {
+                if matches!(o.unit, OffsetUnit::Char) {
+                    let s = o.start.min(char_to_byte.len() - 1);
+                    let e = o.end.min(char_to_byte.len() - 1);
+                    o.start = char_to_byte[s];
+                    o.end = char_to_byte[e];
+                    o.unit = OffsetUnit::Byte;
+                }
+            }
         }
     }
 
@@ -141,7 +253,163 @@ impl TextPropertyEntry {
             end,
             style,
             properties: HashMap::new(),
+            unit: OffsetUnit::Byte,
         });
         self
+    }
+}
+
+#[cfg(test)]
+mod normalize_tests {
+    use super::*;
+
+    fn entry(text: &str) -> TextPropertyEntry {
+        TextPropertyEntry::text(text)
+    }
+
+    #[test]
+    fn pad_to_chars_pads_short_ascii_text() {
+        let mut e = entry("hi");
+        e.pad_to_chars = Some(5);
+        e.normalize_widths();
+        assert_eq!(e.text, "hi   ");
+    }
+
+    #[test]
+    fn pad_to_chars_is_noop_when_text_already_wider() {
+        let mut e = entry("longer than five");
+        e.pad_to_chars = Some(5);
+        e.normalize_widths();
+        assert_eq!(e.text, "longer than five");
+    }
+
+    #[test]
+    fn pad_to_chars_counts_codepoints_not_bytes() {
+        // 'é' is two UTF-8 bytes but one codepoint.
+        let mut e = entry("éé");
+        e.pad_to_chars = Some(4);
+        e.normalize_widths();
+        assert_eq!(e.text, "éé  ");
+    }
+
+    #[test]
+    fn truncate_to_chars_appends_ellipsis_when_budget_over_three() {
+        let mut e = entry("abcdefghij");
+        e.truncate_to_chars = Some(6);
+        e.normalize_widths();
+        assert_eq!(e.text, "abc...");
+    }
+
+    #[test]
+    fn truncate_to_chars_cuts_without_ellipsis_when_budget_three_or_less() {
+        let mut e = entry("abcdef");
+        e.truncate_to_chars = Some(3);
+        e.normalize_widths();
+        assert_eq!(e.text, "abc");
+    }
+
+    #[test]
+    fn truncate_to_chars_respects_codepoint_boundary() {
+        // 'é' is two UTF-8 bytes; cutting at byte 1 would split it.
+        let mut e = entry("éééé");
+        e.truncate_to_chars = Some(2);
+        e.normalize_widths();
+        assert_eq!(e.text, "éé");
+    }
+
+    #[test]
+    fn truncate_then_pad_combines_correctly() {
+        let mut e = entry("abcdefghij");
+        e.truncate_to_chars = Some(6);
+        e.pad_to_chars = Some(8);
+        e.normalize_widths();
+        assert_eq!(e.text, "abc...  ");
+    }
+
+    #[test]
+    fn char_unit_overlay_converted_to_byte_offsets_against_ascii() {
+        let mut e = entry("hello world");
+        e.inline_overlays.push(InlineOverlay {
+            start: 6,
+            end: 11,
+            style: OverlayOptions::default(),
+            properties: HashMap::new(),
+            unit: OffsetUnit::Char,
+        });
+        e.normalize_widths();
+        let o = &e.inline_overlays[0];
+        assert_eq!(o.start, 6);
+        assert_eq!(o.end, 11);
+        assert_eq!(o.unit, OffsetUnit::Byte);
+    }
+
+    #[test]
+    fn char_unit_overlay_converted_to_byte_offsets_with_multibyte_chars() {
+        // "éxé" = é(2) x(1) é(2) = 5 bytes, 3 codepoints
+        let mut e = entry("éxé");
+        e.inline_overlays.push(InlineOverlay {
+            start: 1,
+            end: 2,
+            style: OverlayOptions::default(),
+            properties: HashMap::new(),
+            unit: OffsetUnit::Char,
+        });
+        e.normalize_widths();
+        let o = &e.inline_overlays[0];
+        assert_eq!(o.start, 2);
+        assert_eq!(o.end, 3);
+        assert_eq!(o.unit, OffsetUnit::Byte);
+        assert_eq!(&e.text[o.start..o.end], "x");
+    }
+
+    #[test]
+    fn char_unit_overlay_after_pad_indexes_into_padded_text() {
+        let mut e = entry("hi");
+        e.pad_to_chars = Some(6);
+        e.inline_overlays.push(InlineOverlay {
+            start: 0,
+            end: 6,
+            style: OverlayOptions::default(),
+            properties: HashMap::new(),
+            unit: OffsetUnit::Char,
+        });
+        e.normalize_widths();
+        let o = &e.inline_overlays[0];
+        assert_eq!(o.start, 0);
+        assert_eq!(o.end, 6);
+    }
+
+    #[test]
+    fn char_unit_overlay_after_truncate_clamps_to_remaining_text() {
+        let mut e = entry("abcdefghij");
+        e.truncate_to_chars = Some(6); // becomes "abc..."
+        e.inline_overlays.push(InlineOverlay {
+            start: 0,
+            end: 100, // overshoots — clamp to text length in codepoints
+            style: OverlayOptions::default(),
+            properties: HashMap::new(),
+            unit: OffsetUnit::Char,
+        });
+        e.normalize_widths();
+        let o = &e.inline_overlays[0];
+        assert_eq!(o.start, 0);
+        assert_eq!(o.end, e.text.len());
+    }
+
+    #[test]
+    fn byte_unit_overlay_unchanged_by_normalize() {
+        let mut e = entry("hello");
+        e.inline_overlays.push(InlineOverlay {
+            start: 1,
+            end: 4,
+            style: OverlayOptions::default(),
+            properties: HashMap::new(),
+            unit: OffsetUnit::Byte,
+        });
+        e.normalize_widths();
+        let o = &e.inline_overlays[0];
+        assert_eq!(o.start, 1);
+        assert_eq!(o.end, 4);
+        assert_eq!(o.unit, OffsetUnit::Byte);
     }
 }

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -124,6 +124,10 @@ type TextPropertyEntry = {
 	* See `TextPropertyEntry::truncate_to_chars`.
 	*/
 	truncateToChars?: number;
+	/**
+	* See `TextPropertyEntry::segments`.
+	*/
+	segments?: Array<StyledSegment>;
 };
 type TsCompositeLayoutConfig = {
 	/**
@@ -688,6 +692,24 @@ type InlineOverlay = {
 	unit?: OffsetUnit;
 };
 type OffsetUnit = "byte" | "char";
+type StyledSegment = {
+	/**
+	* Verbatim text for this segment.
+	*/
+	text: string;
+	/**
+	* When set, the host emits an `InlineOverlay` covering this
+	* segment's text in the final entry.
+	*/
+	style?: Partial<OverlayOptions>;
+	/**
+	* Additional overlays inside this segment. Offsets are in
+	* the overlay's own `unit`, relative to the segment's start
+	* (NOT the final entry text); the host shifts them by the
+	* segment's position during concatenation.
+	*/
+	overlays?: Array<InlineOverlay>;
+};
 type GrammarInfoSnapshot = {
 	/**
 	* The grammar name as used in config files (case-insensitive matching)

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -116,6 +116,14 @@ type TextPropertyEntry = {
 	* Optional sub-range styling within this entry
 	*/
 	inlineOverlays?: Array<InlineOverlay>;
+	/**
+	* See `TextPropertyEntry::pad_to_chars`.
+	*/
+	padToChars?: number;
+	/**
+	* See `TextPropertyEntry::truncate_to_chars`.
+	*/
+	truncateToChars?: number;
 };
 type TsCompositeLayoutConfig = {
 	/**
@@ -659,11 +667,11 @@ type OverlayOptions = {
 type OverlayColorSpec = [number, number, number] | string;
 type InlineOverlay = {
 	/**
-	* Start byte offset within the entry's text
+	* Start offset within the entry's text. See `unit`.
 	*/
 	start: number;
 	/**
-	* End byte offset within the entry's text (exclusive)
+	* End offset within the entry's text (exclusive). See `unit`.
 	*/
 	end: number;
 	/**
@@ -674,7 +682,12 @@ type InlineOverlay = {
 	* Optional properties for this sub-range (e.g., click target metadata)
 	*/
 	properties?: Record<string, any>;
+	/**
+	* Unit for `start` / `end`. Defaults to `byte`.
+	*/
+	unit?: OffsetUnit;
 };
+type OffsetUnit = "byte" | "char";
 type GrammarInfoSnapshot = {
 	/**
 	* The grammar name as used in config files (case-insensitive matching)

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -45,7 +45,10 @@ export type ButtonKind = globalThis.ButtonKind;
 export type WidgetAction = globalThis.WidgetAction;
 export type WidgetMutation = globalThis.WidgetMutation;
 export type TreeNode = globalThis.TreeNode;
+export type StyledSegment = globalThis.StyledSegment;
 type TextPropertyEntry = globalThis.TextPropertyEntry;
+type InlineOverlay = globalThis.InlineOverlay;
+type OverlayOptions = globalThis.OverlayOptions;
 
 // =============================================================================
 // Builder helpers — preferred over hand-writing `{ kind: "row", ... }`.
@@ -75,7 +78,49 @@ export function hintBar(entries: HintEntry[]): WidgetSpec {
  * already accepts) so a plugin can migrate its panel one widget at a
  * time. */
 export function raw(entries: TextPropertyEntry[]): WidgetSpec {
-  return { kind: "raw", entries };
+ return { kind: "raw", entries };
+}
+
+/** Build a `TextPropertyEntry` from a sequence of styled segments.
+ *
+ * The plugin describes row content structurally — each segment is a
+ * piece of text plus optional `style` and optional nested
+ * `overlays`. The host concatenates the segments and emits one
+ * inline overlay per styled segment plus the segment's nested
+ * overlays shifted by the segment's start position; both happen in
+ * Rust against the final text, so the plugin never names byte or
+ * codepoint offsets between segments.
+ *
+ * Use `padToChars` / `truncateToChars` to constrain the entry's
+ * total width — both are applied AFTER segment concatenation (so
+ * `padToChars: 80` pads the full row to 80 codepoints, regardless
+ * of how the segments split it).
+ *
+ * For freeform overlays inside a single segment (e.g. highlighting
+ * pattern matches inside a context string), pass them via the
+ * segment's `overlays` field with `unit: "char"`. */
+export function styledRow(
+  segments: StyledSegment[],
+  options?: {
+    padToChars?: number;
+    truncateToChars?: number;
+    properties?: Record<string, unknown>;
+    style?: Partial<OverlayOptions>;
+    inlineOverlays?: InlineOverlay[];
+  },
+): TextPropertyEntry {
+  // Build the entry by spreading only set fields. The plugin
+  // bridge converts JS `undefined` to JSON `null` when an object
+  // key is present, which then fails to deserialize as the
+  // matching `Option<…>` / `Vec<…>` field on the host. Omitting
+  // the key entirely lets serde fall back to `#[serde(default)]`.
+  const entry: TextPropertyEntry = { text: "", segments };
+  if (options?.padToChars !== undefined) entry.padToChars = options.padToChars;
+  if (options?.truncateToChars !== undefined) entry.truncateToChars = options.truncateToChars;
+  if (options?.properties !== undefined) entry.properties = options.properties;
+  if (options?.style !== undefined) entry.style = options.style;
+  if (options?.inlineOverlays !== undefined) entry.inlineOverlays = options.inlineOverlays;
+  return entry;
 }
 
 /** Boolean toggle, rendered as `[v] label` / `[ ] label`.

--- a/crates/fresh-editor/plugins/schemas/theme.schema.json
+++ b/crates/fresh-editor/plugins/schemas/theme.schema.json
@@ -40,6 +40,7 @@
           79,
           120
         ],
+        "selection_modifier": null,
         "current_line_bg": [
           40,
           40,
@@ -180,6 +181,8 @@
         "status_palette_bg": null,
         "status_lsp_on_fg": null,
         "status_lsp_on_bg": null,
+        "status_lsp_actionable_fg": null,
+        "status_lsp_actionable_bg": null,
         "prompt_fg": "White",
         "prompt_bg": "Black",
         "prompt_selection_fg": "White",
@@ -246,6 +249,7 @@
           60,
           80
         ],
+        "semantic_highlight_modifier": null,
         "terminal_bg": "Default",
         "terminal_fg": "Default",
         "status_warning_indicator_bg": [

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -144,12 +144,24 @@ const C = {
 // Helpers
 // =============================================================================
 
+// Codepoint outside the 7-bit ASCII range — used to fast-path
+// `byteLen` and `charLen` for the common case (file paths, source
+// code) where the JS string's `.length` already equals both the
+// UTF-8 byte count and the codepoint count.
+const NON_ASCII = /[^\x00-\x7f]/;
+
+function isAscii(s: string): boolean {
+  return !NON_ASCII.test(s);
+}
+
 function byteLen(s: string): number {
+  if (isAscii(s)) return s.length;
   return editor.utf8ByteLength(s);
 }
 
 /** Count display columns (codepoints; approximation for monospace terminal). */
 function charLen(s: string): number {
+  if (isAscii(s)) return s.length;
   let len = 0;
   for (const _c of s) { len++; }
   return len;
@@ -163,10 +175,16 @@ function padStr(s: string, width: number): string {
 
 /** Truncate to at most maxLen display columns (codepoint-aware). */
 function truncate(s: string, maxLen: number): string {
+  // ASCII fast path: JS substring is equivalent to codepoint slice
+  // and skipping the for-of avoids the QuickJS iterator overhead.
+  if (isAscii(s)) {
+    if (s.length <= maxLen) return s;
+    if (maxLen <= 3) return s.slice(0, maxLen);
+    return s.slice(0, maxLen - 3) + "...";
+  }
   const sLen = charLen(s);
   if (sLen <= maxLen) return s;
   if (maxLen <= 3) {
-    // Take first maxLen codepoints
     let result = "";
     let count = 0;
     for (const c of s) {
@@ -176,7 +194,6 @@ function truncate(s: string, maxLen: number): string {
     }
     return result;
   }
-  // Take first (maxLen-3) codepoints + "..."
   let result = "";
   let count = 0;
   for (const c of s) {
@@ -449,9 +466,15 @@ function flatItemKey(item: FlatItem): string {
 // Render one flat tree item as a single TextPropertyEntry. The
 // Tree widget owns the indent (depth * 2 spaces) + disclosure glyph
 // (▶ / ▼) prefix and the selection bg — this function emits *just*
-// the row's content starting from byte 0 of the row's body. Files
+// the row's content starting from offset 0 of the row's body. Files
 // pass `depth: 0, hasChildren: true`; matches pass `depth: 1,
 // hasChildren: false` (see `buildMatchListSpec`).
+//
+// Overlay offsets are emitted in character (codepoint) units; the
+// host converts to byte offsets after applying `padToChars`. This
+// keeps the per-row work proportional to the visible content,
+// without the per-overlay `editor.utf8ByteLength` bridge calls
+// that otherwise dominate hot-path renders.
 function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   if (!panel) return { text: "" };
   if (item.type === "file") {
@@ -463,16 +486,18 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
     // pad budget = W - 4 (the widget's prefix consumes 4 cols at
     // depth 0).
     const fileLineText = `${badge} ${group.relPath} (${selectedInFile}/${matchCount})`;
+    const badgeChars = charLen(badge);
+    const pathStart = badgeChars + 1; // " " separator (always 1 codepoint)
+    const pathEnd = pathStart + charLen(group.relPath);
 
-    const overlays: InlineOverlay[] = [];
-    const bgEnd = byteLen(badge);
-    overlays.push({ start: 0, end: bgEnd, style: { fg: C.fileIcon, bold: true } });
-    const fpStart = bgEnd + byteLen(" ");
-    const fpEnd = fpStart + byteLen(group.relPath);
-    overlays.push({ start: fpStart, end: fpEnd, style: { fg: C.filePath } });
+    const overlays: InlineOverlay[] = [
+      { start: 0, end: badgeChars, style: { fg: C.fileIcon, bold: true }, unit: "char" },
+      { start: pathStart, end: pathEnd, style: { fg: C.filePath }, unit: "char" },
+    ];
 
     return {
-      text: padStr(fileLineText, Math.max(0, W - 4)),
+      text: fileLineText,
+      padToChars: Math.max(0, W - 4),
       properties: { type: "file-row", fileIndex: item.fileIndex },
       inlineOverlays: overlays,
     };
@@ -484,29 +509,30 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   const checkbox = result.selected ? "[v]" : "[ ]";
   const location = `${group.relPath}:${result.match.line}`;
   const context = result.match.context.trim();
-  // Body starts at column 0 of the row (host indents); leading
-  // spaces here pad the checkbox a touch off the prefix.
   const prefixText = `${checkbox} `;
   const innerWidth = Math.max(0, W - 6); // host prefix consumes 6 cols
-  const maxCtx = innerWidth - charLen(prefixText) - charLen(location) - 3;
+  const prefixChars = charLen(prefixText);
+  const locationChars = charLen(location);
+  const maxCtx = innerWidth - prefixChars - locationChars - 3;
   const displayCtx = truncate(context, Math.max(10, maxCtx));
   const matchLineText = `${prefixText}${location} - ${displayCtx}`;
 
   const inlines: InlineOverlay[] = [];
-  const cbStart = 0;
-  const cbEnd = cbStart + byteLen(checkbox);
-  inlines.push({ start: cbStart, end: cbEnd, style: { fg: result.selected ? C.checkOn : C.checkOff } });
-  const locStart = cbEnd + byteLen(" ");
-  const locEnd = locStart + byteLen(location);
-  inlines.push({ start: locStart, end: locEnd, style: { fg: C.lineNum } });
+  // checkbox is "[v]" or "[ ]" — always 3 ASCII chars.
+  const cbEnd = checkbox.length;
+  inlines.push({ start: 0, end: cbEnd, style: { fg: result.selected ? C.checkOn : C.checkOff }, unit: "char" });
+  const locStart = cbEnd + 1; // " "
+  const locEnd = locStart + locationChars;
+  inlines.push({ start: locStart, end: locEnd, style: { fg: C.lineNum }, unit: "char" });
 
   if (panel.searchPattern) {
-    const ctxStart = locEnd + byteLen(" - ");
+    const ctxStart = locEnd + 3; // " - " is always 3 ASCII chars
     highlightMatches(displayCtx, panel.searchPattern, ctxStart, panel.useRegex, panel.caseSensitive, inlines);
   }
 
   return {
-    text: padStr(matchLineText, innerWidth),
+    text: matchLineText,
+    padToChars: innerWidth,
     properties: { type: "match-row", fileIndex: item.fileIndex, matchIndex: item.matchIndex },
     inlineOverlays: inlines.length > 0 ? inlines : undefined,
   };
@@ -701,9 +727,21 @@ function addCursorOverlay(value: string, cursorPos: number, fieldByteStart: numb
   overlays.push({ start: cursorBytePos, end: cursorByteEnd, style: { fg: [0, 0, 0], bg: C.cursorBg } });
 }
 
-// Highlight search pattern occurrences in a display string
-function highlightMatches(text: string, pattern: string, baseByteOffset: number, isRegex: boolean, caseSensitive: boolean, overlays: InlineOverlay[]): void {
+// Highlight search pattern occurrences in a display string.
+//
+// `baseCharOffset` is in character (codepoint) units within the
+// containing row. Overlays are emitted in the same unit so the
+// host can convert them to byte offsets in one pass. For ASCII
+// `text` (the common case for source-code matches) overlay math
+// uses JS string indices directly without the bridge calls a
+// byte-offset path would require.
+function highlightMatches(text: string, pattern: string, baseCharOffset: number, isRegex: boolean, caseSensitive: boolean, overlays: InlineOverlay[]): void {
   if (!pattern) return;
+  // ASCII-only fast path: JS `indexOf` returns codepoint-equivalent
+  // offsets (no surrogate pairs), so `idx` is the char offset
+  // directly. The non-ASCII path uses `charLen(prefix)` to convert.
+  const textAscii = isAscii(text);
+  const patternChars = isAscii(pattern) ? pattern.length : charLen(pattern);
   try {
     if (!isRegex) {
       let searchText = text;
@@ -716,9 +754,9 @@ function highlightMatches(text: string, pattern: string, baseByteOffset: number,
       while (pos < searchText.length) {
         const idx = searchText.indexOf(searchPat, pos);
         if (idx < 0) break;
-        const startByte = baseByteOffset + byteLen(text.substring(0, idx));
-        const endByte = startByte + byteLen(text.substring(idx, idx + pattern.length));
-        overlays.push({ start: startByte, end: endByte, style: { bg: C.matchBg, fg: C.matchFg } });
+        const startChar = baseCharOffset + (textAscii ? idx : charLen(text.substring(0, idx)));
+        const endChar = startChar + patternChars;
+        overlays.push({ start: startChar, end: endChar, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
         pos = idx + pattern.length;
       }
     } else {
@@ -727,9 +765,10 @@ function highlightMatches(text: string, pattern: string, baseByteOffset: number,
       let m;
       while ((m = re.exec(text)) !== null) {
         if (m[0].length === 0) { re.lastIndex++; continue; }
-        const startByte = baseByteOffset + byteLen(text.substring(0, m.index));
-        const endByte = startByte + byteLen(m[0]);
-        overlays.push({ start: startByte, end: endByte, style: { bg: C.matchBg, fg: C.matchFg } });
+        const startChar = baseCharOffset + (textAscii ? m.index : charLen(text.substring(0, m.index)));
+        const matchChars = isAscii(m[0]) ? m[0].length : charLen(m[0]);
+        const endChar = startChar + matchChars;
+        overlays.push({ start: startChar, end: endChar, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
       }
     }
   } catch (_e) { /* invalid regex */ }

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -9,6 +9,8 @@ import {
   raw,
   row,
   spacer,
+  type StyledSegment,
+  styledRow,
   textInput,
   textInputChar,
   toggle,
@@ -144,24 +146,12 @@ const C = {
 // Helpers
 // =============================================================================
 
-// Codepoint outside the 7-bit ASCII range — used to fast-path
-// `byteLen` and `charLen` for the common case (file paths, source
-// code) where the JS string's `.length` already equals both the
-// UTF-8 byte count and the codepoint count.
-const NON_ASCII = /[^\x00-\x7f]/;
-
-function isAscii(s: string): boolean {
-  return !NON_ASCII.test(s);
-}
-
 function byteLen(s: string): number {
-  if (isAscii(s)) return s.length;
   return editor.utf8ByteLength(s);
 }
 
 /** Count display columns (codepoints; approximation for monospace terminal). */
 function charLen(s: string): number {
-  if (isAscii(s)) return s.length;
   let len = 0;
   for (const _c of s) { len++; }
   return len;
@@ -175,13 +165,6 @@ function padStr(s: string, width: number): string {
 
 /** Truncate to at most maxLen display columns (codepoint-aware). */
 function truncate(s: string, maxLen: number): string {
-  // ASCII fast path: JS substring is equivalent to codepoint slice
-  // and skipping the for-of avoids the QuickJS iterator overhead.
-  if (isAscii(s)) {
-    if (s.length <= maxLen) return s;
-    if (maxLen <= 3) return s.slice(0, maxLen);
-    return s.slice(0, maxLen - 3) + "...";
-  }
   const sLen = charLen(s);
   if (sLen <= maxLen) return s;
   if (maxLen <= 3) {
@@ -470,11 +453,14 @@ function flatItemKey(item: FlatItem): string {
 // pass `depth: 0, hasChildren: true`; matches pass `depth: 1,
 // hasChildren: false` (see `buildMatchListSpec`).
 //
-// Overlay offsets are emitted in character (codepoint) units; the
-// host converts to byte offsets after applying `padToChars`. This
-// keeps the per-row work proportional to the visible content,
-// without the per-overlay `editor.utf8ByteLength` bridge calls
-// that otherwise dominate hot-path renders.
+// Row content is described as a sequence of styled segments rather
+// than a pre-rendered string + offset overlays. The host concats
+// segments and computes the byte offsets natively in Rust, so the
+// plugin doesn't count codepoints or bytes for layout-piece widths
+// at all. Per-row freeform overlays (e.g. pattern-match highlights
+// inside the context substring) ride on the relevant segment via
+// its `overlays` field, addressed in char units relative to that
+// segment alone.
 function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   if (!panel) return { text: "" };
   if (item.type === "file") {
@@ -482,25 +468,21 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
     const badge = getFileExtBadge(group.relPath);
     const matchCount = group.matches.length;
     const selectedInFile = group.matches.filter(m => m.selected).length;
-    // The widget prefixes ` ▶ ` / ` ▼ ` (4 cols) before this body;
-    // pad budget = W - 4 (the widget's prefix consumes 4 cols at
-    // depth 0).
-    const fileLineText = `${badge} ${group.relPath} (${selectedInFile}/${matchCount})`;
-    const badgeChars = charLen(badge);
-    const pathStart = badgeChars + 1; // " " separator (always 1 codepoint)
-    const pathEnd = pathStart + charLen(group.relPath);
-
-    const overlays: InlineOverlay[] = [
-      { start: 0, end: badgeChars, style: { fg: C.fileIcon, bold: true }, unit: "char" },
-      { start: pathStart, end: pathEnd, style: { fg: C.filePath }, unit: "char" },
-    ];
-
-    return {
-      text: fileLineText,
-      padToChars: Math.max(0, W - 4),
-      properties: { type: "file-row", fileIndex: item.fileIndex },
-      inlineOverlays: overlays,
-    };
+    return styledRow(
+      [
+        { text: badge, style: { fg: C.fileIcon, bold: true } },
+        { text: " " },
+        { text: group.relPath, style: { fg: C.filePath } },
+        { text: ` (${selectedInFile}/${matchCount})` },
+      ],
+      {
+        // The widget prefixes ` ▶ ` / ` ▼ ` (4 cols) before this body;
+        // pad budget = W - 4 (the widget's prefix consumes 4 cols at
+        // depth 0).
+        padToChars: Math.max(0, W - 4),
+        properties: { type: "file-row", fileIndex: item.fileIndex },
+      },
+    );
   }
   // Match row. The Tree widget's prefix at depth=1 is 6 cols
   // (4 indent + 2 alignment). Use the remaining width for content.
@@ -509,33 +491,37 @@ function renderFlatItemEntry(item: FlatItem, W: number): TextPropertyEntry {
   const checkbox = result.selected ? "[v]" : "[ ]";
   const location = `${group.relPath}:${result.match.line}`;
   const context = result.match.context.trim();
-  const prefixText = `${checkbox} `;
   const innerWidth = Math.max(0, W - 6); // host prefix consumes 6 cols
-  const prefixChars = charLen(prefixText);
-  const locationChars = charLen(location);
-  const maxCtx = innerWidth - prefixChars - locationChars - 3;
+
+  // Best-effort context budget: enough room for the fixed leading
+  // pieces plus " - " plus the context itself. JS `.length` gives
+  // UTF-16 code-unit counts which match codepoint counts for the
+  // overwhelmingly-ASCII case (paths + line numbers); slight
+  // over-counting on rare non-BMP filenames just trims a little
+  // more of the context, which is fine.
+  const maxCtx = innerWidth - checkbox.length - 1 - location.length - 3;
   const displayCtx = truncate(context, Math.max(10, maxCtx));
-  const matchLineText = `${prefixText}${location} - ${displayCtx}`;
 
-  const inlines: InlineOverlay[] = [];
-  // checkbox is "[v]" or "[ ]" — always 3 ASCII chars.
-  const cbEnd = checkbox.length;
-  inlines.push({ start: 0, end: cbEnd, style: { fg: result.selected ? C.checkOn : C.checkOff }, unit: "char" });
-  const locStart = cbEnd + 1; // " "
-  const locEnd = locStart + locationChars;
-  inlines.push({ start: locStart, end: locEnd, style: { fg: C.lineNum }, unit: "char" });
-
+  // Pattern-match highlights inside the context substring. Emitted
+  // in segment-local char units; the host shifts them by the
+  // context segment's char start during entry concatenation.
+  const ctxOverlays: InlineOverlay[] = [];
   if (panel.searchPattern) {
-    const ctxStart = locEnd + 3; // " - " is always 3 ASCII chars
-    highlightMatches(displayCtx, panel.searchPattern, ctxStart, panel.useRegex, panel.caseSensitive, inlines);
+    highlightMatches(displayCtx, panel.searchPattern, panel.useRegex, panel.caseSensitive, ctxOverlays);
   }
 
-  return {
-    text: matchLineText,
+  const segments: StyledSegment[] = [
+    { text: checkbox, style: { fg: result.selected ? C.checkOn : C.checkOff } },
+    { text: " " },
+    { text: location, style: { fg: C.lineNum } },
+    { text: " - " },
+    { text: displayCtx, overlays: ctxOverlays },
+  ];
+
+  return styledRow(segments, {
     padToChars: innerWidth,
     properties: { type: "match-row", fileIndex: item.fileIndex, matchIndex: item.matchIndex },
-    inlineOverlays: inlines.length > 0 ? inlines : undefined,
-  };
+  });
 }
 
 // Build the typed spec for the matches body — either a Tree widget
@@ -727,21 +713,19 @@ function addCursorOverlay(value: string, cursorPos: number, fieldByteStart: numb
   overlays.push({ start: cursorBytePos, end: cursorByteEnd, style: { fg: [0, 0, 0], bg: C.cursorBg } });
 }
 
-// Highlight search pattern occurrences in a display string.
+// Append pattern-match highlight overlays (one per occurrence) to
+// `overlays`. Offsets are in char (codepoint) units within `text`
+// itself — the caller is expected to attach `overlays` to a
+// segment whose body equals `text`, so the host shifts them into
+// entry-coordinate space during segment resolution.
 //
-// `baseCharOffset` is in character (codepoint) units within the
-// containing row. Overlays are emitted in the same unit so the
-// host can convert them to byte offsets in one pass. For ASCII
-// `text` (the common case for source-code matches) overlay math
-// uses JS string indices directly without the bridge calls a
-// byte-offset path would require.
-function highlightMatches(text: string, pattern: string, baseCharOffset: number, isRegex: boolean, caseSensitive: boolean, overlays: InlineOverlay[]): void {
+// `text` and `pattern` are treated as JS UTF-16 strings. For BMP
+// content (which includes nearly all source code) UTF-16 code unit
+// indices and Unicode codepoint indices coincide, so `indexOf` /
+// `RegExp.exec` indices map directly to char offsets without a
+// per-overlay codepoint walk.
+function highlightMatches(text: string, pattern: string, isRegex: boolean, caseSensitive: boolean, overlays: InlineOverlay[]): void {
   if (!pattern) return;
-  // ASCII-only fast path: JS `indexOf` returns codepoint-equivalent
-  // offsets (no surrogate pairs), so `idx` is the char offset
-  // directly. The non-ASCII path uses `charLen(prefix)` to convert.
-  const textAscii = isAscii(text);
-  const patternChars = isAscii(pattern) ? pattern.length : charLen(pattern);
   try {
     if (!isRegex) {
       let searchText = text;
@@ -754,9 +738,7 @@ function highlightMatches(text: string, pattern: string, baseCharOffset: number,
       while (pos < searchText.length) {
         const idx = searchText.indexOf(searchPat, pos);
         if (idx < 0) break;
-        const startChar = baseCharOffset + (textAscii ? idx : charLen(text.substring(0, idx)));
-        const endChar = startChar + patternChars;
-        overlays.push({ start: startChar, end: endChar, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
+        overlays.push({ start: idx, end: idx + pattern.length, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
         pos = idx + pattern.length;
       }
     } else {
@@ -765,10 +747,7 @@ function highlightMatches(text: string, pattern: string, baseCharOffset: number,
       let m;
       while ((m = re.exec(text)) !== null) {
         if (m[0].length === 0) { re.lastIndex++; continue; }
-        const startChar = baseCharOffset + (textAscii ? m.index : charLen(text.substring(0, m.index)));
-        const matchChars = isAscii(m[0]) ? m[0].length : charLen(m[0]);
-        const endChar = startChar + matchChars;
-        overlays.push({ start: startChar, end: endChar, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
+        overlays.push({ start: m.index, end: m.index + m[0].length, style: { bg: C.matchBg, fg: C.matchFg }, unit: "char" });
       }
     }
   } catch (_e) { /* invalid regex */ }

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -323,6 +323,7 @@ fn render_collected(
                                 properties: Default::default(),
                                 style: None,
                                 inline_overlays: Vec::new(),
+                                segments: Vec::new(),
                                 pad_to_chars: None,
                                 truncate_to_chars: None,
                             };
@@ -460,6 +461,7 @@ fn render_collected(
                 properties: Default::default(),
                 style: None,
                 inline_overlays: Vec::new(),
+                segments: Vec::new(),
                 pad_to_chars: None,
                 truncate_to_chars: None,
             };
@@ -981,6 +983,7 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        segments: Vec::new(),
         pad_to_chars: None,
         truncate_to_chars: None,
     }
@@ -1039,6 +1042,7 @@ pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyE
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        segments: Vec::new(),
         pad_to_chars: None,
         truncate_to_chars: None,
     }
@@ -1104,6 +1108,7 @@ pub fn render_button(label: &str, focused: bool, kind: ButtonKind) -> TextProper
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        segments: Vec::new(),
         pad_to_chars: None,
         truncate_to_chars: None,
     }
@@ -1206,10 +1211,11 @@ pub fn render_tree_row(node: &TreeNode, expanded: bool) -> RenderedTreeRow {
         properties: node.text.properties.clone(),
         style: node.text.style.clone(),
         inline_overlays: overlays,
-        // pad/truncate hints are consumed by the caller before
-        // render_tree_row is invoked (see normalize_widths in the
-        // Tree match arm). The output entry's text is already
-        // final, so these are cleared.
+        // segments / pad / truncate hints are consumed by the
+        // caller before render_tree_row is invoked (see
+        // normalize_widths in the Tree match arm). The output
+        // entry's text is already final, so these are cleared.
+        segments: Vec::new(),
         pad_to_chars: None,
         truncate_to_chars: None,
     };
@@ -1402,6 +1408,7 @@ pub fn render_text_input(
             properties: Default::default(),
             style: None,
             inline_overlays: overlays,
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         },
@@ -1527,6 +1534,7 @@ pub fn render_text_area(
             properties: Default::default(),
             style: None,
             inline_overlays: Vec::new(),
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         });
@@ -1591,6 +1599,7 @@ pub fn render_text_area(
             properties: Default::default(),
             style: None,
             inline_overlays: overlays,
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         });
@@ -2807,6 +2816,110 @@ mod tests {
         assert_eq!(bold.start, 4);
         assert_eq!(bold.end, 5);
         assert_eq!(&trimmed[bold.start..bold.end], "x");
+    }
+
+    #[test]
+    fn tree_node_segments_concatenate_into_row_text_with_per_segment_overlays() {
+        let mut node = tnode("", 0, false);
+        node.text.segments = vec![
+            fresh_core::text_property::StyledSegment {
+                text: "AB".to_string(),
+                style: None,
+                overlays: vec![],
+            },
+            fresh_core::text_property::StyledSegment {
+                text: " ".to_string(),
+                style: None,
+                overlays: vec![],
+            },
+            fresh_core::text_property::StyledSegment {
+                text: "CD".to_string(),
+                style: Some(OverlayOptions {
+                    bold: true,
+                    ..Default::default()
+                }),
+                overlays: vec![],
+            },
+        ];
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let trimmed = entries[0].text.trim_end_matches('\n');
+        // Leaf row: 2-space prefix + concatenated segments.
+        assert!(
+            trimmed.ends_with("AB CD"),
+            "row should end with concatenated segments, got {trimmed:?}"
+        );
+        let bold = entries[0]
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("styled segment overlay carried through");
+        // Bold covers the third segment only ("CD" at byte 5..7
+        // after 2-byte prefix + "AB " = 3 bytes).
+        assert_eq!(&trimmed[bold.start..bold.end], "CD");
+    }
+
+    #[test]
+    fn tree_node_segment_nested_overlay_shifts_to_segment_position() {
+        // Build a row whose third segment carries a nested overlay
+        // covering chars [0..3] within itself ("CDE"). The host
+        // shifts those by the segment's start in the entry; final
+        // bytes resolve against the assembled text.
+        let mut node = tnode("", 0, false);
+        node.text.segments = vec![
+            fresh_core::text_property::StyledSegment {
+                text: "AB".to_string(),
+                style: None,
+                overlays: vec![],
+            },
+            fresh_core::text_property::StyledSegment {
+                text: " - ".to_string(),
+                style: None,
+                overlays: vec![],
+            },
+            fresh_core::text_property::StyledSegment {
+                text: "CDEFG".to_string(),
+                style: None,
+                overlays: vec![InlineOverlay {
+                    start: 0,
+                    end: 3,
+                    style: OverlayOptions {
+                        bold: true,
+                        ..Default::default()
+                    },
+                    properties: Default::default(),
+                    unit: OffsetUnit::Char,
+                }],
+            },
+        ];
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let trimmed = entries[0].text.trim_end_matches('\n');
+        let bold = entries[0]
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("nested overlay carried through");
+        assert_eq!(&trimmed[bold.start..bold.end], "CDE");
+    }
+
+    #[test]
+    fn tree_node_segments_with_pad_pad_after_concatenation() {
+        let mut node = tnode("", 0, false);
+        node.text.segments = vec![fresh_core::text_property::StyledSegment {
+            text: "ab".to_string(),
+            style: None,
+            overlays: vec![],
+        }];
+        node.text.pad_to_chars = Some(5);
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let trimmed = entries[0].text.trim_end_matches('\n');
+        // Two-space leaf prefix + "ab" + three padding spaces = "  ab   ".
+        assert!(
+            trimmed.ends_with("ab   "),
+            "row should be padded after segment concat, got {trimmed:?}"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -24,7 +24,7 @@ use crate::widgets::registry::{HitArea, WidgetInstanceState};
 use fresh_core::api::{
     ButtonKind, HintEntry, OverlayColorSpec, OverlayOptions, TreeNode, WidgetSpec,
 };
-use fresh_core::text_property::{InlineOverlay, TextPropertyEntry};
+use fresh_core::text_property::{InlineOverlay, OffsetUnit, TextPropertyEntry};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 
@@ -323,6 +323,8 @@ fn render_collected(
                                 properties: Default::default(),
                                 style: None,
                                 inline_overlays: Vec::new(),
+                                pad_to_chars: None,
+                                truncate_to_chars: None,
                             };
                             match acc.as_mut() {
                                 Some(merged) => {
@@ -458,6 +460,8 @@ fn render_collected(
                 properties: Default::default(),
                 style: None,
                 inline_overlays: Vec::new(),
+                pad_to_chars: None,
+                truncate_to_chars: None,
             };
             ensure_trailing_newline(&mut entry);
             entries.push(entry);
@@ -537,6 +541,7 @@ fn render_collected(
             for (offset, item) in items[start..end].iter().enumerate() {
                 let i = start + offset;
                 let mut entry = item.clone();
+                entry.normalize_widths();
                 let is_selected = i as i32 == effective_sel;
                 if is_selected {
                     let mut style = entry.style.unwrap_or_default();
@@ -695,11 +700,16 @@ fn render_collected(
             let start = scroll as usize;
             let end = ((scroll + visible) as usize).min(visible_indices.len());
             for &abs_idx in &visible_indices[start..end] {
-                let node = &nodes[abs_idx];
+                // Apply pad/truncate hints and convert any char-unit
+                // overlays to byte offsets *before* the disclosure
+                // prefix is prepended; render_tree_row then byte-shifts
+                // the (now byte-unit) overlays uniformly.
+                let mut node = nodes[abs_idx].clone();
+                node.text.normalize_widths();
                 let item_key = item_keys.get(abs_idx).cloned().unwrap_or_default();
                 let is_expanded =
                     node.has_children && !item_key.is_empty() && prev_expanded.contains(&item_key);
-                let rendered = render_tree_row(node, is_expanded);
+                let rendered = render_tree_row(&node, is_expanded);
                 let mut entry = rendered.entry;
                 let is_selected = abs_idx as i32 == effective_sel_abs;
                 if is_selected {
@@ -919,6 +929,7 @@ fn render_collected(
             // unaffected.
             for raw_entry in raw_entries {
                 let mut e = raw_entry.clone();
+                e.normalize_widths();
                 ensure_trailing_newline(&mut e);
                 entries.push(e);
             }
@@ -957,6 +968,7 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
                     ..Default::default()
                 },
                 properties: Default::default(),
+                unit: OffsetUnit::Byte,
             });
         }
         if !entry.label.is_empty() {
@@ -969,6 +981,8 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        pad_to_chars: None,
+        truncate_to_chars: None,
     }
 }
 
@@ -1000,6 +1014,7 @@ pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyE
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1015,6 +1030,7 @@ pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyE
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1023,6 +1039,8 @@ pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyE
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        pad_to_chars: None,
+        truncate_to_chars: None,
     }
 }
 
@@ -1077,6 +1095,7 @@ pub fn render_button(label: &str, focused: bool, kind: ButtonKind) -> TextProper
             end: text.len(),
             style,
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1085,6 +1104,8 @@ pub fn render_button(label: &str, focused: bool, kind: ButtonKind) -> TextProper
         properties: Default::default(),
         style: None,
         inline_overlays: overlays,
+        pad_to_chars: None,
+        truncate_to_chars: None,
     }
 }
 
@@ -1168,6 +1189,7 @@ pub fn render_tree_row(node: &TreeNode, expanded: bool) -> RenderedTreeRow {
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1184,6 +1206,12 @@ pub fn render_tree_row(node: &TreeNode, expanded: bool) -> RenderedTreeRow {
         properties: node.text.properties.clone(),
         style: node.text.style.clone(),
         inline_overlays: overlays,
+        // pad/truncate hints are consumed by the caller before
+        // render_tree_row is invoked (see normalize_widths in the
+        // Tree match arm). The output entry's text is already
+        // final, so these are cleared.
+        pad_to_chars: None,
+        truncate_to_chars: None,
     };
     RenderedTreeRow {
         entry,
@@ -1345,6 +1373,7 @@ pub fn render_text_input(
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1357,6 +1386,7 @@ pub fn render_text_input(
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
     }
 
@@ -1372,6 +1402,8 @@ pub fn render_text_input(
             properties: Default::default(),
             style: None,
             inline_overlays: overlays,
+            pad_to_chars: None,
+            truncate_to_chars: None,
         },
         cursor_byte_in_entry,
     }
@@ -1495,6 +1527,8 @@ pub fn render_text_area(
             properties: Default::default(),
             style: None,
             inline_overlays: Vec::new(),
+            pad_to_chars: None,
+            truncate_to_chars: None,
         });
     }
     let label_offset: u32 = entries.len() as u32;
@@ -1522,6 +1556,7 @@ pub fn render_text_area(
                     ..Default::default()
                 },
                 properties: Default::default(),
+                unit: OffsetUnit::Byte,
             });
         }
 
@@ -1536,6 +1571,7 @@ pub fn render_text_area(
                     ..Default::default()
                 },
                 properties: Default::default(),
+                unit: OffsetUnit::Byte,
             });
         }
 
@@ -1555,6 +1591,8 @@ pub fn render_text_area(
             properties: Default::default(),
             style: None,
             inline_overlays: overlays,
+            pad_to_chars: None,
+            truncate_to_chars: None,
         });
     }
 
@@ -1614,6 +1652,7 @@ fn merge_inline(merged: &mut TextPropertyEntry, next: &mut TextPropertyEntry) {
             end: overlay.end + shift,
             style: overlay.style,
             properties: overlay.properties,
+            unit: overlay.unit,
         });
     }
     // `style` and `properties` from `next` are dropped — Row inline
@@ -2657,6 +2696,7 @@ mod tests {
                 ..Default::default()
             },
             properties: Default::default(),
+            unit: OffsetUnit::Byte,
         });
         let r = render_tree_row(&node, false);
         // depth=1 → 2 indent + 2 alignment = 4 prefix bytes (ASCII).
@@ -2669,6 +2709,104 @@ mod tests {
             .expect("bold overlay carried through");
         assert_eq!(plugin_overlay.start, 4);
         assert_eq!(plugin_overlay.end, 9);
+    }
+
+    #[test]
+    fn tree_node_pad_to_chars_pads_text_before_prefix_offset_shift() {
+        // depth=0 prefix is "▶ " (1 codepoint glyph + 1 space).
+        // Plugin sends body "x" with pad_to_chars=5; renderer pads
+        // body to "x    " then prepends prefix.
+        let mut node = tnode("x", 0, true);
+        node.text.pad_to_chars = Some(5);
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec!["x"], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        assert_eq!(entries.len(), 1);
+        // The full row is prefix + padded body + trailing newline.
+        // Body region must be "x    " (5 columns).
+        let trimmed = entries[0].text.trim_end_matches('\n');
+        assert!(
+            trimmed.ends_with("x    "),
+            "row should end with the padded body, got {trimmed:?}"
+        );
+    }
+
+    #[test]
+    fn tree_node_truncate_to_chars_cuts_body_before_prefix_offset_shift() {
+        let mut node = tnode("abcdefghij", 0, false);
+        node.text.truncate_to_chars = Some(6);
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let trimmed = entries[0].text.trim_end_matches('\n');
+        // With budget=6, truncation produces "abc..." (3 head chars
+        // + ellipsis), then prefix is prepended.
+        assert!(
+            trimmed.ends_with("abc..."),
+            "row should end with truncated body, got {trimmed:?}"
+        );
+    }
+
+    #[test]
+    fn tree_node_char_unit_overlay_resolves_against_padded_text_and_shifts_by_prefix() {
+        // Body text "x" padded to 5 codepoints — the host pads to
+        // "x    " before resolving overlays. A char-unit overlay at
+        // [0..5] must end up covering the full padded body in bytes,
+        // shifted right by the prefix length.
+        let mut node = tnode("x", 0, false);
+        node.text.pad_to_chars = Some(5);
+        node.text.inline_overlays.push(InlineOverlay {
+            start: 0,
+            end: 5,
+            style: OverlayOptions {
+                bold: true,
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Char,
+        });
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let entry = &entries[0];
+        let bold = entry
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("bold overlay carried through");
+        // depth=0, leaf → prefix is two spaces (no glyph). Body
+        // starts at byte 2 and is 5 bytes (ASCII pad), so [2..7].
+        assert_eq!(bold.start, 2);
+        assert_eq!(bold.end, 7);
+    }
+
+    #[test]
+    fn tree_node_char_unit_overlay_with_multibyte_body_resolves_correctly() {
+        // Body text "éxé" — 3 codepoints, 5 bytes. A char-unit
+        // overlay at [1..2] (just the "x") becomes byte [3..4]
+        // within the body, then shifted by leaf prefix (2 bytes).
+        let mut node = tnode("éxé", 0, false);
+        node.text.inline_overlays.push(InlineOverlay {
+            start: 1,
+            end: 2,
+            style: OverlayOptions {
+                bold: true,
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Char,
+        });
+        let spec = make_tree(vec![node], vec!["x"], -1, 10, vec![], Some("T"));
+        let (entries, _hits, _state) = render_no_focus(&spec, &HashMap::new());
+        let entry = &entries[0];
+        let bold = entry
+            .inline_overlays
+            .iter()
+            .find(|o| o.style.bold)
+            .expect("bold overlay carried through");
+        // Prefix is 2 bytes (two ASCII spaces), char→byte [1..2]
+        // resolves to body byte [2..3], then shift +2 → [4..5].
+        let trimmed = entry.text.trim_end_matches('\n');
+        assert_eq!(bold.start, 4);
+        assert_eq!(bold.end, 5);
+        assert_eq!(&trimmed[bold.start..bold.end], "x");
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -724,6 +724,7 @@ fn test_next_buffer_skips_hidden_buffers() {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         }],

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -724,6 +724,8 @@ fn test_next_buffer_skips_hidden_buffers() {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            pad_to_chars: None,
+            truncate_to_chars: None,
         }],
         show_line_numbers: true,
         show_cursors: true,

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -20,6 +20,7 @@ fn reproduce_cursor_panic() {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            segments: Vec::new(),
             pad_to_chars: None,
             truncate_to_chars: None,
         }],

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -20,6 +20,8 @@ fn reproduce_cursor_panic() {
             properties: HashMap::new(),
             style: None,
             inline_overlays: Vec::new(),
+            pad_to_chars: None,
+            truncate_to_chars: None,
         }],
         show_line_numbers: true,
         show_cursors: false, // <--- The trigger: hiding cursors

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -616,11 +616,26 @@ fn parse_text_property_entry(
         .ok()
         .map(|v| v.max(0.0) as u32);
 
+    let segments: Vec<fresh_core::text_property::StyledSegment> = obj
+        .get::<_, rquickjs::Array>("segments")
+        .ok()
+        .map(|arr| {
+            arr.iter::<Object>()
+                .flatten()
+                .filter_map(|item| {
+                    let json_val = js_to_json(ctx, Value::from_object(item));
+                    serde_json::from_value(json_val).ok()
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     Some(TextPropertyEntry {
         text,
         properties,
         style,
         inline_overlays,
+        segments,
         pad_to_chars,
         truncate_to_chars,
     })
@@ -4088,6 +4103,7 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                segments: e.segments.unwrap_or_default(),
                 pad_to_chars: e.pad_to_chars,
                 truncate_to_chars: e.truncate_to_chars,
             })
@@ -4141,6 +4157,7 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                segments: e.segments.unwrap_or_default(),
                 pad_to_chars: e.pad_to_chars,
                 truncate_to_chars: e.truncate_to_chars,
             })
@@ -4195,6 +4212,7 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                segments: e.segments.unwrap_or_default(),
                 pad_to_chars: e.pad_to_chars,
                 truncate_to_chars: e.truncate_to_chars,
             })

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -607,11 +607,22 @@ fn parse_text_property_entry(
         })
         .unwrap_or_default();
 
+    let pad_to_chars: Option<u32> = obj
+        .get::<_, f64>("padToChars")
+        .ok()
+        .map(|v| v.max(0.0) as u32);
+    let truncate_to_chars: Option<u32> = obj
+        .get::<_, f64>("truncateToChars")
+        .ok()
+        .map(|v| v.max(0.0) as u32);
+
     Some(TextPropertyEntry {
         text,
         properties,
         style,
         inline_overlays,
+        pad_to_chars,
+        truncate_to_chars,
     })
 }
 
@@ -4077,6 +4088,8 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                pad_to_chars: e.pad_to_chars,
+                truncate_to_chars: e.truncate_to_chars,
             })
             .collect();
 
@@ -4128,6 +4141,8 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                pad_to_chars: e.pad_to_chars,
+                truncate_to_chars: e.truncate_to_chars,
             })
             .collect();
 
@@ -4180,6 +4195,8 @@ impl JsEditorApi {
                 properties: e.properties.unwrap_or_default(),
                 style: e.style,
                 inline_overlays: e.inline_overlays.unwrap_or_default(),
+                pad_to_chars: e.pad_to_chars,
+                truncate_to_chars: e.truncate_to_chars,
             })
             .collect();
 

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -127,6 +127,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         "OverlayColorSpec" => Some(OverlayColorSpec::decl(&cfg)),
         "InlineOverlay" => Some(InlineOverlay::decl(&cfg)),
         "OffsetUnit" => Some(fresh_core::text_property::OffsetUnit::decl(&cfg)),
+        "StyledSegment" => Some(fresh_core::text_property::StyledSegment::decl(&cfg)),
         "StyledText" => Some(fresh_core::api::StyledText::decl(&cfg)),
 
         // Widget library types — declarative plugin UI.
@@ -249,6 +250,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "OverlayColorSpec",               // Used by OverlayOptions.fg/bg
     "InlineOverlay",                  // Used by TextPropertyEntry.inlineOverlays
     "OffsetUnit",                     // Used by InlineOverlay.unit
+    "StyledSegment",                  // Used by TextPropertyEntry.segments
     "GrammarInfoSnapshot",            // Used by listGrammars
     "AnimationRect",                  // Used by animateArea
     "PluginAnimationEdge",            // Used by PluginAnimationKind

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -126,6 +126,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         "OverlayOptions" => Some(OverlayOptions::decl(&cfg)),
         "OverlayColorSpec" => Some(OverlayColorSpec::decl(&cfg)),
         "InlineOverlay" => Some(InlineOverlay::decl(&cfg)),
+        "OffsetUnit" => Some(fresh_core::text_property::OffsetUnit::decl(&cfg)),
         "StyledText" => Some(fresh_core::api::StyledText::decl(&cfg)),
 
         // Widget library types — declarative plugin UI.
@@ -247,6 +248,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "OverlayOptions",                 // Used by TextPropertyEntry.style and InlineOverlay
     "OverlayColorSpec",               // Used by OverlayOptions.fg/bg
     "InlineOverlay",                  // Used by TextPropertyEntry.inlineOverlays
+    "OffsetUnit",                     // Used by InlineOverlay.unit
     "GrammarInfoSnapshot",            // Used by listGrammars
     "AnimationRect",                  // Used by animateArea
     "PluginAnimationEdge",            // Used by PluginAnimationKind

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -1,11 +1,12 @@
 # Plugin widget library — design + implementation plan
 
-Status: **rev 3 — implementation in progress, partial in tree.** See
-§2 for what's shipped, §3 for how to pick up the work, §4 for the
-remaining roadmap.
-Branch: `claude/plugin-ui-component-library-wO76I`
-Original design author: staff-eng review, rev 1 + rev 2.
-Related: `docs/internal/UNIFIED_UI_FRAMEWORK_PLAN.md`,
+Status: foundation shipped, one plugin migrated end-to-end, several
+widget kinds and the Compositor still to build. See §2 for what's
+in tree, §3 for how to pick up the work, §4 for the remaining
+roadmap.
+
+Related:
+`docs/internal/UNIFIED_UI_FRAMEWORK_PLAN.md`,
 `docs/internal/unified-hit-test-theme-plan.md`,
 `docs/internal/unified-keybinding-resolution.md`,
 `docs/internal/event-dispatch-architecture.md`,
@@ -13,14 +14,14 @@ Related: `docs/internal/UNIFIED_UI_FRAMEWORK_PLAN.md`,
 `docs/internal/plugin-usability-review.md`,
 `docs/internal/settings-controls-usability-report.md`
 
-Criterion: end-state UX, robustness, flexibility. Shipping speed is
-explicitly *not* a constraint. (See Appendix A for the rejected
-TS-only alternative on `claude/design-plugin-ui-library-pxri8`, which
-optimizes for the opposite tradeoff.)
+Design criterion: end-state UX, robustness, flexibility. Shipping
+speed is explicitly *not* a constraint. See Appendix A for the
+rejected TS-only alternative that optimizes for the opposite
+tradeoff.
 
 ---
 
-## 1. Recommendation (unchanged from rev 2)
+## 1. Recommendation
 
 **Hybrid: a Rust-resident widget runtime with a thin TypeScript
 declarative front-end. Plugins describe widgets as data, the host
@@ -38,12 +39,12 @@ you're picking up the work and need the *why* before the *what*.
 
 ## 2. Implementation status
 
-### 2.1 What's in tree on this branch
+### 2.1 What's in tree
 
 The runtime is real. Plugins can mount widget panels today; one
 plugin (`search_replace.ts`) is migrated end-to-end across the bulk
-of its UI. ~13 commits, `3257fa7..a436874`. cargo check workspace
-clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
+of its UI. cargo check workspace clean, widget unit tests green,
+tsc clean, interactively verified in tmux.
 
 **Rust runtime** (`crates/fresh-editor/src/widgets/`)
 
@@ -51,8 +52,8 @@ clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
 |---|---|
 | `mod.rs` | Public surface: re-exports `render_spec`, `RenderOutput`, `FocusCursor`, `WidgetRegistry`, `HitArea`, `WidgetInstanceState`, `find_widget_by_key`, `apply_text_input_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec` |
 | `registry.rs` | `WidgetRegistry`: `panel_id → WidgetPanelState { buffer_id, spec, hits, instance_states, focus_key, tabbable }`. Hit-test, get/get_mut, focus_key getter/setter, mount/update/unmount. |
-| `render.rs` | The reconciler. `render_spec(spec, prev_state, prev_focus, panel_width) → RenderOutput { entries, hits, instance_states, focus_key, tabbable, focus_cursor }`. Two-pass Row layout for flex spacers. Per-widget renderers (`render_hint_bar`, `render_toggle`, `render_button`, `render_text_input`). |
-| `actions.rs` | Pure helpers used by dispatch: `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling), `find_widget_by_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`. 14+ unit tests. |
+| `render.rs` | The reconciler. `render_spec(spec, prev_state, prev_focus, panel_width) → RenderOutput { entries, hits, instance_states, focus_key, tabbable, focus_cursor }`. Two-pass Row layout for flex spacers. Per-widget renderers (`render_hint_bar`, `render_toggle`, `render_button`, `render_text_input`, `render_text_area`, `render_tree_row`, plus inline list rendering). |
+| `actions.rs` | Pure helpers used by dispatch: `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling), `find_widget_by_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`, `set_tree_expanded_keys_in_spec`. |
 
 **Core types** (`crates/fresh-core/src/api.rs`)
 
@@ -62,8 +63,8 @@ clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
 | `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` | Shapes referenced by the spec / IPC. |
 | `PluginCommand::MountWidgetPanel`, `UpdateWidgetPanel`, `UnmountWidgetPanel` | Spec lifecycle. |
 | `PluginCommand::WidgetCommand { panel_id, action }` | Routes a `WidgetAction` (key dispatch / focus / activate / select-move / text-input). |
-| `PluginCommand::WidgetMutate { panel_id, mutation }` | Targeted in-place mutation (the "Path A" fast path). `setValue` / `setChecked` / `setSelectedIndex` / `setItems`. |
-| `HookArgs::WidgetEvent` | `widget_event` hook payload: `panel_id`, `widget_key`, `event_type`, `payload`. Fired for `select` / `activate` / `toggle` / `change`. |
+| `PluginCommand::WidgetMutate { panel_id, mutation }` | Targeted in-place mutation (the "Path A" fast path). `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys`. |
+| `HookArgs::WidgetEvent` | `widget_event` hook payload: `panel_id`, `widget_key`, `event_type`, `payload`. Fired for `select` / `activate` / `toggle` / `change` / `expand`. |
 
 **Dispatch glue** (`crates/fresh-editor/src/app/`)
 
@@ -88,10 +89,10 @@ clean, 70 widget tests passing, tsc clean, interactive tmux-verified.
 |---|---|
 | HintBar (footer) | `parseHintString(t("panel.help"))` → `hintBar(...)`. Theme-keyed key styling. |
 | Options row (3 toggles + Replace All button) | `row(toggle("case"), toggle("regex"), toggle("whole"), flexSpacer(), button("replaceAll", { intent: "primary" }))`. Right-aligns the button via flex. |
-| Search / Replace text fields | `textInput(value, { fieldWidth: 25, key: "searchField" })`. Constant-width with head-truncate scrolling, host-owned hardware cursor. |
-| Match tree | `list({ items, itemKeys, selectedIndex, visibleRows, key: "matchList" })`. Widget-owned scroll, click-to-select, Enter-to-activate. |
+| Search / Replace text fields | `textInput(...)`. Constant-width with head-truncate scrolling, host-owned hardware cursor. |
+| Match tree | `tree({ nodes, itemKeys, selectedIndex, visibleRows, expandedKeys, key: "matchTree" })`. Widget-owned scroll, expansion, click-to-select, Enter-to-activate, disclosure-glyph hit area. |
 | Mode bindings (Tab / Shift+Tab / Enter / Space / Backspace / Delete / Home / End / Up / Down / Left / Right / mode_text_input) | All route through `dispatch(widgetKey("Tab"))` etc. The smart-key dispatcher in core handles based on focused widget kind. |
-| `widget_event` handlers (`change` / `select` / `activate` / `toggle`) | Plugin updates its app model from events; toggle writes back via `panel.setChecked` (mutator fast path); selection / value changes don't re-emit spec. |
+| `widget_event` handlers (`change` / `select` / `activate` / `toggle` / `expand`) | Plugin updates its app model from events; toggle writes back via `panel.setChecked` (mutator fast path); selection / value / expansion changes don't re-emit spec. |
 
 What's *not* migrated in `search_replace.ts`: the matches-section
 separator (still in `Raw`), the `truncated` warning in matchStats
@@ -118,76 +119,73 @@ per-spec `theme` override map yet.
 
 ### 2.2 What's not yet built
 
-In rough decreasing user impact:
+Decisions taken on items considered but not pursued:
 
-1. ~~**`Tree` widget.**~~ Shipped. `search_replace.ts` migrated to
-   `tree(...)` with host-owned expansion + scroll + selection.
-2. ~~**Targeted spec subtree replacement (`WidgetMutation::SetSpec`).**~~
-   Skipped. The reconciler already preserves instance state across
-   a full `panel.set(spec)` re-emit, so a SetSpec fast path is a
-   pure IPC-byte optimization with no UX consequence; revisit only
-   if profiling on a large-spec panel shows it matters.
-3. ~~**`Tabs` / `Group` widget.**~~ Skipped — no in-tree consumer.
-   `git_log.ts`'s "tab" toolbar is a strip of action buttons
-   (Tab/RET/y/r/q), not a UI tab switcher; the buffer-group panes
-   are managed by the editor's panel manager outside the widget
-   runtime. Revisit when a real consumer appears.
-4. ~~**`TextArea` widget.**~~ Shipped. Multi-line input with
-   host-owned value, cursor, and vertical scroll; `Enter` inserts
-   a newline (form-style "Enter submits" remains the `TextInput`
-   default), `Up`/`Down` walk lines preserving column,
-   `Home`/`End` jump within the current line. Smart-key dispatch
-   table extended in `WidgetAction::Key` doc.
-5. **`Prompt` / `Layer` / Compositor (§7 in this doc).** The big
-   architectural piece. Today `Popup`, `Prompt`, `showActionPopup`,
-   hover tooltips, completion popups all live in separate
-   subsystems. Unifying them under one Compositor with a `mountLayer`
-   IPC subsumes a lot of duplicated focus/dismiss/event-routing
-   logic, but no plugin can currently mount a tooltip or modal via
-   the widget runtime.
-6. **`Transient` widget (Magit menu).** Discoverability per
-   `plugin-usability-review.md`.
-7. **`Table` widget.** `git_log.ts` log, `find_references.ts`, audit.
-8. **Role-based theming.** The §11 design says widgets carry roles
-   (`Role::Action`, `Role::Destructive`, …) and the host resolves to
-   theme keys. Today the renderer's theme keys are hardcoded in
+- **Targeted spec subtree replacement (`WidgetMutation::SetSpec`)**.
+  Skipped. The reconciler already preserves instance state across
+  a full `panel.set(spec)` re-emit, so a SetSpec fast path is a
+  pure IPC-byte optimization with no UX consequence; revisit only
+  if profiling on a large-spec panel shows it matters.
+- **`Tabs` / `Group` widget**. Skipped — no in-tree consumer.
+  `git_log.ts`'s "tab" toolbar is a strip of action buttons, not
+  a UI tab switcher; the buffer-group panes are managed by the
+  editor's panel manager outside the widget runtime. Revisit when
+  a real consumer appears.
+
+Remaining work, in rough decreasing user impact:
+
+1. **`Prompt` / `Layer` / Compositor (§7).** The big architectural
+   piece. Today `Popup`, `Prompt`, `showActionPopup`, hover
+   tooltips, completion popups all live in separate subsystems.
+   Unifying them under one Compositor with a `mountLayer` IPC
+   subsumes a lot of duplicated focus/dismiss/event-routing logic,
+   but no plugin can currently mount a tooltip or modal via the
+   widget runtime.
+2. **`Transient` widget (Magit menu).** Discoverability per
+   `plugin-usability-review.md`. Falls out as one kind of Layer.
+3. **`Table` widget.** `git_log.ts` log, `find_references.ts`,
+   audit.
+4. **Role-based theming.** The §11 design says widgets carry roles
+   (`Role::Action`, `Role::Destructive`, …) and the host resolves
+   to theme keys. Today the renderer's theme keys are hardcoded in
    `widgets/render.rs`. Adding a `roles.rs` translation layer lets
    plugins override per-widget without touching colors and lets
    accessibility variants (high-contrast, color-blind) drop in.
-9. **Spec-as-first-class-state (§10).** Session restore, theme-switch
-   live re-render, replay, headless rendering, cross-plugin
-   composition (`embed`). The `Spec` is already data; what's missing
-   is the persistence layer and the plumbing to re-render every
-   active panel on a `theme_changed` event.
-10. **Accessibility (§13).** Screen-reader bridge (OSC 52), ARIA strings
-    on focus change, motion-reduce gating. Library-default
-    `lib-widgets.i18n.json`.
-11. **IME composition in TextInput.** `mode_text_input` already
-    delivers composed text but the widget cursor model doesn't track
-    composition states.
-12. **Built-in chord support inside widgets.** Today
-    `apply_text_input_key` only handles single-key edits; chords
-    (`g g`) still bubble to the plugin's `defineMode`.
-13. **Settings adoption.** §11 says Settings should adopt the
-    `view/controls/*` renderers shared with widgets. Today widgets
-    have their own renderer in `widgets/render.rs`; the Settings
-    renderer is separate. Sharing requires extracting a common
-    "render a *State* + *Layout* + *Colors*" shape, which the
-    `view/controls/*` modules already have.
+5. **Spec-as-first-class-state (§10).** Session restore,
+   theme-switch live re-render, replay, headless rendering,
+   cross-plugin composition (`embed`). The `Spec` is already data;
+   what's missing is the persistence layer and the plumbing to
+   re-render every active panel on a `theme_changed` event.
+6. **Accessibility (§13).** Screen-reader bridge (OSC 52), ARIA
+   strings on focus change, motion-reduce gating. Library-default
+   `lib-widgets.i18n.json`.
+7. **IME composition in TextInput.** `mode_text_input` already
+   delivers composed text but the widget cursor model doesn't
+   track composition states.
+8. **Built-in chord support inside widgets.** Today
+   `apply_text_input_key` only handles single-key edits; chords
+   (`g g`) still bubble to the plugin's `defineMode`.
+9. **Settings adoption.** §11 says Settings should adopt the
+   `view/controls/*` renderers shared with widgets. Today widgets
+   have their own renderer in `widgets/render.rs`; the Settings
+   renderer is separate. Sharing requires extracting a common
+   "render a *State* + *Layout* + *Colors*" shape, which the
+   `view/controls/*` modules already have.
 
 ### 2.3 Open architectural questions
 
 * **`Spec::SetSpec` mutator** vs **per-field mutators**. Currently
-  field mutators cover `SetValue`/`SetChecked`/`SetSelectedIndex`/
-  `SetItems`. For richer subtree changes — e.g. a toolbar that grows
-  a button — the choice is: add `SetSpec { widget_key, sub_spec }`
-  (clean) or add more per-field mutators (incrementally simpler).
-  Recommendation: ship `SetSpec` next — generic enough that future
-  changes don't keep adding variants.
+  field mutators cover `SetValue` / `SetChecked` / `SetSelectedIndex` /
+  `SetItems` / `SetExpandedKeys`. For richer subtree changes — e.g.
+  a toolbar that grows a button — the choice is: add
+  `SetSpec { widget_key, sub_spec }` (clean) or add more per-field
+  mutators (incrementally simpler). Currently deferred (see §2.2);
+  re-evaluate if a real consumer needs it or profiling on a
+  large-spec panel shows IPC cost matters.
 * **Cursor focus on click.** Click-to-focus moves the focus key to
   the clicked widget *and* fires the click event. Mouse drag /
-  hover / double-click are not yet plumbed. The `Layer` work
-  (§7 in this doc / §3.5 in the original rev 2) absorbs this.
+  hover / double-click are not yet plumbed. The `Layer` work (§7)
+  absorbs this.
 * **Re-render-on-buffer-resize.** Flex spacers size against
   `widget_panel_width(buffer_id)`. When the buffer's split resizes,
   we don't currently re-render — the plugin gets a `resize` event
@@ -195,10 +193,11 @@ In rough decreasing user impact:
   is for the host to re-render automatically when `viewport.width`
   changes for any buffer with a mounted widget panel.
 * **The "Spec is initial; instance state is the truth" rule.**
-  Implemented for `TextInput` (value+cursor) and `List` (selected_index +
-  scroll_offset). The rule will need to extend to `Tree` (expanded
-  keys), `TextArea` (cursor + selection + scroll), `Prompt` / `Layer`
-  (open/closed). Pattern is set; just apply it consistently as new
+  Implemented for `TextInput` (value + cursor), `TextArea` (value +
+  cursor + scroll), `List` (selected_index + scroll_offset), and
+  `Tree` (selected_index + scroll_offset + expanded_keys). The rule
+  will need to extend to `Prompt` / `Layer` (open/closed) when
+  those land. Pattern is set; just apply it consistently as new
   widgets land.
 * **Widget keymap layer above `defineMode`.** Today the plugin's
   `defineMode` binds keys → `dispatch(widgetKey("Tab"))`. The §8
@@ -220,7 +219,7 @@ Standard fresh checkout. The widget runtime is part of `fresh-editor`:
 
 ```bash
 cargo build -p fresh-editor --bin fresh
-cargo test -p fresh-editor --lib widgets    # 70 unit tests
+cargo test -p fresh-editor --lib widgets
 crates/fresh-editor/plugins/check-types.sh  # tsc on plugins
 ```
 
@@ -352,7 +351,7 @@ those are done.
   queue in one editor tick before the plugin processes any
   `widget_event`. Read state from instance state, not from the spec
   field, to avoid the race that bit the original "renderer reads
-  spec value" design (commit `0922463` is the fix).
+  spec value" design.
 * **`tmux capture-pane` doesn't show colors.** Use `-e` to dump ANSI
   escapes, or `display-message -p '#{cursor_x},#{cursor_y}'` for the
   hardware cursor. Theme keys resolve at render time; capture-pane
@@ -367,92 +366,11 @@ those are done.
 
 ## 4. Roadmap: what to build next, in order
 
-Each item is roughly one to two PRs. Most build on the existing
-plumbing; only items 5 and 7 are major architectural lifts.
+Most items build on the existing plumbing; only the Compositor
+(§4.2) and Spec-as-state persistence (§4.3) are major architectural
+lifts.
 
-### 4.1 `Tree` widget — top user value
-
-**Plugins waiting**: `search_replace.ts` (file → matches),
-`audit_mode.ts` (files → hunks), file-explorer, find_references.
-
-**Spec shape**: tracks the v1 catalogue.
-
-```rust
-WidgetSpec::Tree {
-    nodes: Vec<TreeNode>,         // flat list with depth + parent key
-    item_keys: Vec<String>,       // parallel
-    selected_index: i32,           // initial-only
-    visible_rows: u32,
-    expanded_keys: Vec<String>,    // initial-only; instance state takes over
-    key: Option<String>,
-}
-
-struct TreeNode {
-    text: TextPropertyEntry,       // pre-rendered row
-    depth: u32,                    // for indent
-    has_children: bool,            // disclosure-glyph hit area
-}
-```
-
-**Instance state**: `WidgetInstanceState::Tree { scroll_offset,
-selected_index, expanded_keys: HashSet<String> }`.
-
-**Renderer**:
-* Compute visible flat list = nodes filtered by which expanded_keys
-  cover them (parent must be expanded).
-* For each visible row, emit a `TextPropertyEntry` with depth
-  indent + disclosure glyph (`▶` / `▼`) + node.text.
-* Selected row gets `ui.menu_active_bg` extend_to_line_end.
-* HitArea per row: clicking the disclosure column fires `expand`,
-  clicking the row fires `select`. (Two HitAreas per row, narrow byte
-  ranges.)
-
-**Smart-key dispatch additions**:
-* `Right` → expand currently-selected node
-* `Left` → collapse, or move to parent if already collapsed
-* `Up`/`Down` → select prev/next visible (existing select-move
-  generalizes)
-
-**Mutators**: `SetExpandedKeys { widget_key, keys }` for plugins that
-want to toggle expansion without re-emitting.
-
-**Migration**: `search_replace.ts`'s `buildFlatItems` already returns
-the right shape; convert to `tree(...)` and the plugin's existing
-expand-on-Enter handler becomes redundant (host owns expansion).
-
-**Estimated effort**: 1-2 days. Mostly mechanical follow of §3.3
-recipe.
-
-### 4.2 `WidgetMutation::SetSpec { widget_key, sub_spec }`
-
-Replaces a named subtree without re-emitting the whole panel. Lets
-a plugin update e.g. a toolbar's child set without re-transmitting
-the surrounding `Col`.
-
-Implementation: tree walk + replace by key in the host's
-`WidgetPanelState::spec`. One ~20 LOC helper in `widgets/actions.rs`,
-one `WidgetMutation` variant, one TS builder.
-
-### 4.3 `Tabs` / `Group` widget
-
-`git_log.ts` has tab-style buffer-group panels. The widget version is
-a horizontal Row of buttons that switches the body's visible
-sub-spec. Pairs with `SetSpec` (above) for swapping the body.
-
-### 4.4 `TextArea` widget
-
-Multi-line cousin of `TextInput`. Adds:
-* Vertical scroll instance state (extends the focus-cursor to handle
-  scrolled content — the `RenderOutput::focus_cursor.buffer_row` may
-  be larger than `visible_rows`; renderer clamps and reports the
-  visible row).
-* Submit policy: per the §8 terminal constraint, `singleSubmitsOnEnter`
-  vs `altEnter` (default). The widget renders the chosen submit key
-  in its own footer (or relies on the panel's HintBar).
-
-Plugins waiting: composer-style plugins.
-
-### 4.5 Role-based theming
+### 4.1 Role-based theming
 
 Today widgets pick theme keys themselves (constants in
 `widgets/render.rs`). Move to a `Role` enum + a `Role → theme key`
@@ -473,9 +391,9 @@ in one place (renderer); accessibility variants (high-contrast,
 color-blind) drop in by changing the role-resolution table without
 touching plugin code.
 
-### 4.6 Compositor / `Layer` (the big one)
+### 4.2 Compositor / `Layer` (the big one)
 
-This is §7 of this doc / §3.5 of rev 2. Unifies `Popup`, `Prompt`,
+This is §7 of this doc. Unifies `Popup`, `Prompt`,
 `showActionPopup`, hover tooltips, completion popup, plugin-mounted
 modals/tooltips/context-menus into one `Component` trait + Z-ordered
 stack + `mountLayer` IPC. Subsumes a lot of duplicated focus / dismiss
@@ -491,7 +409,7 @@ Key invariants to preserve during migration:
   `event-dispatch-architecture.md` Phase 2; if that's not in tree
   yet, it lands first.
 
-### 4.7 Spec-as-state persistence
+### 4.3 Spec-as-state persistence
 
 §10 tells the full story. Concretely:
 
@@ -512,7 +430,7 @@ Key invariants to preserve during migration:
 Headless rendering and `embed` cross-plugin composition both fall
 out of "Spec is data" once the persistence layer exists.
 
-### 4.8 Accessibility
+### 4.4 Accessibility
 
 * `lib-widgets.i18n.json` for default labels (`Confirm`, `Cancel`,
   `Toggle`, …) translatable independent of plugins.
@@ -523,17 +441,16 @@ out of "Spec is data" once the persistence layer exists.
 * Motion-reduce: gate the two library animations (focus-flash,
   hover-fade) on `theme.accessibility.reduce_motion`.
 
-### 4.9 Plugin migrations beyond `search_replace.ts`
+### 4.5 Plugin migrations beyond `search_replace.ts`
 
 The heaviest payoff order, per call-site density:
-* `git_log.ts` — Toolbar + Tabs + Table.
+* `git_log.ts` — Toolbar + Table.
 * `lib/finder.ts` — already a panel manager; convert to `List` +
   `Prompt` (after Layer lands).
 * `audit_mode.ts` — Tree + List + RawBuffer escape hatch.
 * `dashboard.ts` — Toolbar + List.
 * `theme_editor.ts` — settings-style controls.
-* `pkg.ts` — what `claude/design-plugin-ui-library-pxri8` started
-  with; the `// TODO: Plugin UI Component Library` literal.
+* `pkg.ts` — the `// TODO: Plugin UI Component Library` literal.
 
 Each plugin migration is mostly mechanical once the widgets it needs
 exist. The work is in (a) discovering hidden assumptions in plugin
@@ -541,7 +458,7 @@ state machines (e.g. `search_replace`'s `focusPanel`/`queryField`/
 `optionIndex` triple), and (b) reconciling event flow with whatever
 async work the plugin already does (debounce, LSP, git).
 
-### 4.10 Settings adoption
+### 4.6 Settings adoption
 
 §11 says shared renderers. The shape today is
 `widgets/render.rs::render_*` for plugin widgets, separate
@@ -550,15 +467,14 @@ extracting a common `(State, Layout, Colors) → TextPropertyEntry`
 shape; both already have it. The work is moving the renderers to
 a common location (probably `view/controls/`) and having
 `widgets/render.rs` call them. This is purely refactoring; no new
-behavior. Defer until role-based theming (4.5) lands; without it
+behavior. Defer until role-based theming (§4.1) lands; without it
 the shared renderers would still pick theme keys in different ways.
 
 ---
 
 ## 5. Widget catalogue
 
-Updated from the rev 2 catalogue. **Status** column: ✅ shipped,
-🚧 partial, ❌ not yet, ⏸ deferred.
+**Status** column: ✅ shipped, 🚧 partial, ❌ not yet, ⏸ deferred.
 
 | Widget | Status | Used by | Notes |
 |---|---|---|---|
@@ -569,15 +485,15 @@ Updated from the rev 2 catalogue. **Status** column: ✅ shipped,
 | `Toggle` / `Checkbox` | ✅ migrated | search_replace toggles | `[v]`/`[ ]` glyph + label |
 | `Button` | ✅ migrated | search_replace Replace All | `intent: "normal" \| "primary" \| "danger"` |
 | `TextInput` | ✅ migrated | search_replace fields | host-owned cursor + value, constant-width with scroll, hardware caret |
-| `List` (virtual-scrolled) | ✅ migrated | search_replace match list | host owns scroll + selection |
-| `Tree` | ❌ → 4.1 | search_replace tree, audit, file-explorer | next priority |
-| `Tabs` / `Group` | ❌ → 4.3 | git_log buffer group, settings categories | |
-| `TextArea` | ❌ → 4.4 | composer plugins | |
-| `Layer` (compositor) | ❌ → 4.6 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
-| `Prompt` | ❌ → 4.6 | finder, every confirm | built on Layer |
-| `Transient` (Magit) | ❌ → 4.6 | discoverability | one of the Layer kinds |
+| `List` (virtual-scrolled) | ✅ | candidates for finder-style consumers | host owns scroll + selection |
+| `Tree` | ✅ migrated | search_replace match tree, audit, file-explorer | host owns scroll + selection + expansion; disclosure-glyph hit area |
+| `TextArea` | ✅ | composer-style plugins | multi-line; host-owned value + cursor + vertical scroll; submit policy via panel HintBar |
+| `Tabs` / `Group` | ⏸ | (no current consumer) | skipped; revisit when needed |
+| `Layer` (compositor) | ❌ → §4.2 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
+| `Prompt` | ❌ → §4.2 | finder, every confirm | built on Layer |
+| `Transient` (Magit) | ❌ → §4.2 | discoverability | one of the Layer kinds |
 | `Table` | ❌ | git_log, find_references, audit | |
-| `Toolbar` | ❌ → 4.3 | git_log, audit_mode | composes Button + Toggle |
+| `Toolbar` | ❌ | git_log, audit_mode | composes Button + Toggle |
 | `Panel` | ⏸ | every panelled plugin | currently unbuilt as a widget; today's `Col` does the job |
 | `KeybindingList`, `MapInput` | ⏸ | mirrors of Settings widgets | low priority |
 | `Diagnostic` / `InlineHint` | ⏸ | LSP plugins | |
@@ -615,8 +531,12 @@ type WidgetSpec =
   | { kind: "button"; label: string; focused: boolean; intent: ButtonKind; key?: string }
   | { kind: "textInput"; value: string; cursorByte: number; focused: boolean; label?: string;
         placeholder?: string | null; maxVisibleChars: number; fieldWidth: number; key?: string }
+  | { kind: "textArea"; value: string; cursorByte: number; focused: boolean;
+        visibleRows: number; key?: string }
   | { kind: "list"; items: TextPropertyEntry[]; itemKeys: string[];
         selectedIndex: number; visibleRows: number; key?: string }
+  | { kind: "tree"; nodes: TreeNode[]; itemKeys: string[];
+        selectedIndex: number; visibleRows: number; expandedKeys: string[]; key?: string }
   | { kind: "raw"; entries: TextPropertyEntry[]; key?: string };
 ```
 
@@ -625,15 +545,13 @@ Row layout works in two passes — see `render_collected` in
 sum(non-flex widths)` split evenly across flex spacers.
 
 Not yet shipped: `fill`, `fixed`, `wrap: "never" | "soft"`, and the
-`embed` composition primitive. These are in §6 of the rev 2 design;
-add them when a plugin needs them.
+`embed` composition primitive. Add them when a plugin needs them.
 
 ---
 
 ## 7. Compositor: layered Components
 
-(rev 2 §3.5, unchanged, partially blocked on `event-dispatch-architecture.md`
-Phase 2.)
+Partially blocked on `event-dispatch-architecture.md` Phase 2.
 
 Today the editor has half a dozen overlapping subsystems for "thing
 that paints over content": `Popup` (`view/popup.rs`), `Prompt`
@@ -695,14 +613,14 @@ lives in `WidgetPanelState`; `WidgetCommand::FocusAdvance { delta }`
 cycles. The smart-key dispatch (`WidgetCommand::Key { key }`) routes
 keystrokes to the right action based on the focused widget's kind.
 
-**Dispatch order today** (one direction off from the rev 2 design):
+**Dispatch order today** (one direction off from the design intent):
 1. Plugin's `defineMode` bindings (the plugin opts in by binding
    keys to `dispatch(widgetKey("Tab"))` etc.)
 2. The smart-key dispatcher in `handle_widget_key`, which routes to
    `handle_widget_focus_advance` / `handle_widget_activate` /
    `handle_widget_select_move` / `handle_widget_text_input_*`.
 
-**Dispatch order rev 2 wanted**:
+**Dispatch order intended**:
 1. Global resolver
 2. Active widget's built-in keymap
 3. Active panel's `defineMode` bindings
@@ -741,7 +659,7 @@ buffer_col)`; it receives semantic events.
   `{}`; List → `{ index, key }`; TextInput → `{ value, cursorByte }`.
 
 **Not yet implemented**:
-* Right-click → context menu (`onContext` in the rev 2 design).
+* Right-click → context menu (`onContext`).
 * Drag (`onPress` / `onDrag` / `onRelease`).
 * Hover (`onHover(true|false)`). Important for the Layer tooltip
   flow.
@@ -772,18 +690,18 @@ applies a minimal patch.
   involvement. Used by focus advance, select move, text-input
   mutation, and toggle/items mutators.
 * The targeted-mutator fast path: `WidgetMutate::SetValue` /
-  `SetChecked` / `SetSelectedIndex` / `SetItems` — the IPC fast
-  path discussed in §3 of the user Q&A. Plugin ships a one-field
-  change instead of the full spec.
+  `SetChecked` / `SetSelectedIndex` / `SetItems` /
+  `SetExpandedKeys`. Plugin ships a one-field change instead of
+  the full spec.
 
-**Not yet implemented (rev 2 §6)**:
-* Session restore (4.7).
-* Live theme switching (4.7).
-* Replay (`--record-spec-stream`) (4.7).
+**Not yet implemented**:
+* Session restore (§4.3).
+* Live theme switching (§4.3).
+* Replay (`--record-spec-stream`) (§4.3).
 * Headless rendering (falls out of "Spec is data" + the renderer
   being a pure function; the test harness already calls
   `render_spec` directly).
-* Cross-plugin composition (`embed` widget kind) (4.7).
+* Cross-plugin composition (`embed` widget kind) (§4.3).
 * Versioning (`spec.version: 1`) — unused since v1 only.
 * Fault isolation: today a panicking renderer for one widget kind
   takes down the whole panel render. The reconciler would need to
@@ -794,8 +712,7 @@ applies a minimal patch.
 
 ## 11. Theming
 
-Widgets carry **roles**, never colors. (rev 2 §7 — partly
-implemented.)
+Widgets carry **roles**, never colors. Partly implemented.
 
 **Implemented**:
 * `Button.intent: "normal" | "primary" | "danger"` — the only
@@ -809,7 +726,7 @@ implemented.)
 * High-contrast / color-blind variant resolution path.
 * Role enum with three-level cap (e.g. `Button.danger.hover.fg`).
 
-The path forward is item 4.5 in the roadmap.
+The path forward is §4.1 in the roadmap.
 
 ---
 
@@ -824,7 +741,7 @@ handles the existing per-plugin help strings.
 
 ## 13. Accessibility
 
-Required for v1 (per rev 2 §9):
+Required for v1:
 
 * High-contrast themes (blocked on role-based theming).
 * Configurable keybindings via `keybindings.json` against
@@ -844,45 +761,22 @@ Nice-to-have (deferred):
 
 ## 14. Migration plan: `search_replace.ts`
 
-Status of the rev 2 5-pass plan:
+Status of the original 5-pass plan:
 
 | Pass | Description | Status |
 |---|---|---|
-| 1 | Mount as `Panel`, body stays `Raw`, HintBar real, toggles real | ✅ commits 3257fa7 (HintBar), 7ddfb05 (toggles + button) |
-| 2 | Replace search/replace fields with `TextInput` | ✅ commit 7ed8276 (initial render-only); 5325ea3 (host owns hardware cursor + constant width) |
-| 3 | Replace match list with `Tree` | 🚧 `List` shipped (commit 7a5a7fd); `Tree` not yet (roadmap 4.1). User-visible regression: Right-arrow-to-expand and click-on-disclosure-glyph don't work; `Enter` on a file row toggles expanded as a fallback. |
+| 1 | Mount as `Panel`, body stays `Raw`, HintBar real, toggles real | ✅ |
+| 2 | Replace search/replace fields with `TextInput` (host-owned cursor + constant width) | ✅ |
+| 3 | Replace match list with `Tree` | ✅ host owns expansion + scroll + selection; disclosure glyph hit area |
 | 4 | Glob filter as `TextInput` with validator | ❌ |
-| 5 | Delete dead code | 🚧 `buildFieldDisplay`, `addCursorOverlay`, the cursor-byte arithmetic, the focus enums, ~12 hand-rolled mode handlers all gone. Remaining dead: `panel.scrollOffset`, `panel.focusPanel`/`queryField`/`optionIndex` (legacy fields kept for the Raw separator path). |
+| 5 | Delete dead code | 🚧 `buildFieldDisplay`, `addCursorOverlay`, the cursor-byte arithmetic, the focus enums, the per-key mode handlers all gone. Remaining dead: `panel.scrollOffset`, `panel.focusPanel`/`queryField`/`optionIndex` (legacy fields kept for the Raw separator path). |
 
-Net diff so far: ~600 LOC removed from `search_replace.ts`, ~80 LOC
-of widget builders added. The plugin's `defineMode` table shrank
-from per-key handlers to twelve one-liner `dispatch(widgetKey("..."))`
-forwarders.
+The plugin's `defineMode` table shrank from per-key handlers to a
+small set of one-liner `dispatch(widgetKey("..."))` forwarders.
 
 ---
 
-## 15. Shipped commit map
-
-| Commit | What it landed | Files |
-|---|---|---|
-| `3257fa7` | Foundation: `WidgetSpec` enum, MountWidgetPanel/UpdateWidgetPanel/UnmountWidgetPanel IPC, render_spec, registry, plugins/lib/widgets.ts, search_replace HintBar. | api.rs, hooks.rs, plugin_dispatch.rs, widgets/{mod,registry,render}.rs, widgets.ts, fresh.d.ts |
-| `7ddfb05` | Toggle, Button, Spacer + search_replace options row. | api.rs, render.rs, widgets.ts, search_replace.ts |
-| `2c87651` | Hit-test + widget_event firing on click. | render.rs (HitArea), registry.rs (hit_test), click_handlers.rs |
-| `7ed8276` | TextInput widget (render-only, plugin owned cursor). | api.rs, render.rs, widgets.ts, search_replace.ts |
-| `7a5a7fd` | List with widget-owned virtual scrolling; instance-state mechanism. | api.rs, registry.rs, render.rs, widgets.ts, search_replace.ts |
-| `b9c415b` | Focus management (tabbable collection, focus_key) + WidgetCommand IPC dispatch. | api.rs, render.rs, plugin_dispatch.rs, widgets/actions.rs (new) |
-| `53ee226` | Smart-Key dispatch + search_replace mode-binding migration. | api.rs, plugin_dispatch.rs, search_replace.ts |
-| `0922463` | Fix concurrent-keystroke race: host-owned TextInput value + List selection. | registry.rs, render.rs, plugin_dispatch.rs |
-| `b7baeee` | Flex Spacer + panel-width-aware layout. | api.rs, render.rs, widgets.ts, search_replace.ts |
-| `aaed59e` | cargo fmt + clippy clean. | various |
-| `5325ea3` | Host owns hardware cursor + constant-width TextInput (`fieldWidth`). | api.rs, render.rs (FocusCursor), plugin_dispatch.rs (apply_widget_focus_cursor), widgets.ts |
-| `a436874` | Targeted mutators (Path A): WidgetMutation IPC, setValue/setChecked/setSelectedIndex/setItems. | api.rs, plugin_dispatch.rs, widgets/actions.rs, widgets.ts, search_replace.ts |
-
-Test count: 70 widget unit tests, all green.
-
----
-
-## 16. Prior art — what we steal, what we reject
+## 15. Prior art — what we steal, what we reject
 
 | System | Steal | Reject | Why |
 |---|---|---|---|
@@ -895,55 +789,49 @@ Test count: 70 widget unit tests, all green.
 
 ---
 
-## 17. Risks
+## 16. Risks
 
 | Risk | Mitigation |
 |---|---|
 | Reconciler complexity grows past what one engineer can hold | Keep Spec flat (no nested per-widget keys beyond `key: string`); cap recursion depth; ship the dirtiest plugin (`search_replace.ts`) as the regression test for every reconciler change |
-| Per-keystroke event IPC dominates if plugins re-emit Spec on every keystroke | Document the rule: in `widget_event "change"`, never call `updateWidgetPanel` unless the rest of the spec actually changed. Use mutators (`SetValue`/`SetChecked`/`SetItems`) for hot-path. The lint is "panel.update calls per second"; expose it on the dev HUD |
+| Per-keystroke event IPC dominates if plugins re-emit Spec on every keystroke | Document the rule: in `widget_event "change"`, never call `updateWidgetPanel` unless the rest of the spec actually changed. Use mutators (`SetValue`/`SetChecked`/`SetItems`/`SetExpandedKeys`) for hot-path. The lint is "panel.update calls per second"; expose it on the dev HUD |
 | Capability creep through widget callbacks | Widgets only emit *events* the plugin can already subscribe to. Code review checklist: a new widget MUST NOT introduce a new `PluginCommand`-equivalent capability |
 | Theme role explosion (`Button.danger.hover.fg`...) | Cap the role tree at three levels; review additions in PRs that touch `theme/types.rs` |
-| Reach: Settings doesn't actually adopt the widget tree | Keep the *renderers* shared (item 4.10) and the *Spec* shape compatible. Settings can stay on its current direct calls indefinitely |
+| Reach: Settings doesn't actually adopt the widget tree | Keep the *renderers* shared (§4.6) and the *Spec* shape compatible. Settings can stay on its current direct calls indefinitely |
 | Plugin author confusion: Spec vs imperative vs mutators | One way per use-case in the docs. `Raw` exists for *escape hatches*, not for rendering rich UI. Mutators are for hot-path single-field updates |
 | Terminal-constraint violations (Shift+Enter etc.) | Static lint in TS: any `keys` string in a `HintBar` or `Transient` matching `^Shift\+(Enter\|Alt\+Enter)` is a build error |
-| Drift from `event-dispatch-architecture` Phase 2 / `unified-keybinding-resolution` / `unified-hit-test-theme-plan` | This proposal builds on them. The Compositor migration (4.6) blocks until Phase 2 lands |
+| Drift from `event-dispatch-architecture` Phase 2 / `unified-keybinding-resolution` / `unified-hit-test-theme-plan` | This proposal builds on them. The Compositor migration (§4.2) blocks until Phase 2 lands |
 
 ---
 
-## 18. Order of landing — updated
+## 17. Order of landing
 
-1. ✅ ~~event-dispatch Phase 2 hit-test dispatcher~~ — bypassed for v1; the widget runtime owns its own hit-test against `WidgetRegistry::hits`. The general dispatcher is still desirable for the Layer compositor (4.6).
-2. ✅ ~~`unified-hit-test-theme-plan.md` `region_at` extension~~ — same; bypassed.
-3. ✅ ~~`unified-keybinding-resolution.md` collapse~~ — same; bypassed. Plugin's `defineMode` already routes through the existing resolver; widget commands are explicit handler dispatches.
-4. ✅ `crates/fresh-editor/src/widgets/{mod,registry,render,actions}.rs`.
-5. ✅ `crates/fresh-core/src/api.rs` — Mount/Update/Unmount/WidgetCommand/WidgetMutate variants + WidgetSpec/WidgetAction/WidgetMutation types.
-6. ✅ `crates/fresh-editor/plugins/lib/widgets.ts` — TS surface.
-7. ✅ Search_replace migration through Pass 2; partial Pass 3 (List, no Tree).
-8. → 4.1 Tree widget.
-9. → 4.2 SetSpec mutator.
-10. → 4.3-4.4 Tabs, TextArea.
-11. → 4.5 Role-based theming.
-12. → 4.6 Compositor / Layer.
-13. → 4.7 Spec-as-state persistence.
-14. → 4.8 Accessibility.
-15. → 4.9 Plugin migrations beyond `search_replace.ts`.
-16. → 4.10 Settings adoption (last; depends on 4.5).
+Foundation (widget runtime, core types, TS surface, search_replace
+migration through Pass 3) is shipped. Remaining work, in order:
+
+1. → §4.1 Role-based theming.
+2. → §4.2 Compositor / Layer.
+3. → §4.3 Spec-as-state persistence.
+4. → §4.4 Accessibility.
+5. → §4.5 Plugin migrations beyond `search_replace.ts`.
+6. → §4.6 Settings adoption (last; depends on §4.1).
+
+The hit-test dispatcher / `region_at` extension / unified-keybinding
+collapse from related design docs were bypassed for v1: the widget
+runtime owns its own hit-test against `WidgetRegistry::hits`, and
+plugin `defineMode` already routes through the existing resolver.
+The general dispatcher remains desirable for the Layer compositor.
 
 ---
 
-## 19. Go / don't go
+## 18. Go / don't go
 
-**Going.** Foundation shipped on this branch; one plugin migrated end-
-to-end through the bulk of its UI. cargo check workspace clean,
-70 widget tests passing, tsc clean, interactively verified in tmux.
+**Going.** Foundation shipped, one plugin (`search_replace.ts`)
+migrated end-to-end through the bulk of its UI; cargo check
+workspace clean, widget unit tests green, tsc clean, interactively
+verified in tmux.
 
-The next maintainer's quickest path to value is §3.3's recipe applied
-to `Tree` (4.1) — that's the single biggest user-visible win, and the
-plumbing is fully in place for it. Then 4.2 (SetSpec) closes the
-"plugin can mutate any subtree" gap, after which most plugin migrations
-become mechanical.
-
-The big architectural lift is 4.6 (Compositor / Layer). It's not
+The big architectural lift is §4.2 (Compositor / Layer). It's not
 blocked on anything in tree; it's blocked on planning capacity.
 Until it lands, plugins that want tooltips / modals / context menus
 keep using `editor.startPrompt` / `editor.showActionPopup` / etc.,
@@ -954,13 +842,12 @@ panels.
 
 ## Appendix A — Rejected: TS-only thin helper library
 
-A parallel proposal exists on `claude/design-plugin-ui-library-pxri8`
-(`docs/internal/plugin-ui-library-design.md`, 1,231 lines) that takes
-the opposite shape: ~800 LOC of TypeScript helpers, one
+A parallel proposal in `docs/internal/plugin-ui-library-design.md`
+takes the opposite shape: a thin TypeScript helper library — one
 `VirtualBufferBuilder`, a `TextInputState` + `TextInputRouter`
-wrapping `mode_text_input`, a `FocusRing<T>` cycle helper, seven new
-theme keys. **Zero new IPC.** Migrates `pkg.ts`,
-`search_replace.ts`, `theme_editor.ts` in ~3 weeks.
+wrapping `mode_text_input`, a `FocusRing<T>` cycle helper, a small
+set of new theme keys. **Zero new IPC.** Migrates `pkg.ts`,
+`search_replace.ts`, `theme_editor.ts` quickly.
 
 It is a coherent v1 if shipping speed is the binding constraint.
 It is the wrong end-state under the criterion stated at the top of
@@ -982,27 +869,26 @@ structurally cannot reach:
    emits one semantic event back; if the plugin's model doesn't
    change, no re-render IPC fires at all. (Shipped — instance state
    plus targeted mutators.)
-4. **Theme as roles, not colors.** The TS-only proposal adds 7 theme
+4. **Theme as roles, not colors.** The TS-only proposal adds theme
    keys; plugins still pick which key to pass to which widget.
    Theme packs and accessibility variants only stay consistent when
    the role→key mapping is centralized in the renderer. (Partially
    shipped — `intent: "primary"|"danger"` is the only role today;
-   see roadmap 4.5 for the rest.)
+   see roadmap §4.1 for the rest.)
 5. **Reach across built-in surfaces.** The Rust `view/controls/*`
    renderers paint plugin widgets too — Settings, file explorer,
    prompts, plugin panels share one render path. The TS-only proposal
-   freezes the split forever (its §2.1 acknowledges and accepts the
-   parallel TS stack). (Not shipped — see roadmap 4.10.)
+   freezes the split forever. (Not shipped — see roadmap §4.6.)
 
 Three further capabilities the TS-only design forecloses:
 
 * **Layered compositor** (`Popup`/`Prompt`/`showActionPopup`/hover/
   modals/context-menus/completion under one dismiss-and-focus model)
-  — see §7 / roadmap 4.6.
+  — see §7 / roadmap §4.2.
 * **Spec as first-class state** (session restore, theme switch,
   deterministic replay, headless rendering, cross-plugin composition)
-  — see §10 / roadmap 4.7. Spec is already data; the missing piece is
-  persistence.
+  — see §10 / roadmap §4.3. Spec is already data; the missing piece
+  is persistence.
 * **Fault isolation.** A panicking widget renderer in the TS-only
   design takes down the panel render. With Rust-side widget kinds,
   the reconciler can paint a placeholder for the offending subtree
@@ -1021,9 +907,9 @@ Where the TS-only proposal is right and we keep its discipline:
   hatch. (Followed — plugin's `defineMode` is how it opts into widget
   key dispatch.)
 
-**Net.** The TS-only proposal answers "what is the minimum useful help
-in the next three weeks?" cleanly. It does not answer "what should
+**Net.** The TS-only proposal answers "what is the minimum useful
+help we can ship soon?" cleanly. It does not answer "what should
 this library *be*?" Under the criterion stated at the top — end-state
 UX, robustness, flexibility, with shipping speed deliberately not a
 constraint — the maximalist version is the answer, and is what's in
-tree on this branch.
+tree.

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -369,32 +369,15 @@ those are done.
 
 ## 4. Roadmap: what to build next, in order
 
-Most items build on the existing plumbing; only the Compositor
-(§4.2) and Spec-as-state persistence (§4.3) are major architectural
-lifts.
+The blocking work is the Compositor (§4.1), then plugin migrations
+that bring more surfaces under the widget runtime (§4.2), then
+Settings adoption (§4.3). The smaller follow-ups (§4.4) move
+the existing surface forward without architectural lifts.
 
-### 4.1 Role-based theming
+§4.5 covers items previously elevated in the roadmap that are now
+deferred — pick them up when a real consumer materializes.
 
-Today widgets pick theme keys themselves (constants in
-`widgets/render.rs`). Move to a `Role` enum + a `Role → theme key`
-mapping table:
-
-```rust
-pub enum Role {
-    HelpKey, ToggleOn, FocusedFg, FocusedBg, DangerFg, InputBg,
-    PlaceholderFg, ListSelectedBg, …
-}
-
-fn role_to_theme_key(role: Role, theme_overrides: &Option<HashMap<...>>) -> &str { … }
-```
-
-Plus a per-spec `theme: Option<HashMap<Role, OverlayColorSpec>>` that
-plugins can pass to override individual roles. The translation lives
-in one place (renderer); accessibility variants (high-contrast,
-color-blind) drop in by changing the role-resolution table without
-touching plugin code.
-
-### 4.2 Compositor / `Layer` (the big one)
+### 4.1 Compositor / `Layer` (the big one)
 
 This is §7 of this doc. Unifies `Popup`, `Prompt`,
 `showActionPopup`, hover tooltips, completion popup, plugin-mounted
@@ -402,6 +385,14 @@ modals/tooltips/context-menus into one `Component` trait + Z-ordered
 stack + `mountLayer` IPC. Subsumes a lot of duplicated focus / dismiss
 / event-routing logic. Touches a lot of files. Worth a dedicated
 multi-PR effort.
+
+Why this is the central blocker: the goal is "all plugin UI is
+declarative widgets". Today `editor.startPrompt` and friends work
+fine, but they don't share dismiss / focus / keymap rules with
+the widget runtime. The keymap-claim inversion from §8 (host
+claims widget keys *before* `defineMode` sees them) only reaches
+end-state across panels *and* overlays once one Compositor owns
+the focus stack.
 
 Key invariants to preserve during migration:
 * `editor.startPrompt`, `editor.showActionPopup` keep working —
@@ -412,41 +403,11 @@ Key invariants to preserve during migration:
   `event-dispatch-architecture.md` Phase 2; if that's not in tree
   yet, it lands first.
 
-### 4.3 Spec-as-state persistence
+### 4.2 Plugin migrations beyond `search_replace.ts`
 
-§10 tells the full story. Concretely:
+This is how reach (goal #5: same shape across every panel) gets
+done. Heaviest payoff order, per call-site density:
 
-* Per-workspace `state.json` gains a `widget_panels: { [panel_id]:
-  { spec, instance_states, focus_key } }` section. Persisted on
-  panel update; loaded on workspace open.
-* A new `editor_init` step iterates persisted panels: emits the
-  stored spec to whichever plugin "owns" it (the plugin's `init.ts`
-  can opt in by registering a panel-id → handler mapping).
-* Theme switching: on `theme_changed`, host iterates
-  `widget_registry.panel_ids()` and calls `rerender_widget_panel`
-  for each. Plugin not involved.
-* Replay capture: `--record-spec-stream` flag dumps every
-  Mount/Update/Mutate/WidgetEvent to a JSONL file. A `replay-spec`
-  binary feeds the file to a stub plugin and snapshots the
-  rendered output.
-
-Headless rendering and `embed` cross-plugin composition both fall
-out of "Spec is data" once the persistence layer exists.
-
-### 4.4 Accessibility
-
-* `lib-widgets.i18n.json` for default labels (`Confirm`, `Cancel`,
-  `Toggle`, …) translatable independent of plugins.
-* `aria` string per widget, emitted on focus change.
-* OSC 52 / IDE bridge: widget focus changes route through
-  `view/accessibility.rs` (new) which already serializes selection
-  for clipboard.
-* Motion-reduce: gate the two library animations (focus-flash,
-  hover-fade) on `theme.accessibility.reduce_motion`.
-
-### 4.5 Plugin migrations beyond `search_replace.ts`
-
-The heaviest payoff order, per call-site density:
 * `git_log.ts` — Toolbar + Table.
 * `lib/finder.ts` — already a panel manager; convert to `List` +
   `Prompt` (after Layer lands).
@@ -461,7 +422,12 @@ state machines (e.g. `search_replace`'s `focusPanel`/`queryField`/
 `optionIndex` triple), and (b) reconciling event flow with whatever
 async work the plugin already does (debounce, LSP, git).
 
-### 4.6 Settings adoption
+`Toolbar` (composes Button + Toggle into a horizontal Row) and
+`Table` (`git_log` log, `find_references`, audit) need to land as
+new widget kinds during this phase. `Transient` (Magit-style menu)
+falls out of the Compositor work.
+
+### 4.3 Settings adoption
 
 §11 says shared renderers. The shape today is
 `widgets/render.rs::render_*` for plugin widgets, separate
@@ -469,9 +435,59 @@ async work the plugin already does (debounce, LSP, git).
 extracting a common `(State, Layout, Colors) → TextPropertyEntry`
 shape; both already have it. The work is moving the renderers to
 a common location (probably `view/controls/`) and having
-`widgets/render.rs` call them. This is purely refactoring; no new
-behavior. Defer until role-based theming (§4.1) lands; without it
-the shared renderers would still pick theme keys in different ways.
+`widgets/render.rs` call them. Pure refactoring; no new behavior.
+
+Brings goal #5 to the built-in Settings surface so widgets really
+do paint everywhere.
+
+### 4.4 Smaller follow-ups
+
+* **Fault isolation.** `catch_unwind` around per-widget `render_<kind>`
+  calls so one panicking renderer paints a placeholder + logs a
+  `RenderError` instead of taking down the whole panel. Pure host
+  work; doesn't depend on §4.5 deferred items.
+* **IME composition in TextInput.** `mode_text_input` already
+  delivers composed text but the widget cursor model doesn't
+  track composition states. Needed for international input.
+* **Built-in chord support inside widgets.** Today
+  `apply_text_input_key` only handles single-key edits; chords
+  (`g g`) still bubble to the plugin's `defineMode`.
+* **Keymap-claim inversion (§2.3).** Host claims widget keys
+  before `defineMode` sees them, so plugins stop repeating the
+  Tab / Backspace / arrows binding table. A `defineMode`
+  extension or a "panel has a widget runtime" registry. Closes
+  goal #1 fully.
+
+### 4.5 Deferred (no current driver)
+
+These items remain valuable design work but are not blocking the
+end-state and have no in-tree consumer pushing for them. Pick up
+when real demand surfaces.
+
+* **Role-based theming.** Today widgets pick theme keys directly
+  from `widgets/render.rs` constants; only `Button.intent:
+  "primary" | "danger"` is a real role. The full design
+  (`Role` enum + `Role → theme key` table + per-spec override
+  map) lets accessibility variants and theme packs drop in
+  centrally. Pain point today: zero — every widget has a
+  reasonable default theme key. Revisit when a high-contrast
+  theme or a plugin needing per-widget color overrides arrives.
+* **Accessibility.** Library i18n defaults
+  (`lib-widgets.i18n.json`), `aria` strings on focus change,
+  OSC 52 / IDE screen-reader bridge, motion-reduce gating for
+  the (not-yet-shipped) library animations. Most of this depends
+  on role-based theming for the high-contrast piece.
+* **Spec-as-state persistence (§10).** Five separate features
+  bundled together: (a) session restore — panels survive
+  workspace close; (b) live theme-switch correctness — host
+  re-renders all mounted panels on `theme_changed` so plugins
+  don't have to subscribe; (c) `--record-spec-stream` JSONL
+  replay for plugin-bug repro; (d) headless rendering for
+  snapshot tests; (e) `embed` cross-plugin composition. None
+  blocks a user flow today; (a) and (b) are small UX wins, the
+  rest are developer / plugin-author tooling. Build the
+  persistence layer when a real consumer asks (a session-restore
+  feature request, a theme-switch bug report, etc.).
 
 ---
 
@@ -492,9 +508,9 @@ the shared renderers would still pick theme keys in different ways.
 | `Tree` | ✅ migrated | search_replace match tree, audit, file-explorer | host owns scroll + selection + expansion; disclosure-glyph hit area |
 | `TextArea` | ✅ | composer-style plugins | multi-line; host-owned value + cursor + vertical scroll; submit policy via panel HintBar |
 | `Tabs` / `Group` | ⏸ | (no current consumer) | skipped; revisit when needed |
-| `Layer` (compositor) | ❌ → §4.2 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
-| `Prompt` | ❌ → §4.2 | finder, every confirm | built on Layer |
-| `Transient` (Magit) | ❌ → §4.2 | discoverability | one of the Layer kinds |
+| `Layer` (compositor) | ❌ → §4.1 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
+| `Prompt` | ❌ → §4.1 | finder, every confirm | built on Layer |
+| `Transient` (Magit) | ❌ → §4.1 | discoverability | one of the Layer kinds |
 | `Table` | ❌ | git_log, find_references, audit | |
 | `Toolbar` | ❌ | git_log, audit_mode | composes Button + Toggle |
 | `Panel` | ⏸ | every panelled plugin | currently unbuilt as a widget; today's `Col` does the job |
@@ -763,18 +779,20 @@ applies a minimal patch.
   pay no per-row codepoint walks or per-overlay bridge calls.
 
 **Not yet implemented**:
-* Session restore (§4.3).
-* Live theme switching (§4.3).
-* Replay (`--record-spec-stream`) (§4.3).
-* Headless rendering (falls out of "Spec is data" + the renderer
-  being a pure function; the test harness already calls
-  `render_spec` directly).
-* Cross-plugin composition (`embed` widget kind) (§4.3).
+* Session restore — deferred (§4.5).
+* Live theme switching — deferred (§4.5).
+* Replay (`--record-spec-stream`) — deferred (§4.5).
+* Headless rendering — deferred (§4.5). Falls out of "Spec is
+  data" + the renderer being a pure function; the test harness
+  already calls `render_spec` directly.
+* Cross-plugin composition (`embed` widget kind) — deferred
+  (§4.5).
 * Versioning (`spec.version: 1`) — unused since v1 only.
-* Fault isolation: today a panicking renderer for one widget kind
-  takes down the whole panel render. The reconciler would need to
-  catch_unwind around per-widget `render_<kind>` calls, paint a
-  placeholder, log a `RenderError` event.
+* Fault isolation — small follow-up (§4.4). Today a panicking
+  renderer for one widget kind takes down the whole panel render;
+  the reconciler should `catch_unwind` around per-widget
+  `render_<kind>` calls, paint a placeholder, and log a
+  `RenderError` event.
 
 ---
 
@@ -794,7 +812,9 @@ Widgets carry **roles**, never colors. Partly implemented.
 * High-contrast / color-blind variant resolution path.
 * Role enum with three-level cap (e.g. `Button.danger.hover.fg`).
 
-The path forward is §4.1 in the roadmap.
+The path forward is §4.5 in the roadmap (deferred without a
+current driver — every widget has a reasonable default theme
+key today).
 
 ---
 
@@ -809,7 +829,7 @@ handles the existing per-plugin help strings.
 
 ## 13. Accessibility
 
-Required for v1:
+Deferred (§4.5) without a current driver. The full design:
 
 * High-contrast themes (blocked on role-based theming).
 * Configurable keybindings via `keybindings.json` against
@@ -817,13 +837,14 @@ Required for v1:
   commands once the plugin binds them).
 * Screen-reader output via OSC 52 / IDE bridges (not implemented).
 * Motion-reduction: gates the library's two animations
-  (focus-flash, hover-fade) — neither is shipped yet, so this is
-  ready to add when they are.
+  (focus-flash, hover-fade) — neither is shipped yet.
+* Full ARIA-tree model (parent/child/level-of) is the eventual
+  end-state; the cheaper interim is flat live-region announcements
+  per focus change with one-per-100ms throttling.
 
-Nice-to-have (deferred):
-* Full ARIA-tree model (parent/child/level-of). v1 ships flat
-  live-region announcements per focus change.
-* Live-region throttling (one announcement per 100 ms).
+Pick this up when an a11y review or a user request surfaces. The
+keybinding piece already works through the existing resolver;
+the rest is genuinely new code.
 
 ---
 
@@ -865,24 +886,29 @@ small set of one-liner `dispatch(widgetKey("..."))` forwarders.
 | Per-keystroke event IPC dominates if plugins re-emit Spec on every keystroke | Document the rule: in `widget_event "change"`, never call `updateWidgetPanel` unless the rest of the spec actually changed. Use mutators (`SetValue`/`SetChecked`/`SetItems`/`SetExpandedKeys`) for hot-path. The lint is "panel.update calls per second"; expose it on the dev HUD |
 | Capability creep through widget callbacks | Widgets only emit *events* the plugin can already subscribe to. Code review checklist: a new widget MUST NOT introduce a new `PluginCommand`-equivalent capability |
 | Theme role explosion (`Button.danger.hover.fg`...) | Cap the role tree at three levels; review additions in PRs that touch `theme/types.rs` |
-| Reach: Settings doesn't actually adopt the widget tree | Keep the *renderers* shared (§4.6) and the *Spec* shape compatible. Settings can stay on its current direct calls indefinitely |
+| Reach: Settings doesn't actually adopt the widget tree | Keep the *renderers* shared (§4.3) and the *Spec* shape compatible. Settings can stay on its current direct calls indefinitely |
 | Plugin author confusion: Spec vs imperative vs mutators | One way per use-case in the docs. `Raw` exists for *escape hatches*, not for rendering rich UI. Mutators are for hot-path single-field updates |
 | Terminal-constraint violations (Shift+Enter etc.) | Static lint in TS: any `keys` string in a `HintBar` or `Transient` matching `^Shift\+(Enter\|Alt\+Enter)` is a build error |
-| Drift from `event-dispatch-architecture` Phase 2 / `unified-keybinding-resolution` / `unified-hit-test-theme-plan` | This proposal builds on them. The Compositor migration (§4.2) blocks until Phase 2 lands |
+| Drift from `event-dispatch-architecture` Phase 2 / `unified-keybinding-resolution` / `unified-hit-test-theme-plan` | This proposal builds on them. The Compositor migration (§4.1) blocks until Phase 2 lands |
 
 ---
 
 ## 17. Order of landing
 
 Foundation (widget runtime, core types, TS surface, search_replace
-migration through Pass 3) is shipped. Remaining work, in order:
+migration through Pass 3) is shipped. Blocking remaining work, in
+order:
 
-1. → §4.1 Role-based theming.
-2. → §4.2 Compositor / Layer.
-3. → §4.3 Spec-as-state persistence.
-4. → §4.4 Accessibility.
-5. → §4.5 Plugin migrations beyond `search_replace.ts`.
-6. → §4.6 Settings adoption (last; depends on §4.1).
+1. → §4.1 Compositor / Layer.
+2. → §4.2 Plugin migrations beyond `search_replace.ts` (with
+   `Toolbar` and `Table` widgets landing alongside).
+3. → §4.3 Settings adoption.
+4. → §4.4 Smaller follow-ups (fault isolation, IME, chord support,
+   keymap-claim inversion). Independent of the above; can land
+   in parallel.
+
+Deferred without a current driver: role-based theming,
+accessibility, spec-as-state persistence (§4.5).
 
 The hit-test dispatcher / `region_at` extension / unified-keybinding
 collapse from related design docs were bypassed for v1: the widget
@@ -899,12 +925,14 @@ migrated end-to-end through the bulk of its UI; cargo check
 workspace clean, widget unit tests green, tsc clean, interactively
 verified in tmux.
 
-The big architectural lift is §4.2 (Compositor / Layer). It's not
+The big architectural lift is §4.1 (Compositor / Layer). It's not
 blocked on anything in tree; it's blocked on planning capacity.
 Until it lands, plugins that want tooltips / modals / context menus
 keep using `editor.startPrompt` / `editor.showActionPopup` / etc.,
 which work fine but don't share dismiss/focus rules with widget
-panels.
+panels — and goal #1 (host-claimed widget keymaps) only reaches
+end-state across panels *and* overlays once one Compositor owns
+the focus stack.
 
 ---
 
@@ -942,25 +970,26 @@ structurally cannot reach:
    Theme packs and accessibility variants only stay consistent when
    the role→key mapping is centralized in the renderer. (Partially
    shipped — `intent: "primary"|"danger"` is the only role today;
-   see roadmap §4.1 for the rest.)
+   the full design is deferred without a current driver, see
+   roadmap §4.5.)
 5. **Reach across built-in surfaces.** The Rust `view/controls/*`
    renderers paint plugin widgets too — Settings, file explorer,
    prompts, plugin panels share one render path. The TS-only proposal
-   freezes the split forever. (Not shipped — see roadmap §4.6.)
+   freezes the split forever. (Not shipped — see roadmap §4.3.)
 
 Three further capabilities the TS-only design forecloses:
 
 * **Layered compositor** (`Popup`/`Prompt`/`showActionPopup`/hover/
   modals/context-menus/completion under one dismiss-and-focus model)
-  — see §7 / roadmap §4.2.
+  — see §7 / roadmap §4.1.
 * **Spec as first-class state** (session restore, theme switch,
   deterministic replay, headless rendering, cross-plugin composition)
-  — see §10 / roadmap §4.3. Spec is already data; the missing piece
-  is persistence.
+  — see §10. Spec is already data; the persistence layer is
+  deferred without a current driver (roadmap §4.5).
 * **Fault isolation.** A panicking widget renderer in the TS-only
   design takes down the panel render. With Rust-side widget kinds,
   the reconciler can paint a placeholder for the offending subtree
-  and keep going. (Not shipped here either — see §10.)
+  and keep going. (Not shipped here either — see §4.4.)
 
 Where the TS-only proposal is right and we keep its discipline:
 

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -60,6 +60,9 @@ tsc clean, interactively verified in tmux.
 | Type | Notes |
 |---|---|
 | `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `TextArea`, `List`, `Tree`, `Spacer`, `Raw`. |
+| `TextPropertyEntry` (`fresh-core::text_property`) | Row-content payload for `List`, `Tree`, and `Raw`. Carries `text`, `inline_overlays: Vec<InlineOverlay>`, `segments: Vec<StyledSegment>`, `pad_to_chars: Option<u32>`, `truncate_to_chars: Option<u32>`. The host calls `normalize_widths` on each visible entry — segments concatenate into `text` with one Char-unit overlay per styled segment, then truncate, then pad, then char→byte conversion for any remaining char-unit overlays. Plugins describe row content structurally and never name byte/codepoint offsets between segments. |
+| `InlineOverlay` | `start`, `end`, `style`, `properties`, `unit: OffsetUnit { Byte, Char }` (default `Byte`). Char offsets resolve to bytes during `normalize_widths`. |
+| `StyledSegment` | `text` + optional `style` + optional nested `overlays`. Building block for `TextPropertyEntry::segments`. |
 | `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` | Shapes referenced by the spec / IPC. |
 | `PluginCommand::MountWidgetPanel`, `UpdateWidgetPanel`, `UnmountWidgetPanel` | Spec lifecycle. |
 | `PluginCommand::WidgetCommand { panel_id, action }` | Routes a `WidgetAction` (key dispatch / focus / activate / select-move / text-input). |
@@ -79,9 +82,9 @@ tsc clean, interactively verified in tmux.
 
 | File | Exports |
 |---|---|
-| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree`, `treeNode`, `spacer`, `flexSpacer`, `raw`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `unmount`. |
+| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree`, `treeNode`, `spacer`, `flexSpacer`, `raw`, `styledRow`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `unmount`. |
 | `index.ts` | Re-exports the above. |
-| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` types. `widget_event` hook. |
+| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation`, `StyledSegment`, `OffsetUnit` types. `widget_event` hook. |
 
 **Plugin migration: `search_replace.ts`**
 
@@ -547,6 +550,64 @@ sum(non-flex widths)` split evenly across flex spacers.
 Not yet shipped: `fill`, `fixed`, `wrap: "never" | "soft"`, and the
 `embed` composition primitive. Add them when a plugin needs them.
 
+### 6.1 Entry construction shape
+
+Row content for `List`, `Tree`, and `Raw` flows through a single
+`TextPropertyEntry` shape. Plugins have two ways to build one:
+
+```ts
+// (a) Pre-rendered text + offset overlays. Overlay offsets default
+// to bytes (UTF-8); set `unit: "char"` to address codepoints
+// instead — the host converts to bytes natively in Rust during
+// `normalize_widths`.
+{
+  text: "TX file.rs (3/5)",
+  inlineOverlays: [
+    { start: 0, end: 2, style: { fg: ICON, bold: true }, unit: "char" },
+    { start: 3, end: 10, style: { fg: PATH }, unit: "char" },
+  ],
+  padToChars: 80,    // host pads with spaces after overlays resolve
+  truncateToChars: 80, // host truncates at codepoint boundary, "..." suffix
+}
+
+// (b) Structural segments. The plugin describes the row as a
+// sequence of (text, optional style, optional nested overlays);
+// the host concatenates and emits one Char-unit overlay per
+// styled segment plus each segment's nested overlays shifted by
+// the segment's start. The plugin never names a byte or codepoint
+// offset between segments.
+styledRow([
+  { text: "TX",    style: { fg: ICON, bold: true } },
+  { text: " " },
+  { text: "file.rs", style: { fg: PATH } },
+  { text: " (3/5)" },
+], { padToChars: 80 })
+```
+
+Use (b) when row structure is a flat sequence of styled pieces —
+the typical file-tree row, breadcrumb, or label-with-suffix.
+Use (a) when overlays land *inside* a single string the plugin
+already has (regex hits inside a context substring, syntax
+highlights inside a code line). The two compose: a segment can
+carry nested `overlays` against its own text, and the host
+shifts them into entry coordinates.
+
+Why this matters for hot paths: with structural segments the
+plugin pays no per-row codepoint walks and no per-overlay
+`utf8ByteLength` bridge calls. The host's normalize step is
+O(visible_rows × row_text_bytes), all in Rust. The
+`search_replace` match-tree is the regression test; profiling
+notes in commit history.
+
+`InlineOverlay`, `TextPropertyEntry`, and `StyledSegment` all
+deliberately omit `Default` derives — every Rust construction site
+lists every field explicitly, so future field additions break
+compilation at each site instead of silently picking up a default.
+On the TS side the `styledRow` builder omits keys whose value is
+`undefined` (the JS↔Rust JSON bridge maps JS `undefined` to JSON
+`null`, which fails to deserialize as `Option<…>` / `Vec<…>` host
+fields; absence triggers `#[serde(default)]` instead).
+
 ---
 
 ## 7. Compositor: layered Components
@@ -693,6 +754,13 @@ applies a minimal patch.
   `SetChecked` / `SetSelectedIndex` / `SetItems` /
   `SetExpandedKeys`. Plugin ships a one-field change instead of
   the full spec.
+* Entry-shape primitives (§6.1): `TextPropertyEntry` carries
+  `segments`, `pad_to_chars`, `truncate_to_chars`; `InlineOverlay`
+  carries `unit: Byte | Char`. The host's `normalize_widths`
+  resolves segments → text + overlays, applies truncate/pad, then
+  converts char-unit overlays to bytes — all in Rust against the
+  final text. Plugins describe row structure declaratively and
+  pay no per-row codepoint walks or per-overlay bridge calls.
 
 **Not yet implemented**:
 * Session restore (§4.3).


### PR DESCRIPTION
## Summary

This PR introduces a structural approach to building text rows via styled segments, along with text normalization capabilities (padding, truncation, and offset unit conversion). Plugins can now describe row content as a sequence of (text, optional style, optional nested overlays) instead of pre-rendering text and computing byte/codepoint offsets manually.

## Key Changes

- **New `OffsetUnit` enum**: Allows `InlineOverlay` offsets to be specified in either byte or codepoint units. Defaults to byte for ASCII-only content; plugins working with multi-byte characters can use char units and let the host convert at consumption time.

- **New `StyledSegment` struct**: Represents one styled piece of a row. Contains text, optional style (emitted as an overlay), and optional nested overlays with offsets relative to the segment.

- **New `TextPropertyEntry` fields**:
  - `segments`: List of styled segments; when non-empty, concatenated into `text` during normalization
  - `pad_to_chars`: Pad text with spaces to a minimum codepoint width
  - `truncate_to_chars`: Truncate text to a maximum codepoint width (with `...` suffix when budget > 3)
  - `unit` field on `InlineOverlay`: Tracks whether offsets are in bytes or codepoints

- **New `normalize_widths()` method**: Idempotent normalization that:
  1. Resolves segments into text and overlays (segment styles become char-unit overlays; nested overlays shift by segment position)
  2. Applies truncation (respecting UTF-8 boundaries)
  3. Applies padding
  4. Converts all char-unit overlays to byte offsets via a codepoint-index lookup table

- **Updated `search_replace.ts` plugin**: Migrated from manual byte-offset computation to the new `styledRow()` builder, eliminating truncation/padding logic from the plugin.

- **Comprehensive test suite**: 15 tests covering padding, truncation, codepoint boundary handling, segment concatenation, and overlay conversion.

## Implementation Details

- Segment offsets are relative to the segment's own text, not the final entry—the host shifts them during concatenation
- Char-unit overlays beyond the final codepoint count are clamped to that count
- Truncation rounds byte cuts to UTF-8 codepoint boundaries to avoid splitting multi-byte characters
- The char-to-byte lookup table is built once and reused for all overlay conversions
- All widget renderers updated to initialize new fields with sensible defaults

https://claude.ai/code/session_01WFQwUtVo4nuDhJsY7xnCAC