### PR TITLE
fix(#1991): move orchestrator persistence out of working_dir/.fresh/

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -159,9 +159,10 @@ pub(super) struct EditorParts {
     pub(super) time_source: SharedTimeSource,
 
     // Persisted plugin global state (one map per plugin). Pulled from
-    // `.fresh/state/<plugin>.json` by the factory so plugins reading
-    // `getGlobalState(...)` on first tick see the previous run's
-    // values without a separate post-construction load step.
+    // `<data_dir>/orchestrator/<encoded>/state/<plugin>.json` by the
+    // factory so plugins reading `getGlobalState(...)` on first tick
+    // see the previous run's values without a separate
+    // post-construction load step.
     pub(super) plugin_global_state: HashMap<String, HashMap<String, serde_json::Value>>,
 
     /// Editor-wide event broadcaster, shared with every WindowResources.
@@ -541,23 +542,26 @@ impl Editor {
         let mut buffer_metadata: HashMap<BufferId, BufferMetadata> = HashMap::new();
         buffer_metadata.insert(buffer_id, BufferMetadata::new());
 
-        // Read orchestrator persistence (`.fresh/windows.json` and
-        // `.fresh/state/*.json`) before the LSP and base-window
-        // construction below. Pulling persistence in here lets the
-        // factory build the right windows up front: previously this
-        // ran from `main.rs` after construction, so the freshly
-        // built single-base window had to be torn down and replaced
-        // with an inert shell — leaving the active window with
+        // Read orchestrator persistence (`windows.json` and
+        // `state/*.json` under `<data_dir>/orchestrator/<encoded>/`)
+        // before the LSP and base-window construction below.
+        // Pulling persistence in here lets the factory build the
+        // right windows up front: previously this ran from
+        // `main.rs` after construction, so the freshly built
+        // single-base window had to be torn down and replaced with
+        // an inert shell — leaving the active window with
         // `splits = None` until something re-seeded it. Now the
         // factory picks the persisted active id/root, attaches the
         // seed buffer + LSP to it directly, and the constructor
         // sees a well-formed windows map.
         let persisted_env = crate::app::orchestrator_persistence::read_persisted_windows_env(
             filesystem.as_ref(),
+            &dir_context.data_dir,
             &working_dir,
         );
         let plugin_global_state = crate::app::orchestrator_persistence::read_persisted_plugin_state(
             filesystem.as_ref(),
+            &dir_context.data_dir,
             &working_dir,
         );
 

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -2,12 +2,21 @@
 //! plugin global state.
 //!
 //! On quit, `save_orchestrator_state` writes:
-//!   - `<working_dir>/.fresh/windows.json` — list of sessions
-//!     (id, label, root, per-session plugin_state) plus the
-//!     last-active session id and the next id to allocate so
-//!     id-based references on disk stay stable across restarts.
-//!   - `<working_dir>/.fresh/state/<plugin>.json` — one file per
-//!     plugin holding its `editor.setGlobalState(...)` map.
+//!   - `<data_dir>/orchestrator/<encoded_working_dir>/windows.json`
+//!     — list of sessions (id, label, root, per-session
+//!     plugin_state) plus the last-active session id and the
+//!     next id to allocate so id-based references on disk stay
+//!     stable across restarts.
+//!   - `<data_dir>/orchestrator/<encoded_working_dir>/state/<plugin>.json`
+//!     — one file per plugin holding its
+//!     `editor.setGlobalState(...)` map.
+//!
+//! The state lives under the platform data directory
+//! (`$XDG_DATA_HOME/fresh/` on Linux), keyed by the working
+//! directory using the same encoding as the `workspace` module.
+//! This mirrors how other per-project editor state is stored
+//! and keeps the user's working tree free of stray dotfiles
+//! (issue #1991).
 //!
 //! On startup, [`read_persisted_windows_env`] +
 //! [`read_persisted_plugin_state`] are called from
@@ -48,7 +57,7 @@ pub(crate) struct PersistedWindow {
     pub(crate) plugin_state: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 
-/// Top-level shape of `.fresh/windows.json`.
+/// Top-level shape of `windows.json`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct PersistedWindows {
     /// Last active session id at quit time. The loader makes
@@ -62,19 +71,20 @@ pub(crate) struct PersistedWindows {
     pub(crate) windows: Vec<PersistedWindow>,
 }
 
-/// Read `.fresh/windows.json` from `working_dir` and return the
-/// parsed envelope. Returns `None` when the file doesn't exist or
-/// fails to parse — those are not error cases at the editor level
-/// (a missing or corrupted file just means "no persisted state").
+/// Read `windows.json` for `working_dir` and return the parsed
+/// envelope. Returns `None` when the file doesn't exist or fails
+/// to parse — those are not error cases at the editor level (a
+/// missing or corrupted file just means "no persisted state").
 ///
 /// Pure file IO + JSON parse. Used by the editor factory to
 /// decide how to build the initial windows map before any `Editor`
 /// instance exists.
 pub(crate) fn read_persisted_windows_env(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
     working_dir: &Path,
 ) -> Option<PersistedWindows> {
-    let windows_p = windows_path(working_dir);
+    let windows_p = windows_path(data_dir, working_dir);
     if !filesystem.exists(&windows_p) {
         return None;
     }
@@ -93,17 +103,18 @@ pub(crate) fn read_persisted_windows_env(
     }
 }
 
-/// Read every `.fresh/state/<plugin>.json` from `working_dir` into
-/// a flat `plugin → key → value` map. Skips files with unsafe
-/// names, non-JSON extensions, parse errors, and empty maps. Same
+/// Read every `state/<plugin>.json` for `working_dir` into a flat
+/// `plugin → key → value` map. Skips files with unsafe names,
+/// non-JSON extensions, parse errors, and empty maps. Same
 /// motivations as [`read_persisted_windows_env`] — used by the
 /// editor factory pre-construction.
 pub(crate) fn read_persisted_plugin_state(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
     working_dir: &Path,
 ) -> HashMap<String, HashMap<String, serde_json::Value>> {
     let mut out: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
-    let state_dir = state_dir(working_dir);
+    let state_dir = state_dir(data_dir, working_dir);
     if !filesystem.exists(&state_dir) {
         return out;
     }
@@ -145,21 +156,32 @@ pub(crate) fn read_persisted_plugin_state(
     out
 }
 
-fn windows_path(working_dir: &Path) -> PathBuf {
-    working_dir.join(".fresh").join("windows.json")
+/// Per-working-dir orchestrator directory under the platform
+/// data dir. The working dir is encoded with the same scheme
+/// as `workspace::encode_path_for_filename`, so the per-project
+/// state lives at a stable, collision-free location regardless
+/// of where the user invokes the editor from. See issue #1991
+/// for why this is no longer rooted at `<working_dir>/.fresh`.
+fn orchestrator_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    let encoded = crate::workspace::encode_path_for_filename(working_dir);
+    data_dir.join("orchestrator").join(encoded)
 }
 
-fn state_dir(working_dir: &Path) -> PathBuf {
-    working_dir.join(".fresh").join("state")
+fn windows_path(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    orchestrator_dir(data_dir, working_dir).join("windows.json")
 }
 
-fn plugin_state_path(working_dir: &Path, plugin: &str) -> PathBuf {
+fn state_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    orchestrator_dir(data_dir, working_dir).join("state")
+}
+
+fn plugin_state_path(data_dir: &Path, working_dir: &Path, plugin: &str) -> PathBuf {
     // Plugin names are short identifiers (`orchestrator`,
     // `live_grep`, …) so no escaping is needed for typical
     // input. Reject anything that would escape the state dir to
     // avoid `../`-style traversal in case a plugin picks a
     // pathological name.
-    state_dir(working_dir).join(format!("{plugin}.json"))
+    state_dir(data_dir, working_dir).join(format!("{plugin}.json"))
 }
 
 fn plugin_name_is_safe(name: &str) -> bool {
@@ -173,13 +195,13 @@ fn plugin_name_is_safe(name: &str) -> bool {
 impl Editor {
     /// Persist `sessions` + `plugin_global_state` to disk. Best-
     /// effort: filesystem errors are logged at WARN and swallowed
-    /// so a transient `.fresh/` permission glitch doesn't block
-    /// quit.
+    /// so a transient permission glitch doesn't block quit.
     pub fn save_orchestrator_state(&self) {
         let working_dir = self.working_dir().to_path_buf();
-        let fresh_dir = working_dir.join(".fresh");
-        if let Err(e) = self.authority.filesystem.create_dir_all(&fresh_dir) {
-            tracing::warn!("orchestrator persistence: failed to create {fresh_dir:?}: {e}");
+        let data_dir = self.dir_context.data_dir.clone();
+        let orchestrator_dir = orchestrator_dir(&data_dir, &working_dir);
+        if let Err(e) = self.authority.filesystem.create_dir_all(&orchestrator_dir) {
+            tracing::warn!("orchestrator persistence: failed to create {orchestrator_dir:?}: {e}");
             return;
         }
 
@@ -195,8 +217,8 @@ impl Editor {
             })
             .collect();
         // Stable on-disk order — `HashMap` iteration order would
-        // make the file diff differently every quit, which is
-        // ugly for users who keep `.fresh/` in version control.
+        // make the file diff differently every quit, producing
+        // noisy diffs for anyone inspecting the persisted state.
         windows.sort_by_key(|s| s.id);
         let envelope = PersistedWindows {
             active: self.active_window.0,
@@ -205,7 +227,7 @@ impl Editor {
         };
         match serde_json::to_vec_pretty(&envelope) {
             Ok(bytes) => {
-                let path = windows_path(&working_dir);
+                let path = windows_path(&data_dir, &working_dir);
                 if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
                     tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
                 }
@@ -218,7 +240,7 @@ impl Editor {
         // Plugin global state — one file per plugin so concurrent
         // editors writing different plugins don't clobber each
         // other (a future feature; today single-process).
-        let state_dir = state_dir(&working_dir);
+        let state_dir = state_dir(&data_dir, &working_dir);
         if !self.plugin_global_state.is_empty() {
             if let Err(e) = self.authority.filesystem.create_dir_all(&state_dir) {
                 tracing::warn!("orchestrator persistence: failed to create {state_dir:?}: {e}");
@@ -237,7 +259,7 @@ impl Editor {
             }
             match serde_json::to_vec_pretty(map) {
                 Ok(bytes) => {
-                    let path = plugin_state_path(&working_dir, plugin);
+                    let path = plugin_state_path(&data_dir, &working_dir, plugin);
                     if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
                         tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
                     }
@@ -249,5 +271,66 @@ impl Editor {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paths_live_under_data_dir_not_working_dir() {
+        // Regression test for issue #1991: orchestrator persistence
+        // must never write inside the user's working tree.
+        let data_dir = Path::new("/tmp/fresh-data");
+        let working_dir = Path::new("/home/user/project");
+
+        let wp = windows_path(data_dir, working_dir);
+        let sd = state_dir(data_dir, working_dir);
+        let psp = plugin_state_path(data_dir, working_dir, "orchestrator");
+
+        assert!(
+            wp.starts_with(data_dir),
+            "windows_path must live under data_dir, got {wp:?}"
+        );
+        assert!(
+            sd.starts_with(data_dir),
+            "state_dir must live under data_dir, got {sd:?}"
+        );
+        assert!(
+            psp.starts_with(data_dir),
+            "plugin_state_path must live under data_dir, got {psp:?}"
+        );
+
+        for p in [&wp, &sd, &psp] {
+            assert!(
+                !p.starts_with(working_dir),
+                "orchestrator path must not be inside the working tree: {p:?}"
+            );
+            for component in p.components() {
+                if let std::path::Component::Normal(c) = component {
+                    assert_ne!(
+                        c, ".fresh",
+                        "orchestrator path must not contain a `.fresh` component: {p:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn paths_are_keyed_by_working_dir() {
+        // Two distinct working dirs must map to two distinct
+        // orchestrator subtrees, otherwise different projects
+        // would clobber each other's state.
+        let data_dir = Path::new("/tmp/fresh-data");
+        let a = windows_path(data_dir, Path::new("/home/user/proj-a"));
+        let b = windows_path(data_dir, Path::new("/home/user/proj-b"));
+        assert_ne!(a, b);
+        // Same working dir must map to same path (idempotent
+        // encoding — relied on so a quit + restart sees the
+        // same file).
+        let a_again = windows_path(data_dir, Path::new("/home/user/proj-a"));
+        assert_eq!(a, a_again);
     }
 }

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3588,9 +3588,10 @@ fn real_main() -> AnyhowResult<()> {
 
         // Orchestrator cross-restart persistence is now loaded by
         // `Editor::with_options` before construction — it reads
-        // `.fresh/windows.json` + `.fresh/state/*.json` and builds
-        // the initial windows map / `plugin_global_state` directly
-        // into the constructor's inputs. This used to happen here
+        // `windows.json` + `state/*.json` from under the platform
+        // data dir and builds the initial windows map /
+        // `plugin_global_state` directly into the constructor's
+        // inputs. This used to happen here
         // as a post-construction swap, which left the active window
         // in an inert-shell state until something re-seeded it (see
         // the panic at `effective_active_pair` when workspace
@@ -3988,8 +3989,9 @@ where
             }
 
             // Orchestrator cross-restart persistence: write
-            // `.fresh/sessions.json` and `.fresh/state/*.json`. Best-
-            // effort; failures are logged inside, never block quit.
+            // `windows.json` and `state/*.json` under the platform
+            // data dir (see `orchestrator_persistence`). Best-effort;
+            // failures are logged inside, never block quit.
             editor.save_orchestrator_state();
             break;
         }

--- a/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
+++ b/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
@@ -1,0 +1,81 @@
+//! Regression test for issue #1991.
+//!
+//! Pre-fix, `Editor::save_orchestrator_state` wrote `windows.json`
+//! into `<working_dir>/.fresh/` on every quit — leaving a stray
+//! directory in the user's working tree even for sessions that never
+//! touched any orchestrator feature.
+//!
+//! Post-fix, orchestrator state lives under
+//! `<data_dir>/orchestrator/<encoded_working_dir>/`, mirroring how
+//! other per-project editor state is stored.
+
+mod common;
+
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use fresh::model::filesystem::StdFileSystem;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+#[test]
+fn save_orchestrator_state_does_not_create_dotfresh_in_working_dir() {
+    // Use two separate temp dirs: one for the editor's working dir
+    // (the user's project), one for the platform data dir. This
+    // mirrors the production layout where `dir_context.data_dir`
+    // is `$XDG_DATA_HOME/fresh/`, completely separate from the
+    // CWD the user invokes `fresh` from.
+    let project_dir = TempDir::new().unwrap();
+    let data_root = TempDir::new().unwrap();
+
+    let dir_context = DirectoryContext::for_testing(data_root.path());
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+
+    let editor = fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project_dir.path().to_path_buf()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,  // time source
+        None,  // grammar registry
+        false, // enable_plugins
+        false, // enable_embedded_plugins
+    )
+    .unwrap();
+
+    // Trigger the quit-time persistence write.
+    editor.save_orchestrator_state();
+
+    // The bug: a `.fresh/` directory used to appear right here,
+    // inside the user's project tree. After the fix it must not.
+    let stray = project_dir.path().join(".fresh");
+    assert!(
+        !stray.exists(),
+        "save_orchestrator_state must not create {stray:?} in the working tree (issue #1991)"
+    );
+
+    // And the corresponding orchestrator state must have landed
+    // under the platform data dir instead.
+    let canonical_project = project_dir
+        .path()
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.path().to_path_buf());
+    let encoded = fresh::workspace::encode_path_for_filename(&canonical_project);
+    let expected_windows_file = dir_context
+        .data_dir
+        .join("orchestrator")
+        .join(&encoded)
+        .join("windows.json");
+    assert!(
+        expected_windows_file.exists(),
+        "expected orchestrator state at {expected_windows_file:?}"
+    );
+}


### PR DESCRIPTION
Fixes #1991.

## Summary

`Editor::save_orchestrator_state` was writing `windows.json` and per-plugin state files into `<working_dir>/.fresh/` on every quit. Because that path is rooted at the user's CWD and the call is unconditional, every Fresh session — even one that never touched any orchestrator feature — left a stray `.fresh/` directory in the user's project tree (showing up as untracked in `git status`).

This PR routes the orchestrator persistence paths through `DirectoryContext::data_dir`, under a per-project subtree:

```
<data_dir>/orchestrator/<encoded_working_dir>/windows.json
<data_dir>/orchestrator/<encoded_working_dir>/state/<plugin>.json
```

The working dir is encoded with `workspace::encode_path_for_filename`, the same scheme the `workspace` module already uses for its per-project state. So the same project maps to a stable, collision-free subtree across both subsystems.

## Changes

- `crates/fresh-editor/src/app/orchestrator_persistence.rs`
  - `windows_path`, `state_dir`, `plugin_state_path` now take `(data_dir, working_dir)` and return paths under `<data_dir>/orchestrator/<encoded>/`.
  - `read_persisted_windows_env` and `read_persisted_plugin_state` take an additional `data_dir` parameter.
  - `save_orchestrator_state` pulls `data_dir` from `self.dir_context.data_dir`.
  - Docs / module comment updated to reflect the new layout.
- `crates/fresh-editor/src/app/editor_init.rs`: pass `&dir_context.data_dir` to the readers.
- `crates/fresh-editor/src/main.rs`: stale `.fresh/...` references in comments updated.
- `crates/fresh-editor/tests/orchestrator_persistence_paths.rs` (new): regression test that builds an Editor, calls `save_orchestrator_state`, and asserts (a) no `.fresh/` appears in the working tree, (b) `windows.json` lands under the data dir.
- Unit tests inside `orchestrator_persistence.rs` for the path helpers themselves.

## Migration / compatibility

Existing `.fresh/` directories created by 0.3.6 are not touched by the new code (no reads from there, no deletes). They contain only window labels and per-plugin global state — both regenerated on next use — so abandoning them is safe. Users who care can delete the leftover `.fresh/` directories manually.

## Test plan

- [x] New regression test `save_orchestrator_state_does_not_create_dotfresh_in_working_dir` — verified it fails against the pre-fix code (asserts the bug), passes after the fix.
- [x] Unit tests `paths_live_under_data_dir_not_working_dir` and `paths_are_keyed_by_working_dir` for the path helpers.
- [x] `cargo test --package fresh-editor --lib` — 2463 passed, 0 failed.
- [x] `cargo test --package fresh-editor --test property_persistence_tests` — 41 passed.
- [x] `cargo clippy --package fresh-editor --lib` — no new warnings in changed code.
- [x] `cargo fmt --check` — clean.
- [x] Manual validation in tmux:
  - Launched `fresh` in `/tmp/fresh-manual-test/`, quit with `Ctrl+Q`.
  - Working dir stayed clean (no `.fresh/`).
  - State landed at `~/.local/share/fresh/orchestrator/tmp_fresh-manual-test/windows.json`.
  - Restart + quit cycle preserved state in the new location.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VM3LQ338BJiPhs8KYw1eBy)_