### PR TITLE
feat(widgets): floating widget panel primitive

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3016,6 +3016,28 @@ pub enum PluginCommand {
         panel_id: u64,
         mutation: WidgetMutation,
     },
+
+    /// Mount a declarative widget panel as a centered floating
+    /// overlay rather than into a virtual buffer. `width_pct` and
+    /// `height_pct` size the overlay rect relative to the terminal
+    /// (clamped 1..=100). Only one floating widget panel may be
+    /// mounted at a time; a second `MountFloatingWidget` replaces
+    /// any existing one.
+    MountFloatingWidget {
+        panel_id: u64,
+        spec: WidgetSpec,
+        width_pct: u8,
+        height_pct: u8,
+    },
+
+    /// Replace the spec of the currently-mounted floating widget
+    /// panel. No-op when no floating panel is mounted, or when the
+    /// `panel_id` doesn't match the mounted one.
+    UpdateFloatingWidget { panel_id: u64, spec: WidgetSpec },
+
+    /// Tear down the floating widget panel. No-op when no floating
+    /// panel is mounted, or when the `panel_id` doesn't match.
+    UnmountFloatingWidget { panel_id: u64 },
 }
 
 impl PluginCommand {

--- a/crates/fresh-editor/plugins/conductor.ts
+++ b/crates/fresh-editor/plugins/conductor.ts
@@ -282,8 +282,7 @@ async function spawnCollect(
   args: string[],
   cwd: string,
 ): Promise<SpawnResult> {
-  const handle = editor.spawnProcess(command, args, cwd);
-  return await editor.spawnProcessWait(handle.processId);
+  return await editor.spawnProcess(command, args, cwd);
 }
 
 async function detectDefaultBranch(repoRoot: string): Promise<string> {

--- a/crates/fresh-editor/plugins/conductor.ts
+++ b/crates/fresh-editor/plugins/conductor.ts
@@ -4,24 +4,32 @@
 //
 // MVP scope (`docs/internal/conductor-sessions-design.md`):
 //
-//   - "Conductor: Open" opens a floating overlay prompt (same
-//     UX shape as Live Grep) listing every session with its
-//     state column. Up/Down navigates, Enter dives into the
-//     selected session.
-//   - "Conductor: New Session" prompts for branch name + agent
-//     command, allocates a worktree-rooted session and spawns
-//     the agent in a terminal attached to it.
+//   - "Conductor: Open" opens a floating overlay prompt listing
+//     every session with its state column. Up/Down navigates,
+//     Enter dives into the selected session.
+//   - "Conductor: New Session" opens a single floating widget
+//     form with three optional fields (session name, agent
+//     command, branch), allocates a worktree-rooted session and
+//     spawns the agent in a terminal attached to it.
 //   - "Conductor: Kill Selected" closes the session whose row is
 //     currently highlighted in the open prompt.
 //   - Agent state column updates from terminal_output regex and
 //     terminal_exit code: RUNNING / AWAITING / READY / ERRORED.
-//
-// Why a floating prompt rather than a utility-dock panel:
-// floating overlays don't mutate the split tree, so opening
-// Conductor (and closing it) leaves the user's editor layout
-// undisturbed. The previous utility-dock implementation stuck
-// to the dock and clashed with reopen flows. This shape mirrors
-// the existing Live Grep / Quick Open patterns.
+
+import {
+  button,
+  col,
+  flexSpacer,
+  FloatingWidgetPanel,
+  hintBar,
+  key as widgetKey,
+  row,
+  spacer,
+  styledRow,
+  text,
+  textInputChar,
+  type WidgetSpec,
+} from "./lib/widgets.ts";
 
 const editor = getEditor();
 
@@ -54,18 +62,33 @@ interface AgentSession {
 
 const conductorSessions = new Map<number, AgentSession>();
 
-// Two-step "New Session" prompt: store the branch from step 1
-// so step 2's confirm handler can read it.
-let pendingBranchName: string | null = null;
-
 // Pending session-creation intent. Stashed across the
 // async `createWindow → window_created hook` handoff so the
 // hook handler can attach the spawned terminal. (Internally
 // the editor calls these "windows"; Conductor still presents
 // them as "sessions" in its UX.)
 let pendingNewSession:
-  | { branch: string; cmd: string; root: string }
+  | { label: string; branch: string; cmd: string; root: string }
   | null = null;
+
+// New-session form state. `null` ⇒ the floating form isn't
+// open. Each field's `value` + `cursor` mirrors what the host
+// renders inside the panel's TextInput widgets; the `submitting`
+// flag debounces double-Enter on the Create button; `lastError`
+// is rendered as a styled error row inside the form when the
+// most recent submit failed (status bar would get clobbered —
+// see MEMORY.md).
+interface NewSessionForm {
+  name: { value: string; cursor: number };
+  cmd: { value: string; cursor: number };
+  branch: { value: string; cursor: number };
+  submitting: boolean;
+  lastError: string | null;
+}
+let form: NewSessionForm | null = null;
+let formPanel: FloatingWidgetPanel | null = null;
+
+const NEW_SESSION_MODE = "conductor-new-form";
 
 // Last suggestion list shown in the open prompt. Mirrors the
 // snapshot the user sees so prompt_confirmed can map the
@@ -214,7 +237,7 @@ editor.on("prompt_selection_changed", (e) => {
   }
 });
 
-editor.on("prompt_confirmed", async (e) => {
+editor.on("prompt_confirmed", (e) => {
   if (e.prompt_type === PROMPT_TYPE) {
     // Enter commits: dive into the highlighted session for
     // real. Clear the preview override so the next prompt
@@ -227,34 +250,6 @@ editor.on("prompt_confirmed", async (e) => {
     originalActiveSessionBeforePrompt = null;
     return;
   }
-
-  if (e.prompt_type === "conductor-new-branch") {
-    const name = (e.input || "").trim();
-    if (!name) return;
-    pendingBranchName = name;
-    editor.startPrompt(
-      "Agent command (e.g. 'aider', 'claude -p \"...\"')",
-      "conductor-new-cmd",
-      true,
-    );
-    return;
-  }
-
-  if (e.prompt_type === "conductor-new-cmd") {
-    const cmd = (e.input || "").trim();
-    const branch = pendingBranchName;
-    pendingBranchName = null;
-    if (!branch || !cmd) return;
-    const cwd = editor.getCwd();
-    const root = editor.pathJoin(cwd, ".fresh", "conductor", branch);
-    try {
-      await editor.spawnProcess("mkdir", ["-p", root], cwd);
-    } catch {
-      // best-effort; createTerminal will surface failures
-    }
-    pendingNewSession = { branch, cmd, root };
-    editor.createWindow(root, branch);
-  }
 });
 
 editor.on("prompt_cancelled", (e) => {
@@ -265,24 +260,334 @@ editor.on("prompt_cancelled", (e) => {
     originalActiveSessionBeforePrompt = null;
     return;
   }
-  if (
-    e.prompt_type === "conductor-new-branch" ||
-    e.prompt_type === "conductor-new-cmd"
-  ) {
-    pendingBranchName = null;
-    pendingNewSession = null;
-  }
 });
 
-function startNewSession(): void {
-  pendingBranchName = null;
-  pendingNewSession = null;
-  editor.startPrompt(
-    "New session — branch / worktree name",
-    "conductor-new-branch",
-    true,
-  );
+// =============================================================================
+// New-session floating form
+// =============================================================================
+
+function slugify(p: string): string {
+  // Drop any leading separator so the slug isn't anchored to the
+  // filesystem root; replace remaining separators with underscores.
+  return p.replace(/^[\\\/]+/, "").replace(/[\\\/]+/g, "_");
 }
+
+function lastNonEmptyLine(s: string): string {
+  const lines = (s || "").split(/\r?\n/).filter((l) => l.trim().length > 0);
+  return lines.length ? lines[lines.length - 1].trim() : "";
+}
+
+async function spawnCollect(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<SpawnResult> {
+  const handle = editor.spawnProcess(command, args, cwd);
+  return await editor.spawnProcessWait(handle.processId);
+}
+
+async function detectDefaultBranch(repoRoot: string): Promise<string> {
+  // `git symbolic-ref refs/remotes/origin/HEAD` → e.g.
+  // `refs/remotes/origin/main`. Strip the prefix; fall back to
+  // `HEAD` when no remote is set or the symbolic ref is missing.
+  const res = await spawnCollect(
+    "git",
+    ["-C", repoRoot, "symbolic-ref", "refs/remotes/origin/HEAD"],
+    repoRoot,
+  );
+  if (res.exit_code === 0) {
+    const trimmed = (res.stdout || "").trim();
+    const prefix = "refs/remotes/origin/";
+    if (trimmed.startsWith(prefix)) {
+      return trimmed.slice(prefix.length);
+    }
+  }
+  return "HEAD";
+}
+
+function nextAutoSessionName(): string {
+  // Persisted counter so consecutive empty submits produce
+  // session-1, session-2, … even across plugin reloads.
+  const counter = (editor.getGlobalState("conductor.session_counter") as
+    | number
+    | undefined) ?? 0;
+  const next = counter + 1;
+  editor.setGlobalState("conductor.session_counter", next);
+  return `session-${next}`;
+}
+
+function buildFormSpec(): WidgetSpec {
+  if (!form) return col();
+  const children: WidgetSpec[] = [
+    {
+      kind: "raw",
+      entries: [
+        styledRow([
+          {
+            text: "Conductor — New Session",
+            style: { fg: "ui.popup_border_fg", bold: true },
+          },
+        ]),
+      ],
+    },
+    spacer(0),
+    text({
+      value: form.name.value,
+      cursorByte: form.name.cursor,
+      label: "Session name",
+      placeholder: "(auto-generated)",
+      fieldWidth: 40,
+      key: "name",
+    }),
+    text({
+      value: form.cmd.value,
+      cursorByte: form.cmd.cursor,
+      label: "Agent command",
+      placeholder: "(plain shell)",
+      fieldWidth: 40,
+      key: "cmd",
+    }),
+    text({
+      value: form.branch.value,
+      cursorByte: form.branch.cursor,
+      label: "Branch",
+      placeholder: "(off default branch)",
+      fieldWidth: 40,
+      key: "branch",
+    }),
+    spacer(0),
+  ];
+  if (form.lastError) {
+    children.push({
+      kind: "raw",
+      entries: [
+        styledRow([
+          { text: "Error: ", style: { fg: "ui.error_fg", bold: true } },
+          { text: form.lastError },
+        ]),
+      ],
+    });
+    children.push(spacer(0));
+  }
+  children.push(
+    row(
+      flexSpacer(),
+      button("Cancel", { key: "cancel" }),
+      spacer(2),
+      button("Create", { intent: "primary", key: "create" }),
+    ),
+    spacer(0),
+    hintBar([
+      { keys: "Tab", label: "next" },
+      { keys: "S-Tab", label: "prev" },
+      { keys: "Enter", label: "submit" },
+      { keys: "Esc", label: "cancel" },
+    ]),
+  );
+  return col(...children);
+}
+
+function renderForm(): void {
+  if (!form || !formPanel) return;
+  formPanel.update(buildFormSpec());
+}
+
+function openForm(): void {
+  pendingNewSession = null;
+  const lastCmd =
+    (editor.getGlobalState("conductor.last_cmd") as string | undefined) ?? "";
+  form = {
+    name: { value: "", cursor: 0 },
+    cmd: { value: lastCmd, cursor: lastCmd.length },
+    branch: { value: "", cursor: 0 },
+    submitting: false,
+    lastError: null,
+  };
+  formPanel = new FloatingWidgetPanel();
+  formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
+  editor.setEditorMode(NEW_SESSION_MODE);
+}
+
+function closeForm(): void {
+  if (formPanel) {
+    formPanel.unmount();
+    formPanel = null;
+  }
+  form = null;
+  editor.setEditorMode(null);
+}
+
+async function submitForm(): Promise<void> {
+  if (!form || form.submitting) return;
+  form.submitting = true;
+  form.lastError = null;
+  renderForm();
+
+  const sessionName = form.name.value.trim() || nextAutoSessionName();
+  const cmd = form.cmd.value.trim();
+  const branchInput = form.branch.value.trim();
+
+  const cwd = editor.getCwd();
+  const top = await spawnCollect("git", ["rev-parse", "--show-toplevel"], cwd);
+  if (top.exit_code !== 0) {
+    if (!form) return;
+    form.submitting = false;
+    form.lastError = lastNonEmptyLine(top.stderr) || "not a git repository";
+    renderForm();
+    return;
+  }
+  const repoRoot = (top.stdout || "").trim();
+
+  const root = editor.pathJoin(
+    editor.getDataDir(),
+    "conductor",
+    slugify(repoRoot),
+    sessionName,
+  );
+  const parent = editor.pathDirname(root);
+  if (!editor.createDir(parent)) {
+    if (!form) return;
+    form.submitting = false;
+    form.lastError = `mkdir failed: ${parent}`;
+    renderForm();
+    return;
+  }
+
+  const defaultBranch = await detectDefaultBranch(repoRoot);
+  const branchName = branchInput || sessionName;
+  // Try `-b <new>` first; if it fails because the branch already
+  // exists, fall back to checking out the existing branch into a
+  // new worktree.
+  let addRes = await spawnCollect(
+    "git",
+    ["-C", repoRoot, "worktree", "add", root, "-b", branchName, defaultBranch],
+    repoRoot,
+  );
+  if (addRes.exit_code !== 0) {
+    const fallback = await spawnCollect(
+      "git",
+      ["-C", repoRoot, "worktree", "add", root, branchName],
+      repoRoot,
+    );
+    if (fallback.exit_code !== 0) {
+      if (!form) return;
+      form.submitting = false;
+      form.lastError = lastNonEmptyLine(addRes.stderr) ||
+        lastNonEmptyLine(fallback.stderr) ||
+        "git worktree add failed";
+      renderForm();
+      return;
+    }
+    addRes = fallback;
+  }
+
+  if (cmd) {
+    editor.setGlobalState("conductor.last_cmd", cmd);
+  }
+
+  pendingNewSession = { label: sessionName, branch: branchName, cmd, root };
+  closeForm();
+  editor.createWindow(root, sessionName);
+}
+
+function startNewSession(): void {
+  if (form) return; // already open
+  openForm();
+}
+
+// Form key bindings — each delegates to smart-key dispatch on the
+// panel, which routes to the focused widget. `mode_text_input`
+// handles printable input outside this list.
+const FORM_MODE_BINDINGS: [string, string][] = [
+  ["Tab", "conductor_form_key_tab"],
+  ["S-Tab", "conductor_form_key_shift_tab"],
+  ["Return", "conductor_form_key_enter"],
+  ["Escape", "conductor_form_key_escape"],
+  ["Backspace", "conductor_form_key_backspace"],
+  ["Delete", "conductor_form_key_delete"],
+  ["Home", "conductor_form_key_home"],
+  ["End", "conductor_form_key_end"],
+  ["Left", "conductor_form_key_left"],
+  ["Right", "conductor_form_key_right"],
+  ["Up", "conductor_form_key_up"],
+  ["Down", "conductor_form_key_down"],
+];
+
+editor.defineMode(NEW_SESSION_MODE, FORM_MODE_BINDINGS, true, true);
+
+function dispatchFormKey(name: string): void {
+  if (!form || !formPanel) return;
+  formPanel.command(widgetKey(name));
+}
+
+registerHandler("conductor_form_key_tab", () => dispatchFormKey("Tab"));
+registerHandler(
+  "conductor_form_key_shift_tab",
+  () => dispatchFormKey("Shift+Tab"),
+);
+registerHandler("conductor_form_key_enter", () => dispatchFormKey("Enter"));
+registerHandler("conductor_form_key_escape", () => {
+  if (form) closeForm();
+});
+registerHandler(
+  "conductor_form_key_backspace",
+  () => dispatchFormKey("Backspace"),
+);
+registerHandler("conductor_form_key_delete", () => dispatchFormKey("Delete"));
+registerHandler("conductor_form_key_home", () => dispatchFormKey("Home"));
+registerHandler("conductor_form_key_end", () => dispatchFormKey("End"));
+registerHandler("conductor_form_key_left", () => dispatchFormKey("Left"));
+registerHandler("conductor_form_key_right", () => dispatchFormKey("Right"));
+registerHandler("conductor_form_key_up", () => dispatchFormKey("Up"));
+registerHandler("conductor_form_key_down", () => dispatchFormKey("Down"));
+
+// Printable input arrives via the global `mode_text_input` action.
+// Other plugins may also register a `mode_text_input` handler;
+// guard on `form` so this handler is a no-op outside the form.
+function conductor_mode_text_input(args: { text: string }): void {
+  if (!form || !formPanel || !args?.text) return;
+  formPanel.command(textInputChar(args.text));
+}
+registerHandler("mode_text_input", conductor_mode_text_input);
+
+editor.on("widget_event", (e) => {
+  if (!form || !formPanel) return;
+  if (e.panel_id !== formPanel.id()) return;
+  if (e.event_type === "change") {
+    const field = e.widget_key;
+    const payload = (e.payload ?? {}) as Record<string, unknown>;
+    const value = payload.value;
+    const cursor = payload.cursorByte;
+    if (typeof value !== "string") return;
+    const slot = field === "name"
+      ? form.name
+      : field === "cmd"
+      ? form.cmd
+      : field === "branch"
+      ? form.branch
+      : null;
+    if (slot) {
+      slot.value = value;
+      if (typeof cursor === "number") slot.cursor = cursor;
+    }
+    return;
+  }
+  if (e.event_type === "activate") {
+    if (e.widget_key === "create") {
+      void submitForm();
+    } else if (e.widget_key === "cancel") {
+      closeForm();
+    }
+    return;
+  }
+  if (e.event_type === "cancel") {
+    // Host fires this when Esc unmounts the floating panel —
+    // clean up our own state to match.
+    form = null;
+    formPanel = null;
+    editor.setEditorMode(null);
+  }
+});
 
 function killSelected(): void {
   if (promptSessionIds.length === 0) {
@@ -321,7 +626,7 @@ editor.on("window_created", async (payload) => {
   const id = payload.id;
   if (
     pendingNewSession &&
-    payload.label === pendingNewSession.branch
+    payload.label === pendingNewSession.label
   ) {
     const intent = pendingNewSession;
     pendingNewSession = null;
@@ -335,14 +640,16 @@ editor.on("window_created", async (payload) => {
     });
     const tracked: AgentSession = {
       id,
-      label: intent.branch,
+      label: intent.label,
       root: intent.root,
       terminalId: term.terminalId,
       state: "running",
       createdAt: Date.now(),
     };
     conductorSessions.set(id, tracked);
-    editor.sendTerminalInput(term.terminalId, intent.cmd + "\n");
+    if (intent.cmd) {
+      editor.sendTerminalInput(term.terminalId, intent.cmd + "\n");
+    }
   }
   refreshPromptIfOpen();
 });

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2390,6 +2390,19 @@ interface EditorAPI {
 	*/
 	widgetMutate(panelId: number, mutationObj: unknown): boolean;
 	/**
+	* Mount a declarative widget panel as a centered floating
+	* overlay (not bound to any virtual buffer).
+	*/
+	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number): boolean;
+	/**
+	* Replace the spec of the currently-mounted floating widget panel.
+	*/
+	updateFloatingWidget(panelId: number, specObj: unknown): boolean;
+	/**
+	* Tear down the floating widget panel.
+	*/
+	unmountFloatingWidget(panelId: number): boolean;
+	/**
 	* Spawn a process (async, returns request_id)
 	*/
 	spawnProcess(command: string, args: string[], cwd?: string): ProcessHandle<SpawnResult>;

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -545,6 +545,118 @@ export class WidgetPanel {
 }
 
 // =============================================================================
+// FloatingWidgetPanel — mount-once-update-many wrapper for centered
+// floating overlays (no virtual buffer required).
+// =============================================================================
+
+/** A handle to a floating widget panel — a modal-ish overlay
+ * rendered in a centered frame on top of the editor, dimming the
+ * background. Unlike `WidgetPanel`, no virtual buffer is needed;
+ * the host owns the rect and paints the spec inside it.
+ *
+ * `mount({ widthPct, heightPct })` mounts the panel and renders
+ * the spec; `update(spec)` re-renders against the previous instance
+ * state; `unmount()` tears it down. The host routes keys to the
+ * focused widget automatically while a floating panel is up: Esc
+ * unmounts and fires a `widget_event` "cancel"; Tab / Enter /
+ * arrows / Backspace / printable chars route through the same
+ * smart-key dispatch as `WidgetPanel.command(key(...))`. */
+export class FloatingWidgetPanel {
+  private mounted = false;
+  private readonly panelId: number;
+
+  constructor(panelId?: number) {
+    this.panelId = panelId ?? allocatePanelId();
+  }
+
+  /** Returns the plugin-allocated panel id, useful for routing
+   * widget events back through `editor.on("widget_event", ...)`. */
+  id(): number {
+    return this.panelId;
+  }
+
+  /** Mount the panel as a centered overlay sized by `widthPct` /
+   * `heightPct` (percent of terminal, clamped 1..=100). Cheap to
+   * call repeatedly with a new spec — re-mounting replaces the
+   * existing panel. */
+  mount(
+    spec: WidgetSpec,
+    options: { widthPct?: number; heightPct?: number } = {},
+  ): boolean {
+    // deno-lint-ignore no-explicit-any
+    const editor = (globalThis as any).editor;
+    const wp = options.widthPct ?? 60;
+    const hp = options.heightPct ?? 40;
+    this.mounted = true;
+    return editor.mountFloatingWidget(this.panelId, spec, wp, hp);
+  }
+
+  /** Re-render the panel against the given spec; instance state on
+   * keyed widgets is preserved. No-op when not mounted. */
+  update(spec: WidgetSpec): boolean {
+    if (!this.mounted) return false;
+    // deno-lint-ignore no-explicit-any
+    const editor = (globalThis as any).editor;
+    return editor.updateFloatingWidget(this.panelId, spec);
+  }
+
+  /** Tear down the panel and let the editor return to its normal
+   * key/click routing. */
+  unmount(): boolean {
+    if (!this.mounted) return true;
+    this.mounted = false;
+    // deno-lint-ignore no-explicit-any
+    const editor = (globalThis as any).editor;
+    return editor.unmountFloatingWidget(this.panelId);
+  }
+
+  /** Route a key/nav action to the focused widget. The host
+   * automatically routes keystrokes while a floating panel is up,
+   * so plugins rarely need to call this directly — it's exposed
+   * for symmetry with `WidgetPanel`. */
+  command(action: WidgetAction): boolean {
+    // deno-lint-ignore no-explicit-any
+    const editor = (globalThis as any).editor;
+    return editor.widgetCommand(this.panelId, action);
+  }
+
+  /** Apply a targeted mutation in place — the IPC fast path. */
+  mutate(mutation: WidgetMutation): boolean {
+    // deno-lint-ignore no-explicit-any
+    const editor = (globalThis as any).editor;
+    return editor.widgetMutate(this.panelId, mutation);
+  }
+
+  setValue(widgetKey: string, value: string, cursorByte?: number): boolean {
+    return this.mutate({ kind: "setValue", widgetKey, value, cursorByte });
+  }
+
+  setChecked(widgetKey: string, checked: boolean): boolean {
+    return this.mutate({ kind: "setChecked", widgetKey, checked });
+  }
+
+  setSelectedIndex(widgetKey: string, index: number): boolean {
+    return this.mutate({ kind: "setSelectedIndex", widgetKey, index });
+  }
+
+  setItems(
+    widgetKey: string,
+    items: TextPropertyEntry[],
+    itemKeys: string[] = [],
+  ): boolean {
+    return this.mutate({ kind: "setItems", widgetKey, items, itemKeys });
+  }
+
+  setExpandedKeys(widgetKey: string, keys: string[]): boolean {
+    return this.mutate({ kind: "setExpandedKeys", widgetKey, keys });
+  }
+
+  setCheckedKeys(widgetKey: string, checked: boolean, keys: string[]): boolean {
+    return this.mutate({ kind: "setCheckedKeys", widgetKey, checked, keys });
+  }
+}
+
+// =============================================================================
 // WidgetAction builders — convenience wrappers around `panel.command(...)`.
 // Plugin's mode bindings call these for keys handled by the widget layer.
 // =============================================================================

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -266,6 +266,7 @@ impl Editor {
             cursor_jump_animation: None,
             pending_vb_animations: Vec::new(),
             widget_registry: crate::widgets::WidgetRegistry::new(),
+            floating_widget_panel: None,
         }
     }
 

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -494,6 +494,18 @@ impl Editor {
             return Ok(());
         }
 
+        // Floating widget panel claims all keys while visible. Esc
+        // unmounts + fires a `widget_event` "cancel"; smart-key names
+        // (Tab/Return/Backspace/…/Up/Down) route through the widget
+        // command dispatcher; printable chars feed `textInputChar` to
+        // the focused TextInput. Mouse clicks outside the panel are
+        // swallowed (handled in `mouse_input`).
+        if self.floating_widget_panel.is_some()
+            && self.dispatch_floating_widget_key(code, modifiers)
+        {
+            return Ok(());
+        }
+
         // Clear skip_ensure_visible flag so cursor becomes visible after key press
         // (scroll actions will set it again if needed). Use the *effective*
         // active split so this clears the flag on a focused buffer-group
@@ -2551,5 +2563,100 @@ impl Editor {
         }
 
         Ok(())
+    }
+
+    /// Route a keystroke to the floating widget panel when one is
+    /// mounted. Returns `true` if the key was consumed.
+    ///
+    /// Esc unmounts the panel and fires a `widget_event` `cancel`
+    /// so the plugin can clean up its own state (clear mode, drop
+    /// form state, etc.). Tab / S-Tab / Return / Space / Backspace /
+    /// Delete / Home / End / Left / Right / Up / Down route through
+    /// the same smart-key dispatch the bound mode handlers would
+    /// use. Printable characters feed `textInputChar` to the
+    /// currently focused TextInput.
+    fn dispatch_floating_widget_key(
+        &mut self,
+        code: crossterm::event::KeyCode,
+        modifiers: crossterm::event::KeyModifiers,
+    ) -> bool {
+        use crossterm::event::{KeyCode, KeyModifiers};
+        let panel_id = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => fwp.panel_id,
+            None => return false,
+        };
+        let key_name: Option<&str> = match code {
+            KeyCode::Esc => {
+                let widget_key = self
+                    .widget_registry
+                    .get(panel_id)
+                    .map(|p| p.focus_key.clone())
+                    .unwrap_or_default();
+                if self
+                    .plugin_manager
+                    .read()
+                    .unwrap()
+                    .has_hook_handlers("widget_event")
+                {
+                    self.plugin_manager.read().unwrap().run_hook(
+                        "widget_event",
+                        crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                            panel_id,
+                            widget_key,
+                            event_type: "cancel".to_string(),
+                            payload: serde_json::json!({}),
+                        },
+                    );
+                }
+                self.floating_widget_panel = None;
+                let _ = self.widget_registry.unmount(panel_id);
+                return true;
+            }
+            KeyCode::Tab => Some(if modifiers.contains(KeyModifiers::SHIFT) {
+                "Shift+Tab"
+            } else {
+                "Tab"
+            }),
+            KeyCode::BackTab => Some("Shift+Tab"),
+            KeyCode::Enter => Some("Enter"),
+            KeyCode::Backspace => Some("Backspace"),
+            KeyCode::Delete => Some("Delete"),
+            KeyCode::Home => Some("Home"),
+            KeyCode::End => Some("End"),
+            KeyCode::Left => Some("Left"),
+            KeyCode::Right => Some("Right"),
+            KeyCode::Up => Some("Up"),
+            KeyCode::Down => Some("Down"),
+            KeyCode::PageUp => Some("PageUp"),
+            KeyCode::PageDown => Some("PageDown"),
+            _ => None,
+        };
+        if let Some(name) = key_name {
+            self.handle_widget_command(
+                panel_id,
+                fresh_core::api::WidgetAction::Key {
+                    key: name.to_string(),
+                },
+            );
+            return true;
+        }
+        if let KeyCode::Char(c) = code {
+            if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                return false;
+            }
+            let ch = if modifiers.contains(KeyModifiers::SHIFT) {
+                c.to_uppercase().next().unwrap_or(c)
+            } else {
+                c
+            };
+            self.handle_widget_command(
+                panel_id,
+                fresh_core::api::WidgetAction::TextInputChar {
+                    text: ch.to_string(),
+                },
+            );
+            return true;
+        }
+        false
     }
 }

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -894,6 +894,43 @@ pub struct Editor {
     /// the originating plugin needing to re-emit. See
     /// `docs/internal/plugin-widget-library-design.md`.
     pub(crate) widget_registry: crate::widgets::WidgetRegistry,
+
+    /// Currently-mounted floating widget panel, if any.
+    ///
+    /// At most one floating widget panel is shown at a time — the
+    /// overlay is modal-ish (input is routed to it) and stacking
+    /// floaters would obscure each other without a usable focus
+    /// model. Mounting a second one replaces the first.
+    pub(crate) floating_widget_panel: Option<FloatingWidgetState>,
+}
+
+/// Sentinel `BufferId` registered with the widget registry for the
+/// floating panel — never appears in the editor's buffer table, so
+/// `set_virtual_buffer_content` against it would fail. The mount /
+/// rerender paths special-case this id and paint into the overlay
+/// rect instead.
+pub(crate) const FLOATING_PANEL_BUFFER_ID: BufferId = BufferId(usize::MAX);
+
+/// A widget panel rendered as a centered floating overlay rather
+/// than into a virtual buffer. The panel still lives in the shared
+/// `widget_registry` (so the existing reconcile / widget-command /
+/// mutate paths apply), but its rendered entries are painted into
+/// the overlay rect at draw time instead of being written into a
+/// virtual buffer.
+#[derive(Debug, Clone)]
+pub(crate) struct FloatingWidgetState {
+    pub panel_id: crate::widgets::PanelId,
+    pub width_pct: u8,
+    pub height_pct: u8,
+    /// Most-recently rendered entries. Refreshed on every spec /
+    /// command / mutate; painted into the overlay rect at draw
+    /// time.
+    pub entries: Vec<fresh_core::text_property::TextPropertyEntry>,
+    /// Hardware-cursor target when a `TextInput` is focused.
+    pub focus_cursor: Option<crate::widgets::FocusCursor>,
+    /// Inner rect (frame interior) of the last draw — used by the
+    /// click hit-test to map terminal coords back to buffer coords.
+    pub last_inner_rect: Option<ratatui::layout::Rect>,
 }
 
 /// A file that should be opened after the TUI starts

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1388,6 +1388,15 @@ impl Editor {
         row: u16,
         modifiers: crossterm::event::KeyModifiers,
     ) -> AnyhowResult<()> {
+        // Floating widget panel is modal: clicks inside hit-test
+        // against its widget hits; clicks outside are swallowed so
+        // the user can't accidentally focus another split while the
+        // form is up. Auto-dismiss on outside-click is deliberately
+        // NOT done — the form has explicit Cancel / Esc.
+        if self.floating_widget_panel.is_some() {
+            self.handle_floating_widget_click(col, row);
+            return Ok(());
+        }
         if let Some(r) = self.handle_click_context_menus(col, row) {
             return r;
         }
@@ -3344,4 +3353,107 @@ impl Editor {
             Some(modified_files)
         }
     }
+
+    /// Hit-test a click against the floating widget panel. Clicks
+    /// inside the panel's inner rect resolve to a widget row/byte
+    /// and fire `widget_event` via the same path
+    /// `handle_editor_click` uses; clicks outside the rect are
+    /// swallowed without dismissing the panel.
+    fn handle_floating_widget_click(&mut self, col: u16, row: u16) {
+        let (panel_id, inner) = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => match fwp.last_inner_rect {
+                Some(rect) => (fwp.panel_id, rect),
+                None => return,
+            },
+            None => return,
+        };
+        if col < inner.x || col >= inner.x + inner.width {
+            return;
+        }
+        if row < inner.y || row >= inner.y + inner.height {
+            return;
+        }
+        let brow = (row - inner.y) as u32;
+        let entries = self
+            .floating_widget_panel
+            .as_ref()
+            .map(|f| f.entries.clone())
+            .unwrap_or_default();
+        let local_screen_col = (col - inner.x) as usize;
+        let bcol = match entries.get(brow as usize) {
+            Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
+            None => return,
+        };
+        let (hit_payload, hit_event, hit_key, hit_kind) =
+            match self
+                .widget_registry
+                .hit_test(super::FLOATING_PANEL_BUFFER_ID, brow, bcol as u32)
+            {
+                Some((_, hit)) => (
+                    hit.payload.clone(),
+                    hit.event_type.to_string(),
+                    hit.widget_key.clone(),
+                    hit.widget_kind,
+                ),
+                None => return,
+            };
+        if !hit_key.is_empty() {
+            let tabbable = self
+                .widget_registry
+                .get(panel_id)
+                .map(|p| p.tabbable.iter().any(|k| k == &hit_key))
+                .unwrap_or(false);
+            if tabbable {
+                self.widget_registry
+                    .set_focus_key(panel_id, hit_key.clone());
+            }
+            self.rerender_widget_panel(panel_id);
+        }
+        let handled_specially = if hit_kind == "tree" && hit_event == "expand" {
+            if let Some(item_key) = hit_payload.get("key").and_then(|v| v.as_str()) {
+                self.handle_widget_tree_expand_toggle(panel_id, &hit_key, item_key);
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+        if !handled_specially
+            && self
+                .plugin_manager
+                .read()
+                .unwrap()
+                .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key: hit_key,
+                    event_type: hit_event,
+                    payload: hit_payload,
+                },
+            );
+        }
+    }
+}
+
+/// Translate a display-column offset within a rendered line into a
+/// UTF-8 byte offset inside the entry's text. Walks the string
+/// codepoint-by-codepoint using `unicode-width` so wide glyphs
+/// (CJK, emoji) advance by their actual screen width.
+fn screen_col_to_byte(text: &str, target_col: usize) -> usize {
+    use unicode_width::UnicodeWidthChar;
+    let mut byte = 0;
+    let mut col = 0usize;
+    for ch in text.chars() {
+        let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if col + w > target_col {
+            return byte;
+        }
+        col += w;
+        byte += ch.len_utf8();
+    }
+    byte
 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -22,7 +22,7 @@ use crate::services::async_bridge::AsyncMessage;
 use crate::view::split::SplitViewState;
 
 use super::window::Window;
-use super::Editor;
+use super::{Editor, FloatingWidgetState, FLOATING_PANEL_BUFFER_ID};
 
 /// Snapshot of the focused `Text` widget's host-owned state.
 /// Returned by `read_focused_text` and consumed by
@@ -1298,6 +1298,23 @@ impl Editor {
 
             PluginCommand::WidgetMutate { panel_id, mutation } => {
                 self.handle_widget_mutate(panel_id, mutation);
+            }
+
+            PluginCommand::MountFloatingWidget {
+                panel_id,
+                spec,
+                width_pct,
+                height_pct,
+            } => {
+                self.handle_mount_floating_widget(panel_id, spec, width_pct, height_pct);
+            }
+
+            PluginCommand::UpdateFloatingWidget { panel_id, spec } => {
+                self.handle_update_floating_widget(panel_id, spec);
+            }
+
+            PluginCommand::UnmountFloatingWidget { panel_id } => {
+                self.handle_unmount_floating_widget(panel_id);
             }
         }
         Ok(())
@@ -3529,13 +3546,15 @@ impl Editor {
             .focus_key(panel_id)
             .map(|s| s.to_string())
             .unwrap_or_default();
-        let panel_width = self.widget_panel_width(buffer_id);
+        let is_floating = buffer_id == FLOATING_PANEL_BUFFER_ID;
+        let panel_width = if is_floating {
+            self.floating_panel_inner_width()
+        } else {
+            self.widget_panel_width(buffer_id)
+        };
         let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
-        // The panel exists (we read it just above) — `update`'s
-        // Err arm only fires for unknown panels, so an error here
-        // would mean the registry was mutated mid-call.
         if self
             .widget_registry
             .update(
@@ -3549,6 +3568,15 @@ impl Editor {
             .is_err()
         {
             tracing::warn!("rerender_widget_panel({}) lost panel mid-call", panel_id);
+            return;
+        }
+        if is_floating {
+            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                if fwp.panel_id == panel_id {
+                    fwp.entries = entries;
+                    fwp.focus_cursor = focus_cursor;
+                }
+            }
             return;
         }
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
@@ -3703,7 +3731,11 @@ impl Editor {
         self.rerender_widget_panel(panel_id);
     }
 
-    fn handle_widget_command(&mut self, panel_id: u64, action: fresh_core::api::WidgetAction) {
+    pub(super) fn handle_widget_command(
+        &mut self,
+        panel_id: u64,
+        action: fresh_core::api::WidgetAction,
+    ) {
         use fresh_core::api::WidgetAction;
         match action {
             WidgetAction::FocusAdvance { delta } => {
@@ -4748,6 +4780,136 @@ impl Editor {
                 tracing::debug!("UnmountWidgetPanel for unknown panel {} ignored", panel_id);
             }
         }
+    }
+
+    fn handle_mount_floating_widget(
+        &mut self,
+        panel_id: u64,
+        spec: fresh_core::api::WidgetSpec,
+        width_pct: u8,
+        height_pct: u8,
+    ) {
+        let width_pct = width_pct.clamp(1, 100);
+        let height_pct = height_pct.clamp(1, 100);
+        if let Some(existing) = self.floating_widget_panel.take() {
+            if existing.panel_id != panel_id {
+                let _ = self.widget_registry.unmount(existing.panel_id);
+            }
+        }
+        self.floating_widget_panel = Some(FloatingWidgetState {
+            panel_id,
+            width_pct,
+            height_pct,
+            entries: Vec::new(),
+            focus_cursor: None,
+            last_inner_rect: None,
+        });
+        let prev = std::collections::HashMap::new();
+        let prev_focus = String::new();
+        let panel_width = self.floating_panel_inner_width();
+        let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
+        let focus_cursor = out.focus_cursor;
+        let entries = out.entries;
+        self.widget_registry.mount(
+            panel_id,
+            FLOATING_PANEL_BUFFER_ID,
+            spec,
+            out.hits,
+            out.instance_states,
+            out.focus_key,
+            out.tabbable,
+        );
+        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            fwp.entries = entries;
+            fwp.focus_cursor = focus_cursor;
+        }
+        tracing::debug!(
+            "Mounted floating widget panel {} ({}%x{}%)",
+            panel_id,
+            width_pct,
+            height_pct
+        );
+    }
+
+    fn handle_update_floating_widget(&mut self, panel_id: u64, spec: fresh_core::api::WidgetSpec) {
+        match self.floating_widget_panel.as_ref() {
+            Some(fwp) if fwp.panel_id == panel_id => {}
+            _ => {
+                tracing::debug!(
+                    "UpdateFloatingWidget for unknown / mismatched panel {} ignored",
+                    panel_id
+                );
+                return;
+            }
+        }
+        let prev = self
+            .widget_registry
+            .instance_states(panel_id)
+            .cloned()
+            .unwrap_or_default();
+        let prev_focus = self
+            .widget_registry
+            .focus_key(panel_id)
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        let panel_width = self.floating_panel_inner_width();
+        let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
+        let focus_cursor = out.focus_cursor;
+        let entries = out.entries;
+        if self
+            .widget_registry
+            .update(
+                panel_id,
+                spec,
+                out.hits,
+                out.instance_states,
+                out.focus_key,
+                out.tabbable,
+            )
+            .is_err()
+        {
+            tracing::debug!(
+                "UpdateFloatingWidget for unknown panel {} ignored (not in registry)",
+                panel_id
+            );
+            return;
+        }
+        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            fwp.entries = entries;
+            fwp.focus_cursor = focus_cursor;
+        }
+    }
+
+    fn handle_unmount_floating_widget(&mut self, panel_id: u64) {
+        match self.floating_widget_panel.as_ref() {
+            Some(fwp) if fwp.panel_id == panel_id => {}
+            _ => {
+                tracing::debug!(
+                    "UnmountFloatingWidget for unknown / mismatched panel {} ignored",
+                    panel_id
+                );
+                return;
+            }
+        }
+        self.floating_widget_panel = None;
+        let _ = self.widget_registry.unmount(panel_id);
+        tracing::debug!("Unmounted floating widget panel {}", panel_id);
+    }
+
+    /// Inner-rect column budget for a floating panel render — the
+    /// terminal width × `width_pct`, minus 2 cols for the frame
+    /// border. Mirrors the `widget_panel_width` reservation; never
+    /// goes below 10 cols so flex spacers don't collapse to zero on
+    /// narrow terminals.
+    pub(super) fn floating_panel_inner_width(&self) -> u32 {
+        let term_w = self.terminal_width.max(1) as u32;
+        let pct = self
+            .floating_widget_panel
+            .as_ref()
+            .map(|f| f.width_pct.clamp(1, 100) as u32)
+            .unwrap_or(80);
+        let w = (term_w * pct) / 100;
+        w.saturating_sub(2).max(10)
     }
 
     fn handle_get_text_properties_at_cursor(&self, buffer_id: BufferId) {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1596,6 +1596,13 @@ impl Editor {
         self.active_window_mut()
             .animations
             .apply_all(frame.buffer_mut());
+
+        // Floating widget panel is drawn last so it sits above every
+        // other layer (prompts, popups, animations).
+        if self.floating_widget_panel.is_some() {
+            let frame_area = frame.area();
+            self.render_floating_widget_panel(frame, frame_area);
+        }
     }
 
     /// Compare the hardware cursor's screen position to the previous frame's
@@ -2336,7 +2343,6 @@ impl Editor {
     /// `ratatui` overdraw, so dismissing leaves the user's underlying
     /// layout exactly as it was (the issue-#1796 acceptance test).
     fn render_overlay_prompt(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
-        use crate::view::popup::PopupPosition;
         use ratatui::layout::Rect;
         use ratatui::style::{Modifier, Style};
         use ratatui::text::{Line, Span};
@@ -2344,30 +2350,7 @@ impl Editor {
 
         // Compute the overlay rect via the same percentage logic the
         // popup engine uses. 80% × 80% of the terminal, centred.
-        let overlay_pos = PopupPosition::CenteredOverlay {
-            width_pct: 80,
-            height_pct: 80,
-        };
-        let overlay_rect = match overlay_pos {
-            PopupPosition::CenteredOverlay {
-                width_pct,
-                height_pct,
-            } => {
-                let w_pct = width_pct.clamp(1, 100) as u32;
-                let h_pct = height_pct.clamp(1, 100) as u32;
-                let w = ((area.width as u32 * w_pct) / 100) as u16;
-                let h = ((area.height as u32 * h_pct) / 100) as u16;
-                let w = w.max(20).min(area.width);
-                let h = h.max(8).min(area.height);
-                Rect {
-                    x: (area.width.saturating_sub(w)) / 2,
-                    y: (area.height.saturating_sub(h)) / 2,
-                    width: w,
-                    height: h,
-                }
-            }
-            _ => unreachable!(),
-        };
+        let overlay_rect = Self::centered_overlay_rect(area, 80, 80);
 
         // Snapshot view-relevant state before any mutable borrows.
         let theme = self.theme.read().unwrap().clone();
@@ -3372,6 +3355,102 @@ impl Editor {
     /// `OverlayFace::from_options` + char_style.rs do for buffer
     /// overlays — pulled here so the prompt-frame renderer can build
     /// styled spans inline.
+    /// Compute a centered overlay rect of `width_pct` × `height_pct`
+    /// of the given area. Mirrors `PopupPosition::CenteredOverlay`
+    /// math used by `render_overlay_prompt`; minimum 20×8 cells so
+    /// content stays legible on tiny terminals.
+    pub(super) fn centered_overlay_rect(
+        area: ratatui::layout::Rect,
+        width_pct: u8,
+        height_pct: u8,
+    ) -> ratatui::layout::Rect {
+        let w_pct = width_pct.clamp(1, 100) as u32;
+        let h_pct = height_pct.clamp(1, 100) as u32;
+        let w = ((area.width as u32 * w_pct) / 100) as u16;
+        let h = ((area.height as u32 * h_pct) / 100) as u16;
+        let w = w.max(20).min(area.width);
+        let h = h.max(8).min(area.height);
+        ratatui::layout::Rect {
+            x: area.x + (area.width.saturating_sub(w)) / 2,
+            y: area.y + (area.height.saturating_sub(h)) / 2,
+            width: w,
+            height: h,
+        }
+    }
+
+    /// Render the currently-mounted floating widget panel: dim the
+    /// background outside the centered rect, draw the frame, paint
+    /// the panel's rendered entries inside, and place the hardware
+    /// caret at the focused TextInput. Stores the inner rect on the
+    /// `FloatingWidgetState` so the click hit-test can recover the
+    /// geometry on the next mouse event.
+    pub(super) fn render_floating_widget_panel(
+        &mut self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+    ) {
+        use ratatui::widgets::{Block, Borders, Clear};
+
+        let (width_pct, height_pct, entries, focus_cursor) =
+            match self.floating_widget_panel.as_ref() {
+                Some(fwp) => (
+                    fwp.width_pct,
+                    fwp.height_pct,
+                    fwp.entries.clone(),
+                    fwp.focus_cursor,
+                ),
+                None => return,
+            };
+        let theme = self.theme.read().unwrap().clone();
+        let overlay_rect = Self::centered_overlay_rect(area, width_pct, height_pct);
+
+        crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
+        frame.render_widget(Clear, overlay_rect);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(ratatui::style::Style::default().fg(theme.popup_border_fg))
+            .style(ratatui::style::Style::default().bg(theme.suggestion_bg));
+        let inner = block.inner(overlay_rect);
+        frame.render_widget(block, overlay_rect);
+
+        if inner.width == 0 || inner.height == 0 {
+            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                fwp.last_inner_rect = Some(inner);
+            }
+            return;
+        }
+
+        let max_rows = inner.height as usize;
+        for (i, entry) in entries.iter().take(max_rows).enumerate() {
+            paint_text_property_entry(
+                frame,
+                entry,
+                inner.x,
+                inner.y + i as u16,
+                inner.width,
+                &theme,
+            );
+        }
+
+        if let Some(fc) = focus_cursor {
+            let cx = inner.x.saturating_add(byte_to_screen_col(
+                entries
+                    .get(fc.buffer_row as usize)
+                    .map(|e| e.text.as_str())
+                    .unwrap_or(""),
+                fc.byte_in_row as usize,
+            ) as u16);
+            let cy = inner.y.saturating_add(fc.buffer_row as u16);
+            if cx < inner.x + inner.width && cy < inner.y + inner.height {
+                frame.set_cursor_position((cx, cy));
+            }
+        }
+
+        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            fwp.last_inner_rect = Some(inner);
+        }
+    }
+
     fn resolve_overlay_style(
         opts: &fresh_core::api::OverlayOptions,
         theme: &crate::view::theme::Theme,
@@ -3418,4 +3497,100 @@ impl Editor {
         }
         style
     }
+}
+
+/// Paint a single rendered widget entry into the frame buffer at
+/// `(x, y)` over `width` cells. Resolves the entry's segments / inline
+/// overlays to styled spans using the panel's theme; trailing columns
+/// are filled with spaces in the panel's bg so the row reads as one
+/// solid line.
+fn paint_text_property_entry(
+    frame: &mut ratatui::Frame,
+    entry: &fresh_core::text_property::TextPropertyEntry,
+    x: u16,
+    y: u16,
+    width: u16,
+    theme: &crate::view::theme::Theme,
+) {
+    use ratatui::style::Style;
+    use ratatui::text::{Line, Span};
+    use ratatui::widgets::Paragraph;
+
+    let mut normalized = entry.clone();
+    normalized.normalize_widths();
+    let mut text = normalized.text.clone();
+    while text.ends_with('\n') {
+        text.pop();
+    }
+
+    let base_bg = theme.suggestion_bg;
+    let base_style = if let Some(opts) = normalized.style.as_ref() {
+        Editor::resolve_overlay_style(opts, theme).bg(base_bg)
+    } else {
+        Style::default().bg(base_bg)
+    };
+
+    // Split the line at inline-overlay byte boundaries so each
+    // resulting span carries one consistent style. The overlays are
+    // produced in declaration order by the widget renderer; later
+    // overlays override earlier ones for any cells they cover.
+    let boundaries: std::collections::BTreeSet<usize> = std::iter::once(0)
+        .chain(std::iter::once(text.len()))
+        .chain(
+            normalized
+                .inline_overlays
+                .iter()
+                .flat_map(|o| [o.start.min(text.len()), o.end.min(text.len())]),
+        )
+        .collect();
+    let bounds: Vec<usize> = boundaries.into_iter().collect();
+
+    let mut spans: Vec<Span<'_>> = Vec::new();
+    for win in bounds.windows(2) {
+        let (a, b) = (win[0], win[1]);
+        if a >= b {
+            continue;
+        }
+        let slice = text[a..b].to_string();
+        let mut style = base_style;
+        for o in &normalized.inline_overlays {
+            let os = o.start.min(text.len());
+            let oe = o.end.min(text.len());
+            if a >= os && b <= oe && oe > os {
+                style = Editor::resolve_overlay_style(&o.style, theme).bg(
+                    Editor::resolve_overlay_style(&o.style, theme)
+                        .bg
+                        .unwrap_or(base_bg),
+                );
+            }
+        }
+        spans.push(Span::styled(slice, style));
+    }
+
+    let line = Line::from(spans);
+    let rect = ratatui::layout::Rect {
+        x,
+        y,
+        width,
+        height: 1,
+    };
+    frame.render_widget(Paragraph::new(line).style(base_style), rect);
+}
+
+/// Translate a UTF-8 byte offset within a rendered line into a
+/// display-column offset, walking codepoints with their Unicode
+/// width. Used to place the hardware caret on the focused
+/// TextInput's byte position.
+fn byte_to_screen_col(text: &str, target_byte: usize) -> usize {
+    use unicode_width::UnicodeWidthChar;
+    let mut byte = 0;
+    let mut col = 0usize;
+    for ch in text.chars() {
+        if byte >= target_byte {
+            break;
+        }
+        col += UnicodeWidthChar::width(ch).unwrap_or(0);
+        byte += ch.len_utf8();
+    }
+    col
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4491,6 +4491,73 @@ impl JsEditorApi {
             .is_ok())
     }
 
+    /// Mount a declarative widget panel as a centered floating
+    /// overlay (not bound to any virtual buffer).
+    #[qjs(rename = "mountFloatingWidget")]
+    pub fn mount_floating_widget<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        panel_id: f64,
+        spec_obj: rquickjs::Value<'js>,
+        width_pct: f64,
+        height_pct: f64,
+    ) -> rquickjs::Result<bool> {
+        let json = js_to_json(&ctx, spec_obj);
+        let spec: fresh_core::api::WidgetSpec = match serde_json::from_value(json) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("mountFloatingWidget: invalid spec: {}", e);
+                return Ok(false);
+            }
+        };
+        let width_pct = width_pct.clamp(1.0, 100.0) as u8;
+        let height_pct = height_pct.clamp(1.0, 100.0) as u8;
+        Ok(self
+            .command_sender
+            .send(PluginCommand::MountFloatingWidget {
+                panel_id: panel_id as u64,
+                spec,
+                width_pct,
+                height_pct,
+            })
+            .is_ok())
+    }
+
+    /// Replace the spec of the currently-mounted floating widget panel.
+    #[qjs(rename = "updateFloatingWidget")]
+    pub fn update_floating_widget<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        panel_id: f64,
+        spec_obj: rquickjs::Value<'js>,
+    ) -> rquickjs::Result<bool> {
+        let json = js_to_json(&ctx, spec_obj);
+        let spec: fresh_core::api::WidgetSpec = match serde_json::from_value(json) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::error!("updateFloatingWidget: invalid spec: {}", e);
+                return Ok(false);
+            }
+        };
+        Ok(self
+            .command_sender
+            .send(PluginCommand::UpdateFloatingWidget {
+                panel_id: panel_id as u64,
+                spec,
+            })
+            .is_ok())
+    }
+
+    /// Tear down the floating widget panel.
+    #[qjs(rename = "unmountFloatingWidget")]
+    pub fn unmount_floating_widget(&self, panel_id: f64) -> bool {
+        self.command_sender
+            .send(PluginCommand::UnmountFloatingWidget {
+                panel_id: panel_id as u64,
+            })
+            .is_ok()
+    }
+
     // === Async Operations ===
 
     /// Spawn a process (async, returns request_id)

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1289,6 +1289,9 @@ mod tests {
             "unloadPlugin",
             "reloadPlugin",
             "listPlugins",
+            "mountFloatingWidget",
+            "updateFloatingWidget",
+            "unmountFloatingWidget",
         ];
 
         let mut missing = Vec::new();


### PR DESCRIPTION
Existing widget panels mount inside a virtual buffer, which must
live in a split — so plugins can't host widget UI in a centered
modal overlay. Floating overlays existed only for the prompt
mechanism (Live Grep, Conductor: Open), and that path can't render
a `WidgetSpec` tree. This primitive fills that gap: a plugin
allocates a panel id and calls `mountFloatingWidget(id, spec,
widthPct, heightPct)` to render the spec inside a centered frame
on top of the editor, with the background dimmed.

Pieces:

* `PluginCommand::{Mount,Update,Unmount}FloatingWidget` in
  `fresh-core` plus `mount/update/unmountFloatingWidget` JS
  bindings on the QuickJS backend.
* `Editor::floating_widget_panel: Option<FloatingWidgetState>`
  with a sentinel `BufferId` registered in the widget registry —
  reuses the existing reconcile / widget-command / mutate paths
  without putting a buffer in the buffer table.
* Render pass: centered-rect math factored into a helper, dimming
  + frame + entry painter (segments → styled spans via theme keys
  only) + hardware-caret placement at the focused TextInput.
* Input pass: while the panel is up, Esc unmounts and fires
  `widget_event` "cancel"; Tab / S-Tab / Return / Backspace /
  Delete / Home / End / arrows / PageUp/Down route through
  `WidgetAction::Key`; printable chars feed `TextInputChar`.
* Click pass: clicks inside the rect hit-test against the panel's
  widget hits and fire `widget_event`; clicks outside are
  swallowed (no auto-dismiss — the form has explicit Cancel / Esc).
* `FloatingWidgetPanel` class in `plugins/lib/widgets.ts` mirrors
  `WidgetPanel`'s shape (`mount`/`update`/`unmount`/`command`/
  `mutate`/`setValue`/etc.).

Co-Authored-By: claude-opus-4-7