### PR TITLE
fix: don't draw phantom cursor when buffer cursor is offscreen (#1965)

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -927,6 +927,11 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             // visible byte that is >= the cursor byte on the same line — this keeps
             // the cursor visible for the one frame between cursor movement and the
             // plugin's conceal-refresh response.
+            //
+            // The fallback is gated by `is_on_cursor_line` so that lines below the
+            // cursor don't snap a phantom cursor onto themselves when the cursor's
+            // own line is offscreen (issue #1965: mouse-wheel scroll past the
+            // cursor drew a phantom cursor at the top of the new viewport).
             let mut nearest_fallback: Option<(u16, usize)> = None; // (screen_x, byte_distance)
             for (screen_x, source_offset) in line_view_map.iter().enumerate() {
                 if let Some(src) = source_offset {
@@ -937,7 +942,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                         have_cursor = true;
                     }
                     // Track nearest visible byte >= cursor position for fallback
-                    if !have_cursor && *src >= primary_cursor_position {
+                    if !have_cursor && is_on_cursor_line && *src >= primary_cursor_position {
                         let dist = *src - primary_cursor_position;
                         if nearest_fallback.is_none() || dist < nearest_fallback.unwrap().1 {
                             nearest_fallback = Some((screen_x as u16, dist));

--- a/crates/fresh-editor/tests/e2e/issue_1965_cursor_after_mouse_scroll.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1965_cursor_after_mouse_scroll.rs
@@ -1,0 +1,84 @@
+//! End-to-end regression test for issue #1965: "Cursor issues while scrolling
+//! down with mouse wheel".
+//!
+//! Bug: When the user scrolls the viewport with the mouse wheel so that the
+//! cursor's actual buffer position scrolls off-screen, a phantom hardware
+//! cursor visual appears on the first visible row of the new viewport.  The
+//! cursor isn't really there — pressing an arrow key snaps the viewport back
+//! to the real cursor location — but the visual is misleading.
+//!
+//! Expected: when the cursor's buffer position is outside the visible
+//! viewport after a mouse-wheel scroll, the hardware cursor should not be
+//! drawn anywhere in the viewport.
+
+use crate::common::harness::EditorTestHarness;
+
+/// Scroll down past the cursor with the mouse wheel and verify the hardware
+/// cursor is not rendered at the top of the visible viewport.
+#[test]
+fn cursor_not_drawn_after_mouse_wheel_scrolls_past_it() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Buffer with many lines so we have plenty of room to scroll past the
+    // cursor's logical position.
+    let content: String = (0..200).map(|i| format!("Line {i}\n")).collect();
+    let _fixture = harness.load_buffer_from_text(&content).unwrap();
+
+    // Park the cursor on line 0 (cursor_position == 0).
+    use crossterm::event::{KeyCode, KeyModifiers};
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    let cursor_before = harness.cursor_position();
+    assert_eq!(
+        cursor_before, 0,
+        "test precondition: cursor should be at start of buffer"
+    );
+
+    // Render and confirm the cursor is visible at the top of the viewport.
+    let baseline = harness.render_observing_cursor().unwrap();
+    assert!(
+        baseline.is_some(),
+        "baseline: hardware cursor should be visible when the cursor is in-view"
+    );
+
+    // Scroll the viewport down many times.  Each ScrollDown moves the
+    // viewport down by ~3 logical lines (the default wheel step), so after
+    // 30 events we are well past line 0.
+    let (content_first_row, _) = harness.content_area_rows();
+    let scroll_col = 10u16;
+    let scroll_row = content_first_row as u16 + 5;
+    for _ in 0..30 {
+        harness.mouse_scroll_down(scroll_col, scroll_row).unwrap();
+    }
+
+    // The mouse-wheel scroll must not move the actual cursor.
+    assert_eq!(
+        harness.cursor_position(),
+        cursor_before,
+        "mouse wheel scroll must not move the buffer cursor"
+    );
+
+    // The viewport must have actually scrolled (sanity: line 0 should be
+    // gone from the visible content area).
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Line 0\n")
+            && !screen
+                .lines()
+                .any(|l| l.trim_start().starts_with("Line 0 ")),
+        "viewport should have scrolled away from Line 0 after wheel events.\nScreen:\n{screen}"
+    );
+
+    // The bug: a phantom hardware cursor shows at the top of the new
+    // viewport even though the real cursor (at byte 0) is now offscreen.
+    // The fix: hardware cursor should be hidden when the real cursor is
+    // not in the visible range.
+    let cursor_after = harness.render_observing_cursor().unwrap();
+    assert!(
+        cursor_after.is_none(),
+        "hardware cursor should be hidden when the buffer cursor has scrolled out of view, \
+         but it was rendered at {:?}",
+        cursor_after
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -71,6 +71,7 @@ pub mod issue_1697_ctrl_d_after_search;
 pub mod issue_1718_settings_search_utf8_panic;
 pub mod issue_1790_compose_wrap_highlight;
 pub mod issue_1901_multicursor_with_completion_popup;
+pub mod issue_1965_cursor_after_mouse_scroll;
 pub mod issue_779_after_eof_shade;
 pub mod redraw_screen;
 pub mod suspend_process;


### PR DESCRIPTION
Fixes #1965.

## Symptom

When the user scrolls the viewport (mouse wheel, or `Ctrl+Up`/`Ctrl+Down`)
so that the cursor's buffer position falls *outside* the visible range,
a phantom hardware cursor visually appears at the top-left of the new
viewport. Pressing any arrow key then snaps the viewport back to the
real cursor location — confirming the cursor itself never moved; only
its visual was drawn in the wrong place.

## Root cause

`render_view_lines` (in `render_line/mod.rs`) has a cursor-fallback that
exists for the *compose-mode conceal* edge case: when the cursor's byte
falls inside a concealed range (syntax markers hidden by compose-mode
plugins), no `line_view_map` entry matches `primary_cursor_position`, so
the renderer snaps to the nearest visible byte `>= primary_cursor_position`
on the same line. This keeps the cursor visible for the one frame
between cursor movement and the plugin's conceal-refresh response.

The fallback's intent is "...on the same line," but the code only
enforced the `>=` half of that contract — it didn't check that the
current row actually belonged to the cursor's logical line. When the
viewport was scrolled below the cursor's line, every visible byte on
every visible row was `>= primary_cursor_position`, so the fallback
fired on the first such row and drew the phantom there.

## Fix

Gate the fallback on `is_on_cursor_line` (already maintained per-row a
few lines above) so it only fires when the current row actually belongs
to the cursor's logical line. Lines below an offscreen cursor no longer
attract a phantom.

The conceal case continues to work: the cursor's own line still
qualifies, and the fallback still picks the nearest visible byte `>=`
the cursor position on that line.

## Test plan

- [x] New e2e regression test
  `issue_1965_cursor_after_mouse_scroll::cursor_not_drawn_after_mouse_wheel_scrolls_past_it`
  that drives `ScrollDown` mouse events through the harness past a
  cursor parked at byte 0, then asserts via `render_observing_cursor()`
  that ratatui's hardware cursor is hidden. Fails on `master`, passes
  with the fix.
- [x] Manual validation in tmux: open a 200-line file, `Ctrl+Down`
  through the viewport, captured pane with colors shows no REVERSED
  cursor cell anywhere; scrolling back up restores the cursor on its
  original line.
- [x] `cargo test --test e2e_tests cursor` — 229 passed, 0 failed
- [x] `cargo test --test e2e_tests scroll` — 213 passed, 0 failed
- [x] `cargo test --test e2e_tests compose` — 66 passed, 0 failed
  (covers the original conceal use case the fallback was added for)
- [x] `cargo test --test e2e_tests rendering` — 44 passed, 0 failed
- [x] `cargo check --all-targets` — clean
- [x] `cargo fmt`


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKgwBJ5kMseQ9bwEsoZ5NX)_