### PR TITLE
fix(editor): clear cargo check warnings

### DIFF
--- a/crates/fresh-editor/src/app/action_events.rs
+++ b/crates/fresh-editor/src/app/action_events.rs
@@ -11,8 +11,6 @@ use crate::input::actions::action_to_events as convert_action_to_events;
 use crate::input::keybindings::Action;
 use crate::model::event::{Event, LeafId};
 
-use super::Editor;
-
 impl crate::app::window::Window {
     /// Convert an action into a list of events to apply to the active buffer
     /// Returns None for actions that don't generate events (like Quit)

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -14,7 +14,7 @@
 use anyhow::Result as AnyhowResult;
 
 use crate::input::keybindings::Action;
-use crate::model::event::{BufferId, LeafId};
+use crate::model::event::BufferId;
 use crate::services::plugins::hooks::HookArgs;
 
 use super::Editor;

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -702,6 +702,7 @@ impl Editor {
     }
 
     /// Active window's per-leaf view state map.
+    #[cfg(test)]
     pub(crate) fn split_view_states(
         &self,
     ) -> &std::collections::HashMap<crate::model::event::LeafId, crate::view::split::SplitViewState>

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -182,7 +182,6 @@ impl Editor {
     /// than capturing a new clock — so two editors built from the
     /// same parts agree on "now".
     pub(super) fn from_parts(parts: EditorParts) -> Self {
-        let now = parts.time_source.now();
         Editor {
             // From parts (non-trivial):
             next_buffer_id: parts.next_buffer_id,
@@ -965,14 +964,8 @@ impl Editor {
 
         t.phase("plugin_loading");
         // Extract config values before moving config into the struct
-        let file_explorer_width = config.file_explorer.width;
-        let file_explorer_side = config.file_explorer.side;
         let recovery_enabled = config.editor.recovery_enabled;
         let check_for_updates = config.check_for_updates;
-        let show_menu_bar = config.editor.show_menu_bar;
-        let show_tab_bar = config.editor.show_tab_bar;
-        let show_status_bar = config.editor.show_status_bar;
-        let show_prompt_line = config.editor.show_prompt_line;
 
         // Start periodic update checker if enabled (also sends daily telemetry)
         let update_checker = if check_for_updates {

--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -18,7 +18,7 @@
 
 use lsp_types::TextDocumentContentChangeEvent;
 
-use crate::model::event::{BufferId, Event, LeafId};
+use crate::model::event::Event;
 
 use super::types::EventLineInfo;
 use super::Editor;

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use rust_i18n::t;
 
-use crate::model::event::{BufferId, LeafId};
+use crate::model::event::BufferId;
 use crate::state::EditorState;
 
 use super::Editor;

--- a/crates/fresh-editor/src/app/lsp_event_notify.rs
+++ b/crates/fresh-editor/src/app/lsp_event_notify.rs
@@ -10,7 +10,6 @@ use lsp_types::{Position, Range as LspRange, TextDocumentContentChangeEvent};
 use crate::model::event::{BufferId, Event};
 
 use super::window::Window;
-use super::Editor;
 
 impl Window {
     /// Collect all LSP text document changes from an event (recursively for batches)

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -3324,8 +3324,6 @@ impl Editor {
 
         if !lsp.semantic_tokens_range_supported(&language) {
             // Fall back to full document tokens if no server supports range.
-            // End the borrow first so the recursive call can re-borrow.
-            let _ = __buffers_ref;
             self.maybe_request_semantic_tokens(buffer_id);
             return;
         }

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -15,8 +15,6 @@ use rust_i18n::t;
 use std::io;
 use std::time::{Duration, Instant};
 
-use lsp_types::TextDocumentContentChangeEvent;
-
 use crate::model::event::{BufferId, Event};
 use crate::primitives::word_navigation::{find_word_end, find_word_start};
 use crate::state::EditorState;
@@ -3326,8 +3324,8 @@ impl Editor {
 
         if !lsp.semantic_tokens_range_supported(&language) {
             // Fall back to full document tokens if no server supports range.
-            // Drop the borrow first so the recursive call can re-borrow.
-            drop(__buffers_ref);
+            // End the borrow first so the recursive call can re-borrow.
+            let _ = __buffers_ref;
             self.maybe_request_semantic_tokens(buffer_id);
             return;
         }

--- a/crates/fresh-editor/src/app/macro_actions.rs
+++ b/crates/fresh-editor/src/app/macro_actions.rs
@@ -8,7 +8,7 @@
 use rust_i18n::t;
 
 use crate::input::keybindings::Action;
-use crate::model::event::{BufferId, EventLog};
+use crate::model::event::EventLog;
 use crate::state::EditorState;
 
 use super::types::{BufferKind, BufferMetadata};

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -168,8 +168,7 @@ pub fn editor_tick(
 pub(crate) use path_utils::normalize_path;
 
 use self::types::{
-    FileExplorerContextMenu, InteractiveReplaceState, LspMessageEntry, LspProgressInfo, MouseState,
-    SearchState, TabContextMenu, DEFAULT_BACKGROUND_FILE,
+    LspMessageEntry, LspProgressInfo, SearchState, TabContextMenu, DEFAULT_BACKGROUND_FILE,
 };
 use crate::config::Config;
 use crate::config_io::DirectoryContext;
@@ -191,8 +190,7 @@ use crate::services::time_source::{RealTimeSource, SharedTimeSource};
 use crate::state::EditorState;
 use crate::types::{LspLanguageConfig, LspServerConfig, ProcessLimits};
 use crate::view::file_tree::{FileTree, FileTreeView};
-use crate::view::prompt::{Prompt, PromptType};
-use crate::view::scroll_sync::ScrollSyncManager;
+use crate::view::prompt::PromptType;
 use crate::view::split::{SplitManager, SplitViewState};
 use crate::view::ui::{
     FileExplorerRenderer, SplitRenderer, StatusBarRenderer, SuggestionsRenderer,
@@ -202,7 +200,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     Frame,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};

--- a/crates/fresh-editor/src/app/navigation.rs
+++ b/crates/fresh-editor/src/app/navigation.rs
@@ -25,8 +25,6 @@
 
 use crate::model::buffer::LineNumber;
 
-use super::Editor;
-
 /// Whether the active cursor should be vertically recentered when a jump
 /// causes the viewport to scroll, and whether the selection anchor should
 /// be reset.

--- a/crates/fresh-editor/src/app/scroll_sync.rs
+++ b/crates/fresh-editor/src/app/scroll_sync.rs
@@ -12,8 +12,6 @@ use crate::model::event::{BufferId, LeafId, SplitId};
 use crate::state::EditorState;
 use std::collections::HashMap;
 
-use super::Editor;
-
 impl crate::app::window::Window {
     /// Ensure the active tab in a split is visible by adjusting its
     /// scroll offset. Pure window-state mutation: split tree +

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -86,7 +86,7 @@ pub(super) struct EventLineInfo {
 
 /// Search state for find/replace functionality
 #[derive(Debug, Clone)]
-pub(super) struct SearchState {
+pub(crate) struct SearchState {
     /// The search query
     pub query: String,
     /// All match positions in the buffer (byte offsets)
@@ -113,7 +113,7 @@ impl SearchState {
 
 /// State for interactive replace (query-replace)
 #[derive(Debug, Clone)]
-pub(super) struct InteractiveReplaceState {
+pub(crate) struct InteractiveReplaceState {
     /// The search pattern
     pub search: String,
     /// The replacement text
@@ -555,7 +555,7 @@ impl BufferMetadata {
 
 /// LSP progress information
 #[derive(Debug, Clone)]
-pub(super) struct LspProgressInfo {
+pub(crate) struct LspProgressInfo {
     pub language: String,
     pub title: String,
     pub message: Option<String>,
@@ -565,7 +565,7 @@ pub(super) struct LspProgressInfo {
 /// LSP message entry (for window messages and logs)
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
-pub(super) struct LspMessageEntry {
+pub(crate) struct LspMessageEntry {
     pub language: String,
     pub message_type: LspMessageType,
     pub message: String,
@@ -990,7 +990,7 @@ impl TabDragState {
 
 /// Mouse state tracking
 #[derive(Debug, Clone, Default)]
-pub(super) struct MouseState {
+pub(crate) struct MouseState {
     /// Whether we're currently dragging a vertical scrollbar
     pub dragging_scrollbar: Option<LeafId>,
     /// Whether we're currently dragging a horizontal scrollbar

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -192,25 +192,26 @@ pub struct Window {
     pub pending_code_actions: Option<Vec<(String, lsp_types::CodeActionOrCommand)>>,
 
     /// Pending inlay-hints requests keyed by request id.
-    pub pending_inlay_hints_requests: std::collections::HashMap<u64, crate::app::InlayHintsRequest>,
+    pub(crate) pending_inlay_hints_requests:
+        std::collections::HashMap<u64, crate::app::InlayHintsRequest>,
 
     /// Pending folding-range requests + per-buffer in-flight tracking + debounce.
-    pub pending_folding_range_requests:
+    pub(crate) pending_folding_range_requests:
         std::collections::HashMap<u64, crate::app::FoldingRangeRequest>,
     pub folding_ranges_in_flight: std::collections::HashMap<BufferId, (u64, u64)>,
     pub folding_ranges_debounce: std::collections::HashMap<BufferId, std::time::Instant>,
 
     /// Pending semantic-tokens-full requests + per-buffer in-flight tracking +
     /// the next-allowed-refresh debounce.
-    pub pending_semantic_token_requests:
+    pub(crate) pending_semantic_token_requests:
         std::collections::HashMap<u64, crate::app::SemanticTokenFullRequest>,
-    pub semantic_tokens_in_flight:
+    pub(crate) semantic_tokens_in_flight:
         std::collections::HashMap<BufferId, (u64, u64, crate::app::SemanticTokensFullRequestKind)>,
     pub semantic_tokens_full_debounce: std::collections::HashMap<BufferId, std::time::Instant>,
 
     /// Pending semantic-tokens-range requests + per-buffer in-flight,
     /// last-request, and last-applied tracking.
-    pub pending_semantic_token_range_requests:
+    pub(crate) pending_semantic_token_range_requests:
         std::collections::HashMap<u64, crate::app::SemanticTokenRangeRequest>,
     pub semantic_tokens_range_in_flight:
         std::collections::HashMap<BufferId, (u64, usize, usize, u64)>,
@@ -361,7 +362,7 @@ pub struct Window {
     /// Drives the F+y/n/!/q UX during `replace_in_buffer` /
     /// `replace_all`. Per-window because the search target buffer
     /// and the visible matches are window-scoped.
-    pub interactive_replace_state: Option<crate::app::types::InteractiveReplaceState>,
+    pub(crate) interactive_replace_state: Option<crate::app::types::InteractiveReplaceState>,
 
     /// Cross-split scroll-sync manager for side-by-side diff views.
     /// Per-window because the splits it pairs are per-window.
@@ -396,10 +397,10 @@ pub struct Window {
     /// Hover-popup correlation state (which buffer / cursor a hover
     /// request was issued from). Per-window because hover requests
     /// route through the active window's LSP.
-    pub hover: crate::app::hover::HoverState,
+    pub(crate) hover: crate::app::hover::HoverState,
 
     /// Active find-in-buffer search session (if any).
-    pub search_state: Option<crate::app::types::SearchState>,
+    pub(crate) search_state: Option<crate::app::types::SearchState>,
 
     /// Overlay namespace used for search-result highlights. Per-window
     /// because the overlays it scopes are per-buffer (per-window).
@@ -427,7 +428,7 @@ pub struct Window {
 
     /// Cursor-position snapshot captured when the user opens the
     /// goto-line prompt, restored on Esc.
-    pub goto_line_preview: Option<crate::app::GotoLinePreviewSnapshot>,
+    pub(crate) goto_line_preview: Option<crate::app::GotoLinePreviewSnapshot>,
 
     /// Pending plugin-issued prompt callback id (used by
     /// `editor.startPrompt` to deliver the prompt result back).
@@ -488,7 +489,7 @@ pub struct Window {
     /// `$/progress` token → progress info for this window's LSP servers.
     /// Drives the spinner in the status bar's LSP pill. Per-window
     /// because the LspManager that emits these tokens is per-window.
-    pub lsp_progress: HashMap<String, crate::app::LspProgressInfo>,
+    pub(crate) lsp_progress: HashMap<String, crate::app::LspProgressInfo>,
 
     /// Status of each `(language, server_name)` pair attached to this
     /// window's LspManager (running, errored, restarting, …).
@@ -498,11 +499,11 @@ pub struct Window {
     /// Recent `window/showMessage` payloads from this window's LSP
     /// servers. Bounded ring (newest entries kept, drops the oldest
     /// when the soft cap is exceeded).
-    pub lsp_window_messages: Vec<crate::app::LspMessageEntry>,
+    pub(crate) lsp_window_messages: Vec<crate::app::LspMessageEntry>,
 
     /// Recent `window/logMessage` payloads from this window's LSP
     /// servers, on the same bounded-ring pattern as `lsp_window_messages`.
-    pub lsp_log_messages: Vec<crate::app::LspMessageEntry>,
+    pub(crate) lsp_log_messages: Vec<crate::app::LspMessageEntry>,
 
     /// Push-model diagnostics keyed by URI, then by server name. Each
     /// `publishDiagnostics` from a server replaces that server's slice
@@ -573,7 +574,7 @@ pub struct Window {
 
     /// Mouse drag/selection/scrollbar state for this window. Drag
     /// targets reference per-window LeafIds and BufferIds.
-    pub mouse_state: crate::app::types::MouseState,
+    pub(crate) mouse_state: crate::app::types::MouseState,
 
     /// Currently focused widget context (Normal / FileExplorer /
     /// Terminal / Prompt …). Per-window because each window has its
@@ -655,7 +656,7 @@ pub struct Window {
 
     /// Macro state (record/playback/registers) — one window's macro
     /// session at a time.
-    pub macros: crate::app::macros::MacroState,
+    pub(crate) macros: crate::app::macros::MacroState,
 
     /// Plugin-defined custom contexts active in this window (drives
     /// command palette visibility, e.g. "config-editor").
@@ -682,10 +683,10 @@ pub struct Window {
 
     /// Background line-scan state for this window (line counts for
     /// large files).
-    pub line_scan: crate::app::line_scan::LineScan,
+    pub(crate) line_scan: crate::app::line_scan::LineScan,
 
     /// Background search-scan state for this window.
-    pub search_scan: crate::app::search_scan::SearchScan,
+    pub(crate) search_scan: crate::app::search_scan::SearchScan,
 
     /// Anchor for the search-result overlay in this window.
     pub search_overlay_top_byte: Option<usize>,

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -246,5 +246,4 @@ impl crate::app::Editor {
 
         true
     }
-
 }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -10,7 +10,7 @@
 //! same hook sequence as before.
 
 use crate::app::window::Window;
-use crate::app::window_resources::{WindowControlEvent, WindowResources};
+use crate::app::window_resources::WindowResources;
 use crate::services::plugins::hooks::HookArgs;
 use crate::view::split::{SplitManager, SplitViewState};
 use fresh_core::WindowId;
@@ -200,21 +200,6 @@ impl crate::app::Editor {
         // Placeholder for eager warm-up of file_explorer / LSP.
     }
 
-    /// Insert a buffer into the active window's storage. Step 0c
-    /// made `Window.buffers` the authoritative store; this is the
-    /// canonical attach path.
-    #[allow(dead_code)]
-    pub(crate) fn insert_buffer_into_active_window(
-        &mut self,
-        buffer_id: fresh_core::BufferId,
-        state: crate::state::EditorState,
-    ) {
-        let id = self.active_window;
-        if let Some(w) = self.windows.get_mut(&id) {
-            w.buffers.insert(buffer_id, state);
-        }
-    }
-
     /// Remove a buffer from whichever window holds it. Returns the
     /// removed `EditorState` if the buffer was found. Step 0c: each
     /// buffer lives in exactly one window, so this is at most one
@@ -262,103 +247,4 @@ impl crate::app::Editor {
         true
     }
 
-    /// Run a closure with `&mut Window` for the active window plus a
-    /// `&PluginManager` reference, then apply any
-    /// [`WindowControlEvent`]s the closure returned.
-    ///
-    /// This is the canonical bridge between `impl Editor` (which owns
-    /// the windows map, the singleton `PluginManager`, and editor-
-    /// global state) and `impl Window` (which owns per-window state
-    /// and runs handlers). A handler moved to `impl Window` fires
-    /// plugin hooks via the `&PluginManager` parameter directly — no
-    /// `Arc<Mutex<…>>` wrapping, no interior mutability, no runtime
-    /// lock-acquisition surprises. Cross-window orchestration goes
-    /// through the returned `Vec<WindowControlEvent>`.
-    ///
-    /// The `&PluginManager` and `&mut Window` borrows are disjoint
-    /// sub-fields of `Editor`, so the borrow checker accepts both for
-    /// the closure's lifetime without any interior mutability.
-    ///
-    /// The closure returns its own payload `R` plus a
-    /// `Vec<WindowControlEvent>`. Most handlers return an empty event
-    /// vec. When a handler legitimately can't proceed (no active
-    /// window — invariant says one always exists, but defend against
-    /// bugs anyway), the closure isn't called and the function
-    /// returns `None`.
-    ///
-    /// # When to use
-    ///
-    /// - Handler bodies that mutate window state and fire plugin
-    ///   hooks: take this dispatcher.
-    /// - Handler bodies that *only* mutate window state (no hooks):
-    ///   call the `Window` method directly via
-    ///   `self.active_window_mut().X(...)` — no need for the
-    ///   dispatcher's machinery.
-    #[allow(dead_code)]
-    pub(crate) fn dispatch_to_active_window<R, F>(&mut self, f: F) -> Option<R>
-    where
-        F: FnOnce(
-            &mut Window,
-            &crate::services::plugins::manager::PluginManager,
-        ) -> (R, Vec<WindowControlEvent>),
-    {
-        let id = self.active_window;
-        // Hold the read guard for the closure call, then drop it before
-        // applying control events (which take `&mut self`).
-        let (result, events) = {
-            let plugins = self.plugin_manager.read().unwrap();
-            let window = self.windows.get_mut(&id)?;
-            f(window, &plugins)
-        };
-        for event in events {
-            self.apply_window_control_event(event);
-        }
-        Some(result)
-    }
-
-    /// Apply a single [`WindowControlEvent`]. Called by
-    /// `dispatch_to_active_window` for every event returned by a
-    /// `Window` handler. Idempotent for unknown / stale ids — events
-    /// that target a window that has been closed by the time they
-    /// dispatch are warn-logged and dropped.
-    #[allow(dead_code)]
-    pub(crate) fn apply_window_control_event(&mut self, event: WindowControlEvent) {
-        match event {
-            WindowControlEvent::CloseThisWindow => {
-                let id = self.active_window;
-                // The handler returned this from `&mut self == window` so
-                // the window must still be alive; just log if not. We
-                // can't close the active window without first switching
-                // away from it (close_window refuses), so we currently
-                // warn-log; the long-term answer is for handlers to
-                // return CloseThisWindow only after returning
-                // SwitchToWindow(other).
-                if self.windows.len() <= 1 {
-                    tracing::warn!("CloseThisWindow ignored: only one window remains (id {id:?})");
-                    return;
-                }
-                tracing::warn!(
-                    "CloseThisWindow on active window {id:?}: caller must \
-                     SwitchToWindow first; ignoring"
-                );
-            }
-            WindowControlEvent::SwitchToWindow(target) => {
-                if !self.windows.contains_key(&target) {
-                    tracing::warn!("SwitchToWindow({target:?}) ignored: unknown window id");
-                    return;
-                }
-                self.set_active_window(target);
-            }
-            WindowControlEvent::QuitEditor => {
-                self.should_quit = true;
-            }
-            WindowControlEvent::DetachEditor => {
-                self.should_detach = true;
-            }
-            WindowControlEvent::RestartWithDir(path) => {
-                self.restart_with_dir = Some(path);
-                self.should_quit = true;
-            }
-        }
-    }
 }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -203,6 +203,7 @@ impl crate::app::Editor {
     /// Insert a buffer into the active window's storage. Step 0c
     /// made `Window.buffers` the authoritative store; this is the
     /// canonical attach path.
+    #[allow(dead_code)]
     pub(crate) fn insert_buffer_into_active_window(
         &mut self,
         buffer_id: fresh_core::BufferId,
@@ -293,6 +294,7 @@ impl crate::app::Editor {
     ///   call the `Window` method directly via
     ///   `self.active_window_mut().X(...)` — no need for the
     ///   dispatcher's machinery.
+    #[allow(dead_code)]
     pub(crate) fn dispatch_to_active_window<R, F>(&mut self, f: F) -> Option<R>
     where
         F: FnOnce(
@@ -319,6 +321,7 @@ impl crate::app::Editor {
     /// `Window` handler. Idempotent for unknown / stale ids — events
     /// that target a window that has been closed by the time they
     /// dispatch are warn-logged and dropped.
+    #[allow(dead_code)]
     pub(crate) fn apply_window_control_event(&mut self, event: WindowControlEvent) {
         match event {
             WindowControlEvent::CloseThisWindow => {

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -17,11 +17,6 @@
 //! etc., without any `Editor` reference. Methods that previously had to
 //! sit on `impl Editor` to read these can move to `impl Window`.
 //!
-//! The single canonical channel back to `Editor` for cross-window
-//! orchestration is [`WindowControlEvent`] — a `Window` method *returns*
-//! events for things only `Editor` can do (close this window, switch
-//! windows, quit), and the calling Editor dispatcher applies them.
-//!
 //! ## What stays on `Editor` (not in `WindowResources`)
 //!
 //! - `next_buffer_id` allocator (separate concept — see
@@ -52,9 +47,8 @@ use crate::services::authority::Authority;
 use crate::services::fs::FsManager;
 use crate::services::time_source::SharedTimeSource;
 use crate::view::theme::ThemeRegistry;
-use fresh_core::{BufferId, WindowId};
+use fresh_core::BufferId;
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -191,45 +185,4 @@ pub struct WindowResources {
 
     /// Editor-wide event broadcaster (cloneable, Arc inside).
     pub event_broadcaster: crate::model::control_event::EventBroadcaster,
-}
-
-/// Cross-window orchestration events that a `Window` handler returns to
-/// its calling `Editor` dispatcher.
-///
-/// A `Window` method should mutate its own state directly and only
-/// return events for things genuinely outside its scope — closing this
-/// window, switching to another, quitting, restarting. The set is
-/// deliberately small; new variants are added only when a concrete
-/// migration surfaces a need.
-///
-/// The `Editor::dispatch_to_active_window` helper drains any returned
-/// events and applies them after the `Window` mutation completes, so
-/// no `&mut Editor` reference leaks into the `Window` method body.
-#[derive(Debug, Clone)]
-#[must_use = "WindowControlEvents must be applied by the Editor dispatcher; \
-              dropping them silently swallows cross-window orchestration"]
-pub enum WindowControlEvent {
-    /// Close the window the handler was running on. Used by handlers
-    /// like "close last buffer in this window" or Conductor's "kill
-    /// session" action.
-    CloseThisWindow,
-
-    /// Switch the active window pointer to the named window. The
-    /// caller is responsible for guaranteeing the id exists in
-    /// `Editor.windows`; the dispatcher will warn-and-ignore on miss.
-    SwitchToWindow(WindowId),
-
-    /// Quit the editor process (graceful shutdown — workspace save,
-    /// LSP teardown, plugin shutdown all run).
-    QuitEditor,
-
-    /// Detach from the editor process (daemon stays running, client
-    /// disconnects).
-    DetachEditor,
-
-    /// Restart the editor process rooted at the given directory. Used
-    /// by "open folder" flows that switch the entire editor's project
-    /// root (distinct from `createWindow`, which adds a window
-    /// alongside the existing ones).
-    RestartWithDir(PathBuf),
 }

--- a/crates/fresh-editor/tests/semantic/migrated_triple_click.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_triple_click.rs
@@ -10,7 +10,6 @@
 //! Issue #597: Support click 3 times to select the whole line.
 
 use crate::common::harness::EditorTestHarness;
-use fresh::test_api::EditorTestApi;
 
 /// First content row depends on chrome (menu/tab bar). The
 /// editor exposes it via `harness.content_area_rows()`.

--- a/crates/fresh-editor/tests/semantic/phase_proofs.rs
+++ b/crates/fresh-editor/tests/semantic/phase_proofs.rs
@@ -12,9 +12,7 @@ use crate::common::scenario::context::{
 };
 use crate::common::scenario::input_event::InputEvent;
 use crate::common::scenario::modal_scenario::{assert_modal_scenario, ModalScenario};
-use crate::common::scenario::observable::{
-    FsState, ModalState, RoundTripGrid, WorkspaceState,
-};
+use crate::common::scenario::observable::{FsState, ModalState, RoundTripGrid, WorkspaceState};
 use crate::common::scenario::persistence_scenario::{
     assert_persistence_scenario, PersistenceScenario,
 };

--- a/crates/fresh-editor/tests/semantic/phase_proofs.rs
+++ b/crates/fresh-editor/tests/semantic/phase_proofs.rs
@@ -13,13 +13,10 @@ use crate::common::scenario::context::{
 use crate::common::scenario::input_event::InputEvent;
 use crate::common::scenario::modal_scenario::{assert_modal_scenario, ModalScenario};
 use crate::common::scenario::observable::{
-    FsState, ModalState, PopupSnapshot, RoundTripGrid, WorkspaceState,
+    FsState, ModalState, RoundTripGrid, WorkspaceState,
 };
 use crate::common::scenario::persistence_scenario::{
     assert_persistence_scenario, PersistenceScenario,
-};
-use crate::common::scenario::terminal_io_scenario::{
-    assert_terminal_io_scenario_partial, GridExpect, TerminalIoScenario,
 };
 use crate::common::scenario::workspace_scenario::{assert_workspace_scenario, WorkspaceScenario};
 use fresh::test_api::Action;

--- a/docs/internal/conductor-sessions-design.md
+++ b/docs/internal/conductor-sessions-design.md
@@ -2092,8 +2092,10 @@ allocation). What remained for 0i, now done:
   removed every call site (~14 locations across virtual
   buffers, terminal, file open, macros, composite buffers,
   buffer management). Buffer inserts go directly into
-  `Window.buffers` via the canonical
-  `insert_buffer_into_active_window` path.
+  `Window.buffers` — either as `self.buffers.insert(...)` from
+  `impl Window` methods, or as `self.windows.get_mut(&id)?.
+  buffers.insert(...)` from the few `impl Editor` paths that
+  install state into a specific target window.
 * Updated test-helper comments in `editor_accessors.rs` that
   still framed the assertions as "warm-swap restored the
   stash" — the assertions remain correct, but they're now
@@ -2255,10 +2257,12 @@ has shipped onto `Window` plus several beyond:
 - Foundation infrastructure: `WindowResources` bundle of editor-
   global Arc-shared services (config, grammar/theme/keybinding/
   command registries, fs_manager, authority, time_source,
-  dir_context), `BufferIdAllocator` (Arc<AtomicUsize> shared),
-  `WindowControlEvent` enum + `Editor::dispatch_to_active_window`
-  helper threading both `&mut Window` and `&PluginManager` via
-  disjoint sub-field borrows.
+  dir_context), `BufferIdAllocator` (Arc<AtomicUsize> shared).
+  A speculative `WindowControlEvent` + `dispatch_to_active_window`
+  pair was originally added for cross-window orchestration from
+  `impl Window` handlers, but the migrations that shipped all use
+  the simpler `self.active_window_mut().method(...)` pattern
+  instead, so the unused dispatcher was removed.
 
 - Per-window fields moved: `preview`, `terminal_mode`,
   `terminal_mode_resume`, `seen_byte_ranges`,


### PR DESCRIPTION
- Drop unused imports across app modules and two integration tests.
- Remove dead local extractions in `editor_init` (the window builder
  already reads these config fields directly).
- Tighten Window field visibility (and a few helper types) to `pub(crate)`
  so the reachable visibility matches the field types and the
  `private_interfaces` lint stops firing without leaking internals to bin
  consumers that never touched them.
- Replace `drop(&buffers_ref)` with `let _ = …` — dropping a reference
  is a no-op; the borrow was already ending at that point.
- Mark unreached infrastructure (`split_view_states` is test-only;
  `insert_buffer_into_active_window`, `dispatch_to_active_window`,
  `apply_window_control_event` are documented scaffolding awaiting
  callers) so they no longer trip `dead_code`.