### PR TITLE
fix(splits): paint separator cells with editor_bg so they blend with panes (#1963)

### DIFF
--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
@@ -2134,125 +2134,245 @@
   <rect x="1053" y="252" width="9" height="18" fill="#0a0a0a"/>
   <rect x="1062" y="252" width="9" height="18" fill="#0a0a0a"/>
   <rect x="1071" y="252" width="9" height="18" fill="#ffff00"/>
+  <rect x="0" y="270" width="9" height="18" fill="#000000"/>
   <text x="1" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="9" y="270" width="9" height="18" fill="#000000"/>
   <text x="10" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="18" y="270" width="9" height="18" fill="#000000"/>
   <text x="19" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="27" y="270" width="9" height="18" fill="#000000"/>
   <text x="28" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="36" y="270" width="9" height="18" fill="#000000"/>
   <text x="37" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="45" y="270" width="9" height="18" fill="#000000"/>
   <text x="46" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="54" y="270" width="9" height="18" fill="#000000"/>
   <text x="55" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="63" y="270" width="9" height="18" fill="#000000"/>
   <text x="64" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="72" y="270" width="9" height="18" fill="#000000"/>
   <text x="73" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="81" y="270" width="9" height="18" fill="#000000"/>
   <text x="82" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="90" y="270" width="9" height="18" fill="#000000"/>
   <text x="91" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="99" y="270" width="9" height="18" fill="#000000"/>
   <text x="100" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="108" y="270" width="9" height="18" fill="#000000"/>
   <text x="109" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="117" y="270" width="9" height="18" fill="#000000"/>
   <text x="118" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="126" y="270" width="9" height="18" fill="#000000"/>
   <text x="127" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="135" y="270" width="9" height="18" fill="#000000"/>
   <text x="136" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="144" y="270" width="9" height="18" fill="#000000"/>
   <text x="145" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="153" y="270" width="9" height="18" fill="#000000"/>
   <text x="154" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="162" y="270" width="9" height="18" fill="#000000"/>
   <text x="163" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="171" y="270" width="9" height="18" fill="#000000"/>
   <text x="172" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="180" y="270" width="9" height="18" fill="#000000"/>
   <text x="181" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="189" y="270" width="9" height="18" fill="#000000"/>
   <text x="190" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="198" y="270" width="9" height="18" fill="#000000"/>
   <text x="199" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="207" y="270" width="9" height="18" fill="#000000"/>
   <text x="208" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="216" y="270" width="9" height="18" fill="#000000"/>
   <text x="217" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="225" y="270" width="9" height="18" fill="#000000"/>
   <text x="226" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="234" y="270" width="9" height="18" fill="#000000"/>
   <text x="235" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="243" y="270" width="9" height="18" fill="#000000"/>
   <text x="244" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="252" y="270" width="9" height="18" fill="#000000"/>
   <text x="253" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="261" y="270" width="9" height="18" fill="#000000"/>
   <text x="262" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="270" y="270" width="9" height="18" fill="#000000"/>
   <text x="271" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="279" y="270" width="9" height="18" fill="#000000"/>
   <text x="280" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="288" y="270" width="9" height="18" fill="#000000"/>
   <text x="289" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="297" y="270" width="9" height="18" fill="#000000"/>
   <text x="298" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="306" y="270" width="9" height="18" fill="#000000"/>
   <text x="307" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="315" y="270" width="9" height="18" fill="#000000"/>
   <text x="316" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="324" y="270" width="9" height="18" fill="#000000"/>
   <text x="325" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="333" y="270" width="9" height="18" fill="#000000"/>
   <text x="334" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="342" y="270" width="9" height="18" fill="#000000"/>
   <text x="343" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="351" y="270" width="9" height="18" fill="#000000"/>
   <text x="352" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="360" y="270" width="9" height="18" fill="#000000"/>
   <text x="361" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="369" y="270" width="9" height="18" fill="#000000"/>
   <text x="370" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="378" y="270" width="9" height="18" fill="#000000"/>
   <text x="379" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="387" y="270" width="9" height="18" fill="#000000"/>
   <text x="388" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="396" y="270" width="9" height="18" fill="#000000"/>
   <text x="397" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="405" y="270" width="9" height="18" fill="#000000"/>
   <text x="406" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="414" y="270" width="9" height="18" fill="#000000"/>
   <text x="415" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="423" y="270" width="9" height="18" fill="#000000"/>
   <text x="424" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="432" y="270" width="9" height="18" fill="#000000"/>
   <text x="433" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="441" y="270" width="9" height="18" fill="#000000"/>
   <text x="442" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="450" y="270" width="9" height="18" fill="#000000"/>
   <text x="451" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="459" y="270" width="9" height="18" fill="#000000"/>
   <text x="460" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="468" y="270" width="9" height="18" fill="#000000"/>
   <text x="469" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="477" y="270" width="9" height="18" fill="#000000"/>
   <text x="478" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="486" y="270" width="9" height="18" fill="#000000"/>
   <text x="487" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="495" y="270" width="9" height="18" fill="#000000"/>
   <text x="496" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="504" y="270" width="9" height="18" fill="#000000"/>
   <text x="505" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="513" y="270" width="9" height="18" fill="#000000"/>
   <text x="514" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="522" y="270" width="9" height="18" fill="#000000"/>
   <text x="523" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="531" y="270" width="9" height="18" fill="#000000"/>
   <text x="532" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="540" y="270" width="9" height="18" fill="#000000"/>
   <text x="541" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="549" y="270" width="9" height="18" fill="#000000"/>
   <text x="550" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="558" y="270" width="9" height="18" fill="#000000"/>
   <text x="559" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="567" y="270" width="9" height="18" fill="#000000"/>
   <text x="568" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="576" y="270" width="9" height="18" fill="#000000"/>
   <text x="577" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="585" y="270" width="9" height="18" fill="#000000"/>
   <text x="586" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="594" y="270" width="9" height="18" fill="#000000"/>
   <text x="595" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="603" y="270" width="9" height="18" fill="#000000"/>
   <text x="604" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="612" y="270" width="9" height="18" fill="#000000"/>
   <text x="613" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="621" y="270" width="9" height="18" fill="#000000"/>
   <text x="622" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="630" y="270" width="9" height="18" fill="#000000"/>
   <text x="631" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="639" y="270" width="9" height="18" fill="#000000"/>
   <text x="640" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="648" y="270" width="9" height="18" fill="#000000"/>
   <text x="649" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="657" y="270" width="9" height="18" fill="#000000"/>
   <text x="658" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="666" y="270" width="9" height="18" fill="#000000"/>
   <text x="667" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="675" y="270" width="9" height="18" fill="#000000"/>
   <text x="676" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="684" y="270" width="9" height="18" fill="#000000"/>
   <text x="685" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="693" y="270" width="9" height="18" fill="#000000"/>
   <text x="694" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="702" y="270" width="9" height="18" fill="#000000"/>
   <text x="703" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="711" y="270" width="9" height="18" fill="#000000"/>
   <text x="712" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="720" y="270" width="9" height="18" fill="#000000"/>
   <text x="721" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="729" y="270" width="9" height="18" fill="#000000"/>
   <text x="730" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="738" y="270" width="9" height="18" fill="#000000"/>
   <text x="739" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="747" y="270" width="9" height="18" fill="#000000"/>
   <text x="748" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="756" y="270" width="9" height="18" fill="#000000"/>
   <text x="757" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="765" y="270" width="9" height="18" fill="#000000"/>
   <text x="766" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="774" y="270" width="9" height="18" fill="#000000"/>
   <text x="775" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="783" y="270" width="9" height="18" fill="#000000"/>
   <text x="784" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="792" y="270" width="9" height="18" fill="#000000"/>
   <text x="793" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="801" y="270" width="9" height="18" fill="#000000"/>
   <text x="802" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="810" y="270" width="9" height="18" fill="#000000"/>
   <text x="811" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="819" y="270" width="9" height="18" fill="#000000"/>
   <text x="820" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="828" y="270" width="9" height="18" fill="#000000"/>
   <text x="829" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="837" y="270" width="9" height="18" fill="#000000"/>
   <text x="838" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="846" y="270" width="9" height="18" fill="#000000"/>
   <text x="847" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="855" y="270" width="9" height="18" fill="#000000"/>
   <text x="856" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="864" y="270" width="9" height="18" fill="#000000"/>
   <text x="865" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="873" y="270" width="9" height="18" fill="#000000"/>
   <text x="874" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="882" y="270" width="9" height="18" fill="#000000"/>
   <text x="883" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="891" y="270" width="9" height="18" fill="#000000"/>
   <text x="892" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="900" y="270" width="9" height="18" fill="#000000"/>
   <text x="901" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="909" y="270" width="9" height="18" fill="#000000"/>
   <text x="910" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="918" y="270" width="9" height="18" fill="#000000"/>
   <text x="919" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="927" y="270" width="9" height="18" fill="#000000"/>
   <text x="928" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="936" y="270" width="9" height="18" fill="#000000"/>
   <text x="937" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="945" y="270" width="9" height="18" fill="#000000"/>
   <text x="946" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="954" y="270" width="9" height="18" fill="#000000"/>
   <text x="955" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="963" y="270" width="9" height="18" fill="#000000"/>
   <text x="964" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="972" y="270" width="9" height="18" fill="#000000"/>
   <text x="973" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="981" y="270" width="9" height="18" fill="#000000"/>
   <text x="982" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="990" y="270" width="9" height="18" fill="#000000"/>
   <text x="991" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="999" y="270" width="9" height="18" fill="#000000"/>
   <text x="1000" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1008" y="270" width="9" height="18" fill="#000000"/>
   <text x="1009" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1017" y="270" width="9" height="18" fill="#000000"/>
   <text x="1018" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1026" y="270" width="9" height="18" fill="#000000"/>
   <text x="1027" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1035" y="270" width="9" height="18" fill="#000000"/>
   <text x="1036" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1044" y="270" width="9" height="18" fill="#000000"/>
   <text x="1045" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1053" y="270" width="9" height="18" fill="#000000"/>
   <text x="1054" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1062" y="270" width="9" height="18" fill="#000000"/>
   <text x="1063" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
+  <rect x="1071" y="270" width="9" height="18" fill="#000000"/>
   <text x="1072" y="284" fill="#8c8c8c" class="terminal" style="">─</text>
   <rect x="0" y="288" width="9" height="18" fill="#000000"/>
   <text x="1" y="302" fill="#00ffff" class="terminal" style="">┌</text>

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2835,11 +2835,11 @@ impl Editor {
                 // Highlight the separator with hover color
                 for (sid, dir, x, y, length) in &self.active_layout().separator_areas {
                     if sid == split_id && dir == direction {
-                        let hover_style = Style::default().fg(self
-                            .theme
-                            .read()
-                            .unwrap()
-                            .split_separator_hover_fg);
+                        let (hover_fg, editor_bg) = {
+                            let theme = self.theme.read().unwrap();
+                            (theme.split_separator_hover_fg, theme.editor_bg)
+                        };
+                        let hover_style = Style::default().fg(hover_fg).bg(editor_bg);
                         match dir {
                             SplitDirection::Horizontal => {
                                 let line_text = "─".repeat(*length as usize);
@@ -2916,8 +2916,11 @@ impl Editor {
             Some(HoverTarget::FileExplorerBorder) => {
                 // Highlight the file explorer border for resize
                 if let Some(explorer_area) = self.active_layout().file_explorer_area {
-                    let hover_style =
-                        Style::default().fg(self.theme.read().unwrap().split_separator_hover_fg);
+                    let (hover_fg, editor_bg) = {
+                        let theme = self.theme.read().unwrap();
+                        (theme.split_separator_hover_fg, theme.editor_bg)
+                    };
+                    let hover_style = Style::default().fg(hover_fg).bg(editor_bg);
                     let border_x = explorer_area.x + explorer_area.width.saturating_sub(1);
                     for row_offset in 0..explorer_area.height {
                         let paragraph = Paragraph::new(Span::styled("│", hover_style));

--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -287,19 +287,20 @@ pub(super) fn render_separator(
     length: u16,
     theme: &Theme,
 ) {
+    let style = Style::default()
+        .fg(theme.split_separator_fg)
+        .bg(theme.editor_bg);
     match direction {
         SplitDirection::Horizontal => {
             let line_area = Rect::new(x, y, length, 1);
             let line_text = "─".repeat(length as usize);
-            let paragraph =
-                Paragraph::new(line_text).style(Style::default().fg(theme.split_separator_fg));
+            let paragraph = Paragraph::new(line_text).style(style);
             frame.render_widget(paragraph, line_area);
         }
         SplitDirection::Vertical => {
             for offset in 0..length {
                 let cell_area = Rect::new(x, y + offset, 1, 1);
-                let paragraph =
-                    Paragraph::new("│").style(Style::default().fg(theme.split_separator_fg));
+                let paragraph = Paragraph::new("│").style(style);
                 frame.render_widget(paragraph, cell_area);
             }
         }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -418,7 +418,11 @@ pub(crate) fn render_composite_buffer(
 
             if show_separator && pane_idx < pane_count - 1 {
                 let sep_area = Rect::new(x_offset, content_y + view_row as u16, separator_width, 1);
-                let sep = Paragraph::new("│").style(Style::default().fg(theme.split_separator_fg));
+                let sep = Paragraph::new("│").style(
+                    Style::default()
+                        .fg(theme.split_separator_fg)
+                        .bg(theme.editor_bg),
+                );
                 frame.render_widget(sep, sep_area);
                 x_offset += separator_width;
             }

--- a/crates/fresh-editor/tests/e2e/issue_1963_light_theme_split_borders.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1963_light_theme_split_borders.rs
@@ -1,0 +1,132 @@
+//! Regression test for issue #1963: split borders look bad in Light theme.
+//!
+//! Before the fix, `render_separator` (and the matching hover render path) set
+//! only `fg` on separator cells, leaving the cell `bg` as the terminal default.
+//! In the Light theme, where editor panes are white, the separator strips
+//! between panes leaked the terminal's default background (typically dark),
+//! producing harsh dark bands between white panels. The fix sets `bg` to the
+//! theme's `editor_bg` so the separator integrates with surrounding panes.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use ratatui::style::Color;
+
+fn split_vertical(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("split vert").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+fn split_horizontal(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("split horiz").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+fn find_cell_with_symbol(harness: &EditorTestHarness, symbol: &str) -> Option<(u16, u16)> {
+    let buffer = harness.buffer();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            let pos = buffer.index_of(x, y);
+            if let Some(cell) = buffer.content.get(pos) {
+                if cell.symbol() == symbol {
+                    return Some((x, y));
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn test_light_theme_vertical_split_separator_has_editor_bg() {
+    let config = Config {
+        theme: "light".into(),
+        ..Default::default()
+    };
+    let mut harness = EditorTestHarness::with_config(120, 30, config).unwrap();
+    let (expected_fg, expected_bg) = {
+        let theme = harness.editor().theme();
+        (theme.split_separator_fg, theme.editor_bg)
+    };
+
+    harness.type_text("hello").unwrap();
+    harness.render().unwrap();
+
+    split_vertical(&mut harness);
+
+    let (sep_x, sep_y) = find_cell_with_symbol(&harness, "│")
+        .expect("vertical split should render at least one │ separator cell");
+
+    let style = harness
+        .get_cell_style(sep_x, sep_y)
+        .expect("separator cell should have a style");
+
+    assert_eq!(
+        style.fg,
+        Some(expected_fg),
+        "separator cell fg should be theme.split_separator_fg"
+    );
+    assert_eq!(
+        style.bg,
+        Some(expected_bg),
+        "separator cell bg should be theme.editor_bg (got {:?}); otherwise the separator \
+         leaks the terminal default bg and looks like a harsh dark strip on light themes",
+        style.bg
+    );
+    assert_ne!(
+        style.bg,
+        Some(Color::Reset),
+        "separator cell bg should not be Color::Reset"
+    );
+}
+
+#[test]
+fn test_light_theme_horizontal_split_separator_has_editor_bg() {
+    let config = Config {
+        theme: "light".into(),
+        ..Default::default()
+    };
+    let mut harness = EditorTestHarness::with_config(120, 30, config).unwrap();
+    let (expected_fg, expected_bg) = {
+        let theme = harness.editor().theme();
+        (theme.split_separator_fg, theme.editor_bg)
+    };
+
+    harness.type_text("hello").unwrap();
+    harness.render().unwrap();
+
+    split_horizontal(&mut harness);
+
+    let (sep_x, sep_y) = find_cell_with_symbol(&harness, "─")
+        .expect("horizontal split should render at least one ─ separator cell");
+
+    let style = harness
+        .get_cell_style(sep_x, sep_y)
+        .expect("separator cell should have a style");
+
+    assert_eq!(
+        style.fg,
+        Some(expected_fg),
+        "separator cell fg should be theme.split_separator_fg"
+    );
+    assert_eq!(
+        style.bg,
+        Some(expected_bg),
+        "separator cell bg should be theme.editor_bg (got {:?})",
+        style.bg
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -71,6 +71,7 @@ pub mod issue_1697_ctrl_d_after_search;
 pub mod issue_1718_settings_search_utf8_panic;
 pub mod issue_1790_compose_wrap_highlight;
 pub mod issue_1901_multicursor_with_completion_popup;
+pub mod issue_1963_light_theme_split_borders;
 pub mod issue_1965_cursor_after_mouse_scroll;
 pub mod issue_779_after_eof_shade;
 pub mod redraw_screen;


### PR DESCRIPTION
Closes #1963.

## Problem

`render_separator` (and the matching hover render path) styled separator cells with `fg` only, leaving the cell `bg` as `Color::Reset`. In the Light theme the panes around the separator are painted white via `theme.editor_bg`, but the separator strip itself fell through to the terminal's default background — typically dark — producing the harsh dark bands visible in the issue screenshot.

ANSI capture before the fix (Light theme, vertical split):

```
[38;5;244m[49m│       ← fg = mid-gray, bg = default (terminal default, often dark)
```

After the fix:

```
[38;5;244m[48;5;231m│   ← fg = mid-gray, bg = white (editor_bg)
```

## Fix

Set `bg = theme.editor_bg` on every separator render site:

- `view/ui/split_rendering/layout.rs::render_separator` — main split tree, both directions.
- `view/ui/split_rendering/orchestration/render_composite.rs` — per-row separators in composite (grouped) panes.
- `app/render.rs::render_hover_highlights` — `SplitSeparator` and `FileExplorerBorder` hover overlays (so the hover repaint doesn't reintroduce the leak).

No theme JSON changed: the existing `split_separator_fg` is the right *line* color; the bug was that the cell underneath that glyph was never painted.

## Test plan

Regression test: `tests/e2e/issue_1963_light_theme_split_borders.rs`

- Loads the `light` theme, creates a vertical (resp. horizontal) split, locates a `│` (resp. `─`) cell, and asserts its style has `fg = theme.split_separator_fg` and `bg = theme.editor_bg`.
- Confirmed to **fail before the fix** (`bg = Some(Reset)` vs expected `Some(Rgb(255, 255, 255))`) and **pass with the fix**.

Also verified:

- All existing `split_view_expectations` (34), separator-drag, and `theme` (64) tests still pass.
- The auto-generated visual-regression SVG `Comprehensive_UI_B_01_state_b.svg` is updated to include the new bg rects for separator cells — that's the expected visual delta from this fix.
- Manual tmux smoke test with both `light` and `dark` themes: separators now render with the correct theme bg in both.

https://claude.ai/code/session_01Q9W5bLzUsd8QoueNHWKEPi

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9W5bLzUsd8QoueNHWKEPi)_