### PR TITLE
Fix Toggle Line Wrap command not updating viewport layout

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1422,12 +1422,13 @@ impl Editor {
             Action::ToggleLineWrap => {
                 let new_value = !self.config.editor.line_wrap;
                 self.config_mut().editor.line_wrap = new_value;
-                // Window-side reads (`Window::config()`, which backs
-                // `resolve_line_wrap_for_buffer` below) read a separate Arc
-                // clone of the config. Without this sync the resolve call
-                // would see the pre-toggle value and we'd write the *old*
-                // line-wrap state back into the viewport — silently no-op'ing
-                // the toggle while still flipping the status message.
+                // `resolve_line_wrap_for_buffer` below reads
+                // `Window::config()`, which holds a *separate* `Arc<Config>`
+                // clone from the Editor's. Without this sync the resolve
+                // would return the pre-toggle value and we'd write the
+                // *old* line-wrap state back into the viewport — silently
+                // no-op'ing the toggle while still flipping the status
+                // message. See `Editor::config_mut` for the broader rule.
                 self.sync_windows_config();
 
                 // Update all viewports to reflect the new line wrap setting,

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1422,6 +1422,13 @@ impl Editor {
             Action::ToggleLineWrap => {
                 let new_value = !self.config.editor.line_wrap;
                 self.config_mut().editor.line_wrap = new_value;
+                // Window-side reads (`Window::config()`, which backs
+                // `resolve_line_wrap_for_buffer` below) read a separate Arc
+                // clone of the config. Without this sync the resolve call
+                // would see the pre-toggle value and we'd write the *old*
+                // line-wrap state back into the viewport — silently no-op'ing
+                // the toggle while still flipping the status message.
+                self.sync_windows_config();
 
                 // Update all viewports to reflect the new line wrap setting,
                 // respecting per-language overrides

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -212,6 +212,7 @@ pub mod theme;
 pub mod theme_screenshots;
 pub mod toggle_bars;
 pub mod toggle_comment;
+pub mod toggle_line_wrap_command;
 pub mod triple_click;
 pub mod undo_bulk_edit_after_save;
 pub mod undo_redo;

--- a/crates/fresh-editor/tests/e2e/toggle_line_wrap_command.rs
+++ b/crates/fresh-editor/tests/e2e/toggle_line_wrap_command.rs
@@ -1,0 +1,132 @@
+//! Regression test: the `Toggle Line Wrap` command must actually change
+//! how the open buffer is rendered.
+//!
+//! Bug: when `editor.line_wrap = true` is set in the user config, opening
+//! a file shows long lines wrapped (as expected), but running the
+//! `Toggle Line Wrap` command from the command palette updates
+//! `config.editor.line_wrap` and the status message — yet the buffer
+//! keeps rendering with the previous wrap layout, because the per-leaf
+//! wrap state on the viewport is updated without invalidating the
+//! line-wrap cache / view layout that drives rendering.
+//!
+//! Reproduced interactively in tmux with the release binary; this test
+//! is the automation of that reproduction.
+//!
+//! The assertion is purely on what shows up in the rendered screen:
+//! we plant a unique `END-MARKER` far past the right edge of the
+//! viewport, so it can only appear when the line wraps to additional
+//! visual rows. Toggling wrap off must remove `END-MARKER` from the
+//! screen; toggling it back on must restore it.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+use tempfile::TempDir;
+
+const WIDTH: u16 = 60;
+const HEIGHT: u16 = 24;
+
+/// Run a command from the command palette by typing its name and pressing Enter.
+fn run_command(harness: &mut EditorTestHarness, command_name: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(command_name).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// File content whose long line is much wider than `WIDTH` so it must
+/// wrap onto multiple visual rows when wrapping is enabled. The
+/// `END-MARKER` token sits past the right edge of the viewport — it
+/// can only become visible if wrapping pushes it to a new visual row.
+fn long_line_fixture() -> String {
+    let filler = "filler ".repeat(30); // ~210 chars of filler past the screen edge
+    format!("short before\nBEGIN-MARKER {filler}END-MARKER tail\nshort after\n")
+}
+
+fn open_long_file(harness: &mut EditorTestHarness) -> TempDir {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("long.txt");
+    fs::write(&path, long_line_fixture()).unwrap();
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+    dir
+}
+
+/// Toggling line wrap OFF from a config that starts with wrap ON must
+/// stop wrapping the buffer on screen.
+#[test]
+fn toggle_line_wrap_off_actually_unwraps_buffer() {
+    let mut config = Config::default();
+    config.editor.line_wrap = true;
+
+    let mut harness = EditorTestHarness::with_config(WIDTH, HEIGHT, config).unwrap();
+    let _dir = open_long_file(&mut harness);
+
+    let initial = harness.screen_to_string();
+    assert!(
+        initial.contains("BEGIN-MARKER"),
+        "start of the long line should always be on screen.\nScreen:\n{}",
+        initial
+    );
+    assert!(
+        initial.contains("END-MARKER"),
+        "with line_wrap=true, the wrapped tail of the long line should be on screen \
+         (END-MARKER sits far past the right edge and is only reachable via wrapping).\nScreen:\n{}",
+        initial
+    );
+
+    run_command(&mut harness, "Toggle Line Wrap");
+
+    let after = harness.screen_to_string();
+    assert!(
+        after.contains("BEGIN-MARKER"),
+        "start of the long line should still be visible after toggling wrap off.\nScreen:\n{}",
+        after
+    );
+    assert!(
+        !after.contains("END-MARKER"),
+        "after Toggle Line Wrap with wrap previously on, the line must no longer wrap, \
+         so END-MARKER (well past the right edge) must be off-screen.\nScreen:\n{}",
+        after
+    );
+}
+
+/// Symmetric case: toggling line wrap ON from a config that starts with
+/// wrap OFF must start wrapping the buffer on screen.
+#[test]
+fn toggle_line_wrap_on_actually_wraps_buffer() {
+    let mut config = Config::default();
+    config.editor.line_wrap = false;
+
+    let mut harness = EditorTestHarness::with_config(WIDTH, HEIGHT, config).unwrap();
+    let _dir = open_long_file(&mut harness);
+
+    let initial = harness.screen_to_string();
+    assert!(
+        initial.contains("BEGIN-MARKER"),
+        "start of the long line should always be on screen.\nScreen:\n{}",
+        initial
+    );
+    assert!(
+        !initial.contains("END-MARKER"),
+        "with line_wrap=false, END-MARKER must be off-screen (past the right edge).\nScreen:\n{}",
+        initial
+    );
+
+    run_command(&mut harness, "Toggle Line Wrap");
+
+    let after = harness.screen_to_string();
+    assert!(
+        after.contains("END-MARKER"),
+        "after Toggle Line Wrap with wrap previously off, the line must now wrap, \
+         so END-MARKER must appear on a continuation visual row.\nScreen:\n{}",
+        after
+    );
+}


### PR DESCRIPTION
## Summary
Fixed a bug where the `Toggle Line Wrap` command would update the configuration and status message but fail to actually change how the buffer renders on screen. The issue was that the per-window config state wasn't being synchronized after toggling the setting, causing the viewport to use stale line-wrap state when recalculating the layout.

## Changes
- **Input handler fix**: Added `sync_windows_config()` call in the `ToggleLineWrap` action handler to ensure all window viewports read the updated configuration value before recalculating line-wrap layout. This prevents the viewport from writing back the old line-wrap state and silently no-op'ing the toggle.

- **Regression test**: Added comprehensive e2e test suite (`toggle_line_wrap_command.rs`) that verifies the toggle actually changes rendering behavior:
  - Tests toggling wrap OFF: verifies wrapped content disappears from screen
  - Tests toggling wrap ON: verifies previously off-screen wrapped content appears
  - Uses a unique marker token positioned far past the viewport edge to detect whether wrapping is active based on what's rendered

## Implementation Details
The root cause was a config synchronization issue: `Editor::config_mut()` updates the editor's `Arc<Config>`, but `Window::config()` holds a separate clone. Without explicit synchronization, the window's resolve logic would read the pre-toggle value and write back the old state, effectively canceling the toggle while still updating the UI message.

https://claude.ai/code/session_017LMhPr8VKih5MZNUQYoNFg