### PR TITLE
fix(split): un-maximize when navigating to next/prev split (#1961)

### DIFF
--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -250,6 +250,16 @@ impl Editor {
         // `terminal_mode` whenever the terminal isn't the active buffer.
         let previous_buffer = self.active_buffer();
 
+        // `next_split`/`prev_split` auto-unmaximize so the newly-active
+        // split is visible (issue #1961). Detect that here so terminal
+        // PTYs can be resized to match the restored layout.
+        let was_maximized = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .map(|(mgr, _)| mgr.is_maximized())
+            .unwrap_or(false);
+
         if next {
             self.windows
                 .get_mut(&self.active_window)
@@ -262,6 +272,10 @@ impl Editor {
                 .and_then(|w| w.split_manager_mut())
                 .expect("active window must have a populated split layout")
                 .prev_split();
+        }
+
+        if was_maximized {
+            self.active_window_mut().resize_visible_terminals();
         }
 
         // Ensure the active tab is visible in the newly active split

--- a/crates/fresh-editor/src/view/split.rs
+++ b/crates/fresh-editor/src/view/split.rs
@@ -1569,6 +1569,11 @@ impl SplitManager {
 
     /// Navigate to the next split (circular)
     pub fn next_split(&mut self) {
+        // Switching away from a maximized split would route focus to a
+        // hidden leaf — only the maximized split is rendered — making
+        // the cursor disappear (issue #1961). Restore the full layout
+        // first. Mirrors the auto-unmaximize in `close_split`.
+        self.maximized_split = None;
         let leaf_ids = self.root.leaf_split_ids();
         if let Some(pos) = leaf_ids.iter().position(|id| *id == self.active_split) {
             let next_pos = (pos + 1) % leaf_ids.len();
@@ -1578,6 +1583,8 @@ impl SplitManager {
 
     /// Navigate to the previous split (circular)
     pub fn prev_split(&mut self) {
+        // See `next_split` for why we clear the maximized state.
+        self.maximized_split = None;
         let leaf_ids = self.root.leaf_split_ids();
         if let Some(pos) = leaf_ids.iter().position(|id| *id == self.active_split) {
             let prev_pos = if pos == 0 { leaf_ids.len() } else { pos } - 1;
@@ -2105,6 +2112,66 @@ mod tests {
         assert_ne!(
             dock_leaf, active_before,
             "dock must be a new sibling of the root, not the previously-active leaf"
+        );
+    }
+
+    /// Regression test for issue #1961: navigating to the next split
+    /// while a split is maximized must unmaximize first, otherwise the
+    /// newly-active split is hidden behind the maximized split's
+    /// full-viewport rendering and the cursor "disappears".
+    #[test]
+    fn test_next_split_unmaximizes_when_maximized() {
+        let buffer_a = BufferId(0);
+        let buffer_b = BufferId(1);
+
+        let mut manager = SplitManager::new(buffer_a);
+        manager
+            .split_active(SplitDirection::Vertical, buffer_b, 0.5)
+            .expect("vertical split");
+        let first_active = manager.active_split();
+
+        manager.maximize_split().expect("maximize");
+        assert!(manager.is_maximized());
+
+        manager.next_split();
+
+        assert!(
+            !manager.is_maximized(),
+            "next_split must unmaximize so the newly-active split is visible"
+        );
+        assert_ne!(
+            manager.active_split(),
+            first_active,
+            "next_split must actually move to a different split"
+        );
+    }
+
+    /// Companion regression test for issue #1961 covering `prev_split`,
+    /// which shares the same hidden-split hazard as `next_split`.
+    #[test]
+    fn test_prev_split_unmaximizes_when_maximized() {
+        let buffer_a = BufferId(0);
+        let buffer_b = BufferId(1);
+
+        let mut manager = SplitManager::new(buffer_a);
+        manager
+            .split_active(SplitDirection::Vertical, buffer_b, 0.5)
+            .expect("vertical split");
+        let first_active = manager.active_split();
+
+        manager.maximize_split().expect("maximize");
+        assert!(manager.is_maximized());
+
+        manager.prev_split();
+
+        assert!(
+            !manager.is_maximized(),
+            "prev_split must unmaximize so the newly-active split is visible"
+        );
+        assert_ne!(
+            manager.active_split(),
+            first_active,
+            "prev_split must actually move to a different split"
         );
     }
 }


### PR DESCRIPTION
Fixes #1961.

## Problem

Triggering **Next Split** / **Previous Split** (Alt+]/Alt+[) while a split was maximized left the maximized layout in place but moved focus to a hidden leaf. The visible behavior matched the bug report: status bar reads "Switched to next split", the maximized pane keeps occupying the screen, and the cursor "disappears" — typing or arrow keys still operate on the now-invisible split.

## Fix

Clear `maximized_split` inside `SplitManager::next_split` / `prev_split`. This mirrors the existing auto-unmaximize already present in `close_split` for the same reason (you can't keep a layout focused on a leaf that's no longer the active one). The caller in `split_actions.rs::switch_split` detects the maximized → unmaximized transition and calls `resize_visible_terminals` so any terminal PTYs get the new dimensions, matching what `toggle_maximize_split` already does.

This corresponds to the issue's preferred resolution: "un-maximize the split and switch".

## Test plan

- [x] New unit tests in `crates/fresh-editor/src/view/split.rs` (`test_next_split_unmaximizes_when_maximized`, `test_prev_split_unmaximizes_when_maximized`) — verified failing on master, passing with this change.
- [x] All existing `view::split` unit tests still pass.
- [x] `cargo check --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets -p fresh-editor` clean.
- [x] Manual tmux validation: open two side-by-side splits, maximize one, press Alt+] → both splits become visible again with focus on the other one (no cursor disappearance). Non-maximized switching is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NUACjZYa3DHJeizeXDmhk9)_