### PR TITLE
fix: scaffold fresh.entry instead of fresh.main in plugin init

### DIFF
--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -676,7 +676,7 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
 
   // For plugins, validate entry file exists
   if (manifest.type === "plugin") {
-    const entryFile = manifest.fresh?.entry || `${manifest.name}.ts`;
+    const entryFile = manifest.fresh?.entry || manifest.fresh?.main || `${manifest.name}.ts`;
     const entryPath = editor.pathJoin(packageDir, entryFile);
 
     if (!editor.fileExists(entryPath)) {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -2062,7 +2062,7 @@ fn create_plugin_package(
         "plugin",
         "A Fresh plugin",
         r#"{
-    "main": "plugin.ts"
+    "entry": "plugin.ts"
   }"#,
     )?;
 


### PR DESCRIPTION
Fixes https://github.com/sinelaw/fresh/issues/1986

## Summary
- Fixed `fresh --init plugin` generating `"fresh": { "main": "plugin.ts" }` instead of `"fresh": { "entry": "plugin.ts" }`
- The JS package validation code reads `fresh.entry` — with `fresh.main` the entry was `undefined`, causing "Missing entry file" errors
- Added backwards-compatibility fallback for `fresh.main` in the JS validation so existing plugins using the old field (if any) still work

## Changes
1. **`crates/fresh-editor/src/main.rs`** — Changed scaffold template from `"main"` to `"entry"`
2. **`crates/fresh-editor/plugins/pkg.ts`** — Added `manifest.fresh?.main` as fallback for backwards compatibility