### PR TITLE
refactor(terminal): hoist terminal-creation onto impl Window; fix invisible-agent bug

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -5176,6 +5176,7 @@ mod tests {
             action_name: String::new(),
             plugin_name: String::new(),
             custom_contexts: Vec::new(),
+            terminal_bypass: false,
         }
     }
 

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2979,6 +2979,17 @@ pub enum PluginCommand {
         /// Falls back to active session if the id is unknown.
         #[serde(default)]
         window_id: Option<WindowId>,
+        /// Argv to spawn directly in the PTY in lieu of the host's
+        /// configured shell. See `CreateTerminalOptions::command` for
+        /// the full semantics — `None` keeps the shell-and-type
+        /// behaviour, `Some(argv)` runs `argv` as the PTY child.
+        #[serde(default)]
+        command: Option<Vec<String>>,
+        /// Tab title override. Defaults to `command[0]` (when
+        /// `command` is set) or `"Terminal N"` (when it isn't).
+        /// See `CreateTerminalOptions::title`.
+        #[serde(default)]
+        title: Option<String>,
         /// Callback ID for async response
         request_id: u64,
     },
@@ -3790,6 +3801,27 @@ pub struct CreateTerminalOptions {
     #[serde(default, rename = "windowId")]
     #[ts(optional, rename = "windowId")]
     pub window_id: Option<WindowId>,
+    /// Argv to spawn directly inside the PTY instead of the host's
+    /// configured shell. `None` (default) keeps the historical
+    /// behaviour: spawn the user's shell and let the caller type into
+    /// it via `sendTerminalInput`. `Some([cmd, ...args])` runs that
+    /// exact command as the PTY child — no shell middleman, so the
+    /// process exits cleanly when the agent does and the
+    /// terminal-buffer's `terminal_exit` plugin hook reflects the
+    /// agent's real exit status. Used by Orchestrator so a session
+    /// with agent `python3` is just python3 in the PTY rather than
+    /// bash-running-python3-as-a-subshell-command.
+    #[serde(default)]
+    #[ts(optional)]
+    pub command: Option<Vec<String>>,
+    /// Tab title for the terminal buffer. Defaults to `command[0]`
+    /// (when `command` is set) or `"Terminal N"` (the historical
+    /// auto-numbered title). If another terminal in the same window
+    /// already uses the requested title, the host appends `" (k)"`
+    /// to disambiguate. Empty string is treated the same as `None`.
+    #[serde(default)]
+    #[ts(optional)]
+    pub title: Option<String>,
 }
 
 /// Result of getTextPropertiesAtCursor - array of property objects

--- a/crates/fresh-core/src/command.rs
+++ b/crates/fresh-core/src/command.rs
@@ -25,6 +25,16 @@ pub struct Command {
     pub plugin_name: String,
     /// Custom contexts required for this command (plugin-defined contexts like "vi-mode")
     pub custom_contexts: Vec<String>,
+    /// When `true`, a key bound to this command bypasses terminal
+    /// keyboard capture — the action fires instead of the keystroke
+    /// being forwarded to the PTY child. Use for commands the user
+    /// must always be able to reach (e.g. the orchestrator picker,
+    /// "switch to other session", a global panic-exit) so a focused
+    /// terminal pane doesn't trap them. Default `false` — keys
+    /// bound to non-bypassing commands still go to the PTY when
+    /// keyboard capture is on, matching the existing UX.
+    #[serde(default)]
+    pub terminal_bypass: bool,
 }
 
 /// A single suggestion item for autocomplete

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1437,7 +1437,37 @@ async function submitForm(): Promise<void> {
     renderForm();
     return;
   }
-  const repoRoot = (top.stdout || "").trim();
+  const currentToplevel = (top.stdout || "").trim();
+
+  // Resolve to the *main* worktree's root, not the current
+  // worktree. When the user runs `Orchestrator: New` from inside
+  // an existing orchestrator session (whose cwd is a linked
+  // worktree under `<XDG>/orchestrator/<slug>/<session>`), the
+  // current `--show-toplevel` is that worktree's root. Using it
+  // as the slug source would produce
+  // `<XDG>/orchestrator/<slug>/<slug-of-slug>/<session>` — paths
+  // that nest one level deeper each time the user creates a
+  // session from inside a session, eventually blowing past the
+  // filesystem's path-name limits (the WARN/ERROR logs about
+  // `File name too long (os error 36)`).
+  //
+  // `git rev-parse --path-format=absolute --git-common-dir`
+  // returns the absolute path of the shared `.git` directory —
+  // for the main worktree this is `<main>/.git`, for a linked
+  // worktree this is the *same* `<main>/.git`. The parent of
+  // that is the main worktree's root regardless of which worktree
+  // we're in. The fallback to `currentToplevel` is just defensive
+  // for unusual layouts (git versions older than 2.13 didn't
+  // support `--path-format=absolute`, but plugin runs under
+  // recent git so this is mostly belt-and-suspenders).
+  const gitCommon = await spawnCollect(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    currentToplevel,
+  );
+  const repoRoot = gitCommon.exit_code === 0
+    ? editor.pathDirname((gitCommon.stdout || "").trim()) || currentToplevel
+    : currentToplevel;
 
   // Name resolution: explicit value wins. Otherwise auto-generate
   // by scanning `refs/heads/session-N` for the next free index —

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -495,6 +495,7 @@ function buildOpenSpec(): WidgetSpec {
       hintBar([
         { keys: "↑↓", label: "nav" },
         { keys: "Enter", label: "dive" },
+        { keys: "Alt+N", label: "new" },
         { keys: "Tab", label: "focus" },
         { keys: "Esc", label: "close" },
       ]),
@@ -1055,7 +1056,24 @@ async function deleteConfirmedSession(): Promise<void> {
   triggerSyncAsync(repoRoot);
 }
 
-editor.defineMode(OPEN_MODE, [], true, true);
+// `Alt+N` from inside the picker opens the new-session form — saves
+// the user the "Esc, Ctrl+P, type Orchestrator: New Session, Enter"
+// dance when they realise mid-picker that they want to spawn another
+// agent. All other keys (Up/Down/Enter/Tab/Esc/printable chars)
+// route through `dispatch_floating_widget_key`'s smart-key defaults
+// since OPEN_MODE doesn't claim them here.
+editor.defineMode(
+  OPEN_MODE,
+  [["M-n", "orchestrator_open_new_from_picker"]],
+  true,
+  true,
+);
+
+registerHandler("orchestrator_open_new_from_picker", () => {
+  if (!openDialog) return;
+  closeOpenDialog();
+  openForm();
+});
 
 // =============================================================================
 // New-session floating form

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -555,7 +555,14 @@ function openControlRoom(): void {
     listVisibleRows,
     // Mirror buildPreviewPane's chrome: 1 button row + 1 spacer
     // + 2 info rows + 1 spacer = 4 rows reserved above the embed.
-    embedRows: Math.max(4, listVisibleRows - 4),
+    // Preview chrome above the embed: 1 button row + 1 spacer + 2
+    // info rows + 1 spacer = 5 rows. The labeledSection's top/bottom
+    // borders match the sessions list's, so subtracting just the
+    // chrome makes the preview pane's apparent height match the
+    // list pane's (`visible_rows + 2 borders`) exactly. Floored at
+    // 3 so a tiny terminal still leaves enough rows for the embed
+    // to paint something meaningful.
+    embedRows: Math.max(3, listVisibleRows - 5),
   };
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
@@ -1741,7 +1748,7 @@ editor.on("resize", () => {
   if (openDialog && openPanel) {
     const listVisibleRows = openListVisibleRows();
     openDialog.listVisibleRows = listVisibleRows;
-    openDialog.embedRows = Math.max(4, listVisibleRows - 4);
+    openDialog.embedRows = Math.max(3, listVisibleRows - 5);
     refreshOpenDialog();
   }
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1053,6 +1053,46 @@ function lastNonEmptyLine(s: string): string {
   return lines.length ? lines[lines.length - 1].trim() : "";
 }
 
+/// Split the user's "Agent Command" string into an argv suitable for
+/// `editor.createTerminal({ command })`. Honours single- and
+/// double-quoted segments so `claude --append "hello world"` parses
+/// as three args rather than four. Backslash escaping is intentionally
+/// *not* supported — agent commands are short typed-in strings; if
+/// they need that level of escaping the user should write a wrapper
+/// shell script.
+///
+/// Returns `[]` for an empty or whitespace-only input.
+function splitAgentCmd(s: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      if (c === quote) {
+        quote = null;
+      } else {
+        cur += c;
+      }
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      continue;
+    }
+    if (c === " " || c === "\t") {
+      if (cur.length > 0) {
+        out.push(cur);
+        cur = "";
+      }
+      continue;
+    }
+    cur += c;
+  }
+  if (cur.length > 0) out.push(cur);
+  return out;
+}
+
 async function spawnCollect(
   command: string,
   args: string[],
@@ -1649,9 +1689,17 @@ editor.on("window_created", async (payload) => {
     // the dive isn't user-visible flicker, it's the desired
     // landing state.
     editor.setActiveWindow(id);
+    // When the user provided a non-empty agent command, spawn it as
+    // the PTY child directly (no shell middleman). Tab title reads
+    // the command name ("python3", "claude", ...) instead of the
+    // generic "*Terminal N*". When `cmd` is empty the host picks
+    // the user's shell as before.
+    const argv = splitAgentCmd(intent.cmd);
     const term = await editor.createTerminal({
       cwd: intent.root,
       focus: false,
+      command: argv.length > 0 ? argv : undefined,
+      title: argv.length > 0 ? argv[0] : undefined,
     });
     const tracked: AgentSession = {
       id,
@@ -1662,9 +1710,11 @@ editor.on("window_created", async (payload) => {
       createdAt: Date.now(),
     };
     orchestratorSessions.set(id, tracked);
-    if (intent.cmd) {
-      editor.sendTerminalInput(term.terminalId, intent.cmd + "\n");
-    }
+    // Legacy `sendTerminalInput` path is no longer needed when the
+    // command is spawned directly. Kept for the shell-only case
+    // would be `editor.sendTerminalInput(term.terminalId, "\n")` to
+    // wake up the prompt, but that's unnecessary — the shell prints
+    // its own prompt on startup.
   }
   refreshOpenDialog();
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -142,6 +142,12 @@ interface OpenDialogState {
   // height vs. a file buffer's).
   listVisibleRows: number;
   embedRows: number;
+  // Toggle between "compact preview" (default — buttons + live
+  // embed only, no info row) and "details" (state + path metadata
+  // row visible above the embed). Compact is the default because
+  // the embed is the part the user actually wants to see; the
+  // metadata row is rarely read and just eats embed height.
+  showDetails: boolean;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -363,14 +369,20 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       });
     }
   }
-  // The embed reserves the bulk of the preview pane so the host
-  // can paint the selected window's live UI (splits, terminals,
-  // syntax highlighting) underneath the action button row. The
-  // row count is captured at dialog-open into `openDialog` and
-  // used verbatim across re-renders, so the preview pane stays
-  // a constant height regardless of which window's viewport the
-  // host happens to be reporting through `getViewport()`.
-  const embedRows = openDialog?.embedRows ?? 4;
+  // Total embed area we can afford if no details row is shown:
+  // `listVisibleRows - 2` (button row + one spacer above the
+  // embed). When details ARE shown, two info rows + a spacer eat
+  // three more lines — `_DETAILS_CHROME_ROWS` accounts for that.
+  // Either way the preview pane's apparent height matches the
+  // sessions list pane's `visible_rows + 2 borders` for the
+  // wireframed dialog shape.
+  const totalEmbedBase = (openDialog?.listVisibleRows ?? 6) - 2;
+  const detailsOn = openDialog?.showDetails ?? false;
+  const _DETAILS_CHROME_ROWS = 3; // 2 info rows + 1 spacer
+  const embedRows = Math.max(
+    3,
+    totalEmbedBase - (detailsOn ? _DETAILS_CHROME_ROWS : 0),
+  );
   // Gate the action buttons on having a session to act on. When
   // the filter matches nothing (or no session is highlighted) the
   // preview pane shows just "No session selected" + an empty
@@ -389,27 +401,41 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       ),
     });
   }
+  // The "details" toggle: when off, the picker shows just the
+  // action buttons + the live embed (compact, max embed height).
+  // When on, the state/age/path metadata row appears above the
+  // embed and the embed shrinks to make room. Toggle button
+  // labels with the *target* state — pressing `[ Details ]`
+  // turns details on, pressing `[ Preview ]` turns them off
+  // (back to compact).
+  const detailsToggleLabel = detailsOn ? "Preview" : "Details";
+  const buttonRow = row(
+    flexSpacer(),
+    button(detailsToggleLabel, { key: "toggle-details" }),
+    spacer(2),
+    button("Stop", { key: "stop" }),
+    spacer(2),
+    button("Archive", { key: "archive" }),
+    spacer(2),
+    button("Delete", { intent: "danger", key: "delete" }),
+  );
+  const embedWidget = windowEmbed({
+    windowId: s.id,
+    rows: embedRows,
+    key: "live-preview",
+  });
+  const body = detailsOn
+    ? col(
+        buttonRow,
+        spacer(0),
+        { kind: "raw", entries: buildPreviewEntries(s) },
+        spacer(0),
+        embedWidget,
+      )
+    : col(buttonRow, spacer(0), embedWidget);
   return labeledSection({
     label: `[${s.id}] ${s.label}`,
-    child: col(
-      row(
-        flexSpacer(),
-        button("Stop", { key: "stop" }),
-        spacer(2),
-        button("Archive", { key: "archive" }),
-        spacer(2),
-        button("Delete", { intent: "danger", key: "delete" }),
-      ),
-      spacer(0),
-      { kind: "raw", entries: buildPreviewEntries(s) },
-      spacer(0),
-      // Live window render of the highlighted session's split tree.
-      windowEmbed({
-        windowId: s.id,
-        rows: embedRows,
-        key: "live-preview",
-      }),
-    ),
+    child: body,
   });
 }
 
@@ -581,6 +607,7 @@ function openControlRoom(): void {
     // 3 so a tiny terminal still leaves enough rows for the embed
     // to paint something meaningful.
     embedRows: Math.max(3, listVisibleRows - 5),
+    showDetails: false,
   };
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
@@ -1696,6 +1723,11 @@ editor.on("widget_event", (e) => {
         editor.setActiveWindow(id);
       }
       closeOpenDialog();
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "toggle-details") {
+      openDialog.showDetails = !openDialog.showDetails;
+      refreshOpenDialog();
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "stop") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -415,15 +415,20 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
 
 function buildOpenSpec(): WidgetSpec {
   if (!openDialog) return col();
-  // Recompute the row-count knobs against the current viewport on
-  // every spec build, not just at open-time. The host's `resize`
-  // plugin hook isn't always reliable through tmux's SIGWINCH
-  // propagation, so we re-derive listVisibleRows / embedRows from
-  // `editor.getViewport()` here — every refresh (filter typing,
-  // session selection change, periodic poll, post-resize re-render)
-  // picks up the live viewport (Finding I).
+  // Re-derive row counts on every spec build as a fallback for the
+  // resize hook not always firing reliably through tmux's SIGWINCH
+  // propagation (Finding I). **One-way ratchet**: only adopt the
+  // new value when it's *larger* than the current one. The
+  // `editor.getViewport()` height shrinks while the picker is
+  // mounted (the floating panel covers part of the buffer area),
+  // and naively re-reading it on every refresh fed that shrink
+  // back into the dialog size — pressing Up/Down caused the
+  // picker to oscillate smaller on every keystroke. A real
+  // terminal-grow event still flows through because the new
+  // viewport height exceeds the cached value; a spurious shrink
+  // (because the panel itself is up) is ignored.
   const liveListVisibleRows = openListVisibleRows();
-  if (liveListVisibleRows !== openDialog.listVisibleRows) {
+  if (liveListVisibleRows > openDialog.listVisibleRows) {
     openDialog.listVisibleRows = liveListVisibleRows;
     openDialog.embedRows = Math.max(3, liveListVisibleRows - 5);
   }
@@ -1166,13 +1171,41 @@ async function detectDefaultBranch(repoRoot: string): Promise<string> {
   return "HEAD";
 }
 
-function nextAutoSessionName(): string {
+async function nextAutoSessionName(repoRoot: string): Promise<string> {
   // Persisted counter so consecutive empty submits produce
-  // session-1, session-2, … even across plugin reloads.
-  const counter = (editor.getGlobalState("orchestrator.session_counter") as
+  // session-1, session-2, … even across plugin reloads. But the
+  // counter alone isn't sufficient: a previous run may have left a
+  // branch / worktree behind (orchestrator's archive / external git
+  // delete / interrupted submit), so `session-${counter+1}` can
+  // collide and `git worktree add` would fail with the noisy
+  // "already used by worktree at …" message. Probe the local git
+  // refs once and increment past any reserved name before
+  // returning.
+  const counterBefore = (editor.getGlobalState("orchestrator.session_counter") as
     | number
     | undefined) ?? 0;
-  const next = counter + 1;
+  let next = counterBefore + 1;
+
+  // Collect existing branch names that look like `session-N` so we
+  // can skip past them. `git for-each-ref` is faster and tighter
+  // than parsing `git worktree list` output.
+  const refs = await spawnCollect(
+    "git",
+    ["-C", repoRoot, "for-each-ref", "--format=%(refname:short)", "refs/heads/"],
+    repoRoot,
+  );
+  const taken = new Set<number>();
+  if (refs.exit_code === 0) {
+    for (const line of (refs.stdout || "").split(/\r?\n/)) {
+      const m = /^session-(\d+)$/.exec(line.trim());
+      if (m) {
+        taken.add(parseInt(m[1], 10));
+      }
+    }
+  }
+  while (taken.has(next)) {
+    next += 1;
+  }
   editor.setGlobalState("orchestrator.session_counter", next);
   return `session-${next}`;
 }
@@ -1391,7 +1424,6 @@ async function submitForm(): Promise<void> {
   form.lastError = null;
   renderForm();
 
-  const sessionName = form.name.value.trim() || nextAutoSessionName();
   const cmd = form.cmd.value.trim();
   const branchInput = form.branch.value.trim();
 
@@ -1406,6 +1438,13 @@ async function submitForm(): Promise<void> {
     return;
   }
   const repoRoot = (top.stdout || "").trim();
+
+  // Name resolution: explicit value wins. Otherwise auto-generate
+  // by scanning `refs/heads/session-N` for the next free index —
+  // the counter alone can collide with branches a previous run
+  // left behind. Async because the probe spawns git; placed after
+  // `rev-parse` so we know we're in a git repo first.
+  const sessionName = form.name.value.trim() || (await nextAutoSessionName(repoRoot));
 
   const root = editor.pathJoin(
     editor.getDataDir(),

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -97,6 +97,13 @@ interface NewSessionForm {
   // the exact base ref the worktree will fork off if they
   // leave the field blank.
   defaultBranch: string;
+  // Previously-submitted Agent Command (persisted across editor
+  // sessions via `orchestrator.last_cmd`). Rendered as the cmd
+  // field's *placeholder* — pre-filling the value would survive
+  // a failed submit and silently feed stale text into the next
+  // attempt; the placeholder gives the same memory aid without
+  // that hazard.
+  lastCmd: string;
 }
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
@@ -364,8 +371,21 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   // a constant height regardless of which window's viewport the
   // host happens to be reporting through `getViewport()`.
   const embedRows = openDialog?.embedRows ?? 4;
+  // Gate the action buttons on having a session to act on. When
+  // the filter matches nothing (or no session is highlighted) the
+  // preview pane is just the "No session selected" raw entry —
+  // showing Stop/Archive/Delete in that state is misleading
+  // because they have nothing to operate on.
+  if (!s) {
+    return labeledSection({
+      label: "Preview",
+      child: col(
+        { kind: "raw", entries: buildPreviewEntries(s) },
+      ),
+    });
+  }
   return labeledSection({
-    label: s ? `[${s.id}] ${s.label}` : "Preview",
+    label: `[${s.id}] ${s.label}`,
     child: col(
       row(
         flexSpacer(),
@@ -378,11 +398,9 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       spacer(0),
       { kind: "raw", entries: buildPreviewEntries(s) },
       spacer(0),
-      // Live window render. `windowId: 0` (no session selected)
-      // is a no-op on the host side — the embed reserves the
-      // rows but no paint happens.
+      // Live window render of the highlighted session's split tree.
       windowEmbed({
-        windowId: s ? s.id : 0,
+        windowId: s.id,
         rows: embedRows,
         key: "live-preview",
       }),
@@ -1130,8 +1148,13 @@ function buildFormSpec(): WidgetSpec {
     ),
     spacer(0),
     // === Form body: three labeled, full-width inputs. ============
+    // Labels are plain — the `▸` glyph used to be baked into all
+    // three strings and stayed put regardless of focus, which was
+    // misleading. The input's own focused-bg styling (set by the
+    // host based on the panel's focus_key) is the authoritative
+    // focus cue.
     labeledSection({
-      label: "▸ Session Name",
+      label: "Session Name",
       child: text({
         value: form.name.value,
         cursorByte: form.name.cursor,
@@ -1141,21 +1164,24 @@ function buildFormSpec(): WidgetSpec {
       }),
     }),
     labeledSection({
-      label: "▸ Agent Command",
+      label: "Agent Command",
       child: text({
         value: form.cmd.value,
         cursorByte: form.cmd.cursor,
         // Empty submission spawns a bare terminal — the host
         // picks the shell with the same logic it uses for any
         // other embedded terminal, so the plugin doesn't have
-        // to second-guess `$SHELL` resolution.
-        placeholder: "terminal",
+        // to second-guess `$SHELL` resolution. If the user
+        // submitted a non-empty cmd in the previous run we
+        // surface it here as a hint (placeholder only — see
+        // `NewSessionForm.lastCmd`).
+        placeholder: form.lastCmd || "terminal",
         fullWidth: true,
         key: "cmd",
       }),
     }),
     labeledSection({
-      label: "▸ Branch",
+      label: "Branch",
       child: text({
         value: form.branch.value,
         cursorByte: form.branch.cursor,
@@ -1232,12 +1258,17 @@ function openForm(): void {
     (editor.getGlobalState("orchestrator.last_cmd") as string | undefined) ?? "";
   form = {
     name: { value: "", cursor: 0 },
-    cmd: { value: lastCmd, cursor: lastCmd.length },
+    // Empty value — `lastCmd` shows as the placeholder instead so
+    // an empty submit falls back to the host's default shell
+    // ("terminal") rather than silently re-running the previous
+    // agent. See `NewSessionForm.lastCmd`.
+    cmd: { value: "", cursor: 0 },
     branch: { value: "", cursor: 0 },
     submitting: false,
     lastError: null,
     projectLabel: deriveProjectLabel(),
     defaultBranch: "",
+    lastCmd,
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
@@ -1288,6 +1319,7 @@ async function submitForm(): Promise<void> {
     if (!form) return;
     form.submitting = false;
     form.lastError = lastNonEmptyLine(top.stderr) || "not a git repository";
+    editor.setStatus(`Orchestrator: ${form.lastError}`);
     renderForm();
     return;
   }
@@ -1304,6 +1336,7 @@ async function submitForm(): Promise<void> {
     if (!form) return;
     form.submitting = false;
     form.lastError = `mkdir failed: ${parent}`;
+    editor.setStatus(`Orchestrator: ${form.lastError}`);
     renderForm();
     return;
   }
@@ -1327,9 +1360,19 @@ async function submitForm(): Promise<void> {
     if (fallback.exit_code !== 0) {
       if (!form) return;
       form.submitting = false;
-      form.lastError = lastNonEmptyLine(addRes.stderr) ||
-        lastNonEmptyLine(fallback.stderr) ||
+      // Prefer the fallback's stderr: when both attempts fail, the
+      // `-b` branch's error is usually "branch already exists" (which
+      // is *why* we tried the fallback in the first place), and the
+      // fallback's error is the more progressed / informative one.
+      // Fall back to `addRes.stderr` only when the fallback didn't
+      // produce its own line.
+      form.lastError = lastNonEmptyLine(fallback.stderr) ||
+        lastNonEmptyLine(addRes.stderr) ||
         "git worktree add failed";
+      // Mirror to the status bar so the error survives if the user
+      // dismisses the dialog before reading it. `form.lastError`
+      // still drives the in-dialog "Error: …" row.
+      editor.setStatus(`Orchestrator: ${form.lastError}`);
       renderForm();
       return;
     }
@@ -1380,7 +1423,21 @@ registerHandler(
   "orchestrator_form_key_shift_tab",
   () => dispatchFormKey("Shift+Tab"),
 );
-registerHandler("orchestrator_form_key_enter", () => dispatchFormKey("Enter"));
+registerHandler("orchestrator_form_key_enter", () => {
+  // The hint bar promises "Enter submit". The host's default Text-
+  // widget behaviour for Enter inside a single-line input is "advance
+  // focus to next widget" (see plugin_dispatch.rs smart-key router),
+  // which made Enter a no-op on every form field and the user had to
+  // tab to the "Create Session" button to commit. Short-circuit at
+  // the plugin handler: when the form is open, Enter from anywhere
+  // submits — the dialog already routes Esc to cancel, so there's
+  // no ambiguity.
+  if (form) {
+    void submitForm();
+    return;
+  }
+  dispatchFormKey("Enter");
+});
 registerHandler("orchestrator_form_key_escape", () => {
   if (form) closeForm();
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1936,21 +1936,31 @@ registerHandler("orchestrator_open", openControlRoom);
 registerHandler("orchestrator_new", startNewSession);
 registerHandler("orchestrator_kill", killSelected);
 
+// `terminalBypass: true` keeps these commands reachable from a
+// keyboard-focused terminal pane — a user with `Ctrl+O` bound to
+// `Orchestrator: Open` shouldn't need to first hit `Ctrl+Space` to
+// exit terminal mode to switch sessions. The bypass routes the
+// key past `TerminalModeInputHandler` (which would otherwise
+// forward it to the PTY child) and dispatches the action
+// directly.
 editor.registerCommand(
   "Orchestrator: Open",
   "Show all editor sessions in a floating selector",
   "orchestrator_open",
   null,
+  { terminalBypass: true },
 );
 editor.registerCommand(
   "Orchestrator: New Session",
   "Spawn a new editor session in a worktree",
   "orchestrator_new",
   null,
+  { terminalBypass: true },
 );
 editor.registerCommand(
   "Orchestrator: Kill Selected",
   "Close the session highlighted in the open Orchestrator prompt",
   "orchestrator_kill",
   null,
+  { terminalBypass: true },
 );

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1580,13 +1580,17 @@ editor.on("window_created", async (payload) => {
   ) {
     const intent = pendingNewSession;
     pendingNewSession = null;
-    // windowId attaches the terminal to the new session's split
-    // tree; we then dive so the user sees the shell/agent
-    // immediately — creating a session is a visit-now action.
+    // Dive into the new session FIRST so its terminal_manager is
+    // the editor-active one. Subsequent `createTerminal` /
+    // `sendTerminalInput` calls then resolve against the new
+    // session's window without needing a cross-window terminal
+    // lookup. Creating a session is a visit-now action anyway —
+    // the dive isn't user-visible flicker, it's the desired
+    // landing state.
+    editor.setActiveWindow(id);
     const term = await editor.createTerminal({
       cwd: intent.root,
       focus: false,
-      windowId: id,
     });
     const tracked: AgentSession = {
       id,
@@ -1600,7 +1604,6 @@ editor.on("window_created", async (payload) => {
     if (intent.cmd) {
       editor.sendTerminalInput(term.terminalId, intent.cmd + "\n");
     }
-    editor.setActiveWindow(id);
   }
   refreshOpenDialog();
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -373,14 +373,19 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   const embedRows = openDialog?.embedRows ?? 4;
   // Gate the action buttons on having a session to act on. When
   // the filter matches nothing (or no session is highlighted) the
-  // preview pane is just the "No session selected" raw entry —
-  // showing Stop/Archive/Delete in that state is misleading
-  // because they have nothing to operate on.
+  // preview pane shows just "No session selected" + an empty
+  // embed reservation — showing Stop/Archive/Delete in that state
+  // is misleading because they have nothing to operate on. The
+  // empty `windowEmbed({windowId: 0})` is a no-op on the host
+  // side but keeps the preview pane the same height as the
+  // (padded) sessions list pane so the dialog doesn't shrink
+  // jarringly when the filter matches nothing.
   if (!s) {
     return labeledSection({
       label: "Preview",
       child: col(
         { kind: "raw", entries: buildPreviewEntries(s) },
+        windowEmbed({ windowId: 0, rows: embedRows, key: "live-preview" }),
       ),
     });
   }
@@ -1424,14 +1429,13 @@ registerHandler(
   () => dispatchFormKey("Shift+Tab"),
 );
 registerHandler("orchestrator_form_key_enter", () => {
-  // The hint bar promises "Enter submit". The host's default Text-
-  // widget behaviour for Enter inside a single-line input is "advance
-  // focus to next widget" (see plugin_dispatch.rs smart-key router),
-  // which made Enter a no-op on every form field and the user had to
-  // tab to the "Create Session" button to commit. Short-circuit at
-  // the plugin handler: when the form is open, Enter from anywhere
-  // submits — the dialog already routes Esc to cancel, so there's
-  // no ambiguity.
+  // The hint bar promises "Enter submit". The host's floating-panel
+  // input dispatcher (input.rs:`dispatch_floating_widget_key`)
+  // defers to plugin-defined mode bindings when present, so the
+  // smart-key router's "Enter = advance focus" default doesn't fire
+  // for the orchestrator-new-form mode — this handler does. From
+  // anywhere in the form, Enter submits; the form's existing
+  // `Esc → closeForm` keeps the cancel path unambiguous.
   if (form) {
     void submitForm();
     return;
@@ -1671,6 +1675,25 @@ editor.on("window_closed", () => {
 
 editor.on("active_window_changed", () => {
   refreshOpenDialog();
+});
+
+// Re-flow the open-picker on terminal resize. The dialog's
+// `listVisibleRows` / `embedRows` are captured at open-time
+// (orchestrator.ts:`openControlRoom`); without this subscription
+// they stay frozen at the pre-resize values and the live preview
+// embed gets clipped (or leaves blank space) when the user
+// resizes their tmux pane. The host also re-renders the panel
+// against the new screen width unconditionally (see
+// `Editor::resize` in `lifecycle.rs`); this handler just refreshes
+// the spec so the *plugin's* row-count knobs adopt the new
+// viewport at the same time.
+editor.on("resize", () => {
+  if (openDialog && openPanel) {
+    const listVisibleRows = openListVisibleRows();
+    openDialog.listVisibleRows = listVisibleRows;
+    openDialog.embedRows = Math.max(4, listVisibleRows - 4);
+    refreshOpenDialog();
+  }
 });
 
 // =============================================================================

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -415,6 +415,18 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
 
 function buildOpenSpec(): WidgetSpec {
   if (!openDialog) return col();
+  // Recompute the row-count knobs against the current viewport on
+  // every spec build, not just at open-time. The host's `resize`
+  // plugin hook isn't always reliable through tmux's SIGWINCH
+  // propagation, so we re-derive listVisibleRows / embedRows from
+  // `editor.getViewport()` here — every refresh (filter typing,
+  // session selection change, periodic poll, post-resize re-render)
+  // picks up the live viewport (Finding I).
+  const liveListVisibleRows = openListVisibleRows();
+  if (liveListVisibleRows !== openDialog.listVisibleRows) {
+    openDialog.listVisibleRows = liveListVisibleRows;
+    openDialog.embedRows = Math.max(3, liveListVisibleRows - 5);
+  }
   const filtered = openDialog.filteredIds;
   const activeId = editor.activeWindow();
   const items = filtered.map((id) => renderListItem(id, activeId));

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -248,6 +248,18 @@ impl Editor {
     /// editor mode, so that e.g. a search-replace panel isn't hijacked by
     /// a markdown-source or vi-mode global mode.
     pub fn effective_mode(&self) -> Option<&str> {
+        // When a floating widget panel is mounted, its plugin-defined
+        // mode (`editor.setEditorMode(...)`) takes precedence over the
+        // underlying buffer's virtual mode. Without this, opening the
+        // Orchestrator picker from a python3 terminal session would
+        // resolve mode-keybindings against `"terminal"` instead of
+        // `"orchestrator-open"`, so picker-specific shortcuts like
+        // `Alt+N` never reached their handlers.
+        if self.floating_widget_panel.is_some() {
+            if let Some(mode) = self.active_window().editor_mode.as_deref() {
+                return Some(mode);
+            }
+        }
         self.active_buffer_mode()
             .or(self.active_window().editor_mode.as_deref())
     }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2642,6 +2642,14 @@ impl Editor {
             // New-Session form relies on this so Enter submits the
             // form regardless of which field is focused (matching the
             // dialog's `Enter: submit` hint).
+            //
+            // Important: only count bindings that are *explicitly* set
+            // for the mode (user / default / plugin defaults). The
+            // resolver's full `resolve()` falls back to Normal-context
+            // bindings for any mode, which would falsely report Enter
+            // as bound everywhere (Normal's Enter inserts a newline).
+            // We check the three context-scoped maps directly so the
+            // Normal-fallback path doesn't taint the precedence check.
             let mode_has_binding = self
                 .active_window()
                 .editor_mode
@@ -2650,11 +2658,8 @@ impl Editor {
                     let key_event = crossterm::event::KeyEvent::new(code, modifiers);
                     let mode_ctx =
                         crate::input::keybindings::KeyContext::Mode(mode_name.to_string());
-                    self.keybindings
-                        .read()
-                        .unwrap()
-                        .resolve(&key_event, mode_ctx)
-                        != crate::input::keybindings::Action::None
+                    let keybindings = self.keybindings.read().unwrap();
+                    keybindings.has_explicit_binding(&key_event, &mode_ctx)
                 })
                 .unwrap_or(false);
             if mode_has_binding {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2682,7 +2682,30 @@ impl Editor {
             // not leak keys to global bindings like Ctrl-P or
             // Alt-F. Plain (or Shift-only) chars feed printable
             // text into the focused TextInput.
+            //
+            // Exception: the active editor mode may have explicitly
+            // claimed the chord via `defineMode` (the Orchestrator
+            // picker binds `Alt+N` to its new-session shortcut, for
+            // example). Defer to that path so plugin-declared
+            // modal shortcuts work, mirroring the same precedence
+            // check the named-key branch above uses.
             if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                let mode_has_binding = self
+                    .active_window()
+                    .editor_mode
+                    .as_ref()
+                    .map(|mode_name| {
+                        let key_event = crossterm::event::KeyEvent::new(code, modifiers);
+                        let mode_ctx = crate::input::keybindings::KeyContext::Mode(
+                            mode_name.to_string(),
+                        );
+                        let keybindings = self.keybindings.read().unwrap();
+                        keybindings.has_explicit_binding(&key_event, &mode_ctx)
+                    })
+                    .unwrap_or(false);
+                if mode_has_binding {
+                    return false;
+                }
                 return true;
             }
             let ch = if modifiers.contains(KeyModifiers::SHIFT) {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -439,6 +439,17 @@ impl Editor {
             && (self.global_popups.is_visible() || self.active_state().popups.is_visible())
         {
             KeyContext::Popup
+        } else if self.floating_widget_panel.is_some() {
+            // A modal floating panel (picker / new-session form /
+            // plugin overlay) is the keyboard owner. Resolve keys
+            // as Normal regardless of the underlying buffer's stale
+            // `key_context` (which can still be Terminal when the
+            // panel was opened from a python3 session). Without
+            // this, `should_check_mode_bindings = matches!(ctx,
+            // Normal)` skipped the mode-keybinding lookup for any
+            // Ctrl/Alt chord the plugin had bound on the panel's
+            // mode, e.g. `Alt+N` for "new session from the picker".
+            KeyContext::Normal
         } else if self
             .active_window()
             .is_composite_buffer(self.active_buffer())

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2632,6 +2632,34 @@ impl Editor {
             _ => None,
         };
         if let Some(name) = key_name {
+            // Mode-binding precedence: if the active editor mode has a
+            // plugin-defined binding for this key, let it win instead
+            // of applying the floating panel's default smart-key
+            // behaviour. This is what `defineMode` exists for — a
+            // plugin saying "in MY mode, Enter does X" must be
+            // authoritative, not silently overridden by the host's
+            // generic "Enter = focus-advance" default. The orchestrator
+            // New-Session form relies on this so Enter submits the
+            // form regardless of which field is focused (matching the
+            // dialog's `Enter: submit` hint).
+            let mode_has_binding = self
+                .active_window()
+                .editor_mode
+                .as_ref()
+                .map(|mode_name| {
+                    let key_event = crossterm::event::KeyEvent::new(code, modifiers);
+                    let mode_ctx =
+                        crate::input::keybindings::KeyContext::Mode(mode_name.to_string());
+                    self.keybindings
+                        .read()
+                        .unwrap()
+                        .resolve(&key_event, mode_ctx)
+                        != crate::input::keybindings::Action::None
+                })
+                .unwrap_or(false);
+            if mode_has_binding {
+                return false;
+            }
             self.handle_widget_command(
                 panel_id,
                 fresh_core::api::WidgetAction::Key {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -479,7 +479,10 @@ impl Editor {
             return Ok(());
         }
 
-        // Try terminal input dispatch first (handles terminal mode and re-entry)
+        // Try terminal input dispatch first (handles terminal mode and re-entry).
+        // Note: `dispatch_terminal_input` short-circuits to None when a floating
+        // widget panel is mounted, so picker / form keys reach the panel below
+        // instead of being forwarded to the PTY child of the underlying terminal.
         if self.dispatch_terminal_input(&key_event).is_some() {
             return Ok(());
         }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2707,9 +2707,8 @@ impl Editor {
                     .as_ref()
                     .map(|mode_name| {
                         let key_event = crossterm::event::KeyEvent::new(code, modifiers);
-                        let mode_ctx = crate::input::keybindings::KeyContext::Mode(
-                            mode_name.to_string(),
-                        );
+                        let mode_ctx =
+                            crate::input::keybindings::KeyContext::Mode(mode_name.to_string());
                         let keybindings = self.keybindings.read().unwrap();
                         keybindings.has_explicit_binding(&key_event, &mode_ctx)
                     })

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -6,7 +6,7 @@
 use super::terminal_input::{should_enter_terminal_mode, TerminalModeInputHandler};
 use super::Editor;
 use crate::input::handler::{DeferredAction, InputContext, InputHandler, InputResult};
-use crate::input::keybindings::Action;
+use crate::input::keybindings::{Action, KeyContext};
 use crate::view::file_browser_input::FileBrowserInputHandler;
 use crate::view::query_replace_input::QueryReplaceConfirmInputHandler;
 use crate::view::ui::MenuInputHandler;
@@ -54,6 +54,36 @@ impl Editor {
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;
                 return None; // fall through to normal input dispatch
+            }
+            // Plugin commands flagged `terminalBypass: true` (via
+            // `editor.registerCommand(..., { terminalBypass: true })`)
+            // resolve to actions that must reach the editor even
+            // when a terminal pane owns the keyboard — that's how
+            // bound shortcuts to commands like `Orchestrator: Open`
+            // stay reachable from inside `top`/`htop`/a shell.
+            // Resolve the key against the regular (Normal) context;
+            // if it's a registered bypass action, dispatch it and
+            // return *before* the terminal handler claims the key.
+            // Builtin UI actions (CommandPalette, QuickOpen, …)
+            // still flow through `TerminalModeInputHandler`'s own
+            // `is_terminal_ui_action` allowlist below.
+            let bypass_action = {
+                let keybindings = self.keybindings.read().unwrap();
+                let action = keybindings.resolve(event, KeyContext::Normal);
+                if self
+                    .command_registry
+                    .read()
+                    .unwrap()
+                    .is_terminal_bypass_action(&action)
+                {
+                    Some(action)
+                } else {
+                    None
+                }
+            };
+            if let Some(action) = bypass_action {
+                let _ = self.handle_action(action);
+                return Some(InputResult::Consumed);
             }
             let mut ctx = InputContext::new();
             let keyboard_capture = self.active_window().keyboard_capture;

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -82,7 +82,9 @@ impl Editor {
                 }
             };
             if let Some(action) = bypass_action {
-                let _ = self.handle_action(action);
+                if let Err(e) = self.handle_action(action) {
+                    tracing::warn!("terminal-bypass action failed: {e}");
+                }
                 return Some(InputResult::Consumed);
             }
             let mut ctx = InputContext::new();

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -21,13 +21,20 @@ impl Editor {
     /// `None` if not in terminal mode or if a modal is active.
     pub fn dispatch_terminal_input(&mut self, event: &KeyEvent) -> Option<InputResult> {
         // Skip if we're in a prompt/popup (those need to handle keys normally)
+        // — including the floating widget panel (Orchestrator picker,
+        // new-session form, plugin overlays), which is the editor-wide
+        // modal owner of the keyboard while it's up. Without this skip,
+        // a terminal-buffer-active window with `terminal_mode=true` would
+        // route keys to the PTY child even when the user's keystrokes
+        // are meant for the picker on top of it.
         let in_modal = self.is_prompting()
             || self.global_popups.is_visible()
             || self.active_state().popups.is_visible()
             || self.menu_state.active_menu.is_some()
             || self.settings_state.as_ref().is_some_and(|s| s.visible)
             || self.calibration_wizard.is_some()
-            || self.keybinding_editor.is_some();
+            || self.keybinding_editor.is_some()
+            || self.floating_widget_panel.is_some();
 
         if in_modal {
             return None;

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -267,6 +267,19 @@ impl Editor {
             window.resize(width, height);
         }
 
+        // Refresh the plugin-facing snapshot BEFORE firing the
+        // resize hook. Without this, the orchestrator's resize
+        // handler reads `editor.getViewport()` from a snapshot
+        // whose `viewport.height` still reflects the pre-resize
+        // size — the one-way ratchet in `buildOpenSpec` then sees
+        // `old > old` and skips the update, leaving the picker
+        // stuck small even after a terminal-grow event. (The
+        // ratchet itself is correct; the input it consumes was
+        // stale.) Updating the snapshot here lets plugins observe
+        // the new dimensions when they react to the hook.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
+
         // Notify plugins of the resize so they can adjust layouts.
         self.plugin_manager.read().unwrap().run_hook(
             "resize",

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -272,6 +272,18 @@ impl Editor {
             "resize",
             fresh_core::hooks::HookArgs::Resize { width, height },
         );
+
+        // If a floating widget panel is currently mounted (the
+        // Orchestrator picker, New-Session form, plugin overlays),
+        // its cached `entries` were laid out against the old screen
+        // width — re-render against the new one so column widths,
+        // side borders and embed rects all reflect the new
+        // dimensions (Bug 13). The hook above lets plugins update
+        // their spec; this rerender picks up either the updated
+        // spec or the existing spec at the new width.
+        if let Some(panel_id) = self.floating_widget_panel.as_ref().map(|f| f.panel_id) {
+            self.rerender_widget_panel(panel_id);
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1985,6 +1985,7 @@ impl Editor {
             contexts: vec![], // Plugin commands available in all contexts by default
             custom_contexts: command.custom_contexts,
             source: CommandSource::Plugin(command.plugin_name),
+            terminal_bypass: command.terminal_bypass,
         };
 
         tracing::debug!(

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1234,8 +1234,7 @@ impl Editor {
                 request_id,
             } => {
                 self.handle_create_terminal(
-                    cwd, direction, ratio, focus, persistent, window_id, command, title,
-                    request_id,
+                    cwd, direction, ratio, focus, persistent, window_id, command, title, request_id,
                 );
             }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1229,10 +1229,13 @@ impl Editor {
                 focus,
                 persistent,
                 window_id,
+                command,
+                title,
                 request_id,
             } => {
                 self.handle_create_terminal(
-                    cwd, direction, ratio, focus, persistent, window_id, request_id,
+                    cwd, direction, ratio, focus, persistent, window_id, command, title,
+                    request_id,
                 );
             }
 
@@ -2719,6 +2722,8 @@ impl Editor {
         focus: Option<bool>,
         persistent: bool,
         target_session_id: Option<fresh_core::WindowId>,
+        command: Option<Vec<String>>,
+        title: Option<String>,
         request_id: u64,
     ) {
         // Resolve target window. Explicit `windowId` wins when the
@@ -2762,6 +2767,8 @@ impl Editor {
                 ratio,
                 focus.unwrap_or(true),
                 persistent,
+                command,
+                title.filter(|t| !t.is_empty()),
             )
         };
         match result {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -2721,452 +2721,89 @@ impl Editor {
         target_session_id: Option<fresh_core::WindowId>,
         request_id: u64,
     ) {
-        // If the caller specified an inactive session, route the new
-        // terminal into that session's stashed split tree without
-        // diving. The active session's UI is undisturbed; on next
-        // dive into the target session, the terminal appears in its
-        // restored split layout. Orchestrator uses this so spawning an
-        // agent doesn't pull the user away from the base session.
-        let route_to_inactive = match target_session_id {
-            Some(id) if id != self.active_window && self.windows.contains_key(&id) => Some(id),
-            _ => None,
-        };
-        if let Some(target) = route_to_inactive {
-            self.handle_create_terminal_in_inactive_session(target, cwd, persistent, request_id);
-            return;
-        }
-        let (cols, rows) = self.get_terminal_dimensions();
+        // Resolve target window. Explicit `windowId` wins when the
+        // window exists; otherwise we operate on the active window.
+        // Both cases route through `Window::create_plugin_terminal`
+        // so spawning into an inactive session reuses the same code
+        // path — no separate migration helper, no half-state leaks
+        // between windows.
+        let target_id = target_session_id
+            .filter(|id| self.windows.contains_key(id))
+            .unwrap_or(self.active_window);
+        let is_active_target = target_id == self.active_window;
 
-        // Set up async bridge for terminal manager — per-window
-        // bridge so terminal output flows back through the window
-        // that owns the PTY.
-        let __window_bridge = self.active_window().bridge.clone();
-        self.active_window_mut()
-            .terminal_manager
-            .set_async_bridge(__window_bridge);
+        let cwd_buf = cwd.map(std::path::PathBuf::from);
+        let split_direction = direction.as_deref().map(|d| match d {
+            "horizontal" => crate::model::event::SplitDirection::Horizontal,
+            _ => crate::model::event::SplitDirection::Vertical,
+        });
 
-        // Determine working directory
-        let working_dir = cwd
-            .map(std::path::PathBuf::from)
-            .unwrap_or_else(|| self.working_dir.clone());
-
-        // Prepare persistent storage paths
-        let terminal_root = self.dir_context.terminal_dir_for(&working_dir);
-        if let Err(e) = self.authority.filesystem.create_dir_all(&terminal_root) {
-            tracing::warn!("Failed to create terminal directory: {}", e);
-        }
-        let predicted_terminal_id = self.active_window().terminal_manager.next_terminal_id();
-        // Ephemeral terminals get a per-spawn suffix on their backing
-        // files so there is no possibility of picking up the scrollback
-        // that a previous run (with the same numeric terminal ID) wrote
-        // to `fresh-terminal-N.{txt,log}`. Persistent terminals keep
-        // the stable `fresh-terminal-N.*` name so workspace restore
-        // can still find them.
-        let name_stem = if persistent {
-            format!("fresh-terminal-{}", predicted_terminal_id.0)
+        // Capture the editor-active buffer before the spawn so we
+        // can detect whether `Window::create_plugin_terminal`'s
+        // per-window mutations also flipped the editor-active buffer
+        // (only possible when `is_active_target`). If it did, the
+        // `buffer_activated` plugin hook needs to fire here at the
+        // Editor level — the Window method only mutates per-window
+        // state.
+        let prev_active = if is_active_target {
+            Some(self.active_window().active_buffer())
         } else {
-            let nanos = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-            format!("fresh-terminal-eph-{}-{}", predicted_terminal_id.0, nanos)
+            None
         };
-        let log_path = terminal_root.join(format!("{}.log", name_stem));
-        let backing_path = terminal_root.join(format!("{}.txt", name_stem));
-        self.active_window_mut()
-            .terminal_backing_files
-            .insert(predicted_terminal_id, backing_path);
-        let backing_path_for_spawn = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.terminal_backing_files)
-            .expect("active window present")
-            .get(&predicted_terminal_id)
-            .cloned();
-        let wrapper_for_spawn = self.resolved_terminal_wrapper();
 
-        match self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.terminal_manager)
-            .expect("active window present")
-            .spawn(
-                cols,
-                rows,
-                Some(working_dir),
-                Some(log_path.clone()),
-                backing_path_for_spawn,
-                wrapper_for_spawn,
-            ) {
-            Ok(terminal_id) => {
-                // Track log file path
-                self.active_window_mut()
-                    .terminal_log_files
-                    .insert(terminal_id, log_path.clone());
-                // Register the spawned pty session leader pid
-                // with the active window's process-group tracker
-                // so window-level signal operations (Stop /
-                // Archive / Delete) can reach it.
-                let leader_pid = self
-                    .active_window()
-                    .terminal_manager
-                    .get(terminal_id)
-                    .and_then(|h| h.pid());
-                if let Some(pid) = leader_pid {
-                    let label = format!("terminal #{}", terminal_id.0);
-                    self.active_window_mut().process_groups.register(pid, label);
-                }
-                // Fix up backing path if the predicted ID didn't match
-                // the one the terminal manager handed out. Persistent
-                // terminals re-derive the stable `fresh-terminal-N.txt`
-                // name so the workspace restore path can find them;
-                // ephemeral terminals just keep the already-spawned
-                // file (it has a nanos-unique name either way) and
-                // rebind the HashMap key to the real ID.
-                if terminal_id != predicted_terminal_id {
-                    let existing = self
-                        .active_window_mut()
-                        .terminal_backing_files
-                        .remove(&predicted_terminal_id);
-                    let fixed_backing = if persistent {
-                        terminal_root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
-                    } else {
-                        existing.unwrap_or_else(|| terminal_root.join(format!("{}.txt", name_stem)))
-                    };
-                    self.active_window_mut()
-                        .terminal_backing_files
-                        .insert(terminal_id, fixed_backing);
-                }
-                if !persistent {
-                    self.active_window_mut()
-                        .ephemeral_terminals
-                        .insert(terminal_id);
-                }
-
-                // Pick buffer-attachment strategy based on whether the
-                // plugin asked for its own split:
-                //
-                // - direction = Some: use `_detached` so the buffer
-                //   isn't also added as a tab to the user's active
-                //   split. The new split below owns it exclusively,
-                //   so when the user closes that split the terminal
-                //   disappears entirely instead of leaving a ghost
-                //   tab behind in the main split.
-                // - direction = None: use `_attached` — the plugin
-                //   is intentionally placing the terminal as a new
-                //   tab in the active split, which is the whole
-                //   point of the no-split branch.
-                let active_split = self
-                    .windows
-                    .get(&self.active_window)
-                    .and_then(|w| w.buffers.splits())
-                    .map(|(mgr, _)| mgr)
-                    .expect("active window must have a populated split layout")
-                    .active_split();
-                let buffer_id = if direction.is_some() {
-                    self.create_terminal_buffer_detached(terminal_id)
-                } else {
-                    self.create_terminal_buffer_attached(terminal_id, active_split)
-                };
-
-                let created_split_id = if let Some(dir_str) = direction.as_deref() {
-                    let split_dir = match dir_str {
-                        "horizontal" => crate::model::event::SplitDirection::Horizontal,
-                        _ => crate::model::event::SplitDirection::Vertical,
-                    };
-
-                    let split_ratio = ratio.unwrap_or(0.5);
-                    match self
-                        .split_manager_mut()
-                        .split_active(split_dir, buffer_id, split_ratio)
-                    {
-                        Ok(new_split_id) => {
-                            let mut view_state = SplitViewState::with_buffer(
-                                self.terminal_width,
-                                self.terminal_height,
-                                buffer_id,
-                            );
-                            view_state.apply_config_defaults(
-                                self.config.editor.line_numbers,
-                                self.config.editor.highlight_current_line,
-                                false,
-                                false,
-                                None,
-                                self.config.editor.rulers.clone(),
-                            );
-                            // Terminal output is ANSI-sequenced and
-                            // assumes a fixed column count; wrapping
-                            // would mangle cursor positioning.
-                            view_state.viewport.line_wrap_enabled = false;
-                            self.windows
-                                .get_mut(&self.active_window)
-                                .and_then(|w| w.split_view_states_mut())
-                                .expect("active window must have a populated split layout")
-                                .insert(new_split_id, view_state);
-
-                            if focus.unwrap_or(true) {
-                                self.windows
-                                    .get_mut(&self.active_window)
-                                    .and_then(|w| w.split_manager_mut())
-                                    .expect("active window must have a populated split layout")
-                                    .set_active_split(new_split_id);
-                            }
-
-                            tracing::info!(
-                                "Created {:?} split for terminal {:?} with buffer {:?}",
-                                split_dir,
-                                terminal_id,
-                                buffer_id
-                            );
-                            Some(new_split_id)
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to create split for terminal: {}; \
-                                         falling back to active split",
-                                e
-                            );
-                            // The buffer was created detached. Split
-                            // creation failed, so attach it to the
-                            // active split as a graceful fallback
-                            // rather than leaving an orphan buffer.
-                            if let Some(view_state) = self
-                                .windows
-                                .get_mut(&self.active_window)
-                                .and_then(|w| w.split_view_states_mut())
-                                .expect("active window must have a populated split layout")
-                                .get_mut(&active_split)
-                            {
-                                view_state.add_buffer(buffer_id);
-                                view_state.viewport.line_wrap_enabled = false;
-                            }
-                            self.set_active_buffer(buffer_id);
-                            None
-                        }
+        let result = {
+            let target = self
+                .windows
+                .get_mut(&target_id)
+                .expect("target window present (existence checked above)");
+            target.create_plugin_terminal(
+                cwd_buf,
+                split_direction,
+                ratio,
+                focus.unwrap_or(true),
+                persistent,
+            )
+        };
+        match result {
+            Ok((terminal_id, buffer_id, created_split_id)) => {
+                if is_active_target {
+                    let new_active = self.active_window().active_buffer();
+                    if prev_active != Some(new_active) {
+                        #[cfg(feature = "plugins")]
+                        self.update_plugin_state_snapshot();
+                        #[cfg(feature = "plugins")]
+                        self.plugin_manager.read().unwrap().run_hook(
+                            "buffer_activated",
+                            crate::services::plugins::hooks::HookArgs::BufferActivated {
+                                buffer_id: new_active,
+                            },
+                        );
                     }
-                } else {
-                    // No split — just switch to the terminal buffer in the active split
-                    self.set_active_buffer(buffer_id);
-                    None
-                };
-
-                // Resize terminal to match actual split content area
-                self.active_window_mut().resize_visible_terminals();
-
-                // Resolve the callback with TerminalResult
-                let result = fresh_core::api::TerminalResult {
+                }
+                let api_result = fresh_core::api::TerminalResult {
                     buffer_id: buffer_id.0 as u64,
                     terminal_id: terminal_id.0 as u64,
                     split_id: created_split_id.map(|s| s.0 .0 as u64),
                 };
                 self.plugin_manager.read().unwrap().resolve_callback(
                     fresh_core::api::JsCallbackId::from(request_id),
-                    serde_json::to_string(&result).unwrap_or_default(),
+                    serde_json::to_string(&api_result).unwrap_or_default(),
                 );
-
                 tracing::info!(
-                    "Plugin created terminal {:?} with buffer {:?}",
+                    "Plugin created terminal {:?} with buffer {:?} in window {:?}",
                     terminal_id,
-                    buffer_id
-                );
-            }
-            Err(e) => {
-                tracing::error!("Failed to create terminal for plugin: {}", e);
-                self.plugin_manager.read().unwrap().reject_callback(
-                    fresh_core::api::JsCallbackId::from(request_id),
-                    format!("Failed to create terminal: {}", e),
-                );
-            }
-        }
-    }
-    /// Spawn a terminal whose buffer attaches to an *inactive*
-    /// session. The user's active editor view is undisturbed. The
-    /// terminal lands as a new tab in the target session's stashed
-    /// split tree, ready to be revealed on next dive.
-    ///
-    /// This bypasses split-direction / ratio / focus options
-    /// because the target session isn't active — there's nothing
-    /// to focus, and laying out a split in a stashed tree without
-    /// known dimensions is fragile. The active-path handler still
-    /// honours all those options when target == active session
-    /// (or window_id is omitted).
-    fn handle_create_terminal_in_inactive_session(
-        &mut self,
-        target: fresh_core::WindowId,
-        cwd: Option<String>,
-        persistent: bool,
-        request_id: u64,
-    ) {
-        let (cols, rows) = self.get_terminal_dimensions();
-        let __bridge_clone = self.async_bridge.clone();
-        if let Some(bridge) = __bridge_clone {
-            self.active_window_mut()
-                .terminal_manager
-                .set_async_bridge(bridge);
-        }
-
-        // Default cwd to the *target session's* root, not the
-        // active session's, so plugins that omit `cwd` get the
-        // expected behaviour ("spawn this agent in its worktree").
-        let working_dir = cwd.map(std::path::PathBuf::from).unwrap_or_else(|| {
-            self.windows
-                .get(&target)
-                .map(|s| s.root.clone())
-                .unwrap_or_else(|| self.working_dir.clone())
-        });
-
-        let terminal_root = self.dir_context.terminal_dir_for(&working_dir);
-        if let Err(e) = self.authority.filesystem.create_dir_all(&terminal_root) {
-            tracing::warn!("Failed to create terminal directory: {}", e);
-        }
-        let predicted_terminal_id = self.active_window().terminal_manager.next_terminal_id();
-        let name_stem = if persistent {
-            format!("fresh-terminal-{}", predicted_terminal_id.0)
-        } else {
-            let nanos = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-            format!("fresh-terminal-eph-{}-{}", predicted_terminal_id.0, nanos)
-        };
-        let log_path = terminal_root.join(format!("{}.log", name_stem));
-        let backing_path = terminal_root.join(format!("{}.txt", name_stem));
-        self.active_window_mut()
-            .terminal_backing_files
-            .insert(predicted_terminal_id, backing_path);
-        let backing_path_for_spawn = self
-            .active_window()
-            .terminal_backing_files
-            .get(&predicted_terminal_id)
-            .cloned();
-
-        let wrapper_for_spawn = self.resolved_terminal_wrapper();
-        let terminal_id = match self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.terminal_manager)
-            .expect("active window present")
-            .spawn(
-                cols,
-                rows,
-                Some(working_dir),
-                Some(log_path.clone()),
-                backing_path_for_spawn,
-                wrapper_for_spawn,
-            ) {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::error!("Failed to create terminal for inactive session: {}", e);
-                self.plugin_manager.read().unwrap().reject_callback(
-                    fresh_core::api::JsCallbackId::from(request_id),
-                    format!("Failed to create terminal: {}", e),
-                );
-                return;
-            }
-        };
-        self.active_window_mut()
-            .terminal_log_files
-            .insert(terminal_id, log_path.clone());
-        if terminal_id != predicted_terminal_id {
-            self.active_window_mut()
-                .terminal_backing_files
-                .remove(&predicted_terminal_id);
-            let backing_path = terminal_root.join(format!("fresh-terminal-{}.txt", terminal_id.0));
-            self.active_window_mut()
-                .terminal_backing_files
-                .insert(terminal_id, backing_path);
-        }
-        if !persistent {
-            self.active_window_mut()
-                .ephemeral_terminals
-                .insert(terminal_id);
-        }
-
-        // Allocate a buffer for the terminal in editor-global
-        // storage but attach it to the *target* session's
-        // membership instead of the active session's.
-        let buffer_id = self.create_terminal_buffer_detached(terminal_id);
-        if let Some(state) = self.detach_buffer_from_all_windows(buffer_id) {
-            if let Some(s) = self.windows.get_mut(&target) {
-                s.buffers.insert(buffer_id, state);
-            }
-        }
-        // Register the spawned pty session leader pid with the
-        // *target* window's process-group tracker. The terminal
-        // logically belongs to that session, so window-level
-        // lifecycle ops (Stop / Archive / Delete) on the target
-        // need to reach this pid even though the terminal_manager
-        // lives on the active window.
-        let leader_pid = self
-            .active_window()
-            .terminal_manager
-            .get(terminal_id)
-            .and_then(|h| h.pid());
-        if let Some(pid) = leader_pid {
-            let label = format!("terminal #{}", terminal_id.0);
-            if let Some(target_window) = self.windows.get_mut(&target) {
-                target_window.process_groups.register(pid, label);
-            }
-        }
-
-        // Mutate the target session's stashed split tree to add
-        // the terminal as a new horizontal split off its current
-        // active leaf. If the session has no stash yet (never
-        // dived into), we seed one rooted at the terminal buffer.
-        let target_session = self.windows.get_mut(&target);
-        let new_split_id = if let Some(session) = target_session {
-            if let Some((mgr, view_states)) = session.buffers.splits_mut() {
-                let split_dir = crate::model::event::SplitDirection::Horizontal;
-                match mgr.split_active(split_dir, buffer_id, 0.5) {
-                    Ok(new_split_id) => {
-                        let mut view_state = SplitViewState::with_buffer(
-                            self.terminal_width,
-                            self.terminal_height,
-                            buffer_id,
-                        );
-                        view_state.viewport.line_wrap_enabled = false;
-                        view_states.insert(new_split_id, view_state);
-                        Some(new_split_id)
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to split target session's tree for terminal: {}; \
-                             buffer is attached to the session but not visible in any leaf",
-                            e
-                        );
-                        None
-                    }
-                }
-            } else {
-                // Never-activated session: seed its splits stash
-                // rooted at the terminal. First dive will pick up
-                // this layout and the terminal is the active leaf.
-                let manager = crate::view::split::SplitManager::new(buffer_id);
-                let active_leaf = manager.active_split();
-                let mut view_states = std::collections::HashMap::new();
-                let mut vs = SplitViewState::with_buffer(
-                    self.terminal_width,
-                    self.terminal_height,
                     buffer_id,
+                    target_id
                 );
-                vs.viewport.line_wrap_enabled = false;
-                view_states.insert(active_leaf, vs);
-                session.buffers.set_splits((manager, view_states));
-                Some(active_leaf.into())
             }
-        } else {
-            None
-        };
-
-        let result = fresh_core::api::TerminalResult {
-            buffer_id: buffer_id.0 as u64,
-            terminal_id: terminal_id.0 as u64,
-            split_id: new_split_id.map(|s| s.0 .0 as u64),
-        };
-        self.plugin_manager.read().unwrap().resolve_callback(
-            fresh_core::api::JsCallbackId::from(request_id),
-            serde_json::to_string(&result).unwrap(),
-        );
+            Err(e) => {
+                tracing::error!("Failed to create terminal for plugin: {e}");
+                self.plugin_manager.read().unwrap().reject_callback(
+                    fresh_core::api::JsCallbackId::from(request_id),
+                    format!("Failed to create terminal: {e}"),
+                );
+            }
+        }
     }
 
     // ==================== Extracted handlers for previously inline match arms ====================

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -1077,11 +1077,11 @@ impl Editor {
         self.active_window_mut().prompt.as_mut()
     }
 
-    /// Set a status message to display in the status bar
+    /// Set a status message to display in the active window's status
+    /// bar. Editor-side thin wrapper; per-window body lives in
+    /// `Window::set_status_message`.
     pub fn set_status_message(&mut self, message: String) {
-        tracing::info!(target: "status", "{}", message);
-        self.active_window_mut().plugin_status_message = None;
-        self.active_window_mut().status_message = Some(message);
+        self.active_window_mut().set_status_message(message);
     }
 
     /// Get the current status message

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3423,7 +3423,32 @@ impl Editor {
                 None => return,
             };
         let theme = self.theme.read().unwrap().clone();
-        let overlay_rect = Self::centered_overlay_rect(area, width_pct, height_pct);
+        // Compute the requested rect from width%/height%, then
+        // shrink the height to fit the rendered content (Bug 7).
+        // Plugins call `mount({widthPct, heightPct})` mostly because
+        // they don't know how tall their content is up front; the
+        // requested height should act as a *max*, not a fixed
+        // canvas. Without this shrink, the new-session form's 10
+        // content rows leave ~20 blank rows under "Tab next  S-Tab
+        // prev  Enter submit  Esc cancel" inside a 90%-of-screen
+        // panel.
+        //
+        // Entries include every row the spec produces — including
+        // WindowEmbed reservations (each `windowEmbed({rows: N})`
+        // contributes N blank entries plus an EmbedRect that paints
+        // over them at draw time). So `entries.len() + 2` (top
+        // border + content + bottom border) is the natural fit.
+        let overlay_rect = {
+            let requested = Self::centered_overlay_rect(area, width_pct, height_pct);
+            let needed_h = (entries.len() as u16).saturating_add(2);
+            let effective_h = needed_h.min(requested.height).max(3);
+            ratatui::layout::Rect {
+                x: requested.x,
+                y: area.y + (area.height.saturating_sub(effective_h)) / 2,
+                width: requested.width,
+                height: effective_h,
+            }
+        };
 
         crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
         frame.render_widget(Clear, overlay_rect);

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1926,19 +1926,29 @@ impl Editor {
             .get(&sid)
             .map(|s| s.buffers.ids())
             .unwrap_or_default();
+        // Pre-refactor this loop looked at `self.active_window()`'s
+        // terminal_buffers / backing_files / terminal_manager.
+        // That happened to work back when orchestrator-spawned
+        // terminals leaked half their state onto the active window
+        // (Bug A); now that each terminal lives entirely on the
+        // window that owns it, the lookups have to target `sid`
+        // (the previewed window).
         for bid in preview_buffers {
-            let Some(&terminal_id) = self.active_window().terminal_buffers.get(&bid) else {
+            let preview_win = match self.windows.get(&sid) {
+                Some(w) => w,
+                None => break,
+            };
+            let Some(&terminal_id) = preview_win.terminal_buffers.get(&bid) else {
                 continue;
             };
-            let Some(backing_file) = self
-                .active_window()
+            let Some(backing_file) = preview_win
                 .terminal_backing_files
                 .get(&terminal_id)
                 .cloned()
             else {
                 continue;
             };
-            if let Some(handle) = self.active_window().terminal_manager.get(terminal_id) {
+            if let Some(handle) = preview_win.terminal_manager.get(terminal_id) {
                 if let Ok(mut state) = handle.state.lock() {
                     if let Ok(metadata) = self.authority.filesystem.metadata(&backing_file) {
                         state.set_backing_file_history_end(metadata.size);
@@ -1978,6 +1988,14 @@ impl Editor {
                     *state = new_state;
                     state.buffer.set_modified(false);
                     state.editing_disabled = true;
+                    // Terminal buffers must never show a line-number
+                    // gutter; reloading from the backing file lost
+                    // the margin configuration that
+                    // `Window::create_terminal_buffer_attached` set
+                    // at creation time. Re-apply it here so the
+                    // preview pane matches the live editor view of
+                    // the same terminal (Bug 5).
+                    state.margins.configure_for_line_numbers(false);
                 }
             }
         }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1948,11 +1948,24 @@ impl Editor {
             else {
                 continue;
             };
+            // Capture the file size *before* appending the visible
+            // screen so we can truncate back to it afterwards. The
+            // append makes the live screen visible in the previewed
+            // buffer; the truncate keeps the file from growing on
+            // every preview-render frame. Without this, opening the
+            // picker against a session with a few lines on screen
+            // grew the backing file by `screen_height` bytes per
+            // frame — visible to the user as the same banner
+            // repeating dozens of times when they later dived in.
+            let pre_append_size = self
+                .authority
+                .filesystem
+                .metadata(&backing_file)
+                .map(|m| m.size)
+                .unwrap_or(0);
             if let Some(handle) = preview_win.terminal_manager.get(terminal_id) {
                 if let Ok(mut state) = handle.state.lock() {
-                    if let Ok(metadata) = self.authority.filesystem.metadata(&backing_file) {
-                        state.set_backing_file_history_end(metadata.size);
-                    }
+                    state.set_backing_file_history_end(pre_append_size);
                     if let Ok(mut file) = self
                         .authority
                         .filesystem
@@ -1997,6 +2010,34 @@ impl Editor {
                     // the same terminal (Bug 5).
                     state.margins.configure_for_line_numbers(false);
                 }
+            }
+            // Truncate the file back to its pre-append size so the
+            // next preview frame starts from the same baseline as
+            // this one. Without truncation the file grows by one
+            // visible-screen-worth of bytes on every render and the
+            // user sees the same banner repeated N times when they
+            // later dive into the session (Finding J).
+            //
+            // The in-memory `EditorState` keeps the appended view so
+            // the preview pane has something to paint — `SplitRenderer`
+            // below renders the buffer's state directly into the
+            // embed rect, and resetting state to match the truncated
+            // file would leave the preview blank for any
+            // hasn't-scrolled-yet terminal. The "live editor view
+            // when the user dives in" path uses `render_terminal_splits`
+            // which overlays the live PTY grid on top of the buffer,
+            // so the slightly-stale appended content the state
+            // carries is irrelevant there.
+            if let Err(e) = self
+                .authority
+                .filesystem
+                .set_file_length(&backing_file, pre_append_size)
+            {
+                tracing::error!(
+                    "preview: failed to truncate backing file {} back to {} bytes: {e}",
+                    backing_file.display(),
+                    pre_append_size,
+                );
             }
         }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -854,8 +854,10 @@ impl Editor {
             __vp_win.previous_viewports.insert(split_id, vp);
         }
 
-        // Render terminal content on top of split content for terminal buffers
-        self.render_terminal_splits(frame, &split_areas);
+        // Render terminal content on top of split content for terminal buffers.
+        // Active-window path: cursor blinks normally when terminal_mode is on.
+        self.active_window()
+            .render_terminal_splits(frame, &split_areas, true);
 
         self.active_layout_mut().split_areas = split_areas;
         self.active_layout_mut().horizontal_scrollbar_areas = horizontal_scrollbar_areas;
@@ -1912,134 +1914,22 @@ impl Editor {
             return;
         };
 
-        // Terminal grid → buffer text sync, preview-safe variant.
-        // `sync_terminal_to_buffer` is the canonical sync but it
-        // also mutates `self.split_view_states[active_split]` —
-        // which during preview is the *active* (caller) session's
-        // view-state, not the previewed one. That corrupts the
-        // active session's viewport (cursor jumps past EOF, top
-        // line becomes blank). Here we do just the parts that are
-        // safe to run from a foreign session: append visible
-        // screen to backing file, then reload that one buffer.
-        let preview_buffers: Vec<fresh_core::BufferId> = self
-            .windows
-            .get(&sid)
-            .map(|s| s.buffers.ids())
-            .unwrap_or_default();
-        // Pre-refactor this loop looked at `self.active_window()`'s
-        // terminal_buffers / backing_files / terminal_manager.
-        // That happened to work back when orchestrator-spawned
-        // terminals leaked half their state onto the active window
-        // (Bug A); now that each terminal lives entirely on the
-        // window that owns it, the lookups have to target `sid`
-        // (the previewed window).
-        for bid in preview_buffers {
-            let preview_win = match self.windows.get(&sid) {
-                Some(w) => w,
-                None => break,
-            };
-            let Some(&terminal_id) = preview_win.terminal_buffers.get(&bid) else {
-                continue;
-            };
-            let Some(backing_file) = preview_win
-                .terminal_backing_files
-                .get(&terminal_id)
-                .cloned()
-            else {
-                continue;
-            };
-            // Capture the file size *before* appending the visible
-            // screen so we can truncate back to it afterwards. The
-            // append makes the live screen visible in the previewed
-            // buffer; the truncate keeps the file from growing on
-            // every preview-render frame. Without this, opening the
-            // picker against a session with a few lines on screen
-            // grew the backing file by `screen_height` bytes per
-            // frame — visible to the user as the same banner
-            // repeating dozens of times when they later dived in.
-            let pre_append_size = self
-                .authority
-                .filesystem
-                .metadata(&backing_file)
-                .map(|m| m.size)
-                .unwrap_or(0);
-            if let Some(handle) = preview_win.terminal_manager.get(terminal_id) {
-                if let Ok(mut state) = handle.state.lock() {
-                    state.set_backing_file_history_end(pre_append_size);
-                    if let Ok(mut file) = self
-                        .authority
-                        .filesystem
-                        .open_file_for_append(&backing_file)
-                    {
-                        use std::io::BufWriter;
-                        let mut writer = BufWriter::new(&mut *file);
-                        if let Err(e) = state.append_visible_screen(&mut writer) {
-                            tracing::error!(
-                                "preview: failed to append visible screen for terminal buffer {bid:?}: {e}"
-                            );
-                        }
-                    }
-                }
-            }
-            let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-            if let Ok(new_state) = crate::state::EditorState::from_file_with_languages(
-                &backing_file,
-                self.terminal_width,
-                self.terminal_height,
-                large_file_threshold,
-                &self.grammar_registry,
-                &self.config.languages,
-                std::sync::Arc::clone(&self.authority.filesystem),
-            ) {
-                if let Some(state) = self
-                    .windows
-                    .get_mut(&sid)
-                    .map(|w| &mut w.buffers)
-                    .expect("preview window present")
-                    .get_mut(&bid)
-                {
-                    *state = new_state;
-                    state.buffer.set_modified(false);
-                    state.editing_disabled = true;
-                    // Terminal buffers must never show a line-number
-                    // gutter; reloading from the backing file lost
-                    // the margin configuration that
-                    // `Window::create_terminal_buffer_attached` set
-                    // at creation time. Re-apply it here so the
-                    // preview pane matches the live editor view of
-                    // the same terminal (Bug 5).
-                    state.margins.configure_for_line_numbers(false);
-                }
-            }
-            // Truncate the file back to its pre-append size so the
-            // next preview frame starts from the same baseline as
-            // this one. Without truncation the file grows by one
-            // visible-screen-worth of bytes on every render and the
-            // user sees the same banner repeated N times when they
-            // later dive into the session (Finding J).
-            //
-            // The in-memory `EditorState` keeps the appended view so
-            // the preview pane has something to paint — `SplitRenderer`
-            // below renders the buffer's state directly into the
-            // embed rect, and resetting state to match the truncated
-            // file would leave the preview blank for any
-            // hasn't-scrolled-yet terminal. The "live editor view
-            // when the user dives in" path uses `render_terminal_splits`
-            // which overlays the live PTY grid on top of the buffer,
-            // so the slightly-stale appended content the state
-            // carries is irrelevant there.
-            if let Err(e) = self
-                .authority
-                .filesystem
-                .set_file_length(&backing_file, pre_append_size)
-            {
-                tracing::error!(
-                    "preview: failed to truncate backing file {} back to {} bytes: {e}",
-                    backing_file.display(),
-                    pre_append_size,
-                );
-            }
-        }
+        // Terminal grid → buffer text "sync" was previously a
+        // multi-step append/reload/truncate dance that mutated the
+        // backing file on every preview-render frame just to make
+        // the live screen visible inside the embed. That worked
+        // around `render_terminal_splits` being hard-coded to the
+        // active window's `terminal_buffers` map — during preview
+        // the active window is the *caller's* session, so the
+        // overlay couldn't find the previewed terminal.
+        //
+        // `render_terminal_splits` is now an `impl Window` method,
+        // so the preview path can ask the previewed window
+        // directly. The overlay paints the live PTY grid (with
+        // colors, attributes, no cursor) on top of `SplitRenderer`'s
+        // text rendering for every terminal buffer in the embed —
+        // no file mutation, no reload, no truncate. The buffer's
+        // backing file stays untouched between frames.
 
         // Pull the previewed window's split stash and sub-fields
         // out under one `&mut Window` borrow. Multiple disjoint
@@ -2075,10 +1965,18 @@ impl Editor {
             crate::view::split::SplitNode,
         > = std::collections::HashMap::new();
 
+        let mut preview_split_areas: Vec<(
+            crate::model::event::LeafId,
+            fresh_core::BufferId,
+            ratatui::layout::Rect,
+            ratatui::layout::Rect,
+            usize,
+            usize,
+        )> = Vec::new();
         __win_for_preview
             .buffers
             .with_all_mut(|preview_buffers, mgr, view_states| {
-                let _ = crate::view::ui::SplitRenderer::render_content(
+                let result = crate::view::ui::SplitRenderer::render_content(
                     frame,
                     inner,
                     &*mgr,
@@ -2118,7 +2016,18 @@ impl Editor {
                     inner.width,
                     &mut scratch_pending_cursor,
                 );
+                preview_split_areas = result.0;
             });
+
+        // Overlay live PTY grids for terminal buffers in the
+        // previewed window's splits — paints colors, attributes,
+        // and the visible screen on top of `SplitRenderer`'s text
+        // rendering. `cursor_visible_if_active = false` keeps the
+        // preview read-only: no blinking cursor over a session
+        // the user isn't currently driving.
+        if let Some(win) = self.windows.get(&sid) {
+            win.render_terminal_splits(frame, &preview_split_areas, false);
+        }
     }
 
     fn prepare_overlay_preview(&mut self) {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2019,6 +2019,29 @@ impl Editor {
                 preview_split_areas = result.0;
             });
 
+        // Resize the previewed window's terminal PTYs to fit the
+        // preview embed before painting their grids. Without this,
+        // the PTY child (e.g. `top`, `htop`, `vim`, claude) keeps
+        // drawing at the dimensions it had when last active — often
+        // the full terminal height — so the preview embed only
+        // shows the top slice of a much taller frame. Resizing
+        // SIGWINCHes the PTY, which redraws at the new size, and
+        // the next render frame paints the correctly-sized grid.
+        // When the user dives into the session,
+        // `Window::resize_visible_terminals` will resize back up to
+        // the dive view's split rect.
+        if let Some(win) = self.windows.get_mut(&sid) {
+            for (_split_id, buffer_id, content_rect, _scrollbar_rect, _, _) in &preview_split_areas
+            {
+                if win.terminal_buffers.contains_key(buffer_id)
+                    && content_rect.width > 0
+                    && content_rect.height > 0
+                {
+                    win.resize_terminal(*buffer_id, content_rect.width, content_rect.height);
+                }
+            }
+        }
+
         // Overlay live PTY grids for terminal buffers in the
         // previewed window's splits — paints colors, attributes,
         // and the visible screen on top of `SplitRenderer`'s text

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -79,6 +79,7 @@ impl Window {
         &mut self,
         cwd: Option<PathBuf>,
         persistent: bool,
+        command_override: Option<Vec<String>>,
     ) -> Option<TerminalId> {
         let (cols, rows) = self.get_terminal_dimensions();
 
@@ -121,7 +122,24 @@ impl Window {
         self.terminal_backing_files
             .insert(predicted_terminal_id, backing_path.clone());
 
-        let wrapper = self.resolved_terminal_wrapper();
+        // When the caller supplies an explicit argv, build a wrapper
+        // that runs it directly instead of the authority's shell. We
+        // keep `manages_cwd: false` so the PTY's cwd is honoured by
+        // the spawn (the authority's `manages_cwd` flag only applies
+        // when the wrapper itself re-roots cwd, like the docker /
+        // ssh paths). Empty argv falls back to the shell — there's
+        // nothing for the host to run.
+        let wrapper = match command_override {
+            Some(argv) if !argv.is_empty() => {
+                let (command, args) = argv.split_first().expect("non-empty argv");
+                crate::services::authority::TerminalWrapper {
+                    command: command.clone(),
+                    args: args.to_vec(),
+                    manages_cwd: false,
+                }
+            }
+            _ => self.resolved_terminal_wrapper(),
+        };
         match self.terminal_manager.spawn(
             cols,
             rows,
@@ -262,9 +280,26 @@ impl Window {
         ratio: Option<f32>,
         focus: bool,
         persistent: bool,
+        command: Option<Vec<String>>,
+        title: Option<String>,
     ) -> Result<(TerminalId, BufferId, Option<LeafId>), String> {
+        // Derive the auto-title from the command's executable name
+        // (basename of argv[0]). The host writes this into the
+        // terminal buffer's `BufferMetadata::name` so the tab reads
+        // e.g. "python3" instead of "*Terminal N*" when the plugin
+        // runs python3 directly. Explicit `title` overrides.
+        let auto_title = command.as_ref().and_then(|argv| {
+            argv.first().map(|cmd| {
+                std::path::Path::new(cmd)
+                    .file_name()
+                    .and_then(|os| os.to_str())
+                    .unwrap_or(cmd.as_str())
+                    .to_string()
+            })
+        });
+        let resolved_title = title.or(auto_title);
         let terminal_id = self
-            .spawn_terminal_session(cwd, persistent)
+            .spawn_terminal_session(cwd, persistent, command)
             .ok_or_else(|| "Failed to spawn terminal".to_string())?;
 
         // Register the leader pid with this window's process_groups
@@ -397,8 +432,57 @@ impl Window {
             }
         };
 
+        // Override the auto-generated `*Terminal N*` display name
+        // when the plugin requested an explicit title (or one was
+        // derived from `command[0]`). Disambiguates against other
+        // terminals in this window using a `name (k)` suffix so two
+        // simultaneous python3 sessions read as "python3" and
+        // "python3 (2)" instead of colliding.
+        if let Some(title) = resolved_title {
+            let final_name = self.disambiguate_terminal_title(&title, buffer_id);
+            if let Some(meta) = self.buffer_metadata.get_mut(&buffer_id) {
+                meta.display_name = final_name;
+            }
+        }
+
         self.resize_visible_terminals();
         Ok((terminal_id, buffer_id, created_split_id))
+    }
+
+    /// Pick the next free `name (k)` variant of `desired` for this
+    /// window's set of terminal buffers. `for_buffer` is the
+    /// freshly-created buffer being titled — its own metadata is
+    /// excluded from the scan so we don't collide with ourselves
+    /// when callers pre-set it.
+    ///
+    /// Returns `desired` verbatim when no collision exists, otherwise
+    /// `desired (2)`, `desired (3)`, … as needed.
+    fn disambiguate_terminal_title(&self, desired: &str, for_buffer: BufferId) -> String {
+        // Collect existing terminal-buffer display names that share
+        // the desired prefix. Only inspect buffers that are actually
+        // terminals — non-terminal buffers happen to use the same
+        // metadata map but their names don't collide semantically.
+        let used: std::collections::HashSet<&str> = self
+            .terminal_buffers
+            .keys()
+            .filter(|bid| **bid != for_buffer)
+            .filter_map(|bid| self.buffer_metadata.get(bid).map(|m| m.display_name.as_str()))
+            .collect();
+        if !used.contains(desired) {
+            return desired.to_string();
+        }
+        // Linear scan from k=2 upward. Two simultaneous duplicates is
+        // already rare; ten is unheard of, so the loop bound is fine.
+        for k in 2..=1024 {
+            let candidate = format!("{} ({})", desired, k);
+            if !used.contains(candidate.as_str()) {
+                return candidate;
+            }
+        }
+        // Fall back to `desired (∞)` if for some reason 1024 names
+        // are taken — still unique because the loop exhausted the
+        // numeric variants we considered. Practically unreachable.
+        format!("{} (n)", desired)
     }
 
     /// Open a new terminal in this window: spawn the PTY, create
@@ -413,7 +497,10 @@ impl Window {
     /// editor-active one. See `Editor::open_terminal` for the
     /// active-window wrapper that does both.
     pub fn open_terminal_in_window(&mut self) -> Option<(TerminalId, BufferId)> {
-        let terminal_id = self.spawn_terminal_session(None, true)?;
+        // `None` command override — `Open Terminal` always spawns the
+        // user's shell, never a one-off command. Plugin-driven
+        // terminals route through `create_plugin_terminal` instead.
+        let terminal_id = self.spawn_terminal_session(None, true, None)?;
         let split_id = self
             .buffers
             .splits()
@@ -499,8 +586,9 @@ impl Editor {
     /// be seeded with the terminal directly rather than with a
     /// placeholder buffer that would linger as a phantom tab).
     pub(crate) fn spawn_terminal_session(&mut self) -> Option<TerminalId> {
+        // No command override — see comment on `Window::open_terminal_in_window`.
         self.active_window_mut()
-            .spawn_terminal_session(None, true)
+            .spawn_terminal_session(None, true, None)
     }
 
     /// Open a new terminal in the active window's current split, fire

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1069,6 +1069,82 @@ impl Window {
             .active_split();
         self.enter_terminal_scrollback_view(buffer_id, active_split);
     }
+
+    /// Render terminal content for terminal buffers in this window's
+    /// split areas. Overlays the live PTY grid (colors, attributes,
+    /// optional cursor) on top of the buffer's regular text content
+    /// inside `content_rect`.
+    ///
+    /// `cursor_visible_if_active` controls whether the cursor is
+    /// painted at all. The active-window render passes `true` so a
+    /// focused terminal in `terminal_mode` blinks normally; the
+    /// preview path passes `false` so the picker preview stays
+    /// read-only.
+    ///
+    /// Window-local in every respect — reads `terminal_buffers`,
+    /// `terminal_manager`, `terminal_mode`, `active_buffer()`, and
+    /// `resources.theme` from `self`. The caller picks the window
+    /// (active vs previewed); this method never reaches back to an
+    /// `Editor` or to any other window.
+    pub fn render_terminal_splits(
+        &self,
+        frame: &mut ratatui::Frame,
+        split_areas: &[(
+            crate::model::event::LeafId,
+            BufferId,
+            ratatui::layout::Rect,
+            ratatui::layout::Rect,
+            usize,
+            usize,
+        )],
+        cursor_visible_if_active: bool,
+    ) {
+        for (_split_id, buffer_id, content_rect, _scrollbar_rect, _thumb_start, _thumb_end) in
+            split_areas
+        {
+            let Some(&terminal_id) = self.terminal_buffers.get(buffer_id) else {
+                continue;
+            };
+            // When the user's current tab is a terminal but they're
+            // *not* in terminal mode, the buffer is showing the
+            // synced scrollback view — defer to the normal text
+            // rendering so the user can scroll. The live grid only
+            // overlays when terminal mode is active, or when the
+            // tab isn't the active one (so a split's hidden tab
+            // still gets live updates).
+            let is_active = *buffer_id == self.active_buffer();
+            if is_active && !self.terminal_mode {
+                continue;
+            }
+            let Some(handle) = self.terminal_manager.get(terminal_id) else {
+                continue;
+            };
+            let Ok(state) = handle.state.lock() else {
+                continue;
+            };
+            let cursor_pos = state.cursor_position();
+            let cursor_visible = state.cursor_visible()
+                && is_active
+                && self.terminal_mode
+                && cursor_visible_if_active;
+            let (_, rows) = state.size();
+            let mut content = Vec::with_capacity(rows as usize);
+            for row in 0..rows {
+                content.push(state.get_line(row));
+            }
+            frame.render_widget(ratatui::widgets::Clear, *content_rect);
+            let theme = self.resources.theme.read().unwrap();
+            render::render_terminal_content(
+                &content,
+                cursor_pos,
+                cursor_visible,
+                *content_rect,
+                frame.buffer_mut(),
+                theme.terminal_fg,
+                theme.terminal_bg,
+            );
+        }
+    }
 }
 
 impl Editor {
@@ -1161,70 +1237,11 @@ impl Editor {
             })
     }
 
-    /// Render terminal content for all terminal buffers in split areas
-    ///
-    /// Renders all visible terminal buffers from their live terminal state.
-    /// This ensures terminals continue updating even when not focused, as long
-    /// as they remain visible in a split.
-    pub fn render_terminal_splits(
-        &self,
-        frame: &mut ratatui::Frame,
-        split_areas: &[(
-            crate::model::event::LeafId,
-            BufferId,
-            ratatui::layout::Rect,
-            ratatui::layout::Rect,
-            usize,
-            usize,
-        )],
-    ) {
-        for (_split_id, buffer_id, content_rect, _scrollbar_rect, _thumb_start, _thumb_end) in
-            split_areas
-        {
-            // Only render terminal buffers - skip regular file buffers
-            if let Some(&terminal_id) = self.active_window().terminal_buffers.get(buffer_id) {
-                // Only render from live terminal state if in terminal mode OR if not the active buffer
-                // (when it's the active buffer but not in terminal mode, we're in read-only scrollback mode
-                // and should show the synced buffer content instead)
-                let is_active = *buffer_id == self.active_buffer();
-                if is_active && !self.active_window().terminal_mode {
-                    // Active buffer in read-only mode - let normal buffer rendering handle it
-                    continue;
-                }
-                // Get terminal content and cursor info
-                if let Some(handle) = self.active_window().terminal_manager.get(terminal_id) {
-                    if let Ok(state) = handle.state.lock() {
-                        let cursor_pos = state.cursor_position();
-                        // Only show cursor for the active terminal in terminal mode
-                        let cursor_visible = state.cursor_visible()
-                            && is_active
-                            && self.active_window().terminal_mode;
-                        let (_, rows) = state.size();
-
-                        // Collect content
-                        let mut content = Vec::with_capacity(rows as usize);
-                        for row in 0..rows {
-                            content.push(state.get_line(row));
-                        }
-
-                        // Clear the content area first
-                        frame.render_widget(ratatui::widgets::Clear, *content_rect);
-
-                        // Render terminal content with theme colors
-                        render::render_terminal_content(
-                            &content,
-                            cursor_pos,
-                            cursor_visible,
-                            *content_rect,
-                            frame.buffer_mut(),
-                            self.theme.read().unwrap().terminal_fg,
-                            self.theme.read().unwrap().terminal_bg,
-                        );
-                    }
-                }
-            }
-        }
-    }
+    // `render_terminal_splits` moved to `impl Window`. Active-window
+    // callers reach it via `self.active_window().render_terminal_splits(...)`;
+    // the picker preview path reaches it via the previewed window
+    // directly, so the live PTY grid renders into the preview embed
+    // without going through the active-window state.
 }
 
 /// Terminal rendering utilities

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -25,112 +25,127 @@
 
 use super::window::Window;
 use super::{BufferId, BufferMetadata, Editor};
+use crate::model::event::LeafId;
 use crate::services::authority::TerminalWrapper;
 use crate::services::terminal::TerminalId;
 use crate::state::EditorState;
+use crate::view::split::SplitViewState;
 use rust_i18n::t;
+use std::path::PathBuf;
 
-impl Editor {
+impl Window {
     /// Resolve the terminal wrapper used to spawn a new integrated
-    /// terminal, applying the `terminal.shell` config override on top of
-    /// the authority's wrapper when appropriate.
+    /// terminal in this window, applying the `terminal.shell` config
+    /// override on top of the authority's wrapper when appropriate.
     ///
     /// See `TerminalWrapper::with_user_shell_override` for the override
-    /// rules; this is just the Editor-side wiring that supplies the
+    /// rules; this is just the per-window wiring that supplies the
     /// active config.
     pub(crate) fn resolved_terminal_wrapper(&self) -> TerminalWrapper {
-        self.authority
+        self.resources
+            .authority
             .terminal_wrapper
             .clone()
-            .with_user_shell_override(self.config.terminal.shell.as_ref())
+            .with_user_shell_override(self.resources.config.terminal.shell.as_ref())
     }
 
-    /// Spawn a new PTY-backed terminal session and record its
-    /// log/backing files. Returns the terminal id on success — does
-    /// **not** create a buffer or attach to any split. Callers are
-    /// responsible for the rest of the wiring (creating the terminal
-    /// buffer via `create_terminal_buffer_attached` /
-    /// `create_terminal_buffer_detached`, switching active buffer,
-    /// flipping terminal mode, etc.).
+    /// Get terminal dimensions appropriate for spawning a PTY in this
+    /// window. Derived from the window's cached screen size minus a
+    /// small constant for menu/status chrome.
+    pub(crate) fn get_terminal_dimensions(&self) -> (u16, u16) {
+        let cols = self.terminal_width.saturating_sub(2).max(40);
+        let rows = self.terminal_height.saturating_sub(4).max(10);
+        (cols, rows)
+    }
+
+    /// Spawn a new PTY-backed terminal session in this window and
+    /// record its log/backing files. Returns the terminal id on
+    /// success — does **not** create a buffer or attach to any
+    /// split. Callers are responsible for the rest of the wiring
+    /// (see `create_terminal_buffer_attached` /
+    /// `create_terminal_buffer_detached`).
     ///
-    /// Used by `open_terminal` (regular spawn into the active split)
-    /// and by `Action::OpenTerminalInDock` (which needs the buffer
-    /// id *before* it has a split to attach to, so the dock leaf can
-    /// be seeded with the terminal directly rather than with a
-    /// placeholder buffer that would linger as a phantom tab).
-    pub(crate) fn spawn_terminal_session(&mut self) -> Option<TerminalId> {
-        // Get the current split dimensions for the terminal size.
-        // For dock-creation callers the dock doesn't exist yet, so
-        // these dimensions are an initial guess — `resize_visible_terminals`
-        // (called after attach) will correct it once the dock split
-        // has actual rect dimensions.
+    /// `cwd` defaults to this window's `root` when None. `persistent`
+    /// controls whether the backing files use stable names
+    /// (`fresh-terminal-N.{log,txt}`) so workspace restore can find
+    /// them, or per-spawn ephemeral suffixes
+    /// (`fresh-terminal-eph-N-<ts>.{log,txt}`); non-persistent
+    /// terminals are also added to `ephemeral_terminals` so the
+    /// workspace serialiser skips them.
+    ///
+    /// On spawn failure the error is logged and a status message is
+    /// set on this window; the caller gets `None` back.
+    pub fn spawn_terminal_session(
+        &mut self,
+        cwd: Option<PathBuf>,
+        persistent: bool,
+    ) -> Option<TerminalId> {
         let (cols, rows) = self.get_terminal_dimensions();
 
-        // Set up async bridge for terminal manager if not already done.
-        // Use the window's per-window bridge (terminals are per-window),
-        // not the editor-global bridge — terminal output then arrives
-        // on the window's channel and is drained per-window.
-        let __window_bridge = self.active_window().bridge.clone();
-        self.active_window_mut()
-            .terminal_manager
-            .set_async_bridge(__window_bridge);
+        // Per-window async bridge — terminal output flows back through
+        // the window that owns the PTY.
+        let bridge = self.bridge.clone();
+        self.terminal_manager.set_async_bridge(bridge);
 
-        // Prepare persistent storage paths under the user's data directory
-        let terminal_root = self.dir_context.terminal_dir_for(&self.working_dir);
-        if let Err(e) = self.authority.filesystem.create_dir_all(&terminal_root) {
+        let working_dir = cwd.unwrap_or_else(|| self.root.clone());
+        let terminal_root = self
+            .resources
+            .dir_context
+            .terminal_dir_for(&working_dir);
+        if let Err(e) = self
+            .resources
+            .authority
+            .filesystem
+            .create_dir_all(&terminal_root)
+        {
             tracing::warn!("Failed to create terminal directory: {}", e);
         }
-        // Precompute paths using the next terminal ID so we capture from the first byte
-        let predicted_terminal_id = self.active_window().terminal_manager.next_terminal_id();
-        let log_path =
-            terminal_root.join(format!("fresh-terminal-{}.log", predicted_terminal_id.0));
-        let backing_path =
-            terminal_root.join(format!("fresh-terminal-{}.txt", predicted_terminal_id.0));
-        // Stash backing path now so buffer creation can reuse it
-        self.active_window_mut()
-            .terminal_backing_files
-            .insert(predicted_terminal_id, backing_path);
 
-        // Spawn terminal with incremental scrollback streaming.
-        // Pre-extract everything self-borrowing before grabbing the
-        // mutable terminal_manager so the args don't conflict.
-        let backing_path_for_spawn = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.terminal_backing_files)
-            .expect("active window present")
-            .get(&predicted_terminal_id)
-            .cloned();
-        let working_dir_for_spawn = self.working_dir.clone();
-        let wrapper_for_spawn = self.resolved_terminal_wrapper();
-        match self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.terminal_manager)
-            .expect("active window present")
-            .spawn(
-                cols,
-                rows,
-                Some(working_dir_for_spawn),
-                Some(log_path.clone()),
-                backing_path_for_spawn,
-                wrapper_for_spawn,
-            ) {
+        // Precompute paths using the next terminal ID so we capture
+        // from the first byte. Ephemeral terminals get a per-spawn
+        // suffix so there is no possibility of picking up scrollback
+        // a previous run (with the same numeric terminal ID) wrote
+        // to the same path.
+        let predicted_terminal_id = self.terminal_manager.next_terminal_id();
+        let name_stem = if persistent {
+            format!("fresh-terminal-{}", predicted_terminal_id.0)
+        } else {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            format!("fresh-terminal-eph-{}-{}", predicted_terminal_id.0, nanos)
+        };
+        let log_path = terminal_root.join(format!("{}.log", name_stem));
+        let backing_path = terminal_root.join(format!("{}.txt", name_stem));
+        self.terminal_backing_files
+            .insert(predicted_terminal_id, backing_path.clone());
+
+        let wrapper = self.resolved_terminal_wrapper();
+        match self.terminal_manager.spawn(
+            cols,
+            rows,
+            Some(working_dir),
+            Some(log_path.clone()),
+            Some(backing_path),
+            wrapper,
+        ) {
             Ok(terminal_id) => {
-                // Track log file path (use actual ID in case it differs)
-                self.active_window_mut()
-                    .terminal_log_files
-                    .insert(terminal_id, log_path.clone());
-                // If predicted differs, move backing path entry
+                self.terminal_log_files.insert(terminal_id, log_path);
+                // If the actual terminal id differs from the predicted
+                // one, move the backing-file entry to the real id and
+                // rename to the persistent (no-eph-suffix) form. This
+                // mirrors the pre-migration behaviour exactly.
                 if terminal_id != predicted_terminal_id {
-                    self.active_window_mut()
-                        .terminal_backing_files
+                    self.terminal_backing_files
                         .remove(&predicted_terminal_id);
                     let backing_path =
                         terminal_root.join(format!("fresh-terminal-{}.txt", terminal_id.0));
-                    self.active_window_mut()
-                        .terminal_backing_files
+                    self.terminal_backing_files
                         .insert(terminal_id, backing_path);
+                }
+                if !persistent {
+                    self.ephemeral_terminals.insert(terminal_id);
                 }
                 Some(terminal_id)
             }
@@ -144,34 +159,376 @@ impl Editor {
         }
     }
 
-    /// Open a new terminal in the current split
+    /// Create a buffer for a terminal session in this window, attached
+    /// to the specified split. Mirrors the pre-migration body of
+    /// `Editor::create_terminal_buffer_attached`.
+    pub fn create_terminal_buffer_attached(
+        &mut self,
+        terminal_id: TerminalId,
+        split_id: LeafId,
+    ) -> BufferId {
+        let buffer_id = self.alloc_buffer_id();
+        let large_file_threshold =
+            self.resources.config.editor.large_file_threshold_bytes as usize;
+
+        // Rendered backing file for scrollback view (reuse if already
+        // recorded by `spawn_terminal_session`).
+        let backing_file = self
+            .terminal_backing_files
+            .get(&terminal_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                let root = self.resources.dir_context.terminal_dir_for(&self.root);
+                if let Err(e) = self.resources.authority.filesystem.create_dir_all(&root) {
+                    tracing::warn!("Failed to create terminal directory: {}", e);
+                }
+                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
+            });
+
+        // Ensure the file exists — but DON'T truncate if it already has
+        // content. The PTY read loop may have already started writing
+        // scrollback.
+        if !self.resources.authority.filesystem.exists(&backing_file) {
+            if let Err(e) = self
+                .resources
+                .authority
+                .filesystem
+                .write_file(&backing_file, &[])
+            {
+                tracing::warn!("Failed to create terminal backing file: {}", e);
+            }
+        }
+
+        self.terminal_backing_files
+            .insert(terminal_id, backing_file.clone());
+
+        let mut state = EditorState::new_with_path(
+            large_file_threshold,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
+            backing_file.clone(),
+        );
+        state.margins.configure_for_line_numbers(false);
+        self.buffers.insert(buffer_id, state);
+
+        // Virtual metadata so the tab shows "*Terminal N*" and LSP
+        // stays off.
+        let metadata = BufferMetadata::virtual_buffer(
+            format!("*Terminal {}*", terminal_id.0),
+            "terminal".into(),
+            false,
+        );
+        self.buffer_metadata.insert(buffer_id, metadata);
+        self.terminal_buffers.insert(buffer_id, terminal_id);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+
+        if let Some(view_states) = self.split_view_states_mut() {
+            if let Some(view_state) = view_states.get_mut(&split_id) {
+                view_state.add_buffer(buffer_id);
+                // Terminal buffers should not wrap lines so escape
+                // sequences stay intact.
+                view_state.viewport.line_wrap_enabled = false;
+            }
+        }
+
+        buffer_id
+    }
+
+    /// Plugin-facing terminal creation in this window. Handles all
+    /// the variants the JS `editor.createTerminal` API exposes:
+    ///
+    /// - `direction = None`: attach the terminal as a new tab in the
+    ///   window's active split (or seed a fresh split layout rooted
+    ///   at the terminal if the window has never been activated and
+    ///   therefore has no layout yet).
+    /// - `direction = Some(dir)`: create a new horizontal/vertical
+    ///   split off the active split and place the terminal there.
+    ///   `ratio` controls the split's size (default 0.5). `focus`
+    ///   controls whether the new split becomes the window's active
+    ///   split.
+    ///
+    /// In all cases the leader pid is registered with the window's
+    /// `process_groups` tracker so cross-window signal operations
+    /// (Stop / Archive / Delete) can reach the spawned process group.
+    ///
+    /// Returns `(terminal_id, buffer_id, created_split_id)` on
+    /// success. `created_split_id` is `Some` when a split was created
+    /// (either explicitly via `direction = Some` or implicitly when
+    /// seeding a fresh layout in a never-activated window).
+    pub fn create_plugin_terminal(
+        &mut self,
+        cwd: Option<PathBuf>,
+        direction: Option<crate::model::event::SplitDirection>,
+        ratio: Option<f32>,
+        focus: bool,
+        persistent: bool,
+    ) -> Result<(TerminalId, BufferId, Option<LeafId>), String> {
+        let terminal_id = self
+            .spawn_terminal_session(cwd, persistent)
+            .ok_or_else(|| "Failed to spawn terminal".to_string())?;
+
+        // Register the leader pid with this window's process_groups
+        // so window-level signal operations reach the spawned group.
+        if let Some(pid) = self
+            .terminal_manager
+            .get(terminal_id)
+            .and_then(|h| h.pid())
+        {
+            let label = format!("terminal #{}", terminal_id.0);
+            self.process_groups.register(pid, label);
+        }
+
+        // Compute split-creation behaviour. The two cases (with /
+        // without direction) diverge in whether we attach to the
+        // active split as a new tab or create a fresh split off it.
+        // The "never-activated, no layout yet" case is handled in
+        // both branches by seeding a SplitManager rooted at the new
+        // terminal buffer.
+        let active_split = self.buffers.splits().map(|(mgr, _)| mgr.active_split());
+
+        let (buffer_id, created_split_id) = if let Some(split_dir) = direction {
+            let buffer_id = self.create_terminal_buffer_detached(terminal_id);
+            match active_split {
+                Some(parent) => {
+                    let split_ratio = ratio.unwrap_or(0.5);
+                    let line_numbers = self.resources.config.editor.line_numbers;
+                    let highlight_current_line =
+                        self.resources.config.editor.highlight_current_line;
+                    let rulers = self.resources.config.editor.rulers.clone();
+                    let terminal_width = self.terminal_width;
+                    let terminal_height = self.terminal_height;
+                    let split_result = self
+                        .split_manager_mut()
+                        .expect("active split implies populated layout")
+                        .split_active(split_dir, buffer_id, split_ratio);
+                    match split_result {
+                        Ok(new_split_id) => {
+                            let mut view_state = SplitViewState::with_buffer(
+                                terminal_width,
+                                terminal_height,
+                                buffer_id,
+                            );
+                            view_state.apply_config_defaults(
+                                line_numbers,
+                                highlight_current_line,
+                                false,
+                                false,
+                                None,
+                                rulers,
+                            );
+                            // Terminal output is ANSI-sequenced and
+                            // assumes a fixed column count; wrapping
+                            // would mangle cursor positioning.
+                            view_state.viewport.line_wrap_enabled = false;
+                            self.split_view_states_mut()
+                                .expect("active split implies populated layout")
+                                .insert(new_split_id, view_state);
+                            if focus {
+                                self.split_manager_mut()
+                                    .expect("active split implies populated layout")
+                                    .set_active_split(new_split_id);
+                            }
+                            (buffer_id, Some(new_split_id))
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to create split for terminal: {e}; \
+                                 falling back to attaching to active split"
+                            );
+                            // Graceful fallback: attach to the active
+                            // split so the buffer isn't orphaned.
+                            if let Some(view_state) = self
+                                .split_view_states_mut()
+                                .and_then(|m| m.get_mut(&parent))
+                            {
+                                view_state.add_buffer(buffer_id);
+                                view_state.viewport.line_wrap_enabled = false;
+                            }
+                            self.set_active_buffer(buffer_id);
+                            (buffer_id, None)
+                        }
+                    }
+                }
+                None => {
+                    // Never-activated window with no layout — seed
+                    // one rooted at the terminal buffer. First dive
+                    // picks it up and the terminal is the active leaf.
+                    let manager = crate::view::split::SplitManager::new(buffer_id);
+                    let active_leaf = manager.active_split();
+                    let mut view_states = std::collections::HashMap::new();
+                    let mut vs = SplitViewState::with_buffer(
+                        self.terminal_width,
+                        self.terminal_height,
+                        buffer_id,
+                    );
+                    vs.viewport.line_wrap_enabled = false;
+                    view_states.insert(active_leaf, vs);
+                    self.buffers.set_splits((manager, view_states));
+                    (buffer_id, Some(active_leaf))
+                }
+            }
+        } else {
+            match active_split {
+                Some(split_id) => {
+                    let buffer_id = self.create_terminal_buffer_attached(terminal_id, split_id);
+                    // Switch tabs to the terminal. Window-side
+                    // mutation only — the editor-wide
+                    // `buffer_activated` hook is fired by the
+                    // Editor wrapper iff this window is the
+                    // editor-active one.
+                    self.set_active_buffer(buffer_id);
+                    (buffer_id, None)
+                }
+                None => {
+                    let buffer_id = self.create_terminal_buffer_detached(terminal_id);
+                    let manager = crate::view::split::SplitManager::new(buffer_id);
+                    let active_leaf = manager.active_split();
+                    let mut view_states = std::collections::HashMap::new();
+                    let mut vs = SplitViewState::with_buffer(
+                        self.terminal_width,
+                        self.terminal_height,
+                        buffer_id,
+                    );
+                    vs.viewport.line_wrap_enabled = false;
+                    view_states.insert(active_leaf, vs);
+                    self.buffers.set_splits((manager, view_states));
+                    (buffer_id, Some(active_leaf))
+                }
+            }
+        };
+
+        self.resize_visible_terminals();
+        Ok((terminal_id, buffer_id, created_split_id))
+    }
+
+    /// Open a new terminal in this window: spawn the PTY, create
+    /// the buffer, attach to the active split, switch this window's
+    /// active buffer to it, enable terminal mode, and resize the PTY
+    /// to match the split's content area. Returns `(terminal_id,
+    /// buffer_id)` on success.
+    ///
+    /// Editor-wide effects (the `buffer_activated` plugin hook, the
+    /// status-bar exit-key message) are NOT fired here — that's the
+    /// caller's responsibility, gated on whether this window is the
+    /// editor-active one. See `Editor::open_terminal` for the
+    /// active-window wrapper that does both.
+    pub fn open_terminal_in_window(&mut self) -> Option<(TerminalId, BufferId)> {
+        let terminal_id = self.spawn_terminal_session(None, true)?;
+        let split_id = self
+            .buffers
+            .splits()
+            .map(|(mgr, _)| mgr.active_split())
+            .expect("window must have a populated split layout");
+        let buffer_id = self.create_terminal_buffer_attached(terminal_id, split_id);
+        // Window-side activation: per-window mutation only — the
+        // editor-wide plugin hook fires in the Editor wrapper.
+        self.set_active_buffer(buffer_id);
+        self.terminal_mode = true;
+        self.key_context = crate::input::keybindings::KeyContext::Terminal;
+        self.resize_visible_terminals();
+        Some((terminal_id, buffer_id))
+    }
+
+    /// Create a buffer for a terminal session in this window without
+    /// attaching to any split (used during session restore).
+    pub fn create_terminal_buffer_detached(&mut self, terminal_id: TerminalId) -> BufferId {
+        let buffer_id = self.alloc_buffer_id();
+        let large_file_threshold =
+            self.resources.config.editor.large_file_threshold_bytes as usize;
+
+        let backing_file = self
+            .terminal_backing_files
+            .get(&terminal_id)
+            .cloned()
+            .unwrap_or_else(|| {
+                let root = self.resources.dir_context.terminal_dir_for(&self.root);
+                if let Err(e) = self.resources.authority.filesystem.create_dir_all(&root) {
+                    tracing::warn!("Failed to create terminal directory: {}", e);
+                }
+                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
+            });
+
+        if !self.resources.authority.filesystem.exists(&backing_file) {
+            if let Err(e) = self
+                .resources
+                .authority
+                .filesystem
+                .write_file(&backing_file, &[])
+            {
+                tracing::warn!("Failed to create terminal backing file: {}", e);
+            }
+        }
+
+        let mut state = EditorState::new_with_path(
+            large_file_threshold,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
+            backing_file.clone(),
+        );
+        state.margins.configure_for_line_numbers(false);
+        self.buffers.insert(buffer_id, state);
+
+        let metadata = BufferMetadata::virtual_buffer(
+            format!("*Terminal {}*", terminal_id.0),
+            "terminal".into(),
+            false,
+        );
+        self.buffer_metadata.insert(buffer_id, metadata);
+        self.terminal_buffers.insert(buffer_id, terminal_id);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+
+        buffer_id
+    }
+}
+
+impl Editor {
+    /// Editor-side thin wrapper. Delegates to the active window. New code
+    /// on `impl Window` should call `Window::resolved_terminal_wrapper`
+    /// directly.
+    pub(crate) fn resolved_terminal_wrapper(&self) -> TerminalWrapper {
+        self.active_window().resolved_terminal_wrapper()
+    }
+
+    /// Spawn a new PTY-backed terminal session in the active window
+    /// using its `root` as cwd. Editor-side thin wrapper; per-window
+    /// body lives in `Window::spawn_terminal_session`.
+    ///
+    /// Used by `open_terminal` (regular spawn into the active split)
+    /// and by `Action::OpenTerminalInDock` (which needs the buffer
+    /// id *before* it has a split to attach to, so the dock leaf can
+    /// be seeded with the terminal directly rather than with a
+    /// placeholder buffer that would linger as a phantom tab).
+    pub(crate) fn spawn_terminal_session(&mut self) -> Option<TerminalId> {
+        self.active_window_mut()
+            .spawn_terminal_session(None, true)
+    }
+
+    /// Open a new terminal in the active window's current split, fire
+    /// the editor-wide `buffer_activated` plugin hook, and post a
+    /// status-bar message with the terminal-mode exit key.
+    ///
+    /// Window-side body lives in `Window::open_terminal_in_window`;
+    /// this router adds only the cross-cutting effects that require
+    /// editor-level state (the plugin hook + status message).
     pub fn open_terminal(&mut self) {
-        let Some(terminal_id) = self.spawn_terminal_session() else {
+        let Some((terminal_id, buffer_id)) = self.active_window_mut().open_terminal_in_window()
+        else {
             return;
         };
 
-        // Create a buffer for this terminal, attached to the active split
-        let buffer_id = self.create_terminal_buffer_attached(
-            terminal_id,
-            self.windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .active_split(),
+        // Editor-wide: refresh the plugin-state snapshot so plugin
+        // hooks see the new active buffer, then fire `buffer_activated`.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
+        #[cfg(feature = "plugins")]
+        self.plugin_manager.read().unwrap().run_hook(
+            "buffer_activated",
+            crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );
 
-        // Switch to the terminal buffer
-        self.set_active_buffer(buffer_id);
-
-        // Enable terminal mode
-        self.active_window_mut().terminal_mode = true;
-        self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
-
-        // Resize terminal to match actual split content area
-        self.active_window_mut().resize_visible_terminals();
-
-        // Get the terminal escape keybinding dynamically
+        // Status bar with the terminal-mode exit key. Looked up here
+        // (not in Window) because the keybinding resolver is shared
+        // editor state read through the `Arc<RwLock<…>>`.
         let exit_key = self
             .keybindings
             .read()
@@ -191,149 +548,12 @@ impl Editor {
         );
     }
 
-    /// Create a buffer for a terminal session
-    pub(crate) fn create_terminal_buffer_attached(
-        &mut self,
-        terminal_id: TerminalId,
-        split_id: crate::model::event::LeafId,
-    ) -> BufferId {
-        let buffer_id = self.alloc_buffer_id();
-
-        // Get config values
-        let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-
-        // Rendered backing file for scrollback view (reuse if already recorded)
-        let backing_file = self
-            .active_window()
-            .terminal_backing_files
-            .get(&terminal_id)
-            .cloned()
-            .unwrap_or_else(|| {
-                let root = self.dir_context.terminal_dir_for(&self.working_dir);
-                if let Err(e) = self.authority.filesystem.create_dir_all(&root) {
-                    tracing::warn!("Failed to create terminal directory: {}", e);
-                }
-                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
-            });
-
-        // Ensure the file exists - but DON'T truncate if it already has content
-        // The PTY read loop may have already started writing scrollback
-        if !self.authority.filesystem.exists(&backing_file) {
-            if let Err(e) = self.authority.filesystem.write_file(&backing_file, &[]) {
-                tracing::warn!("Failed to create terminal backing file: {}", e);
-            }
-        }
-
-        // Store the backing file path
-        self.active_window_mut()
-            .terminal_backing_files
-            .insert(terminal_id, backing_file.clone());
-
-        // Create editor state with the backing file
-        let mut state = EditorState::new_with_path(
-            large_file_threshold,
-            std::sync::Arc::clone(&self.authority.filesystem),
-            backing_file.clone(),
-        );
-        // Terminal buffers should never show line numbers
-        state.margins.configure_for_line_numbers(false);
-        self.windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .insert(buffer_id, state);
-        // Use virtual metadata so the tab shows "*Terminal N*" and LSP stays off.
-        // The backing file is still tracked separately for syncing scrollback.
-        let metadata = BufferMetadata::virtual_buffer(
-            format!("*Terminal {}*", terminal_id.0),
-            "terminal".into(),
-            false,
-        );
-        self.active_window_mut()
-            .buffer_metadata
-            .insert(buffer_id, metadata);
-
-        // Map buffer to terminal
-        self.active_window_mut()
-            .terminal_buffers
-            .insert(buffer_id, terminal_id);
-
-        // Initialize event log for undo/redo
-        self.active_window_mut()
-            .event_logs
-            .insert(buffer_id, crate::model::event::EventLog::new());
-
-        // Set up split view state
-        if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
-            .expect("active window must have a populated split layout")
-            .get_mut(&split_id)
-        {
-            view_state.add_buffer(buffer_id);
-            // Terminal buffers should not wrap lines so escape sequences stay intact
-            view_state.viewport.line_wrap_enabled = false;
-        }
-
-        buffer_id
-    }
-
-    /// Create a terminal buffer without attaching it to any split (used during session restore).
+    /// Editor-side thin wrapper. Delegates to the active window's
+    /// `Window::create_terminal_buffer_detached` (used during session
+    /// restore by `input.rs`).
     pub(crate) fn create_terminal_buffer_detached(&mut self, terminal_id: TerminalId) -> BufferId {
-        let buffer_id = self.alloc_buffer_id();
-
-        // Get config values
-        let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
-
-        let backing_file = self
-            .active_window()
-            .terminal_backing_files
-            .get(&terminal_id)
-            .cloned()
-            .unwrap_or_else(|| {
-                let root = self.dir_context.terminal_dir_for(&self.working_dir);
-                if let Err(e) = self.authority.filesystem.create_dir_all(&root) {
-                    tracing::warn!("Failed to create terminal directory: {}", e);
-                }
-                root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
-            });
-
-        // Create the file only if it doesn't exist (preserve existing scrollback for restore)
-        if !self.authority.filesystem.exists(&backing_file) {
-            if let Err(e) = self.authority.filesystem.write_file(&backing_file, &[]) {
-                tracing::warn!("Failed to create terminal backing file: {}", e);
-            }
-        }
-
-        // Create editor state with the backing file
-        let mut state = EditorState::new_with_path(
-            large_file_threshold,
-            std::sync::Arc::clone(&self.authority.filesystem),
-            backing_file.clone(),
-        );
-        state.margins.configure_for_line_numbers(false);
-        self.windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .insert(buffer_id, state);
-        let metadata = BufferMetadata::virtual_buffer(
-            format!("*Terminal {}*", terminal_id.0),
-            "terminal".into(),
-            false,
-        );
         self.active_window_mut()
-            .buffer_metadata
-            .insert(buffer_id, metadata);
-        self.active_window_mut()
-            .terminal_buffers
-            .insert(buffer_id, terminal_id);
-        self.active_window_mut()
-            .event_logs
-            .insert(buffer_id, crate::model::event::EventLog::new());
-
-        buffer_id
+            .create_terminal_buffer_detached(terminal_id)
     }
 
     /// Close the current terminal (if viewing a terminal buffer)
@@ -396,15 +616,6 @@ impl Editor {
     // `is_terminal_in_alternate_screen` live on `impl Window` — they
     // only touch this window's `terminal_buffers` + `terminal_manager`.
     // Call them via `self.active_window()` / `self.active_window_mut()`.
-
-    /// Get terminal dimensions based on split size
-    pub(crate) fn get_terminal_dimensions(&self) -> (u16, u16) {
-        // Use the visible area of the current split
-        // Subtract 1 for status bar, tab bar, etc.
-        let cols = self.terminal_width.saturating_sub(2).max(40);
-        let rows = self.terminal_height.saturating_sub(4).max(10);
-        (cols, rows)
-    }
 
     /// Handle terminal input when in terminal mode
     pub fn handle_terminal_key(

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -89,10 +89,7 @@ impl Window {
         self.terminal_manager.set_async_bridge(bridge);
 
         let working_dir = cwd.unwrap_or_else(|| self.root.clone());
-        let terminal_root = self
-            .resources
-            .dir_context
-            .terminal_dir_for(&working_dir);
+        let terminal_root = self.resources.dir_context.terminal_dir_for(&working_dir);
         if let Err(e) = self
             .resources
             .authority
@@ -155,8 +152,7 @@ impl Window {
                 // rename to the persistent (no-eph-suffix) form. This
                 // mirrors the pre-migration behaviour exactly.
                 if terminal_id != predicted_terminal_id {
-                    self.terminal_backing_files
-                        .remove(&predicted_terminal_id);
+                    self.terminal_backing_files.remove(&predicted_terminal_id);
                     let backing_path =
                         terminal_root.join(format!("fresh-terminal-{}.txt", terminal_id.0));
                     self.terminal_backing_files
@@ -186,8 +182,7 @@ impl Window {
         split_id: LeafId,
     ) -> BufferId {
         let buffer_id = self.alloc_buffer_id();
-        let large_file_threshold =
-            self.resources.config.editor.large_file_threshold_bytes as usize;
+        let large_file_threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
 
         // Rendered backing file for scrollback view (reuse if already
         // recorded by `spawn_terminal_session`).
@@ -304,11 +299,7 @@ impl Window {
 
         // Register the leader pid with this window's process_groups
         // so window-level signal operations reach the spawned group.
-        if let Some(pid) = self
-            .terminal_manager
-            .get(terminal_id)
-            .and_then(|h| h.pid())
-        {
+        if let Some(pid) = self.terminal_manager.get(terminal_id).and_then(|h| h.pid()) {
             let label = format!("terminal #{}", terminal_id.0);
             self.process_groups.register(pid, label);
         }
@@ -355,14 +346,8 @@ impl Window {
                             // is independent.
                             let _ = line_numbers;
                             let _ = highlight_current_line;
-                            view_state.apply_config_defaults(
-                                false,
-                                false,
-                                false,
-                                false,
-                                None,
-                                rulers,
-                            );
+                            view_state
+                                .apply_config_defaults(false, false, false, false, None, rulers);
                             // Terminal output is ANSI-sequenced and
                             // assumes a fixed column count; wrapping
                             // would mangle cursor positioning.
@@ -478,7 +463,11 @@ impl Window {
             .terminal_buffers
             .keys()
             .filter(|bid| **bid != for_buffer)
-            .filter_map(|bid| self.buffer_metadata.get(bid).map(|m| m.display_name.as_str()))
+            .filter_map(|bid| {
+                self.buffer_metadata
+                    .get(bid)
+                    .map(|m| m.display_name.as_str())
+            })
             .collect();
         if !used.contains(desired) {
             return desired.to_string();
@@ -532,8 +521,7 @@ impl Window {
     /// attaching to any split (used during session restore).
     pub fn create_terminal_buffer_detached(&mut self, terminal_id: TerminalId) -> BufferId {
         let buffer_id = self.alloc_buffer_id();
-        let large_file_threshold =
-            self.resources.config.editor.large_file_threshold_bytes as usize;
+        let large_file_threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
 
         let backing_file = self
             .terminal_backing_files

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -343,9 +343,21 @@ impl Window {
                                 terminal_height,
                                 buffer_id,
                             );
+                            // Terminal-dedicated splits never show
+                            // line numbers or current-line highlight
+                            // — the buffer is a PTY scrollback view,
+                            // not source code. (Pre-fix the config
+                            // default was applied, so a default-on
+                            // line-numbers user saw `1 │ Python …`
+                            // in every orchestrator agent split.)
+                            // Other splits in the window aren't
+                            // affected because each `SplitViewState`
+                            // is independent.
+                            let _ = line_numbers;
+                            let _ = highlight_current_line;
                             view_state.apply_config_defaults(
-                                line_numbers,
-                                highlight_current_line,
+                                false,
+                                false,
                                 false,
                                 false,
                                 None,

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -154,6 +154,20 @@ impl crate::app::Editor {
                 active_id: id.0,
             },
         );
+
+        // Resize the newly-active window's visible terminal PTYs to
+        // match their dive-view split rects. Without this, a session
+        // that was just previewed in the orchestrator picker
+        // (`render_session_preview_into_rect` resizes PTYs to the
+        // embed rect — typically ~half the terminal's height) keeps
+        // drawing at that smaller size after the dive, leaving the
+        // bottom of the dive view blank until something else triggers
+        // a resize. Same applies for the inverse: dive away while a
+        // session has a small split, dive back when the window is
+        // bigger — the terminal needs the new dimensions.
+        if let Some(win) = self.windows.get_mut(&id) {
+            win.resize_visible_terminals();
+        }
     }
 
     /// Build a fresh seed buffer + split layout for `id` if that

--- a/crates/fresh-editor/src/input/command_registry.rs
+++ b/crates/fresh-editor/src/input/command_registry.rs
@@ -865,6 +865,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-a".to_string()),
+            terminal_bypass: false,
         };
 
         let cmd_b = Command {
@@ -874,6 +875,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-b".to_string()),
+            terminal_bypass: false,
         };
 
         // First registration succeeds
@@ -901,6 +903,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-a".to_string()),
+            terminal_bypass: false,
         };
 
         let cmd2 = Command {
@@ -910,6 +913,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-a".to_string()),
+            terminal_bypass: false,
         };
 
         assert!(registry.try_register(cmd1).is_ok());
@@ -932,6 +936,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-a".to_string()),
+            terminal_bypass: false,
         };
 
         let cmd_b = Command {
@@ -941,6 +946,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Plugin("plugin-b".to_string()),
+            terminal_bypass: false,
         };
 
         // Plugin A registers

--- a/crates/fresh-editor/src/input/command_registry.rs
+++ b/crates/fresh-editor/src/input/command_registry.rs
@@ -43,6 +43,29 @@ impl CommandRegistry {
         self.builtin_commands = get_all_commands();
     }
 
+    /// `true` iff `action` matches a registered command that was
+    /// declared with `terminalBypass: true` (plugins) or already
+    /// bypasses via the built-in `is_terminal_ui_action` allowlist.
+    ///
+    /// Built-in actions (CommandPalette, QuickOpen, …) are intentionally
+    /// not flagged here — they bypass through
+    /// [`KeybindingResolver::is_terminal_ui_action`] which the
+    /// terminal input handler checks separately. This method is the
+    /// plugin-driven extension: any plugin command can opt in to the
+    /// same bypass-while-terminal-is-focused behaviour via the
+    /// `registerCommand({ terminalBypass: true })` option.
+    pub fn is_terminal_bypass_action(&self, action: &crate::input::keybindings::Action) -> bool {
+        use crate::input::keybindings::Action;
+        let Action::PluginAction(target) = action else {
+            return false;
+        };
+        let plugins = self.plugin_commands.read().unwrap();
+        plugins.iter().any(|cmd| {
+            cmd.terminal_bypass
+                && matches!(&cmd.action, Action::PluginAction(name) if name == target)
+        })
+    }
+
     /// Record that a command was used (for history/sorting)
     ///
     /// This moves the command to the front of the history list.
@@ -382,6 +405,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         };
 
         registry.register(custom_command.clone());
@@ -403,6 +427,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         };
 
         registry.register(custom_command);
@@ -423,6 +448,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         };
 
         let command2 = Command {
@@ -432,6 +458,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         };
 
         registry.register(command1);
@@ -455,6 +482,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         registry.register(Command {
@@ -464,6 +492,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         registry.register(Command {
@@ -473,6 +502,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         assert_eq!(registry.plugin_command_count(), 3);
@@ -500,6 +530,7 @@ mod tests {
             contexts: vec![KeyContext::Normal],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         let empty_contexts = std::collections::HashSet::new();
@@ -535,6 +566,7 @@ mod tests {
             contexts: vec![KeyContext::Normal],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         registry.register(Command {
@@ -544,6 +576,7 @@ mod tests {
             contexts: vec![KeyContext::Popup],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         // In normal context, "Popup Only" should be disabled
@@ -588,6 +621,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         registry.register(Command {
@@ -597,6 +631,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         let all = registry.get_all();
@@ -620,6 +655,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         // Should now find the custom version
@@ -723,6 +759,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         registry.register(Command {
@@ -732,6 +769,7 @@ mod tests {
             contexts: vec![],
             custom_contexts: vec![],
             source: CommandSource::Builtin,
+            terminal_bypass: false,
         });
 
         // Use one built-in command

--- a/crates/fresh-editor/src/input/commands.rs
+++ b/crates/fresh-editor/src/input/commands.rs
@@ -29,6 +29,17 @@ pub struct Command {
     pub custom_contexts: Vec<String>,
     /// Source of the command (builtin or plugin)
     pub source: CommandSource,
+    /// When `true`, a key bound to this command bypasses terminal
+    /// keyboard capture: the action fires even while a terminal pane
+    /// owns the keyboard. Plugins set this via
+    /// `editor.registerCommand(..., { terminalBypass: true })` so
+    /// commands the user must always reach (orchestrator picker /
+    /// new-session form / panic-exit) aren't trapped by a focused
+    /// PTY. Built-in editor commands like `CommandPalette` rely on
+    /// `KeybindingResolver::is_terminal_ui_action` instead, so the
+    /// flag stays `false` for them and they still bypass the
+    /// existing way.
+    pub terminal_bypass: bool,
 }
 
 impl Command {
@@ -1374,6 +1385,10 @@ pub fn get_all_commands() -> Vec<Command> {
             contexts: def.contexts.to_vec(),
             custom_contexts: def.custom_contexts.iter().map(|s| s.to_string()).collect(),
             source: CommandSource::Builtin,
+            // Built-in commands use the legacy `is_terminal_ui_action`
+            // path; the plugin-driven `terminal_bypass` flag isn't
+            // wired into them.
+            terminal_bypass: false,
         })
         .collect()
 }

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -1887,6 +1887,33 @@ impl KeybindingResolver {
         None
     }
 
+    /// `true` iff this context has its own binding for `event` —
+    /// either user-customised, built-in default, or plugin-default
+    /// (from `defineMode`). Unlike [`resolve`], this does **not**
+    /// fall back to Global or Normal-context bindings; it's the
+    /// "did someone *explicitly* claim this key for this mode"
+    /// check used by `dispatch_floating_widget_key` to decide
+    /// whether to let mode dispatch override its smart-key defaults.
+    pub fn has_explicit_binding(&self, event: &KeyEvent, context: &KeyContext) -> bool {
+        let norm = normalize_key(event.code, event.modifiers);
+        if let Some(bindings) = self.bindings.get(context) {
+            if bindings.contains_key(&norm) {
+                return true;
+            }
+        }
+        if let Some(bindings) = self.default_bindings.get(context) {
+            if bindings.contains_key(&norm) {
+                return true;
+            }
+        }
+        if let Some(bindings) = self.plugin_defaults.get(context) {
+            if bindings.contains_key(&norm) {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Resolve a key event to a UI action for terminal mode.
     /// Only returns actions that are classified as UI actions (is_terminal_ui_action).
     /// Returns Action::None if the key doesn't map to a UI action.

--- a/crates/fresh-editor/src/services/plugins/bridge.rs
+++ b/crates/fresh-editor/src/services/plugins/bridge.rs
@@ -75,6 +75,7 @@ impl PluginServiceBridge for EditorServiceBridge {
             contexts: vec![KeyContext::Global],
             custom_contexts: command.custom_contexts,
             source: CommandSource::Plugin(command.plugin_name),
+            terminal_bypass: command.terminal_bypass,
         };
         self.command_registry
             .read()

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1461,8 +1461,8 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
 /// Layout: `[v] label` when checked, `[ ] label` when not. The check
 /// glyph is colored via `ui.tab_active_fg` when checked (no override
 /// when unchecked). When focused, the entire entry is given a focused
-/// fg/bg pair (`ui.menu_active_fg`/`ui.menu_active_bg`) plus bold —
-/// matching the Settings UI's selected-control affordance.
+/// fg/bg pair (`ui.popup_selection_fg`/`ui.popup_selection_bg`) plus
+/// bold — matching the prompt / palette's selected-row affordance.
 pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyEntry {
     let glyph = if checked { "[v]" } else { "[ ]" };
     let mut text = String::with_capacity(glyph.len() + 1 + label.len());
@@ -2648,16 +2648,22 @@ mod tests {
     }
 
     #[test]
-    fn button_focused_overrides_with_menu_active_keys() {
+    fn button_focused_overrides_with_popup_selection_keys() {
+        // Picker / palette / list / button focus now resolves through
+        // `ui.popup_selection_{fg,bg}` (white-on-blue) instead of
+        // `ui.menu_active_{fg,bg}` (white-on-rgb(60,60,60)) — the
+        // former has ~6× the perceptual contrast against the popup
+        // bg and is the same key the prompt already uses. See the
+        // `KEY_FOCUSED_FG/BG` const comment.
         let entry = render_button("OK", true, ButtonKind::Normal);
         let style = &entry.inline_overlays[0].style;
         assert_eq!(
             style.fg.as_ref().and_then(|c| c.as_theme_key()),
-            Some("ui.menu_active_fg")
+            Some("ui.popup_selection_fg")
         );
         assert_eq!(
             style.bg.as_ref().and_then(|c| c.as_theme_key()),
-            Some("ui.menu_active_bg")
+            Some("ui.popup_selection_bg")
         );
         assert!(style.bold);
     }
@@ -3044,13 +3050,14 @@ mod tests {
         // Two overlays expected from the focused B: one for B's
         // glyph (none, since unchecked) — actually unchecked emits
         // no glyph overlay. So only the focused-style overlay.
-        // Find the focused overlay by its menu_active_bg key.
+        // Find the focused overlay by its popup_selection_bg key
+        // (white-on-blue; see KEY_FOCUSED_BG).
         let entry = &out.entries[0];
         let focused_overlay = entry
             .inline_overlays
             .iter()
             .find(|o| {
-                o.style.bg.as_ref().and_then(|c| c.as_theme_key()) == Some("ui.menu_active_bg")
+                o.style.bg.as_ref().and_then(|c| c.as_theme_key()) == Some("ui.popup_selection_bg")
             })
             .expect("focused overlay present on B");
         // B's text is "[ ] B", starting after "[ ] A".len()==5 + spacer 0 (no spacer here).
@@ -3092,7 +3099,14 @@ mod tests {
             key: None,
         };
         let (entries, hits, _state) = render_no_focus(&spec, &HashMap::new());
-        assert_eq!(entries.len(), 3);
+        // 3 real items + 7 blank padding rows to fill `visible_rows=10`.
+        // Padding ensures the labeledSection that wraps a List stays
+        // the height it advertises, so a sibling pane lands its
+        // bottom border on the matching row (orchestrator picker
+        // depends on this).
+        assert_eq!(entries.len(), 10);
+        // Real items still produce exactly one hit each; padded rows
+        // are intentionally not clickable.
         assert_eq!(hits.len(), 3);
         for (i, h) in hits.iter().enumerate() {
             assert_eq!(h.buffer_row, i as u32);
@@ -3122,7 +3136,7 @@ mod tests {
         let style = entries[1].style.as_ref().expect("selected row gets style");
         assert_eq!(
             style.bg.as_ref().and_then(|c| c.as_theme_key()),
-            Some("ui.menu_active_bg"),
+            Some("ui.popup_selection_bg"),
         );
         assert!(style.extend_to_line_end);
     }
@@ -3153,7 +3167,11 @@ mod tests {
             key: None,
         };
         let (entries, hits, _state) = render_no_focus(&spec, &HashMap::new());
-        assert_eq!(entries.len(), 3);
+        // HintBar (1 row) + List items (2) + padding rows (8) to fill
+        // `visible_rows=10` = 11 total entries.
+        assert_eq!(entries.len(), 11);
+        // Real list rows still produce one hit each; padding is not
+        // clickable.
         assert_eq!(hits.len(), 2);
         // List rows land at buffer_row 1 and 2 (after the HintBar).
         assert_eq!(hits[0].buffer_row, 1);
@@ -3311,7 +3329,11 @@ mod tests {
     fn list_does_not_scroll_when_total_smaller_than_visible() {
         let spec = make_list(-1, 10, 3, Some("L"));
         let (entries, _hits, state) = render_no_focus(&spec, &HashMap::new());
-        assert_eq!(entries.len(), 3, "all items fit");
+        // 3 items + 7 blank padding rows to fill `visible_rows=10`.
+        // The labeledSection wrapping a List keeps the height it
+        // advertises so a sibling pane (orchestrator picker's
+        // preview) can match.
+        assert_eq!(entries.len(), 10);
         let scroll = match state.get("L").unwrap() {
             WidgetInstanceState::List { scroll_offset, .. } => *scroll_offset,
             _ => unreachable!(),
@@ -3995,7 +4017,7 @@ mod tests {
         let style = entries[1].style.as_ref().expect("selected gets style");
         assert_eq!(
             style.bg.as_ref().and_then(|c| c.as_theme_key()),
-            Some("ui.menu_active_bg")
+            Some("ui.popup_selection_bg")
         );
         assert!(style.extend_to_line_end);
     }

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1307,13 +1307,25 @@ fn wrap_in_side_border(mut child: TextPropertyEntry, inner_width: usize) -> Text
         }
     } else if cur_cols > inner_width {
         // Tail-truncate at the codepoint boundary corresponding
-        // to `inner_width` chars.
+        // to `inner_width` chars, then if there's room replace
+        // the final visible char with `…` so the cut is visible
+        // (mirrors `pad_or_truncate_cols`).
         let indices: Vec<usize> = child.text.char_indices().map(|(i, _)| i).collect();
         let byte_cutoff = indices
             .get(inner_width)
             .copied()
             .unwrap_or(child.text.len());
         child.text.truncate(byte_cutoff);
+        if inner_width >= 2 {
+            // Replace the last visible char with `…`. `pop()` walks
+            // codepoint boundaries so multi-byte tails are handled
+            // correctly. We then update `byte_cutoff` to the new
+            // string length so overlay clamping below uses the
+            // post-ellipsis boundary.
+            child.text.pop();
+            child.text.push('…');
+        }
+        let byte_cutoff = child.text.len();
         // Drop any overlay that would now reference past the
         // truncation point; clamp the rest.
         child.inline_overlays.retain_mut(|o| {
@@ -2197,6 +2209,12 @@ fn merge_inline(merged: &mut TextPropertyEntry, next: &mut TextPropertyEntry) {
 /// place. Uses char count as the display-width approximation —
 /// good for ASCII; wide-char-aware width would need
 /// `unicode-width`, but no current caller relies on that.
+///
+/// When truncating, the final visible column is replaced with `…`
+/// so the cut is visually distinguishable from a value that
+/// happens to be exactly `cols` long. Degenerate `cols == 0` and
+/// `cols == 1` (no room for the ellipsis itself) fall back to a
+/// plain cut.
 fn pad_or_truncate_cols(text: &mut String, cols: usize) {
     let cur = text.chars().count();
     if cur < cols {
@@ -2204,12 +2222,20 @@ fn pad_or_truncate_cols(text: &mut String, cols: usize) {
             text.push(' ');
         }
     } else if cur > cols {
+        // Cut to `cols` chars, then if we have room replace the
+        // last char with `…` so the truncation is visible.
         let cutoff = text
             .char_indices()
             .nth(cols)
             .map(|(i, _)| i)
             .unwrap_or(text.len());
         text.truncate(cutoff);
+        if cols >= 2 {
+            // Drop the last char and append the ellipsis. We pop a
+            // char (not a byte) so multi-byte tails stay intact.
+            text.pop();
+            text.push('…');
+        }
     }
 }
 

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -33,8 +33,18 @@ use std::collections::{HashMap, HashSet};
 // substitute the role→key mapping.
 const KEY_HELP_KEY_FG: &str = "ui.help_key_fg";
 const KEY_TOGGLE_ON_FG: &str = "ui.tab_active_fg";
-const KEY_FOCUSED_FG: &str = "ui.menu_active_fg";
-const KEY_FOCUSED_BG: &str = "ui.menu_active_bg";
+// Selection/focus highlight for widgets inside floating panels
+// (list rows, tree nodes, buttons). Originally pointed at
+// `ui.menu_active_{fg,bg}` which defaults to rgb(255,255,255) on
+// rgb(60,60,60) — a 30-unit gray-on-gray bump that quantizes flat
+// on 256-colour terminals and is hard to see on dark themes (the
+// surrounding panel bg is rgb(30,30,30)). `ui.popup_selection_{fg,bg}`
+// is the theme key designed for "selected item inside a popup
+// surface" — white on rgb(58,79,120) blue, ~6× the perceptual
+// contrast — and it's the same key the prompt/palette already uses
+// so the cue reads consistently across selection UIs.
+const KEY_FOCUSED_FG: &str = "ui.popup_selection_fg";
+const KEY_FOCUSED_BG: &str = "ui.popup_selection_bg";
 // `ui.status_error_indicator_fg` defaults to white (designed as
 // the text-on-red status badge), so using it as a standalone fg
 // renders invisible against the panel bg. The diagnostic.error_fg
@@ -700,9 +710,17 @@ fn render_collected(
 
             // Render the visible window, emitting one entry + one
             // hit area per visible item. Selected row gets the
-            // menu_active_bg + extend_to_line_end style. Hit-area
+            // popup_selection_bg + extend_to_line_end style. Hit-area
             // payload uses the *absolute* item index so the plugin
             // never needs to translate window-relative coordinates.
+            //
+            // After the real items we pad with blank entries up to
+            // `visible` rows so the List occupies the full height
+            // its `visible_rows` advertises (Bug 1). Without this
+            // padding, a list with 3 items inside a `visible_rows=20`
+            // labeledSection closes its bottom border 17 rows above
+            // where the sibling preview pane closes — the
+            // wireframed dialog shape called for matched heights.
             let start = scroll as usize;
             let end = ((scroll + visible) as usize).min(items.len());
             for (offset, item) in items[start..end].iter().enumerate() {
@@ -733,6 +751,23 @@ fn render_collected(
                     }),
                     event_type: "select",
                 });
+            }
+            // Pad to `visible` rows with blank entries. Hit areas
+            // intentionally not emitted for the padding — those rows
+            // aren't clickable items.
+            let rendered_items = (end - start) as u32;
+            for _ in rendered_items..visible {
+                let mut padding = TextPropertyEntry {
+                    text: String::new(),
+                    properties: Default::default(),
+                    style: None,
+                    inline_overlays: Vec::new(),
+                    segments: Vec::new(),
+                    pad_to_chars: None,
+                    truncate_to_chars: None,
+                };
+                ensure_trailing_newline(&mut padding);
+                entries.push(padding);
             }
         }
         WidgetSpec::Tree {

--- a/crates/fresh-editor/tests/e2e/sessions.rs
+++ b/crates/fresh-editor/tests/e2e/sessions.rs
@@ -151,6 +151,8 @@ fn create_terminal_targets_inactive_session_via_session_id() {
             focus: None,
             persistent: false,
             window_id: Some(alpha),
+            command: None,
+            title: None,
             request_id: 9999,
         })
         .unwrap();

--- a/crates/fresh-editor/tests/e2e/workspace.rs
+++ b/crates/fresh-editor/tests/e2e/workspace.rs
@@ -1917,6 +1917,8 @@ fn test_plugin_ephemeral_terminal_excluded_from_workspace() {
             focus: Some(false),
             persistent: false,
             window_id: None,
+            command: None,
+            title: None,
             request_id: 0,
         })
         .unwrap();
@@ -1961,6 +1963,8 @@ fn test_plugin_persistent_terminal_included_in_workspace() {
             focus: Some(false),
             persistent: true,
             window_id: None,
+            command: None,
+            title: None,
             request_id: 0,
         })
         .unwrap();
@@ -2011,6 +2015,8 @@ fn test_plugin_split_terminal_not_duplicated_in_active_split() {
             focus: Some(false),
             persistent: true,
             window_id: None,
+            command: None,
+            title: None,
             request_id: 0,
         })
         .unwrap();

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -6783,6 +6783,7 @@ impl Editor {
                 ratio,
                 focus,
                 request_id,
+                ..
             } => {
                 let (cols, rows) = self.get_terminal_dimensions();
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -994,6 +994,8 @@ impl JsEditorApi {
         #[plugin_api(ts_type = "string | null")] context: rquickjs::function::Opt<
             rquickjs::Value<'js>,
         >,
+        #[plugin_api(ts_type = "{ terminalBypass?: boolean } | null")]
+        options: rquickjs::function::Opt<rquickjs::Value<'js>>,
     ) -> rquickjs::Result<bool> {
         // Use stored plugin name instead of global lookup
         let plugin_name = self.plugin_name.clone();
@@ -1052,6 +1054,21 @@ impl JsEditorApi {
             },
         );
 
+        // Extract `options.terminalBypass`. JS shape: `{ terminalBypass: true }`
+        // or omitted/null. Anything else is ignored — wrong shape stays at the
+        // safe default of `false`.
+        let terminal_bypass: bool = options
+            .0
+            .and_then(|v| {
+                if v.is_null() || v.is_undefined() {
+                    None
+                } else {
+                    v.into_object()
+                        .and_then(|obj| obj.get::<&str, bool>("terminalBypass").ok())
+                }
+            })
+            .unwrap_or(false);
+
         // Register with editor
         let command = Command {
             name: name.clone(),
@@ -1059,6 +1076,7 @@ impl JsEditorApi {
             action_name: handler_name,
             plugin_name,
             custom_contexts: context_str.into_iter().collect(),
+            terminal_bypass,
         };
 
         Ok(self

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5034,6 +5034,8 @@ impl JsEditorApi {
             focus: None,
             persistent: None,
             window_id: None,
+            command: None,
+            title: None,
         });
 
         // Track request_id → plugin_name for async resource tracking
@@ -5050,6 +5052,8 @@ impl JsEditorApi {
             // by passing `persistent: true` in the options if the plugin wants
             // the terminal to survive workspace save/restore.
             persistent: opts.persistent.unwrap_or(false),
+            command: opts.command,
+            title: opts.title,
             request_id: id,
         });
         Ok(id)


### PR DESCRIPTION
The orchestrator's "create terminal in inactive session" path was
spawning the PTY on the *active* window's terminal_manager and then
trying to migrate state to the target window. Only the `buffers` map
got migrated; `buffer_metadata`, `terminal_buffers`, `event_logs`, and
`terminal_backing_files` were stranded on the wrong window, so the
live-PTY overlay (gated on `terminal_buffers` lookup) silently fell
back to painting the empty `.txt` backing file. Any session created
via `Orchestrator: New Session` rendered an empty terminal pane even
though the agent process was alive.

Fix the architecture rather than the symptom: move all per-window
terminal lifecycle methods onto `impl Window` so spawning into any
window is a single direct call, with no migration helper to leak state.

Per-window bodies moved to impl Window:
- `Window::resolved_terminal_wrapper`
- `Window::get_terminal_dimensions`
- `Window::spawn_terminal_session(cwd, persistent)`
- `Window::create_terminal_buffer_attached(terminal_id, split_id)`
- `Window::create_terminal_buffer_detached(terminal_id)`
- `Window::open_terminal_in_window` — composes the above plus
  set-active-buffer + terminal-mode + resize, returns ids
- `Window::create_plugin_terminal(cwd, direction, ratio, focus,
  persistent)` — the full plugin-facing flow including the
  vertical/horizontal split-creation paths and the never-activated
  layout-seeding fallback

Editor-side wrappers become thin routers:
- `Editor::open_terminal` delegates to the active window's
  `open_terminal_in_window`, then fires the editor-wide
  `buffer_activated` plugin hook + the exit-key status message
- `Editor::handle_create_terminal` resolves the target window
  (explicit `windowId` or active), borrows it once via
  `windows.get_mut(target_id)`, and calls
  `create_plugin_terminal`. Detects active-buffer changes by
  comparing before/after and fires `buffer_activated` only when
  the editor-active buffer actually changed.
- `Editor::set_status_message` delegates to
  `Window::set_status_message` (already exists).

Deleted:
- `Editor::handle_create_terminal_in_inactive_session` — the
  buggy migration helper; the unified router handles both cases.
- The pre-refactor active-path body of `Editor::handle_create_terminal`
- `Editor::create_terminal_buffer_attached` and
  `Editor::get_terminal_dimensions` — unused after the moves.

Orchestrator plugin: reorder the `window_created` handler to dive
into the new session *before* spawning its terminal. The dive isn't
visible flicker (creating a session is a visit-now action anyway) and
this way the terminal lands on the editor-active window, so subsequent
`sendTerminalInput` calls reach the right `terminal_manager` without
needing cross-window terminal-id lookups in the host.

Verified: created an Orchestrator session with `python3` as the agent
command, the new window opens with `*Terminal 0*` showing the live
shell prompt instead of an empty `fresh-terminal-eph-N.txt` buffer.
All 2455 unit tests pass.

Pattern matches the existing `Window::set_active_buffer` /
`Editor::set_active_buffer` split (active_focus.rs:51 vs 87) — per-
window body on `impl Window`, cross-cutting plugin-hook firing on
`impl Editor`.

https://claude.ai/code/session_01414a7ZCmfZYFEiMLt4ES67