### PR TITLE
orchestrator: picker UX — Visit/New Session buttons, confirm prompts, in-dialog errors

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1059,6 +1059,25 @@ pub struct EditorStateSnapshot {
     #[serde(default)]
     #[ts(type = "any")]
     pub active_session_plugin_states: HashMap<String, HashMap<String, serde_json::Value>>,
+
+    /// Total terminal dimensions in cells. Refreshed on every
+    /// resize event. Plugins read this via `editor.getScreenSize()`
+    /// when they need to size floating overlays against the whole
+    /// terminal — `getViewport()` only reports the active split,
+    /// which is smaller than the screen whenever splits exist.
+    #[serde(default)]
+    pub terminal_width: u16,
+    #[serde(default)]
+    pub terminal_height: u16,
+}
+
+/// Total terminal size in cells. Returned by `editor.getScreenSize()`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export, rename_all = "camelCase")]
+pub struct ScreenSize {
+    pub width: u16,
+    pub height: u16,
 }
 
 impl EditorStateSnapshot {
@@ -1092,6 +1111,8 @@ impl EditorStateSnapshot {
             keybinding_labels: HashMap::new(),
             plugin_global_states: HashMap::new(),
             active_session_plugin_states: HashMap::new(),
+            terminal_width: 0,
+            terminal_height: 0,
         }
     }
 }
@@ -4572,6 +4593,15 @@ impl PluginApi {
     pub fn get_viewport(&self) -> Option<ViewportInfo> {
         let snapshot = self.state_snapshot.read().unwrap();
         snapshot.viewport.clone()
+    }
+
+    /// Get total terminal dimensions.
+    pub fn get_screen_size(&self) -> ScreenSize {
+        let snapshot = self.state_snapshot.read().unwrap();
+        ScreenSize {
+            width: snapshot.terminal_width,
+            height: snapshot.terminal_height,
+        }
     }
 
     /// Get access to the state snapshot Arc (for internal use)

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -252,6 +252,10 @@ type ViewportInfo = {
 	*/
 	height: number;
 };
+type ScreenSize = {
+	width: number;
+	height: number;
+};
 type KeyEventPayload = {
 	/**
 	* Key name (e.g. `"a"`, `"escape"`, `"f1"`).
@@ -636,6 +640,27 @@ type CreateTerminalOptions = {
 	* target session's membership set rather than the active one's.
 	*/
 	windowId?: WindowId;
+	/**
+	* Argv to spawn directly inside the PTY instead of the host's
+	* configured shell. `None` (default) keeps the historical
+	* behaviour: spawn the user's shell and let the caller type into
+	* it via `sendTerminalInput`. `Some([cmd, ...args])` runs that
+	* exact command as the PTY child — no shell middleman, so the
+	* process exits cleanly when the agent does and the
+	* terminal-buffer's `terminal_exit` plugin hook reflects the
+	* agent's real exit status. Used by Orchestrator so a session
+	* with agent `python3` is just python3 in the PTY rather than
+	* bash-running-python3-as-a-subshell-command.
+	*/
+	command?: Array<string>;
+	/**
+	* Tab title for the terminal buffer. Defaults to `command[0]`
+	* (when `command` is set) or `"Terminal N"` (the historical
+	* auto-numbered title). If another terminal in the same window
+	* already uses the requested title, the host appends `" (k)"`
+	* to disambiguate. Empty string is treated the same as `None`.
+	*/
+	title?: string;
 };
 type CursorInfo = {
 	/**
@@ -1074,6 +1099,17 @@ type AuthorityPayload = {
 	spawner: AuthoritySpawner;
 	terminal_wrapper: AuthorityTerminalWrapper;
 	display_label?: string;
+	/**
+	* Optional host↔remote workspace path mapping. The dev-container
+	* authority sets both roots (editor.getCwd() on host;
+	* remoteWorkspaceFolder on container) so LSP URIs translate at the
+	* host/container boundary. Local and SSH authorities omit it.
+	*/
+	path_translation?: PathTranslationSpec;
+};
+type PathTranslationSpec = {
+	host_root: string;
+	remote_root: string;
 };
 type BackgroundProcessResult = {
 	/**
@@ -1388,7 +1424,7 @@ interface EditorAPI {
 	* again with the same `name` replaces the previous registration
 	* (idempotent — reload works). Exports are auto-dropped when the
 	* calling plugin is unloaded.
-	*
+	* 
 	* Returns `true` on success. Rejects with a TypeError if `name` is
 	* empty or `api` is not an object (functions and primitives are not
 	* valid API surfaces — only objects).
@@ -1430,7 +1466,7 @@ interface EditorAPI {
 	getKeybindingLabel(action: string, mode: string | null): string | null;
 	/**
 	* Register a command in the command palette (Ctrl+P).
-	*
+	* 
 	* Usually you should omit `context` so the command is always visible.
 	* If provided, the command is **hidden** unless your plugin has activated
 	* that context with `editor.setContext(name, true)` or the focused buffer's
@@ -1438,7 +1474,9 @@ interface EditorAPI {
 	* contexts only (e.g. `"tour-active"`, `"review-mode"`), not built-in
 	* editor modes.
 	*/
-	registerCommand(name: string, description: string, handlerName: string, context?: string | null): boolean;
+	registerCommand(name: string, description: string, handlerName: string, context?: string | null, options?: {
+		terminalBypass?: boolean;
+	} | null): boolean;
 	/**
 	* Unregister a command by name
 	*/
@@ -1458,8 +1496,8 @@ interface EditorAPI {
 	*/
 	registerStatusBarElement(tokenName: string, title: string): boolean;
 	/**
-	* Set the value of a registered status-bar token for a specific buffer.
-	* The token key sent to the editor is "plugin_name:token_name".
+	* Set the value of a status-bar token for a specific buffer.
+	* The full token key sent to the editor is "plugin_name:token_name".
 	*/
 	setStatusBarValue(bufferId: number, tokenName: string, value: string): boolean;
 	/**
@@ -1509,8 +1547,15 @@ interface EditorAPI {
 	*/
 	getViewport(): ViewportInfo | null;
 	/**
+	* Total terminal dimensions in cells. Unlike `getViewport()`
+	* (which reports the active split, shrunk by any vertical
+	* split layout), this reflects the full terminal — what a
+	* floating overlay sized by `heightPct` actually gets.
+	*/
+	getScreenSize(): ScreenSize;
+	/**
 	* List every split with its active buffer and viewport.
-	*
+	* 
 	* Plugins that need to operate on every visible buffer
 	* simultaneously (multi-split flash labels, syncing decorations
 	* across panes, …) iterate this list rather than only seeing
@@ -1656,7 +1701,7 @@ interface EditorAPI {
 	getCwd(): string;
 	/**
 	* Get the active authority's display label.
-	*
+	* 
 	* Empty means the local (default) authority. A non-empty value
 	* means a plugin-installed or SSH authority is in effect (e.g.
 	* `"Container:abc123def456"` for a devcontainer). Intended as a
@@ -1668,7 +1713,7 @@ interface EditorAPI {
 	/**
 	* Join path components (variadic - accepts multiple string arguments)
 	* Always uses forward slashes for cross-platform consistency (like Node.js path.posix.join)
-	*
+	* 
 	* Preserves up to 2 leading slashes, which matters on Windows: Rust's
 	* `Path::canonicalize` returns `\\?\`-prefixed paths, and `editor.getCwd()`
 	* surfaces that to plugin code verbatim. After the backslash→slash
@@ -1707,7 +1752,7 @@ interface EditorAPI {
 	pathToFileUri(path: string): string;
 	/**
 	* Get the UTF-8 byte length of a JavaScript string.
-	*
+	* 
 	* JS strings are UTF-16 internally, so `str.length` returns the number of
 	* UTF-16 code units, not the number of bytes in a UTF-8 encoding.  The
 	* editor API uses byte offsets for all buffer positions (overlays, cursor,
@@ -1758,18 +1803,18 @@ interface EditorAPI {
 	getTempDir(): string;
 	/**
 	* Parse a JSONC (JSON with comments) string into a JS value.
-	*
+	* 
 	* Accepts the JSONC superset: line and block comments, trailing
 	* commas, single-quoted strings, and unquoted object keys — matching
 	* devcontainer.json / tsconfig.json / VS Code settings.json.
-	*
+	* 
 	* Throws a JS error (catchable with try/catch) when the input is not
 	* valid JSONC, like `JSON.parse` does for invalid JSON.
 	*/
 	parseJsonc(text: string): unknown;
 	/**
 	* Get current config as JS object.
-	*
+	* 
 	* The snapshot holds an `Arc<serde_json::Value>` that was serialized
 	* on the editor side the last time the underlying `Arc<Config>`
 	* changed. Cloning the Arc inside the read lock is a refcount bump;
@@ -1786,14 +1831,14 @@ interface EditorAPI {
 	reloadConfig(): void;
 	/**
 	* Set a single config setting in the runtime layer for this session.
-	*
+	* 
 	* `path` is dot-separated (e.g. `"editor.tab_size"`). `value` is any JSON
 	* value in the shape the setting expects. The write lives in an
 	* in-memory layer scoped to the calling plugin — it does not modify
 	* `config.json`, and unloading the plugin (or reloading init.ts) drops
 	* it. Intended use is `init.ts` running a conditional:
 	* `if (editor.getEnv("SSH_TTY")) editor.setSetting("terminal.mouse", false);`
-	*
+	* 
 	* Returns `true` if the write was queued. The actual update is
 	* asynchronous; a subsequent `getConfig()` will reflect it after the
 	* editor processes the command.
@@ -1854,7 +1899,7 @@ interface EditorAPI {
 	* Override theme colors in-memory for the running session. `overrides`
 	* is a JS object mapping `"section.field"` keys (same namespace as
 	* `getThemeSchema`) to `[r, g, b]` triplets (0–255 each).
-	*
+	* 
 	* Unknown keys are dropped silently; out-of-range values are clamped
 	* to `0..=255`. Overrides survive until the next `applyTheme` call
 	* (which replaces the whole `Theme`). Intended for fast animation
@@ -1908,14 +1953,14 @@ interface EditorAPI {
 	pluginTranslate(pluginName: string, key: string, args?: Record<string, unknown>): string;
 	/**
 	* Create a composite buffer (async)
-	*
+	* 
 	* Uses typed CreateCompositeBufferOptions - serde validates field names at runtime
 	* via `deny_unknown_fields` attribute
 	*/
 	createCompositeBuffer(opts: TsCreateCompositeBufferOptions): Promise<number>;
 	/**
 	* Update alignment hunks for a composite buffer
-	*
+	* 
 	* Uses typed Vec<CompositeHunk> - serde validates field names at runtime
 	*/
 	updateCompositeAlignment(bufferId: number, hunks: TsCompositeHunk[]): boolean;
@@ -1943,15 +1988,15 @@ interface EditorAPI {
 	getHighlights(bufferId: number, start: number, end: number): Promise<TsHighlightSpan[]>;
 	/**
 	* Add an overlay with styling options
-	*
+	* 
 	* Colors can be specified as RGB arrays `[r, g, b]` or theme key strings.
 	* Theme keys are resolved at render time, so overlays update with theme changes.
-	*
+	* 
 	* Theme key examples: "ui.status_bar_fg", "editor.selection_bg", "syntax.keyword"
-	*
+	* 
 	* Options: fg, bg (RGB array or theme key string), bold, italic, underline,
 	* strikethrough, extend_to_line_end (all booleans, default false).
-	*
+	* 
 	* Example usage in TypeScript:
 	* ```typescript
 	* editor.addOverlay(bufferId, "my-namespace", 0, 10, {
@@ -2016,10 +2061,10 @@ interface EditorAPI {
 	clearSoftBreaksInRange(bufferId: number, start: number, end: number): boolean;
 	/**
 	* Submit a view transform for a buffer/split
-	*
+	* 
 	* Accepts tokens in the simple format:
 	* {kind: "text"|"newline"|"space"|"break", text: "...", sourceOffset: N, style?: {...}}
-	*
+	* 
 	* Also accepts the TypeScript-defined format for backwards compatibility:
 	* {kind: {Text: "..."} | "Newline" | "Space" | "Break", source_offset: N, style?: {...}}
 	*/
@@ -2071,7 +2116,7 @@ interface EditorAPI {
 	clearVirtualTextNamespace(bufferId: number, namespace: string): boolean;
 	/**
 	* Add a virtual line (full line above/below a position)
-	*
+	* 
 	* The `options` object accepts:
 	* * `fg`, `bg` — either an `[r, g, b]` array (each `0..=255`) or a
 	* theme-key string (e.g. `"editor.line_number_fg"`).  Theme keys
@@ -2093,7 +2138,7 @@ interface EditorAPI {
 	prompt(label: string, initialValue: string): Promise<string | null>;
 	/**
 	* Start an interactive prompt.
-	*
+	* 
 	* When `floatingOverlay` is true, the editor renders the prompt
 	* and its suggestions inside a centred floating frame instead of
 	* the bottom minibuffer row (issue #1796 — Live Grep). The flag
@@ -2103,7 +2148,7 @@ interface EditorAPI {
 	startPrompt(label: string, promptType: string, floatingOverlay?: boolean): boolean;
 	/**
 	* Begin a key-capture window for the calling plugin.
-	*
+	* 
 	* Pair with `endKeyCapture()` around any `getNextKey()` loop.
 	* While capture is active, keys arriving between two
 	* `getNextKey()` calls are buffered in-order rather than
@@ -2121,27 +2166,26 @@ interface EditorAPI {
 	endKeyCapture(): boolean;
 	/**
 	* Wait for the next keypress and resolve with a `KeyEventPayload`.
-	*
+	* 
 	* While the returned promise is pending the editor consumes the
 	* next key and resolves it; the key does not propagate to mode
 	* bindings or other dispatch. Multiple in-flight requests across
 	* plugins are FIFO. Designed for short input loops (flash labels,
 	* vi find-char, replace-char) that would otherwise need to bind
 	* every printable key in `defineMode`.
-	*
+	* 
 	* For lossless capture against fast typing or paste, wrap the
 	* loop with `beginKeyCapture()` / `endKeyCapture()`.
 	*/
 	getNextKey(): Promise<KeyEventPayload>;
 	/**
-	* Start a prompt with initial value. See `start_prompt` for why
-	* `floating_overlay` uses `rquickjs::function::Opt` (so JS
-	* callers can omit the argument).
+	* Start a prompt with initial value. See `startPrompt` for the
+	* meaning of `floatingOverlay`.
 	*/
 	startPromptWithInitial(label: string, promptType: string, initialValue: string, floatingOverlay?: boolean): boolean;
 	/**
 	* Set suggestions for the current prompt
-	*
+	* 
 	* Uses typed Vec<Suggestion> - serde validates field names at runtime
 	*/
 	setPromptSuggestions(suggestions: PromptSuggestion[]): boolean;
@@ -2305,7 +2349,7 @@ interface EditorAPI {
 	setBufferCursor(bufferId: number, position: number): boolean;
 	/**
 	* Toggle whether the editor draws a native caret in this buffer.
-	*
+	* 
 	* Buffer-group panel buffers default to `show_cursors = false`, which
 	* also blocks all native movement actions in `action_to_events`. Plugins
 	* that want native cursor motion in a panel (e.g. magit-style row
@@ -2386,13 +2430,13 @@ interface EditorAPI {
 	removeScrollSyncGroup(groupId: number): boolean;
 	/**
 	* Execute multiple actions in sequence
-	*
+	* 
 	* Takes typed ActionSpec array - serde validates field names at runtime
 	*/
 	executeActions(actions: ActionSpec[]): boolean;
 	/**
 	* Show an action popup
-	*
+	* 
 	* Takes a typed ActionPopupOptions struct - serde validates field names at runtime
 	*/
 	showActionPopup(opts: ActionPopupOptions): boolean;
@@ -2449,7 +2493,7 @@ interface EditorAPI {
 	focusBufferGroupPanel(groupId: number, panelName: string): boolean;
 	/**
 	* Set virtual buffer content (takes array of entry objects)
-	*
+	* 
 	* Note: entries should be TextPropertyEntry[] - uses manual parsing for HashMap support
 	*/
 	setVirtualBufferContent(bufferId: number, entriesArr: Record<string, unknown>[]): boolean;
@@ -2517,7 +2561,7 @@ interface EditorAPI {
 	spawnProcess(command: string, args: string[], cwd?: string): ProcessHandle<SpawnResult>;
 	/**
 	* Spawn a process on the host regardless of the active authority.
-	*
+	* 
 	* Intended for plugin internals that must run host-side work
 	* (e.g. `devcontainer up`) before installing an authority that
 	* would otherwise route the spawn elsewhere. Same calling shape
@@ -2526,7 +2570,7 @@ interface EditorAPI {
 	spawnHostProcess(command: string, args: string[], cwd?: string): ProcessHandle<SpawnResult>;
 	/**
 	* Install a new authority via an opaque payload.
-	*
+	* 
 	* The payload is a JS object describing filesystem + spawner +
 	* terminal wrapper + display label. The canonical schema lives in
 	* the `AuthorityPayload` type in `fresh-editor`; plugins should
@@ -2545,7 +2589,7 @@ interface EditorAPI {
 	* this to surface lifecycle transitions that the authority layer
 	* doesn't know about yet — "Connecting" while `devcontainer up`
 	* runs, "FailedAttach" after a non-zero exit, etc.
-	*
+	* 
 	* Accepts a tagged JS object:
 	* ```ts
 	* editor.setRemoteIndicatorState({ kind: "connecting", label: "Building" });
@@ -2553,7 +2597,7 @@ interface EditorAPI {
 	* editor.setRemoteIndicatorState({ kind: "connected", label: "Container:abc" });
 	* editor.setRemoteIndicatorState({ kind: "local" });
 	* ```
-	*
+	* 
 	* The override sticks until replaced or cleared via
 	* `clearRemoteIndicatorState`. Editor restart (e.g. on
 	* `setAuthority`) resets it — plugins must reassert after a

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -626,37 +626,24 @@ function buildOpenSpec(): WidgetSpec {
     ? `+ New Session  ${newKey}`
     : "+ New Session";
   const inConfirm = openDialog.pendingConfirm !== null;
-  // Filter is replaced by a non-tabbable display row while a
-  // confirmation prompt is up — typing into the filter shouldn't
-  // change anything when the user's next decision is binary
-  // (Cancel / Confirm). Removing the text widget from the spec
-  // also takes it out of the tab cycle, so the post-confirm
-  // `focusAdvance(1)` lands directly on the Cancel button.
-  const filterSection: WidgetSpec = inConfirm
-    ? labeledSection({
-        label: "Filter",
-        child: {
-          kind: "raw",
-          entries: [
-            styledRow([
-              {
-                text: " (disabled while confirming)",
-                style: { fg: "ui.menu_disabled_fg", italic: true },
-              },
-            ]),
-          ],
-        },
-      })
-    : labeledSection({
-        label: "Filter",
-        child: text({
-          value: openDialog.filter.value,
-          cursorByte: openDialog.filter.cursor,
-          placeholder: "type to filter…",
-          fullWidth: true,
-          key: "filter",
-        }),
-      });
+  // While a confirmation prompt is up the filter is rendered
+  // without a `key`. The host's `collect_tabbable` only adds
+  // widgets that carry a non-empty key, so a keyless text widget
+  // is unreachable by Tab and doesn't receive `mode_text_input`
+  // — the bracketed input still paints normally, just inert.
+  // Keeping the visual chrome (instead of swapping it for a
+  // "(disabled)" label) means the dialog doesn't reflow under
+  // the user's eyes when the confirm view opens / closes.
+  const filterSection = labeledSection({
+    label: "Filter",
+    child: text({
+      value: openDialog.filter.value,
+      cursorByte: openDialog.filter.cursor,
+      placeholder: "type to filter…",
+      fullWidth: true,
+      key: inConfirm ? undefined : "filter",
+    }),
+  });
   const errorBanner: WidgetSpec | null = openDialog.lastError
     ? {
         kind: "raw",

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -111,22 +111,7 @@ interface NewSessionForm {
   // button) we re-open the picker so the user lands back where
   // they were instead of being dropped into the bare editor.
   fromPicker: boolean;
-  // Mirror of the host's currently-focused widget key. Updated
-  // by the Tab/Shift+Tab handlers below as they cycle through
-  // the form's tabbable order. The Enter handler reads this so
-  // a press on the Cancel button cancels instead of submitting
-  // (the host's smart-key Enter on a button would activate it,
-  // but the plugin's mode binding for Enter intercepts before
-  // smart-key dispatch runs — without this mirror, every Enter
-  // would always submit regardless of focus).
-  focusedKey: string;
 }
-
-// Tabbable order in the new-session form. Mirrors the spec
-// builder's declaration order in `buildFormSpec`. Used by the
-// Enter / Tab / Shift+Tab handlers to keep `form.focusedKey` in
-// sync with the host's focus tracking.
-const FORM_TABBABLE: readonly string[] = ["name", "cmd", "branch", "cancel", "create"];
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
 
@@ -724,7 +709,15 @@ function buildOpenSpec(): WidgetSpec {
           // smart-keys, so Tab jumps straight to the action
           // buttons instead of stopping here.
           focusable: false,
-          key: "sessions",
+          // Drop the `key` while a confirmation prompt is up so
+          // `find_scrollable_widget_key` (`plugin_dispatch.rs`)
+          // can't find this list — Up/Down on the focused Cancel
+          // button would otherwise forward to the list and let
+          // the user move the selection off the session being
+          // confirmed (which would break the confirm view because
+          // it only renders when the selected row matches
+          // `pendingConfirm.sessionId`).
+          key: inConfirm ? undefined : "sessions",
         }),
       }),
       // Preview pane has no explicit width — picks up the
@@ -1655,7 +1648,7 @@ function buildFormSpec(): WidgetSpec {
       hintBar([
         { keys: "Tab", label: "next" },
         { keys: "S-Tab", label: "prev" },
-        { keys: "Enter", label: "submit" },
+        { keys: "Enter", label: "advance / act" },
         { keys: "Esc", label: "cancel" },
       ]),
       flexSpacer(),
@@ -1701,9 +1694,6 @@ function openForm(options?: { fromPicker?: boolean }): void {
     defaultBranch: "",
     lastCmd,
     fromPicker: !!options?.fromPicker,
-    // Host's render_spec picks the first tabbable when there's
-    // no previous focus — that's "name" in our declaration order.
-    focusedKey: FORM_TABBABLE[0],
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
@@ -1884,10 +1874,18 @@ function startNewSession(): void {
 // Form key bindings — each delegates to smart-key dispatch on the
 // panel, which routes to the focused widget. `mode_text_input`
 // handles printable input outside this list.
+// Enter is intentionally NOT bound here: we want the host's
+// floating-widget smart-key dispatch to handle it natively. That
+// gives Enter-on-button → activate (so Cancel cancels and Create
+// Session submits via their respective `widget_event` "activate"
+// branches), and Enter-on-text-input → focus advance (next
+// field). Adding Enter to this list previously caused a regression
+// where pressing Enter on the focused Cancel button submitted
+// the form, because the plugin's handler always called
+// `submitForm` regardless of which widget the host had focused.
 const FORM_MODE_BINDINGS: [string, string][] = [
   ["Tab", "orchestrator_form_key_tab"],
   ["S-Tab", "orchestrator_form_key_shift_tab"],
-  ["Return", "orchestrator_form_key_enter"],
   ["Escape", "orchestrator_form_key_escape"],
   ["Backspace", "orchestrator_form_key_backspace"],
   ["Delete", "orchestrator_form_key_delete"],
@@ -1906,54 +1904,11 @@ function dispatchFormKey(name: string): void {
   formPanel.command(widgetKey(name));
 }
 
-// Local mirror of focus advancement. The host still owns the
-// authoritative focus_key (and re-renders against it); this side
-// tracks it so the Enter handler can dispatch correctly without
-// querying the host.
-function advanceFormFocus(delta: number): void {
-  if (!form) return;
-  const idx = FORM_TABBABLE.indexOf(form.focusedKey);
-  const cur = idx < 0 ? 0 : idx;
-  const n = FORM_TABBABLE.length;
-  form.focusedKey = FORM_TABBABLE[(cur + delta + n) % n];
-}
-
-registerHandler("orchestrator_form_key_tab", () => {
-  advanceFormFocus(1);
-  dispatchFormKey("Tab");
-});
+registerHandler("orchestrator_form_key_tab", () => dispatchFormKey("Tab"));
 registerHandler(
   "orchestrator_form_key_shift_tab",
-  () => {
-    advanceFormFocus(-1);
-    dispatchFormKey("Shift+Tab");
-  },
+  () => dispatchFormKey("Shift+Tab"),
 );
-registerHandler("orchestrator_form_key_enter", () => {
-  // The hint bar promises "Enter submit". The host's floating-panel
-  // input dispatcher (input.rs:`dispatch_floating_widget_key`)
-  // defers to plugin-defined mode bindings when present, so the
-  // smart-key router's "Enter = advance focus / activate" default
-  // doesn't fire for the orchestrator-new-form mode — this
-  // handler does.
-  //
-  // Dispatch:
-  //   - focus on `cancel` button → cancel (was a bug: every Enter
-  //     submitted, so pressing Enter on Cancel created a session)
-  //   - focus on `create` button → submit
-  //   - focus on a text field → submit (matches the "Enter submit"
-  //     hint; otherwise users would have to Tab to Create just to
-  //     fire it, defeating the hint)
-  if (!form) {
-    dispatchFormKey("Enter");
-    return;
-  }
-  if (form.focusedKey === "cancel") {
-    cancelForm();
-    return;
-  }
-  void submitForm();
-});
 registerHandler("orchestrator_form_key_escape", () => {
   if (form) cancelForm();
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -157,15 +157,18 @@ interface OpenDialogState {
   // the embed is the part the user actually wants to see; the
   // metadata row is rarely read and just eats embed height.
   showDetails: boolean;
-  // Sessions the user just archived/deleted. The async cleanup
-  // (kill processes, run `git worktree remove` / `move`) takes
-  // ~300 ms during which `editor.listWindows()` still returns the
-  // session, so reconcileSessions would re-surface it in the
-  // picker mid-flight. Stashing the id here lets `filterSessions`
-  // hide the row synchronously when the user clicks Confirm; the
-  // entry is cleared once the cleanup completes (or the dialog
-  // closes).
-  hiddenIds: Set<number>;
+  // The session id whose lifecycle action (archive / delete) is
+  // currently running. While set:
+  //   - that session's preview pane swaps to an "Archiving…" /
+  //     "Deleting…" panel with no action buttons, so the user
+  //     sees the operation is in flight rather than wondering
+  //     why their click took no effect.
+  //   - the user can still navigate to other sessions and act on
+  //     them; only the in-flight session is disabled.
+  // Cleared by the async handler on success or failure. The row
+  // disappears from the list naturally once the editor's
+  // `window_closed` hook fires `refreshOpenDialog`.
+  inFlight: { action: "archive" | "delete"; sessionId: number } | null;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -239,10 +242,7 @@ function ageString(createdAt: number): string {
 // first. Empty needle returns the full list in numeric-id order.
 function filterSessions(needle: string): number[] {
   reconcileSessions();
-  const hidden = openDialog?.hiddenIds ?? new Set<number>();
-  const ids = Array.from(orchestratorSessions.keys())
-    .filter((id) => !hidden.has(id))
-    .sort((a, b) => a - b);
+  const ids = Array.from(orchestratorSessions.keys()).sort((a, b) => a - b);
   if (!needle) return ids;
   const n = needle.toLowerCase();
   type Scored = { id: number; score: number; len: number };
@@ -344,6 +344,42 @@ function openListVisibleRows(): number {
 // <action>?" panel with [ Confirm <action> ] / [ Cancel ]
 // buttons. Cancel is default-focused for safety.
 function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
+  // In-flight overlay: when the selected session is currently
+  // being archived/deleted, swap the preview pane for a
+  // non-interactive status panel. The git operations take a few
+  // hundred ms; without this the user clicks Confirm Archive and
+  // sees no visible reaction until the editor's `window_closed`
+  // hook eventually fires and drops the row. The overlay makes
+  // the in-flight state explicit and hides the action buttons so
+  // a second click can't double-fire.
+  if (openDialog?.inFlight && s && openDialog.inFlight.sessionId === s.id) {
+    const label = openDialog.inFlight.action === "archive"
+      ? "Archiving…"
+      : "Deleting…";
+    return labeledSection({
+      label,
+      child: col(
+        {
+          kind: "raw",
+          entries: [
+            styledRow([
+              {
+                text: `${label} [${s.id}] ${s.label}`,
+                style: { bold: true, fg: "ui.menu_disabled_fg" },
+              },
+            ]),
+            styledRow([{ text: "" }]),
+            styledRow([
+              {
+                text: "Waiting for git…",
+                style: { fg: "ui.menu_disabled_fg", italic: true },
+              },
+            ]),
+          ],
+        },
+      ),
+    });
+  }
   if (openDialog?.pendingConfirm && s && openDialog.pendingConfirm.sessionId === s.id) {
     const action = openDialog.pendingConfirm.action;
     if (action === "stop") {
@@ -720,7 +756,7 @@ function openControlRoom(): void {
     // to paint something meaningful.
     embedRows: Math.max(3, listVisibleRows - 5),
     showDetails: false,
-    hiddenIds: new Set<number>(),
+    inFlight: null,
   };
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
@@ -858,33 +894,35 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
   const id = typeof explicitId === "number"
     ? explicitId
     : openDialog.filteredIds[openDialog.selectedIndex];
-  // Unhide the row + refresh on any pre-close failure so the user
-  // sees the session reappear instead of vanishing silently — the
-  // archive flow's confirm handler synchronously hides via
-  // `hiddenIds.add(id)` before the async work starts. Anything
-  // that returns before `closeWindow` needs to undo that.
-  const cancelHide = () => {
-    if (openDialog && typeof id === "number") {
-      openDialog.hiddenIds.delete(id);
+  // Clear the in-flight marker so the preview pane stops showing
+  // "Archiving…" if the operation refuses or fails. After
+  // `closeWindow` succeeds the row is gone from `listWindows()`
+  // anyway, so clearing then is harmless.
+  const clearInFlight = () => {
+    if (
+      openDialog?.inFlight && typeof id === "number" &&
+      openDialog.inFlight.sessionId === id
+    ) {
+      openDialog.inFlight = null;
       refreshOpenDialog();
     }
   };
   if (typeof id !== "number" || id <= 0) return;
   if (id === 1) {
     editor.setStatus("Orchestrator: cannot archive the base session");
-    cancelHide();
+    clearInFlight();
     return;
   }
   if (id === editor.activeWindow()) {
     editor.setStatus(
       "Orchestrator: dive elsewhere first, then archive this session",
     );
-    cancelHide();
+    clearInFlight();
     return;
   }
   const session = orchestratorSessions.get(id);
   if (!session) {
-    cancelHide();
+    clearInFlight();
     return;
   }
 
@@ -898,7 +936,7 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
   );
   if (top.exit_code !== 0) {
     editor.setStatus("Orchestrator: archive failed — not a git repository");
-    cancelHide();
+    clearInFlight();
     return;
   }
   const repoRoot = (top.stdout || "").trim();
@@ -929,6 +967,7 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
     editor.setStatus(
       `Orchestrator: archive failed — could not create ${parent}`,
     );
+    clearInFlight();
     return;
   }
   const moveRes = await spawnCollect(
@@ -942,6 +981,7 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
         lastNonEmptyLine(moveRes.stderr) || "unknown error"
       }`,
     );
+    clearInFlight();
     return;
   }
 
@@ -964,6 +1004,7 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
   } else {
     editor.setStatus(`Orchestrator: archived [${id}] ${session.label}`);
   }
+  clearInFlight();
   triggerSyncAsync(repoRoot);
 }
 
@@ -1176,26 +1217,27 @@ async function deleteConfirmedSession(): Promise<void> {
   if (!openDialog || !openDialog.pendingConfirm) return;
   const { sessionId: id } = openDialog.pendingConfirm;
   openDialog.pendingConfirm = null;
-  // The confirm-delete handler synchronously hid the row via
-  // `hiddenIds.add(id)`. Any pre-closeWindow failure path needs to
-  // unhide so the user sees the row come back instead of vanishing
-  // silently.
-  const cancelHide = () => {
-    if (openDialog) {
-      openDialog.hiddenIds.delete(id);
+  // Clear the in-flight marker on early failure. Mirrors the
+  // pattern in `archiveSelectedSession` — the confirm-delete
+  // handler set `inFlight` before kicking off this async work,
+  // and any path that aborts before `closeWindow` needs to undo
+  // it so the "Deleting…" overlay disappears.
+  const clearInFlight = () => {
+    if (openDialog?.inFlight && openDialog.inFlight.sessionId === id) {
+      openDialog.inFlight = null;
       refreshOpenDialog();
     }
   };
   const session = orchestratorSessions.get(id);
   if (!session) {
-    cancelHide();
+    clearInFlight();
     return;
   }
   if (id === editor.activeWindow()) {
     editor.setStatus(
       "Orchestrator: dive elsewhere first, then delete this session",
     );
-    cancelHide();
+    clearInFlight();
     return;
   }
 
@@ -1207,7 +1249,7 @@ async function deleteConfirmedSession(): Promise<void> {
   );
   if (top.exit_code !== 0) {
     editor.setStatus("Orchestrator: delete failed — not a git repository");
-    cancelHide();
+    clearInFlight();
     return;
   }
   const repoRoot = (top.stdout || "").trim();
@@ -1229,7 +1271,7 @@ async function deleteConfirmedSession(): Promise<void> {
         lastNonEmptyLine(removeRes.stderr) || "unknown error"
       }`,
     );
-    if (openPanel) openPanel.update(buildOpenSpec());
+    clearInFlight();
     return;
   }
 
@@ -1246,7 +1288,7 @@ async function deleteConfirmedSession(): Promise<void> {
   }
 
   editor.setStatus(`Orchestrator: deleted [${id}] ${session.label}`);
-  if (openPanel) openPanel.update(buildOpenSpec());
+  clearInFlight();
   triggerSyncAsync(repoRoot);
 }
 
@@ -1962,13 +2004,15 @@ editor.on("widget_event", (e) => {
     if (e.event_type === "activate" && e.widget_key === "confirm-archive") {
       const id = openDialog.filteredIds[openDialog.selectedIndex];
       openDialog.pendingConfirm = null;
-      // Hide the row synchronously so the user sees the session
-      // leave the list the moment they confirm. The async archive
-      // work (kill, git worktree move) takes a few hundred ms and
-      // re-surfacing the row mid-flight via reconcileSessions
-      // would look like the action didn't take.
+      // Mark the session in-flight so the preview swaps to
+      // "Archiving…" and its action buttons disappear until git
+      // finishes. The row stays in the list — `editor.listWindows()`
+      // is still the source of truth and will drop it on
+      // `closeWindow`, which is intentional: a slightly-laggy real
+      // state beats a synchronously faked one that can desync from
+      // git reality (e.g. when `git worktree move` fails).
       if (typeof id === "number" && id > 0) {
-        openDialog.hiddenIds.add(id);
+        openDialog.inFlight = { action: "archive", sessionId: id };
       }
       void archiveSelectedSession(id);
       refreshOpenDialog();
@@ -1976,11 +2020,11 @@ editor.on("widget_event", (e) => {
     }
     if (e.event_type === "activate" && e.widget_key === "confirm-delete") {
       const id = openDialog.pendingConfirm?.sessionId;
-      // Hide synchronously — see comment on confirm-archive above.
+      // Mark in-flight — see comment on confirm-archive above.
       // `deleteConfirmedSession` clears `pendingConfirm` itself, so
       // we capture the id here before it goes away.
       if (typeof id === "number" && id > 0) {
-        openDialog.hiddenIds.add(id);
+        openDialog.inFlight = { action: "delete", sessionId: id };
       }
       void deleteConfirmedSession();
       refreshOpenDialog();

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -157,6 +157,15 @@ interface OpenDialogState {
   // the embed is the part the user actually wants to see; the
   // metadata row is rarely read and just eats embed height.
   showDetails: boolean;
+  // Sessions the user just archived/deleted. The async cleanup
+  // (kill processes, run `git worktree remove` / `move`) takes
+  // ~300 ms during which `editor.listWindows()` still returns the
+  // session, so reconcileSessions would re-surface it in the
+  // picker mid-flight. Stashing the id here lets `filterSessions`
+  // hide the row synchronously when the user clicks Confirm; the
+  // entry is cleared once the cleanup completes (or the dialog
+  // closes).
+  hiddenIds: Set<number>;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -230,7 +239,10 @@ function ageString(createdAt: number): string {
 // first. Empty needle returns the full list in numeric-id order.
 function filterSessions(needle: string): number[] {
   reconcileSessions();
-  const ids = Array.from(orchestratorSessions.keys()).sort((a, b) => a - b);
+  const hidden = openDialog?.hiddenIds ?? new Set<number>();
+  const ids = Array.from(orchestratorSessions.keys())
+    .filter((id) => !hidden.has(id))
+    .sort((a, b) => a - b);
   if (!needle) return ids;
   const n = needle.toLowerCase();
   type Scored = { id: number; score: number; len: number };
@@ -708,6 +720,7 @@ function openControlRoom(): void {
     // to paint something meaningful.
     embedRows: Math.max(3, listVisibleRows - 5),
     showDetails: false,
+    hiddenIds: new Set<number>(),
   };
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
@@ -834,22 +847,46 @@ function saveArchiveManifest(repoRoot: string, m: ArchiveManifest): boolean {
 // session, move the worktree to the `.archived/` graveyard,
 // and append a manifest entry so a future Unarchive flow can
 // reverse it.
-async function archiveSelectedSession(): Promise<void> {
+async function archiveSelectedSession(explicitId?: number): Promise<void> {
   if (!openDialog) return;
-  const id = openDialog.filteredIds[openDialog.selectedIndex];
+  // Prefer the explicit id from the confirm path. Otherwise read
+  // the currently selected row — used by the legacy direct-call
+  // entry points. Once the row is hidden synchronously after
+  // confirm, `filteredIds[selectedIndex]` no longer points at the
+  // session being archived (it shifts to whatever is now under
+  // the cursor).
+  const id = typeof explicitId === "number"
+    ? explicitId
+    : openDialog.filteredIds[openDialog.selectedIndex];
+  // Unhide the row + refresh on any pre-close failure so the user
+  // sees the session reappear instead of vanishing silently — the
+  // archive flow's confirm handler synchronously hides via
+  // `hiddenIds.add(id)` before the async work starts. Anything
+  // that returns before `closeWindow` needs to undo that.
+  const cancelHide = () => {
+    if (openDialog && typeof id === "number") {
+      openDialog.hiddenIds.delete(id);
+      refreshOpenDialog();
+    }
+  };
   if (typeof id !== "number" || id <= 0) return;
   if (id === 1) {
     editor.setStatus("Orchestrator: cannot archive the base session");
+    cancelHide();
     return;
   }
   if (id === editor.activeWindow()) {
     editor.setStatus(
       "Orchestrator: dive elsewhere first, then archive this session",
     );
+    cancelHide();
     return;
   }
   const session = orchestratorSessions.get(id);
-  if (!session) return;
+  if (!session) {
+    cancelHide();
+    return;
+  }
 
   // Resolve the repo root from cwd (the user is in the
   // umbrella session's tree).
@@ -861,6 +898,7 @@ async function archiveSelectedSession(): Promise<void> {
   );
   if (top.exit_code !== 0) {
     editor.setStatus("Orchestrator: archive failed — not a git repository");
+    cancelHide();
     return;
   }
   const repoRoot = (top.stdout || "").trim();
@@ -1138,16 +1176,26 @@ async function deleteConfirmedSession(): Promise<void> {
   if (!openDialog || !openDialog.pendingConfirm) return;
   const { sessionId: id } = openDialog.pendingConfirm;
   openDialog.pendingConfirm = null;
+  // The confirm-delete handler synchronously hid the row via
+  // `hiddenIds.add(id)`. Any pre-closeWindow failure path needs to
+  // unhide so the user sees the row come back instead of vanishing
+  // silently.
+  const cancelHide = () => {
+    if (openDialog) {
+      openDialog.hiddenIds.delete(id);
+      refreshOpenDialog();
+    }
+  };
   const session = orchestratorSessions.get(id);
   if (!session) {
-    if (openPanel) openPanel.update(buildOpenSpec());
+    cancelHide();
     return;
   }
   if (id === editor.activeWindow()) {
     editor.setStatus(
       "Orchestrator: dive elsewhere first, then delete this session",
     );
-    if (openPanel) openPanel.update(buildOpenSpec());
+    cancelHide();
     return;
   }
 
@@ -1159,7 +1207,7 @@ async function deleteConfirmedSession(): Promise<void> {
   );
   if (top.exit_code !== 0) {
     editor.setStatus("Orchestrator: delete failed — not a git repository");
-    if (openPanel) openPanel.update(buildOpenSpec());
+    cancelHide();
     return;
   }
   const repoRoot = (top.stdout || "").trim();
@@ -1912,13 +1960,30 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "confirm-archive") {
+      const id = openDialog.filteredIds[openDialog.selectedIndex];
       openDialog.pendingConfirm = null;
-      void archiveSelectedSession();
-      if (openPanel) openPanel.update(buildOpenSpec());
+      // Hide the row synchronously so the user sees the session
+      // leave the list the moment they confirm. The async archive
+      // work (kill, git worktree move) takes a few hundred ms and
+      // re-surfacing the row mid-flight via reconcileSessions
+      // would look like the action didn't take.
+      if (typeof id === "number" && id > 0) {
+        openDialog.hiddenIds.add(id);
+      }
+      void archiveSelectedSession(id);
+      refreshOpenDialog();
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "confirm-delete") {
+      const id = openDialog.pendingConfirm?.sessionId;
+      // Hide synchronously — see comment on confirm-archive above.
+      // `deleteConfirmedSession` clears `pendingConfirm` itself, so
+      // we capture the id here before it goes away.
+      if (typeof id === "number" && id > 0) {
+        openDialog.hiddenIds.add(id);
+      }
       void deleteConfirmedSession();
+      refreshOpenDialog();
       return;
     }
     if (e.event_type === "cancel") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -330,6 +330,12 @@ function buildPreviewEntries(
   ];
 }
 
+// Blank-row separator used inside the Sessions column between
+// the filter, the new-session button, and the list.
+function sessionsSeparator(): WidgetSpec {
+  return spacer(0);
+}
+
 // Approximate number of session rows the picker's list pane
 // should show. Sized off the full terminal (not the active
 // buffer's viewport — that shrinks with vertical splits and made
@@ -338,10 +344,12 @@ function openListVisibleRows(): number {
   const screen = editor.getScreenSize();
   const h = screen.height > 0 ? screen.height : 30;
   const panelH = Math.floor(h * 0.9);
-  // header (1) + spacer (1) + filter section (3) + sessions
-  // section borders (2) + hint bar (1) = 8 rows of chrome.
-  // Floor at 4 so a tiny terminal still shows something.
-  return Math.max(4, panelH - 8);
+  // panel borders (2) + header (1) + spacer (1) + sessions
+  // section borders (2) + filter row (1) + separator (1) +
+  // new-session button row (1) + separator (1) + footer (1) =
+  // 11 rows of chrome. Floor at 4 so a tiny terminal still
+  // shows something.
+  return Math.max(4, panelH - 11);
 }
 
 // Compose the right-hand preview pane. Normally it shows info
@@ -501,14 +509,15 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       });
     }
   }
-  // Total embed area we can afford if no details row is shown:
-  // `listVisibleRows - 2` (button row + one spacer above the
-  // embed). When details ARE shown, two info rows + a spacer eat
-  // three more lines — `_DETAILS_CHROME_ROWS` accounts for that.
-  // Either way the preview pane's apparent height matches the
-  // sessions list pane's `visible_rows + 2 borders` for the
-  // wireframed dialog shape.
-  const totalEmbedBase = (openDialog?.listVisibleRows ?? 6) - 2;
+  // Match the sessions column's content height so the two panes'
+  // bottom borders land on the same row. Sessions column inside
+  // its borders = filter (1) + separator (1) + new-session button
+  // (1) + separator (1) + list (listVisibleRows) = listVisibleRows
+  // + 4. Preview inside its borders = button row (1) + spacer (1)
+  // + embedRows, so embedRows must equal listVisibleRows + 2.
+  // When details ARE shown, two info rows + a spacer eat three
+  // more lines — `_DETAILS_CHROME_ROWS` accounts for that.
+  const totalEmbedBase = (openDialog?.listVisibleRows ?? 6) + 2;
   const detailsOn = openDialog?.showDetails ?? false;
   const _DETAILS_CHROME_ROWS = 3; // 2 info rows + 1 spacer
   const embedRows = Math.max(
@@ -633,15 +642,12 @@ function buildOpenSpec(): WidgetSpec {
   // Keeping the visual chrome (instead of swapping it for a
   // "(disabled)" label) means the dialog doesn't reflow under
   // the user's eyes when the confirm view opens / closes.
-  const filterSection = labeledSection({
-    label: "Filter",
-    child: text({
-      value: openDialog.filter.value,
-      cursorByte: openDialog.filter.cursor,
-      placeholder: "type to filter…",
-      fullWidth: true,
-      key: inConfirm ? undefined : "filter",
-    }),
+  const filterInput = text({
+    value: openDialog.filter.value,
+    cursorByte: openDialog.filter.cursor,
+    placeholder: "type to filter…",
+    fullWidth: true,
+    key: inConfirm ? undefined : "filter",
   });
   const errorBanner: WidgetSpec | null = openDialog.lastError
     ? {
@@ -674,7 +680,6 @@ function buildOpenSpec(): WidgetSpec {
     },
     ...(errorBanner ? [errorBanner] : []),
     spacer(0),
-    filterSection,
     // Two-pane: sessions list | preview. Renderer's `row()`
     // horizontally zips multi-line children so this composes
     // the wireframed shape directly. Width split 25 / 75 —
@@ -685,26 +690,40 @@ function buildOpenSpec(): WidgetSpec {
       labeledSection({
         label: `Sessions (${filtered.length})`,
         widthPct: 25,
-        child: list({
-          items,
-          itemKeys,
-          selectedIndex: selIdx,
-          visibleRows: openDialog.listVisibleRows,
-          // Excluded from the Tab cycle — Up/Down on the
-          // filter input forwards to this list via host
-          // smart-keys, so Tab jumps straight to the action
-          // buttons instead of stopping here.
-          focusable: false,
-          // Drop the `key` while a confirmation prompt is up so
-          // `find_scrollable_widget_key` (`plugin_dispatch.rs`)
-          // can't find this list — Up/Down on the focused Cancel
-          // button would otherwise forward to the list and let
-          // the user move the selection off the session being
-          // confirmed (which would break the confirm view because
-          // it only renders when the selected row matches
-          // `pendingConfirm.sessionId`).
-          key: inConfirm ? undefined : "sessions",
-        }),
+        // Sessions column: filter, separator, new-session
+        // button, separator, list. Separators are long `─`
+        // strings that the renderer truncates to the column's
+        // inner width — no need to measure cells from the
+        // plugin side.
+        child: col(
+          row(
+            button(newLabel, { intent: "primary", key: "new-session" }),
+            flexSpacer(),
+          ),
+          sessionsSeparator(),
+          filterInput,
+          sessionsSeparator(),
+          list({
+            items,
+            itemKeys,
+            selectedIndex: selIdx,
+            visibleRows: openDialog.listVisibleRows,
+            // Excluded from the Tab cycle — Up/Down on the
+            // filter input forwards to this list via host
+            // smart-keys, so Tab jumps straight to the action
+            // buttons instead of stopping here.
+            focusable: false,
+            // Drop the `key` while a confirmation prompt is up so
+            // `find_scrollable_widget_key` (`plugin_dispatch.rs`)
+            // can't find this list — Up/Down on the focused Cancel
+            // button would otherwise forward to the list and let
+            // the user move the selection off the session being
+            // confirmed (which would break the confirm view because
+            // it only renders when the selected row matches
+            // `pendingConfirm.sessionId`).
+            key: inConfirm ? undefined : "sessions",
+          }),
+        ),
       }),
       // Preview pane has no explicit width — picks up the
       // remaining 75% by default since the sessions list took
@@ -712,7 +731,6 @@ function buildOpenSpec(): WidgetSpec {
       buildPreviewPane(selectedSession),
     ),
     row(
-      button(newLabel, { intent: "primary", key: "new-session" }),
       flexSpacer(),
       hintBar([
         { keys: "↑↓", label: "nav" },

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -331,13 +331,12 @@ function buildPreviewEntries(
 }
 
 // Approximate number of session rows the picker's list pane
-// should show. Derived from the active buffer's viewport so the
-// picker's row(list, preview) fills the panel and the hint bar
-// sits flush at the panel's last row. Conservative — leaves
-// room for header, filter input, footer, and section borders.
+// should show. Sized off the full terminal (not the active
+// buffer's viewport — that shrinks with vertical splits and made
+// the picker collapse to ~half its `heightPct: 90` budget).
 function openListVisibleRows(): number {
-  const vp = editor.getViewport();
-  const h = vp ? vp.height : 30;
+  const screen = editor.getScreenSize();
+  const h = screen.height > 0 ? screen.height : 30;
   const panelH = Math.floor(h * 0.9);
   // header (1) + spacer (1) + filter section (3) + sessions
   // section borders (2) + hint bar (1) = 8 rows of chrome.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -111,7 +111,22 @@ interface NewSessionForm {
   // button) we re-open the picker so the user lands back where
   // they were instead of being dropped into the bare editor.
   fromPicker: boolean;
+  // Mirror of the host's currently-focused widget key. Updated
+  // by the Tab/Shift+Tab handlers below as they cycle through
+  // the form's tabbable order. The Enter handler reads this so
+  // a press on the Cancel button cancels instead of submitting
+  // (the host's smart-key Enter on a button would activate it,
+  // but the plugin's mode binding for Enter intercepts before
+  // smart-key dispatch runs — without this mirror, every Enter
+  // would always submit regardless of focus).
+  focusedKey: string;
 }
+
+// Tabbable order in the new-session form. Mirrors the spec
+// builder's declaration order in `buildFormSpec`. Used by the
+// Enter / Tab / Shift+Tab handlers to keep `form.focusedKey` in
+// sync with the host's focus tracking.
+const FORM_TABBABLE: readonly string[] = ["name", "cmd", "branch", "cancel", "create"];
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
 
@@ -169,6 +184,13 @@ interface OpenDialogState {
   // disappears from the list naturally once the editor's
   // `window_closed` hook fires `refreshOpenDialog`.
   inFlight: { action: "archive" | "delete"; sessionId: number } | null;
+  // Last user-visible error from a refused lifecycle action
+  // (e.g. "cannot archive the base session", "dive elsewhere
+  // first…"). Rendered as a banner row above the filter so it's
+  // hard to miss — the status bar at the bottom of the screen is
+  // too easy to skip over when the user's eyes are on the dialog.
+  // Cleared on the next nav / filter change.
+  lastError: string | null;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -618,6 +640,55 @@ function buildOpenSpec(): WidgetSpec {
   const newLabel = newKey
     ? `+ New Session  ${newKey}`
     : "+ New Session";
+  const inConfirm = openDialog.pendingConfirm !== null;
+  // Filter is replaced by a non-tabbable display row while a
+  // confirmation prompt is up — typing into the filter shouldn't
+  // change anything when the user's next decision is binary
+  // (Cancel / Confirm). Removing the text widget from the spec
+  // also takes it out of the tab cycle, so the post-confirm
+  // `focusAdvance(1)` lands directly on the Cancel button.
+  const filterSection: WidgetSpec = inConfirm
+    ? labeledSection({
+        label: "Filter",
+        child: {
+          kind: "raw",
+          entries: [
+            styledRow([
+              {
+                text: " (disabled while confirming)",
+                style: { fg: "ui.menu_disabled_fg", italic: true },
+              },
+            ]),
+          ],
+        },
+      })
+    : labeledSection({
+        label: "Filter",
+        child: text({
+          value: openDialog.filter.value,
+          cursorByte: openDialog.filter.cursor,
+          placeholder: "type to filter…",
+          fullWidth: true,
+          key: "filter",
+        }),
+      });
+  const errorBanner: WidgetSpec | null = openDialog.lastError
+    ? {
+        kind: "raw",
+        entries: [
+          styledRow([
+            {
+              text: "⚠ ",
+              style: { fg: "ui.status_error_indicator_fg", bold: true },
+            },
+            {
+              text: openDialog.lastError,
+              style: { fg: "ui.status_error_indicator_fg" },
+            },
+          ]),
+        ],
+      }
+    : null;
   return col(
     {
       kind: "raw",
@@ -630,17 +701,9 @@ function buildOpenSpec(): WidgetSpec {
         ]),
       ],
     },
+    ...(errorBanner ? [errorBanner] : []),
     spacer(0),
-    labeledSection({
-      label: "Filter",
-      child: text({
-        value: openDialog.filter.value,
-        cursorByte: openDialog.filter.cursor,
-        placeholder: "type to filter…",
-        fullWidth: true,
-        key: "filter",
-      }),
-    }),
+    filterSection,
     // Two-pane: sessions list | preview. Renderer's `row()`
     // horizontally zips multi-line children so this composes
     // the wireframed shape directly. Width split 25 / 75 —
@@ -710,6 +773,25 @@ function syncIndicator(): WidgetSpec {
   };
 }
 
+// Surface a lifecycle-action refusal in two places: the dialog
+// itself (a coloured banner above the filter, hard to miss while
+// the user's attention is on the dialog) and the status bar
+// (matches the long-standing convention and survives if the
+// dialog closes). Pass the bare reason — the picker prepends
+// "Orchestrator: " for the status bar.
+function setDialogError(msg: string): void {
+  if (openDialog) {
+    openDialog.lastError = msg;
+  }
+  editor.setStatus(`Orchestrator: ${msg}`);
+}
+
+function clearDialogError(): void {
+  if (openDialog?.lastError) {
+    openDialog.lastError = null;
+  }
+}
+
 function refreshOpenDialog(): void {
   if (!openPanel || !openDialog) return;
   openDialog.filteredIds = filterSessions(openDialog.filter.value);
@@ -757,6 +839,7 @@ function openControlRoom(): void {
     embedRows: Math.max(3, listVisibleRows - 5),
     showDetails: false,
     inFlight: null,
+    lastError: null,
   };
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
@@ -802,7 +885,8 @@ function stopSelectedSession(): void {
   const id = openDialog.filteredIds[openDialog.selectedIndex];
   if (typeof id !== "number" || id <= 0) return;
   if (id === 1) {
-    editor.setStatus("Orchestrator: cannot stop the base session");
+    setDialogError("cannot stop the base session");
+    refreshOpenDialog();
     return;
   }
   editor.signalWindow(id, "SIGTERM");
@@ -909,13 +993,13 @@ async function archiveSelectedSession(explicitId?: number): Promise<void> {
   };
   if (typeof id !== "number" || id <= 0) return;
   if (id === 1) {
-    editor.setStatus("Orchestrator: cannot archive the base session");
+    setDialogError("cannot archive the base session");
     clearInFlight();
     return;
   }
   if (id === editor.activeWindow()) {
-    editor.setStatus(
-      "Orchestrator: dive elsewhere first, then archive this session",
+    setDialogError(
+      "dive elsewhere first, then archive this session",
     );
     clearInFlight();
     return;
@@ -1234,8 +1318,8 @@ async function deleteConfirmedSession(): Promise<void> {
     return;
   }
   if (id === editor.activeWindow()) {
-    editor.setStatus(
-      "Orchestrator: dive elsewhere first, then delete this session",
+    setDialogError(
+      "dive elsewhere first, then delete this session",
     );
     clearInFlight();
     return;
@@ -1617,6 +1701,9 @@ function openForm(options?: { fromPicker?: boolean }): void {
     defaultBranch: "",
     lastCmd,
     fromPicker: !!options?.fromPicker,
+    // Host's render_spec picks the first tabbable when there's
+    // no previous focus — that's "name" in our declaration order.
+    focusedKey: FORM_TABBABLE[0],
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
@@ -1819,24 +1906,53 @@ function dispatchFormKey(name: string): void {
   formPanel.command(widgetKey(name));
 }
 
-registerHandler("orchestrator_form_key_tab", () => dispatchFormKey("Tab"));
+// Local mirror of focus advancement. The host still owns the
+// authoritative focus_key (and re-renders against it); this side
+// tracks it so the Enter handler can dispatch correctly without
+// querying the host.
+function advanceFormFocus(delta: number): void {
+  if (!form) return;
+  const idx = FORM_TABBABLE.indexOf(form.focusedKey);
+  const cur = idx < 0 ? 0 : idx;
+  const n = FORM_TABBABLE.length;
+  form.focusedKey = FORM_TABBABLE[(cur + delta + n) % n];
+}
+
+registerHandler("orchestrator_form_key_tab", () => {
+  advanceFormFocus(1);
+  dispatchFormKey("Tab");
+});
 registerHandler(
   "orchestrator_form_key_shift_tab",
-  () => dispatchFormKey("Shift+Tab"),
+  () => {
+    advanceFormFocus(-1);
+    dispatchFormKey("Shift+Tab");
+  },
 );
 registerHandler("orchestrator_form_key_enter", () => {
   // The hint bar promises "Enter submit". The host's floating-panel
   // input dispatcher (input.rs:`dispatch_floating_widget_key`)
   // defers to plugin-defined mode bindings when present, so the
-  // smart-key router's "Enter = advance focus" default doesn't fire
-  // for the orchestrator-new-form mode — this handler does. From
-  // anywhere in the form, Enter submits; the form's existing
-  // `Esc → closeForm` keeps the cancel path unambiguous.
-  if (form) {
-    void submitForm();
+  // smart-key router's "Enter = advance focus / activate" default
+  // doesn't fire for the orchestrator-new-form mode — this
+  // handler does.
+  //
+  // Dispatch:
+  //   - focus on `cancel` button → cancel (was a bug: every Enter
+  //     submitted, so pressing Enter on Cancel created a session)
+  //   - focus on `create` button → submit
+  //   - focus on a text field → submit (matches the "Enter submit"
+  //     hint; otherwise users would have to Tab to Create just to
+  //     fire it, defeating the hint)
+  if (!form) {
+    dispatchFormKey("Enter");
     return;
   }
-  dispatchFormKey("Enter");
+  if (form.focusedKey === "cancel") {
+    cancelForm();
+    return;
+  }
+  void submitForm();
 });
 registerHandler("orchestrator_form_key_escape", () => {
   if (form) cancelForm();
@@ -1861,6 +1977,32 @@ function orchestrator_mode_text_input(args: { text: string }): void {
   formPanel.command(textInputChar(args.text));
 }
 registerHandler("mode_text_input", orchestrator_mode_text_input);
+
+// Open the confirm panel for `action` against the currently
+// selected session, rebuild the spec, and ensure the Cancel
+// button gets default focus.
+//
+// Because `buildOpenSpec` replaces the filter input with a
+// non-keyed disabled label while `pendingConfirm` is set, the
+// filter is no longer in the tab cycle and Cancel ends up as the
+// first tabbable — the host's "first-tabbable wins when
+// `prev_focus_key` doesn't match any current widget" fallback
+// then lands focus on Cancel automatically. The previous focus
+// key was the Stop/Archive/Delete button (gone after the
+// rebuild), so the fallback fires.
+//
+// Why Cancel rather than Confirm: confirm prompts for destructive
+// actions should be biased toward the safe path. Enter
+// immediately activates whichever button is focused (host
+// smart-key dispatch), so landing on Cancel means a stray Enter
+// is a no-op rather than a worktree wipe.
+function enterConfirm(action: "stop" | "archive" | "delete"): void {
+  if (!openDialog || !openPanel) return;
+  const id = openDialog.filteredIds[openDialog.selectedIndex];
+  if (typeof id !== "number" || id <= 0) return;
+  openDialog.pendingConfirm = { action, sessionId: id };
+  openPanel.update(buildOpenSpec());
+}
 
 editor.on("widget_event", (e) => {
   // ---------------------------------------------------------------------
@@ -1921,6 +2063,10 @@ editor.on("widget_event", (e) => {
       if (typeof value !== "string") return;
       openDialog.filter.value = value;
       if (typeof cursor === "number") openDialog.filter.cursor = cursor;
+      // Filter change implies the user has moved on from any
+      // previous error — clear the banner so it doesn't shadow
+      // the typing experience.
+      clearDialogError();
       // Preserve highlighted session across the filter narrowing
       // when possible — if the previously selected id is still in
       // the new filtered set, keep it; otherwise reset to 0.
@@ -1937,6 +2083,7 @@ editor.on("widget_event", (e) => {
       const idx = payload.index;
       if (typeof idx === "number") {
         openDialog.selectedIndex = idx;
+        clearDialogError();
         // Update preview pane.
         openPanel.update(buildOpenSpec());
         // Re-pin the list selection so the spec re-emit doesn't
@@ -1967,27 +2114,15 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "stop") {
-      const id = openDialog.filteredIds[openDialog.selectedIndex];
-      if (typeof id === "number" && id > 0) {
-        openDialog.pendingConfirm = { action: "stop", sessionId: id };
-        openPanel.update(buildOpenSpec());
-      }
+      enterConfirm("stop");
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "archive") {
-      const id = openDialog.filteredIds[openDialog.selectedIndex];
-      if (typeof id === "number" && id > 0) {
-        openDialog.pendingConfirm = { action: "archive", sessionId: id };
-        openPanel.update(buildOpenSpec());
-      }
+      enterConfirm("archive");
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "delete") {
-      const id = openDialog.filteredIds[openDialog.selectedIndex];
-      if (typeof id === "number" && id > 0) {
-        openDialog.pendingConfirm = { action: "delete", sessionId: id };
-        openPanel.update(buildOpenSpec());
-      }
+      enterConfirm("delete");
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "confirm-cancel") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -21,6 +21,7 @@ import {
   col,
   flexSpacer,
   FloatingWidgetPanel,
+  focusAdvance,
   hintBar,
   key as widgetKey,
   labeledSection,
@@ -99,11 +100,17 @@ interface NewSessionForm {
   defaultBranch: string;
   // Previously-submitted Agent Command (persisted across editor
   // sessions via `orchestrator.last_cmd`). Rendered as the cmd
-  // field's *placeholder* — pre-filling the value would survive
-  // a failed submit and silently feed stale text into the next
-  // attempt; the placeholder gives the same memory aid without
-  // that hazard.
+  // field's *placeholder*, and used as the actual command when
+  // the user leaves the field blank — submitting "" with a
+  // visible placeholder of "python3" was confusing because the
+  // host ignored the hint and spawned a bare shell. Now the
+  // placeholder is the command if the value is empty.
   lastCmd: string;
+  // True when this form was opened from the picker (Alt+N or
+  // the "+ New Session" button). On cancel (Esc / Cancel
+  // button) we re-open the picker so the user lands back where
+  // they were instead of being dropped into the bare editor.
+  fromPicker: boolean;
 }
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
@@ -133,7 +140,9 @@ interface OpenDialogState {
   // When non-null, the preview pane swaps to a confirmation
   // panel for the named action against the named session id.
   // Cleared on Cancel or after the action completes.
-  pendingConfirm: { action: "delete"; sessionId: number } | null;
+  pendingConfirm:
+    | { action: "stop" | "archive" | "delete"; sessionId: number }
+    | null;
   // Rows the embed reserves and rows the sessions list shows.
   // Captured once at dialog-open from the editor's viewport so
   // the layout stays constant across re-renders — recomputing
@@ -325,6 +334,75 @@ function openListVisibleRows(): number {
 function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   if (openDialog?.pendingConfirm && s && openDialog.pendingConfirm.sessionId === s.id) {
     const action = openDialog.pendingConfirm.action;
+    if (action === "stop") {
+      return labeledSection({
+        label: "Confirm Stop",
+        child: col(
+          {
+            kind: "raw",
+            entries: [
+              styledRow([
+                {
+                  text: `Stop session [${s.id}] ${s.label}?`,
+                  style: { bold: true },
+                },
+              ]),
+              styledRow([{ text: "" }]),
+              styledRow([{ text: "This will:" }]),
+              styledRow([{ text: "  • send SIGTERM to all session processes" }]),
+              styledRow([{ text: "  • SIGKILL after a short grace period" }]),
+              styledRow([{ text: "" }]),
+              styledRow([{ text: "The worktree and session record remain." }]),
+            ],
+          },
+          spacer(0),
+          row(
+            flexSpacer(),
+            button("Cancel", { key: "confirm-cancel" }),
+            spacer(2),
+            button("Confirm Stop", {
+              intent: "danger",
+              key: "confirm-stop",
+            }),
+          ),
+        ),
+      });
+    }
+    if (action === "archive") {
+      return labeledSection({
+        label: "Confirm Archive",
+        child: col(
+          {
+            kind: "raw",
+            entries: [
+              styledRow([
+                {
+                  text: `Archive session [${s.id}] ${s.label}?`,
+                  style: { bold: true },
+                },
+              ]),
+              styledRow([{ text: "" }]),
+              styledRow([{ text: "This will:" }]),
+              styledRow([{ text: "  • SIGKILL all session processes" }]),
+              styledRow([{ text: "  • close the editor session" }]),
+              styledRow([{ text: "  • move the worktree to .archived/" }]),
+              styledRow([{ text: "" }]),
+              styledRow([{ text: "Reversible via Unarchive." }]),
+            ],
+          },
+          spacer(0),
+          row(
+            flexSpacer(),
+            button("Cancel", { key: "confirm-cancel" }),
+            spacer(2),
+            button("Confirm Archive", {
+              intent: "danger",
+              key: "confirm-archive",
+            }),
+          ),
+        ),
+      });
+    }
     if (action === "delete") {
       return labeledSection({
         label: "Confirm Delete",
@@ -410,6 +488,8 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   // (back to compact).
   const detailsToggleLabel = detailsOn ? "Preview" : "Details";
   const buttonRow = row(
+    button("Visit", { intent: "primary", key: "visit" }),
+    spacer(2),
     flexSpacer(),
     button(detailsToggleLabel, { key: "toggle-details" }),
     spacer(2),
@@ -470,6 +550,26 @@ function buildOpenSpec(): WidgetSpec {
     ? orchestratorSessions.get(selectedId)
     : undefined;
 
+  // The "New Session" button advertises Alt+N (or whatever the
+  // user re-bound `orchestrator_open_new_from_picker` to). The
+  // label reads the binding dynamically through the host's
+  // `getKeybindingLabel` so a re-bound key shows correctly, and
+  // the host's `format_keybinding` already renders Mac-native
+  // symbols (⌥, ⌘, …) when running on macOS — no plugin-side
+  // platform detection needed.
+  //
+  // The button is declared in the footer (last tabbable) on
+  // purpose: Visit lives in the preview pane and we want it as
+  // the *first* tabbable after the filter so default focus
+  // lands on it after the post-mount `focusAdvance(1)` in
+  // `openControlRoom`.
+  const newKey = editor.getKeybindingLabel(
+    "orchestrator_open_new_from_picker",
+    OPEN_MODE,
+  );
+  const newLabel = newKey
+    ? `+ New Session  ${newKey}`
+    : "+ New Session";
   return col(
     {
       kind: "raw",
@@ -522,11 +622,11 @@ function buildOpenSpec(): WidgetSpec {
       buildPreviewPane(selectedSession),
     ),
     row(
+      button(newLabel, { intent: "primary", key: "new-session" }),
       flexSpacer(),
       hintBar([
         { keys: "↑↓", label: "nav" },
         { keys: "Enter", label: "dive" },
-        { keys: "Alt+N", label: "new" },
         { keys: "Tab", label: "focus" },
         { keys: "Esc", label: "close" },
       ]),
@@ -618,6 +718,18 @@ function openControlRoom(): void {
     openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
   }
   editor.setEditorMode(OPEN_MODE);
+  // Default focus is the first tabbable (the filter input). The
+  // user-facing default we want is the Visit button so Enter
+  // commits the dive and ↑/↓ navigate the list — Visit is the
+  // second tabbable (filter, then visit, then the rest of the
+  // preview-pane buttons, then the footer's New Session). Fire
+  // a one-step focus advance immediately after mount so the
+  // user lands on Visit without typing anything. When no
+  // session is selected (empty list) Visit isn't rendered and
+  // the advance is a no-op (focus stays on filter).
+  if (openDialog.filteredIds.length > 0) {
+    openPanel.command(focusAdvance(1));
+  }
 }
 
 function closeOpenDialog(): void {
@@ -648,10 +760,12 @@ function stopSelectedSession(): void {
   // SIGKILL fallback for agents that ignore SIGTERM. The
   // host's signalWindow is idempotent on already-exited
   // process groups, so the second call is safe whether or
-  // not the first one took.
-  setTimeout(() => {
+  // not the first one took. QuickJS has no `setTimeout`;
+  // the host exposes `editor.delay(ms)` as the asynchronous
+  // sleep primitive, which we kick off but don't await.
+  void editor.delay(2000).then(() => {
     editor.signalWindow(id, "SIGKILL");
-  }, 2000);
+  });
   editor.setStatus(`Orchestrator: stop signal sent to session [${id}]`);
 }
 
@@ -761,7 +875,7 @@ async function archiveSelectedSession(): Promise<void> {
 
   // Brief settle so the filesystem reflects the pty's exit
   // before we move the worktree out from under it.
-  await new Promise((r) => setTimeout(r, 250));
+  await editor.delay(250);
 
   // git worktree move keeps git's internal bookkeeping
   // consistent (the new path stays registered as a worktree).
@@ -1052,7 +1166,7 @@ async function deleteConfirmedSession(): Promise<void> {
 
   editor.signalWindow(id, "SIGKILL");
   editor.closeWindow(id);
-  await new Promise((r) => setTimeout(r, 250));
+  await editor.delay(250);
 
   // `--force` because the worktree may have unstaged changes
   // the user explicitly chose to discard via the confirm step.
@@ -1104,7 +1218,7 @@ editor.defineMode(
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
   closeOpenDialog();
-  openForm();
+  openForm({ fromPicker: true });
 });
 
 // =============================================================================
@@ -1394,16 +1508,17 @@ function renderForm(): void {
   formPanel.update(buildFormSpec());
 }
 
-function openForm(): void {
+function openForm(options?: { fromPicker?: boolean }): void {
   pendingNewSession = null;
   const lastCmd =
     (editor.getGlobalState("orchestrator.last_cmd") as string | undefined) ?? "";
   form = {
     name: { value: "", cursor: 0 },
-    // Empty value — `lastCmd` shows as the placeholder instead so
-    // an empty submit falls back to the host's default shell
-    // ("terminal") rather than silently re-running the previous
-    // agent. See `NewSessionForm.lastCmd`.
+    // Empty value — `lastCmd` shows as the placeholder. If the
+    // user submits an empty cmd, the placeholder is used as the
+    // actual command (see `submitForm`). This makes the
+    // placeholder a genuine "press Enter to re-use this" hint
+    // rather than a visual lie.
     cmd: { value: "", cursor: 0 },
     branch: { value: "", cursor: 0 },
     submitting: false,
@@ -1411,6 +1526,7 @@ function openForm(): void {
     projectLabel: deriveProjectLabel(),
     defaultBranch: "",
     lastCmd,
+    fromPicker: !!options?.fromPicker,
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
@@ -1445,13 +1561,30 @@ function closeForm(): void {
   editor.setEditorMode(null);
 }
 
+// Cancel path: tear down the form, and if it was reached via the
+// picker (Alt+N or "+ New Session" button), reopen the picker so
+// Esc behaves like a true "back" rather than dropping the user
+// into the bare editor.
+function cancelForm(): void {
+  const wasFromPicker = !!form?.fromPicker;
+  closeForm();
+  if (wasFromPicker) {
+    openControlRoom();
+  }
+}
+
 async function submitForm(): Promise<void> {
   if (!form || form.submitting) return;
   form.submitting = true;
   form.lastError = null;
   renderForm();
 
-  const cmd = form.cmd.value.trim();
+  // Honour the placeholder: when the user leaves Agent Command
+  // blank, fall back to `lastCmd` (the placeholder text). The
+  // placeholder is rendered as a hint — if the user accepts it by
+  // pressing Enter on an empty field, the dialog should actually
+  // run that command rather than silently spawning a bare shell.
+  const cmd = form.cmd.value.trim() || form.lastCmd.trim();
   const branchInput = form.branch.value.trim();
 
   const cwd = editor.getCwd();
@@ -1616,7 +1749,7 @@ registerHandler("orchestrator_form_key_enter", () => {
   dispatchFormKey("Enter");
 });
 registerHandler("orchestrator_form_key_escape", () => {
-  if (form) closeForm();
+  if (form) cancelForm();
 });
 registerHandler(
   "orchestrator_form_key_backspace",
@@ -1667,16 +1800,21 @@ editor.on("widget_event", (e) => {
       if (e.widget_key === "create") {
         void submitForm();
       } else if (e.widget_key === "cancel") {
-        closeForm();
+        cancelForm();
       }
       return;
     }
     if (e.event_type === "cancel") {
       // Host fires this when Esc unmounts the floating panel —
-      // clean up our own state to match.
+      // mirror our own state and (if reached from the picker)
+      // bounce back to the picker so Esc is "back", not "out".
+      const wasFromPicker = !!form?.fromPicker;
       form = null;
       formPanel = null;
       editor.setEditorMode(null);
+      if (wasFromPicker) {
+        openControlRoom();
+      }
       return;
     }
     return;
@@ -1717,12 +1855,20 @@ editor.on("widget_event", (e) => {
       }
       return;
     }
-    if (e.event_type === "activate" && e.widget_key === "sessions") {
+    if (
+      e.event_type === "activate" &&
+      (e.widget_key === "sessions" || e.widget_key === "visit")
+    ) {
       const id = openDialog.filteredIds[openDialog.selectedIndex];
       if (typeof id === "number" && id > 0 && id !== editor.activeWindow()) {
         editor.setActiveWindow(id);
       }
       closeOpenDialog();
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "new-session") {
+      closeOpenDialog();
+      openForm({ fromPicker: true });
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "toggle-details") {
@@ -1731,11 +1877,19 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "stop") {
-      stopSelectedSession();
+      const id = openDialog.filteredIds[openDialog.selectedIndex];
+      if (typeof id === "number" && id > 0) {
+        openDialog.pendingConfirm = { action: "stop", sessionId: id };
+        openPanel.update(buildOpenSpec());
+      }
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "archive") {
-      void archiveSelectedSession();
+      const id = openDialog.filteredIds[openDialog.selectedIndex];
+      if (typeof id === "number" && id > 0) {
+        openDialog.pendingConfirm = { action: "archive", sessionId: id };
+        openPanel.update(buildOpenSpec());
+      }
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "delete") {
@@ -1749,6 +1903,18 @@ editor.on("widget_event", (e) => {
     if (e.event_type === "activate" && e.widget_key === "confirm-cancel") {
       openDialog.pendingConfirm = null;
       openPanel.update(buildOpenSpec());
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "confirm-stop") {
+      openDialog.pendingConfirm = null;
+      stopSelectedSession();
+      if (openPanel) openPanel.update(buildOpenSpec());
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "confirm-archive") {
+      openDialog.pendingConfirm = null;
+      void archiveSelectedSession();
+      if (openPanel) openPanel.update(buildOpenSpec());
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "confirm-delete") {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -152,6 +152,12 @@ impl Editor {
         snapshot.clipboard = self.clipboard.get_internal().to_string();
         snapshot.working_dir = self.working_dir.clone();
 
+        // Total terminal dimensions (full screen, not the active
+        // split's viewport). Plugins read this via `getScreenSize()`
+        // to size floating overlays against the whole terminal.
+        snapshot.terminal_width = self.terminal_width;
+        snapshot.terminal_height = self.terminal_height;
+
         // Authority label tracks `Editor::authority` (the active
         // authority). It can't be sourced from `Window::resources.authority`
         // because `set_boot_authority` replaces `self.authority` by value

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1950,8 +1950,16 @@ impl Editor {
         // side-effect plumbing — matching design Primitive #1.
         // Bail if the session has no stash yet (never been
         // activated and never had a terminal / file routed in via
-        // createTerminal({windowId})).
-        let __win_for_preview = self.windows.get_mut(&sid).expect("preview window present");
+        // createTerminal({windowId})), or has been closed under us
+        // — e.g. an Orchestrator Archive / Delete completes between
+        // the floating panel's spec being rebuilt and the next
+        // render, so the embed's `windowId` momentarily points to
+        // a window the host already removed. Early-return rather
+        // than panic; the next plugin refresh re-emits the spec
+        // without the dead embed.
+        let Some(__win_for_preview) = self.windows.get_mut(&sid) else {
+            return;
+        };
         let __preview_metadata = &__win_for_preview.buffer_metadata;
         let __preview_event_logs = &mut __win_for_preview.event_logs;
         let __preview_composite_buffers = &mut __win_for_preview.composite_buffers;

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1313,6 +1313,27 @@ impl JsEditorApi {
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
+    /// Total terminal dimensions in cells. Unlike `getViewport()`
+    /// (which reports the active split, shrunk by any vertical
+    /// split layout), this reflects the full terminal — what a
+    /// floating overlay sized by `heightPct` actually gets.
+    #[plugin_api(ts_return = "ScreenSize")]
+    pub fn get_screen_size<'js>(&self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<Value<'js>> {
+        let size = if let Ok(s) = self.state_snapshot.read() {
+            fresh_core::api::ScreenSize {
+                width: s.terminal_width,
+                height: s.terminal_height,
+            }
+        } else {
+            fresh_core::api::ScreenSize {
+                width: 0,
+                height: 0,
+            }
+        };
+        rquickjs_serde::to_value(ctx, &size)
+            .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
+    }
+
     /// List every split with its active buffer and viewport.
     ///
     /// Plugins that need to operate on every visible buffer

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -22,10 +22,10 @@ use fresh_core::api::{
     CreateVirtualBufferOptions, CursorInfo, DirEntry, FormatterPackConfig, GrammarInfoSnapshot,
     GrepMatch, JsDiagnostic, JsPosition, JsRange, JsTextPropertyEntry, KeyEventPayload,
     LanguagePackConfig, LayoutHints, LspServerPackConfig, OverlayColorSpec, OverlayOptions,
-    PluginAnimationEdge, PluginAnimationKind, ProcessLimitsPackConfig, ReplaceResult,
+    PluginAnimationEdge, PluginAnimationKind, ProcessLimitsPackConfig, ReplaceResult, ScreenSize,
     SearchTakeResult, SpawnResult, SplitSnapshot, TerminalResult, TextPropertiesAtCursor,
-    ScreenSize, TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire, ViewTokenWireKind,
-    ViewportInfo, VirtualBufferResult, WindowInfo,
+    TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire, ViewTokenWireKind, ViewportInfo,
+    VirtualBufferResult, WindowInfo,
 };
 use fresh_core::command::Suggestion;
 use fresh_core::file_explorer::FileExplorerDecoration;

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -24,8 +24,8 @@ use fresh_core::api::{
     LanguagePackConfig, LayoutHints, LspServerPackConfig, OverlayColorSpec, OverlayOptions,
     PluginAnimationEdge, PluginAnimationKind, ProcessLimitsPackConfig, ReplaceResult,
     SearchTakeResult, SpawnResult, SplitSnapshot, TerminalResult, TextPropertiesAtCursor,
-    TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire, ViewTokenWireKind, ViewportInfo,
-    VirtualBufferResult, WindowInfo,
+    ScreenSize, TokenColor, TsHighlightSpan, ViewTokenStyle, ViewTokenWire, ViewTokenWireKind,
+    ViewportInfo, VirtualBufferResult, WindowInfo,
 };
 use fresh_core::command::Suggestion;
 use fresh_core::file_explorer::FileExplorerDecoration;
@@ -50,6 +50,7 @@ fn get_type_decl(type_name: &str) -> Option<String> {
         "WindowInfo" => Some(WindowInfo::decl(&cfg)),
         "CursorInfo" => Some(CursorInfo::decl(&cfg)),
         "ViewportInfo" => Some(ViewportInfo::decl(&cfg)),
+        "ScreenSize" => Some(ScreenSize::decl(&cfg)),
         "KeyEventPayload" => Some(KeyEventPayload::decl(&cfg)),
         "SplitSnapshot" => Some(SplitSnapshot::decl(&cfg)),
         "ActionSpec" => Some(ActionSpec::decl(&cfg)),
@@ -233,6 +234,7 @@ const DEPENDENCY_TYPES: &[&str] = &[
     "TsCompositeHunk",                // Used in createCompositeBuffer opts.hunks
     "TsCreateCompositeBufferOptions", // Options for createCompositeBuffer
     "ViewportInfo",                   // Used by plugins for viewport queries
+    "ScreenSize",                     // Used by editor.getScreenSize()
     "KeyEventPayload",                // Used by editor.getNextKey()
     "SplitSnapshot",                  // Used by editor.listSplits()
     "LayoutHints",                    // Used by plugins for view transforms
@@ -733,6 +735,7 @@ mod tests {
             "WindowInfo",
             "CursorInfo",
             "ViewportInfo",
+            "ScreenSize",
             "KeyEventPayload",
             "SplitSnapshot",
             "ActionSpec",
@@ -1140,6 +1143,7 @@ mod tests {
             "getAllCursors",
             "getAllCursorPositions",
             "getViewport",
+            "getScreenSize",
             "getCursorLine",
             "getLineStartPosition",
             "getLineEndPosition",


### PR DESCRIPTION
Tackles the picker bugs surfaced in #1971 through interactive tmux testing. Six commits on top of `master`.

## Picker

- **Visit button** on the preview pane, primary intent. Default focus advances to it after mount (`focusAdvance(1)` from filter → visit), so Enter dives and ↑/↓ navigate the list. Visit is wired to the same handler as Enter-on-list.
- **`+ New Session` button** in the footer. Label reads `editor.getKeybindingLabel("orchestrator_open_new_from_picker", "orchestrator-open")` so a re-bound shortcut is reflected automatically; the host's `format_keybinding` renders `⌥N` on macOS (no plugin-side platform detection needed).
- **Confirm prompts for Stop and Archive** matching the existing Delete pattern (`Confirm <action>?` + `[ Cancel ] [ Confirm <action> ]`). Verified all three handlers target the previewed session, not the active one.
- **In-flight overlay**: Confirm Archive / Confirm Delete swap the preview pane for an `Archiving…` / `Deleting…` panel with no action buttons until the editor's `window_closed` hook drops the row. `editor.listWindows()` stays the single source of truth — no synchronous row hiding, no de-syncs from git reality. Failed pre-`closeWindow` paths (cannot-archive-base, dive-elsewhere-first, mkdir/move failure) clear the overlay so the row returns to its normal preview.
- **In-dialog error banner**: Refusal messages (`cannot stop the base session`, `dive elsewhere first, then archive this session`, …) render as `⚠ <message>` above the filter via `setDialogError(msg)`, which also writes the status bar for consistency. Cleared on filter change or list navigation.

## Confirm-mode UX

- **Filter goes inert** while `pendingConfirm` is set — same widget chrome, no `key`, so it isn't tabbable and `mode_text_input` skips it. Layout doesn't reflow under the user's eyes.
- **Cancel gets default focus**: with the filter out of the tab cycle, Cancel is the first tabbable after the previous Stop/Archive/Delete button is replaced. The host's "first-tabbable fallback when `prev_focus_key` doesn't match" lands focus on Cancel — Enter immediately cancels (the safe default for a destructive prompt).
- **List nav locked**: list's `key` is also dropped during confirm so `find_scrollable_widget_key` can't find it; the Cancel button's ↑/↓ → scrollable forwarding has no target and the arrows are inert. Without this, the user could move selection off the session being confirmed and the prompt would visually disappear while `pendingConfirm` stayed live.

## New-session form

- **Esc / Cancel returns to the picker** when the form was launched from it (`NewSessionForm.fromPicker` flag). Set by both the Alt+N handler and the `+ New Session` button.
- **Cancel button no longer creates a session.** Removed the `Return → orchestrator_form_key_enter` mode binding and the `focusedKey` mirror — the host's smart-key dispatch already fires Enter → `activate` on a focused Button, which the `widget_event` listener routes to `cancelForm` / `submitForm` via the `cancel` / `create` keys. Side effect: Enter on a text input now advances focus to the next field instead of submitting; hint footer changed to `Enter advance / act`.
- **Placeholder honoured as actual command**: empty submit on `Agent Command` falls back to `form.lastCmd` (the placeholder), so an empty submit re-runs the previous command instead of silently spawning a bare shell.

## Host fixes

- **`setTimeout` → `editor.delay(ms)`**: QuickJS doesn't expose `setTimeout`, so the orchestrator's three uses (`stopSelectedSession` SIGKILL fallback, archive/delete settle waits) rejected mid-flight. The async teardown silently no-op'd. Replaced with the runtime's `editor.delay()` primitive.
- **Preview render no longer panics on a closed window**: `render_session_preview_into_rect` used `self.windows.get_mut(&sid).expect("preview window present")`. When Archive/Delete completed between the spec rebuild and the next render, the embed's `windowId` momentarily pointed at a window the host had already removed. Replaced with an early-return; the next plugin refresh re-emits without the dead embed.

## Verified in tmux

- Visit dives into the previewed session
- Enter on the (focused) filter also dives (host picker-style activate fires the list)
- `+ New Session` button shows the live `Alt+N` label
- Confirm Stop / Archive / Delete prompts up; Tab navigates Cancel ↔ Confirm; Enter on default-focused Cancel cancels
- ↑/↓ inert during confirm
- Filter typing inert during confirm
- Archive moves worktree to `.archived/` and writes `archived.json`; Delete removes worktree; Stop sends SIGTERM then SIGKILL after 2s
- Attempting to archive the active session shows `⚠ dive elsewhere first, then archive this session` banner in the dialog (and the status bar)
- Esc from a picker-launched form returns to the picker (not the bare editor)
- Tab-Tab-Tab-Enter on Cancel in the form returns without creating a session

Issue context: https://github.com/sinelaw/fresh/issues/1971