### PR TITLE
Move per-window state from Editor to Window struct

### DIFF
--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -13,12 +13,12 @@ use crate::model::event::{Event, LeafId};
 
 use super::Editor;
 
-impl Editor {
+impl crate::app::window::Window {
     /// Convert an action into a list of events to apply to the active buffer
     /// Returns None for actions that don't generate events (like Quit)
     pub fn action_to_events(&mut self, action: Action) -> Option<Vec<Event>> {
-        let auto_indent = self.config.editor.auto_indent;
-        let estimated_line_length = self.config.editor.estimated_line_length;
+        let auto_indent = self.config().editor.auto_indent;
+        let estimated_line_length = self.config().editor.estimated_line_length;
 
         // Use the *effective* active split: when the user is focused on an
         // inner panel of a grouped buffer (e.g. a magit-style review panel),
@@ -28,9 +28,8 @@ impl Editor {
         // group host's.
         let active_split = self.effective_active_split();
         let viewport_height = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
+            .splits
+            .as_ref()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&active_split)
@@ -63,15 +62,10 @@ impl Editor {
         }
 
         let buffer_id = self.active_buffer();
-        let active_id = self.active_window;
-        // Single &mut borrow on the active window, split-access into
-        // disjoint sub-fields (buffers + split-view-state cursors).
-        let window = self
-            .windows
-            .get_mut(&active_id)
-            .expect("active window must exist");
-        let state = window.buffers.get_mut(&buffer_id).unwrap();
-        let cursors = &mut window
+        // Split-access disjoint sub-fields (buffers + split-view-state cursors)
+        // directly on self (we ARE the active window).
+        let state = self.buffers.get_mut(&buffer_id).unwrap();
+        let cursors = &mut self
             .splits
             .as_mut()
             .expect("active window must have a populated split layout")
@@ -127,19 +121,17 @@ impl Editor {
         let delta = (viewport_height.saturating_sub(overlap).max(1) as isize) * direction;
 
         let old_top_byte = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
+            .splits
+            .as_ref()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&split_id)?
             .viewport
             .top_byte;
-        self.active_window_mut().handle_scroll_event(delta);
+        self.handle_scroll_event(delta);
         let new_top_byte = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
+            .splits
+            .as_ref()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&split_id)?
@@ -159,9 +151,8 @@ impl Editor {
         // viewport) and each press advances by exactly a full page of view
         // rows — the same way it does when line wrap is off.
         let cursors = &self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
+            .splits
+            .as_ref()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .get(&split_id)?
@@ -228,16 +219,16 @@ impl Editor {
             // When line wrapping is off, Home/End should move to the physical line
             // start/end, not the visual (horizontally-scrolled) row boundary.
             // Fall through to the standard handler which uses line_iterator.
-            Action::MoveLineEnd if self.config.editor.line_wrap => {
+            Action::MoveLineEnd if self.config().editor.line_wrap => {
                 VisualAction::LineEnd { is_select: false }
             }
-            Action::SelectLineEnd if self.config.editor.line_wrap => {
+            Action::SelectLineEnd if self.config().editor.line_wrap => {
                 VisualAction::LineEnd { is_select: true }
             }
-            Action::MoveLineStart if self.config.editor.line_wrap => {
+            Action::MoveLineStart if self.config().editor.line_wrap => {
                 VisualAction::LineStart { is_select: false }
             }
-            Action::SelectLineStart if self.config.editor.line_wrap => {
+            Action::SelectLineStart if self.config().editor.line_wrap => {
                 VisualAction::LineStart { is_select: true }
             }
             _ => return None, // Not a visual line action
@@ -251,21 +242,14 @@ impl Editor {
             let active_split = self.effective_active_split();
             let active_buffer = self.active_buffer();
             let cursors = &self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
+                .splits
+                .as_ref()
                 .map(|(_, vs)| vs)
                 .expect("active window must have a populated split layout")
                 .get(&active_split)
                 .unwrap()
                 .cursors;
-            let state = self
-                .windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-                .get(&active_buffer)
-                .unwrap();
+            let state = (&self.buffers).get(&active_buffer).unwrap();
             cursors
                 .iter()
                 .map(|(cursor_id, cursor)| {
@@ -339,7 +323,7 @@ impl Editor {
 
                     // Calculate current visual column from cached layout
                     let current_visual_col = self
-                        .active_layout()
+                        .layout_cache
                         .byte_to_visual_column(split_id, from_pos)?;
 
                     let goal_visual_col = if sticky_column > 0 {
@@ -348,7 +332,7 @@ impl Editor {
                         current_visual_col
                     };
 
-                    match self.active_layout().move_visual_line(
+                    match self.layout_cache.move_visual_line(
                         split_id,
                         from_pos,
                         goal_visual_col,
@@ -384,7 +368,7 @@ impl Editor {
                     // Allow advancing to next visual segment only if not at a physical line ending
                     let allow_advance = !at_line_ending;
                     match self
-                        .active_layout()
+                        .layout_cache
                         .visual_line_end(split_id, position, allow_advance)
                     {
                         Some(end_pos) => (end_pos, 0),
@@ -395,7 +379,7 @@ impl Editor {
                     // Allow advancing to previous visual segment only if not at a physical line start
                     let allow_advance = !at_line_start;
                     match self
-                        .active_layout()
+                        .layout_cache
                         .visual_line_start(split_id, position, allow_advance)
                     {
                         Some(start_pos) => (start_pos, 0),
@@ -470,7 +454,7 @@ impl Editor {
         direction: i8,
         estimated_line_length: usize,
     ) -> Option<(usize, usize)> {
-        if !self.config.editor.line_wrap {
+        if !self.config().editor.line_wrap {
             // Non-wrap mode: the byte-based fallback is correct, let it run.
             return None;
         }
@@ -483,19 +467,12 @@ impl Editor {
             // authoritative "end of current visual row" position that the
             // renderer itself uses.
             let cur_row_line_end = {
-                let mappings = self.active_layout().view_line_mappings.get(&active_split)?;
-                let row_idx = self
-                    .active_layout()
-                    .find_visual_row(active_split, from_pos)?;
+                let mappings = self.layout_cache.view_line_mappings.get(&active_split)?;
+                let row_idx = self.layout_cache.find_visual_row(active_split, from_pos)?;
                 mappings.get(row_idx)?.line_end_byte
             };
 
-            let state = self
-                .windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .get_mut(&active_buffer)?;
+            let state = (&mut self.buffers).get_mut(&active_buffer)?;
             let buffer = &mut state.buffer;
             let buffer_len = buffer.len();
             if cur_row_line_end >= buffer_len {
@@ -546,10 +523,8 @@ impl Editor {
             // stepping back one byte lands on the previous line's
             // trailing newline — again the end of its last visual row.
             let (cur_row_anchor, row_is_empty) = {
-                let mappings = self.active_layout().view_line_mappings.get(&active_split)?;
-                let row_idx = self
-                    .active_layout()
-                    .find_visual_row(active_split, from_pos)?;
+                let mappings = self.layout_cache.view_line_mappings.get(&active_split)?;
+                let row_idx = self.layout_cache.find_visual_row(active_split, from_pos)?;
                 let row = mappings.get(row_idx)?;
                 match row.char_source_bytes.iter().find_map(|b| *b) {
                     Some(start) => (start, false),
@@ -570,12 +545,7 @@ impl Editor {
             // the user wouldn't expect (issue #1574, Windows-CRLF
             // variant).  For LF or a lone CR the byte arithmetic falls
             // through to a one-byte step.
-            let state = self
-                .windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .get_mut(&active_buffer)?;
+            let state = (&mut self.buffers).get_mut(&active_buffer)?;
             let buffer = &mut state.buffer;
             let _ = row_is_empty;
             let target_pos = step_before_line_break(buffer, cur_row_anchor);

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -1,9 +1,12 @@
-//! Active-buffer / active-split focus management on `Editor`.
+//! Active-buffer / active-split focus management.
 //!
-//! `set_active_buffer` and `focus_split` are the centralized methods for
-//! switching what the user is looking at. Both fire several invariants:
-//! split manager updates, tab list updates, file-explorer sync, terminal
-//! buffer resume, semantic-token cleanup for deleted buffers, etc.
+//! `set_active_buffer` and `focus_split` are the centralized methods
+//! for switching what the user is looking at. The Window-side methods
+//! own the per-window state mutation (split manager, view states, tab
+//! list, terminal-mode toggles, focus history); the thin `impl Editor`
+//! wrappers orchestrate the editor-scoped side-effects that can't yet
+//! be expressed without an `Editor` reference (terminal-buffer sync,
+//! file-explorer follow, plugin state snapshot, plugin hook).
 //!
 //! ## Pane-buffer invariant
 //!
@@ -14,78 +17,139 @@
 //! (notably `apply_event_to_active_buffer`) index one using the other
 //! without re-validating.
 //!
-//! All writes to this fact MUST go through [`Editor::set_pane_buffer`]
+//! All writes to this fact MUST go through [`Window::set_pane_buffer`]
 //! (or the higher-level wrappers `set_active_buffer` / `focus_split`
 //! that call it). Raw `split_manager.set_split_buffer` /
 //! `split_manager.set_active_buffer_id` calls updated only one side,
 //! which caused issue #1620 (a `None.unwrap()` panic when clicking
 //! after a buffer was closed from another split).
 
+use super::window::Window;
 use super::*;
 
-impl Editor {
-    // `set_pane_buffer` moved to `impl Window`. Editor callers reach
-    // it via `self.active_window_mut().set_pane_buffer(...)`.
+/// Result of [`Window::set_active_buffer`] describing the side-effects
+/// the Editor orchestrator must apply after the per-window state has
+/// already been mutated.
+///
+/// The Window method drains all the per-window work (focus loss, prompt
+/// cancel, split/view-state updates, terminal-mode toggles, tab
+/// visibility) directly. The fields below flag deferred cross-cutting
+/// effects that the Editor wrapper handles, since they reach state
+/// outside the Window (filesystem, plugin runtime, file-explorer
+/// follow target).
+#[must_use]
+pub(super) struct ActiveBufferChange {
+    pub buffer_id: BufferId,
+    /// Switched to a terminal buffer in read-only view mode (i.e.
+    /// not resuming live terminal input). The Editor must sync the
+    /// terminal's backing file into the buffer.
+    pub sync_terminal_readonly: bool,
+    /// Caller should ask the file explorer to follow the new active
+    /// file. Already gated by `file_explorer_visible`,
+    /// `config.file_explorer.follow_active_buffer`, and "key context
+    /// isn't the file explorer itself."
+    pub sync_file_explorer: bool,
+}
 
-    /// Set the active buffer and trigger all necessary side effects
+/// Result of [`Window::focus_split`].
+#[must_use]
+pub(super) enum FocusSplitOutcome {
+    /// Click was on a non-scrollable buffer-group panel, or the
+    /// inner-leaf focus path completed without changing the active
+    /// pane-buffer. No further work for Editor.
+    Handled,
+    /// "Same split, different buffer" — fall through to the full
+    /// active-buffer orchestration so the deferred deps (terminal
+    /// sync, file-explorer follow, plugin snapshot/hook) fire.
+    DelegateToActiveBuffer(BufferId),
+}
+
+impl Editor {
+    /// Set the active buffer and trigger all necessary side effects.
     ///
-    /// This is the centralized method for switching buffers. It:
-    /// - Updates split manager (single source of truth for active buffer)
-    /// - Adds buffer to active split's tabs (if not already there)
-    /// - Syncs file explorer to the new active file (if visible)
-    ///
-    /// Use this instead of directly calling split_manager.set_active_buffer_id()
-    /// to ensure all side effects happen consistently.
+    /// This is the centralized method for switching buffers. Window-side
+    /// state mutation lives in [`Window::set_active_buffer`]; this thin
+    /// wrapper handles the editor-scoped follow-ups.
     pub(super) fn set_active_buffer(&mut self, buffer_id: BufferId) {
+        let Some(change) = self.active_window_mut().set_active_buffer(buffer_id) else {
+            return;
+        };
+        self.apply_active_buffer_change(change);
+    }
+
+    fn apply_active_buffer_change(&mut self, change: ActiveBufferChange) {
+        if change.sync_terminal_readonly {
+            self.sync_terminal_to_buffer(change.buffer_id);
+        }
+        if change.sync_file_explorer {
+            self.sync_file_explorer_to_active_file();
+        }
+        // Update plugin state snapshot BEFORE firing the hook so that
+        // the handler sees the new active buffer, not the old one.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
+        self.plugin_manager.read().unwrap().run_hook(
+            "buffer_activated",
+            crate::services::plugins::hooks::HookArgs::BufferActivated {
+                buffer_id: change.buffer_id,
+            },
+        );
+    }
+
+    /// Focus a split and its buffer, handling all side effects including
+    /// terminal mode. Window-side body in [`Window::focus_split`].
+    pub(super) fn focus_split(&mut self, split_id: LeafId, buffer_id: BufferId) {
+        match self.active_window_mut().focus_split(split_id, buffer_id) {
+            FocusSplitOutcome::Handled => {}
+            FocusSplitOutcome::DelegateToActiveBuffer(target) => {
+                self.set_active_buffer(target);
+            }
+        }
+    }
+}
+
+impl Window {
+    /// Window-side body of `set_active_buffer`. Mutates per-window state
+    /// (focus loss, prompt cancel, split manager, view-state, terminal
+    /// mode toggle, tab visibility) and returns an [`ActiveBufferChange`]
+    /// describing the deferred Editor-side side-effects, or `None` if
+    /// the requested buffer is already active.
+    pub(super) fn set_active_buffer(&mut self, buffer_id: BufferId) -> Option<ActiveBufferChange> {
         if self.active_buffer() == buffer_id {
-            return; // No change
+            return None;
         }
 
         // Dismiss transient popups and clear hover state when switching buffers
-        self.active_window_mut().on_editor_focus_lost();
+        self.on_editor_focus_lost();
 
         // Cancel search/replace prompts when switching buffers
         // (they are buffer-specific and don't make sense across buffers)
-        self.active_window_mut().cancel_search_prompt_if_active();
+        self.cancel_search_prompt_if_active();
 
         // Track the previous buffer for "Switch to Previous Tab" command
         let previous = self.active_buffer();
 
         // If leaving a terminal buffer while in terminal mode, remember it should resume
-        if self.active_window().terminal_mode && self.active_window().is_terminal_buffer(previous) {
-            self.active_window_mut()
-                .terminal_mode_resume
-                .insert(previous);
-            self.active_window_mut().terminal_mode = false;
-            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
+        if self.terminal_mode && self.is_terminal_buffer(previous) {
+            self.terminal_mode_resume.insert(previous);
+            self.terminal_mode = false;
+            self.key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Capture the previous focus target BEFORE set_pane_buffer runs,
         // so the LRU records the right thing.
-        let active_split = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .active_split();
-        let previous_target = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(_, vs)| vs)
-            .expect("active window must have a populated split layout")
-            .get(&active_split)
-            .map(|vs| vs.active_target());
+        let (mgr, vs) = self
+            .splits
+            .as_ref()
+            .expect("active window must have a populated split layout");
+        let active_split = mgr.active_split();
+        let previous_target = vs.get(&active_split).map(|vs| vs.active_target());
 
         // Atomic pane-buffer update: tree + SVS in lockstep.
-        self.active_window_mut()
-            .set_pane_buffer(active_split, buffer_id);
+        self.set_pane_buffer(active_split, buffer_id);
 
         if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
+            .split_view_states_mut()
             .expect("active window must have a populated split layout")
             .get_mut(&active_split)
         {
@@ -98,18 +162,12 @@ impl Editor {
         }
 
         // If switching to a terminal buffer that should resume terminal mode, re-enter it
-        if self
-            .active_window()
-            .terminal_mode_resume
-            .contains(&buffer_id)
-            && self.active_window().is_terminal_buffer(buffer_id)
-        {
-            self.active_window_mut().terminal_mode = true;
-            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
-        } else if self.active_window().is_terminal_buffer(buffer_id) {
-            // Switching to terminal in read-only mode - sync buffer to show current terminal content
-            // This ensures the backing file content and cursor position are up to date
-            self.sync_terminal_to_buffer(buffer_id);
+        let resume_terminal_mode =
+            self.terminal_mode_resume.contains(&buffer_id) && self.is_terminal_buffer(buffer_id);
+        let sync_terminal_readonly = !resume_terminal_mode && self.is_terminal_buffer(buffer_id);
+        if resume_terminal_mode {
+            self.terminal_mode = true;
+            self.key_context = crate::input::keybindings::KeyContext::Terminal;
         }
 
         // Window resize events only resize terminals that are currently the
@@ -118,53 +176,41 @@ impl Editor {
         // sees the new size, so its PTY child keeps reporting stale
         // dimensions when the user switches back. Re-running the visible
         // resize here picks up the now-revealed terminal. Issue #1795.
-        if self.active_window().is_terminal_buffer(buffer_id) {
-            self.active_window_mut().resize_visible_terminals();
+        if self.is_terminal_buffer(buffer_id) {
+            self.resize_visible_terminals();
         }
 
         // Ensure the newly active tab is visible
-        let tabs_width = self.active_window().effective_tabs_width();
-        self.active_window_mut()
-            .ensure_active_tab_visible(active_split, buffer_id, tabs_width);
+        let tabs_width = self.effective_tabs_width();
+        self.ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 
-        if self.file_explorer_visible()
-            && self.config.file_explorer.follow_active_buffer
-            && self.active_window_mut().key_context
-                != crate::input::keybindings::KeyContext::FileExplorer
-        {
-            self.sync_file_explorer_to_active_file();
-        }
+        let sync_file_explorer = self.file_explorer_visible
+            && self.resources.config.file_explorer.follow_active_buffer
+            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer;
 
-        // Update plugin state snapshot BEFORE firing the hook so that
-        // the handler sees the new active buffer, not the old one.
-        #[cfg(feature = "plugins")]
-        self.update_plugin_state_snapshot();
-
-        // Emit buffer_activated hook for plugins
-        self.plugin_manager.read().unwrap().run_hook(
-            "buffer_activated",
-            crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
-        );
+        Some(ActiveBufferChange {
+            buffer_id,
+            sync_terminal_readonly,
+            sync_file_explorer,
+        })
     }
 
-    /// Focus a split and its buffer, handling all side effects including terminal mode.
-    ///
-    /// This is the primary method for switching focus between splits via mouse clicks.
-    /// It handles:
-    /// - Exiting terminal mode when leaving a terminal buffer
-    /// - Updating split manager state
-    /// - Managing tab state and previous buffer tracking
-    /// - Syncing file explorer
-    ///
-    /// Use this instead of calling set_active_split directly when switching focus.
-    pub(super) fn focus_split(&mut self, split_id: LeafId, buffer_id: BufferId) {
+    /// Window-side body of `focus_split`. Returns a [`FocusSplitOutcome`]
+    /// indicating whether the caller should fall through to the full
+    /// active-buffer orchestration (for the "same split, different
+    /// buffer" branch which needs the deferred Editor side-effects).
+    pub(super) fn focus_split(
+        &mut self,
+        split_id: LeafId,
+        buffer_id: BufferId,
+    ) -> FocusSplitOutcome {
         // Fixed buffer-group panels (toolbars, headers, footers) aren't focus
         // targets: focusing them would route keyboard input at an invisible
         // cursor. Plugins can still detect clicks via the mouse_click hook,
         // which fires in the click handlers before reaching here. Scrollable
         // panels still receive focus even with a hidden cursor.
-        if self.active_window().is_non_scrollable_buffer(buffer_id) {
-            return;
+        if self.is_non_scrollable_buffer(buffer_id) {
+            return FocusSplitOutcome::Handled;
         }
 
         // Clicking a buffer pane (e.g. a tab) explicitly moves focus to
@@ -173,18 +219,15 @@ impl Editor {
         // subsequent keystrokes target the buffer. The terminal branch
         // below can still upgrade to KeyContext::Terminal when needed.
         // Issue #1540.
-        if self.active_window_mut().key_context
-            == crate::input::keybindings::KeyContext::FileExplorer
-        {
-            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
+        if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
+            self.key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         let previous_split = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
+            .splits
+            .as_ref()
             .expect("active window must have a populated split layout")
+            .0
             .active_split();
         let previous_buffer = self.active_buffer(); // Get BEFORE changing split
         let split_changed = previous_split != split_id;
@@ -192,8 +235,7 @@ impl Editor {
         // Preview is anchored to the split it was opened in. Moving focus to
         // a different split commits the preview — walking away is commitment.
         if split_changed {
-            self.active_window_mut()
-                .promote_preview_if_not_in_split(split_id);
+            self.promote_preview_if_not_in_split(split_id);
         }
 
         // If `split_id` is not in the main split tree, it must be an inner
@@ -202,19 +244,17 @@ impl Editor {
         // split remains active). Instead, find the host split and update
         // its `focused_group_leaf` marker so `active_buffer()` routes to
         // the clicked inner panel buffer.
-        if !self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
+        let in_main_tree = self
+            .splits
+            .as_ref()
             .expect("active window must have a populated split layout")
+            .0
             .root()
             .leaf_split_ids()
-            .contains(&split_id)
-        {
+            .contains(&split_id);
+        if !in_main_tree {
             // Find which group contains this inner leaf.
-            let host_split = self
-                .active_window()
+            let group_leaf_id = self
                 .grouped_subtrees
                 .iter()
                 .find(|(_, node)| {
@@ -224,29 +264,24 @@ impl Editor {
                         false
                     }
                 })
-                .map(|(group_leaf_id, _)| *group_leaf_id)
-                .and_then(|group_leaf_id| {
-                    // Find the split whose open_buffers has this group tab.
-                    self.windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.splits.as_ref())
-                        .map(|(_, vs)| vs)
-                        .expect("active window must have a populated split layout")
-                        .iter()
-                        .find(|(_, vs)| vs.has_group(group_leaf_id))
-                        .map(|(sid, _)| (*sid, group_leaf_id))
-                });
+                .map(|(group_leaf_id, _)| *group_leaf_id);
+            let host_split = group_leaf_id.and_then(|group_leaf_id| {
+                // Find the split whose open_buffers has this group tab.
+                self.splits
+                    .as_ref()
+                    .expect("active window must have a populated split layout")
+                    .1
+                    .iter()
+                    .find(|(_, vs)| vs.has_group(group_leaf_id))
+                    .map(|(sid, _)| (*sid, group_leaf_id))
+            });
 
             if let Some((host, group_leaf_id)) = host_split {
-                self.windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_manager_mut())
+                self.split_manager_mut()
                     .expect("active window must have a populated split layout")
                     .set_active_split(host);
                 if let Some(vs) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
+                    .split_view_states_mut()
                     .expect("active window must have a populated split layout")
                     .get_mut(&host)
                 {
@@ -254,17 +289,14 @@ impl Editor {
                     vs.focused_group_leaf = Some(split_id);
                 }
                 if let Some(inner_vs) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
+                    .split_view_states_mut()
                     .expect("active window must have a populated split layout")
                     .get_mut(&split_id)
                 {
                     inner_vs.switch_buffer(buffer_id);
                 }
-                self.active_window_mut().key_context =
-                    crate::input::keybindings::KeyContext::Normal;
-                return;
+                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                return FocusSplitOutcome::Handled;
             }
             // Fall through: we couldn't find the group; the original path
             // will set_active_split which will fail silently.
@@ -272,18 +304,13 @@ impl Editor {
 
         if split_changed {
             // Switching to a different split - exit terminal mode if active
-            if self.active_window().terminal_mode
-                && self.active_window().is_terminal_buffer(previous_buffer)
-            {
-                self.active_window_mut().terminal_mode = false;
-                self.active_window_mut().key_context =
-                    crate::input::keybindings::KeyContext::Normal;
+            if self.terminal_mode && self.is_terminal_buffer(previous_buffer) {
+                self.terminal_mode = false;
+                self.key_context = crate::input::keybindings::KeyContext::Normal;
             }
 
             // Update split manager to focus this split
-            self.windows
-                .get_mut(&self.active_window)
-                .and_then(|w| w.split_manager_mut())
+            self.split_manager_mut()
                 .expect("active window must have a populated split layout")
                 .set_active_split(split_id);
 
@@ -291,30 +318,23 @@ impl Editor {
             // the previous pair of split_manager.set_active_buffer_id +
             // view_state.switch_buffer that could desync if either leg
             // silently no-op'd (issue #1620).
-            self.active_window_mut()
-                .set_pane_buffer(split_id, buffer_id);
+            self.set_pane_buffer(split_id, buffer_id);
 
             // Set key context based on target buffer type
-            if self.active_window().is_terminal_buffer(buffer_id) {
-                self.active_window_mut().terminal_mode = true;
-                self.active_window_mut().key_context =
-                    crate::input::keybindings::KeyContext::Terminal;
+            if self.is_terminal_buffer(buffer_id) {
+                self.terminal_mode = true;
+                self.key_context = crate::input::keybindings::KeyContext::Terminal;
             } else {
                 // Ensure key context is Normal when focusing a non-terminal buffer
                 // This handles the case of clicking on editor from FileExplorer context
-                self.active_window_mut().key_context =
-                    crate::input::keybindings::KeyContext::Normal;
+                self.key_context = crate::input::keybindings::KeyContext::Normal;
             }
 
             // Handle buffer change side effects
             if previous_buffer != buffer_id {
-                self.active_window_mut()
-                    .position_history
-                    .commit_pending_movement();
+                self.position_history.commit_pending_movement();
                 if let Some(view_state) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
+                    .split_view_states_mut()
                     .expect("active window must have a populated split layout")
                     .get_mut(&split_id)
                 {
@@ -324,9 +344,13 @@ impl Editor {
                 // Note: We don't sync file explorer here to avoid flicker during split focus changes.
                 // File explorer syncs when explicitly focused via focus_file_explorer().
             }
+            FocusSplitOutcome::Handled
         } else {
-            // Same split, different buffer (tab switch) - use set_active_buffer for terminal resume
-            self.set_active_buffer(buffer_id);
+            // Same split, different buffer (tab switch) — defer to the
+            // full set_active_buffer orchestration so the deferred deps
+            // (terminal sync, file-explorer follow, plugin snapshot/hook)
+            // run.
+            FocusSplitOutcome::DelegateToActiveBuffer(buffer_id)
         }
     }
 }

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -119,7 +119,7 @@ impl Editor {
         // dimensions when the user switches back. Re-running the visible
         // resize here picks up the now-revealed terminal. Issue #1795.
         if self.active_window().is_terminal_buffer(buffer_id) {
-            self.resize_visible_terminals();
+            self.active_window_mut().resize_visible_terminals();
         }
 
         // Ensure the newly active tab is visible

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -27,30 +27,6 @@
 use super::window::Window;
 use super::*;
 
-/// Result of [`Window::set_active_buffer`] describing the side-effects
-/// the Editor orchestrator must apply after the per-window state has
-/// already been mutated.
-///
-/// The Window method drains all the per-window work (focus loss, prompt
-/// cancel, split/view-state updates, terminal-mode toggles, tab
-/// visibility) directly. The fields below flag deferred cross-cutting
-/// effects that the Editor wrapper handles, since they reach state
-/// outside the Window (filesystem, plugin runtime, file-explorer
-/// follow target).
-#[must_use]
-pub(super) struct ActiveBufferChange {
-    pub buffer_id: BufferId,
-    /// Switched to a terminal buffer in read-only view mode (i.e.
-    /// not resuming live terminal input). The Editor must sync the
-    /// terminal's backing file into the buffer.
-    pub sync_terminal_readonly: bool,
-    /// Caller should ask the file explorer to follow the new active
-    /// file. Already gated by `file_explorer_visible`,
-    /// `config.file_explorer.follow_active_buffer`, and "key context
-    /// isn't the file explorer itself."
-    pub sync_file_explorer: bool,
-}
-
 /// Result of [`Window::focus_split`].
 #[must_use]
 pub(super) enum FocusSplitOutcome {
@@ -59,41 +35,31 @@ pub(super) enum FocusSplitOutcome {
     /// pane-buffer. No further work for Editor.
     Handled,
     /// "Same split, different buffer" — fall through to the full
-    /// active-buffer orchestration so the deferred deps (terminal
-    /// sync, file-explorer follow, plugin snapshot/hook) fire.
+    /// active-buffer orchestration (`Editor::set_active_buffer`) so
+    /// the editor-wide plugin snapshot + hook fire.
     DelegateToActiveBuffer(BufferId),
 }
 
 impl Editor {
     /// Set the active buffer and trigger all necessary side effects.
     ///
-    /// This is the centralized method for switching buffers. Window-side
-    /// state mutation lives in [`Window::set_active_buffer`]; this thin
-    /// wrapper handles the editor-scoped follow-ups.
+    /// The per-window state mutation lives on
+    /// [`Window::set_active_buffer`] (and the per-window terminal /
+    /// file-explorer sync calls now nested inside it). This thin
+    /// wrapper only adds the editor-wide plugin state snapshot
+    /// refresh + the `buffer_activated` plugin hook.
     pub(super) fn set_active_buffer(&mut self, buffer_id: BufferId) {
-        let Some(change) = self.active_window_mut().set_active_buffer(buffer_id) else {
+        if !self.active_window_mut().set_active_buffer(buffer_id) {
             return;
-        };
-        self.apply_active_buffer_change(change);
-    }
-
-    fn apply_active_buffer_change(&mut self, change: ActiveBufferChange) {
-        if change.sync_terminal_readonly {
-            self.active_window_mut()
-                .sync_terminal_to_buffer(change.buffer_id);
         }
-        if change.sync_file_explorer {
-            self.active_window_mut().sync_file_explorer_to_active_file();
-        }
-        // Update plugin state snapshot BEFORE firing the hook so that
-        // the handler sees the new active buffer, not the old one.
+        // Plugin state snapshot reaches editor-wide state (clipboard,
+        // windows list, config cache) so it stays on Editor. Run it
+        // BEFORE the hook so the handler sees the new active buffer.
         #[cfg(feature = "plugins")]
         self.update_plugin_state_snapshot();
         self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
-            crate::services::plugins::hooks::HookArgs::BufferActivated {
-                buffer_id: change.buffer_id,
-            },
+            crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );
     }
 
@@ -112,12 +78,15 @@ impl Editor {
 impl Window {
     /// Window-side body of `set_active_buffer`. Mutates per-window state
     /// (focus loss, prompt cancel, split manager, view-state, terminal
-    /// mode toggle, tab visibility) and returns an [`ActiveBufferChange`]
-    /// describing the deferred Editor-side side-effects, or `None` if
-    /// the requested buffer is already active.
-    pub(super) fn set_active_buffer(&mut self, buffer_id: BufferId) -> Option<ActiveBufferChange> {
+    /// mode toggle, tab visibility, and the dependent terminal-sync /
+    /// file-explorer-follow per-window side effects).
+    ///
+    /// Returns `true` when the active buffer actually changed (so the
+    /// caller fires the editor-wide plugin snapshot + hook), `false`
+    /// if the requested buffer was already active.
+    pub(super) fn set_active_buffer(&mut self, buffer_id: BufferId) -> bool {
         if self.active_buffer() == buffer_id {
-            return None;
+            return false;
         }
 
         // Dismiss transient popups and clear hover state when switching buffers
@@ -165,10 +134,16 @@ impl Window {
         // If switching to a terminal buffer that should resume terminal mode, re-enter it
         let resume_terminal_mode =
             self.terminal_mode_resume.contains(&buffer_id) && self.is_terminal_buffer(buffer_id);
-        let sync_terminal_readonly = !resume_terminal_mode && self.is_terminal_buffer(buffer_id);
+        let is_terminal_buffer = self.is_terminal_buffer(buffer_id);
+        let sync_terminal_readonly = !resume_terminal_mode && is_terminal_buffer;
         if resume_terminal_mode {
             self.terminal_mode = true;
             self.key_context = crate::input::keybindings::KeyContext::Terminal;
+        } else if sync_terminal_readonly {
+            // Switching to terminal in read-only mode — sync buffer to
+            // show current terminal content. Updates backing file +
+            // cursor.
+            self.sync_terminal_to_buffer(buffer_id);
         }
 
         // Window resize events only resize terminals that are currently the
@@ -177,7 +152,7 @@ impl Window {
         // sees the new size, so its PTY child keeps reporting stale
         // dimensions when the user switches back. Re-running the visible
         // resize here picks up the now-revealed terminal. Issue #1795.
-        if self.is_terminal_buffer(buffer_id) {
+        if is_terminal_buffer {
             self.resize_visible_terminals();
         }
 
@@ -185,15 +160,14 @@ impl Window {
         let tabs_width = self.effective_tabs_width();
         self.ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 
-        let sync_file_explorer = self.file_explorer_visible
+        if self.file_explorer_visible
             && self.resources.config.file_explorer.follow_active_buffer
-            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer;
+            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
+        {
+            self.sync_file_explorer_to_active_file();
+        }
 
-        Some(ActiveBufferChange {
-            buffer_id,
-            sync_terminal_readonly,
-            sync_file_explorer,
-        })
+        true
     }
 
     /// Window-side body of `focus_split`. Returns a [`FocusSplitOutcome`]

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -141,7 +141,7 @@ impl Editor {
         self.update_plugin_state_snapshot();
 
         // Emit buffer_activated hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
             crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -127,7 +127,7 @@ impl Editor {
         self.active_window_mut()
             .ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 
-        if self.active_window().file_explorer_visible
+        if self.file_explorer_visible()
             && self.config.file_explorer.follow_active_buffer
             && self.active_window_mut().key_context
                 != crate::input::keybindings::KeyContext::FileExplorer

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -42,11 +42,11 @@ impl Editor {
         }
 
         // Dismiss transient popups and clear hover state when switching buffers
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
 
         // Cancel search/replace prompts when switching buffers
         // (they are buffer-specific and don't make sense across buffers)
-        self.cancel_search_prompt_if_active();
+        self.active_window_mut().cancel_search_prompt_if_active();
 
         // Track the previous buffer for "Switch to Previous Tab" command
         let previous = self.active_buffer();
@@ -123,7 +123,7 @@ impl Editor {
         }
 
         // Ensure the newly active tab is visible
-        let tabs_width = self.effective_tabs_width();
+        let tabs_width = self.active_window().effective_tabs_width();
         self.active_window_mut()
             .ensure_active_tab_visible(active_split, buffer_id, tabs_width);
 

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -57,7 +57,7 @@ impl Editor {
                 .terminal_mode_resume
                 .insert(previous);
             self.active_window_mut().terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Capture the previous focus target BEFORE set_pane_buffer runs,
@@ -105,7 +105,7 @@ impl Editor {
             && self.active_window().is_terminal_buffer(buffer_id)
         {
             self.active_window_mut().terminal_mode = true;
-            self.key_context = crate::input::keybindings::KeyContext::Terminal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         } else if self.active_window().is_terminal_buffer(buffer_id) {
             // Switching to terminal in read-only mode - sync buffer to show current terminal content
             // This ensures the backing file content and cursor position are up to date
@@ -129,7 +129,8 @@ impl Editor {
 
         if self.active_window().file_explorer_visible
             && self.config.file_explorer.follow_active_buffer
-            && self.key_context != crate::input::keybindings::KeyContext::FileExplorer
+            && self.active_window_mut().key_context
+                != crate::input::keybindings::KeyContext::FileExplorer
         {
             self.sync_file_explorer_to_active_file();
         }
@@ -172,8 +173,10 @@ impl Editor {
         // subsequent keystrokes target the buffer. The terminal branch
         // below can still upgrade to KeyContext::Terminal when needed.
         // Issue #1540.
-        if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+        if self.active_window_mut().key_context
+            == crate::input::keybindings::KeyContext::FileExplorer
+        {
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         let previous_split = self
@@ -259,7 +262,8 @@ impl Editor {
                 {
                     inner_vs.switch_buffer(buffer_id);
                 }
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
                 return;
             }
             // Fall through: we couldn't find the group; the original path
@@ -272,7 +276,8 @@ impl Editor {
                 && self.active_window().is_terminal_buffer(previous_buffer)
             {
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
             }
 
             // Update split manager to focus this split
@@ -292,11 +297,13 @@ impl Editor {
             // Set key context based on target buffer type
             if self.active_window().is_terminal_buffer(buffer_id) {
                 self.active_window_mut().terminal_mode = true;
-                self.key_context = crate::input::keybindings::KeyContext::Terminal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Terminal;
             } else {
                 // Ensure key context is Normal when focusing a non-terminal buffer
                 // This handles the case of clicking on editor from FileExplorer context
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
             }
 
             // Handle buffer change side effects

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -79,10 +79,11 @@ impl Editor {
 
     fn apply_active_buffer_change(&mut self, change: ActiveBufferChange) {
         if change.sync_terminal_readonly {
-            self.sync_terminal_to_buffer(change.buffer_id);
+            self.active_window_mut()
+                .sync_terminal_to_buffer(change.buffer_id);
         }
         if change.sync_file_explorer {
-            self.sync_file_explorer_to_active_file();
+            self.active_window_mut().sync_file_explorer_to_active_file();
         }
         // Update plugin state snapshot BEFORE firing the hook so that
         // the handler sees the new active buffer, not the old one.

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -23,7 +23,7 @@ impl Editor {
     pub fn process_async_messages(&mut self) -> bool {
         // Check plugin thread health - will panic if thread died due to error
         // This ensures plugin errors surface quickly instead of causing silent hangs
-        self.plugin_manager.check_thread_health();
+        self.plugin_manager.write().unwrap().check_thread_health();
 
         let Some(bridge) = &self.async_bridge else {
             return false;
@@ -123,7 +123,7 @@ impl Editor {
                     .to_string();
 
                     // Fire the LspServerError hook for plugins
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "lsp_server_error",
                         crate::services::plugins::hooks::HookArgs::LspServerError {
                             language: language.clone(),
@@ -325,13 +325,13 @@ impl Editor {
                             );
                         }
                         PluginAsyncMessage::DelayComplete { callback_id } => {
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 JsCallbackId::from(callback_id),
                                 "null".to_string(),
                             );
                         }
                         PluginAsyncMessage::ProcessStdout { process_id, data } => {
-                            self.plugin_manager.run_hook(
+                            self.plugin_manager.read().unwrap().run_hook(
                                 "onProcessStdout",
                                 crate::services::plugins::hooks::HookArgs::ProcessOutput {
                                     process_id,
@@ -340,7 +340,7 @@ impl Editor {
                             );
                         }
                         PluginAsyncMessage::ProcessStderr { process_id, data } => {
-                            self.plugin_manager.run_hook(
+                            self.plugin_manager.read().unwrap().run_hook(
                                 "onProcessStderr",
                                 crate::services::plugins::hooks::HookArgs::ProcessOutput {
                                     process_id,
@@ -358,7 +358,7 @@ impl Editor {
                                 process_id,
                                 exit_code,
                             };
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 JsCallbackId::from(callback_id),
                                 serde_json::to_string(&result).unwrap(),
                             );
@@ -451,7 +451,7 @@ impl Editor {
                         .get(terminal_id)
                         .and_then(|handle| handle.state.lock().ok().map(|s| s.last_visible_line()))
                         .unwrap_or_default();
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "terminal_output",
                         crate::services::plugins::hooks::HookArgs::TerminalOutput {
                             terminal_id: terminal_id.0 as u64,
@@ -461,7 +461,7 @@ impl Editor {
                 }
                 AsyncMessage::PathChanged { handle, path, kind } => {
                     self.last_path_change_for_test = Some((handle, path.clone(), kind.as_str()));
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "path_changed",
                         crate::services::plugins::hooks::HookArgs::PathChanged {
                             handle,
@@ -545,7 +545,7 @@ impl Editor {
                     // to transition agents to READY (code 0) or ERRORED.
                     // `exit_code` is currently always `None` here; full
                     // wait-status capture is a follow-up commit.
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "terminal_exit",
                         crate::services::plugins::hooks::HookArgs::TerminalExited {
                             terminal_id: terminal_id.0 as u64,
@@ -647,6 +647,8 @@ impl Editor {
                     #[cfg(feature = "plugins")]
                     for cb_id in callback_ids {
                         self.plugin_manager
+                            .read()
+                            .unwrap()
                             .resolve_callback(cb_id, "null".to_string());
                     }
 

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -490,7 +490,7 @@ impl Editor {
                         }
 
                         // Sync terminal content to buffer (final screen state)
-                        self.sync_terminal_to_buffer(buffer_id);
+                        self.active_window_mut().sync_terminal_to_buffer(buffer_id);
 
                         // Append exit message to the backing file and reload
                         let exit_msg = "\n[Terminal process exited]\n";

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -485,7 +485,8 @@ impl Editor {
                         // Exit terminal mode if this is the active buffer
                         if self.active_buffer() == buffer_id && self.active_window().terminal_mode {
                             self.active_window_mut().terminal_mode = false;
-                            self.key_context = crate::input::keybindings::KeyContext::Normal;
+                            self.active_window_mut().key_context =
+                                crate::input::keybindings::KeyContext::Normal;
                         }
 
                         // Sync terminal content to buffer (final screen state)

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -155,7 +155,7 @@ impl Editor {
 
         // Emit diagnostics_updated hook for plugins
         let count = merged.len();
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "diagnostics_updated",
             crate::services::plugins::hooks::HookArgs::DiagnosticsUpdated {
                 uri: uri.to_string(),
@@ -1198,7 +1198,7 @@ impl Editor {
         let params_str = params.map(|p| p.to_string());
 
         // Run the lsp_server_request hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "lsp_server_request",
             crate::services::plugins::hooks::HookArgs::LspServerRequest {
                 language,
@@ -1221,10 +1221,15 @@ impl Editor {
         match result {
             Ok(value) => {
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .resolve_callback(callback_id, value.to_string());
             }
             Err(err) => {
-                self.plugin_manager.reject_callback(callback_id, err);
+                self.plugin_manager
+                    .read()
+                    .unwrap()
+                    .reject_callback(callback_id, err);
             }
         }
     }
@@ -1426,6 +1431,8 @@ impl Editor {
             exit_code,
         };
         self.plugin_manager
+            .read()
+            .unwrap()
             .resolve_callback(callback_id, serde_json::to_string(&result).unwrap());
     }
 
@@ -1434,7 +1441,7 @@ impl Editor {
     /// Returns true if any visual commands were processed (i.e. a re-render is needed).
     /// No-op sentinels like `HookCompleted` do not count.
     pub(super) fn process_plugin_commands(&mut self) -> bool {
-        let commands = self.plugin_manager.process_commands();
+        let commands = self.plugin_manager.write().unwrap().process_commands();
         if commands.is_empty() {
             return false;
         }

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -103,7 +103,7 @@ impl Editor {
         let updated = crate::services::lsp::diagnostics::apply_diagnostics_to_state_cached(
             state,
             diagnostics,
-            &self.theme,
+            &*self.theme.read().unwrap(),
         );
         Some((buffer_id, updated))
     }
@@ -594,7 +594,7 @@ impl Editor {
                             state,
                             range.clone(),
                             &spans,
-                            &self.theme,
+                            &*self.theme.read().unwrap(),
                         );
                         if applied {
                             self.active_window_mut()
@@ -666,7 +666,7 @@ impl Editor {
                         crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                             state,
                             &decoded.spans,
-                            &self.theme,
+                            &*self.theme.read().unwrap(),
                         );
 
                         state.set_semantic_tokens(SemanticTokenStore {
@@ -777,7 +777,7 @@ impl Editor {
                         crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                             state,
                             &spans,
-                            &self.theme,
+                            &*self.theme.read().unwrap(),
                         );
 
                         state.set_semantic_tokens(SemanticTokenStore {

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1371,7 +1371,7 @@ impl Editor {
         // ran before this initialization completed (file_explorer was still
         // None) and did nothing. Run it again now so the tree auto-expands
         // to reveal the current file on first open (issue #1569).
-        if self.active_window().file_explorer_visible {
+        if self.file_explorer_visible() {
             self.sync_file_explorer_to_active_file();
         }
     }

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1377,7 +1377,7 @@ impl Editor {
         // None) and did nothing. Run it again now so the tree auto-expands
         // to reveal the current file on first open (issue #1569).
         if self.file_explorer_visible() {
-            self.sync_file_explorer_to_active_file();
+            self.active_window_mut().sync_file_explorer_to_active_file();
         }
     }
 

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -118,12 +118,12 @@ impl Editor {
     fn merge_and_apply_diagnostics(&mut self, uri: &str) {
         // Merge diagnostics from all servers (push model) and pull model
         let mut merged = Vec::new();
-        if let Some(server_map) = self.stored_push_diagnostics.get(uri) {
+        if let Some(server_map) = self.active_window_mut().stored_push_diagnostics.get(uri) {
             for diagnostics in server_map.values() {
                 merged.extend(diagnostics.iter().cloned());
             }
         }
-        if let Some(pull) = self.stored_pull_diagnostics.get(uri) {
+        if let Some(pull) = self.active_window_mut().stored_pull_diagnostics.get(uri) {
             merged.extend(pull.iter().cloned());
         }
 
@@ -192,12 +192,18 @@ impl Editor {
             uri
         );
 
-        let server_map = self.stored_push_diagnostics.entry(uri.clone()).or_default();
+        let server_map = self
+            .active_window_mut()
+            .stored_push_diagnostics
+            .entry(uri.clone())
+            .or_default();
         if diagnostics.is_empty() {
             server_map.remove(&server_name);
             // Clean up empty outer entry
             if server_map.is_empty() {
-                self.stored_push_diagnostics.remove(&uri);
+                self.active_window_mut()
+                    .stored_push_diagnostics
+                    .remove(&uri);
             }
         } else {
             server_map.insert(server_name, diagnostics);
@@ -232,13 +238,18 @@ impl Editor {
 
         // Store result_id for incremental updates
         if let Some(result_id) = result_id {
-            self.diagnostic_result_ids.insert(uri.clone(), result_id);
+            self.active_window_mut()
+                .diagnostic_result_ids
+                .insert(uri.clone(), result_id);
         }
 
         if diagnostics.is_empty() {
-            self.stored_pull_diagnostics.remove(&uri);
+            self.active_window_mut()
+                .stored_pull_diagnostics
+                .remove(&uri);
         } else {
-            self.stored_pull_diagnostics
+            self.active_window_mut()
+                .stored_pull_diagnostics
                 .insert(uri.clone(), diagnostics);
         }
 
@@ -253,6 +264,7 @@ impl Editor {
     pub(crate) fn clear_diagnostics_for_server(&mut self, server_name: &str) {
         // Collect URIs that have diagnostics from this server.
         let affected_uris: Vec<String> = self
+            .active_window()
             .stored_push_diagnostics
             .iter()
             .filter_map(|(uri, server_map)| {
@@ -275,10 +287,14 @@ impl Editor {
         );
 
         for uri in &affected_uris {
-            if let Some(server_map) = self.stored_push_diagnostics.get_mut(uri) {
+            if let Some(server_map) = self
+                .active_window_mut()
+                .stored_push_diagnostics
+                .get_mut(uri)
+            {
                 server_map.remove(server_name);
                 if server_map.is_empty() {
-                    self.stored_push_diagnostics.remove(uri);
+                    self.active_window_mut().stored_push_diagnostics.remove(uri);
                 }
             }
 
@@ -437,6 +453,7 @@ impl Editor {
         }
 
         let lsp_ranges = self
+            .active_window()
             .stored_folding_ranges
             .get(&uri)
             .cloned()
@@ -894,11 +911,10 @@ impl Editor {
         }
 
         let __active_id = self.active_window;
-        let diagnostic_result_ids = &self.diagnostic_result_ids;
-
         let Some(__win) = self.windows.get_mut(&__active_id) else {
             return;
         };
+        let diagnostic_result_ids = &__win.diagnostic_result_ids;
         let Some(lsp) = __win.lsp.as_mut() else {
             return;
         };
@@ -940,7 +956,7 @@ impl Editor {
                 message,
                 percentage,
             } => {
-                self.lsp_progress.insert(
+                self.active_window_mut().lsp_progress.insert(
                     token.clone(),
                     LspProgressInfo {
                         language,
@@ -954,13 +970,13 @@ impl Editor {
                 message,
                 percentage,
             } => {
-                if let Some(info) = self.lsp_progress.get_mut(&token) {
+                if let Some(info) = self.active_window_mut().lsp_progress.get_mut(&token) {
                     info.message = message;
                     info.percentage = percentage;
                 }
             }
             LspProgressValue::End { .. } => {
-                self.lsp_progress.remove(&token);
+                self.active_window_mut().lsp_progress.remove(&token);
             }
         }
         // If the LSP status popup is open, rebuild it so the progress line
@@ -978,16 +994,18 @@ impl Editor {
         message: String,
     ) {
         // Add to window messages list
-        self.lsp_window_messages.push(LspMessageEntry {
-            language: language.clone(),
-            message_type,
-            message: message.clone(),
-            timestamp: Instant::now(),
-        });
+        self.active_window_mut()
+            .lsp_window_messages
+            .push(LspMessageEntry {
+                language: language.clone(),
+                message_type,
+                message: message.clone(),
+                timestamp: Instant::now(),
+            });
 
         // Keep only last 100 messages
-        if self.lsp_window_messages.len() > 100 {
-            self.lsp_window_messages.remove(0);
+        if self.active_window_mut().lsp_window_messages.len() > 100 {
+            self.active_window_mut().lsp_window_messages.remove(0);
         }
 
         // Show important messages in status bar
@@ -1009,16 +1027,18 @@ impl Editor {
         message_type: LspMessageType,
         message: String,
     ) {
-        self.lsp_log_messages.push(LspMessageEntry {
-            language,
-            message_type,
-            message,
-            timestamp: Instant::now(),
-        });
+        self.active_window_mut()
+            .lsp_log_messages
+            .push(LspMessageEntry {
+                language,
+                message_type,
+                message,
+                timestamp: Instant::now(),
+            });
 
         // Keep only last 500 log messages
-        if self.lsp_log_messages.len() > 500 {
-            self.lsp_log_messages.remove(0);
+        if self.active_window_mut().lsp_log_messages.len() > 500 {
+            self.active_window_mut().lsp_log_messages.remove(0);
         }
     }
 
@@ -1035,10 +1055,16 @@ impl Editor {
         let key = (language.clone(), server_name);
 
         // Get old status for event
-        let old_status = self.lsp_server_statuses.get(&key).cloned();
+        let old_status = self
+            .active_window_mut()
+            .lsp_server_statuses
+            .get(&key)
+            .cloned();
 
         // Update server status
-        self.lsp_server_statuses.insert(key, status);
+        self.active_window_mut()
+            .lsp_server_statuses
+            .insert(key, status);
 
         // Update warning domain for LSP status indicator
         self.update_lsp_warning_domain();

--- a/crates/fresh-editor/src/app/bookmark_actions.rs
+++ b/crates/fresh-editor/src/app/bookmark_actions.rs
@@ -121,7 +121,8 @@ impl Editor {
         // Bookmarks can point anywhere in the file; the viewport must scroll
         // to follow the jump even when the bookmark target is in the same
         // buffer that's already visible (#1689).
-        self.ensure_active_cursor_visible_for_navigation(true);
+        self.active_window_mut()
+            .ensure_active_cursor_visible_for_navigation(true);
         self.set_status_message(t!("bookmark.jumped", key = key).to_string());
     }
 }

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -372,7 +372,7 @@ impl Editor {
         // (e.g. a plugin that owns a buffer group clears its `isOpen` flag
         // when the group is closed via the tab's close button rather than
         // through the plugin's own close command).
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "buffer_closed",
             fresh_core::hooks::HookArgs::BufferClosed { buffer_id: id },
         );

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -51,8 +51,8 @@ impl Editor {
         }
 
         // Complete any --wait tracking for this buffer
-        if let Some((wait_id, _)) = self.wait_tracking.remove(&id) {
-            self.completed_waits.push(wait_id);
+        if let Some((wait_id, _)) = self.active_window_mut().wait_tracking.remove(&id) {
+            self.active_window_mut().completed_waits.push(wait_id);
         }
 
         // Save file state before closing (for per-file session persistence)
@@ -97,7 +97,8 @@ impl Editor {
             // Exit terminal mode if we were in it
             if self.active_window().terminal_mode {
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
             }
         }
 
@@ -462,7 +463,7 @@ impl Editor {
         if self.active_window().terminal_mode && self.active_window().is_terminal_buffer(buffer_id)
         {
             self.active_window_mut().terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Count how many splits have this buffer in their open_buffers
@@ -745,7 +746,7 @@ impl Editor {
         if self.active_window().terminal_mode && self.active_window().is_terminal_buffer(buffer_id)
         {
             self.active_window_mut().terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Count how many splits have this buffer in their open_buffers
@@ -996,7 +997,8 @@ impl Editor {
                 // Position-history entries can land anywhere in the buffer;
                 // the viewport must scroll to the restored cursor or the user
                 // sees the same page after Ctrl+- / Ctrl+= (#1689).
-                self.ensure_active_cursor_visible_for_navigation(true);
+                self.active_window_mut()
+                    .ensure_active_cursor_visible_for_navigation(true);
             }
         }
 
@@ -1051,7 +1053,8 @@ impl Editor {
                 // Position-history entries can land anywhere in the buffer;
                 // the viewport must scroll to the restored cursor or the user
                 // sees the same page after Ctrl+- / Ctrl+= (#1689).
-                self.ensure_active_cursor_visible_for_navigation(true);
+                self.active_window_mut()
+                    .ensure_active_cursor_visible_for_navigation(true);
             }
         }
 

--- a/crates/fresh-editor/src/app/buffer_groups.rs
+++ b/crates/fresh-editor/src/app/buffer_groups.rs
@@ -61,8 +61,8 @@ impl super::Editor {
             serde_json::from_str(&layout_json).map_err(|e| format!("Invalid layout: {}", e))?;
 
         // Allocate group ID
-        let group_id = BufferGroupId(self.next_buffer_group_id);
-        self.next_buffer_group_id += 1;
+        let group_id = BufferGroupId(self.active_window_mut().next_buffer_group_id);
+        self.active_window_mut().next_buffer_group_id += 1;
 
         // Build buffers for each leaf in the layout
         let mut panel_buffers: HashMap<String, BufferId> = HashMap::new();
@@ -191,10 +191,14 @@ impl super::Editor {
 
         // Register reverse mapping
         for buffer_id in panel_buffers.values() {
-            self.buffer_to_group.insert(*buffer_id, group_id);
+            self.active_window_mut()
+                .buffer_to_group
+                .insert(*buffer_id, group_id);
         }
 
-        self.buffer_groups.insert(group_id, group);
+        self.active_window_mut()
+            .buffer_groups
+            .insert(group_id, group);
 
         // Build result
         let panels: HashMap<String, u64> = panel_buffers
@@ -368,6 +372,7 @@ impl super::Editor {
     ) {
         let bg_id = BufferGroupId(group_id);
         let buffer_id = self
+            .active_window_mut()
             .buffer_groups
             .get(&bg_id)
             .and_then(|g| g.panel_buffers.get(&panel_name).copied());
@@ -386,10 +391,10 @@ impl super::Editor {
     pub(super) fn close_buffer_group(&mut self, group_id: usize) {
         use crate::view::split::TabTarget;
         let bg_id = BufferGroupId(group_id);
-        if let Some(group) = self.buffer_groups.remove(&bg_id) {
+        if let Some(group) = self.active_window_mut().buffer_groups.remove(&bg_id) {
             // Remove reverse mappings
             for buffer_id in group.panel_buffers.values() {
-                self.buffer_to_group.remove(buffer_id);
+                self.active_window_mut().buffer_to_group.remove(buffer_id);
             }
 
             // Find the group_leaf_id (it's the `representative_split` now).
@@ -468,7 +473,7 @@ impl super::Editor {
     /// and marks the panel's leaf as the focused inner leaf.
     pub(super) fn focus_panel(&mut self, group_id: usize, panel_name: String) {
         let bg_id = BufferGroupId(group_id);
-        let (group_leaf_id, inner_leaf) = match self.buffer_groups.get(&bg_id) {
+        let (group_leaf_id, inner_leaf) = match self.active_window_mut().buffer_groups.get(&bg_id) {
             Some(group) => {
                 let Some(&inner) = group.panel_splits.get(&panel_name) else {
                     return;
@@ -523,7 +528,7 @@ impl super::Editor {
             }
             // Transfer focus away from File Explorer (or any other context)
             // to the editor, since we're explicitly focusing a panel.
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
     }
 
@@ -559,8 +564,11 @@ impl super::Editor {
         {
             self.active_window_mut()
                 .promote_preview_if_not_in_split(split_id);
-            if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+            if self.active_window_mut().key_context
+                == crate::input::keybindings::KeyContext::FileExplorer
+            {
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
             }
             self.windows
                 .get_mut(&self.active_window)
@@ -612,6 +620,7 @@ impl super::Editor {
         // Find the BufferGroupId whose stored representative_split matches
         // this Grouped node's LeafId.
         let bg_id_opt = self
+            .active_window_mut()
             .buffer_groups
             .iter()
             .find(|(_, g)| g.representative_split == Some(group_leaf))

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -623,7 +623,8 @@ impl Editor {
     /// Get the current mouse hover state for testing
     /// Returns Some((byte_position, screen_x, screen_y)) if hovering over text
     pub fn get_mouse_hover_state(&self) -> Option<(usize, u16, u16)> {
-        self.mouse_state
+        self.active_window()
+            .mouse_state
             .lsp_hover_state
             .map(|(pos, _, x, y)| (pos, x, y))
     }
@@ -639,14 +640,16 @@ impl Editor {
     /// Force check the mouse hover timer (for testing)
     /// This bypasses the normal 500ms delay
     pub fn force_check_mouse_hover(&mut self) -> bool {
-        if let Some((byte_pos, _, screen_x, screen_y)) = self.mouse_state.lsp_hover_state {
-            if !self.mouse_state.lsp_hover_request_sent {
+        if let Some((byte_pos, _, screen_x, screen_y)) =
+            self.active_window_mut().mouse_state.lsp_hover_state
+        {
+            if !self.active_window_mut().mouse_state.lsp_hover_request_sent {
                 self.active_window_mut()
                     .hover
                     .set_screen_position((screen_x, screen_y));
                 match self.request_hover_at_position(byte_pos) {
                     Ok(true) => {
-                        self.mouse_state.lsp_hover_request_sent = true;
+                        self.active_window_mut().mouse_state.lsp_hover_request_sent = true;
                         return true;
                     }
                     Ok(false) => return false, // no server ready, retry later

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -362,8 +362,14 @@ impl Editor {
                         handled_specially = true;
                     }
                 }
-                if !handled_specially && self.plugin_manager.has_hook_handlers("widget_event") {
-                    self.plugin_manager.run_hook(
+                if !handled_specially
+                    && self
+                        .plugin_manager
+                        .read()
+                        .unwrap()
+                        .has_hook_handlers("widget_event")
+                {
+                    self.plugin_manager.read().unwrap().run_hook(
                         "widget_event",
                         HookArgs::WidgetEvent {
                             panel_id,
@@ -378,8 +384,13 @@ impl Editor {
 
         // Dispatch MouseClick hook to plugins
         // Plugins can handle clicks on their virtual buffers
-        if self.plugin_manager.has_hook_handlers("mouse_click") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("mouse_click")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "mouse_click",
                 HookArgs::MouseClick {
                     column: col,

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -416,7 +416,7 @@ impl Editor {
         // Ensure key context is Normal for non-terminal buffers
         // This handles the edge case where split/buffer don't change but we clicked from FileExplorer
         if !self.active_window().is_terminal_buffer(buffer_id) {
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Get cached view line mappings for this split (before mutable borrow of buffers)
@@ -594,9 +594,10 @@ impl Editor {
         self.track_cursor_movement(&event);
 
         // Start text selection drag for potential mouse drag
-        self.mouse_state.dragging_text_selection = true;
-        self.mouse_state.drag_selection_split = Some(split_id);
-        self.mouse_state.drag_selection_anchor = Some(new_anchor.unwrap_or(target_position));
+        self.active_window_mut().mouse_state.dragging_text_selection = true;
+        self.active_window_mut().mouse_state.drag_selection_split = Some(split_id);
+        self.active_window_mut().mouse_state.drag_selection_anchor =
+            Some(new_anchor.unwrap_or(target_position));
 
         Ok(())
     }
@@ -620,7 +621,7 @@ impl Editor {
         }
 
         // Focus file explorer
-        self.key_context = crate::input::keybindings::KeyContext::FileExplorer;
+        self.active_window_mut().key_context = crate::input::keybindings::KeyContext::FileExplorer;
 
         // Calculate which item was clicked (accounting for border and title)
         // The file explorer has a 1-line border at top and bottom

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -1293,6 +1293,8 @@ impl Editor {
             // Return just the buffer ID as a number (consistent with createVirtualBuffer)
             let result = buffer_id.0.to_string();
             self.plugin_manager
+                .read()
+                .unwrap()
                 .resolve_callback(fresh_core::api::JsCallbackId::from(req_id), result);
             tracing::info!(
                 "CreateCompositeBuffer: resolve_callback sent for request_id={}",

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -173,6 +173,161 @@ impl crate::app::window::Window {
             view_state.focus_prev_pane();
         }
     }
+
+    /// Effective viewport height for composite-buffer scrolling on
+    /// `split_id`. Subtracts the one-row composite header from the
+    /// raw split viewport. Falls back to a 24-row default when the
+    /// split doesn't yet have a viewport (pre-first-render).
+    fn get_composite_viewport_height(&self, split_id: LeafId) -> usize {
+        const COMPOSITE_HEADER_HEIGHT: u16 = 1;
+        const DEFAULT_VIEWPORT_HEIGHT: usize = 24;
+
+        self.splits
+            .as_ref()
+            .map(|(_, vs)| vs)
+            .expect("window must have a populated split layout")
+            .get(&split_id)
+            .map(|vs| vs.viewport.height.saturating_sub(COMPOSITE_HEADER_HEIGHT) as usize)
+            .unwrap_or(DEFAULT_VIEWPORT_HEIGHT)
+    }
+
+    /// Mirror the composite view's cursor row/column back onto the
+    /// underlying buffer's `EditorState` and the active split's view
+    /// state. Called from hunk-navigation handlers so the status-bar
+    /// `Ln/Col` reflects the new alignment row instead of stale
+    /// pre-jump data.
+    fn sync_editor_cursor_from_composite(&mut self, split_id: LeafId, buffer_id: BufferId) {
+        let (cursor_row, cursor_column, focused_pane) = self
+            .composite_view_states
+            .get(&(split_id, buffer_id))
+            .map(|vs| (vs.cursor_row, vs.cursor_column, vs.focused_pane))
+            .unwrap_or((0, 0, 0));
+
+        let display_line = self
+            .composite_buffers
+            .get(&buffer_id)
+            .and_then(|composite| composite.alignment.get_row(cursor_row))
+            .and_then(|row| row.get_pane_line(focused_pane))
+            .map(|line_ref| line_ref.line)
+            .unwrap_or(cursor_row);
+
+        if let Some(state) = self.buffers.get_mut(&buffer_id) {
+            state.primary_cursor_line_number =
+                crate::model::buffer::LineNumber::Absolute(display_line);
+        }
+
+        let active_split = self
+            .splits
+            .as_ref()
+            .map(|(mgr, _)| mgr)
+            .expect("window must have a populated split layout")
+            .active_split();
+        if let Some((_, vs_map)) = self.splits.as_mut() {
+            if let Some(view_state) = vs_map.get_mut(&active_split) {
+                view_state.cursors.primary_mut().position = cursor_column;
+            }
+        }
+    }
+
+    /// Navigate to the next hunk (composite-buffer diff view) on
+    /// `split_id`. Centers the new hunk header roughly a third of the
+    /// way down the viewport and syncs the editor cursor so the status
+    /// bar's Ln/Col follows. Returns `true` iff a next hunk existed.
+    pub fn composite_next_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
+        let viewport_height = self.get_composite_viewport_height(split_id);
+        let moved = if let (Some(composite), Some(view_state)) = (
+            self.composite_buffers.get(&buffer_id),
+            self.composite_view_states.get_mut(&(split_id, buffer_id)),
+        ) {
+            if let Some(next_row) = composite.alignment.next_hunk_row(view_state.cursor_row) {
+                view_state.cursor_row = next_row;
+                let context_above = viewport_height / 3;
+                view_state.scroll_row = next_row.saturating_sub(context_above);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if moved {
+            self.sync_editor_cursor_from_composite(split_id, buffer_id);
+        }
+        moved
+    }
+
+    /// Navigate to the previous hunk in a composite-buffer diff view.
+    /// See `composite_next_hunk` for behaviour.
+    pub fn composite_prev_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
+        let viewport_height = self.get_composite_viewport_height(split_id);
+        let moved = if let (Some(composite), Some(view_state)) = (
+            self.composite_buffers.get(&buffer_id),
+            self.composite_view_states.get_mut(&(split_id, buffer_id)),
+        ) {
+            if let Some(prev_row) = composite.alignment.prev_hunk_row(view_state.cursor_row) {
+                view_state.cursor_row = prev_row;
+                let context_above = viewport_height / 3;
+                view_state.scroll_row = prev_row.saturating_sub(context_above);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if moved {
+            self.sync_editor_cursor_from_composite(split_id, buffer_id);
+        }
+        moved
+    }
+
+    /// Hunk navigation entry point that resolves `split_id` from this
+    /// window's active split. Used by keybinding handlers that don't
+    /// carry a split id.
+    pub fn composite_next_hunk_active(&mut self, buffer_id: BufferId) -> bool {
+        let split_id = self
+            .splits
+            .as_ref()
+            .map(|(mgr, _)| mgr)
+            .expect("window must have a populated split layout")
+            .active_split();
+        self.composite_next_hunk(split_id, buffer_id)
+    }
+
+    /// `composite_prev_hunk` flavour for the active split.
+    pub fn composite_prev_hunk_active(&mut self, buffer_id: BufferId) -> bool {
+        let split_id = self
+            .splits
+            .as_ref()
+            .map(|(mgr, _)| mgr)
+            .expect("window must have a populated split layout")
+            .active_split();
+        self.composite_prev_hunk(split_id, buffer_id)
+    }
+
+    /// Scroll a composite-buffer view by `delta` rows, clamped to the
+    /// composite's row count. No-op if the buffer or view state is
+    /// missing.
+    pub fn composite_scroll(&mut self, split_id: LeafId, buffer_id: BufferId, delta: isize) {
+        if let (Some(composite), Some(view_state)) = (
+            self.composite_buffers.get(&buffer_id),
+            self.composite_view_states.get_mut(&(split_id, buffer_id)),
+        ) {
+            let max_row = composite.row_count().saturating_sub(1);
+            view_state.scroll(delta, max_row);
+        }
+    }
+
+    /// Scroll a composite-buffer view to absolute row `row`, clamped.
+    pub fn composite_scroll_to(&mut self, split_id: LeafId, buffer_id: BufferId, row: usize) {
+        if let (Some(composite), Some(view_state)) = (
+            self.composite_buffers.get(&buffer_id),
+            self.composite_view_states.get_mut(&(split_id, buffer_id)),
+        ) {
+            let max_row = composite.row_count().saturating_sub(1);
+            view_state.set_scroll_row(row, max_row);
+        }
+    }
 }
 
 impl Editor {
@@ -338,132 +493,9 @@ impl Editor {
     // `impl Window` above. Editor callers reach them via
     // `self.active_window_mut().X(...)`.
 
-    /// Navigate to the next hunk using the active split.
-    pub fn composite_next_hunk_active(&mut self, buffer_id: BufferId) -> bool {
-        let split_id = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .active_split();
-        self.composite_next_hunk(split_id, buffer_id)
-    }
-
-    /// Navigate to the previous hunk using the active split.
-    pub fn composite_prev_hunk_active(&mut self, buffer_id: BufferId) -> bool {
-        let split_id = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .active_split();
-        self.composite_prev_hunk(split_id, buffer_id)
-    }
-
-    /// Navigate to the next hunk in a composite buffer's diff view.
-    /// Centers the hunk header in the viewport and moves the cursor to it.
-    pub fn composite_next_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
-        let viewport_height = self.get_composite_viewport_height(split_id);
-        let win = self.active_window_mut();
-        let moved = if let (Some(composite), Some(view_state)) = (
-            win.composite_buffers.get(&buffer_id),
-            win.composite_view_states.get_mut(&(split_id, buffer_id)),
-        ) {
-            // Search from cursor position (not scroll position) to avoid
-            // finding the same hunk when scroll is offset for centering
-            if let Some(next_row) = composite.alignment.next_hunk_row(view_state.cursor_row) {
-                view_state.cursor_row = next_row;
-                // Scroll so the hunk header is ~1/3 from the top of the viewport
-                let context_above = viewport_height / 3;
-                view_state.scroll_row = next_row.saturating_sub(context_above);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        // Keep the EditorState / split-view cursor in lockstep with the
-        // composite view so the status bar's Ln/Col reflects the new row.
-        // Arrow keys do this via handle_cursor_movement_action; hunk
-        // navigation used to skip it, leaving "Ln 1" stale after n/p.
-        if moved {
-            self.sync_editor_cursor_from_composite(split_id, buffer_id);
-        }
-        moved
-    }
-
-    /// Navigate to the previous hunk in a composite buffer's diff view.
-    /// Centers the hunk header in the viewport and moves the cursor to it.
-    pub fn composite_prev_hunk(&mut self, split_id: LeafId, buffer_id: BufferId) -> bool {
-        let viewport_height = self.get_composite_viewport_height(split_id);
-        let win = self.active_window_mut();
-        let moved = if let (Some(composite), Some(view_state)) = (
-            win.composite_buffers.get(&buffer_id),
-            win.composite_view_states.get_mut(&(split_id, buffer_id)),
-        ) {
-            if let Some(prev_row) = composite.alignment.prev_hunk_row(view_state.cursor_row) {
-                view_state.cursor_row = prev_row;
-                let context_above = viewport_height / 3;
-                view_state.scroll_row = prev_row.saturating_sub(context_above);
-                true
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-        if moved {
-            self.sync_editor_cursor_from_composite(split_id, buffer_id);
-        }
-        moved
-    }
-
-    /// Scroll a composite buffer view
-    pub fn composite_scroll(&mut self, split_id: LeafId, buffer_id: BufferId, delta: isize) {
-        let win = self.active_window_mut();
-        if let (Some(composite), Some(view_state)) = (
-            win.composite_buffers.get(&buffer_id),
-            win.composite_view_states.get_mut(&(split_id, buffer_id)),
-        ) {
-            let max_row = composite.row_count().saturating_sub(1);
-            view_state.scroll(delta, max_row);
-        }
-    }
-
-    /// Scroll composite buffer to a specific row
-    pub fn composite_scroll_to(&mut self, split_id: LeafId, buffer_id: BufferId, row: usize) {
-        let win = self.active_window_mut();
-        if let (Some(composite), Some(view_state)) = (
-            win.composite_buffers.get(&buffer_id),
-            win.composite_view_states.get_mut(&(split_id, buffer_id)),
-        ) {
-            let max_row = composite.row_count().saturating_sub(1);
-            view_state.set_scroll_row(row, max_row);
-        }
-    }
-
     // =========================================================================
     // Action Handling for Composite Buffers
     // =========================================================================
-
-    /// Get the effective viewport height for composite buffer scrolling.
-    /// This accounts for the composite header row showing pane labels (e.g., "OLD (HEAD)" / "NEW (Working)")
-    fn get_composite_viewport_height(&self, split_id: LeafId) -> usize {
-        const COMPOSITE_HEADER_HEIGHT: u16 = 1;
-        const DEFAULT_VIEWPORT_HEIGHT: usize = 24;
-
-        self.windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(_, vs)| vs)
-            .expect("active window must have a populated split layout")
-            .get(&split_id)
-            .map(|vs| vs.viewport.height.saturating_sub(COMPOSITE_HEADER_HEIGHT) as usize)
-            .unwrap_or(DEFAULT_VIEWPORT_HEIGHT)
-    }
 
     /// Get information about the line at the cursor position
     fn get_cursor_line_info(&self, split_id: LeafId, buffer_id: BufferId) -> CursorLineInfo {
@@ -834,56 +866,6 @@ impl Editor {
         }
     }
 
-    /// Sync the EditorState cursor with CompositeViewState (for status bar display)
-    fn sync_editor_cursor_from_composite(&mut self, split_id: LeafId, buffer_id: BufferId) {
-        let (cursor_row, cursor_column, focused_pane) = self
-            .active_window_mut()
-            .composite_view_states
-            .get(&(split_id, buffer_id))
-            .map(|vs| (vs.cursor_row, vs.cursor_column, vs.focused_pane))
-            .unwrap_or((0, 0, 0));
-
-        // Look up the actual file line number from the alignment
-        // The cursor_row is an alignment row index, which may include hunk headers
-        // We want to display the actual source file line number
-        let display_line = self
-            .active_window_mut()
-            .composite_buffers
-            .get(&buffer_id)
-            .and_then(|composite| composite.alignment.get_row(cursor_row))
-            .and_then(|row| row.get_pane_line(focused_pane))
-            .map(|line_ref| line_ref.line)
-            .unwrap_or(cursor_row); // Fall back to cursor_row if no source line
-
-        if let Some(state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .get_mut(&buffer_id)
-        {
-            state.primary_cursor_line_number =
-                crate::model::buffer::LineNumber::Absolute(display_line);
-        }
-        // Update cursor position in SplitViewState
-        let active_split = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .active_split();
-        if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
-            .expect("active window must have a populated split layout")
-            .get_mut(&active_split)
-        {
-            view_state.cursors.primary_mut().position = cursor_column;
-        }
-    }
-
     /// Handle cursor movement actions (both Move and Select variants)
     fn handle_cursor_movement_action(
         &mut self,
@@ -892,7 +874,7 @@ impl Editor {
         movement: CursorMovement,
         extend_selection: bool,
     ) -> Option<bool> {
-        let viewport_height = self.get_composite_viewport_height(split_id);
+        let viewport_height = self.active_window().get_composite_viewport_height(split_id);
 
         let line_info = self.get_cursor_line_info(split_id, buffer_id);
 
@@ -921,7 +903,8 @@ impl Editor {
         }
 
         self.apply_cursor_movement(split_id, buffer_id, movement, &line_info, viewport_height);
-        self.sync_editor_cursor_from_composite(split_id, buffer_id);
+        self.active_window_mut()
+            .sync_editor_cursor_from_composite(split_id, buffer_id);
 
         Some(true)
     }
@@ -1069,7 +1052,7 @@ impl Editor {
 
             // Page navigation
             Action::MovePageDown | Action::MovePageUp => {
-                let viewport_height = self.get_composite_viewport_height(split_id);
+                let viewport_height = self.active_window().get_composite_viewport_height(split_id);
                 let win = self.active_window_mut();
                 if let Some(view_state) = win.composite_view_states.get_mut(&(split_id, buffer_id))
                 {
@@ -1084,13 +1067,14 @@ impl Editor {
                         view_state.cursor_row = view_state.scroll_row;
                     }
                 }
-                self.sync_editor_cursor_from_composite(split_id, buffer_id);
+                self.active_window_mut()
+                    .sync_editor_cursor_from_composite(split_id, buffer_id);
                 Some(true)
             }
 
             // Document start/end
             Action::MoveDocumentStart | Action::MoveDocumentEnd => {
-                let viewport_height = self.get_composite_viewport_height(split_id);
+                let viewport_height = self.active_window().get_composite_viewport_height(split_id);
                 let win = self.active_window_mut();
                 if let Some(view_state) = win.composite_view_states.get_mut(&(split_id, buffer_id))
                 {
@@ -1101,7 +1085,8 @@ impl Editor {
                         view_state.move_cursor_to_bottom(max_row, viewport_height);
                     }
                 }
-                self.sync_editor_cursor_from_composite(split_id, buffer_id);
+                self.active_window_mut()
+                    .sync_editor_cursor_from_composite(split_id, buffer_id);
                 Some(true)
             }
 
@@ -1112,7 +1097,8 @@ impl Editor {
                 } else {
                     -1
                 };
-                self.composite_scroll(split_id, buffer_id, delta);
+                self.active_window_mut()
+                    .composite_scroll(split_id, buffer_id, delta);
                 Some(true)
             }
 
@@ -1475,11 +1461,12 @@ impl Editor {
         }
 
         // Store state for potential text selection drag
-        self.mouse_state.dragging_text_selection = false; // Disable regular text selection for composite
-        self.mouse_state.drag_selection_split = Some(split_id);
+        self.active_window_mut().mouse_state.dragging_text_selection = false; // Disable regular text selection for composite
+        self.active_window_mut().mouse_state.drag_selection_split = Some(split_id);
 
         // Sync cursor position to EditorState for status bar display
-        self.sync_editor_cursor_from_composite(split_id, buffer_id);
+        self.active_window_mut()
+            .sync_editor_cursor_from_composite(split_id, buffer_id);
 
         Ok(())
     }

--- a/crates/fresh-editor/src/app/dabbrev_actions.rs
+++ b/crates/fresh-editor/src/app/dabbrev_actions.rs
@@ -282,7 +282,10 @@ impl Editor {
             other_buffers,
         };
 
-        let candidates = self.completion_service.request(&ctx, &buffer_window);
+        let candidates = self
+            .active_window_mut()
+            .completion_service
+            .request(&ctx, &buffer_window);
 
         candidates
             .into_iter()

--- a/crates/fresh-editor/src/app/diagnostic_jumps.rs
+++ b/crates/fresh-editor/src/app/diagnostic_jumps.rs
@@ -14,7 +14,7 @@ use super::Editor;
 impl Editor {
     /// Jump to next error/diagnostic
     pub(super) fn jump_to_next_error(&mut self) {
-        let diagnostic_ns = self.lsp_diagnostic_namespace.clone();
+        let diagnostic_ns = self.active_window().lsp_diagnostic_namespace.clone();
         let cursor_pos = self.active_cursors().primary().position;
         let cursor_id = self.active_cursors().primary_id();
         let cursor = *self.active_cursors().primary();
@@ -65,7 +65,8 @@ impl Editor {
             self.apply_event_to_active_buffer(&event);
             // Diagnostics can be on any line; the viewport must scroll so the
             // user actually sees the error after pressing F8 (#1689).
-            self.ensure_active_cursor_visible_for_navigation(true);
+            self.active_window_mut()
+                .ensure_active_cursor_visible_for_navigation(true);
 
             // Show diagnostic message in status bar
             let state = self.active_state();
@@ -84,7 +85,7 @@ impl Editor {
 
     /// Jump to previous error/diagnostic
     pub(super) fn jump_to_previous_error(&mut self) {
-        let diagnostic_ns = self.lsp_diagnostic_namespace.clone();
+        let diagnostic_ns = self.active_window().lsp_diagnostic_namespace.clone();
         let cursor_pos = self.active_cursors().primary().position;
         let cursor_id = self.active_cursors().primary_id();
         let cursor = *self.active_cursors().primary();
@@ -136,7 +137,8 @@ impl Editor {
             self.apply_event_to_active_buffer(&event);
             // Diagnostics can be on any line; the viewport must scroll so the
             // user actually sees the error after pressing F8 (#1689).
-            self.ensure_active_cursor_visible_for_navigation(true);
+            self.active_window_mut()
+                .ensure_active_cursor_visible_for_navigation(true);
 
             // Show diagnostic message in status bar
             let state = self.active_state();

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -85,7 +85,10 @@ impl Editor {
 
     /// Send a response to a plugin for an async operation
     pub(super) fn send_plugin_response(&self, response: fresh_core::api::PluginResponse) {
-        self.plugin_manager.deliver_response(response);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .deliver_response(response);
     }
 
     /// Remove a pending semantic token request from tracking maps.
@@ -570,7 +573,7 @@ impl Editor {
             // here keeps in-process transitions and the test harness
             // (which simulates the restart inline) consistent.
             let label = self.authority.display_label.clone();
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "authority_changed",
                 crate::services::plugins::hooks::HookArgs::AuthorityChanged { label },
             );

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -50,21 +50,22 @@ impl Editor {
         self.user_config_raw = Arc::new(value);
     }
 
-    /// Mutable access to the merged diagnostics map. Routes through
-    /// `Arc::make_mut`, which CoW-clones while the plugin snapshot still
-    /// holds the old map — readers never observe an in-place mutation.
+    /// Mutable access to the active window's merged diagnostics map.
+    /// Routes through `Arc::make_mut`, which CoW-clones while the
+    /// plugin snapshot still holds the old map — readers never
+    /// observe an in-place mutation.
     pub(crate) fn stored_diagnostics_mut(
         &mut self,
     ) -> &mut HashMap<String, Vec<lsp_types::Diagnostic>> {
-        Arc::make_mut(&mut self.stored_diagnostics)
+        Arc::make_mut(&mut self.active_window_mut().stored_diagnostics)
     }
 
-    /// Mutable access to the folding-ranges map. CoW-clones through
-    /// `Arc::make_mut` for the same reason as `stored_diagnostics_mut`.
+    /// Mutable access to the active window's folding-ranges map.
+    /// Same `Arc::make_mut` CoW pattern as `stored_diagnostics_mut`.
     pub(crate) fn stored_folding_ranges_mut(
         &mut self,
     ) -> &mut HashMap<String, Vec<lsp_types::FoldingRange>> {
-        Arc::make_mut(&mut self.stored_folding_ranges)
+        Arc::make_mut(&mut self.active_window_mut().stored_folding_ranges)
     }
 
     /// Get a reference to the key translator (for input calibration)
@@ -136,7 +137,7 @@ impl Editor {
         self.keybindings
             .read()
             .unwrap()
-            .find_keybinding_for_action(action_name, self.key_context.clone())
+            .find_keybinding_for_action(action_name, self.active_window().key_context.clone())
     }
 
     /// Raw-event counterpart: return the `(KeyCode, KeyModifiers)` currently
@@ -293,12 +294,6 @@ impl Editor {
         false
     }
 
-    /// Check if editing should be disabled for the active buffer
-    /// This returns true when editing_disabled is true (e.g., for read-only virtual buffers)
-    pub fn is_editing_disabled(&self) -> bool {
-        self.active_state().editing_disabled
-    }
-
     /// Mark a buffer as read-only, setting both metadata and editor state consistently.
     /// This is the single entry point for making a buffer read-only.
     pub fn mark_buffer_read_only(&mut self, buffer_id: BufferId, read_only: bool) {
@@ -328,12 +323,13 @@ impl Editor {
 
     /// Check if LSP has any active progress tasks (e.g., indexing)
     pub fn has_active_lsp_progress(&self) -> bool {
-        !self.lsp_progress.is_empty()
+        !self.active_window().lsp_progress.is_empty()
     }
 
     /// Get the current LSP progress info (if any)
     pub fn get_lsp_progress(&self) -> Vec<(String, String, Option<String>)> {
-        self.lsp_progress
+        self.active_window()
+            .lsp_progress
             .iter()
             .map(|(token, info)| (token.clone(), info.title.clone(), info.message.clone()))
             .collect()
@@ -342,7 +338,8 @@ impl Editor {
     /// Check if any LSP server for a given language is running (ready)
     pub fn is_lsp_server_ready(&self, language: &str) -> bool {
         use crate::services::async_bridge::LspServerStatus;
-        self.lsp_server_statuses
+        self.active_window()
+            .lsp_server_statuses
             .iter()
             .any(|((lang, server_name), status)| {
                 if !matches!(status, LspServerStatus::Running) {
@@ -362,7 +359,7 @@ impl Editor {
     /// Get stored LSP diagnostics (for testing and external access)
     /// Returns a reference to the diagnostics map keyed by file URI
     pub fn get_stored_diagnostics(&self) -> &HashMap<String, Vec<lsp_types::Diagnostic>> {
-        &self.stored_diagnostics
+        &self.active_window().stored_diagnostics
     }
 
     /// Check if an update is available
@@ -944,38 +941,55 @@ impl Editor {
     /// Updates the general warning domain for the status bar.
     /// Returns true if new warnings were found.
     pub fn check_warning_log(&mut self) -> bool {
-        let Some((receiver, path)) = &self.warning_log else {
-            return false;
+        let path = match &self.warning_log {
+            Some((receiver, path)) => {
+                let mut new_warning_count = 0usize;
+                while receiver.try_recv().is_ok() {
+                    new_warning_count += 1;
+                }
+                if new_warning_count == 0 {
+                    return false;
+                }
+                (path.clone(), new_warning_count)
+            }
+            None => return false,
         };
+        let (path, new_warning_count) = path;
+        self.active_window_mut()
+            .warning_domains
+            .general
+            .add_warnings(new_warning_count);
+        self.active_window_mut()
+            .warning_domains
+            .general
+            .set_log_path(path);
 
-        // Non-blocking check for any warnings
-        let mut new_warning_count = 0usize;
-        while receiver.try_recv().is_ok() {
-            new_warning_count += 1;
-        }
-
-        if new_warning_count > 0 {
-            // Update general warning domain (don't auto-open file)
-            self.warning_domains.general.add_warnings(new_warning_count);
-            self.warning_domains.general.set_log_path(path.clone());
-        }
-
-        new_warning_count > 0
+        true
     }
 
     /// Get the warning domain registry
     pub fn get_warning_domains(&self) -> &WarningDomainRegistry {
-        &self.warning_domains
+        &self.active_window().warning_domains
     }
 
     /// Get the warning log path (for opening when user clicks indicator)
     pub fn get_warning_log_path(&self) -> Option<&PathBuf> {
-        self.warning_domains.general.log_path.as_ref()
+        self.active_window()
+            .warning_domains
+            .general
+            .log_path
+            .as_ref()
     }
 
     /// Open the warning log file (user-initiated action)
     pub fn open_warning_log(&mut self) {
-        if let Some(path) = self.warning_domains.general.log_path.clone() {
+        if let Some(path) = self
+            .active_window_mut()
+            .warning_domains
+            .general
+            .log_path
+            .clone()
+        {
             // Use open_local_file since log files are always local
             match self.open_local_file(&path) {
                 Ok(buffer_id) => {
@@ -990,42 +1004,51 @@ impl Editor {
 
     /// Clear the general warning indicator (user dismissed)
     pub fn clear_warning_indicator(&mut self) {
-        self.warning_domains.general.clear();
+        self.active_window_mut().warning_domains.general.clear();
     }
 
     /// Clear all warning indicators (user dismissed via command)
     pub fn clear_warnings(&mut self) {
-        self.warning_domains.general.clear();
-        self.warning_domains.lsp.clear();
+        self.active_window_mut().warning_domains.general.clear();
+        self.active_window_mut().warning_domains.lsp.clear();
         self.active_window_mut().status_message = Some("Warnings cleared".to_string());
     }
 
     /// Check if any LSP server is in error state
     pub fn has_lsp_error(&self) -> bool {
-        self.warning_domains.lsp.level() == WarningLevel::Error
+        self.active_window().warning_domains.lsp.level() == WarningLevel::Error
     }
 
     /// Get the effective warning level for the status bar (LSP indicator)
     /// Returns Error if LSP has errors, Warning if there are warnings, None otherwise
     pub fn get_effective_warning_level(&self) -> WarningLevel {
-        self.warning_domains.lsp.level()
+        self.active_window().warning_domains.lsp.level()
     }
 
     /// Get the general warning level (for the general warning badge)
     pub fn get_general_warning_level(&self) -> WarningLevel {
-        self.warning_domains.general.level()
+        self.active_window().warning_domains.general.level()
     }
 
     /// Get the general warning count
     pub fn get_general_warning_count(&self) -> usize {
-        self.warning_domains.general.count
+        self.active_window().warning_domains.general.count
     }
 
     /// Update LSP warning domain from server statuses
     pub fn update_lsp_warning_domain(&mut self) {
-        self.warning_domains
+        let active_id = self.active_window;
+        // Clone statuses to avoid borrowing self while we mutate active_window_mut().
+        let statuses = self
+            .windows
+            .get(&active_id)
+            .expect("active window present")
+            .lsp_server_statuses
+            .clone();
+        self.active_window_mut()
+            .warning_domains
             .lsp
-            .update_from_statuses(&self.lsp_server_statuses);
+            .update_from_statuses(&statuses);
     }
 
     /// Check if mouse hover timer has expired and trigger LSP hover request
@@ -1042,9 +1065,9 @@ impl Editor {
         let hover_delay = std::time::Duration::from_millis(self.config.editor.mouse_hover_delay_ms);
 
         // Get hover state without borrowing self
-        let hover_info = match self.mouse_state.lsp_hover_state {
+        let hover_info = match self.active_window_mut().mouse_state.lsp_hover_state {
             Some((byte_pos, start_time, screen_x, screen_y)) => {
-                if self.mouse_state.lsp_hover_request_sent {
+                if self.active_window_mut().mouse_state.lsp_hover_request_sent {
                     return false; // Already sent request for this position
                 }
                 if start_time.elapsed() < hover_delay {
@@ -1067,7 +1090,7 @@ impl Editor {
         // Request hover at the byte position — only mark as sent if dispatched
         match self.request_hover_at_position(byte_pos) {
             Ok(true) => {
-                self.mouse_state.lsp_hover_request_sent = true;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = true;
                 true
             }
             Ok(false) => false, // no server ready, timer will retry
@@ -1135,10 +1158,10 @@ impl Editor {
 
         let __active_id = self.active_window;
 
-        let diagnostic_result_ids = &self.diagnostic_result_ids;
         let Some(__win) = self.windows.get_mut(&__active_id) else {
             return false;
         };
+        let diagnostic_result_ids = &__win.diagnostic_result_ids;
         let Some(lsp) = __win.lsp.as_mut() else {
             return false;
         };

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -741,6 +741,20 @@ impl Editor {
         &mut self.active_window_mut().layout_cache
     }
 
+    /// The active window's editor-chrome layout cache (status bar,
+    /// menu, popups, prompt overlay, full-frame cell-theme map).
+    /// Mouse hit-testing reads from here.
+    pub(crate) fn active_chrome(&self) -> &crate::app::types::ChromeLayout {
+        &self.active_window().chrome_layout
+    }
+
+    /// Mutable handle to the active window's chrome-layout cache.
+    /// Renderer writes status-bar / menu / popup / prompt-overlay
+    /// hit-test rects here at the end of each frame.
+    pub(crate) fn active_chrome_mut(&mut self) -> &mut crate::app::types::ChromeLayout {
+        &mut self.active_window_mut().chrome_layout
+    }
+
     /// Active window's utility-dock panel-id → buffer-id map.
     /// Each window owns its own dock; switching windows shows a
     /// different (possibly empty) dock.

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -237,7 +237,6 @@ impl Editor {
             mode_registry: ModeRegistry::new(),
             pending_authority: None,
             remote_indicator_override: None,
-            file_explorer_clipboard: None,
             menus: crate::config::MenuConfig::translated(),
             chrome_layout: ChromeLayout::default(),
             background_process_handles: HashMap::new(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -150,7 +150,7 @@ pub(super) struct EditorParts {
     // Registries / managers
     pub(super) command_registry: Arc<RwLock<CommandRegistry>>,
     pub(super) quick_open_registry: QuickOpenRegistry,
-    pub(super) plugin_manager: PluginManager,
+    pub(super) plugin_manager: Arc<RwLock<PluginManager>>,
     pub(super) recovery_service: RecoveryService,
     pub(super) key_translator: crate::input::key_translator::KeyTranslator,
     pub(super) update_checker: Option<crate::services::release_checker::PeriodicUpdateChecker>,
@@ -708,18 +708,18 @@ impl Editor {
 
         t.phase("split_quickopen_authority");
         // Initialize plugin manager (handles both enabled and disabled cases internally)
-        let plugin_manager = PluginManager::new(
+        let plugin_manager = Arc::new(RwLock::new(PluginManager::new(
             enable_plugins,
             Arc::clone(&command_registry),
             dir_context.clone(),
             Arc::clone(&theme_cache),
-        );
+        )));
         t.phase("PluginManager::new");
 
         // Update the plugin state snapshot with working_dir BEFORE loading plugins
         // This ensures plugins can call getCwd() correctly during initialization
         #[cfg(feature = "plugins")]
-        if let Some(snapshot_handle) = plugin_manager.state_snapshot_handle() {
+        if let Some(snapshot_handle) = plugin_manager.read().unwrap().state_snapshot_handle() {
             let mut snapshot = snapshot_handle.write().unwrap();
             snapshot.working_dir = working_dir.clone();
             // Pre-populate keybinding labels for the static built-in
@@ -738,7 +738,7 @@ impl Editor {
         //    when embed-plugins feature is enabled)
         // 3. User plugins directory (~/.config/fresh/plugins)
         // 4. Package manager installed plugins (~/.config/fresh/plugins/packages/*)
-        if plugin_manager.is_active() {
+        if plugin_manager.read().unwrap().is_active() {
             let mut plugin_dirs: Vec<std::path::PathBuf> = vec![];
 
             // Check next to executable first (for cargo-dist installations)
@@ -836,13 +836,15 @@ impl Editor {
                             plugin_dir
                         );
                         if let Some(rx) = plugin_manager
+                            .read()
+                            .unwrap()
                             .load_plugins_from_dir_with_config_request(plugin_dir, &config.plugins)
                         {
                             dir_receivers.push((plugin_dir.clone(), rx));
                         }
                     }
                     let declarations_rx = if !dir_receivers.is_empty() {
-                        plugin_manager.list_plugins_request()
+                        plugin_manager.read().unwrap().list_plugins_request()
                     } else {
                         None
                     };
@@ -913,6 +915,8 @@ impl Editor {
                     tracing::info!("Loading TypeScript plugins from: {:?}", plugin_dir);
                     let load_start = std::time::Instant::now();
                     let (errors, discovered_plugins) = plugin_manager
+                        .read()
+                        .unwrap()
                         .load_plugins_from_dir_with_config(&plugin_dir, &config.plugins);
                     tracing::info!(
                         "Loaded TypeScript plugins from {:?} in {:?}",
@@ -947,7 +951,7 @@ impl Editor {
                 // that uses `declare global { interface FreshPluginRegistry }`
                 // contributes its augmentation, and init.ts's tsconfig
                 // picks the aggregate up via `files`.
-                let declarations = plugin_manager.plugin_declarations();
+                let declarations = plugin_manager.read().unwrap().plugin_declarations();
                 crate::init_script::write_plugin_declarations(
                     &dir_context.config_dir,
                     &declarations,
@@ -1029,6 +1033,7 @@ impl Editor {
             dir_context: dir_context.clone(),
             tokio_runtime: tokio_runtime.clone(),
             async_bridge: Some(async_bridge.clone()),
+            plugin_manager: Arc::clone(&plugin_manager),
         };
 
         // Build the active window — the one that holds the seed
@@ -1103,6 +1108,7 @@ impl Editor {
                     dir_context: dir_context.clone(),
                     tokio_runtime: tokio_runtime.clone(),
                     async_bridge: Some(async_bridge.clone()),
+                    plugin_manager: Arc::clone(&plugin_manager),
                 };
                 let mut shell = crate::app::window::Window::new(
                     id,
@@ -1206,8 +1212,8 @@ impl Editor {
         #[cfg(feature = "plugins")]
         {
             editor.update_plugin_state_snapshot();
-            if editor.plugin_manager.is_active() {
-                editor.plugin_manager.run_hook(
+            if editor.plugin_manager.read().unwrap().is_active() {
+                editor.plugin_manager.read().unwrap().run_hook(
                     "editor_initialized",
                     crate::services::plugins::hooks::HookArgs::EditorInitialized {},
                 );
@@ -1310,13 +1316,13 @@ impl Editor {
         let outcome = match decide_load(&config_dir, enabled) {
             LoadDecision::Skip(outcome) => outcome,
             LoadDecision::Load { source } => {
-                if !self.plugin_manager.is_active() {
+                if !self.plugin_manager.read().unwrap().is_active() {
                     InitOutcome::Failed {
                         message: "plugin runtime inactive (--no-plugins); init.ts cannot run"
                             .into(),
                     }
                 } else {
-                    match self.plugin_manager.load_plugin_from_source(
+                    match self.plugin_manager.read().unwrap().load_plugin_from_source(
                         &source,
                         crate::init_script::INIT_PLUGIN_NAME,
                         true,
@@ -1395,7 +1401,7 @@ impl Editor {
                 InitOutcome::Failed { message } => PluginInitScriptOutcome::Failed { message },
             }),
             LoadDecision::Load { source } => {
-                if !self.plugin_manager.is_active() {
+                if !self.plugin_manager.read().unwrap().is_active() {
                     Some(PluginInitScriptOutcome::Failed {
                         message: "plugin runtime inactive (--no-plugins); init.ts cannot run"
                             .into(),
@@ -1426,11 +1432,12 @@ impl Editor {
         let Some(bridge) = &self.async_bridge else {
             return;
         };
-        let Some(rx) = self.plugin_manager.load_plugin_from_source_request(
-            &source,
-            crate::init_script::INIT_PLUGIN_NAME,
-            true,
-        ) else {
+        let Some(rx) = self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .load_plugin_from_source_request(&source, crate::init_script::INIT_PLUGIN_NAME, true)
+        else {
             return;
         };
         let sender = bridge.sender();
@@ -1565,8 +1572,8 @@ impl Editor {
     /// Fire the `plugins_loaded` hook (design M2, §3.3 phase 2).
     pub fn fire_plugins_loaded_hook(&self) {
         #[cfg(feature = "plugins")]
-        if self.plugin_manager.is_active() {
-            self.plugin_manager.run_hook(
+        if self.plugin_manager.read().unwrap().is_active() {
+            self.plugin_manager.read().unwrap().run_hook(
                 "plugins_loaded",
                 crate::services::plugins::hooks::HookArgs::PluginsLoaded {},
             );
@@ -1576,8 +1583,10 @@ impl Editor {
     /// Fire the `ready` hook (design M2, §3.3 phase 3).
     pub fn fire_ready_hook(&self) {
         #[cfg(feature = "plugins")]
-        if self.plugin_manager.is_active() {
+        if self.plugin_manager.read().unwrap().is_active() {
             self.plugin_manager
+                .read()
+                .unwrap()
                 .run_hook("ready", crate::services::plugins::hooks::HookArgs::Ready {});
         }
     }
@@ -1651,7 +1660,7 @@ impl Editor {
     /// adding refresh hooks to every keymap-mutation site.
     #[cfg(feature = "plugins")]
     pub(crate) fn refresh_keybinding_labels_snapshot(&self) {
-        if let Some(snapshot_handle) = self.plugin_manager.state_snapshot_handle() {
+        if let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle() {
             if let Ok(mut snapshot) = snapshot_handle.write() {
                 populate_builtin_keybinding_labels(&mut snapshot, &self.keybindings);
             }

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -132,7 +132,7 @@ pub(super) struct EditorParts {
     pub(super) color_capability: crate::view::color_support::ColorCapability,
 
     // Async / IO
-    pub(super) tokio_runtime: Option<tokio::runtime::Runtime>,
+    pub(super) tokio_runtime: Option<Arc<tokio::runtime::Runtime>>,
     pub(super) async_bridge: AsyncBridge,
     pub(super) fs_manager: Arc<FsManager>,
     pub(super) authority: crate::services::authority::Authority,
@@ -583,7 +583,8 @@ impl Editor {
             .thread_name("editor-async")
             .enable_all()
             .build()
-            .ok();
+            .ok()
+            .map(Arc::new);
         t.phase("tokio_runtime");
 
         // Create editor-global async bridge for editor-scoped async
@@ -1027,6 +1028,8 @@ impl Editor {
             authority: authority.clone(),
             time_source: Arc::clone(&time_source),
             dir_context: dir_context.clone(),
+            tokio_runtime: tokio_runtime.clone(),
+            async_bridge: Some(async_bridge.clone()),
         };
 
         // Build the active window — the one that holds the seed
@@ -1099,6 +1102,8 @@ impl Editor {
                     authority: authority.clone(),
                     time_source: Arc::clone(&time_source),
                     dir_context: dir_context.clone(),
+                    tokio_runtime: tokio_runtime.clone(),
+                    async_bridge: Some(async_bridge.clone()),
                 };
                 let mut shell = crate::app::window::Window::new(
                     id,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -1060,6 +1060,13 @@ impl Editor {
             active_root,
             base_resources,
         );
+        // Seed the window's terminal dimensions from the editor's
+        // initial size — `Window::new` defaults to 80x24, which is
+        // wrong for any harness that constructs the editor at a
+        // different size (issue surfaces in
+        // test_hidden_terminal_resyncs_pty_size_when_revealed).
+        active_win.terminal_width = width;
+        active_win.terminal_height = height;
         // Hand the eagerly-spawned LSP manager + the initial split
         // layout off to the active window — that's where they live
         // now (Step 0b).
@@ -1124,6 +1131,8 @@ impl Editor {
                     ps.root.clone(),
                     resources,
                 );
+                shell.terminal_width = width;
+                shell.terminal_height = height;
                 shell.plugin_state = ps.plugin_state.clone();
                 windows.insert(id, shell);
             }

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -112,7 +112,7 @@ pub(super) struct EditorParts {
     pub(super) working_dir: PathBuf,
 
     // Themes
-    pub(super) theme: crate::view::theme::Theme,
+    pub(super) theme: Arc<RwLock<crate::view::theme::Theme>>,
     pub(super) theme_registry: Arc<crate::view::theme::ThemeRegistry>,
     pub(super) theme_cache: Arc<RwLock<HashMap<String, serde_json::Value>>>,
 
@@ -163,6 +163,9 @@ pub(super) struct EditorParts {
     // `getGlobalState(...)` on first tick see the previous run's
     // values without a separate post-construction load step.
     pub(super) plugin_global_state: HashMap<String, HashMap<String, serde_json::Value>>,
+
+    /// Editor-wide event broadcaster, shared with every WindowResources.
+    pub(super) event_broadcaster: crate::model::control_event::EventBroadcaster,
 }
 
 impl Editor {
@@ -241,7 +244,7 @@ impl Editor {
             chrome_layout: ChromeLayout::default(),
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
-            event_broadcaster: crate::model::control_event::EventBroadcaster::default(),
+            event_broadcaster: parts.event_broadcaster,
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),
             #[cfg(feature = "plugins")]
@@ -486,7 +489,7 @@ impl Editor {
         tracing::info!("Themes loaded");
 
         // Get active theme from registry, falling back to default if not found
-        let theme = theme_registry.get_cloned(&config.theme).unwrap_or_else(|| {
+        let theme_inner = theme_registry.get_cloned(&config.theme).unwrap_or_else(|| {
             tracing::warn!(
                 "Theme '{}' not found, falling back to default theme",
                 config.theme.0
@@ -499,7 +502,8 @@ impl Editor {
         });
 
         // Set terminal cursor color to match theme
-        theme.set_terminal_cursor_color();
+        theme_inner.set_terminal_cursor_color();
+        let theme = Arc::new(RwLock::new(theme_inner));
 
         t.phase("theme_setup");
         let keybindings = Arc::new(RwLock::new(KeybindingResolver::new(&config)));
@@ -592,6 +596,7 @@ impl Editor {
         // async expansion) flow through their owning window's
         // bridge instead — see `Window.bridge`.
         let async_bridge = AsyncBridge::new();
+        let event_broadcaster = crate::model::control_event::EventBroadcaster::default();
 
         // Create the base window's per-window bridge up front so the
         // LSP manager (configured below) can receive its responses
@@ -1034,6 +1039,8 @@ impl Editor {
             tokio_runtime: tokio_runtime.clone(),
             async_bridge: Some(async_bridge.clone()),
             plugin_manager: Arc::clone(&plugin_manager),
+            theme: Arc::clone(&theme),
+            event_broadcaster: event_broadcaster.clone(),
         };
 
         // Build the active window — the one that holds the seed
@@ -1109,6 +1116,8 @@ impl Editor {
                     tokio_runtime: tokio_runtime.clone(),
                     async_bridge: Some(async_bridge.clone()),
                     plugin_manager: Arc::clone(&plugin_manager),
+                    theme: Arc::clone(&theme),
+                    event_broadcaster: event_broadcaster.clone(),
                 };
                 let mut shell = crate::app::window::Window::new(
                     id,
@@ -1201,6 +1210,7 @@ impl Editor {
             update_checker,
             time_source: time_source.clone(),
             plugin_global_state,
+            event_broadcaster: event_broadcaster.clone(),
         };
 
         let mut editor = Editor::from_parts(parts);
@@ -1475,7 +1485,7 @@ impl Editor {
                 self.config = Arc::new(new_config);
                 if old_theme != self.config.theme {
                     if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
-                        self.theme = theme;
+                        *self.theme.write().unwrap() = theme;
                     }
                 }
                 *self.keybindings.write().unwrap() =

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -241,7 +241,6 @@ impl Editor {
             pending_authority: None,
             remote_indicator_override: None,
             menus: crate::config::MenuConfig::translated(),
-            chrome_layout: ChromeLayout::default(),
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
             event_broadcaster: parts.event_broadcaster,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -139,10 +139,6 @@ pub(super) struct EditorParts {
     pub(super) local_filesystem: Arc<dyn FileSystem + Send + Sync>,
 
     // Chrome flags resolved from config
-    pub(super) menu_bar_visible: bool,
-    pub(super) tab_bar_visible: bool,
-    pub(super) status_bar_visible: bool,
-    pub(super) prompt_line_visible: bool,
 
     // Windows — the whole point of the split: the factory builds these
     // (from disk persistence or a single seed window), the constructor
@@ -207,10 +203,6 @@ impl Editor {
             fs_manager: parts.fs_manager,
             authority: parts.authority,
             local_filesystem: parts.local_filesystem,
-            menu_bar_visible: parts.menu_bar_visible,
-            tab_bar_visible: parts.tab_bar_visible,
-            status_bar_visible: parts.status_bar_visible,
-            prompt_line_visible: parts.prompt_line_visible,
             menu_state: crate::view::ui::MenuState::new(parts.dir_context.themes_dir()),
             working_dir: parts.working_dir,
             windows: parts.windows,
@@ -242,92 +234,34 @@ impl Editor {
             pending_escape_sequences: Vec::new(),
             restart_with_dir: None,
             last_window_title: None,
-            plugin_errors: Vec::new(),
             mode_registry: ModeRegistry::new(),
             pending_authority: None,
             remote_indicator_override: None,
             file_explorer_clipboard: None,
-            menu_bar_auto_shown: false,
-            mouse_enabled: true,
-            mouse_cursor_position: None,
-            gpm_active: false,
-            key_context: KeyContext::Normal,
             menus: crate::config::MenuConfig::translated(),
-            completion_service: crate::services::completion::CompletionService::new(),
-            lsp_diagnostic_namespace: crate::view::overlay::OverlayNamespace::from_string(
-                "lsp-diagnostic".to_string(),
-            ),
-            mouse_state: MouseState::default(),
-            tab_context_menu: None,
-            file_explorer_context_menu: None,
-            theme_info_popup: None,
             chrome_layout: ChromeLayout::default(),
-            plugin_dev_workspaces: HashMap::new(),
-            buffer_groups: HashMap::new(),
-            buffer_to_group: HashMap::new(),
-            next_buffer_group_id: 0,
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
-            pending_next_key_callbacks: std::collections::VecDeque::new(),
-            key_capture_active: false,
-            pending_key_capture_buffer: std::collections::VecDeque::new(),
-            lsp_progress: std::collections::HashMap::new(),
-            lsp_server_statuses: std::collections::HashMap::new(),
-            lsp_window_messages: Vec::new(),
-            lsp_log_messages: Vec::new(),
-            diagnostic_result_ids: HashMap::new(),
-            stored_push_diagnostics: HashMap::new(),
-            stored_pull_diagnostics: HashMap::new(),
-            stored_diagnostics: Arc::new(HashMap::new()),
-            stored_folding_ranges: Arc::new(HashMap::new()),
             event_broadcaster: crate::model::control_event::EventBroadcaster::default(),
-            macros: macros::MacroState::default(),
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),
             #[cfg(feature = "plugins")]
             plugin_render_requested: false,
-            chord_state: Vec::new(),
-            last_auto_revert_poll: now,
-            last_file_tree_poll: now,
-            git_index_resolved: false,
-            dir_mod_times: HashMap::new(),
-            pending_file_poll_rx: None,
-            pending_dir_poll_rx: None,
-            file_open_state: None,
-            file_browser_layout: None,
             full_redraw_requested: false,
             suspend_requested: false,
-            last_auto_recovery_save: now,
-            last_persistent_auto_save: now,
-            active_custom_contexts: HashSet::new(),
             plugin_global_state: parts.plugin_global_state,
             warning_log: None,
             status_log_path: None,
-            warning_domains: WarningDomainRegistry::new(),
             file_watcher_manager: crate::services::file_watcher::FileWatcherManager::new(),
             last_path_change_for_test: None,
             last_watch_response_for_test: None,
             preview_window_id: None,
-            ephemeral_terminals: std::collections::HashSet::new(),
-            keyboard_capture: false,
-            previous_click_time: None,
-            previous_click_position: None,
-            click_count: 0,
             settings_state: None,
             calibration_wizard: None,
             event_debug: None,
             keybinding_editor: None,
-            pending_file_opens: Vec::new(),
-            pending_hot_exit_recovery: false,
-            wait_tracking: HashMap::new(),
-            completed_waits: Vec::new(),
             stdin_stream: stdin_stream::StdinStream::default(),
-            line_scan: line_scan::LineScan::default(),
-            search_scan: search_scan::SearchScan::default(),
-            search_overlay_top_byte: None,
-            review_hunks: Vec::new(),
             global_popups: crate::view::popup::PopupManager::new(),
-            animations: crate::view::animation::AnimationRunner::new(),
             previous_cursor_screen_pos: None,
             cursor_jump_animation: None,
             pending_vb_animations: Vec::new(),
@@ -1246,10 +1180,6 @@ impl Editor {
             fs_manager,
             authority,
             local_filesystem: Arc::clone(&local_filesystem),
-            menu_bar_visible: show_menu_bar,
-            tab_bar_visible: show_tab_bar,
-            status_bar_visible: show_status_bar,
-            prompt_line_visible: show_prompt_line,
             windows,
             active_window: active_window_id,
             next_window_id,
@@ -1540,10 +1470,14 @@ impl Editor {
                 *self.keybindings.write().unwrap() =
                     crate::input::keybindings::KeybindingResolver::new(&self.config);
                 self.clipboard.apply_config(&self.config.clipboard);
-                self.menu_bar_visible = self.config.editor.show_menu_bar;
-                self.tab_bar_visible = self.config.editor.show_tab_bar;
-                self.status_bar_visible = self.config.editor.show_status_bar;
-                self.prompt_line_visible = self.config.editor.show_prompt_line;
+                {
+                    let cfg = self.config.editor.clone();
+                    let win = self.active_window_mut();
+                    win.menu_bar_visible = cfg.show_menu_bar;
+                    win.tab_bar_visible = cfg.show_tab_bar;
+                    win.status_bar_visible = cfg.show_status_bar;
+                    win.prompt_line_visible = cfg.show_prompt_line;
+                }
                 #[cfg(feature = "plugins")]
                 self.update_plugin_state_snapshot();
             }

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -683,7 +683,10 @@ impl Editor {
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
 
-            self.plugin_manager.run_hook(hook_name, args.clone());
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .run_hook(hook_name, args.clone());
         }
 
         // After inter-line cursor_moved, proactively refresh lines so

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -1010,10 +1010,10 @@ impl Editor {
         // the clipboard stayed primed, so the next Ctrl+V in the explorer
         // would silently move a file the user had effectively "forgotten".
         if matches!(
-            self.file_explorer_clipboard,
+            self.active_window().file_explorer_clipboard,
             Some(FileExplorerClipboard { is_cut: true, .. })
         ) {
-            self.file_explorer_clipboard = None;
+            self.active_window_mut().file_explorer_clipboard = None;
             self.set_status_message(t!("explorer.cut_cancelled").to_string());
             return;
         }
@@ -1093,7 +1093,7 @@ impl Editor {
     }
 
     pub fn file_explorer_clipboard(&self) -> Option<&FileExplorerClipboard> {
-        self.file_explorer_clipboard.as_ref()
+        self.active_window().file_explorer_clipboard.as_ref()
     }
 
     pub fn file_explorer_copy(&mut self) {
@@ -1143,12 +1143,13 @@ impl Editor {
                 t!("explorer.copied_n", count = count).to_string()
             }
         };
-        self.file_explorer_clipboard = Some(FileExplorerClipboard { paths, is_cut });
+        self.active_window_mut().file_explorer_clipboard =
+            Some(FileExplorerClipboard { paths, is_cut });
         self.set_status_message(msg);
     }
 
     pub fn file_explorer_paste(&mut self) {
-        let clipboard = match self.file_explorer_clipboard.clone() {
+        let clipboard = match self.active_window().file_explorer_clipboard.clone() {
             Some(c) => c,
             None => {
                 self.set_status_message(t!("explorer.paste_no_source").to_string());
@@ -1186,7 +1187,7 @@ impl Editor {
                     // mind": treat it as a cancel rather than surfacing a
                     // scary error. Must clear the clipboard, otherwise a
                     // later paste elsewhere would silently move the file.
-                    self.file_explorer_clipboard = None;
+                    self.active_window_mut().file_explorer_clipboard = None;
                     self.set_status_message(t!("explorer.cut_cancelled").to_string());
                     return;
                 } else {
@@ -1249,7 +1250,7 @@ impl Editor {
                 // single-path branch above). Clear the clipboard so a
                 // later paste can't silently move the files after all.
                 if is_cut {
-                    self.file_explorer_clipboard = None;
+                    self.active_window_mut().file_explorer_clipboard = None;
                     self.set_status_message(t!("explorer.cut_cancelled").to_string());
                 } else {
                     self.set_status_message(t!("explorer.paste_same_location").to_string());
@@ -1404,7 +1405,7 @@ impl Editor {
         // source is still sitting at its original location the user may
         // want to retry, and the clipboard still contains the right path.
         if is_cut && first_error.is_none() && partial_moves.is_empty() {
-            self.file_explorer_clipboard = None;
+            self.active_window_mut().file_explorer_clipboard = None;
         }
         self.active_window_mut().key_context = KeyContext::FileExplorer;
     }
@@ -1597,7 +1598,7 @@ impl Editor {
                 }
                 self.refresh_tree_after_paste(&src, &dst, is_cut);
                 if is_cut {
-                    self.file_explorer_clipboard = None;
+                    self.active_window_mut().file_explorer_clipboard = None;
                     self.set_status_message(t!("explorer.pasted_moved", name = &name).to_string());
                 } else {
                     self.set_status_message(t!("explorer.pasted", name = &name).to_string());

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -88,7 +88,7 @@ impl Editor {
         }
 
         // Notify plugins that the viewport dimensions changed (sidebar affects available width)
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "resize",
             fresh_core::hooks::HookArgs::Resize {
                 width: self.terminal_width,
@@ -1571,7 +1571,7 @@ impl Editor {
     /// Multi-target operations call this once per refresh, not once per
     /// file.
     pub(super) fn notify_file_explorer_change(&self, path: &Path) {
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "after_file_explorer_change",
             crate::services::plugins::hooks::HookArgs::AfterFileExplorerChange {
                 path: path.to_path_buf(),

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -79,11 +79,11 @@ impl Editor {
             if self.file_explorer().is_none() {
                 self.init_file_explorer();
             }
-            self.key_context = KeyContext::FileExplorer;
+            self.active_window_mut().key_context = KeyContext::FileExplorer;
             self.set_status_message(t!("explorer.opened").to_string());
             self.sync_file_explorer_to_active_file();
         } else {
-            self.key_context = KeyContext::Normal;
+            self.active_window_mut().key_context = KeyContext::Normal;
             self.set_status_message(t!("explorer.closed").to_string());
         }
 
@@ -163,7 +163,7 @@ impl Editor {
             // Cancel search/replace prompts when switching focus away from editor
             self.cancel_search_prompt_if_active();
 
-            self.key_context = KeyContext::FileExplorer;
+            self.active_window_mut().key_context = KeyContext::FileExplorer;
             self.set_status_message(t!("explorer.focused").to_string());
             self.sync_file_explorer_to_active_file();
         } else {
@@ -172,7 +172,7 @@ impl Editor {
     }
 
     pub fn focus_editor(&mut self) {
-        self.key_context = KeyContext::Normal;
+        self.active_window_mut().key_context = KeyContext::Normal;
         self.set_status_message(t!("editor.focused").to_string());
     }
 
@@ -796,7 +796,7 @@ impl Editor {
                 self.notify_file_explorer_change(&path);
 
                 // Ensure focus remains on file explorer
-                self.key_context = KeyContext::FileExplorer;
+                self.active_window_mut().key_context = KeyContext::FileExplorer;
             }
             Err(e) => {
                 self.set_status_message(
@@ -939,7 +939,7 @@ impl Editor {
                     // being created. For renames from the explorer, keep
                     // focus in the explorer.
                     if is_new_file && !relocated.is_empty() {
-                        self.key_context = KeyContext::Normal;
+                        self.active_window_mut().key_context = KeyContext::Normal;
                     }
 
                     self.set_status_message(
@@ -1406,7 +1406,7 @@ impl Editor {
         if is_cut && first_error.is_none() && partial_moves.is_empty() {
             self.file_explorer_clipboard = None;
         }
-        self.key_context = KeyContext::FileExplorer;
+        self.active_window_mut().key_context = KeyContext::FileExplorer;
     }
 
     /// Move or copy a single item at the filesystem level. No tree or UI
@@ -1602,7 +1602,7 @@ impl Editor {
                 } else {
                     self.set_status_message(t!("explorer.pasted", name = &name).to_string());
                 }
-                self.key_context = KeyContext::FileExplorer;
+                self.active_window_mut().key_context = KeyContext::FileExplorer;
             }
             PasteOpOutcome::SourceRemovalFailed {
                 dst: landed_dst,
@@ -1623,7 +1623,7 @@ impl Editor {
                 );
                 // NB: don't clear the clipboard — source is still at its
                 // original location and the user may want to retry.
-                self.key_context = KeyContext::FileExplorer;
+                self.active_window_mut().key_context = KeyContext::FileExplorer;
             }
             PasteOpOutcome::Failed(e) => {
                 let msg = if is_cut {
@@ -1716,7 +1716,7 @@ impl Editor {
             t!("explorer.duplicated_n", count = succeeded.len()).to_string()
         };
         self.set_status_message(msg);
-        self.key_context = KeyContext::FileExplorer;
+        self.active_window_mut().key_context = KeyContext::FileExplorer;
     }
 
     /// Copy the selected node's path(s) to the clipboard.

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -158,10 +158,10 @@ impl Editor {
     pub fn focus_file_explorer(&mut self) {
         if self.file_explorer_visible() {
             // Dismiss transient popups and clear hover state when focusing file explorer
-            self.on_editor_focus_lost();
+            self.active_window_mut().on_editor_focus_lost();
 
             // Cancel search/replace prompts when switching focus away from editor
-            self.cancel_search_prompt_if_active();
+            self.active_window_mut().cancel_search_prompt_if_active();
 
             self.active_window_mut().key_context = KeyContext::FileExplorer;
             self.set_status_message(t!("explorer.focused").to_string());

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -81,7 +81,7 @@ impl Editor {
             }
             self.active_window_mut().key_context = KeyContext::FileExplorer;
             self.set_status_message(t!("explorer.opened").to_string());
-            self.sync_file_explorer_to_active_file();
+            self.active_window_mut().sync_file_explorer_to_active_file();
         } else {
             self.active_window_mut().key_context = KeyContext::Normal;
             self.set_status_message(t!("explorer.closed").to_string());
@@ -103,58 +103,6 @@ impl Editor {
         }
     }
 
-    pub fn sync_file_explorer_to_active_file(&mut self) {
-        if !self.file_explorer_visible() {
-            return;
-        }
-
-        // Don't start a new sync if one is already in progress
-        if self.active_window().file_explorer_sync_in_progress {
-            return;
-        }
-
-        if let Some(metadata) = self
-            .active_window()
-            .buffer_metadata
-            .get(&self.active_buffer())
-        {
-            if let Some(file_path) = metadata.file_path() {
-                let target_path = file_path.clone();
-                let working_dir = self.working_dir.clone();
-
-                if target_path.starts_with(&working_dir) {
-                    let active_id = self.active_window;
-                    if let Some(mut view) = self
-                        .windows
-                        .get_mut(&active_id)
-                        .and_then(|w| w.file_explorer.take())
-                    {
-                        tracing::trace!(
-                            "sync_file_explorer_to_active_file: taking file_explorer for async expand to {:?}",
-                            target_path
-                        );
-                        let runtime_handle =
-                            self.tokio_runtime.as_ref().map(|r| r.handle().clone());
-                        let sender = self.async_bridge.as_ref().map(|b| b.sender());
-                        if let (Some(runtime), Some(sender)) = (runtime_handle, sender) {
-                            // Mark sync as in progress so render knows to keep the layout
-                            self.active_window_mut().file_explorer_sync_in_progress = true;
-
-                            runtime.spawn(async move {
-                                let _success = view.expand_and_select_file(&target_path).await;
-                                // Receiver may have been dropped during shutdown.
-                                #[allow(clippy::let_underscore_must_use)]
-                                let _ = sender.send(AsyncMessage::FileExplorerExpandedToPath(view));
-                            });
-                        } else {
-                            self.active_window_mut().file_explorer = Some(view);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     pub fn focus_file_explorer(&mut self) {
         if self.file_explorer_visible() {
             // Dismiss transient popups and clear hover state when focusing file explorer
@@ -165,7 +113,7 @@ impl Editor {
 
             self.active_window_mut().key_context = KeyContext::FileExplorer;
             self.set_status_message(t!("explorer.focused").to_string());
-            self.sync_file_explorer_to_active_file();
+            self.active_window_mut().sync_file_explorer_to_active_file();
         } else {
             self.toggle_file_explorer();
         }
@@ -1765,6 +1713,65 @@ impl Editor {
             t!("clipboard.copied_paths_n", count = rendered.len()).to_string()
         };
         self.set_status_message(msg);
+    }
+}
+
+impl crate::app::window::Window {
+    /// Spawn an async expand-to-path of this window's file-explorer tree,
+    /// targeting the active buffer's file. No-op when the explorer isn't
+    /// visible, a sync is already running, or the target path is outside
+    /// the window's root.
+    pub fn sync_file_explorer_to_active_file(&mut self) {
+        if !self.file_explorer_visible {
+            return;
+        }
+
+        // Don't start a new sync if one is already in progress
+        if self.file_explorer_sync_in_progress {
+            return;
+        }
+
+        let active_buf = self.active_buffer();
+        let Some(metadata) = self.buffer_metadata.get(&active_buf) else {
+            return;
+        };
+        let Some(file_path) = metadata.file_path() else {
+            return;
+        };
+        let target_path = file_path.clone();
+
+        if !target_path.starts_with(&self.root) {
+            return;
+        }
+
+        let Some(mut view) = self.file_explorer.take() else {
+            return;
+        };
+        tracing::trace!(
+            "sync_file_explorer_to_active_file: taking file_explorer for async expand to {:?}",
+            target_path
+        );
+        let runtime_handle = self
+            .resources
+            .tokio_runtime
+            .as_ref()
+            .map(|r| r.handle().clone());
+        let sender = self.resources.async_bridge.as_ref().map(|b| b.sender());
+        if let (Some(runtime), Some(sender)) = (runtime_handle, sender) {
+            // Mark sync as in progress so render knows to keep the layout
+            self.file_explorer_sync_in_progress = true;
+
+            runtime.spawn(async move {
+                let _success = view.expand_and_select_file(&target_path).await;
+                // Receiver may have been dropped during shutdown.
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = sender.send(
+                    crate::services::async_bridge::AsyncMessage::FileExplorerExpandedToPath(view),
+                );
+            });
+        } else {
+            self.file_explorer = Some(view);
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -72,10 +72,10 @@ impl Editor {
     }
 
     pub fn toggle_file_explorer(&mut self) {
-        self.active_window_mut().file_explorer_visible =
-            !self.active_window().file_explorer_visible;
+        let new_visible = !self.active_window().file_explorer_visible;
+        self.active_window_mut().file_explorer_visible = new_visible;
 
-        if self.active_window().file_explorer_visible {
+        if new_visible {
             if self.file_explorer().is_none() {
                 self.init_file_explorer();
             }
@@ -98,13 +98,13 @@ impl Editor {
     }
 
     pub fn show_file_explorer(&mut self) {
-        if !self.active_window().file_explorer_visible {
+        if !self.file_explorer_visible() {
             self.toggle_file_explorer();
         }
     }
 
     pub fn sync_file_explorer_to_active_file(&mut self) {
-        if !self.active_window().file_explorer_visible {
+        if !self.file_explorer_visible() {
             return;
         }
 
@@ -156,7 +156,7 @@ impl Editor {
     }
 
     pub fn focus_file_explorer(&mut self) {
-        if self.active_window().file_explorer_visible {
+        if self.file_explorer_visible() {
             // Dismiss transient popups and clear hover state when focusing file explorer
             self.on_editor_focus_lost();
 

--- a/crates/fresh-editor/src/app/file_open_input.rs
+++ b/crates/fresh-editor/src/app/file_open_input.rs
@@ -24,7 +24,7 @@ impl Editor {
                 )
             })
             .unwrap_or(false)
-            && self.file_open_state.is_some()
+            && self.active_window().file_open_state.is_some()
     }
 
     /// Check if we're in folder-only selection mode (Switch Project)
@@ -55,25 +55,25 @@ impl Editor {
         match action {
             // Navigation actions - Up/Down in file list
             Action::PromptSelectPrev => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.select_prev();
                 }
                 true
             }
             Action::PromptSelectNext => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.select_next();
                 }
                 true
             }
             Action::PromptPageUp => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.page_up(10);
                 }
                 true
             }
             Action::PromptPageDown => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.page_down(10);
                 }
                 true
@@ -90,17 +90,21 @@ impl Editor {
             // Tab to autocomplete to selected item (and navigate into dir if it's a directory)
             Action::PromptAcceptSuggestion => {
                 // Get the selected entry info
-                let selected_info = self.file_open_state.as_ref().and_then(|s| {
-                    s.selected_index
-                        .and_then(|idx| s.entries.get(idx))
-                        .map(|e| {
-                            (
-                                e.fs_entry.name.clone(),
-                                e.fs_entry.is_dir(),
-                                e.fs_entry.path.clone(),
-                            )
-                        })
-                });
+                let selected_info =
+                    self.active_window_mut()
+                        .file_open_state
+                        .as_ref()
+                        .and_then(|s| {
+                            s.selected_index
+                                .and_then(|idx| s.entries.get(idx))
+                                .map(|e| {
+                                    (
+                                        e.fs_entry.name.clone(),
+                                        e.fs_entry.is_dir(),
+                                        e.fs_entry.path.clone(),
+                                    )
+                                })
+                        });
 
                 if let Some((name, is_dir, path)) = selected_info {
                     if is_dir {
@@ -122,6 +126,7 @@ impl Editor {
             // Backspace when filter is empty goes to parent
             Action::PromptBackspace => {
                 let filter_empty = self
+                    .active_window_mut()
                     .file_open_state
                     .as_ref()
                     .map(|s| s.filter.is_empty())
@@ -145,7 +150,7 @@ impl Editor {
             // Escape cancels
             Action::PromptCancel => {
                 self.cancel_prompt();
-                self.file_open_state = None;
+                self.active_window_mut().file_open_state = None;
                 true
             }
 
@@ -180,6 +185,7 @@ impl Editor {
 
         // Get the current directory from file open state
         let current_dir = self
+            .active_window_mut()
             .file_open_state
             .as_ref()
             .map(|s| s.current_dir.clone())
@@ -226,7 +232,7 @@ impl Editor {
 
         // Use the selected entry from the file list
         let (path, is_dir) = {
-            let state = match &self.file_open_state {
+            let state = match &self.active_window_mut().file_open_state {
                 Some(s) => s,
                 None => {
                     // If no file is selected but we're in folder mode, use the current directory
@@ -277,7 +283,7 @@ impl Editor {
     /// Select a folder as the new project root (for SwitchProject mode)
     fn file_open_select_folder(&mut self, path: std::path::PathBuf) {
         // Close the file browser
-        self.file_open_state = None;
+        self.active_window_mut().file_open_state = None;
         self.active_window_mut().prompt = None;
 
         // Change the working directory
@@ -310,13 +316,14 @@ impl Editor {
     ) {
         // Check if encoding detection is disabled - if so, prompt for encoding first
         let detect_encoding = self
+            .active_window_mut()
             .file_open_state
             .as_ref()
             .map(|s| s.detect_encoding)
             .unwrap_or(true);
 
         // Close the file browser
-        self.file_open_state = None;
+        self.active_window_mut().file_open_state = None;
         self.active_window_mut().prompt = None;
 
         if !detect_encoding {
@@ -327,7 +334,7 @@ impl Editor {
 
         // Reset key context to Normal so editor gets focus
         // This is important when the file explorer was focused before opening the file browser
-        self.key_context = crate::input::keybindings::KeyContext::Normal;
+        self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
 
         // Open the file with auto-detected encoding
         tracing::info!("[SYNTAX DEBUG] file_open_dialog opening file: {:?}", path);
@@ -446,12 +453,12 @@ impl Editor {
     /// Create a new file (opens an unsaved buffer that will create the file on save)
     fn file_open_create_new_file(&mut self, path: std::path::PathBuf) {
         // Close the file browser
-        self.file_open_state = None;
+        self.active_window_mut().file_open_state = None;
         self.active_window_mut().prompt = None;
 
         // Reset key context to Normal so editor gets focus
         // This is important when the file explorer was focused before opening the file browser
-        self.key_context = crate::input::keybindings::KeyContext::Normal;
+        self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
 
         // Open the file - this will create an unsaved buffer with the path set
         if let Err(e) = self.open_file(&path) {
@@ -466,7 +473,7 @@ impl Editor {
     /// Save the current buffer to a file (for SaveFileAs mode)
     fn file_open_save_file(&mut self, path: std::path::PathBuf) {
         // Close the file browser
-        self.file_open_state = None;
+        self.active_window_mut().file_open_state = None;
         self.active_window_mut().prompt = None;
 
         self.save_file_as_with_checks(path);
@@ -491,6 +498,7 @@ impl Editor {
     /// Navigate to parent directory
     fn file_open_go_parent(&mut self) {
         let parent = self
+            .active_window_mut()
             .file_open_state
             .as_ref()
             .and_then(|s| s.current_dir.parent())
@@ -518,6 +526,7 @@ impl Editor {
         // Navigate to the parent directory of the path (so the file appears in the list)
         if filter.contains('/') {
             let current_dir = self
+                .active_window_mut()
                 .file_open_state
                 .as_ref()
                 .map(|s| s.current_dir.clone())
@@ -559,28 +568,28 @@ impl Editor {
                 self.load_file_open_directory(target_dir);
 
                 // Apply filter with the filename only
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.apply_filter(&filename);
                 }
                 return;
             }
         }
 
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             state.apply_filter(&filter);
         }
     }
 
     /// Handle sorting toggle (called from keybinding)
     pub fn file_open_toggle_sort(&mut self, mode: SortMode) {
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             state.set_sort_mode(mode);
         }
     }
 
     /// Handle hidden files toggle
     pub fn file_open_toggle_hidden(&mut self) {
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             let show_hidden = state.show_hidden;
             state.show_hidden = !show_hidden;
             let new_state = state.show_hidden;
@@ -601,7 +610,7 @@ impl Editor {
 
     /// Handle encoding detection toggle
     pub fn file_open_toggle_detect_encoding(&mut self) {
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             state.toggle_detect_encoding();
             let new_state = state.detect_encoding;
 
@@ -623,12 +632,13 @@ impl Editor {
         }
 
         let visible_rows = self
+            .active_window_mut()
             .file_browser_layout
             .as_ref()
             .map(|l| l.visible_rows)
             .unwrap_or(10);
 
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             let total_entries = state.entries.len();
             if total_entries <= visible_rows {
                 // No scrolling needed if all entries fit
@@ -658,7 +668,7 @@ impl Editor {
             return false;
         }
 
-        let layout = match &self.file_browser_layout {
+        let layout = match &self.active_window_mut().file_browser_layout {
             Some(l) => l.clone(),
             None => return false,
         };
@@ -666,6 +676,7 @@ impl Editor {
         // Check if click is in the file list
         if layout.is_in_list(x, y) {
             let scroll_offset = self
+                .active_window_mut()
                 .file_open_state
                 .as_ref()
                 .map(|s| s.scroll_offset)
@@ -674,12 +685,13 @@ impl Editor {
             if let Some(index) = layout.click_to_index(y, scroll_offset) {
                 // Get the entry name before mutating state
                 let entry_name = self
+                    .active_window_mut()
                     .file_open_state
                     .as_ref()
                     .and_then(|s| s.entries.get(index))
                     .map(|e| e.fs_entry.name.clone());
 
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.active_section = FileOpenSection::Files;
                     if index < state.entries.len() {
                         state.selected_index = Some(index);
@@ -713,6 +725,7 @@ impl Editor {
         if layout.is_in_nav(x, y) {
             // Get shortcut labels for hit testing
             let shortcut_labels: Vec<&str> = self
+                .active_window_mut()
                 .file_open_state
                 .as_ref()
                 .map(|s| s.shortcuts.iter().map(|sc| sc.label.as_str()).collect())
@@ -721,13 +734,14 @@ impl Editor {
             if let Some(shortcut_idx) = layout.nav_shortcut_at(x, y, &shortcut_labels) {
                 // Get the path from the shortcut and navigate there
                 let target_path = self
+                    .active_window_mut()
                     .file_open_state
                     .as_ref()
                     .and_then(|s| s.shortcuts.get(shortcut_idx))
                     .map(|sc| sc.path.clone());
 
                 if let Some(path) = target_path {
-                    if let Some(state) = &mut self.file_open_state {
+                    if let Some(state) = &mut self.active_window_mut().file_open_state {
                         state.active_section = FileOpenSection::Navigation;
                         state.selected_shortcut = shortcut_idx;
                     }
@@ -735,7 +749,7 @@ impl Editor {
                 }
             } else {
                 // Clicked in nav area but not on a shortcut
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.active_section = FileOpenSection::Navigation;
                 }
             }
@@ -756,7 +770,7 @@ impl Editor {
             let rel_y = y.saturating_sub(layout.scrollbar_area.y) as usize;
             let track_height = layout.scrollbar_area.height as usize;
 
-            if let Some(state) = &mut self.file_open_state {
+            if let Some(state) = &mut self.active_window_mut().file_open_state {
                 let total_items = state.entries.len();
                 let visible_items = layout.visible_rows;
 
@@ -779,7 +793,7 @@ impl Editor {
             return false;
         }
 
-        let layout = match &self.file_browser_layout {
+        let layout = match &self.active_window_mut().file_browser_layout {
             Some(l) => l.clone(),
             None => return false,
         };
@@ -797,7 +811,7 @@ impl Editor {
     pub fn compute_file_browser_hover(&self, x: u16, y: u16) -> Option<super::types::HoverTarget> {
         use super::types::HoverTarget;
 
-        let layout = self.file_browser_layout.as_ref()?;
+        let layout = self.active_window().file_browser_layout.as_ref()?;
 
         // Check "Show Hidden" checkbox first (priority over navigation shortcuts)
         if layout.is_on_show_hidden_checkbox(x, y) {
@@ -812,6 +826,7 @@ impl Editor {
         // Check navigation shortcuts
         if layout.is_in_nav(x, y) {
             let shortcut_labels: Vec<&str> = self
+                .active_window()
                 .file_open_state
                 .as_ref()
                 .map(|s| s.shortcuts.iter().map(|sc| sc.label.as_str()).collect())
@@ -832,6 +847,7 @@ impl Editor {
         // Check file list entries
         if layout.is_in_list(x, y) {
             let scroll_offset = self
+                .active_window()
                 .file_open_state
                 .as_ref()
                 .map(|s| s.scroll_offset)
@@ -839,6 +855,7 @@ impl Editor {
 
             if let Some(idx) = layout.click_to_index(y, scroll_offset) {
                 let total_entries = self
+                    .active_window()
                     .file_open_state
                     .as_ref()
                     .map(|s| s.entries.len())

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -82,7 +82,7 @@ impl Editor {
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
 
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "buffer_activated",
                 crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
             );
@@ -481,7 +481,7 @@ impl Editor {
         self.watch_file(path);
 
         // Fire AfterFileOpen hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "after_file_open",
             crate::services::plugins::hooks::HookArgs::AfterFileOpen {
                 buffer_id,

--- a/crates/fresh-editor/src/app/file_open_queue.rs
+++ b/crates/fresh-editor/src/app/file_open_queue.rs
@@ -20,7 +20,7 @@ impl Editor {
     /// Schedule hot exit recovery to run after the next batch of pending file opens.
     pub fn schedule_hot_exit_recovery(&mut self) {
         if self.config.editor.hot_exit {
-            self.pending_hot_exit_recovery = true;
+            self.active_window_mut().pending_hot_exit_recovery = true;
         }
     }
 
@@ -35,15 +35,17 @@ impl Editor {
         message: Option<String>,
         wait_id: Option<u64>,
     ) {
-        self.pending_file_opens.push(super::PendingFileOpen {
-            path,
-            line,
-            column,
-            end_line,
-            end_column,
-            message,
-            wait_id,
-        });
+        self.active_window_mut()
+            .pending_file_opens
+            .push(super::PendingFileOpen {
+                path,
+                line,
+                column,
+                end_line,
+                end_column,
+                message,
+                wait_id,
+            });
     }
 
     /// Process pending file opens (called from the event loop).
@@ -51,12 +53,12 @@ impl Editor {
     /// Opens files that were queued during startup, using the same error handling
     /// as interactive file opens. Returns true if any files were processed.
     pub fn process_pending_file_opens(&mut self) -> bool {
-        if self.pending_file_opens.is_empty() {
+        if self.active_window_mut().pending_file_opens.is_empty() {
             return false;
         }
 
         // Take all pending files to process
-        let pending = std::mem::take(&mut self.pending_file_opens);
+        let pending = std::mem::take(&mut self.active_window_mut().pending_file_opens);
         let mut processed_any = false;
 
         for pending_file in pending {
@@ -87,7 +89,9 @@ impl Editor {
                     // Track wait ID for --wait support
                     if let Some(wait_id) = pending_file.wait_id {
                         let buffer_id = self.active_buffer();
-                        self.wait_tracking.insert(buffer_id, (wait_id, has_popup));
+                        self.active_window_mut()
+                            .wait_tracking
+                            .insert(buffer_id, (wait_id, has_popup));
                     }
                     processed_any = true;
                 }
@@ -110,8 +114,8 @@ impl Editor {
         }
 
         // Apply hot exit recovery if flagged (one-shot after CLI files are opened)
-        if processed_any && self.pending_hot_exit_recovery {
-            self.pending_hot_exit_recovery = false;
+        if processed_any && self.active_window_mut().pending_hot_exit_recovery {
+            self.active_window_mut().pending_hot_exit_recovery = false;
             match self.apply_hot_exit_recovery() {
                 Ok(count) if count > 0 => {
                     tracing::info!("Hot exit: restored unsaved changes for {} buffer(s)", count);
@@ -128,11 +132,13 @@ impl Editor {
 
     /// Take and return completed wait IDs (for --wait support).
     pub fn take_completed_waits(&mut self) -> Vec<u64> {
-        std::mem::take(&mut self.completed_waits)
+        std::mem::take(&mut self.active_window_mut().completed_waits)
     }
 
     /// Remove wait tracking for a given wait_id (e.g., when waiting client disconnects).
     pub fn remove_wait_tracking(&mut self, wait_id: u64) {
-        self.wait_tracking.retain(|_, (wid, _)| *wid != wait_id);
+        self.active_window_mut()
+            .wait_tracking
+            .retain(|_, (wid, _)| *wid != wait_id);
     }
 }

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -171,7 +171,7 @@ impl Editor {
 
         // Fire AfterFileSave hook for plugins
         if let Some(ref p) = path {
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "after_file_save",
                 crate::services::plugins::hooks::HookArgs::AfterFileSave {
                     buffer_id,
@@ -806,7 +806,7 @@ impl Editor {
                     self.active_window_mut()
                         .dir_mod_times
                         .insert(path, current_mtime);
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "focus_gained",
                         crate::services::plugins::hooks::HookArgs::FocusGained {},
                     );

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -152,7 +152,7 @@ impl Editor {
         }
 
         // Notify LSP of save
-        self.notify_lsp_save_buffer(buffer_id);
+        self.active_window_mut().notify_lsp_save_buffer(buffer_id);
 
         // Delete recovery file (buffer is now saved)
         if let Err(e) = self.delete_buffer_recovery(buffer_id) {
@@ -223,13 +223,13 @@ impl Editor {
             std::time::Duration::from_secs(self.config.editor.auto_save_interval_secs as u64);
         if self
             .time_source
-            .elapsed_since(self.last_persistent_auto_save)
+            .elapsed_since(self.active_window().last_persistent_auto_save)
             < interval
         {
             return Ok(0);
         }
 
-        self.last_persistent_auto_save = self.time_source.now();
+        self.active_window_mut().last_persistent_auto_save = self.time_source.now();
 
         // Collect info for modified buffers that have a file path
         let mut to_save = Vec::new();
@@ -556,10 +556,10 @@ impl Editor {
 
         // Check for results from a previous background poll
         let mut any_changed = false;
-        if let Some(ref rx) = self.pending_file_poll_rx {
+        if let Some(ref rx) = self.active_window_mut().pending_file_poll_rx {
             match rx.try_recv() {
                 Ok(results) => {
-                    self.pending_file_poll_rx = None;
+                    self.active_window_mut().pending_file_poll_rx = None;
                     any_changed = self.process_file_poll_results(results);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {
@@ -568,7 +568,7 @@ impl Editor {
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
                     // Background task panicked or was dropped
-                    self.pending_file_poll_rx = None;
+                    self.active_window_mut().pending_file_poll_rx = None;
                 }
             }
         }
@@ -576,7 +576,8 @@ impl Editor {
         // Check poll interval
         let poll_interval =
             std::time::Duration::from_millis(self.config.editor.auto_revert_poll_interval_ms);
-        let elapsed = self.time_source.elapsed_since(self.last_auto_revert_poll);
+        let last_poll = self.active_window().last_auto_revert_poll;
+        let elapsed = self.time_source.elapsed_since(last_poll);
         tracing::trace!(
             "poll_file_changes: elapsed={:?}, poll_interval={:?}",
             elapsed,
@@ -585,7 +586,7 @@ impl Editor {
         if elapsed < poll_interval {
             return any_changed;
         }
-        self.last_auto_revert_poll = self.time_source.now();
+        self.active_window_mut().last_auto_revert_poll = self.time_source.now();
 
         // Collect paths of open files that need checking
         let files_to_check: Vec<PathBuf> = self
@@ -616,7 +617,7 @@ impl Editor {
                 if tx.send(results).is_err() {}
             })
             .ok();
-        self.pending_file_poll_rx = Some(rx);
+        self.active_window_mut().pending_file_poll_rx = Some(rx);
 
         any_changed
     }
@@ -660,17 +661,17 @@ impl Editor {
         // Check for results from a previous background poll
         let mut any_refreshed = false;
         let mut dir_poll_pending = false;
-        if let Some(ref rx) = self.pending_dir_poll_rx {
+        if let Some(ref rx) = self.active_window_mut().pending_dir_poll_rx {
             match rx.try_recv() {
                 Ok((dir_results, git_index_mtime)) => {
-                    self.pending_dir_poll_rx = None;
+                    self.active_window_mut().pending_dir_poll_rx = None;
                     any_refreshed = self.process_dir_poll_results(dir_results, git_index_mtime);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {
                     dir_poll_pending = true;
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    self.pending_dir_poll_rx = None;
+                    self.active_window_mut().pending_dir_poll_rx = None;
                 }
             }
         }
@@ -678,10 +679,11 @@ impl Editor {
         // Check poll interval
         let poll_interval =
             std::time::Duration::from_millis(self.config.editor.file_tree_poll_interval_ms);
-        if self.time_source.elapsed_since(self.last_file_tree_poll) < poll_interval {
+        let last_tree_poll = self.active_window().last_file_tree_poll;
+        if self.time_source.elapsed_since(last_tree_poll) < poll_interval {
             return any_refreshed;
         }
-        self.last_file_tree_poll = self.time_source.now();
+        self.active_window_mut().last_file_tree_poll = self.time_source.now();
 
         // Re-stat every loaded .gitignore and reload/drop as needed, so
         // external edits (git pull, sed, another editor) and deletions take
@@ -700,12 +702,12 @@ impl Editor {
         // Resolve the git index path once (first poll only). This uses the
         // ProcessSpawner which may block briefly on the first call, but only
         // happens once per session.
-        if !self.git_index_resolved {
-            self.git_index_resolved = true;
+        if !self.active_window_mut().git_index_resolved {
+            self.active_window_mut().git_index_resolved = true;
             if let Some(path) = self.resolve_git_index() {
                 if let Ok(meta) = self.authority.filesystem.metadata(&path) {
                     if let Some(mtime) = meta.modified {
-                        self.dir_mod_times.insert(path, mtime);
+                        self.active_window_mut().dir_mod_times.insert(path, mtime);
                     }
                 }
             }
@@ -726,6 +728,7 @@ impl Editor {
 
         // Find the git index path to include in the background metadata check
         let git_index_path: Option<PathBuf> = self
+            .active_window()
             .dir_mod_times
             .keys()
             .find(|p| p.ends_with(".git/index") || p.ends_with(".git\\index"))
@@ -759,7 +762,7 @@ impl Editor {
                 if tx.send((results, git_index_mtime)).is_err() {}
             })
             .ok();
-        self.pending_dir_poll_rx = Some(rx);
+        self.active_window_mut().pending_dir_poll_rx = Some(rx);
 
         any_refreshed
     }
@@ -781,22 +784,28 @@ impl Editor {
                 continue;
             };
 
-            if let Some(&stored_mtime) = self.dir_mod_times.get(&path) {
+            if let Some(&stored_mtime) = self.active_window_mut().dir_mod_times.get(&path) {
                 if current_mtime != stored_mtime {
-                    self.dir_mod_times.insert(path.clone(), current_mtime);
+                    self.active_window_mut()
+                        .dir_mod_times
+                        .insert(path.clone(), current_mtime);
                     dirs_to_refresh.push((node_id, path.clone()));
                     tracing::debug!("Directory changed: {:?}", path);
                 }
             } else {
-                self.dir_mod_times.insert(path, current_mtime);
+                self.active_window_mut()
+                    .dir_mod_times
+                    .insert(path, current_mtime);
             }
         }
 
         // Check if .git/index mtime changed (detected in background thread)
         let git_index_changed = if let Some((path, current_mtime)) = git_index_mtime {
-            if let Some(&stored_mtime) = self.dir_mod_times.get(&path) {
+            if let Some(&stored_mtime) = self.active_window_mut().dir_mod_times.get(&path) {
                 if current_mtime != stored_mtime {
-                    self.dir_mod_times.insert(path, current_mtime);
+                    self.active_window_mut()
+                        .dir_mod_times
+                        .insert(path, current_mtime);
                     self.plugin_manager.run_hook(
                         "focus_gained",
                         crate::services::plugins::hooks::HookArgs::FocusGained {},
@@ -1015,7 +1024,11 @@ impl Editor {
         };
 
         let enable_inlay_hints = self.config.editor.enable_inlay_hints;
-        let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
+        let previous_result_id = self
+            .active_window()
+            .diagnostic_result_ids
+            .get(uri.as_str())
+            .cloned();
 
         // Get buffer line count and version for inlay hints
         let (last_line, last_char, buffer_version) = self

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -62,7 +62,10 @@ impl Editor {
             .pop_front()
         {
             let json = serde_json::to_string(&payload).unwrap_or_else(|_| "null".to_string());
-            self.plugin_manager.resolve_callback(callback_id, json);
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .resolve_callback(callback_id, json);
             return true;
         }
         if self.active_window_mut().key_capture_active {
@@ -1073,9 +1076,12 @@ impl Editor {
                 // direct keybinding (Alt+/) instead of palette-only access.
                 #[cfg(feature = "plugins")]
                 {
-                    if let Some(result) =
-                        self.plugin_manager.execute_action_async("start_live_grep")
-                    {
+                    let result = self
+                        .plugin_manager
+                        .read()
+                        .unwrap()
+                        .execute_action_async("start_live_grep");
+                    if let Some(result) = result {
                         match result {
                             Ok(receiver) => {
                                 self.pending_plugin_actions
@@ -1145,19 +1151,24 @@ impl Editor {
                     _ => {
                         // No cache — kick off a fresh Live Grep.
                         #[cfg(feature = "plugins")]
-                        if let Some(result) =
-                            self.plugin_manager.execute_action_async("start_live_grep")
                         {
-                            match result {
-                                Ok(receiver) => {
-                                    self.pending_plugin_actions
-                                        .push(("start_live_grep".to_string(), receiver));
-                                }
-                                Err(e) => {
-                                    self.set_status_message(format!(
-                                        "Live Grep unavailable: {}",
-                                        e
-                                    ));
+                            let result = self
+                                .plugin_manager
+                                .read()
+                                .unwrap()
+                                .execute_action_async("start_live_grep");
+                            if let Some(result) = result {
+                                match result {
+                                    Ok(receiver) => {
+                                        self.pending_plugin_actions
+                                            .push(("start_live_grep".to_string(), receiver));
+                                    }
+                                    Err(e) => {
+                                        self.set_status_message(format!(
+                                            "Live Grep unavailable: {}",
+                                            e
+                                        ));
+                                    }
                                 }
                             }
                         }
@@ -1262,10 +1273,12 @@ impl Editor {
                 }
                 #[cfg(feature = "plugins")]
                 {
-                    if let Some(result) = self
+                    let result = self
                         .plugin_manager
-                        .execute_action_async("live_grep_cycle_provider")
-                    {
+                        .read()
+                        .unwrap()
+                        .execute_action_async("live_grep_cycle_provider");
+                    if let Some(result) = result {
                         match result {
                             Ok(receiver) => {
                                 self.pending_plugin_actions
@@ -2131,22 +2144,31 @@ impl Editor {
                 // Execute the plugin callback via TypeScript plugin thread
                 // Use non-blocking version to avoid deadlock with async plugin ops
                 #[cfg(feature = "plugins")]
-                if let Some(result) = self.plugin_manager.execute_action_async(&action_name) {
-                    match result {
-                        Ok(receiver) => {
-                            // Store pending action for processing in main loop
-                            self.pending_plugin_actions
-                                .push((action_name.clone(), receiver));
+                {
+                    let result = self
+                        .plugin_manager
+                        .read()
+                        .unwrap()
+                        .execute_action_async(&action_name);
+                    if let Some(result) = result {
+                        match result {
+                            Ok(receiver) => {
+                                // Store pending action for processing in main loop
+                                self.pending_plugin_actions
+                                    .push((action_name.clone(), receiver));
+                            }
+                            Err(e) => {
+                                self.set_status_message(
+                                    t!("view.plugin_error", error = e.to_string()).to_string(),
+                                );
+                                tracing::error!("Plugin action error: {}", e);
+                            }
                         }
-                        Err(e) => {
-                            self.set_status_message(
-                                t!("view.plugin_error", error = e.to_string()).to_string(),
-                            );
-                            tracing::error!("Plugin action error: {}", e);
-                        }
+                    } else {
+                        self.set_status_message(
+                            t!("status.plugin_manager_unavailable").to_string(),
+                        );
                     }
-                } else {
-                    self.set_status_message(t!("status.plugin_manager_unavailable").to_string());
                 }
                 #[cfg(not(feature = "plugins"))]
                 {
@@ -2182,10 +2204,12 @@ impl Editor {
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "buffer-plugin".to_string());
 
-                    match self
+                    let load_result = self
                         .plugin_manager
-                        .load_plugin_from_source(&content, &name, is_ts)
-                    {
+                        .read()
+                        .unwrap()
+                        .load_plugin_from_source(&content, &name, is_ts);
+                    match load_result {
                         Ok(()) => {
                             self.set_status_message(format!(
                                 "Plugin '{}' loaded from buffer",
@@ -2233,7 +2257,8 @@ impl Editor {
                         // tsconfig.json lists this file in `files`, so a
                         // stale copy is exactly when `getPluginApi("foo")`
                         // loses its typed overload.
-                        let declarations = self.plugin_manager.plugin_declarations();
+                        let declarations =
+                            self.plugin_manager.read().unwrap().plugin_declarations();
                         crate::init_script::write_plugin_declarations(&config_dir, &declarations);
                         match self.open_file(&path) {
                             Ok(_) => {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1379,7 +1379,7 @@ impl Editor {
                             self.active_window_mut().terminal_mode = true;
                             self.active_window_mut().key_context =
                                 crate::input::keybindings::KeyContext::Terminal;
-                            self.resize_visible_terminals();
+                            self.active_window_mut().resize_visible_terminals();
                             let exit_key = self
                                 .keybindings
                                 .read()

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -56,13 +56,19 @@ impl Editor {
     /// between iterations.
     fn try_resolve_next_key_callback(&mut self, key_event: &crossterm::event::KeyEvent) -> bool {
         let payload = key_event_to_payload(key_event);
-        if let Some(callback_id) = self.pending_next_key_callbacks.pop_front() {
+        if let Some(callback_id) = self
+            .active_window_mut()
+            .pending_next_key_callbacks
+            .pop_front()
+        {
             let json = serde_json::to_string(&payload).unwrap_or_else(|_| "null".to_string());
             self.plugin_manager.resolve_callback(callback_id, json);
             return true;
         }
-        if self.key_capture_active {
-            self.pending_key_capture_buffer.push_back(payload);
+        if self.active_window_mut().key_capture_active {
+            self.active_window_mut()
+                .pending_key_capture_buffer
+                .push_back(payload);
             return true;
         }
         false
@@ -290,7 +296,7 @@ impl Editor {
     /// and `dispatch_modal_input` (handler routing) so the two cannot drift.
     pub(crate) fn popups_capture_keys(&self) -> bool {
         use crate::input::keybindings::KeyContext;
-        if matches!(self.key_context, KeyContext::FileExplorer) {
+        if matches!(self.active_window().key_context, KeyContext::FileExplorer) {
             return false;
         }
         self.topmost_popup_focused()
@@ -356,7 +362,7 @@ impl Editor {
         // resolves to `remove_secondary_cursors`, which would shadow the
         // popup-dismiss intent here.
         let popup_focus_match = matches!(
-            kb.resolve_in_context_only(event, self.key_context.clone()),
+            kb.resolve_in_context_only(event, self.active_window().key_context.clone()),
             Some(Action::PopupFocus),
         );
         if popup_focus_match {
@@ -434,7 +440,7 @@ impl Editor {
             KeyContext::CompositeBuffer
         } else {
             // Use the current context (can be FileExplorer or Normal)
-            self.key_context.clone()
+            self.active_window().key_context.clone()
         }
     }
 
@@ -501,11 +507,15 @@ impl Editor {
         }
 
         // Dismiss theme info popup on any key press
-        if self.theme_info_popup.is_some() {
-            self.theme_info_popup = None;
+        if self.active_window_mut().theme_info_popup.is_some() {
+            self.active_window_mut().theme_info_popup = None;
         }
 
-        if self.file_explorer_context_menu.is_some() {
+        if self
+            .active_window_mut()
+            .file_explorer_context_menu
+            .is_some()
+        {
             if let Some(result) = self.handle_file_explorer_context_menu_key(code, modifiers) {
                 return result;
             }
@@ -608,26 +618,29 @@ impl Editor {
                 // Mode chord resolution (via KeybindingResolver)
                 let (chord_result, resolved_action) = {
                     let keybindings = self.keybindings.read().unwrap();
-                    let chord_result =
-                        keybindings.resolve_chord(&self.chord_state, &key_event, mode_ctx.clone());
+                    let chord_result = keybindings.resolve_chord(
+                        &self.active_window().chord_state,
+                        &key_event,
+                        mode_ctx.clone(),
+                    );
                     let resolved = keybindings.resolve(&key_event, mode_ctx);
                     (chord_result, resolved)
                 };
                 match chord_result {
                     crate::input::keybindings::ChordResolution::Complete(action) => {
                         tracing::debug!("Mode chord resolved to action: {:?}", action);
-                        self.chord_state.clear();
+                        self.active_window_mut().chord_state.clear();
                         return self.handle_action(action);
                     }
                     crate::input::keybindings::ChordResolution::Partial => {
                         tracing::debug!("Potential chord prefix in mode '{}'", mode_name);
-                        self.chord_state.push((code, modifiers));
+                        self.active_window_mut().chord_state.push((code, modifiers));
                         return Ok(());
                     }
                     crate::input::keybindings::ChordResolution::NoMatch => {
-                        if !self.chord_state.is_empty() {
+                        if !self.active_window_mut().chord_state.is_empty() {
                             tracing::debug!("Chord sequence abandoned in mode, clearing state");
-                            self.chord_state.clear();
+                            self.active_window_mut().chord_state.clear();
                         }
                     }
                 }
@@ -700,8 +713,11 @@ impl Editor {
         let key_event = crossterm::event::KeyEvent::new(code, modifiers);
         let (chord_result, action) = {
             let keybindings = self.keybindings.read().unwrap();
-            let chord_result =
-                keybindings.resolve_chord(&self.chord_state, &key_event, context.clone());
+            let chord_result = keybindings.resolve_chord(
+                &self.active_window().chord_state,
+                &key_event,
+                context.clone(),
+            );
             let action = keybindings.resolve(&key_event, context.clone());
             (chord_result, action)
         };
@@ -710,20 +726,20 @@ impl Editor {
             crate::input::keybindings::ChordResolution::Complete(action) => {
                 // Complete chord match - execute action and clear chord state
                 tracing::debug!("Complete chord match -> Action: {:?}", action);
-                self.chord_state.clear();
+                self.active_window_mut().chord_state.clear();
                 return self.handle_action(action);
             }
             crate::input::keybindings::ChordResolution::Partial => {
                 // Partial match - add to chord state and wait for more keys
                 tracing::debug!("Partial chord match - waiting for next key");
-                self.chord_state.push((code, modifiers));
+                self.active_window_mut().chord_state.push((code, modifiers));
                 return Ok(());
             }
             crate::input::keybindings::ChordResolution::NoMatch => {
                 // No chord match - clear state and try regular resolution
-                if !self.chord_state.is_empty() {
+                if !self.active_window_mut().chord_state.is_empty() {
                     tracing::debug!("Chord sequence abandoned, clearing state");
-                    self.chord_state.clear();
+                    self.active_window_mut().chord_state.clear();
                 }
             }
         }
@@ -743,7 +759,7 @@ impl Editor {
             }
             _ => {
                 // Cancel any pending LSP requests
-                self.cancel_pending_lsp_requests();
+                self.active_window_mut().cancel_pending_lsp_requests();
             }
         }
 
@@ -932,7 +948,9 @@ impl Editor {
                         }
                     }
                 }
-                if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
+                if self.active_window_mut().key_context
+                    == crate::input::keybindings::KeyContext::FileExplorer
+                {
                     self.file_explorer_copy();
                     return Ok(());
                 }
@@ -949,22 +967,26 @@ impl Editor {
             Action::CopyFilePath => self.copy_active_buffer_path(false),
             Action::CopyRelativeFilePath => self.copy_active_buffer_path(true),
             Action::Cut => {
-                if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
+                if self.active_window_mut().key_context
+                    == crate::input::keybindings::KeyContext::FileExplorer
+                {
                     self.file_explorer_cut();
                     return Ok(());
                 }
-                if self.is_editing_disabled() {
+                if self.active_window().is_editing_disabled() {
                     self.set_status_message(t!("buffer.editing_disabled").to_string());
                     return Ok(());
                 }
                 self.cut_selection()
             }
             Action::Paste => {
-                if self.key_context == crate::input::keybindings::KeyContext::FileExplorer {
+                if self.active_window_mut().key_context
+                    == crate::input::keybindings::KeyContext::FileExplorer
+                {
                     self.file_explorer_paste();
                     return Ok(());
                 }
-                if self.is_editing_disabled() {
+                if self.active_window().is_editing_disabled() {
                     self.set_status_message(t!("buffer.editing_disabled").to_string());
                     return Ok(());
                 }
@@ -1342,7 +1364,8 @@ impl Editor {
                             // its tab list contains only the terminal,
                             // exactly the desired final state.
                             self.active_window_mut().terminal_mode = true;
-                            self.key_context = crate::input::keybindings::KeyContext::Terminal;
+                            self.active_window_mut().key_context =
+                                crate::input::keybindings::KeyContext::Terminal;
                             self.resize_visible_terminals();
                             let exit_key = self
                                 .keybindings
@@ -1703,10 +1726,10 @@ impl Editor {
             Action::ToggleVerticalScrollbar => self.toggle_vertical_scrollbar(),
             Action::ToggleHorizontalScrollbar => self.toggle_horizontal_scrollbar(),
             Action::ToggleLineNumbers => self.toggle_line_numbers(),
-            Action::ToggleScrollSync => self.toggle_scroll_sync(),
+            Action::ToggleScrollSync => self.active_window_mut().toggle_scroll_sync(),
             Action::ToggleMouseCapture => self.toggle_mouse_capture(),
             Action::ToggleMouseHover => self.toggle_mouse_hover(),
-            Action::ToggleDebugHighlights => self.toggle_debug_highlights(),
+            Action::ToggleDebugHighlights => self.active_window_mut().toggle_debug_highlights(),
             // Rulers
             Action::AddRuler => {
                 self.start_prompt(t!("rulers.add_prompt").to_string(), PromptType::AddRuler);
@@ -1814,7 +1837,10 @@ impl Editor {
             Action::FileExplorerSelectAll => self.active_window_mut().file_explorer_select_all(),
             Action::RemoveSecondaryCursors => {
                 // Convert action to events and apply them
-                if let Some(events) = self.action_to_events(Action::RemoveSecondaryCursors) {
+                if let Some(events) = self
+                    .active_window_mut()
+                    .action_to_events(Action::RemoveSecondaryCursors)
+                {
                     // Wrap in batch for atomic undo
                     let batch = Event::Batch {
                         events: events.clone(),
@@ -2051,7 +2077,7 @@ impl Editor {
                 self.start_prompt("Play macro (0-9): ".to_string(), PromptType::PlayMacro);
             }
             Action::PlayLastMacro => {
-                if let Some(key) = self.macros.last_register() {
+                if let Some(key) = self.active_window_mut().macros.last_register() {
                     self.play_macro(key);
                 } else {
                     self.set_status_message(t!("status.no_macro_recorded").to_string());
@@ -2068,20 +2094,23 @@ impl Editor {
             }
             Action::CompositeNextHunk => {
                 let buf = self.active_buffer();
-                self.composite_next_hunk_active(buf);
+                self.active_window_mut().composite_next_hunk_active(buf);
             }
             Action::CompositePrevHunk => {
                 let buf = self.active_buffer();
-                self.composite_prev_hunk_active(buf);
+                self.active_window_mut().composite_prev_hunk_active(buf);
             }
             Action::None => {}
             Action::DeleteBackward => {
-                if self.is_editing_disabled() {
+                if self.active_window().is_editing_disabled() {
                     self.set_status_message(t!("buffer.editing_disabled").to_string());
                     return Ok(());
                 }
                 // Normal backspace handling
-                if let Some(events) = self.action_to_events(Action::DeleteBackward) {
+                if let Some(events) = self
+                    .active_window_mut()
+                    .action_to_events(Action::DeleteBackward)
+                {
                     if events.len() > 1 {
                         // Multi-cursor: use optimized bulk edit (O(n) instead of O(n²))
                         let description = "Delete backward".to_string();
@@ -2256,7 +2285,7 @@ impl Editor {
                     .is_terminal_buffer(self.active_buffer())
                 {
                     self.active_window_mut().terminal_mode = true;
-                    self.key_context = KeyContext::Terminal;
+                    self.active_window_mut().key_context = KeyContext::Terminal;
                     self.set_status_message(t!("status.terminal_mode_enabled").to_string());
                 }
             }
@@ -2264,15 +2293,16 @@ impl Editor {
                 // Exit terminal mode back to editor
                 if self.active_window().terminal_mode {
                     self.active_window_mut().terminal_mode = false;
-                    self.key_context = KeyContext::Normal;
+                    self.active_window_mut().key_context = KeyContext::Normal;
                     self.set_status_message(t!("status.terminal_mode_disabled").to_string());
                 }
             }
             Action::ToggleKeyboardCapture => {
                 // Toggle keyboard capture mode in terminal
                 if self.active_window().terminal_mode {
-                    self.keyboard_capture = !self.keyboard_capture;
-                    if self.keyboard_capture {
+                    self.active_window_mut().keyboard_capture =
+                        !self.active_window_mut().keyboard_capture;
+                    if self.active_window_mut().keyboard_capture {
                         self.set_status_message(
                             "Keyboard capture ON - all keys go to terminal (F9 to toggle)"
                                 .to_string(),
@@ -2424,7 +2454,7 @@ impl Editor {
             Action::InsertChar(c) => {
                 if self.is_prompting() {
                     return self.handle_insert_char_prompt(c);
-                } else if self.key_context == KeyContext::FileExplorer {
+                } else if self.active_window_mut().key_context == KeyContext::FileExplorer {
                     self.active_window_mut().file_explorer_search_push_char(c);
                 } else {
                     self.handle_insert_char_editor(c)?;

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -333,7 +333,7 @@ impl Editor {
                             _ => None,
                         });
                 if let Some(custom_type) = plugin_custom_type {
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "prompt_selection_changed",
                         crate::services::plugins::hooks::HookArgs::PromptSelectionChanged {
                             prompt_type: custom_type.clone(),

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -469,7 +469,10 @@ impl Editor {
                     // User explicitly exited - don't auto-resume when switching back
                     let buf = self.active_buffer();
                     self.active_window_mut().terminal_mode_resume.remove(&buf);
-                    self.sync_terminal_to_buffer(self.active_buffer());
+                    {
+                        let __b = self.active_buffer();
+                        self.active_window_mut().sync_terminal_to_buffer(__b);
+                    };
                     self.set_status_message(
                         "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
                     );
@@ -479,7 +482,10 @@ impl Editor {
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;
-                self.sync_terminal_to_buffer(self.active_buffer());
+                {
+                    let __b = self.active_buffer();
+                    self.active_window_mut().sync_terminal_to_buffer(__b);
+                };
                 self.set_status_message(
                     "Scrollback mode - use PageUp/Down to scroll (Ctrl+Space to resume)"
                         .to_string(),

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -44,12 +44,14 @@ impl Editor {
                 .is_terminal_buffer(self.active_buffer())
             {
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
                 return None; // fall through to normal input dispatch
             }
             let mut ctx = InputContext::new();
+            let keyboard_capture = self.active_window().keyboard_capture;
             let keybindings = self.keybindings.read().unwrap();
-            let mut handler = TerminalModeInputHandler::new(self.keyboard_capture, &keybindings);
+            let mut handler = TerminalModeInputHandler::new(keyboard_capture, &keybindings);
             let result = handler.dispatch_input(event, &mut ctx);
             drop(keybindings);
             self.process_deferred_actions(ctx);
@@ -152,7 +154,7 @@ impl Editor {
                     .get_mut(&active_window_id)
                     .expect("active window present");
                 if let (Some(ref mut file_state), Some(ref mut prompt)) =
-                    (&mut self.file_open_state, &mut __win.prompt)
+                    (&mut __win.file_open_state, &mut __win.prompt)
                 {
                     let mut handler = FileBrowserInputHandler::new(file_state, prompt);
                     let result = handler.dispatch_input(event, &mut ctx);
@@ -379,22 +381,22 @@ impl Editor {
 
             // File browser actions
             DeferredAction::FileBrowserSelectPrev => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.select_prev();
                 }
             }
             DeferredAction::FileBrowserSelectNext => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.select_next();
                 }
             }
             DeferredAction::FileBrowserPageUp => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.page_up(10);
                 }
             }
             DeferredAction::FileBrowserPageDown => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.page_down(10);
                 }
             }
@@ -409,6 +411,7 @@ impl Editor {
             DeferredAction::FileBrowserGoParent => {
                 // Navigate to parent directory
                 let parent = self
+                    .active_window_mut()
                     .file_open_state
                     .as_ref()
                     .and_then(|s| s.current_dir.parent())
@@ -435,8 +438,9 @@ impl Editor {
 
             // Terminal mode actions
             DeferredAction::ToggleKeyboardCapture => {
-                self.keyboard_capture = !self.keyboard_capture;
-                if self.keyboard_capture {
+                self.active_window_mut().keyboard_capture =
+                    !self.active_window_mut().keyboard_capture;
+                if self.active_window_mut().keyboard_capture {
                     self.set_status_message(
                         "Keyboard capture ON - all keys go to terminal (F9 to toggle)".to_string(),
                     );
@@ -459,7 +463,8 @@ impl Editor {
             }
             DeferredAction::ExitTerminalMode { explicit } => {
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
                 if explicit {
                     // User explicitly exited - don't auto-resume when switching back
                     let buf = self.active_buffer();
@@ -472,7 +477,8 @@ impl Editor {
             }
             DeferredAction::EnterScrollbackMode => {
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
                 self.sync_terminal_to_buffer(self.active_buffer());
                 self.set_status_message(
                     "Scrollback mode - use PageUp/Down to scroll (Ctrl+Space to resume)"

--- a/crates/fresh-editor/src/app/input_helpers.rs
+++ b/crates/fresh-editor/src/app/input_helpers.rs
@@ -231,15 +231,18 @@ impl Editor {
     /// Handle character insertion in normal editor mode.
     pub(super) fn handle_insert_char_editor(&mut self, c: char) -> AnyhowResult<()> {
         // Check if editing is disabled (show_cursors = false)
-        if self.is_editing_disabled() {
+        if self.active_window().is_editing_disabled() {
             self.set_status_message(t!("buffer.editing_disabled").to_string());
             return Ok(());
         }
 
         // Cancel any pending LSP requests since the text is changing
-        self.cancel_pending_lsp_requests();
+        self.active_window_mut().cancel_pending_lsp_requests();
 
-        if let Some(events) = self.action_to_events(Action::InsertChar(c)) {
+        if let Some(events) = self
+            .active_window_mut()
+            .action_to_events(Action::InsertChar(c))
+        {
             if events.len() > 1 {
                 // Multi-cursor: use optimized bulk edit (O(n) instead of O(n²))
                 let description = format!("Insert '{}'", c);
@@ -300,12 +303,12 @@ impl Editor {
                 | Action::ToggleComment
         );
 
-        if is_editing_action && self.is_editing_disabled() {
+        if is_editing_action && self.active_window().is_editing_disabled() {
             self.set_status_message(t!("buffer.editing_disabled").to_string());
             return Ok(());
         }
 
-        if let Some(events) = self.action_to_events(action) {
+        if let Some(events) = self.active_window_mut().action_to_events(action) {
             if events.len() > 1 {
                 // Check if this batch contains buffer modifications
                 let has_buffer_mods = events
@@ -394,7 +397,8 @@ impl Editor {
                     ScrollAction::Down(n) => n as isize,
                     _ => return Some(Ok(())),
                 };
-                self.composite_scroll(split_id, buffer_id, delta);
+                self.active_window_mut()
+                    .composite_scroll(split_id, buffer_id, delta);
                 Some(Ok(()))
             }
 

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -254,30 +254,41 @@ impl Editor {
         );
     }
 
-    /// Resize all buffers to match new terminal size
+    /// Resize all buffers to match new terminal size. Loops over every
+    /// `Window` so each one updates its own split viewports and visible
+    /// terminal PTYs; the plugin `resize` hook fires once for the editor
+    /// as a whole.
     pub fn resize(&mut self, width: u16, height: u16) {
-        // Update terminal dimensions for future buffer creation
+        // Editor's canonical screen dimensions (used to seed new windows).
         self.terminal_width = width;
         self.terminal_height = height;
 
-        // Resize all SplitViewState viewports (viewport is now owned by SplitViewState)
-        for view_state in self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
-            .expect("active window must have a populated split layout")
-            .values_mut()
-        {
-            view_state.viewport.resize(width, height);
+        for window in self.windows.values_mut() {
+            window.resize(width, height);
         }
 
-        // Resize visible terminal PTYs to match new dimensions
-        self.resize_visible_terminals();
-
-        // Notify plugins of the resize so they can adjust layouts
+        // Notify plugins of the resize so they can adjust layouts.
         self.plugin_manager.read().unwrap().run_hook(
             "resize",
             fresh_core::hooks::HookArgs::Resize { width, height },
         );
+    }
+}
+
+impl crate::app::window::Window {
+    /// Adopt the new terminal dimensions for this window: update the
+    /// cached `terminal_width` / `terminal_height`, resize every split
+    /// viewport, and resize any visible terminal PTYs.
+    pub fn resize(&mut self, width: u16, height: u16) {
+        self.terminal_width = width;
+        self.terminal_height = height;
+
+        if let Some(view_states) = self.split_view_states_mut() {
+            for view_state in view_states.values_mut() {
+                view_state.viewport.resize(width, height);
+            }
+        }
+
+        self.resize_visible_terminals();
     }
 }

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -248,7 +248,7 @@ impl Editor {
 
     /// Handle terminal focus gained event
     pub fn focus_gained(&mut self) {
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "focus_gained",
             crate::services::plugins::hooks::HookArgs::FocusGained {},
         );
@@ -275,7 +275,7 @@ impl Editor {
         self.resize_visible_terminals();
 
         // Notify plugins of the resize so they can adjust layouts
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "resize",
             fresh_core::hooks::HookArgs::Resize { width, height },
         );

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -140,9 +140,9 @@ impl Editor {
         self.should_quit = true;
     }
 
-    /// Get the active theme
-    pub fn theme(&self) -> &crate::view::theme::Theme {
-        &self.theme
+    /// Get the active theme (read lock).
+    pub fn theme(&self) -> std::sync::RwLockReadGuard<'_, crate::view::theme::Theme> {
+        self.theme.read().unwrap()
     }
 
     /// Check if the settings dialog is open and visible

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -26,10 +26,12 @@ impl Editor {
         self.clipboard.set_session_mode(session_mode);
         // Also set custom context for command palette filtering
         if session_mode {
-            self.active_custom_contexts
+            self.active_window_mut()
+                .active_custom_contexts
                 .insert(crate::types::context_keys::SESSION_MODE.to_string());
         } else {
-            self.active_custom_contexts
+            self.active_window_mut()
+                .active_custom_contexts
                 .remove(crate::types::context_keys::SESSION_MODE);
         }
     }

--- a/crates/fresh-editor/src/app/lsp_actions.rs
+++ b/crates/fresh-editor/src/app/lsp_actions.rs
@@ -393,30 +393,6 @@ impl Editor {
         }
     }
 
-    /// Is the given language currently user-dismissed via the LSP popup?
-    pub fn is_lsp_language_user_dismissed(&self, language: &str) -> bool {
-        self.active_window()
-            .user_dismissed_lsp_languages
-            .contains(language)
-    }
-
-    /// Dismiss the LSP pill for a language until the next editor session
-    /// (or until the user re-enables it from the popup). See docs on
-    /// `Editor::user_dismissed_lsp_languages` for the rationale.
-    pub fn dismiss_lsp_language(&mut self, language: &str) {
-        self.active_window_mut()
-            .user_dismissed_lsp_languages
-            .insert(language.to_string());
-    }
-
-    /// Undo a previous dismissal — the pill returns to the normal
-    /// yellow `LSP (off)` for this language.
-    pub fn undismiss_lsp_language(&mut self, language: &str) {
-        self.active_window_mut()
-            .user_dismissed_lsp_languages
-            .remove(language);
-    }
-
     /// Handle an action from the LSP status details popup.
     ///
     /// Action keys have the format:
@@ -527,7 +503,8 @@ impl Editor {
                     lsp.shutdown_server_by_name(language, server_name);
                 }
                 // Remove the status entry so it gets re-created on spawn
-                self.lsp_server_statuses
+                self.active_window_mut()
+                    .lsp_server_statuses
                     .remove(&(language.to_string(), server_name.to_string()));
                 let __active_id = self.active_window;
                 if let Some(lsp) = self
@@ -591,7 +568,7 @@ impl Editor {
             // the persisted state until the in-memory cache next
             // re-reads config.
             let lang = language.to_string();
-            self.dismiss_lsp_language(&lang);
+            self.active_window_mut().dismiss_lsp_language(&lang);
             let mut changed = false;
             if let Some(lsp_configs) = self.config_mut().lsp.get_mut(&lang) {
                 for c in lsp_configs.as_mut_slice() {
@@ -622,7 +599,7 @@ impl Editor {
             // the disable action, so it must undo both halves —
             // session dismissal and the on-disk flag.
             let lang = language.to_string();
-            self.undismiss_lsp_language(&lang);
+            self.active_window_mut().undismiss_lsp_language(&lang);
             let mut changed = false;
             if let Some(lsp_configs) = self.config_mut().lsp.get_mut(&lang) {
                 for c in lsp_configs.as_mut_slice() {
@@ -970,7 +947,8 @@ impl Editor {
         }
 
         for name in &stopping_names {
-            self.lsp_server_statuses
+            self.active_window_mut()
+                .lsp_server_statuses
                 .remove(&(language.to_string(), name.clone()));
             // Clear diagnostics this server published so overlays clear
             // from every buffer it touched (not just the active one).
@@ -996,7 +974,8 @@ impl Editor {
             .as_ref()
             .is_some_and(|lsp| lsp.has_handles(language));
         if !any_handle_left {
-            self.lsp_progress
+            self.active_window_mut()
+                .lsp_progress
                 .retain(|_, info| info.language != language);
         }
 
@@ -1072,9 +1051,15 @@ impl Editor {
 
         if let Some(uri_str) = uri {
             self.stored_diagnostics_mut().remove(&uri_str);
-            self.stored_push_diagnostics.remove(&uri_str);
-            self.stored_pull_diagnostics.remove(&uri_str);
-            self.diagnostic_result_ids.remove(&uri_str);
+            self.active_window_mut()
+                .stored_push_diagnostics
+                .remove(&uri_str);
+            self.active_window_mut()
+                .stored_pull_diagnostics
+                .remove(&uri_str);
+            self.active_window_mut()
+                .diagnostic_result_ids
+                .remove(&uri_str);
             self.stored_folding_ranges_mut().remove(&uri_str);
         }
 
@@ -1177,12 +1162,12 @@ impl Editor {
                 )
             });
         let __active_id = self.active_window;
-        let diagnostic_result_ids = &self.diagnostic_result_ids;
         let enable_inlay_hints = self.config.editor.enable_inlay_hints;
 
         let Some(__win) = self.windows.get_mut(&__active_id) else {
             return;
         };
+        let diagnostic_result_ids = &__win.diagnostic_result_ids;
         let __next_id = &mut __win.next_lsp_request_id;
         let buffer_metadata = &mut __win.buffer_metadata;
         let Some(lsp) = __win.lsp.as_mut() else {
@@ -1363,7 +1348,9 @@ impl Editor {
 
                 // Store workspace for cleanup
                 let workspace_dir = workspace.dir().to_path_buf();
-                self.plugin_dev_workspaces.insert(buffer_id, workspace);
+                self.active_window_mut()
+                    .plugin_dev_workspaces
+                    .insert(buffer_id, workspace);
 
                 // Actually spawn the LSP server and send didOpen for this buffer
                 self.send_lsp_did_open_for_buffer(buffer_id, "typescript");

--- a/crates/fresh-editor/src/app/lsp_event_notify.rs
+++ b/crates/fresh-editor/src/app/lsp_event_notify.rs
@@ -156,7 +156,7 @@ impl Window {
     }
 }
 
-impl Editor {
+impl crate::app::window::Window {
     // === LSP Diagnostics Display ===
     // NOTE: Diagnostics are now applied automatically via process_async_messages()
     // when received from the LSP server asynchronously. No manual polling needed!
@@ -170,7 +170,7 @@ impl Editor {
     /// Notify LSP of a file save for a specific buffer
     pub(super) fn notify_lsp_save_buffer(&mut self, buffer_id: BufferId) {
         // Check if LSP is enabled for this buffer
-        let metadata = match self.active_window().buffer_metadata.get(&buffer_id) {
+        let metadata = match self.buffer_metadata.get(&buffer_id) {
             Some(m) => m,
             None => {
                 tracing::debug!(
@@ -204,7 +204,7 @@ impl Editor {
         // Get the file path for language detection
         // Use buffer's stored language
         let language = match self
-            .buffers()
+            .buffers
             .get(&self.active_buffer())
             .map(|s| s.language.clone())
         {
@@ -230,12 +230,7 @@ impl Editor {
         );
 
         // Only send didSave if LSP is already running (respect auto_start setting)
-        let __active_id = self.active_window;
-        if let Some(lsp) = self
-            .windows
-            .get_mut(&__active_id)
-            .and_then(|w| w.lsp.as_mut())
-        {
+        if let Some(lsp) = self.lsp.as_mut() {
             use crate::services::lsp::manager::LspSpawnResult;
             if lsp.try_spawn(&language, file_path.as_deref()) != LspSpawnResult::Spawned {
                 tracing::debug!(

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -2069,7 +2069,7 @@ impl Editor {
         );
 
         // Fire the lsp_references hook so plugins can display the results
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "lsp_references",
             crate::services::plugins::hooks::HookArgs::LspReferences {
                 symbol: symbol.clone(),

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1025,13 +1025,20 @@ impl Editor {
         let hover_lines: Vec<StyledLine> = if contents.is_empty() {
             Vec::new()
         } else if is_markdown {
-            parse_markdown(&contents, &self.theme, Some(&self.grammar_registry))
+            parse_markdown(
+                &contents,
+                &*self.theme.read().unwrap(),
+                Some(&self.grammar_registry),
+            )
         } else {
             contents
                 .lines()
                 .map(|s| {
                     let mut sl = StyledLine::new();
-                    sl.push(s.to_string(), Style::default().fg(self.theme.popup_text_fg));
+                    sl.push(
+                        s.to_string(),
+                        Style::default().fg(self.theme.read().unwrap().popup_text_fg),
+                    );
                     sl
                 })
                 .collect()
@@ -1047,7 +1054,7 @@ impl Editor {
             let mut sep = StyledLine::new();
             sep.push(
                 "─".repeat(12),
-                Style::default().fg(self.theme.popup_border_fg),
+                Style::default().fg(self.theme.read().unwrap().popup_border_fg),
             );
             all_lines.push(sep);
         }
@@ -1080,7 +1087,7 @@ impl Editor {
         let dynamic_height = (self.terminal_height * 60 / 100).clamp(15, 40);
 
         // Construct the popup with the fused content.
-        let mut popup = Popup::text(Vec::new(), &self.theme);
+        let mut popup = Popup::text(Vec::new(), &*self.theme.read().unwrap());
         popup.content = PopupContent::Markdown(all_lines);
         popup.title = Some(t!("lsp.popup_hover").to_string());
         popup.transient = true;
@@ -1092,8 +1099,8 @@ impl Editor {
         };
         popup.width = popup_width;
         popup.max_height = dynamic_height;
-        popup.border_style = Style::default().fg(self.theme.popup_border_fg);
-        popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.border_style = Style::default().fg(self.theme.read().unwrap().popup_border_fg);
+        popup.background_style = Style::default().bg(self.theme.read().unwrap().popup_bg);
         popup.focus_key_hint = self.popup_focus_key_hint();
 
         // Show the popup. Replace any existing transient (hover/signature)
@@ -1165,15 +1172,21 @@ impl Editor {
             }
 
             let (label, marker, severity_color) = match diag.severity {
-                Some(DiagnosticSeverity::ERROR) => ("Error", "✖", self.theme.diagnostic_error_fg),
-                Some(DiagnosticSeverity::WARNING) => {
-                    ("Warning", "⚠", self.theme.diagnostic_warning_fg)
+                Some(DiagnosticSeverity::ERROR) => {
+                    ("Error", "✖", self.theme.read().unwrap().diagnostic_error_fg)
                 }
+                Some(DiagnosticSeverity::WARNING) => (
+                    "Warning",
+                    "⚠",
+                    self.theme.read().unwrap().diagnostic_warning_fg,
+                ),
                 Some(DiagnosticSeverity::INFORMATION) => {
-                    ("Info", "ℹ", self.theme.diagnostic_info_fg)
+                    ("Info", "ℹ", self.theme.read().unwrap().diagnostic_info_fg)
                 }
-                Some(DiagnosticSeverity::HINT) => ("Hint", "ℹ", self.theme.diagnostic_hint_fg),
-                _ => ("Diagnostic", "•", self.theme.popup_text_fg),
+                Some(DiagnosticSeverity::HINT) => {
+                    ("Hint", "ℹ", self.theme.read().unwrap().diagnostic_hint_fg)
+                }
+                _ => ("Diagnostic", "•", self.theme.read().unwrap().popup_text_fg),
             };
 
             let header_style = Style::default()
@@ -1187,7 +1200,7 @@ impl Editor {
                 header.push(
                     format!("  ({})", source),
                     Style::default()
-                        .fg(self.theme.tab_inactive_fg)
+                        .fg(self.theme.read().unwrap().tab_inactive_fg)
                         .add_modifier(Modifier::ITALIC),
                 );
             }
@@ -1200,7 +1213,7 @@ impl Editor {
                 let mut line = StyledLine::new();
                 line.push(
                     message_line.to_string(),
-                    Style::default().fg(self.theme.popup_text_fg),
+                    Style::default().fg(self.theme.read().unwrap().popup_text_fg),
                 );
                 out.push(line);
             }
@@ -1497,14 +1510,18 @@ impl Editor {
         use crate::view::popup::{Popup, PopupPosition};
         use ratatui::style::Style;
 
-        let mut popup = Popup::markdown(&content, &self.theme, Some(&self.grammar_registry));
+        let mut popup = Popup::markdown(
+            &content,
+            &*self.theme.read().unwrap(),
+            Some(&self.grammar_registry),
+        );
         popup.title = Some(t!("lsp.popup_signature").to_string());
         popup.transient = true;
         popup.position = PopupPosition::BelowCursor;
         popup.width = 60;
         popup.max_height = 20;
-        popup.border_style = Style::default().fg(self.theme.popup_border_fg);
-        popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.border_style = Style::default().fg(self.theme.read().unwrap().popup_border_fg);
+        popup.background_style = Style::default().bg(self.theme.read().unwrap().popup_bg);
         popup.focus_key_hint = self.popup_focus_key_hint();
 
         // Show the popup
@@ -1743,14 +1760,14 @@ impl Editor {
                 .collect()
         };
 
-        let mut popup = Popup::list(items, &self.theme);
+        let mut popup = Popup::list(items, &*self.theme.read().unwrap());
         popup.kind = crate::view::popup::PopupKind::Action;
         popup.title = Some(t!("lsp.popup_code_actions").to_string());
         popup.position = PopupPosition::BelowCursor;
         popup.width = 60;
         popup.max_height = 15;
-        popup.border_style = Style::default().fg(self.theme.popup_border_fg);
-        popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.border_style = Style::default().fg(self.theme.read().unwrap().popup_border_fg);
+        popup.background_style = Style::default().bg(self.theme.read().unwrap().popup_bg);
         // Confirm reads the selected row's `data` as an index into
         // `self.active_window_mut().pending_code_actions` — the heavy lsp_types payload
         // stays on the Editor to keep the view crate LSP-free.

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -295,7 +295,8 @@ impl Editor {
             // Without this the cursor lands at the definition but the
             // viewport never scrolls when the target file is already
             // open (#1689).
-            self.ensure_active_cursor_visible_for_navigation(true);
+            self.active_window_mut()
+                .ensure_active_cursor_visible_for_navigation(true);
         }
 
         let display_path = self
@@ -313,79 +314,6 @@ impl Editor {
         );
 
         Ok(())
-    }
-
-    /// Check if there are any pending LSP requests
-    pub fn has_pending_lsp_requests(&self) -> bool {
-        !self.active_window().pending_completion_requests.is_empty()
-            || self
-                .active_window()
-                .pending_goto_definition_request
-                .is_some()
-    }
-
-    /// Cancel any pending LSP requests
-    /// This should be called when the user performs an action that would make
-    /// the pending request's results stale (e.g., cursor movement, text editing)
-    pub(crate) fn cancel_pending_lsp_requests(&mut self) {
-        // Cancel scheduled (not yet sent) completion trigger
-        self.active_window_mut().scheduled_completion_trigger = None;
-        if !self.active_window().pending_completion_requests.is_empty() {
-            let ids: Vec<u64> = self
-                .active_window_mut()
-                .pending_completion_requests
-                .drain()
-                .collect();
-            for request_id in ids {
-                tracing::debug!("Canceling pending LSP completion request {}", request_id);
-                self.send_lsp_cancel_request(request_id);
-            }
-        }
-        if let Some(request_id) = self
-            .active_window_mut()
-            .pending_goto_definition_request
-            .take()
-        {
-            tracing::debug!(
-                "Canceling pending LSP goto-definition request {}",
-                request_id
-            );
-            // Send cancellation to the LSP server
-            self.send_lsp_cancel_request(request_id);
-        }
-    }
-
-    /// Send a cancel request to the LSP server for a specific request ID
-    fn send_lsp_cancel_request(&mut self, request_id: u64) {
-        // Get language from buffer state
-        let buffer_id = self.active_buffer();
-        let Some(language) = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
-            .get(&buffer_id)
-            .map(|s| s.language.clone())
-        else {
-            return;
-        };
-
-        let __active_id = self.active_window;
-
-        if let Some(lsp) = self
-            .windows
-            .get_mut(&__active_id)
-            .and_then(|w| w.lsp.as_mut())
-        {
-            // Only send cancel if LSP is already running (no need to spawn just to cancel)
-            if let Some(handle) = lsp.get_handle_mut(&language) {
-                if let Err(e) = handle.cancel_request(request_id) {
-                    tracing::warn!("Failed to send LSP cancel request: {}", e);
-                } else {
-                    tracing::debug!("Sent $/cancelRequest for request_id={}", request_id);
-                }
-            }
-        }
     }
 
     /// Dispatch an exclusive LSP feature request to the first handle that allows the feature.
@@ -645,7 +573,7 @@ impl Editor {
                     "Canceling previous pending LSP completion request {}",
                     request_id
                 );
-                self.send_lsp_cancel_request(request_id);
+                self.active_window_mut().send_lsp_cancel_request(request_id);
             }
         }
         self.active_window_mut().completion_items = None;
@@ -1055,24 +983,25 @@ impl Editor {
         } else {
             // No range provided by LSP - compute word boundaries at hover position
             // This prevents the popup from following the mouse within the same word
-            let computed_range =
-                if let Some((hover_byte_pos, _, _, _)) = self.mouse_state.lsp_hover_state {
-                    let state = self.active_state();
-                    let start_byte = find_word_start(&state.buffer, hover_byte_pos);
-                    let end_byte = find_word_end(&state.buffer, hover_byte_pos);
-                    if start_byte < end_byte {
-                        tracing::debug!(
-                            "Hover symbol range (computed from word boundaries): {}..{}",
-                            start_byte,
-                            end_byte
-                        );
-                        Some((start_byte, end_byte))
-                    } else {
-                        None
-                    }
+            let computed_range = if let Some((hover_byte_pos, _, _, _)) =
+                self.active_window_mut().mouse_state.lsp_hover_state
+            {
+                let state = self.active_state();
+                let start_byte = find_word_start(&state.buffer, hover_byte_pos);
+                let end_byte = find_word_end(&state.buffer, hover_byte_pos);
+                if start_byte < end_byte {
+                    tracing::debug!(
+                        "Hover symbol range (computed from word boundaries): {}..{}",
+                        start_byte,
+                        end_byte
+                    );
+                    Some((start_byte, end_byte))
                 } else {
                     None
-                };
+                }
+            } else {
+                None
+            };
             self.active_window_mut()
                 .hover
                 .set_symbol_range(computed_range);
@@ -1187,7 +1116,7 @@ impl Editor {
 
         // Mark hover request as sent to prevent duplicate popups during race conditions
         // (e.g., when mouse moves while a hover response is pending)
-        self.mouse_state.lsp_hover_request_sent = true;
+        self.active_window_mut().mouse_state.lsp_hover_request_sent = true;
     }
 
     /// Pre-style any diagnostics overlapping the hover position into lines
@@ -1621,7 +1550,7 @@ impl Editor {
                     "Canceling previous pending LSP code actions request {}",
                     request_id
                 );
-                self.send_lsp_cancel_request(request_id);
+                self.active_window_mut().send_lsp_cancel_request(request_id);
             }
         }
         self.active_window_mut()
@@ -1871,7 +1800,7 @@ impl Editor {
                 if ca.edit.is_none()
                     && ca.command.is_none()
                     && ca.data.is_some()
-                    && self.server_supports_code_action_resolve()
+                    && self.active_window().server_supports_code_action_resolve()
                 {
                     tracing::info!(
                         "Code action '{}' needs resolve, sending codeAction/resolve",
@@ -1977,84 +1906,6 @@ impl Editor {
             for sh in lsp.get_handles_mut(&language) {
                 if let Err(e) = sh.handle.code_action_resolve(request_id, action.clone()) {
                     tracing::warn!("Failed to send codeAction/resolve to '{}': {}", sh.name, e);
-                }
-            }
-        }
-    }
-
-    /// Check if any LSP server for the current buffer supports codeAction/resolve
-    fn server_supports_code_action_resolve(&self) -> bool {
-        let language = match self
-            .buffers()
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-        {
-            Some(l) => l,
-            None => return false,
-        };
-
-        if let Some(lsp) = self.lsp() {
-            for sh in lsp.get_handles(&language) {
-                if sh.capabilities.code_action_resolve {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    /// Check if any LSP server for the current buffer supports completionItem/resolve
-    pub(crate) fn server_supports_completion_resolve(&self) -> bool {
-        let language = match self
-            .buffers()
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-        {
-            Some(l) => l,
-            None => return false,
-        };
-
-        if let Some(lsp) = self.lsp() {
-            for sh in lsp.get_handles(&language) {
-                if sh.capabilities.completion_resolve {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
-    /// Send completionItem/resolve to the LSP server
-    pub(crate) fn send_completion_resolve(&mut self, item: lsp_types::CompletionItem) {
-        let language = match self
-            .buffers()
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-        {
-            Some(l) => l,
-            None => return,
-        };
-
-        self.active_window_mut().next_lsp_request_id += 1;
-        let request_id = self.active_window_mut().next_lsp_request_id;
-
-        let __active_id = self.active_window;
-
-        if let Some(lsp) = self
-            .windows
-            .get_mut(&__active_id)
-            .and_then(|w| w.lsp.as_mut())
-        {
-            for sh in lsp.get_handles_mut(&language) {
-                if sh.capabilities.completion_resolve {
-                    if let Err(e) = sh.handle.completion_resolve(request_id, item.clone()) {
-                        tracing::warn!(
-                            "Failed to send completionItem/resolve to '{}': {}",
-                            sh.name,
-                            e
-                        );
-                    }
-                    return;
                 }
             }
         }
@@ -2909,8 +2760,8 @@ impl Editor {
     /// Start rename mode - select the symbol at cursor and allow inline editing
     pub(crate) fn start_rename(&mut self) -> AnyhowResult<()> {
         // If server supports prepareRename, validate first
-        if self.server_supports_prepare_rename() {
-            self.send_prepare_rename();
+        if self.active_window().server_supports_prepare_rename() {
+            self.active_window_mut().send_prepare_rename();
             return Ok(());
         }
 
@@ -2938,81 +2789,7 @@ impl Editor {
         }
     }
 
-    /// Check if any LSP server for the current buffer supports prepareRename
-    fn server_supports_prepare_rename(&self) -> bool {
-        let language = match self
-            .buffers()
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-        {
-            Some(l) => l,
-            None => return false,
-        };
-
-        if let Some(lsp) = self.lsp() {
-            for sh in lsp.get_handles(&language) {
-                if sh.capabilities.rename {
-                    // prepareRename is advertised via prepare_support in client caps
-                    // and supported if server has rename capability
-                    return true;
-                }
-            }
-        }
-        false
-    }
-
     /// Send textDocument/prepareRename to the LSP server
-    fn send_prepare_rename(&mut self) {
-        let cursor_pos = self.active_cursors().primary().position;
-        let (line, character) = self
-            .active_state()
-            .buffer
-            .position_to_lsp_position(cursor_pos);
-
-        let buffer_id = self.active_buffer();
-        let metadata = match self.active_window().buffer_metadata.get(&buffer_id) {
-            Some(m) if m.lsp_enabled => m,
-            _ => return,
-        };
-        let uri = match metadata.file_uri() {
-            Some(u) => u.clone(),
-            None => return,
-        };
-        let language = match self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
-            .get(&buffer_id)
-            .map(|s| s.language.clone())
-        {
-            Some(l) => l,
-            None => return,
-        };
-
-        self.active_window_mut().next_lsp_request_id += 1;
-        let request_id = self.active_window_mut().next_lsp_request_id;
-
-        let __active_id = self.active_window;
-
-        if let Some(lsp) = self
-            .windows
-            .get_mut(&__active_id)
-            .and_then(|w| w.lsp.as_mut())
-        {
-            if let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::Rename) {
-                if let Err(e) = sh.handle.prepare_rename(
-                    request_id,
-                    uri.as_uri().clone(),
-                    line as u32,
-                    character as u32,
-                ) {
-                    tracing::warn!("Failed to send prepareRename: {}", e);
-                }
-            }
-        }
-    }
-
     /// Show the rename prompt (called directly or after prepareRename succeeds).
     fn show_rename_prompt(&mut self) -> AnyhowResult<()> {
         use crate::primitives::word_navigation::{find_word_end, find_word_start};

--- a/crates/fresh-editor/src/app/macro_actions.rs
+++ b/crates/fresh-editor/src/app/macro_actions.rs
@@ -122,8 +122,8 @@ impl Editor {
 
         self.active_window_mut().macros.begin_play();
         let action_count = actions.len();
-        let width = self.chrome_layout.last_frame_width;
-        let height = self.chrome_layout.last_frame_height;
+        let width = self.active_chrome().last_frame_width;
+        let height = self.active_chrome().last_frame_height;
         for action in actions {
             if let Err(e) = self.handle_action(action) {
                 tracing::warn!("Macro action failed: {}", e);

--- a/crates/fresh-editor/src/app/macro_actions.rs
+++ b/crates/fresh-editor/src/app/macro_actions.rs
@@ -17,7 +17,7 @@ use super::Editor;
 impl Editor {
     /// Toggle macro recording for the given register
     pub(super) fn toggle_macro_recording(&mut self, key: char) {
-        match self.macros.recording_key() {
+        match self.active_window_mut().macros.recording_key() {
             Some(k) if k == key => self.stop_macro_recording(),
             Some(_) => {
                 self.stop_macro_recording();
@@ -29,7 +29,7 @@ impl Editor {
 
     /// Start recording a macro
     pub(super) fn start_macro_recording(&mut self, key: char) {
-        self.macros.start_recording(key);
+        self.active_window_mut().macros.start_recording(key);
 
         // Build the stop hint dynamically from keybindings
         let stop_hint = self.build_macro_stop_hint(key);
@@ -68,7 +68,7 @@ impl Editor {
 
     /// Stop recording and save the macro
     pub(super) fn stop_macro_recording(&mut self) {
-        let Some((key, action_count)) = self.macros.stop_recording() else {
+        let Some((key, action_count)) = self.active_window_mut().macros.stop_recording() else {
             self.set_status_message(t!("macro.not_recording").to_string());
             return;
         };
@@ -107,11 +107,11 @@ impl Editor {
     /// Drawing is deferred until the next render cycle.
     pub(super) fn play_macro(&mut self, key: char) {
         // Prevent recursive macro playback
-        if self.macros.is_playing() {
+        if self.active_window_mut().macros.is_playing() {
             return;
         }
 
-        let Some(actions) = self.macros.get(key).map(<[_]>::to_vec) else {
+        let Some(actions) = self.active_window_mut().macros.get(key).map(<[_]>::to_vec) else {
             self.set_status_message(t!("macro.not_found", key = key).to_string());
             return;
         };
@@ -120,7 +120,7 @@ impl Editor {
             return;
         }
 
-        self.macros.begin_play();
+        self.active_window_mut().macros.begin_play();
         let action_count = actions.len();
         let width = self.chrome_layout.last_frame_width;
         let height = self.chrome_layout.last_frame_height;
@@ -130,7 +130,7 @@ impl Editor {
             }
             self.recompute_layout(width, height);
         }
-        self.macros.end_play();
+        self.active_window_mut().macros.end_play();
 
         self.set_status_message(t!("macro.played", key = key, count = action_count).to_string());
     }
@@ -146,18 +146,19 @@ impl Editor {
         if let Action::PromptConfirm = action {
             if let Some(prompt) = &self.active_window_mut().prompt {
                 let text = prompt.get_text().to_string();
-                self.macros
+                self.active_window_mut()
+                    .macros
                     .record_transformed(Action::PromptConfirmWithText(text));
                 return;
             }
         }
-        self.macros.record_if_recording(action);
+        self.active_window_mut().macros.record_if_recording(action);
     }
 
     /// Show a macro in a buffer as JSON
     pub(super) fn show_macro_in_buffer(&mut self, key: char) {
         // Get macro data and cache what we need before any mutable borrows
-        let (json, actions_len) = match self.macros.get(key) {
+        let (json, actions_len) = match self.active_window_mut().macros.get(key) {
             Some(actions) => {
                 let json = match serde_json::to_string_pretty(actions) {
                     Ok(json) => json,
@@ -250,7 +251,7 @@ impl Editor {
 
     /// List all recorded macros in a buffer
     pub(super) fn list_macros_in_buffer(&mut self) {
-        if self.macros.is_empty() {
+        if self.active_window_mut().macros.is_empty() {
             self.set_status_message(t!("macro.none_recorded").to_string());
             return;
         }
@@ -259,8 +260,8 @@ impl Editor {
         let mut content =
             String::from("// Recorded Macros\n// Use ShowMacro(key) to see details\n\n");
 
-        for key in self.macros.keys_sorted() {
-            if let Some(actions) = self.macros.get(key) {
+        for key in self.active_window_mut().macros.keys_sorted() {
+            if let Some(actions) = self.active_window_mut().macros.get(key) {
                 content.push_str(&format!("Macro '{}': {} actions\n", key, actions.len()));
 
                 // Show all actions
@@ -330,6 +331,7 @@ impl Editor {
 
         // Switch to the new buffer
         self.set_active_buffer(buffer_id);
-        self.set_status_message(t!("macro.showing", count = self.macros.count()).to_string());
+        let count = self.active_window().macros.count();
+        self.set_status_message(t!("macro.showing", count = count).to_string());
     }
 }

--- a/crates/fresh-editor/src/app/menu_actions.rs
+++ b/crates/fresh-editor/src/app/menu_actions.rs
@@ -61,9 +61,9 @@ impl Editor {
     /// If the menu bar is hidden, it will be temporarily shown.
     pub fn handle_menu_activate(&mut self) {
         // Auto-show menu bar if hidden
-        if !self.menu_bar_visible {
-            self.menu_bar_visible = true;
-            self.menu_bar_auto_shown = true;
+        if !self.active_window_mut().menu_bar_visible {
+            self.active_window_mut().menu_bar_visible = true;
+            self.active_window_mut().menu_bar_auto_shown = true;
         }
         self.on_editor_focus_lost();
         self.menu_state.open_menu(0);
@@ -73,9 +73,9 @@ impl Editor {
     /// Use this method instead of `menu_state.close_menu()` to ensure auto-hide works.
     pub fn close_menu_with_auto_hide(&mut self) {
         self.menu_state.close_menu();
-        if self.menu_bar_auto_shown {
-            self.menu_bar_visible = false;
-            self.menu_bar_auto_shown = false;
+        if self.active_window_mut().menu_bar_auto_shown {
+            self.active_window_mut().menu_bar_visible = false;
+            self.active_window_mut().menu_bar_auto_shown = false;
         }
     }
 
@@ -135,13 +135,13 @@ impl Editor {
 
         // Update context before checking if action is enabled
         use crate::view::ui::context_keys;
+        let has_sel = self.has_active_selection();
+        let fe_focused =
+            self.active_window().key_context == crate::input::keybindings::KeyContext::FileExplorer;
         self.menu_state
             .context
-            .set(context_keys::HAS_SELECTION, self.has_active_selection())
-            .set(
-                context_keys::FILE_EXPLORER_FOCUSED,
-                self.key_context == crate::input::keybindings::KeyContext::FileExplorer,
-            );
+            .set(context_keys::HAS_SELECTION, has_sel)
+            .set(context_keys::FILE_EXPLORER_FOCUSED, fe_focused);
 
         if let Some((action_name, args)) = self.menu_state.get_highlighted_action(&all_menus) {
             // Close the menu with auto-hide support
@@ -163,9 +163,9 @@ impl Editor {
     /// If the menu bar is hidden, it will be temporarily shown.
     pub fn handle_menu_open(&mut self, menu_name: &str) {
         // Auto-show menu bar if hidden
-        if !self.menu_bar_visible {
-            self.menu_bar_visible = true;
-            self.menu_bar_auto_shown = true;
+        if !self.active_window_mut().menu_bar_visible {
+            self.active_window_mut().menu_bar_visible = true;
+            self.active_window_mut().menu_bar_auto_shown = true;
         }
         self.on_editor_focus_lost();
 

--- a/crates/fresh-editor/src/app/menu_actions.rs
+++ b/crates/fresh-editor/src/app/menu_actions.rs
@@ -65,7 +65,7 @@ impl Editor {
             self.active_window_mut().menu_bar_visible = true;
             self.active_window_mut().menu_bar_auto_shown = true;
         }
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
         self.menu_state.open_menu(0);
     }
 
@@ -167,7 +167,7 @@ impl Editor {
             self.active_window_mut().menu_bar_visible = true;
             self.active_window_mut().menu_bar_auto_shown = true;
         }
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
 
         let all_menus = self.all_menus();
         for (idx, menu) in all_menus.iter().enumerate() {

--- a/crates/fresh-editor/src/app/menu_actions.rs
+++ b/crates/fresh-editor/src/app/menu_actions.rs
@@ -187,7 +187,7 @@ impl Editor {
         row: u16,
         menu_index: usize,
     ) -> Option<HoverTarget> {
-        let menu_layout = self.chrome_layout.menu_layout.as_ref()?;
+        let menu_layout = self.active_chrome().menu_layout.as_ref()?;
 
         // Check submenu items first (they're rendered on top)
         if let Some((depth, item_idx)) = menu_layout.submenu_item_at(col, row) {
@@ -213,7 +213,7 @@ impl Editor {
     ) -> AnyhowResult<Option<AnyhowResult<()>>> {
         use crate::view::ui::menu::MenuHit;
 
-        let menu_layout = match &self.chrome_layout.menu_layout {
+        let menu_layout = match &self.active_chrome().menu_layout {
             Some(layout) => layout.clone(),
             None => return Ok(None),
         };

--- a/crates/fresh-editor/src/app/menu_context.rs
+++ b/crates/fresh-editor/src/app/menu_context.rs
@@ -65,9 +65,9 @@ impl Editor {
         // or in the editor only when no file is in the clipboard. There's no
         // buffer to paste into in placeholder mode, so suppress it there.
         let can_paste = if file_explorer_focused {
-            self.file_explorer_clipboard.is_some()
+            self.active_window().file_explorer_clipboard.is_some()
         } else {
-            has_buffer && self.file_explorer_clipboard.is_none()
+            has_buffer && self.active_window().file_explorer_clipboard.is_none()
         };
         let menu_bar = self.active_window_mut().menu_bar_visible;
         let vertical_scrollbar = self.config.editor.show_vertical_scrollbar;

--- a/crates/fresh-editor/src/app/menu_context.rs
+++ b/crates/fresh-editor/src/app/menu_context.rs
@@ -39,7 +39,7 @@ impl Editor {
         let line_numbers = self.is_line_numbers_visible();
         let line_wrap = self.is_line_wrap_enabled();
         let page_view = self.is_page_view();
-        let file_explorer_visible = self.active_window().file_explorer_visible;
+        let file_explorer_visible = self.file_explorer_visible();
         let file_explorer_focused = self.is_file_explorer_focused();
         let mouse_capture = self.active_window_mut().mouse_enabled;
         let mouse_hover = self.config.editor.mouse_hover_enabled;

--- a/crates/fresh-editor/src/app/menu_context.rs
+++ b/crates/fresh-editor/src/app/menu_context.rs
@@ -41,7 +41,7 @@ impl Editor {
         let page_view = self.is_page_view();
         let file_explorer_visible = self.active_window().file_explorer_visible;
         let file_explorer_focused = self.is_file_explorer_focused();
-        let mouse_capture = self.mouse_enabled;
+        let mouse_capture = self.active_window_mut().mouse_enabled;
         let mouse_hover = self.config.editor.mouse_hover_enabled;
         let inlay_hints = self.config.editor.enable_inlay_hints;
         // True for any real buffer; false when the active buffer is the
@@ -69,7 +69,7 @@ impl Editor {
         } else {
             has_buffer && self.file_explorer_clipboard.is_none()
         };
-        let menu_bar = self.menu_bar_visible;
+        let menu_bar = self.active_window_mut().menu_bar_visible;
         let vertical_scrollbar = self.config.editor.show_vertical_scrollbar;
         let horizontal_scrollbar = self.config.editor.show_horizontal_scrollbar;
 
@@ -183,7 +183,7 @@ impl Editor {
 
     /// Check if the file explorer is currently focused.
     fn is_file_explorer_focused(&self) -> bool {
-        self.key_context == crate::input::keybindings::KeyContext::FileExplorer
+        self.active_window().key_context == crate::input::keybindings::KeyContext::FileExplorer
     }
 
     /// Check if the file explorer is showing hidden files.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -952,7 +952,6 @@ impl Editor {
         Ok(())
     }
 
-
     /// Total number of open buffers across the workspace. Test
     /// support for `EditorTestApi::buffer_count` (Phase 7 of the
     /// scenario migration).

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -553,7 +553,7 @@ pub struct Editor {
     // file-explorer view itself was already per-window since Step 0b;
     // these chrome flags follow.
     /// File explorer clipboard for cut/copy/paste of files and directories
-    pub(crate) file_explorer_clipboard: Option<crate::app::file_explorer::FileExplorerClipboard>,
+    // `file_explorer_clipboard` moved onto `Window`.
 
     // `menu_bar_visible`, `menu_bar_auto_shown`, `tab_bar_visible`,
     // `status_bar_visible`, `prompt_line_visible`, `mouse_enabled`

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -626,7 +626,13 @@ pub struct Editor {
     quick_open_registry: QuickOpenRegistry,
 
     /// Plugin manager (handles both enabled and disabled cases)
-    plugin_manager: PluginManager,
+    /// Plugin manager, wrapped in `Arc<RwLock<>>` so windows can fire
+    /// hooks (`run_hook`) via WindowResources without holding an
+    /// `&mut Editor` reference. `&self` methods (run_hook,
+    /// deliver_response, has_hook_handlers, …) take a read lock; the
+    /// few `&mut self` methods (process_commands, check_thread_health,
+    /// test_inject_command) take a write lock.
+    plugin_manager: Arc<RwLock<PluginManager>>,
 
     // `plugin_dev_workspaces` moved onto `Window` — keyed by `BufferId`,
     // and buffers are per-window, so the workspace map follows.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -491,7 +491,7 @@ pub struct Editor {
     mode_registry: ModeRegistry,
 
     /// Tokio runtime for async I/O tasks
-    tokio_runtime: Option<tokio::runtime::Runtime>,
+    tokio_runtime: Option<Arc<tokio::runtime::Runtime>>,
 
     /// Bridge for async messages from tokio tasks to main loop
     async_bridge: Option<AsyncBridge>,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -617,7 +617,6 @@ pub struct Editor {
     // moved onto `Window`.
     // `chrome_layout` moved onto `Window` — each window has its own
     // status bar, menu, prompt overlay, and popups.
-
     /// Command registry for dynamic commands
     command_registry: Arc<RwLock<CommandRegistry>>,
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -952,21 +952,6 @@ impl Editor {
         Ok(())
     }
 
-    /// Calculate the effective width available for tabs.
-    ///
-    /// When the file explorer is visible, tabs only get a portion of the
-    /// terminal width. Matches the layout calculation in render.rs.
-    fn effective_tabs_width(&self) -> u16 {
-        if self.file_explorer_visible() && self.file_explorer().is_some() {
-            let explorer = self
-                .active_window()
-                .file_explorer_width
-                .to_cols(self.terminal_width);
-            self.terminal_width.saturating_sub(explorer)
-        } else {
-            self.terminal_width
-        }
-    }
 
     /// Total number of open buffers across the workspace. Test
     /// support for `EditorTestApi::buffer_count` (Phase 7 of the

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -416,7 +416,10 @@ pub struct Editor {
     pending_grammar_callbacks: Vec<fresh_core::api::JsCallbackId>,
 
     /// Active theme
-    theme: crate::view::theme::Theme,
+    /// Active resolved theme, shared with windows via WindowResources.
+    /// Wrapped in `Arc<RwLock<>>` so a theme reload propagates to every
+    /// window without copying.
+    pub(crate) theme: Arc<RwLock<crate::view::theme::Theme>>,
 
     /// All loaded themes (embedded + user). Held as `Arc` so
     /// `expanded_menus_cache` can detect a registry swap via `Arc::ptr_eq`.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -475,10 +475,7 @@ pub struct Editor {
     /// than on every frame.
     last_window_title: Option<String>,
 
-    /// Accumulated plugin errors (for test assertions)
-    /// These are collected when plugin error messages are received
-    plugin_errors: Vec<String>,
-
+    // `plugin_errors` moved onto `Window`.
     /// Terminal dimensions (for creating new buffers)
     terminal_width: u16,
     terminal_height: u16,
@@ -558,37 +555,16 @@ pub struct Editor {
     /// File explorer clipboard for cut/copy/paste of files and directories
     pub(crate) file_explorer_clipboard: Option<crate::app::file_explorer::FileExplorerClipboard>,
 
-    /// Whether menu bar is visible
-    menu_bar_visible: bool,
-
-    /// Whether menu bar was auto-shown (temporarily visible due to menu activation)
-    /// When true, the menu bar will be hidden again when the menu is closed
-    menu_bar_auto_shown: bool,
-
-    /// Whether tab bar is visible
-    tab_bar_visible: bool,
-
-    /// Whether status bar is visible
-    status_bar_visible: bool,
-
-    /// Whether prompt line is visible (when no prompt is active)
-    prompt_line_visible: bool,
-
-    /// Whether mouse capture is enabled
-    mouse_enabled: bool,
+    // `menu_bar_visible`, `menu_bar_auto_shown`, `tab_bar_visible`,
+    // `status_bar_visible`, `prompt_line_visible`, `mouse_enabled`
+    // moved onto `Window` — per-window UI toggles.
 
     // `same_buffer_scroll_sync` moved onto `Window` — per-window UX
     // toggle, since the split tree it controls is per-window.
     /// Mouse cursor position (for GPM software cursor rendering)
     /// When GPM is active, we need to draw our own cursor since GPM can't
     /// draw on the alternate screen buffer used by TUI applications.
-    mouse_cursor_position: Option<(u16, u16)>,
-
-    /// Whether GPM is being used for mouse input (requires software cursor)
-    gpm_active: bool,
-
-    /// Current keybinding context
-    key_context: KeyContext,
+    // `mouse_cursor_position`, `gpm_active`, `key_context` moved onto `Window`.
 
     /// Menu state (active menu, highlighted item)
     menu_state: crate::view::ui::MenuState,
@@ -625,25 +601,17 @@ pub struct Editor {
     // LSP request-tracking state (next_lsp_request_id,
     // pending_*_requests, *_in_flight, completion_items,
     // dabbrev_state, etc.) all moved onto `Window` in Step 0k.
-    /// Pluggable completion service that orchestrates multiple providers
-    /// (dabbrev, buffer words, LSP, plugin providers).
-    completion_service: crate::services::completion::CompletionService,
-    /// LSP diagnostic namespace (for filtering and bulk removal)
-    lsp_diagnostic_namespace: crate::view::overlay::OverlayNamespace,
+    // `completion_service` moved onto `Window` — orchestrates this
+    // window's per-window completion providers (dabbrev, buffer words,
+    // LSP, plugin providers).
+    // `lsp_diagnostic_namespace` moved onto `Window` — overlay
+    // namespace key for diagnostic overlays, which are buffer overlays
+    // and follow buffers onto the window.
     // `interactive_replace_state` moved onto `Window` — per-window
     // search-and-replace session state.
-    /// Mouse state for scrollbar dragging
-    mouse_state: MouseState,
-
-    /// Tab context menu state (right-click on tabs)
-    tab_context_menu: Option<TabContextMenu>,
-
-    /// File explorer context menu state (right-click in file explorer)
-    file_explorer_context_menu: Option<FileExplorerContextMenu>,
-
-    /// Theme inspector popup state (Ctrl+Right-Click)
-    theme_info_popup: Option<types::ThemeInfoPopup>,
-
+    // `mouse_state` moved onto `Window` — drag targets reference per-window LeafIds.
+    // `tab_context_menu`, `file_explorer_context_menu`, `theme_info_popup`
+    // moved onto `Window`.
     /// Editor-chrome layout from last render (status bar, menu, prompt
     /// overlay, popups, full-frame cell-theme map). Per-window
     /// content-area layout (split panes, tabs, file explorer) lives on
@@ -660,11 +628,8 @@ pub struct Editor {
     /// Plugin manager (handles both enabled and disabled cases)
     plugin_manager: PluginManager,
 
-    /// Active plugin development workspaces (buffer_id → workspace)
-    /// These provide LSP support for plugin buffers by creating temp directories
-    /// with fresh.d.ts and tsconfig.json
-    plugin_dev_workspaces:
-        HashMap<BufferId, crate::services::plugins::plugin_dev_workspace::PluginDevWorkspace>,
+    // `plugin_dev_workspaces` moved onto `Window` — keyed by `BufferId`,
+    // and buffers are per-window, so the workspace map follows.
 
     // `seen_byte_ranges` moved onto `Window` — keyed by `BufferId`
     // which lives on `Window`, so the tracker follows the buffers.
@@ -673,12 +638,8 @@ pub struct Editor {
     // `Editor::panel_ids()` / `panel_ids_mut()` — those resolve to
     // the active window's dock occupancy. Each window owns its own
     // utility-dock; switching windows doesn't share dock state.
-    /// Buffer groups: multiple splits/buffers appearing as one tab
-    buffer_groups: HashMap<types::BufferGroupId, types::BufferGroup>,
-    /// Reverse index: buffer ID → group ID (for lookups)
-    buffer_to_group: HashMap<BufferId, types::BufferGroupId>,
-    /// Next buffer group ID
-    next_buffer_group_id: usize,
+    // `buffer_groups`, `buffer_to_group`, `next_buffer_group_id`
+    // moved onto `Window` — each window has its own buffer groups.
 
     // grouped_subtrees moved onto `Window` — each window owns its
     // own buffer-group subtrees (a window with a Live Grep panel
@@ -697,61 +658,26 @@ pub struct Editor {
     /// keypress. While non-empty, the next key arriving in
     /// `handle_key` is consumed by resolving the front-most callback
     /// rather than dispatching to mode bindings or other handlers.
-    pending_next_key_callbacks: std::collections::VecDeque<fresh_core::api::JsCallbackId>,
+    // `pending_next_key_callbacks`, `key_capture_active`,
+    // `pending_key_capture_buffer` moved onto `Window`.
+    // `lsp_progress`, `lsp_server_statuses`, `lsp_window_messages`,
+    // `lsp_log_messages` moved onto `Window` — each window has its own
+    // LspManager, so the progress/status/message streams describe that
+    // manager's servers, not the editor's.
 
-    /// `true` while a plugin is in a `getNextKey()` loop and has
-    /// declared (via `editor.beginKeyCapture()`) that it wants every
-    /// key delivered, in order, regardless of timing.  Keys arriving
-    /// while no callback is pending are buffered in
-    /// `pending_key_capture_buffer` instead of dispatched.  Closes the
-    /// race where fast typing or paste outruns the plugin's re-arm.
-    key_capture_active: bool,
-
-    /// Keys that arrived while `key_capture_active` was set but no
-    /// `getNextKey()` callback was pending. Drained on the next
-    /// `AwaitNextKey` (resolved immediately, in order). Cleared when
-    /// the plugin ends capture.
-    pending_key_capture_buffer: std::collections::VecDeque<fresh_core::api::KeyEventPayload>,
-    /// LSP progress tracking (token -> progress info)
-    lsp_progress: std::collections::HashMap<String, LspProgressInfo>,
-
-    /// LSP server statuses ((language, server_name) -> status)
-    lsp_server_statuses:
-        std::collections::HashMap<(String, String), crate::services::async_bridge::LspServerStatus>,
-
-    /// LSP window messages (recent messages from window/showMessage)
-    lsp_window_messages: Vec<LspMessageEntry>,
-
-    /// LSP log messages (recent messages from window/logMessage)
-    lsp_log_messages: Vec<LspMessageEntry>,
-
-    /// Diagnostic result IDs per URI (for incremental pull diagnostics)
-    /// Maps URI string to last result_id received from server
-    diagnostic_result_ids: HashMap<String, String>,
-    /// Stored LSP diagnostics per URI, per server (push model - publishDiagnostics)
-    /// Outer key: URI string, Inner key: server name
-    stored_push_diagnostics: HashMap<String, HashMap<String, Vec<lsp_types::Diagnostic>>>,
-
-    /// Stored LSP diagnostics per URI (pull model - native RA diagnostics)
-    stored_pull_diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
-
-    /// Merged view of push + pull diagnostics per URI (for plugin access).
-    /// `Arc` wrapper: snapshot refresh is a refcount bump, and mutation is
-    /// forced through `Arc::make_mut` which CoW-clones while the snapshot
-    /// still references the previous map.
-    stored_diagnostics: Arc<HashMap<String, Vec<lsp_types::Diagnostic>>>,
-
-    /// Stored LSP folding ranges per URI
-    /// Maps file URI string to Vec of folding ranges for that file
-    stored_folding_ranges: Arc<HashMap<String, Vec<lsp_types::FoldingRange>>>,
-
+    // `diagnostic_result_ids` moved onto `Window` — each window has its
+    // own LspManager and therefore its own per-URI result_id stream.
+    // `stored_push_diagnostics`, `stored_pull_diagnostics`,
+    // `stored_diagnostics`, `stored_folding_ranges` moved onto
+    // `Window` — URI-keyed but each URI maps to a buffer in a specific
+    // window's LSP set, so the maps describe one window's diagnostics.
     /// Event broadcaster for control events (observable by external systems)
     event_broadcaster: crate::model::control_event::EventBroadcaster,
 
     // bookmarks moved onto `Window` (Step 0f).
     /// Macro record/playback subsystem (owns `macros`, `recording`,
     /// `last_register`, and the `playing` guard flag).
-    macros: macros::MacroState,
+    // `macros` moved onto `Window`.
 
     /// Pending plugin action receivers (for async action execution)
     #[cfg(feature = "plugins")]
@@ -766,7 +692,7 @@ pub struct Editor {
 
     /// Pending chord sequence for multi-key bindings (e.g., C-x C-s in Emacs)
     /// Stores the keys pressed so far in a chord sequence
-    chord_state: Vec<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)>,
+    // `chord_state` moved onto `Window`.
 
     // (Historical `pending_lsp_confirmation` and `pending_lsp_status_popup`
     // fields moved onto `Popup::resolver` — each popup carries its own
@@ -778,47 +704,16 @@ pub struct Editor {
     ///
     /// Pending Save-As queue for the "save and quit" flow.
     ///
-    /// Last time we polled for file changes (for auto-revert)
-    last_auto_revert_poll: std::time::Instant,
-
-    /// Last time we polled for directory changes (for file tree refresh)
-    last_file_tree_poll: std::time::Instant,
-
-    /// Whether we've resolved and seeded the .git/index path in dir_mod_times
-    git_index_resolved: bool,
-
-    // file_mod_times moved onto `Window`. Auto-revert is per-window
-    // (matches "a dormant window is paused"); access via
-    // `Editor::file_mod_times()` / `file_mod_times_mut()`.
-    /// Last known modification times for expanded directories (for file tree refresh)
-    /// Maps directory path to last known modification time
-    dir_mod_times: HashMap<PathBuf, std::time::SystemTime>,
-
-    /// Receiver for background file change poll results.
-    /// When Some, a background metadata poll is in progress. Results arrive as
-    /// `(path, Option<mtime>)` pairs — None means metadata() failed.
-    #[allow(clippy::type_complexity)]
-    pending_file_poll_rx:
-        Option<std::sync::mpsc::Receiver<Vec<(PathBuf, Option<std::time::SystemTime>)>>>,
-
-    /// Receiver for background directory change poll results.
-    /// The tuple contains: (dir metadata results, optional git index mtime).
-    #[allow(clippy::type_complexity)]
-    pending_dir_poll_rx: Option<
-        std::sync::mpsc::Receiver<(
-            Vec<(
-                crate::view::file_tree::NodeId,
-                PathBuf,
-                Option<std::time::SystemTime>,
-            )>,
-            Option<(PathBuf, std::time::SystemTime)>,
-        )>,
-    >,
+    // `last_auto_revert_poll`, `last_file_tree_poll`, `git_index_resolved`,
+    // `dir_mod_times`, `pending_file_poll_rx`, `pending_dir_poll_rx`
+    // all moved onto `Window` — auto-revert and file-tree change
+    // detection are per-window, paired with the already-per-window
+    // `file_mod_times`.
     /// File open dialog state (when PromptType::OpenFile is active)
-    file_open_state: Option<file_open::FileOpenState>,
+    // `file_open_state` moved onto `Window`.
 
     /// Cached layout for file browser (for mouse hit testing)
-    file_browser_layout: Option<crate::view::ui::FileBrowserLayout>,
+    // `file_browser_layout` moved onto `Window`.
 
     /// Recovery service for auto-recovery-save and crash recovery
     recovery_service: RecoveryService,
@@ -834,14 +729,11 @@ pub struct Editor {
     time_source: SharedTimeSource,
 
     /// Last auto-recovery-save time for rate limiting
-    last_auto_recovery_save: std::time::Instant,
-
-    /// Last persistent auto-save time for rate limiting (disk)
-    last_persistent_auto_save: std::time::Instant,
+    // `last_auto_recovery_save`, `last_persistent_auto_save` moved onto `Window`.
 
     /// Active custom contexts for command visibility
     /// Plugin-defined contexts like "config-editor" that control command availability
-    active_custom_contexts: HashSet<String>,
+    // `active_custom_contexts` moved onto `Window`.
 
     /// Plugin-managed global state, isolated per plugin name.
     /// Outer key is plugin name, inner key is the state key set by the plugin.
@@ -854,7 +746,7 @@ pub struct Editor {
 
     /// Warning domain registry for extensible warning indicators
     /// Contains LSP warnings, general warnings, and can be extended by plugins
-    warning_domains: WarningDomainRegistry,
+    // `warning_domains` moved onto `Window`.
 
     /// Periodic update checker (checks for new releases every hour)
     update_checker: Option<crate::services::release_checker::PeriodicUpdateChecker>,
@@ -892,31 +784,21 @@ pub struct Editor {
 
     // terminal_buffers / terminal_backing_files / terminal_log_files
     // moved onto `Window` (Step 0d).
-    /// Terminals that should not be persisted to the workspace session file.
-    /// A terminal is in this set iff it was created with `persistent = false`
-    /// (the default for plugin-created terminals). On workspace save these
-    /// terminals are skipped; on close their backing/log files are removed.
-    /// User-opened terminals are absent from this set and persist as before.
-    ephemeral_terminals: std::collections::HashSet<crate::services::terminal::TerminalId>,
+    // `ephemeral_terminals` moved onto `Window` — TerminalManager and
+    // its terminals are per-window (Step 0d), so the ephemeral set
+    // follows.
 
     // `terminal_mode` moved onto `Window`. Per-window because each
     // window has its own active terminal buffer.
     /// Whether keyboard capture is enabled in terminal mode.
     /// When true, ALL keys go to the terminal (except Ctrl+` to toggle).
     /// When false, UI keybindings (split nav, palette, etc.) are processed first.
-    keyboard_capture: bool,
+    // `keyboard_capture` moved onto `Window`.
 
     // `terminal_mode_resume` moved onto `Window` — terminal buffers
     // are per-window (Step 0d), so the auto-resume set follows.
     /// Timestamp of the previous mouse click (for multi-click detection)
-    previous_click_time: Option<std::time::Instant>,
-
-    /// Position of the previous mouse click (for multi-click detection)
-    /// Multi-click is only detected if all clicks are at the same position
-    previous_click_position: Option<(u16, u16)>,
-
-    /// Click count for multi-click detection (1=single, 2=double, 3=triple)
-    click_count: u8,
+    // `previous_click_time`, `previous_click_position`, `click_count` moved onto `Window`.
 
     /// Settings UI state (when settings modal is open)
     pub(crate) settings_state: Option<crate::view::settings::SettingsState>,
@@ -937,7 +819,7 @@ pub struct Editor {
     color_capability: crate::view::color_support::ColorCapability,
 
     /// Hunks for the Review Diff tool
-    review_hunks: Vec<fresh_core::api::ReviewHunk>,
+    // `review_hunks` moved onto `Window`.
 
     /// Editor-level popups that float above any buffer regardless of which
     /// one is active. Plugin notifications (showActionPopup) live here so a
@@ -954,33 +836,33 @@ pub struct Editor {
     /// Pending file opens from CLI arguments (processed after TUI starts)
     /// This allows CLI files to go through the same code path as interactive file opens,
     /// ensuring consistent error handling (e.g., encoding confirmation prompts).
-    pending_file_opens: Vec<PendingFileOpen>,
+    // `pending_file_opens` moved onto `Window`.
 
     /// When true, apply hot exit recovery after the next batch of pending file opens
-    pending_hot_exit_recovery: bool,
+    // `pending_hot_exit_recovery` moved onto `Window`.
 
     /// Tracks buffers opened with --wait: maps buffer_id → (wait_id, has_popup)
-    wait_tracking: HashMap<BufferId, (u64, bool)>,
+    // `wait_tracking` moved onto `Window`.
     /// Wait IDs that have completed (buffer closed or popup dismissed)
-    completed_waits: Vec<u64>,
+    // `completed_waits` moved onto `Window`.
 
     /// Stdin streaming state (if reading from stdin)
     stdin_stream: stdin_stream::StdinStream,
 
     /// Incremental line scan state (for non-blocking progress during Go to Line)
-    line_scan: line_scan::LineScan,
+    // `line_scan` moved onto `Window`.
 
     /// Incremental search scan state (for non-blocking search on large files)
-    search_scan: search_scan::SearchScan,
+    // `search_scan` moved onto `Window`.
 
     /// Viewport top_byte when search overlays were last refreshed.
     /// Used to detect viewport scrolling so overlays can be updated.
-    search_overlay_top_byte: Option<usize>,
+    // `search_overlay_top_byte` moved onto `Window`.
 
     /// Frame-buffer animation layer. Applied at the end of `render`; the
     /// main loop consults `is_active`/`next_deadline` to keep re-rendering
     /// while animations are running.
-    pub animations: crate::view::animation::AnimationRunner,
+    // `animations` moved onto `Window`.
 
     /// Hardware-cursor screen position from the previous render pass, paired
     /// with the active split that owned the cursor at that time. Used to
@@ -1258,30 +1140,6 @@ impl Editor {
             .get_mut(&buffer_id)
             .unwrap()
     }
-
-    /// Update the buffer's modified flag based on event log position
-    /// Call this after undo/redo to correctly track whether the buffer
-    /// has returned to its saved state
-    pub(super) fn update_modified_from_event_log(&mut self) {
-        let is_at_saved = self
-            .active_window()
-            .event_logs
-            .get(&self.active_buffer())
-            .map(|log| log.is_at_saved_position())
-            .unwrap_or(false);
-
-        let __buffer_id = self.active_buffer();
-
-        if let Some(state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .get_mut(&__buffer_id)
-        {
-            state.buffer.set_modified(!is_at_saved);
-        }
-    }
 }
 
 /// Parse a key string like "RET", "C-n", "M-x", "q" into KeyCode and KeyModifiers
@@ -1480,7 +1338,9 @@ mod tests {
         )
         .unwrap();
 
-        let events = editor.action_to_events(Action::InsertChar('a'));
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::InsertChar('a'));
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1517,7 +1377,9 @@ mod tests {
             cursor_id,
         });
 
-        let events = editor.action_to_events(Action::MoveRight);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::MoveRight);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1571,7 +1433,7 @@ mod tests {
         });
 
         // Test move up
-        let events = editor.action_to_events(Action::MoveUp);
+        let events = editor.active_window_mut().action_to_events(Action::MoveUp);
         assert!(events.is_some());
         let events = events.unwrap();
         assert_eq!(events.len(), 1);
@@ -1598,7 +1460,9 @@ mod tests {
         )
         .unwrap();
 
-        let events = editor.action_to_events(Action::InsertNewline);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::InsertNewline);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1627,9 +1491,18 @@ mod tests {
         .unwrap();
 
         // These actions should return None (not yet implemented)
-        assert!(editor.action_to_events(Action::Save).is_none());
-        assert!(editor.action_to_events(Action::Quit).is_none());
-        assert!(editor.action_to_events(Action::Undo).is_none());
+        assert!(editor
+            .active_window_mut()
+            .action_to_events(Action::Save)
+            .is_none());
+        assert!(editor
+            .active_window_mut()
+            .action_to_events(Action::Quit)
+            .is_none());
+        assert!(editor
+            .active_window_mut()
+            .action_to_events(Action::Undo)
+            .is_none());
     }
 
     #[test]
@@ -1654,7 +1527,9 @@ mod tests {
             cursor_id,
         });
 
-        let events = editor.action_to_events(Action::DeleteBackward);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::DeleteBackward);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1706,7 +1581,9 @@ mod tests {
             new_sticky_column: 0,
         });
 
-        let events = editor.action_to_events(Action::DeleteForward);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::DeleteForward);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1758,7 +1635,9 @@ mod tests {
             new_sticky_column: 0,
         });
 
-        let events = editor.action_to_events(Action::SelectRight);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::SelectRight);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1799,7 +1678,9 @@ mod tests {
             cursor_id,
         });
 
-        let events = editor.action_to_events(Action::SelectAll);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::SelectAll);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1841,7 +1722,9 @@ mod tests {
         });
 
         // Test MoveDocumentStart
-        let events = editor.action_to_events(Action::MoveDocumentStart);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::MoveDocumentStart);
         assert!(events.is_some());
         let events = events.unwrap();
         match &events[0] {
@@ -1852,7 +1735,9 @@ mod tests {
         }
 
         // Test MoveDocumentEnd
-        let events = editor.action_to_events(Action::MoveDocumentEnd);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::MoveDocumentEnd);
         assert!(events.is_some());
         let events = events.unwrap();
         match &events[0] {
@@ -1910,7 +1795,9 @@ mod tests {
             .expect("Should have at least one cursor");
 
         // RemoveSecondaryCursors should generate RemoveCursor events
-        let events = editor.action_to_events(Action::RemoveSecondaryCursors);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::RemoveSecondaryCursors);
         assert!(events.is_some());
 
         let events = events.unwrap();
@@ -1948,7 +1835,9 @@ mod tests {
         .unwrap();
 
         // Test ScrollUp
-        let events = editor.action_to_events(Action::ScrollUp);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::ScrollUp);
         assert!(events.is_some());
         let events = events.unwrap();
         assert_eq!(events.len(), 1);
@@ -1960,7 +1849,9 @@ mod tests {
         }
 
         // Test ScrollDown
-        let events = editor.action_to_events(Action::ScrollDown);
+        let events = editor
+            .active_window_mut()
+            .action_to_events(Action::ScrollDown);
         assert!(events.is_some());
         let events = events.unwrap();
         assert_eq!(events.len(), 1);
@@ -1987,7 +1878,7 @@ mod tests {
         .unwrap();
 
         // None action should return None
-        let events = editor.action_to_events(Action::None);
+        let events = editor.active_window_mut().action_to_events(Action::None);
         assert!(events.is_none());
     }
 
@@ -2447,7 +2338,7 @@ mod tests {
             running_line: 1,
         };
 
-        editor.search_scan.start(
+        editor.active_window_mut().search_scan.start(
             buffer_id,
             Vec::new(),
             chunked,
@@ -2467,7 +2358,7 @@ mod tests {
 
         // The scan state should be consumed (drained)
         assert_eq!(
-            editor.search_scan.buffer_id(),
+            editor.active_window().search_scan.buffer_id(),
             None,
             "search_scan should be drained after capped scan completes"
         );

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -953,7 +953,7 @@ impl Editor {
     /// When the file explorer is visible, tabs only get a portion of the
     /// terminal width. Matches the layout calculation in render.rs.
     fn effective_tabs_width(&self) -> u16 {
-        if self.active_window().file_explorer_visible && self.file_explorer().is_some() {
+        if self.file_explorer_visible() && self.file_explorer().is_some() {
             let explorer = self
                 .active_window()
                 .file_explorer_width

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -168,8 +168,8 @@ pub fn editor_tick(
 pub(crate) use path_utils::normalize_path;
 
 use self::types::{
-    ChromeLayout, FileExplorerContextMenu, InteractiveReplaceState, LspMessageEntry,
-    LspProgressInfo, MouseState, SearchState, TabContextMenu, DEFAULT_BACKGROUND_FILE,
+    FileExplorerContextMenu, InteractiveReplaceState, LspMessageEntry, LspProgressInfo, MouseState,
+    SearchState, TabContextMenu, DEFAULT_BACKGROUND_FILE,
 };
 use crate::config::Config;
 use crate::config_io::DirectoryContext;
@@ -615,12 +615,8 @@ pub struct Editor {
     // `mouse_state` moved onto `Window` — drag targets reference per-window LeafIds.
     // `tab_context_menu`, `file_explorer_context_menu`, `theme_info_popup`
     // moved onto `Window`.
-    /// Editor-chrome layout from last render (status bar, menu, prompt
-    /// overlay, popups, full-frame cell-theme map). Per-window
-    /// content-area layout (split panes, tabs, file explorer) lives on
-    /// the active window's `Window::layout_cache`; `Editor::active_layout()`
-    /// is the accessor to use for those.
-    pub(crate) chrome_layout: ChromeLayout,
+    // `chrome_layout` moved onto `Window` — each window has its own
+    // status bar, menu, prompt overlay, and popups.
 
     /// Command registry for dynamic commands
     command_registry: Arc<RwLock<CommandRegistry>>,

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -216,7 +216,7 @@ impl Editor {
 
                     let (content_x, content_y) = content_rect.map(|r| (r.x, r.y)).unwrap_or((0, 0));
 
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "mouse_move",
                         HookArgs::MouseMove {
                             column: col,

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1651,7 +1651,8 @@ impl Editor {
     }
 
     fn handle_click_global_popups(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        for (popup_idx, popup_rect, inner_rect, scroll_offset, num_items) in self.active_chrome()
+        for (popup_idx, popup_rect, inner_rect, scroll_offset, num_items) in self
+            .active_chrome()
             .global_popup_areas
             .clone()
             .into_iter()
@@ -1770,7 +1771,8 @@ impl Editor {
     fn handle_click_menu_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         if self.active_window_mut().menu_bar_visible {
             // Resolve the hit before any &mut operations to avoid borrow conflicts.
-            let hit = self.active_chrome()
+            let hit = self
+                .active_chrome()
                 .menu_layout
                 .as_ref()
                 .and_then(|ml| ml.menu_at(col, row));
@@ -2377,7 +2379,8 @@ impl Editor {
         // If selecting text in popup, extend selection
         if let Some(popup_idx) = self.active_window_mut().mouse_state.selecting_in_popup {
             // Find the popup area from cached layout
-            if let Some((_, _, inner_rect, scroll_offset, _, _, _)) = self.active_chrome()
+            if let Some((_, _, inner_rect, scroll_offset, _, _, _)) = self
+                .active_chrome()
                 .popup_areas
                 .iter()
                 .find(|(idx, _, _, _, _, _, _)| *idx == popup_idx)
@@ -2445,7 +2448,8 @@ impl Editor {
             .dragging_popup_scrollbar
         {
             // Find the popup's scrollbar rect from cached layout
-            if let Some((_, _, inner_rect, _, _, Some(sb_rect), total_lines)) = self.active_chrome()
+            if let Some((_, _, inner_rect, _, _, Some(sb_rect), total_lines)) = self
+                .active_chrome()
                 .popup_areas
                 .iter()
                 .find(|(idx, _, _, _, _, _, _)| *idx == popup_idx)

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -198,7 +198,7 @@ impl Editor {
 
                 // If we finished dragging a separator, resize visible terminals
                 if was_dragging_separator {
-                    self.resize_visible_terminals();
+                    self.active_window_mut().resize_visible_terminals();
                 }
 
                 needs_render = true;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -745,7 +745,7 @@ impl Editor {
 
     /// Check if mouse position is over a transient popup (hover, signature help)
     fn is_mouse_over_transient_popup(&self, col: u16, row: u16) -> bool {
-        let layouts = popup_areas_to_layout_info(&self.chrome_layout.popup_areas);
+        let layouts = popup_areas_to_layout_info(&self.active_chrome().popup_areas);
         let hit_tester = PopupHitTester::new(&layouts, &self.active_state().popups);
         hit_tester.is_over_transient_popup(col, row)
     }
@@ -754,7 +754,7 @@ impl Editor {
     fn is_mouse_over_any_popup(&self, col: u16, row: u16) -> bool {
         // Editor-level popup overlays absorb every click within their outer
         // rect so the buffer below doesn't receive a stray cursor placement.
-        for (_, popup_area, _, _, _) in &self.chrome_layout.global_popup_areas {
+        for (_, popup_area, _, _, _) in &self.active_chrome().global_popup_areas {
             if in_rect(col, row, *popup_area) {
                 return true;
             }
@@ -762,12 +762,12 @@ impl Editor {
         // The prompt's suggestions popup also absorbs clicks across its full
         // outer rect (border + items): clicking the chrome must not move the
         // buffer cursor below.
-        if let Some(outer) = self.chrome_layout.suggestions_outer_area {
+        if let Some(outer) = self.active_chrome().suggestions_outer_area {
             if in_rect(col, row, outer) {
                 return true;
             }
         }
-        let layouts = popup_areas_to_layout_info(&self.chrome_layout.popup_areas);
+        let layouts = popup_areas_to_layout_info(&self.active_chrome().popup_areas);
         let hit_tester = PopupHitTester::new(&layouts, &self.active_state().popups);
         hit_tester.is_over_popup(col, row)
     }
@@ -801,8 +801,8 @@ impl Editor {
     fn compute_hover_target(&self, col: u16, row: u16) -> Option<HoverTarget> {
         if let Some(ref menu) = self.active_window().file_explorer_context_menu {
             let (menu_x, menu_y) = menu.clamped_position(
-                self.chrome_layout.last_frame_width,
-                self.chrome_layout.last_frame_height,
+                self.active_chrome().last_frame_width,
+                self.active_chrome().last_frame_height,
             );
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
             let menu_height = menu.height();
@@ -841,7 +841,7 @@ impl Editor {
 
         // Check suggestions area first (command palette, autocomplete)
         if let Some((inner_rect, start_idx, _visible_count, total_count)) =
-            &self.chrome_layout.suggestions_area
+            &self.active_chrome().suggestions_area
         {
             if in_rect(col, row, *inner_rect) {
                 let relative_row = (row - inner_rect.y) as usize;
@@ -856,7 +856,7 @@ impl Editor {
         // Check popups (they're rendered on top)
         // Check from top to bottom (reverse order since last popup is on top)
         for (popup_idx, _popup_rect, inner_rect, scroll_offset, num_items, _, _) in
-            self.chrome_layout.popup_areas.iter().rev()
+            self.active_chrome().popup_areas.iter().rev()
         {
             if in_rect(col, row, *inner_rect) && *num_items > 0 {
                 // Calculate which item is being hovered
@@ -879,7 +879,7 @@ impl Editor {
         // Check menu bar (row 0, only when visible)
         // Check menu bar using cached layout from previous render
         if self.active_window().menu_bar_visible {
-            if let Some(ref menu_layout) = self.chrome_layout.menu_layout {
+            if let Some(ref menu_layout) = self.active_chrome().menu_layout {
                 if let Some(menu_idx) = menu_layout.menu_at(col, row) {
                     return Some(HoverTarget::MenuBarItem(menu_idx));
                 }
@@ -1007,31 +1007,31 @@ impl Editor {
         }
 
         // Check status bar indicators
-        if let Some((status_row, _status_x, _status_width)) = self.chrome_layout.status_bar_area {
+        if let Some((status_row, _status_x, _status_width)) = self.active_chrome().status_bar_area {
             if row == status_row {
                 let indicators = [
                     (
-                        self.chrome_layout.status_bar_line_ending_area,
+                        self.active_chrome().status_bar_line_ending_area,
                         HoverTarget::StatusBarLineEndingIndicator,
                     ),
                     (
-                        self.chrome_layout.status_bar_encoding_area,
+                        self.active_chrome().status_bar_encoding_area,
                         HoverTarget::StatusBarEncodingIndicator,
                     ),
                     (
-                        self.chrome_layout.status_bar_language_area,
+                        self.active_chrome().status_bar_language_area,
                         HoverTarget::StatusBarLanguageIndicator,
                     ),
                     (
-                        self.chrome_layout.status_bar_lsp_area,
+                        self.active_chrome().status_bar_lsp_area,
                         HoverTarget::StatusBarLspIndicator,
                     ),
                     (
-                        self.chrome_layout.status_bar_remote_area,
+                        self.active_chrome().status_bar_remote_area,
                         HoverTarget::StatusBarRemoteIndicator,
                     ),
                     (
-                        self.chrome_layout.status_bar_warning_area,
+                        self.active_chrome().status_bar_warning_area,
                         HoverTarget::StatusBarWarningBadge,
                     ),
                 ];
@@ -1046,7 +1046,7 @@ impl Editor {
         }
 
         // Check search options bar checkboxes
-        if let Some(ref layout) = self.chrome_layout.search_options_layout {
+        if let Some(ref layout) = self.active_chrome().search_options_layout {
             use crate::view::ui::status_bar::SearchOptionsHover;
             if let Some(hover) = layout.checkbox_at(col, row) {
                 return Some(match hover {
@@ -1508,7 +1508,7 @@ impl Editor {
     /// the inner item area or no suggestions are visible.
     fn suggestion_at(&self, col: u16, row: u16) -> Option<usize> {
         let (inner_rect, start_idx, _visible_count, total_count) =
-            self.chrome_layout.suggestions_area?;
+            self.active_chrome().suggestions_area?;
         if col < inner_rect.x
             || col >= inner_rect.x + inner_rect.width
             || row < inner_rect.y
@@ -1566,7 +1566,7 @@ impl Editor {
     /// behaviour is consistent across the editor.
     fn handle_click_prompt_scrollbar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         use crate::view::ui::scrollbar::ScrollbarState;
-        let sb_rect = self.chrome_layout.suggestions_scrollbar_rect?;
+        let sb_rect = self.active_chrome().suggestions_scrollbar_rect?;
         if col < sb_rect.x
             || col >= sb_rect.x + sb_rect.width
             || row < sb_rect.y
@@ -1581,7 +1581,7 @@ impl Editor {
         // prompt — `active_window_mut()` is a method call so the
         // compiler can't see that `prompt` and `chrome_layout` are
         // disjoint sub-fields.
-        let suggestions_area_visible = self.chrome_layout.suggestions_area.map(|(_, _, v, _)| v);
+        let suggestions_area_visible = self.active_chrome().suggestions_area.map(|(_, _, v, _)| v);
         let active_window_id = self.active_window;
         let prompt = self
             .windows
@@ -1604,7 +1604,7 @@ impl Editor {
     fn handle_click_popup_scrollbar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         // Collect all needed data before mutating self.
         let scrollbar_info: Option<(usize, i32)> =
-            self.chrome_layout.popup_areas.iter().rev().find_map(
+            self.active_chrome().popup_areas.iter().rev().find_map(
                 |(popup_idx, _popup_rect, inner_rect, _scroll, _n, scrollbar_rect, total_lines)| {
                     let sb_rect = scrollbar_rect.as_ref()?;
                     if col >= sb_rect.x
@@ -1651,8 +1651,7 @@ impl Editor {
     }
 
     fn handle_click_global_popups(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        for (popup_idx, popup_rect, inner_rect, scroll_offset, num_items) in self
-            .chrome_layout
+        for (popup_idx, popup_rect, inner_rect, scroll_offset, num_items) in self.active_chrome()
             .global_popup_areas
             .clone()
             .into_iter()
@@ -1684,7 +1683,7 @@ impl Editor {
 
     fn handle_click_buffer_popups(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         // Check close-button overlay ("[×]") on each popup.
-        let close_hit = self.chrome_layout.popup_areas.iter().rev().find_map(
+        let close_hit = self.active_chrome().popup_areas.iter().rev().find_map(
             |(_idx, popup_rect, _inner, _scroll, _n, _sb, _tl)| {
                 if popup_rect.width < 5 {
                     return None;
@@ -1702,7 +1701,7 @@ impl Editor {
         }
 
         // Content area clicks — clone to allow &mut self calls inside the loop.
-        let popup_areas = self.chrome_layout.popup_areas.clone();
+        let popup_areas = self.active_chrome().popup_areas.clone();
         for (popup_idx, _popup_rect, inner_rect, scroll_offset, num_items, _, _) in
             popup_areas.iter().rev()
         {
@@ -1771,12 +1770,11 @@ impl Editor {
     fn handle_click_menu_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         if self.active_window_mut().menu_bar_visible {
             // Resolve the hit before any &mut operations to avoid borrow conflicts.
-            let hit = self
-                .chrome_layout
+            let hit = self.active_chrome()
                 .menu_layout
                 .as_ref()
                 .and_then(|ml| ml.menu_at(col, row));
-            let layout_exists = self.chrome_layout.menu_layout.is_some();
+            let layout_exists = self.active_chrome().menu_layout.is_some();
             if layout_exists {
                 if let Some(menu_idx) = hit {
                     if self.menu_state.active_menu == Some(menu_idx) {
@@ -1972,41 +1970,41 @@ impl Editor {
     }
 
     fn handle_click_status_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        let (status_row, _status_x, _status_width) = self.chrome_layout.status_bar_area?;
+        let (status_row, _status_x, _status_width) = self.active_chrome().status_bar_area?;
         if row != status_row {
             return None;
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_line_ending_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_line_ending_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::SetLineEnding));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_encoding_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_encoding_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::SetEncoding));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_language_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_language_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::SetLanguage));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_lsp_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_lsp_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::ShowLspStatus));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_remote_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_remote_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::ShowRemoteIndicatorMenu));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_warning_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_warning_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::ShowWarnings));
             }
         }
-        if let Some((r, s, e)) = self.chrome_layout.status_bar_message_area {
+        if let Some((r, s, e)) = self.active_chrome().status_bar_message_area {
             if row == r && col >= s && col < e {
                 return Some(self.handle_action(Action::ShowStatusLog));
             }
@@ -2016,7 +2014,7 @@ impl Editor {
 
     fn handle_click_search_options(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         use crate::view::ui::status_bar::SearchOptionsHover;
-        let layout = self.chrome_layout.search_options_layout.clone()?;
+        let layout = self.active_chrome().search_options_layout.clone()?;
         match layout.checkbox_at(col, row)? {
             SearchOptionsHover::CaseSensitive => {
                 Some(self.handle_action(Action::ToggleSearchCaseSensitive))
@@ -2379,8 +2377,7 @@ impl Editor {
         // If selecting text in popup, extend selection
         if let Some(popup_idx) = self.active_window_mut().mouse_state.selecting_in_popup {
             // Find the popup area from cached layout
-            if let Some((_, _, inner_rect, scroll_offset, _, _, _)) = self
-                .chrome_layout
+            if let Some((_, _, inner_rect, scroll_offset, _, _, _)) = self.active_chrome()
                 .popup_areas
                 .iter()
                 .find(|(idx, _, _, _, _, _, _)| *idx == popup_idx)
@@ -2416,9 +2413,9 @@ impl Editor {
             use crate::view::ui::scrollbar::ScrollbarState;
             // Snapshot chrome rects up front so the prompt borrow on
             // active_window_mut() doesn't conflict.
-            let sb_rect = self.chrome_layout.suggestions_scrollbar_rect;
+            let sb_rect = self.active_chrome().suggestions_scrollbar_rect;
             let suggestions_area_visible =
-                self.chrome_layout.suggestions_area.map(|(_, _, v, _)| v);
+                self.active_chrome().suggestions_area.map(|(_, _, v, _)| v);
             let active_window_id = self.active_window;
             if let (Some(sb_rect), Some(prompt)) = (
                 sb_rect,
@@ -2448,8 +2445,7 @@ impl Editor {
             .dragging_popup_scrollbar
         {
             // Find the popup's scrollbar rect from cached layout
-            if let Some((_, _, inner_rect, _, _, Some(sb_rect), total_lines)) = self
-                .chrome_layout
+            if let Some((_, _, inner_rect, _, _, Some(sb_rect), total_lines)) = self.active_chrome()
                 .popup_areas
                 .iter()
                 .find(|(idx, _, _, _, _, _, _)| *idx == popup_idx)
@@ -2748,8 +2744,8 @@ impl Editor {
 
     /// Handle right-click event
     pub(super) fn handle_right_click(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
-        let frame_w = self.chrome_layout.last_frame_width;
-        let frame_h = self.chrome_layout.last_frame_height;
+        let frame_w = self.active_chrome().last_frame_width;
+        let frame_h = self.active_chrome().last_frame_height;
         if let Some(ref menu) = self.active_window().file_explorer_context_menu {
             let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
@@ -2981,8 +2977,8 @@ impl Editor {
         row: u16,
     ) -> Option<AnyhowResult<()>> {
         // Extract all needed values while the immutable borrow is live, then mutate.
-        let frame_w = self.chrome_layout.last_frame_width;
-        let frame_h = self.chrome_layout.last_frame_height;
+        let frame_w = self.active_chrome().last_frame_width;
+        let frame_h = self.active_chrome().last_frame_height;
         let clicked_item: Option<super::types::FileExplorerContextMenuItem> = {
             let menu = self.active_window().file_explorer_context_menu.as_ref()?;
             let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3160,14 +3160,14 @@ impl Editor {
         }
 
         // Create popup
-        let mut popup = Popup::text(lines, &self.theme);
+        let mut popup = Popup::text(lines, &*self.theme.read().unwrap());
         popup.title = Some("Git Status".to_string());
         popup.transient = true;
         popup.position = PopupPosition::Fixed { x: col, y: row + 1 };
         popup.width = 50;
         popup.max_height = 15;
-        popup.border_style = Style::default().fg(self.theme.popup_border_fg);
-        popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.border_style = Style::default().fg(self.theme.read().unwrap().popup_border_fg);
+        popup.background_style = Style::default().bg(self.theme.read().unwrap().popup_bg);
 
         // Show the popup
         let __buffer_id = self.active_buffer();

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1782,7 +1782,7 @@ impl Editor {
                     if self.menu_state.active_menu == Some(menu_idx) {
                         self.close_menu_with_auto_hide();
                     } else {
-                        self.on_editor_focus_lost();
+                        self.active_window_mut().on_editor_focus_lost();
                         self.menu_state.open_menu(menu_idx);
                     }
                     return Some(Ok(()));

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -63,9 +63,9 @@ impl Editor {
 
         // Update mouse cursor position for software cursor rendering (used by GPM)
         // When GPM is active, we always need to re-render to update the cursor position
-        let cursor_moved = self.mouse_cursor_position != Some((col, row));
-        self.mouse_cursor_position = Some((col, row));
-        if self.gpm_active && cursor_moved {
+        let cursor_moved = self.active_window_mut().mouse_cursor_position != Some((col, row));
+        self.active_window_mut().mouse_cursor_position = Some((col, row));
+        if self.active_window_mut().gpm_active && cursor_moved {
             needs_render = true;
         }
 
@@ -83,7 +83,7 @@ impl Editor {
         }
 
         // Dismiss theme info popup on any left-click; check if click is on the button first
-        if self.theme_info_popup.is_some() {
+        if self.active_window_mut().theme_info_popup.is_some() {
             if let MouseEventKind::Down(MouseButton::Left) = mouse_event.kind {
                 if let Some((popup_rect, button_row_offset)) = self.theme_info_popup_rect() {
                     if in_rect(col, row, popup_rect) {
@@ -91,10 +91,11 @@ impl Editor {
                         let actual_button_row = popup_rect.y + button_row_offset;
                         if row == actual_button_row {
                             let fg_key = self
+                                .active_window_mut()
                                 .theme_info_popup
                                 .as_ref()
                                 .and_then(|p| p.info.fg_key.clone());
-                            self.theme_info_popup = None;
+                            self.active_window_mut().theme_info_popup = None;
                             if let Some(key) = fg_key {
                                 self.fire_theme_inspect_hook(key);
                             }
@@ -105,7 +106,7 @@ impl Editor {
                     }
                 }
                 // Click outside popup - dismiss
-                self.theme_info_popup = None;
+                self.active_window_mut().theme_info_popup = None;
                 needs_render = true;
             }
         }
@@ -142,10 +143,14 @@ impl Editor {
             }
             MouseEventKind::Up(MouseButton::Left) => {
                 // Check if we were dragging a separator to trigger terminal resize
-                let was_dragging_separator = self.mouse_state.dragging_separator.is_some();
+                let was_dragging_separator = self
+                    .active_window_mut()
+                    .mouse_state
+                    .dragging_separator
+                    .is_some();
 
                 // Check if we were dragging a tab and complete the drop
-                if let Some(drag_state) = self.mouse_state.dragging_tab.take() {
+                if let Some(drag_state) = self.active_window_mut().mouse_state.dragging_tab.take() {
                     if drag_state.is_dragging() {
                         if let Some(drop_zone) = drag_state.drop_zone {
                             self.execute_tab_drop(
@@ -158,30 +163,38 @@ impl Editor {
                 }
 
                 // Stop dragging and clear drag state
-                self.mouse_state.dragging_scrollbar = None;
-                self.mouse_state.drag_start_row = None;
-                self.mouse_state.drag_start_top_byte = None;
-                self.mouse_state.dragging_horizontal_scrollbar = None;
-                self.mouse_state.drag_start_hcol = None;
-                self.mouse_state.drag_start_left_column = None;
-                self.mouse_state.dragging_separator = None;
-                self.mouse_state.drag_start_position = None;
-                self.mouse_state.drag_start_ratio = None;
-                self.mouse_state.dragging_file_explorer = false;
-                self.mouse_state.drag_start_explorer_width = None;
+                self.active_window_mut().mouse_state.dragging_scrollbar = None;
+                self.active_window_mut().mouse_state.drag_start_row = None;
+                self.active_window_mut().mouse_state.drag_start_top_byte = None;
+                self.active_window_mut()
+                    .mouse_state
+                    .dragging_horizontal_scrollbar = None;
+                self.active_window_mut().mouse_state.drag_start_hcol = None;
+                self.active_window_mut().mouse_state.drag_start_left_column = None;
+                self.active_window_mut().mouse_state.dragging_separator = None;
+                self.active_window_mut().mouse_state.drag_start_position = None;
+                self.active_window_mut().mouse_state.drag_start_ratio = None;
+                self.active_window_mut().mouse_state.dragging_file_explorer = false;
+                self.active_window_mut()
+                    .mouse_state
+                    .drag_start_explorer_width = None;
                 // Clear text selection drag state (selection remains in cursor)
-                self.mouse_state.dragging_text_selection = false;
-                self.mouse_state.drag_selection_split = None;
-                self.mouse_state.drag_selection_anchor = None;
-                self.mouse_state.drag_selection_by_words = false;
-                self.mouse_state.drag_selection_word_end = None;
+                self.active_window_mut().mouse_state.dragging_text_selection = false;
+                self.active_window_mut().mouse_state.drag_selection_split = None;
+                self.active_window_mut().mouse_state.drag_selection_anchor = None;
+                self.active_window_mut().mouse_state.drag_selection_by_words = false;
+                self.active_window_mut().mouse_state.drag_selection_word_end = None;
                 // Clear popup scrollbar drag state
-                self.mouse_state.dragging_popup_scrollbar = None;
-                self.mouse_state.drag_start_popup_scroll = None;
+                self.active_window_mut()
+                    .mouse_state
+                    .dragging_popup_scrollbar = None;
+                self.active_window_mut().mouse_state.drag_start_popup_scroll = None;
                 // Clear prompt scrollbar drag state (issue #1796)
-                self.mouse_state.dragging_prompt_scrollbar = false;
+                self.active_window_mut()
+                    .mouse_state
+                    .dragging_prompt_scrollbar = false;
                 // Clear popup text selection drag state (selection remains in popup)
-                self.mouse_state.selecting_in_popup = None;
+                self.active_window_mut().mouse_state.selecting_in_popup = None;
 
                 // If we finished dragging a separator, resize visible terminals
                 if was_dragging_separator {
@@ -225,7 +238,7 @@ impl Editor {
                     let new_highlighted = row == button_row
                         && col >= popup_rect.x
                         && col < popup_rect.x + popup_rect.width;
-                    if let Some(ref mut popup) = self.theme_info_popup {
+                    if let Some(ref mut popup) = self.active_window_mut().theme_info_popup {
                         if popup.button_highlighted != new_highlighted {
                             popup.button_highlighted = new_highlighted;
                             needs_render = true;
@@ -272,7 +285,7 @@ impl Editor {
             }
         }
 
-        self.mouse_state.last_position = Some((col, row));
+        self.active_window_mut().mouse_state.last_position = Some((col, row));
         Ok(needs_render)
     }
 
@@ -289,26 +302,27 @@ impl Editor {
         }
         let now = self.time_source.now();
         let threshold = std::time::Duration::from_millis(self.config.editor.double_click_time_ms);
-        let is_consecutive = if let (Some(prev_time), Some(prev_pos)) =
-            (self.previous_click_time, self.previous_click_position)
-        {
+        let is_consecutive = if let (Some(prev_time), Some(prev_pos)) = (
+            self.active_window_mut().previous_click_time,
+            self.active_window_mut().previous_click_position,
+        ) {
             now.duration_since(prev_time) < threshold && prev_pos == (col, row)
         } else {
             false
         };
         if is_consecutive {
-            self.click_count += 1;
+            self.active_window_mut().click_count += 1;
         } else {
-            self.click_count = 1;
+            self.active_window_mut().click_count = 1;
         }
-        self.previous_click_time = Some(now);
-        self.previous_click_position = Some((col, row));
-        let is_triple = self.click_count >= 3;
-        let is_double = self.click_count == 2;
+        self.active_window_mut().previous_click_time = Some(now);
+        self.active_window_mut().previous_click_position = Some((col, row));
+        let is_triple = self.active_window_mut().click_count >= 3;
+        let is_double = self.active_window_mut().click_count == 2;
         if is_triple {
-            self.click_count = 0;
-            self.previous_click_time = None;
-            self.previous_click_position = None;
+            self.active_window_mut().click_count = 0;
+            self.active_window_mut().previous_click_time = None;
+            self.active_window_mut().previous_click_position = None;
         }
         (is_double, is_triple)
     }
@@ -347,7 +361,8 @@ impl Editor {
             {
                 self.sync_terminal_to_buffer(self.active_buffer());
                 self.active_window_mut().terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
             }
             self.dismiss_transient_popups();
             self.handle_mouse_scroll(col, row, delta)?;
@@ -358,10 +373,10 @@ impl Editor {
     /// Update the current hover target based on mouse position
     /// Returns true if the hover target changed (requiring a re-render)
     pub(super) fn update_hover_target(&mut self, col: u16, row: u16) -> bool {
-        let old_target = self.mouse_state.hover_target.clone();
+        let old_target = self.active_window_mut().mouse_state.hover_target.clone();
         let new_target = self.compute_hover_target(col, row);
         let changed = old_target != new_target;
-        self.mouse_state.hover_target = new_target.clone();
+        self.active_window_mut().mouse_state.hover_target = new_target.clone();
 
         // If a menu is currently open and we're hovering over a different menu bar item,
         // switch to that menu automatically
@@ -487,7 +502,7 @@ impl Editor {
 
         // Handle tab context menu hover - update highlighted item
         if let Some(HoverTarget::TabContextMenuItem(item_idx)) = new_target.clone() {
-            if let Some(ref mut menu) = self.tab_context_menu {
+            if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
                 if menu.highlighted != item_idx {
                     menu.highlighted = item_idx;
                     return true;
@@ -496,7 +511,7 @@ impl Editor {
         }
 
         if let Some(&HoverTarget::FileExplorerContextMenuItem(item_idx)) = new_target.as_ref() {
-            if let Some(ref mut menu) = self.file_explorer_context_menu {
+            if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
                 if menu.highlighted != item_idx {
                     menu.highlighted = item_idx;
                     return true;
@@ -539,13 +554,21 @@ impl Editor {
 
         // Suppress LSP hover when a popup is already visible (e.g. theme info popup,
         // tab context menu) to avoid hover tooltips overlapping other popups.
-        if self.theme_info_popup.is_some()
-            || self.tab_context_menu.is_some()
-            || self.file_explorer_context_menu.is_some()
+        if self.active_window_mut().theme_info_popup.is_some()
+            || self.active_window_mut().tab_context_menu.is_some()
+            || self
+                .active_window_mut()
+                .file_explorer_context_menu
+                .is_some()
         {
-            if self.mouse_state.lsp_hover_state.is_some() {
-                self.mouse_state.lsp_hover_state = None;
-                self.mouse_state.lsp_hover_request_sent = false;
+            if self
+                .active_window_mut()
+                .mouse_state
+                .lsp_hover_state
+                .is_some()
+            {
+                self.active_window_mut().mouse_state.lsp_hover_state = None;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
                 self.dismiss_transient_popups();
             }
             return;
@@ -568,9 +591,14 @@ impl Editor {
 
         let Some((split_id, buffer_id, content_rect)) = split_info else {
             // Mouse is not over editor content - clear hover state and dismiss popup
-            if self.mouse_state.lsp_hover_state.is_some() {
-                self.mouse_state.lsp_hover_state = None;
-                self.mouse_state.lsp_hover_request_sent = false;
+            if self
+                .active_window_mut()
+                .mouse_state
+                .lsp_hover_state
+                .is_some()
+            {
+                self.active_window_mut().mouse_state.lsp_hover_state = None;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
                 self.dismiss_transient_popups();
             }
             return;
@@ -617,9 +645,14 @@ impl Editor {
             // Mouse is in the gutter — stop tracking a pending request but keep
             // any existing popup visible. The popup is only dismissed when the
             // mouse leaves the editor area entirely (see docstring).
-            if self.mouse_state.lsp_hover_state.is_some() {
-                self.mouse_state.lsp_hover_state = None;
-                self.mouse_state.lsp_hover_request_sent = false;
+            if self
+                .active_window_mut()
+                .mouse_state
+                .lsp_hover_state
+                .is_some()
+            {
+                self.active_window_mut().mouse_state.lsp_hover_state = None;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
             }
             return;
         };
@@ -671,9 +704,14 @@ impl Editor {
             // request but keep any existing popup visible. The popup is only
             // dismissed when the mouse leaves the editor area entirely
             // (see docstring).
-            if self.mouse_state.lsp_hover_state.is_some() {
-                self.mouse_state.lsp_hover_state = None;
-                self.mouse_state.lsp_hover_request_sent = false;
+            if self
+                .active_window_mut()
+                .mouse_state
+                .lsp_hover_state
+                .is_some()
+            {
+                self.active_window_mut().mouse_state.lsp_hover_state = None;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
             }
             return;
         }
@@ -687,7 +725,7 @@ impl Editor {
         }
 
         // Check if we're still hovering the same position
-        if let Some((old_pos, _, _, _)) = self.mouse_state.lsp_hover_state {
+        if let Some((old_pos, _, _, _)) = self.active_window_mut().mouse_state.lsp_hover_state {
             if old_pos == byte_pos {
                 // Same position - keep existing state
                 return;
@@ -700,8 +738,9 @@ impl Editor {
         }
 
         // Start tracking new hover position
-        self.mouse_state.lsp_hover_state = Some((byte_pos, std::time::Instant::now(), col, row));
-        self.mouse_state.lsp_hover_request_sent = false;
+        self.active_window_mut().mouse_state.lsp_hover_state =
+            Some((byte_pos, std::time::Instant::now(), col, row));
+        self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
     }
 
     /// Check if mouse position is over a transient popup (hover, signature help)
@@ -735,7 +774,8 @@ impl Editor {
 
     /// Check if mouse position is over the file browser popup
     fn is_mouse_over_file_browser(&self, col: u16, row: u16) -> bool {
-        self.file_browser_layout
+        self.active_window()
+            .file_browser_layout
             .as_ref()
             .is_some_and(|layout| layout.contains(col, row))
     }
@@ -759,7 +799,7 @@ impl Editor {
 
     /// Compute what hover target is at the given position
     fn compute_hover_target(&self, col: u16, row: u16) -> Option<HoverTarget> {
-        if let Some(ref menu) = self.file_explorer_context_menu {
+        if let Some(ref menu) = self.active_window().file_explorer_context_menu {
             let (menu_x, menu_y) = menu.clamped_position(
                 self.chrome_layout.last_frame_width,
                 self.chrome_layout.last_frame_height,
@@ -780,7 +820,7 @@ impl Editor {
         }
 
         // Check tab context menu first (it's rendered on top)
-        if let Some(ref menu) = self.tab_context_menu {
+        if let Some(ref menu) = self.active_window().tab_context_menu {
             let menu_x = menu.position.0;
             let menu_y = menu.position.1;
             let menu_width = 22u16;
@@ -838,7 +878,7 @@ impl Editor {
 
         // Check menu bar (row 0, only when visible)
         // Check menu bar using cached layout from previous render
-        if self.menu_bar_visible {
+        if self.active_window().menu_bar_visible {
             if let Some(ref menu_layout) = self.chrome_layout.menu_layout {
                 if let Some(menu_idx) = menu_layout.menu_at(col, row) {
                     return Some(HoverTarget::MenuBarItem(menu_idx));
@@ -1070,12 +1110,14 @@ impl Editor {
             if in_rect(col, row, *content_rect) {
                 // Double-clicked on an editor split
                 if self.active_window().is_terminal_buffer(*buffer_id) {
-                    self.key_context = crate::input::keybindings::KeyContext::Terminal;
+                    self.active_window_mut().key_context =
+                        crate::input::keybindings::KeyContext::Terminal;
                     // Don't select word in terminal buffers
                     return Ok(());
                 }
 
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
 
                 // Position cursor at click location and select word
                 self.handle_editor_double_click(col, row, *split_id, *buffer_id, *content_rect)?;
@@ -1199,11 +1241,11 @@ impl Editor {
             // anchor when dragging forward (use word start) vs backward (use word end).
             let sel_start = cursor.selection_start();
             let sel_end = cursor.selection_end();
-            self.mouse_state.dragging_text_selection = true;
-            self.mouse_state.drag_selection_split = Some(split_id);
-            self.mouse_state.drag_selection_anchor = Some(sel_start);
-            self.mouse_state.drag_selection_by_words = true;
-            self.mouse_state.drag_selection_word_end = Some(sel_end);
+            self.active_window_mut().mouse_state.dragging_text_selection = true;
+            self.active_window_mut().mouse_state.drag_selection_split = Some(split_id);
+            self.active_window_mut().mouse_state.drag_selection_anchor = Some(sel_start);
+            self.active_window_mut().mouse_state.drag_selection_by_words = true;
+            self.active_window_mut().mouse_state.drag_selection_word_end = Some(sel_end);
         }
 
         Ok(())
@@ -1230,7 +1272,8 @@ impl Editor {
                     return Ok(());
                 }
 
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
 
                 // Use the same pattern as handle_editor_double_click:
                 // first focus and position cursor, then select line
@@ -1443,12 +1486,16 @@ impl Editor {
     // Each returns Some(result) if the click was consumed, None to fall through.
 
     fn handle_click_context_menus(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        if self.file_explorer_context_menu.is_some() {
+        if self
+            .active_window_mut()
+            .file_explorer_context_menu
+            .is_some()
+        {
             if let Some(result) = self.handle_file_explorer_context_menu_click(col, row) {
                 return Some(result);
             }
         }
-        if self.tab_context_menu.is_some() {
+        if self.active_window_mut().tab_context_menu.is_some() {
             if let Some(result) = self.handle_tab_context_menu_click(col, row) {
                 return Some(result);
             }
@@ -1548,7 +1595,9 @@ impl Editor {
         prompt.scroll_offset = state.click_to_offset(track_height, click_row);
         // Hand off to the drag follow-up so subsequent mouse moves
         // keep tracking the thumb.
-        self.mouse_state.dragging_prompt_scrollbar = true;
+        self.active_window_mut()
+            .mouse_state
+            .dragging_prompt_scrollbar = true;
         Some(Ok(()))
     }
 
@@ -1583,15 +1632,17 @@ impl Editor {
                 },
             );
         let (popup_idx, target_scroll) = scrollbar_info?;
-        self.mouse_state.dragging_popup_scrollbar = Some(popup_idx);
-        self.mouse_state.drag_start_row = Some(row);
+        self.active_window_mut()
+            .mouse_state
+            .dragging_popup_scrollbar = Some(popup_idx);
+        self.active_window_mut().mouse_state.drag_start_row = Some(row);
         let current_scroll = self
             .active_state()
             .popups
             .get(popup_idx)
             .map(|p| p.scroll_offset)
             .unwrap_or(0);
-        self.mouse_state.drag_start_popup_scroll = Some(current_scroll);
+        self.active_window_mut().mouse_state.drag_start_popup_scroll = Some(current_scroll);
         let state = self.active_state_mut();
         if let Some(popup) = state.popups.get_mut(popup_idx) {
             popup.scroll_by(target_scroll - current_scroll as i32);
@@ -1710,7 +1761,7 @@ impl Editor {
                 if let Some(popup) = state.popups.top_mut() {
                     popup.start_selection(line, relative_col);
                 }
-                self.mouse_state.selecting_in_popup = Some(popup_idx_copy);
+                self.active_window_mut().mouse_state.selecting_in_popup = Some(popup_idx_copy);
                 return Some(Ok(()));
             }
         }
@@ -1718,7 +1769,7 @@ impl Editor {
     }
 
     fn handle_click_menu_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        if self.menu_bar_visible {
+        if self.active_window_mut().menu_bar_visible {
             // Resolve the hit before any &mut operations to avoid borrow conflicts.
             let hit = self
                 .chrome_layout
@@ -1769,10 +1820,11 @@ impl Editor {
         let border_x = explorer_area.x + explorer_area.width.saturating_sub(1);
         if col == border_x && row >= explorer_area.y && row < explorer_area.y + explorer_area.height
         {
-            self.mouse_state.dragging_file_explorer = true;
-            self.mouse_state.drag_start_position = Some((col, row));
-            self.mouse_state.drag_start_explorer_width =
-                Some(self.active_window().file_explorer_width);
+            self.active_window_mut().mouse_state.dragging_file_explorer = true;
+            self.active_window_mut().mouse_state.drag_start_position = Some((col, row));
+            self.active_window_mut()
+                .mouse_state
+                .drag_start_explorer_width = Some(self.active_window().file_explorer_width);
             return Some(Ok(()));
         }
         if in_rect(col, row, explorer_area) {
@@ -1797,36 +1849,42 @@ impl Editor {
 
         self.focus_split(split_id, buffer_id);
         if is_on_thumb {
-            self.mouse_state.dragging_scrollbar = Some(split_id);
-            self.mouse_state.drag_start_row = Some(row);
+            self.active_window_mut().mouse_state.dragging_scrollbar = Some(split_id);
+            self.active_window_mut().mouse_state.drag_start_row = Some(row);
             if self.active_window().is_composite_buffer(buffer_id) {
                 if let Some(vs) = self
                     .active_window()
                     .composite_view_states
                     .get(&(split_id, buffer_id))
                 {
-                    self.mouse_state.drag_start_composite_scroll_row = Some(vs.scroll_row);
+                    self.active_window_mut()
+                        .mouse_state
+                        .drag_start_composite_scroll_row = Some(vs.scroll_row);
                 }
-            } else if let Some(vs) = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
-                .get(&split_id)
-            {
-                self.mouse_state.drag_start_top_byte = Some(vs.viewport.top_byte);
-                self.mouse_state.drag_start_view_line_offset =
-                    Some(vs.viewport.top_view_line_offset);
+            } else {
+                let snap = self
+                    .windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.splits.as_ref())
+                    .map(|(_, vs)| vs)
+                    .expect("active window must have a populated split layout")
+                    .get(&split_id)
+                    .map(|vs| (vs.viewport.top_byte, vs.viewport.top_view_line_offset));
+                if let Some((top_byte, top_view_line_offset)) = snap {
+                    let ms = &mut self.active_window_mut().mouse_state;
+                    ms.drag_start_top_byte = Some(top_byte);
+                    ms.drag_start_view_line_offset = Some(top_view_line_offset);
+                }
             }
         } else {
-            self.mouse_state.dragging_scrollbar = Some(split_id);
+            self.active_window_mut().mouse_state.dragging_scrollbar = Some(split_id);
             if let Err(e) =
                 self.handle_scrollbar_jump(col, row, split_id, buffer_id, scrollbar_rect)
             {
                 return Some(Err(e));
             }
-            self.mouse_state.hover_target = Some(HoverTarget::ScrollbarThumb(split_id));
+            self.active_window_mut().mouse_state.hover_target =
+                Some(HoverTarget::ScrollbarThumb(split_id));
         }
         Some(Ok(()))
     }
@@ -1870,9 +1928,11 @@ impl Editor {
             )?;
 
         self.focus_split(split_id, buffer_id);
-        self.mouse_state.dragging_horizontal_scrollbar = Some(split_id);
+        self.active_window_mut()
+            .mouse_state
+            .dragging_horizontal_scrollbar = Some(split_id);
         if is_on_thumb {
-            self.mouse_state.drag_start_hcol = Some(col);
+            self.active_window_mut().mouse_state.drag_start_hcol = Some(col);
             if let Some(vs) = self
                 .windows
                 .get(&self.active_window)
@@ -1881,11 +1941,12 @@ impl Editor {
                 .expect("active window must have a populated split layout")
                 .get(&split_id)
             {
-                self.mouse_state.drag_start_left_column = Some(vs.viewport.left_column);
+                self.active_window_mut().mouse_state.drag_start_left_column =
+                    Some(vs.viewport.left_column);
             }
         } else {
-            self.mouse_state.drag_start_hcol = None;
-            self.mouse_state.drag_start_left_column = None;
+            self.active_window_mut().mouse_state.drag_start_hcol = None;
+            self.active_window_mut().mouse_state.drag_start_left_column = None;
             let relative_col = col.saturating_sub(hscrollbar_rect.x) as f64;
             let track_width = hscrollbar_rect.width as f64;
             let ratio = if track_width > 1.0 {
@@ -1983,14 +2044,15 @@ impl Editor {
                 }
             };
             if is_on_separator {
-                self.mouse_state.dragging_separator = Some((*split_id, *direction));
-                self.mouse_state.drag_start_position = Some((col, row));
+                self.active_window_mut().mouse_state.dragging_separator =
+                    Some((*split_id, *direction));
+                self.active_window_mut().mouse_state.drag_start_position = Some((col, row));
                 let ratio = self
                     .split_manager_mut()
                     .get_ratio((*split_id).into())
                     .or_else(|| self.grouped_split_ratio(*split_id));
                 if let Some(ratio) = ratio {
-                    self.mouse_state.drag_start_ratio = Some(ratio);
+                    self.active_window_mut().mouse_state.drag_start_ratio = Some(ratio);
                 }
                 return Some(Ok(()));
             }
@@ -2162,11 +2224,9 @@ impl Editor {
                         self.focus_split(split_id, buffer_id);
                         self.active_window_mut()
                             .promote_buffer_from_preview(buffer_id);
-                        self.mouse_state.dragging_tab = Some(super::types::TabDragState::new(
-                            buffer_id,
-                            split_id,
-                            (col, row),
-                        ));
+                        self.active_window_mut().mouse_state.dragging_tab = Some(
+                            super::types::TabDragState::new(buffer_id, split_id, (col, row)),
+                        );
                     }
                     crate::view::split::TabTarget::Group(group_leaf) => {
                         self.activate_group_tab(split_id, group_leaf);
@@ -2207,14 +2267,14 @@ impl Editor {
     /// Handle mouse drag event
     pub(super) fn handle_mouse_drag(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
         // If dragging scrollbar, update scroll position
-        if let Some(dragging_split_id) = self.mouse_state.dragging_scrollbar {
+        if let Some(dragging_split_id) = self.active_window_mut().mouse_state.dragging_scrollbar {
             // Find the buffer and scrollbar rect for this split
             for (split_id, buffer_id, _content_rect, scrollbar_rect, _thumb_start, _thumb_end) in
                 &self.active_layout().split_areas
             {
                 if *split_id == dragging_split_id {
                     // Check if we started dragging from the thumb (have drag_start_row)
-                    if self.mouse_state.drag_start_row.is_some() {
+                    if self.active_window().mouse_state.drag_start_row.is_some() {
                         // Relative drag from thumb
                         self.handle_scrollbar_drag_relative(
                             row,
@@ -2238,7 +2298,11 @@ impl Editor {
         }
 
         // If dragging horizontal scrollbar, update horizontal scroll position
-        if let Some(dragging_split_id) = self.mouse_state.dragging_horizontal_scrollbar {
+        if let Some(dragging_split_id) = self
+            .active_window_mut()
+            .mouse_state
+            .dragging_horizontal_scrollbar
+        {
             // Clone the scrollbar layout so the loop doesn't hold an
             // immutable borrow on `self` while it mutates
             // `self.split_view_states`. The active window's layout cache
@@ -2260,8 +2324,8 @@ impl Editor {
                     }
 
                     if let (Some(drag_start_hcol), Some(drag_start_left_column)) = (
-                        self.mouse_state.drag_start_hcol,
-                        self.mouse_state.drag_start_left_column,
+                        self.active_window_mut().mouse_state.drag_start_hcol,
+                        self.active_window_mut().mouse_state.drag_start_left_column,
                     ) {
                         // Relative drag from thumb - move proportionally to mouse offset
                         // Use thumb size to compute the correct ratio so thumb tracks with mouse
@@ -2313,7 +2377,7 @@ impl Editor {
         }
 
         // If selecting text in popup, extend selection
-        if let Some(popup_idx) = self.mouse_state.selecting_in_popup {
+        if let Some(popup_idx) = self.active_window_mut().mouse_state.selecting_in_popup {
             // Find the popup area from cached layout
             if let Some((_, _, inner_rect, scroll_offset, _, _, _)) = self
                 .chrome_layout
@@ -2344,7 +2408,11 @@ impl Editor {
         // (issue #1796), update its scroll_offset using the same
         // math as the click handler. Same shared-widget logic the
         // popup-scrollbar drag uses below.
-        if self.mouse_state.dragging_prompt_scrollbar {
+        if self
+            .active_window_mut()
+            .mouse_state
+            .dragging_prompt_scrollbar
+        {
             use crate::view::ui::scrollbar::ScrollbarState;
             // Snapshot chrome rects up front so the prompt borrow on
             // active_window_mut() doesn't conflict.
@@ -2374,7 +2442,11 @@ impl Editor {
         }
 
         // If dragging popup scrollbar, update popup scroll position
-        if let Some(popup_idx) = self.mouse_state.dragging_popup_scrollbar {
+        if let Some(popup_idx) = self
+            .active_window_mut()
+            .mouse_state
+            .dragging_popup_scrollbar
+        {
             // Find the popup's scrollbar rect from cached layout
             if let Some((_, _, inner_rect, _, _, Some(sb_rect), total_lines)) = self
                 .chrome_layout
@@ -2406,25 +2478,26 @@ impl Editor {
         }
 
         // If dragging separator, update split ratio
-        if let Some((split_id, direction)) = self.mouse_state.dragging_separator {
+        if let Some((split_id, direction)) = self.active_window_mut().mouse_state.dragging_separator
+        {
             self.handle_separator_drag(col, row, split_id, direction)?;
             return Ok(());
         }
 
         // If dragging file explorer border, update width
-        if self.mouse_state.dragging_file_explorer {
+        if self.active_window_mut().mouse_state.dragging_file_explorer {
             self.handle_file_explorer_border_drag(col)?;
             return Ok(());
         }
 
         // If dragging to select text
-        if self.mouse_state.dragging_text_selection {
+        if self.active_window_mut().mouse_state.dragging_text_selection {
             self.handle_text_selection_drag(col, row)?;
             return Ok(());
         }
 
         // If dragging a tab, update position and compute drop zone
-        if self.mouse_state.dragging_tab.is_some() {
+        if self.active_window_mut().mouse_state.dragging_tab.is_some() {
             self.handle_tab_drag(col, row)?;
             return Ok(());
         }
@@ -2437,10 +2510,11 @@ impl Editor {
         use crate::model::event::Event;
         use crate::primitives::word_navigation::{find_word_end, find_word_start};
 
-        let Some(split_id) = self.mouse_state.drag_selection_split else {
+        let Some(split_id) = self.active_window_mut().mouse_state.drag_selection_split else {
             return Ok(());
         };
-        let Some(anchor_position) = self.mouse_state.drag_selection_anchor else {
+        let Some(anchor_position) = self.active_window_mut().mouse_state.drag_selection_anchor
+        else {
             return Ok(());
         };
 
@@ -2488,8 +2562,8 @@ impl Editor {
         // Calculate the target position and selection geometry by
         // reading buffer state directly, then dispatch the move via
         // Window helpers.
-        let drag_by_words = self.mouse_state.drag_selection_by_words;
-        let drag_word_end = self.mouse_state.drag_selection_word_end;
+        let drag_by_words = self.active_window_mut().mouse_state.drag_selection_by_words;
+        let drag_word_end = self.active_window_mut().mouse_state.drag_selection_word_end;
 
         let Some((target_position, new_position, anchor_position, new_sticky_column)) = self
             .active_window()
@@ -2568,10 +2642,16 @@ impl Editor {
 
     /// Handle file explorer border drag for resizing
     pub(super) fn handle_file_explorer_border_drag(&mut self, col: u16) -> AnyhowResult<()> {
-        let Some((start_col, _start_row)) = self.mouse_state.drag_start_position else {
+        let Some((start_col, _start_row)) =
+            self.active_window_mut().mouse_state.drag_start_position
+        else {
             return Ok(());
         };
-        let Some(start_width) = self.mouse_state.drag_start_explorer_width else {
+        let Some(start_width) = self
+            .active_window_mut()
+            .mouse_state
+            .drag_start_explorer_width
+        else {
             return Ok(());
         };
 
@@ -2607,10 +2687,11 @@ impl Editor {
         split_id: ContainerId,
         direction: SplitDirection,
     ) -> AnyhowResult<()> {
-        let Some((start_col, start_row)) = self.mouse_state.drag_start_position else {
+        let Some((start_col, start_row)) = self.active_window_mut().mouse_state.drag_start_position
+        else {
             return Ok(());
         };
-        let Some(start_ratio) = self.mouse_state.drag_start_ratio else {
+        let Some(start_ratio) = self.active_window_mut().mouse_state.drag_start_ratio else {
             return Ok(());
         };
         let Some(editor_area) = self.active_layout().editor_content_area else {
@@ -2667,11 +2748,10 @@ impl Editor {
 
     /// Handle right-click event
     pub(super) fn handle_right_click(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
-        if let Some(ref menu) = self.file_explorer_context_menu {
-            let (menu_x, menu_y) = menu.clamped_position(
-                self.chrome_layout.last_frame_width,
-                self.chrome_layout.last_frame_height,
-            );
+        let frame_w = self.chrome_layout.last_frame_width;
+        let frame_h = self.chrome_layout.last_frame_height;
+        if let Some(ref menu) = self.active_window().file_explorer_context_menu {
+            let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
             let menu_height = menu.height();
             if col >= menu_x
@@ -2684,7 +2764,7 @@ impl Editor {
         }
 
         // First check if a tab context menu is open and the click is on a menu item
-        if let Some(ref menu) = self.tab_context_menu {
+        if let Some(ref menu) = self.active_window_mut().tab_context_menu {
             let menu_x = menu.position.0;
             let menu_y = menu.position.1;
             let menu_width = 22u16; // "Close to the Right" + padding
@@ -2724,19 +2804,21 @@ impl Editor {
                     } else {
                         (false, false)
                     };
-                self.key_context = crate::input::keybindings::KeyContext::FileExplorer;
-                self.tab_context_menu = None;
-                self.file_explorer_context_menu = Some(super::types::FileExplorerContextMenu::new(
-                    col,
-                    row + 1,
-                    is_multi,
-                    is_root_selected,
-                ));
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::FileExplorer;
+                self.active_window_mut().tab_context_menu = None;
+                self.active_window_mut().file_explorer_context_menu =
+                    Some(super::types::FileExplorerContextMenu::new(
+                        col,
+                        row + 1,
+                        is_multi,
+                        is_root_selected,
+                    ));
                 return Ok(());
             }
         }
 
-        self.file_explorer_context_menu = None;
+        self.active_window_mut().file_explorer_context_menu = None;
 
         // Check if right-click is on a tab
         let tab_hit = self
@@ -2756,10 +2838,11 @@ impl Editor {
 
         if let Some((split_id, buffer_id)) = tab_hit {
             // Open tab context menu
-            self.tab_context_menu = Some(TabContextMenu::new(buffer_id, split_id, col, row + 1));
+            self.active_window_mut().tab_context_menu =
+                Some(TabContextMenu::new(buffer_id, split_id, col, row + 1));
         } else {
             // Click outside tab - close context menu if open
-            self.tab_context_menu = None;
+            self.active_window_mut().tab_context_menu = None;
         }
 
         Ok(())
@@ -2771,7 +2854,7 @@ impl Editor {
         col: u16,
         row: u16,
     ) -> Option<AnyhowResult<()>> {
-        let menu = self.tab_context_menu.as_ref()?;
+        let menu = self.active_window_mut().tab_context_menu.as_ref()?;
         let menu_x = menu.position.0;
         let menu_y = menu.position.1;
         let menu_width = 22u16;
@@ -2782,7 +2865,7 @@ impl Editor {
         if col < menu_x || col >= menu_x + menu_width || row < menu_y || row >= menu_y + menu_height
         {
             // Click outside menu - close it
-            self.tab_context_menu = None;
+            self.active_window_mut().tab_context_menu = None;
             return Some(Ok(()));
         }
 
@@ -2803,7 +2886,7 @@ impl Editor {
         let item = items[item_idx];
 
         // Close the menu
-        self.tab_context_menu = None;
+        self.active_window_mut().tab_context_menu = None;
 
         // Execute the action
         Some(self.execute_tab_context_menu_action(item, buffer_id, split_id))
@@ -2860,28 +2943,31 @@ impl Editor {
 
         match code {
             KeyCode::Up => {
-                if let Some(ref mut menu) = self.file_explorer_context_menu {
+                if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
                     menu.prev_item();
                 }
                 Some(Ok(()))
             }
             KeyCode::Down => {
-                if let Some(ref mut menu) = self.file_explorer_context_menu {
+                if let Some(ref mut menu) = self.active_window_mut().file_explorer_context_menu {
                     menu.next_item();
                 }
                 Some(Ok(()))
             }
             KeyCode::Enter => {
                 let item = {
-                    let menu = self.file_explorer_context_menu.as_ref()?;
+                    let menu = self
+                        .active_window_mut()
+                        .file_explorer_context_menu
+                        .as_ref()?;
                     menu.items()[menu.highlighted]
                 };
-                self.file_explorer_context_menu = None;
+                self.active_window_mut().file_explorer_context_menu = None;
                 self.execute_file_explorer_context_menu_action(item);
                 Some(Ok(()))
             }
             KeyCode::Esc => {
-                self.file_explorer_context_menu = None;
+                self.active_window_mut().file_explorer_context_menu = None;
                 Some(Ok(()))
             }
             _ => None,
@@ -2895,12 +2981,11 @@ impl Editor {
         row: u16,
     ) -> Option<AnyhowResult<()>> {
         // Extract all needed values while the immutable borrow is live, then mutate.
+        let frame_w = self.chrome_layout.last_frame_width;
+        let frame_h = self.chrome_layout.last_frame_height;
         let clicked_item: Option<super::types::FileExplorerContextMenuItem> = {
-            let menu = self.file_explorer_context_menu.as_ref()?;
-            let (menu_x, menu_y) = menu.clamped_position(
-                self.chrome_layout.last_frame_width,
-                self.chrome_layout.last_frame_height,
-            );
+            let menu = self.active_window().file_explorer_context_menu.as_ref()?;
+            let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
             let menu_height = menu.height();
 
@@ -2909,7 +2994,7 @@ impl Editor {
                 || row < menu_y
                 || row >= menu_y + menu_height
             {
-                self.file_explorer_context_menu = None;
+                self.active_window_mut().file_explorer_context_menu = None;
                 return Some(Ok(()));
             }
 
@@ -2921,7 +3006,7 @@ impl Editor {
             menu.items().get(item_idx).copied()
         };
 
-        self.file_explorer_context_menu = None;
+        self.active_window_mut().file_explorer_context_menu = None;
         if let Some(item) = clicked_item {
             self.execute_file_explorer_context_menu_action(item);
         }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -359,7 +359,10 @@ impl Editor {
                     .active_window()
                     .is_terminal_buffer(self.active_buffer())
             {
-                self.sync_terminal_to_buffer(self.active_buffer());
+                {
+                    let __b = self.active_buffer();
+                    self.active_window_mut().sync_terminal_to_buffer(__b);
+                };
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;

--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -58,7 +58,7 @@ impl JumpOptions {
     }
 }
 
-impl Editor {
+impl crate::app::window::Window {
     /// Move the active cursor to `position` and guarantee that position is
     /// rendered in the active viewport.
     ///
@@ -73,16 +73,13 @@ impl Editor {
     /// [`Editor::ensure_active_cursor_visible_for_navigation`] afterwards.
     pub fn jump_active_cursor_to(&mut self, position: usize, opts: JumpOptions) {
         let active_split = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
+            .splits
+            .as_ref()
             .map(|(mgr, _)| mgr)
             .expect("active window must have a populated split layout")
             .active_split();
         let active_buffer = self.active_buffer();
-        if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
+        if let Some(view_state) = Some(&mut *self)
             .and_then(|w| w.split_view_states_mut())
             .expect("active window must have a populated split layout")
             .get_mut(&active_split)
@@ -91,13 +88,7 @@ impl Editor {
             if opts.clear_anchor {
                 view_state.cursors.primary_mut().anchor = None;
             }
-            if let Some(state) = self
-                .windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .get_mut(&active_buffer)
-            {
+            if let Some(state) = (&mut self.buffers).get_mut(&active_buffer) {
                 if let Some(pos) = state.buffer.offset_to_position(position) {
                     state.primary_cursor_line_number = LineNumber::Absolute(pos.line);
                 }
@@ -127,8 +118,7 @@ impl Editor {
     /// lower-level scroll machinery decides to do.
     pub fn ensure_active_cursor_visible_for_navigation(&mut self, recenter_on_scroll: bool) {
         let active_buffer = self.active_buffer();
-        self.active_window_mut()
-            .ensure_cursor_visible_for_navigation(active_buffer, recenter_on_scroll);
+        self.ensure_cursor_visible_for_navigation(active_buffer, recenter_on_scroll);
     }
 }
 

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1842,7 +1842,7 @@ impl Editor {
         // Fire the prompt_changed hook immediately with empty input
         // This allows plugins to initialize the prompt state
         use crate::services::plugins::hooks::HookArgs;
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "prompt_changed",
             HookArgs::PromptChanged {
                 prompt_type: prompt_type.clone(),
@@ -1877,7 +1877,7 @@ impl Editor {
 
         // Fire the prompt_changed hook immediately with the initial value
         use crate::services::plugins::hooks::HookArgs;
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "prompt_changed",
             HookArgs::PromptChanged {
                 prompt_type: prompt_type.clone(),
@@ -1906,7 +1906,7 @@ impl Editor {
 
         // Fire the prompt_changed hook
         use crate::services::plugins::hooks::HookArgs;
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "prompt_changed",
             HookArgs::PromptChanged {
                 prompt_type: "async_prompt".to_string(),
@@ -2073,7 +2073,9 @@ impl Editor {
         // Update keybinding labels in plugin state snapshot for getKeybindingLabel API
         #[cfg(feature = "plugins")]
         {
-            if let Some(snapshot_handle) = self.plugin_manager.state_snapshot_handle() {
+            if let Some(snapshot_handle) =
+                self.plugin_manager.read().unwrap().state_snapshot_handle()
+            {
                 if let Ok(mut snapshot) = snapshot_handle.write() {
                     // Remove old labels for this mode
                     snapshot
@@ -2142,6 +2144,8 @@ impl Editor {
         };
         if let Some(err_msg) = error {
             self.plugin_manager
+                .read()
+                .unwrap()
                 .reject_callback(fresh_core::api::JsCallbackId::from(request_id), err_msg);
         }
     }
@@ -2371,6 +2375,8 @@ impl Editor {
             #[cfg(feature = "plugins")]
             for cb_id in self.pending_grammar_callbacks.drain(..) {
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .resolve_callback(cb_id, "null".to_string());
             }
             #[cfg(not(feature = "plugins"))]
@@ -2466,7 +2472,10 @@ impl Editor {
         if pattern.is_empty() {
             let json = serde_json::to_string(&Vec::<GrepMatch>::new())
                 .unwrap_or_else(|_| "[]".to_string());
-            self.plugin_manager.resolve_callback(callback_id, json);
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .resolve_callback(callback_id, json);
             return;
         }
 
@@ -2478,6 +2487,8 @@ impl Editor {
             Ok(re) => re,
             Err(e) => {
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .reject_callback(callback_id, format!("Invalid regex: {}", e));
                 return;
             }
@@ -2591,7 +2602,10 @@ impl Editor {
         }
 
         let json = serde_json::to_string(&results).unwrap_or_else(|_| "[]".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .resolve_callback(callback_id, json);
     }
 
     // ==================== Pull-Based Streaming Search ====================
@@ -2616,7 +2630,7 @@ impl Editor {
         // Look up the handle the plugin pre-registered. If it's missing
         // (registry races with a unit test), drop the request — there's no
         // observer to deliver results to.
-        let Some(registry) = self.plugin_manager.search_handles_handle() else {
+        let Some(registry) = self.plugin_manager.read().unwrap().search_handles_handle() else {
             return;
         };
         let entry = match registry.lock() {
@@ -2900,7 +2914,10 @@ impl Editor {
                 buffer_id: 0,
             };
             let json = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
-            self.plugin_manager.resolve_callback(callback_id, json);
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .resolve_callback(callback_id, json);
             return;
         }
 
@@ -2940,7 +2957,7 @@ impl Editor {
                     bid
                 }
                 Err(e) => {
-                    self.plugin_manager.reject_callback(
+                    self.plugin_manager.read().unwrap().reject_callback(
                         callback_id,
                         format!("Failed to open file {:?}: {}", file_path, e),
                     );
@@ -3034,7 +3051,7 @@ impl Editor {
             // wiping the event log we're about to append (see bug #1).
             if let Some(path) = state.buffer.file_path().map(|p| p.to_path_buf()) {
                 if let Err(e) = state.buffer.save_to_file(&path) {
-                    self.plugin_manager.reject_callback(
+                    self.plugin_manager.read().unwrap().reject_callback(
                         callback_id,
                         format!("Failed to save file {:?}: {}", path, e),
                     );
@@ -3111,7 +3128,10 @@ impl Editor {
             buffer_id: buffer_id.0,
         };
         let json = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .resolve_callback(callback_id, json);
     }
 
     /// Handle StartAnimationArea: translate the plugin description into an

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1220,7 +1220,7 @@ impl Editor {
         // Funnel through the navigation primitive so the cursor is guaranteed
         // visible in the viewport (#1689 — without this, jump_to_line_column
         // could land off-screen if a prior scroll set skip_ensure_visible).
-        self.jump_active_cursor_to(
+        self.active_window_mut().jump_active_cursor_to(
             clamped_position,
             super::navigation::JumpOptions::navigation(),
         );
@@ -1384,13 +1384,17 @@ impl Editor {
         }
 
         // If this buffer belongs to a group, route through the group's tab.
-        if let Some(&group_id) = self.buffer_to_group.get(&buffer_id) {
+        if let Some(&group_id) = self.active_window_mut().buffer_to_group.get(&buffer_id) {
             // Find the panel name for this buffer in the group, then focus it.
-            let panel_name = self.buffer_groups.get(&group_id).and_then(|g| {
-                g.panel_buffers
-                    .iter()
-                    .find_map(|(name, &bid)| (bid == buffer_id).then(|| name.clone()))
-            });
+            let panel_name = self
+                .active_window_mut()
+                .buffer_groups
+                .get(&group_id)
+                .and_then(|g| {
+                    g.panel_buffers
+                        .iter()
+                        .find_map(|(name, &bid)| (bid == buffer_id).then(|| name.clone()))
+                });
             if let Some(panel_name) = panel_name {
                 self.focus_panel(group_id.0, panel_name);
                 tracing::info!(
@@ -1802,7 +1806,7 @@ impl Editor {
                 || lower.contains("handler error")
                 || lower.contains("error in")
             {
-                self.plugin_errors.push(message.clone());
+                self.active_window_mut().plugin_errors.push(message.clone());
             }
             // Clear core status message so only plugin message shows
             self.active_window_mut().status_message = None;
@@ -3126,7 +3130,7 @@ impl Editor {
             return;
         }
         let animation_kind = translate_plugin_animation_kind(kind);
-        self.animations.start_with_id(
+        self.active_window_mut().animations.start_with_id(
             crate::view::animation::AnimationId::from_raw(id),
             area,
             animation_kind,
@@ -3151,7 +3155,7 @@ impl Editor {
         match self.virtual_buffer_screen_rect(buffer_id) {
             Some(area) => {
                 let animation_kind = translate_plugin_animation_kind(kind);
-                self.animations.start_with_id(
+                self.active_window_mut().animations.start_with_id(
                     crate::view::animation::AnimationId::from_raw(id),
                     area,
                     animation_kind,
@@ -3180,7 +3184,7 @@ impl Editor {
             match self.virtual_buffer_screen_rect(buffer_id) {
                 Some(area) => {
                     let animation_kind = translate_plugin_animation_kind(kind);
-                    self.animations.start_with_id(
+                    self.active_window_mut().animations.start_with_id(
                         crate::view::animation::AnimationId::from_raw(id),
                         area,
                         animation_kind,

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1003,7 +1003,7 @@ impl Editor {
                 &state.buffer,
                 range.start,
                 range.end,
-                &self.theme,
+                &*self.theme.read().unwrap(),
                 self.config.editor.highlight_context_bytes,
             );
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3149,7 +3149,7 @@ impl Editor {
                 };
 
                 // Resize terminal to match actual split content area
-                self.resize_visible_terminals();
+                self.active_window_mut().resize_visible_terminals();
 
                 // Resolve the callback with TerminalResult
                 let result = fresh_core::api::TerminalResult {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -137,7 +137,7 @@ impl Editor {
     #[cfg(feature = "plugins")]
     pub(super) fn update_plugin_state_snapshot(&mut self) {
         // Update TypeScript plugin manager state
-        if let Some(snapshot_handle) = self.plugin_manager.state_snapshot_handle() {
+        if let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle() {
             use fresh_core::api::{BufferInfo, CursorInfo, ViewportInfo};
             let mut snapshot = snapshot_handle.write().unwrap();
 
@@ -1675,15 +1675,19 @@ impl Editor {
     /// Load a plugin from a file path
     #[cfg(feature = "plugins")]
     fn handle_load_plugin(&mut self, path: std::path::PathBuf, callback_id: JsCallbackId) {
-        match self.plugin_manager.load_plugin(&path) {
+        match self.plugin_manager.read().unwrap().load_plugin(&path) {
             Ok(()) => {
                 tracing::info!("Loaded plugin from {:?}", path);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to load plugin from {:?}: {}", path, e);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .reject_callback(callback_id, format!("{}", e));
             }
         }
@@ -1692,15 +1696,19 @@ impl Editor {
     /// Unload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_unload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.unload_plugin(&name) {
+        match self.plugin_manager.read().unwrap().unload_plugin(&name) {
             Ok(()) => {
                 tracing::info!("Unloaded plugin: {}", name);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to unload plugin '{}': {}", name, e);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .reject_callback(callback_id, format!("{}", e));
             }
         }
@@ -1709,15 +1717,19 @@ impl Editor {
     /// Reload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_reload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.reload_plugin(&name) {
+        match self.plugin_manager.read().unwrap().reload_plugin(&name) {
             Ok(()) => {
                 tracing::info!("Reloaded plugin: {}", name);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to reload plugin '{}': {}", name, e);
                 self.plugin_manager
+                    .read()
+                    .unwrap()
                     .reject_callback(callback_id, format!("{}", e));
             }
         }
@@ -1726,7 +1738,7 @@ impl Editor {
     /// List all loaded plugins
     #[cfg(feature = "plugins")]
     fn handle_list_plugins(&mut self, callback_id: JsCallbackId) {
-        let plugins = self.plugin_manager.list_plugins();
+        let plugins = self.plugin_manager.read().unwrap().list_plugins();
         // Serialize to JSON array of { name, path, enabled }
         let json_array: Vec<serde_json::Value> = plugins
             .iter()
@@ -1739,7 +1751,10 @@ impl Editor {
             })
             .collect();
         let json_str = serde_json::to_string(&json_array).unwrap_or_else(|_| "[]".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json_str);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .resolve_callback(callback_id, json_str);
     }
 
     /// Execute an editor action by name (for vi mode plugin)
@@ -1822,10 +1837,16 @@ impl Editor {
             Ok(text) => {
                 // Serialize text as JSON string
                 let json = serde_json::to_string(&text).unwrap_or_else(|_| "null".to_string());
-                self.plugin_manager.resolve_callback(callback_id, json);
+                self.plugin_manager
+                    .read()
+                    .unwrap()
+                    .resolve_callback(callback_id, json);
             }
             Err(error) => {
-                self.plugin_manager.reject_callback(callback_id, error);
+                self.plugin_manager
+                    .read()
+                    .unwrap()
+                    .reject_callback(callback_id, error);
             }
         }
     }
@@ -1849,7 +1870,10 @@ impl Editor {
     fn resolve_json_callback<T: serde::Serialize>(&mut self, request_id: u64, value: T) {
         let callback_id = fresh_core::api::JsCallbackId::from(request_id);
         let json = serde_json::to_string(&value).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .resolve_callback(callback_id, json);
     }
 
     /// Get the byte offset of the start of a line in the active buffer
@@ -2156,6 +2180,8 @@ impl Editor {
             });
         } else {
             self.plugin_manager
+                .read()
+                .unwrap()
                 .reject_callback(callback_id, "Async runtime not available".to_string());
         }
     }
@@ -2272,6 +2298,8 @@ impl Editor {
         } else {
             // No runtime - reject immediately
             self.plugin_manager
+                .read()
+                .unwrap()
                 .reject_callback(callback_id, "Async runtime not available".to_string());
         }
     }
@@ -2364,7 +2392,7 @@ impl Editor {
                         buffer_id: buffer_id.0 as u64,
                         split_id: None,
                     };
-                    self.plugin_manager.resolve_callback(
+                    self.plugin_manager.read().unwrap().resolve_callback(
                         fresh_core::api::JsCallbackId::from(req_id),
                         serde_json::to_string(&result).unwrap_or_default(),
                     );
@@ -2478,7 +2506,7 @@ impl Editor {
                         buffer_id: buffer_id.0 as u64,
                         split_id: Some(dock_leaf.0 .0 as u64),
                     };
-                    self.plugin_manager.resolve_callback(
+                    self.plugin_manager.read().unwrap().resolve_callback(
                         fresh_core::api::JsCallbackId::from(req_id),
                         serde_json::to_string(&result).unwrap_or_default(),
                     );
@@ -2539,7 +2567,7 @@ impl Editor {
                             buffer_id: existing_buffer_id.0 as u64,
                             split_id: splits.first().map(|s| s.0 .0 as u64),
                         };
-                        self.plugin_manager.resolve_callback(
+                        self.plugin_manager.read().unwrap().resolve_callback(
                             fresh_core::api::JsCallbackId::from(req_id),
                             serde_json::to_string(&result).unwrap_or_default(),
                         );
@@ -2729,7 +2757,7 @@ impl Editor {
                 buffer_id: buffer_id.0 as u64,
                 split_id: created_split_id.map(|s| s.0 .0 as u64),
             };
-            self.plugin_manager.resolve_callback(
+            self.plugin_manager.read().unwrap().resolve_callback(
                 fresh_core::api::JsCallbackId::from(req_id),
                 serde_json::to_string(&result).unwrap_or_default(),
             );
@@ -2822,7 +2850,7 @@ impl Editor {
                 buffer_id: buffer_id.0 as u64,
                 split_id: Some(split_id.0 as u64),
             };
-            self.plugin_manager.resolve_callback(
+            self.plugin_manager.read().unwrap().resolve_callback(
                 fresh_core::api::JsCallbackId::from(req_id),
                 serde_json::to_string(&result).unwrap_or_default(),
             );
@@ -3129,7 +3157,7 @@ impl Editor {
                     terminal_id: terminal_id.0 as u64,
                     split_id: created_split_id.map(|s| s.0 .0 as u64),
                 };
-                self.plugin_manager.resolve_callback(
+                self.plugin_manager.read().unwrap().resolve_callback(
                     fresh_core::api::JsCallbackId::from(request_id),
                     serde_json::to_string(&result).unwrap_or_default(),
                 );
@@ -3142,7 +3170,7 @@ impl Editor {
             }
             Err(e) => {
                 tracing::error!("Failed to create terminal for plugin: {}", e);
-                self.plugin_manager.reject_callback(
+                self.plugin_manager.read().unwrap().reject_callback(
                     fresh_core::api::JsCallbackId::from(request_id),
                     format!("Failed to create terminal: {}", e),
                 );
@@ -3227,7 +3255,7 @@ impl Editor {
             Ok(id) => id,
             Err(e) => {
                 tracing::error!("Failed to create terminal for inactive session: {}", e);
-                self.plugin_manager.reject_callback(
+                self.plugin_manager.read().unwrap().reject_callback(
                     fresh_core::api::JsCallbackId::from(request_id),
                     format!("Failed to create terminal: {}", e),
                 );
@@ -3316,7 +3344,7 @@ impl Editor {
             terminal_id: terminal_id.0 as u64,
             split_id: new_split_id.map(|s| s.0 .0 as u64),
         };
-        self.plugin_manager.resolve_callback(
+        self.plugin_manager.read().unwrap().resolve_callback(
             fresh_core::api::JsCallbackId::from(request_id),
             serde_json::to_string(&result).unwrap(),
         );
@@ -3335,7 +3363,10 @@ impl Editor {
         let callback_id = fresh_core::api::JsCallbackId::from(request_id);
         let json =
             serde_json::to_string(&split_id.map(|s| s.0 .0)).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .resolve_callback(callback_id, json);
     }
 
     fn handle_set_buffer_show_cursors(&mut self, buffer_id: BufferId, show: bool) {
@@ -3377,7 +3408,10 @@ impl Editor {
             .pop_front()
         {
             let json = serde_json::to_string(&payload).unwrap_or_else(|_| "null".to_string());
-            self.plugin_manager.resolve_callback(callback_id, json);
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .resolve_callback(callback_id, json);
         } else {
             self.active_window_mut()
                 .pending_next_key_callbacks
@@ -3423,6 +3457,8 @@ impl Editor {
             });
         } else {
             self.plugin_manager
+                .read()
+                .unwrap()
                 .reject_callback(callback_id, "Async runtime not available".to_string());
         }
     }
@@ -3490,7 +3526,7 @@ impl Editor {
             "SpawnProcessWait not fully implemented - process_id={}",
             process_id
         );
-        self.plugin_manager.reject_callback(
+        self.plugin_manager.read().unwrap().reject_callback(
             callback_id,
             format!(
                 "SpawnProcessWait not yet fully implemented for process_id={}",
@@ -3515,6 +3551,8 @@ impl Editor {
         } else {
             std::thread::sleep(std::time::Duration::from_millis(duration_ms));
             self.plugin_manager
+                .read()
+                .unwrap()
                 .resolve_callback(callback_id, "null".to_string());
         }
     }
@@ -4105,8 +4143,13 @@ impl Editor {
             }
             _ => return,
         };
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4147,8 +4190,13 @@ impl Editor {
             return;
         }
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4218,8 +4266,13 @@ impl Editor {
         }
         // Re-render so the new selection's bg paints.
         self.rerender_widget_panel(panel_id);
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4302,8 +4355,13 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4556,9 +4614,14 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
-        if self.plugin_manager.has_hook_handlers("widget_event") {
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
             if let Some(now_expanded) = expansion_changed {
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "widget_event",
                     fresh_core::hooks::HookArgs::WidgetEvent {
                         panel_id,
@@ -4572,7 +4635,7 @@ impl Editor {
                     },
                 );
             } else if new_sel != cur_sel {
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "widget_event",
                     fresh_core::hooks::HookArgs::WidgetEvent {
                         panel_id,
@@ -4631,8 +4694,13 @@ impl Editor {
             next
         };
         self.rerender_widget_panel(panel_id);
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4694,8 +4762,13 @@ impl Editor {
         };
         let new_checked = !cur_checked;
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4736,8 +4809,13 @@ impl Editor {
             return;
         }
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -4838,8 +4916,13 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
-        if self.plugin_manager.has_hook_handlers("widget_event") {
-            self.plugin_manager.run_hook(
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 fresh_core::hooks::HookArgs::WidgetEvent {
                     panel_id,
@@ -5114,6 +5197,8 @@ impl Editor {
                 if let Some(req_id) = request_id {
                     let json = serde_json::to_string(&result).unwrap_or_default();
                     self.plugin_manager
+                        .read()
+                        .unwrap()
                         .resolve_callback(fresh_core::api::JsCallbackId::from(req_id), json);
                 }
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -21,6 +21,7 @@ use crate::model::event::{BufferId, LeafId, SplitId};
 use crate::services::async_bridge::AsyncMessage;
 use crate::view::split::SplitViewState;
 
+use super::window::Window;
 use super::Editor;
 
 /// Snapshot of the focused `Text` widget's host-owned state.
@@ -133,435 +134,77 @@ fn collect_visible_tree_indices(
 }
 
 impl Editor {
-    /// Update the plugin state snapshot with current editor state
+    /// Update the plugin state snapshot with current editor state.
+    ///
+    /// Per-window snapshot population (active buffer, splits, view
+    /// states, cursors, diagnostics, folding ranges, plugin view
+    /// states) lives in [`Window::populate_plugin_state_snapshot`].
+    /// This function adds the editor-wide fields that no single Window
+    /// owns (clipboard, the full `windows` list, the memoized config
+    /// JSON cache, `user_config_raw`, and `plugin_global_state`).
     #[cfg(feature = "plugins")]
     pub(super) fn update_plugin_state_snapshot(&mut self) {
-        // Update TypeScript plugin manager state
-        if let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle() {
-            use fresh_core::api::{BufferInfo, CursorInfo, ViewportInfo};
-            let mut snapshot = snapshot_handle.write().unwrap();
+        let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle()
+        else {
+            return;
+        };
+        let mut snapshot = snapshot_handle.write().unwrap();
 
-            // Rebuild only on registry mutation. Compares the registry's
-            // monotonic catalog_gen against the last-seen value on the
-            // snapshot — a single integer check, no allocation, no
-            // count-mismatch ambiguity between the syntect set and the
-            // unified catalog.
-            let current_gen = self.grammar_registry.catalog_gen();
-            if snapshot.last_grammar_gen != current_gen {
-                snapshot.available_grammars = self
-                    .grammar_registry
-                    .available_grammar_info()
-                    .into_iter()
-                    .map(|g| fresh_core::api::GrammarInfoSnapshot {
-                        name: g.name,
-                        source: g.source.to_string(),
-                        file_extensions: g.file_extensions,
-                        short_name: g.short_name,
-                    })
-                    .collect();
-                snapshot.last_grammar_gen = current_gen;
-            }
+        self.active_window_mut()
+            .populate_plugin_state_snapshot(&mut snapshot);
 
-            // Update active buffer ID
-            snapshot.active_buffer_id = self.active_buffer();
+        // Editor-wide fields below — these reach state outside any
+        // single Window.
 
-            // Update active split ID
-            snapshot.active_split_id = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .active_split()
-                .0
-                 .0;
+        snapshot.clipboard = self.clipboard.get_internal().to_string();
+        snapshot.working_dir = self.working_dir.clone();
 
-            // Clear and update buffer info
-            snapshot.buffers.clear();
-            snapshot.buffer_saved_diffs.clear();
-            snapshot.buffer_cursor_positions.clear();
-            snapshot.buffer_text_properties.clear();
+        // Publish the session list so plugins (Conductor, etc.)
+        // see updates from createWindow/closeWindow without
+        // a separate notification path. Sorted by id for
+        // deterministic order — `next_window_id` is monotonic
+        // so this is "creation order".
+        let mut session_infos: Vec<fresh_core::api::WindowInfo> = self
+            .windows
+            .values()
+            .map(|s| fresh_core::api::WindowInfo {
+                id: s.id,
+                label: s.label.clone(),
+                root: s.root.clone(),
+            })
+            .collect();
+        session_infos.sort_by_key(|s| s.id.0);
+        snapshot.windows = session_infos;
+        snapshot.active_window_id = self.active_window;
 
-            for (buffer_id, state) in self
-                .windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-            {
-                let is_virtual = self
-                    .active_window()
-                    .buffer_metadata
-                    .get(buffer_id)
-                    .map(|m| m.is_virtual())
-                    .unwrap_or(false);
-                // Report the ACTIVE split's view_mode so plugins can distinguish
-                // which mode the user is currently in. Separately, report whether
-                // ANY split has compose mode so plugins can maintain decorations
-                // for compose-mode splits even when a source-mode split is active.
-                let active_split = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.splits.as_ref())
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .active_split();
-                let active_vs = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.splits.as_ref())
-                    .map(|(_, vs)| vs)
-                    .expect("active window must have a populated split layout")
-                    .get(&active_split);
-                let view_mode = active_vs
-                    .and_then(|vs| vs.buffer_state(*buffer_id))
-                    .map(|bs| match bs.view_mode {
-                        crate::state::ViewMode::Source => "source",
-                        crate::state::ViewMode::PageView => "compose",
-                    })
-                    .unwrap_or("source");
-                let compose_width = active_vs
-                    .and_then(|vs| vs.buffer_state(*buffer_id))
-                    .and_then(|bs| bs.compose_width);
-                let is_composing_in_any_split = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.splits.as_ref())
-                    .map(|(_, vs)| vs)
-                    .expect("active window must have a populated split layout")
-                    .values()
-                    .any(|vs| {
-                        vs.buffer_state(*buffer_id)
-                            .map(|bs| matches!(bs.view_mode, crate::state::ViewMode::PageView))
-                            .unwrap_or(false)
-                    });
-                let is_preview = self
-                    .active_window()
-                    .buffer_metadata
-                    .get(buffer_id)
-                    .map(|m| m.is_preview)
-                    .unwrap_or(false);
-                // Which splits currently hold this buffer — lets plugins
-                // implement "focus existing if visible, else open new"
-                // without tracking split ids across editor restarts
-                // (the restart reassigns them). SplitManager has the
-                // authoritative map; we just mirror it.
-                let splits: Vec<fresh_core::SplitId> = self
-                    .split_manager()
-                    .splits_for_buffer(*buffer_id)
-                    .into_iter()
-                    .map(|leaf_id| leaf_id.0)
-                    .collect();
-                let buffer_info = BufferInfo {
-                    id: *buffer_id,
-                    path: state.buffer.file_path().map(|p| p.to_path_buf()),
-                    modified: state.buffer.is_modified(),
-                    length: state.buffer.len(),
-                    is_virtual,
-                    view_mode: view_mode.to_string(),
-                    is_composing_in_any_split,
-                    compose_width,
-                    language: state.language.clone(),
-                    is_preview,
-                    splits,
-                };
-                snapshot.buffers.insert(*buffer_id, buffer_info);
+        // Reserialize config only when the underlying `Arc<Config>`
+        // pointer has actually moved since the last refresh —
+        // `Arc::ptr_eq` vs `config_snapshot_anchor` is a sound cache
+        // key because the anchor keeps `self.config`'s strong count
+        // at ≥ 2, forcing every `Arc::make_mut` on the editor side
+        // to CoW into a new allocation. On idle (no config mutation),
+        // this branch is skipped entirely and the snapshot update is
+        // a refcount bump.
+        if !Arc::ptr_eq(&self.config, &self.config_snapshot_anchor) {
+            let json = serde_json::to_value(&*self.config).unwrap_or(serde_json::Value::Null);
+            self.config_cached_json = Arc::new(json);
+            self.config_snapshot_anchor = Arc::clone(&self.config);
+        }
+        snapshot.config = Arc::clone(&self.config_cached_json);
 
-                let diff = {
-                    let diff = state.buffer.diff_since_saved();
-                    BufferSavedDiff {
-                        equal: diff.equal,
-                        byte_ranges: diff.byte_ranges.clone(),
-                    }
-                };
-                snapshot.buffer_saved_diffs.insert(*buffer_id, diff);
+        // Cached raw user config file contents (not merged with defaults).
+        // Lets plugins distinguish user-set from default values.
+        snapshot.user_config = Arc::clone(&self.user_config_raw);
 
-                // Regular buffers live in exactly one split's keyed_states.
-                // Panel (hidden) buffers natively live inside a group's inner
-                // split — but the close-buffer path can leave a *shadow*
-                // entry in the group's host split (from `switch_buffer`'s
-                // auto-insert, kept to preserve the
-                // `active_buffer ∈ keyed_states` invariant). For hidden
-                // buffers we therefore skip group-host splits and pick the
-                // inner split, which is the authoritative home.
-                let is_hidden = self
-                    .active_window()
-                    .buffer_metadata
-                    .get(buffer_id)
-                    .is_some_and(|m| m.hidden_from_tabs);
-                let source_split = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.splits.as_ref())
-                    .map(|(_, vs)| vs)
-                    .expect("active window must have a populated split layout")
-                    .iter()
-                    .find(|(split_id, vs)| {
-                        vs.keyed_states.contains_key(buffer_id)
-                            && !(is_hidden
-                                && self.active_window().grouped_subtrees.contains_key(split_id))
-                    });
-                let cursor_pos = source_split
-                    .and_then(|(_, vs)| vs.buffer_state(*buffer_id))
-                    .map(|bs| bs.cursors.primary().position)
-                    .unwrap_or(0);
-                tracing::trace!(
-                    "snapshot: buffer {:?} cursor_pos={} (from split {:?})",
-                    buffer_id,
-                    cursor_pos,
-                    source_split.map(|(id, _)| *id),
-                );
-                snapshot
-                    .buffer_cursor_positions
-                    .insert(*buffer_id, cursor_pos);
-
-                // Store text properties if this buffer has any
-                if !state.text_properties.is_empty() {
-                    snapshot
-                        .buffer_text_properties
-                        .insert(*buffer_id, state.text_properties.all().to_vec());
-                }
-            }
-
-            // Update cursor information for active buffer.
-            // Pre-extract active_buffer id before taking the &mut window
-            // borrow (since active_buffer() reads self).
-            let __active_buf_id = self.active_buffer();
-            // Single &mut window borrow, split-access into mgr + vs_map + buffers.
-            let __win_dispatch = self
-                .windows
-                .get_mut(&self.active_window)
-                .expect("active window must exist");
-            let __buffers_dispatch = &mut __win_dispatch.buffers;
-            let (__mgr_dispatch, __vs_dispatch) = __win_dispatch
-                .splits
-                .as_mut()
-                .map(|(m, vs)| (&*m, &*vs))
-                .expect("active window must have a populated split layout");
-            let __active_split_id = __mgr_dispatch.active_split();
-            if let Some(active_vs) = __vs_dispatch.get(&__active_split_id) {
-                // Primary cursor (from SplitViewState)
-                let active_cursors = &active_vs.cursors;
-                let primary = active_cursors.primary();
-                let primary_position = primary.position;
-                let primary_selection = primary.selection_range();
-
-                snapshot.primary_cursor = Some(CursorInfo {
-                    position: primary_position,
-                    selection: primary_selection.clone(),
-                });
-
-                // All cursors
-                snapshot.all_cursors = active_cursors
-                    .iter()
-                    .map(|(_, cursor)| CursorInfo {
-                        position: cursor.position,
-                        selection: cursor.selection_range(),
-                    })
-                    .collect();
-
-                // Selected text from primary cursor (for clipboard plugin)
-                if let Some(range) = primary_selection {
-                    if let Some(active_state) = __buffers_dispatch.get_mut(&__active_buf_id) {
-                        snapshot.selected_text =
-                            Some(active_state.get_text_range(range.start, range.end));
-                    }
-                }
-
-                // Viewport - get from SplitViewState (the authoritative source)
-                let top_line = __buffers_dispatch.get(&__active_buf_id).and_then(|state| {
-                    if state.buffer.line_count().is_some() {
-                        Some(state.buffer.get_line_number(active_vs.viewport.top_byte))
-                    } else {
-                        None
-                    }
-                });
-                snapshot.viewport = Some(ViewportInfo {
-                    top_byte: active_vs.viewport.top_byte,
-                    top_line,
-                    left_column: active_vs.viewport.left_column,
-                    width: active_vs.viewport.width,
-                    height: active_vs.viewport.height,
-                });
-            } else {
-                snapshot.primary_cursor = None;
-                snapshot.all_cursors.clear();
-                snapshot.viewport = None;
-                snapshot.selected_text = None;
-            }
-
-            // Per-split snapshot — every split's active buffer + viewport
-            // so plugins (multi-split flash labels, sync decorations,
-            // etc.) can iterate every visible buffer instead of only the
-            // active one.
-            snapshot.splits.clear();
-            for (leaf_id, vs) in self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
-            {
-                let buf_id = vs.active_buffer;
-                let top_line = self
-                    .windows
-                    .get(&self.active_window)
-                    .map(|w| &w.buffers)
-                    .expect("active window present")
-                    .get(&buf_id)
-                    .and_then(|state| {
-                        if state.buffer.line_count().is_some() {
-                            Some(state.buffer.get_line_number(vs.viewport.top_byte))
-                        } else {
-                            None
-                        }
-                    });
-                snapshot.splits.push(fresh_core::api::SplitSnapshot {
-                    split_id: leaf_id.0 .0,
-                    buffer_id: buf_id,
-                    viewport: ViewportInfo {
-                        top_byte: vs.viewport.top_byte,
-                        top_line,
-                        left_column: vs.viewport.left_column,
-                        width: vs.viewport.width,
-                        height: vs.viewport.height,
-                    },
-                });
-            }
-
-            // Update clipboard (provide internal clipboard content to plugins)
-            snapshot.clipboard = self.clipboard.get_internal().to_string();
-
-            // Update working directory (for spawning processes in correct directory)
-            snapshot.working_dir = self.working_dir.clone();
-
-            // Publish the session list so plugins (Conductor, etc.)
-            // see updates from createWindow/closeWindow without
-            // a separate notification path. Sorted by id for
-            // deterministic order — `next_window_id` is monotonic
-            // so this is "creation order".
-            let mut session_infos: Vec<fresh_core::api::WindowInfo> = self
-                .windows
-                .values()
-                .map(|s| fresh_core::api::WindowInfo {
-                    id: s.id,
-                    label: s.label.clone(),
-                    root: s.root.clone(),
-                })
-                .collect();
-            session_infos.sort_by_key(|s| s.id.0);
-            snapshot.windows = session_infos;
-            snapshot.active_window_id = self.active_window;
-
-            // Mirror the active session's plugin_state into the
-            // snapshot so getWindowState reads cheaply. Cloning
-            // is fine here: the per-session state is small (one
-            // entry per plugin per key); plugins that store
-            // megabyte-scale blobs in setWindowState will see
-            // proportional snapshot-update cost, which is the
-            // desired feedback signal — store large blobs in
-            // global state or out-of-band instead.
-            if let Some(session) = self.windows.get(&self.active_window) {
-                snapshot.active_session_plugin_states = session.plugin_state.clone();
-            } else {
-                snapshot.active_session_plugin_states.clear();
-            }
-
-            snapshot.authority_label = self.authority.display_label.clone();
-
-            // Update LSP diagnostics: Arc refcount bump; no clone.
-            snapshot.diagnostics = Arc::clone(&self.active_window().stored_diagnostics);
-
-            // Update LSP folding ranges: Arc refcount bump; no clone.
-            snapshot.folding_ranges = Arc::clone(&self.active_window().stored_folding_ranges);
-
-            // Update config. Reserialize only when the underlying
-            // `Arc<Config>` pointer has actually moved since the last
-            // refresh — `Arc::ptr_eq` vs `config_snapshot_anchor` is a
-            // sound cache key because the anchor keeps `self.config`'s
-            // strong count at ≥ 2, forcing every `Arc::make_mut` on the
-            // editor side to CoW into a new allocation. On idle (no
-            // config mutation), this branch is skipped entirely and the
-            // snapshot update is a refcount bump.
-            if !Arc::ptr_eq(&self.config, &self.config_snapshot_anchor) {
-                let json = serde_json::to_value(&*self.config).unwrap_or(serde_json::Value::Null);
-                self.config_cached_json = Arc::new(json);
-                self.config_snapshot_anchor = Arc::clone(&self.config);
-            }
-            snapshot.config = Arc::clone(&self.config_cached_json);
-
-            // Update user config (cached raw file contents, not merged with defaults).
-            // This allows plugins to distinguish between user-set and default values.
-            // Arc refcount bump; no clone.
-            snapshot.user_config = Arc::clone(&self.user_config_raw);
-
-            // Update editor mode (for vi mode and other modal editing)
-            snapshot.editor_mode = self.active_window().editor_mode.clone();
-
-            // Update plugin global states from Rust-side store.
-            // Merge using or_insert to preserve JS-side write-through entries.
-            for (plugin_name, state_map) in &self.plugin_global_state {
-                let entry = snapshot
-                    .plugin_global_states
-                    .entry(plugin_name.clone())
-                    .or_default();
-                for (key, value) in state_map {
-                    entry.entry(key.clone()).or_insert_with(|| value.clone());
-                }
-            }
-
-            // Update plugin view states from active split's BufferViewState.plugin_state.
-            // If the active split changed, fully repopulate. Otherwise, merge using
-            // or_insert to preserve JS-side write-through entries that haven't
-            // round-tripped through the command channel yet.
-            let active_split_id = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .active_split()
-                .0
-                 .0;
-            let split_changed = snapshot.plugin_view_states_split != active_split_id;
-            if split_changed {
-                snapshot.plugin_view_states.clear();
-                snapshot.plugin_view_states_split = active_split_id;
-            }
-
-            // Clean up entries for buffers that are no longer open
-            {
-                let open_bids: Vec<_> = snapshot.buffers.keys().copied().collect();
-                snapshot
-                    .plugin_view_states
-                    .retain(|bid, _| open_bids.contains(bid));
-            }
-
-            // Merge from Rust-side plugin_state (source of truth for persisted state)
-            if let Some(active_vs) = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
-                .get(
-                    &self
-                        .windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.splits.as_ref())
-                        .map(|(mgr, _)| mgr)
-                        .expect("active window must have a populated split layout")
-                        .active_split(),
-                )
-            {
-                for (buffer_id, buf_state) in &active_vs.keyed_states {
-                    if !buf_state.plugin_state.is_empty() {
-                        let entry = snapshot.plugin_view_states.entry(*buffer_id).or_default();
-                        for (key, value) in &buf_state.plugin_state {
-                            // Use or_insert to preserve JS write-through values
-                            entry.entry(key.clone()).or_insert_with(|| value.clone());
-                        }
-                    }
-                }
+        // Merge plugin global states from Rust-side store.
+        // `or_insert` preserves JS-side write-through entries.
+        for (plugin_name, state_map) in &self.plugin_global_state {
+            let entry = snapshot
+                .plugin_global_states
+                .entry(plugin_name.clone())
+                .or_default();
+            for (key, value) in state_map {
+                entry.entry(key.clone()).or_insert_with(|| value.clone());
             }
         }
     }
@@ -5381,6 +5024,304 @@ mod tests {
             // Touch `pid` so the unused-variable lint doesn't fire on
             // non-Unix builds.
             let _ = pid;
+        }
+    }
+}
+
+impl Window {
+    /// Populate the per-window fields of the plugin state snapshot.
+    ///
+    /// Called by `Editor::update_plugin_state_snapshot` while it holds
+    /// the snapshot write lock. Covers everything that a single Window
+    /// owns: active buffer/split ids, all this window's buffers (with
+    /// per-buffer view-mode, compose state, preview flag, split
+    /// membership), per-buffer cursor positions and text properties,
+    /// the active buffer's cursors / viewport / selected text, the
+    /// per-split snapshot list, this window's active-session plugin
+    /// state, this window's authority label, diagnostics, folding
+    /// ranges, editor mode, and the per-window plugin view states.
+    /// Editor-wide fields (clipboard, windows list, config cache,
+    /// user_config_raw, plugin_global_state) are populated by the
+    /// Editor coda after this returns.
+    #[cfg(feature = "plugins")]
+    pub(crate) fn populate_plugin_state_snapshot(
+        &mut self,
+        snapshot: &mut fresh_core::api::EditorStateSnapshot,
+    ) {
+        use fresh_core::api::{BufferInfo, CursorInfo, ViewportInfo};
+
+        // Rebuild only on registry mutation. Compares the registry's
+        // monotonic catalog_gen against the last-seen value on the
+        // snapshot — a single integer check, no allocation, no
+        // count-mismatch ambiguity between the syntect set and the
+        // unified catalog.
+        let current_gen = self.resources.grammar_registry.catalog_gen();
+        if snapshot.last_grammar_gen != current_gen {
+            snapshot.available_grammars = self
+                .resources
+                .grammar_registry
+                .available_grammar_info()
+                .into_iter()
+                .map(|g| fresh_core::api::GrammarInfoSnapshot {
+                    name: g.name,
+                    source: g.source.to_string(),
+                    file_extensions: g.file_extensions,
+                    short_name: g.short_name,
+                })
+                .collect();
+            snapshot.last_grammar_gen = current_gen;
+        }
+
+        snapshot.active_buffer_id = self.active_buffer();
+
+        let (mgr_ref, vs_ref) = self
+            .splits
+            .as_ref()
+            .expect("active window must have a populated split layout");
+        let active_split = mgr_ref.active_split();
+        snapshot.active_split_id = active_split.0 .0;
+
+        // Clear and update buffer info
+        snapshot.buffers.clear();
+        snapshot.buffer_saved_diffs.clear();
+        snapshot.buffer_cursor_positions.clear();
+        snapshot.buffer_text_properties.clear();
+
+        let active_vs_opt = vs_ref.get(&active_split);
+        for (buffer_id, state) in &self.buffers {
+            let is_virtual = self
+                .buffer_metadata
+                .get(buffer_id)
+                .map(|m| m.is_virtual())
+                .unwrap_or(false);
+            // Report the ACTIVE split's view_mode so plugins can distinguish
+            // which mode the user is currently in. Separately, report whether
+            // ANY split has compose mode so plugins can maintain decorations
+            // for compose-mode splits even when a source-mode split is active.
+            let view_mode = active_vs_opt
+                .and_then(|vs| vs.buffer_state(*buffer_id))
+                .map(|bs| match bs.view_mode {
+                    crate::state::ViewMode::Source => "source",
+                    crate::state::ViewMode::PageView => "compose",
+                })
+                .unwrap_or("source");
+            let compose_width = active_vs_opt
+                .and_then(|vs| vs.buffer_state(*buffer_id))
+                .and_then(|bs| bs.compose_width);
+            let is_composing_in_any_split = vs_ref.values().any(|vs| {
+                vs.buffer_state(*buffer_id)
+                    .map(|bs| matches!(bs.view_mode, crate::state::ViewMode::PageView))
+                    .unwrap_or(false)
+            });
+            let is_preview = self
+                .buffer_metadata
+                .get(buffer_id)
+                .map(|m| m.is_preview)
+                .unwrap_or(false);
+            // Which splits currently hold this buffer — lets plugins
+            // implement "focus existing if visible, else open new"
+            // without tracking split ids across editor restarts
+            // (the restart reassigns them). SplitManager has the
+            // authoritative map; we just mirror it.
+            let splits: Vec<fresh_core::SplitId> = mgr_ref
+                .splits_for_buffer(*buffer_id)
+                .into_iter()
+                .map(|leaf_id| leaf_id.0)
+                .collect();
+            let buffer_info = BufferInfo {
+                id: *buffer_id,
+                path: state.buffer.file_path().map(|p| p.to_path_buf()),
+                modified: state.buffer.is_modified(),
+                length: state.buffer.len(),
+                is_virtual,
+                view_mode: view_mode.to_string(),
+                is_composing_in_any_split,
+                compose_width,
+                language: state.language.clone(),
+                is_preview,
+                splits,
+            };
+            snapshot.buffers.insert(*buffer_id, buffer_info);
+
+            let diff = {
+                let diff = state.buffer.diff_since_saved();
+                BufferSavedDiff {
+                    equal: diff.equal,
+                    byte_ranges: diff.byte_ranges.clone(),
+                }
+            };
+            snapshot.buffer_saved_diffs.insert(*buffer_id, diff);
+
+            // Regular buffers live in exactly one split's keyed_states.
+            // Panel (hidden) buffers natively live inside a group's inner
+            // split — but the close-buffer path can leave a *shadow*
+            // entry in the group's host split (from `switch_buffer`'s
+            // auto-insert, kept to preserve the
+            // `active_buffer ∈ keyed_states` invariant). For hidden
+            // buffers we therefore skip group-host splits and pick the
+            // inner split, which is the authoritative home.
+            let is_hidden = self
+                .buffer_metadata
+                .get(buffer_id)
+                .is_some_and(|m| m.hidden_from_tabs);
+            let source_split = vs_ref.iter().find(|(split_id, vs)| {
+                vs.keyed_states.contains_key(buffer_id)
+                    && !(is_hidden && self.grouped_subtrees.contains_key(split_id))
+            });
+            let cursor_pos = source_split
+                .and_then(|(_, vs)| vs.buffer_state(*buffer_id))
+                .map(|bs| bs.cursors.primary().position)
+                .unwrap_or(0);
+            tracing::trace!(
+                "snapshot: buffer {:?} cursor_pos={} (from split {:?})",
+                buffer_id,
+                cursor_pos,
+                source_split.map(|(id, _)| *id),
+            );
+            snapshot
+                .buffer_cursor_positions
+                .insert(*buffer_id, cursor_pos);
+
+            // Store text properties if this buffer has any
+            if !state.text_properties.is_empty() {
+                snapshot
+                    .buffer_text_properties
+                    .insert(*buffer_id, state.text_properties.all().to_vec());
+            }
+        }
+
+        // Update cursor information for active buffer.
+        // Single &mut split across self.splits + self.buffers via direct
+        // field access (both are sibling fields on Window, so disjoint).
+        let active_buf_id = snapshot.active_buffer_id;
+        let buffers_mut = &mut self.buffers;
+        let (mgr_mut, vs_mut) = self
+            .splits
+            .as_mut()
+            .map(|(m, vs)| (&*m, &*vs))
+            .expect("active window must have a populated split layout");
+        let active_split_id = mgr_mut.active_split();
+        if let Some(active_vs) = vs_mut.get(&active_split_id) {
+            // Primary cursor (from SplitViewState)
+            let active_cursors = &active_vs.cursors;
+            let primary = active_cursors.primary();
+            let primary_position = primary.position;
+            let primary_selection = primary.selection_range();
+
+            snapshot.primary_cursor = Some(CursorInfo {
+                position: primary_position,
+                selection: primary_selection.clone(),
+            });
+
+            // All cursors
+            snapshot.all_cursors = active_cursors
+                .iter()
+                .map(|(_, cursor)| CursorInfo {
+                    position: cursor.position,
+                    selection: cursor.selection_range(),
+                })
+                .collect();
+
+            // Selected text from primary cursor (for clipboard plugin)
+            if let Some(range) = primary_selection {
+                if let Some(active_state) = buffers_mut.get_mut(&active_buf_id) {
+                    snapshot.selected_text =
+                        Some(active_state.get_text_range(range.start, range.end));
+                }
+            }
+
+            // Viewport - get from SplitViewState (the authoritative source)
+            let top_line = buffers_mut.get(&active_buf_id).and_then(|state| {
+                if state.buffer.line_count().is_some() {
+                    Some(state.buffer.get_line_number(active_vs.viewport.top_byte))
+                } else {
+                    None
+                }
+            });
+            snapshot.viewport = Some(ViewportInfo {
+                top_byte: active_vs.viewport.top_byte,
+                top_line,
+                left_column: active_vs.viewport.left_column,
+                width: active_vs.viewport.width,
+                height: active_vs.viewport.height,
+            });
+        } else {
+            snapshot.primary_cursor = None;
+            snapshot.all_cursors.clear();
+            snapshot.viewport = None;
+            snapshot.selected_text = None;
+        }
+
+        // Per-split snapshot — every split's active buffer + viewport
+        // so plugins (multi-split flash labels, sync decorations, etc.)
+        // can iterate every visible buffer instead of only the active one.
+        snapshot.splits.clear();
+        for (leaf_id, vs) in vs_mut {
+            let buf_id = vs.active_buffer;
+            let top_line = self.buffers.get(&buf_id).and_then(|state| {
+                if state.buffer.line_count().is_some() {
+                    Some(state.buffer.get_line_number(vs.viewport.top_byte))
+                } else {
+                    None
+                }
+            });
+            snapshot.splits.push(fresh_core::api::SplitSnapshot {
+                split_id: leaf_id.0 .0,
+                buffer_id: buf_id,
+                viewport: ViewportInfo {
+                    top_byte: vs.viewport.top_byte,
+                    top_line,
+                    left_column: vs.viewport.left_column,
+                    width: vs.viewport.width,
+                    height: vs.viewport.height,
+                },
+            });
+        }
+
+        // Mirror the active session's plugin_state into the snapshot
+        // so getWindowState reads cheaply. Cloning is fine here: the
+        // per-session state is small; plugins that store megabyte-
+        // scale blobs in setWindowState will see proportional snapshot-
+        // update cost, which is the desired feedback signal.
+        snapshot.active_session_plugin_states = self.plugin_state.clone();
+        snapshot.authority_label = self.resources.authority.display_label.clone();
+
+        // Update LSP diagnostics / folding ranges: Arc refcount bumps.
+        snapshot.diagnostics = Arc::clone(&self.stored_diagnostics);
+        snapshot.folding_ranges = Arc::clone(&self.stored_folding_ranges);
+
+        // Update editor mode (for vi mode and other modal editing)
+        snapshot.editor_mode = self.editor_mode.clone();
+
+        // Update plugin view states from active split's BufferViewState.plugin_state.
+        // If the active split changed, fully repopulate. Otherwise, merge
+        // using or_insert to preserve JS-side write-through entries that
+        // haven't round-tripped through the command channel yet.
+        let active_split_id_u64 = active_split_id.0 .0;
+        let split_changed = snapshot.plugin_view_states_split != active_split_id_u64;
+        if split_changed {
+            snapshot.plugin_view_states.clear();
+            snapshot.plugin_view_states_split = active_split_id_u64;
+        }
+
+        // Clean up entries for buffers that are no longer open
+        {
+            let open_bids: Vec<_> = snapshot.buffers.keys().copied().collect();
+            snapshot
+                .plugin_view_states
+                .retain(|bid, _| open_bids.contains(bid));
+        }
+
+        // Merge from Rust-side plugin_state (source of truth for persisted state)
+        if let Some(active_vs) = vs_mut.get(&active_split_id) {
+            for (buffer_id, buf_state) in &active_vs.keyed_states {
+                if !buf_state.plugin_state.is_empty() {
+                    let entry = snapshot.plugin_view_states.entry(*buffer_id).or_default();
+                    for (key, value) in &buf_state.plugin_state {
+                        entry.entry(key.clone()).or_insert_with(|| value.clone());
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -469,10 +469,10 @@ impl Editor {
             snapshot.authority_label = self.authority.display_label.clone();
 
             // Update LSP diagnostics: Arc refcount bump; no clone.
-            snapshot.diagnostics = Arc::clone(&self.stored_diagnostics);
+            snapshot.diagnostics = Arc::clone(&self.active_window().stored_diagnostics);
 
             // Update LSP folding ranges: Arc refcount bump; no clone.
-            snapshot.folding_ranges = Arc::clone(&self.stored_folding_ranges);
+            snapshot.folding_ranges = Arc::clone(&self.active_window().stored_folding_ranges);
 
             // Update config. Reserialize only when the underlying
             // `Arc<Config>` pointer has actually moved since the last
@@ -1000,12 +1000,12 @@ impl Editor {
                 self.handle_await_next_key(callback_id);
             }
             PluginCommand::SetKeyCaptureActive { active } => {
-                self.key_capture_active = active;
+                self.active_window_mut().key_capture_active = active;
                 if !active {
                     // Capture window closed; any leftover queued keys
                     // were intended for the plugin and should not now
                     // leak into the editor's normal dispatch.
-                    self.pending_key_capture_buffer.clear();
+                    self.active_window_mut().pending_key_capture_buffer.clear();
                 }
             }
             PluginCommand::SetPromptSuggestions { suggestions } => {
@@ -1154,7 +1154,8 @@ impl Editor {
                 self.handle_start_animation_virtual_buffer(id, buffer_id, kind);
             }
             PluginCommand::CancelAnimation { id } => {
-                self.animations
+                self.active_window_mut()
+                    .animations
                     .cancel(crate::view::animation::AnimationId::from_raw(id));
             }
 
@@ -1344,8 +1345,11 @@ impl Editor {
 
             // ==================== Review Diff Commands ====================
             PluginCommand::SetReviewDiffHunks { hunks } => {
-                self.review_hunks = hunks;
-                tracing::debug!("Set {} review hunks", self.review_hunks.len());
+                self.active_window_mut().review_hunks = hunks;
+                tracing::debug!(
+                    "Set {} review hunks",
+                    self.active_window_mut().review_hunks.len()
+                );
             }
 
             // ==================== Vi Mode Commands ====================
@@ -1471,7 +1475,8 @@ impl Editor {
                     .map(|(mgr, _)| mgr)
                     .expect("active window must have a populated split layout")
                     .active_split();
-                self.composite_next_hunk(split_id, buffer_id);
+                self.active_window_mut()
+                    .composite_next_hunk(split_id, buffer_id);
             }
             PluginCommand::CompositePrevHunk { buffer_id } => {
                 let split_id = self
@@ -1481,7 +1486,8 @@ impl Editor {
                     .map(|(mgr, _)| mgr)
                     .expect("active window must have a populated split layout")
                     .active_split();
-                self.composite_prev_hunk(split_id, buffer_id);
+                self.active_window_mut()
+                    .composite_prev_hunk(split_id, buffer_id);
             }
 
             // ==================== Buffer Groups ====================
@@ -3002,7 +3008,9 @@ impl Editor {
                         .insert(terminal_id, fixed_backing);
                 }
                 if !persistent {
-                    self.ephemeral_terminals.insert(terminal_id);
+                    self.active_window_mut()
+                        .ephemeral_terminals
+                        .insert(terminal_id);
                 }
 
                 // Pick buffer-attachment strategy based on whether the
@@ -3239,7 +3247,9 @@ impl Editor {
                 .insert(terminal_id, backing_path);
         }
         if !persistent {
-            self.ephemeral_terminals.insert(terminal_id);
+            self.active_window_mut()
+                .ephemeral_terminals
+                .insert(terminal_id);
         }
 
         // Allocate a buffer for the terminal in editor-global
@@ -3361,11 +3371,17 @@ impl Editor {
         // If keys arrived during a key-capture window while no callback was
         // pending, drain the front-most buffered key and resolve immediately.
         // Otherwise enqueue the callback for the next live keypress.
-        if let Some(payload) = self.pending_key_capture_buffer.pop_front() {
+        if let Some(payload) = self
+            .active_window_mut()
+            .pending_key_capture_buffer
+            .pop_front()
+        {
             let json = serde_json::to_string(&payload).unwrap_or_else(|_| "null".to_string());
             self.plugin_manager.resolve_callback(callback_id, json);
         } else {
-            self.pending_next_key_callbacks.push_back(callback_id);
+            self.active_window_mut()
+                .pending_next_key_callbacks
+                .push_back(callback_id);
         }
     }
 
@@ -4924,10 +4940,14 @@ impl Editor {
 
     fn handle_set_context(&mut self, name: String, active: bool) {
         if active {
-            self.active_custom_contexts.insert(name.clone());
+            self.active_window_mut()
+                .active_custom_contexts
+                .insert(name.clone());
             tracing::debug!("Set custom context: {}", name);
         } else {
-            self.active_custom_contexts.remove(&name);
+            self.active_window_mut()
+                .active_custom_contexts
+                .remove(&name);
             tracing::debug!("Unset custom context: {}", name);
         }
     }
@@ -4960,7 +4980,7 @@ impl Editor {
             self.active_window_mut().status_message =
                 Some(format!("LSP disabled for {}", language));
         }
-        self.warning_domains.lsp.clear();
+        self.active_window_mut().warning_domains.lsp.clear();
     }
 
     fn handle_restart_lsp_for_language(&mut self, language: String) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3390,7 +3390,7 @@ impl Editor {
         let pairs = overrides
             .into_iter()
             .map(|(k, [r, g, b])| (k, ratatui::style::Color::Rgb(r, g, b)));
-        let applied = self.theme.override_colors(pairs);
+        let applied = self.theme.write().unwrap().override_colors(pairs);
         if applied > 0 {
             // Diagnostics / semantic overlays bake RGB at creation time — rebuild
             // them so the override is visible everywhere on the next frame.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -159,6 +159,14 @@ impl Editor {
         snapshot.clipboard = self.clipboard.get_internal().to_string();
         snapshot.working_dir = self.working_dir.clone();
 
+        // Authority label tracks `Editor::authority` (the active
+        // authority). It can't be sourced from `Window::resources.authority`
+        // because `set_boot_authority` replaces `self.authority` by value
+        // — the per-window resource clones still point at the previous
+        // authority handle. Reading from `Editor` keeps the snapshot in
+        // lockstep with the canonical seat.
+        snapshot.authority_label = self.authority.display_label.clone();
+
         // Publish the session list so plugins (Conductor, etc.)
         // see updates from createWindow/closeWindow without
         // a separate notification path. Sorted by id for
@@ -5284,7 +5292,8 @@ impl Window {
         // scale blobs in setWindowState will see proportional snapshot-
         // update cost, which is the desired feedback signal.
         snapshot.active_session_plugin_states = self.plugin_state.clone();
-        snapshot.authority_label = self.resources.authority.display_label.clone();
+        // `authority_label` is populated by the Editor coda — see the
+        // comment there for why it can't come from `self.resources`.
 
         // Update LSP diagnostics / folding ranges: Arc refcount bumps.
         snapshot.diagnostics = Arc::clone(&self.stored_diagnostics);

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -52,7 +52,7 @@ impl Editor {
                     .and_then(|item| item.data.clone())
                     .unwrap_or_else(|| "dismissed".to_string());
                 self.hide_popup();
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "action_popup_result",
                     crate::services::plugins::hooks::HookArgs::ActionPopupResult {
                         popup_id,
@@ -289,7 +289,7 @@ impl Editor {
                     popup_id
                 );
                 self.hide_popup();
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "action_popup_result",
                     crate::services::plugins::hooks::HookArgs::ActionPopupResult {
                         popup_id,

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -259,12 +259,12 @@ impl Editor {
         }
 
         // No additional_text_edits present — try resolve if server supports it
-        if self.server_supports_completion_resolve() {
+        if self.active_window().server_supports_completion_resolve() {
             tracing::info!(
                 "Completion '{}' has no additional_text_edits, sending completionItem/resolve",
                 label
             );
-            self.send_completion_resolve(item);
+            self.active_window_mut().send_completion_resolve(item);
         }
     }
 

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -95,7 +95,7 @@ impl Editor {
             .is_lsp_language_user_dismissed(&language);
 
         // Fire the LspStatusClicked hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "lsp_status_clicked",
             crate::services::plugins::hooks::HookArgs::LspStatusClicked {
                 language: language.clone(),

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -535,7 +535,8 @@ impl Editor {
         // segment isn't visible (e.g. first render). `status_row` comes
         // from the same cached layout so the popup hugs the status bar
         // even in prompt-auto-hide mode.
-        let position = self.active_chrome()
+        let position = self
+            .active_chrome()
             .status_bar_lsp_area
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
@@ -801,7 +802,8 @@ impl Editor {
         // right corner so the popup still appears. `status_row` comes
         // from the same cached layout so the popup hugs the status bar
         // even in prompt-auto-hide mode.
-        let position = self.active_chrome()
+        let position = self
+            .active_chrome()
             .status_bar_remote_area
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -567,8 +567,8 @@ impl Editor {
             width: popup_width,
             max_height: 15,
             bordered: true,
-            border_style: Style::default().fg(self.theme.popup_border_fg),
-            background_style: Style::default().bg(self.theme.popup_bg),
+            border_style: Style::default().fg(self.theme.read().unwrap().popup_border_fg),
+            background_style: Style::default().bg(self.theme.read().unwrap().popup_bg),
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
@@ -833,8 +833,8 @@ impl Editor {
             width: popup_width.clamp(28, 50),
             max_height: 10,
             bordered: true,
-            border_style: Style::default().fg(self.theme.popup_border_fg),
-            background_style: Style::default().bg(self.theme.popup_bg),
+            border_style: Style::default().fg(self.theme.read().unwrap().popup_border_fg),
+            background_style: Style::default().bg(self.theme.read().unwrap().popup_bg),
             scroll_offset: 0,
             text_selection: None,
             accept_key_hint: None,
@@ -942,13 +942,17 @@ impl Editor {
         let hint_width = 16u16; // "*esc to dismiss*"
         let popup_width = (content_width.max(hint_width) + 4).clamp(20, 60);
 
-        let mut popup = Popup::markdown(&md, &self.theme, Some(&self.grammar_registry));
+        let mut popup = Popup::markdown(
+            &md,
+            &*self.theme.read().unwrap(),
+            Some(&self.grammar_registry),
+        );
         popup.transient = false;
         popup.position = PopupPosition::BelowCursor;
         popup.width = popup_width;
         popup.max_height = 15;
-        popup.border_style = Style::default().fg(self.theme.popup_border_fg);
-        popup.background_style = Style::default().bg(self.theme.popup_bg);
+        popup.border_style = Style::default().fg(self.theme.read().unwrap().popup_border_fg);
+        popup.background_style = Style::default().bg(self.theme.read().unwrap().popup_bg);
 
         let buffer_id = self.active_buffer();
         if let Some(state) = self

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -28,7 +28,7 @@ impl Editor {
     /// If there are no warnings, shows a brief status message.
     /// Otherwise, opens the warning log file for the user to view.
     pub fn show_warnings_popup(&mut self) {
-        if !self.warning_domains.has_any_warnings() {
+        if !self.active_window_mut().warning_domains.has_any_warnings() {
             self.active_window_mut().status_message = Some(t!("warnings.none").to_string());
             return;
         }
@@ -58,7 +58,8 @@ impl Editor {
             return;
         }
 
-        let has_error = self.warning_domains.lsp.level() == crate::app::WarningLevel::Error;
+        let has_error =
+            self.active_window_mut().warning_domains.lsp.level() == crate::app::WarningLevel::Error;
         let language = self
             .buffers()
             .get(&self.active_buffer())
@@ -89,7 +90,9 @@ impl Editor {
                     .collect()
             })
             .unwrap_or_default();
-        let user_dismissed = self.is_lsp_language_user_dismissed(&language);
+        let user_dismissed = self
+            .active_window()
+            .is_lsp_language_user_dismissed(&language);
 
         // Fire the LspStatusClicked hook for plugins
         self.plugin_manager.run_hook(
@@ -150,6 +153,7 @@ impl Editor {
         // Build a unified list of all configured servers for this language,
         // merged with their runtime status (if running).
         let running_statuses: std::collections::HashMap<String, LspServerStatus> = self
+            .active_window()
             .lsp_server_statuses
             .iter()
             .filter(|((lang, _), _)| lang == language)
@@ -210,7 +214,9 @@ impl Editor {
                     .collect()
             })
             .unwrap_or_default();
-        let user_dismissed = self.is_lsp_language_user_dismissed(language);
+        let user_dismissed = self
+            .active_window()
+            .is_lsp_language_user_dismissed(language);
 
         if configured_servers.is_empty() && running_statuses.is_empty() {
             self.active_window_mut().status_message = Some(t!("lsp.no_server_active").to_string());
@@ -314,6 +320,7 @@ impl Editor {
             // width is pinned in advance (see below) so the row's content
             // changing never reshapes the popup.
             if let Some(info) = self
+                .active_window()
                 .lsp_progress
                 .values()
                 .find(|info| info.language == language)

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -535,8 +535,7 @@ impl Editor {
         // segment isn't visible (e.g. first render). `status_row` comes
         // from the same cached layout so the popup hugs the status bar
         // even in prompt-auto-hide mode.
-        let position = self
-            .chrome_layout
+        let position = self.active_chrome()
             .status_bar_lsp_area
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
@@ -802,8 +801,7 @@ impl Editor {
         // right corner so the popup still appears. `status_row` comes
         // from the same cached layout so the popup hugs the status bar
         // even in prompt-auto-hide mode.
-        let position = self
-            .chrome_layout
+        let position = self.active_chrome()
             .status_bar_remote_area
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -176,7 +176,6 @@ impl Editor {
         }
     }
 
-
     /// Clear all popups
     pub fn clear_popups(&mut self) {
         let event = Event::ClearPopups;
@@ -597,7 +596,9 @@ impl Window {
         // reach back through `Editor::apply_event_to_active_buffer`.
         if let Some(handle) = self.hover.take_symbol_overlay() {
             let state = self.active_state_mut();
-            state.overlays.remove_by_handle(&handle, &mut state.marker_list);
+            state
+                .overlays
+                .remove_by_handle(&handle, &mut state.marker_list);
         }
         self.hover.set_symbol_range(None);
 

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -17,6 +17,7 @@ use rust_i18n::t;
 
 use crate::model::event::Event;
 
+use super::window::Window;
 use super::Editor;
 
 impl Editor {
@@ -175,34 +176,6 @@ impl Editor {
         }
     }
 
-    /// Called when the editor buffer loses focus (e.g., switching buffers,
-    /// opening prompts/menus, focusing file explorer, etc.)
-    ///
-    /// This is the central handler for focus loss that:
-    /// - Dismisses transient popups (Hover, Signature Help)
-    /// - Clears LSP hover state and pending requests
-    /// - Removes hover symbol highlighting
-    pub(super) fn on_editor_focus_lost(&mut self) {
-        // Dismiss transient popups via EditorState
-        self.active_state_mut().on_focus_lost();
-
-        // Clear hover state
-        self.active_window_mut().mouse_state.lsp_hover_state = None;
-        self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
-        self.active_window_mut().hover.clear_pending();
-
-        // Clear hover symbol highlight if present
-        if let Some(handle) = self.active_window_mut().hover.take_symbol_overlay() {
-            let remove_overlay_event = crate::model::event::Event::RemoveOverlay { handle };
-            self.apply_event_to_active_buffer(&remove_overlay_event);
-        }
-        self.active_window_mut().hover.set_symbol_range(None);
-
-        // Any focus change (buffer switch, file explorer, menus, …) ends the
-        // goto-line preview flow. Drop the snapshot so a later Esc cannot
-        // rubber-band the cursor over state the user has moved past.
-        self.active_window_mut().goto_line_preview = None;
-    }
 
     /// Clear all popups
     pub fn clear_popups(&mut self) {
@@ -601,5 +574,36 @@ impl Editor {
         let event = Event::PopupPageUp;
         self.active_event_log_mut().append(event.clone());
         self.apply_event_to_active_buffer(&event);
+    }
+}
+
+impl Window {
+    /// Called when the editor buffer loses focus (e.g., switching buffers,
+    /// opening prompts/menus, focusing file explorer, etc.)
+    ///
+    /// Dismisses transient popups, clears LSP hover state and pending requests,
+    /// and removes hover symbol highlighting.
+    pub(crate) fn on_editor_focus_lost(&mut self) {
+        // Dismiss transient popups via EditorState
+        self.active_state_mut().on_focus_lost();
+
+        // Clear hover state
+        self.mouse_state.lsp_hover_state = None;
+        self.mouse_state.lsp_hover_request_sent = false;
+        self.hover.clear_pending();
+
+        // Clear hover symbol highlight if present. Inlined from
+        // `Event::RemoveOverlay` handling (state.rs) so we don't have to
+        // reach back through `Editor::apply_event_to_active_buffer`.
+        if let Some(handle) = self.hover.take_symbol_overlay() {
+            let state = self.active_state_mut();
+            state.overlays.remove_by_handle(&handle, &mut state.marker_list);
+        }
+        self.hover.set_symbol_range(None);
+
+        // Any focus change (buffer switch, file explorer, menus, …) ends the
+        // goto-line preview flow. Drop the snapshot so a later Esc cannot
+        // rubber-band the cursor over state the user has moved past.
+        self.goto_line_preview = None;
     }
 }

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -129,8 +129,8 @@ impl Editor {
 
         // Complete --wait tracking if this buffer had a popup-based wait
         let active = self.active_buffer();
-        if let Some((wait_id, true)) = self.wait_tracking.remove(&active) {
-            self.completed_waits.push(wait_id);
+        if let Some((wait_id, true)) = self.active_window_mut().wait_tracking.remove(&active) {
+            self.active_window_mut().completed_waits.push(wait_id);
         }
 
         // Clear hover symbol highlight if present
@@ -187,8 +187,8 @@ impl Editor {
         self.active_state_mut().on_focus_lost();
 
         // Clear hover state
-        self.mouse_state.lsp_hover_state = None;
-        self.mouse_state.lsp_hover_request_sent = false;
+        self.active_window_mut().mouse_state.lsp_hover_state = None;
+        self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
         self.active_window_mut().hover.clear_pending();
 
         // Clear hover symbol highlight if present
@@ -454,12 +454,12 @@ impl Editor {
 
         // Send didOpen to all LSP handles (use force_spawn to ensure they're started)
         let __active_id = self.active_window;
-        let diagnostic_result_ids = &self.diagnostic_result_ids;
         let enable_inlay_hints = self.config.editor.enable_inlay_hints;
         let __win = self
             .windows
             .get_mut(&__active_id)
             .expect("active window must exist");
+        let diagnostic_result_ids = &__win.diagnostic_result_ids;
         let __next_id = &mut __win.next_lsp_request_id;
         if let Some(lsp) = __win.lsp.as_mut() {
             // force_spawn starts all servers for this language

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -288,7 +288,7 @@ impl Editor {
                     "prompt_confirmed: dispatching hook for prompt_type='{}', input='{}', selected_index={:?}",
                     custom_type, input, selected_index
                 );
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "prompt_confirmed",
                     HookArgs::PromptConfirmed {
                         prompt_type: custom_type.clone(),
@@ -671,7 +671,10 @@ impl Editor {
                 {
                     // Serialize the input as a JSON string
                     let json = serde_json::to_string(&input).unwrap_or_else(|_| "null".to_string());
-                    self.plugin_manager.resolve_callback(callback_id, json);
+                    self.plugin_manager
+                        .read()
+                        .unwrap()
+                        .resolve_callback(callback_id, json);
                 }
             }
         }
@@ -794,7 +797,7 @@ impl Editor {
                 if language_changed {
                     #[cfg(feature = "plugins")]
                     self.update_plugin_state_snapshot();
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "language_changed",
                         crate::services::plugins::hooks::HookArgs::LanguageChanged {
                             buffer_id: self.active_buffer(),
@@ -823,7 +826,7 @@ impl Editor {
                     serde_json::json!({"path": full_path.display().to_string()}),
                 );
 
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "after_file_save",
                     crate::services::plugins::hooks::HookArgs::AfterFileSave {
                         buffer_id: self.active_buffer(),
@@ -1248,7 +1251,7 @@ impl Editor {
             }
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "language_changed",
                 crate::services::plugins::hooks::HookArgs::LanguageChanged {
                     buffer_id: self.active_buffer(),
@@ -1278,7 +1281,7 @@ impl Editor {
             }
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "language_changed",
                 crate::services::plugins::hooks::HookArgs::LanguageChanged {
                     buffer_id,

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -816,7 +816,7 @@ impl Editor {
                     }
                 }
 
-                self.notify_lsp_save();
+                self.active_window_mut().notify_lsp_save();
 
                 self.emit_event(
                     crate::model::control_event::events::FILE_SAVED.name,
@@ -1167,7 +1167,8 @@ impl Editor {
                 }
 
                 // Reset key context to Normal so editor gets focus
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
 
                 // Open the file with the specified encoding
                 if let Err(e) = self.open_file_with_encoding(path, enc) {

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -386,7 +386,6 @@ impl Editor {
         }
     }
 
-
     /// Pre-fill the Open File prompt input with the current buffer directory
     pub(super) fn prefill_open_file_prompt(&mut self) {
         // With the native file browser, the directory is shown from file_open_state.current_dir

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -695,7 +695,7 @@ impl Editor {
                 PromptType::Plugin { custom_type } => {
                     // Fire plugin hook for prompt cancellation
                     use crate::services::plugins::hooks::HookArgs;
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "prompt_cancelled",
                         HookArgs::PromptCancelled {
                             prompt_type: custom_type.clone(),
@@ -776,6 +776,8 @@ impl Editor {
                         .take()
                     {
                         self.plugin_manager
+                            .read()
+                            .unwrap()
                             .resolve_callback(callback_id, "null".to_string());
                     }
                 }
@@ -1061,14 +1063,18 @@ impl Editor {
         &self.command_registry
     }
 
-    /// Get access to the plugin manager
-    pub fn plugin_manager(&self) -> &PluginManager {
-        &self.plugin_manager
+    /// Get access to the plugin manager (read lock).
+    ///
+    /// Callers should use `editor.plugin_manager()` instead of locking
+    /// directly so they're decoupled from the field's `Arc<RwLock<>>`
+    /// internals.
+    pub fn plugin_manager(&self) -> std::sync::RwLockReadGuard<'_, PluginManager> {
+        self.plugin_manager.read().unwrap()
     }
 
-    /// Get mutable access to the plugin manager
-    pub fn plugin_manager_mut(&mut self) -> &mut PluginManager {
-        &mut self.plugin_manager
+    /// Mutable access to the plugin manager (write lock).
+    pub fn plugin_manager_mut(&mut self) -> std::sync::RwLockWriteGuard<'_, PluginManager> {
+        self.plugin_manager.write().unwrap()
     }
 
     /// Check if file explorer has focus
@@ -1180,7 +1186,7 @@ impl Editor {
                 }
                 // Fire plugin hook for prompt input change
                 use crate::services::plugins::hooks::HookArgs;
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "prompt_changed",
                     HookArgs::PromptChanged {
                         prompt_type: custom_type,

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -193,8 +193,8 @@ impl Editor {
                 .file_path()
                 .map(|p| p.display().to_string()),
             has_selection: self.has_active_selection(),
-            key_context: self.key_context.clone(),
-            custom_contexts: self.active_custom_contexts.clone(),
+            key_context: self.active_window().key_context.clone(),
+            custom_contexts: self.active_window().active_custom_contexts.clone(),
             buffer_mode: self
                 .active_window()
                 .buffer_metadata
@@ -451,7 +451,7 @@ impl Editor {
 
         // Create the file open state with config-based show_hidden setting
         let show_hidden = self.config.file_browser.show_hidden;
-        self.file_open_state = Some(file_open::FileOpenState::new(
+        self.active_window_mut().file_open_state = Some(file_open::FileOpenState::new(
             initial_dir.clone(),
             show_hidden,
             self.authority.filesystem.clone(),
@@ -472,7 +472,7 @@ impl Editor {
 
         // Create the file open state with config-based show_hidden setting
         let show_hidden = self.config.file_browser.show_hidden;
-        self.file_open_state = Some(file_open::FileOpenState::new(
+        self.active_window_mut().file_open_state = Some(file_open::FileOpenState::new(
             initial_dir.clone(),
             show_hidden,
             self.authority.filesystem.clone(),
@@ -504,7 +504,7 @@ impl Editor {
     /// Load directory contents for the file open dialog
     pub(super) fn load_file_open_directory(&mut self, path: PathBuf) {
         // Update state to loading
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             state.current_dir = path.clone();
             state.loading = true;
             state.error = None;
@@ -526,7 +526,7 @@ impl Editor {
             });
         } else {
             // No runtime, set error
-            if let Some(state) = &mut self.file_open_state {
+            if let Some(state) = &mut self.active_window_mut().file_open_state {
                 state.set_error("Async runtime not available".to_string());
             }
         }
@@ -539,7 +539,7 @@ impl Editor {
     ) {
         match result {
             Ok(entries) => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.set_entries(entries);
                 }
                 // Re-apply filter from prompt (entries were just loaded, filter needs to select matching entry)
@@ -550,13 +550,13 @@ impl Editor {
                     .map(|p| p.input.clone())
                     .unwrap_or_default();
                 if !filter.is_empty() {
-                    if let Some(state) = &mut self.file_open_state {
+                    if let Some(state) = &mut self.active_window_mut().file_open_state {
                         state.apply_filter(&filter);
                     }
                 }
             }
             Err(e) => {
-                if let Some(state) = &mut self.file_open_state {
+                if let Some(state) = &mut self.active_window_mut().file_open_state {
                     state.set_error(e.to_string());
                 }
             }
@@ -593,7 +593,7 @@ impl Editor {
         &mut self,
         shortcuts: Vec<file_open::NavigationShortcut>,
     ) {
-        if let Some(state) = &mut self.file_open_state {
+        if let Some(state) = &mut self.active_window_mut().file_open_state {
             state.merge_async_shortcuts(shortcuts);
         }
     }
@@ -751,8 +751,8 @@ impl Editor {
                 }
                 PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs => {
                     // Clear file browser state
-                    self.file_open_state = None;
-                    self.file_browser_layout = None;
+                    self.active_window_mut().file_open_state = None;
+                    self.active_window_mut().file_browser_layout = None;
 
                     // Cancelling a Save-As that was opened as part of the
                     // "save and quit" chain aborts the quit — the user
@@ -1073,7 +1073,7 @@ impl Editor {
 
     /// Check if file explorer has focus
     pub fn file_explorer_is_focused(&self) -> bool {
-        self.key_context == KeyContext::FileExplorer
+        self.active_window().key_context == KeyContext::FileExplorer
     }
 
     /// Get current prompt input (for display)
@@ -1112,12 +1112,12 @@ impl Editor {
     /// Get accumulated plugin errors (for test assertions)
     /// Returns all error messages that were detected in plugin status messages
     pub fn get_plugin_errors(&self) -> &[String] {
-        &self.plugin_errors
+        &self.active_window().plugin_errors
     }
 
     /// Clear accumulated plugin errors
     pub fn clear_plugin_errors(&mut self) {
-        self.plugin_errors.clear();
+        self.active_window_mut().plugin_errors.clear();
     }
 
     /// Update prompt suggestions based on current input

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -18,6 +18,7 @@ use crate::services::plugins::PluginManager;
 use crate::view::prompt::{Prompt, PromptType};
 
 use super::file_open;
+use super::window::Window;
 use super::Editor;
 
 impl Editor {
@@ -91,7 +92,7 @@ impl Editor {
         suggestions: Vec<Suggestion>,
     ) {
         // Dismiss transient popups and clear hover state when opening a prompt
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
 
         // Clear search highlights when starting a new search prompt
         // This ensures old highlights from previous searches don't persist
@@ -125,7 +126,7 @@ impl Editor {
         initial_text: String,
     ) {
         // Dismiss transient popups and clear hover state when opening a prompt
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
 
         self.active_window_mut().prompt = Some(Prompt::with_initial_text(
             message,
@@ -141,7 +142,7 @@ impl Editor {
 
     /// Start Quick Open prompt with specified prefix
     pub fn start_quick_open_with_prefix(&mut self, prefix: &str) {
-        self.on_editor_focus_lost();
+        self.active_window_mut().on_editor_focus_lost();
         self.active_window_mut().status_message = None;
         self.active_window_mut().goto_line_preview = None;
 
@@ -385,29 +386,6 @@ impl Editor {
         }
     }
 
-    /// Cancel search/replace prompts if one is active.
-    /// Called when focus leaves the editor (e.g., switching buffers, focusing file explorer).
-    pub(super) fn cancel_search_prompt_if_active(&mut self) {
-        if let Some(ref prompt) = self.active_window_mut().prompt {
-            if matches!(
-                prompt.prompt_type,
-                PromptType::Search
-                    | PromptType::ReplaceSearch
-                    | PromptType::Replace { .. }
-                    | PromptType::QueryReplaceSearch
-                    | PromptType::QueryReplace { .. }
-                    | PromptType::QueryReplaceConfirm
-            ) {
-                self.active_window_mut().prompt = None;
-                // Also cancel interactive replace if active
-                self.active_window_mut().interactive_replace_state = None;
-                // Clear search highlights from current buffer
-                let ns = self.active_window().search_namespace.clone();
-                let state = self.active_state_mut();
-                state.overlays.clear_namespace(&ns, &mut state.marker_list);
-            }
-        }
-    }
 
     /// Pre-fill the Open File prompt input with the current buffer directory
     pub(super) fn prefill_open_file_prompt(&mut self) {
@@ -1219,6 +1197,32 @@ impl Editor {
                 }
             }
             _ => {}
+        }
+    }
+}
+
+impl Window {
+    /// Cancel search/replace prompts if one is active.
+    /// Called when focus leaves the editor (e.g., switching buffers, focusing file explorer).
+    pub(crate) fn cancel_search_prompt_if_active(&mut self) {
+        if let Some(ref prompt) = self.prompt {
+            if matches!(
+                prompt.prompt_type,
+                PromptType::Search
+                    | PromptType::ReplaceSearch
+                    | PromptType::Replace { .. }
+                    | PromptType::QueryReplaceSearch
+                    | PromptType::QueryReplace { .. }
+                    | PromptType::QueryReplaceConfirm
+            ) {
+                self.prompt = None;
+                // Also cancel interactive replace if active
+                self.interactive_replace_state = None;
+                // Clear search highlights from current buffer
+                let ns = self.search_namespace.clone();
+                let state = self.active_state_mut();
+                state.overlays.clear_namespace(&ns, &mut state.marker_list);
+            }
         }
     }
 }

--- a/crates/fresh-editor/src/app/recovery_actions.rs
+++ b/crates/fresh-editor/src/app/recovery_actions.rs
@@ -418,12 +418,16 @@ impl Editor {
         let interval = std::time::Duration::from_secs(
             self.config.editor.auto_recovery_save_interval_secs as u64,
         );
-        if self.time_source.elapsed_since(self.last_auto_recovery_save) < interval {
+        if self
+            .time_source
+            .elapsed_since(self.active_window().last_auto_recovery_save)
+            < interval
+        {
             return Ok(0);
         }
 
         let saved = self.save_pending_recovery_buffers()?;
-        self.last_auto_recovery_save = self.time_source.now();
+        self.active_window_mut().last_auto_recovery_save = self.time_source.now();
         Ok(saved)
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -318,7 +318,7 @@ impl Editor {
 
                 let keybindings = self.keybindings.read().unwrap();
                 let empty: Vec<std::path::PathBuf> = Vec::new();
-                let cut_paths = self
+                let cut_paths = __win
                     .file_explorer_clipboard
                     .as_ref()
                     .filter(|cb| cb.is_cut)

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -353,7 +353,7 @@ impl Editor {
         // This allows plugins to add overlays before rendering
         // Only lines that haven't been seen before are sent (batched for efficiency)
         // Use non-blocking hooks to avoid deadlock when actions are awaiting
-        if self.plugin_manager.is_active() {
+        if self.plugin_manager.read().unwrap().is_active() {
             let hooks_start = std::time::Instant::now();
             // Get visible buffers and their areas
             let visible_buffers = self
@@ -384,7 +384,7 @@ impl Editor {
                     .expect("active window must exist");
                 if let Some(state) = __win.buffers.get_mut(&buffer_id) {
                     // Fire render_start hook once per buffer
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "render_start",
                         crate::services::plugins::hooks::HookArgs::RenderStart { buffer_id },
                     );
@@ -417,7 +417,7 @@ impl Editor {
                         .get(&split_id)
                         .map(|vs| vs.cursors.iter().map(|(_, c)| c.position).collect())
                         .unwrap_or_default();
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "view_transform_request",
                         crate::services::plugins::hooks::HookArgs::ViewTransformRequest {
                             buffer_id,
@@ -477,7 +477,7 @@ impl Editor {
                     // Send batched hook if there are new lines
                     if !new_lines.is_empty() {
                         total_new_lines += new_lines.len();
-                        self.plugin_manager.run_hook(
+                        self.plugin_manager.read().unwrap().run_hook(
                             "lines_changed",
                             crate::services::plugins::hooks::HookArgs::LinesChanged {
                                 buffer_id,
@@ -506,7 +506,7 @@ impl Editor {
             // load), the response arrives one frame late, which is imperceptible
             // at 60fps. The plugin's own refreshLines() call from cursor_moved
             // ensures a follow-up render cycle picks up any missed commands.
-            let commands = self.plugin_manager.process_commands();
+            let commands = self.plugin_manager.write().unwrap().process_commands();
             let dispatched_any = !commands.is_empty();
             if dispatched_any {
                 let cmd_names: Vec<String> =
@@ -756,7 +756,7 @@ impl Editor {
         // Detect viewport changes and fire hooks
         // Compare against previous frame's viewport state (stored in self.active_window().previous_viewports)
         // This correctly detects changes from scroll events that happen before render()
-        if self.plugin_manager.is_active() {
+        if self.plugin_manager.read().unwrap().is_active() {
             for (split_id, view_state) in self
                 .windows
                 .get(&self.active_window)
@@ -815,7 +815,7 @@ impl Editor {
                             view_state.viewport.top_byte,
                             top_line
                         );
-                        self.plugin_manager.run_hook(
+                        self.plugin_manager.read().unwrap().run_hook(
                             "viewport_changed",
                             crate::services::plugins::hooks::HookArgs::ViewportChanged {
                                 split_id: (*split_id).into(),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1082,8 +1082,10 @@ impl Editor {
             self.active_chrome_mut().status_bar_warning_area = status_bar_layout.warning_badge;
             self.active_chrome_mut().status_bar_line_ending_area =
                 status_bar_layout.line_ending_indicator;
-            self.active_chrome_mut().status_bar_encoding_area = status_bar_layout.encoding_indicator;
-            self.active_chrome_mut().status_bar_language_area = status_bar_layout.language_indicator;
+            self.active_chrome_mut().status_bar_encoding_area =
+                status_bar_layout.encoding_indicator;
+            self.active_chrome_mut().status_bar_language_area =
+                status_bar_layout.language_indicator;
             self.active_chrome_mut().status_bar_message_area = status_bar_layout.message_area;
             self.active_chrome_mut().status_bar_remote_area = status_bar_layout.remote_indicator;
         }
@@ -1704,14 +1706,16 @@ impl Editor {
                 && y < rect.y.saturating_add(rect.height)
         };
 
-        if self.active_chrome()
+        if self
+            .active_chrome()
             .popup_areas
             .iter()
             .any(|entry| inside(entry.1))
         {
             return true;
         }
-        if self.active_chrome()
+        if self
+            .active_chrome()
             .global_popup_areas
             .iter()
             .any(|entry| inside(entry.1))

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -15,11 +15,11 @@ impl Editor {
         self.active_window_mut().animations.capture_before_all();
 
         // Save frame dimensions for recompute_layout (used by macro replay)
-        self.chrome_layout.last_frame_width = size.width;
-        self.chrome_layout.last_frame_height = size.height;
+        self.active_chrome_mut().last_frame_width = size.width;
+        self.active_chrome_mut().last_frame_height = size.height;
 
         // Reset per-cell theme key map for this frame
-        self.chrome_layout.reset_cell_theme_map();
+        self.active_chrome_mut().reset_cell_theme_map();
 
         // For scroll sync groups, we need to update the active split's viewport position BEFORE
         // calling sync_scroll_groups, so that the sync reads the correct position.
@@ -686,6 +686,7 @@ impl Editor {
         let __grouped_ref = &__win.grouped_subtrees;
         let __composite_buffers_mut = &mut __win.composite_buffers;
         let __composite_view_states_mut = &mut __win.composite_view_states;
+        let __cell_theme_map_mut = &mut __win.chrome_layout.cell_theme_map;
         let (mgr_for_split, split_view_states): (
             &crate::view::split::SplitManager,
             &mut HashMap<crate::model::event::LeafId, crate::view::split::SplitViewState>,
@@ -739,7 +740,7 @@ impl Editor {
             self.config.editor.diagnostics_inline_text,
             self.config.editor.show_tilde,
             self.config.editor.highlight_current_column,
-            &mut self.chrome_layout.cell_theme_map,
+            __cell_theme_map_mut,
             size.width,
             &mut pending_hardware_cursor,
         );
@@ -891,8 +892,8 @@ impl Editor {
         self.render_hover_highlights(frame);
 
         // Initialize popup/suggestion layout state (rendered after status bar below)
-        self.chrome_layout.suggestions_area = None;
-        self.chrome_layout.suggestions_outer_area = None;
+        self.active_chrome_mut().suggestions_area = None;
+        self.active_chrome_mut().suggestions_outer_area = None;
         self.active_window_mut().file_browser_layout = None;
 
         // Clone all immutable values before the mutable borrow
@@ -1075,16 +1076,16 @@ impl Editor {
 
             // Store status bar layout for click detection
             let status_bar_area = main_chunks[status_bar_idx];
-            self.chrome_layout.status_bar_area =
+            self.active_chrome_mut().status_bar_area =
                 Some((status_bar_area.y, status_bar_area.x, status_bar_area.width));
-            self.chrome_layout.status_bar_lsp_area = status_bar_layout.lsp_indicator;
-            self.chrome_layout.status_bar_warning_area = status_bar_layout.warning_badge;
-            self.chrome_layout.status_bar_line_ending_area =
+            self.active_chrome_mut().status_bar_lsp_area = status_bar_layout.lsp_indicator;
+            self.active_chrome_mut().status_bar_warning_area = status_bar_layout.warning_badge;
+            self.active_chrome_mut().status_bar_line_ending_area =
                 status_bar_layout.line_ending_indicator;
-            self.chrome_layout.status_bar_encoding_area = status_bar_layout.encoding_indicator;
-            self.chrome_layout.status_bar_language_area = status_bar_layout.language_indicator;
-            self.chrome_layout.status_bar_message_area = status_bar_layout.message_area;
-            self.chrome_layout.status_bar_remote_area = status_bar_layout.remote_indicator;
+            self.active_chrome_mut().status_bar_encoding_area = status_bar_layout.encoding_indicator;
+            self.active_chrome_mut().status_bar_language_area = status_bar_layout.language_indicator;
+            self.active_chrome_mut().status_bar_message_area = status_bar_layout.message_area;
+            self.active_chrome_mut().status_bar_remote_area = status_bar_layout.remote_indicator;
         }
 
         // Render search options bar when in search prompt
@@ -1125,9 +1126,9 @@ impl Editor {
                 &keybindings_cloned,
                 search_options_hover,
             );
-            self.chrome_layout.search_options_layout = Some(search_options_layout);
+            self.active_chrome_mut().search_options_layout = Some(search_options_layout);
         } else {
-            self.chrome_layout.search_options_layout = None;
+            self.active_chrome_mut().search_options_layout = None;
         }
 
         // Render prompt line if active. Overlay prompts (Live Grep)
@@ -1192,7 +1193,7 @@ impl Editor {
         let hover_target = self.active_window_mut().mouse_state.hover_target.clone();
 
         // Clear popup areas and recalculate
-        self.chrome_layout.popup_areas.clear();
+        self.active_chrome_mut().popup_areas.clear();
 
         // Collect popup information without holding a mutable borrow
         let popup_info: Vec<_> = {
@@ -1349,7 +1350,7 @@ impl Editor {
         };
 
         // Store popup areas for mouse hit testing
-        self.chrome_layout.popup_areas = popup_info.clone();
+        self.active_chrome_mut().popup_areas = popup_info.clone();
 
         // Now render popups
         let state = self.active_state_mut();
@@ -1376,7 +1377,7 @@ impl Editor {
         // but only the top one renders & receives input. Deeper popups
         // surface as the top is resolved — the alternative (drawing all at
         // the same BottomRight slot) makes them illegible.
-        self.chrome_layout.global_popup_areas.clear();
+        self.active_chrome_mut().global_popup_areas.clear();
         if let Some(popup) = self.global_popups.top() {
             let top_idx = self.global_popups.all().len() - 1;
             let popup_area = popup.calculate_area(size, None);
@@ -1400,14 +1401,15 @@ impl Editor {
                 crate::view::popup::PopupContent::List { items, .. } => items.len(),
                 _ => 0,
             };
-            self.chrome_layout.global_popup_areas.push((
+            let scroll_offset = popup.scroll_offset;
+            popup.render_with_hover(frame, popup_area, &theme_clone, hover_target.as_ref());
+            self.active_chrome_mut().global_popup_areas.push((
                 top_idx,
                 popup_area,
                 inner_area,
-                popup.scroll_offset,
+                scroll_offset,
                 num_items,
             ));
-            popup.render_with_hover(frame, popup_area, &theme_clone, hover_target.as_ref());
         }
 
         // Render menu bar last so dropdown appears on top of all other content
@@ -1434,7 +1436,7 @@ impl Editor {
                     settings_state,
                     &*self.theme.read().unwrap(),
                 );
-                self.chrome_layout.settings_layout = Some(settings_layout);
+                self.active_chrome_mut().settings_layout = Some(settings_layout);
             }
         }
 
@@ -1486,7 +1488,7 @@ impl Editor {
             let menu_bar_mnemonics = self.config.editor.menu_bar_mnemonics;
             let expanded = self.expanded_menus_cache.get().expect("just updated");
             let keybindings = self.keybindings.read().unwrap();
-            self.chrome_layout.menu_layout = Some(crate::view::ui::MenuRenderer::render(
+            let new_menu_layout = crate::view::ui::MenuRenderer::render(
                 frame,
                 menu_bar_area,
                 expanded,
@@ -1495,9 +1497,11 @@ impl Editor {
                 &*self.theme.read().unwrap(),
                 hover_target.as_ref(),
                 menu_bar_mnemonics,
-            ));
+            );
+            drop(keybindings);
+            self.active_chrome_mut().menu_layout = Some(new_menu_layout);
         } else {
-            self.chrome_layout.menu_layout = None;
+            self.active_chrome_mut().menu_layout = None;
         }
 
         // Render tab context menu if open
@@ -1700,23 +1704,21 @@ impl Editor {
                 && y < rect.y.saturating_add(rect.height)
         };
 
-        if self
-            .chrome_layout
+        if self.active_chrome()
             .popup_areas
             .iter()
             .any(|entry| inside(entry.1))
         {
             return true;
         }
-        if self
-            .chrome_layout
+        if self.active_chrome()
             .global_popup_areas
             .iter()
             .any(|entry| inside(entry.1))
         {
             return true;
         }
-        if let Some((rect, _, _, _)) = self.chrome_layout.suggestions_area {
+        if let Some((rect, _, _, _)) = self.active_chrome().suggestions_area {
             if inside(rect) {
                 return true;
             }
@@ -1847,7 +1849,7 @@ impl Editor {
             return;
         };
 
-        self.chrome_layout.suggestions_area = SuggestionsRenderer::render_with_hover(
+        let new_suggestions_area = SuggestionsRenderer::render_with_hover(
             frame,
             suggestions_area,
             prompt,
@@ -1855,8 +1857,10 @@ impl Editor {
             self.active_window().mouse_state.hover_target.as_ref(),
             true,
         );
-        if self.chrome_layout.suggestions_area.is_some() {
-            self.chrome_layout.suggestions_outer_area = Some(suggestions_area);
+        let chrome = self.active_chrome_mut();
+        chrome.suggestions_area = new_suggestions_area;
+        if chrome.suggestions_area.is_some() {
+            chrome.suggestions_outer_area = Some(suggestions_area);
         }
 
         if is_quick_open {
@@ -2639,7 +2643,7 @@ impl Editor {
                 width: results_area.width.saturating_sub(scrollbar_w),
                 height: results_area.height - chrome_above_list - footer_h,
             };
-            self.chrome_layout.suggestions_area = SuggestionsRenderer::render_with_hover(
+            self.active_chrome_mut().suggestions_area = SuggestionsRenderer::render_with_hover(
                 frame,
                 list_area,
                 &prompt,
@@ -2647,8 +2651,8 @@ impl Editor {
                 self.active_window_mut().mouse_state.hover_target.as_ref(),
                 false,
             );
-            if self.chrome_layout.suggestions_area.is_some() {
-                self.chrome_layout.suggestions_outer_area = Some(list_area);
+            if self.active_chrome_mut().suggestions_area.is_some() {
+                self.active_chrome_mut().suggestions_outer_area = Some(list_area);
             }
             // Render the scrollbar in the carved lane. Reuses the
             // shared `view::ui::scrollbar` widget so thumb sizing
@@ -2680,12 +2684,12 @@ impl Editor {
                 );
                 // Cache the rect for mouse hit testing in
                 // `mouse_input.rs::handle_click_prompt_scrollbar`.
-                self.chrome_layout.suggestions_scrollbar_rect = Some(scrollbar_rect);
+                self.active_chrome_mut().suggestions_scrollbar_rect = Some(scrollbar_rect);
             } else {
-                self.chrome_layout.suggestions_scrollbar_rect = None;
+                self.active_chrome_mut().suggestions_scrollbar_rect = None;
             }
         } else {
-            self.chrome_layout.suggestions_scrollbar_rect = None;
+            self.active_chrome_mut().suggestions_scrollbar_rect = None;
         }
 
         // Plugin-supplied footer chrome row (Primitive #2 chrome
@@ -2776,10 +2780,10 @@ impl Editor {
                     .expect("active window present");
                 let buffers = &mut __win.buffers;
                 let event_logs = &mut __win.event_logs;
+                let cell_theme_map = &mut __win.chrome_layout.cell_theme_map;
                 let Some(preview_state) = __win.overlay_preview_state.as_mut() else {
                     return;
                 };
-                let cell_theme_map = &mut self.chrome_layout.cell_theme_map;
                 preview_state
                     .view_state
                     .viewport

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -12,7 +12,7 @@ impl Editor {
         // from the runner's own cache. We can't read the live
         // `frame.buffer_mut()` — ratatui resets it before each draw —
         // so the runner keeps a post-apply clone from the last frame.
-        self.animations.capture_before_all();
+        self.active_window_mut().animations.capture_before_all();
 
         // Save frame dimensions for recompute_layout (used by macro replay)
         self.chrome_layout.last_frame_width = size.width;
@@ -34,14 +34,15 @@ impl Editor {
             .active_split();
         {
             let _span = tracing::info_span!("pre_sync_ensure_visible").entered();
-            self.pre_sync_ensure_visible(active_split);
+            self.active_window_mut()
+                .pre_sync_ensure_visible(active_split);
         }
 
         // Synchronize scroll sync groups (anchor-based scroll for side-by-side diffs)
         // This sets viewport positions based on the authoritative scroll_line in each group
         {
             let _span = tracing::info_span!("sync_scroll_groups").entered();
-            self.sync_scroll_groups();
+            self.active_window_mut().sync_scroll_groups();
         }
 
         // NOTE: Viewport sync with cursor is handled by split_rendering.rs which knows the
@@ -190,7 +191,7 @@ impl Editor {
                 p.prompt_type,
                 PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
             )
-        }) && self.file_open_state.is_some();
+        }) && self.active_window_mut().file_open_state.is_some();
 
         // Build main vertical layout: [menu_bar, main_content, status_bar, search_options, prompt_line]
         // Status bar is hidden when suggestions popup is shown
@@ -198,23 +199,31 @@ impl Editor {
         let mut main_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(vec![
-                Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }), // Menu bar
-                Constraint::Min(0),                                            // Main content area
+                Constraint::Length(if self.active_window_mut().menu_bar_visible {
+                    1
+                } else {
+                    0
+                }), // Menu bar
+                Constraint::Min(0), // Main content area
                 Constraint::Length(
-                    if !self.status_bar_visible || has_suggestions || has_file_browser {
+                    if !self.active_window_mut().status_bar_visible
+                        || has_suggestions
+                        || has_file_browser
+                    {
                         0
                     } else {
                         1
                     },
                 ), // Status bar (hidden when toggled off or with popups)
-                Constraint::Length(if show_search_options { 1 } else { 0 }),   // Search options bar
+                Constraint::Length(if show_search_options { 1 } else { 0 }), // Search options bar
                 Constraint::Length(
                     // Prompt line is auto-hidden when no prompt active.
                     // Overlay prompts (Live Grep, issue #1796) host the
                     // input row inside the centred frame, so the
                     // bottom row stays available for editor content
                     // rather than being reserved as dead space.
-                    if (self.prompt_line_visible || self.active_window().prompt.is_some())
+                    if (self.active_window_mut().prompt_line_visible
+                        || self.active_window().prompt.is_some())
                         && !prompt_is_overlay
                     {
                         1
@@ -279,6 +288,14 @@ impl Editor {
             // can keep reading other Editor fields (buffers, theme, keybindings, …) — Rust
             // splits the borrow on `self.windows` from the borrows on those other fields.
             let active_id = self.active_window;
+            // Read window-state inputs before taking the &mut borrow on the
+            // window for the explorer/buffer access below.
+            let is_focused = self.active_window().key_context == KeyContext::FileExplorer;
+            let key_context_clone = self.active_window().key_context.clone();
+            let close_button_hovered = matches!(
+                &self.active_window().mouse_state.hover_target,
+                Some(HoverTarget::FileExplorerCloseButton)
+            );
             // Take one &mut on the active window; the explorer + buffers
             // come from disjoint sub-fields so they can coexist.
             let __win = self
@@ -287,8 +304,6 @@ impl Editor {
                 .expect("active window must exist");
             let __buffers_ref: &HashMap<BufferId, EditorState> = &__win.buffers;
             if let Some(explorer) = __win.file_explorer.as_mut() {
-                let is_focused = self.key_context == KeyContext::FileExplorer;
-
                 // Build set of files with unsaved changes
                 let mut files_with_unsaved_changes = std::collections::HashSet::new();
                 for (buffer_id, state) in __buffers_ref {
@@ -301,10 +316,6 @@ impl Editor {
                     }
                 }
 
-                let close_button_hovered = matches!(
-                    &self.mouse_state.hover_target,
-                    Some(HoverTarget::FileExplorerCloseButton)
-                );
                 let keybindings = self.keybindings.read().unwrap();
                 let empty: Vec<std::path::PathBuf> = Vec::new();
                 let cut_paths = self
@@ -321,7 +332,7 @@ impl Editor {
                     &files_with_unsaved_changes,
                     &__win.file_explorer_decoration_cache,
                     &keybindings,
-                    self.key_context.clone(),
+                    key_context_clone,
                     &self.theme,
                     close_button_hovered,
                     remote_connection.as_deref(),
@@ -565,14 +576,21 @@ impl Editor {
                         p.prompt_type,
                         PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
                     )
-                }) && self.file_open_state.is_some();
+                }) && self.active_window_mut().file_open_state.is_some();
                 main_chunks = Layout::default()
                     .direction(Direction::Vertical)
                     .constraints(vec![
-                        Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }),
+                        Constraint::Length(if self.active_window_mut().menu_bar_visible {
+                            1
+                        } else {
+                            0
+                        }),
                         Constraint::Min(0),
                         Constraint::Length(
-                            if !self.status_bar_visible || has_suggestions || has_file_browser {
+                            if !self.active_window_mut().status_bar_visible
+                                || has_suggestions
+                                || has_file_browser
+                            {
                                 0
                             } else {
                                 1
@@ -580,7 +598,8 @@ impl Editor {
                         ),
                         Constraint::Length(if show_search_options { 1 } else { 0 }),
                         Constraint::Length(
-                            if (self.prompt_line_visible || self.active_window().prompt.is_some())
+                            if (self.active_window_mut().prompt_line_visible
+                                || self.active_window().prompt.is_some())
                                 && !prompt_is_overlay
                             {
                                 1
@@ -608,26 +627,26 @@ impl Editor {
         // This also causes visual cursor indicators in the editor to be dimmed
         let settings_visible = self.settings_state.as_ref().is_some_and(|s| s.visible);
         let hide_cursor = self.menu_state.active_menu.is_some()
-            || self.key_context == KeyContext::FileExplorer
+            || self.active_window_mut().key_context == KeyContext::FileExplorer
             || self.active_window().terminal_mode
             || settings_visible
             || self.keybinding_editor.is_some();
 
         // Convert HoverTarget to tab hover info for rendering
-        let hovered_tab = match &self.mouse_state.hover_target {
+        let hovered_tab = match &self.active_window_mut().mouse_state.hover_target {
             Some(HoverTarget::TabName(target, split_id)) => Some((*target, *split_id, false)),
             Some(HoverTarget::TabCloseButton(target, split_id)) => Some((*target, *split_id, true)),
             _ => None,
         };
 
         // Get hovered close split button
-        let hovered_close_split = match &self.mouse_state.hover_target {
+        let hovered_close_split = match &self.active_window_mut().mouse_state.hover_target {
             Some(HoverTarget::CloseSplitButton(split_id)) => Some(*split_id),
             _ => None,
         };
 
         // Get hovered maximize split button
-        let hovered_maximize_split = match &self.mouse_state.hover_target {
+        let hovered_maximize_split = match &self.active_window_mut().mouse_state.hover_target {
             Some(HoverTarget::MaximizeSplitButton(split_id)) => Some(*split_id),
             _ => None,
         };
@@ -711,7 +730,7 @@ impl Editor {
             hovered_maximize_split,
             is_maximized,
             self.config.editor.relative_line_numbers,
-            self.tab_bar_visible,
+            __win.tab_bar_visible,
             self.config.editor.use_terminal_bg,
             self.session_mode || !self.software_cursor_only,
             self.software_cursor_only,
@@ -874,7 +893,7 @@ impl Editor {
         // Initialize popup/suggestion layout state (rendered after status bar below)
         self.chrome_layout.suggestions_area = None;
         self.chrome_layout.suggestions_outer_area = None;
-        self.file_browser_layout = None;
+        self.active_window_mut().file_browser_layout = None;
 
         // Clone all immutable values before the mutable borrow
         let display_name = self
@@ -928,20 +947,20 @@ impl Editor {
         let (lsp_status, lsp_indicator_state) = compose_lsp_status(
             &current_language,
             buffer_lsp_disabled_reason,
-            &self.lsp_progress,
-            &self.lsp_server_statuses,
+            &self.active_window().lsp_progress,
+            &self.active_window().lsp_server_statuses,
             &self.config.lsp,
             &self.active_window().user_dismissed_lsp_languages,
         );
         let theme = self.theme.clone();
         let keybindings_cloned = self.keybindings.read().unwrap().clone(); // Clone the keybindings
-        let chord_state_cloned = self.chord_state.clone(); // Clone the chord state
+        let chord_state_cloned = self.active_window_mut().chord_state.clone(); // Clone the chord state
 
         // Get update availability info
         let update_available = self.latest_version().map(|v| v.to_string());
 
         // Render status bar (hidden when toggled off, or when suggestions/file browser popup is shown)
-        if self.status_bar_visible && !has_suggestions && !has_file_browser {
+        if self.active_window_mut().status_bar_visible && !has_suggestions && !has_file_browser {
             // Get warning level for colored indicator (respects config setting)
             // LSP warning level is scoped to the current buffer's language
             let (warning_level, general_warning_count) =
@@ -949,7 +968,7 @@ impl Editor {
                     let lsp_level = {
                         use crate::services::async_bridge::LspServerStatus;
                         let mut level = WarningLevel::None;
-                        for ((lang, _), status) in &self.lsp_server_statuses {
+                        for ((lang, _), status) in &self.active_window().lsp_server_statuses {
                             if lang == &current_language {
                                 match status {
                                     LspServerStatus::Error => {
@@ -974,7 +993,7 @@ impl Editor {
 
             // Compute status bar hover state for styling
             use crate::view::ui::status_bar::StatusBarHover;
-            let status_bar_hover = match &self.mouse_state.hover_target {
+            let status_bar_hover = match &self.active_window_mut().mouse_state.hover_target {
                 Some(HoverTarget::StatusBarLspIndicator) => StatusBarHover::LspIndicator,
                 Some(HoverTarget::StatusBarWarningBadge) => StatusBarHover::WarningBadge,
                 Some(HoverTarget::StatusBarLineEndingIndicator) => {
@@ -1087,7 +1106,7 @@ impl Editor {
 
             // Determine hover state for search options
             use crate::view::ui::status_bar::SearchOptionsHover;
-            let search_options_hover = match &self.mouse_state.hover_target {
+            let search_options_hover = match &self.active_window_mut().mouse_state.hover_target {
                 Some(HoverTarget::SearchOptionCaseSensitive) => SearchOptionsHover::CaseSensitive,
                 Some(HoverTarget::SearchOptionWholeWord) => SearchOptionsHover::WholeWord,
                 Some(HoverTarget::SearchOptionRegex) => SearchOptionsHover::Regex,
@@ -1123,7 +1142,7 @@ impl Editor {
                     crate::view::prompt::PromptType::OpenFile
                         | crate::view::prompt::PromptType::SwitchProject
                 ) {
-                    if let Some(file_open_state) = &self.file_open_state {
+                    if let Some(file_open_state) = &self.active_window_mut().file_open_state {
                         StatusBarRenderer::render_file_open_prompt(
                             frame,
                             main_chunks[prompt_line_idx],
@@ -1170,7 +1189,7 @@ impl Editor {
         // Render popups from the active buffer state
         // Clone theme to avoid borrow checker issues with active_state_mut()
         let theme_clone = self.theme.clone();
-        let hover_target = self.mouse_state.hover_target.clone();
+        let hover_target = self.active_window_mut().mouse_state.hover_target.clone();
 
         // Clear popup areas and recalculate
         self.chrome_layout.popup_areas.clear();
@@ -1449,7 +1468,7 @@ impl Editor {
             crate::view::event_debug::render_event_debug(frame, size, debug, &self.theme);
         }
 
-        if self.menu_bar_visible {
+        if self.active_window_mut().menu_bar_visible {
             // Pre-expand DynamicSubmenu items once per registry; without this
             // MenuRenderer::render rescans + reparses every theme JSON file
             // on every frame.
@@ -1458,6 +1477,8 @@ impl Editor {
                 &self.menus,
                 &self.menu_state.themes_dir,
             );
+            let hover_target = self.active_window().mouse_state.hover_target.clone();
+            let menu_bar_mnemonics = self.config.editor.menu_bar_mnemonics;
             let expanded = self.expanded_menus_cache.get().expect("just updated");
             let keybindings = self.keybindings.read().unwrap();
             self.chrome_layout.menu_layout = Some(crate::view::ui::MenuRenderer::render(
@@ -1467,20 +1488,22 @@ impl Editor {
                 &self.menu_state,
                 &keybindings,
                 &self.theme,
-                self.mouse_state.hover_target.as_ref(),
-                self.config.editor.menu_bar_mnemonics,
+                hover_target.as_ref(),
+                menu_bar_mnemonics,
             ));
         } else {
             self.chrome_layout.menu_layout = None;
         }
 
         // Render tab context menu if open
-        if let Some(ref menu) = self.tab_context_menu {
-            self.render_tab_context_menu(frame, menu);
+        let tab_ctx_menu = self.active_window().tab_context_menu.clone();
+        if let Some(menu) = tab_ctx_menu {
+            self.render_tab_context_menu(frame, &menu);
         }
 
-        if let Some(ref menu) = self.file_explorer_context_menu {
-            self.render_file_explorer_context_menu(frame, menu);
+        let fe_ctx_menu = self.active_window().file_explorer_context_menu.clone();
+        if let Some(menu) = fe_ctx_menu {
+            self.render_file_explorer_context_menu(frame, &menu);
         }
 
         // Record non-editor region theme keys for the theme inspector
@@ -1490,7 +1513,8 @@ impl Editor {
         self.render_theme_info_popup(frame);
 
         // Render tab drag drop zone overlay if dragging a tab
-        if let Some(ref drag_state) = self.mouse_state.dragging_tab {
+        let drag_state_clone = self.active_window().mouse_state.dragging_tab.clone();
+        if let Some(ref drag_state) = drag_state_clone {
             if drag_state.is_dragging() {
                 self.render_tab_drop_zone(frame, drag_state);
             }
@@ -1501,8 +1525,8 @@ impl Editor {
         // so we draw our own cursor at the tracked mouse position.
         // This must happen LAST in the render flow so we can read the already-rendered
         // cell content and invert it.
-        if self.gpm_active {
-            if let Some((col, row)) = self.mouse_cursor_position {
+        if self.active_window_mut().gpm_active {
+            if let Some((col, row)) = self.active_window_mut().mouse_cursor_position {
                 use ratatui::style::Modifier;
 
                 // Only render if within screen bounds
@@ -1518,7 +1542,7 @@ impl Editor {
 
         // When keyboard capture mode is active, dim all UI elements outside the terminal
         // to visually indicate that focus is exclusively on the terminal
-        if self.keyboard_capture && self.active_window().terminal_mode {
+        if self.active_window_mut().keyboard_capture && self.active_window().terminal_mode {
             // Find the active split's content area
             let active_split = self
                 .windows
@@ -1562,7 +1586,9 @@ impl Editor {
         );
 
         // Frame-buffer animations run last so they mutate the final paint.
-        self.animations.apply_all(frame.buffer_mut());
+        self.active_window_mut()
+            .animations
+            .apply_all(frame.buffer_mut());
     }
 
     /// Compare the hardware cursor's screen position to the previous frame's
@@ -1633,10 +1659,12 @@ impl Editor {
 
         // Cancel any prior cursor-jump animation so trails don't stack.
         if let Some(prev_anim) = self.cursor_jump_animation.take() {
-            self.animations.cancel(prev_anim);
+            self.active_window_mut().animations.cancel(prev_anim);
         }
 
-        let id = self.animations.start(
+        let cursor_color = self.theme.cursor;
+        let bg_color = self.theme.editor_bg;
+        let id = self.active_window_mut().animations.start(
             // The bounding box is for runner bookkeeping only — CursorJump
             // paints at absolute screen coords and ignores `area`.
             ratatui::layout::Rect {
@@ -1649,8 +1677,8 @@ impl Editor {
                 from: prev,
                 to: current,
                 duration: std::time::Duration::from_millis(140),
-                cursor_color: self.theme.cursor,
-                bg_color: self.theme.editor_bg,
+                cursor_color,
+                bg_color,
             },
         );
         self.cursor_jump_animation = Some(id);
@@ -1688,7 +1716,7 @@ impl Editor {
                 return true;
             }
         }
-        if let Some(ref fb) = self.file_browser_layout {
+        if let Some(ref fb) = self.active_window().file_browser_layout {
             if inside(fb.popup_area) {
                 return true;
             }
@@ -1760,9 +1788,11 @@ impl Editor {
             prompt.prompt_type,
             PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
         ) {
-            let Some(file_open_state) = &mut self.file_open_state else {
-                return;
-            };
+            let hover_target = self.active_window().mouse_state.hover_target.clone();
+            let theme = self.theme.clone();
+            let keybindings = self.keybindings.read().unwrap();
+            let kb_clone = keybindings.clone();
+            drop(keybindings);
             let max_height = prompt_area.y.saturating_sub(1).min(20);
             let popup_area = ratatui::layout::Rect {
                 x: 0,
@@ -1770,14 +1800,17 @@ impl Editor {
                 width,
                 height: max_height,
             };
-            let keybindings = self.keybindings.read().unwrap();
-            self.file_browser_layout = crate::view::ui::FileBrowserRenderer::render(
+            let __win = self.active_window_mut();
+            let Some(file_open_state) = &mut __win.file_open_state else {
+                return;
+            };
+            __win.file_browser_layout = crate::view::ui::FileBrowserRenderer::render(
                 frame,
                 popup_area,
                 file_open_state,
-                &self.theme,
-                &self.mouse_state.hover_target,
-                Some(&*keybindings),
+                &theme,
+                &hover_target,
+                Some(&kb_clone),
             );
             return;
         }
@@ -1814,7 +1847,7 @@ impl Editor {
             suggestions_area,
             prompt,
             &self.theme,
-            self.mouse_state.hover_target.as_ref(),
+            self.active_window().mouse_state.hover_target.as_ref(),
             true,
         );
         if self.chrome_layout.suggestions_area.is_some() {
@@ -1996,7 +2029,7 @@ impl Editor {
             None,
             false, // not maximized
             self.config.editor.relative_line_numbers,
-            self.tab_bar_visible,
+            __win_for_preview.tab_bar_visible,
             self.config.editor.use_terminal_bg,
             self.session_mode || !self.software_cursor_only,
             self.software_cursor_only,
@@ -2606,7 +2639,7 @@ impl Editor {
                 list_area,
                 &prompt,
                 &theme,
-                self.mouse_state.hover_target.as_ref(),
+                self.active_window_mut().mouse_state.hover_target.as_ref(),
                 false,
             );
             if self.chrome_layout.suggestions_area.is_some() {
@@ -2807,7 +2840,7 @@ impl Editor {
         use ratatui::text::Span;
         use ratatui::widgets::Paragraph;
 
-        match &self.mouse_state.hover_target {
+        match &self.active_window().mouse_state.hover_target {
             Some(HoverTarget::SplitSeparator(split_id, direction)) => {
                 // Highlight the separator with hover color
                 for (sid, dir, x, y, length) in &self.active_layout().separator_areas {
@@ -3169,17 +3202,30 @@ impl Editor {
             .map(|(mgr, _)| mgr)
             .expect("active window must have a populated split layout")
             .active_split();
-        self.pre_sync_ensure_visible(active_split);
-        self.sync_scroll_groups();
+        self.active_window_mut()
+            .pre_sync_ensure_visible(active_split);
+        self.active_window_mut().sync_scroll_groups();
 
         // Replicate the layout computation that produces editor_content_area.
         // Same constraints as render(): [menu_bar, main_content, status_bar, search_options, prompt_line]
         let constraints = vec![
-            Constraint::Length(if self.menu_bar_visible { 1 } else { 0 }),
+            Constraint::Length(if self.active_window_mut().menu_bar_visible {
+                1
+            } else {
+                0
+            }),
             Constraint::Min(0),
-            Constraint::Length(if self.status_bar_visible { 1 } else { 0 }), // status bar
+            Constraint::Length(if self.active_window_mut().status_bar_visible {
+                1
+            } else {
+                0
+            }), // status bar
             Constraint::Length(0), // search options (doesn't matter for layout)
-            Constraint::Length(if self.prompt_line_visible { 1 } else { 0 }), // prompt line
+            Constraint::Length(if self.active_window_mut().prompt_line_visible {
+                1
+            } else {
+                0
+            }), // prompt line
         ];
         let main_chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -3235,7 +3281,7 @@ impl Editor {
             self.config.editor.use_terminal_bg,
             self.session_mode || !self.software_cursor_only,
             self.software_cursor_only,
-            self.tab_bar_visible,
+            __win_l.tab_bar_visible,
             self.config.editor.show_vertical_scrollbar,
             self.config.editor.show_horizontal_scrollbar,
             self.config.editor.diagnostics_inline_text,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -333,7 +333,7 @@ impl Editor {
                     &__win.file_explorer_decoration_cache,
                     &keybindings,
                     key_context_clone,
-                    &self.theme,
+                    &*self.theme.read().unwrap(),
                     close_button_hovered,
                     remote_connection.as_deref(),
                     cut_paths,
@@ -714,7 +714,7 @@ impl Editor {
             __event_logs_mut,
             __composite_buffers_mut,
             __composite_view_states_mut,
-            &self.theme,
+            &*self.theme.read().unwrap(),
             self.ansi_background.as_ref(),
             self.background_fade,
             lsp_waiting,
@@ -952,7 +952,7 @@ impl Editor {
             &self.config.lsp,
             &self.active_window().user_dismissed_lsp_languages,
         );
-        let theme = self.theme.clone();
+        let theme = self.theme.read().unwrap().clone();
         let keybindings_cloned = self.keybindings.read().unwrap().clone(); // Clone the keybindings
         let chord_state_cloned = self.active_window_mut().chord_state.clone(); // Clone the chord state
 
@@ -1188,7 +1188,7 @@ impl Editor {
 
         // Render popups from the active buffer state
         // Clone theme to avoid borrow checker issues with active_state_mut()
-        let theme_clone = self.theme.clone();
+        let theme_clone = self.theme.read().unwrap().clone();
         let hover_target = self.active_window_mut().mouse_state.hover_target.clone();
 
         // Clear popup areas and recalculate
@@ -1432,7 +1432,7 @@ impl Editor {
                     frame,
                     size,
                     settings_state,
-                    &self.theme,
+                    &*self.theme.read().unwrap(),
                 );
                 self.chrome_layout.settings_layout = Some(settings_layout);
             }
@@ -1446,7 +1446,7 @@ impl Editor {
                 frame,
                 size,
                 wizard,
-                &self.theme,
+                &*self.theme.read().unwrap(),
             );
         }
 
@@ -1457,7 +1457,7 @@ impl Editor {
                 frame,
                 size,
                 kb_editor,
-                &self.theme,
+                &*self.theme.read().unwrap(),
             );
         }
 
@@ -1465,7 +1465,12 @@ impl Editor {
         if let Some(ref debug) = self.event_debug {
             // Dim the editor content behind the dialog modal
             crate::view::dimming::apply_dimming(frame, size);
-            crate::view::event_debug::render_event_debug(frame, size, debug, &self.theme);
+            crate::view::event_debug::render_event_debug(
+                frame,
+                size,
+                debug,
+                &*self.theme.read().unwrap(),
+            );
         }
 
         if self.active_window_mut().menu_bar_visible {
@@ -1487,7 +1492,7 @@ impl Editor {
                 expanded,
                 &self.menu_state,
                 &keybindings,
-                &self.theme,
+                &*self.theme.read().unwrap(),
                 hover_target.as_ref(),
                 menu_bar_mnemonics,
             ));
@@ -1662,8 +1667,8 @@ impl Editor {
             self.active_window_mut().animations.cancel(prev_anim);
         }
 
-        let cursor_color = self.theme.cursor;
-        let bg_color = self.theme.editor_bg;
+        let cursor_color = self.theme.read().unwrap().cursor;
+        let bg_color = self.theme.read().unwrap().editor_bg;
         let id = self.active_window_mut().animations.start(
             // The bounding box is for runner bookkeeping only — CursorJump
             // paints at absolute screen coords and ignores `area`.
@@ -1789,7 +1794,7 @@ impl Editor {
             PromptType::OpenFile | PromptType::SwitchProject | PromptType::SaveFileAs
         ) {
             let hover_target = self.active_window().mouse_state.hover_target.clone();
-            let theme = self.theme.clone();
+            let theme = self.theme.read().unwrap().clone();
             let keybindings = self.keybindings.read().unwrap();
             let kb_clone = keybindings.clone();
             drop(keybindings);
@@ -1846,7 +1851,7 @@ impl Editor {
             frame,
             suggestions_area,
             prompt,
-            &self.theme,
+            &*self.theme.read().unwrap(),
             self.active_window().mouse_state.hover_target.as_ref(),
             true,
         );
@@ -1862,7 +1867,7 @@ impl Editor {
                 height: hints_height,
             };
             frame.render_widget(ratatui::widgets::Clear, hints_area);
-            Self::render_quick_open_hints(frame, hints_area, &self.theme);
+            Self::render_quick_open_hints(frame, hints_area, &*self.theme.read().unwrap());
         }
     }
 
@@ -2360,7 +2365,7 @@ impl Editor {
         };
 
         // Snapshot view-relevant state before any mutable borrows.
-        let theme = self.theme.clone();
+        let theme = self.theme.read().unwrap().clone();
         // The suggestion list inside the overlay can be ~30 rows
         // tall on a typical terminal. Pass the *actual* visible
         // count to `ensure_selected_visible_within` so the scroll
@@ -2845,7 +2850,11 @@ impl Editor {
                 // Highlight the separator with hover color
                 for (sid, dir, x, y, length) in &self.active_layout().separator_areas {
                     if sid == split_id && dir == direction {
-                        let hover_style = Style::default().fg(self.theme.split_separator_hover_fg);
+                        let hover_style = Style::default().fg(self
+                            .theme
+                            .read()
+                            .unwrap()
+                            .split_separator_hover_fg);
                         match dir {
                             SplitDirection::Horizontal => {
                                 let line_text = "─".repeat(*length as usize);
@@ -2875,7 +2884,11 @@ impl Editor {
                     &self.active_layout().split_areas
                 {
                     if sid == split_id {
-                        let hover_style = Style::default().bg(self.theme.scrollbar_thumb_hover_fg);
+                        let hover_style = Style::default().bg(self
+                            .theme
+                            .read()
+                            .unwrap()
+                            .scrollbar_thumb_hover_fg);
                         for row_offset in *thumb_start..*thumb_end {
                             let paragraph = Paragraph::new(Span::styled(" ", hover_style));
                             frame.render_widget(
@@ -2897,8 +2910,11 @@ impl Editor {
                     &self.active_layout().split_areas
                 {
                     if sid == split_id {
-                        let track_hover_style =
-                            Style::default().bg(self.theme.scrollbar_track_hover_fg);
+                        let track_hover_style = Style::default().bg(self
+                            .theme
+                            .read()
+                            .unwrap()
+                            .scrollbar_track_hover_fg);
                         let paragraph = Paragraph::new(Span::styled(" ", track_hover_style));
                         frame.render_widget(
                             paragraph,
@@ -2915,7 +2931,8 @@ impl Editor {
             Some(HoverTarget::FileExplorerBorder) => {
                 // Highlight the file explorer border for resize
                 if let Some(explorer_area) = self.active_layout().file_explorer_area {
-                    let hover_style = Style::default().fg(self.theme.split_separator_hover_fg);
+                    let hover_style =
+                        Style::default().fg(self.theme.read().unwrap().split_separator_hover_fg);
                     let border_x = explorer_area.x + explorer_area.width.saturating_sub(1);
                     for row_offset in 0..explorer_area.height {
                         let paragraph = Paragraph::new(Span::styled("│", hover_style));
@@ -2974,12 +2991,12 @@ impl Editor {
 
             let style = if is_highlighted {
                 Style::default()
-                    .fg(self.theme.menu_highlight_fg)
-                    .bg(self.theme.menu_highlight_bg)
+                    .fg(self.theme.read().unwrap().menu_highlight_fg)
+                    .bg(self.theme.read().unwrap().menu_highlight_bg)
             } else {
                 Style::default()
-                    .fg(self.theme.menu_dropdown_fg)
-                    .bg(self.theme.menu_dropdown_bg)
+                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
+                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
             };
 
             // Pad the label to fill the menu width
@@ -2992,8 +3009,8 @@ impl Editor {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.theme.menu_border_fg))
-            .style(Style::default().bg(self.theme.menu_dropdown_bg));
+            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
+            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
 
         let paragraph = Paragraph::new(lines).block(block);
         frame.render_widget(paragraph, area);
@@ -3024,12 +3041,12 @@ impl Editor {
 
             let style = if is_highlighted {
                 Style::default()
-                    .fg(self.theme.menu_highlight_fg)
-                    .bg(self.theme.menu_highlight_bg)
+                    .fg(self.theme.read().unwrap().menu_highlight_fg)
+                    .bg(self.theme.read().unwrap().menu_highlight_bg)
             } else {
                 Style::default()
-                    .fg(self.theme.menu_dropdown_fg)
-                    .bg(self.theme.menu_dropdown_bg)
+                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
+                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
             };
 
             let label = item.label();
@@ -3041,8 +3058,8 @@ impl Editor {
 
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(self.theme.menu_border_fg))
-            .style(Style::default().bg(self.theme.menu_dropdown_bg));
+            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
+            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
 
         let paragraph = Paragraph::new(lines).block(block);
         frame.render_widget(paragraph, area);
@@ -3116,8 +3133,8 @@ impl Editor {
         // Draw the overlay with the drop zone color
         // We apply a semi-transparent effect by modifying existing cells
         let buf = frame.buffer_mut();
-        let drop_zone_bg = self.theme.tab_drop_zone_bg;
-        let drop_zone_border = self.theme.tab_drop_zone_border;
+        let drop_zone_bg = self.theme.read().unwrap().tab_drop_zone_bg;
+        let drop_zone_border = self.theme.read().unwrap().tab_drop_zone_border;
 
         // Fill the highlight area with a semi-transparent overlay
         for y in highlight_area.y..highlight_area.y + highlight_area.height {
@@ -3273,7 +3290,7 @@ impl Editor {
             split_mgr_l,
             __buffers_l,
             split_view_states_l,
-            &self.theme,
+            &*self.theme.read().unwrap(),
             false, // lsp_waiting — not relevant for layout
             self.config.editor.estimated_line_length,
             self.config.editor.highlight_context_bytes,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -243,7 +243,7 @@ impl Editor {
         // Split main content area based on file explorer visibility
         // Also keep the layout split if a sync is in progress (to avoid flicker)
         let editor_content_area;
-        let file_explorer_should_show = self.active_window().file_explorer_visible
+        let file_explorer_should_show = self.file_explorer_visible()
             && (self.file_explorer().is_some()
                 || self.active_window().file_explorer_sync_in_progress);
 
@@ -3234,7 +3234,7 @@ impl Editor {
         let main_content_area = main_chunks[1];
 
         // Compute editor_content_area (with file explorer split if visible)
-        let file_explorer_should_show = self.active_window().file_explorer_visible
+        let file_explorer_should_show = self.file_explorer_visible()
             && (self.file_explorer().is_some()
                 || self.active_window().file_explorer_sync_in_progress);
         let editor_content_area = if file_explorer_should_show {

--- a/crates/fresh-editor/src/app/scan_orchestrators.rs
+++ b/crates/fresh-editor/src/app/scan_orchestrators.rs
@@ -33,8 +33,13 @@ impl Editor {
         {
             let (chunks, total_bytes) = state.buffer.prepare_line_scan();
             let leaves = state.buffer.piece_tree_leaves();
-            self.line_scan
-                .start(buffer_id, leaves, chunks, total_bytes, open_goto_line);
+            self.active_window_mut().line_scan.start(
+                buffer_id,
+                leaves,
+                chunks,
+                total_bytes,
+                open_goto_line,
+            );
             self.set_status_message(t!("goto.scanning_progress", percent = 0).to_string());
         }
     }
@@ -44,7 +49,7 @@ impl Editor {
     pub fn process_line_scan(&mut self) -> bool {
         let _span = tracing::info_span!("process_line_scan").entered();
 
-        let Some(buffer_id) = self.line_scan.buffer_id() else {
+        let Some(buffer_id) = self.active_window_mut().line_scan.buffer_id() else {
             return false;
         };
 
@@ -54,10 +59,10 @@ impl Editor {
             return true;
         }
 
-        if self.line_scan.is_done() {
+        if self.active_window_mut().line_scan.is_done() {
             self.finish_line_scan_ok();
         } else {
-            let pct = self.line_scan.progress_percent();
+            let pct = self.active_window_mut().line_scan.progress_percent();
             self.set_status_message(t!("goto.scanning_progress", percent = pct).to_string());
         }
         true
@@ -74,21 +79,27 @@ impl Editor {
         let _span = tracing::info_span!("process_line_scan_batch").entered();
         let concurrency = self.config.editor.read_concurrency.max(1);
 
-        let state = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
-            .get(&buffer_id);
-
         let mut results: Vec<(usize, usize)> = Vec::new();
         let mut io_work: Vec<(usize, std::path::PathBuf, u64, usize)> = Vec::new();
+        let active_id = self.active_window;
+        let has_state = self
+            .windows
+            .get(&active_id)
+            .expect("active window present")
+            .buffers
+            .contains_key(&buffer_id);
+        if !has_state {
+            return Ok(());
+        }
 
         // Pull chunks up to the concurrency budget, skipping already-known
         // leaves. The budget is in terms of actual work items, so we keep
         // asking for more chunks until we fill it or run out.
         'outer: while results.len() + io_work.len() < concurrency {
             let batch = self
+                .windows
+                .get_mut(&active_id)
+                .expect("active window present")
                 .line_scan
                 .take_next_chunks(concurrency - (results.len() + io_work.len()));
             if batch.is_empty() {
@@ -100,12 +111,19 @@ impl Editor {
                     continue;
                 }
 
-                let Some(state) = state else {
+                let leaf = self
+                    .windows
+                    .get(&active_id)
+                    .expect("active window present")
+                    .line_scan
+                    .leaves()[chunk.leaf_index]
+                    .clone();
+                let leaf = &leaf;
+
+                let win = self.windows.get(&active_id).expect("active window present");
+                let Some(state) = win.buffers.get(&buffer_id) else {
                     break 'outer;
                 };
-
-                let leaf = &self.line_scan.leaves()[chunk.leaf_index];
-
                 match state.buffer.leaf_io_params(leaf) {
                     None => {
                         // Loaded: count in-memory via scan_leaf
@@ -122,7 +140,13 @@ impl Editor {
 
         // Run I/O concurrently using tokio::task::spawn_blocking
         if !io_work.is_empty() {
-            let fs = match state {
+            let fs = match self
+                .windows
+                .get(&active_id)
+                .expect("active window present")
+                .buffers
+                .get(&buffer_id)
+            {
                 Some(s) => s.buffer.filesystem().clone(),
                 None => return Ok(()),
             };
@@ -155,7 +179,9 @@ impl Editor {
         }
 
         for (leaf_idx, count) in results {
-            self.line_scan.append_update(leaf_idx, count);
+            self.active_window_mut()
+                .line_scan
+                .append_update(leaf_idx, count);
         }
 
         Ok(())
@@ -163,7 +189,7 @@ impl Editor {
 
     fn finish_line_scan_ok(&mut self) {
         let _span = tracing::info_span!("finish_line_scan_ok").entered();
-        let Some(finished) = self.line_scan.take_finished() else {
+        let Some(finished) = self.active_window_mut().line_scan.take_finished() else {
             return;
         };
         if let Some(state) = self
@@ -189,7 +215,7 @@ impl Editor {
     }
 
     fn finish_line_scan_with_error(&mut self, e: std::io::Error) {
-        let Some(finished) = self.line_scan.take_finished() else {
+        let Some(finished) = self.active_window_mut().line_scan.take_finished() else {
             return;
         };
         self.set_status_message(t!("goto.scan_failed", error = e.to_string()).to_string());
@@ -212,22 +238,22 @@ impl Editor {
     /// Process chunks for the incremental search scan.
     /// Returns `true` if the UI should re-render (progress updated or scan finished).
     pub fn process_search_scan(&mut self) -> bool {
-        let Some(buffer_id) = self.search_scan.buffer_id() else {
+        let Some(buffer_id) = self.active_window_mut().search_scan.buffer_id() else {
             return false;
         };
 
         if let Err(e) = self.process_search_scan_batch(buffer_id) {
             tracing::warn!("Search scan error: {e}");
-            self.search_scan.abandon();
+            self.active_window_mut().search_scan.abandon();
             self.set_status_message(format!("Search failed: {e}"));
             return true;
         }
 
-        if self.search_scan.is_done() {
+        if self.active_window_mut().search_scan.is_done() {
             self.finish_search_scan();
         } else {
-            let pct = self.search_scan.progress_percent();
-            let match_count = self.search_scan.match_count();
+            let pct = self.active_window_mut().search_scan.progress_percent();
+            let match_count = self.active_window_mut().search_scan.match_count();
             self.set_status_message(format!(
                 "Searching... {}% ({} matches so far)",
                 pct, match_count
@@ -245,7 +271,7 @@ impl Editor {
         let concurrency = self.config.editor.read_concurrency.max(1);
 
         for _ in 0..concurrency {
-            if self.search_scan.is_done() {
+            if self.active_window_mut().search_scan.is_done() {
                 break;
             }
 
@@ -253,7 +279,7 @@ impl Editor {
             // then put it back. This is the same take/restore dance the
             // previous `Option<SearchScanState>` code did, now wrapped in
             // the subsystem's API so we're not poking its internals.
-            let Some(mut chunked) = self.search_scan.take_chunked() else {
+            let Some(mut chunked) = self.active_window_mut().search_scan.take_chunked() else {
                 return Ok(());
             };
             let result = if let Some(state) = self
@@ -267,7 +293,9 @@ impl Editor {
             } else {
                 Ok(false)
             };
-            self.search_scan.restore_chunked(chunked);
+            self.active_window_mut()
+                .search_scan
+                .restore_chunked(chunked);
 
             match result {
                 Ok(false) => break, // scan complete
@@ -283,7 +311,7 @@ impl Editor {
     /// and hand them to `finalize_search()` which sets search_state, moves
     /// the cursor, and creates viewport overlays.
     fn finish_search_scan(&mut self) {
-        let Some(finished) = self.search_scan.take_finished() else {
+        let Some(finished) = self.active_window_mut().search_scan.take_finished() else {
             return;
         };
 

--- a/crates/fresh-editor/src/app/scroll_sync.rs
+++ b/crates/fresh-editor/src/app/scroll_sync.rs
@@ -104,23 +104,24 @@ impl crate::app::window::Window {
         );
         view_state.tab_scroll_offset = new_scroll_offset;
     }
-}
 
-impl Editor {
-    /// Synchronize viewports for all scroll sync groups
+    /// Synchronize viewports for all scroll-sync groups in this window.
     ///
-    /// This syncs the inactive split's viewport to match the active split's position.
-    /// By deriving from the active split's actual viewport, we capture all viewport
-    /// changes regardless of source (scroll events, cursor movements, etc.).
+    /// For each registered group containing the active split, derive the
+    /// active split's top line from its viewport and project it onto the
+    /// paired split via the group's mapping. Then, when same-buffer
+    /// scroll sync is enabled, also mirror the active split's `top_byte`
+    /// onto every other split that shows the same buffer (and isn't in
+    /// an explicit sync group). The bottom-edge case sets
+    /// `sync_scroll_to_end` so the render pass does the
+    /// soft-break-aware fix-up using view lines.
     pub(super) fn sync_scroll_groups(&mut self) {
-        let active_split = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .active_split();
-        let group_count = self.active_window().scroll_sync_manager.groups().len();
+        let (mgr, vs_map) = self
+            .splits
+            .as_ref()
+            .expect("window must have a populated split layout");
+        let active_split = mgr.active_split();
+        let group_count = self.scroll_sync_manager.groups().len();
 
         if group_count > 0 {
             tracing::debug!(
@@ -130,10 +131,7 @@ impl Editor {
             );
         }
 
-        // Collect sync info: for each group where active split participates,
-        // get the active split's current line position
         let sync_info: Vec<_> = self
-            .active_window()
             .scroll_sync_manager
             .groups()
             .iter()
@@ -153,15 +151,9 @@ impl Editor {
                     return None;
                 }
 
-                // Get active split's current viewport top_byte
-                let active_top_byte = self.windows.get(&self.active_window).and_then(|w| w.splits.as_ref()).map(|(_, vs)| vs).expect("active window must have a populated split layout")
-                    .get(&active_split)?
-                    .viewport
-                    .top_byte;
-
-                // Get active split's buffer to convert bytes → line
-                let active_buffer_id = self.windows.get(&self.active_window).and_then(|w| w.splits.as_ref()).map(|(mgr, _)| mgr).expect("active window must have a populated split layout").buffer_for_split(active_split)?;
-                let buffer_state = self.active_window().buffers.get(&active_buffer_id)?;
+                let active_top_byte = vs_map.get(&active_split)?.viewport.top_byte;
+                let active_buffer_id = mgr.buffer_for_split(active_split)?;
+                let buffer_state = self.buffers.get(&active_buffer_id)?;
                 let buffer_len = buffer_state.buffer.len();
                 let active_line = buffer_state.buffer.get_line_number(active_top_byte);
 
@@ -174,12 +166,9 @@ impl Editor {
                     active_line
                 );
 
-                // Determine the other split and compute its target line
                 let (other_split, other_line) = if group.is_left_split(active_split.into()) {
-                    // Active is left, sync right
                     (group.right_split, group.left_to_right_line(active_line))
                 } else {
-                    // Active is right, sync left
                     (group.left_split, group.right_to_left_line(active_line))
                 };
 
@@ -193,101 +182,52 @@ impl Editor {
             })
             .collect();
 
-        // Apply sync to other splits
         for (other_split, target_line) in sync_info {
             let other_leaf = LeafId(other_split);
-            if let Some(buffer_id) = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .buffer_for_split(other_leaf)
-            {
-                self.active_window_mut().scroll_split_viewport_to(
-                    buffer_id,
-                    other_leaf,
-                    target_line,
-                    false,
-                );
+            let buffer_id = self
+                .splits
+                .as_ref()
+                .expect("window must have a populated split layout")
+                .0
+                .buffer_for_split(other_leaf);
+            if let Some(buffer_id) = buffer_id {
+                self.scroll_split_viewport_to(buffer_id, other_leaf, target_line, false);
             }
         }
 
-        // Same-buffer scroll sync: when two splits show the same buffer (e.g., source
-        // vs compose mode), sync the inactive split's viewport to match the active
-        // split's scroll position.  Gated on the user-togglable scroll sync flag.
-        //
-        // We copy top_byte directly for the general case.  At the bottom edge the
-        // two splits may disagree because compose mode has soft-break virtual lines.
-        // Rather than computing the correct position here (where view lines aren't
-        // available), we set a flag and let `render_buffer_in_split` fix it up using
-        // the same view-line-based logic that `ensure_visible_in_layout` uses.
-        let active_buffer_id = if self.active_window().same_buffer_scroll_sync {
-            self.windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
+        let active_buffer_id = if self.same_buffer_scroll_sync {
+            self.splits
+                .as_ref()
+                .expect("window must have a populated split layout")
+                .0
                 .buffer_for_split(active_split)
         } else {
             None
         };
         if let Some(active_buf_id) = active_buffer_id {
-            let active_top_byte = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
-                .get(&active_split)
-                .map(|vs| vs.viewport.top_byte);
-            let active_viewport_height = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
+            let (mgr, vs_map) = self
+                .splits
+                .as_ref()
+                .expect("window must have a populated split layout");
+            let active_top_byte = vs_map.get(&active_split).map(|vs| vs.viewport.top_byte);
+            let active_viewport_height = vs_map
                 .get(&active_split)
                 .map(|vs| vs.viewport.visible_line_count())
                 .unwrap_or(0);
 
             if let Some(top_byte) = active_top_byte {
-                // Find other splits showing the same buffer (not in an explicit sync group)
-                let other_splits: Vec<_> = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.splits.as_ref())
-                    .map(|(_, vs)| vs)
-                    .expect("active window must have a populated split layout")
+                let other_splits: Vec<_> = vs_map
                     .keys()
                     .filter(|&&s| {
                         s != active_split
-                            && self
-                                .windows
-                                .get(&self.active_window)
-                                .and_then(|w| w.splits.as_ref())
-                                .map(|(mgr, _)| mgr)
-                                .expect("active window must have a populated split layout")
-                                .buffer_for_split(s)
-                                == Some(active_buf_id)
-                            && !self
-                                .active_window()
-                                .scroll_sync_manager
-                                .is_split_synced(s.into())
+                            && mgr.buffer_for_split(s) == Some(active_buf_id)
+                            && !self.scroll_sync_manager.is_split_synced(s.into())
                     })
                     .copied()
                     .collect();
 
                 if !other_splits.is_empty() {
-                    // Detect whether the active split is at the bottom of the
-                    // buffer (remaining lines fit within the viewport).
-                    let at_bottom = if let Some(state) = self
-                        .windows
-                        .get_mut(&self.active_window)
-                        .map(|w| &mut w.buffers)
-                        .expect("active window present")
-                        .get_mut(&active_buf_id)
-                    {
+                    let at_bottom = if let Some(state) = self.buffers.get_mut(&active_buf_id) {
                         let mut iter = state.buffer.line_iterator(top_byte, 80);
                         let mut lines_remaining = 0;
                         while iter.next_line().is_some() {
@@ -301,17 +241,13 @@ impl Editor {
                         false
                     };
 
+                    let (_, vs_map_mut) = self
+                        .splits
+                        .as_mut()
+                        .expect("window must have a populated split layout");
                     for other_split in other_splits {
-                        if let Some(view_state) = self
-                            .windows
-                            .get_mut(&self.active_window)
-                            .and_then(|w| w.split_view_states_mut())
-                            .expect("active window must have a populated split layout")
-                            .get_mut(&other_split)
-                        {
+                        if let Some(view_state) = vs_map_mut.get_mut(&other_split) {
                             view_state.viewport.top_byte = top_byte;
-                            // At the bottom edge, tell the render pass to
-                            // adjust using view lines (soft-break-aware).
                             view_state.viewport.sync_scroll_to_end = at_bottom;
                         }
                     }
@@ -320,30 +256,31 @@ impl Editor {
         }
     }
 
-    /// Pre-sync ensure_visible for scroll sync groups
+    /// Pre-sync ensure-visible hook for scroll-sync groups in this window.
     ///
-    /// When the active split is in a scroll sync group, we need to update its viewport
-    /// BEFORE sync_scroll_groups runs. This ensures cursor movements like 'G' (go to end)
-    /// properly sync to the other split.
-    ///
-    /// After updating the active split's viewport, we mark the OTHER splits in the group
-    /// to skip ensure_visible so the sync position isn't undone during rendering.
+    /// When the active split is in a sync group we update its viewport
+    /// here (before `sync_scroll_groups`) so commands like `G` produce
+    /// the right scroll position that gets mirrored. The other split in
+    /// the group is then marked to skip `ensure_visible` during render
+    /// so the sync isn't undone. Same-buffer sync mirrors the same
+    /// "skip" mark across the other splits showing the same buffer.
     pub(super) fn pre_sync_ensure_visible(&mut self, active_split: LeafId) {
-        // Check if active split is in any scroll sync group
         let group_info = self
-            .active_window()
             .scroll_sync_manager
             .find_group_for_split(active_split.into())
             .map(|g| (g.left_split, g.right_split));
 
         if let Some((left_split, right_split)) = group_info {
-            // Get the active split's buffer and update its viewport
-            if let Some(buffer_id) = self.split_manager().buffer_for_split(active_split) {
-                self.active_window_mut()
-                    .ensure_cursor_visible_for_split(buffer_id, active_split);
+            let buffer_id = self
+                .splits
+                .as_ref()
+                .expect("window must have a populated split layout")
+                .0
+                .buffer_for_split(active_split);
+            if let Some(buffer_id) = buffer_id {
+                self.ensure_cursor_visible_for_split(buffer_id, active_split);
             }
 
-            // Mark the OTHER split to skip ensure_visible so the sync position isn't undone
             let active_sid: SplitId = active_split.into();
             let other_split: SplitId = if active_sid == left_split {
                 right_split
@@ -351,66 +288,50 @@ impl Editor {
                 left_split
             };
 
-            if let Some(view_state) = self
-                .windows
-                .get_mut(&self.active_window)
-                .and_then(|w| w.split_view_states_mut())
-                .expect("active window must have a populated split layout")
-                .get_mut(&LeafId(other_split))
-            {
-                view_state.viewport.set_skip_ensure_visible();
-                tracing::debug!(
-                    "pre_sync_ensure_visible: marked other split {:?} to skip ensure_visible",
-                    other_split
-                );
+            if let Some((_, vs_map)) = self.splits.as_mut() {
+                if let Some(view_state) = vs_map.get_mut(&LeafId(other_split)) {
+                    view_state.viewport.set_skip_ensure_visible();
+                    tracing::debug!(
+                        "pre_sync_ensure_visible: marked other split {:?} to skip ensure_visible",
+                        other_split
+                    );
+                }
             }
         }
 
-        // Same-buffer scroll sync: also mark other splits showing the same buffer
-        // to skip ensure_visible, so our sync_scroll_groups position isn't undone.
-        if !self.active_window().same_buffer_scroll_sync {
-            // Scroll sync disabled — don't interfere with other splits.
-        } else if let Some(active_buf_id) = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
+        if !self.same_buffer_scroll_sync {
+            return;
+        }
+        let active_buf_id = match self
+            .splits
+            .as_ref()
+            .expect("window must have a populated split layout")
+            .0
             .buffer_for_split(active_split)
         {
-            let other_same_buffer_splits: Vec<_> = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.splits.as_ref())
-                .map(|(_, vs)| vs)
-                .expect("active window must have a populated split layout")
+            Some(b) => b,
+            None => return,
+        };
+
+        let other_same_buffer_splits: Vec<_> = {
+            let (mgr, vs_map) = self
+                .splits
+                .as_ref()
+                .expect("window must have a populated split layout");
+            vs_map
                 .keys()
                 .filter(|&&s| {
                     s != active_split
-                        && self
-                            .windows
-                            .get(&self.active_window)
-                            .and_then(|w| w.splits.as_ref())
-                            .map(|(mgr, _)| mgr)
-                            .expect("active window must have a populated split layout")
-                            .buffer_for_split(s)
-                            == Some(active_buf_id)
-                        && !self
-                            .active_window()
-                            .scroll_sync_manager
-                            .is_split_synced(s.into())
+                        && mgr.buffer_for_split(s) == Some(active_buf_id)
+                        && !self.scroll_sync_manager.is_split_synced(s.into())
                 })
                 .copied()
-                .collect();
+                .collect()
+        };
 
+        if let Some((_, vs_map)) = self.splits.as_mut() {
             for other_split in other_same_buffer_splits {
-                if let Some(view_state) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_view_states_mut())
-                    .expect("active window must have a populated split layout")
-                    .get_mut(&other_split)
-                {
+                if let Some(view_state) = vs_map.get_mut(&other_split) {
                     view_state.viewport.set_skip_ensure_visible();
                 }
             }

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -22,7 +22,7 @@ impl Editor {
     ) -> AnyhowResult<()> {
         // Notify plugins of mouse scroll so they can handle it for virtual buffers
         let buffer_id = self.active_buffer();
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "mouse_scroll",
             fresh_core::hooks::HookArgs::MouseScroll {
                 buffer_id,

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -194,7 +194,7 @@ impl Editor {
         buffer_id: BufferId,
         scrollbar_rect: ratatui::layout::Rect,
     ) -> AnyhowResult<()> {
-        let drag_start_row = match self.mouse_state.drag_start_row {
+        let drag_start_row = match self.active_window_mut().mouse_state.drag_start_row {
             Some(r) => r,
             None => return Ok(()), // No drag start, shouldn't happen
         };
@@ -210,12 +210,16 @@ impl Editor {
             );
         }
 
-        let drag_start_top_byte = match self.mouse_state.drag_start_top_byte {
+        let drag_start_top_byte = match self.active_window_mut().mouse_state.drag_start_top_byte {
             Some(b) => b,
             None => return Ok(()), // No drag start, shouldn't happen
         };
 
-        let drag_start_view_line_offset = self.mouse_state.drag_start_view_line_offset.unwrap_or(0);
+        let drag_start_view_line_offset = self
+            .active_window_mut()
+            .mouse_state
+            .drag_start_view_line_offset
+            .unwrap_or(0);
 
         // Calculate the offset in rows (still used for large files)
         let row_offset = (row as i32) - (drag_start_row as i32);
@@ -628,7 +632,11 @@ impl Editor {
         buffer_id: BufferId,
         scrollbar_rect: ratatui::layout::Rect,
     ) -> AnyhowResult<()> {
-        let drag_start_scroll_row = match self.mouse_state.drag_start_composite_scroll_row {
+        let drag_start_scroll_row = match self
+            .active_window_mut()
+            .mouse_state
+            .drag_start_composite_scroll_row
+        {
             Some(r) => r,
             None => return Ok(()),
         };

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -40,16 +40,6 @@ impl Editor {
             .update_search_highlights(query, search_fg, search_bg);
     }
 
-    /// Build a compiled regex from the current search settings and query.
-    fn build_search_regex(&self, query: &str) -> Result<regex::Regex, String> {
-        super::regex_replace::build_search_regex(
-            query,
-            self.active_window().search_use_regex,
-            self.active_window().search_whole_word,
-            self.active_window().search_case_sensitive,
-        )
-    }
-
     /// Perform a search and update search state.
     ///
     /// For large files (lazy-loaded buffers), this starts an incremental
@@ -69,7 +59,8 @@ impl Editor {
     /// vertically centered on the match to provide surrounding context
     /// (issue #1251); matches already visible are not re-scrolled.
     fn move_cursor_to_match(&mut self, position: usize) {
-        self.jump_active_cursor_to(position, super::navigation::JumpOptions::navigation());
+        self.active_window_mut()
+            .jump_active_cursor_to(position, super::navigation::JumpOptions::navigation());
     }
 
     pub(super) fn perform_search(&mut self, query: &str) {
@@ -82,7 +73,7 @@ impl Editor {
         let search_range = self.active_window_mut().pending_search_range.take();
 
         // Build the regex early so we can bail on invalid patterns
-        let regex = match self.build_search_regex(query) {
+        let regex = match self.active_window().build_search_regex(query) {
             Ok(r) => r,
             Err(e) => {
                 self.active_window_mut().search_state = None;
@@ -275,7 +266,7 @@ impl Editor {
 
         // Remember the viewport we computed overlays for so we can detect
         // scrolling in check_search_overlay_refresh().
-        self.search_overlay_top_byte = Some(top_byte);
+        self.active_window_mut().search_overlay_top_byte = Some(top_byte);
 
         let state = self.active_state_mut();
 
@@ -362,7 +353,7 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .get(&active_split)
             .map(|vs| vs.viewport.top_byte);
-        if current_top != self.search_overlay_top_byte {
+        if current_top != self.active_window_mut().search_overlay_top_byte {
             self.refresh_search_overlays();
             true
         } else {
@@ -397,15 +388,18 @@ impl Editor {
                 super::SearchState::MAX_MATCHES,
                 query.len(),
             );
-            self.search_scan.start(
+            let cs = self.active_window().search_case_sensitive;
+            let ww = self.active_window().search_whole_word;
+            let ur = self.active_window().search_use_regex;
+            self.active_window_mut().search_scan.start(
                 buffer_id,
                 leaves,
                 scan,
                 query.to_string(),
                 None,
-                self.active_window().search_case_sensitive,
-                self.active_window().search_whole_word,
-                self.active_window().search_use_regex,
+                cs,
+                ww,
+                ur,
             );
             self.set_status_message(t!("goto.scanning_progress", percent = 0).to_string());
         }

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -34,8 +34,8 @@ impl Editor {
     /// Update search highlights in visible viewport only (for incremental search)
     /// This is called as the user types in the search prompt for real-time feedback
     pub(super) fn update_search_highlights(&mut self, query: &str) {
-        let search_bg = self.theme.search_match_bg;
-        let search_fg = self.theme.search_match_fg;
+        let search_bg = self.theme.read().unwrap().search_match_bg;
+        let search_fg = self.theme.read().unwrap().search_match_fg;
         self.active_window_mut()
             .update_search_highlights(query, search_fg, search_bg);
     }
@@ -184,8 +184,8 @@ impl Editor {
             self.refresh_search_overlays();
         } else {
             // Small file: overlays for ALL matches so markers auto-track edits
-            let search_bg = self.theme.search_match_bg;
-            let search_fg = self.theme.search_match_fg;
+            let search_bg = self.theme.read().unwrap().search_match_bg;
+            let search_fg = self.theme.read().unwrap().search_match_fg;
             let ns = self.active_window().search_namespace.clone();
             let state = self.active_state_mut();
             state.overlays.clear_namespace(&ns, &mut state.marker_list);
@@ -242,8 +242,8 @@ impl Editor {
     /// so it is O(log N + visible_matches) regardless of total match count.
     pub(super) fn refresh_search_overlays(&mut self) {
         let _span = tracing::info_span!("refresh_search_overlays").entered();
-        let search_bg = self.theme.search_match_bg;
-        let search_fg = self.theme.search_match_fg;
+        let search_bg = self.theme.read().unwrap().search_match_bg;
+        let search_fg = self.theme.read().unwrap().search_match_fg;
         let ns = self.active_window().search_namespace.clone();
 
         // Determine the visible byte range from the active viewport

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -698,7 +698,8 @@ impl Editor {
                 // Plugin was disabled, now enabled - load it
                 if let Some(ref path) = path {
                     tracing::info!("Loading newly enabled plugin: {}", name);
-                    if let Err(e) = self.plugin_manager.load_plugin(path) {
+                    let load_result = self.plugin_manager.read().unwrap().load_plugin(path);
+                    if let Err(e) = load_result {
                         tracing::error!("Failed to load plugin '{}': {}", name, e);
                         self.set_status_message(format!("Failed to load plugin '{}': {}", name, e));
                     }
@@ -706,7 +707,8 @@ impl Editor {
             } else {
                 // Plugin was enabled, now disabled - unload it
                 tracing::info!("Unloading disabled plugin: {}", name);
-                if let Err(e) = self.plugin_manager.unload_plugin(&name) {
+                let unload_result = self.plugin_manager.read().unwrap().unload_plugin(&name);
+                if let Err(e) = unload_result {
                     tracing::error!("Failed to unload plugin '{}': {}", name, e);
                     self.set_status_message(format!("Failed to unload plugin '{}': {}", name, e));
                 }

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -104,7 +104,7 @@ impl Editor {
         // Apply runtime changes
         if old_theme != self.config.theme {
             if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
-                self.theme = theme;
+                *self.theme.write().unwrap() = theme;
                 tracing::info!("Theme changed to '{}'", self.config.theme.0);
             } else {
                 tracing::error!("Theme '{}' not found", self.config.theme.0);

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -174,10 +174,10 @@ impl Editor {
         }
 
         // Apply bar visibility changes immediately
-        self.menu_bar_visible = self.config.editor.show_menu_bar;
-        self.tab_bar_visible = self.config.editor.show_tab_bar;
-        self.status_bar_visible = self.config.editor.show_status_bar;
-        self.prompt_line_visible = self.config.editor.show_prompt_line;
+        self.active_window_mut().menu_bar_visible = self.config.editor.show_menu_bar;
+        self.active_window_mut().tab_bar_visible = self.config.editor.show_tab_bar;
+        self.active_window_mut().status_bar_visible = self.config.editor.show_status_bar;
+        self.active_window_mut().prompt_line_visible = self.config.editor.show_prompt_line;
 
         // Propagate file-explorer settings to live runtime state (IgnorePatterns
         // and width are shadows of config, not read live on each render).
@@ -202,8 +202,8 @@ impl Editor {
                 fresh_winterm::MouseMode::AllMotion
             } else {
                 // Clear any pending hover state when disabling
-                self.mouse_state.lsp_hover_state = None;
-                self.mouse_state.lsp_hover_request_sent = false;
+                self.active_window_mut().mouse_state.lsp_hover_state = None;
+                self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
                 fresh_winterm::MouseMode::CellMotion
             };
             if let Err(e) = fresh_winterm::set_mouse_mode(mode) {

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -401,10 +401,10 @@ impl Editor {
     pub(super) fn apply_theme(&mut self, key_or_name: &str) {
         if !key_or_name.is_empty() {
             if let Some(theme) = self.theme_registry.get_cloned(key_or_name) {
-                self.theme = theme;
+                *self.theme.write().unwrap() = theme;
 
                 // Set terminal cursor color to match theme
-                self.theme.set_terminal_cursor_color();
+                self.theme.read().unwrap().set_terminal_cursor_color();
 
                 // Re-apply all overlays so colors match the new theme
                 // (diagnostic and semantic token overlays bake RGB at creation time).
@@ -433,7 +433,11 @@ impl Editor {
                 self.save_theme_to_config();
 
                 self.set_status_message(
-                    t!("view.theme_changed", theme = self.theme.name.clone()).to_string(),
+                    t!(
+                        "view.theme_changed",
+                        theme = self.theme.read().unwrap().name.clone()
+                    )
+                    .to_string(),
                 );
             } else {
                 self.set_status_message(format!("Theme '{}' not found", key_or_name));
@@ -465,7 +469,7 @@ impl Editor {
                     crate::services::lsp::diagnostics::apply_diagnostics_to_state_cached(
                         state,
                         &diagnostics,
-                        &self.theme,
+                        &*self.theme.read().unwrap(),
                     );
                 }
             }
@@ -497,7 +501,7 @@ impl Editor {
                     crate::services::lsp::semantic_tokens::apply_semantic_tokens_to_state(
                         state,
                         &tokens,
-                        &self.theme,
+                        &*self.theme.read().unwrap(),
                     );
                 }
             }
@@ -509,9 +513,9 @@ impl Editor {
     pub(super) fn preview_theme(&mut self, key_or_name: &str) {
         if !key_or_name.is_empty() {
             if let Some(theme) = self.theme_registry.get_cloned(key_or_name) {
-                if theme.name != self.theme.name {
-                    self.theme = theme;
-                    self.theme.set_terminal_cursor_color();
+                if theme.name != self.theme.read().unwrap().name {
+                    *self.theme.write().unwrap() = theme;
+                    self.theme.read().unwrap().set_terminal_cursor_color();
                     self.reapply_all_overlays();
                 }
             }

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -448,6 +448,7 @@ impl Editor {
         // --- Diagnostics ---
         crate::services::lsp::diagnostics::invalidate_cache_all();
         let entries: Vec<(String, Vec<lsp_types::Diagnostic>)> = self
+            .active_window()
             .stored_diagnostics
             .iter()
             .map(|(uri, diags)| (uri.clone(), diags.clone()))

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -330,7 +330,7 @@ impl Editor {
             let percent = (delta * 100.0) as i32;
             self.set_status_message(t!("split.size_adjusted", percent = percent).to_string());
             // Resize visible terminals to match new split dimensions
-            self.resize_visible_terminals();
+            self.active_window_mut().resize_visible_terminals();
         }
     }
 
@@ -350,7 +350,7 @@ impl Editor {
                     self.set_status_message(t!("split.restored").to_string());
                 }
                 // Resize visible terminals to match new split dimensions
-                self.resize_visible_terminals();
+                self.active_window_mut().resize_visible_terminals();
             }
             Err(e) => self.set_status_message(e),
         }

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -292,7 +292,7 @@ impl Editor {
         }
 
         // Emit buffer_activated hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
             crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -288,7 +288,7 @@ impl Editor {
             && !self.active_window().is_terminal_buffer(buffer_id)
         {
             self.active_window_mut().terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
         }
 
         // Emit buffer_activated hook for plugins
@@ -300,7 +300,7 @@ impl Editor {
         // Enter terminal mode if switching to a terminal split
         if self.active_window().is_terminal_buffer(buffer_id) {
             self.active_window_mut().terminal_mode = true;
-            self.key_context = crate::input::keybindings::KeyContext::Terminal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         }
     }
 

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -275,7 +275,7 @@ impl Editor {
         self.active_window_mut()
             .promote_preview_if_not_in_split(split_id);
         let buffer = self.active_buffer();
-        let tabs_width = self.effective_tabs_width();
+        let tabs_width = self.active_window().effective_tabs_width();
         self.active_window_mut()
             .ensure_active_tab_visible(split_id, buffer, tabs_width);
 

--- a/crates/fresh-editor/src/app/tab_drag.rs
+++ b/crates/fresh-editor/src/app/tab_drag.rs
@@ -18,7 +18,7 @@ impl Editor {
     pub(super) fn handle_tab_drag(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
         // Update current position and check if we're dragging
         let (is_dragging, source_split_id) =
-            if let Some(ref mut drag_state) = self.mouse_state.dragging_tab {
+            if let Some(ref mut drag_state) = self.active_window_mut().mouse_state.dragging_tab {
                 drag_state.current_position = (col, row);
                 (drag_state.is_dragging(), drag_state.source_split_id)
             } else {
@@ -27,7 +27,7 @@ impl Editor {
 
         // Only compute drop zone if we've moved past threshold
         if !is_dragging {
-            if let Some(ref mut drag_state) = self.mouse_state.dragging_tab {
+            if let Some(ref mut drag_state) = self.active_window_mut().mouse_state.dragging_tab {
                 drag_state.drop_zone = None;
             }
             return Ok(());
@@ -35,7 +35,7 @@ impl Editor {
 
         // Compute the drop zone based on mouse position
         let drop_zone = self.compute_tab_drop_zone(col, row, source_split_id);
-        if let Some(ref mut drag_state) = self.mouse_state.dragging_tab {
+        if let Some(ref mut drag_state) = self.active_window_mut().mouse_state.dragging_tab {
             drag_state.drop_zone = drop_zone;
         }
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -169,7 +169,7 @@ impl Editor {
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
 
         // Resize terminal to match actual split content area
-        self.resize_visible_terminals();
+        self.active_window_mut().resize_visible_terminals();
 
         // Get the terminal escape keybinding dynamically
         let exit_key = self
@@ -509,20 +509,6 @@ impl Editor {
         (cols, rows)
     }
 
-    /// Resize a terminal buffer's PTY in the active window.
-    pub fn resize_terminal(&mut self, buffer_id: BufferId, cols: u16, rows: u16) {
-        self.active_window_mut()
-            .resize_terminal(buffer_id, cols, rows);
-    }
-
-    /// Resize the active window's visible terminal PTYs to match their
-    /// current split dimensions. Thin shim over
-    /// [`Window::resize_visible_terminals`] — call this from `impl Editor`
-    /// contexts; per-window callers should use the `Window` method directly.
-    pub fn resize_visible_terminals(&mut self) {
-        self.active_window_mut().resize_visible_terminals();
-    }
-
     /// Handle terminal input when in terminal mode
     pub fn handle_terminal_key(
         &mut self,
@@ -722,7 +708,7 @@ impl Editor {
             }
 
             // Ensure terminal PTY is sized correctly for current split dimensions
-            self.resize_visible_terminals();
+            self.active_window_mut().resize_visible_terminals();
 
             self.set_status_message(t!("status.terminal_mode_enabled").to_string());
         }

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -23,6 +23,7 @@
 //!   - Resumes live terminal rendering
 //!   - Performance: O(1) ≈ 1ms
 
+use super::window::Window;
 use super::{BufferId, BufferMetadata, Editor};
 use crate::services::authority::TerminalWrapper;
 use crate::services::terminal::TerminalId;
@@ -508,64 +509,18 @@ impl Editor {
         (cols, rows)
     }
 
-    /// Resize terminal to match split dimensions
+    /// Resize a terminal buffer's PTY in the active window.
     pub fn resize_terminal(&mut self, buffer_id: BufferId, cols: u16, rows: u16) {
-        if let Some(&terminal_id) = self.active_window().terminal_buffers.get(&buffer_id) {
-            if let Some(handle) = self
-                .active_window_mut()
-                .terminal_manager
-                .get_mut(terminal_id)
-            {
-                handle.resize(cols, rows);
-            }
-        }
+        self.active_window_mut()
+            .resize_terminal(buffer_id, cols, rows);
     }
 
-    /// Resize all visible terminal PTYs to match their current split dimensions.
-    /// Call this after operations that change split layout (maximize, resize, etc.)
+    /// Resize the active window's visible terminal PTYs to match their
+    /// current split dimensions. Thin shim over
+    /// [`Window::resize_visible_terminals`] — call this from `impl Editor`
+    /// contexts; per-window callers should use the `Window` method directly.
     pub fn resize_visible_terminals(&mut self) {
-        // Get the content area excluding file explorer
-        let file_explorer_width = if self.file_explorer_visible() {
-            self.active_window()
-                .file_explorer_width
-                .to_cols(self.terminal_width)
-        } else {
-            0
-        };
-        let editor_width = self.terminal_width.saturating_sub(file_explorer_width);
-        let editor_area = ratatui::layout::Rect::new(
-            file_explorer_width,
-            1, // menu bar
-            editor_width,
-            self.terminal_height.saturating_sub(2), // menu bar + status bar
-        );
-
-        // Get visible buffers with their areas
-        let visible_buffers = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.splits.as_ref())
-            .map(|(mgr, _)| mgr)
-            .expect("active window must have a populated split layout")
-            .get_visible_buffers(editor_area);
-
-        // Resize each terminal buffer to match its split content area
-        for (_split_id, buffer_id, split_area) in visible_buffers {
-            if self
-                .active_window()
-                .terminal_buffers
-                .contains_key(&buffer_id)
-            {
-                // Calculate content dimensions (accounting for tab bar and borders)
-                // Tab bar takes 1 row, and we leave 1 for scrollbar width on right
-                let content_height = split_area.height.saturating_sub(2);
-                let content_width = split_area.width.saturating_sub(2);
-
-                if content_width > 0 && content_height > 0 {
-                    self.resize_terminal(buffer_id, content_width, content_height);
-                }
-            }
-        }
+        self.active_window_mut().resize_visible_terminals();
     }
 
     /// Handle terminal input when in terminal mode
@@ -790,6 +745,54 @@ impl Editor {
         }
 
         Some(content)
+    }
+}
+
+impl Window {
+    /// Resize a single terminal buffer's PTY (only if `buffer_id`
+    /// belongs to this window's terminal_buffers map).
+    pub fn resize_terminal(&mut self, buffer_id: BufferId, cols: u16, rows: u16) {
+        if let Some(&terminal_id) = self.terminal_buffers.get(&buffer_id) {
+            if let Some(handle) = self.terminal_manager.get_mut(terminal_id) {
+                handle.resize(cols, rows);
+            }
+        }
+    }
+
+    /// Resize all this window's visible terminal PTYs to match their
+    /// current split dimensions. Reads the window's cached
+    /// `terminal_width` / `terminal_height` for the screen size.
+    pub fn resize_visible_terminals(&mut self) {
+        // Get the content area excluding file explorer
+        let file_explorer_width = if self.file_explorer_visible {
+            self.file_explorer_width.to_cols(self.terminal_width)
+        } else {
+            0
+        };
+        let editor_width = self.terminal_width.saturating_sub(file_explorer_width);
+        let editor_area = ratatui::layout::Rect::new(
+            file_explorer_width,
+            1, // menu bar
+            editor_width,
+            self.terminal_height.saturating_sub(2), // menu bar + status bar
+        );
+
+        let Some((mgr, _)) = self.splits.as_ref() else {
+            return;
+        };
+        let visible_buffers = mgr.get_visible_buffers(editor_area);
+
+        for (_split_id, buffer_id, split_area) in visible_buffers {
+            if self.terminal_buffers.contains_key(&buffer_id) {
+                // Tab bar takes 1 row, scrollbar takes 1 column on the right.
+                let content_height = split_area.height.saturating_sub(2);
+                let content_width = split_area.width.saturating_sub(2);
+
+                if content_width > 0 && content_height > 0 {
+                    self.resize_terminal(buffer_id, content_width, content_height);
+                }
+            }
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Mode Switching Methods
 //!
-//! - [`Editor::sync_terminal_to_buffer`]: Terminal → Scrollback mode
+//! - [`Window::sync_terminal_to_buffer`]: Terminal → Scrollback mode
 //!   - Appends visible screen (~50 lines) to backing file
 //!   - Loads backing file as read-only buffer
 //!   - Performance: O(screen_size) ≈ 5ms
@@ -526,7 +526,10 @@ impl Editor {
                     self.active_window_mut().terminal_mode = false;
                     self.active_window_mut().key_context =
                         crate::input::keybindings::KeyContext::Normal;
-                    self.sync_terminal_to_buffer(self.active_buffer());
+                    {
+                        let __b = self.active_buffer();
+                        self.active_window_mut().sync_terminal_to_buffer(__b);
+                    };
                     self.set_status_message(
                         "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
                     );
@@ -539,106 +542,6 @@ impl Editor {
         // Send the key to the terminal
         self.send_terminal_key(code, modifiers);
         true
-    }
-
-    /// Sync terminal content to the text buffer for read-only viewing/selection
-    ///
-    /// This uses the incremental streaming architecture:
-    /// 1. Scrollback has already been streamed to the backing file during PTY reads
-    /// 2. We just append the visible screen (~50 lines) to the backing file
-    /// 3. Reload the buffer from the backing file (lazy load for large files)
-    ///
-    /// Performance: O(screen_size) instead of O(total_history)
-    pub fn sync_terminal_to_buffer(&mut self, buffer_id: BufferId) {
-        if let Some(&terminal_id) = self.active_window().terminal_buffers.get(&buffer_id) {
-            // Get the backing file path
-            let backing_file = match self
-                .active_window()
-                .terminal_backing_files
-                .get(&terminal_id)
-            {
-                Some(path) => path.clone(),
-                None => return,
-            };
-
-            // Append visible screen to backing file
-            // The scrollback has already been incrementally streamed by the PTY read loop
-            if let Some(handle) = self.active_window().terminal_manager.get(terminal_id) {
-                if let Ok(mut state) = handle.state.lock() {
-                    // Record the current file size as the history end point
-                    // (before appending visible screen) so we can truncate back to it
-                    if let Ok(metadata) = self.authority.filesystem.metadata(&backing_file) {
-                        state.set_backing_file_history_end(metadata.size);
-                    }
-
-                    // Open backing file in append mode to add visible screen
-                    if let Ok(mut file) = self
-                        .authority
-                        .filesystem
-                        .open_file_for_append(&backing_file)
-                    {
-                        use std::io::BufWriter;
-                        let mut writer = BufWriter::new(&mut *file);
-                        if let Err(e) = state.append_visible_screen(&mut writer) {
-                            tracing::error!(
-                                "Failed to append visible screen to backing file: {}",
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-
-            // Reload buffer from the backing file (reusing existing file loading)
-            let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-            if let Ok(new_state) = EditorState::from_file_with_languages(
-                &backing_file,
-                self.terminal_width,
-                self.terminal_height,
-                large_file_threshold,
-                &self.grammar_registry,
-                &self.config.languages,
-                std::sync::Arc::clone(&self.authority.filesystem),
-            ) {
-                // Replace buffer state
-                if let Some(state) = self
-                    .windows
-                    .get_mut(&self.active_window)
-                    .map(|w| &mut w.buffers)
-                    .expect("active window present")
-                    .get_mut(&buffer_id)
-                {
-                    let total_bytes = new_state.buffer.total_bytes();
-                    *state = new_state;
-                    // Terminal buffers should never be considered "modified"
-                    state.buffer.set_modified(false);
-                    // Move cursor to end of buffer in SplitViewState
-                    let __active_split = self.split_manager().active_split();
-                    if let Some(view_state) = self.split_view_states_mut().get_mut(&__active_split)
-                    {
-                        view_state.cursors.primary_mut().position = total_bytes;
-                    }
-                }
-            }
-
-            // Mark buffer as editing-disabled while in non-terminal mode
-            if let Some(state) = self
-                .windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .get_mut(&buffer_id)
-            {
-                state.editing_disabled = true;
-                state.margins.configure_for_line_numbers(false);
-            }
-
-            // In read-only view, keep line wrapping disabled for terminal buffers
-            // Also scroll viewport to show the end of the buffer where the cursor is.
-            let active_split = self.split_manager().active_split();
-            self.active_window_mut()
-                .enter_terminal_scrollback_view(buffer_id, active_split);
-        }
     }
 
     /// Re-enter terminal mode from read-only buffer view
@@ -779,6 +682,94 @@ impl Window {
                 }
             }
         }
+    }
+
+    /// Sync terminal content to the active terminal buffer's text view
+    /// for read-only viewing / selection.
+    ///
+    /// Incremental streaming architecture:
+    /// 1. Scrollback has already been streamed to the backing file during PTY reads.
+    /// 2. We append the visible screen (~50 lines) to the backing file.
+    /// 3. Reload the buffer from the backing file (lazy load for large files).
+    ///
+    /// Performance: O(screen_size) instead of O(total_history).
+    pub fn sync_terminal_to_buffer(&mut self, buffer_id: BufferId) {
+        let Some(&terminal_id) = self.terminal_buffers.get(&buffer_id) else {
+            return;
+        };
+        // Get the backing file path
+        let backing_file = match self.terminal_backing_files.get(&terminal_id) {
+            Some(path) => path.clone(),
+            None => return,
+        };
+
+        // Append visible screen to backing file
+        // The scrollback has already been incrementally streamed by the PTY read loop
+        if let Some(handle) = self.terminal_manager.get(terminal_id) {
+            if let Ok(mut state) = handle.state.lock() {
+                // Record the current file size as the history end point
+                // (before appending visible screen) so we can truncate back to it
+                if let Ok(metadata) = self.resources.authority.filesystem.metadata(&backing_file) {
+                    state.set_backing_file_history_end(metadata.size);
+                }
+
+                // Open backing file in append mode to add visible screen
+                if let Ok(mut file) = self
+                    .resources
+                    .authority
+                    .filesystem
+                    .open_file_for_append(&backing_file)
+                {
+                    use std::io::BufWriter;
+                    let mut writer = BufWriter::new(&mut *file);
+                    if let Err(e) = state.append_visible_screen(&mut writer) {
+                        tracing::error!("Failed to append visible screen to backing file: {}", e);
+                    }
+                }
+            }
+        }
+
+        // Reload buffer from the backing file (reusing existing file loading)
+        let large_file_threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
+        if let Ok(new_state) = EditorState::from_file_with_languages(
+            &backing_file,
+            self.terminal_width,
+            self.terminal_height,
+            large_file_threshold,
+            &self.resources.grammar_registry,
+            &self.resources.config.languages,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
+        ) {
+            let total_bytes = new_state.buffer.total_bytes();
+            if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                *state = new_state;
+                // Terminal buffers should never be considered "modified"
+                state.buffer.set_modified(false);
+            }
+            // Move cursor to end of buffer in SplitViewState
+            if let Some((mgr, view_states)) = self.splits.as_mut() {
+                let active_split = mgr.active_split();
+                if let Some(view_state) = view_states.get_mut(&active_split) {
+                    view_state.cursors.primary_mut().position = total_bytes;
+                }
+            }
+        }
+
+        // Mark buffer as editing-disabled while in non-terminal mode
+        if let Some(state) = self.buffers.get_mut(&buffer_id) {
+            state.editing_disabled = true;
+            state.margins.configure_for_line_numbers(false);
+        }
+
+        // In read-only view, keep line wrapping disabled for terminal buffers
+        // Also scroll viewport to show the end of the buffer where the cursor is.
+        let active_split = self
+            .splits
+            .as_ref()
+            .expect("active window must have a populated split layout")
+            .0
+            .active_split();
+        self.enter_terminal_scrollback_view(buffer_id, active_split);
     }
 }
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -525,7 +525,7 @@ impl Editor {
     /// Call this after operations that change split layout (maximize, resize, etc.)
     pub fn resize_visible_terminals(&mut self) {
         // Get the content area excluding file explorer
-        let file_explorer_width = if self.active_window().file_explorer_visible {
+        let file_explorer_width = if self.file_explorer_visible() {
             self.active_window()
                 .file_explorer_width
                 .to_cols(self.terminal_width)

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -939,8 +939,8 @@ impl Editor {
                             cursor_visible,
                             *content_rect,
                             frame.buffer_mut(),
-                            self.theme.terminal_fg,
-                            self.theme.terminal_bg,
+                            self.theme.read().unwrap().terminal_fg,
+                            self.theme.read().unwrap().terminal_bg,
                         );
                     }
                 }

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -165,7 +165,7 @@ impl Editor {
 
         // Enable terminal mode
         self.active_window_mut().terminal_mode = true;
-        self.key_context = crate::input::keybindings::KeyContext::Terminal;
+        self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
 
         // Resize terminal to match actual split content area
         self.resize_visible_terminals();
@@ -343,7 +343,9 @@ impl Editor {
             // Close the terminal
             self.active_window_mut().terminal_manager.close(terminal_id);
             self.active_window_mut().terminal_buffers.remove(&buffer_id);
-            self.ephemeral_terminals.remove(&terminal_id);
+            self.active_window_mut()
+                .ephemeral_terminals
+                .remove(&terminal_id);
 
             // Clean up backing/rendering file
             let backing_file = self
@@ -370,7 +372,7 @@ impl Editor {
 
             // Exit terminal mode
             self.active_window_mut().terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
 
             // Close the buffer
             if let Err(e) = self.close_buffer(buffer_id) {
@@ -581,7 +583,8 @@ impl Editor {
                 | crossterm::event::KeyCode::Char('`') => {
                     // Exit terminal mode and sync buffer
                     self.active_window_mut().terminal_mode = false;
-                    self.key_context = crate::input::keybindings::KeyContext::Normal;
+                    self.active_window_mut().key_context =
+                        crate::input::keybindings::KeyContext::Normal;
                     self.sync_terminal_to_buffer(self.active_buffer());
                     self.set_status_message(
                         "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
@@ -708,7 +711,7 @@ impl Editor {
             .is_terminal_buffer(self.active_buffer())
         {
             self.active_window_mut().terminal_mode = true;
-            self.key_context = crate::input::keybindings::KeyContext::Terminal;
+            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
 
             // Re-enable editing when in terminal mode (input goes to PTY)
             let __buffer_id = self.active_buffer();
@@ -805,7 +808,7 @@ impl Editor {
 
     /// Check if keyboard capture is enabled in terminal mode (for testing)
     pub fn is_keyboard_capture(&self) -> bool {
-        self.keyboard_capture
+        self.active_window().keyboard_capture
     }
 
     /// Set terminal jump_to_end_on_output config option (for testing)

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -169,7 +169,12 @@ impl Editor {
         }
 
         // Menu bar
-        if let Some(bar_area) = self.active_chrome().menu_layout.as_ref().map(|m| m.bar_area) {
+        if let Some(bar_area) = self
+            .active_chrome()
+            .menu_layout
+            .as_ref()
+            .map(|m| m.bar_area)
+        {
             let info = CellThemeInfo {
                 fg_key: Some("ui.menu_fg"),
                 bg_key: Some("ui.menu_bg"),

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -42,7 +42,7 @@ impl Editor {
             .theme_registry
             .resolve_key(&self.config.theme.0)
             .unwrap_or_else(|| self.config.theme.0.clone());
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "theme_inspect_key",
             HookArgs::ThemeInspectKey { theme_name, key },
         );

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -121,7 +121,7 @@ impl Editor {
     /// Resolve which theme key(s) style the character at screen position (col, row).
     /// Looks up the per-cell theme key map populated during rendering.
     fn resolve_theme_key_at(&self, col: u16, row: u16) -> Option<ThemeKeyInfo> {
-        let cell = self.chrome_layout.cell_theme_at(col, row)?;
+        let cell = self.active_chrome().cell_theme_at(col, row)?;
         let theme = &*self.theme.read().unwrap();
 
         // Resolve actual colors from theme keys
@@ -150,10 +150,10 @@ impl Editor {
     pub(super) fn record_non_editor_theme_regions(&mut self) {
         use super::types::CellThemeInfo;
 
-        let sw = self.chrome_layout.last_frame_width as usize;
+        let sw = self.active_chrome().last_frame_width as usize;
 
         // Status bar
-        if let Some((row, x, width)) = self.chrome_layout.status_bar_area {
+        if let Some((row, x, width)) = self.active_chrome().status_bar_area {
             let info = CellThemeInfo {
                 fg_key: Some("ui.status_bar_fg"),
                 bg_key: Some("ui.status_bar_bg"),
@@ -162,14 +162,14 @@ impl Editor {
             };
             for col in x..x + width {
                 let idx = row as usize * sw + col as usize;
-                if let Some(cell) = self.chrome_layout.cell_theme_map.get_mut(idx) {
+                if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
                     *cell = info.clone();
                 }
             }
         }
 
         // Menu bar
-        if let Some(bar_area) = self.chrome_layout.menu_layout.as_ref().map(|m| m.bar_area) {
+        if let Some(bar_area) = self.active_chrome().menu_layout.as_ref().map(|m| m.bar_area) {
             let info = CellThemeInfo {
                 fg_key: Some("ui.menu_fg"),
                 bg_key: Some("ui.menu_bg"),
@@ -179,7 +179,7 @@ impl Editor {
             for row in bar_area.y..bar_area.y + bar_area.height {
                 for col in bar_area.x..bar_area.x + bar_area.width {
                     let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.chrome_layout.cell_theme_map.get_mut(idx) {
+                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
                         *cell = info.clone();
                     }
                 }
@@ -197,7 +197,7 @@ impl Editor {
             for row in area.y..area.y + area.height {
                 for col in area.x..area.x + area.width {
                     let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.chrome_layout.cell_theme_map.get_mut(idx) {
+                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
                         *cell = info.clone();
                     }
                 }
@@ -226,7 +226,7 @@ impl Editor {
                 };
                 for col in scrollbar_rect.x..scrollbar_rect.x + scrollbar_rect.width {
                     let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.chrome_layout.cell_theme_map.get_mut(idx) {
+                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
                         *cell = info.clone();
                     }
                 }
@@ -247,7 +247,7 @@ impl Editor {
                 for row in area.y..area.y + area.height {
                     for col in area.x..area.x + area.width {
                         let idx = row as usize * sw + col as usize;
-                        if let Some(cell) = self.chrome_layout.cell_theme_map.get_mut(idx) {
+                        if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
                             *cell = info.clone();
                         }
                     }
@@ -363,8 +363,8 @@ impl Editor {
         let button_row_offset = line_count; // 0-indexed from popup y + 1 (top border)
 
         // Use the same screen-aware positioning as render to match the actual drawn rect
-        let screen_w = self.chrome_layout.last_frame_width;
-        let screen_h = self.chrome_layout.last_frame_height;
+        let screen_w = self.active_chrome().last_frame_width;
+        let screen_h = self.active_chrome().last_frame_height;
         let rect = compute_popup_rect(popup.position, width, height, screen_w, screen_h);
 
         Some((rect, button_row_offset))

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -16,14 +16,14 @@ impl Editor {
     pub(super) fn show_theme_info_popup(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
         if let Some(info) = self.resolve_theme_key_at(col, row) {
             // Dismiss any existing LSP hover popup to avoid overlapping popups
-            self.mouse_state.lsp_hover_state = None;
-            self.mouse_state.lsp_hover_request_sent = false;
+            self.active_window_mut().mouse_state.lsp_hover_state = None;
+            self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
             self.dismiss_transient_popups();
 
             // Position the popup near the click, offset down-right by 1
             let popup_x = col.saturating_add(1);
             let popup_y = row.saturating_add(1);
-            self.theme_info_popup = Some(ThemeInfoPopup {
+            self.active_window_mut().theme_info_popup = Some(ThemeInfoPopup {
                 position: (popup_x, popup_y),
                 info,
                 button_highlighted: false,
@@ -258,7 +258,7 @@ impl Editor {
 
     /// Render the theme info popup.
     pub(super) fn render_theme_info_popup(&self, frame: &mut Frame) {
-        let popup = match &self.theme_info_popup {
+        let popup = match &self.active_window().theme_info_popup {
             Some(p) => p,
             None => return,
         };
@@ -334,7 +334,7 @@ impl Editor {
 
     /// Compute the bounding rect of the theme info popup (for hit-testing).
     pub(super) fn theme_info_popup_rect(&self) -> Option<(Rect, u16)> {
-        let popup = self.theme_info_popup.as_ref()?;
+        let popup = self.active_window().theme_info_popup.as_ref()?;
         let info = &popup.info;
 
         // Count lines (must match render_theme_info_popup logic)

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -122,7 +122,7 @@ impl Editor {
     /// Looks up the per-cell theme key map populated during rendering.
     fn resolve_theme_key_at(&self, col: u16, row: u16) -> Option<ThemeKeyInfo> {
         let cell = self.chrome_layout.cell_theme_at(col, row)?;
-        let theme = &self.theme;
+        let theme = &*self.theme.read().unwrap();
 
         // Resolve actual colors from theme keys
         let fg_color = cell.fg_key.and_then(|k| theme.resolve_theme_key(k));
@@ -262,7 +262,7 @@ impl Editor {
             Some(p) => p,
             None => return,
         };
-        let theme = &self.theme;
+        let theme = &*self.theme.read().unwrap();
         let info = &popup.info;
 
         let mut lines = vec![];

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -378,7 +378,7 @@ impl Editor {
         // Apply theme change if needed
         if old_theme != self.config.theme {
             if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
-                self.theme = theme;
+                *self.theme.write().unwrap() = theme;
                 tracing::info!("Theme changed to '{}'", self.config.theme.0);
             } else {
                 tracing::error!("Theme '{}' not found", self.config.theme.0);
@@ -444,7 +444,7 @@ impl Editor {
 
         // Re-apply current theme if it still exists, otherwise it might have been updated
         if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
-            self.theme = theme;
+            *self.theme.write().unwrap() = theme;
         }
 
         tracing::info!(

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -21,17 +21,6 @@ impl Editor {
     /// Line number visibility is stored per-split in `BufferViewState` so that
     /// different splits of the same buffer can independently show/hide line numbers
     /// (e.g., source mode shows them, compose mode hides them).
-    /// Toggle scroll sync for same-buffer splits.
-    pub fn toggle_scroll_sync(&mut self) {
-        self.active_window_mut().same_buffer_scroll_sync =
-            !self.active_window().same_buffer_scroll_sync;
-        if self.active_window().same_buffer_scroll_sync {
-            self.set_status_message(t!("toggle.scroll_sync_enabled").to_string());
-        } else {
-            self.set_status_message(t!("toggle.scroll_sync_disabled").to_string());
-        }
-    }
-
     pub fn toggle_line_numbers(&mut self) {
         let active_split = self
             .windows
@@ -57,43 +46,23 @@ impl Editor {
         }
     }
 
-    /// Toggle debug highlight mode for the active buffer
-    /// When enabled, shows byte positions and highlight span info for debugging
-    pub fn toggle_debug_highlights(&mut self) {
-        let __buffer_id = self.active_buffer();
-        if let Some(state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .get_mut(&__buffer_id)
-        {
-            state.debug_highlight_mode = !state.debug_highlight_mode;
-            if state.debug_highlight_mode {
-                self.set_status_message(t!("toggle.debug_mode_on").to_string());
-            } else {
-                self.set_status_message(t!("toggle.debug_mode_off").to_string());
-            }
-        }
-    }
-
     /// Toggle menu bar visibility.
     ///
     /// `editor.show_menu_bar` is a global preference, so the toggle updates the
     /// runtime config and persists the change to the user config layer (same
     /// pattern as the file-explorer toggles). See issue #1156.
     pub fn toggle_menu_bar(&mut self) {
-        let new_value = !self.menu_bar_visible;
+        let new_value = !self.active_window_mut().menu_bar_visible;
         self.config_mut().editor.show_menu_bar = new_value;
-        self.menu_bar_visible = new_value;
+        self.active_window_mut().menu_bar_visible = new_value;
         // When explicitly toggling, clear auto-show state
-        self.menu_bar_auto_shown = false;
+        self.active_window_mut().menu_bar_auto_shown = false;
         // Close any open menu when hiding the menu bar
-        if !self.menu_bar_visible {
+        if !self.active_window_mut().menu_bar_visible {
             self.menu_state.close_menu();
         }
         self.persist_config_change("/editor/show_menu_bar", serde_json::Value::Bool(new_value));
-        let status = if self.menu_bar_visible {
+        let status = if self.active_window_mut().menu_bar_visible {
             t!("toggle.menu_bar_shown")
         } else {
             t!("toggle.menu_bar_hidden")
@@ -103,8 +72,8 @@ impl Editor {
 
     /// Toggle tab bar visibility
     pub fn toggle_tab_bar(&mut self) {
-        self.tab_bar_visible = !self.tab_bar_visible;
-        let status = if self.tab_bar_visible {
+        self.active_window_mut().tab_bar_visible = !self.active_window_mut().tab_bar_visible;
+        let status = if self.active_window_mut().tab_bar_visible {
             t!("toggle.tab_bar_shown")
         } else {
             t!("toggle.tab_bar_hidden")
@@ -114,13 +83,13 @@ impl Editor {
 
     /// Get tab bar visibility
     pub fn tab_bar_visible(&self) -> bool {
-        self.tab_bar_visible
+        self.active_window().tab_bar_visible
     }
 
     /// Toggle status bar visibility
     pub fn toggle_status_bar(&mut self) {
-        self.status_bar_visible = !self.status_bar_visible;
-        let status = if self.status_bar_visible {
+        self.active_window_mut().status_bar_visible = !self.active_window_mut().status_bar_visible;
+        let status = if self.active_window_mut().status_bar_visible {
             t!("toggle.status_bar_shown")
         } else {
             t!("toggle.status_bar_hidden")
@@ -130,13 +99,14 @@ impl Editor {
 
     /// Get status bar visibility
     pub fn status_bar_visible(&self) -> bool {
-        self.status_bar_visible
+        self.active_window().status_bar_visible
     }
 
     /// Toggle prompt line visibility
     pub fn toggle_prompt_line(&mut self) {
-        self.prompt_line_visible = !self.prompt_line_visible;
-        let status = if self.prompt_line_visible {
+        self.active_window_mut().prompt_line_visible =
+            !self.active_window_mut().prompt_line_visible;
+        let status = if self.active_window_mut().prompt_line_visible {
             t!("toggle.prompt_line_shown")
         } else {
             t!("toggle.prompt_line_hidden")
@@ -146,7 +116,7 @@ impl Editor {
 
     /// Get prompt line visibility
     pub fn prompt_line_visible(&self) -> bool {
-        self.prompt_line_visible
+        self.active_window().prompt_line_visible
     }
 
     /// Toggle vertical scrollbar visibility
@@ -235,9 +205,9 @@ impl Editor {
     pub fn toggle_mouse_capture(&mut self) {
         use std::io::stdout;
 
-        self.mouse_enabled = !self.mouse_enabled;
+        self.active_window_mut().mouse_enabled = !self.active_window_mut().mouse_enabled;
 
-        if self.mouse_enabled {
+        if self.active_window_mut().mouse_enabled {
             // Best-effort terminal mouse capture toggle.
             #[allow(clippy::let_underscore_must_use)]
             let _ = crossterm::execute!(stdout(), crossterm::event::EnableMouseCapture);
@@ -252,7 +222,7 @@ impl Editor {
 
     /// Check if mouse capture is enabled
     pub fn is_mouse_enabled(&self) -> bool {
-        self.mouse_enabled
+        self.active_window().mouse_enabled
     }
 
     /// Toggle mouse hover for LSP on/off
@@ -267,8 +237,8 @@ impl Editor {
             self.set_status_message(t!("toggle.mouse_hover_enabled").to_string());
         } else {
             // Clear any pending hover state
-            self.mouse_state.lsp_hover_state = None;
-            self.mouse_state.lsp_hover_request_sent = false;
+            self.active_window_mut().mouse_state.lsp_hover_state = None;
+            self.active_window_mut().mouse_state.lsp_hover_request_sent = false;
             self.set_status_message(t!("toggle.mouse_hover_disabled").to_string());
         }
 
@@ -297,7 +267,7 @@ impl Editor {
     /// our own mouse cursor because GPM can't draw on the alternate screen
     /// buffer used by TUI applications.
     pub fn set_gpm_active(&mut self, active: bool) {
-        self.gpm_active = active;
+        self.active_window_mut().gpm_active = active;
     }
 
     /// Toggle inlay hints visibility
@@ -422,10 +392,10 @@ impl Editor {
         self.clipboard.apply_config(&self.config.clipboard);
 
         // Apply bar visibility changes immediately
-        self.menu_bar_visible = self.config.editor.show_menu_bar;
-        self.tab_bar_visible = self.config.editor.show_tab_bar;
-        self.status_bar_visible = self.config.editor.show_status_bar;
-        self.prompt_line_visible = self.config.editor.show_prompt_line;
+        self.active_window_mut().menu_bar_visible = self.config.editor.show_menu_bar;
+        self.active_window_mut().tab_bar_visible = self.config.editor.show_tab_bar;
+        self.active_window_mut().status_bar_visible = self.config.editor.show_status_bar;
+        self.active_window_mut().prompt_line_visible = self.config.editor.show_prompt_line;
 
         // Update LSP configs
         let __active_id = self.active_window;

--- a/crates/fresh-editor/src/app/undo_actions.rs
+++ b/crates/fresh-editor/src/app/undo_actions.rs
@@ -6,7 +6,7 @@ use rust_i18n::t;
 impl Editor {
     /// Handle Undo action - revert the last edit operation.
     pub fn handle_undo(&mut self) {
-        if self.is_editing_disabled() {
+        if self.active_window().is_editing_disabled() {
             self.set_status_message(t!("buffer.editing_disabled").to_string());
             return;
         }
@@ -43,12 +43,12 @@ impl Editor {
         }
 
         // Update modified status based on event log position
-        self.update_modified_from_event_log();
+        self.active_window_mut().update_modified_from_event_log();
     }
 
     /// Handle Redo action - reapply an undone edit operation.
     pub fn handle_redo(&mut self) {
-        if self.is_editing_disabled() {
+        if self.active_window().is_editing_disabled() {
             self.set_status_message(t!("buffer.editing_disabled").to_string());
             return;
         }
@@ -61,6 +61,6 @@ impl Editor {
         }
 
         // Update modified status based on event log position
-        self.update_modified_from_event_log();
+        self.active_window_mut().update_modified_from_event_log();
     }
 }

--- a/crates/fresh-editor/src/app/view_actions.rs
+++ b/crates/fresh-editor/src/app/view_actions.rs
@@ -118,7 +118,7 @@ impl Editor {
         } else {
             crate::view::animation::Edge::Left
         };
-        self.animations.start(
+        self.active_window_mut().animations.start(
             area,
             crate::view::animation::AnimationKind::SlideIn {
                 from,

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -424,7 +424,8 @@ impl Editor {
         buffer_id: BufferId,
         entries: Vec<crate::primitives::text_property::TextPropertyEntry>,
     ) -> Result<(), String> {
-        self.set_virtual_buffer_content(buffer_id, entries)
+        self.active_window_mut()
+            .set_virtual_buffer_content(buffer_id, entries)
     }
 }
 

--- a/crates/fresh-editor/src/app/virtual_buffers.rs
+++ b/crates/fresh-editor/src/app/virtual_buffers.rs
@@ -424,8 +424,7 @@ impl Editor {
         buffer_id: BufferId,
         entries: Vec<crate::primitives::text_property::TextPropertyEntry>,
     ) -> Result<(), String> {
-        self.active_window_mut()
-            .set_virtual_buffer_content(buffer_id, entries)
+        self.set_virtual_buffer_content(buffer_id, entries)
     }
 }
 

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -676,6 +676,11 @@ pub struct Window {
     /// Plugin error log (populated when plugin status messages match
     /// error patterns; tests assert against this).
     pub plugin_errors: Vec<String>,
+
+    /// Cut/copy clipboard for file-explorer ops in this window. Each
+    /// window has its own paste buffer; cross-window file ops would
+    /// require a separately-shared clipboard.
+    pub file_explorer_clipboard: Option<crate::app::file_explorer::FileExplorerClipboard>,
 }
 
 impl Window {
@@ -1581,6 +1586,7 @@ impl Window {
             search_overlay_top_byte: None,
             animations: crate::view::animation::AnimationRunner::default(),
             plugin_errors: Vec::new(),
+            file_explorer_clipboard: None,
             resources,
         }
     }

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -1447,6 +1447,13 @@ impl Window {
                 .map(str::to_owned)
                 .unwrap_or_else(|| "main".to_owned());
         }
+        // Seed every poll/throttle timestamp with the *editor's* time
+        // source rather than real wall-clock — otherwise tests using
+        // `TestTimeSource::advance` see a misaligned baseline and
+        // `elapsed_since` returns less than the configured interval
+        // (broke auto-save / auto-recovery tests after these fields
+        // moved off `Editor`).
+        let now = resources.time_source.now();
         Self {
             id,
             label,
@@ -1556,8 +1563,8 @@ impl Window {
             stored_diagnostics: Arc::new(HashMap::new()),
             stored_folding_ranges: Arc::new(HashMap::new()),
             dir_mod_times: HashMap::new(),
-            last_auto_revert_poll: std::time::Instant::now(),
-            last_file_tree_poll: std::time::Instant::now(),
+            last_auto_revert_poll: now,
+            last_file_tree_poll: now,
             git_index_resolved: false,
             pending_file_poll_rx: None,
             pending_dir_poll_rx: None,
@@ -1577,8 +1584,8 @@ impl Window {
             tab_bar_visible: resources.config.editor.show_tab_bar,
             status_bar_visible: resources.config.editor.show_status_bar,
             prompt_line_visible: resources.config.editor.show_prompt_line,
-            last_auto_recovery_save: std::time::Instant::now(),
-            last_persistent_auto_save: std::time::Instant::now(),
+            last_auto_recovery_save: now,
+            last_persistent_auto_save: now,
             warning_domains: crate::app::warning_domains::WarningDomainRegistry::default(),
             tab_context_menu: None,
             file_explorer_context_menu: None,

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -306,6 +306,14 @@ pub struct Window {
     /// active window every frame.
     pub(crate) chrome_layout: ChromeLayout,
 
+    /// Last-known terminal screen dimensions, mirrored from
+    /// `Editor::terminal_width` / `Editor::terminal_height` whenever
+    /// `Editor::resize` loops over windows. Per-window because
+    /// `Window::resize_visible_terminals` and other per-window resize
+    /// logic need the screen size without reaching back to `Editor`.
+    pub(crate) terminal_width: u16,
+    pub(crate) terminal_height: u16,
+
     /// Editor-global resources shared by `Arc` clone (config, theme
     /// registry, keybindings, command registry, filesystem authority,
     /// the buffer-id allocator, …). See [`WindowResources`] for the
@@ -1492,6 +1500,8 @@ impl Window {
             composite_view_states: HashMap::new(),
             layout_cache: WindowLayoutCache::default(),
             chrome_layout: ChromeLayout::default(),
+            terminal_width: 80,
+            terminal_height: 24,
             preview: None,
             terminal_mode: false,
             terminal_mode_resume: std::collections::HashSet::new(),

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -39,7 +39,7 @@
 //! is a pointer write (plus first-dive seed allocation for
 //! windows that have never been activated).
 
-use crate::app::types::WindowLayoutCache;
+use crate::app::types::{ChromeLayout, WindowLayoutCache};
 use crate::app::window_resources::WindowResources;
 use crate::model::event::{Event, LeafId};
 use crate::services::lsp::manager::LspManager;
@@ -296,8 +296,15 @@ pub struct Window {
     /// frame; stale until the next render after a window switch (the
     /// post-switch render fills it in before any input handling).
     /// Editor-chrome rects (status bar, menu, popups, prompt overlay)
-    /// live on `Editor::chrome_layout` instead.
+    /// live on `Window::chrome_layout` (also per-window).
     pub(crate) layout_cache: WindowLayoutCache,
+
+    /// Per-window editor-chrome layout cache: status bar, menu,
+    /// popups, prompt overlay, full-frame cell-theme map. Each
+    /// window has its own status bar / prompt / popup state, so the
+    /// cache is per-window. Repopulated by the renderer for the
+    /// active window every frame.
+    pub(crate) chrome_layout: ChromeLayout,
 
     /// Editor-global resources shared by `Arc` clone (config, theme
     /// registry, keybindings, command registry, filesystem authority,
@@ -1484,6 +1491,7 @@ impl Window {
             composite_buffers: HashMap::new(),
             composite_view_states: HashMap::new(),
             layout_cache: WindowLayoutCache::default(),
+            chrome_layout: ChromeLayout::default(),
             preview: None,
             terminal_mode: false,
             terminal_mode_resume: std::collections::HashSet::new(),

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -43,11 +43,13 @@ use crate::app::types::WindowLayoutCache;
 use crate::app::window_resources::WindowResources;
 use crate::model::event::{Event, LeafId};
 use crate::services::lsp::manager::LspManager;
+use crate::types::LspFeature;
 use crate::view::file_tree::FileTreeView;
 use crate::view::split::{SplitManager, SplitViewState};
 use fresh_core::{BufferId, WindowId};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// A project-rooted unit of editor state.
 ///
@@ -451,6 +453,229 @@ pub struct Window {
     /// Buffer id pending close-confirmation prompt resolution.
     /// Per-window because the prompt that produced this is per-window.
     pub pending_close_buffer: Option<BufferId>,
+
+    /// Pluggable completion service that orchestrates this window's
+    /// completion providers (dabbrev, buffer words, LSP, plugin
+    /// providers). Per-window because the providers it orchestrates
+    /// (notably the LSP set) are per-window.
+    pub completion_service: crate::services::completion::CompletionService,
+
+    /// Overlay namespace for LSP diagnostic overlays in this window
+    /// (filter / bulk-remove key). The diagnostics it scopes are buffer
+    /// overlays, and buffers are per-window, so the namespace follows.
+    pub lsp_diagnostic_namespace: crate::view::overlay::OverlayNamespace,
+
+    /// Last `result_id` seen from the LSP server per URI for incremental
+    /// pull diagnostics. Per-window because each window has its own
+    /// LSP manager and therefore its own result-id stream.
+    pub diagnostic_result_ids: HashMap<String, String>,
+
+    /// `$/progress` token → progress info for this window's LSP servers.
+    /// Drives the spinner in the status bar's LSP pill. Per-window
+    /// because the LspManager that emits these tokens is per-window.
+    pub lsp_progress: HashMap<String, crate::app::LspProgressInfo>,
+
+    /// Status of each `(language, server_name)` pair attached to this
+    /// window's LspManager (running, errored, restarting, …).
+    pub lsp_server_statuses:
+        HashMap<(String, String), crate::services::async_bridge::LspServerStatus>,
+
+    /// Recent `window/showMessage` payloads from this window's LSP
+    /// servers. Bounded ring (newest entries kept, drops the oldest
+    /// when the soft cap is exceeded).
+    pub lsp_window_messages: Vec<crate::app::LspMessageEntry>,
+
+    /// Recent `window/logMessage` payloads from this window's LSP
+    /// servers, on the same bounded-ring pattern as `lsp_window_messages`.
+    pub lsp_log_messages: Vec<crate::app::LspMessageEntry>,
+
+    /// Push-model diagnostics keyed by URI, then by server name. Each
+    /// `publishDiagnostics` from a server replaces that server's slice
+    /// for the URI; the merged view is materialised in
+    /// `stored_diagnostics`.
+    pub stored_push_diagnostics: HashMap<String, HashMap<String, Vec<lsp_types::Diagnostic>>>,
+
+    /// Pull-model diagnostics (rust-analyzer-style native pull)
+    /// keyed by URI. Independent of `stored_push_diagnostics`; the
+    /// two are merged into `stored_diagnostics` for plugin / overlay
+    /// consumption.
+    pub stored_pull_diagnostics: HashMap<String, Vec<lsp_types::Diagnostic>>,
+
+    /// Merged view of push + pull diagnostics, exposed to plugins.
+    /// `Arc` wrapper so plugin snapshots can hold a refcount-bumped
+    /// reference; mutation goes through `Arc::make_mut` (CoW).
+    pub stored_diagnostics: Arc<HashMap<String, Vec<lsp_types::Diagnostic>>>,
+
+    /// Per-URI folding ranges from `textDocument/foldingRange`. Same
+    /// `Arc` + CoW pattern as `stored_diagnostics` so plugin snapshots
+    /// don't pin the underlying map across mutations.
+    pub stored_folding_ranges: Arc<HashMap<String, Vec<lsp_types::FoldingRange>>>,
+
+    /// Per-directory mtime cache (paired with `file_mod_times`) for
+    /// detecting file-tree changes in this window. Per-window because
+    /// the file tree is per-window.
+    pub dir_mod_times: HashMap<PathBuf, std::time::SystemTime>,
+
+    /// Last time auto-revert polled this window's open buffers.
+    pub last_auto_revert_poll: std::time::Instant,
+
+    /// Last time the file-tree change-detection poll fired for this window.
+    pub last_file_tree_poll: std::time::Instant,
+
+    /// Whether this window has resolved and seeded the `.git/index`
+    /// path in `dir_mod_times`.
+    pub git_index_resolved: bool,
+
+    /// Receiver for background file change poll results for this window.
+    /// `Some` while a metadata poll is in flight.
+    #[allow(clippy::type_complexity)]
+    pub pending_file_poll_rx:
+        Option<std::sync::mpsc::Receiver<Vec<(PathBuf, Option<std::time::SystemTime>)>>>,
+
+    /// Receiver for background directory change poll results for this window.
+    #[allow(clippy::type_complexity)]
+    pub pending_dir_poll_rx: Option<
+        std::sync::mpsc::Receiver<(
+            Vec<(
+                crate::view::file_tree::NodeId,
+                PathBuf,
+                Option<std::time::SystemTime>,
+            )>,
+            Option<(PathBuf, std::time::SystemTime)>,
+        )>,
+    >,
+
+    /// Terminals in this window that should not persist to the
+    /// workspace file. Plugin-created terminals default to ephemeral;
+    /// user-opened terminals are absent and persist as before.
+    pub ephemeral_terminals: std::collections::HashSet<crate::services::terminal::TerminalId>,
+
+    /// Plugin-development workspace per buffer (temp dir + LSP
+    /// configuration for plugin buffers). Buffer-keyed and buffers
+    /// are per-window, so the workspace map follows.
+    pub plugin_dev_workspaces:
+        HashMap<BufferId, crate::services::plugins::plugin_dev_workspace::PluginDevWorkspace>,
+
+    /// Mouse drag/selection/scrollbar state for this window. Drag
+    /// targets reference per-window LeafIds and BufferIds.
+    pub mouse_state: crate::app::types::MouseState,
+
+    /// Currently focused widget context (Normal / FileExplorer /
+    /// Terminal / Prompt …). Per-window because each window has its
+    /// own focus state — switching windows preserves each window's
+    /// focused widget.
+    pub key_context: crate::input::keybindings::KeyContext,
+
+    /// Pending chord sequence for multi-key bindings (e.g. C-x C-s).
+    /// Each window tracks its own in-progress chord.
+    pub chord_state: Vec<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)>,
+
+    /// Multi-click detection state (per-window because clicks land
+    /// inside a window).
+    pub previous_click_time: Option<std::time::Instant>,
+    pub previous_click_position: Option<(u16, u16)>,
+    pub click_count: u8,
+
+    /// Whether mouse capture is enabled in this window.
+    pub mouse_enabled: bool,
+
+    /// GPM software-cursor position for this window (when GPM is
+    /// active and we draw our own cursor).
+    pub mouse_cursor_position: Option<(u16, u16)>,
+    pub gpm_active: bool,
+
+    /// Per-window chrome toggles. Each window can independently show
+    /// or hide its menu bar / tab bar / status bar / prompt line.
+    pub menu_bar_visible: bool,
+    pub menu_bar_auto_shown: bool,
+    pub tab_bar_visible: bool,
+    pub status_bar_visible: bool,
+    pub prompt_line_visible: bool,
+
+    /// Timing state for auto-recovery saves and persistent auto-saves
+    /// in this window.
+    pub last_auto_recovery_save: std::time::Instant,
+    pub last_persistent_auto_save: std::time::Instant,
+
+    /// Warning domain registry for this window's status indicator.
+    pub warning_domains: crate::app::warning_domains::WarningDomainRegistry,
+
+    /// Tab context menu state (right-click on a tab in this window).
+    pub tab_context_menu: Option<crate::app::types::TabContextMenu>,
+
+    /// File-explorer context menu state (right-click in the explorer).
+    pub file_explorer_context_menu: Option<crate::app::types::FileExplorerContextMenu>,
+
+    /// Theme inspector popup (Ctrl+Right-Click) anchored in this window.
+    pub theme_info_popup: Option<crate::app::types::ThemeInfoPopup>,
+
+    /// File-open dialog state (when PromptType::OpenFile is active in
+    /// this window's prompt).
+    pub file_open_state: Option<crate::app::file_open::FileOpenState>,
+
+    /// Cached layout for the file browser (mouse hit-testing).
+    pub file_browser_layout: Option<crate::view::ui::FileBrowserLayout>,
+
+    /// Buffer groups (multiple buffers shown as one tab) in this window.
+    pub buffer_groups: HashMap<crate::app::types::BufferGroupId, crate::app::types::BufferGroup>,
+    /// Reverse index: buffer ID → group ID.
+    pub buffer_to_group: HashMap<BufferId, crate::app::types::BufferGroupId>,
+    /// Next buffer group id within this window.
+    pub next_buffer_group_id: usize,
+
+    /// Plugin keystroke-callback queue (in-flight `getNextKey()` callbacks).
+    pub pending_next_key_callbacks: std::collections::VecDeque<fresh_core::api::JsCallbackId>,
+
+    /// Whether a plugin currently has key-capture active in this window.
+    pub key_capture_active: bool,
+
+    /// Keys queued while `key_capture_active` was set but no callback
+    /// was pending — drained on the next `AwaitNextKey`.
+    pub pending_key_capture_buffer: std::collections::VecDeque<fresh_core::api::KeyEventPayload>,
+
+    /// Macro state (record/playback/registers) — one window's macro
+    /// session at a time.
+    pub macros: crate::app::macros::MacroState,
+
+    /// Plugin-defined custom contexts active in this window (drives
+    /// command palette visibility, e.g. "config-editor").
+    pub active_custom_contexts: std::collections::HashSet<String>,
+
+    /// Whether keyboard capture is active for the terminal in this
+    /// window (terminal mode swallows non-toggle keys).
+    pub keyboard_capture: bool,
+
+    /// In-flight review session hunks for this window.
+    pub review_hunks: Vec<fresh_core::api::ReviewHunk>,
+
+    /// Pending file-open queue (PendingFileOpen) for this window.
+    pub pending_file_opens: Vec<crate::app::PendingFileOpen>,
+
+    /// Whether this window has a hot-exit recovery prompt pending.
+    pub pending_hot_exit_recovery: bool,
+
+    /// Plugin "wait until file opens" tracking (buffer_id → (wait_id, …)).
+    pub wait_tracking: HashMap<BufferId, (u64, bool)>,
+
+    /// Wait ids that have completed and need to be reported back to plugins.
+    pub completed_waits: Vec<u64>,
+
+    /// Background line-scan state for this window (line counts for
+    /// large files).
+    pub line_scan: crate::app::line_scan::LineScan,
+
+    /// Background search-scan state for this window.
+    pub search_scan: crate::app::search_scan::SearchScan,
+
+    /// Anchor for the search-result overlay in this window.
+    pub search_overlay_top_byte: Option<usize>,
+
+    /// Per-window UI animation runner.
+    pub animations: crate::view::animation::AnimationRunner,
+
+    /// Plugin error log (populated when plugin status messages match
+    /// error patterns; tests assert against this).
+    pub plugin_errors: Vec<String>,
 }
 
 impl Window {
@@ -478,6 +703,267 @@ impl Window {
         let id = self.next_lsp_request_id;
         self.next_lsp_request_id += 1;
         id
+    }
+
+    /// True if this window has any in-flight LSP completion or
+    /// goto-definition request whose response would still be relevant.
+    pub fn has_pending_lsp_requests(&self) -> bool {
+        !self.pending_completion_requests.is_empty()
+            || self.pending_goto_definition_request.is_some()
+    }
+
+    /// Cancel any in-flight LSP requests on this window. Called when
+    /// the user does something that would make the response stale
+    /// (cursor movement, text edit, scroll). Drains the pending
+    /// completion id set, clears the goto-definition slot, and sends
+    /// `$/cancelRequest` to the appropriate server for each.
+    pub(crate) fn cancel_pending_lsp_requests(&mut self) {
+        self.scheduled_completion_trigger = None;
+        if !self.pending_completion_requests.is_empty() {
+            let ids: Vec<u64> = self.pending_completion_requests.drain().collect();
+            for request_id in ids {
+                tracing::debug!("Canceling pending LSP completion request {}", request_id);
+                self.send_lsp_cancel_request(request_id);
+            }
+        }
+        if let Some(request_id) = self.pending_goto_definition_request.take() {
+            tracing::debug!(
+                "Canceling pending LSP goto-definition request {}",
+                request_id
+            );
+            self.send_lsp_cancel_request(request_id);
+        }
+    }
+
+    /// Send `$/cancelRequest` to the LSP server backing the active
+    /// buffer's language, if a server is already running. Called only
+    /// from cancel paths — does not spawn a server just to cancel.
+    pub(crate) fn send_lsp_cancel_request(&mut self, request_id: u64) {
+        let buffer_id = self.active_buffer();
+        let Some(language) = self.buffers.get(&buffer_id).map(|s| s.language.clone()) else {
+            return;
+        };
+        if let Some(lsp) = self.lsp.as_mut() {
+            if let Some(handle) = lsp.get_handle_mut(&language) {
+                if let Err(e) = handle.cancel_request(request_id) {
+                    tracing::warn!("Failed to send LSP cancel request: {}", e);
+                } else {
+                    tracing::debug!("Sent $/cancelRequest for request_id={}", request_id);
+                }
+            }
+        }
+    }
+
+    /// Toggle this window's same-buffer scroll-sync flag and post a
+    /// status message announcing the new state.
+    pub fn toggle_scroll_sync(&mut self) {
+        self.same_buffer_scroll_sync = !self.same_buffer_scroll_sync;
+        let key = if self.same_buffer_scroll_sync {
+            "toggle.scroll_sync_enabled"
+        } else {
+            "toggle.scroll_sync_disabled"
+        };
+        self.set_status_message(rust_i18n::t!(key).to_string());
+    }
+
+    /// Toggle the active buffer's `debug_highlight_mode` (shows byte
+    /// positions and highlight-span info on screen). No-op if there is
+    /// no active buffer.
+    pub fn toggle_debug_highlights(&mut self) {
+        let buffer_id = self.active_buffer();
+        if let Some(state) = self.buffers.get_mut(&buffer_id) {
+            state.debug_highlight_mode = !state.debug_highlight_mode;
+            let key = if state.debug_highlight_mode {
+                "toggle.debug_mode_on"
+            } else {
+                "toggle.debug_mode_off"
+            };
+            self.set_status_message(rust_i18n::t!(key).to_string());
+        }
+    }
+
+    /// Build a compiled `regex::Regex` from this window's current
+    /// search-flags (`use_regex`, `whole_word`, `case_sensitive`)
+    /// applied to `query`. Returns the compiled regex or a
+    /// human-readable error string.
+    pub(crate) fn build_search_regex(&self, query: &str) -> Result<regex::Regex, String> {
+        crate::app::regex_replace::build_search_regex(
+            query,
+            self.search_use_regex,
+            self.search_whole_word,
+            self.search_case_sensitive,
+        )
+    }
+
+    /// True iff editing should be disabled for the active buffer
+    /// (e.g. read-only virtual buffers like the help manual).
+    pub fn is_editing_disabled(&self) -> bool {
+        self.active_state().editing_disabled
+    }
+
+    /// Recompute the active buffer's `modified` flag from the event log's
+    /// position relative to its last-saved point. Called after undo/redo
+    /// to correctly report "buffer is dirty / clean" in the status bar.
+    pub(super) fn update_modified_from_event_log(&mut self) {
+        let buffer_id = self.active_buffer();
+        let is_at_saved = self
+            .event_logs
+            .get(&buffer_id)
+            .map(|log| log.is_at_saved_position())
+            .unwrap_or(false);
+        if let Some(state) = self.buffers.get_mut(&buffer_id) {
+            state.buffer.set_modified(!is_at_saved);
+        }
+    }
+
+    /// True iff `language` is currently user-dismissed in this window's
+    /// LSP status pill.
+    pub fn is_lsp_language_user_dismissed(&self, language: &str) -> bool {
+        self.user_dismissed_lsp_languages.contains(language)
+    }
+
+    /// Dismiss the LSP pill for `language` in this window until the user
+    /// re-enables it (or the editor restarts).
+    pub fn dismiss_lsp_language(&mut self, language: &str) {
+        self.user_dismissed_lsp_languages
+            .insert(language.to_string());
+    }
+
+    /// Undo a previous dismissal — the pill for `language` returns to its
+    /// normal style.
+    pub fn undismiss_lsp_language(&mut self, language: &str) {
+        self.user_dismissed_lsp_languages.remove(language);
+    }
+
+    /// True iff at least one LSP server attached to the active buffer's
+    /// language advertises `codeAction/resolve`.
+    pub(crate) fn server_supports_code_action_resolve(&self) -> bool {
+        let Some(language) = self
+            .buffers
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone())
+        else {
+            return false;
+        };
+        if let Some(lsp) = self.lsp.as_ref() {
+            for sh in lsp.get_handles(&language) {
+                if sh.capabilities.code_action_resolve {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// True iff at least one LSP server attached to the active buffer's
+    /// language advertises `completionItem/resolve`.
+    pub(crate) fn server_supports_completion_resolve(&self) -> bool {
+        let Some(language) = self
+            .buffers
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone())
+        else {
+            return false;
+        };
+        if let Some(lsp) = self.lsp.as_ref() {
+            for sh in lsp.get_handles(&language) {
+                if sh.capabilities.completion_resolve {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// True iff at least one LSP server attached to the active buffer's
+    /// language advertises `textDocument/rename` (and therefore the
+    /// `prepareRename` request, which the editor surfaces only through
+    /// the rename feature flag).
+    pub(crate) fn server_supports_prepare_rename(&self) -> bool {
+        let Some(language) = self
+            .buffers
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone())
+        else {
+            return false;
+        };
+        if let Some(lsp) = self.lsp.as_ref() {
+            for sh in lsp.get_handles(&language) {
+                if sh.capabilities.rename {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Send `textDocument/prepareRename` for the symbol at the active
+    /// cursor. No-op if the buffer has no LSP metadata, no language, or
+    /// no rename-capable handle. The response is dispatched to
+    /// `handle_prepare_rename_response`.
+    pub(crate) fn send_prepare_rename(&mut self) {
+        let cursor_pos = self.active_cursors().primary().position;
+        let (line, character) = self
+            .active_state()
+            .buffer
+            .position_to_lsp_position(cursor_pos);
+
+        let buffer_id = self.active_buffer();
+        let metadata = match self.buffer_metadata.get(&buffer_id) {
+            Some(m) if m.lsp_enabled => m,
+            _ => return,
+        };
+        let uri = match metadata.file_uri() {
+            Some(u) => u.clone(),
+            None => return,
+        };
+        let Some(language) = self.buffers.get(&buffer_id).map(|s| s.language.clone()) else {
+            return;
+        };
+
+        let request_id = self.alloc_lsp_request_id();
+
+        if let Some(lsp) = self.lsp.as_mut() {
+            if let Some(sh) = lsp.handle_for_feature_mut(&language, LspFeature::Rename) {
+                if let Err(e) = sh.handle.prepare_rename(
+                    request_id,
+                    uri.as_uri().clone(),
+                    line as u32,
+                    character as u32,
+                ) {
+                    tracing::warn!("Failed to send prepareRename: {}", e);
+                }
+            }
+        }
+    }
+
+    /// Send `completionItem/resolve` for `item` to the first LSP server
+    /// (in language order) that advertises `completion_resolve` for the
+    /// active buffer's language. No-op if no server is running or no
+    /// server supports the resolve.
+    pub(crate) fn send_completion_resolve(&mut self, item: lsp_types::CompletionItem) {
+        let Some(language) = self
+            .buffers
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone())
+        else {
+            return;
+        };
+        let request_id = self.alloc_lsp_request_id();
+        if let Some(lsp) = self.lsp.as_mut() {
+            for sh in lsp.get_handles_mut(&language) {
+                if sh.capabilities.completion_resolve {
+                    if let Err(e) = sh.handle.completion_resolve(request_id, item.clone()) {
+                        tracing::warn!(
+                            "Failed to send completionItem/resolve to '{}': {}",
+                            sh.name,
+                            e
+                        );
+                    }
+                    return;
+                }
+            }
+        }
     }
 
     /// Apply an event to a buffer + the cursors of a split inside this
@@ -1033,6 +1519,68 @@ impl Window {
             editor_mode: None,
             prompt_histories: HashMap::new(),
             pending_close_buffer: None,
+            completion_service: crate::services::completion::CompletionService::new(),
+            lsp_diagnostic_namespace: crate::view::overlay::OverlayNamespace::from_string(
+                "lsp-diagnostic".to_string(),
+            ),
+            diagnostic_result_ids: HashMap::new(),
+            lsp_progress: HashMap::new(),
+            lsp_server_statuses: HashMap::new(),
+            lsp_window_messages: Vec::new(),
+            lsp_log_messages: Vec::new(),
+            stored_push_diagnostics: HashMap::new(),
+            stored_pull_diagnostics: HashMap::new(),
+            stored_diagnostics: Arc::new(HashMap::new()),
+            stored_folding_ranges: Arc::new(HashMap::new()),
+            dir_mod_times: HashMap::new(),
+            last_auto_revert_poll: std::time::Instant::now(),
+            last_file_tree_poll: std::time::Instant::now(),
+            git_index_resolved: false,
+            pending_file_poll_rx: None,
+            pending_dir_poll_rx: None,
+            ephemeral_terminals: std::collections::HashSet::new(),
+            plugin_dev_workspaces: HashMap::new(),
+            mouse_state: crate::app::types::MouseState::default(),
+            key_context: crate::input::keybindings::KeyContext::Normal,
+            chord_state: Vec::new(),
+            previous_click_time: None,
+            previous_click_position: None,
+            click_count: 0,
+            mouse_enabled: false,
+            mouse_cursor_position: None,
+            gpm_active: false,
+            menu_bar_visible: resources.config.editor.show_menu_bar,
+            menu_bar_auto_shown: false,
+            tab_bar_visible: resources.config.editor.show_tab_bar,
+            status_bar_visible: resources.config.editor.show_status_bar,
+            prompt_line_visible: resources.config.editor.show_prompt_line,
+            last_auto_recovery_save: std::time::Instant::now(),
+            last_persistent_auto_save: std::time::Instant::now(),
+            warning_domains: crate::app::warning_domains::WarningDomainRegistry::default(),
+            tab_context_menu: None,
+            file_explorer_context_menu: None,
+            theme_info_popup: None,
+            file_open_state: None,
+            file_browser_layout: None,
+            buffer_groups: HashMap::new(),
+            buffer_to_group: HashMap::new(),
+            next_buffer_group_id: 0,
+            pending_next_key_callbacks: std::collections::VecDeque::new(),
+            key_capture_active: false,
+            pending_key_capture_buffer: std::collections::VecDeque::new(),
+            macros: crate::app::macros::MacroState::default(),
+            active_custom_contexts: std::collections::HashSet::new(),
+            keyboard_capture: false,
+            review_hunks: Vec::new(),
+            pending_file_opens: Vec::new(),
+            pending_hot_exit_recovery: false,
+            wait_tracking: HashMap::new(),
+            completed_waits: Vec::new(),
+            line_scan: crate::app::line_scan::LineScan::default(),
+            search_scan: crate::app::search_scan::SearchScan::default(),
+            search_overlay_top_byte: None,
+            animations: crate::view::animation::AnimationRunner::default(),
+            plugin_errors: Vec::new(),
             resources,
         }
     }

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -1689,6 +1689,18 @@ impl Window {
         buf
     }
 
+    /// Width available for tabs in this window. When the file explorer is
+    /// visible the tabs row only spans the editor area; otherwise it spans
+    /// the full terminal width.
+    pub fn effective_tabs_width(&self) -> u16 {
+        if self.file_explorer_visible && self.file_explorer.is_some() {
+            let explorer = self.file_explorer_width.to_cols(self.terminal_width);
+            self.terminal_width.saturating_sub(explorer)
+        } else {
+            self.terminal_width
+        }
+    }
+
     /// The split id whose `SplitViewState` owns the currently-focused
     /// cursors/viewport for this window.
     #[inline]

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -37,6 +37,8 @@ impl crate::app::Editor {
             authority: self.authority.clone(),
             time_source: std::sync::Arc::clone(&self.time_source),
             dir_context: self.dir_context.clone(),
+            tokio_runtime: self.tokio_runtime.clone(),
+            async_bridge: self.async_bridge.clone(),
         }
     }
 

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -39,6 +39,7 @@ impl crate::app::Editor {
             dir_context: self.dir_context.clone(),
             tokio_runtime: self.tokio_runtime.clone(),
             async_bridge: self.async_bridge.clone(),
+            plugin_manager: std::sync::Arc::clone(&self.plugin_manager),
         }
     }
 
@@ -57,7 +58,7 @@ impl crate::app::Editor {
         let resolved_label = session.label.clone();
         self.windows.insert(id, session);
 
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "window_created",
             HookArgs::WindowCreated {
                 id: id.0,
@@ -119,7 +120,7 @@ impl crate::app::Editor {
             }
         }
 
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "active_window_changed",
             HookArgs::ActiveWindowChanged {
                 previous_id: Some(previous_id.0),
@@ -249,6 +250,8 @@ impl crate::app::Editor {
         }
 
         self.plugin_manager
+            .read()
+            .unwrap()
             .run_hook("window_closed", HookArgs::WindowClosed { id: id.0 });
 
         true
@@ -294,13 +297,13 @@ impl crate::app::Editor {
         ) -> (R, Vec<WindowControlEvent>),
     {
         let id = self.active_window;
-        // Disjoint sub-field borrows: `self.plugin_manager` (immut)
-        // and `self.windows` (mut) are different fields, so the
-        // borrow checker is happy with both held for the closure's
-        // duration.
-        let plugins = &self.plugin_manager;
-        let window = self.windows.get_mut(&id)?;
-        let (result, events) = f(window, plugins);
+        // Hold the read guard for the closure call, then drop it before
+        // applying control events (which take `&mut self`).
+        let (result, events) = {
+            let plugins = self.plugin_manager.read().unwrap();
+            let window = self.windows.get_mut(&id)?;
+            f(window, &plugins)
+        };
         for event in events {
             self.apply_window_control_event(event);
         }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -56,7 +56,9 @@ impl crate::app::Editor {
         self.next_window_id += 1;
 
         let resources = self.window_resources();
-        let session = Window::new(id, label, root.clone(), resources);
+        let mut session = Window::new(id, label, root.clone(), resources);
+        session.terminal_width = self.terminal_width;
+        session.terminal_height = self.terminal_height;
         let resolved_label = session.label.clone();
         self.windows.insert(id, session);
 

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -40,6 +40,8 @@ impl crate::app::Editor {
             tokio_runtime: self.tokio_runtime.clone(),
             async_bridge: self.async_bridge.clone(),
             plugin_manager: std::sync::Arc::clone(&self.plugin_manager),
+            theme: std::sync::Arc::clone(&self.theme),
+            event_broadcaster: self.event_broadcaster.clone(),
         }
     }
 

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -165,6 +165,16 @@ pub struct WindowResources {
     /// Directory context (config dir, themes dir, plugins dir, etc.).
     /// Cloned by value because it's a small struct of `PathBuf`s.
     pub dir_context: DirectoryContext,
+
+    /// Tokio runtime for async I/O tasks (LSP, file watchers, git, etc.).
+    /// Single runtime shared across all windows via `Arc`. `None` means
+    /// the editor was constructed without async support (rare).
+    pub tokio_runtime: Option<Arc<tokio::runtime::Runtime>>,
+
+    /// Async-message bridge (Sender + Arc'd Receiver). Windows clone this
+    /// to publish messages back to the editor's main loop. The Receiver
+    /// is `Arc<Mutex<>>` internally, so all clones drain the same queue.
+    pub async_bridge: Option<crate::services::async_bridge::AsyncBridge>,
 }
 
 /// Cross-window orchestration events that a `Window` handler returns to

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -175,6 +175,13 @@ pub struct WindowResources {
     /// to publish messages back to the editor's main loop. The Receiver
     /// is `Arc<Mutex<>>` internally, so all clones drain the same queue.
     pub async_bridge: Option<crate::services::async_bridge::AsyncBridge>,
+
+    /// Plugin manager (single QuickJS instance), wrapped in
+    /// `Arc<RwLock<>>` so windows can fire hooks and read state
+    /// without going through `Editor`. Reads take a read lock; the
+    /// few `&mut self` methods (process_commands, check_thread_health,
+    /// test_inject_command) take a write lock.
+    pub plugin_manager: Arc<RwLock<crate::services::plugins::manager::PluginManager>>,
 }
 
 /// Cross-window orchestration events that a `Window` handler returns to

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -182,6 +182,15 @@ pub struct WindowResources {
     /// few `&mut self` methods (process_commands, check_thread_health,
     /// test_inject_command) take a write lock.
     pub plugin_manager: Arc<RwLock<crate::services::plugins::manager::PluginManager>>,
+
+    /// Active resolved theme, mirrored from `Editor.theme`. Each
+    /// `set_theme` / theme-reload pushes the new value into this
+    /// `Arc<RwLock<>>` so Window methods can read colors without
+    /// going through Editor.
+    pub theme: Arc<RwLock<crate::view::theme::Theme>>,
+
+    /// Editor-wide event broadcaster (cloneable, Arc inside).
+    pub event_broadcaster: crate::model::control_event::EventBroadcaster,
 }
 
 /// Cross-window orchestration events that a `Window` handler returns to

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -850,7 +850,7 @@ impl Editor {
                 "Firing buffer_activated for active buffer {:?} after workspace restore",
                 buffer_id
             );
-            self.plugin_manager.run_hook(
+            self.plugin_manager.read().unwrap().run_hook(
                 "buffer_activated",
                 crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
             );

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -164,7 +164,11 @@ impl Editor {
                 // from being serialized, which is what used to cause a newly
                 // spawned plugin terminal to come back with scrollback from
                 // the prior run.
-                if self.ephemeral_terminals.contains(&terminal_id) {
+                if self
+                    .active_window()
+                    .ephemeral_terminals
+                    .contains(&terminal_id)
+                {
                     continue;
                 }
                 let idx = terminals.len();
@@ -326,7 +330,7 @@ impl Editor {
             line_wrap: Some(self.config.editor.line_wrap),
             syntax_highlighting: Some(self.config.editor.syntax_highlighting),
             enable_inlay_hints: Some(self.config.editor.enable_inlay_hints),
-            mouse_enabled: Some(self.mouse_enabled),
+            mouse_enabled: Some(self.active_window().mouse_enabled),
             menu_bar_hidden: None,
         };
 
@@ -872,7 +876,7 @@ impl Editor {
             self.config_mut().editor.enable_inlay_hints = enable_inlay_hints;
         }
         if let Some(mouse_enabled) = overrides.mouse_enabled {
-            self.mouse_enabled = mouse_enabled;
+            self.active_window_mut().mouse_enabled = mouse_enabled;
         }
         // `overrides.menu_bar_hidden` is a legacy field — kept for serde
         // compatibility with workspaces written by older builds, but no

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -300,7 +300,7 @@ impl Editor {
             // Get expanded directories from the tree
             let expanded_dirs = get_expanded_dirs(explorer, &self.working_dir);
             FileExplorerState {
-                visible: self.active_window().file_explorer_visible,
+                visible: self.file_explorer_visible(),
                 width: self.active_window().file_explorer_width,
                 side: self.active_window().file_explorer_side,
                 expanded_dirs,
@@ -310,7 +310,7 @@ impl Editor {
             }
         } else {
             FileExplorerState {
-                visible: self.active_window().file_explorer_visible,
+                visible: self.file_explorer_visible(),
                 width: self.active_window().file_explorer_width,
                 side: self.active_window().file_explorer_side,
                 expanded_dirs: Vec::new(),
@@ -927,7 +927,7 @@ impl Editor {
         }
 
         // Keep key_context as Normal so the editor (not the explorer) has focus.
-        if self.active_window().file_explorer_visible && self.file_explorer().is_none() {
+        if self.file_explorer_visible() && self.file_explorer().is_none() {
             self.init_file_explorer();
         }
     }

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3992,7 +3992,7 @@ where
         }
 
         // Active animations force a render every FRAME_DURATION.
-        let animations_active = editor.animations.is_active();
+        let animations_active = editor.active_window().animations.is_active();
         if animations_active {
             needs_render = true;
         }
@@ -4020,10 +4020,10 @@ where
             // While animations are running, cap the timeout so the next
             // iteration fires in time for the next frame — but never past
             // the earliest animation deadline.
-            if editor.animations.is_active() {
+            if editor.active_window().animations.is_active() {
                 let until_next_frame = FRAME_DURATION.saturating_sub(last_render.elapsed());
                 timeout = timeout.min(until_next_frame);
-                if let Some(deadline) = editor.animations.next_deadline() {
+                if let Some(deadline) = editor.active_window().animations.next_deadline() {
                     let until_deadline = deadline.saturating_duration_since(Instant::now());
                     timeout = timeout.min(until_deadline);
                 }

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -471,7 +471,7 @@ impl EditorServer {
                 // switch paints its first frame and then freezes mid-slide
                 // until the user nudges the terminal. Mirrors the direct
                 // (non-server) loop in `main.rs`.
-                if editor.animations.is_active() {
+                if editor.active_window().animations.is_active() {
                     needs_render = true;
                 }
             }

--- a/crates/fresh-editor/src/view/settings/mouse.rs
+++ b/crates/fresh-editor/src/view/settings/mouse.rs
@@ -146,7 +146,8 @@ impl Editor {
         // Track hover position and compute hover hit for visual feedback
         match mouse_event.kind {
             MouseEventKind::Moved => {
-                let hover_hit = self.active_chrome()
+                let hover_hit = self
+                    .active_chrome()
                     .settings_layout
                     .as_ref()
                     .and_then(|layout: &SettingsLayout| layout.hit_test(col, row));
@@ -224,7 +225,8 @@ impl Editor {
         }
 
         // Use cached settings layout for hit testing
-        let Some(hit) = self.active_chrome()
+        let Some(hit) = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|layout: &SettingsLayout| layout.hit_test(col, row))
@@ -524,7 +526,8 @@ impl Editor {
     }
 
     fn settings_scrollbar_click(&mut self, row: u16) {
-        if let Some(ref scrollbar_area) = self.active_chrome()
+        if let Some(ref scrollbar_area) = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.scrollbar_area)
@@ -540,7 +543,8 @@ impl Editor {
     }
 
     fn settings_scrollbar_drag(&mut self, col: u16, row: u16) -> bool {
-        if let Some(ref scrollbar_area) = self.active_chrome()
+        if let Some(ref scrollbar_area) = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.scrollbar_area)
@@ -559,7 +563,8 @@ impl Editor {
     }
 
     fn search_scrollbar_click(&mut self, row: u16) {
-        if let Some(ref scrollbar_area) = self.active_chrome()
+        if let Some(ref scrollbar_area) = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.search_scrollbar_area)
@@ -575,7 +580,8 @@ impl Editor {
     }
 
     fn search_scrollbar_drag(&mut self, col: u16, row: u16) -> Option<bool> {
-        if let Some(ref scrollbar_area) = self.active_chrome()
+        if let Some(ref scrollbar_area) = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.search_scrollbar_area)
@@ -834,7 +840,8 @@ impl Editor {
 
     /// Returns which confirm dialog button (0-2) is at the given position, if any
     fn get_confirm_dialog_button_at(&self, col: u16, row: u16) -> Option<usize> {
-        let modal_area = self.active_chrome()
+        let modal_area = self
+            .active_chrome()
             .settings_layout
             .as_ref()
             .map(|l| l.modal_area)?;

--- a/crates/fresh-editor/src/view/settings/mouse.rs
+++ b/crates/fresh-editor/src/view/settings/mouse.rs
@@ -146,8 +146,7 @@ impl Editor {
         // Track hover position and compute hover hit for visual feedback
         match mouse_event.kind {
             MouseEventKind::Moved => {
-                let hover_hit = self
-                    .chrome_layout
+                let hover_hit = self.active_chrome()
                     .settings_layout
                     .as_ref()
                     .and_then(|layout: &SettingsLayout| layout.hit_test(col, row));
@@ -225,8 +224,7 @@ impl Editor {
         }
 
         // Use cached settings layout for hit testing
-        let Some(hit) = self
-            .chrome_layout
+        let Some(hit) = self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|layout: &SettingsLayout| layout.hit_test(col, row))
@@ -499,7 +497,7 @@ impl Editor {
     /// Whether the given screen coords sit inside the categories panel —
     /// used to route mouse-wheel events to the correct scroll target.
     fn over_categories_panel(&self, col: u16, row: u16) -> bool {
-        self.chrome_layout
+        self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|layout| layout.categories_panel_area)
@@ -526,8 +524,7 @@ impl Editor {
     }
 
     fn settings_scrollbar_click(&mut self, row: u16) {
-        if let Some(ref scrollbar_area) = self
-            .chrome_layout
+        if let Some(ref scrollbar_area) = self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.scrollbar_area)
@@ -543,8 +540,7 @@ impl Editor {
     }
 
     fn settings_scrollbar_drag(&mut self, col: u16, row: u16) -> bool {
-        if let Some(ref scrollbar_area) = self
-            .chrome_layout
+        if let Some(ref scrollbar_area) = self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.scrollbar_area)
@@ -563,8 +559,7 @@ impl Editor {
     }
 
     fn search_scrollbar_click(&mut self, row: u16) {
-        if let Some(ref scrollbar_area) = self
-            .chrome_layout
+        if let Some(ref scrollbar_area) = self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.search_scrollbar_area)
@@ -580,8 +575,7 @@ impl Editor {
     }
 
     fn search_scrollbar_drag(&mut self, col: u16, row: u16) -> Option<bool> {
-        if let Some(ref scrollbar_area) = self
-            .chrome_layout
+        if let Some(ref scrollbar_area) = self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| l.search_scrollbar_area)
@@ -600,7 +594,7 @@ impl Editor {
     }
 
     fn entry_dialog_layout(&self) -> Option<EntryDialogLayout> {
-        self.chrome_layout
+        self.active_chrome()
             .settings_layout
             .as_ref()
             .and_then(|l| EntryDialogLayout::from_modal(l.modal_area))
@@ -840,8 +834,7 @@ impl Editor {
 
     /// Returns which confirm dialog button (0-2) is at the given position, if any
     fn get_confirm_dialog_button_at(&self, col: u16, row: u16) -> Option<usize> {
-        let modal_area = self
-            .chrome_layout
+        let modal_area = self.active_chrome()
             .settings_layout
             .as_ref()
             .map(|l| l.modal_area)?;

--- a/crates/fresh-editor/tests/e2e/animation.rs
+++ b/crates/fresh-editor/tests/e2e/animation.rs
@@ -44,9 +44,9 @@ fn next_buffer_kicks_off_a_slide_animation() {
         .unwrap();
     // Baseline: any open-time animation has settled.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
-    let baseline = harness.editor().animations.total_started();
+    let baseline = harness.editor().active_window().animations.total_started();
 
     // Switch to the previous tab. The Editor should start a
     // horizontal slide (prev → from the left).
@@ -56,12 +56,12 @@ fn next_buffer_kicks_off_a_slide_animation() {
     // monotonic so this catches the kick-off even if the animation has
     // already finished by the time we poll.
     harness
-        .wait_until(|h| h.editor().animations.total_started() > baseline)
+        .wait_until(|h| h.editor().active_window().animations.total_started() > baseline)
         .unwrap();
 
     // Settle, then confirm the alpha buffer is now the active one.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
     assert!(
         harness.screen_to_string().contains("ALPHA_BUFFER_CONTENT"),
@@ -141,9 +141,9 @@ fn tab_switch_from_group_to_file_animates() {
     // Wait for any open-time animation to settle so is_active is a
     // clean false baseline.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
-    let baseline = harness.editor().animations.total_started();
+    let baseline = harness.editor().active_window().animations.total_started();
 
     // Cycle to the previous tab: group → file. Before the fix,
     // total_started never incremented and the wait never returned.
@@ -152,11 +152,11 @@ fn tab_switch_from_group_to_file_animates() {
     // 260 ms animation and miss its `true` window entirely.
     harness.editor_mut().prev_buffer();
     harness
-        .wait_until(|h| h.editor().animations.total_started() > baseline)
+        .wait_until(|h| h.editor().active_window().animations.total_started() > baseline)
         .unwrap();
 
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
     assert!(
         harness.screen_to_string().contains("FILE_BUFFER_CONTENT"),
@@ -197,7 +197,7 @@ fn rapid_tab_switches_settle_on_target_content() {
     // Let the post-open animation settle so the rapid-switch
     // sequence starts from a clean baseline.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
 
     // Fire four switches back-to-back without waiting for any to
@@ -211,7 +211,7 @@ fn rapid_tab_switches_settle_on_target_content() {
     // Wait for everything to settle, then confirm the target is the
     // only buffer content visible on screen.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
     let screen = harness.screen_to_string();
     assert!(
@@ -267,10 +267,10 @@ fn cursor_jump_long_move_test(cursor_jump_enabled: bool) -> u64 {
         .unwrap();
     harness.render().unwrap();
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
 
-    let baseline = harness.editor().animations.total_started();
+    let baseline = harness.editor().active_window().animations.total_started();
 
     // Long jump: top → end of buffer.
     harness
@@ -282,7 +282,7 @@ fn cursor_jump_long_move_test(cursor_jump_enabled: bool) -> u64 {
     // this frame can call `start()` if it's going to.
     harness.render().unwrap();
 
-    harness.editor().animations.total_started() - baseline
+    harness.editor().active_window().animations.total_started() - baseline
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/binary_file.rs
+++ b/crates/fresh-editor/tests/e2e/binary_file.rs
@@ -29,7 +29,7 @@ fn test_png_file_detected_as_binary() {
 
     // Verify the file is detected as binary by checking editing is disabled
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "Binary file should have editing disabled"
     );
 
@@ -64,7 +64,7 @@ fn test_jpeg_file_detected_as_binary() {
     harness.render().unwrap();
 
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "JPEG file should have editing disabled"
     );
     harness.assert_screen_contains("[BIN]");
@@ -92,7 +92,7 @@ fn test_elf_executable_detected_as_binary() {
     harness.render().unwrap();
 
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "ELF binary should have editing disabled"
     );
     harness.assert_screen_contains("[BIN]");
@@ -112,7 +112,7 @@ fn test_text_file_not_detected_as_binary() {
 
     // Text files should allow editing
     assert!(
-        !harness.editor().is_editing_disabled(),
+        !harness.editor().active_window().is_editing_disabled(),
         "Text file should allow editing"
     );
 
@@ -136,7 +136,7 @@ fn test_ansi_escape_sequences_not_binary() {
 
     // ANSI files should allow editing (not binary)
     assert!(
-        !harness.editor().is_editing_disabled(),
+        !harness.editor().active_window().is_editing_disabled(),
         "File with ANSI escape sequences should allow editing"
     );
 }

--- a/crates/fresh-editor/tests/e2e/issue_1554_scrollbar_theme_color.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1554_scrollbar_theme_color.rs
@@ -36,9 +36,10 @@ fn test_vertical_scrollbar_uses_theme_track_and_thumb_colors() {
     };
 
     let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
-    let theme = harness.editor().theme();
-    let expected_track = theme.scrollbar_track_fg;
-    let expected_thumb = theme.scrollbar_thumb_fg;
+    let (expected_track, expected_thumb) = {
+        let theme = harness.editor().theme();
+        (theme.scrollbar_track_fg, theme.scrollbar_thumb_fg)
+    };
 
     harness.load_buffer_from_text(&long_content(200)).unwrap();
     harness.render().unwrap();
@@ -72,8 +73,7 @@ fn test_horizontal_scrollbar_uses_theme_track_color() {
     config.editor.show_horizontal_scrollbar = true;
 
     let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
-    let theme = harness.editor().theme();
-    let expected_track = theme.scrollbar_track_fg;
+    let expected_track = harness.editor().theme().scrollbar_track_fg;
 
     let long_line_content: String = (0..50)
         .map(|i| format!("line {i}: {}", "X".repeat(200)))

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -1500,7 +1500,7 @@ fn test_lsp_completion_canceled_on_cursor_move() -> anyhow::Result<()> {
     // Verify pending request is cleared in editor
     let editor = harness.editor();
     assert!(
-        !editor.has_pending_lsp_requests(),
+        !editor.active_window().has_pending_lsp_requests(),
         "Expected no pending LSP requests after cursor move"
     );
 
@@ -1649,7 +1649,7 @@ fn test_lsp_completion_canceled_on_text_edit() -> anyhow::Result<()> {
     // Verify pending request is cleared
     let editor = harness.editor();
     assert!(
-        !editor.has_pending_lsp_requests(),
+        !editor.active_window().has_pending_lsp_requests(),
         "Expected no pending LSP requests after text edit"
     );
 

--- a/crates/fresh-editor/tests/e2e/mouse.rs
+++ b/crates/fresh-editor/tests/e2e/mouse.rs
@@ -1964,8 +1964,7 @@ fn test_blinking_bar_selection_first_char_color() {
     let (content_first_row, _) = harness.content_area_rows();
 
     // Get the selection background color from the theme
-    let theme = harness.editor().theme();
-    let selection_bg = theme.selection_bg;
+    let selection_bg = harness.editor().theme().selection_bg;
 
     // Drag from end of line 2 to start of line 1 (upward and to the left)
     // This reproduces the bug scenario described in issue #614

--- a/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
@@ -135,14 +135,14 @@ fn dashboard_bringup_animation_settles_and_renders() {
     // transient `is_active()` so a slow-polling iteration on a busy
     // CI box can't straddle the entire animation window.
     harness
-        .wait_until(|h| h.editor().animations.total_started() > 0)
+        .wait_until(|h| h.editor().active_window().animations.total_started() > 0)
         .unwrap();
 
     // Now settle the bringup animation: the runner flips is_active to
     // false once every effect returns Done, so this fires exactly
     // when the final resting frame has been painted.
     harness
-        .wait_until(|h| !h.editor().animations.is_active())
+        .wait_until(|h| !h.editor().active_window().animations.is_active())
         .unwrap();
 
     // Post-settle: the banner row is at its natural position and the

--- a/crates/fresh-editor/tests/e2e/side_by_side_diff_hunk_nav.rs
+++ b/crates/fresh-editor/tests/e2e/side_by_side_diff_hunk_nav.rs
@@ -127,6 +127,7 @@ fn test_next_hunk_navigation_shows_hunk_content() {
     // Jump to hunk 1 (around line 20)
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id);
     harness.render().unwrap();
 
@@ -140,6 +141,7 @@ fn test_next_hunk_navigation_shows_hunk_content() {
     // Jump to hunk 2 (around line 60)
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id);
     harness.render().unwrap();
 
@@ -153,6 +155,7 @@ fn test_next_hunk_navigation_shows_hunk_content() {
     // Jump to hunk 3 (around line 120)
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id);
     harness.render().unwrap();
 
@@ -175,6 +178,7 @@ fn test_prev_hunk_navigation() {
     for _ in 0..3 {
         harness
             .editor_mut()
+            .active_window_mut()
             .composite_next_hunk_active(composite_id);
     }
     harness.render().unwrap();
@@ -189,6 +193,7 @@ fn test_prev_hunk_navigation() {
     // Go back to hunk 2
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_prev_hunk_active(composite_id);
     harness.render().unwrap();
 
@@ -211,9 +216,11 @@ fn test_hunk_navigation_shows_context_above() {
     // Jump to hunk 2 (at line 60)
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id);
     harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id);
     harness.render().unwrap();
 
@@ -451,6 +458,7 @@ fn test_flush_layout_enables_hunk_nav_before_render() {
     // Without flushLayout, composite_next_hunk returns false (no view state)
     let result_without_flush = harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id2);
     assert!(
         !result_without_flush,
@@ -463,6 +471,7 @@ fn test_flush_layout_enables_hunk_nav_before_render() {
     // Now composite_next_hunk should succeed
     let result_with_flush = harness
         .editor_mut()
+        .active_window_mut()
         .composite_next_hunk_active(composite_id2);
     assert!(
         result_with_flush,
@@ -538,6 +547,7 @@ fn test_flush_layout_jump_to_third_hunk_before_render() {
     for _ in 0..3 {
         harness
             .editor_mut()
+            .active_window_mut()
             .composite_next_hunk_active(composite_id);
     }
 

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -445,7 +445,10 @@ fn test_terminal_resize() {
     let (initial_cols, initial_rows) = handle.size();
 
     // Resize the terminal
-    harness.editor_mut().resize_terminal(buffer_id, 120, 40);
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .resize_terminal(buffer_id, 120, 40);
 
     // Get new size
     let handle = harness

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -2966,7 +2966,7 @@ fn test_terminal_exit_keeps_buffer_with_message() {
 
     // Buffer should be read-only (editing disabled) - verify via is_editing_disabled
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "Buffer should be read-only after terminal exit"
     );
 

--- a/crates/fresh-editor/tests/e2e/warning_indicators.rs
+++ b/crates/fresh-editor/tests/e2e/warning_indicators.rs
@@ -312,7 +312,7 @@ fn test_status_log_stays_read_only_after_revert() {
 
     // Verify the buffer is read-only
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "Status log buffer should be read-only immediately after opening"
     );
 
@@ -338,7 +338,7 @@ fn test_status_log_stays_read_only_after_revert() {
 
     // The key assertion: editing_disabled must survive the revert
     assert!(
-        harness.editor().is_editing_disabled(),
+        harness.editor().active_window().is_editing_disabled(),
         "Status log buffer should remain read-only after revert"
     );
 }

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -1256,7 +1256,7 @@ impl Editor {
         // Update the plugin state snapshot with working_dir BEFORE loading plugins
         // This ensures plugins can call getCwd() correctly during initialization
         #[cfg(feature = "plugins")]
-        if let Some(snapshot_handle) = plugin_manager.state_snapshot_handle() {
+        if let Some(snapshot_handle) = plugin_manager.read().unwrap().state_snapshot_handle() {
             let mut snapshot = snapshot_handle.write().unwrap();
             snapshot.working_dir = working_dir.clone();
         }
@@ -1267,7 +1267,7 @@ impl Editor {
         // 3. From embedded plugins (for cargo-binstall, when embed-plugins feature is enabled)
         // 4. User plugins directory (~/.config/fresh/plugins)
         // 5. Package manager installed plugins (~/.config/fresh/plugins/packages/*)
-        if plugin_manager.is_active() {
+        if plugin_manager.read().unwrap().is_active() {
             let mut plugin_dirs: Vec<std::path::PathBuf> = vec![];
 
             // Check next to executable first (for cargo-dist installations)
@@ -1340,7 +1340,7 @@ impl Editor {
             for plugin_dir in plugin_dirs {
                 tracing::info!("Loading TypeScript plugins from: {:?}", plugin_dir);
                 let (errors, discovered_plugins) =
-                    plugin_manager.load_plugins_from_dir_with_config(&plugin_dir, &config.plugins);
+                    plugin_manager.read().unwrap().load_plugins_from_dir_with_config(&plugin_dir, &config.plugins);
 
                 // Merge discovered plugins into config
                 // discovered_plugins already contains the merged config (saved enabled state + discovered path)
@@ -1626,8 +1626,8 @@ impl Editor {
         #[cfg(feature = "plugins")]
         {
             editor.update_plugin_state_snapshot();
-            if editor.plugin_manager.is_active() {
-                editor.plugin_manager.run_hook(
+            if editor.plugin_manager.read().unwrap().is_active() {
+                editor.plugin_manager.read().unwrap().run_hook(
                     "editor_initialized",
                     crate::services::plugins::hooks::HookArgs::EditorInitialized {},
                 );
@@ -1712,7 +1712,7 @@ impl Editor {
 
     /// Send a response to a plugin for an async operation
     fn send_plugin_response(&self, response: fresh_core::api::PluginResponse) {
-        self.plugin_manager.deliver_response(response);
+        self.plugin_manager.read().unwrap().deliver_response(response);
     }
 
     /// Remove a pending semantic token request from tracking maps.
@@ -2361,7 +2361,7 @@ impl Editor {
         self.update_plugin_state_snapshot();
 
         // Emit buffer_activated hook for plugins
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
             crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );
@@ -3080,7 +3080,7 @@ impl Editor {
             #[cfg(feature = "plugins")]
             self.update_plugin_state_snapshot();
 
-            self.plugin_manager.run_hook(hook_name, args.clone());
+            self.plugin_manager.read().unwrap().run_hook(hook_name, args.clone());
         }
 
         // After inter-line cursor_moved, proactively refresh lines so
@@ -3587,7 +3587,7 @@ impl Editor {
         self.resize_visible_terminals();
 
         // Notify plugins of the resize so they can adjust layouts
-        self.plugin_manager.run_hook(
+        self.plugin_manager.read().unwrap().run_hook(
             "resize",
             fresh_core::hooks::HookArgs::Resize { width, height },
         );
@@ -4135,7 +4135,7 @@ impl Editor {
                 PromptType::Plugin { custom_type } => {
                     // Fire plugin hook for prompt cancellation
                     use crate::services::plugins::hooks::HookArgs;
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "prompt_cancelled",
                         HookArgs::PromptCancelled {
                             prompt_type: custom_type.clone(),
@@ -4158,8 +4158,7 @@ impl Editor {
                 PromptType::AsyncPrompt => {
                     // Resolve the pending async prompt callback with null (cancelled)
                     if let Some(callback_id) = self.pending_async_prompt_callback.take() {
-                        self.plugin_manager
-                            .resolve_callback(callback_id, "null".to_string());
+                        self.plugin_manager.read().unwrap().resolve_callback(callback_id, "null".to_string());
                     }
                 }
                 _ => {}
@@ -4512,7 +4511,7 @@ impl Editor {
                 }
                 // Fire plugin hook for prompt input change
                 use crate::services::plugins::hooks::HookArgs;
-                self.plugin_manager.run_hook(
+                self.plugin_manager.read().unwrap().run_hook(
                     "prompt_changed",
                     HookArgs::PromptChanged {
                         prompt_type: custom_type,
@@ -4558,7 +4557,7 @@ impl Editor {
     pub fn process_async_messages(&mut self) -> bool {
         // Check plugin thread health - will panic if thread died due to error
         // This ensures plugin errors surface quickly instead of causing silent hangs
-        self.plugin_manager.check_thread_health();
+        self.plugin_manager.write().unwrap().check_thread_health();
 
         let Some(bridge) = &self.async_bridge else {
             return false;
@@ -4635,7 +4634,7 @@ impl Editor {
                     .to_string();
 
                     // Fire the LspServerError hook for plugins
-                    self.plugin_manager.run_hook(
+                    self.plugin_manager.read().unwrap().run_hook(
                         "lsp_server_error",
                         crate::services::plugins::hooks::HookArgs::LspServerError {
                             language: language.clone(),
@@ -4837,13 +4836,13 @@ impl Editor {
                             );
                         }
                         PluginAsyncMessage::DelayComplete { callback_id } => {
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 JsCallbackId::from(callback_id),
                                 "null".to_string(),
                             );
                         }
                         PluginAsyncMessage::ProcessStdout { process_id, data } => {
-                            self.plugin_manager.run_hook(
+                            self.plugin_manager.read().unwrap().run_hook(
                                 "onProcessStdout",
                                 crate::services::plugins::hooks::HookArgs::ProcessOutput {
                                     process_id,
@@ -4852,7 +4851,7 @@ impl Editor {
                             );
                         }
                         PluginAsyncMessage::ProcessStderr { process_id, data } => {
-                            self.plugin_manager.run_hook(
+                            self.plugin_manager.read().unwrap().run_hook(
                                 "onProcessStderr",
                                 crate::services::plugins::hooks::HookArgs::ProcessOutput {
                                     process_id,
@@ -4870,7 +4869,7 @@ impl Editor {
                                 process_id,
                                 exit_code,
                             };
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 JsCallbackId::from(callback_id),
                                 serde_json::to_string(&result).unwrap(),
                             );
@@ -4894,7 +4893,7 @@ impl Editor {
                                 search_id,
                                 matches_json.len()
                             );
-                            self.plugin_manager.call_streaming_callback(
+                            self.plugin_manager.read().unwrap().call_streaming_callback(
                                 JsCallbackId::from(search_id),
                                 matches_json,
                                 false,
@@ -4907,7 +4906,7 @@ impl Editor {
                             truncated,
                         } => {
                             self.streaming_grep_cancellation = None;
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 JsCallbackId::from(callback_id),
                                 format!(
                                     r#"{{"totalMatches":{},"truncated":{}}}"#,
@@ -5101,8 +5100,7 @@ impl Editor {
                     // Resolve plugin callbacks that were waiting for this build
                     #[cfg(feature = "plugins")]
                     for cb_id in callback_ids {
-                        self.plugin_manager
-                            .resolve_callback(cb_id, "null".to_string());
+                        self.plugin_manager.read().unwrap().resolve_callback(cb_id, "null".to_string());
                     }
 
                     // Flush any plugin grammars that arrived during the build
@@ -5251,7 +5249,7 @@ impl Editor {
     #[cfg(feature = "plugins")]
     fn update_plugin_state_snapshot(&mut self) {
         // Update TypeScript plugin manager state
-        if let Some(snapshot_handle) = self.plugin_manager.state_snapshot_handle() {
+        if let Some(snapshot_handle) = self.plugin_manager.read().unwrap().state_snapshot_handle() {
             use fresh_core::api::{BufferInfo, CursorInfo, ViewportInfo};
             let mut snapshot = snapshot_handle.write().unwrap();
 
@@ -5669,7 +5667,7 @@ impl Editor {
                 let callback_id = fresh_core::api::JsCallbackId::from(request_id);
                 let json = serde_json::to_string(&split_id.map(|s| s.0 .0))
                     .unwrap_or_else(|_| "null".to_string());
-                self.plugin_manager.resolve_callback(callback_id, json);
+                self.plugin_manager.read().unwrap().resolve_callback(callback_id, json);
             }
             PluginCommand::DistributeSplitsEvenly { split_ids: _ } => {
                 self.handle_distribute_splits_evenly();
@@ -5939,8 +5937,7 @@ impl Editor {
                     });
                 } else {
                     // No async runtime - reject the callback
-                    self.plugin_manager
-                        .reject_callback(callback_id, "Async runtime not available".to_string());
+                    self.plugin_manager.read().unwrap().reject_callback(callback_id, "Async runtime not available".to_string());
                 }
             }
 
@@ -5954,7 +5951,7 @@ impl Editor {
                     "SpawnProcessWait not fully implemented - process_id={}",
                     process_id
                 );
-                self.plugin_manager.reject_callback(
+                self.plugin_manager.read().unwrap().reject_callback(
                     callback_id,
                     format!(
                         "SpawnProcessWait not yet fully implemented for process_id={}",
@@ -5984,8 +5981,7 @@ impl Editor {
                 } else {
                     // Fallback to blocking if no runtime available
                     std::thread::sleep(std::time::Duration::from_millis(duration_ms));
-                    self.plugin_manager
-                        .resolve_callback(callback_id, "null".to_string());
+                    self.plugin_manager.read().unwrap().resolve_callback(callback_id, "null".to_string());
                 }
             }
 
@@ -6101,8 +6097,7 @@ impl Editor {
                         .insert(process_id, handle.abort_handle());
                 } else {
                     // No runtime - reject immediately
-                    self.plugin_manager
-                        .reject_callback(callback_id, "Async runtime not available".to_string());
+                    self.plugin_manager.read().unwrap().reject_callback(callback_id, "Async runtime not available".to_string());
                 }
             }
 
@@ -6197,7 +6192,7 @@ impl Editor {
                                 buffer_id: buffer_id.0 as u64,
                                 split_id: None,
                             };
-                            self.plugin_manager.resolve_callback(
+                            self.plugin_manager.read().unwrap().resolve_callback(
                                 fresh_core::api::JsCallbackId::from(req_id),
                                 serde_json::to_string(&result).unwrap_or_default(),
                             );
@@ -6257,7 +6252,7 @@ impl Editor {
                                     buffer_id: existing_buffer_id.0 as u64,
                                     split_id: splits.first().map(|s| s.0 .0 as u64),
                                 };
-                                self.plugin_manager.resolve_callback(
+                                self.plugin_manager.read().unwrap().resolve_callback(
                                     fresh_core::api::JsCallbackId::from(req_id),
                                     serde_json::to_string(&result).unwrap_or_default(),
                                 );
@@ -6369,7 +6364,7 @@ impl Editor {
                         buffer_id: buffer_id.0 as u64,
                         split_id: created_split_id.map(|s| s.0 .0 as u64),
                     };
-                    self.plugin_manager.resolve_callback(
+                    self.plugin_manager.read().unwrap().resolve_callback(
                         fresh_core::api::JsCallbackId::from(req_id),
                         serde_json::to_string(&result).unwrap_or_default(),
                     );
@@ -6470,7 +6465,7 @@ impl Editor {
                         buffer_id: buffer_id.0 as u64,
                         split_id: Some(split_id.0 as u64),
                     };
-                    self.plugin_manager.resolve_callback(
+                    self.plugin_manager.read().unwrap().resolve_callback(
                         fresh_core::api::JsCallbackId::from(req_id),
                         serde_json::to_string(&result).unwrap_or_default(),
                     );
@@ -6895,7 +6890,7 @@ impl Editor {
                             terminal_id: terminal_id.0 as u64,
                             split_id: created_split_id.map(|s| s.0 .0 as u64),
                         };
-                        self.plugin_manager.resolve_callback(
+                        self.plugin_manager.read().unwrap().resolve_callback(
                             fresh_core::api::JsCallbackId::from(request_id),
                             serde_json::to_string(&result).unwrap_or_default(),
                         );
@@ -6908,7 +6903,7 @@ impl Editor {
                     }
                     Err(e) => {
                         tracing::error!("Failed to create terminal for plugin: {}", e);
-                        self.plugin_manager.reject_callback(
+                        self.plugin_manager.read().unwrap().reject_callback(
                             fresh_core::api::JsCallbackId::from(request_id),
                             format!("Failed to create terminal: {}", e),
                         );
@@ -7029,16 +7024,14 @@ impl Editor {
     /// Load a plugin from a file path
     #[cfg(feature = "plugins")]
     fn handle_load_plugin(&mut self, path: std::path::PathBuf, callback_id: JsCallbackId) {
-        match self.plugin_manager.load_plugin(&path) {
+        match self.plugin_manager.read().unwrap().load_plugin(&path) {
             Ok(()) => {
                 tracing::info!("Loaded plugin from {:?}", path);
-                self.plugin_manager
-                    .resolve_callback(callback_id, "true".to_string());
+                self.plugin_manager.read().unwrap().resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to load plugin from {:?}: {}", path, e);
-                self.plugin_manager
-                    .reject_callback(callback_id, format!("{}", e));
+                self.plugin_manager.read().unwrap().reject_callback(callback_id, format!("{}", e));
             }
         }
     }
@@ -7046,16 +7039,14 @@ impl Editor {
     /// Unload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_unload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.unload_plugin(&name) {
+        match self.plugin_manager.read().unwrap().unload_plugin(&name) {
             Ok(()) => {
                 tracing::info!("Unloaded plugin: {}", name);
-                self.plugin_manager
-                    .resolve_callback(callback_id, "true".to_string());
+                self.plugin_manager.read().unwrap().resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to unload plugin '{}': {}", name, e);
-                self.plugin_manager
-                    .reject_callback(callback_id, format!("{}", e));
+                self.plugin_manager.read().unwrap().reject_callback(callback_id, format!("{}", e));
             }
         }
     }
@@ -7063,16 +7054,14 @@ impl Editor {
     /// Reload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_reload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.reload_plugin(&name) {
+        match self.plugin_manager.read().unwrap().reload_plugin(&name) {
             Ok(()) => {
                 tracing::info!("Reloaded plugin: {}", name);
-                self.plugin_manager
-                    .resolve_callback(callback_id, "true".to_string());
+                self.plugin_manager.read().unwrap().resolve_callback(callback_id, "true".to_string());
             }
             Err(e) => {
                 tracing::error!("Failed to reload plugin '{}': {}", name, e);
-                self.plugin_manager
-                    .reject_callback(callback_id, format!("{}", e));
+                self.plugin_manager.read().unwrap().reject_callback(callback_id, format!("{}", e));
             }
         }
     }
@@ -7080,7 +7069,7 @@ impl Editor {
     /// List all loaded plugins
     #[cfg(feature = "plugins")]
     fn handle_list_plugins(&mut self, callback_id: JsCallbackId) {
-        let plugins = self.plugin_manager.list_plugins();
+        let plugins = self.plugin_manager.read().unwrap().list_plugins();
         // Serialize to JSON array of { name, path, enabled }
         let json_array: Vec<serde_json::Value> = plugins
             .iter()
@@ -7093,7 +7082,7 @@ impl Editor {
             })
             .collect();
         let json_str = serde_json::to_string(&json_array).unwrap_or_else(|_| "[]".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json_str);
+        self.plugin_manager.read().unwrap().resolve_callback(callback_id, json_str);
     }
 
     /// Execute an editor action by name (for vi mode plugin)
@@ -7170,10 +7159,10 @@ impl Editor {
             Ok(text) => {
                 // Serialize text as JSON string
                 let json = serde_json::to_string(&text).unwrap_or_else(|_| "null".to_string());
-                self.plugin_manager.resolve_callback(callback_id, json);
+                self.plugin_manager.read().unwrap().resolve_callback(callback_id, json);
             }
             Err(error) => {
-                self.plugin_manager.reject_callback(callback_id, error);
+                self.plugin_manager.read().unwrap().reject_callback(callback_id, error);
             }
         }
     }
@@ -7228,7 +7217,7 @@ impl Editor {
         let callback_id = fresh_core::api::JsCallbackId::from(request_id);
         // Serialize as JSON (null for None, number for Some)
         let json = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager.read().unwrap().resolve_callback(callback_id, json);
     }
 
     /// Get the byte offset of the end of a line in the active buffer
@@ -7273,7 +7262,7 @@ impl Editor {
 
         let callback_id = fresh_core::api::JsCallbackId::from(request_id);
         let json = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager.read().unwrap().resolve_callback(callback_id, json);
     }
 
     /// Get the total number of lines in a buffer
@@ -7308,7 +7297,7 @@ impl Editor {
 
         let callback_id = fresh_core::api::JsCallbackId::from(request_id);
         let json = serde_json::to_string(&result).unwrap_or_else(|_| "null".to_string());
-        self.plugin_manager.resolve_callback(callback_id, json);
+        self.plugin_manager.read().unwrap().resolve_callback(callback_id, json);
     }
 
     /// Scroll a split to center a specific line in the viewport


### PR DESCRIPTION
This PR continues the multi-window refactoring by moving additional per-window state fields from the `Editor` struct onto the `Window` struct. This improves the architecture by ensuring state that logically belongs to a window (rather than the global editor) is properly scoped.

## Summary

Relocates approximately 30+ state fields from `Editor` to `Window`, including UI toggles, mouse state, LSP-related state, file operations state, and animation state. This change makes the per-window nature of these fields explicit in the type system and reduces the coupling between the global editor and window-specific concerns.

## Key Changes

- **UI Toggles**: Moved `menu_bar_visible`, `menu_bar_auto_shown`, `tab_bar_visible`, `status_bar_visible`, `prompt_line_visible`, and `mouse_enabled` to `Window`
- **Mouse State**: Moved `mouse_cursor_position`, `gpm_active`, and the entire `mouse_state` struct to `Window`
- **LSP & Diagnostics**: Moved `completion_service`, `lsp_diagnostic_namespace`, `stored_push_diagnostics`, `stored_pull_diagnostics`, `stored_diagnostics`, `stored_folding_ranges`, `diagnostic_result_ids`, `lsp_progress`, `lsp_server_statuses`, `lsp_window_messages`, and `lsp_log_messages` to `Window`
- **File Operations**: Moved `file_open_state`, `pending_hot_exit_recovery`, `dir_mod_times`, `last_auto_revert_poll`, `last_file_tree_poll`, `git_index_resolved`, `pending_file_poll_rx`, and `pending_dir_poll_rx` to `Window`
- **Input & Context**: Moved `key_context`, `pending_next_key_callbacks`, `key_capture_active`, `pending_key_capture_buffer`, and `theme_info_popup` to `Window`
- **Other State**: Moved `animations`, `ephemeral_terminals`, `plugin_dev_workspaces`, `tab_context_menu`, `file_explorer_context_menu`, and `line_scan` to `Window`

## Implementation Details

- Updated all call sites to access these fields through `self.active_window()` or `self.active_window_mut()` where appropriate
- Moved several methods from `Editor` impl blocks to `Window` impl blocks (e.g., `action_to_events`, `sync_scroll_groups`, navigation methods)
- Updated test harnesses to access window-scoped state correctly
- Maintained backward compatibility by keeping the accessor pattern consistent with existing per-window state
- Added new helper methods like `get_composite_viewport_height` and `sync_editor_cursor_from_composite` to `Window` for composite buffer operations

This refactoring improves code clarity by making the window-scoped nature of these fields explicit and reduces the cognitive load of understanding which state is global vs. per-window.

https://claude.ai/code/session_016iwfjS4F1YZAvnQmHczN7X