### PR TITLE
perf(highlighter): preserve cache across bulk edits (fixes #1958)

### DIFF
--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -468,7 +468,11 @@ impl Editor {
             }
         }
 
-        // Invalidate highlighter
+        // Notify the highlighter of each edit so the cache can take the
+        // partial-update path on the next render. Throwing the whole cache
+        // away here (the previous behaviour) wiped every checkpoint as well,
+        // forcing a cold reparse from byte zero on the next keystroke — see
+        // https://github.com/sinelaw/fresh/issues/1958.
         self.windows
             .get_mut(&self.active_window)
             .map(|w| &mut w.buffers)
@@ -476,7 +480,7 @@ impl Editor {
             .get_mut(&active_buf)
             .unwrap()
             .highlighter
-            .invalidate_all();
+            .notify_edits(&edit_lengths);
 
         // Create BulkEdit event with both buffer snapshots
         let bulk_edit = Event::BulkEdit {

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1338,6 +1338,30 @@ impl HighlightEngine {
         }
     }
 
+    /// Track a sequence of bulk edits in the cache.
+    ///
+    /// Each edit is `(pos, del_len, ins_len)`. The slice must be sorted in
+    /// descending position order — the same order `apply_bulk_edits` uses to
+    /// mutate the buffer — so positions remain valid as the buffer changes.
+    ///
+    /// This mirrors the `notify_*` + `invalidate_range` pattern used by
+    /// single-edit paths. It preserves the TextMate engine's checkpoints and
+    /// dirty-from anchor (so the next render uses the partial-update path
+    /// rather than a cold reparse from byte zero) and drops the tree-sitter
+    /// viewport cache only when an edit overlaps it.
+    pub fn notify_edits(&mut self, edits: &[(usize, usize, usize)]) {
+        for &(pos, del_len, ins_len) in edits {
+            if del_len > 0 {
+                self.notify_delete(pos, del_len);
+            }
+            if ins_len > 0 {
+                self.notify_insert(pos, ins_len);
+            }
+            let edit_end = pos + del_len.max(ins_len);
+            self.invalidate_range(pos..edit_end);
+        }
+    }
+
     /// Check if this engine has highlighting available
     pub fn has_highlighting(&self) -> bool {
         !matches!(self, Self::None)
@@ -1949,6 +1973,102 @@ mod tests {
         assert!(
             parsed < buf_len,
             "edit must not trigger a whole-file reparse (parsed {parsed}, file {buf_len})"
+        );
+    }
+
+    /// Bulk edits (multi-cursor typing, "select word + type letter" replace,
+    /// search-replace, etc.) must take the same partial-update path as single
+    /// edits. Regression for #1958: the previous code called `invalidate_all()`
+    /// after a bulk edit, wiping every checkpoint and forcing a cold reparse
+    /// from byte zero on the next keystroke.
+    #[test]
+    fn test_bulk_edit_uses_partial_update() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("test.rs"), None, &registry);
+
+        let mut content = String::new();
+        for i in 0..200 {
+            content.push_str(&format!("fn f_{i}() {{ let x = {i}; }}\n"));
+        }
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        // Warm cache.
+        let _ = engine.highlight_viewport(&buffer, 0, 100, &theme, 10_000);
+        let bytes_before_edit = match &engine {
+            HighlightEngine::TextMate(h) => h.stats().bytes_parsed,
+            _ => panic!("expected TextMate engine for .rs"),
+        };
+        let buf_len = buffer.len();
+        assert!(
+            buf_len > 4000,
+            "test needs a buffer larger than the partial-update region"
+        );
+
+        // Simulate "select a word, type a letter" deep in the file: a single
+        // bulk edit that deletes 8 bytes and inserts 1 byte at the same
+        // position. This is exactly the user-facing scenario in #1958.
+        let edit_pos = buf_len / 2;
+        let edits = vec![(edit_pos, 8usize, 1usize)];
+        engine.notify_edits(&edits);
+
+        let _ = engine.highlight_viewport(&buffer, 0, 100, &theme, 10_000);
+        let bytes_after_edit = match &engine {
+            HighlightEngine::TextMate(h) => h.stats().bytes_parsed,
+            _ => unreachable!(),
+        };
+        let parsed = bytes_after_edit - bytes_before_edit;
+
+        assert!(
+            parsed < buf_len,
+            "bulk edit must not trigger a whole-file reparse \
+             (parsed {parsed}, file {buf_len})"
+        );
+    }
+
+    /// Bulk edits whose positions are all outside the cached viewport must
+    /// not invalidate the cache at all on the tree-sitter / `Highlighter`
+    /// path. (TextMate has a richer convergence model, but for both engines
+    /// the regression to guard against is: "any bulk edit, even a tiny one,
+    /// destroys the cache and forces a full reparse.")
+    #[test]
+    fn test_bulk_edit_outside_cache_keeps_textmate_partial_update() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("test.rs"), None, &registry);
+
+        let mut content = String::new();
+        for i in 0..400 {
+            content.push_str(&format!("fn f_{i}() {{ let x = {i}; }}\n"));
+        }
+        let buffer = Buffer::from_str(&content, 0, test_fs());
+        let theme = Theme::load_builtin(theme::THEME_LIGHT).unwrap();
+
+        // Warm a viewport near the start.
+        let _ = engine.highlight_viewport(&buffer, 0, 200, &theme, 1_000);
+        let bytes_before = match &engine {
+            HighlightEngine::TextMate(h) => h.stats().bytes_parsed,
+            _ => panic!("expected TextMate engine for .rs"),
+        };
+
+        // Apply a bulk edit far past the warmed viewport.
+        let far_pos = buffer.len() - 100;
+        engine.notify_edits(&[(far_pos, 3, 1)]);
+
+        // Re-render the original viewport. The partial-update path must keep
+        // parsed bytes well below a whole-file reparse.
+        let _ = engine.highlight_viewport(&buffer, 0, 200, &theme, 1_000);
+        let bytes_after = match &engine {
+            HighlightEngine::TextMate(h) => h.stats().bytes_parsed,
+            _ => unreachable!(),
+        };
+        let parsed = bytes_after - bytes_before;
+        let buf_len = buffer.len();
+        assert!(
+            parsed < buf_len,
+            "bulk edit outside the viewport must not force a whole-file \
+             reparse (parsed {parsed}, file {buf_len})"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1958. Replacing a selected word with a single character felt laggy
because the bulk-edit path discarded the whole highlight cache (plus every
TextMate checkpoint) on every keystroke, forcing a cold reparse from byte zero.

## What was wrong

`Editor::apply_events_as_bulk_edit` is the path used whenever a single
keystroke produces more than one event — most commonly "select a word, type a
letter" (delete + insert) and any multi-cursor edit. After applying the edits,
it called `HighlightEngine::invalidate_all()`, which:

- Drops the span cache (`cache = None`)
- Drops *every* TextMate checkpoint (`checkpoint_states.clear()`)
- Resets `dirty_from` to `None`

The cache-clear alone would have been recoverable via the forward-extension
path, but clearing the checkpoints means the next render has no resume anchor
and has to parse from byte zero. The author's hypothesis in the issue was
exactly this.

## Fix

Introduce `HighlightEngine::notify_edits(&[(pos, del_len, ins_len)])` — the
bulk-edit counterpart of the `notify_insert` / `notify_delete` +
`invalidate_range` calls that single-character edits already make. It walks the
merged edit list in descending position order (the same order
`apply_bulk_edits` uses to mutate the buffer, so positions stay valid as the
buffer changes) and:

- For TextMate: shifts cached spans in place, keeps checkpoints, sets
  `dirty_from` so the next render takes the partial-update path.
- For tree-sitter: drops the viewport cache only when an edit actually
  intersects it.

`event_apply.rs::apply_events_as_bulk_edit` now calls this helper instead of
`invalidate_all()`. Other `invalidate_all()` call sites (snapshot-based undo/redo
replay in `state.rs`, plugin bulk replace, LSP edits) are intentionally left
untouched — their position semantics interact with snapshot restoration and
inverted edits, which is out of scope for this fix.

## Test plan

- [x] New `test_bulk_edit_uses_partial_update`: simulate "select word, type
      letter" via `notify_edits`, assert the next render parses fewer bytes
      than the whole file.
- [x] New `test_bulk_edit_outside_cache_keeps_textmate_partial_update`: bulk
      edit far past the warmed viewport, assert no whole-file reparse on
      re-render.
- [x] Both new tests **fail** when `notify_edits` is short-circuited to
      `invalidate_all()` (verified locally — pre-fix behaviour parses the
      entire file, post-fix it parses ~viewport-sized work).
- [x] `cargo test -p fresh-editor --lib` — 2463 passed.
- [x] `cargo test -p fresh-editor --test e2e_tests -- syntax_highlighting` —
      108 passed.
- [x] `cargo test -p fresh-editor --test e2e_tests -- multi_cursor replace` —
      72 passed.
- [x] `cargo test -p fresh-editor --test e2e_tests -- undo redo bulk` —
      53 passed.
- [x] `cargo fmt --check -p fresh-editor` — clean.
- [x] Manual: launched the editor in tmux, opened a `.rs` file, did "select
      word + type letter" and "select word + type long replacement"; syntax
      highlighting stayed correct in both cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WTTx5Maaq6gAGPY1ZHWCzj)_