### PR TITLE
fix(terminal): nostalgia theme blue now covers full terminal pane (#1890)

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1261,6 +1261,12 @@ pub mod render {
         default_fg: Color,
         default_bg: Color,
     ) {
+        // Fill the rendered area with the theme's terminal bg first so any
+        // cells past the PTY grid (e.g. transiently smaller than the rect
+        // mid-resize) show the theme background rather than leaking the
+        // host terminal's default bg. Issue #1890.
+        buf.set_style(area, Style::default().fg(default_fg).bg(default_bg));
+
         for (row_idx, row) in content.iter().enumerate() {
             if row_idx as u16 >= area.height {
                 break;
@@ -1310,6 +1316,47 @@ pub mod render {
                 }
 
                 buf.set_string(x, y, cell.c.to_string(), style);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::services::terminal::TerminalCell;
+
+        #[test]
+        fn cells_past_pty_grid_get_theme_bg() {
+            // PTY grid is 2x2, render area is 4x3 — the cells outside
+            // the grid must still carry the theme's terminal_bg so the
+            // nostalgia theme's blue fully covers the terminal pane
+            // (issue #1890).
+            let area = Rect::new(0, 0, 4, 3);
+            let mut buf = Buffer::empty(area);
+            let row = vec![TerminalCell::default(), TerminalCell::default()];
+            let content = vec![row.clone(), row];
+
+            let default_bg = Color::Rgb(0, 0, 170);
+            let default_fg = Color::Rgb(255, 255, 85);
+
+            render_terminal_content(
+                &content,
+                (0, 0),
+                false,
+                area,
+                &mut buf,
+                default_fg,
+                default_bg,
+            );
+
+            for y in area.top()..area.bottom() {
+                for x in area.left()..area.right() {
+                    assert_eq!(
+                        buf[(x, y)].bg,
+                        default_bg,
+                        "cell ({x}, {y}) bg should be the theme terminal_bg",
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1890: in the nostalgia theme the terminal pane's right and bottom edges weren't covered by the theme's blue — the host terminal's default background leaked through instead.

## Root cause

`render_terminal_content` (`crates/fresh-editor/src/app/terminal.rs`) only applies `theme.terminal_bg` per-cell while iterating the PTY grid. The caller renders a `Clear` widget first, which resets cells to `Color::Reset`. When the PTY grid is briefly smaller than the render rect (resize race, or rows/cols < area dimensions), the cells outside the iterated grid keep `Color::Reset` and show the host terminal's default bg instead of the theme's `terminal_bg`.

## Fix

Fill the whole render area with `default_fg`/`default_bg` via `Buffer::set_style` at the start of `render_terminal_content`. In-grid cells continue to be overwritten by their per-cell style; the only behavior change is that uncovered cells now show the theme bg.

## Test plan

- [x] Added unit test `cells_past_pty_grid_get_theme_bg` — fails on baseline (`cell (2, 0) bg ... left: Reset, right: Rgb(0, 0, 170)`), passes with the fix.
- [x] `cargo test -p fresh-editor --features runtime --lib app::terminal` — 7 passed.
- [x] `cargo fmt --check` clean.
- [x] Manual: launched `fresh` in a tmux pane, switched to nostalgia theme, opened a terminal split, captured the pane with `tmux capture-pane -e` — every cell inside the terminal pane now reports `[48;5;19m` (nostalgia blue) instead of leaving uncovered cells at the host default.


---
_Generated by [Claude Code](https://claude.ai/code/session_017yfgNudJbQgsZ7LBxMazvh)_