### PR TITLE
Add plugin API for custom status bar elements

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1683,8 +1683,13 @@ pub enum PluginCommand {
         title: String,
     },
 
-    /// Set the value for a custom statusbar token
-    SetStatusBarElementValue { name: String, value: String },
+    /// Set the value of a status-bar token for a specific buffer.
+    /// `key` is the full "plugin_name:token_name" form.
+    SetStatusBarValue {
+        buffer_id: u64,
+        key: String,
+        value: String,
+    },
 
     /// Unregister a command by name
     UnregisterCommand { name: String },

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1676,6 +1676,16 @@ pub enum PluginCommand {
     /// Register a custom command
     RegisterCommand { command: Command },
 
+    /// Register a custom statusbar token
+    RegisterStatusBarElement {
+        plugin_name: String,
+        token_name: String,
+        title: String,
+    },
+
+    /// Set the value for a custom statusbar token
+    SetStatusBarElementValue { name: String, value: String },
+
     /// Unregister a command by name
     UnregisterCommand { name: String },
 

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -794,7 +794,7 @@
           ],
           "x-section": "Status Bar",
           "x-dual-list-sibling": "/editor/status_bar/right",
-          "x-dynamicly-extendable-status-bar-elements": true
+          "x-dynamically-extendable-status-bar-elements": true
         },
         "right": {
           "description": "Elements shown on the right side of the status bar.\nDefault: [\"{line_ending}\", \"{encoding}\", \"{language}\", \"{lsp}\", \"{warnings}\", \"{update}\", \"{palette}\"]",
@@ -813,7 +813,7 @@
           ],
           "x-section": "Status Bar",
           "x-dual-list-sibling": "/editor/status_bar/left",
-          "x-dynamicly-extendable-status-bar-elements": true
+          "x-dynamically-extendable-status-bar-elements": true
         }
       }
     },

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -793,7 +793,8 @@
             "{messages}"
           ],
           "x-section": "Status Bar",
-          "x-dual-list-sibling": "/editor/status_bar/right"
+          "x-dual-list-sibling": "/editor/status_bar/right",
+          "x-dynamicly-extendable-status-bar-elements": true
         },
         "right": {
           "description": "Elements shown on the right side of the status bar.\nDefault: [\"{line_ending}\", \"{encoding}\", \"{language}\", \"{lsp}\", \"{warnings}\", \"{update}\", \"{palette}\"]",
@@ -811,7 +812,8 @@
             "{palette}"
           ],
           "x-section": "Status Bar",
-          "x-dual-list-sibling": "/editor/status_bar/left"
+          "x-dual-list-sibling": "/editor/status_bar/left",
+          "x-dynamicly-extendable-status-bar-elements": true
         }
       }
     },

--- a/crates/fresh-editor/plugins/git_statusbar.i18n.json
+++ b/crates/fresh-editor/plugins/git_statusbar.i18n.json
@@ -1,0 +1,72 @@
+{
+  "cs": {
+    "status.detecting_branch": "Detekuji větev ...",
+    "status.not_in_git": "Není v git",
+    "status.git_branch": "Git: větev"
+  },
+  "de": {
+    "status.detecting_branch": "Branch erkennen ...",
+    "status.not_in_git": "Nicht in git",
+    "status.git_branch": "Git: Branch"
+  },
+  "en": {
+    "status.detecting_branch": "Detecting branch ...",
+    "status.not_in_git": "Not in git",
+    "status.git_branch": "Git: branch"
+  },
+  "es": {
+    "status.detecting_branch": "Detectando rama ...",
+    "status.not_in_git": "No está en git",
+    "status.git_branch": "Git: rama"
+  },
+  "fr": {
+    "status.detecting_branch": "Détection de la branche ...",
+    "status.not_in_git": "Pas dans git",
+    "status.git_branch": "Git : branche"
+  },
+  "it": {
+    "status.detecting_branch": "Rilevamento branch ...",
+    "status.not_in_git": "Non in git",
+    "status.git_branch": "Git: branch"
+  },
+  "ja": {
+    "status.detecting_branch": "ブランチを検出中...",
+    "status.not_in_git": "git外",
+    "status.git_branch": "Git: ブランチ"
+  },
+  "ko": {
+    "status.detecting_branch": "브랜치 감지 중...",
+    "status.not_in_git": "git 아님",
+    "status.git_branch": "Git: 브랜치"
+  },
+  "pt-BR": {
+    "status.detecting_branch": "Detectando ramo ...",
+    "status.not_in_git": "Não está em git",
+    "status.git_branch": "Git: ramo"
+  },
+  "ru": {
+    "status.detecting_branch": "Определение ветки ...",
+    "status.not_in_git": "Не в git",
+    "status.git_branch": "Git: ветка"
+  },
+  "th": {
+    "status.detecting_branch": "กำลังตรวจจับสาขา ...",
+    "status.not_in_git": "ไม่ได้อยู่ใน git",
+    "status.git_branch": "Git: สาขา"
+  },
+  "uk": {
+    "status.detecting_branch": "Визначення гілки ...",
+    "status.not_in_git": "Не в git",
+    "status.git_branch": "Git: гілка"
+  },
+  "vi": {
+    "status.detecting_branch": "Đang phát hiện nhánh ...",
+    "status.not_in_git": "Không trong git",
+    "status.git_branch": "Git: nhánh"
+  },
+  "zh-CN": {
+    "status.detecting_branch": "正在检测分支...",
+    "status.not_in_git": "不在 git 中",
+    "status.git_branch": "Git: 分支"
+  }
+}

--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -1,0 +1,53 @@
+/// <reference path="./lib/fresh.d.ts" />
+
+const editor = getEditor();
+
+const GIT_BRANCH = "branch";
+
+let lastDetectedTimestamp = 0;
+let lastDetectedBranch = "Detecting branch ...";
+
+async function getCurrentGitBranch(): Promise<string> {
+  const now = Date.now();
+
+  if (now - lastDetectedTimestamp < 5000) {
+    return lastDetectedBranch;
+  }
+
+  const cwd = editor.getCwd();
+  const result = await editor.spawnProcess(
+    "git",
+    ["rev-parse", "--abbrev-ref", "HEAD"],
+    cwd,
+  );
+
+  if (result.exit_code === 0) {
+    const branch = result.stdout.trim();
+
+    lastDetectedBranch = branch || "HEAD";
+  } else {
+    lastDetectedBranch = "Not in git";
+  }
+
+  lastDetectedTimestamp = now;
+
+  return lastDetectedBranch;
+}
+
+editor.registerStatusBarElement(GIT_BRANCH, "Git: branch");
+
+[
+  "buffer_activated",
+  "buffer_deactivated",
+  "buffer_closed",
+  "after_file_open",
+  "after_file_save",
+  "after_insert",
+  "after_delete",
+  "cursor_moved",
+  "render_start",
+].forEach((event) => {
+  editor.on(event, async () => {
+    editor.setStatusBarElementValue(GIT_BRANCH, await getCurrentGitBranch());
+  });
+});

--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -5,7 +5,7 @@ const editor = getEditor();
 const GIT_BRANCH = "branch";
 
 let lastDetectedTimestamp = 0;
-let lastDetectedBranch = "Detecting branch ...";
+let lastDetectedBranch = editor.t("status.detecting_branch");
 
 async function getCurrentGitBranch(): Promise<string> {
   const now = Date.now();
@@ -26,7 +26,7 @@ async function getCurrentGitBranch(): Promise<string> {
 
     lastDetectedBranch = branch || "HEAD";
   } else {
-    lastDetectedBranch = "Not in git";
+    lastDetectedBranch = editor.t("status.not_in_git");
   }
 
   lastDetectedTimestamp = now;
@@ -34,7 +34,7 @@ async function getCurrentGitBranch(): Promise<string> {
   return lastDetectedBranch;
 }
 
-editor.registerStatusBarElement(GIT_BRANCH, "Git: branch");
+editor.registerStatusBarElement(GIT_BRANCH, editor.t("status.git_branch"));
 
 [
   "buffer_activated",

--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -48,6 +48,10 @@ editor.registerStatusBarElement(GIT_BRANCH, editor.t("status.git_branch"));
   "render_start",
 ].forEach((event) => {
   editor.on(event, async () => {
-    editor.setStatusBarElementValue(GIT_BRANCH, await getCurrentGitBranch());
+    const bufferId = editor.getActiveBufferId();
+    if (bufferId === 0) {
+      return;
+    }
+    editor.setStatusBarValue(bufferId, GIT_BRANCH, await getCurrentGitBranch());
   });
 });

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1380,10 +1380,10 @@ interface EditorAPI {
 	*/
 	registerStatusBarElement(tokenName: string, title: string): boolean;
 	/**
-	* Set the value for a previously registered custom statusbar token.
-	* Token name is "plugin_name:token_name" where plugin_name is the current plugin.
+	* Set the value of a registered status-bar token for a specific buffer.
+	* The token key sent to the editor is "plugin_name:token_name".
 	*/
-	setStatusBarElementValue(tokenName: string, value: string): boolean;
+	setStatusBarValue(bufferId: number, tokenName: string, value: string): boolean;
 	/**
 	* Translate a string - reads plugin name from __pluginName__ global
 	* Args is optional - can be omitted, undefined, null, or an object

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -996,17 +996,6 @@ type AuthorityPayload = {
 	spawner: AuthoritySpawner;
 	terminal_wrapper: AuthorityTerminalWrapper;
 	display_label?: string;
-	/**
-	* Optional host↔remote workspace path mapping. The dev-container
-	* authority sets both roots (editor.getCwd() on host;
-	* remoteWorkspaceFolder on container) so LSP URIs translate at the
-	* host/container boundary. Local and SSH authorities omit it.
-	*/
-	path_translation?: PathTranslationSpec;
-};
-type PathTranslationSpec = {
-	host_root: string;
-	remote_root: string;
 };
 type BackgroundProcessResult = {
 	/**
@@ -1321,7 +1310,7 @@ interface EditorAPI {
 	* again with the same `name` replaces the previous registration
 	* (idempotent — reload works). Exports are auto-dropped when the
 	* calling plugin is unloaded.
-	* 
+	*
 	* Returns `true` on success. Rejects with a TypeError if `name` is
 	* empty or `api` is not an object (functions and primitives are not
 	* valid API surfaces — only objects).
@@ -1363,7 +1352,7 @@ interface EditorAPI {
 	getKeybindingLabel(action: string, mode: string | null): string | null;
 	/**
 	* Register a command in the command palette (Ctrl+P).
-	* 
+	*
 	* Usually you should omit `context` so the command is always visible.
 	* If provided, the command is **hidden** unless your plugin has activated
 	* that context with `editor.setContext(name, true)` or the focused buffer's
@@ -1384,6 +1373,17 @@ interface EditorAPI {
 	* Execute a built-in action
 	*/
 	executeAction(actionName: string): boolean;
+	/**
+	* Register a custom statusbar token.
+	* Token will be named "plugin_name:token_name" where plugin_name is the current plugin.
+	* Returns true if registration succeeded, false if invalid or already registered.
+	*/
+	registerStatusBarElement(tokenName: string, title: string): boolean;
+	/**
+	* Set the value for a previously registered custom statusbar token.
+	* Token name is "plugin_name:token_name" where plugin_name is the current plugin.
+	*/
+	setStatusBarElementValue(tokenName: string, value: string): boolean;
 	/**
 	* Translate a string - reads plugin name from __pluginName__ global
 	* Args is optional - can be omitted, undefined, null, or an object
@@ -1432,7 +1432,7 @@ interface EditorAPI {
 	getViewport(): ViewportInfo | null;
 	/**
 	* List every split with its active buffer and viewport.
-	* 
+	*
 	* Plugins that need to operate on every visible buffer
 	* simultaneously (multi-split flash labels, syncing decorations
 	* across panes, …) iterate this list rather than only seeing
@@ -1554,7 +1554,7 @@ interface EditorAPI {
 	getCwd(): string;
 	/**
 	* Get the active authority's display label.
-	* 
+	*
 	* Empty means the local (default) authority. A non-empty value
 	* means a plugin-installed or SSH authority is in effect (e.g.
 	* `"Container:abc123def456"` for a devcontainer). Intended as a
@@ -1566,7 +1566,7 @@ interface EditorAPI {
 	/**
 	* Join path components (variadic - accepts multiple string arguments)
 	* Always uses forward slashes for cross-platform consistency (like Node.js path.posix.join)
-	* 
+	*
 	* Preserves up to 2 leading slashes, which matters on Windows: Rust's
 	* `Path::canonicalize` returns `\\?\`-prefixed paths, and `editor.getCwd()`
 	* surfaces that to plugin code verbatim. After the backslash→slash
@@ -1605,7 +1605,7 @@ interface EditorAPI {
 	pathToFileUri(path: string): string;
 	/**
 	* Get the UTF-8 byte length of a JavaScript string.
-	* 
+	*
 	* JS strings are UTF-16 internally, so `str.length` returns the number of
 	* UTF-16 code units, not the number of bytes in a UTF-8 encoding.  The
 	* editor API uses byte offsets for all buffer positions (overlays, cursor,
@@ -1656,18 +1656,18 @@ interface EditorAPI {
 	getTempDir(): string;
 	/**
 	* Parse a JSONC (JSON with comments) string into a JS value.
-	* 
+	*
 	* Accepts the JSONC superset: line and block comments, trailing
 	* commas, single-quoted strings, and unquoted object keys — matching
 	* devcontainer.json / tsconfig.json / VS Code settings.json.
-	* 
+	*
 	* Throws a JS error (catchable with try/catch) when the input is not
 	* valid JSONC, like `JSON.parse` does for invalid JSON.
 	*/
 	parseJsonc(text: string): unknown;
 	/**
 	* Get current config as JS object.
-	* 
+	*
 	* The snapshot holds an `Arc<serde_json::Value>` that was serialized
 	* on the editor side the last time the underlying `Arc<Config>`
 	* changed. Cloning the Arc inside the read lock is a refcount bump;
@@ -1684,14 +1684,14 @@ interface EditorAPI {
 	reloadConfig(): void;
 	/**
 	* Set a single config setting in the runtime layer for this session.
-	* 
+	*
 	* `path` is dot-separated (e.g. `"editor.tab_size"`). `value` is any JSON
 	* value in the shape the setting expects. The write lives in an
 	* in-memory layer scoped to the calling plugin — it does not modify
 	* `config.json`, and unloading the plugin (or reloading init.ts) drops
 	* it. Intended use is `init.ts` running a conditional:
 	* `if (editor.getEnv("SSH_TTY")) editor.setSetting("terminal.mouse", false);`
-	* 
+	*
 	* Returns `true` if the write was queued. The actual update is
 	* asynchronous; a subsequent `getConfig()` will reflect it after the
 	* editor processes the command.
@@ -1752,7 +1752,7 @@ interface EditorAPI {
 	* Override theme colors in-memory for the running session. `overrides`
 	* is a JS object mapping `"section.field"` keys (same namespace as
 	* `getThemeSchema`) to `[r, g, b]` triplets (0–255 each).
-	* 
+	*
 	* Unknown keys are dropped silently; out-of-range values are clamped
 	* to `0..=255`. Overrides survive until the next `applyTheme` call
 	* (which replaces the whole `Theme`). Intended for fast animation
@@ -1806,14 +1806,14 @@ interface EditorAPI {
 	pluginTranslate(pluginName: string, key: string, args?: Record<string, unknown>): string;
 	/**
 	* Create a composite buffer (async)
-	* 
+	*
 	* Uses typed CreateCompositeBufferOptions - serde validates field names at runtime
 	* via `deny_unknown_fields` attribute
 	*/
 	createCompositeBuffer(opts: TsCreateCompositeBufferOptions): Promise<number>;
 	/**
 	* Update alignment hunks for a composite buffer
-	* 
+	*
 	* Uses typed Vec<CompositeHunk> - serde validates field names at runtime
 	*/
 	updateCompositeAlignment(bufferId: number, hunks: TsCompositeHunk[]): boolean;
@@ -1841,15 +1841,15 @@ interface EditorAPI {
 	getHighlights(bufferId: number, start: number, end: number): Promise<TsHighlightSpan[]>;
 	/**
 	* Add an overlay with styling options
-	* 
+	*
 	* Colors can be specified as RGB arrays `[r, g, b]` or theme key strings.
 	* Theme keys are resolved at render time, so overlays update with theme changes.
-	* 
+	*
 	* Theme key examples: "ui.status_bar_fg", "editor.selection_bg", "syntax.keyword"
-	* 
+	*
 	* Options: fg, bg (RGB array or theme key string), bold, italic, underline,
 	* strikethrough, extend_to_line_end (all booleans, default false).
-	* 
+	*
 	* Example usage in TypeScript:
 	* ```typescript
 	* editor.addOverlay(bufferId, "my-namespace", 0, 10, {
@@ -1914,10 +1914,10 @@ interface EditorAPI {
 	clearSoftBreaksInRange(bufferId: number, start: number, end: number): boolean;
 	/**
 	* Submit a view transform for a buffer/split
-	* 
+	*
 	* Accepts tokens in the simple format:
 	* {kind: "text"|"newline"|"space"|"break", text: "...", sourceOffset: N, style?: {...}}
-	* 
+	*
 	* Also accepts the TypeScript-defined format for backwards compatibility:
 	* {kind: {Text: "..."} | "Newline" | "Space" | "Break", source_offset: N, style?: {...}}
 	*/
@@ -1969,7 +1969,7 @@ interface EditorAPI {
 	clearVirtualTextNamespace(bufferId: number, namespace: string): boolean;
 	/**
 	* Add a virtual line (full line above/below a position)
-	* 
+	*
 	* The `options` object accepts:
 	* * `fg`, `bg` — either an `[r, g, b]` array (each `0..=255`) or a
 	* theme-key string (e.g. `"editor.line_number_fg"`).  Theme keys
@@ -1984,7 +1984,7 @@ interface EditorAPI {
 	prompt(label: string, initialValue: string): Promise<string | null>;
 	/**
 	* Start an interactive prompt.
-	* 
+	*
 	* When `floatingOverlay` is true, the editor renders the prompt
 	* and its suggestions inside a centred floating frame instead of
 	* the bottom minibuffer row (issue #1796 — Live Grep). The flag
@@ -1994,7 +1994,7 @@ interface EditorAPI {
 	startPrompt(label: string, promptType: string, floatingOverlay?: boolean): boolean;
 	/**
 	* Begin a key-capture window for the calling plugin.
-	* 
+	*
 	* Pair with `endKeyCapture()` around any `getNextKey()` loop.
 	* While capture is active, keys arriving between two
 	* `getNextKey()` calls are buffered in-order rather than
@@ -2012,26 +2012,27 @@ interface EditorAPI {
 	endKeyCapture(): boolean;
 	/**
 	* Wait for the next keypress and resolve with a `KeyEventPayload`.
-	* 
+	*
 	* While the returned promise is pending the editor consumes the
 	* next key and resolves it; the key does not propagate to mode
 	* bindings or other dispatch. Multiple in-flight requests across
 	* plugins are FIFO. Designed for short input loops (flash labels,
 	* vi find-char, replace-char) that would otherwise need to bind
 	* every printable key in `defineMode`.
-	* 
+	*
 	* For lossless capture against fast typing or paste, wrap the
 	* loop with `beginKeyCapture()` / `endKeyCapture()`.
 	*/
 	getNextKey(): Promise<KeyEventPayload>;
 	/**
-	* Start a prompt with initial value. See `startPrompt` for the
-	* meaning of `floatingOverlay`.
+	* Start a prompt with initial value. See `start_prompt` for why
+	* `floating_overlay` uses `rquickjs::function::Opt` (so JS
+	* callers can omit the argument).
 	*/
 	startPromptWithInitial(label: string, promptType: string, initialValue: string, floatingOverlay?: boolean): boolean;
 	/**
 	* Set suggestions for the current prompt
-	* 
+	*
 	* Uses typed Vec<Suggestion> - serde validates field names at runtime
 	*/
 	setPromptSuggestions(suggestions: PromptSuggestion[]): boolean;
@@ -2185,7 +2186,7 @@ interface EditorAPI {
 	setBufferCursor(bufferId: number, position: number): boolean;
 	/**
 	* Toggle whether the editor draws a native caret in this buffer.
-	* 
+	*
 	* Buffer-group panel buffers default to `show_cursors = false`, which
 	* also blocks all native movement actions in `action_to_events`. Plugins
 	* that want native cursor motion in a panel (e.g. magit-style row
@@ -2266,13 +2267,13 @@ interface EditorAPI {
 	removeScrollSyncGroup(groupId: number): boolean;
 	/**
 	* Execute multiple actions in sequence
-	* 
+	*
 	* Takes typed ActionSpec array - serde validates field names at runtime
 	*/
 	executeActions(actions: ActionSpec[]): boolean;
 	/**
 	* Show an action popup
-	* 
+	*
 	* Takes a typed ActionPopupOptions struct - serde validates field names at runtime
 	*/
 	showActionPopup(opts: ActionPopupOptions): boolean;
@@ -2323,7 +2324,7 @@ interface EditorAPI {
 	focusBufferGroupPanel(groupId: number, panelName: string): boolean;
 	/**
 	* Set virtual buffer content (takes array of entry objects)
-	* 
+	*
 	* Note: entries should be TextPropertyEntry[] - uses manual parsing for HashMap support
 	*/
 	setVirtualBufferContent(bufferId: number, entriesArr: Record<string, unknown>[]): boolean;
@@ -2378,7 +2379,7 @@ interface EditorAPI {
 	spawnProcess(command: string, args: string[], cwd?: string): ProcessHandle<SpawnResult>;
 	/**
 	* Spawn a process on the host regardless of the active authority.
-	* 
+	*
 	* Intended for plugin internals that must run host-side work
 	* (e.g. `devcontainer up`) before installing an authority that
 	* would otherwise route the spawn elsewhere. Same calling shape
@@ -2387,7 +2388,7 @@ interface EditorAPI {
 	spawnHostProcess(command: string, args: string[], cwd?: string): ProcessHandle<SpawnResult>;
 	/**
 	* Install a new authority via an opaque payload.
-	* 
+	*
 	* The payload is a JS object describing filesystem + spawner +
 	* terminal wrapper + display label. The canonical schema lives in
 	* the `AuthorityPayload` type in `fresh-editor`; plugins should
@@ -2406,7 +2407,7 @@ interface EditorAPI {
 	* this to surface lifecycle transitions that the authority layer
 	* doesn't know about yet — "Connecting" while `devcontainer up`
 	* runs, "FailedAttach" after a non-zero exit, etc.
-	* 
+	*
 	* Accepts a tagged JS object:
 	* ```ts
 	* editor.setRemoteIndicatorState({ kind: "connecting", label: "Building" });
@@ -2414,7 +2415,7 @@ interface EditorAPI {
 	* editor.setRemoteIndicatorState({ kind: "connected", label: "Container:abc" });
 	* editor.setRemoteIndicatorState({ kind: "local" });
 	* ```
-	* 
+	*
 	* The override sticks until replaced or cleared via
 	* `clearRemoteIndicatorState`. Editor restart (e.g. on
 	* `setAuthority`) resets it — plugins must reassert after a

--- a/crates/fresh-editor/plugins/tsconfig.json
+++ b/crates/fresh-editor/plugins/tsconfig.json
@@ -48,6 +48,7 @@
     "git_grep.ts",
     "git_gutter.ts",
     "git_log.ts",
+    "git_statusbar.ts",
     "gleam-lsp.ts",
     "goto_with_selection.ts",
     "go-lsp.ts",

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -314,6 +314,7 @@ impl Editor {
         self.active_window_mut().event_logs.remove(&id);
         self.active_window_mut().seen_byte_ranges.remove(&id);
         self.active_window_mut().buffer_metadata.remove(&id);
+        self.active_window_mut().status_bar_values.remove(&id);
         if let Some((request_id, _, _)) = self
             .active_window_mut()
             .semantic_tokens_in_flight

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -243,7 +243,7 @@ impl Editor {
             menus: crate::config::MenuConfig::translated(),
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
-            status_bar_elements: Mutex::new(HashMap::new()),
+            status_bar_token_registry: Mutex::new(HashMap::new()),
             event_broadcaster: parts.event_broadcaster,
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -243,6 +243,7 @@ impl Editor {
             menus: crate::config::MenuConfig::translated(),
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
+            status_bar_elements: Mutex::new(HashMap::new()),
             event_broadcaster: parts.event_broadcaster,
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1179,11 +1179,7 @@ impl Editor {
 
     /// Set the value for a previously registered status bar element.
     /// Token name format: "plugin_name:token_name".
-    pub fn set_status_bar_element_value(
-        &self,
-        name: &str,
-        value: String,
-    ) -> Result<(), String> {
+    pub fn set_status_bar_element_value(&self, name: &str, value: String) -> Result<(), String> {
         let elements = self.status_bar_elements.lock().unwrap();
         match elements.get(name) {
             Some(elem) => {

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -205,7 +205,7 @@ use ratatui::{
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
 // Re-export BufferId from event module for backward compatibility
@@ -321,6 +321,17 @@ pub(crate) struct GotoLinePreviewSnapshot {
     pub viewport_top_view_line_offset: usize,
     pub viewport_left_column: usize,
     pub last_jump_position: usize,
+}
+
+/// A custom status bar element registered by a plugin.
+///
+/// The `value` is updated by the plugin at runtime and read by the
+/// renderer via `StatusBarContext`.
+pub struct CustomStatusBarElement {
+    /// Human-readable name shown in Settings UI (e.g., "Git: branch")
+    pub title: String,
+    /// Current value to render (None = element is skipped).
+    pub value: Mutex<Option<String>>,
 }
 
 /// The main editor struct - manages multiple buffers, clipboard, and rendering
@@ -634,6 +645,10 @@ pub struct Editor {
 
     // `plugin_dev_workspaces` moved onto `Window` — keyed by `BufferId`,
     // and buffers are per-window, so the workspace map follows.
+
+    /// Custom status bar elements registered by plugins.
+    /// Key format: "plugin_name:token_name" (e.g., "git_statusbar:branch")
+    status_bar_elements: Mutex<HashMap<String, CustomStatusBarElement>>,
 
     // `seen_byte_ranges` moved onto `Window` — keyed by `BufferId`
     // which lives on `Window`, so the tracker follows the buffers.
@@ -1127,6 +1142,91 @@ impl Editor {
             .event_logs
             .get_mut(&buffer_id)
             .unwrap()
+    }
+
+    /// Register a custom status bar element.
+    /// Token key is "plugin_name:token_name".
+    /// Returns Err if token already registered or inputs are invalid.
+    pub fn register_status_bar_element(
+        &self,
+        plugin_name: &str,
+        token_name: &str,
+        title: &str,
+    ) -> Result<(), String> {
+        if plugin_name.is_empty() {
+            return Err("Plugin name cannot be empty".to_string());
+        }
+        if token_name.is_empty() {
+            return Err("Token name cannot be empty".to_string());
+        }
+
+        let key = format!("{}:{}", plugin_name, token_name);
+        let mut elements = self.status_bar_elements.lock().unwrap();
+
+        if elements.contains_key(&key) {
+            return Err(format!("Token '{}' already registered", key));
+        }
+
+        elements.insert(
+            key,
+            CustomStatusBarElement {
+                title: title.to_string(),
+                value: Mutex::new(None),
+            },
+        );
+        Ok(())
+    }
+
+    /// Set the value for a previously registered status bar element.
+    /// Token name format: "plugin_name:token_name".
+    pub fn set_status_bar_element_value(
+        &self,
+        name: &str,
+        value: String,
+    ) -> Result<(), String> {
+        let elements = self.status_bar_elements.lock().unwrap();
+        match elements.get(name) {
+            Some(elem) => {
+                *elem.value.lock().unwrap() = Some(value);
+                Ok(())
+            }
+            None => Err(format!("Token '{}' not found", name)),
+        }
+    }
+
+    /// Get all registered status bar elements for Settings UI.
+    /// Returns Vec of (token_key_with_braces, title).
+    pub fn get_status_bar_elements(&self) -> Vec<(String, String)> {
+        let elements = self.status_bar_elements.lock().unwrap();
+        elements
+            .iter()
+            .map(|(k, v)| (format!("{{{}}}", k), v.title.clone()))
+            .collect()
+    }
+
+    /// Get a snapshot of all token values for the renderer.
+    /// Only includes tokens with a set value (None values are filtered out).
+    pub fn get_status_bar_element_values(&self) -> HashMap<String, String> {
+        let elements = self.status_bar_elements.lock().unwrap();
+        elements
+            .iter()
+            .filter_map(|(k, v)| {
+                v.value
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map(|val| (k.clone(), val.clone()))
+            })
+            .collect()
+    }
+
+    /// Remove all status bar tokens belonging to a plugin.
+    /// Called when a plugin is unloaded.
+    fn remove_plugin_status_bar_elements(&self, plugin_name: &str) {
+        self.status_bar_elements
+            .lock()
+            .unwrap()
+            .retain(|k, _| !k.starts_with(&format!("{}:", plugin_name)));
     }
 }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -323,17 +323,6 @@ pub(crate) struct GotoLinePreviewSnapshot {
     pub last_jump_position: usize,
 }
 
-/// A custom status bar element registered by a plugin.
-///
-/// The `value` is updated by the plugin at runtime and read by the
-/// renderer via `StatusBarContext`.
-pub struct CustomStatusBarElement {
-    /// Human-readable name shown in Settings UI (e.g., "Git: branch")
-    pub title: String,
-    /// Current value to render (None = element is skipped).
-    pub value: Mutex<Option<String>>,
-}
-
 /// The main editor struct - manages multiple buffers, clipboard, and rendering
 pub struct Editor {
     // Buffers moved onto `Window` (Step 0c). Each window owns its
@@ -645,10 +634,10 @@ pub struct Editor {
 
     // `plugin_dev_workspaces` moved onto `Window` — keyed by `BufferId`,
     // and buffers are per-window, so the workspace map follows.
-
-    /// Custom status bar elements registered by plugins.
-    /// Key format: "plugin_name:token_name" (e.g., "git_statusbar:branch")
-    status_bar_elements: Mutex<HashMap<String, CustomStatusBarElement>>,
+    /// Registry of status-bar tokens contributed by plugins.
+    /// Key: "plugin_name:token_name" (e.g., "git_statusbar:branch"); value: display title.
+    /// Global and lifetime-checked. Per-buffer values live on each `Window`.
+    status_bar_token_registry: Mutex<HashMap<String, String>>,
 
     // `seen_byte_ranges` moved onto `Window` — keyed by `BufferId`
     // which lives on `Window`, so the tracker follows the buffers.
@@ -1144,7 +1133,7 @@ impl Editor {
             .unwrap()
     }
 
-    /// Register a custom status bar element.
+    /// Register a status-bar token contributed by a plugin.
     /// Token key is "plugin_name:token_name".
     /// Returns Err if token already registered or inputs are invalid.
     pub fn register_status_bar_element(
@@ -1161,68 +1150,73 @@ impl Editor {
         }
 
         let key = format!("{}:{}", plugin_name, token_name);
-        let mut elements = self.status_bar_elements.lock().unwrap();
+        let mut registry = self.status_bar_token_registry.lock().unwrap();
 
-        if elements.contains_key(&key) {
+        if registry.contains_key(&key) {
             return Err(format!("Token '{}' already registered", key));
         }
 
-        elements.insert(
-            key,
-            CustomStatusBarElement {
-                title: title.to_string(),
-                value: Mutex::new(None),
-            },
-        );
+        registry.insert(key, title.to_string());
         Ok(())
     }
 
-    /// Set the value for a previously registered status bar element.
-    /// Token name format: "plugin_name:token_name".
-    pub fn set_status_bar_element_value(&self, name: &str, value: String) -> Result<(), String> {
-        let elements = self.status_bar_elements.lock().unwrap();
-        match elements.get(name) {
-            Some(elem) => {
-                *elem.value.lock().unwrap() = Some(value);
-                Ok(())
+    /// Set the value for a status-bar token on a specific buffer.
+    /// Key format: "plugin_name:token_name". The buffer is located across
+    /// every window — buffers are uniquely owned, so at most one window
+    /// matches.
+    pub fn set_status_bar_value(
+        &mut self,
+        buffer_id: BufferId,
+        key: &str,
+        value: String,
+    ) -> Result<(), String> {
+        for window in self.windows.values_mut() {
+            if window.buffers.contains_key(&buffer_id) {
+                window
+                    .status_bar_values
+                    .entry(buffer_id)
+                    .or_default()
+                    .insert(key.to_string(), value);
+                return Ok(());
             }
-            None => Err(format!("Token '{}' not found", name)),
         }
+        Err(format!("Buffer {:?} not found", buffer_id))
     }
 
-    /// Get all registered status bar elements for Settings UI.
+    /// Get all registered status bar tokens for Settings UI.
     /// Returns Vec of (token_key_with_braces, title).
     pub fn get_status_bar_elements(&self) -> Vec<(String, String)> {
-        let elements = self.status_bar_elements.lock().unwrap();
-        elements
-            .iter()
-            .map(|(k, v)| (format!("{{{}}}", k), v.title.clone()))
-            .collect()
-    }
-
-    /// Get a snapshot of all token values for the renderer.
-    /// Only includes tokens with a set value (None values are filtered out).
-    pub fn get_status_bar_element_values(&self) -> HashMap<String, String> {
-        let elements = self.status_bar_elements.lock().unwrap();
-        elements
-            .iter()
-            .filter_map(|(k, v)| {
-                v.value
-                    .lock()
-                    .unwrap()
-                    .as_ref()
-                    .map(|val| (k.clone(), val.clone()))
-            })
-            .collect()
-    }
-
-    /// Remove all status bar tokens belonging to a plugin.
-    /// Called when a plugin is unloaded.
-    fn remove_plugin_status_bar_elements(&self, plugin_name: &str) {
-        self.status_bar_elements
+        self.status_bar_token_registry
             .lock()
             .unwrap()
-            .retain(|k, _| !k.starts_with(&format!("{}:", plugin_name)));
+            .iter()
+            .map(|(k, title)| (format!("{{{}}}", k), title.clone()))
+            .collect()
+    }
+
+    /// Snapshot of token values for a specific buffer (render path).
+    pub fn get_status_bar_element_values(&self, buffer_id: BufferId) -> HashMap<String, String> {
+        for window in self.windows.values() {
+            if let Some(values) = window.status_bar_values.get(&buffer_id) {
+                return values.clone();
+            }
+        }
+        HashMap::new()
+    }
+
+    /// Remove every registry entry and per-buffer value belonging to a plugin.
+    /// Called when a plugin is unloaded.
+    fn remove_plugin_status_bar_elements(&mut self, plugin_name: &str) {
+        let prefix = format!("{}:", plugin_name);
+        self.status_bar_token_registry
+            .lock()
+            .unwrap()
+            .retain(|k, _| !k.starts_with(&prefix));
+        for window in self.windows.values_mut() {
+            for values in window.status_bar_values.values_mut() {
+                values.retain(|k, _| !k.starts_with(&prefix));
+            }
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -747,16 +747,15 @@ impl Editor {
                 token_name,
                 title,
             } => {
-if let Err(e) =
-    self.register_status_bar_element(&plugin_name, &token_name, &title)
-{
-    tracing::warn!("Failed to register statusbar element: {}", e);
-}
+                if let Err(e) = self.register_status_bar_element(&plugin_name, &token_name, &title)
+                {
+                    tracing::warn!("Failed to register statusbar element: {}", e);
+                }
             }
             PluginCommand::SetStatusBarElementValue { name, value } => {
-if let Err(e) = self.set_status_bar_element_value(&name, value) {
-    tracing::warn!("Failed to set statusbar element value: {}", e);
-}
+                if let Err(e) = self.set_status_bar_element_value(&name, value) {
+                    tracing::warn!("Failed to set statusbar element value: {}", e);
+                }
             }
             PluginCommand::UnregisterCommand { name } => {
                 self.handle_unregister_command(name);

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -742,6 +742,22 @@ impl Editor {
             PluginCommand::RegisterCommand { command } => {
                 self.handle_register_command(command);
             }
+            PluginCommand::RegisterStatusBarElement {
+                plugin_name,
+                token_name,
+                title,
+            } => {
+                if let Err(e) =
+                    crate::config::register_status_bar_element(&plugin_name, &token_name, &title)
+                {
+                    tracing::warn!("Failed to register statusbar element: {}", e);
+                }
+            }
+            PluginCommand::SetStatusBarElementValue { name, value } => {
+                if let Err(e) = crate::config::set_custom_status_bar_value(&name, value) {
+                    tracing::warn!("Failed to set statusbar element value: {}", e);
+                }
+            }
             PluginCommand::UnregisterCommand { name } => {
                 self.handle_unregister_command(name);
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -752,9 +752,15 @@ impl Editor {
                     tracing::warn!("Failed to register statusbar element: {}", e);
                 }
             }
-            PluginCommand::SetStatusBarElementValue { name, value } => {
-                if let Err(e) = self.set_status_bar_element_value(&name, value) {
-                    tracing::warn!("Failed to set statusbar element value: {}", e);
+            PluginCommand::SetStatusBarValue {
+                buffer_id,
+                key,
+                value,
+            } => {
+                if let Err(e) =
+                    self.set_status_bar_value(fresh_core::BufferId(buffer_id as usize), &key, value)
+                {
+                    tracing::warn!("Failed to set statusbar value: {}", e);
                 }
             }
             PluginCommand::UnregisterCommand { name } => {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1364,7 +1364,7 @@ impl Editor {
     /// Unload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_unload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.read().unwrap().unload_plugin(&name) {
+        match self.plugin_manager.write().unwrap().unload_plugin(&name) {
             Ok(()) => {
                 tracing::info!("Unloaded plugin: {}", name);
                 self.plugin_manager

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -747,16 +747,16 @@ impl Editor {
                 token_name,
                 title,
             } => {
-                if let Err(e) =
-                    crate::config::register_status_bar_element(&plugin_name, &token_name, &title)
-                {
-                    tracing::warn!("Failed to register statusbar element: {}", e);
-                }
+if let Err(e) =
+    self.register_status_bar_element(&plugin_name, &token_name, &title)
+{
+    tracing::warn!("Failed to register statusbar element: {}", e);
+}
             }
             PluginCommand::SetStatusBarElementValue { name, value } => {
-                if let Err(e) = crate::config::set_custom_status_bar_value(&name, value) {
-                    tracing::warn!("Failed to set statusbar element value: {}", e);
-                }
+if let Err(e) = self.set_status_bar_element_value(&name, value) {
+    tracing::warn!("Failed to set statusbar element value: {}", e);
+}
             }
             PluginCommand::UnregisterCommand { name } => {
                 self.handle_unregister_command(name);

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1031,7 +1031,7 @@ impl Editor {
                 .unwrap_or(false);
             // Compute plugin-provided status-bar values before taking the
             // mutable window borrow below.
-            let dynamic_status_bar_elements = self.get_status_bar_element_values();
+            let dynamic_status_bar_elements = self.get_status_bar_element_values(active_buf);
             // Single window borrow, split into buffers + cursors so the
             // status-bar context can hold both.
             let __active_id = self.active_window;

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1029,6 +1029,9 @@ impl Editor {
                 .get(&active_buf)
                 .map(|m| m.synthetic_placeholder)
                 .unwrap_or(false);
+            // Compute plugin-provided status-bar values before taking the
+            // mutable window borrow below.
+            let dynamic_status_bar_elements = self.get_status_bar_element_values();
             // Single window borrow, split into buffers + cursors so the
             // status-bar context can hold both.
             let __active_id = self.active_window;
@@ -1069,6 +1072,7 @@ impl Editor {
                 // safe default for the rare path that builds the
                 // ctx but doesn't run `render_status`.
                 remote_indicator_on_bar: false,
+                dynamic_status_bar_elements,
             };
             let status_bar_layout = StatusBarRenderer::render_status_bar(
                 frame,

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -32,6 +32,8 @@ impl Editor {
                     if let Ok(sources) = resolver.get_layer_sources() {
                         state.set_layer_sources(sources);
                     }
+                    // Set editor for runtime plugin data (status bar elements)
+                    state.set_editor(self);
                     state.show();
                     self.settings_state = Some(state);
                 }
@@ -711,6 +713,9 @@ impl Editor {
                 if let Err(e) = unload_result {
                     tracing::error!("Failed to unload plugin '{}': {}", name, e);
                     self.set_status_message(format!("Failed to unload plugin '{}': {}", name, e));
+                } else {
+                    // Clean up status bar tokens for this plugin
+                    self.remove_plugin_status_bar_elements(&name);
                 }
             }
         }

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -32,8 +32,9 @@ impl Editor {
                     if let Ok(sources) = resolver.get_layer_sources() {
                         state.set_layer_sources(sources);
                     }
-                    // Set editor for runtime plugin data (status bar elements)
-                    state.set_editor(self);
+                    // Snapshot plugin-registered status-bar tokens for the dual-list picker.
+                    let tokens = self.status_bar_token_registry.lock().unwrap().clone();
+                    state.set_status_bar_tokens(tokens);
                     state.show();
                     self.settings_state = Some(state);
                 }
@@ -43,8 +44,12 @@ impl Editor {
                     );
                 }
             }
-        } else if let Some(ref mut state) = self.settings_state {
-            state.show();
+        } else {
+            let tokens = self.status_bar_token_registry.lock().unwrap().clone();
+            if let Some(ref mut state) = self.settings_state {
+                state.set_status_bar_tokens(tokens);
+                state.show();
+            }
         }
     }
 

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -709,7 +709,7 @@ impl Editor {
             } else {
                 // Plugin was enabled, now disabled - unload it
                 tracing::info!("Unloading disabled plugin: {}", name);
-                let unload_result = self.plugin_manager.read().unwrap().unload_plugin(&name);
+                let unload_result = self.plugin_manager.write().unwrap().unload_plugin(&name);
                 if let Err(e) = unload_result {
                     tracing::error!("Failed to unload plugin '{}': {}", name, e);
                     self.set_status_message(format!("Failed to unload plugin '{}': {}", name, e));

--- a/crates/fresh-editor/src/app/window.rs
+++ b/crates/fresh-editor/src/app/window.rs
@@ -571,6 +571,13 @@ pub struct Window {
     pub plugin_dev_workspaces:
         HashMap<BufferId, crate::services::plugins::plugin_dev_workspace::PluginDevWorkspace>,
 
+    /// Per-buffer plugin status-bar token values. Outer key: BufferId;
+    /// inner key: "plugin_name:token_name"; inner value: current text
+    /// to render. The registry of which tokens exist lives globally on
+    /// `Editor.status_bar_token_registry`; this map holds only the
+    /// values plugins have pushed for individual buffers.
+    pub status_bar_values: HashMap<BufferId, HashMap<String, String>>,
+
     /// Mouse drag/selection/scrollbar state for this window. Drag
     /// targets reference per-window LeafIds and BufferIds.
     pub mouse_state: crate::app::types::MouseState,
@@ -1608,6 +1615,7 @@ impl Window {
             pending_dir_poll_rx: None,
             ephemeral_terminals: std::collections::HashSet::new(),
             plugin_dev_workspaces: HashMap::new(),
+            status_bar_values: HashMap::new(),
             mouse_state: crate::app::types::MouseState::default(),
             key_context: crate::input::keybindings::KeyContext::Normal,
             chord_state: Vec::new(),

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -801,6 +801,13 @@ pub fn get_custom_status_bar_tokens() -> Vec<(String, String)> {
         .collect()
 }
 
+/// Clear all registered custom statusbar tokens.
+/// Used for test isolation between parallel test runs.
+pub fn clear_custom_status_bar_tokens() {
+    let mut tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
+    tokens.clear();
+}
+
 /// Get the value for a custom token by key.
 pub fn get_custom_status_bar_value(key: &str) -> Option<String> {
     let token = {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -749,18 +749,6 @@ impl Default for StatusBarConfig {
     }
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
 /// Editor behavior configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct EditorConfig {

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -730,13 +730,13 @@ pub struct StatusBarConfig {
     /// Elements shown on the left side of the status bar.
     /// Default: ["{filename}", "{cursor}", "{diagnostics}", "{cursor_count}", "{messages}"]
     #[serde(default = "default_status_bar_left")]
-    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/right"))]
+    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/right", "x-dynamicly-extendable-status-bar-elements" = true))]
     pub left: Vec<StatusBarElement>,
 
     /// Elements shown on the right side of the status bar.
     /// Default: ["{line_ending}", "{encoding}", "{language}", "{lsp}", "{warnings}", "{update}", "{palette}"]
     #[serde(default = "default_status_bar_right")]
-    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/left"))]
+    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/left", "x-dynamicly-extendable-status-bar-elements" = true))]
     pub right: Vec<StatusBarElement>,
 }
 

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::Path;
-use std::sync::{Arc, LazyLock, Mutex};
+
 /// Newtype for theme name that generates proper JSON Schema with enum options
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -749,87 +749,17 @@ impl Default for StatusBarConfig {
     }
 }
 
-/// Registry for custom statusbar tokens registered by plugins.
-/// Key format: "plugin_name:token_name" (e.g., "git:branch")
-pub struct CustomStatusBarToken {
-    pub title: String,
-    pub value: Mutex<Option<String>>,
-}
 
-static CUSTOM_STATUS_BAR_TOKENS: LazyLock<Mutex<HashMap<String, Arc<CustomStatusBarToken>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Register a custom statusbar token from a plugin.
-/// Returns error if token name is invalid or already registered.
-pub fn register_status_bar_element(
-    plugin_name: &str,
-    token_name: &str,
-    title: &str,
-) -> Result<(), String> {
-    // Validate inputs are non-empty
-    if plugin_name.is_empty() {
-        return Err("Plugin name cannot be empty".to_string());
-    }
-    if token_name.is_empty() {
-        return Err("Token name cannot be empty".to_string());
-    }
 
-    let key = format!("{}:{}", plugin_name, token_name);
 
-    let token = Arc::new(CustomStatusBarToken {
-        title: title.to_string(),
-        value: Mutex::new(None),
-    });
 
-    let mut tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
-    if tokens.contains_key(&key) {
-        return Err(format!("Token '{}' already registered", key));
-    }
-    tokens.insert(key, token);
-    Ok(())
-}
 
-/// Get all registered custom statusbar tokens for Settings UI.
-/// Returns Vec of (value, title) where:
-/// - value is "{plugin:token}" format (stored in config)
-/// - title is the human-readable name shown in Settings UI
-pub fn get_custom_status_bar_tokens() -> Vec<(String, String)> {
-    let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
-    tokens
-        .iter()
-        .map(|(k, t)| (format!("{{{}}}", k), t.title.clone()))
-        .collect()
-}
 
-/// Clear all registered custom statusbar tokens.
-/// Used for test isolation between parallel test runs.
-pub fn clear_custom_status_bar_tokens() {
-    let mut tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
-    tokens.clear();
-}
 
-/// Get the value for a custom token by key.
-pub fn get_custom_status_bar_value(key: &str) -> Option<String> {
-    let token = {
-        let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
-        tokens.get(key).cloned()
-    };
-    token.and_then(|t| t.value.lock().unwrap().clone())
-}
 
-/// Set the value for a custom token (called from plugin dispatch).
-pub fn set_custom_status_bar_value(key: &str, value: String) -> Result<(), String> {
-    let token = {
-        let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
-        tokens.get(key).cloned()
-    };
-    if let Some(token) = token {
-        *token.value.lock().unwrap() = Some(value);
-        Ok(())
-    } else {
-        Err(format!("Token '{}' not found", key))
-    }
-}
+
+
 
 /// Editor behavior configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -730,13 +730,13 @@ pub struct StatusBarConfig {
     /// Elements shown on the left side of the status bar.
     /// Default: ["{filename}", "{cursor}", "{diagnostics}", "{cursor_count}", "{messages}"]
     #[serde(default = "default_status_bar_left")]
-    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/right", "x-dynamicly-extendable-status-bar-elements" = true))]
+    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/right", "x-dynamically-extendable-status-bar-elements" = true))]
     pub left: Vec<StatusBarElement>,
 
     /// Elements shown on the right side of the status bar.
     /// Default: ["{line_ending}", "{encoding}", "{language}", "{lsp}", "{warnings}", "{update}", "{palette}"]
     #[serde(default = "default_status_bar_right")]
-    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/left", "x-dynamicly-extendable-status-bar-elements" = true))]
+    #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/left", "x-dynamically-extendable-status-bar-elements" = true))]
     pub right: Vec<StatusBarElement>,
 }
 

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::Path;
-
+use std::sync::{Arc, LazyLock, Mutex};
 /// Newtype for theme name that generates proper JSON Schema with enum options
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -583,6 +583,8 @@ pub enum StatusBarElement {
     /// the bottom-left of the status bar as a persistent remote-state entry
     /// point.
     RemoteIndicator,
+    /// Custom token registered by a plugin (format: "plugin_name:token_name")
+    CustomToken(String),
 }
 
 impl TryFrom<String> for StatusBarElement {
@@ -610,7 +612,14 @@ impl TryFrom<String> for StatusBarElement {
             "palette" => Ok(Self::Palette),
             "clock" => Ok(Self::Clock),
             "remote" => Ok(Self::RemoteIndicator),
-            _ => Err(format!("Unknown status bar element: {}", s)),
+            _ => {
+                // Check if it's a custom token (contains ':')
+                if inner.contains(':') {
+                    Ok(Self::CustomToken(inner.to_string()))
+                } else {
+                    Err(format!("Unknown status bar element: {}", s))
+                }
+            }
         }
     }
 }
@@ -634,6 +643,7 @@ impl From<StatusBarElement> for String {
             StatusBarElement::Palette => "{palette}".to_string(),
             StatusBarElement::Clock => "{clock}".to_string(),
             StatusBarElement::RemoteIndicator => "{remote}".to_string(),
+            StatusBarElement::CustomToken(name) => format!("{{{}}}", name),
         }
     }
 }
@@ -736,6 +746,81 @@ impl Default for StatusBarConfig {
             left: default_status_bar_left(),
             right: default_status_bar_right(),
         }
+    }
+}
+
+/// Registry for custom statusbar tokens registered by plugins.
+/// Key format: "plugin_name:token_name" (e.g., "git:branch")
+pub struct CustomStatusBarToken {
+    pub title: String,
+    pub value: Mutex<Option<String>>,
+}
+
+static CUSTOM_STATUS_BAR_TOKENS: LazyLock<Mutex<HashMap<String, Arc<CustomStatusBarToken>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Register a custom statusbar token from a plugin.
+/// Returns error if token name is invalid or already registered.
+pub fn register_status_bar_element(
+    plugin_name: &str,
+    token_name: &str,
+    title: &str,
+) -> Result<(), String> {
+    // Validate inputs are non-empty
+    if plugin_name.is_empty() {
+        return Err("Plugin name cannot be empty".to_string());
+    }
+    if token_name.is_empty() {
+        return Err("Token name cannot be empty".to_string());
+    }
+
+    let key = format!("{}:{}", plugin_name, token_name);
+
+    let token = Arc::new(CustomStatusBarToken {
+        title: title.to_string(),
+        value: Mutex::new(None),
+    });
+
+    let mut tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
+    if tokens.contains_key(&key) {
+        return Err(format!("Token '{}' already registered", key));
+    }
+    tokens.insert(key, token);
+    Ok(())
+}
+
+/// Get all registered custom statusbar tokens for Settings UI.
+/// Returns Vec of (value, title) where:
+/// - value is "{plugin:token}" format (stored in config)
+/// - title is the human-readable name shown in Settings UI
+pub fn get_custom_status_bar_tokens() -> Vec<(String, String)> {
+    let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
+    tokens
+        .iter()
+        .map(|(k, t)| (format!("{{{}}}", k), t.title.clone()))
+        .collect()
+}
+
+/// Get the value for a custom token by key.
+pub fn get_custom_status_bar_value(key: &str) -> Option<String> {
+    let token = {
+        let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
+        tokens.get(key).cloned()
+    };
+    token.and_then(|t| t.value.lock().unwrap().clone())
+}
+
+/// Set the value for a custom token (called from plugin dispatch).
+pub fn set_custom_status_bar_value(key: &str, value: String) -> Result<(), String> {
+    let token = {
+        let tokens = CUSTOM_STATUS_BAR_TOKENS.lock().unwrap();
+        tokens.get(key).cloned()
+    };
+    if let Some(token) = token {
+        *token.value.lock().unwrap() = Some(value);
+        Ok(())
+    } else {
+        Err(format!("Token '{}' not found", key))
     }
 }
 

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -189,7 +189,8 @@ impl PluginManager {
     pub fn unload_plugin(&mut self, name: &str) -> anyhow::Result<()> {
         #[cfg(feature = "plugins")]
         {
-            let result = self.inner
+            let result = self
+                .inner
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Plugin system not active"))?
                 .unload_plugin(name);

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -186,13 +186,15 @@ impl PluginManager {
     }
 
     /// Unload a plugin by name.
-    pub fn unload_plugin(&self, name: &str) -> anyhow::Result<()> {
+    pub fn unload_plugin(&mut self, name: &str) -> anyhow::Result<()> {
         #[cfg(feature = "plugins")]
         {
-            self.inner
+            let result = self.inner
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("Plugin system not active"))?
-                .unload_plugin(name)
+                .unload_plugin(name);
+
+            result
         }
         #[cfg(not(feature = "plugins"))]
         {

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -8,6 +8,7 @@ use super::items::{
 };
 use super::schema::{SettingSchema, SettingType};
 use crate::view::controls::{FocusState, TextInputState};
+use crate::app::Editor;
 use serde_json::Value;
 
 /// State for the entry detail dialog
@@ -68,6 +69,7 @@ impl EntryDialogState {
         map_path: &str,
         is_new: bool,
         no_delete: bool,
+        editor: Option<*const Editor>,
     ) -> Self {
         let mut items = Vec::new();
 
@@ -97,13 +99,13 @@ impl EntryDialogState {
             for prop in properties {
                 let field_name = prop.path.trim_start_matches('/');
                 let field_value = value.get(field_name);
-                let item = build_item_from_value(prop, field_value);
+                let item = build_item_from_value(prop, field_value, editor);
                 items.push(item);
             }
         } else {
             // For non-object types (e.g., ObjectArray, Map), build a single item
             // from the entire value so the dialog can render it
-            let item = build_item_from_value(schema, Some(value));
+            let item = build_item_from_value(schema, Some(value), editor);
             items.push(item);
         }
 
@@ -169,6 +171,7 @@ impl EntryDialogState {
         schema: &SettingSchema,
         array_path: &str,
         is_new: bool,
+        editor: Option<*const Editor>,
     ) -> Self {
         let mut items = Vec::new();
 
@@ -177,7 +180,7 @@ impl EntryDialogState {
             for prop in properties {
                 let field_name = prop.path.trim_start_matches('/');
                 let field_value = value.get(field_name);
-                let item = build_item_from_value(prop, field_value);
+                let item = build_item_from_value(prop, field_value, editor);
                 items.push(item);
             }
         }
@@ -1347,6 +1350,7 @@ mod tests {
             "/test",
             false,
             false,
+            None,
         );
 
         assert!(!dialog.items.is_empty());
@@ -1364,6 +1368,7 @@ mod tests {
             "/test",
             false,
             false,
+            None,
         );
 
         // Key + 2 properties = 3 items
@@ -1382,6 +1387,7 @@ mod tests {
             "/test",
             false,
             false,
+            None,
         );
 
         assert_eq!(dialog.get_key(), "mykey");
@@ -1397,6 +1403,7 @@ mod tests {
             "/test",
             false,
             false,
+            None,
         );
 
         let value = dialog.to_value();
@@ -1414,6 +1421,7 @@ mod tests {
             "/test",
             false, // existing entry - Key is read-only
             false, // allow delete
+            None,
         );
 
         // With is_new=false, Key is read-only and sorted first
@@ -1454,6 +1462,7 @@ mod tests {
             "/lsp",
             false,
             false,
+            None,
         );
         assert_eq!(existing.entry_path(), "/lsp/rust");
 
@@ -1466,6 +1475,7 @@ mod tests {
             "/lsp",
             true,
             false,
+            None,
         );
         assert_eq!(new_entry.entry_path(), "/lsp");
     }
@@ -1480,6 +1490,7 @@ mod tests {
             "/universal_lsp",
             true,
             false,
+            None,
         );
 
         // User types a key into the editable key field.
@@ -1505,6 +1516,7 @@ mod tests {
             "/test",
             true,
             false,
+            None,
         );
         assert_eq!(new_dialog.button_count(), 2); // Save, Cancel
 
@@ -1515,6 +1527,7 @@ mod tests {
             "/test",
             false,
             false, // allow delete
+            None,
         );
         assert_eq!(existing_dialog.button_count(), 3); // Save, Delete, Cancel
 
@@ -1526,6 +1539,7 @@ mod tests {
             "/test",
             false,
             true, // no delete (auto-managed entries like plugins)
+            None,
         );
         assert_eq!(no_delete_dialog.button_count(), 2); // Save, Cancel (no Delete)
     }

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -7,8 +7,8 @@ use super::items::{
     build_item_from_value, control_to_value, ItemBoxStyle, SettingControl, SettingItem,
 };
 use super::schema::{SettingSchema, SettingType};
-use crate::view::controls::{FocusState, TextInputState};
 use crate::app::Editor;
+use crate::view::controls::{FocusState, TextInputState};
 use serde_json::Value;
 
 /// State for the entry detail dialog

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -1308,6 +1308,7 @@ mod tests {
                         nullable: false,
                         enum_from: None,
                         dual_list_sibling: None,
+                        dynamicly_extendable_status_bar_elements: false,
                     },
                     SettingSchema {
                         path: "/command".to_string(),
@@ -1321,6 +1322,7 @@ mod tests {
                         nullable: false,
                         enum_from: None,
                         dual_list_sibling: None,
+                        dynamicly_extendable_status_bar_elements: false,
                     },
                 ],
             },
@@ -1331,6 +1333,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         }
     }
 

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -1308,7 +1308,7 @@ mod tests {
                         nullable: false,
                         enum_from: None,
                         dual_list_sibling: None,
-                        dynamicly_extendable_status_bar_elements: false,
+                        dynamically_extendable_status_bar_elements: false,
                     },
                     SettingSchema {
                         path: "/command".to_string(),
@@ -1322,7 +1322,7 @@ mod tests {
                         nullable: false,
                         enum_from: None,
                         dual_list_sibling: None,
-                        dynamicly_extendable_status_bar_elements: false,
+                        dynamically_extendable_status_bar_elements: false,
                     },
                 ],
             },
@@ -1333,7 +1333,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         }
     }
 

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -7,9 +7,9 @@ use super::items::{
     build_item_from_value, control_to_value, ItemBoxStyle, SettingControl, SettingItem,
 };
 use super::schema::{SettingSchema, SettingType};
-use crate::app::Editor;
 use crate::view::controls::{FocusState, TextInputState};
 use serde_json::Value;
+use std::collections::HashMap;
 
 /// State for the entry detail dialog
 #[derive(Debug, Clone)]
@@ -69,7 +69,7 @@ impl EntryDialogState {
         map_path: &str,
         is_new: bool,
         no_delete: bool,
-        editor: Option<*const Editor>,
+        available_status_bar_tokens: &HashMap<String, String>,
     ) -> Self {
         let mut items = Vec::new();
 
@@ -99,13 +99,13 @@ impl EntryDialogState {
             for prop in properties {
                 let field_name = prop.path.trim_start_matches('/');
                 let field_value = value.get(field_name);
-                let item = build_item_from_value(prop, field_value, editor);
+                let item = build_item_from_value(prop, field_value, available_status_bar_tokens);
                 items.push(item);
             }
         } else {
             // For non-object types (e.g., ObjectArray, Map), build a single item
             // from the entire value so the dialog can render it
-            let item = build_item_from_value(schema, Some(value), editor);
+            let item = build_item_from_value(schema, Some(value), available_status_bar_tokens);
             items.push(item);
         }
 
@@ -171,7 +171,7 @@ impl EntryDialogState {
         schema: &SettingSchema,
         array_path: &str,
         is_new: bool,
-        editor: Option<*const Editor>,
+        available_status_bar_tokens: &HashMap<String, String>,
     ) -> Self {
         let mut items = Vec::new();
 
@@ -180,7 +180,7 @@ impl EntryDialogState {
             for prop in properties {
                 let field_name = prop.path.trim_start_matches('/');
                 let field_value = value.get(field_name);
-                let item = build_item_from_value(prop, field_value, editor);
+                let item = build_item_from_value(prop, field_value, available_status_bar_tokens);
                 items.push(item);
             }
         }
@@ -1350,7 +1350,7 @@ mod tests {
             "/test",
             false,
             false,
-            None,
+            &HashMap::new(),
         );
 
         assert!(!dialog.items.is_empty());
@@ -1368,7 +1368,7 @@ mod tests {
             "/test",
             false,
             false,
-            None,
+            &HashMap::new(),
         );
 
         // Key + 2 properties = 3 items
@@ -1387,7 +1387,7 @@ mod tests {
             "/test",
             false,
             false,
-            None,
+            &HashMap::new(),
         );
 
         assert_eq!(dialog.get_key(), "mykey");
@@ -1403,7 +1403,7 @@ mod tests {
             "/test",
             false,
             false,
-            None,
+            &HashMap::new(),
         );
 
         let value = dialog.to_value();
@@ -1421,7 +1421,7 @@ mod tests {
             "/test",
             false, // existing entry - Key is read-only
             false, // allow delete
-            None,
+            &HashMap::new(),
         );
 
         // With is_new=false, Key is read-only and sorted first
@@ -1462,7 +1462,7 @@ mod tests {
             "/lsp",
             false,
             false,
-            None,
+            &HashMap::new(),
         );
         assert_eq!(existing.entry_path(), "/lsp/rust");
 
@@ -1475,7 +1475,7 @@ mod tests {
             "/lsp",
             true,
             false,
-            None,
+            &HashMap::new(),
         );
         assert_eq!(new_entry.entry_path(), "/lsp");
     }
@@ -1490,7 +1490,7 @@ mod tests {
             "/universal_lsp",
             true,
             false,
-            None,
+            &HashMap::new(),
         );
 
         // User types a key into the editable key field.
@@ -1516,7 +1516,7 @@ mod tests {
             "/test",
             true,
             false,
-            None,
+            &HashMap::new(),
         );
         assert_eq!(new_dialog.button_count(), 2); // Save, Cancel
 
@@ -1527,7 +1527,7 @@ mod tests {
             "/test",
             false,
             false, // allow delete
-            None,
+            &HashMap::new(),
         );
         assert_eq!(existing_dialog.button_count(), 3); // Save, Delete, Cancel
 
@@ -1539,7 +1539,7 @@ mod tests {
             "/test",
             false,
             true, // no delete (auto-managed entries like plugins)
-            None,
+            &HashMap::new(),
         );
         assert_eq!(no_delete_dialog.button_count(), 2); // Save, Cancel (no Delete)
     }

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -3,13 +3,13 @@
 //! Converts schema information into renderable setting items.
 
 use super::schema::{SettingCategory, SettingSchema, SettingType};
+use crate::app::Editor;
 use crate::config_io::ConfigLayer;
 use crate::view::controls::{
     DropdownState, DualListState, FocusState, KeybindingListState, MapState, NumberInputState,
     TextInputState, TextListState, ToggleState,
 };
 use crate::view::ui::{FocusRegion, ScrollItem, TextEdit};
-use crate::app::Editor;
 use std::collections::{HashMap, HashSet};
 
 /// State for multiline JSON editing

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -246,9 +246,8 @@ fn build_dual_list_state(
         .map(|o| (o.value.clone(), o.name.clone()))
         .collect();
 
-    // Add runtime options (custom tokens from plugins) if this is status bar config
-    // Check for exact status bar left/right field paths
-    if schema.path == "/editor/status_bar/left" || schema.path == "/editor/status_bar/right" {
+    // Add runtime options (custom tokens from plugins) for fields that support them
+    if schema.dynamicly_extendable_status_bar_elements {
         let custom_tokens = crate::config::get_custom_status_bar_tokens();
         for (key, display) in custom_tokens {
             // Only add if not already present in options
@@ -1566,6 +1565,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1599,6 +1599,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1630,6 +1631,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1662,6 +1664,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -240,10 +240,24 @@ fn build_dual_list_state(
     current_value: Option<&serde_json::Value>,
     excluded: Vec<String>,
 ) -> DualListState {
-    let all_options: Vec<(String, String)> = options
+    // Start with static schema options (built-in tokens)
+    let mut all_options: Vec<(String, String)> = options
         .iter()
         .map(|o| (o.value.clone(), o.name.clone()))
         .collect();
+
+    // Add runtime options (custom tokens from plugins) if this is status bar config
+    // Check if the schema path contains "status_bar"
+    if schema.path.contains("status_bar") {
+        let custom_tokens = crate::config::get_custom_status_bar_tokens();
+        for (key, display) in custom_tokens {
+            // Only add if not already present in options
+            if !all_options.iter().any(|(v, _)| v == &key) {
+                all_options.push((key, display));
+            }
+        }
+    }
+
     let included = value_as_string_array(current_value, schema.default.as_ref());
     DualListState::new(&schema.name, all_options)
         .with_included(included)

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -247,7 +247,7 @@ fn build_dual_list_state(
         .collect();
 
     // Add runtime options (custom tokens from plugins) for fields that support them
-    if schema.dynamicly_extendable_status_bar_elements {
+    if schema.dynamically_extendable_status_bar_elements {
         let custom_tokens = crate::config::get_custom_status_bar_tokens();
         for (key, display) in custom_tokens {
             // Only add if not already present in options
@@ -1565,7 +1565,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1599,7 +1599,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1631,7 +1631,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();
@@ -1664,7 +1664,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         let config = sample_config();

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -9,6 +9,7 @@ use crate::view::controls::{
     TextInputState, TextListState, ToggleState,
 };
 use crate::view::ui::{FocusRegion, ScrollItem, TextEdit};
+use crate::app::Editor;
 use std::collections::{HashMap, HashSet};
 
 /// State for multiline JSON editing
@@ -239,6 +240,7 @@ fn build_dual_list_state(
     options: &[crate::view::settings::schema::EnumOption],
     current_value: Option<&serde_json::Value>,
     excluded: Vec<String>,
+    editor: Option<*const Editor>,
 ) -> DualListState {
     // Start with static schema options (built-in tokens)
     let mut all_options: Vec<(String, String)> = options
@@ -248,11 +250,14 @@ fn build_dual_list_state(
 
     // Add runtime options (custom tokens from plugins) for fields that support them
     if schema.dynamically_extendable_status_bar_elements {
-        let custom_tokens = crate::config::get_custom_status_bar_tokens();
-        for (key, display) in custom_tokens {
-            // Only add if not already present in options
-            if !all_options.iter().any(|(v, _)| v == &key) {
-                all_options.push((key, display));
+        if let Some(editor_ptr) = editor {
+            let ed = unsafe { &*editor_ptr };
+            let custom_tokens = ed.get_status_bar_elements();
+            for (key, display) in custom_tokens {
+                // Only add if not already present in options
+                if !all_options.iter().any(|(v, _)| v == &key) {
+                    all_options.push((key, display));
+                }
             }
         }
     }
@@ -831,6 +836,9 @@ pub struct BuildContext<'a> {
     pub layer_sources: &'a HashMap<String, ConfigLayer>,
     /// The layer currently being edited
     pub target_layer: ConfigLayer,
+    /// Editor reference for accessing runtime plugin data (None if not available)
+    /// Stored as raw pointer since Editor owns SettingsState
+    pub editor_ptr: Option<*const Editor>,
 }
 
 /// Convert a category tree into pages with control states
@@ -839,11 +847,13 @@ pub fn build_pages(
     config_value: &serde_json::Value,
     layer_sources: &HashMap<String, ConfigLayer>,
     target_layer: ConfigLayer,
+    editor_ptr: Option<*const Editor>,
 ) -> Vec<SettingsPage> {
     let ctx = BuildContext {
         config_value,
         layer_sources,
         target_layer,
+        editor_ptr,
     };
     categories.iter().map(|cat| build_page(cat, &ctx)).collect()
 }
@@ -1080,6 +1090,7 @@ pub fn build_item(schema: &SettingSchema, ctx: &BuildContext) -> SettingItem {
                 options,
                 current_value,
                 excluded,
+                ctx.editor_ptr,
             ))
         }
 
@@ -1212,6 +1223,7 @@ pub fn build_item(schema: &SettingSchema, ctx: &BuildContext) -> SettingItem {
 pub fn build_item_from_value(
     schema: &SettingSchema,
     current_value: Option<&serde_json::Value>,
+    editor: Option<*const Editor>,
 ) -> SettingItem {
     // Create control based on type
     let control = match &schema.setting_type {
@@ -1299,6 +1311,7 @@ pub fn build_item_from_value(
                 options,
                 current_value,
                 vec![],
+                editor,
             ))
         }
 
@@ -1535,6 +1548,7 @@ mod tests {
             config_value: config,
             layer_sources: &EMPTY_SOURCES,
             target_layer: ConfigLayer::User,
+            editor_ptr: None,
         }
     }
 
@@ -1548,6 +1562,7 @@ mod tests {
             config_value: config,
             layer_sources,
             target_layer,
+            editor_ptr: None,
         }
     }
 

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -247,8 +247,8 @@ fn build_dual_list_state(
         .collect();
 
     // Add runtime options (custom tokens from plugins) if this is status bar config
-    // Check if the schema path contains "status_bar"
-    if schema.path.contains("status_bar") {
+    // Check for exact status bar left/right field paths
+    if schema.path == "/editor/status_bar/left" || schema.path == "/editor/status_bar/right" {
         let custom_tokens = crate::config::get_custom_status_bar_tokens();
         for (key, display) in custom_tokens {
             // Only add if not already present in options

--- a/crates/fresh-editor/src/view/settings/items.rs
+++ b/crates/fresh-editor/src/view/settings/items.rs
@@ -3,7 +3,6 @@
 //! Converts schema information into renderable setting items.
 
 use super::schema::{SettingCategory, SettingSchema, SettingType};
-use crate::app::Editor;
 use crate::config_io::ConfigLayer;
 use crate::view::controls::{
     DropdownState, DualListState, FocusState, KeybindingListState, MapState, NumberInputState,
@@ -240,7 +239,7 @@ fn build_dual_list_state(
     options: &[crate::view::settings::schema::EnumOption],
     current_value: Option<&serde_json::Value>,
     excluded: Vec<String>,
-    editor: Option<*const Editor>,
+    available_status_bar_tokens: &HashMap<String, String>,
 ) -> DualListState {
     // Start with static schema options (built-in tokens)
     let mut all_options: Vec<(String, String)> = options
@@ -248,16 +247,12 @@ fn build_dual_list_state(
         .map(|o| (o.value.clone(), o.name.clone()))
         .collect();
 
-    // Add runtime options (custom tokens from plugins) for fields that support them
+    // Append plugin-registered tokens when this control opts in.
     if schema.dynamically_extendable_status_bar_elements {
-        if let Some(editor_ptr) = editor {
-            let ed = unsafe { &*editor_ptr };
-            let custom_tokens = ed.get_status_bar_elements();
-            for (key, display) in custom_tokens {
-                // Only add if not already present in options
-                if !all_options.iter().any(|(v, _)| v == &key) {
-                    all_options.push((key, display));
-                }
+        for (key, display) in available_status_bar_tokens {
+            let token = format!("{{{}}}", key);
+            if !all_options.iter().any(|(v, _)| v == &token) {
+                all_options.push((token, display.clone()));
             }
         }
     }
@@ -836,9 +831,9 @@ pub struct BuildContext<'a> {
     pub layer_sources: &'a HashMap<String, ConfigLayer>,
     /// The layer currently being edited
     pub target_layer: ConfigLayer,
-    /// Editor reference for accessing runtime plugin data (None if not available)
-    /// Stored as raw pointer since Editor owns SettingsState
-    pub editor_ptr: Option<*const Editor>,
+    /// Plugin-registered status-bar tokens (key → display title). Always
+    /// present; pass an empty map in tests.
+    pub available_status_bar_tokens: &'a HashMap<String, String>,
 }
 
 /// Convert a category tree into pages with control states
@@ -847,13 +842,13 @@ pub fn build_pages(
     config_value: &serde_json::Value,
     layer_sources: &HashMap<String, ConfigLayer>,
     target_layer: ConfigLayer,
-    editor_ptr: Option<*const Editor>,
+    available_status_bar_tokens: &HashMap<String, String>,
 ) -> Vec<SettingsPage> {
     let ctx = BuildContext {
         config_value,
         layer_sources,
         target_layer,
-        editor_ptr,
+        available_status_bar_tokens,
     };
     categories.iter().map(|cat| build_page(cat, &ctx)).collect()
 }
@@ -1090,7 +1085,7 @@ pub fn build_item(schema: &SettingSchema, ctx: &BuildContext) -> SettingItem {
                 options,
                 current_value,
                 excluded,
-                ctx.editor_ptr,
+                ctx.available_status_bar_tokens,
             ))
         }
 
@@ -1223,7 +1218,7 @@ pub fn build_item(schema: &SettingSchema, ctx: &BuildContext) -> SettingItem {
 pub fn build_item_from_value(
     schema: &SettingSchema,
     current_value: Option<&serde_json::Value>,
-    editor: Option<*const Editor>,
+    available_status_bar_tokens: &HashMap<String, String>,
 ) -> SettingItem {
     // Create control based on type
     let control = match &schema.setting_type {
@@ -1311,7 +1306,7 @@ pub fn build_item_from_value(
                 options,
                 current_value,
                 vec![],
-                editor,
+                available_status_bar_tokens,
             ))
         }
 
@@ -1544,11 +1539,13 @@ mod tests {
         // Create static empty HashMap for layer_sources
         static EMPTY_SOURCES: std::sync::LazyLock<HashMap<String, ConfigLayer>> =
             std::sync::LazyLock::new(HashMap::new);
+        static EMPTY_TOKENS: std::sync::LazyLock<HashMap<String, String>> =
+            std::sync::LazyLock::new(HashMap::new);
         BuildContext {
             config_value: config,
             layer_sources: &EMPTY_SOURCES,
             target_layer: ConfigLayer::User,
-            editor_ptr: None,
+            available_status_bar_tokens: &EMPTY_TOKENS,
         }
     }
 
@@ -1558,11 +1555,13 @@ mod tests {
         layer_sources: &'a HashMap<String, ConfigLayer>,
         target_layer: ConfigLayer,
     ) -> BuildContext<'a> {
+        static EMPTY_TOKENS: std::sync::LazyLock<HashMap<String, String>> =
+            std::sync::LazyLock::new(HashMap::new);
         BuildContext {
             config_value: config,
             layer_sources,
             target_layer,
-            editor_ptr: None,
+            available_status_bar_tokens: &EMPTY_TOKENS,
         }
     }
 

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -488,7 +488,9 @@ fn parse_setting(
             .dual_list_sibling
             .clone()
             .or_else(|| resolved.dual_list_sibling.clone()),
-        dynamically_extendable_status_bar_elements: schema.dynamically_extendable_status_bar_elements || resolved.dynamically_extendable_status_bar_elements,
+        dynamically_extendable_status_bar_elements: schema
+            .dynamically_extendable_status_bar_elements
+            || resolved.dynamically_extendable_status_bar_elements,
     }
 }
 

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -84,6 +84,8 @@ pub struct SettingSchema {
     pub enum_from: Option<String>,
     /// Path to the sibling dual-list setting (for cross-exclusion)
     pub dual_list_sibling: Option<String>,
+    /// Whether this field can be dynamically extended with runtime options (e.g., custom tokens from plugins)
+    pub dynamicly_extendable_status_bar_elements: bool,
 }
 
 /// Type of a setting, determines which control to render
@@ -216,6 +218,9 @@ struct RawSchema {
     /// Path to the sibling dual-list setting (for cross-exclusion)
     #[serde(rename = "x-dual-list-sibling")]
     dual_list_sibling: Option<String>,
+    /// Whether this field can be dynamically extended with runtime options (e.g., custom tokens from plugins)
+    #[serde(rename = "x-dynamicly-extendable-status-bar-elements", default)]
+    dynamicly_extendable_status_bar_elements: bool,
 }
 
 /// An entry in the x-enum-values array
@@ -483,6 +488,7 @@ fn parse_setting(
             .dual_list_sibling
             .clone()
             .or_else(|| resolved.dual_list_sibling.clone()),
+        dynamicly_extendable_status_bar_elements: schema.dynamicly_extendable_status_bar_elements || resolved.dynamicly_extendable_status_bar_elements,
     }
 }
 

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -85,7 +85,7 @@ pub struct SettingSchema {
     /// Path to the sibling dual-list setting (for cross-exclusion)
     pub dual_list_sibling: Option<String>,
     /// Whether this field can be dynamically extended with runtime options (e.g., custom tokens from plugins)
-    pub dynamicly_extendable_status_bar_elements: bool,
+    pub dynamically_extendable_status_bar_elements: bool,
 }
 
 /// Type of a setting, determines which control to render
@@ -219,8 +219,8 @@ struct RawSchema {
     #[serde(rename = "x-dual-list-sibling")]
     dual_list_sibling: Option<String>,
     /// Whether this field can be dynamically extended with runtime options (e.g., custom tokens from plugins)
-    #[serde(rename = "x-dynamicly-extendable-status-bar-elements", default)]
-    dynamicly_extendable_status_bar_elements: bool,
+    #[serde(rename = "x-dynamically-extendable-status-bar-elements", default)]
+    dynamically_extendable_status_bar_elements: bool,
 }
 
 /// An entry in the x-enum-values array
@@ -488,7 +488,7 @@ fn parse_setting(
             .dual_list_sibling
             .clone()
             .or_else(|| resolved.dual_list_sibling.clone()),
-        dynamicly_extendable_status_bar_elements: schema.dynamicly_extendable_status_bar_elements || resolved.dynamicly_extendable_status_bar_elements,
+        dynamically_extendable_status_bar_elements: schema.dynamically_extendable_status_bar_elements || resolved.dynamically_extendable_status_bar_elements,
     }
 }
 

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -3099,7 +3099,7 @@ mod tests {
                     nullable: false,
                     enum_from: None,
                     dual_list_sibling: None,
-                    dynamicly_extendable_status_bar_elements: false,
+                    dynamically_extendable_status_bar_elements: false,
                 }],
             },
             default: None,
@@ -3109,7 +3109,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         // universal_lsp's value schema: ObjectArray of the item schema above.
@@ -3131,7 +3131,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
-            dynamicly_extendable_status_bar_elements: false,
+            dynamically_extendable_status_bar_elements: false,
         };
 
         // Parent dialog: user is editing the existing "quicklsp" entry

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -109,6 +109,8 @@ pub struct SettingsState {
     /// User layer is the default (global settings).
     /// Project layer saves to the current project's .fresh/config.json.
     pub target_layer: ConfigLayer,
+    /// Editor reference (stored as raw pointer since Editor owns SettingsState)
+    editor_ptr: Option<*const crate::app::Editor>,
     /// Source layer for each setting path (where the value came from).
     /// Maps JSON pointer paths (e.g., "/editor/tab_size") to their source layer.
     /// Values not in this map come from system defaults.
@@ -178,7 +180,7 @@ impl SettingsState {
         let layer_sources = HashMap::new(); // Populated via set_layer_sources()
         let target_layer = ConfigLayer::User; // Default to user-global settings
         let pages =
-            super::items::build_pages(&categories, &config_value, &layer_sources, target_layer);
+            super::items::build_pages(&categories, &config_value, &layer_sources, target_layer, None);
 
         Ok(Self {
             categories,
@@ -210,6 +212,7 @@ impl SettingsState {
             scroll_panel: ScrollablePanel::new(),
             sub_focus: None,
             editing_text: false,
+            editor_ptr: None,
             hover_position: None,
             hover_hit: None,
             entry_dialog_stack: Vec::new(),
@@ -247,6 +250,17 @@ impl SettingsState {
         self.reset_dialog_selection = 0;
         self.reset_dialog_hover = None;
         self.showing_help = false;
+    }
+
+    /// Rebuild pages with current state
+    fn rebuild_pages(&mut self) {
+        self.pages = super::items::build_pages(
+            &self.categories,
+            &self.original_config,
+            &self.layer_sources,
+            self.target_layer,
+            self.editor_ptr,
+        );
     }
 
     /// Hide the settings panel
@@ -872,12 +886,7 @@ impl SettingsState {
         self.pending_changes.clear();
         self.pending_deletions.clear();
         // Rebuild pages from original config with layer info
-        self.pages = super::items::build_pages(
-            &self.categories,
-            &self.original_config,
-            &self.layer_sources,
-            self.target_layer,
-        );
+        self.rebuild_pages();
     }
 
     /// Set the target layer for saving changes.
@@ -889,12 +898,7 @@ impl SettingsState {
             self.pending_changes.clear();
             self.pending_deletions.clear();
             // Rebuild pages with new target layer (affects "modified" indicators)
-            self.pages = super::items::build_pages(
-                &self.categories,
-                &self.original_config,
-                &self.layer_sources,
-                self.target_layer,
-            );
+            self.rebuild_pages();
         }
     }
 
@@ -910,12 +914,7 @@ impl SettingsState {
         self.pending_changes.clear();
         self.pending_deletions.clear();
         // Rebuild pages with new target layer (affects "modified" indicators)
-        self.pages = super::items::build_pages(
-            &self.categories,
-            &self.original_config,
-            &self.layer_sources,
-            self.target_layer,
-        );
+        self.rebuild_pages();
     }
 
     /// Get a display name for the current target layer.
@@ -933,12 +932,14 @@ impl SettingsState {
     pub fn set_layer_sources(&mut self, sources: HashMap<String, ConfigLayer>) {
         self.layer_sources = sources;
         // Rebuild pages with new layer sources (affects "modified" indicators)
-        self.pages = super::items::build_pages(
-            &self.categories,
-            &self.original_config,
-            &self.layer_sources,
-            self.target_layer,
-        );
+        self.rebuild_pages();
+    }
+
+    /// Set the editor (called by Editor when opening settings).
+    /// This also rebuilds pages to include plugin status bar elements.
+    pub fn set_editor(&mut self, editor: &crate::app::Editor) {
+        self.editor_ptr = Some(editor as *const _);
+        self.rebuild_pages();
     }
 
     /// Get the source layer for a setting path.
@@ -1399,7 +1400,7 @@ impl SettingsState {
 
         // Create dialog from schema
         let dialog =
-            EntryDialogState::from_schema(key.clone(), value, schema, path, false, no_delete);
+            EntryDialogState::from_schema(key.clone(), value, schema, path, false, no_delete, self.editor_ptr);
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1425,6 +1426,7 @@ impl SettingsState {
             &path,
             true,
             false,
+            self.editor_ptr,
         );
         self.entry_dialog_stack.push(dialog);
     }
@@ -1444,7 +1446,7 @@ impl SettingsState {
 
         // Create dialog with empty value - user will fill it in
         let dialog =
-            EntryDialogState::for_array_item(None, &serde_json::json!({}), schema, &path, true);
+            EntryDialogState::for_array_item(None, &serde_json::json!({}), schema, &path, true, self.editor_ptr);
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1467,7 +1469,7 @@ impl SettingsState {
         };
         let path = item.path.clone();
 
-        let dialog = EntryDialogState::for_array_item(Some(index), value, schema, &path, false);
+        let dialog = EntryDialogState::for_array_item(Some(index), value, schema, &path, false, self.editor_ptr);
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1564,14 +1566,14 @@ impl SettingsState {
                     path,
                     is_new,
                     no_delete,
-                } => EntryDialogState::from_schema(key, &value, &schema, &path, is_new, no_delete),
+                } => EntryDialogState::from_schema(key, &value, &schema, &path, is_new, no_delete, self.editor_ptr),
                 NestedDialogInfo::ArrayItem {
                     index,
                     value,
                     schema,
                     path,
                     is_new,
-                } => EntryDialogState::for_array_item(index, &value, &schema, &path, is_new),
+                } => EntryDialogState::for_array_item(index, &value, &schema, &path, is_new, self.editor_ptr),
             };
             self.entry_dialog_stack.push(dialog);
         }
@@ -3136,7 +3138,7 @@ mod tests {
 
         // Parent dialog: user is editing the existing "quicklsp" entry
         // under /universal_lsp. This is the MapEntry dialog the real UI
-        // opens via `open_entry_dialog`.
+        // opened via `open_entry_dialog`.
         let parent = EntryDialogState::from_schema(
             "quicklsp".to_string(),
             &serde_json::json!([{ "enabled": true }]),
@@ -3144,6 +3146,7 @@ mod tests {
             "/universal_lsp",
             false, // existing entry
             false,
+            None,
         );
 
         // Precondition: is_single_value triggers and entry_path is correct.

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -179,8 +179,13 @@ impl SettingsState {
         let config_value = serde_json::to_value(config)?;
         let layer_sources = HashMap::new(); // Populated via set_layer_sources()
         let target_layer = ConfigLayer::User; // Default to user-global settings
-        let pages =
-            super::items::build_pages(&categories, &config_value, &layer_sources, target_layer, None);
+        let pages = super::items::build_pages(
+            &categories,
+            &config_value,
+            &layer_sources,
+            target_layer,
+            None,
+        );
 
         Ok(Self {
             categories,
@@ -1399,8 +1404,15 @@ impl SettingsState {
         let no_delete = map_state.no_add;
 
         // Create dialog from schema
-        let dialog =
-            EntryDialogState::from_schema(key.clone(), value, schema, path, false, no_delete, self.editor_ptr);
+        let dialog = EntryDialogState::from_schema(
+            key.clone(),
+            value,
+            schema,
+            path,
+            false,
+            no_delete,
+            self.editor_ptr,
+        );
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1445,8 +1457,14 @@ impl SettingsState {
         let path = item.path.clone();
 
         // Create dialog with empty value - user will fill it in
-        let dialog =
-            EntryDialogState::for_array_item(None, &serde_json::json!({}), schema, &path, true, self.editor_ptr);
+        let dialog = EntryDialogState::for_array_item(
+            None,
+            &serde_json::json!({}),
+            schema,
+            &path,
+            true,
+            self.editor_ptr,
+        );
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1469,7 +1487,14 @@ impl SettingsState {
         };
         let path = item.path.clone();
 
-        let dialog = EntryDialogState::for_array_item(Some(index), value, schema, &path, false, self.editor_ptr);
+        let dialog = EntryDialogState::for_array_item(
+            Some(index),
+            value,
+            schema,
+            &path,
+            false,
+            self.editor_ptr,
+        );
         self.entry_dialog_stack.push(dialog);
     }
 
@@ -1566,14 +1591,29 @@ impl SettingsState {
                     path,
                     is_new,
                     no_delete,
-                } => EntryDialogState::from_schema(key, &value, &schema, &path, is_new, no_delete, self.editor_ptr),
+                } => EntryDialogState::from_schema(
+                    key,
+                    &value,
+                    &schema,
+                    &path,
+                    is_new,
+                    no_delete,
+                    self.editor_ptr,
+                ),
                 NestedDialogInfo::ArrayItem {
                     index,
                     value,
                     schema,
                     path,
                     is_new,
-                } => EntryDialogState::for_array_item(index, &value, &schema, &path, is_new, self.editor_ptr),
+                } => EntryDialogState::for_array_item(
+                    index,
+                    &value,
+                    &schema,
+                    &path,
+                    is_new,
+                    self.editor_ptr,
+                ),
             };
             self.entry_dialog_stack.push(dialog);
         }

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -3099,6 +3099,7 @@ mod tests {
                     nullable: false,
                     enum_from: None,
                     dual_list_sibling: None,
+                    dynamicly_extendable_status_bar_elements: false,
                 }],
             },
             default: None,
@@ -3108,6 +3109,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         // universal_lsp's value schema: ObjectArray of the item schema above.
@@ -3129,6 +3131,7 @@ mod tests {
             nullable: false,
             enum_from: None,
             dual_list_sibling: None,
+            dynamicly_extendable_status_bar_elements: false,
         };
 
         // Parent dialog: user is editing the existing "quicklsp" entry

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -109,8 +109,9 @@ pub struct SettingsState {
     /// User layer is the default (global settings).
     /// Project layer saves to the current project's .fresh/config.json.
     pub target_layer: ConfigLayer,
-    /// Editor reference (stored as raw pointer since Editor owns SettingsState)
-    editor_ptr: Option<*const crate::app::Editor>,
+    /// Snapshot of plugin-registered status-bar tokens (key → display title).
+    /// Refreshed via `set_status_bar_tokens` when settings are opened.
+    available_status_bar_tokens: HashMap<String, String>,
     /// Source layer for each setting path (where the value came from).
     /// Maps JSON pointer paths (e.g., "/editor/tab_size") to their source layer.
     /// Values not in this map come from system defaults.
@@ -179,12 +180,13 @@ impl SettingsState {
         let config_value = serde_json::to_value(config)?;
         let layer_sources = HashMap::new(); // Populated via set_layer_sources()
         let target_layer = ConfigLayer::User; // Default to user-global settings
+        let available_status_bar_tokens: HashMap<String, String> = HashMap::new();
         let pages = super::items::build_pages(
             &categories,
             &config_value,
             &layer_sources,
             target_layer,
-            None,
+            &available_status_bar_tokens,
         );
 
         Ok(Self {
@@ -217,7 +219,7 @@ impl SettingsState {
             scroll_panel: ScrollablePanel::new(),
             sub_focus: None,
             editing_text: false,
-            editor_ptr: None,
+            available_status_bar_tokens,
             hover_position: None,
             hover_hit: None,
             entry_dialog_stack: Vec::new(),
@@ -264,7 +266,7 @@ impl SettingsState {
             &self.original_config,
             &self.layer_sources,
             self.target_layer,
-            self.editor_ptr,
+            &self.available_status_bar_tokens,
         );
     }
 
@@ -940,10 +942,10 @@ impl SettingsState {
         self.rebuild_pages();
     }
 
-    /// Set the editor (called by Editor when opening settings).
-    /// This also rebuilds pages to include plugin status bar elements.
-    pub fn set_editor(&mut self, editor: &crate::app::Editor) {
-        self.editor_ptr = Some(editor as *const _);
+    /// Refresh the snapshot of plugin-registered status-bar tokens
+    /// (called by Editor when opening settings).
+    pub fn set_status_bar_tokens(&mut self, tokens: HashMap<String, String>) {
+        self.available_status_bar_tokens = tokens;
         self.rebuild_pages();
     }
 
@@ -1411,7 +1413,7 @@ impl SettingsState {
             path,
             false,
             no_delete,
-            self.editor_ptr,
+            &self.available_status_bar_tokens,
         );
         self.entry_dialog_stack.push(dialog);
     }
@@ -1438,7 +1440,7 @@ impl SettingsState {
             &path,
             true,
             false,
-            self.editor_ptr,
+            &self.available_status_bar_tokens,
         );
         self.entry_dialog_stack.push(dialog);
     }
@@ -1463,7 +1465,7 @@ impl SettingsState {
             schema,
             &path,
             true,
-            self.editor_ptr,
+            &self.available_status_bar_tokens,
         );
         self.entry_dialog_stack.push(dialog);
     }
@@ -1493,7 +1495,7 @@ impl SettingsState {
             schema,
             &path,
             false,
-            self.editor_ptr,
+            &self.available_status_bar_tokens,
         );
         self.entry_dialog_stack.push(dialog);
     }
@@ -1598,7 +1600,7 @@ impl SettingsState {
                     &path,
                     is_new,
                     no_delete,
-                    self.editor_ptr,
+                    &self.available_status_bar_tokens,
                 ),
                 NestedDialogInfo::ArrayItem {
                     index,
@@ -1612,7 +1614,7 @@ impl SettingsState {
                     &schema,
                     &path,
                     is_new,
-                    self.editor_ptr,
+                    &self.available_status_bar_tokens,
                 ),
             };
             self.entry_dialog_stack.push(dialog);
@@ -3186,7 +3188,7 @@ mod tests {
             "/universal_lsp",
             false, // existing entry
             false,
-            None,
+            &HashMap::new(),
         );
 
         // Precondition: is_single_value triggers and entry_path is correct.

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -48,6 +48,8 @@ enum ElementKind {
     Clock,
     /// Remote authority indicator — styling driven by connection state
     RemoteIndicator(RemoteIndicatorState),
+    /// Custom plugin token
+    Custom,
 }
 
 /// Visual/semantic state of the remote authority indicator.
@@ -976,6 +978,16 @@ impl StatusBarRenderer {
                     kind: ElementKind::RemoteIndicator(state),
                 })
             }
+            StatusBarElement::CustomToken(key) => {
+                if let Some(value) = crate::config::get_custom_status_bar_value(key) {
+                    Some(RenderedElement {
+                        text: value,
+                        kind: ElementKind::Custom,
+                    })
+                } else {
+                    None // Skip rendering if no value set
+                }
+            }
         }
     }
 
@@ -1096,6 +1108,9 @@ impl StatusBarRenderer {
             ElementKind::Palette => Style::default()
                 .fg(theme.status_palette_fg)
                 .bg(theme.status_palette_bg),
+            ElementKind::Custom => Style::default()
+                .fg(theme.status_bar_fg)
+                .bg(theme.status_bar_bg),
             ElementKind::RemoteIndicator(state) => {
                 let is_hovering = hover == StatusBarHover::RemoteIndicator;
                 let (fg, bg) = match state {

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1,6 +1,7 @@
 //! Status bar and prompt/minibuffer rendering
 
 use std::path::Path;
+use std::collections::HashMap;
 
 use crate::app::WarningLevel;
 use crate::config::{StatusBarConfig, StatusBarElement};
@@ -242,6 +243,10 @@ pub struct StatusBarContext<'a> {
     /// is redundant; when it's not, the filename keeps the prefix
     /// so users still see the connection at a glance.
     pub remote_indicator_on_bar: bool,
+    /// Values of custom status bar elements registered by plugins.
+    /// Key: "plugin_name:token_name", Value: current value to render.
+    /// Populated by `render.rs` before rendering.
+    pub dynamic_status_bar_elements: HashMap<String, String>,
 }
 
 /// Layout information returned from status bar rendering for mouse click detection
@@ -979,9 +984,9 @@ impl StatusBarRenderer {
                 })
             }
             StatusBarElement::CustomToken(key) => {
-                if let Some(value) = crate::config::get_custom_status_bar_value(key) {
+                if let Some(value) = ctx.dynamic_status_bar_elements.get(key) {
                     Some(RenderedElement {
-                        text: value,
+                        text: value.clone(),
                         kind: ElementKind::Custom,
                     })
                 } else {

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1,7 +1,7 @@
 //! Status bar and prompt/minibuffer rendering
 
-use std::path::Path;
 use std::collections::HashMap;
+use std::path::Path;
 
 use crate::app::WarningLevel;
 use crate::config::{StatusBarConfig, StatusBarElement};

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -5,13 +5,11 @@
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::{clear_custom_status_bar_tokens, Config, StatusBarConfig, StatusBarElement};
+use fresh::config::{Config, StatusBarConfig, StatusBarElement};
 use std::fs;
 
 #[test]
 fn test_status_bar_shows_custom_branch_token() {
-    clear_custom_status_bar_tokens();
-
     let mut config = Config::default();
     config.editor.status_bar = StatusBarConfig {
         left: vec![
@@ -51,14 +49,15 @@ fn test_status_bar_shows_custom_branch_token() {
     // Wait for plugin to register custom status bar token
     harness
         .wait_until(|h| {
-            fresh::config::get_custom_status_bar_tokens()
+             h.editor()
+                 .get_status_bar_elements()
                 .iter()
                 .any(|(k, _)| k == "{git_statusbar:branch}")
         })
         .unwrap();
 
     // Verify the custom token is registered by the plugin
-    let tokens = fresh::config::get_custom_status_bar_tokens();
+    let tokens = harness.editor().get_status_bar_elements();
     assert!(
         tokens
             .iter()

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -5,12 +5,13 @@
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::{Config, StatusBarConfig, StatusBarElement};
+use fresh::config::{clear_custom_status_bar_tokens, Config, StatusBarConfig, StatusBarElement};
 use std::fs;
-use std::time::Duration;
 
 #[test]
 fn test_status_bar_shows_custom_branch_token() {
+    clear_custom_status_bar_tokens();
+
     let mut config = Config::default();
     config.editor.status_bar = StatusBarConfig {
         left: vec![
@@ -47,11 +48,14 @@ fn test_status_bar_shows_custom_branch_token() {
         })
         .unwrap();
 
-    // Give more time for the plugin to register its status bar element
-    for _ in 0..20 {
-        let _ = harness.render();
-        std::thread::sleep(Duration::from_millis(50));
-    }
+    // Wait for plugin to register custom status bar token
+    harness
+        .wait_until(|h| {
+            fresh::config::get_custom_status_bar_tokens()
+                .iter()
+                .any(|(k, _)| k == "{git_statusbar:branch}")
+        })
+        .unwrap();
 
     // Verify the custom token is registered by the plugin
     let tokens = fresh::config::get_custom_status_bar_tokens();

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -49,8 +49,8 @@ fn test_status_bar_shows_custom_branch_token() {
     // Wait for plugin to register custom status bar token
     harness
         .wait_until(|h| {
-             h.editor()
-                 .get_status_bar_elements()
+            h.editor()
+                .get_status_bar_elements()
                 .iter()
                 .any(|(k, _)| k == "{git_statusbar:branch}")
         })

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -22,7 +22,9 @@ fn test_status_bar_shows_custom_branch_token() {
     let mut harness = EditorTestHarness::create(
         80,
         24,
-        HarnessOptions::new().with_project_root().with_config(config),
+        HarnessOptions::new()
+            .with_project_root()
+            .with_config(config),
     )
     .unwrap();
 
@@ -35,27 +37,27 @@ fn test_status_bar_shows_custom_branch_token() {
 
     // Verify status bar contains expected elements
     let status_bar = harness.get_status_bar();
-    
+
     // The filename should be visible
     assert!(
         status_bar.contains("test.txt"),
         "Status bar should contain filename. Got: {}",
         status_bar
     );
-    
+
     // Encoding and language should be visible on the right side
     assert!(
         status_bar.contains("ASCII") || status_bar.contains("UTF-8"),
         "Status bar should contain encoding. Got: {}",
         status_bar
     );
-    
+
     assert!(
         status_bar.contains("Text"),
         "Status bar should contain language. Got: {}",
         status_bar
     );
-    
+
     // Note: The "branch" token value comes from the plugin at runtime.
     // Without the plugin loaded, the element shows as empty/placeholder.
     // The actual "Not in git" value appears when the plugin runs.

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -3,62 +3,115 @@
 //! These tests verify that the status bar can be configured to show the
 //! git branch element, which is registered by the git_statusbar plugin.
 
-use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::{Config, StatusBarConfig, StatusBarElement};
 use std::fs;
+use std::time::Duration;
 
 #[test]
 fn test_status_bar_shows_custom_branch_token() {
-    // Configure status bar to include the branch token
     let mut config = Config::default();
     config.editor.status_bar = StatusBarConfig {
         left: vec![
             StatusBarElement::Filename,
-            StatusBarElement::CustomToken("branch".to_string()),
+            StatusBarElement::CustomToken("git_statusbar:branch".to_string()),
         ],
         right: vec![StatusBarElement::Encoding, StatusBarElement::Language],
     };
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir_all(&project_root).unwrap();
+
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "git_statusbar");
+    copy_plugin_lib(&plugins_dir);
 
     let mut harness = EditorTestHarness::create(
         80,
         24,
         HarnessOptions::new()
-            .with_project_root()
+            .with_working_dir(project_root.clone())
             .with_config(config),
     )
     .unwrap();
 
-    let project_dir = harness.project_dir().unwrap();
-    let test_file = project_dir.join("test.txt");
+    // Wait for plugins to load by checking if any commands are registered
+    // This ensures the plugin has at least started executing
+    harness
+        .wait_until(|h| {
+            let commands = h.editor().command_registry().read().unwrap().get_all();
+            !commands.is_empty()
+        })
+        .unwrap();
+
+    // Give more time for the plugin to register its status bar element
+    for _ in 0..20 {
+        let _ = harness.render();
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    // Verify the custom token is registered by the plugin
+    let tokens = fresh::config::get_custom_status_bar_tokens();
+    assert!(
+        tokens
+            .iter()
+            .any(|(k, t)| k == "{git_statusbar:branch}" && t == "Git: branch"),
+        "Custom token should be registered by plugin. Got: {:?}",
+        tokens
+    );
+
+    // Open settings and verify the custom token appears in status bar config
+    harness.open_settings().unwrap();
+    // Navigate: General -> Clipboard -> Editor (2 Downs)
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    // Right to expand Editor section
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    // Navigate down to Status Bar section (12 total from Editor expanded)
+    for _ in 0..12 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+    // Right to expand Status Bar
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    // Look for the custom token "Git: branch" in the settings body
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Git: branch"),
+        "Settings should show custom token 'Git: branch'. Got:\n{}",
+        screen
+    );
+
+    let test_file = project_root.join("test.txt");
     fs::write(&test_file, "test content\n").unwrap();
 
     harness.open_file(&test_file).unwrap();
+
+    // Move cursor to trigger cursor_moved event
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
     harness.render().unwrap();
 
     // Verify status bar contains expected elements
     let status_bar = harness.get_status_bar();
 
-    // The filename should be visible
+    // The branch token value comes from the plugin at runtime.
+    // With the plugin loaded, the status bar should show "Not in git"
+    // since we're not in a git repository.
     assert!(
-        status_bar.contains("test.txt"),
-        "Status bar should contain filename. Got: {}",
+        status_bar.contains("Not in git"),
+        "Status bar should contain 'Not in git' from plugin. Got: {}",
         status_bar
     );
-
-    // Encoding and language should be visible on the right side
-    assert!(
-        status_bar.contains("ASCII") || status_bar.contains("UTF-8"),
-        "Status bar should contain encoding. Got: {}",
-        status_bar
-    );
-
-    assert!(
-        status_bar.contains("Text"),
-        "Status bar should contain language. Got: {}",
-        status_bar
-    );
-
-    // Note: The "branch" token value comes from the plugin at runtime.
-    // Without the plugin loaded, the element shows as empty/placeholder.
-    // The actual "Not in git" value appears when the plugin runs.
 }

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -1,0 +1,62 @@
+//! E2E tests for the git_statusbar plugin
+//!
+//! These tests verify that the status bar can be configured to show the
+//! git branch element, which is registered by the git_statusbar plugin.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::config::{Config, StatusBarConfig, StatusBarElement};
+use std::fs;
+
+#[test]
+fn test_status_bar_shows_custom_branch_token() {
+    // Configure status bar to include the branch token
+    let mut config = Config::default();
+    config.editor.status_bar = StatusBarConfig {
+        left: vec![
+            StatusBarElement::Filename,
+            StatusBarElement::CustomToken("branch".to_string()),
+        ],
+        right: vec![StatusBarElement::Encoding, StatusBarElement::Language],
+    };
+
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new().with_project_root().with_config(config),
+    )
+    .unwrap();
+
+    let project_dir = harness.project_dir().unwrap();
+    let test_file = project_dir.join("test.txt");
+    fs::write(&test_file, "test content\n").unwrap();
+
+    harness.open_file(&test_file).unwrap();
+    harness.render().unwrap();
+
+    // Verify status bar contains expected elements
+    let status_bar = harness.get_status_bar();
+    
+    // The filename should be visible
+    assert!(
+        status_bar.contains("test.txt"),
+        "Status bar should contain filename. Got: {}",
+        status_bar
+    );
+    
+    // Encoding and language should be visible on the right side
+    assert!(
+        status_bar.contains("ASCII") || status_bar.contains("UTF-8"),
+        "Status bar should contain encoding. Got: {}",
+        status_bar
+    );
+    
+    assert!(
+        status_bar.contains("Text"),
+        "Status bar should contain language. Got: {}",
+        status_bar
+    );
+    
+    // Note: The "branch" token value comes from the plugin at runtime.
+    // Without the plugin loaded, the element shows as empty/placeholder.
+    // The actual "Not in git" value appears when the plugin runs.
+}

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -31,6 +31,7 @@ pub mod diff_cursor;
 pub mod find_file;
 pub mod git;
 pub mod git_log_split_tab_focus;
+pub mod git_statusbar;
 pub mod goto_with_selection;
 pub mod gutter;
 pub mod init_script;

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1107,6 +1107,29 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Register a custom statusbar token.
+    /// Token will be named "plugin_name:token_name" where plugin_name is the current plugin.
+    /// Returns true if registration succeeded, false if invalid or already registered.
+    pub fn register_status_bar_element(&self, token_name: String, title: String) -> bool {
+        let plugin_name = self.plugin_name.clone();
+        self.command_sender
+            .send(PluginCommand::RegisterStatusBarElement {
+                plugin_name,
+                token_name,
+                title,
+            })
+            .is_ok()
+    }
+
+    /// Set the value for a previously registered custom statusbar token.
+    /// Token name is "plugin_name:token_name" where plugin_name is the current plugin.
+    pub fn set_status_bar_element_value(&self, token_name: String, value: String) -> bool {
+        let name = format!("{}:{}", self.plugin_name, token_name);
+        self.command_sender
+            .send(PluginCommand::SetStatusBarElementValue { name, value })
+            .is_ok()
+    }
+
     // === Translation ===
 
     /// Translate a string - reads plugin name from __pluginName__ global

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1121,12 +1121,16 @@ impl JsEditorApi {
             .is_ok()
     }
 
-    /// Set the value for a previously registered custom statusbar token.
-    /// Token name is "plugin_name:token_name" where plugin_name is the current plugin.
-    pub fn set_status_bar_element_value(&self, token_name: String, value: String) -> bool {
-        let name = format!("{}:{}", self.plugin_name, token_name);
+    /// Set the value of a status-bar token for a specific buffer.
+    /// The full token key sent to the editor is "plugin_name:token_name".
+    pub fn set_status_bar_value(&self, buffer_id: u64, token_name: String, value: String) -> bool {
+        let key = format!("{}:{}", self.plugin_name, token_name);
         self.command_sender
-            .send(PluginCommand::SetStatusBarElementValue { name, value })
+            .send(PluginCommand::SetStatusBarValue {
+                buffer_id,
+                key,
+                value,
+            })
             .is_ok()
     }
 


### PR DESCRIPTION
## Summary
This PR introduces a plugin API for registering and managing custom status bar elements. Plugins can now register custom tokens that appear in the status bar and settings UI, with per-buffer values that update dynamically.

## Key Changes

### Plugin API (`fresh.d.ts` and runtime)
- Added `registerStatusBarElement(tokenName, title)` to register custom status bar tokens
- Added `setStatusBarValue(bufferId, tokenName, value)` to update token values per buffer
- Tokens are automatically namespaced as `"plugin_name:token_name"`

### Editor Core (`app/mod.rs`)
- Added `status_bar_token_registry` to track all registered tokens globally
- Implemented `register_status_bar_element()` to register tokens with validation
- Implemented `set_status_bar_value()` to update per-buffer token values
- Implemented `get_status_bar_elements()` for Settings UI integration
- Added `remove_plugin_status_bar_elements()` to clean up when plugins unload

### Settings UI Integration
- Modified `SettingsState` to snapshot plugin-registered tokens when settings open
- Added `set_status_bar_tokens()` to refresh token list dynamically
- Updated `build_pages()` and related functions to accept available tokens
- Modified `DualListState` to append plugin tokens to status bar element lists
- Added `dynamically_extendable_status_bar_elements` schema flag to opt-in fields

### Status Bar Rendering
- Added `CustomToken` variant to `StatusBarElement` enum
- Updated `StatusBarContext` to include `dynamic_status_bar_elements` map
- Modified status bar renderer to handle custom tokens with plugin-provided values

### Plugin Dispatch
- Added handlers for `RegisterStatusBarElement` and `SetStatusBarValue` commands
- Integrated with plugin unload to clean up registered elements

### Example Plugin: `git_statusbar`
- New plugin that registers a `branch` token showing current git branch
- Listens to editor events and updates branch value asynchronously
- Includes i18n translations for 12 languages
- Demonstrates the complete plugin lifecycle for status bar elements

### Configuration
- Updated `config.rs` to parse custom tokens in `StatusBarElement::CustomToken`
- Modified schema to mark status bar fields as dynamically extendable

### Testing
- Added comprehensive E2E test verifying plugin registration, settings UI display, and runtime value updates

## Implementation Details
- Token registry uses `Mutex<HashMap>` for thread-safe access
- Per-buffer values stored on `Window` to follow buffer ownership model
- Settings UI refreshes token list when opened to capture newly-loaded plugins
- Custom tokens formatted with braces `{plugin_name:token_name}` in UI
- Plugin cleanup on unload removes all tokens and values with matching prefix

https://claude.ai/code/session_01QwceYrdx8hFg9TJyRtqymf