### PR TITLE
fix(git_blame): jump to the user's source line when opening blame

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2963,11 +2963,14 @@ pub enum PluginCommand {
         editing_disabled: bool,
         /// Whether this buffer should be hidden from tabs (for composite source buffers)
         hidden_from_tabs: bool,
-        /// Optional initial cursor byte position. Applied before the new
-        /// buffer becomes the active buffer, so plugins can land the cursor
-        /// atomically with creation rather than chasing a race against user
-        /// input via a follow-up `SetBufferCursor`.
-        initial_cursor_byte: Option<usize>,
+        /// Optional initial cursor line (0-indexed). Applied before the
+        /// new buffer becomes the active buffer, so plugins can land the
+        /// cursor atomically with creation rather than chasing a race
+        /// against user input via a follow-up `SetBufferCursor`. The host
+        /// resolves the line to a byte position using the buffer content
+        /// it has just set, which keeps the UTF-8 byte math on the host
+        /// side.
+        initial_cursor_line: Option<u32>,
         /// Optional request ID for async response
         request_id: Option<u64>,
     },
@@ -3106,6 +3109,9 @@ pub enum PluginCommand {
         editing_disabled: bool,
         /// Whether line wrapping is enabled for this split (None = use global setting)
         line_wrap: Option<bool>,
+        /// Optional initial cursor line (0-indexed); see the matching
+        /// field on `CreateVirtualBufferWithContent`.
+        initial_cursor_line: Option<u32>,
         /// Optional request ID for async response
         request_id: Option<u64>,
     },
@@ -4371,13 +4377,17 @@ pub struct CreateVirtualBufferOptions {
     #[serde(default)]
     #[ts(optional)]
     pub entries: Option<Vec<JsTextPropertyEntry>>,
-    /// Initial cursor byte position. Set on the new buffer *before* it
-    /// becomes the active buffer, so plugins that want to land the cursor
-    /// at a specific spot don't have to chase a race against user input
-    /// between "buffer becomes active" and a follow-up `setBufferCursor`.
-    #[serde(default, rename = "initialCursorByte")]
-    #[ts(optional, rename = "initialCursorByte")]
-    pub initial_cursor_byte: Option<u32>,
+    /// Initial cursor line (0-indexed). Applied to the new buffer *before*
+    /// it becomes the active buffer, so plugins that want to land the
+    /// cursor on a specific line don't have to chase a race against user
+    /// input between "buffer becomes active" and a follow-up
+    /// `setBufferCursor`. Using a line index (rather than a byte offset)
+    /// keeps the byte-math on the host side where the buffer content is
+    /// already in UTF-8 bytes, avoiding the UTF-16-vs-UTF-8 mismatch a
+    /// plugin would otherwise have to navigate.
+    #[serde(default, rename = "initialCursorLine")]
+    #[ts(optional, rename = "initialCursorLine")]
+    pub initial_cursor_line: Option<u32>,
 }
 
 /// Options for createVirtualBufferInSplit
@@ -4479,6 +4489,12 @@ pub struct CreateVirtualBufferInExistingSplitOptions {
     #[serde(default)]
     #[ts(optional)]
     pub entries: Option<Vec<JsTextPropertyEntry>>,
+    /// Initial cursor line (0-indexed). Applied to the new buffer *before*
+    /// it becomes the active buffer; see the matching field on
+    /// `CreateVirtualBufferOptions` for the rationale.
+    #[serde(default, rename = "initialCursorLine")]
+    #[ts(optional, rename = "initialCursorLine")]
+    pub initial_cursor_line: Option<u32>,
 }
 
 /// Options for createTerminal
@@ -5211,7 +5227,7 @@ impl PluginApi {
             show_cursors: true,
             editing_disabled: false,
             hidden_from_tabs: false,
-            initial_cursor_byte: None,
+            initial_cursor_line: None,
             request_id: None,
         })
     }

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1054,6 +1054,13 @@ pub struct EditorStateSnapshot {
     pub buffer_saved_diffs: HashMap<BufferId, BufferSavedDiff>,
     /// Primary cursor position for the active buffer
     pub primary_cursor: Option<CursorInfo>,
+    /// Primary cursor's line number (0-indexed) for the active buffer.
+    /// Mirrors the editor's `primary_cursor_line_number` cache so plugins
+    /// can read "what line is the cursor on" without scanning the buffer.
+    /// `None` when there is no active view state (e.g. before the first
+    /// buffer is loaded).
+    #[serde(default)]
+    pub primary_cursor_line: Option<u32>,
     /// All cursor positions for the active buffer
     pub all_cursors: Vec<CursorInfo>,
     /// Viewport information for the active buffer
@@ -1243,6 +1250,7 @@ impl EditorStateSnapshot {
             buffers: HashMap::new(),
             buffer_saved_diffs: HashMap::new(),
             primary_cursor: None,
+            primary_cursor_line: None,
             all_cursors: Vec::new(),
             viewport: None,
             splits: Vec::new(),
@@ -2955,6 +2963,11 @@ pub enum PluginCommand {
         editing_disabled: bool,
         /// Whether this buffer should be hidden from tabs (for composite source buffers)
         hidden_from_tabs: bool,
+        /// Optional initial cursor byte position. Applied before the new
+        /// buffer becomes the active buffer, so plugins can land the cursor
+        /// atomically with creation rather than chasing a race against user
+        /// input via a follow-up `SetBufferCursor`.
+        initial_cursor_byte: Option<usize>,
         /// Optional request ID for async response
         request_id: Option<u64>,
     },
@@ -4358,6 +4371,13 @@ pub struct CreateVirtualBufferOptions {
     #[serde(default)]
     #[ts(optional)]
     pub entries: Option<Vec<JsTextPropertyEntry>>,
+    /// Initial cursor byte position. Set on the new buffer *before* it
+    /// becomes the active buffer, so plugins that want to land the cursor
+    /// at a specific spot don't have to chase a race against user input
+    /// between "buffer becomes active" and a follow-up `setBufferCursor`.
+    #[serde(default, rename = "initialCursorByte")]
+    #[ts(optional, rename = "initialCursorByte")]
+    pub initial_cursor_byte: Option<u32>,
 }
 
 /// Options for createVirtualBufferInSplit
@@ -5191,6 +5211,7 @@ impl PluginApi {
             show_cursors: true,
             editing_disabled: false,
             hidden_from_tabs: false,
+            initial_cursor_byte: None,
             request_id: None,
         })
     }

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -297,6 +297,25 @@ function getLineByteOffset(
 }
 
 /**
+ * Find the 0-indexed line containing the given byte position.
+ * `offsets[i]` is the start byte of line i.
+ */
+function lineForBytePos(offsets: number[], bytePos: number): number {
+  if (offsets.length === 0) return 0;
+  let lo = 0;
+  let hi = offsets.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (offsets[mid] <= bytePos) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return lo;
+}
+
+/**
  * Group blame lines into blocks by commit, with byte offset information.
  * Byte offsets are derived from the caller's line table / content length so
  * this stays free of any single global blame state.
@@ -475,6 +494,12 @@ async function show_git_blame() : Promise<void> {
 
   const splitId = editor.getActiveSplitId();
 
+  // Capture the source cursor byte position before opening blame, so we can
+  // jump to the same line in the blame view. The blame buffer mirrors the
+  // file content byte-for-byte (modulo unsaved edits), so the byte position
+  // maps to the same line index.
+  const sourceCursorPos = editor.getCursorPosition();
+
   // Fetch file content and blame data in parallel
   const [fileContent, blameLines] = await Promise.all([
     fetchFileContent(filePath, null),
@@ -529,6 +554,18 @@ async function show_git_blame() : Promise<void> {
 
   // Add virtual lines for blame headers (persistent state model)
   addBlameHeaders(inst);
+
+  // Jump to the same byte position the user was on in the source buffer.
+  // The blame buffer mirrors the file content, so this lands on the same
+  // line. setBufferCursor also runs ensure_cursor_visible so the line is
+  // scrolled into view. Clamp to the blame buffer's content length to
+  // tolerate any unsaved edits in the source buffer.
+  const targetByte = Math.min(sourceCursorPos, fileContent.length);
+  editor.setBufferCursor(result.bufferId, targetByte);
+  if (splitId !== null) {
+    const targetLine = lineForBytePos(lineByteOffsets, targetByte);
+    editor.scrollToLineCenter(splitId, result.bufferId, targetLine);
+  }
 
   editor.setStatus(editor.t("status.blame_ready", { count: String(blocks.length) }));
   editor.debug("Git blame panel opened with virtual lines architecture");

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -695,24 +695,6 @@ function git_blame_copy_hash() : void {
 }
 registerHandler("git_blame_copy_hash", git_blame_copy_hash);
 
-/**
- * Reset state when the blame buffer is closed externally (e.g. the user
- * runs the "Close Buffer" command or clicks the tab's × button rather
- * than pressing `q` / `Escape`). Without this, `blameState.isOpen`
- * stays true and the next "Git Blame" invocation early-returns with
- * "already open" — even though the buffer is gone.
- */
-function on_git_blame_buffer_closed(data: { buffer_id: number }): void {
-  if (!blameState.isOpen) return;
-  if (data.buffer_id === blameState.bufferId) {
-    blameState.isOpen = false;
-    blameState.bufferId = null;
-    resetState();
-  }
-}
-registerHandler("on_git_blame_buffer_closed", on_git_blame_buffer_closed);
-editor.on("buffer_closed", on_git_blame_buffer_closed);
-
 // =============================================================================
 // Command Registration
 // =============================================================================

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -502,6 +502,11 @@ async function show_git_blame() : Promise<void> {
 
   // Create virtual buffer with PURE file content (for syntax highlighting);
   // virtual-line headers are added after buffer creation.
+  // Pass `initialCursorLine` so the host lands the cursor on the same line
+  // the user was on in the source buffer before the new buffer becomes
+  // active — this is the only race-free way to set the cursor, and using a
+  // line index (rather than a byte offset) keeps the UTF-8 byte math on the
+  // host side, where the buffer content is already in UTF-8 bytes.
   const entries = buildContentEntries(fileContent, blocks);
 
   const result = await editor.createVirtualBufferInExistingSplit({
@@ -513,6 +518,7 @@ async function show_git_blame() : Promise<void> {
     showLineNumbers: true,  // We DO want line numbers (headers won't have them due to source_offset: null)
     showCursors: true,
     editingDisabled: true,
+    initialCursorLine: sourceCursorLine,
   });
 
   if (result === null) {
@@ -538,12 +544,8 @@ async function show_git_blame() : Promise<void> {
   // Add virtual lines for blame headers (persistent state model)
   addBlameHeaders(inst);
 
-  // Jump to the same (0-indexed) line the user was on in the source buffer,
-  // and centre it in the viewport. Column doesn't carry meaning in the blame
-  // view, so we land at the start of the line. setBufferCursor also runs
-  // ensure_cursor_visible.
-  const targetByte = getLineByteOffset(lineByteOffsets, fileContent.length, sourceCursorLine + 1);
-  editor.setBufferCursor(result.bufferId, targetByte);
+  // Centre the cursor's line in the viewport. The cursor itself was placed
+  // by the host via `initialCursorLine` (race-free, multi-byte-correct).
   if (splitId !== null) {
     editor.scrollToLineCenter(splitId, result.bufferId, sourceCursorLine);
   }

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -555,15 +555,18 @@ async function show_git_blame() : Promise<void> {
   // Add virtual lines for blame headers (persistent state model)
   addBlameHeaders(inst);
 
-  // Jump to the same byte position the user was on in the source buffer.
-  // The blame buffer mirrors the file content, so this lands on the same
-  // line. setBufferCursor also runs ensure_cursor_visible so the line is
-  // scrolled into view. Clamp to the blame buffer's content length to
-  // tolerate any unsaved edits in the source buffer.
-  const targetByte = Math.min(sourceCursorPos, fileContent.length);
+  // Jump to the same line the user was on in the source buffer. We don't
+  // have a direct byte→line API for the source buffer, but the blame buffer
+  // mirrors the on-disk file content; for an unmodified source (the common
+  // case for blame) its line offsets are the same, so we can map the source
+  // cursor's byte position to a line index via the blame buffer's offset
+  // table. Land the cursor at the start of that line — column doesn't carry
+  // meaning in the blame view. setBufferCursor also runs ensure_cursor_visible,
+  // then we centre the line in the viewport.
+  const targetLine = lineForBytePos(lineByteOffsets, sourceCursorPos);
+  const targetByte = getLineByteOffset(lineByteOffsets, fileContent.length, targetLine + 1);
   editor.setBufferCursor(result.bufferId, targetByte);
   if (splitId !== null) {
-    const targetLine = lineForBytePos(lineByteOffsets, targetByte);
     editor.scrollToLineCenter(splitId, result.bufferId, targetLine);
   }
 

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -297,25 +297,6 @@ function getLineByteOffset(
 }
 
 /**
- * Find the 0-indexed line containing the given byte position.
- * `offsets[i]` is the start byte of line i.
- */
-function lineForBytePos(offsets: number[], bytePos: number): number {
-  if (offsets.length === 0) return 0;
-  let lo = 0;
-  let hi = offsets.length - 1;
-  while (lo < hi) {
-    const mid = (lo + hi + 1) >> 1;
-    if (offsets[mid] <= bytePos) {
-      lo = mid;
-    } else {
-      hi = mid - 1;
-    }
-  }
-  return lo;
-}
-
-/**
  * Group blame lines into blocks by commit, with byte offset information.
  * Byte offsets are derived from the caller's line table / content length so
  * this stays free of any single global blame state.
@@ -494,11 +475,13 @@ async function show_git_blame() : Promise<void> {
 
   const splitId = editor.getActiveSplitId();
 
-  // Capture the source cursor byte position before opening blame, so we can
-  // jump to the same line in the blame view. The blame buffer mirrors the
-  // file content byte-for-byte (modulo unsaved edits), so the byte position
-  // maps to the same line index.
-  const sourceCursorPos = editor.getCursorPosition();
+  // Capture the source cursor's line number (0-indexed) before opening
+  // blame so we can land on the same line in the blame view. We use the
+  // line number rather than the byte position so the jump is robust to
+  // unsaved edits in the source buffer (its bytes can diverge from the
+  // on-disk file the blame view shows, but the line index is still the
+  // most semantically meaningful anchor).
+  const sourceCursorLine = editor.getCursorLine();
 
   // Fetch file content and blame data in parallel
   const [fileContent, blameLines] = await Promise.all([
@@ -555,19 +538,14 @@ async function show_git_blame() : Promise<void> {
   // Add virtual lines for blame headers (persistent state model)
   addBlameHeaders(inst);
 
-  // Jump to the same line the user was on in the source buffer. We don't
-  // have a direct byte→line API for the source buffer, but the blame buffer
-  // mirrors the on-disk file content; for an unmodified source (the common
-  // case for blame) its line offsets are the same, so we can map the source
-  // cursor's byte position to a line index via the blame buffer's offset
-  // table. Land the cursor at the start of that line — column doesn't carry
-  // meaning in the blame view. setBufferCursor also runs ensure_cursor_visible,
-  // then we centre the line in the viewport.
-  const targetLine = lineForBytePos(lineByteOffsets, sourceCursorPos);
-  const targetByte = getLineByteOffset(lineByteOffsets, fileContent.length, targetLine + 1);
+  // Jump to the same (0-indexed) line the user was on in the source buffer,
+  // and centre it in the viewport. Column doesn't carry meaning in the blame
+  // view, so we land at the start of the line. setBufferCursor also runs
+  // ensure_cursor_visible.
+  const targetByte = getLineByteOffset(lineByteOffsets, fileContent.length, sourceCursorLine + 1);
   editor.setBufferCursor(result.bufferId, targetByte);
   if (splitId !== null) {
-    editor.scrollToLineCenter(splitId, result.bufferId, targetLine);
+    editor.scrollToLineCenter(splitId, result.bufferId, sourceCursorLine);
   }
 
   editor.setStatus(editor.t("status.blame_ready", { count: String(blocks.length) }));

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -695,6 +695,24 @@ function git_blame_copy_hash() : void {
 }
 registerHandler("git_blame_copy_hash", git_blame_copy_hash);
 
+/**
+ * Reset state when the blame buffer is closed externally (e.g. the user
+ * runs the "Close Buffer" command or clicks the tab's × button rather
+ * than pressing `q` / `Escape`). Without this, `blameState.isOpen`
+ * stays true and the next "Git Blame" invocation early-returns with
+ * "already open" — even though the buffer is gone.
+ */
+function on_git_blame_buffer_closed(data: { buffer_id: number }): void {
+  if (!blameState.isOpen) return;
+  if (data.buffer_id === blameState.bufferId) {
+    blameState.isOpen = false;
+    blameState.bufferId = null;
+    resetState();
+  }
+}
+registerHandler("on_git_blame_buffer_closed", on_git_blame_buffer_closed);
+editor.on("buffer_closed", on_git_blame_buffer_closed);
+
 // =============================================================================
 // Command Registration
 // =============================================================================

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -1136,21 +1136,14 @@ async function git_log_detail_open_file(): Promise<void> {
     properties: { type: "content", line: i + 1 },
   }));
 
-  // Compute the target byte offset synchronously from the lines we
-  // already have, and pass it as `initialCursorByte` so the host sets
-  // the cursor before the new buffer becomes active. This is the only
-  // race-free way to land the cursor at a specific spot in a freshly
-  // shown virtual buffer — a follow-up `setBufferCursor` after the
-  // buffer is already active would race against any user input the
-  // moment focus lands.
-  const targetLineIdx = Math.max(0, line - 1);
-  let initialCursorByte = 0;
-  for (let i = 0; i < targetLineIdx && i < lines.length; i++) {
-    initialCursorByte += lines[i].length + 1; // +1 for newline
-  }
-
   // `*<hash>:<path>*` matches the virtual-name convention the host uses
   // to detect syntax from the trailing filename's extension.
+  //
+  // Pass `initialCursorLine` (0-indexed) so the host lands the cursor on
+  // the target line before the buffer becomes active. Without this, a
+  // follow-up setBufferCursor would race against user input and could
+  // be silently clobbered by any keypress the moment focus lands on the
+  // new buffer.
   const name = `*${commit.shortHash}:${file}*`;
   const view = await editor.createVirtualBuffer({
     name,
@@ -1159,7 +1152,7 @@ async function git_log_detail_open_file(): Promise<void> {
     editingDisabled: true,
     showLineNumbers: true,
     entries,
-    initialCursorByte,
+    initialCursorLine: Math.max(0, line - 1),
   });
   if (view) {
     editor.setStatus(

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -1136,6 +1136,19 @@ async function git_log_detail_open_file(): Promise<void> {
     properties: { type: "content", line: i + 1 },
   }));
 
+  // Compute the target byte offset synchronously from the lines we
+  // already have, and pass it as `initialCursorByte` so the host sets
+  // the cursor before the new buffer becomes active. This is the only
+  // race-free way to land the cursor at a specific spot in a freshly
+  // shown virtual buffer — a follow-up `setBufferCursor` after the
+  // buffer is already active would race against any user input the
+  // moment focus lands.
+  const targetLineIdx = Math.max(0, line - 1);
+  let initialCursorByte = 0;
+  for (let i = 0; i < targetLineIdx && i < lines.length; i++) {
+    initialCursorByte += lines[i].length + 1; // +1 for newline
+  }
+
   // `*<hash>:<path>*` matches the virtual-name convention the host uses
   // to detect syntax from the trailing filename's extension.
   const name = `*${commit.shortHash}:${file}*`;
@@ -1146,10 +1159,9 @@ async function git_log_detail_open_file(): Promise<void> {
     editingDisabled: true,
     showLineNumbers: true,
     entries,
+    initialCursorByte,
   });
   if (view) {
-    const byte = await editor.getLineStartPosition(Math.max(0, line - 1));
-    if (byte !== null) editor.setBufferCursor(view.bufferId, byte);
     editor.setStatus(
       editor.t("status.file_view_ready", {
         file,

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1465,6 +1465,11 @@ type CreateVirtualBufferInExistingSplitOptions = {
 	* Initial content entries with optional properties
 	*/
 	entries?: Array<TextPropertyEntry>;
+	/**
+	* Initial cursor line (0-indexed); see `initialCursorLine` on
+	* `CreateVirtualBufferOptions`.
+	*/
+	initialCursorLine?: number;
 };
 type CreateVirtualBufferInSplitOptions = {
 	/**
@@ -1557,12 +1562,14 @@ type CreateVirtualBufferOptions = {
 	*/
 	entries?: Array<TextPropertyEntry>;
 	/**
-	* Initial cursor byte position. Set on the new buffer *before* it
-	* becomes the active buffer, so plugins that want to land the cursor
-	* at a specific spot don't have to chase a race against user input
-	* between "buffer becomes active" and a follow-up `setBufferCursor`.
+	* Initial cursor line (0-indexed). Applied to the new buffer *before*
+	* it becomes the active buffer, so plugins that want to land the
+	* cursor on a specific line don't have to chase a race against user
+	* input between "buffer becomes active" and a follow-up
+	* `setBufferCursor`. Using a line index keeps the UTF-8 byte math
+	* on the host side.
 	*/
-	initialCursorByte?: number;
+	initialCursorLine?: number;
 };
 type GrepMatch = {
 	/**

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1556,6 +1556,13 @@ type CreateVirtualBufferOptions = {
 	* Initial content entries with optional properties
 	*/
 	entries?: Array<TextPropertyEntry>;
+	/**
+	* Initial cursor byte position. Set on the new buffer *before* it
+	* becomes the active buffer, so plugins that want to land the cursor
+	* at a specific spot don't have to chase a race against user input
+	* between "buffer becomes active" and a follow-up `setBufferCursor`.
+	*/
+	initialCursorByte?: number;
 };
 type GrepMatch = {
 	/**

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3247,13 +3247,37 @@ impl Editor {
                     target_byte
                 })
                 .unwrap_or(0);
-            let splits: Vec<LeafId> = self
+            // `splits_for_buffer` only walks the main split tree, so a
+            // buffer mounted into an inner leaf of a grouped subtree
+            // (buffer-group panel) wouldn't be found and the cursor move
+            // would silently no-op. Mirror `handle_set_buffer_cursor` and
+            // include any matching inner leaves so the cursor lands
+            // regardless of where the buffer ended up.
+            let mut splits: Vec<LeafId> = self
                 .windows
                 .get(&self.active_window)
                 .and_then(|w| w.buffers.splits())
                 .map(|(mgr, _)| mgr)
                 .expect("active window must have a populated split layout")
                 .splits_for_buffer(buffer_id);
+            for node in self.active_window().grouped_subtrees.values() {
+                if let crate::view::split::SplitNode::Grouped { layout, .. } = node {
+                    for inner_leaf in layout.leaf_split_ids() {
+                        if let Some(vs) = self
+                            .windows
+                            .get(&self.active_window)
+                            .and_then(|w| w.buffers.splits())
+                            .map(|(_, vs)| vs)
+                            .expect("active window must have a populated split layout")
+                            .get(&inner_leaf)
+                        {
+                            if vs.active_buffer == buffer_id && !splits.contains(&inner_leaf) {
+                                splits.push(inner_leaf);
+                            }
+                        }
+                    }
+                }
+            }
             self.active_window_mut()
                 .set_buffer_cursor_in_splits(buffer_id, byte, &splits);
         }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1058,7 +1058,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 hidden_from_tabs,
-                initial_cursor_byte,
+                initial_cursor_line,
                 request_id,
             } => {
                 self.handle_create_virtual_buffer_with_content(
@@ -1070,7 +1070,7 @@ impl Editor {
                     show_cursors,
                     editing_disabled,
                     hidden_from_tabs,
-                    initial_cursor_byte,
+                    initial_cursor_line,
                     request_id,
                 );
             }
@@ -1123,6 +1123,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 line_wrap,
+                initial_cursor_line,
                 request_id,
             } => {
                 self.handle_create_virtual_buffer_in_existing_split(
@@ -1135,6 +1136,7 @@ impl Editor {
                     show_cursors,
                     editing_disabled,
                     line_wrap,
+                    initial_cursor_line,
                     request_id,
                 );
             }
@@ -2808,7 +2810,7 @@ impl Editor {
         show_cursors: bool,
         editing_disabled: bool,
         hidden_from_tabs: bool,
-        initial_cursor_byte: Option<usize>,
+        initial_cursor_line: Option<u32>,
         request_id: Option<u64>,
     ) {
         // Hidden-from-tabs buffers (e.g. composite source panes) must NOT be
@@ -2858,13 +2860,47 @@ impl Editor {
         match self.set_virtual_buffer_content(buffer_id, entries) {
             Ok(()) => {
                 tracing::debug!("Set virtual buffer content for {:?}", buffer_id);
-                // Apply an initial cursor position before switching to the
-                // buffer. Doing this here (rather than as a follow-up
-                // SetBufferCursor command from the plugin) means the cursor
-                // is in place the moment the buffer becomes active, so a
-                // user keypress between the plugin's await and its follow-up
-                // setBufferCursor can no longer race-overwrite that cursor.
-                if let Some(byte) = initial_cursor_byte {
+                // Switch to the new buffer to display it — but only when it's
+                // attached (a detached hidden buffer must not steal the view).
+                if !hidden_from_tabs {
+                    self.set_active_buffer(buffer_id);
+                    tracing::debug!("Switched to virtual buffer {:?}", buffer_id);
+                }
+
+                // Apply an initial cursor position. We do this in the same
+                // command-processing tick as creation, so the cursor is in
+                // place by the time the editor next processes user input —
+                // a follow-up SetBufferCursor from the plugin would race
+                // against the user. The plugin passes a line index; we
+                // resolve it to a byte here using the buffer's own content
+                // so UTF-8-byte math never touches JS-side string-length
+                // semantics. Done AFTER `set_active_buffer` so the new
+                // buffer is actually mounted in a split when
+                // `set_buffer_cursor_in_splits` walks the split tree.
+                if let Some(line) = initial_cursor_line {
+                    let target_line = line as usize;
+                    let byte = self
+                        .windows
+                        .get_mut(&self.active_window)
+                        .and_then(|w| w.buffers.get_mut(&buffer_id))
+                        .map(|s| {
+                            let total = s.buffer.len();
+                            let mut iter = s.buffer.line_iterator(0, 80);
+                            let mut target_byte = 0;
+                            for current_line in 0..=target_line {
+                                if let Some((line_start, _)) = iter.next_line() {
+                                    if current_line == target_line {
+                                        target_byte = line_start;
+                                        break;
+                                    }
+                                } else {
+                                    target_byte = total;
+                                    break;
+                                }
+                            }
+                            target_byte
+                        })
+                        .unwrap_or(0);
                     let splits: Vec<super::LeafId> = self
                         .windows
                         .get(&self.active_window)
@@ -2874,13 +2910,6 @@ impl Editor {
                         .splits_for_buffer(buffer_id);
                     self.active_window_mut()
                         .set_buffer_cursor_in_splits(buffer_id, byte, &splits);
-                }
-
-                // Switch to the new buffer to display it — but only when it's
-                // attached (a detached hidden buffer must not steal the view).
-                if !hidden_from_tabs {
-                    self.set_active_buffer(buffer_id);
-                    tracing::debug!("Switched to virtual buffer {:?}", buffer_id);
                 }
 
                 // Send response if request_id is present
@@ -3128,6 +3157,7 @@ impl Editor {
         show_cursors: bool,
         editing_disabled: bool,
         line_wrap: Option<bool>,
+        initial_cursor_line: Option<u32>,
         request_id: Option<u64>,
     ) {
         // Create the virtual buffer
@@ -3149,6 +3179,10 @@ impl Editor {
             return;
         }
 
+        // Apply an initial cursor position before the buffer becomes the
+        // active buffer in the split. Same rationale as the equivalent
+        // path in `handle_create_virtual_buffer_with_content`: a follow-up
+        // SetBufferCursor from the plugin would race against user input.
         // Show the buffer in the target split. set_pane_buffer
         // covers the tree + SVS updates the old code did by hand.
         let leaf_id = LeafId(split_id);
@@ -3179,6 +3213,49 @@ impl Editor {
             if let Some(wrap) = line_wrap {
                 view_state.active_state_mut().viewport.line_wrap_enabled = wrap;
             }
+        }
+
+        // Apply an initial cursor position after the buffer is mounted in
+        // the target split. Done in the same command-processing tick as
+        // creation so the cursor is in place before the editor next
+        // processes user input — a follow-up SetBufferCursor from the
+        // plugin would race against the user. The plugin passes a line
+        // index; we resolve it to a byte here using the buffer's content
+        // so UTF-8-byte math never touches JS-side string-length
+        // semantics.
+        if let Some(line) = initial_cursor_line {
+            let target_line = line as usize;
+            let byte = self
+                .windows
+                .get_mut(&self.active_window)
+                .and_then(|w| w.buffers.get_mut(&buffer_id))
+                .map(|s| {
+                    let total = s.buffer.len();
+                    let mut iter = s.buffer.line_iterator(0, 80);
+                    let mut target_byte = 0;
+                    for current_line in 0..=target_line {
+                        if let Some((line_start, _)) = iter.next_line() {
+                            if current_line == target_line {
+                                target_byte = line_start;
+                                break;
+                            }
+                        } else {
+                            target_byte = total;
+                            break;
+                        }
+                    }
+                    target_byte
+                })
+                .unwrap_or(0);
+            let splits: Vec<LeafId> = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.splits())
+                .map(|(mgr, _)| mgr)
+                .expect("active window must have a populated split layout")
+                .splits_for_buffer(buffer_id);
+            self.active_window_mut()
+                .set_buffer_cursor_in_splits(buffer_id, byte, &splits);
         }
 
         tracing::info!(

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1058,6 +1058,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 hidden_from_tabs,
+                initial_cursor_byte,
                 request_id,
             } => {
                 self.handle_create_virtual_buffer_with_content(
@@ -1069,6 +1070,7 @@ impl Editor {
                     show_cursors,
                     editing_disabled,
                     hidden_from_tabs,
+                    initial_cursor_byte,
                     request_id,
                 );
             }
@@ -2806,6 +2808,7 @@ impl Editor {
         show_cursors: bool,
         editing_disabled: bool,
         hidden_from_tabs: bool,
+        initial_cursor_byte: Option<usize>,
         request_id: Option<u64>,
     ) {
         // Hidden-from-tabs buffers (e.g. composite source panes) must NOT be
@@ -2855,6 +2858,24 @@ impl Editor {
         match self.set_virtual_buffer_content(buffer_id, entries) {
             Ok(()) => {
                 tracing::debug!("Set virtual buffer content for {:?}", buffer_id);
+                // Apply an initial cursor position before switching to the
+                // buffer. Doing this here (rather than as a follow-up
+                // SetBufferCursor command from the plugin) means the cursor
+                // is in place the moment the buffer becomes active, so a
+                // user keypress between the plugin's await and its follow-up
+                // setBufferCursor can no longer race-overwrite that cursor.
+                if let Some(byte) = initial_cursor_byte {
+                    let splits: Vec<super::LeafId> = self
+                        .windows
+                        .get(&self.active_window)
+                        .and_then(|w| w.buffers.splits())
+                        .map(|(mgr, _)| mgr)
+                        .expect("active window must have a populated split layout")
+                        .splits_for_buffer(buffer_id);
+                    self.active_window_mut()
+                        .set_buffer_cursor_in_splits(buffer_id, byte, &splits);
+                }
+
                 // Switch to the new buffer to display it — but only when it's
                 // attached (a detached hidden buffer must not steal the view).
                 if !hidden_from_tabs {
@@ -5393,6 +5414,17 @@ impl Window {
                         line: line_of(primary_position),
                     });
 
+                    // Mirror the editor's cached primary cursor line number so
+                    // `getCursorLine()` returns a meaningful value without the
+                    // plugin runtime having to scan the buffer. Falls back to
+                    // 0 if the active buffer state isn't available.
+                    snapshot.primary_cursor_line = Some(
+                        buffers_mut
+                            .get(&active_buf_id)
+                            .map(|s| s.primary_cursor_line_number.value() as u32)
+                            .unwrap_or(0),
+                    );
+
                     snapshot.all_cursors = active_cursors
                         .iter()
                         .map(|(_, cursor)| CursorInfo {
@@ -5427,6 +5459,7 @@ impl Window {
                     });
                 } else {
                     snapshot.primary_cursor = None;
+                    snapshot.primary_cursor_line = None;
                     snapshot.all_cursors.clear();
                     snapshot.viewport = None;
                     snapshot.selected_text = None;

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1395,12 +1395,14 @@ impl Window {
     ) {
         self.buffers
             .with_buffer_and_view_states(buffer_id, |state, vs_map| {
+                let mut moved_any = false;
                 for leaf_id in splits {
                     let Some(view_state) = vs_map.get_mut(leaf_id) else {
                         continue;
                     };
                     view_state.cursors.primary_mut().move_to(position, false);
                     view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
+                    moved_any = true;
                 }
                 // Refresh the cached primary cursor line number so the status
                 // bar (and any other consumer of `primary_cursor_line_number`)
@@ -1408,13 +1410,18 @@ impl Window {
                 // this cache themselves; without doing the same here, a
                 // plugin-driven setBufferCursor would leave the cache pinned
                 // to its initial Absolute(0) — the user-visible "off-by-one"
-                // when opening blame from line 2 still shows "Ln 1".
-                let line = state
-                    .buffer
-                    .offset_to_position(position)
-                    .map(|p| p.line)
-                    .unwrap_or(0);
-                state.primary_cursor_line_number = crate::model::buffer::LineNumber::Absolute(line);
+                // when opening blame from line 2 still shows "Ln 1". Guard
+                // on `moved_any` so we don't desync the cache when no split
+                // was actually carrying the buffer's cursor.
+                if moved_any {
+                    let line = state
+                        .buffer
+                        .offset_to_position(position)
+                        .map(|p| p.line)
+                        .unwrap_or(0);
+                    state.primary_cursor_line_number =
+                        crate::model::buffer::LineNumber::Absolute(line);
+                }
             });
     }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1402,6 +1402,17 @@ impl Window {
                     view_state.cursors.primary_mut().move_to(position, false);
                     view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
                 }
+                // Refresh the cached primary cursor line number so the status
+                // bar and any other consumer of `primary_cursor_line_number`
+                // reflect the new position. Without this, the cache stays
+                // pinned to its previous value (issue #1957).
+                let primary_pos = state
+                    .buffer
+                    .offset_to_position(position)
+                    .map(|p| p.line)
+                    .unwrap_or(0);
+                state.primary_cursor_line_number =
+                    crate::model::buffer::LineNumber::Absolute(primary_pos);
             });
     }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1402,6 +1402,19 @@ impl Window {
                     view_state.cursors.primary_mut().move_to(position, false);
                     view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
                 }
+                // Refresh the cached primary cursor line number so the status
+                // bar (and any other consumer of `primary_cursor_line_number`)
+                // reflects the new position. Other cursor-move paths update
+                // this cache themselves; without doing the same here, a
+                // plugin-driven setBufferCursor would leave the cache pinned
+                // to its initial Absolute(0) — the user-visible "off-by-one"
+                // when opening blame from line 2 still shows "Ln 1".
+                let line = state
+                    .buffer
+                    .offset_to_position(position)
+                    .map(|p| p.line)
+                    .unwrap_or(0);
+                state.primary_cursor_line_number = crate::model::buffer::LineNumber::Absolute(line);
             });
     }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1402,17 +1402,6 @@ impl Window {
                     view_state.cursors.primary_mut().move_to(position, false);
                     view_state.ensure_cursor_visible(&mut state.buffer, &state.marker_list);
                 }
-                // Refresh the cached primary cursor line number so the status
-                // bar and any other consumer of `primary_cursor_line_number`
-                // reflect the new position. Without this, the cache stays
-                // pinned to its previous value (issue #1957).
-                let primary_pos = state
-                    .buffer
-                    .offset_to_position(position)
-                    .map(|p| p.line)
-                    .unwrap_or(0);
-                state.primary_cursor_line_number =
-                    crate::model::buffer::LineNumber::Absolute(primary_pos);
             });
     }
 

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -1261,6 +1261,21 @@ impl crate::app::window::Window {
                             buf_state,
                             &mut state.buffer,
                         );
+
+                        // Refresh the buffer's cached primary cursor line number.
+                        // The cursor-position fields above are written directly
+                        // (no MoveCursor event), so without this the cache stays
+                        // at EditorState::new's default `Absolute(0)`. Status bar
+                        // and plugin-side `getCursorLine` both read this cache —
+                        // a Git Blame invoked right after restore would see 0 and
+                        // land on Ln 1 even though the cursor is at line 5000.
+                        let line = state
+                            .buffer
+                            .offset_to_position(cursor_pos)
+                            .map(|p| p.line)
+                            .unwrap_or(0);
+                        state.primary_cursor_line_number =
+                            crate::model::buffer::LineNumber::Absolute(line);
                     }
 
                     // Restore per-buffer view mode and compose width

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -790,7 +790,7 @@ fn test_next_buffer_skips_hidden_buffers() {
         show_cursors: true,
         editing_disabled: true,
         hidden_from_tabs: true, // <-- This makes it hidden
-        initial_cursor_byte: None,
+        initial_cursor_line: None,
         request_id: None,
     };
     harness

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -790,6 +790,7 @@ fn test_next_buffer_skips_hidden_buffers() {
         show_cursors: true,
         editing_disabled: true,
         hidden_from_tabs: true, // <-- This makes it hidden
+        initial_cursor_byte: None,
         request_id: None,
     };
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -3137,3 +3137,88 @@ fn test_git_blame_jumps_to_source_cursor_line() {
         );
     }
 }
+
+/// Regression: activating Git Blame after navigating with Ctrl-G in a large
+/// file with multi-byte characters before the target line must land the
+/// cursor on the same source line.
+///
+/// Models the user-visible scenario from #1957 follow-up: large file
+/// (>5000 lines), multi-byte glyphs scattered before the target line, and
+/// the cursor moved via the Goto Line prompt (Ctrl-G) rather than arrow
+/// keys. The earlier test_git_blame_jumps_to_source_cursor_line covers
+/// arrow-key motion in a 30-line file; this one exercises the host-side
+/// line→byte resolution and the cursor-mount path the user actually hit.
+// TODO: Fix git blame tests on Windows - they fail due to git command output differences
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_git_blame_jumps_to_cursor_line_with_multibyte_and_goto() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+
+    // 5500 lines, with multi-byte glyphs (`█`, `│`) sprinkled in the first
+    // 200 lines — same pattern as crates/fresh-editor/src/config.rs.
+    let mut content = String::with_capacity(120_000);
+    for i in 1..=5500 {
+        if i % 4 == 0 && i <= 200 {
+            content.push_str(&format!("Line {i} █ │\n"));
+        } else {
+            content.push_str(&format!("Line {i}\n"));
+        }
+    }
+    repo.create_file("big.txt", &content);
+    repo.git_add(&["big.txt"]);
+    repo.git_commit("Initial commit");
+    repo.setup_git_blame_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        140,
+        50,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    let file_path = repo.path.join("big.txt");
+    harness.open_file(&file_path).unwrap();
+    harness
+        .wait_until(|h| h.get_buffer_content().unwrap().contains("Line 5500"))
+        .unwrap();
+
+    // Ctrl-G, type 5000, Enter — the exact key sequence from the user's repro.
+    harness
+        .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("5000").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(5000))
+        .unwrap();
+
+    // Inline trigger_git_blame's body — we can't wait for the "──" block
+    // header glyph since this single-commit file collapses to one block
+    // whose header lives at line 1, far off the viewport scrolled to
+    // line 5000. Wait on the status bar's `*blame:` indicator instead.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Blame").unwrap();
+    harness.wait_for_screen_contains("Git Blame").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("*blame:big.txt*"))
+        .unwrap();
+
+    // Status bar must report Ln 5000 in the blame view, not Ln 1.
+    harness
+        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(5000))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -3058,3 +3058,66 @@ fn parse_ln(screen: &str) -> Option<usize> {
     let end = rest.find(',')?;
     rest[..end].trim().parse().ok()
 }
+
+/// Regression: activating Git Blame should land the cursor on the same line
+/// the user was on in the source buffer, not reset to the top of the doc.
+/// Issue #1957.
+// TODO: Fix git blame tests on Windows - they fail due to git command output differences
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_git_blame_jumps_to_source_cursor_line() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+
+    // Single-commit file with enough lines that "top" is clearly distinguishable
+    // from "middle". Cursor will be placed at line 15.
+    let mut content = String::new();
+    for i in 1..=30 {
+        content.push_str(&format!("Line {i}\n"));
+    }
+    repo.create_file("test.txt", &content);
+    repo.git_add(&["test.txt"]);
+    repo.git_commit("Initial commit");
+    repo.setup_git_blame_plugin();
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    let file_path = repo.path.join("test.txt");
+    harness.open_file(&file_path).unwrap();
+    harness
+        .wait_until(|h| h.get_buffer_content().unwrap().contains("Line 30"))
+        .unwrap();
+
+    // Move cursor from line 1 down to line 15.
+    for _ in 0..14 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.process_async_and_render().unwrap();
+
+    // Sanity: status bar should now report line 15 in the source buffer.
+    harness
+        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(15))
+        .unwrap();
+
+    // Activate git blame.
+    trigger_git_blame(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("──"))
+        .unwrap();
+
+    // The cursor in the blame buffer should still be on line 15 — not reset
+    // to the top of the doc. We observe this via the status bar's "Ln N"
+    // indicator (rendered output, no model inspection).
+    harness
+        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(15))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -3114,29 +3114,26 @@ fn test_git_blame_jumps_to_source_cursor_line() {
         .wait_until(|h| h.screen_to_string().contains("──"))
         .unwrap();
 
-    // The cursor in the blame buffer should land on the row that renders
-    // "Line 15" — i.e. the same line the user was on in the source buffer,
-    // not the top of the doc. We observe this via the rendered hardware
-    // cursor position (where the terminal will actually draw the caret)
-    // so the assertion is independent of the status-bar's cached line
-    // number. Poll manually because `wait_until` only exposes `&Self`.
-    let mut on_line_15 = false;
-    for _ in 0..200 {
-        let cursor = harness.render_observing_cursor().ok().flatten();
-        if let Some((_, row)) = cursor {
-            let screen = harness.screen_to_string();
-            let row_text = screen.lines().nth(row as usize).unwrap_or("");
-            if row_text.contains("Line 15") {
-                on_line_15 = true;
-                break;
-            }
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        harness.process_async_and_render().unwrap();
+    // The cursor in the blame view should land on the same line the user
+    // was on in the source buffer (line 15) — both visually (the cursor
+    // row renders "Line 15") and per the status bar's "Ln N" indicator.
+    // The status bar check is the strict assertion: before this fix it
+    // showed "Ln 1" regardless of the source line — the user-visible
+    // "off-by-one" (worst at source line 2, off by N-1 in general).
+    harness
+        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(15))
+        .unwrap();
+    let cursor_row = harness
+        .render_observing_cursor()
+        .ok()
+        .flatten()
+        .map(|(_, row)| row);
+    if let Some(row) = cursor_row {
+        let screen = harness.screen_to_string();
+        let row_text = screen.lines().nth(row as usize).unwrap_or("");
+        assert!(
+            row_text.contains("Line 15"),
+            "cursor row {row} should render 'Line 15', got: {row_text:?}",
+        );
     }
-    assert!(
-        on_line_15,
-        "expected the blame view's cursor to land on the 'Line 15' row. Screen:\n{}",
-        harness.screen_to_string()
-    );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/git.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git.rs
@@ -3114,10 +3114,29 @@ fn test_git_blame_jumps_to_source_cursor_line() {
         .wait_until(|h| h.screen_to_string().contains("──"))
         .unwrap();
 
-    // The cursor in the blame buffer should still be on line 15 — not reset
-    // to the top of the doc. We observe this via the status bar's "Ln N"
-    // indicator (rendered output, no model inspection).
-    harness
-        .wait_until(|h| parse_ln(&h.screen_to_string()) == Some(15))
-        .unwrap();
+    // The cursor in the blame buffer should land on the row that renders
+    // "Line 15" — i.e. the same line the user was on in the source buffer,
+    // not the top of the doc. We observe this via the rendered hardware
+    // cursor position (where the terminal will actually draw the caret)
+    // so the assertion is independent of the status-bar's cached line
+    // number. Poll manually because `wait_until` only exposes `&Self`.
+    let mut on_line_15 = false;
+    for _ in 0..200 {
+        let cursor = harness.render_observing_cursor().ok().flatten();
+        if let Some((_, row)) = cursor {
+            let screen = harness.screen_to_string();
+            let row_text = screen.lines().nth(row as usize).unwrap_or("");
+            if row_text.contains("Line 15") {
+                on_line_15 = true;
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        harness.process_async_and_render().unwrap();
+    }
+    assert!(
+        on_line_15,
+        "expected the blame view's cursor to land on the 'Line 15' row. Screen:\n{}",
+        harness.screen_to_string()
+    );
 }

--- a/crates/fresh-editor/tests/e2e/session_hot_exit.rs
+++ b/crates/fresh-editor/tests/e2e/session_hot_exit.rs
@@ -210,3 +210,93 @@ fn test_session_workspace_preserved_across_restart() {
         harness.assert_screen_contains("Content of file B");
     }
 }
+
+/// Regression: session restore must refresh `primary_cursor_line_number`.
+///
+/// The restore path writes `view_state.cursors.primary().position` directly
+/// (no `Event::MoveCursor`), so the per-buffer `primary_cursor_line_number`
+/// cache stays at `EditorState::new`'s default `Absolute(0)`. Status bar
+/// and plugin-side `getCursorLine` both read that cache — without this fix,
+/// a Git Blame invoked right after restore reads 0 and lands on Ln 1 even
+/// though the cursor's byte position is on line 100.
+#[test]
+fn test_session_restore_refreshes_cursor_line_cache() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    // Enough lines that the target line is clearly distinct from line 1.
+    let file = project_dir.join("big.txt");
+    let mut content = String::new();
+    for i in 1..=200 {
+        content.push_str(&format!("Line {i}\n"));
+    }
+    std::fs::write(&file, &content).unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // First session: open the file, navigate to line 100, shutdown to save.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        harness.editor_mut().set_session_mode(true);
+        harness.open_file(&file).unwrap();
+        harness
+            .wait_until(|h| h.get_buffer_content().unwrap().contains("Line 200"))
+            .unwrap();
+
+        // Navigate to line 100 via Ctrl-G to exercise the real keybinding path.
+        harness
+            .send_key(KeyCode::Char('g'), KeyModifiers::CONTROL)
+            .unwrap();
+        harness.wait_for_prompt().unwrap();
+        harness.type_text("100").unwrap();
+        harness
+            .send_key(KeyCode::Enter, KeyModifiers::NONE)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("Ln 100"))
+            .unwrap();
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Second session: restore and assert status bar shows Ln 100, not Ln 1.
+    {
+        let mut config = Config::default();
+        config.editor.hot_exit = true;
+
+        let mut harness = EditorTestHarness::create(
+            80,
+            24,
+            HarnessOptions::new()
+                .with_config(config)
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "Session should have been restored");
+
+        let screen = harness.screen_to_string();
+        assert!(
+            screen.contains("Ln 100"),
+            "Status bar should report Ln 100 after restore, not the stale \
+             default. Screen:\n{screen}",
+        );
+    }
+}

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -6163,7 +6163,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 hidden_from_tabs,
-                initial_cursor_byte: _,
+                initial_cursor_line: _,
                 request_id,
             } => {
                 let buffer_id = self.create_virtual_buffer(name.clone(), mode.clone(), read_only);

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -6163,6 +6163,7 @@ impl Editor {
                 show_cursors,
                 editing_disabled,
                 hidden_from_tabs,
+                initial_cursor_byte: _,
                 request_id,
             } => {
                 let buffer_id = self.create_virtual_buffer(name.clone(), mode.clone(), read_only);

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -32,7 +32,7 @@ fn reproduce_cursor_panic() {
         show_cursors: false, // <--- The trigger: hiding cursors
         editing_disabled: false,
         hidden_from_tabs: false,
-        initial_cursor_byte: None,
+        initial_cursor_line: None,
         request_id: None,
     };
 

--- a/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
+++ b/crates/fresh-editor/tests/regression_hidden_cursor_panic.rs
@@ -32,6 +32,7 @@ fn reproduce_cursor_panic() {
         show_cursors: false, // <--- The trigger: hiding cursors
         editing_disabled: false,
         hidden_from_tabs: false,
+        initial_cursor_byte: None,
         request_id: None,
     };
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5291,7 +5291,7 @@ impl JsEditorApi {
                 show_cursors: opts.show_cursors.unwrap_or(true),
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 hidden_from_tabs: opts.hidden_from_tabs.unwrap_or(false),
-                initial_cursor_byte: opts.initial_cursor_byte.map(|b| b as usize),
+                initial_cursor_line: opts.initial_cursor_line,
                 request_id: Some(id),
             });
         Ok(id)
@@ -5398,6 +5398,7 @@ impl JsEditorApi {
                 show_cursors: opts.show_cursors.unwrap_or(true),
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 line_wrap: opts.line_wrap,
+                initial_cursor_line: opts.initial_cursor_line,
                 request_id: Some(id),
             });
         Ok(id)

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5291,6 +5291,7 @@ impl JsEditorApi {
                 show_cursors: opts.show_cursors.unwrap_or(true),
                 editing_disabled: opts.editing_disabled.unwrap_or(false),
                 hidden_from_tabs: opts.hidden_from_tabs.unwrap_or(false),
+                initial_cursor_byte: opts.initial_cursor_byte.map(|b| b as usize),
                 request_id: Some(id),
             });
         Ok(id)


### PR DESCRIPTION
Fixes #1957.

## Summary
- Activating Git Blame used to reset the cursor to the top of the blame buffer instead of preserving the line the user was viewing.
- `git_blame.ts` now captures the source buffer's cursor byte position before opening the blame view and repositions the blame buffer's cursor there (scrolling the matching line to the centre of the viewport).
- `Window::set_buffer_cursor_in_splits` now refreshes `primary_cursor_line_number` after moving the cursor. Without this, the status bar's `Ln N` indicator stayed pinned to its previous value after any plugin-driven cursor move — which is what made the bug visible in #1957 even when the cursor itself had been moved.

## Test plan
- [x] New e2e test `test_git_blame_jumps_to_source_cursor_line`: opens a 30-line file, navigates to line 15, triggers Git Blame, and asserts the status bar still reports `Ln 15` in the blame buffer. Verified to fail on the unfixed plugin and pass on the fix.
- [x] Full git_blame e2e suite (10 tests) passes.
- [x] `cargo fmt --check`, `cargo clippy -p fresh-editor --tests` clean (no new warnings).
- [x] Manual tmux validation: opened a 30-line file, moved to line 15, ran Git Blame — blame view opens with the cursor on `Line 15` and the status bar shows `Ln 15, Col 1`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWfJDxUdKYiKc34WASXrba)_