### PR TITLE
fix(fuzzy): prioritise path-segment-prefix matches in Quick Open

### DIFF
--- a/crates/fresh-editor/src/input/fuzzy/matcher.rs
+++ b/crates/fresh-editor/src/input/fuzzy/matcher.rs
@@ -201,6 +201,7 @@ fn score_single_term(
     }
 
     // Exact match bonus: query matches entire target.
+    let mut credited_full_path_prefix = false;
     if query_len == target_len {
         final_score += score::EXACT_MATCH;
     } else if target_len > query_len && is_contiguous {
@@ -212,9 +213,39 @@ fn score_single_term(
             if next_char == '.' {
                 // Highest priority: exact basename match (before extension).
                 final_score += score::EXACT_MATCH;
+                credited_full_path_prefix = true;
             } else if next_char == '-' || next_char == '_' || next_char == ' ' {
                 // Second priority: match before word separator.
                 final_score += score::EXACT_BASENAME_MATCH;
+                credited_full_path_prefix = true;
+            }
+        }
+    }
+
+    // Path-segment prefix bonus.  A contiguous match that begins at the start
+    // of a path segment (basename or interior directory) outranks an equally
+    // contiguous match that lands mid-segment.  This is what users expect
+    // when typing a short query like "ts": a basename starting with "ts"
+    // (e.g. `tsconfig.json`) should rank above unrelated files whose only
+    // `ts` happens to follow an extension dot (e.g. `pkg.ts`, `finder.ts`).
+    //
+    // Skipped when the existing `EXACT_*` block above already credited a
+    // full-path prefix that ends in a separator — those matches are already
+    // in the top tier and would be double-counted otherwise.
+    if is_contiguous
+        && !credited_full_path_prefix
+        && !positions.is_empty()
+        && positions.len() == query_len
+    {
+        let start = positions[0];
+        let starts_segment = start == 0 || (start > 0 && target_chars[start - 1] == '/');
+        if starts_segment {
+            let last_slash = target_chars.iter().rposition(|&c| c == '/');
+            let basename_start = last_slash.map(|i| i + 1).unwrap_or(0);
+            if start == basename_start {
+                final_score += score::BASENAME_PREFIX;
+            } else {
+                final_score += score::PATH_SEGMENT_PREFIX;
             }
         }
     }

--- a/crates/fresh-editor/src/input/fuzzy/mod.rs
+++ b/crates/fresh-editor/src/input/fuzzy/mod.rs
@@ -63,6 +63,19 @@ pub(crate) mod score {
     /// in the target but not necessarily from position 0). This ensures that
     /// e.g. "results" in "results.json" ranks above scattered r-e-s-u-l-t-s.
     pub const CONTIGUOUS_SUBSTRING: i32 = 64;
+    /// Bonus for a contiguous match that begins at the start of the basename
+    /// (immediately after the last `/`, or position 0 if there is no `/`).
+    /// Stacks with the existing word-boundary bonus to give nested basename
+    /// prefix matches (e.g. "ts" -> ".../tsconfig.json") a decisive edge over
+    /// equally-contiguous matches that sit inside the basename (e.g. "ts" ->
+    /// ".../pkg.ts", where "ts" comes after the extension dot).
+    pub const BASENAME_PREFIX: i32 = 64;
+    /// Bonus for a contiguous match that begins at the start of an interior
+    /// path segment (immediately after some `/` other than the one preceding
+    /// the basename). Smaller than `BASENAME_PREFIX` because the basename is
+    /// the more common search target, but still enough to outrank arbitrary
+    /// mid-segment substring matches.
+    pub const PATH_SEGMENT_PREFIX: i32 = 32;
 }
 
 /// Result of a fuzzy match, containing match status and quality score
@@ -454,6 +467,65 @@ mod tests {
             "exact target should score higher: exact={}, partial={}",
             exact.score,
             partial.score
+        );
+    }
+
+    #[test]
+    fn test_basename_prefix_beats_intra_segment_match() {
+        // Typing "ts" should rank `tsconfig.json` (basename starts with the
+        // prefix) above unrelated files whose basename merely *contains*
+        // "ts" as a contiguous substring after the extension dot
+        // (e.g. `pkg.ts`, `finder.ts`).  Without the basename-prefix bonus,
+        // both score identically because each match earns the same
+        // word-boundary + contiguous bonuses.
+        let prefix = fuzzy_match("ts", "crates/fresh-editor/plugins/tsconfig.json");
+        for distractor in &[
+            "crates/fresh-editor/plugins/pkg.ts",
+            "crates/fresh-editor/plugins/lib/finder.ts",
+            "crates/fresh-editor/plugins/lib/index.ts",
+            "crates/fresh-editor/plugins/diagnostics_panel.ts",
+        ] {
+            let other = fuzzy_match("ts", distractor);
+            assert!(prefix.matched && other.matched);
+            assert!(
+                prefix.score > other.score,
+                "tsconfig.json ({}) must outrank {} ({})",
+                prefix.score,
+                distractor,
+                other.score
+            );
+        }
+    }
+
+    #[test]
+    fn test_directory_segment_prefix_beats_intra_segment_match() {
+        // A directory segment that starts with the prefix should also
+        // outrank a mid-segment match, even when it isn't the basename.
+        let dir_prefix = fuzzy_match("ts", "crates/ts-parser/src/lib.rs");
+        let intra = fuzzy_match("ts", "crates/fresh-editor/plugins/pkg.ts");
+        assert!(dir_prefix.matched && intra.matched);
+        assert!(
+            dir_prefix.score > intra.score,
+            "ts-parser/... ({}) must outrank pkg.ts ({})",
+            dir_prefix.score,
+            intra.score
+        );
+    }
+
+    #[test]
+    fn test_basename_prefix_outranks_directory_prefix() {
+        // When both a basename and an interior directory start with the
+        // same prefix, the basename should win — typing "ts" is far more
+        // often a search for a file named tsconfig.json than for a file
+        // *inside* a directory whose name happens to start with "ts".
+        let basename = fuzzy_match("ts", "crates/fresh-editor/plugins/tsconfig.json");
+        let dir = fuzzy_match("ts", "crates/ts-parser/src/lib.rs");
+        assert!(basename.matched && dir.matched);
+        assert!(
+            basename.score > dir.score,
+            "basename-prefix tsconfig.json ({}) must outrank dir-prefix ts-parser/... ({})",
+            basename.score,
+            dir.score
         );
     }
 


### PR DESCRIPTION
Typing a short prefix like "ts" in Quick Open is overwhelmingly a search
for a file whose name starts with that prefix (e.g. `tsconfig.json`),
not for any file whose path happens to contain "t" followed by "s". The
matcher's word-boundary bonus is the same for `/` and `.`, so
`crates/.../tsconfig.json` (basename starts with "ts") tied with
`crates/.../pkg.ts` (just a `.ts` extension) at 112 points each — random
`.ts` files were just as likely to surface as the canonical match.

Add two new bonuses on top of the existing word-boundary/contiguous
scoring:
  - `BASENAME_PREFIX` (+64) for contiguous matches that start at the
    beginning of the basename (after the last `/` or position 0).
  - `PATH_SEGMENT_PREFIX` (+32) for contiguous matches that start at
    the beginning of an interior directory segment.

The position-0 case already credited by the existing `EXACT_*` block
(when the match is followed by a path separator) is skipped to avoid
double-counting.

Three regression tests cover the ranking promises:
  - basename-prefix beats intra-segment matches
  - directory-prefix beats intra-segment matches
  - basename-prefix outranks directory-prefix when both exist

https://claude.ai/code/session_011G4AKhGKBBrPUrtG6EcbDB