### PR TITLE
Unify TextInput and TextArea into single Text widget

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1146,6 +1146,12 @@ fn default_tree_visible_rows() -> u32 {
     20
 }
 
+/// Default `rows` for a `Text` widget — `1` ⇒ single-line. Plugins
+/// opt into multi-line by setting `rows >= 2`.
+fn default_text_rows() -> u32 {
+    1
+}
+
 /// One node in a `Tree` widget's flat-list spec. The plugin walks
 /// its hierarchy depth-first and emits one `TreeNode` per node;
 /// `depth` controls indent, `has_children` controls whether the
@@ -1385,97 +1391,73 @@ pub enum WidgetSpec {
     /// the spec on every change. The keymap-routing layer (host
     /// claims widget keys before the plugin sees them) lands in a
     /// later commit.
-    TextInput {
-        /// Current text in the field.
+    /// Text input — single-line (`rows == 1`, default) or multi-line
+    /// (`rows > 1`). The host owns `value` and `cursor_byte` as
+    /// instance state once the widget renders for the first time;
+    /// the spec's values are initial-only.
+    ///
+    /// Single-line vs multi-line behaviour is selected by `rows`:
+    /// * `rows == 1` — renders as `[value]` with the cursor pinned
+    ///   to a constant `field_width` (head-truncate when the value
+    ///   exceeds it). `Enter` advances focus (form-like UX).
+    ///   `Up`/`Down` are no-ops. `Home`/`End` jump to the start /
+    ///   end of the whole value.
+    /// * `rows > 1` — renders as `rows` lines tall (padded with
+    ///   blanks when `value` is shorter). `Enter` inserts a newline
+    ///   at the cursor. `Up`/`Down` move between lines (clamped to
+    ///   each line's column count). `Home`/`End` jump within the
+    ///   current line. The host auto-scrolls vertically to keep
+    ///   the cursor's line visible.
+    ///
+    /// Smart-key dispatch (`WidgetCommand::Key`) selects the right
+    /// behaviour from `rows`. Plugins that want a different `Enter`
+    /// binding intercept the key in their own mode binding before
+    /// dispatching it through the smart-key router.
+    ///
+    /// `label` (when non-empty) renders inline before `[` for
+    /// single-line, and as a row above the editing region for
+    /// multi-line. `placeholder` shows when `value` is empty and
+    /// the field is unfocused (first row only for multi-line).
+    /// `field_width` controls visible column width: `0` = auto-fit
+    /// (single-line) or panel width (multi-line). `max_visible_chars`
+    /// is a single-line soft cap applied after the field-width pad
+    /// (`0` = no cap; ignored when `rows > 1`).
+    Text {
+        /// Initial text. Spec value is read at first render only;
+        /// instance state takes over thereafter.
+        #[serde(default)]
         value: String,
-        /// Byte offset of the cursor within `value`. Negative
-        /// (encoded as `i32` in JSON; clamped on Rust side) means
-        /// "no cursor" — the input is not the active focus target.
+        /// Initial byte-offset cursor within `value`. Negative
+        /// (encoded as `i32` in JSON) means "no cursor" — clamped
+        /// to `[0, value.len()]` host-side.
         #[serde(default = "default_cursor_byte")]
         cursor_byte: i32,
-        /// Whether this input has visual focus (controls fg/bg
-        /// highlight).
+        /// Whether this widget has visual focus.
         #[serde(default)]
         focused: bool,
-        /// Optional label rendered before the brackets:
-        /// `Label: [value]`. Use the empty string to omit.
+        /// Optional label rendered before / above the editing
+        /// region. Empty = omitted.
         #[serde(default, skip_serializing_if = "String::is_empty")]
         label: String,
-        /// Optional placeholder shown when `value` is empty and the
-        /// input is unfocused.
+        /// Placeholder shown when unfocused and `value` is empty.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         placeholder: Option<String>,
-        /// Maximum visible characters before truncation with an
-        /// ellipsis. `0` means "don't truncate". Distinct from
-        /// `field_width` — this is a soft cap, applied *after*
-        /// the field-width pad. Most callers want `field_width`.
+        /// Number of visible rows of editing region. `0` falls back
+        /// to `1` (single-line). `1` = single-line behaviour;
+        /// `>= 2` = multi-line behaviour. See the type-level doc
+        /// for the per-mode semantics.
+        #[serde(default = "default_text_rows")]
+        rows: u32,
+        /// Visible column width. `0` = auto-fit (single-line) or
+        /// panel width (multi-line). When set, single-line
+        /// head-truncates with `…` and multi-line tail-truncates
+        /// per-line.
+        #[serde(default)]
+        field_width: u32,
+        /// Single-line soft cap on visible chars after the
+        /// `field_width` pad. `0` = no cap. Ignored when `rows > 1`.
         #[serde(default)]
         max_visible_chars: u32,
-        /// Fixed visible width inside the brackets (in display
-        /// columns / chars). `0` (default) = auto-fit, growing with
-        /// the value. `>0` = always render exactly this many chars:
-        /// pad short values with trailing spaces, head-truncate
-        /// long values with `…` so the *tail* (where the cursor
-        /// usually is) stays visible.
-        #[serde(default)]
-        field_width: u32,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        key: Option<String>,
-    },
-    /// Multi-line text input. The host owns value + cursor as
-    /// instance state (mirrors `TextInput`), plus a vertical scroll
-    /// offset that auto-clamps to keep the cursor's line visible
-    /// within `rows` visible rows.
-    ///
-    /// Smart-key dispatch differs from `TextInput`: `Enter` inserts
-    /// a newline at the cursor (rather than advancing focus), so
-    /// the multi-line shape is the natural one. Plugins that want
-    /// `Enter` to submit can intercept the key in their own mode
-    /// binding and call `panel.command(focusAdvance(1))` instead.
-    /// `Up`/`Down` move the cursor between lines (clamped to each
-    /// line's column count); `Home`/`End` jump within the current
-    /// line; `Left`/`Right`/`Backspace`/`Delete` and printable text
-    /// behave exactly as in `TextInput`.
-    ///
-    /// The widget renders `rows` lines tall, padded with blanks
-    /// when `value` is shorter, with `field_width` columns wide
-    /// when set (`0` = use the panel's natural width). When
-    /// unfocused and empty, `placeholder` is rendered in the first
-    /// row only.
-    TextArea {
-        /// Initial text. Spec value is used at first render only;
-        /// instance state takes over thereafter (matching
-        /// `TextInput`'s host-owned value model).
-        #[serde(default)]
-        value: String,
-        /// Initial byte-offset cursor. Negative ⇒ "no cursor"; the
-        /// host clamps to `[0, value.len()]`.
-        #[serde(default = "default_cursor_byte")]
-        cursor_byte: i32,
-        /// Visual focus flag (initial-only — instance state takes
-        /// over once the panel has any tabbable widgets, see
-        /// `focus_key` semantics).
-        #[serde(default)]
-        focused: bool,
-        /// Optional label rendered on its own row above the
-        /// editing region (`Label:` followed by the multi-line
-        /// box). Empty = omitted.
-        #[serde(default, skip_serializing_if = "String::is_empty")]
-        label: String,
-        /// Placeholder text shown on the first row when the value
-        /// is empty and the field is unfocused.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        placeholder: Option<String>,
-        /// Number of visible rows of editing region. Plugin
-        /// computes from its viewport; `0` falls back to a small
-        /// default (3) at render time.
-        #[serde(default)]
-        rows: u32,
-        /// Visible column width inside the editing region. `0`
-        /// (default) = grow with the longest visible line up to
-        /// the panel width.
-        #[serde(default)]
-        field_width: u32,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -123,16 +123,45 @@ editor.defineMode(
 );
 
 function git_log_select_up(): void {
-  state.logPanel?.command(key("Up"));
+  if (isLogPanelActive()) {
+    state.logPanel?.command(key("Up"));
+  } else {
+    editor.executeAction("move_up");
+  }
 }
 function git_log_select_down(): void {
-  state.logPanel?.command(key("Down"));
+  if (isLogPanelActive()) {
+    state.logPanel?.command(key("Down"));
+  } else {
+    editor.executeAction("move_down");
+  }
 }
 function git_log_select_page_up(): void {
-  state.logPanel?.command(key("PageUp"));
+  if (isLogPanelActive()) {
+    state.logPanel?.command(key("PageUp"));
+  } else {
+    editor.executeAction("page_up");
+  }
 }
 function git_log_select_page_down(): void {
-  state.logPanel?.command(key("PageDown"));
+  if (isLogPanelActive()) {
+    state.logPanel?.command(key("PageDown"));
+  } else {
+    editor.executeAction("page_down");
+  }
+}
+
+/** True iff the log panel is the focused buffer in the group. The
+ * group's bindings (j/k/Up/Down/PageUp/PageDown) apply to all panels
+ * uniformly; we only want navigation to drive the List widget when
+ * the user is *on* the log panel. From the detail panel, the same
+ * keys must move the buffer cursor (so users can scroll the diff
+ * before pressing Enter on a diff line to open the file view). */
+function isLogPanelActive(): boolean {
+  return (
+    state.logBufferId !== null &&
+    editor.getActiveBufferId() === state.logBufferId
+  );
 }
 registerHandler("git_log_select_up", git_log_select_up);
 registerHandler("git_log_select_down", git_log_select_down);

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -8,6 +8,7 @@ import {
   fetchCommitShow,
   fetchGitLog,
 } from "./lib/git_history.ts";
+import { button, flexSpacer, row, WidgetPanel } from "./lib/index.ts";
 
 const editor = getEditor();
 
@@ -37,8 +38,10 @@ interface GitLogState {
   logBufferId: number | null;
   detailBufferId: number | null;
   toolbarBufferId: number | null;
-  /** Click-regions for the toolbar's buttons, populated by `renderToolbar`. */
-  toolbarButtons: ToolbarButton[];
+  /** Widget panel rendering the toolbar (Row of Buttons). Created in
+   * `show_git_log` once the buffer group exists; cleaned up in
+   * `git_log_close`. */
+  toolbarPanel: WidgetPanel | null;
   commits: GitCommit[];
   selectedIndex: number;
   /** Cached `git show` output for the currently-displayed detail commit. */
@@ -71,7 +74,7 @@ const state: GitLogState = {
   logBufferId: null,
   detailBufferId: null,
   toolbarBufferId: null,
-  toolbarButtons: [],
+  toolbarPanel: null,
   commits: [],
   selectedIndex: 0,
   detailCache: null,
@@ -177,116 +180,69 @@ const GROUP_LAYOUT = JSON.stringify({
 // =============================================================================
 // Toolbar
 // =============================================================================
+//
+// The toolbar is a one-row panel mounted above the log/detail split. It's
+// rendered through the widget runtime — a `Row` of `Button` widgets — so
+// the host owns hit-testing, focus styling, and keystroke dispatch, and the
+// plugin only handles the resulting `widget_event` actions.
+//
+// Each button's `key` is a stable identifier (`toolbar.tab`, `toolbar.q`,
+// etc.) that `widget_event` carries back so the plugin can look up the
+// right handler without per-row column arithmetic. The previous custom
+// hit-region tracking (`state.toolbarButtons`, `on_git_log_toolbar_click`)
+// is gone.
 
-interface ToolbarHint {
+interface ToolbarItem {
   key: string;
   label: string;
-  /** Click action — `null` for hints that are keyboard-only (j/k, PgUp). */
-  onClick: (() => void | Promise<void>) | null;
+  onClick: () => void | Promise<void>;
 }
 
-interface ToolbarButton {
-  row: number;
-  startCol: number;
-  endCol: number;
-  onClick: (() => void | Promise<void>) | null;
-}
+const TOOLBAR_KEY_PREFIX = "toolbar.";
 
-function toolbarHints(): ToolbarHint[] {
+function toolbarItems(): ToolbarItem[] {
   return [
-    { key: "Tab", label: "switch pane", onClick: git_log_tab },
-    { key: "RET", label: "open file", onClick: git_log_enter },
-    { key: "y", label: "copy hash", onClick: git_log_copy_hash },
-    { key: "r", label: "refresh", onClick: git_log_refresh },
-    { key: "q", label: "quit", onClick: git_log_q },
+    { key: "tab", label: "Tab switch pane", onClick: git_log_tab },
+    { key: "ret", label: "RET open file", onClick: git_log_enter },
+    { key: "y", label: "y copy hash", onClick: git_log_copy_hash },
+    { key: "r", label: "r refresh", onClick: git_log_refresh },
+    { key: "q", label: "q quit", onClick: git_log_q },
   ];
 }
 
-/**
- * Build the single-row toolbar. Each hint renders as a discrete button with
- * its own background so it reads as clickable; the column range of each
- * button is captured in `state.toolbarButtons` so `on_git_log_toolbar_click`
- * can map a mouse click back to the right handler.
- */
-function buildToolbarEntries(width: number): TextPropertyEntry[] {
-  const W = Math.max(20, width);
-  const buttons: ToolbarButton[] = [];
-  let text = "";
-  const overlays: InlineOverlay[] = [];
-
-  for (const hint of toolbarHints()) {
-    const body = ` [${hint.key}] ${hint.label} `;
-    const bodyLen = body.length;
-    const gap = text.length > 0 ? 1 : 0;
-    if (text.length + gap + bodyLen > W) break;
-
-    if (gap) text += " ";
-
-    const startCol = text.length;
-    const startByte = utf8Len(text);
-    text += body;
-    const endByte = utf8Len(text);
-    const endCol = text.length;
-
-    overlays.push({
-      start: startByte,
-      end: endByte,
-      style: { bg: "ui.status_bar_bg" },
-    });
-    const keyDisplay = `[${hint.key}]`;
-    const keyStartByte = startByte + utf8Len(" ");
-    const keyEndByte = keyStartByte + utf8Len(keyDisplay);
-    overlays.push({
-      start: keyStartByte,
-      end: keyEndByte,
-      style: { fg: "editor.fg", bold: true },
-    });
-    overlays.push({
-      start: keyEndByte,
-      end: endByte,
-      style: { fg: "editor.line_number_fg" },
-    });
-
-    buttons.push({ row: 0, startCol, endCol, onClick: hint.onClick });
-  }
-
-  state.toolbarButtons = buttons;
-
-  return [
-    {
-      text: text + "\n",
-      properties: { type: "git-log-toolbar" },
-      style: { bg: "editor.bg", extendToLineEnd: true },
-      inlineOverlays: overlays,
-    },
-  ];
+function toolbarSpec(): WidgetSpec {
+  const items = toolbarItems();
+  // `flexSpacer` at the end pushes the buttons to the left and lets the
+  // toolbar background extend across the row.
+  return row(
+    ...items.map((item) =>
+      button(item.label, { key: TOOLBAR_KEY_PREFIX + item.key }),
+    ),
+    flexSpacer(),
+  );
 }
 
 function renderToolbar(): void {
-  if (state.groupId === null) return;
-  const vp = editor.getViewport();
-  const width = vp ? vp.width : 80;
-  editor.setPanelContent(state.groupId, "toolbar", buildToolbarEntries(width));
+  if (state.toolbarPanel === null) return;
+  state.toolbarPanel.set(toolbarSpec());
 }
 
-function on_git_log_toolbar_click(data: {
-  buffer_id: number | null;
-  buffer_row: number | null;
-  buffer_col: number | null;
-}): void {
-  if (!state.isOpen) return;
-  if (data.buffer_id === null || data.buffer_id !== state.toolbarBufferId) return;
-  if (data.buffer_row === null || data.buffer_col === null) return;
-  const row = data.buffer_row;
-  const col = data.buffer_col;
-  const hit = state.toolbarButtons.find(
-    (b) => b.row === row && col >= b.startCol && col < b.endCol
-  );
-  if (hit && hit.onClick) {
-    void hit.onClick();
+editor.on("widget_event", (data) => {
+  if (
+    state.toolbarPanel === null ||
+    data.panel_id !== state.toolbarPanel.id()
+  ) {
+    return;
   }
-}
-registerHandler("on_git_log_toolbar_click", on_git_log_toolbar_click);
+  if (data.event_type !== "activate") return;
+  const items = toolbarItems();
+  for (const item of items) {
+    if (data.widget_key === TOOLBAR_KEY_PREFIX + item.key) {
+      void item.onClick();
+      return;
+    }
+  }
+});
 
 function on_git_log_resize(_data: { width: number; height: number }): void {
   if (!state.isOpen) return;
@@ -456,6 +412,9 @@ async function show_git_log(): Promise<void> {
   state.logBufferId = (group.panels["log"] as number | undefined) ?? null;
   state.detailBufferId = (group.panels["detail"] as number | undefined) ?? null;
   state.toolbarBufferId = (group.panels["toolbar"] as number | undefined) ?? null;
+  if (state.toolbarBufferId !== null) {
+    state.toolbarPanel = new WidgetPanel(state.toolbarBufferId);
+  }
   state.selectedIndex = 0;
   state.detailCache = null;
   state.isOpen = true;
@@ -489,7 +448,6 @@ async function show_git_log(): Promise<void> {
     editor.focusBufferGroupPanel(state.groupId, "log");
   }
   editor.on("cursor_moved", on_git_log_cursor_moved);
-  editor.on("mouse_click", on_git_log_toolbar_click);
   editor.on("resize", on_git_log_resize);
   editor.on("buffer_closed", on_git_log_buffer_closed);
 
@@ -505,15 +463,18 @@ registerHandler("show_git_log", show_git_log);
 function git_log_cleanup(): void {
   if (!state.isOpen) return;
   editor.off("cursor_moved", on_git_log_cursor_moved);
-  editor.off("mouse_click", on_git_log_toolbar_click);
   editor.off("resize", on_git_log_resize);
   editor.off("buffer_closed", on_git_log_buffer_closed);
+  // The buffer-group's `close` will tear down the toolbar buffer too,
+  // which implicitly drops the widget panel rendering into it. We
+  // still null out the handle so any stray `renderToolbar()` call
+  // post-cleanup is a no-op.
+  state.toolbarPanel = null;
   state.isOpen = false;
   state.groupId = null;
   state.logBufferId = null;
   state.detailBufferId = null;
   state.toolbarBufferId = null;
-  state.toolbarButtons = [];
   state.commits = [];
   state.selectedIndex = 0;
   state.detailCache = null;

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -8,7 +8,7 @@ import {
   fetchCommitShow,
   fetchGitLog,
 } from "./lib/git_history.ts";
-import { button, flexSpacer, row, WidgetPanel } from "./lib/index.ts";
+import { button, flexSpacer, key, list, row, WidgetPanel } from "./lib/index.ts";
 
 const editor = getEditor();
 
@@ -42,6 +42,11 @@ interface GitLogState {
    * `show_git_log` once the buffer group exists; cleaned up in
    * `git_log_close`. */
   toolbarPanel: WidgetPanel | null;
+  /** Widget panel rendering the log (List of commit rows). Owns
+   * `selected_index` + `scroll_offset` as instance state — the
+   * plugin's `state.selectedIndex` mirrors what the host reports
+   * via `widget_event "select"`. */
+  logPanel: WidgetPanel | null;
   commits: GitCommit[];
   selectedIndex: number;
   /** Cached `git show` output for the currently-displayed detail commit. */
@@ -52,20 +57,13 @@ interface GitLogState {
    */
   pendingDetailId: number;
   /**
-   * Debounce token for `cursor_moved`. Rapid cursor motion (PageDown, held
-   * j/k) would otherwise trigger a full log re-render + `git show` per
-   * intermediate row; we bump this id on every event and only do the work
-   * after a short delay if no newer event has arrived.
+   * Debounce token for List `select` events. Rapid selection moves
+   * (PageDown, held j/k) would otherwise trigger a full `git show`
+   * spawn per intermediate row; we bump this id on every event
+   * and only do the work after a short delay if no newer event
+   * has arrived.
    */
-  pendingCursorMoveId: number;
-  /**
-   * Byte offset at the start of each row in the rendered log panel, plus
-   * the total buffer length at the end. Populated by `renderLog` so the
-   * cursor_moved handler can map byte positions to commit indices without
-   * relying on `getCursorLine` (which is not implemented for virtual
-   * buffers).
-   */
-  logRowByteOffsets: number[];
+  pendingSelectId: number;
 }
 
 const state: GitLogState = {
@@ -75,53 +73,20 @@ const state: GitLogState = {
   detailBufferId: null,
   toolbarBufferId: null,
   toolbarPanel: null,
+  logPanel: null,
   commits: [],
   selectedIndex: 0,
   detailCache: null,
   pendingDetailId: 0,
-  pendingCursorMoveId: 0,
-  logRowByteOffsets: [],
+  pendingSelectId: 0,
 };
 
 /**
- * Delay before reacting to `cursor_moved`. Long enough to collapse a burst
- * of events from held j/k or PageDown into a single render, short enough
- * that the detail panel still feels live.
+ * Delay before spawning `git show` after a List `select` event. Long
+ * enough to collapse a burst (held j/k or PageDown) into one fetch,
+ * short enough that the detail panel still feels live.
  */
-const CURSOR_DEBOUNCE_MS = 60;
-
-// UTF-8 byte length — the overlay API expects byte offsets; JS strings are
-// UTF-16. Matches the helper used by `lib/git_history.ts`.
-function utf8Len(s: string): number {
-  let b = 0;
-  for (let i = 0; i < s.length; i++) {
-    const c = s.charCodeAt(i);
-    if (c <= 0x7f) b += 1;
-    else if (c <= 0x7ff) b += 2;
-    else if (c >= 0xd800 && c <= 0xdfff) {
-      b += 4;
-      i++;
-    } else b += 3;
-  }
-  return b;
-}
-
-/**
- * Binary search `logRowByteOffsets` for the 0-indexed row whose byte
- * offset is the largest one ≤ `bytePos`. Returns 0 on an empty table.
- */
-function rowFromByte(bytePos: number): number {
-  const offs = state.logRowByteOffsets;
-  if (offs.length === 0) return 0;
-  let lo = 0;
-  let hi = offs.length - 1;
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1;
-    if (offs[mid] <= bytePos) lo = mid;
-    else hi = mid - 1;
-  }
-  return lo;
-}
+const SELECT_DEBOUNCE_MS = 60;
 
 // =============================================================================
 // Modes
@@ -132,15 +97,20 @@ function rowFromByte(bytePos: number): number {
 // the log, and opens the file at the cursor when pressed in the detail).
 // =============================================================================
 
-// j/k as vi-style aliases for Up/Down, plus the plugin-specific action
-// keys. Everything else (arrows, Page{Up,Down}, Home/End, Shift+motion for
-// selection, Ctrl+C copy, …) is inherited from the Normal keymap because
-// the mode is registered with `inheritNormalBindings: true`.
+// j/k/Up/Down/PageUp/PageDown route to the log List widget so the host
+// owns selection + scroll + auto-scroll. The List's `select` event then
+// fires back into the plugin's `widget_event` handler for detail-pane
+// refresh. Other plugin actions (q/r/y/Tab/Return) stay as direct
+// bindings — they don't depend on which row is highlighted.
 editor.defineMode(
   "git-log",
   [
-    ["k", "move_up"],
-    ["j", "move_down"],
+    ["k", "git_log_select_up"],
+    ["j", "git_log_select_down"],
+    ["Up", "git_log_select_up"],
+    ["Down", "git_log_select_down"],
+    ["PageUp", "git_log_select_page_up"],
+    ["PageDown", "git_log_select_page_down"],
     ["Return", "git_log_enter"],
     ["Tab", "git_log_tab"],
     ["q", "git_log_q"],
@@ -151,6 +121,23 @@ editor.defineMode(
   false, // allow_text_input
   true, // inherit Normal-context bindings for unbound keys
 );
+
+function git_log_select_up(): void {
+  state.logPanel?.command(key("Up"));
+}
+function git_log_select_down(): void {
+  state.logPanel?.command(key("Down"));
+}
+function git_log_select_page_up(): void {
+  state.logPanel?.command(key("PageUp"));
+}
+function git_log_select_page_down(): void {
+  state.logPanel?.command(key("PageDown"));
+}
+registerHandler("git_log_select_up", git_log_select_up);
+registerHandler("git_log_select_down", git_log_select_down);
+registerHandler("git_log_select_page_up", git_log_select_page_up);
+registerHandler("git_log_select_page_down", git_log_select_page_down);
 
 // =============================================================================
 // Panel layout
@@ -228,19 +215,37 @@ function renderToolbar(): void {
 }
 
 editor.on("widget_event", (data) => {
+  // Toolbar (Row of Buttons) — `activate` from keypress or click on a
+  // button.
   if (
-    state.toolbarPanel === null ||
-    data.panel_id !== state.toolbarPanel.id()
+    state.toolbarPanel !== null &&
+    data.panel_id === state.toolbarPanel.id()
   ) {
+    if (data.event_type !== "activate") return;
+    const items = toolbarItems();
+    for (const item of items) {
+      if (data.widget_key === TOOLBAR_KEY_PREFIX + item.key) {
+        void item.onClick();
+        return;
+      }
+    }
     return;
   }
-  if (data.event_type !== "activate") return;
-  const items = toolbarItems();
-  for (const item of items) {
-    if (data.widget_key === TOOLBAR_KEY_PREFIX + item.key) {
-      void item.onClick();
+  // Log pane (List of commit rows) — `select` fires on j/k/Up/Down/
+  // PageUp/PageDown navigation and on row clicks; `activate` fires on
+  // Enter or double-click.
+  if (state.logPanel !== null && data.panel_id === state.logPanel.id()) {
+    if (data.event_type === "select") {
+      const idx =
+        typeof data.payload?.index === "number" ? data.payload.index : -1;
+      if (idx >= 0) void on_log_select(idx);
       return;
     }
+    if (data.event_type === "activate") {
+      void git_log_enter();
+      return;
+    }
+    return;
   }
 });
 
@@ -259,27 +264,29 @@ function detailFooter(hash: string): string {
 }
 
 function renderLog(): void {
-  if (state.groupId === null) return;
-  // No header row and no footer: the sticky toolbar above the group
-  // carries the shortcut hints, and the commit count goes to the status
-  // line when the group opens.
-  const entries = buildCommitLogEntries(state.commits, {
-    selectedIndex: state.selectedIndex,
+  if (state.logPanel === null) return;
+  // List takes the per-row entries directly. selectedIndex: -1 on the
+  // entry builder suppresses the plugin's selection styling — the host
+  // renders the focused-row highlight from the List widget's instance
+  // state instead.
+  const items = buildCommitLogEntries(state.commits, {
+    selectedIndex: -1,
     header: null,
   });
-  // Rebuild the byte-offset table used by cursor_moved to map positions
-  // to commit indices. `offsets[i]` is the byte offset of commit i; the
-  // final entry is the total buffer length, so row lookups clamp
-  // correctly on the last row.
-  const offsets: number[] = [];
-  let running = 0;
-  for (const e of entries) {
-    offsets.push(running);
-    running += utf8Len(e.text);
-  }
-  offsets.push(running);
-  state.logRowByteOffsets = offsets;
-  editor.setPanelContent(state.groupId, "log", entries);
+  const itemKeys = state.commits.map((c) => c.hash);
+  state.logPanel.set(
+    list({
+      items,
+      itemKeys,
+      selectedIndex: state.selectedIndex,
+      // Visible-rows only matters for virtualization; setting it to
+      // commits.length renders all rows and lets the buffer's natural
+      // scroll handle viewport. Revisit if commit lists grow into the
+      // tens of thousands.
+      visibleRows: Math.max(1, state.commits.length),
+      key: "git-log-list",
+    }),
+  );
 }
 
 function renderDetailPlaceholder(message: string): void {
@@ -371,14 +378,6 @@ function selectedCommit(): GitCommit | null {
   return state.commits[i] ?? null;
 }
 
-function indexFromCursorByte(bytePos: number): number {
-  // No header row — row 0 is commit 0.
-  const idx = rowFromByte(bytePos);
-  if (idx < 0) return 0;
-  if (idx >= state.commits.length) return state.commits.length - 1;
-  return idx;
-}
-
 // =============================================================================
 // Commands
 // =============================================================================
@@ -415,16 +414,17 @@ async function show_git_log(): Promise<void> {
   if (state.toolbarBufferId !== null) {
     state.toolbarPanel = new WidgetPanel(state.toolbarBufferId);
   }
+  if (state.logBufferId !== null) {
+    state.logPanel = new WidgetPanel(state.logBufferId);
+  }
   state.selectedIndex = 0;
   state.detailCache = null;
   state.isOpen = true;
 
-  // The log panel owns a native cursor so j/k/Up/Down navigate commits,
-  // and the detail panel also gets a cursor so diff lines can be clicked
-  // / traversed before pressing Enter to open a file.
-  if (state.logBufferId !== null) {
-    editor.setBufferShowCursors(state.logBufferId, true);
-  }
+  // The detail panel still owns a native cursor so diff lines can be
+  // clicked / traversed before pressing Enter to open a file. The log
+  // panel's selection is owned by the List widget — no buffer cursor
+  // needed (the focused-row highlight indicates position).
   if (state.detailBufferId !== null) {
     editor.setBufferShowCursors(state.detailBufferId, true);
     // Wrap long lines in the detail panel — git diffs often exceed the
@@ -437,17 +437,14 @@ async function show_git_log(): Promise<void> {
 
   renderToolbar();
   renderLog();
-  // Position the cursor on the first commit (row 0 now that the header
-  // row is gone).
-  if (state.logBufferId !== null && state.commits.length > 0) {
-    editor.setBufferCursor(state.logBufferId, 0);
-  }
+  // List widget's instance state is the source of truth for selection;
+  // no buffer-cursor positioning needed (the renderer auto-scrolls so
+  // the selected row stays visible).
   await refreshDetail();
 
   if (state.groupId !== null) {
     editor.focusBufferGroupPanel(state.groupId, "log");
   }
-  editor.on("cursor_moved", on_git_log_cursor_moved);
   editor.on("resize", on_git_log_resize);
   editor.on("buffer_closed", on_git_log_buffer_closed);
 
@@ -462,14 +459,14 @@ registerHandler("show_git_log", show_git_log);
  * close button, which triggers `buffer_closed`). */
 function git_log_cleanup(): void {
   if (!state.isOpen) return;
-  editor.off("cursor_moved", on_git_log_cursor_moved);
   editor.off("resize", on_git_log_resize);
   editor.off("buffer_closed", on_git_log_buffer_closed);
-  // The buffer-group's `close` will tear down the toolbar buffer too,
-  // which implicitly drops the widget panel rendering into it. We
-  // still null out the handle so any stray `renderToolbar()` call
-  // post-cleanup is a no-op.
+  // The buffer-group's `close` will tear down the panel buffers too,
+  // which implicitly drops the widget panels rendering into them. We
+  // still null out the handles so any stray `renderToolbar()` /
+  // `renderLog()` call post-cleanup is a no-op.
   state.toolbarPanel = null;
+  state.logPanel = null;
   state.isOpen = false;
   state.groupId = null;
   state.logBufferId = null;
@@ -673,32 +670,18 @@ function git_log_file_view_close(): void {
 registerHandler("git_log_file_view_close", git_log_file_view_close);
 
 // =============================================================================
-// Cursor tracking — live-update the detail panel as the user scrolls through
-// the commit list.
+// Selection tracking — live-update the detail panel as the user
+// navigates the List. Driven by `widget_event "select"` from the host.
 // =============================================================================
 
-async function on_git_log_cursor_moved(data: {
-  buffer_id: number;
-  cursor_id: number;
-  old_position: number;
-  new_position: number;
-}): Promise<void> {
+async function on_log_select(idx: number): Promise<void> {
   if (!state.isOpen) return;
-  // Only react to movement inside the log panel.
-  if (data.buffer_id !== state.logBufferId) return;
-
-  // Map the cursor's byte offset to a commit index via the row-offset
-  // table built in `renderLog`. This avoids relying on `getCursorLine`
-  // which is not implemented for virtual buffers.
-  const idx = indexFromCursorByte(data.new_position);
   if (idx === state.selectedIndex) return;
   state.selectedIndex = idx;
 
-  // Immediate feedback: update the log panel's selection highlight and
-  // either show the cached detail or a "loading" placeholder. Only the
-  // actual `git show` spawn is debounced below, so a burst of j/k events
-  // still feels responsive even though we collapse the fetches into one.
-  renderLog();
+  // Immediate feedback: cached detail or "loading" placeholder.
+  // The host already re-rendered the List with the new selection
+  // highlight, so we only need to update the right-hand pane.
   const pending = refreshDetailImmediate();
 
   const commit = state.commits[state.selectedIndex];
@@ -707,22 +690,21 @@ async function on_git_log_cursor_moved(data: {
       editor.t("status.commit_position", {
         current: String(state.selectedIndex + 1),
         total: String(state.commits.length),
-      })
+      }),
     );
   }
 
   if (!pending) return;
 
   // Debounce: bump the token, wait a beat, bail if a newer event has
-  // arrived. `git show` is expensive; a burst of cursor events (held
+  // arrived. `git show` is expensive; a burst of select events (held
   // j/k, PageDown) must collapse to one spawn.
-  const myId = ++state.pendingCursorMoveId;
-  await editor.delay(CURSOR_DEBOUNCE_MS);
-  if (myId !== state.pendingCursorMoveId) return;
+  const myId = ++state.pendingSelectId;
+  await editor.delay(SELECT_DEBOUNCE_MS);
+  if (myId !== state.pendingSelectId) return;
   if (!state.isOpen) return;
   await fetchAndRenderDetail(pending);
 }
-registerHandler("on_git_log_cursor_moved", on_git_log_cursor_moved);
 
 // =============================================================================
 // Command registration

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -847,91 +847,50 @@ type WidgetSpec = {
 	checkable: boolean;
 	key?: string | null;
 } | {
-	"kind": "textInput";
+	"kind": "text";
 	/**
-	* Current text in the field.
+	* Initial text. Spec value is read at first render only;
+	* instance state takes over thereafter.
 	*/
 	value: string;
 	/**
-	* Byte offset of the cursor within `value`. Negative
-	* (encoded as `i32` in JSON; clamped on Rust side) means
-	* "no cursor" — the input is not the active focus target.
+	* Initial byte-offset cursor within `value`. Negative
+	* (encoded as `i32` in JSON) means "no cursor" — clamped
+	* to `[0, value.len()]` host-side.
 	*/
 	cursorByte: number;
 	/**
-	* Whether this input has visual focus (controls fg/bg
-	* highlight).
+	* Whether this widget has visual focus.
 	*/
 	focused: boolean;
 	/**
-	* Optional label rendered before the brackets:
-	* `Label: [value]`. Use the empty string to omit.
+	* Optional label rendered before / above the editing
+	* region. Empty = omitted.
 	*/
 	label?: string;
 	/**
-	* Optional placeholder shown when `value` is empty and the
-	* input is unfocused.
+	* Placeholder shown when unfocused and `value` is empty.
 	*/
 	placeholder?: string | null;
 	/**
-	* Maximum visible characters before truncation with an
-	* ellipsis. `0` means "don't truncate". Distinct from
-	* `field_width` — this is a soft cap, applied *after*
-	* the field-width pad. Most callers want `field_width`.
-	*/
-	maxVisibleChars: number;
-	/**
-	* Fixed visible width inside the brackets (in display
-	* columns / chars). `0` (default) = auto-fit, growing with
-	* the value. `>0` = always render exactly this many chars:
-	* pad short values with trailing spaces, head-truncate
-	* long values with `…` so the *tail* (where the cursor
-	* usually is) stays visible.
-	*/
-	fieldWidth: number;
-	key?: string | null;
-} | {
-	"kind": "textArea";
-	/**
-	* Initial text. Spec value is used at first render only;
-	* instance state takes over thereafter (matching
-	* `TextInput`'s host-owned value model).
-	*/
-	value: string;
-	/**
-	* Initial byte-offset cursor. Negative ⇒ "no cursor"; the
-	* host clamps to `[0, value.len()]`.
-	*/
-	cursorByte: number;
-	/**
-	* Visual focus flag (initial-only — instance state takes
-	* over once the panel has any tabbable widgets, see
-	* `focus_key` semantics).
-	*/
-	focused: boolean;
-	/**
-	* Optional label rendered on its own row above the
-	* editing region (`Label:` followed by the multi-line
-	* box). Empty = omitted.
-	*/
-	label?: string;
-	/**
-	* Placeholder text shown on the first row when the value
-	* is empty and the field is unfocused.
-	*/
-	placeholder?: string | null;
-	/**
-	* Number of visible rows of editing region. Plugin
-	* computes from its viewport; `0` falls back to a small
-	* default (3) at render time.
+	* Number of visible rows of editing region. `0` falls back
+	* to `1` (single-line). `1` = single-line behaviour;
+	* `>= 2` = multi-line behaviour. See the type-level doc
+	* for the per-mode semantics.
 	*/
 	rows: number;
 	/**
-	* Visible column width inside the editing region. `0`
-	* (default) = grow with the longest visible line up to
-	* the panel width.
+	* Visible column width. `0` = auto-fit (single-line) or
+	* panel width (multi-line). When set, single-line
+	* head-truncates with `…` and multi-line tail-truncates
+	* per-line.
 	*/
 	fieldWidth: number;
+	/**
+	* Single-line soft cap on visible chars after the
+	* `field_width` pad. `0` = no cap. Ignored when `rows > 1`.
+	*/
+	maxVisibleChars: number;
 	key?: string | null;
 } | {
 	"kind": "raw";

--- a/crates/fresh-editor/plugins/lib/index.ts
+++ b/crates/fresh-editor/plugins/lib/index.ts
@@ -60,6 +60,8 @@ export {
   row,
   selectMove,
   spacer,
+  text,
+  textArea,
   textInput,
   textInputChar,
   textInputKey,

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -282,28 +282,69 @@ export function tree(options: {
   };
 }
 
-/** Multi-line text input, rendered as a fixed-height block of
- * `rows` rows. The host owns the value, cursor, and vertical scroll
- * as instance state — same pattern as `textInput`, lifted to a
- * 2-D buffer.
+/** Text input — single-line (`rows: 1`, default) or multi-line
+ * (`rows >= 2`). The host owns `value` and `cursorByte` as instance
+ * state once the widget renders for the first time; multi-line
+ * widgets also own a vertical scroll offset.
  *
- * **Smart-key dispatch differs from `textInput`**:
- * `Enter` inserts a newline (instead of advancing focus);
- * `Up`/`Down` move between lines; `Home`/`End` jump within the
- * current line; `Left`/`Right`/`Backspace`/`Delete` and printable
- * chars work as in `textInput`. Plugins that want `Enter` to
- * submit can intercept the key in their own mode binding and call
- * `panel.command(focusAdvance(1))` instead — this default is
- * non-breaking because the smart-key dispatch is opt-in.
+ * Single-line (`rows: 1`) renders as `[value]` (or `Label: [value]`
+ * if `label` is provided), with `fieldWidth` giving a constant
+ * visible width — short values pad with trailing spaces, long
+ * values head-truncate with `…` so the tail (where the cursor
+ * usually is) stays visible. Smart-key dispatch: `Enter` advances
+ * focus; `Up`/`Down` are no-ops; `Home`/`End` jump to the start /
+ * end of the whole value.
  *
- * `rows` controls visible height (default 3 if omitted).
- * `fieldWidth` controls visible column width inside the editing
- * region; `0` (default) uses the panel width. Long lines
- * tail-truncate with `…`; short lines pad with trailing spaces so
- * the focused-bg block keeps a rectangular shape.
+ * Multi-line (`rows >= 2`) renders as a `rows`-tall block, padded
+ * with blanks when `value` is shorter. Smart-key dispatch differs:
+ * `Enter` inserts a newline; `Up`/`Down` move between lines;
+ * `Home`/`End` are line-relative; long lines tail-truncate with `…`
+ * per-line. Plugins that want `Enter` to submit can intercept the
+ * key in their own mode binding and call
+ * `panel.command(focusAdvance(1))` instead.
  *
- * `key` is required for any TextArea that should preserve its
- * value, cursor, and scroll across re-renders. */
+ * `key` is required for any text widget that should preserve its
+ * value, cursor, and scroll across re-renders.
+ *
+ * Prefer the `textInput()` / `textArea()` helpers below when the
+ * intent is unambiguous — they call this with the right `rows`. */
+export function text(
+  options: {
+    value?: string;
+    cursorByte?: number;
+    focused?: boolean;
+    label?: string;
+    placeholder?: string;
+    /** Number of visible rows of editing region. `1` (default) =
+     * single-line behaviour; `>= 2` = multi-line behaviour. */
+    rows?: number;
+    /** Visible column width. `0` (default) = auto-fit (single-line)
+     * or panel width (multi-line). */
+    fieldWidth?: number;
+    /** Single-line soft cap on visible chars after the
+     * `fieldWidth` pad. `0` = no cap. Ignored when `rows >= 2`. */
+    maxVisibleChars?: number;
+    key?: string;
+  } = {},
+): WidgetSpec {
+  return {
+    kind: "text",
+    value: options.value ?? "",
+    cursorByte: options.cursorByte ?? -1,
+    focused: options.focused ?? false,
+    label: options.label ?? "",
+    placeholder: options.placeholder,
+    rows: options.rows ?? 1,
+    fieldWidth: options.fieldWidth ?? 0,
+    maxVisibleChars: options.maxVisibleChars ?? 0,
+    key: options.key,
+  };
+}
+
+/** Multi-line text widget. Thin wrapper over `text({ rows, ... })`
+ * for ergonomic intent — renders as a `rows`-tall block with
+ * Enter-inserts-newline / Up-Down-line-nav semantics. Default `rows`
+ * is 5; pass `rows: N` to override. */
 export function textArea(
   options: {
     value?: string;
@@ -311,37 +352,23 @@ export function textArea(
     focused?: boolean;
     label?: string;
     placeholder?: string;
-    /** Visible rows of editing area; default 3. */
+    /** Visible rows of editing area; default 5. */
     rows?: number;
     /** Visible column width; `0` = use panel width. */
     fieldWidth?: number;
     key?: string;
   } = {},
 ): WidgetSpec {
-  return {
-    kind: "textArea",
-    value: options.value ?? "",
-    cursorByte: options.cursorByte ?? -1,
-    focused: options.focused ?? false,
-    label: options.label ?? "",
-    placeholder: options.placeholder,
-    rows: options.rows ?? 3,
-    fieldWidth: options.fieldWidth ?? 0,
-    key: options.key,
-  };
+  return text({
+    ...options,
+    rows: options.rows ?? 5,
+  });
 }
 
-/** Single-line text input, rendered as `[value]` (or
- * `Label: [value]` if `label` is provided). The host drives the
- * actual hardware cursor at `cursorByte` when focused — no painted
- * overlay, the terminal's blinking caret follows the focused field.
- *
- * `fieldWidth` (recommended for any non-trivial input) gives the
- * input a constant visible width: short values pad with trailing
- * spaces, long values head-truncate with `…` so the cursor stays
- * visible at the right edge. Without `fieldWidth` the input grows
- * with the value, which is fine for one-shot prompts but causes
- * surrounding row content to shift as the user types. */
+/** Single-line text widget. Thin wrapper over `text({ rows: 1,
+ * ... })` matching the historical `textInput(value, opts)`
+ * signature. Renders as `[value]` (or `Label: [value]` if `label`
+ * is provided), with Enter-advances-focus semantics. */
 export function textInput(
   value: string,
   options?: {
@@ -356,17 +383,17 @@ export function textInput(
     key?: string;
   },
 ): WidgetSpec {
-  return {
-    kind: "textInput",
+  return text({
     value,
-    cursorByte: options?.cursorByte ?? -1,
-    focused: options?.focused ?? false,
+    cursorByte: options?.cursorByte,
+    focused: options?.focused,
     label: options?.label,
     placeholder: options?.placeholder,
-    maxVisibleChars: options?.maxVisibleChars ?? 0,
-    fieldWidth: options?.fieldWidth ?? 0,
+    rows: 1,
+    fieldWidth: options?.fieldWidth,
+    maxVisibleChars: options?.maxVisibleChars,
     key: options?.key,
-  };
+  });
 }
 
 // =============================================================================

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -1,5 +1,13 @@
 /// <reference path="./lib/fresh.d.ts" />
 
+import {
+  hintBar,
+  key,
+  list,
+  parseHintString,
+  WidgetPanel,
+} from "./lib/index.ts";
+
 /**
  * Fresh Package Manager Plugin
  *
@@ -1658,6 +1666,16 @@ interface PkgManagerState {
   // Buffer group fields
   groupId: number | null;
   panelBuffers: Record<string, number>;
+  /** Widget panels owned by the pkg manager. The list panel hosts a
+   * `List` widget (one row per package) so the host owns selection
+   * highlight, scroll, click-to-select, mouse wheel, and PageUp/Down.
+   * The footer panel hosts a `HintBar` widget (the Navigate / Tab /
+   * Search / Esc cheat-sheet). Header and detail panels still use
+   * `setPanelContent` since their UI shape spans cross-panel focus
+   * (filter / sync / search / action buttons) which is a larger
+   * redesign. */
+  listPanel: WidgetPanel | null;
+  footerPanel: WidgetPanel | null;
 }
 
 const pkgState: PkgManagerState = {
@@ -1674,6 +1692,8 @@ const pkgState: PkgManagerState = {
   viewportHeight: 24,
   groupId: null,
   panelBuffers: {},
+  listPanel: null,
+  footerPanel: null,
 };
 
 // Theme-aware color configuration
@@ -2040,53 +2060,163 @@ function buildPkgHeaderEntries(): TextPropertyEntry[] {
   return entries;
 }
 
-function buildPkgListEntries(): TextPropertyEntry[] {
+/** Build the per-row item entries for the package List widget.
+ * The list iterates "installed first, then available" to match the
+ * existing buffer-render order, so the row's index in this array
+ * matches `pkgState.selectedIndex`. The leading `▸` arrow that the
+ * old hand-rolled renderer used on the focused row is gone — the
+ * List widget paints the selection highlight via `ui.menu_active_bg`
+ * which carries the same "this row is selected" signal. Section
+ * headers (`INSTALLED (n)` / `AVAILABLE (n)`) are kept as
+ * non-selectable rows; selecting them would be a no-op so the list
+ * navigation skips them implicitly via the index math. */
+interface PkgListRow {
+  entry: TextPropertyEntry;
+  /** Stable widget-key for the List item. Empty string for non-
+   * selectable header rows (the List still tracks them in
+   * itemKeys but they don't carry useful identity). */
+  key: string;
+  /** Index within `getFilteredItems()` if this row is a real
+   * package, else -1. The widget's `selectedIndex` is reported
+   * back via `widget_event "select"` and we use it to look up
+   * the matching package via this map. */
+  itemIndex: number;
+}
+
+function buildPkgListRows(): PkgListRow[] {
   const items = getFilteredItems();
-  const installedItems = items.filter(i => i.installed);
-  const availableItems = items.filter(i => !i.installed);
-  const entries: TextPropertyEntry[] = [];
+  const installedItems = items.filter((i) => i.installed);
+  const availableItems = items.filter((i) => !i.installed);
+  const rows: PkgListRow[] = [];
 
   if (installedItems.length > 0) {
-    entries.push({ text: `INSTALLED (${installedItems.length})\n`, properties: { type: "section-title" } });
+    rows.push({
+      entry: {
+        text: `INSTALLED (${installedItems.length})`,
+        properties: { type: "section-title" },
+      },
+      key: "section.installed",
+      itemIndex: -1,
+    });
     let idx = 0;
     for (const item of installedItems) {
-      const isSelected = idx === pkgState.selectedIndex;
-      const listFocused = pkgState.focus.type === "list";
-      const prefix = isSelected && listFocused ? "▸" : " ";
       const status = item.updateAvailable ? "↑" : "✓";
-      const ver = item.version.length > 7 ? item.version.slice(0, 6) + "…" : item.version;
+      const ver =
+        item.version.length > 7 ? item.version.slice(0, 6) + "…" : item.version;
       const nameW = Math.max(8, LIST_WIDTH - 16);
-      const name = item.name.length > nameW ? item.name.slice(0, nameW - 1) + "…" : item.name;
-      entries.push({ text: `${prefix} ${name.padEnd(nameW)} ${ver.padEnd(7)} ${status}\n`, properties: { type: "package-row", selected: isSelected, installed: true } });
+      const name =
+        item.name.length > nameW ? item.name.slice(0, nameW - 1) + "…" : item.name;
+      rows.push({
+        entry: {
+          text: `  ${name.padEnd(nameW)} ${ver.padEnd(7)} ${status}`,
+          properties: { type: "package-row", installed: true },
+        },
+        key: `pkg.${item.name}`,
+        itemIndex: idx,
+      });
       idx++;
     }
   }
 
   if (availableItems.length > 0) {
-    if (entries.length > 0) entries.push({ text: "\n", properties: { type: "blank" } });
-    entries.push({ text: `AVAILABLE (${availableItems.length})\n`, properties: { type: "section-title" } });
+    if (rows.length > 0) {
+      rows.push({
+        entry: { text: "", properties: { type: "blank" } },
+        key: "blank",
+        itemIndex: -1,
+      });
+    }
+    rows.push({
+      entry: {
+        text: `AVAILABLE (${availableItems.length})`,
+        properties: { type: "section-title" },
+      },
+      key: "section.available",
+      itemIndex: -1,
+    });
     let idx = installedItems.length;
     for (const item of availableItems) {
-      const isSelected = idx === pkgState.selectedIndex;
-      const listFocused = pkgState.focus.type === "list";
-      const prefix = isSelected && listFocused ? "▸" : " ";
-      const typeTag = item.packageType === "theme" ? "T" : item.packageType === "language" ? "L" : item.packageType === "bundle" ? "B" : "P";
+      const typeTag =
+        item.packageType === "theme"
+          ? "T"
+          : item.packageType === "language"
+            ? "L"
+            : item.packageType === "bundle"
+              ? "B"
+              : "P";
       const availNameW = Math.max(8, LIST_WIDTH - 10);
-      const name = item.name.length > availNameW ? item.name.slice(0, availNameW - 1) + "…" : item.name;
-      entries.push({ text: `${prefix} ${name.padEnd(availNameW)} [${typeTag}]\n`, properties: { type: "package-row", selected: isSelected, installed: false } });
+      const name =
+        item.name.length > availNameW
+          ? item.name.slice(0, availNameW - 1) + "…"
+          : item.name;
+      rows.push({
+        entry: {
+          text: `  ${name.padEnd(availNameW)} [${typeTag}]`,
+          properties: { type: "package-row", installed: false },
+        },
+        key: `pkg.${item.name}`,
+        itemIndex: idx,
+      });
       idx++;
     }
   }
 
   if (items.length === 0) {
-    if (pkgState.isLoading) {
-      entries.push({ text: "Loading...\n", properties: { type: "empty-state" } });
-    } else {
-      entries.push({ text: "No packages found\n", properties: { type: "empty-state" } });
-    }
+    rows.push({
+      entry: {
+        text: pkgState.isLoading ? "Loading..." : "No packages found",
+        properties: { type: "empty-state" },
+      },
+      key: "empty",
+      itemIndex: -1,
+    });
   }
 
-  return entries;
+  return rows;
+}
+
+/** Cache the row→item-index lookup so `widget_event "select"` can
+ * map the host's reported selection index back to a real package
+ * index in O(1) without rebuilding the row array. Refreshed by
+ * `renderPkgList` every time the list is re-emitted. */
+let pkgListRowCache: PkgListRow[] = [];
+
+function selectedRowToItemIndex(rowIndex: number): number {
+  const row = pkgListRowCache[rowIndex];
+  return row ? row.itemIndex : -1;
+}
+
+function itemIndexToRow(itemIndex: number): number {
+  for (let i = 0; i < pkgListRowCache.length; i++) {
+    if (pkgListRowCache[i].itemIndex === itemIndex) return i;
+  }
+  return -1;
+}
+
+function renderPkgList(): void {
+  if (pkgState.listPanel === null) return;
+  const rows = buildPkgListRows();
+  pkgListRowCache = rows;
+  // Map the plugin's item-index selection to the row-index the List
+  // widget understands. -1 falls back to the first selectable row.
+  let rowSel = itemIndexToRow(pkgState.selectedIndex);
+  if (rowSel < 0) {
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i].itemIndex >= 0) {
+        rowSel = i;
+        break;
+      }
+    }
+  }
+  pkgState.listPanel.set(
+    list({
+      items: rows.map((r) => r.entry),
+      itemKeys: rows.map((r) => r.key),
+      selectedIndex: rowSel,
+      visibleRows: Math.max(1, rows.length),
+      key: "pkg-list",
+    }),
+  );
 }
 
 function buildPkgDetailEntries(): TextPropertyEntry[] {
@@ -2133,23 +2263,33 @@ function buildPkgDetailEntries(): TextPropertyEntry[] {
   return entries;
 }
 
-function buildPkgFooterEntries(): TextPropertyEntry[] {
-  let helpText = " ↑↓ Navigate  Tab Next  / Search  Enter ";
-  if (pkgState.focus.type === "action") helpText += "Activate";
-  else if (pkgState.focus.type === "filter") helpText += "Filter";
-  else if (pkgState.focus.type === "sync") helpText += "Sync";
-  else if (pkgState.focus.type === "search") helpText += "Search";
-  else helpText += "Select";
-  helpText += "  Esc Close";
-  return [{ text: helpText + "\n", properties: { type: "help" } }];
+function renderPkgFooter(): void {
+  if (pkgState.footerPanel === null) return;
+  let actionLabel = "Select";
+  if (pkgState.focus.type === "action") actionLabel = "Activate";
+  else if (pkgState.focus.type === "filter") actionLabel = "Filter";
+  else if (pkgState.focus.type === "sync") actionLabel = "Sync";
+  else if (pkgState.focus.type === "search") actionLabel = "Search";
+  // The hint string follows the existing `parseHintString` shape:
+  // tokens separated by two spaces, each token is `<keys>:<label>`
+  // or `<keys> <label>`. The host's HintBar styles the keys portion
+  // with `ui.help_key_fg`.
+  const hintString = `↑↓:Navigate  Tab:Next  /:Search  Enter:${actionLabel}  Esc:Close`;
+  pkgState.footerPanel.set(hintBar(parseHintString(hintString)));
 }
 
 function updatePkgManagerView(): void {
   if (pkgState.groupId === null) return;
+  // Header + detail still flow through the legacy `setPanelContent`
+  // path — their UI shape (filter/sync/search inputs in the header,
+  // action buttons in the detail) spans cross-panel focus, which
+  // is a larger redesign best done together with the §4.1
+  // Compositor work. List and footer migrate independently because
+  // they don't participate in cross-panel focus.
   editor.setPanelContent(pkgState.groupId, "header", buildPkgHeaderEntries());
-  editor.setPanelContent(pkgState.groupId, "list", buildPkgListEntries());
+  renderPkgList();
   editor.setPanelContent(pkgState.groupId, "detail", buildPkgDetailEntries());
-  editor.setPanelContent(pkgState.groupId, "footer", buildPkgFooterEntries());
+  renderPkgFooter();
 }
 
 /**
@@ -2206,6 +2346,17 @@ async function openPackageManager(): Promise<void> {
   pkgState.panelBuffers = groupResult.panels;
   pkgState.isOpen = true;
 
+  // Mount widget panels for the list and footer. Header / detail
+  // still use `setPanelContent` (see `updatePkgManagerView`).
+  const listBufferId = pkgState.panelBuffers["list"];
+  if (typeof listBufferId === "number") {
+    pkgState.listPanel = new WidgetPanel(listBufferId);
+  }
+  const footerBufferId = pkgState.panelBuffers["footer"];
+  if (typeof footerBufferId === "number") {
+    pkgState.footerPanel = new WidgetPanel(footerBufferId);
+  }
+
   // Set initial content for all panels
   updatePkgManagerView();
 
@@ -2239,11 +2390,17 @@ function closePackageManager(): void {
     editor.showBuffer(pkgState.sourceBufferId);
   }
 
-  // Reset state
+  // Reset state. The buffer group's close will tear down the panel
+  // buffers and (implicitly) the widget panels rendering into them;
+  // we just null the handles so any stray render call after close
+  // is a no-op.
   pkgState.isOpen = false;
   pkgState.bufferId = null;
   pkgState.splitId = null;
   pkgState.sourceBufferId = null;
+  pkgState.listPanel = null;
+  pkgState.footerPanel = null;
+  pkgListRowCache = [];
 }
 
 /**
@@ -2290,31 +2447,55 @@ function getCurrentFocusIndex(): number {
 }
 
 // Navigation commands
-function pkg_nav_up() : void {
+function pkg_nav_up(): void {
   if (!pkgState.isOpen) return;
-
-  const items = getFilteredItems();
-  if (items.length === 0) return;
-
-  // Always focus list and navigate (auto-focus behavior)
-  pkgState.selectedIndex = Math.max(0, pkgState.selectedIndex - 1);
+  // Always snap focus back to the list and let the host move the
+  // List widget's selection. The resulting `widget_event "select"`
+  // updates `pkgState.selectedIndex` and refreshes the detail
+  // panel — see the `widget_event` listener installed below.
   pkgState.focus = { type: "list" };
-  updatePkgManagerView();
+  pkgState.listPanel?.command(key("Up"));
 }
 registerHandler("pkg_nav_up", pkg_nav_up);
 
-function pkg_nav_down() : void {
+function pkg_nav_down(): void {
   if (!pkgState.isOpen) return;
-
-  const items = getFilteredItems();
-  if (items.length === 0) return;
-
-  // Always focus list and navigate (auto-focus behavior)
-  pkgState.selectedIndex = Math.min(items.length - 1, pkgState.selectedIndex + 1);
   pkgState.focus = { type: "list" };
-  updatePkgManagerView();
+  pkgState.listPanel?.command(key("Down"));
 }
 registerHandler("pkg_nav_down", pkg_nav_down);
+
+editor.on("widget_event", (data) => {
+  if (
+    pkgState.listPanel === null ||
+    data.panel_id !== pkgState.listPanel.id()
+  ) {
+    return;
+  }
+  if (data.event_type === "select") {
+    const rowIdx =
+      typeof data.payload?.index === "number" ? data.payload.index : -1;
+    if (rowIdx < 0) return;
+    const itemIdx = selectedRowToItemIndex(rowIdx);
+    if (itemIdx < 0) return; // selection landed on a section header
+    if (itemIdx === pkgState.selectedIndex) return;
+    pkgState.selectedIndex = itemIdx;
+    pkgState.focus = { type: "list" };
+    // Re-render header/detail to reflect the new selection;
+    // the list itself is already updated by the host (we don't
+    // need to call renderPkgList again).
+    if (pkgState.groupId !== null) {
+      editor.setPanelContent(pkgState.groupId, "header", buildPkgHeaderEntries());
+      editor.setPanelContent(pkgState.groupId, "detail", buildPkgDetailEntries());
+    }
+    renderPkgFooter();
+    return;
+  }
+  if (data.event_type === "activate") {
+    void pkg_activate();
+    return;
+  }
+});
 
 function pkg_next_button() : void {
   if (!pkgState.isOpen) return;

--- a/crates/fresh-editor/plugins/theme_editor.ts
+++ b/crates/fresh-editor/plugins/theme_editor.ts
@@ -1,4 +1,5 @@
 /// <reference path="./lib/fresh.d.ts" />
+import { hintBar, parseHintString, WidgetPanel } from "./lib/index.ts";
 const editor = getEditor();
 
 
@@ -414,6 +415,12 @@ interface ThemeEditorState {
   viewportWidth: number;
   /** Buffer group ID (when using buffer groups) */
   groupId: number | null;
+  /** Widget panel rendering the footer hint bar. Created when the
+   * buffer-group view opens. The tree and picker panels still use
+   * `setPanelContent` because they own the focus model (header
+   * row, separator, optional filter line, then selectable section /
+   * field rows) which doesn't map cleanly to a single List today. */
+  footerPanel: WidgetPanel | null;
   /** Panel buffer IDs keyed by panel name */
   panelBuffers: Record<string, number>;
 }
@@ -478,6 +485,7 @@ const state: ThemeEditorState = {
   viewportHeight: 40,
   viewportWidth: 120,
   groupId: null,
+  footerPanel: null,
   panelBuffers: {},
 };
 
@@ -1437,9 +1445,16 @@ function buildPickerPanelEntries(): TextPropertyEntry[] {
   return entries;
 }
 
-function buildFooterPanelEntries(): TextPropertyEntry[] {
-  const hintText = " ↑↓ Navigate  Tab Switch Panel  Enter Edit  /Filter  Ctrl+S Save  Esc Close";
-  return [{ text: hintText + "\n", style: { fg: colors.header } }];
+/** Render the footer hints into the footer widget panel. The hint
+ * string follows `parseHintString`'s convention (tokens separated
+ * by two spaces; each token is `<keys>:<label>` or `<keys> <label>`)
+ * so the host's HintBar styles the keys with `ui.help_key_fg`
+ * consistently with every other plugin's footer. */
+function renderThemeEditorFooter(): void {
+  if (state.footerPanel === null) return;
+  const hintString =
+    "↑↓:Navigate  Tab:Switch Panel  Enter:Edit  /:Filter  Ctrl+S:Save  Esc:Close";
+  state.footerPanel.set(hintBar(parseHintString(hintString)));
 }
 
 function updateDisplay(): void {
@@ -1456,7 +1471,7 @@ function updateDisplay(): void {
   if (state.groupId !== null) {
     editor.setPanelContent(state.groupId, "tree", buildTreePanelEntries());
     editor.setPanelContent(state.groupId, "picker", buildPickerPanelEntries());
-    editor.setPanelContent(state.groupId, "footer", buildFooterPanelEntries());
+    renderThemeEditorFooter();
 
     // Keep the selected tree row in view. The plugin's `selectedIndex`
     // navigation doesn't move the buffer cursor, so without this the
@@ -2678,6 +2693,13 @@ async function doOpenThemeEditor(): Promise<void> {
   state.bufferId = groupResult.panels["tree"]; // representative buffer
   state.splitId = null;
 
+  // Mount the footer as a widget panel (HintBar). Tree + picker
+  // panels still use `setPanelContent` (see updateDisplay).
+  const footerBufferId = groupResult.panels["footer"];
+  if (typeof footerBufferId === "number") {
+    state.footerPanel = new WidgetPanel(footerBufferId);
+  }
+
   if (state.bufferId !== null) {
     // Set initial content for all panels
     updateDisplay();
@@ -2714,7 +2736,10 @@ registerHandler("theme_editor_close", theme_editor_close);
  * Actually close the editor (called after confirmation or when no changes)
  */
 function doCloseEditor(): void {
-  // Close the buffer group (or fall back to single buffer close)
+  // Close the buffer group (or fall back to single buffer close).
+  // Closing the buffer group tears down the footer buffer too,
+  // implicitly dropping the widget panel rendering into it.
+  state.footerPanel = null;
   if (state.groupId !== null) {
     editor.closeBufferGroup(state.groupId);
     state.groupId = null;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -23,13 +23,42 @@ use crate::view::split::SplitViewState;
 
 use super::Editor;
 
-/// Discriminator for the two text-bearing widget kinds. Used by the
-/// printable-char dispatcher (`handle_widget_text_input_char`) to
-/// route a key into TextInput or TextArea instance state.
-#[derive(Debug, Clone, Copy)]
-enum TextWidgetKind {
-    TextInput,
-    TextArea,
+/// Snapshot of the focused text-bearing widget's host-owned state,
+/// regardless of kind. Returned by `read_focused_text` and consumed
+/// by `write_focused_text` so the kind-specific instance-state
+/// fields (e.g. TextArea's `scroll_row`) round-trip without forcing
+/// every callsite to fork on kind.
+///
+/// Adding a new text-bearing widget kind: add a variant here, plus
+/// arms in `read_focused_text` / `write_focused_text` /
+/// `handle_widget_text_key` / `handle_widget_text_char`. Every other
+/// site that touches focused text input goes through this enum.
+#[derive(Debug, Clone)]
+enum FocusedText {
+    TextInput {
+        value: String,
+        cursor: usize,
+    },
+    TextArea {
+        value: String,
+        cursor: usize,
+        scroll_row: u32,
+    },
+}
+
+impl FocusedText {
+    fn value(&self) -> &str {
+        match self {
+            FocusedText::TextInput { value, .. } | FocusedText::TextArea { value, .. } => value,
+        }
+    }
+    fn cursor(&self) -> usize {
+        match self {
+            FocusedText::TextInput { cursor, .. } | FocusedText::TextArea { cursor, .. } => {
+                *cursor
+            }
+        }
+    }
 }
 
 /// Returns the byte offset of the start (want_end=false) or end (want_end=true)
@@ -3898,10 +3927,10 @@ impl Editor {
                 self.handle_widget_select_move(panel_id, delta);
             }
             WidgetAction::TextInputKey { key } => {
-                self.handle_widget_text_input_key(panel_id, &key);
+                self.handle_widget_text_key(panel_id, &key);
             }
             WidgetAction::TextInputChar { text } => {
-                self.handle_widget_text_input_char(panel_id, &text);
+                self.handle_widget_text_char(panel_id, &text);
             }
             WidgetAction::Key { key } => {
                 self.handle_widget_key(panel_id, &key);
@@ -3936,7 +3965,7 @@ impl Editor {
                         self.handle_widget_tree_select_move(panel_id, delta);
                     }
                     Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
-                        self.handle_widget_text_area_key(panel_id, key);
+                        self.handle_widget_text_key(panel_id, key);
                     }
                     _ => {}
                 }
@@ -3967,11 +3996,9 @@ impl Editor {
                 }
             }
             "Left" | "Right" => match widget {
-                Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
-                    self.handle_widget_text_input_key(panel_id, key);
-                }
-                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
-                    self.handle_widget_text_area_key(panel_id, key);
+                Some(fresh_core::api::WidgetSpec::TextInput { .. })
+                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_key(panel_id, key);
                 }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                     self.handle_widget_tree_lateral(panel_id, key == "Right");
@@ -3979,11 +4006,9 @@ impl Editor {
                 _ => {}
             },
             "Backspace" | "Delete" | "Home" | "End" => match widget {
-                Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
-                    self.handle_widget_text_input_key(panel_id, key);
-                }
-                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
-                    self.handle_widget_text_area_key(panel_id, key);
+                Some(fresh_core::api::WidgetSpec::TextInput { .. })
+                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_key(panel_id, key);
                 }
                 _ => {}
             },
@@ -4011,7 +4036,7 @@ impl Editor {
                     // the cursor. Plugins that want Enter to submit
                     // can intercept it before dispatching through
                     // the smart-key router.
-                    self.handle_widget_text_area_key(panel_id, "Enter");
+                    self.handle_widget_text_key(panel_id, "Enter");
                 }
                 _ => {}
             },
@@ -4020,11 +4045,9 @@ impl Editor {
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {
                     self.handle_widget_activate(panel_id);
                 }
-                Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
-                    self.handle_widget_text_input_char(panel_id, " ");
-                }
-                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
-                    self.handle_widget_text_area_char(panel_id, " ");
+                Some(fresh_core::api::WidgetSpec::TextInput { .. })
+                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    self.handle_widget_text_char(panel_id, " ");
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
                     self.fire_list_activate(panel_id, &focus_key);
@@ -4733,24 +4756,45 @@ impl Editor {
         }
     }
 
-    /// Read the focused TextInput's current value + cursor — from
-    /// instance state if present (the authoritative source once the
-    /// widget has rendered at least once), else from the spec
-    /// (initial-only fallback).
-    fn read_focused_text_input(&self, panel_id: u64) -> Option<(String, String, usize)> {
+    /// Read the focused text-bearing widget's current `(value,
+    /// cursor)` plus its kind-specific extras — from instance state
+    /// if present (the authoritative source once the widget has
+    /// rendered at least once), else from the spec (initial-only
+    /// fallback). Returns `None` when no text widget is focused.
+    fn read_focused_text(&self, panel_id: u64) -> Option<(String, FocusedText)> {
         let panel = self.widget_registry.get(panel_id)?;
         let focus_key = panel.focus_key.clone();
         if focus_key.is_empty() {
             return None;
         }
-        if let Some(crate::widgets::WidgetInstanceState::TextInput { value, cursor_byte }) =
-            panel.instance_states.get(&focus_key)
-        {
-            return Some((focus_key, value.clone(), *cursor_byte as usize));
+        match panel.instance_states.get(&focus_key) {
+            Some(crate::widgets::WidgetInstanceState::TextInput { value, cursor_byte }) => {
+                return Some((
+                    focus_key,
+                    FocusedText::TextInput {
+                        value: value.clone(),
+                        cursor: *cursor_byte as usize,
+                    },
+                ));
+            }
+            Some(crate::widgets::WidgetInstanceState::TextArea {
+                value,
+                cursor_byte,
+                scroll_row,
+            }) => {
+                return Some((
+                    focus_key,
+                    FocusedText::TextArea {
+                        value: value.clone(),
+                        cursor: *cursor_byte as usize,
+                        scroll_row: *scroll_row,
+                    },
+                ));
+            }
+            _ => {}
         }
-        // Fall back to spec — only happens before the widget has
-        // ever rendered, which in practice should never be true at
-        // the time a WidgetCommand arrives.
+        // Spec fallback — only reached before first render, which in
+        // practice should never be true when a WidgetCommand arrives.
         let widget = crate::widgets::find_widget_by_key(&panel.spec, &focus_key)?;
         match widget {
             fresh_core::api::WidgetSpec::TextInput {
@@ -4761,139 +4805,14 @@ impl Editor {
                 } else {
                     (*cursor_byte as usize).min(value.len())
                 };
-                Some((focus_key, value.clone(), cur))
+                Some((
+                    focus_key,
+                    FocusedText::TextInput {
+                        value: value.clone(),
+                        cursor: cur,
+                    },
+                ))
             }
-            _ => None,
-        }
-    }
-
-    /// Write the focused TextInput's value + cursor into instance
-    /// state, then re-render the panel and fire a `change` event.
-    fn write_focused_text_input(
-        &mut self,
-        panel_id: u64,
-        focus_key: &str,
-        new_value: String,
-        new_cursor: usize,
-    ) {
-        // Update instance state directly so subsequent reads
-        // (including queued WidgetCommands behind this one) see the
-        // new value.
-        if let Some(panel) = self.widget_registry.get_mut(panel_id) {
-            panel.instance_states.insert(
-                focus_key.to_string(),
-                crate::widgets::WidgetInstanceState::TextInput {
-                    value: new_value.clone(),
-                    cursor_byte: new_cursor as u32,
-                },
-            );
-        }
-        // Re-render so the on-screen cursor + value reflect the
-        // mutation without waiting for the plugin to re-emit.
-        self.rerender_widget_panel(panel_id);
-        // Notify the plugin so its model can update too.
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key.to_string(),
-                    event_type: "change".into(),
-                    payload: serde_json::json!({
-                        "value": new_value,
-                        "cursorByte": new_cursor as i64,
-                    }),
-                },
-            );
-        }
-    }
-
-    fn handle_widget_text_input_key(&mut self, panel_id: u64, key: &str) {
-        let (focus_key, value, cur) = match self.read_focused_text_input(panel_id) {
-            Some(t) => t,
-            None => return,
-        };
-        let (new_value, new_cursor) = crate::widgets::apply_text_input_key(&value, cur, key);
-        if new_value == value && new_cursor == cur {
-            return; // no-op
-        }
-        self.write_focused_text_input(panel_id, &focus_key, new_value, new_cursor);
-    }
-
-    fn handle_widget_text_input_char(&mut self, panel_id: u64, text: &str) {
-        if text.is_empty() {
-            return;
-        }
-        // Route to TextArea when that's what's focused — same call
-        // shape, multi-line writer.
-        if let Some(kind) = self.focused_text_widget_kind(panel_id) {
-            match kind {
-                TextWidgetKind::TextArea => {
-                    return self.handle_widget_text_area_char(panel_id, text);
-                }
-                TextWidgetKind::TextInput => {}
-            }
-        }
-        let (focus_key, value, cur) = match self.read_focused_text_input(panel_id) {
-            Some(t) => t,
-            None => return,
-        };
-        let mut new_value = String::with_capacity(value.len() + text.len());
-        new_value.push_str(&value[..cur]);
-        new_value.push_str(text);
-        new_value.push_str(&value[cur..]);
-        let new_cursor = cur + text.len();
-        self.write_focused_text_input(panel_id, &focus_key, new_value, new_cursor);
-    }
-
-    /// Apply a non-printable editing key to the focused TextArea —
-    /// `Backspace`, `Delete`, `Left`, `Right`, `Home`, `End`, `Up`,
-    /// `Down`, or `Enter`. Updates instance state and fires
-    /// `widget_event { event_type: "change", payload: { value,
-    /// cursorByte } }`.
-    fn handle_widget_text_area_key(&mut self, panel_id: u64, key: &str) {
-        let (focus_key, value, cur) = match self.read_focused_text_area(panel_id) {
-            Some(t) => t,
-            None => return,
-        };
-        let (new_value, new_cursor) = crate::widgets::apply_text_area_key(&value, cur, key);
-        if new_value == value && new_cursor == cur {
-            return;
-        }
-        self.write_focused_text_area(panel_id, &focus_key, new_value, new_cursor);
-    }
-
-    /// Insert printable text at the focused TextArea's cursor.
-    fn handle_widget_text_area_char(&mut self, panel_id: u64, text: &str) {
-        if text.is_empty() {
-            return;
-        }
-        let (focus_key, value, cur) = match self.read_focused_text_area(panel_id) {
-            Some(t) => t,
-            None => return,
-        };
-        let mut new_value = String::with_capacity(value.len() + text.len());
-        new_value.push_str(&value[..cur]);
-        new_value.push_str(text);
-        new_value.push_str(&value[cur..]);
-        let new_cursor = cur + text.len();
-        self.write_focused_text_area(panel_id, &focus_key, new_value, new_cursor);
-    }
-
-    fn read_focused_text_area(&self, panel_id: u64) -> Option<(String, String, usize)> {
-        let panel = self.widget_registry.get(panel_id)?;
-        let focus_key = panel.focus_key.clone();
-        if focus_key.is_empty() {
-            return None;
-        }
-        if let Some(crate::widgets::WidgetInstanceState::TextArea {
-            value, cursor_byte, ..
-        }) = panel.instance_states.get(&focus_key)
-        {
-            return Some((focus_key, value.clone(), *cursor_byte as usize));
-        }
-        let widget = crate::widgets::find_widget_by_key(&panel.spec, &focus_key)?;
-        match widget {
             fresh_core::api::WidgetSpec::TextArea {
                 value, cursor_byte, ..
             } => {
@@ -4902,36 +4821,50 @@ impl Editor {
                 } else {
                     (*cursor_byte as usize).min(value.len())
                 };
-                Some((focus_key, value.clone(), cur))
+                Some((
+                    focus_key,
+                    FocusedText::TextArea {
+                        value: value.clone(),
+                        cursor: cur,
+                        scroll_row: 0,
+                    },
+                ))
             }
             _ => None,
         }
     }
 
-    fn write_focused_text_area(
+    /// Write the focused text widget's new `(value, cursor)` into
+    /// instance state, preserving any kind-specific extras (e.g.
+    /// TextArea's `scroll_row`), re-render the panel, and fire a
+    /// `change` event. `prev` is the snapshot returned by
+    /// `read_focused_text`; its variant determines which
+    /// `WidgetInstanceState` shape to write.
+    fn write_focused_text(
         &mut self,
         panel_id: u64,
         focus_key: &str,
+        prev: &FocusedText,
         new_value: String,
         new_cursor: usize,
     ) {
         if let Some(panel) = self.widget_registry.get_mut(panel_id) {
-            // Preserve scroll_row across the mutation; the renderer
-            // re-clamps it on the next render.
-            let scroll_row = match panel.instance_states.get(focus_key) {
-                Some(crate::widgets::WidgetInstanceState::TextArea { scroll_row, .. }) => {
-                    *scroll_row
-                }
-                _ => 0,
-            };
-            panel.instance_states.insert(
-                focus_key.to_string(),
-                crate::widgets::WidgetInstanceState::TextArea {
+            let new_state = match prev {
+                FocusedText::TextInput { .. } => crate::widgets::WidgetInstanceState::TextInput {
                     value: new_value.clone(),
                     cursor_byte: new_cursor as u32,
-                    scroll_row,
                 },
-            );
+                FocusedText::TextArea { scroll_row, .. } => {
+                    crate::widgets::WidgetInstanceState::TextArea {
+                        value: new_value.clone(),
+                        cursor_byte: new_cursor as u32,
+                        scroll_row: *scroll_row,
+                    }
+                }
+            };
+            panel
+                .instance_states
+                .insert(focus_key.to_string(), new_state);
         }
         self.rerender_widget_panel(panel_id);
         if self.plugin_manager.has_hook_handlers("widget_event") {
@@ -4950,20 +4883,47 @@ impl Editor {
         }
     }
 
-    /// Inspect the panel's focused widget kind among the text-bearing
-    /// kinds (TextInput / TextArea). Used by the printable-char
-    /// dispatcher to route between them.
-    fn focused_text_widget_kind(&self, panel_id: u64) -> Option<TextWidgetKind> {
-        let panel = self.widget_registry.get(panel_id)?;
-        let focus_key = panel.focus_key.clone();
-        if focus_key.is_empty() {
-            return None;
+    /// Apply a non-printable editing key to the focused text widget
+    /// — `Backspace` / `Delete` / `Left` / `Right` / `Home` / `End`
+    /// (TextInput + TextArea), plus `Up` / `Down` / `Enter` for
+    /// TextArea. Routes through `apply_text_input_key` or
+    /// `apply_text_area_key` based on the focused widget's variant.
+    fn handle_widget_text_key(&mut self, panel_id: u64, key: &str) {
+        let (focus_key, prev) = match self.read_focused_text(panel_id) {
+            Some(t) => t,
+            None => return,
+        };
+        let (new_value, new_cursor) = match &prev {
+            FocusedText::TextInput { value, cursor } => {
+                crate::widgets::apply_text_input_key(value, *cursor, key)
+            }
+            FocusedText::TextArea { value, cursor, .. } => {
+                crate::widgets::apply_text_area_key(value, *cursor, key)
+            }
+        };
+        if new_value == prev.value() && new_cursor == prev.cursor() {
+            return; // no-op
         }
-        match crate::widgets::find_widget_by_key(&panel.spec, &focus_key)? {
-            fresh_core::api::WidgetSpec::TextInput { .. } => Some(TextWidgetKind::TextInput),
-            fresh_core::api::WidgetSpec::TextArea { .. } => Some(TextWidgetKind::TextArea),
-            _ => None,
+        self.write_focused_text(panel_id, &focus_key, &prev, new_value, new_cursor);
+    }
+
+    /// Insert printable / IME-committed text at the focused text
+    /// widget's cursor. Same path for TextInput and TextArea — the
+    /// kind difference is purely in the instance-state shape, which
+    /// `write_focused_text` handles. `text` may be a single
+    /// codepoint, a grapheme cluster, or a multi-codepoint IME
+    /// commit; `apply_text_char` handles each identically.
+    fn handle_widget_text_char(&mut self, panel_id: u64, text: &str) {
+        if text.is_empty() {
+            return;
         }
+        let (focus_key, prev) = match self.read_focused_text(panel_id) {
+            Some(t) => t,
+            None => return,
+        };
+        let (new_value, new_cursor) =
+            crate::widgets::apply_text_char(prev.value(), prev.cursor(), text);
+        self.write_focused_text(panel_id, &focus_key, &prev, new_value, new_cursor);
     }
 
     fn handle_unmount_widget_panel(&mut self, panel_id: u64) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -23,41 +23,29 @@ use crate::view::split::SplitViewState;
 
 use super::Editor;
 
-/// Snapshot of the focused text-bearing widget's host-owned state,
-/// regardless of kind. Returned by `read_focused_text` and consumed
-/// by `write_focused_text` so the kind-specific instance-state
-/// fields (e.g. TextArea's `scroll_row`) round-trip without forcing
-/// every callsite to fork on kind.
+/// Snapshot of the focused `Text` widget's host-owned state.
+/// Returned by `read_focused_text` and consumed by
+/// `write_focused_text` so the writer round-trips `scroll`
+/// (preserved across mutations — only meaningful when `multiline`)
+/// without re-walking the spec or instance state.
 ///
-/// Adding a new text-bearing widget kind: add a variant here, plus
-/// arms in `read_focused_text` / `write_focused_text` /
-/// `handle_widget_text_key` / `handle_widget_text_char`. Every other
-/// site that touches focused text input goes through this enum.
+/// `multiline` is read from the spec's `rows > 1` at read time and
+/// passed to `apply_text_key` so single-line vs multi-line
+/// semantics select correctly without re-querying the spec.
 #[derive(Debug, Clone)]
-enum FocusedText {
-    TextInput {
-        value: String,
-        cursor: usize,
-    },
-    TextArea {
-        value: String,
-        cursor: usize,
-        scroll_row: u32,
-    },
+struct FocusedText {
+    value: String,
+    cursor: usize,
+    scroll: u32,
+    multiline: bool,
 }
 
 impl FocusedText {
     fn value(&self) -> &str {
-        match self {
-            FocusedText::TextInput { value, .. } | FocusedText::TextArea { value, .. } => value,
-        }
+        &self.value
     }
     fn cursor(&self) -> usize {
-        match self {
-            FocusedText::TextInput { cursor, .. } | FocusedText::TextArea { cursor, .. } => {
-                *cursor
-            }
-        }
+        self.cursor
     }
 }
 
@@ -3776,43 +3764,28 @@ impl Editor {
                 value,
                 cursor_byte,
             } => {
-                // Value+cursor live in instance state for both
-                // TextInput and TextArea; route to the right state
-                // variant based on the spec.
+                // Value+cursor live in instance state for the unified
+                // Text widget. Preserve `scroll` across the mutation
+                // so multi-line viewport offsets don't snap on a
+                // plugin-driven update; the renderer re-clamps next
+                // render anyway.
                 if let Some(panel) = self.widget_registry.get_mut(panel_id) {
                     let cb = match cursor_byte {
                         Some(c) if c >= 0 => (c as u32).min(value.len() as u32),
                         _ => value.len() as u32,
                     };
-                    let widget_kind = crate::widgets::find_widget_by_key(&panel.spec, &widget_key)
-                        .map(|w| match w {
-                            fresh_core::api::WidgetSpec::TextArea { .. } => "textArea",
-                            _ => "textInput",
-                        })
-                        .unwrap_or("textInput");
-                    let new_state = match widget_kind {
-                        "textArea" => {
-                            // Preserve scroll across the mutation;
-                            // the renderer re-clamps it on re-render.
-                            let scroll_row = match panel.instance_states.get(&widget_key) {
-                                Some(crate::widgets::WidgetInstanceState::TextArea {
-                                    scroll_row,
-                                    ..
-                                }) => *scroll_row,
-                                _ => 0,
-                            };
-                            crate::widgets::WidgetInstanceState::TextArea {
-                                value,
-                                cursor_byte: cb,
-                                scroll_row,
-                            }
-                        }
-                        _ => crate::widgets::WidgetInstanceState::TextInput {
+                    let scroll = match panel.instance_states.get(&widget_key) {
+                        Some(crate::widgets::WidgetInstanceState::Text { scroll, .. }) => *scroll,
+                        _ => 0,
+                    };
+                    panel.instance_states.insert(
+                        widget_key,
+                        crate::widgets::WidgetInstanceState::Text {
                             value,
                             cursor_byte: cb,
+                            scroll,
                         },
-                    };
-                    panel.instance_states.insert(widget_key, new_state);
+                    );
                 }
             }
             WidgetMutation::SetChecked {
@@ -3964,7 +3937,12 @@ impl Editor {
                     Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                         self.handle_widget_tree_select_move(panel_id, delta);
                     }
-                    Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                    Some(fresh_core::api::WidgetSpec::Text { rows, .. }) if *rows > 1 => {
+                        // Multi-line Text: line nav. Single-line
+                        // ignores Up/Down (apply_text_input_key
+                        // would no-op anyway, but skipping the
+                        // instance-state churn keeps the focus
+                        // event quiet).
                         self.handle_widget_text_key(panel_id, key);
                     }
                     _ => {}
@@ -3996,8 +3974,7 @@ impl Editor {
                 }
             }
             "Left" | "Right" => match widget {
-                Some(fresh_core::api::WidgetSpec::TextInput { .. })
-                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                Some(fresh_core::api::WidgetSpec::Text { .. }) => {
                     self.handle_widget_text_key(panel_id, key);
                 }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
@@ -4006,8 +3983,7 @@ impl Editor {
                 _ => {}
             },
             "Backspace" | "Delete" | "Home" | "End" => match widget {
-                Some(fresh_core::api::WidgetSpec::TextInput { .. })
-                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                Some(fresh_core::api::WidgetSpec::Text { .. }) => {
                     self.handle_widget_text_key(panel_id, key);
                 }
                 _ => {}
@@ -4023,20 +3999,20 @@ impl Editor {
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                     self.fire_tree_activate(panel_id, &focus_key);
                 }
-                Some(fresh_core::api::WidgetSpec::TextInput { .. }) => {
-                    // Form-like UX: pressing Enter on a single-line text
-                    // input commits the field and moves to the next
-                    // tabbable widget. Plugins that want a different
-                    // Enter binding can intercept the key before
-                    // dispatching it through the smart-key router.
-                    self.handle_widget_focus_advance(panel_id, 1);
-                }
-                Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
-                    // Multi-line input: Enter inserts a newline at
-                    // the cursor. Plugins that want Enter to submit
-                    // can intercept it before dispatching through
-                    // the smart-key router.
-                    self.handle_widget_text_key(panel_id, "Enter");
+                Some(fresh_core::api::WidgetSpec::Text { rows, .. }) => {
+                    if *rows > 1 {
+                        // Multi-line: Enter inserts a newline at the
+                        // cursor. Plugins that want Enter to submit
+                        // can intercept it in their mode binding
+                        // before dispatching through the smart-key
+                        // router.
+                        self.handle_widget_text_key(panel_id, "Enter");
+                    } else {
+                        // Single-line, form-like UX: Enter commits
+                        // the field and moves to the next tabbable
+                        // widget. Same intercept path applies.
+                        self.handle_widget_focus_advance(panel_id, 1);
+                    }
                 }
                 _ => {}
             },
@@ -4045,8 +4021,7 @@ impl Editor {
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {
                     self.handle_widget_activate(panel_id);
                 }
-                Some(fresh_core::api::WidgetSpec::TextInput { .. })
-                | Some(fresh_core::api::WidgetSpec::TextArea { .. }) => {
+                Some(fresh_core::api::WidgetSpec::Text { .. }) => {
                     self.handle_widget_text_char(panel_id, " ");
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
@@ -4767,79 +4742,62 @@ impl Editor {
         if focus_key.is_empty() {
             return None;
         }
-        match panel.instance_states.get(&focus_key) {
-            Some(crate::widgets::WidgetInstanceState::TextInput { value, cursor_byte }) => {
-                return Some((
-                    focus_key,
-                    FocusedText::TextInput {
-                        value: value.clone(),
-                        cursor: *cursor_byte as usize,
-                    },
-                ));
-            }
-            Some(crate::widgets::WidgetInstanceState::TextArea {
+        // Confirm the focused widget is a Text and read its
+        // multi-line flag from the spec (always — even when the
+        // value is sourced from instance state). The renderer
+        // doesn't carry `rows` into instance state, so the spec
+        // remains the single source of truth for the multi-line
+        // discriminator.
+        let widget = crate::widgets::find_widget_by_key(&panel.spec, &focus_key)?;
+        let (spec_value, spec_cursor, multiline) = match widget {
+            fresh_core::api::WidgetSpec::Text {
                 value,
                 cursor_byte,
-                scroll_row,
-            }) => {
-                return Some((
-                    focus_key,
-                    FocusedText::TextArea {
-                        value: value.clone(),
-                        cursor: *cursor_byte as usize,
-                        scroll_row: *scroll_row,
-                    },
-                ));
-            }
-            _ => {}
+                rows,
+                ..
+            } => (value, *cursor_byte, *rows > 1),
+            _ => return None,
+        };
+        // Instance state is authoritative once rendered.
+        if let Some(crate::widgets::WidgetInstanceState::Text {
+            value,
+            cursor_byte,
+            scroll,
+        }) = panel.instance_states.get(&focus_key)
+        {
+            return Some((
+                focus_key,
+                FocusedText {
+                    value: value.clone(),
+                    cursor: *cursor_byte as usize,
+                    scroll: *scroll,
+                    multiline,
+                },
+            ));
         }
-        // Spec fallback — only reached before first render, which in
-        // practice should never be true when a WidgetCommand arrives.
-        let widget = crate::widgets::find_widget_by_key(&panel.spec, &focus_key)?;
-        match widget {
-            fresh_core::api::WidgetSpec::TextInput {
-                value, cursor_byte, ..
-            } => {
-                let cur = if *cursor_byte < 0 {
-                    value.len()
-                } else {
-                    (*cursor_byte as usize).min(value.len())
-                };
-                Some((
-                    focus_key,
-                    FocusedText::TextInput {
-                        value: value.clone(),
-                        cursor: cur,
-                    },
-                ))
-            }
-            fresh_core::api::WidgetSpec::TextArea {
-                value, cursor_byte, ..
-            } => {
-                let cur = if *cursor_byte < 0 {
-                    value.len()
-                } else {
-                    (*cursor_byte as usize).min(value.len())
-                };
-                Some((
-                    focus_key,
-                    FocusedText::TextArea {
-                        value: value.clone(),
-                        cursor: cur,
-                        scroll_row: 0,
-                    },
-                ))
-            }
-            _ => None,
-        }
+        // Spec fallback — only reached before first render, which
+        // in practice should never be true when a WidgetCommand
+        // arrives.
+        let cur = if spec_cursor < 0 {
+            spec_value.len()
+        } else {
+            (spec_cursor as usize).min(spec_value.len())
+        };
+        Some((
+            focus_key,
+            FocusedText {
+                value: spec_value.clone(),
+                cursor: cur,
+                scroll: 0,
+                multiline,
+            },
+        ))
     }
 
     /// Write the focused text widget's new `(value, cursor)` into
-    /// instance state, preserving any kind-specific extras (e.g.
-    /// TextArea's `scroll_row`), re-render the panel, and fire a
-    /// `change` event. `prev` is the snapshot returned by
-    /// `read_focused_text`; its variant determines which
-    /// `WidgetInstanceState` shape to write.
+    /// instance state, preserving `scroll` (only meaningful for
+    /// multi-line, kept across mutations to avoid snap-back), then
+    /// re-render the panel and fire a `change` event.
     fn write_focused_text(
         &mut self,
         panel_id: u64,
@@ -4849,22 +4807,14 @@ impl Editor {
         new_cursor: usize,
     ) {
         if let Some(panel) = self.widget_registry.get_mut(panel_id) {
-            let new_state = match prev {
-                FocusedText::TextInput { .. } => crate::widgets::WidgetInstanceState::TextInput {
+            panel.instance_states.insert(
+                focus_key.to_string(),
+                crate::widgets::WidgetInstanceState::Text {
                     value: new_value.clone(),
                     cursor_byte: new_cursor as u32,
+                    scroll: prev.scroll,
                 },
-                FocusedText::TextArea { scroll_row, .. } => {
-                    crate::widgets::WidgetInstanceState::TextArea {
-                        value: new_value.clone(),
-                        cursor_byte: new_cursor as u32,
-                        scroll_row: *scroll_row,
-                    }
-                }
-            };
-            panel
-                .instance_states
-                .insert(focus_key.to_string(), new_state);
+            );
         }
         self.rerender_widget_panel(panel_id);
         if self.plugin_manager.has_hook_handlers("widget_event") {
@@ -4885,23 +4835,17 @@ impl Editor {
 
     /// Apply a non-printable editing key to the focused text widget
     /// — `Backspace` / `Delete` / `Left` / `Right` / `Home` / `End`
-    /// (TextInput + TextArea), plus `Up` / `Down` / `Enter` for
-    /// TextArea. Routes through `apply_text_input_key` or
-    /// `apply_text_area_key` based on the focused widget's variant.
+    /// always; plus `Up` / `Down` / `Enter` when the widget is
+    /// multi-line. Dispatches through `apply_text_key` which
+    /// branches on `prev.multiline`.
     fn handle_widget_text_key(&mut self, panel_id: u64, key: &str) {
         let (focus_key, prev) = match self.read_focused_text(panel_id) {
             Some(t) => t,
             None => return,
         };
-        let (new_value, new_cursor) = match &prev {
-            FocusedText::TextInput { value, cursor } => {
-                crate::widgets::apply_text_input_key(value, *cursor, key)
-            }
-            FocusedText::TextArea { value, cursor, .. } => {
-                crate::widgets::apply_text_area_key(value, *cursor, key)
-            }
-        };
-        if new_value == prev.value() && new_cursor == prev.cursor() {
+        let (new_value, new_cursor) =
+            crate::widgets::apply_text_key(prev.value(), prev.cursor(), key, prev.multiline);
+        if new_value == *prev.value() && new_cursor == prev.cursor() {
             return; // no-op
         }
         self.write_focused_text(panel_id, &focus_key, &prev, new_value, new_cursor);

--- a/crates/fresh-editor/src/widgets/actions.rs
+++ b/crates/fresh-editor/src/widgets/actions.rs
@@ -30,8 +30,7 @@ pub fn find_widget_by_key<'a>(spec: &'a WidgetSpec, target: &str) -> Option<&'a 
         }
         WidgetSpec::Toggle { key: Some(k), .. }
         | WidgetSpec::Button { key: Some(k), .. }
-        | WidgetSpec::TextInput { key: Some(k), .. }
-        | WidgetSpec::TextArea { key: Some(k), .. }
+        | WidgetSpec::Text { key: Some(k), .. }
         | WidgetSpec::List { key: Some(k), .. }
         | WidgetSpec::Tree { key: Some(k), .. }
             if k == target =>
@@ -39,6 +38,30 @@ pub fn find_widget_by_key<'a>(spec: &'a WidgetSpec, target: &str) -> Option<&'a 
             Some(spec)
         }
         _ => None,
+    }
+}
+
+/// Apply a non-printable editing key to a text widget's `(value,
+/// cursor)` pair, choosing single-line or multi-line semantics from
+/// `multiline`. This is the public entry point used by the host
+/// dispatcher; `apply_text_input_key` and `apply_text_area_key`
+/// remain available as internal helpers (and as the documented test
+/// surface for each kind's behaviour).
+///
+/// `multiline=false` recognises `Backspace` / `Delete` / `Left` /
+/// `Right` / `Home` / `End`. `multiline=true` adds `Up` / `Down` /
+/// `Enter` (newline insertion) and reinterprets `Home` / `End` as
+/// line-relative.
+pub fn apply_text_key(
+    value: &str,
+    cursor: usize,
+    key: &str,
+    multiline: bool,
+) -> (String, usize) {
+    if multiline {
+        apply_text_area_key(value, cursor, key)
+    } else {
+        apply_text_input_key(value, cursor, key)
     }
 }
 
@@ -455,7 +478,7 @@ impl ContainsKey for WidgetSpec {
             }
             WidgetSpec::Toggle { key, .. }
             | WidgetSpec::Button { key, .. }
-            | WidgetSpec::TextInput { key, .. }
+            | WidgetSpec::Text { key, .. }
             | WidgetSpec::List { key, .. }
             | WidgetSpec::Tree { key, .. } => key.as_deref() == Some(widget_key),
             _ => false,

--- a/crates/fresh-editor/src/widgets/actions.rs
+++ b/crates/fresh-editor/src/widgets/actions.rs
@@ -52,12 +52,7 @@ pub fn find_widget_by_key<'a>(spec: &'a WidgetSpec, target: &str) -> Option<&'a 
 /// `Right` / `Home` / `End`. `multiline=true` adds `Up` / `Down` /
 /// `Enter` (newline insertion) and reinterprets `Home` / `End` as
 /// line-relative.
-pub fn apply_text_key(
-    value: &str,
-    cursor: usize,
-    key: &str,
-    multiline: bool,
-) -> (String, usize) {
+pub fn apply_text_key(value: &str, cursor: usize, key: &str, multiline: bool) -> (String, usize) {
     if multiline {
         apply_text_area_key(value, cursor, key)
     } else {

--- a/crates/fresh-editor/src/widgets/actions.rs
+++ b/crates/fresh-editor/src/widgets/actions.rs
@@ -42,6 +42,31 @@ pub fn find_widget_by_key<'a>(spec: &'a WidgetSpec, target: &str) -> Option<&'a 
     }
 }
 
+/// Insert `text` at `cursor` within `value`, returning `(new_value,
+/// new_cursor)`. `cursor` is a UTF-8 byte offset; if it lands
+/// mid-multibyte (which the existing key handlers shouldn't
+/// produce, but external state could) it snaps down to the
+/// preceding char boundary before insertion.
+///
+/// Used by both `TextInput` and `TextArea` for the printable-char
+/// dispatch path (`mode_text_input:<char>`). The terminal layer
+/// only delivers IME-committed text — preedit is invisible to the
+/// editor — so `text` here is always a final UTF-8 string and may
+/// be one codepoint (typical), one grapheme cluster (combining
+/// marks), or a multi-codepoint commit (some IMEs push the full
+/// word in one event).
+pub fn apply_text_char(value: &str, cursor: usize, text: &str) -> (String, usize) {
+    let mut cursor = cursor.min(value.len());
+    while cursor > 0 && !value.is_char_boundary(cursor) {
+        cursor -= 1;
+    }
+    let mut new_value = String::with_capacity(value.len() + text.len());
+    new_value.push_str(&value[..cursor]);
+    new_value.push_str(text);
+    new_value.push_str(&value[cursor..]);
+    (new_value, cursor + text.len())
+}
+
 /// Apply a non-printable editing key to a `(value, cursor)` pair,
 /// returning `(new_value, new_cursor)`. `cursor` is a UTF-8 byte
 /// offset clamped to `[0, value.len()]`.
@@ -537,6 +562,66 @@ mod tests {
     #[test]
     fn unknown_key_is_noop() {
         assert_eq!(apply_text_input_key("abc", 1, "Wat"), ("abc".into(), 1));
+    }
+
+    // ---- apply_text_char (IME-commit / printable insertion) ----
+
+    #[test]
+    fn apply_text_char_inserts_ascii_at_cursor() {
+        assert_eq!(apply_text_char("Hello", 5, "!"), ("Hello!".into(), 6));
+        assert_eq!(apply_text_char("Hxllo", 1, "e"), ("Hexllo".into(), 2));
+    }
+
+    #[test]
+    fn apply_text_char_inserts_multibyte_codepoint() {
+        // "你" is 3 bytes (0xE4 0xBD 0xA0).
+        let (v, c) = apply_text_char("", 0, "你");
+        assert_eq!(v, "你");
+        assert_eq!(c, 3);
+    }
+
+    #[test]
+    fn apply_text_char_ime_commit_step_by_step() {
+        // IME commits "你好" as two consecutive single-codepoint
+        // events (the typical Pinyin → CJK flow).
+        let (v, c) = apply_text_char("", 0, "你");
+        let (v, c) = apply_text_char(&v, c, "好");
+        assert_eq!(v, "你好");
+        assert_eq!(c, 6);
+    }
+
+    #[test]
+    fn apply_text_char_ime_commit_multi_codepoint_in_one_event() {
+        // Some IMEs commit the whole word in one push — must work
+        // identically to step-by-step.
+        let (v, c) = apply_text_char("", 0, "你好");
+        assert_eq!(v, "你好");
+        assert_eq!(c, 6);
+    }
+
+    #[test]
+    fn apply_text_char_inserts_into_middle_of_existing_text() {
+        // "He|llo" — cursor at byte 2, insert "你". Expected:
+        // "He你llo", cursor at byte 5 (2 + 3).
+        let (v, c) = apply_text_char("Hello", 2, "你");
+        assert_eq!(v, "He你llo");
+        assert_eq!(c, 5);
+    }
+
+    #[test]
+    fn apply_text_char_snaps_mid_multibyte_cursor_down_to_boundary() {
+        // Cursor at byte 1 of "你" (mid-multibyte) — snap down to
+        // byte 0, then insert.
+        let (v, c) = apply_text_char("你", 1, "X");
+        assert_eq!(v, "X你");
+        assert_eq!(c, 1);
+    }
+
+    #[test]
+    fn apply_text_char_clamps_cursor_past_end() {
+        let (v, c) = apply_text_char("ab", 99, "c");
+        assert_eq!(v, "abc");
+        assert_eq!(c, 3);
     }
 
     #[test]

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -19,9 +19,9 @@ mod registry;
 mod render;
 
 pub use actions::{
-    apply_text_area_key, apply_text_char, apply_text_input_key, find_widget_by_key,
-    set_list_items_in_spec, set_toggle_checked_in_spec, set_tree_checked_keys_in_spec,
-    set_tree_nodes_in_spec, tree_parent_index,
+    apply_text_area_key, apply_text_char, apply_text_input_key, apply_text_key,
+    find_widget_by_key, set_list_items_in_spec, set_toggle_checked_in_spec,
+    set_tree_checked_keys_in_spec, set_tree_nodes_in_spec, tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
 pub use render::{render_spec, FocusCursor, RenderOutput};

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -19,9 +19,9 @@ mod registry;
 mod render;
 
 pub use actions::{
-    apply_text_area_key, apply_text_input_key, find_widget_by_key, set_list_items_in_spec,
-    set_toggle_checked_in_spec, set_tree_checked_keys_in_spec, set_tree_nodes_in_spec,
-    tree_parent_index,
+    apply_text_area_key, apply_text_char, apply_text_input_key, find_widget_by_key,
+    set_list_items_in_spec, set_toggle_checked_in_spec, set_tree_checked_keys_in_spec,
+    set_tree_nodes_in_spec, tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
 pub use render::{render_spec, FocusCursor, RenderOutput};

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -19,9 +19,9 @@ mod registry;
 mod render;
 
 pub use actions::{
-    apply_text_area_key, apply_text_char, apply_text_input_key, apply_text_key,
-    find_widget_by_key, set_list_items_in_spec, set_toggle_checked_in_spec,
-    set_tree_checked_keys_in_spec, set_tree_nodes_in_spec, tree_parent_index,
+    apply_text_area_key, apply_text_char, apply_text_input_key, apply_text_key, find_widget_by_key,
+    set_list_items_in_spec, set_toggle_checked_in_spec, set_tree_checked_keys_in_spec,
+    set_tree_nodes_in_spec, tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
 pub use render::{render_spec, FocusCursor, RenderOutput};

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -70,27 +70,24 @@ pub enum WidgetInstanceState {
         scroll_offset: u32,
         selected_index: i32,
     },
-    /// `TextInput` instance state: host-owned value + cursor byte
-    /// offset. Becomes authoritative once the widget mounts; the
-    /// spec's `value` / `cursor_byte` are *initial-only* (used at
-    /// first render and ignored thereafter). This guarantees
-    /// correctness under concurrent keystrokes — the plugin's
-    /// spec round-trip can't race against multiple in-flight
-    /// `WidgetCommand` mutations because the host doesn't read
-    /// from the spec for value at all once instance state exists.
-    TextInput { value: String, cursor_byte: u32 },
-    /// `TextArea` instance state: host-owned multi-line value,
-    /// cursor byte offset within `value`, and vertical scroll
-    /// offset (the index of the first visible line). Same
-    /// host-owned semantics as `TextInput` — once instance state
-    /// exists, the spec's `value` / `cursor_byte` are ignored.
-    /// `scroll_row` auto-clamps each render to keep the cursor's
-    /// line within the visible window; plugins never compute
-    /// scroll math.
-    TextArea {
+    /// `Text` instance state: host-owned value + cursor byte
+    /// offset, plus a viewport scroll offset that's only meaningful
+    /// for multi-line (`rows > 1`) variants — the row index of the
+    /// first visible line. Single-line text widgets always render
+    /// from value byte 0 and rely on render-time head-truncate
+    /// scrolling, so they leave `scroll` at `0`.
+    ///
+    /// Becomes authoritative once the widget mounts; the spec's
+    /// `value` / `cursor_byte` are *initial-only* (used at first
+    /// render and ignored thereafter). This guarantees correctness
+    /// under concurrent keystrokes — the plugin's spec round-trip
+    /// can't race against multiple in-flight `WidgetCommand`
+    /// mutations because the host doesn't read from the spec for
+    /// value at all once instance state exists.
+    Text {
         value: String,
         cursor_byte: u32,
-        scroll_row: u32,
+        scroll: u32,
     },
     /// `Tree` instance state: host-owned scroll offset, selected
     /// index, and the set of expanded item keys. All three become

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -174,8 +174,7 @@ fn collect_tabbable(spec: &WidgetSpec, out: &mut Vec<String>) {
         }
         WidgetSpec::Toggle { key: Some(k), .. }
         | WidgetSpec::Button { key: Some(k), .. }
-        | WidgetSpec::TextInput { key: Some(k), .. }
-        | WidgetSpec::TextArea { key: Some(k), .. }
+        | WidgetSpec::Text { key: Some(k), .. }
         | WidgetSpec::List { key: Some(k), .. }
         | WidgetSpec::Tree { key: Some(k), .. }
             if !k.is_empty() =>
@@ -796,74 +795,7 @@ fn render_collected(
                 }
             }
         }
-        WidgetSpec::TextInput {
-            value,
-            cursor_byte,
-            focused,
-            label,
-            placeholder,
-            max_visible_chars,
-            field_width,
-            key,
-        } => {
-            let is_focused = match key.as_deref() {
-                Some(k) if !k.is_empty() => k == focus_key,
-                _ => *focused,
-            };
-            // Host-owned value/cursor: read instance state if it
-            // exists; else seed from spec on first render. This is
-            // what makes concurrent keystroke dispatch correct —
-            // see WidgetInstanceState::TextInput doc.
-            let (effective_value, effective_cursor_byte) = match key
-                .as_deref()
-                .filter(|k| !k.is_empty())
-                .and_then(|k| prev.get(k))
-            {
-                Some(WidgetInstanceState::TextInput { value, cursor_byte }) => {
-                    (value.clone(), *cursor_byte as i32)
-                }
-                _ => (value.clone(), *cursor_byte),
-            };
-            if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
-                let cb = effective_cursor_byte
-                    .max(0)
-                    .min(effective_value.len() as i32) as u32;
-                next_state.insert(
-                    k.to_string(),
-                    WidgetInstanceState::TextInput {
-                        value: effective_value.clone(),
-                        cursor_byte: cb,
-                    },
-                );
-            }
-            let effective_cursor = if is_focused {
-                effective_cursor_byte
-            } else {
-                -1
-            };
-            let rendered = render_text_input(
-                &effective_value,
-                effective_cursor,
-                is_focused,
-                label,
-                placeholder.as_deref(),
-                *max_visible_chars,
-                *field_width,
-            );
-            // Publish the cursor position so the dispatcher can
-            // drive the hardware cursor. Container shifts
-            // (Row/Col) update buffer_row + byte_in_row.
-            if let Some(byte_in_row) = rendered.cursor_byte_in_entry {
-                focus_cursor = Some(FocusCursor {
-                    buffer_row: 0,
-                    byte_in_row: byte_in_row as u32,
-                });
-            }
-            let mut entry = rendered.entry;
-            ensure_trailing_newline(&mut entry);
-            entries.push(entry);
-        }
-        WidgetSpec::TextArea {
+        WidgetSpec::Text {
             value,
             cursor_byte,
             focused,
@@ -871,75 +803,100 @@ fn render_collected(
             placeholder,
             rows,
             field_width,
+            max_visible_chars,
             key,
         } => {
             let is_focused = match key.as_deref() {
                 Some(k) if !k.is_empty() => k == focus_key,
                 _ => *focused,
             };
-            // Host-owned value/cursor + scroll, mirroring TextInput.
-            // First render seeds from the spec; subsequent renders
-            // read the previous instance state and ignore the spec's
-            // value / cursor_byte.
+            // Host-owned value/cursor (+ scroll, multi-line only):
+            // read instance state if it exists; else seed from spec
+            // on first render. See WidgetInstanceState::Text doc.
             let (effective_value, effective_cursor_byte, prev_scroll) = match key
                 .as_deref()
                 .filter(|k| !k.is_empty())
                 .and_then(|k| prev.get(k))
             {
-                Some(WidgetInstanceState::TextArea {
+                Some(WidgetInstanceState::Text {
                     value,
                     cursor_byte,
-                    scroll_row,
-                }) => (value.clone(), *cursor_byte as i32, *scroll_row),
+                    scroll,
+                }) => (value.clone(), *cursor_byte as i32, *scroll),
                 _ => (value.clone(), *cursor_byte, 0),
             };
-            // Default rows to a small value when the plugin omits
-            // it — keeps the editing region from collapsing.
-            let visible_rows = if *rows == 0 { 3 } else { *rows };
-            let rendered = render_text_area(
-                &effective_value,
-                effective_cursor_byte,
-                is_focused,
-                label,
-                placeholder.as_deref(),
-                visible_rows,
-                *field_width,
-                prev_scroll,
-                panel_width,
-            );
-            // Persist instance state for next render. Cursor is
-            // clamped into [0, value.len()]; scroll_row is the
-            // renderer's auto-clamped value (cursor's line stays in
-            // view).
+            let effective_cursor = if is_focused {
+                effective_cursor_byte
+            } else {
+                -1
+            };
+            // `rows == 0` shouldn't happen because of serde's
+            // default = 1, but if it slips through (raw struct
+            // construction in tests, etc.) treat it as single-line.
+            let multiline = *rows > 1;
+            let new_scroll;
+            if multiline {
+                let rendered = render_text_area(
+                    &effective_value,
+                    effective_cursor,
+                    is_focused,
+                    label,
+                    placeholder.as_deref(),
+                    *rows,
+                    *field_width,
+                    prev_scroll,
+                    panel_width,
+                );
+                new_scroll = rendered.scroll_row;
+                if let (Some(buffer_row), Some(byte_in_row)) =
+                    (rendered.cursor_buffer_row, rendered.cursor_byte_in_row)
+                {
+                    focus_cursor = Some(FocusCursor {
+                        buffer_row,
+                        byte_in_row: byte_in_row as u32,
+                    });
+                }
+                for mut e in rendered.entries {
+                    ensure_trailing_newline(&mut e);
+                    entries.push(e);
+                }
+            } else {
+                let rendered = render_text_input(
+                    &effective_value,
+                    effective_cursor,
+                    is_focused,
+                    label,
+                    placeholder.as_deref(),
+                    *max_visible_chars,
+                    *field_width,
+                );
+                new_scroll = 0;
+                if let Some(byte_in_row) = rendered.cursor_byte_in_entry {
+                    focus_cursor = Some(FocusCursor {
+                        buffer_row: 0,
+                        byte_in_row: byte_in_row as u32,
+                    });
+                }
+                let mut entry = rendered.entry;
+                ensure_trailing_newline(&mut entry);
+                entries.push(entry);
+            }
+            // Persist instance state for next render. Cursor clamps
+            // into `[0, value.len()]`; `scroll` carries the
+            // renderer's auto-clamped first-visible-row for
+            // multi-line, or `0` for single-line.
             if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
                 let cb = effective_cursor_byte
                     .max(0)
                     .min(effective_value.len() as i32) as u32;
                 next_state.insert(
                     k.to_string(),
-                    WidgetInstanceState::TextArea {
+                    WidgetInstanceState::Text {
                         value: effective_value.clone(),
                         cursor_byte: cb,
-                        scroll_row: rendered.scroll_row,
+                        scroll: new_scroll,
                     },
                 );
-            }
-            // Publish cursor for the hardware-cursor driver. The
-            // renderer's `cursor_buffer_row` is relative to the
-            // first rendered entry of this widget (label adds a
-            // row), and `cursor_byte_in_entry` is the byte within
-            // that row's text.
-            if let (Some(buffer_row), Some(byte_in_row)) =
-                (rendered.cursor_buffer_row, rendered.cursor_byte_in_row)
-            {
-                focus_cursor = Some(FocusCursor {
-                    buffer_row,
-                    byte_in_row: byte_in_row as u32,
-                });
-            }
-            for mut e in rendered.entries {
-                ensure_trailing_newline(&mut e);
-                entries.push(e);
             }
         }
         WidgetSpec::Raw {
@@ -2178,14 +2135,15 @@ mod tests {
                     ],
                     key: None,
                 },
-                WidgetSpec::TextInput {
+                WidgetSpec::Text {
                     value: "".into(),
                     cursor_byte: -1,
                     focused: false,
                     label: "".into(),
                     placeholder: None,
-                    max_visible_chars: 0,
+                    rows: 1,
                     field_width: 0,
+                    max_visible_chars: 0,
                     key: Some("ti".into()),
                 },
                 WidgetSpec::Toggle {
@@ -3305,14 +3263,19 @@ mod tests {
         field_width: u32,
         key: Option<&str>,
     ) -> WidgetSpec {
-        WidgetSpec::TextArea {
+        WidgetSpec::Text {
             value: value.into(),
             cursor_byte,
             focused,
             label: String::new(),
             placeholder: None,
-            rows,
+            // Force multi-line behaviour even when the test passes
+            // `rows: 1` — the previous TextArea-specific tests
+            // exercise the multi-line code path through this
+            // helper.
+            rows: rows.max(2),
             field_width,
+            max_visible_chars: 0,
             key: key.map(|s| s.into()),
         }
     }
@@ -3383,7 +3346,7 @@ mod tests {
         // With a label, the editing region starts on row 1, so a
         // cursor on line 0 of the value lands on row 1 of the
         // buffer.
-        let spec = WidgetSpec::TextArea {
+        let spec = WidgetSpec::Text {
             value: "hi".into(),
             cursor_byte: 1,
             focused: true,
@@ -3391,6 +3354,7 @@ mod tests {
             placeholder: None,
             rows: 2,
             field_width: 6,
+            max_visible_chars: 0,
             key: Some("ta".into()),
         };
         let prev = HashMap::new();
@@ -3407,13 +3371,13 @@ mod tests {
         let prev = HashMap::new();
         let out = render_spec(&spec, &prev, "ta", 80);
         match out.instance_states.get("ta") {
-            Some(WidgetInstanceState::TextArea {
+            Some(WidgetInstanceState::Text {
                 value, cursor_byte, ..
             }) => {
                 assert_eq!(value, "abc");
                 assert_eq!(*cursor_byte, 2);
             }
-            other => panic!("expected TextArea instance state, got {:?}", other),
+            other => panic!("expected Text instance state, got {:?}", other),
         }
     }
 
@@ -3425,10 +3389,10 @@ mod tests {
         let mut prev = HashMap::new();
         prev.insert(
             "ta".into(),
-            WidgetInstanceState::TextArea {
+            WidgetInstanceState::Text {
                 value: "new".into(),
                 cursor_byte: 3,
-                scroll_row: 0,
+                scroll: 0,
             },
         );
         let out = render_spec(&spec, &prev, "ta", 80);
@@ -3446,10 +3410,10 @@ mod tests {
         let prev = HashMap::new();
         let out = render_spec(&spec, &prev, "ta", 80);
         match out.instance_states.get("ta") {
-            Some(WidgetInstanceState::TextArea { scroll_row, .. }) => {
-                assert_eq!(*scroll_row, 3, "scroll so lines 3..5 are visible");
+            Some(WidgetInstanceState::Text { scroll, .. }) => {
+                assert_eq!(*scroll, 3, "scroll so lines 3..5 are visible");
             }
-            _ => panic!("expected TextArea instance state"),
+            _ => panic!("expected Text instance state"),
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -84,7 +84,7 @@ fn test_theme_editor_command_registered() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with a test theme
@@ -138,7 +138,7 @@ fn test_theme_editor_tab_bar_persists() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -218,7 +218,7 @@ fn test_close_buffer_while_in_group_closes_whole_group() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -295,7 +295,7 @@ fn test_next_buffer_cycles_across_groups_and_buffers() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("cycle_test.txt");
@@ -413,7 +413,7 @@ fn test_theme_editor_opens_without_error() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with a test theme
@@ -495,7 +495,7 @@ fn test_theme_editor_open_close_reopen() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -565,7 +565,7 @@ fn test_theme_editor_reopen_after_close_buffer() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -630,7 +630,7 @@ fn test_theme_editor_shows_color_sections() {
     fs::create_dir(&plugins_dir).unwrap();
 
     // Copy the theme_editor.ts plugin
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with test themes
@@ -700,7 +700,7 @@ fn test_theme_editor_open_builtin() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create harness with isolated directory context
@@ -771,7 +771,7 @@ fn test_theme_editor_displays_correct_colors() {
     fs::create_dir(&plugins_dir).unwrap();
 
     // Copy the theme_editor.ts plugin
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory
@@ -919,7 +919,7 @@ fn test_cursor_position_preserved_after_section_toggle() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -988,7 +988,7 @@ fn test_color_prompt_shows_suggestions() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1094,7 +1094,7 @@ fn test_colors_displayed_in_hex_format() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1158,7 +1158,7 @@ fn test_comments_appear_before_fields() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1240,7 +1240,7 @@ fn test_theme_applied_immediately_after_save() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a test file to see theme changes
@@ -1413,7 +1413,7 @@ fn test_cursor_x_position_preserved_after_section_toggle() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1550,7 +1550,7 @@ fn test_color_suggestions_show_hex_format() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1682,7 +1682,7 @@ fn test_color_prompt_prefilled_with_current_value() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1762,7 +1762,7 @@ fn test_theme_editor_color_values_no_internal_spaces() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1851,7 +1851,7 @@ fn test_theme_editor_navigation_skips_non_selectable_lines() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2006,7 +2006,7 @@ fn test_cursor_position_preserved_after_color_edit() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2137,7 +2137,7 @@ fn test_cursor_on_value_field_when_navigating() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2204,7 +2204,7 @@ fn test_builtin_theme_requires_save_as() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a DirectoryContext so we know where config_dir/themes is
@@ -2326,7 +2326,7 @@ fn test_color_swatches_displayed() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2384,7 +2384,7 @@ fn test_theme_editor_nostalgia_builtin_shows_correct_colors() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Don't create a themes directory - we want to use the built-in themes only
@@ -2470,7 +2470,7 @@ fn test_theme_editor_nostalgia_builtin_via_arrow_selection() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Don't create a themes directory - we want to use the built-in themes only
@@ -2566,7 +2566,7 @@ fn test_theme_editor_select_nostalgia_from_dropdown() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -2809,7 +2809,7 @@ fn test_inspect_theme_at_cursor_opens_theme_editor() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a test file so the cursor is on editor content
@@ -2875,7 +2875,7 @@ fn test_inspect_theme_at_cursor_multiple_rounds() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3005,7 +3005,7 @@ fn test_save_builtin_theme_produces_valid_file() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3196,7 +3196,7 @@ fn test_issue_1180_save_theme_creates_themes_directory() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3363,7 +3363,7 @@ fn test_inspect_after_saving_custom_theme() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3544,7 +3544,7 @@ fn test_palette_swatch_click_targets_correct_column() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -3730,7 +3730,7 @@ fn test_theme_editor_page_up_page_down() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -3870,7 +3870,7 @@ fn test_named_color_swatch_uses_native_ansi_color() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a theme with a named color "Yellow" for tab_active_fg.
@@ -4042,7 +4042,7 @@ fn test_theme_editor_colors_update_on_theme_change() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut config = fresh::config::Config::default();
@@ -4191,7 +4191,7 @@ fn test_paste_in_theme_editor_does_not_panic() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -4244,7 +4244,7 @@ fn test_theme_editor_terminal_builtin_renders_field_rows() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
-        copy_plugin_lib(&plugins_dir);
+    copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =

--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -84,6 +84,7 @@ fn test_theme_editor_command_registered() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with a test theme
@@ -137,6 +138,7 @@ fn test_theme_editor_tab_bar_persists() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -216,6 +218,7 @@ fn test_close_buffer_while_in_group_closes_whole_group() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -292,6 +295,7 @@ fn test_next_buffer_cycles_across_groups_and_buffers() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("cycle_test.txt");
@@ -409,6 +413,7 @@ fn test_theme_editor_opens_without_error() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with a test theme
@@ -490,6 +495,7 @@ fn test_theme_editor_open_close_reopen() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -559,6 +565,7 @@ fn test_theme_editor_reopen_after_close_buffer() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -623,6 +630,7 @@ fn test_theme_editor_shows_color_sections() {
     fs::create_dir(&plugins_dir).unwrap();
 
     // Copy the theme_editor.ts plugin
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory with test themes
@@ -692,6 +700,7 @@ fn test_theme_editor_open_builtin() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create harness with isolated directory context
@@ -762,6 +771,7 @@ fn test_theme_editor_displays_correct_colors() {
     fs::create_dir(&plugins_dir).unwrap();
 
     // Copy the theme_editor.ts plugin
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create themes directory
@@ -909,6 +919,7 @@ fn test_cursor_position_preserved_after_section_toggle() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -977,6 +988,7 @@ fn test_color_prompt_shows_suggestions() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1082,6 +1094,7 @@ fn test_colors_displayed_in_hex_format() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1145,6 +1158,7 @@ fn test_comments_appear_before_fields() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1226,6 +1240,7 @@ fn test_theme_applied_immediately_after_save() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a test file to see theme changes
@@ -1398,6 +1413,7 @@ fn test_cursor_x_position_preserved_after_section_toggle() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1534,6 +1550,7 @@ fn test_color_suggestions_show_hex_format() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1665,6 +1682,7 @@ fn test_color_prompt_prefilled_with_current_value() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1744,6 +1762,7 @@ fn test_theme_editor_color_values_no_internal_spaces() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1832,6 +1851,7 @@ fn test_theme_editor_navigation_skips_non_selectable_lines() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -1986,6 +2006,7 @@ fn test_cursor_position_preserved_after_color_edit() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2116,6 +2137,7 @@ fn test_cursor_on_value_field_when_navigating() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2182,6 +2204,7 @@ fn test_builtin_theme_requires_save_as() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a DirectoryContext so we know where config_dir/themes is
@@ -2303,6 +2326,7 @@ fn test_color_swatches_displayed() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -2360,6 +2384,7 @@ fn test_theme_editor_nostalgia_builtin_shows_correct_colors() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Don't create a themes directory - we want to use the built-in themes only
@@ -2445,6 +2470,7 @@ fn test_theme_editor_nostalgia_builtin_via_arrow_selection() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Don't create a themes directory - we want to use the built-in themes only
@@ -2540,6 +2566,7 @@ fn test_theme_editor_select_nostalgia_from_dropdown() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -2782,6 +2809,7 @@ fn test_inspect_theme_at_cursor_opens_theme_editor() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a test file so the cursor is on editor content
@@ -2847,6 +2875,7 @@ fn test_inspect_theme_at_cursor_multiple_rounds() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -2976,6 +3005,7 @@ fn test_save_builtin_theme_produces_valid_file() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3166,6 +3196,7 @@ fn test_issue_1180_save_theme_creates_themes_directory() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3332,6 +3363,7 @@ fn test_inspect_after_saving_custom_theme() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let test_file = project_root.join("test.txt");
@@ -3512,6 +3544,7 @@ fn test_palette_swatch_click_targets_correct_column() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -3697,6 +3730,7 @@ fn test_theme_editor_page_up_page_down() {
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
 
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let themes_dir = project_root.join("themes");
@@ -3836,6 +3870,7 @@ fn test_named_color_swatch_uses_native_ansi_color() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     // Create a theme with a named color "Yellow" for tab_active_fg.
@@ -4007,6 +4042,7 @@ fn test_theme_editor_colors_update_on_theme_change() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut config = fresh::config::Config::default();
@@ -4155,6 +4191,7 @@ fn test_paste_in_theme_editor_does_not_panic() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =
@@ -4207,6 +4244,7 @@ fn test_theme_editor_terminal_builtin_renders_field_rows() {
 
     let plugins_dir = project_root.join("plugins");
     fs::create_dir(&plugins_dir).unwrap();
+        copy_plugin_lib(&plugins_dir);
     copy_plugin(&plugins_dir, "theme_editor");
 
     let mut harness =

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -456,26 +456,59 @@ Key invariants to preserve during migration:
 ### 4.2 Plugin migrations beyond `search_replace.ts`
 
 This is how reach (goal #5: same shape across every panel) gets
-done. Heaviest payoff order, per call-site density:
+done. Status (✅ migrated, 🚧 partial, ❌ untouched, ⏸ blocked):
 
-* `git_log.ts` — Toolbar + Table.
-* `lib/finder.ts` — already a panel manager; convert to `List` +
-  `Prompt` (after Layer lands).
-* `audit_mode.ts` — Tree + List + RawBuffer escape hatch.
-* `dashboard.ts` — Toolbar + List.
-* `theme_editor.ts` — settings-style controls.
-* `pkg.ts` — the `// TODO: Plugin UI Component Library` literal.
+* ✅ **`git_log.ts`** (commits `c0d90b8` + `ffb413c`). Toolbar
+  → `Row` of `Button`s + `widget_event "activate"` routing.
+  Log pane → `List` widget; dropped the byte-offset row table
+  + `cursor_moved` hook + `setBufferShowCursors`. Detail
+  pane stays on `setPanelContent` (pure diff text, no
+  widget benefit). Toolbar+log net −57 LOC.
+* 🚧 **`pkg.ts`** (commit `59a42b3`). List panel → `List`
+  widget (drop manual `▸` cursor + selection styling, gain
+  click + wheel for free); footer → `HintBar`. Header
+  (search + filter buttons + sync) and detail (action
+  buttons) still use `setPanelContent` because they
+  participate in the plugin's cross-panel `FocusTarget`
+  cycle which a single widget panel can't model — needs
+  either a single combined panel (major UI restructure) or
+  the cross-panel focus stack the §4.1 Compositor work
+  introduces.
+* 🚧 **`theme_editor.ts`** (commit `4f74b97`). Footer →
+  `HintBar`. Tree panel (header + separator + filter line +
+  selectable section/field rows with `▸` markers) and
+  picker panel (named-color list + palette grid + preview
+  lines + color-edit popup) still use `setPanelContent` —
+  the picker's color-edit popup needs `Prompt`/`Layer`
+  (blocked on §4.1).
+* ⏸ **`audit_mode.ts`** (4792 LOC, untouched). Multi-pane
+  review UI: toolbar with grouped key hints separated by
+  `│` (HintBar can't render groups today — needs an
+  enhanced HintBar variant or a custom widget), diff pane,
+  comments pane, sticky header, staging UI. Multi-session
+  migration on its own.
+* ⏸ **`dashboard.ts`** (1903 LOC, untouched). Animated
+  centered ASCII frame with click regions, slide-in
+  transitions, skip-redraw hash optimization. Doesn't map
+  cleanly to a widget tree without losing the visual; would
+  need a UI redesign rather than a substitution.
+* ⏸ **`lib/finder.ts`** + **`find_references.ts`**.
+  Blocked on `Prompt` → `Layer` (§4.1). The shape is right
+  for `List` + `Prompt`; just waiting for the compositor.
 
-Each plugin migration is mostly mechanical once the widgets it needs
+Each migrated plugin is mostly mechanical once the widgets it needs
 exist. The work is in (a) discovering hidden assumptions in plugin
 state machines (e.g. `search_replace`'s `focusPanel`/`queryField`/
-`optionIndex` triple), and (b) reconciling event flow with whatever
-async work the plugin already does (debounce, LSP, git).
+`optionIndex` triple, `pkg.ts`'s `FocusTarget` enum), and (b)
+reconciling event flow with whatever async work the plugin already
+does (debounce, LSP, git).
 
-`Toolbar` (composes Button + Toggle into a horizontal Row) and
-`Table` (`git_log` log, `find_references`, audit) need to land as
-new widget kinds during this phase. `Transient` (Magit-style menu)
-falls out of the Compositor work.
+`Toolbar` is shipped as a TS convention (`row(button(), button(),
+flexSpacer())`) without needing a new widget kind. `Table` was
+considered necessary for `git_log` but `List` turned out to handle
+pre-rendered column-aligned rows fine; revisit when a consumer
+needs explicit columns (live resize, column-header sort, etc.).
+`Transient` (Magit-style menu) falls out of the Compositor work.
 
 ### 4.3 Settings adoption
 

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -50,24 +50,24 @@ tsc clean, interactively verified in tmux.
 
 | File | Purpose |
 |---|---|
-| `mod.rs` | Public surface: re-exports `render_spec`, `RenderOutput`, `FocusCursor`, `WidgetRegistry`, `HitArea`, `WidgetInstanceState`, `find_widget_by_key`, `apply_text_input_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec` |
-| `registry.rs` | `WidgetRegistry`: `panel_id → WidgetPanelState { buffer_id, spec, hits, instance_states, focus_key, tabbable }`. Hit-test, get/get_mut, focus_key getter/setter, mount/update/unmount. |
+| `mod.rs` | Public surface: re-exports `render_spec`, `RenderOutput`, `FocusCursor`, `WidgetRegistry`, `HitArea`, `PanelId`, `WidgetPanelState`, `WidgetInstanceState`, `find_widget_by_key`, `apply_text_input_key`, `apply_text_area_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`, `set_tree_nodes_in_spec`, `set_tree_checked_keys_in_spec`, `tree_parent_index`. |
+| `registry.rs` | `WidgetRegistry`: `panel_id → WidgetPanelState { buffer_id, spec, hits, instance_states, focus_key, tabbable }`. Hit-test, get/get_mut, focus_key getter/setter, mount/update/unmount, `panels_for_buffer` (used by the wheel-scroll path). |
 | `render.rs` | The reconciler. `render_spec(spec, prev_state, prev_focus, panel_width) → RenderOutput { entries, hits, instance_states, focus_key, tabbable, focus_cursor }`. Two-pass Row layout for flex spacers. Per-widget renderers (`render_hint_bar`, `render_toggle`, `render_button`, `render_text_input`, `render_text_area`, `render_tree_row`, plus inline list rendering). |
-| `actions.rs` | Pure helpers used by dispatch: `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling), `find_widget_by_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`, `set_tree_expanded_keys_in_spec`. |
+| `actions.rs` | Pure helpers used by dispatch: `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling); `apply_text_area_key` (adds Up/Down/Enter and line-relative Home/End on top of the TextInput keys); `find_widget_by_key`; `set_toggle_checked_in_spec`; `set_list_items_in_spec`; `set_tree_nodes_in_spec` (replaces `nodes` + `item_keys` for `WidgetMutation::SetItems` on a Tree); `set_tree_checked_keys_in_spec` (stamps `Some(checked)` onto every node whose item-key is in the supplied list, for `WidgetMutation::SetCheckedKeys`); `tree_parent_index` (parent lookup for cascading checkbox updates). Note: there is no `set_tree_expanded_keys_in_spec` — expanded keys live in instance state, not the spec, so the `SetExpandedKeys` mutator writes directly to `WidgetInstanceState::Tree::expanded_keys` without a spec helper. |
 
 **Core types** (`crates/fresh-core/src/api.rs`)
 
 | Type | Notes |
 |---|---|
-| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `TextArea`, `List`, `Tree`, `Spacer`, `Raw`. |
+| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `TextArea`, `List`, `Tree`, `Spacer`, `Raw`. `Tree` carries `checkable: bool` (default false) gating per-row `[v]`/`[ ]` glyphs; `TreeNode` carries `checked: Option<bool>` (None = no glyph for that row). |
 | `TextPropertyEntry` (`fresh-core::text_property`) | Row-content payload for `List`, `Tree`, and `Raw`. Carries `text`, `inline_overlays: Vec<InlineOverlay>`, `segments: Vec<StyledSegment>`, `pad_to_chars: Option<u32>`, `truncate_to_chars: Option<u32>`. The host calls `normalize_widths` on each visible entry — segments concatenate into `text` with one Char-unit overlay per styled segment, then truncate, then pad, then char→byte conversion for any remaining char-unit overlays. Plugins describe row content structurally and never name byte/codepoint offsets between segments. |
 | `InlineOverlay` | `start`, `end`, `style`, `properties`, `unit: OffsetUnit { Byte, Char }` (default `Byte`). Char offsets resolve to bytes during `normalize_widths`. |
 | `StyledSegment` | `text` + optional `style` + optional nested `overlays`. Building block for `TextPropertyEntry::segments`. |
 | `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` | Shapes referenced by the spec / IPC. |
 | `PluginCommand::MountWidgetPanel`, `UpdateWidgetPanel`, `UnmountWidgetPanel` | Spec lifecycle. |
 | `PluginCommand::WidgetCommand { panel_id, action }` | Routes a `WidgetAction` (key dispatch / focus / activate / select-move / text-input). |
-| `PluginCommand::WidgetMutate { panel_id, mutation }` | Targeted in-place mutation (the "Path A" fast path). `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys`. |
-| `HookArgs::WidgetEvent` | `widget_event` hook payload: `panel_id`, `widget_key`, `event_type`, `payload`. Fired for `select` / `activate` / `toggle` / `change` / `expand`. |
+| `PluginCommand::WidgetMutate { panel_id, mutation }` | Targeted in-place mutation (the "Path A" fast path). `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `setCheckedKeys`. |
+| `HookArgs::WidgetEvent` | `widget_event` hook payload: `panel_id`, `widget_key`, `event_type`, `payload`. Fired for `select` / `activate` / `toggle` / `change` / `expand`. `toggle` is emitted both by Toggle widgets (payload `{ checked }`) and by the per-row checkbox glyph on a `checkable: true` Tree (payload `{ key, index, checked }`); the host fires the same `toggle` event when Space is pressed on a focused checkable-Tree row whose `checked` is `Some(_)`. |
 
 **Dispatch glue** (`crates/fresh-editor/src/app/`)
 
@@ -82,9 +82,9 @@ tsc clean, interactively verified in tmux.
 
 | File | Exports |
 |---|---|
-| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree`, `treeNode`, `spacer`, `flexSpacer`, `raw`, `styledRow`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `unmount`. |
+| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree` (`{ checkable }` opt-in), `treeNode` (`{ checked: bool \| undefined }`), `spacer`, `flexSpacer`, `raw`, `styledRow`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `setCheckedKeys` / `unmount`. |
 | `index.ts` | Re-exports the above. |
-| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation`, `StyledSegment`, `OffsetUnit` types. `widget_event` hook. |
+| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` (incl. `SetCheckedKeys`), `StyledSegment`, `OffsetUnit` types. `widget_event` hook (incl. `toggle` payload from checkable Tree rows). |
 
 **Plugin migration: `search_replace.ts`**
 
@@ -93,9 +93,9 @@ tsc clean, interactively verified in tmux.
 | HintBar (footer) | `parseHintString(t("panel.help"))` → `hintBar(...)`. Theme-keyed key styling. |
 | Options row (3 toggles + Replace All button) | `row(toggle("case"), toggle("regex"), toggle("whole"), flexSpacer(), button("replaceAll", { intent: "primary" }))`. Right-aligns the button via flex. |
 | Search / Replace text fields | `textInput(...)`. Constant-width with head-truncate scrolling, host-owned hardware cursor. |
-| Match tree | `tree({ nodes, itemKeys, selectedIndex, visibleRows, expandedKeys, key: "matchTree" })`. Widget-owned scroll, expansion, click-to-select, Enter-to-activate, disclosure-glyph hit area. |
-| Mode bindings (Tab / Shift+Tab / Enter / Space / Backspace / Delete / Home / End / Up / Down / Left / Right / mode_text_input) | All route through `dispatch(widgetKey("Tab"))` etc. The smart-key dispatcher in core handles based on focused widget kind. |
-| `widget_event` handlers (`change` / `select` / `activate` / `toggle` / `expand`) | Plugin updates its app model from events; toggle writes back via `panel.setChecked` (mutator fast path); selection / value / expansion changes don't re-emit spec. |
+| Match tree | `tree({ nodes, itemKeys, selectedIndex, visibleRows, expandedKeys, checkable: true, key: "matchTree" })`. Widget-owned scroll, expansion, click-to-select, Enter-to-activate, disclosure-glyph hit area. Per-match exclusion: `treeNode({ checked })` on every row; click on the `[v]`/`[ ]` glyph or Space on a focused row fires `widget_event "toggle"`; plugin updates `result.selected` and pushes the new state via `panel.setCheckedKeys`. File-row glyph reflects "every match selected" (mixed renders as `[ ]`). Replace All filters by selected. |
+| Mode bindings (Tab / Shift+Tab / Enter / Space / Backspace / Delete / Home / End / Up / Down / Left / Right / PageUp / PageDown / mode_text_input) | All route through `dispatch(widgetKey("Tab"))` etc. The smart-key dispatcher in core handles based on focused widget kind. PageUp/PageDown move List/Tree selection by `visible_rows - 1` (one row of overlap). Space on a focused checkable-Tree row dispatches `toggle` instead of `activate`. |
+| `widget_event` handlers (`change` / `select` / `activate` / `toggle` / `expand`) | Plugin updates its app model from events; Toggle widgets write back via `panel.setChecked`; checkable-Tree toggle writes back via `panel.setCheckedKeys`; selection / value / expansion changes don't re-emit spec. |
 
 What's *not* migrated in `search_replace.ts`: the matches-section
 separator (still in `Raw`), the `truncated` warning in matchStats
@@ -179,8 +179,8 @@ Remaining work, in rough decreasing user impact:
 
 * **`Spec::SetSpec` mutator** vs **per-field mutators**. Currently
   field mutators cover `SetValue` / `SetChecked` / `SetSelectedIndex` /
-  `SetItems` / `SetExpandedKeys`. For richer subtree changes — e.g.
-  a toolbar that grows a button — the choice is: add
+  `SetItems` / `SetExpandedKeys` / `SetCheckedKeys`. For richer subtree
+  changes — e.g. a toolbar that grows a button — the choice is: add
   `SetSpec { widget_key, sub_spec }` (clean) or add more per-field
   mutators (incrementally simpler). Currently deferred (see §2.2);
   re-evaluate if a real consumer needs it or profiling on a
@@ -198,10 +198,13 @@ Remaining work, in rough decreasing user impact:
 * **The "Spec is initial; instance state is the truth" rule.**
   Implemented for `TextInput` (value + cursor), `TextArea` (value +
   cursor + scroll), `List` (selected_index + scroll_offset), and
-  `Tree` (selected_index + scroll_offset + expanded_keys). The rule
-  will need to extend to `Prompt` / `Layer` (open/closed) when
-  those land. Pattern is set; just apply it consistently as new
-  widgets land.
+  `Tree` (selected_index + scroll_offset + expanded_keys). Per-row
+  Tree `checked` is the explicit exception: it lives in the spec
+  (because the plugin owns "which rows are selectable" as an
+  application-data fact, not host state) and is mutated in-spec via
+  `SetCheckedKeys`. The rule will need to extend to `Prompt` /
+  `Layer` (open/closed) when those land. Pattern is set; just
+  apply it consistently as new widgets land.
 * **Widget keymap layer above `defineMode`.** Today the plugin's
   `defineMode` binds keys → `dispatch(widgetKey("Tab"))`. The §8
   design said the widget's keymap should claim keys *before*
@@ -297,8 +300,15 @@ codebase is mechanical at this point.
 6. **Add a `WidgetCommand::Key` arm** in
    `crates/fresh-editor/src/app/plugin_dispatch.rs` (`handle_widget_key`)
    if the widget responds to keystrokes. Existing dispatch table:
-   Tab → focus advance; Up/Down → list select; Backspace/etc. →
-   text input; Enter/Space → activate. Add per-kind handling.
+   Tab/BackTab → focus advance; Up/Down → List/Tree select-move ±1;
+   PageUp/PageDown → List/Tree select-move ±(visible_rows-1);
+   Backspace/Delete/Left/Right/Home/End → text input editing
+   (TextArea also handles Up/Down/Enter for line nav + newline);
+   Enter → activate (or insert `\n` on focused TextArea); Space →
+   activate, except on a `checkable: true` Tree row whose `checked
+   == Some(_)`, where Space fires `widget_event "toggle"` with the
+   inverted value (mirrors clicking the `[v]`/`[ ]` glyph). Add
+   per-kind handling.
 7. **Add a mutator** in `WidgetMutation` if the plugin needs a
    targeted fast-path update (e.g. `Tree` would want
    `SetExpandedKeys { widget_key, expanded_keys: Vec<String> }`).
@@ -364,6 +374,18 @@ those are done.
   test fixtures need updating (`make_list` in `render.rs`, struct
   literals scattered across test functions). The compiler will tell
   you all the call sites.
+* **Printable-letter `defineMode` bindings shadow widget input.**
+  A plugin binding `"x"` to a widget command in `defineMode` will
+  swallow the lowercase `x` in every focused TextInput / TextArea
+  on the same panel — the binding fires before the input character
+  stream gets the keypress. Use Space (host-dispatched on focused
+  widget kind) or a non-letter key for widget commands; reserve
+  letter bindings for non-text-input panels.
+* **`"S-Tab"` plugin bindings.** `defineMode("S-Tab", …)` registers
+  as `(BackTab, NONE)` to match what the resolver actually looks up
+  after `normalize_key` strips the redundant SHIFT modifier from
+  Shift+Tab. Either spelling (`"S-Tab"` or `"BackTab"`) is correct;
+  before commit `b103df2` only `"BackTab"` worked.
 
 ---
 
@@ -505,7 +527,7 @@ when real demand surfaces.
 | `Button` | ✅ migrated | search_replace Replace All | `intent: "normal" \| "primary" \| "danger"` |
 | `TextInput` | ✅ migrated | search_replace fields | host-owned cursor + value, constant-width with scroll, hardware caret |
 | `List` (virtual-scrolled) | ✅ | candidates for finder-style consumers | host owns scroll + selection |
-| `Tree` | ✅ migrated | search_replace match tree, audit, file-explorer | host owns scroll + selection + expansion; disclosure-glyph hit area |
+| `Tree` | ✅ migrated | search_replace match tree, audit, file-explorer | host owns scroll + selection + expansion; disclosure-glyph hit area; opt-in per-row checkboxes (`checkable: true` + `treeNode.checked: Some(_)`) with `toggle` events from glyph clicks or Space, persisted via `WidgetMutation::SetCheckedKeys` |
 | `TextArea` | ✅ | composer-style plugins | multi-line; host-owned value + cursor + vertical scroll; submit policy via panel HintBar |
 | `Tabs` / `Group` | ⏸ | (no current consumer) | skipped; revisit when needed |
 | `Layer` (compositor) | ❌ → §4.1 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
@@ -728,12 +750,24 @@ buffer_col)`; it receives semantic events.
   widget_kind, buffer_row, byte_start, byte_end, payload, event_type
   }` during render. Stored in `WidgetPanelState::hits`.
 * `WidgetRegistry::hit_test(buffer_id, row, col_byte)` does the
-  per-panel scan.
+  per-panel scan; `WidgetRegistry::panels_for_buffer` enumerates
+  every panel mounted on a buffer (used by the wheel-scroll path).
 * `click_handlers.rs` calls `hit_test` for every left-click on a
   widget panel's buffer; on hit, fires `widget_event` with the
   payload, and moves focus_key to the clicked widget.
 * `widget_event` payloads: Toggle → `{ checked: <new> }`; Button →
-  `{}`; List → `{ index, key }`; TextInput → `{ value, cursorByte }`.
+  `{}`; List → `{ index, key }`; Tree row select → `{ index, key }`;
+  Tree disclosure → `expand` event; Tree checkbox glyph (only when
+  `checkable: true` and the row's `checked` is `Some(_)`) →
+  `toggle` event with `{ key, index, checked: <new> }`; TextInput →
+  `{ value, cursorByte }`.
+* Wheel scroll routed to the panel under the cursor: `mouse_input.rs`
+  calls into the widget runtime before falling through to buffer
+  scroll. The first scrollable widget in the panel shifts its
+  viewport; the selection is dragged to the edge of the new
+  visible window so the renderer's keep-selection-in-view
+  auto-scroll doesn't snap the offset back. Wheel does not change
+  focus and does not fire `select`.
 
 **Not yet implemented**:
 * Right-click → context menu (`onContext`).
@@ -742,9 +776,6 @@ buffer_col)`; it receives semantic events.
   flow.
 * Double-click → `onActivate(key)`. Today single-click fires
   `select`; double-click would fire `activate` separately.
-* Wheel scroll routed to deepest scrollable widget. Today the
-  editor's scroll handling sees the wheel events; widget scroll
-  doesn't intercept.
 
 ---
 
@@ -768,8 +799,12 @@ applies a minimal patch.
   mutation, and toggle/items mutators.
 * The targeted-mutator fast path: `WidgetMutate::SetValue` /
   `SetChecked` / `SetSelectedIndex` / `SetItems` /
-  `SetExpandedKeys`. Plugin ships a one-field change instead of
-  the full spec.
+  `SetExpandedKeys` / `SetCheckedKeys`. Plugin ships a one-field
+  change instead of the full spec. `SetCheckedKeys` stamps
+  `Some(checked)` onto every Tree node whose item-key appears in
+  the supplied list; nodes with `checked: None` are left as None
+  (a node only becomes checkable by the plugin emitting `Some(_)`
+  in the spec).
 * Entry-shape primitives (§6.1): `TextPropertyEntry` carries
   `segments`, `pad_to_chars`, `truncate_to_chars`; `InlineOverlay`
   carries `unit: Byte | Char`. The host's `normalize_widths`
@@ -856,7 +891,7 @@ Status of the original 5-pass plan:
 |---|---|---|
 | 1 | Mount as `Panel`, body stays `Raw`, HintBar real, toggles real | ✅ |
 | 2 | Replace search/replace fields with `TextInput` (host-owned cursor + constant width) | ✅ |
-| 3 | Replace match list with `Tree` | ✅ host owns expansion + scroll + selection; disclosure glyph hit area |
+| 3 | Replace match list with `Tree` | ✅ host owns expansion + scroll + selection; disclosure glyph hit area; per-row checkboxes (`checkable: true`) for per-match exclusion — Replace All filters by `result.selected` |
 | 4 | Glob filter as `TextInput` with validator | ❌ |
 | 5 | Delete dead code | 🚧 `buildFieldDisplay`, `addCursorOverlay`, the cursor-byte arithmetic, the focus enums, the per-key mode handlers all gone. Remaining dead: `panel.scrollOffset`, `panel.focusPanel`/`queryField`/`optionIndex` (legacy fields kept for the Raw separator path). |
 

--- a/docs/internal/plugin-widget-library-design.md
+++ b/docs/internal/plugin-widget-library-design.md
@@ -50,16 +50,16 @@ tsc clean, interactively verified in tmux.
 
 | File | Purpose |
 |---|---|
-| `mod.rs` | Public surface: re-exports `render_spec`, `RenderOutput`, `FocusCursor`, `WidgetRegistry`, `HitArea`, `PanelId`, `WidgetPanelState`, `WidgetInstanceState`, `find_widget_by_key`, `apply_text_input_key`, `apply_text_area_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`, `set_tree_nodes_in_spec`, `set_tree_checked_keys_in_spec`, `tree_parent_index`. |
+| `mod.rs` | Public surface: re-exports `render_spec`, `RenderOutput`, `FocusCursor`, `WidgetRegistry`, `HitArea`, `PanelId`, `WidgetPanelState`, `WidgetInstanceState`, `find_widget_by_key`, `apply_text_char`, `apply_text_input_key`, `apply_text_area_key`, `apply_text_key`, `set_toggle_checked_in_spec`, `set_list_items_in_spec`, `set_tree_nodes_in_spec`, `set_tree_checked_keys_in_spec`, `tree_parent_index`. |
 | `registry.rs` | `WidgetRegistry`: `panel_id → WidgetPanelState { buffer_id, spec, hits, instance_states, focus_key, tabbable }`. Hit-test, get/get_mut, focus_key getter/setter, mount/update/unmount, `panels_for_buffer` (used by the wheel-scroll path). |
-| `render.rs` | The reconciler. `render_spec(spec, prev_state, prev_focus, panel_width) → RenderOutput { entries, hits, instance_states, focus_key, tabbable, focus_cursor }`. Two-pass Row layout for flex spacers. Per-widget renderers (`render_hint_bar`, `render_toggle`, `render_button`, `render_text_input`, `render_text_area`, `render_tree_row`, plus inline list rendering). |
-| `actions.rs` | Pure helpers used by dispatch: `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling); `apply_text_area_key` (adds Up/Down/Enter and line-relative Home/End on top of the TextInput keys); `find_widget_by_key`; `set_toggle_checked_in_spec`; `set_list_items_in_spec`; `set_tree_nodes_in_spec` (replaces `nodes` + `item_keys` for `WidgetMutation::SetItems` on a Tree); `set_tree_checked_keys_in_spec` (stamps `Some(checked)` onto every node whose item-key is in the supplied list, for `WidgetMutation::SetCheckedKeys`); `tree_parent_index` (parent lookup for cascading checkbox updates). Note: there is no `set_tree_expanded_keys_in_spec` — expanded keys live in instance state, not the spec, so the `SetExpandedKeys` mutator writes directly to `WidgetInstanceState::Tree::expanded_keys` without a spec helper. |
+| `render.rs` | The reconciler. `render_spec(spec, prev_state, prev_focus, panel_width) → RenderOutput { entries, hits, instance_states, focus_key, tabbable, focus_cursor }`. Two-pass Row layout for flex spacers. Per-widget renderers (`render_hint_bar`, `render_toggle`, `render_button`, `render_tree_row`, plus inline list rendering). The `Text` arm dispatches on `rows > 1` to internal `render_text_input` (single-line, bracket form) or `render_text_area` (multi-line block) — both kept as testable units, but one match arm at the spec layer. |
+| `actions.rs` | Pure helpers used by dispatch: `apply_text_char` (UTF-8-correct insertion at cursor for printable / IME-committed text — single helper used by both single-line and multi-line); `apply_text_input_key` (Backspace/Delete/arrows/Home/End with UTF-8 boundary handling); `apply_text_area_key` (adds Up/Down/Enter and line-relative Home/End on top of the single-line keys); `apply_text_key(value, cursor, key, multiline)` (the public dispatcher — picks between the two based on `multiline`); `find_widget_by_key`; `set_toggle_checked_in_spec`; `set_list_items_in_spec`; `set_tree_nodes_in_spec` (replaces `nodes` + `item_keys` for `WidgetMutation::SetItems` on a Tree); `set_tree_checked_keys_in_spec` (stamps `Some(checked)` onto every node whose item-key is in the supplied list, for `WidgetMutation::SetCheckedKeys`); `tree_parent_index` (parent lookup for cascading checkbox updates). Note: there is no `set_tree_expanded_keys_in_spec` — expanded keys live in instance state, not the spec, so the `SetExpandedKeys` mutator writes directly to `WidgetInstanceState::Tree::expanded_keys` without a spec helper. |
 
 **Core types** (`crates/fresh-core/src/api.rs`)
 
 | Type | Notes |
 |---|---|
-| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `TextInput`, `TextArea`, `List`, `Tree`, `Spacer`, `Raw`. `Tree` carries `checkable: bool` (default false) gating per-row `[v]`/`[ ]` glyphs; `TreeNode` carries `checked: Option<bool>` (None = no glyph for that row). |
+| `WidgetSpec` (enum, tagged) | Variants: `Row`, `Col`, `HintBar`, `Toggle`, `Button`, `Text`, `List`, `Tree`, `Spacer`, `Raw`. `Text` is the single text-input variant — `rows: 1` (default) selects single-line behaviour (`[value]` rendering, Enter-advances-focus, head-truncate scroll); `rows >= 2` selects multi-line (block rendering, Enter-inserts-newline, line nav, vertical scroll). The previous `TextInput` and `TextArea` variants collapsed into this one. `Tree` carries `checkable: bool` (default false) gating per-row `[v]`/`[ ]` glyphs; `TreeNode` carries `checked: Option<bool>` (None = no glyph for that row). |
 | `TextPropertyEntry` (`fresh-core::text_property`) | Row-content payload for `List`, `Tree`, and `Raw`. Carries `text`, `inline_overlays: Vec<InlineOverlay>`, `segments: Vec<StyledSegment>`, `pad_to_chars: Option<u32>`, `truncate_to_chars: Option<u32>`. The host calls `normalize_widths` on each visible entry — segments concatenate into `text` with one Char-unit overlay per styled segment, then truncate, then pad, then char→byte conversion for any remaining char-unit overlays. Plugins describe row content structurally and never name byte/codepoint offsets between segments. |
 | `InlineOverlay` | `start`, `end`, `style`, `properties`, `unit: OffsetUnit { Byte, Char }` (default `Byte`). Char offsets resolve to bytes during `normalize_widths`. |
 | `StyledSegment` | `text` + optional `style` + optional nested `overlays`. Building block for `TextPropertyEntry::segments`. |
@@ -82,9 +82,9 @@ tsc clean, interactively verified in tmux.
 
 | File | Exports |
 |---|---|
-| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `textInput`, `textArea`, `list`, `tree` (`{ checkable }` opt-in), `treeNode` (`{ checked: bool \| undefined }`), `spacer`, `flexSpacer`, `raw`, `styledRow`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar`. `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `setCheckedKeys` / `unmount`. |
-| `index.ts` | Re-exports the above. |
-| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec`, `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` (incl. `SetCheckedKeys`), `StyledSegment`, `OffsetUnit` types. `widget_event` hook (incl. `toggle` payload from checkable Tree rows). |
+| `widgets.ts` | Builders: `row`, `col`, `hintBar`, `toggle`, `button`, `text` (the unified text-input builder; opt into multi-line with `rows: N`), `textInput(value, opts)` and `textArea(opts)` (thin ergonomic wrappers around `text({ rows: 1 })` / `text({ rows: 5 })`), `list`, `tree` (`{ checkable }` opt-in), `treeNode` (`{ checked: bool \| undefined }`), `spacer`, `flexSpacer`, `raw`, `styledRow`, `parseHintString`. Action builders: `key`, `focusAdvance`, `activate`, `selectMove`, `textInputKey`, `textInputChar` (action names kept stable; both single-line and multi-line widgets receive them). `WidgetPanel` class with `set` / `command` / `mutate` / `setValue` / `setChecked` / `setSelectedIndex` / `setItems` / `setExpandedKeys` / `setCheckedKeys` / `unmount`. |
+| `index.ts` | Re-exports the above (incl. `text` and `textArea`). |
+| `fresh.d.ts` | Generated. `editor.mountWidgetPanel`, `updateWidgetPanel`, `unmountWidgetPanel`, `widgetCommand`, `widgetMutate`. `WidgetSpec` (`Text` variant replaces the old `TextInput`/`TextArea` pair), `HintEntry`, `ButtonKind`, `WidgetAction`, `WidgetMutation` (incl. `SetCheckedKeys`), `StyledSegment`, `OffsetUnit` types. `widget_event` hook (incl. `toggle` payload from checkable Tree rows). |
 
 **Plugin migration: `search_replace.ts`**
 
@@ -92,7 +92,7 @@ tsc clean, interactively verified in tmux.
 |---|---|
 | HintBar (footer) | `parseHintString(t("panel.help"))` → `hintBar(...)`. Theme-keyed key styling. |
 | Options row (3 toggles + Replace All button) | `row(toggle("case"), toggle("regex"), toggle("whole"), flexSpacer(), button("replaceAll", { intent: "primary" }))`. Right-aligns the button via flex. |
-| Search / Replace text fields | `textInput(...)`. Constant-width with head-truncate scrolling, host-owned hardware cursor. |
+| Search / Replace text fields | `textInput(...)` (single-line wrapper around `text({ rows: 1 })`). Constant-width with head-truncate scrolling, host-owned hardware cursor. |
 | Match tree | `tree({ nodes, itemKeys, selectedIndex, visibleRows, expandedKeys, checkable: true, key: "matchTree" })`. Widget-owned scroll, expansion, click-to-select, Enter-to-activate, disclosure-glyph hit area. Per-match exclusion: `treeNode({ checked })` on every row; click on the `[v]`/`[ ]` glyph or Space on a focused row fires `widget_event "toggle"`; plugin updates `result.selected` and pushes the new state via `panel.setCheckedKeys`. File-row glyph reflects "every match selected" (mixed renders as `[ ]`). Replace All filters by selected. |
 | Mode bindings (Tab / Shift+Tab / Enter / Space / Backspace / Delete / Home / End / Up / Down / Left / Right / PageUp / PageDown / mode_text_input) | All route through `dispatch(widgetKey("Tab"))` etc. The smart-key dispatcher in core handles based on focused widget kind. PageUp/PageDown move List/Tree selection by `visible_rows - 1` (one row of overlap). Space on a focused checkable-Tree row dispatches `toggle` instead of `activate`. |
 | `widget_event` handlers (`change` / `select` / `activate` / `toggle` / `expand`) | Plugin updates its app model from events; Toggle widgets write back via `panel.setChecked`; checkable-Tree toggle writes back via `panel.setCheckedKeys`; selection / value / expansion changes don't re-emit spec. |
@@ -111,8 +111,8 @@ not blockers for any flow; they're cleanup.
 | Toggle "checked" glyph | `ui.tab_active_fg` |
 | Focused widget bg/fg | `ui.menu_active_bg` / `ui.menu_active_fg` |
 | Button "danger" intent | `ui.status_error_indicator_fg` |
-| TextInput focused bg | `ui.prompt_bg` |
-| TextInput placeholder | `ui.menu_disabled_fg` |
+| Text focused bg | `ui.prompt_bg` |
+| Text placeholder | `ui.menu_disabled_fg` |
 | List selected row | `ui.menu_active_bg` (extend_to_line_end) |
 
 These are all reuses of pre-existing keys. The role-based theme
@@ -162,9 +162,25 @@ Remaining work, in rough decreasing user impact:
 6. **Accessibility (§13).** Screen-reader bridge (OSC 52), ARIA
    strings on focus change, motion-reduce gating. Library-default
    `lib-widgets.i18n.json`.
-7. **IME composition in TextInput.** `mode_text_input` already
-   delivers composed text but the widget cursor model doesn't
-   track composition states.
+7. **IME composition — preedit display.** The committed-text path
+   is shipped and tested: `mode_text_input:<char>` →
+   `WidgetAction::TextInputChar` → `apply_text_char` (one shared
+   helper for single-line and multi-line `Text`). Multi-byte
+   codepoints, multi-codepoint single-event commits, and
+   step-by-step IME commits all round-trip with byte-correct
+   cursor advancement; covered by `apply_text_char_*` unit tests
+   in `widgets/actions.rs`. What's still missing is **preedit
+   display** — the in-flight composition glyph rendered in the
+   widget before commit. That depends on the input layer
+   surfacing preedit events, which `server/input_parser.rs` does
+   not currently parse (crossterm has no native preedit signal,
+   and the editor doesn't yet handle the kitty-keyboard /
+   bracketed-IME extensions). When that lands, the widget side
+   is a small addition: an optional `preedit: Option<{ text,
+   byte_offset }>` field on `WidgetInstanceState::Text`, a
+   `compose` entry point parallel to `apply_text_char`, and an
+   underline overlay in the renderer. Plugins get preedit for
+   free across both single-line and multi-line.
 8. **Built-in chord support inside widgets.** Today
    `apply_text_input_key` only handles single-key edits; chords
    (`g g`) still bubble to the plugin's `defineMode`.
@@ -196,8 +212,9 @@ Remaining work, in rough decreasing user impact:
   is for the host to re-render automatically when `viewport.width`
   changes for any buffer with a mounted widget panel.
 * **The "Spec is initial; instance state is the truth" rule.**
-  Implemented for `TextInput` (value + cursor), `TextArea` (value +
-  cursor + scroll), `List` (selected_index + scroll_offset), and
+  Implemented for `Text` (value + cursor + scroll — `scroll`
+  carries first-visible-row for multi-line, ignored for
+  single-line), `List` (selected_index + scroll_offset), and
   `Tree` (selected_index + scroll_offset + expanded_keys). Per-row
   Tree `checked` is the explicit exception: it lives in the spec
   (because the plugin owns "which rows are selectable" as an
@@ -264,15 +281,15 @@ tmux capture-pane -t sr -p -e           # rendered text + ANSI escapes
 tmux display-message -t sr -p '#{cursor_x},#{cursor_y} flag=#{cursor_flag}'
 ```
 
-`cursor_flag=0` means the hardware cursor is hidden (TextInput not
-focused); `flag=1` means it's visible. `capture-pane -e` is essential
+`cursor_flag=0` means the hardware cursor is hidden (no `Text`
+widget focused); `flag=1` means it's visible. `capture-pane -e` is essential
 for verifying overlay colors / focused-bg styling — plain
 `capture-pane` strips them.
 
 ### 3.3 The "minimum dignity" recipe for adding a new widget kind
 
-For `Tree`, `Tabs`, `TextArea`, `Table` etc. The path through the
-codebase is mechanical at this point.
+For `Tree`, `Tabs`, `Table` etc. The path through the codebase is
+mechanical at this point.
 
 1. **Add a `WidgetSpec::<Kind>` variant** in
    `crates/fresh-core/src/api.rs` next to `Toggle`/`Button`/etc.
@@ -292,7 +309,7 @@ codebase is mechanical at this point.
 4. **Add instance state** in
    `crates/fresh-editor/src/widgets/registry.rs` (`WidgetInstanceState`
    enum). Read from `prev` map by key; write to `next_state`. The
-   `TextInput` and `List` arms in `render_collected` are the
+   `Text` and `List` arms in `render_collected` are the
    templates.
 5. **Add a TS builder** in
    `crates/fresh-editor/plugins/lib/widgets.ts`. Re-export from
@@ -300,15 +317,21 @@ codebase is mechanical at this point.
 6. **Add a `WidgetCommand::Key` arm** in
    `crates/fresh-editor/src/app/plugin_dispatch.rs` (`handle_widget_key`)
    if the widget responds to keystrokes. Existing dispatch table:
-   Tab/BackTab → focus advance; Up/Down → List/Tree select-move ±1;
-   PageUp/PageDown → List/Tree select-move ±(visible_rows-1);
-   Backspace/Delete/Left/Right/Home/End → text input editing
-   (TextArea also handles Up/Down/Enter for line nav + newline);
-   Enter → activate (or insert `\n` on focused TextArea); Space →
-   activate, except on a `checkable: true` Tree row whose `checked
-   == Some(_)`, where Space fires `widget_event "toggle"` with the
-   inverted value (mirrors clicking the `[v]`/`[ ]` glyph). Add
-   per-kind handling.
+   Tab/BackTab → focus advance; Up/Down → List/Tree select-move ±1
+   (or line nav for multi-line `Text`); PageUp/PageDown → List/Tree
+   select-move ±(visible_rows-1);
+   Backspace/Delete/Left/Right/Home/End → `Text` editing (single-
+   line and multi-line both routed through the same
+   `handle_widget_text_key`, which reads `multiline` from the
+   focused widget's `rows > 1` and dispatches to
+   `apply_text_input_key` or `apply_text_area_key`); Enter →
+   activate, except on focused `Text { rows: 1 }` (advances focus —
+   form-like UX) or `Text { rows >= 2 }` (inserts `\n`); Space →
+   activate, except on focused `Text` (inserts " " via
+   `handle_widget_text_char`) or a `checkable: true` Tree row
+   whose `checked == Some(_)` (fires `widget_event "toggle"` with
+   the inverted value — mirrors clicking the `[v]`/`[ ]` glyph).
+   Add per-kind handling.
 7. **Add a mutator** in `WidgetMutation` if the plugin needs a
    targeted fast-path update (e.g. `Tree` would want
    `SetExpandedKeys { widget_key, expanded_keys: Vec<String> }`).
@@ -331,11 +354,12 @@ those are done.
   the same panel id starts fresh. Use `UpdateWidgetPanel` to
   preserve instance state across renders. `WidgetPanel.set()` does
   the right thing automatically (mount on first call, update after).
-* **Spec value vs instance state.** For `TextInput` value + cursor
-  and `List` selected_index + scroll_offset, instance state is the
-  truth after first render. The spec's value is initial-only.
-  Plugin updates via `widget_event` or via `WidgetMutate::SetValue`
-  / `SetSelectedIndex`. Setting them in the spec on every render is
+* **Spec value vs instance state.** For `Text` value + cursor
+  (+ scroll for multi-line) and `List` selected_index +
+  scroll_offset, instance state is the truth after first render.
+  The spec's value is initial-only. Plugin updates via
+  `widget_event` or via `WidgetMutate::SetValue` /
+  `SetSelectedIndex`. Setting them in the spec on every render is
   fine — they're ignored once instance state exists, except via the
   re-mount path. Don't rely on spec value for round-trip.
 * **Newlines in entries.** Every entry pushed at the top level / Col
@@ -348,12 +372,16 @@ those are done.
 * **Focus key clamping.** The renderer clamps the previous focus key
   to a tabbable that exists in the new spec. If the widget you were
   focused on disappears, focus falls back to the first tabbable.
-* **Hardware cursor.** When a `TextInput` is focused, the host sets
-  the buffer's `show_cursors=true` and positions the primary cursor
-  to the byte the renderer emitted in `RenderOutput::focus_cursor`.
-  When focus is on a non-text widget, `show_cursors=false` and the
-  hardware cursor disappears entirely. Don't paint a cursor overlay
-  in the renderer — let the terminal blink the real one.
+* **Hardware cursor.** When a `Text` widget is focused, the host
+  sets the buffer's `show_cursors=true` and positions the primary
+  cursor to the byte the renderer emitted in
+  `RenderOutput::focus_cursor`. Multi-line `Text` publishes the
+  cursor as `(buffer_row, byte_in_row)` (row relative to the
+  widget's first rendered entry, including the optional label
+  row); single-line publishes `(0, byte_in_row)`. When focus is
+  on a non-text widget, `show_cursors=false` and the hardware
+  cursor disappears entirely. Don't paint a cursor overlay in the
+  renderer — let the terminal blink the real one.
 * **Width calculation.** `widget_panel_width()` returns
   `viewport.width - 2` for gutter/scrollbar/border slack. Your
   widget can use the full result via `panel_width` parameter; flex
@@ -376,8 +404,8 @@ those are done.
   you all the call sites.
 * **Printable-letter `defineMode` bindings shadow widget input.**
   A plugin binding `"x"` to a widget command in `defineMode` will
-  swallow the lowercase `x` in every focused TextInput / TextArea
-  on the same panel — the binding fires before the input character
+  swallow the lowercase `x` in every focused `Text` widget on the
+  same panel — the binding fires before the input character
   stream gets the keypress. Use Space (host-dispatched on focused
   widget kind) or a non-letter key for widget commands; reserve
   letter bindings for non-text-input panels.
@@ -468,9 +496,17 @@ do paint everywhere.
   calls so one panicking renderer paints a placeholder + logs a
   `RenderError` instead of taking down the whole panel. Pure host
   work; doesn't depend on §4.5 deferred items.
-* **IME composition in TextInput.** `mode_text_input` already
-  delivers composed text but the widget cursor model doesn't
-  track composition states. Needed for international input.
+* **IME composition — preedit display.** Committed-text path
+  shipped (one shared `apply_text_char` for single-line and
+  multi-line `Text`, regression-tested for multi-byte codepoints
+  and multi-event commits). Preedit display still needs the input
+  layer to surface composition events first — `server/input_parser.rs`
+  doesn't parse the kitty-keyboard / bracketed-IME extensions
+  yet. Once it does, the widget runtime gains a `preedit` field
+  on `WidgetInstanceState::Text` plus a `compose` entry point
+  parallel to `apply_text_char`, and the renderer paints the
+  underline; both single-line and multi-line widgets get it
+  uniformly.
 * **Built-in chord support inside widgets.** Today
   `apply_text_input_key` only handles single-key edits; chords
   (`g g`) still bubble to the plugin's `defineMode`.
@@ -525,10 +561,9 @@ when real demand surfaces.
 | `HintBar` | ✅ migrated | every plugin's footer | `parseHintString` for legacy `Tab:foo  Esc:bar` strings |
 | `Toggle` / `Checkbox` | ✅ migrated | search_replace toggles | `[v]`/`[ ]` glyph + label |
 | `Button` | ✅ migrated | search_replace Replace All | `intent: "normal" \| "primary" \| "danger"` |
-| `TextInput` | ✅ migrated | search_replace fields | host-owned cursor + value, constant-width with scroll, hardware caret |
+| `Text` | ✅ migrated | search_replace fields (single-line); composer-style plugins (multi-line) | unified single-/multi-line widget; `rows: 1` (default) is single-line (`[value]` rendering, Enter-advances-focus, head-truncate scroll); `rows >= 2` is multi-line (block rendering, Enter-inserts-newline, line nav, vertical scroll). Host owns value + cursor + scroll; hardware cursor positioned by host. Builders: `text({ rows })` + ergonomic `textInput(value, opts)` / `textArea(opts)` wrappers |
 | `List` (virtual-scrolled) | ✅ | candidates for finder-style consumers | host owns scroll + selection |
 | `Tree` | ✅ migrated | search_replace match tree, audit, file-explorer | host owns scroll + selection + expansion; disclosure-glyph hit area; opt-in per-row checkboxes (`checkable: true` + `treeNode.checked: Some(_)`) with `toggle` events from glyph clicks or Space, persisted via `WidgetMutation::SetCheckedKeys` |
-| `TextArea` | ✅ | composer-style plugins | multi-line; host-owned value + cursor + vertical scroll; submit policy via panel HintBar |
 | `Tabs` / `Group` | ⏸ | (no current consumer) | skipped; revisit when needed |
 | `Layer` (compositor) | ❌ → §4.1 | tooltips, popovers, modals; subsumes Popup/Prompt | big architectural piece |
 | `Prompt` | ❌ → §4.1 | finder, every confirm | built on Layer |
@@ -570,10 +605,12 @@ type WidgetSpec =
   | { kind: "hintBar"; entries: HintEntry[]; key?: string }
   | { kind: "toggle"; checked: boolean; label: string; focused: boolean; key?: string }
   | { kind: "button"; label: string; focused: boolean; intent: ButtonKind; key?: string }
-  | { kind: "textInput"; value: string; cursorByte: number; focused: boolean; label?: string;
-        placeholder?: string | null; maxVisibleChars: number; fieldWidth: number; key?: string }
-  | { kind: "textArea"; value: string; cursorByte: number; focused: boolean;
-        visibleRows: number; key?: string }
+  | { kind: "text"; value: string; cursorByte: number; focused: boolean;
+        label?: string; placeholder?: string | null;
+        rows: number;            // 1 = single-line, >= 2 = multi-line
+        fieldWidth: number;      // 0 = auto-fit (single) / panel width (multi)
+        maxVisibleChars: number; // single-line soft cap; ignored when rows >= 2
+        key?: string }
   | { kind: "list"; items: TextPropertyEntry[]; itemKeys: string[];
         selectedIndex: number; visibleRows: number; key?: string }
   | { kind: "tree"; nodes: TreeNode[]; itemKeys: string[];
@@ -717,7 +754,10 @@ keystrokes to the right action based on the focused widget's kind.
    keys to `dispatch(widgetKey("Tab"))` etc.)
 2. The smart-key dispatcher in `handle_widget_key`, which routes to
    `handle_widget_focus_advance` / `handle_widget_activate` /
-   `handle_widget_select_move` / `handle_widget_text_input_*`.
+   `handle_widget_select_move` / `handle_widget_text_key` /
+   `handle_widget_text_char`. Single-line vs multi-line `Text`
+   selects automatically inside `handle_widget_text_key` via the
+   focused widget's `rows` field.
 
 **Dispatch order intended**:
 1. Global resolver
@@ -734,9 +774,9 @@ shortcut would let plugins skip the boilerplate.
 ### Terminal constraint
 
 Shift+Enter ≡ Enter at the terminal, Shift+Alt+Enter ≡ Alt+Enter.
-We do not bind Shift+Enter as a distinct key. `TextArea` (when
-shipped) submit defaults to Alt+Enter; the chosen key string shows
-in the panel's HintBar.
+We do not bind Shift+Enter as a distinct key. Multi-line `Text`
+submit defaults to Alt+Enter (Enter inserts a newline); the chosen
+key string shows in the panel's HintBar.
 
 ---
 
@@ -759,8 +799,9 @@ buffer_col)`; it receives semantic events.
   `{}`; List → `{ index, key }`; Tree row select → `{ index, key }`;
   Tree disclosure → `expand` event; Tree checkbox glyph (only when
   `checkable: true` and the row's `checked` is `Some(_)`) →
-  `toggle` event with `{ key, index, checked: <new> }`; TextInput →
-  `{ value, cursorByte }`.
+  `toggle` event with `{ key, index, checked: <new> }`; `Text` →
+  `{ value, cursorByte }` (same payload regardless of single-line
+  vs multi-line).
 * Wheel scroll routed to the panel under the cursor: `mouse_input.rs`
   calls into the widget runtime before falling through to buffer
   scroll. The first scrollable widget in the panel shifts its
@@ -788,9 +829,10 @@ applies a minimal patch.
 
 **Implemented**:
 * Spec/instance separation: `WidgetInstanceState` holds host-owned
-  state per widget key (TextInput value+cursor, List
-  scroll+selection). The spec carries initial values; instance
-  state is the truth after first render.
+  state per widget key (`Text` value+cursor+scroll, `List`
+  scroll+selection, `Tree` scroll+selection+expanded_keys). The
+  spec carries initial values; instance state is the truth after
+  first render.
 * Stable `key` round-trip: re-emitting the spec preserves instance
   state by key.
 * Re-render after host-side state changes: `rerender_widget_panel`


### PR DESCRIPTION
## Summary

This PR consolidates the separate `TextInput` and `TextArea` widget variants into a single unified `Text` widget that selects single-line vs multi-line behavior based on a `rows` parameter. This reduces API surface area, simplifies widget dispatch logic, and provides a cleaner abstraction for text editing across the editor and plugins.

## Key Changes

### Core Widget API (`fresh-core`)
- Replaced `WidgetSpec::TextInput` and `WidgetSpec::TextArea` variants with a single `WidgetSpec::Text` variant
- `Text` widget uses `rows: u32` field (default 1) to select behavior:
  - `rows == 1`: single-line mode (renders as `[value]`, Enter advances focus, head-truncate scroll)
  - `rows > 1`: multi-line mode (block rendering, Enter inserts newline, line navigation, vertical scroll)
- Updated `WidgetInstanceState` to use unified `Text` variant with `value`, `cursor_byte`, and `scroll` fields
- Added `apply_text_char()` helper for printable character insertion (shared by both modes)
- Added `apply_text_key()` dispatcher that routes to single-line or multi-line key handlers based on `multiline` parameter

### Editor Dispatch (`plugin_dispatch.rs`)
- Introduced `FocusedText` struct to snapshot focused text widget state (value, cursor, scroll, multiline flag) for round-tripping through mutations
- Renamed `handle_widget_text_input_key()` → `handle_widget_text_key()` and `handle_widget_text_input_char()` → `handle_widget_text_char()`
- Consolidated separate `TextInput` and `TextArea` match arms throughout dispatch logic into single `Text` arms that branch on `rows > 1`
- Simplified `SetValue` mutation to preserve scroll offset across updates without re-walking spec/instance state
- Updated Enter key handling to check `rows > 1` at dispatch time rather than widget type

### Widget Rendering (`render.rs`)
- Single `WidgetSpec::Text` arm dispatches to internal `render_text_input()` or `render_text_area()` based on `rows > 1`
- Both internal renderers remain as testable units but unified at the spec layer
- Multi-line rendering now preserves scroll state across mutations

### Plugin Library (`lib/widgets.ts`)
- Added unified `text()` helper function with `rows` parameter
- Kept `textInput()` and `textArea()` as convenience wrappers that call `text()` with appropriate `rows` value
- Updated TypeScript definitions to reflect unified `Text` variant

### Plugin Updates
- **git_log.ts**: Migrated from custom cursor tracking to List widget with native selection/scroll handling; toolbar now uses Button widgets in a Row instead of custom click regions
- **pkg.ts**: Migrated list rendering to use List widget; footer uses HintBar widget for keyboard hints
- **theme_editor.ts**: Added footer panel using HintBar widget

## Implementation Details

- The `multiline` flag is captured at read time and passed through to `apply_text_key()` so single-line vs multi-line semantics select correctly without re-querying the spec
- Scroll offset is preserved across plugin-driven mutations to prevent viewport snapping in multi-line widgets
- The renderer re-clamps scroll on the next render anyway, so preserving stale values is safe
- All existing single-line and multi-line key handling logic is preserved; only the dispatch routing and state representation changed

https://claude.ai/code/session_014H6iXqpzBQXVCrfiS65512