### PR TITLE
Add explicit Rust toolchain installation to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
       # - run: vcpkg install openssl:x64-windows-static-md
       #   if: runner.os == 'Windows'
       - uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest


### PR DESCRIPTION
## Summary
Added an explicit step to install the Rust toolchain in the CI workflow before attempting to use Cargo and other Rust tools.

## Key Changes
- Added `dtolnay/rust-toolchain@stable` action to install the stable Rust toolchain
- Positioned the toolchain installation before the Cargo cache step to ensure Rust is available for all subsequent steps

## Details
The CI workflow was relying on Rust being pre-installed in the runner environment. By adding an explicit toolchain installation step, we ensure:
- Consistent Rust version across all CI runs
- Better compatibility with the runner environment
- More reliable and reproducible builds

https://claude.ai/code/session_017VMMHbxH8AnkviMpYfuYz8