### PR TITLE
fix(input): UI/navigation shortcuts work from file explorer (#1903)

### DIFF
--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -256,6 +256,17 @@ impl KeyContext {
         matches!(self, Self::CompositeBuffer)
     }
 
+    /// Whether this context should allow Normal-context bindings to fall
+    /// through when the action is in the curated UI / navigation set
+    /// (`is_terminal_ui_action`): tab/buffer switching, split navigation,
+    /// palette, settings, etc. These actions don't depend on a text cursor
+    /// and naturally apply to whichever buffer is currently active, so
+    /// users expect them to work even when keyboard focus is elsewhere
+    /// (e.g. on the file explorer). Issue #1903.
+    pub fn allows_ui_fallthrough(&self) -> bool {
+        matches!(self, Self::FileExplorer)
+    }
+
     /// Check if a context should allow input
     pub fn allows_text_input(&self) -> bool {
         matches!(self, Self::Normal | Self::Prompt | Self::FileExplorer)
@@ -1668,6 +1679,7 @@ impl KeybindingResolver {
                 | Action::NextBuffer
                 | Action::PrevBuffer
                 | Action::Close
+                | Action::CloseTab
                 | Action::ScrollTabsLeft
                 | Action::ScrollTabsRight
                 // Terminal control
@@ -1827,9 +1839,14 @@ impl KeybindingResolver {
             let full_fallthrough = context.allows_normal_fallthrough()
                 || matches!(&context, KeyContext::Mode(name) if self.inheriting_modes.contains(name));
 
+            let ui_fallthrough = context.allows_ui_fallthrough();
+
             if let Some(normal_bindings) = self.bindings.get(&KeyContext::Normal) {
                 if let Some(action) = normal_bindings.get(norm) {
-                    if full_fallthrough || Self::is_application_wide_action(action) {
+                    if full_fallthrough
+                        || Self::is_application_wide_action(action)
+                        || (ui_fallthrough && Self::is_terminal_ui_action(action))
+                    {
                         tracing::trace!(
                             "  -> Found action in custom normal bindings (fallthrough): {:?}",
                             action
@@ -1841,7 +1858,10 @@ impl KeybindingResolver {
 
             if let Some(normal_bindings) = self.default_bindings.get(&KeyContext::Normal) {
                 if let Some(action) = normal_bindings.get(norm) {
-                    if full_fallthrough || Self::is_application_wide_action(action) {
+                    if full_fallthrough
+                        || Self::is_application_wide_action(action)
+                        || (ui_fallthrough && Self::is_terminal_ui_action(action))
+                    {
                         tracing::trace!(
                             "  -> Found action in default normal bindings (fallthrough): {:?}",
                             action
@@ -2611,7 +2631,9 @@ impl KeybindingResolver {
 
         // For certain contexts, also check Normal context for fallthrough actions
         if context != KeyContext::Normal
-            && (context.allows_normal_fallthrough() || Self::is_application_wide_action(action))
+            && (context.allows_normal_fallthrough()
+                || Self::is_application_wide_action(action)
+                || (context.allows_ui_fallthrough() && Self::is_terminal_ui_action(action)))
         {
             // Check custom normal bindings
             if let Some(normal_bindings) = self.bindings.get(&KeyContext::Normal) {
@@ -2847,6 +2869,82 @@ mod tests {
             resolver.resolve(&shift_backspace, KeyContext::FileExplorer),
             Action::FileExplorerSearchBackspace,
             "Shift+Backspace should resolve to FileExplorerSearchBackspace (same as Backspace) in FileExplorer context"
+        );
+    }
+
+    #[test]
+    fn test_file_explorer_ui_fallthrough() {
+        // Regression test for https://github.com/sinelaw/fresh/issues/1903
+        // From the FileExplorer context, application-level UI / navigation
+        // bindings (next/prev buffer, scroll tabs, close tab, next/prev
+        // split, ...) bound only in Normal must still fire — the user
+        // expects to act on the "tabbed files" without first transferring
+        // focus out of the explorer.
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+
+        let cases = [
+            (
+                KeyCode::PageUp,
+                KeyModifiers::CONTROL,
+                Action::PrevBuffer,
+                "Ctrl+PageUp -> prev_buffer",
+            ),
+            (
+                KeyCode::PageDown,
+                KeyModifiers::CONTROL,
+                Action::NextBuffer,
+                "Ctrl+PageDown -> next_buffer",
+            ),
+            (
+                KeyCode::PageUp,
+                KeyModifiers::ALT,
+                Action::ScrollTabsLeft,
+                "Alt+PageUp -> scroll_tabs_left",
+            ),
+            (
+                KeyCode::PageDown,
+                KeyModifiers::ALT,
+                Action::ScrollTabsRight,
+                "Alt+PageDown -> scroll_tabs_right",
+            ),
+            (
+                KeyCode::Char('w'),
+                KeyModifiers::ALT,
+                Action::CloseTab,
+                "Alt+W -> close_tab",
+            ),
+        ];
+
+        for (code, mods, expected, label) in cases {
+            let event = KeyEvent::new(code, mods);
+            assert_eq!(
+                resolver.resolve(&event, KeyContext::FileExplorer),
+                expected,
+                "{label} should fall through from FileExplorer to Normal"
+            );
+        }
+
+        // Cursor-level Normal bindings (e.g. arrow keys for cursor movement)
+        // must NOT fall through — the explorer has its own arrow handlers.
+        // Up arrow in FileExplorer is bound to file_explorer_up; verify
+        // the explorer binding wins over a hypothetical Normal MoveUp.
+        let up = KeyEvent::new(KeyCode::Up, KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&up, KeyContext::FileExplorer),
+            Action::FileExplorerUp,
+            "Up must continue to navigate the explorer, not move the cursor"
+        );
+
+        // Plain InsertChar fallthrough must NOT happen for non-UI Normal
+        // bindings: 'd' (without Alt/Ctrl) is part of FileExplorer text
+        // input (search-as-you-type), it must remain InsertChar and not
+        // resolve to AddCursorNextMatch (Ctrl+D) or anything else.
+        let plain_d = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&plain_d, KeyContext::FileExplorer),
+            Action::InsertChar('d'),
+            "Plain 'd' must remain text input for explorer search-as-you-type"
         );
     }
 

--- a/crates/fresh-editor/tests/e2e/preview_tabs.rs
+++ b/crates/fresh-editor/tests/e2e/preview_tabs.rs
@@ -447,3 +447,68 @@ fn keyboard_navigation_skips_preview_when_disabled() {
         "with preview_tabs disabled, keyboard nav must not alter the tab bar; got:\n{row}"
     );
 }
+
+/// Regression test for https://github.com/sinelaw/fresh/issues/1903
+///
+/// Buffer/tab navigation shortcuts (e.g. Ctrl+PageUp -> prev_buffer)
+/// must work even while the file explorer holds keyboard focus, so the
+/// user can act on the tabbed files immediately after selecting an
+/// entry instead of clicking out of the explorer first. Driven through
+/// the real input pipeline so the keybinding-resolver fallthrough is
+/// exercised end-to-end. Each file's content is distinctive so the
+/// active buffer can be identified from rendered output alone (the
+/// active-tab marker is style-only and doesn't survive screen
+/// stringification).
+#[test]
+fn buffer_navigation_shortcut_works_from_file_explorer() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project = harness.project_dir().unwrap();
+    fs::write(project.join("alpha.txt"), "ALPHA_FILE_BODY\n").unwrap();
+    fs::write(project.join("beta.txt"), "BETA_FILE_BODY\n").unwrap();
+
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("alpha.txt").unwrap();
+    harness.wait_for_file_explorer_item("beta.txt").unwrap();
+
+    // Open both files as permanent tabs (double-click). After the second
+    // double-click beta.txt is the active tab.
+    double_click_file(&mut harness, "alpha.txt");
+    double_click_file(&mut harness, "beta.txt");
+    harness
+        .wait_until(|h| h.screen_to_string().contains("BETA_FILE_BODY"))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("ALPHA_FILE_BODY"),
+        "Precondition: only beta.txt's content should be visible in the \
+         editor pane after opening it last;\nscreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Move focus back to the file explorer — the user's reported flow:
+    // focus was on the explorer when they pressed the buffer-navigation
+    // shortcut. Ctrl+E focuses the explorer when the editor has focus.
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // From FileExplorer context, Ctrl+PageUp should switch to the
+    // previous buffer via the UI-action fallthrough into Normal. Without
+    // the fallthrough the keypress is a no-op and beta.txt remains
+    // visible in the editor pane.
+    harness
+        .send_key(KeyCode::PageUp, KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ALPHA_FILE_BODY"))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("BETA_FILE_BODY"),
+        "After Ctrl+PageUp from the explorer, beta.txt's content must \
+         no longer be visible — alpha.txt should be the active buffer;\nscreen:\n{}",
+        harness.screen_to_string()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1903 — when the file explorer holds keyboard focus (e.g. right after selecting a file), buffer/tab navigation shortcuts like `Ctrl+PageUp`, `Ctrl+PageDown`, `Alt+W`, `Alt+PageUp/Down`, etc. were no-ops. The user had to click into the editor before those shortcuts would fire.

The fix introduces a per-context fallthrough policy:

- New `KeyContext::allows_ui_fallthrough()` opts a context into Normal-context fallthrough for any action in the existing `is_terminal_ui_action` set — the curated list of "general navigation and UI actions that don't involve text editing" already used to make these same keys work from terminal mode.
- Enabled for `FileExplorer` only; every other context's behavior is unchanged.
- The explorer's own bindings still win (they're checked first), and text-input fallback remains intact (search-as-you-type works for unmodified character keys).

This avoids enumerating individual bindings, which would have to be mirrored across `default.json` / `vscode.json` / `macos.json` / `emacs.json`. As a side benefit, terminal mode also now picks up `Alt+W` because `Action::CloseTab` (which the keymap binds) was missing from `is_terminal_ui_action` despite being an alias for `Action::Close`.

## Test plan

- [x] `cargo test -p fresh-editor --lib input::keybindings::` — 29 passed (incl. new `test_file_explorer_ui_fallthrough` covering `Ctrl+PageUp`, `Ctrl+PageDown`, `Alt+PageUp`, `Alt+PageDown`, `Alt+W`, plus negative cases for `Up` arrow and plain `'d'` to confirm the explorer's own bindings and text-input fallback still win)
- [x] `cargo test -p fresh-editor --test e2e_tests preview_tabs::` — 12 passed (incl. new `buffer_navigation_shortcut_works_from_file_explorer` end-to-end reproducer that asserts on rendered output)
- [x] `cargo test -p fresh-editor --test e2e_tests file_explorer::` — 61 passed, no regressions
- [x] Failing-without-fix verified: temporarily neutralizing `allows_ui_fallthrough` causes the unit test to fail and the e2e test to hang on `wait_until` (the keypress is a no-op so the editor pane never updates)
- [x] `cargo fmt`, `cargo clippy -p fresh-editor` — clean (no new warnings on touched files)
- [x] Manual tmux validation against the built binary: opened a project with three files via the explorer, then with focus on the explorer:
  - `Ctrl+PageUp` switched the editor pane from gamma → beta ✓
  - `Ctrl+PageDown` switched back ✓
  - `Alt+W` closed the active tab ✓
  - Typing `be` triggered explorer search-as-you-type ✓
  - `Up`/`Down` arrows still navigated the explorer tree, not the buffer cursor ✓

https://claude.ai/code/session_01MnKWbm5dE66ppCYusBuFeS

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnKWbm5dE66ppCYusBuFeS)_