### PR TITLE
fix: paste with Ctrl+V into Search & Replace fields (#1960)

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -557,6 +557,17 @@ impl Editor {
             return;
         }
 
+        // If the active buffer hosts a widget panel with a focused
+        // text input (e.g. the project Search & Replace panel — issue
+        // #1960), paste into that widget instead of the underlying
+        // virtual buffer's text.
+        let active_buf = self.active_buffer();
+        if let Some(panel_id) = self.panel_with_focused_text_for_buffer(active_buf) {
+            self.paste_into_focused_widget(panel_id, &normalized);
+            self.active_window_mut().status_message = Some(t!("clipboard.pasted").to_string());
+            return;
+        }
+
         // Collect cursor info sorted in reverse order by position
         let mut cursor_data: Vec<_> = self
             .active_cursors()

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -693,6 +693,24 @@ impl Editor {
                             let action_name = format!("mode_text_input:{}", ch);
                             return self.handle_action(Action::PluginAction(action_name));
                         }
+                        // Ctrl/Alt + char isn't a printable input, but
+                        // users still expect Ctrl+V to paste into the
+                        // focused widget input (e.g. the search field
+                        // of the project Search & Replace panel —
+                        // issue #1960). Resolve against the Normal
+                        // context and let only Paste through; other
+                        // normal bindings (Ctrl+O open-file, Ctrl+S
+                        // save, …) stay blocked so a search field
+                        // doesn't double as a global command bar.
+                        let key_event = crossterm::event::KeyEvent::new(code, modifiers);
+                        let normal_action = {
+                            let keybindings = self.keybindings.read().unwrap();
+                            keybindings
+                                .resolve(&key_event, crate::input::keybindings::KeyContext::Normal)
+                        };
+                        if matches!(normal_action, crate::input::keybindings::Action::Paste) {
+                            return self.handle_action(normal_action);
+                        }
                     }
                     tracing::debug!("Blocking unbound key in text-input mode '{}'", mode_name);
                     return Ok(());
@@ -1003,6 +1021,20 @@ impl Editor {
                     == crate::input::keybindings::KeyContext::FileExplorer
                 {
                     self.file_explorer_paste();
+                    return Ok(());
+                }
+                // A widget panel's text input is editable even when
+                // the underlying virtual buffer is read-only (e.g.
+                // the Search & Replace results buffer — issue #1960).
+                // Route paste through the widget if one is focused
+                // before falling through to the editing-disabled
+                // guard.
+                let active_buf = self.active_buffer();
+                if self
+                    .panel_with_focused_text_for_buffer(active_buf)
+                    .is_some()
+                {
+                    self.paste();
                     return Ok(());
                 }
                 if self.active_window().is_editing_disabled() {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4932,6 +4932,48 @@ impl Editor {
         self.write_focused_text(panel_id, &focus_key, &prev, new_value, new_cursor);
     }
 
+    /// Return the id of the first widget panel mounted on `buffer_id`
+    /// whose currently-focused widget is a text widget (TextInput /
+    /// TextArea). Used by paste routing so clipboard insertion goes
+    /// into the focused input rather than the underlying virtual
+    /// buffer's text. Returns `None` when no panel on this buffer has
+    /// a focused text widget — callers should fall back to the normal
+    /// buffer paste path.
+    pub(super) fn panel_with_focused_text_for_buffer(
+        &self,
+        buffer_id: fresh_core::BufferId,
+    ) -> Option<u64> {
+        self.widget_registry
+            .panels_for_buffer(buffer_id)
+            .into_iter()
+            .find(|&pid| self.read_focused_text(pid).is_some())
+    }
+
+    /// Insert clipboard text at the focused widget's cursor. Newlines
+    /// in `text` are flattened to spaces for single-line widgets so a
+    /// stray trailing newline in the clipboard doesn't push a blank
+    /// line into a search field; multi-line widgets receive the text
+    /// verbatim.
+    pub(super) fn paste_into_focused_widget(&mut self, panel_id: u64, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        let (focus_key, prev) = match self.read_focused_text(panel_id) {
+            Some(t) => t,
+            None => return,
+        };
+        let owned;
+        let to_insert: &str = if prev.multiline {
+            text
+        } else {
+            owned = text.replace('\n', " ");
+            &owned
+        };
+        let (new_value, new_cursor) =
+            crate::widgets::apply_text_char(prev.value(), prev.cursor(), to_insert);
+        self.write_focused_text(panel_id, &focus_key, &prev, new_value, new_cursor);
+    }
+
     fn handle_unmount_widget_panel(&mut self, panel_id: u64) {
         match self.widget_registry.unmount(panel_id) {
             Some(buffer_id) => {

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -1497,3 +1497,83 @@ fn test_search_replace_second_alt_enter_does_not_corrupt_files() {
         after_first, after_second
     );
 }
+
+/// Issue #1960: Ctrl+V must paste the clipboard into the search field.
+///
+/// The Search & Replace panel uses a buffer-local `search-replace-list` mode
+/// that captures printable keys for inline editing. Before the fix, the
+/// text-input-mode handler in `app/input.rs` swallowed every Ctrl/Alt-modified
+/// key, so Ctrl+V never reached the Paste action and pasting was impossible
+/// in the search/replace fields (the user had to rely on terminal-level paste,
+/// which only works on some terminals/setups).
+#[test]
+fn test_search_replace_paste_into_search_field() {
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, Default::default(), project_root)
+            .unwrap();
+    // Internal-only clipboard so the test doesn't depend on the host clipboard.
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("jovial".to_string());
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+
+    // Panel opens with focus on the search field.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Paste via Ctrl+V into the search field.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // The clipboard contents should appear in the Search: field.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("jovial"))
+        .unwrap();
+}
+
+/// Issue #1960 variant: Ctrl+V into the replace field after Tab.
+#[test]
+fn test_search_replace_paste_into_replace_field() {
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, Default::default(), project_root)
+            .unwrap();
+    harness
+        .editor_mut()
+        .set_clipboard_for_test("REPLACEMENT".to_string());
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Type a search term first.
+    harness.type_text("hello").unwrap();
+    // Tab to the replace field.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    // Paste via Ctrl+V into the replace field.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    harness
+        .wait_until(|h| h.screen_to_string().contains("REPLACEMENT"))
+        .unwrap();
+}


### PR DESCRIPTION
Fixes #1960.

## Problem

The project Search & Replace panel (Command Palette → "Search and Replace in Project") runs the focused buffer in a `search-replace-list` mode whose host-side text-input handler in `app/input.rs` swallows every Ctrl/Alt-modified key. As a result Ctrl+V never reached the Paste action and users could not paste into the search or replace fields — a real blocker for any non-typable input (UTF-8 characters, long values from outside the editor, regexes, etc.).

## Fix

Three small changes, all confined to host-side input/clipboard routing:

1. **`app/input.rs` text-input-mode handler** — when a Ctrl/Alt-modified character key reaches the text-input bypass, resolve it against the Normal context first and let only `Action::Paste` through. Other normal bindings (Ctrl+O open-file, Ctrl+S save, …) stay blocked, so the search field is not promoted to a global command bar.
2. **`app/input.rs` `Action::Paste` handler** — route paste through the focused widget input *before* the `editing_disabled` guard, since the Search & Replace results buffer is a read-only virtual buffer and the existing guard would otherwise short-circuit.
3. **`app/clipboard.rs::paste_text` + `app/plugin_dispatch.rs`** — when the active buffer hosts a widget panel with a focused text widget, paste into the widget via a new `paste_into_focused_widget` helper. Newlines are flattened to spaces for single-line widgets; multi-line widgets receive the clipboard text verbatim.

The fix preserves the original safety property of the text-input-mode bypass (random Ctrl-shortcuts cannot leak through) by allowing only the Paste action.

## Tests

Two new e2e tests in `tests/e2e/search_replace.rs`:
- `test_search_replace_paste_into_search_field` — set the internal clipboard to `"jovial"`, open the panel, press Ctrl+V, assert the search field contains `"jovial"`.
- `test_search_replace_paste_into_replace_field` — same flow but Tab to the replace field first.

Both tests hang on master (the action never fires, so `"jovial"` never appears on the screen) and pass with this change. Manual validation in tmux: copying `"hello"` from the buffer, opening Search & Replace, clearing the prefilled field, and pressing Ctrl+V successfully populates the search field and finds the expected match.

## Test plan
- [x] `cargo test -p fresh-editor --test e2e_tests search_replace` — 25 pass / 2 ignored
- [x] `cargo test -p fresh-editor --test e2e_tests paste` — 63 pass / 2 ignored
- [x] `cargo check --all-targets -p fresh-editor` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual tmux validation against the release binary


---
_Generated by [Claude Code](https://claude.ai/code/session_0138njJzQEp5kzmFedEGkHHe)_