### PR TITLE
fix(splits): keep file opens in editor area, target maximize click correctly

### DIFF
--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -116,10 +116,13 @@ impl Editor {
 
     /// If the active split leaf carries `SplitRole::UtilityDock`,
     /// move the active leaf back to the user's last regular editor
-    /// leaf (or the first non-dock leaf as a fallback). Called from
-    /// the file-open path so that opening a file while a utility
-    /// panel holds focus doesn't turn the dock into a tab strip for
-    /// ordinary files.
+    /// leaf. Called from the file-open path so that opening a file
+    /// while a utility panel holds focus doesn't turn the dock into
+    /// a tab strip for ordinary files.
+    ///
+    /// Routing falls back to the first non-dock leaf in tree order
+    /// when the user has only ever interacted with the dock — a
+    /// rare boot-state path.
     fn redirect_active_split_away_from_dock_if_needed(&mut self) {
         use crate::view::split::SplitRole;
         let Some(mgr) = self
@@ -134,7 +137,14 @@ impl Editor {
         if mgr.leaf_role(active) != Some(SplitRole::UtilityDock) {
             return;
         }
-        let Some(target) = mgr.last_non_dock_leaf() else {
+        let is_editor_leaf = |leaf| mgr.leaf_role(leaf) != Some(SplitRole::UtilityDock);
+        let target = mgr.last_focused_where(is_editor_leaf).or_else(|| {
+            mgr.root()
+                .leaf_split_ids()
+                .into_iter()
+                .find(|leaf| is_editor_leaf(*leaf))
+        });
+        let Some(target) = target else {
             return; // Degenerate: every leaf is a dock — leave as is.
         };
         if target == active {

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -27,6 +27,17 @@ impl Editor {
     /// If the file doesn't exist, creates an unsaved buffer with that filename.
     /// Saving the buffer will create the file.
     pub fn open_file(&mut self, path: &Path) -> anyhow::Result<BufferId> {
+        // If the active leaf is a utility-dock pane (Search/Replace,
+        // Quickfix, terminal-in-dock), the user almost never wants the
+        // newly-opened file to land there — the dock hosts panel-style
+        // content, not editor buffers. Snap the active leaf back to
+        // the most recent regular editor leaf BEFORE the open path
+        // runs, so both downstream routing decisions —
+        // `preferred_split_for_file` (which adds the new buffer as a
+        // tab) and `set_active_buffer` (which makes it the active
+        // buffer) — see a non-dock active leaf and route consistently.
+        self.redirect_active_split_away_from_dock_if_needed();
+
         // Check whether the active buffer had a file path before loading.
         // If it didn't, open_file_no_focus may replace the empty initial buffer
         // in-place (same buffer ID, new content), and we need to notify plugins.
@@ -101,6 +112,39 @@ impl Editor {
         }
 
         Ok(buffer_id)
+    }
+
+    /// If the active split leaf carries `SplitRole::UtilityDock`,
+    /// move the active leaf back to the user's last regular editor
+    /// leaf (or the first non-dock leaf as a fallback). Called from
+    /// the file-open path so that opening a file while a utility
+    /// panel holds focus doesn't turn the dock into a tab strip for
+    /// ordinary files.
+    fn redirect_active_split_away_from_dock_if_needed(&mut self) {
+        use crate::view::split::SplitRole;
+        let Some(mgr) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.splits.as_ref())
+            .map(|(m, _)| m)
+        else {
+            return;
+        };
+        let active = mgr.active_split();
+        if mgr.leaf_role(active) != Some(SplitRole::UtilityDock) {
+            return;
+        }
+        let Some(target) = mgr.last_non_dock_leaf() else {
+            return; // Degenerate: every leaf is a dock — leave as is.
+        };
+        if target == active {
+            return;
+        }
+        self.windows
+            .get_mut(&self.active_window)
+            .and_then(|w| w.split_manager_mut())
+            .expect("active window must have a populated split layout")
+            .set_active_split(target);
     }
 
     /// Open a file without switching focus to it

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2030,18 +2030,45 @@ impl Editor {
             return Some(Ok(()));
         }
 
-        let maximize_hit = self.active_layout().maximize_split_areas.iter().any(
-            |(_, btn_row, start_col, end_col)| {
+        let maximize_target = self
+            .active_layout()
+            .maximize_split_areas
+            .iter()
+            .find(|(_, btn_row, start_col, end_col)| {
                 row == *btn_row && col >= *start_col && col < *end_col
-            },
-        );
-        if maximize_hit {
+            })
+            .map(|(split_id, _, _, _)| *split_id);
+        if let Some(target) = maximize_target {
+            // Move focus to the clicked split before maximizing. Otherwise
+            // a click on a non-active split's button leaves the active
+            // split (now hidden by the maximize) silently capturing
+            // keystrokes. Skip when already maximized: the unmaximize
+            // click can only land on the maximized split, which is
+            // already the active one.
+            let already_maximized = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.splits.as_ref())
+                .map(|(mgr, _)| mgr.is_maximized())
+                .unwrap_or(false);
+            if !already_maximized {
+                if let Some(buffer_id) = self
+                    .windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.splits.as_ref())
+                    .map(|(mgr, _)| mgr)
+                    .expect("active window must have a populated split layout")
+                    .buffer_for_split(target)
+                {
+                    self.focus_split(target, buffer_id);
+                }
+            }
             match self
                 .windows
                 .get_mut(&self.active_window)
                 .and_then(|w| w.split_manager_mut())
                 .expect("active window must have a populated split layout")
-                .toggle_maximize()
+                .toggle_maximize_for(target)
             {
                 Ok(maximized) => {
                     let msg = if maximized {

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1065,15 +1065,19 @@ pub struct SplitManager {
     /// Labels for leaf splits (e.g., "sidebar" to mark managed splits)
     labels: HashMap<SplitId, String>,
 
-    /// Most-recently-active leaf that did NOT carry `SplitRole::UtilityDock`.
-    /// Used by file-open routing so that opening a file while a utility
-    /// panel (Search/Replace, Quickfix, terminal-in-dock) holds focus
-    /// lands the new buffer in the user's last editor pane instead of
-    /// turning the dock into a tab strip for ordinary files. Maintained
-    /// transparently by `set_active_split`; falls back to a tree walk
-    /// when this entry is empty or stale.
-    last_non_dock_leaf: Option<LeafId>,
+    /// LRU of leaves that have been the active split, oldest first.
+    /// `set_active_split` pushes the new active and promotes any
+    /// existing entry; `last_focused_where` lets callers query the
+    /// history with an arbitrary predicate (e.g. "last leaf without
+    /// `SplitRole::UtilityDock`" for file-open routing). Stale
+    /// entries (leaves that have since been closed) are filtered at
+    /// read time, not eagerly pruned.
+    focus_history: Vec<LeafId>,
 }
+
+/// Cap on `SplitManager::focus_history` length. Mirrors the same cap
+/// used by `SplitViewState::focus_history` (per-split tab focus).
+const FOCUS_HISTORY_CAP: usize = 50;
 
 impl SplitManager {
     /// Create a new split manager with a single buffer
@@ -1085,7 +1089,7 @@ impl SplitManager {
             next_split_id: 1,
             maximized_split: None,
             labels: HashMap::new(),
-            last_non_dock_leaf: Some(LeafId(split_id)),
+            focus_history: vec![LeafId(split_id)],
         }
     }
 
@@ -1107,14 +1111,10 @@ impl SplitManager {
     pub fn replace_root(&mut self, new_root: SplitNode, new_active: LeafId) {
         self.root = new_root;
         self.active_split = new_active;
-        // The previously-tracked LRU leaf no longer exists in the new
-        // tree. Re-seed from the new active when it isn't a dock,
-        // otherwise leave empty and rely on the tree-walk fallback.
-        self.last_non_dock_leaf = if self.leaf_role(new_active) != Some(SplitRole::UtilityDock) {
-            Some(new_active)
-        } else {
-            None
-        };
+        // None of the previously-tracked focus-history ids exist in
+        // the new tree. Reseed with just the new active.
+        self.focus_history.clear();
+        self.focus_history.push(new_active);
     }
 
     /// Get the currently active split ID
@@ -1127,11 +1127,13 @@ impl SplitManager {
         // Verify the split exists
         if self.root.find(split_id.into()).is_some() {
             self.active_split = split_id;
-            // Track the LRU non-dock leaf so file-open routing can
-            // recover the last editor pane after a utility panel
-            // (Search/Replace, Quickfix, terminal-in-dock) takes focus.
-            if self.leaf_role(split_id) != Some(SplitRole::UtilityDock) {
-                self.last_non_dock_leaf = Some(split_id);
+            // Promote (or insert) the new active leaf in the focus
+            // LRU. Same dedup-and-push pattern as
+            // `SplitViewState::focus_history` for tab focus.
+            self.focus_history.retain(|leaf| *leaf != split_id);
+            self.focus_history.push(split_id);
+            if self.focus_history.len() > FOCUS_HISTORY_CAP {
+                self.focus_history.remove(0);
             }
             true
         } else {
@@ -1145,25 +1147,24 @@ impl SplitManager {
         self.root.find(split_id.into()).and_then(|node| node.role())
     }
 
-    /// Most recent active leaf that wasn't a utility-dock pane, or
-    /// (if no such record exists or it's been since closed) the first
-    /// non-dock leaf encountered in a tree walk. Returns `None` only
-    /// when every leaf in the tree carries `SplitRole::UtilityDock` —
-    /// a degenerate state the editor never actually reaches.
-    pub fn last_non_dock_leaf(&self) -> Option<LeafId> {
-        self.last_non_dock_leaf
-            .filter(|leaf| self.leaf_role(*leaf) != Some(SplitRole::UtilityDock))
-            .filter(|leaf| self.root.find((*leaf).into()).is_some())
-            .or_else(|| self.find_first_non_dock_leaf())
-    }
-
-    /// First leaf in tree order without `SplitRole::UtilityDock`.
-    /// Used as the deterministic fallback when LRU tracking is empty.
-    pub fn find_first_non_dock_leaf(&self) -> Option<LeafId> {
-        self.root
-            .leaf_split_ids()
-            .into_iter()
-            .find(|leaf| self.leaf_role(*leaf) != Some(SplitRole::UtilityDock))
+    /// Walk the focus history newest-first and return the first leaf
+    /// that satisfies `predicate` and still exists in the tree. Stale
+    /// entries (leaves closed since they were focused) are skipped.
+    ///
+    /// Generic by design: callers compose the dock/role/label/buffer
+    /// rule they care about. File-open routing uses
+    /// `|leaf| mgr.leaf_role(leaf) != Some(SplitRole::UtilityDock)`;
+    /// future panel-aware features can pass their own filters
+    /// without touching this method.
+    pub fn last_focused_where<F>(&self, mut predicate: F) -> Option<LeafId>
+    where
+        F: FnMut(LeafId) -> bool,
+    {
+        self.focus_history
+            .iter()
+            .rev()
+            .copied()
+            .find(|leaf| self.root.find((*leaf).into()).is_some() && predicate(*leaf))
     }
 
     /// Get the buffer ID of the active split (if it's a leaf)

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1614,6 +1614,29 @@ impl SplitManager {
         }
     }
 
+    /// Toggle maximize state for a specific leaf split.
+    ///
+    /// Used by the mouse handler so that clicking a split's maximize
+    /// button targets that split rather than whichever split happens
+    /// to be active. When already maximized, this unmaximizes regardless
+    /// of which leaf was passed (only the maximized split's chrome is
+    /// visible while maximized, so the click can only land on it).
+    pub fn toggle_maximize_for(&mut self, target: LeafId) -> Result<bool, String> {
+        if self.is_maximized() {
+            self.unmaximize_split()?;
+            Ok(false)
+        } else {
+            if self.root.count_leaves() <= 1 {
+                return Err("Cannot maximize: only one split exists".to_string());
+            }
+            if self.root.find(target.into()).is_none() {
+                return Err("Cannot maximize: split not found".to_string());
+            }
+            self.maximized_split = Some(target.into());
+            Ok(true)
+        }
+    }
+
     /// Get all leaf split IDs that belong to a specific sync group
     pub fn get_splits_in_group(
         &self,

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1064,6 +1064,15 @@ pub struct SplitManager {
 
     /// Labels for leaf splits (e.g., "sidebar" to mark managed splits)
     labels: HashMap<SplitId, String>,
+
+    /// Most-recently-active leaf that did NOT carry `SplitRole::UtilityDock`.
+    /// Used by file-open routing so that opening a file while a utility
+    /// panel (Search/Replace, Quickfix, terminal-in-dock) holds focus
+    /// lands the new buffer in the user's last editor pane instead of
+    /// turning the dock into a tab strip for ordinary files. Maintained
+    /// transparently by `set_active_split`; falls back to a tree walk
+    /// when this entry is empty or stale.
+    last_non_dock_leaf: Option<LeafId>,
 }
 
 impl SplitManager {
@@ -1076,6 +1085,7 @@ impl SplitManager {
             next_split_id: 1,
             maximized_split: None,
             labels: HashMap::new(),
+            last_non_dock_leaf: Some(LeafId(split_id)),
         }
     }
 
@@ -1097,6 +1107,14 @@ impl SplitManager {
     pub fn replace_root(&mut self, new_root: SplitNode, new_active: LeafId) {
         self.root = new_root;
         self.active_split = new_active;
+        // The previously-tracked LRU leaf no longer exists in the new
+        // tree. Re-seed from the new active when it isn't a dock,
+        // otherwise leave empty and rely on the tree-walk fallback.
+        self.last_non_dock_leaf = if self.leaf_role(new_active) != Some(SplitRole::UtilityDock) {
+            Some(new_active)
+        } else {
+            None
+        };
     }
 
     /// Get the currently active split ID
@@ -1109,10 +1127,43 @@ impl SplitManager {
         // Verify the split exists
         if self.root.find(split_id.into()).is_some() {
             self.active_split = split_id;
+            // Track the LRU non-dock leaf so file-open routing can
+            // recover the last editor pane after a utility panel
+            // (Search/Replace, Quickfix, terminal-in-dock) takes focus.
+            if self.leaf_role(split_id) != Some(SplitRole::UtilityDock) {
+                self.last_non_dock_leaf = Some(split_id);
+            }
             true
         } else {
             false
         }
+    }
+
+    /// Role of a leaf split, or `None` if the leaf has no role tag or
+    /// the id doesn't reference a leaf.
+    pub fn leaf_role(&self, split_id: LeafId) -> Option<SplitRole> {
+        self.root.find(split_id.into()).and_then(|node| node.role())
+    }
+
+    /// Most recent active leaf that wasn't a utility-dock pane, or
+    /// (if no such record exists or it's been since closed) the first
+    /// non-dock leaf encountered in a tree walk. Returns `None` only
+    /// when every leaf in the tree carries `SplitRole::UtilityDock` —
+    /// a degenerate state the editor never actually reaches.
+    pub fn last_non_dock_leaf(&self) -> Option<LeafId> {
+        self.last_non_dock_leaf
+            .filter(|leaf| self.leaf_role(*leaf) != Some(SplitRole::UtilityDock))
+            .filter(|leaf| self.root.find((*leaf).into()).is_some())
+            .or_else(|| self.find_first_non_dock_leaf())
+    }
+
+    /// First leaf in tree order without `SplitRole::UtilityDock`.
+    /// Used as the deterministic fallback when LRU tracking is empty.
+    pub fn find_first_non_dock_leaf(&self) -> Option<LeafId> {
+        self.root
+            .leaf_split_ids()
+            .into_iter()
+            .find(|leaf| self.leaf_role(*leaf) != Some(SplitRole::UtilityDock))
     }
 
     /// Get the buffer ID of the active split (if it's a leaf)

--- a/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
+++ b/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
@@ -1,0 +1,229 @@
+//! E2E reproductions for two bugs in the Utility Dock interaction model.
+//!
+//! 1. **Quick Open routes new file into the dock.** With the Search/Replace
+//!    panel open in the bottom dock (which takes focus), pressing Ctrl+P
+//!    and selecting a file opens that file as a tab in the dock instead
+//!    of the main editor split above. The dock is intended for
+//!    panel-style content (search results, diagnostics, terminal,
+//!    quickfix); ordinary file buffers should never land there.
+//!
+//! 2. **Maximize button targets the active split, not the clicked one.**
+//!    Each split's tab bar has a `□` maximize button. Clicking the top
+//!    split's button while the dock is focused maximizes the dock
+//!    instead of the top split — the click handler ignores which
+//!    button was clicked and toggles the *active* split.
+//!
+//! Both tests assert only on rendered output, per CONTRIBUTING.md §2.
+//! Each fails on `master` and passes once the corresponding fix lands.
+//!
+//! See repro session in tmux for the manual steps these tests automate.
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+/// Set up a project directory with the search_replace plugin and a few text files.
+fn setup_dock_project() -> (tempfile::TempDir, std::path::PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "search_replace");
+
+    fs::write(project_root.join("main.txt"), "main file content\n").unwrap();
+    fs::write(project_root.join("other.txt"), "other file content\n").unwrap();
+
+    // The Quick Open file finder uses `git ls-files`, so the project must
+    // be a git repo with the test files tracked for them to appear in the
+    // picker.
+    let status = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let status = std::process::Command::new("git")
+        .args(["add", "main.txt", "other.txt"])
+        .current_dir(&project_root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    (temp_dir, project_root)
+}
+
+/// Open the Search/Replace panel via the command palette and wait for it
+/// to render in the bottom dock with focus.
+fn open_search_replace_panel(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Search and Replace").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search and Replace"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // Panel renders with the Search field — this is the dock taking focus.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+}
+
+/// Return the screen row index (0-based) of the line containing the given text,
+/// or panic with the screen for debugging.
+fn row_of(harness: &EditorTestHarness, needle: &str) -> usize {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("expected screen to contain '{needle}'\nScreen:\n{screen}"))
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1
+// ---------------------------------------------------------------------------
+
+/// With the Search/Replace dock open and focused, pressing Ctrl+P and
+/// selecting a file should open the file in the **main** split — not as a
+/// new tab in the dock.
+#[test]
+fn test_quick_open_after_search_replace_opens_in_main_split() {
+    let (_temp_dir, project_root) = setup_dock_project();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&project_root.join("main.txt")).unwrap();
+    harness.render().unwrap();
+
+    // Open Search/Replace — splits the bottom dock and gives it focus.
+    open_search_replace_panel(&mut harness);
+
+    // Sanity: dock and main split are distinct rows on screen.
+    let dock_row = row_of(&harness, "*Search/Replace*");
+    let main_tab_row = row_of(&harness, "main.txt");
+    assert!(
+        main_tab_row < dock_row,
+        "expected main split's tab bar above the dock's tab bar (main_tab_row={main_tab_row}, \
+         dock_row={dock_row})"
+    );
+
+    // Now: Ctrl+P → Backspace (drop the ">command" prefix that Quick Open
+    // remembers from the last invocation) → type filename → Enter.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("other").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("other.txt"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Wait for the file to actually finish opening (status message confirms).
+    harness
+        .wait_until(|h| h.screen_to_string().contains("other.txt"))
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    // Let any post-open re-renders settle.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("other.txt"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+
+    // The dock's tab bar (the row containing "*Search/Replace*") must not
+    // host the newly opened ordinary file. Under the bug, this row reads
+    // " *Search/Replace* ×   other.txt ×", which is wrong: the dock is
+    // for utility panels, not file buffers.
+    let dock_tab_line = screen
+        .lines()
+        .find(|l| l.contains("*Search/Replace*"))
+        .unwrap_or_else(|| panic!("dock tab bar gone after open\nScreen:\n{screen}"));
+    assert!(
+        !dock_tab_line.contains("other.txt"),
+        "Bug: ordinary file opened in the bottom dock instead of the main split.\n\
+         Dock tab line: '{dock_tab_line}'\nFull screen:\n{screen}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2
+// ---------------------------------------------------------------------------
+
+/// Clicking the **top** split's maximize button while the dock is focused
+/// must maximize the top split, not the dock. The click handler should
+/// honor the split that owns the clicked button rather than blindly
+/// toggling the currently-active split.
+#[test]
+fn test_maximize_button_click_targets_clicked_split_not_active() {
+    let (_temp_dir, project_root) = setup_dock_project();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&project_root.join("main.txt")).unwrap();
+    harness.render().unwrap();
+
+    // Open Search/Replace — bottom dock takes focus.
+    open_search_replace_panel(&mut harness);
+
+    // Locate the maximize button on the *top* split's tab bar. The icon
+    // is "□" when not maximized; the first occurrence on screen belongs
+    // to the topmost split (the main editor pane).
+    let (max_col, max_row) = harness
+        .find_text_on_screen("□")
+        .expect("expected a '□' maximize button on the top split's tab bar");
+    // Sanity: the button is on the main split's tab bar (above the dock).
+    let dock_row = row_of(&harness, "*Search/Replace*");
+    assert!(
+        (max_row as usize) < dock_row,
+        "expected the first '□' button to belong to the top split (max_row={max_row}, \
+         dock_row={dock_row})"
+    );
+
+    harness.mouse_click(max_col, max_row).unwrap();
+
+    // Wait for the maximize transition to complete (status message confirms).
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Maximized split"))
+        .unwrap();
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("Maximized split"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+
+    // After maximizing the top split, the dock's *Search/Replace* tab
+    // must no longer be visible — only one split is shown. Under the bug
+    // the dock gets maximized instead, so *Search/Replace* stays on
+    // screen and the main split's "main.txt" tab disappears.
+    assert!(
+        !screen.contains("*Search/Replace*"),
+        "Bug: clicking the top split's maximize button maximized the dock instead. \
+         The Search/Replace panel is still visible.\nScreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("main.txt"),
+        "After maximizing the top split, main.txt should still be on screen.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -25,6 +25,7 @@ pub mod ctrl_end_wrapped;
 pub mod cursor_style_rendering;
 pub mod cursor_under_popup;
 pub mod dabbrev_completion;
+pub mod dock_panel_routing;
 pub mod document_model;
 pub mod duplicate_line;
 pub mod emacs_actions;


### PR DESCRIPTION
Fixes two distinct bugs where the bottom Utility Dock — the panel area used by Search/Replace, Quickfix, and terminal-in-dock — interacted incorrectly with the rest of the split layout.

## Bugs

### 1. Quick Open routes new file into the dock
With the Search/Replace panel open in the bottom dock (which takes focus), pressing `Ctrl+P` → `Backspace` → filename → `Enter` opened the file as a tab inside the dock instead of the main editor pane. The dock is for panel-style utility content; ordinary file buffers should never land there.

### 2. Maximize button targets the active split, not the clicked one
Each split's tab bar has a `□` maximize button. With the dock focused, clicking the **top** split's button maximized the dock instead of the top split. The click handler iterated `maximize_split_areas` (each entry carries its owning `LeafId`) but discarded the ID and toggled the *active* split, ignoring which button was clicked.

## Reproduction

Manual repro driven via tmux + raw mouse-escape sequences confirmed both bugs against `master`. The two e2e tests in `tests/e2e/dock_panel_routing.rs` automate the same flows and assert only on rendered output (per CONTRIBUTING.md §2).

## Fixes

### Bug 2 — `fix(splits): maximize button targets clicked split, not active`
- New `SplitManager::toggle_maximize_for(LeafId)` so the click handler can target a specific leaf instead of `active_split`. When already maximized, behavior is unchanged (unmaximize); only the maximized split's chrome is on screen, so the click can only land on it.
- Click handler in `app/mouse_input.rs` now captures the clicked `LeafId` via `find()` (matching the close-split-button code path immediately above) and passes it to `toggle_maximize_for`.
- Move focus to the clicked split before maximizing — otherwise clicking maximize on a non-active split hides the previously-active split but leaves it silently capturing keystrokes.

### Bug 1 — `fix(splits): keep file opens out of the utility dock`
Routes file-opens to the editor area whenever the active leaf carries `SplitRole::UtilityDock`, using an LRU of focus history.

- New `Editor::redirect_active_split_away_from_dock_if_needed`, called at the top of `Editor::open_file`. Snaps the active leaf back to the user's last regular editor leaf so both downstream routing decisions — `preferred_split_for_file` (where `open_file_no_focus_inner` adds the buffer as a tab) and the trailing `set_active_buffer` (which makes it active) — see a non-dock active leaf and route consistently.
- Position-history recording happens after the redirect, so back-nav follows the editor flow.

### Refactor — `refactor(splits): replace last_non_dock_leaf with generic focus_history`
First-pass implementation tracked a single typed `last_non_dock_leaf` field on `SplitManager`, baking the dock concept into the storage. Generalized to a reusable LRU primitive:

- `SplitManager::focus_history: Vec<LeafId>` — push-with-promote on every `set_active_split`, capped at 50 (mirrors the cap `SplitViewState::focus_history` already uses for tab focus).
- `SplitManager::last_focused_where<F: FnMut(LeafId) -> bool>(&self, predicate: F) -> Option<LeafId>` — walks the history newest-first, skips entries for closed leaves, returns the first match.
- The dock rule lives at the call site as a closure: `|leaf| mgr.leaf_role(leaf) != Some(SplitRole::UtilityDock)`. Future panel-aware features (e.g. "last terminal leaf", "last leaf hosting buffer X") can pass their own filters.
- `replace_root` reseeds the history with just the new active leaf.
- Tree-walk fallback (when LRU has no match) lives at the call site, since "what to do when no candidate exists" is caller policy, not focus-history semantics.

## UX coverage for bug 1

| Layout | New file lands in |
|---|---|
| Single editor pane + dock | the editor pane |
| Vertical split editor + dock | last-active editor leaf (LRU) |
| User clicks dock to read results, then `Ctrl+P` | last edit pane, dock untouched |
| Buffer groups + dock | active group's split (groups aren't docks) |
| Multiple docks (future) | gated on the role, not a count |

## Commits

| Commit | What |
|---|---|
| `c9e94d1` | E2E reproductions for both bugs (`tests/e2e/dock_panel_routing.rs`) |
| `ab775a6` | Maximize-button fix |
| `9aa7ff5` | Quick-open dock-routing fix (LRU + tree-walk fallback) |
| `bf94474` | Refactor LRU into generic `focus_history` + `last_focused_where` |

## Test plan

- [x] `cargo test --test e2e_tests -p fresh-editor dock_panel_routing` — both new tests pass with fixes (and fail without, per `c9e94d1`)
- [x] `cargo test --test e2e_tests -p fresh-editor split_view` — 34 passed
- [x] `cargo test --test e2e_tests -p fresh-editor search_replace` — 23 passed
- [x] `cargo test --test e2e_tests -p fresh-editor visual_regression` — 4 passed
- [x] `cargo test --test e2e_tests -p fresh-editor file_browser` — 26 passed
- [x] `cargo test --test e2e_tests -p fresh-editor live_grep` — 8 passed (1 unrelated env-failure on git commit signing)
- [x] `cargo test --lib -p fresh-editor` — 2434 passed
- [x] `cargo fmt`, `cargo clippy` — clean on touched files

https://claude.ai/code/session_014T75QuY4hhmyzePv6LX7JQ