### PR TITLE
fix(grammar/julia): stop adjoint operator from triggering string mode

### DIFF
--- a/crates/fresh-editor/src/grammars/julia.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/julia.sublime-syntax
@@ -28,13 +28,14 @@ contexts:
           scope: variable.interpolation.julia
         - match: '"'
           pop: true
-    - match: "'"
-      push:
-        - meta_scope: string.quoted.single.julia
-        - match: '\\.'
-          scope: constant.character.escape.julia
-        - match: "'"
-          pop: true
+    # Julia uses ' for two distinct purposes:
+    #   1. Character literals: 'a', '\n', '\xff', 'é', '\U0001F600'
+    #   2. The adjoint (conjugate-transpose) postfix operator: A', (A+B)'
+    # Match only well-formed character literals as an atomic span. Any other
+    # ' (notably the adjoint operator) is left alone so it can't push a
+    # string context and bleed into the rest of the file.
+    - match: "'(?:\\\\(?:x[0-9a-fA-F]{1,2}|u[0-9a-fA-F]{1,4}|U[0-9a-fA-F]{1,8}|.)|[^'\\\\])'"
+      scope: constant.character.julia
     - match: '`[^`]*`'
       scope: string.other.command.julia
   keywords:

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -2304,6 +2304,113 @@ mod tests {
         assert_eq!(second_globs, 1, "globs must not duplicate");
     }
 
+    /// Julia: a single-quote after an identifier is the adjoint
+    /// (conjugate-transpose) postfix operator, not the start of a string. The
+    /// old grammar pushed a string context on every `'`, so `A'` swallowed
+    /// the rest of the file until the next quote — wrecking highlighting for
+    /// any subsequent keyword. Issue #1852.
+    #[test]
+    fn test_julia_adjoint_does_not_start_string() {
+        use syntect::parsing::{ParseState, ScopeStack};
+
+        let registry = GrammarRegistry::default();
+        let syntax_set = registry.syntax_set();
+        let syntax = registry
+            .find_syntax_by_name("Julia")
+            .expect("Julia grammar must be loaded");
+        let mut state = ParseState::new(syntax);
+        let mut scopes = ScopeStack::new();
+
+        // Adjoint operator followed by code on later lines.
+        let lines = ["x = A'\n", "function foo()\n", "end\n"];
+        let mut keyword_line_in_string = false;
+        let mut found_function_keyword = false;
+
+        for line in &lines {
+            let ops = state.parse_line(line, syntax_set).unwrap();
+            // Walk byte-by-byte, applying ops as we pass their offset.
+            let mut op_iter = ops.iter().peekable();
+            for (byte_idx, _) in line.char_indices() {
+                while let Some((offset, op)) = op_iter.peek() {
+                    if *offset <= byte_idx {
+                        scopes.apply(op).unwrap();
+                        op_iter.next();
+                    } else {
+                        break;
+                    }
+                }
+                let in_string = scopes
+                    .as_slice()
+                    .iter()
+                    .any(|s| s.build_string().starts_with("string."));
+                let is_function_kw = line[byte_idx..].starts_with("function");
+                if is_function_kw && in_string {
+                    keyword_line_in_string = true;
+                }
+                if is_function_kw && !in_string {
+                    found_function_keyword = true;
+                }
+            }
+            // Drain remaining ops at end of line.
+            for (_, op) in op_iter {
+                scopes.apply(op).unwrap();
+            }
+        }
+
+        assert!(
+            !keyword_line_in_string,
+            "the `function` keyword after an adjoint operator must not be inside a string scope"
+        );
+        assert!(
+            found_function_keyword,
+            "test harness must have reached the `function` keyword"
+        );
+    }
+
+    /// Julia: `'a'` is a valid character literal. The grammar must still
+    /// scope it as a constant/character so themes can color it. Issue #1852.
+    #[test]
+    fn test_julia_char_literal_is_recognized() {
+        use syntect::parsing::{ParseState, ScopeStack};
+
+        let registry = GrammarRegistry::default();
+        let syntax_set = registry.syntax_set();
+        let syntax = registry
+            .find_syntax_by_name("Julia")
+            .expect("Julia grammar must be loaded");
+        let mut state = ParseState::new(syntax);
+        let mut scopes = ScopeStack::new();
+
+        let line = "x = 'a'\n";
+        let ops = state.parse_line(line, syntax_set).unwrap();
+        let mut saw_constant_or_string_at_quote = false;
+        let mut op_iter = ops.iter().peekable();
+        for (byte_idx, _) in line.char_indices() {
+            while let Some((offset, op)) = op_iter.peek() {
+                if *offset <= byte_idx {
+                    scopes.apply(op).unwrap();
+                    op_iter.next();
+                } else {
+                    break;
+                }
+            }
+            if byte_idx == 5 {
+                // position of 'a' (the char)
+                let scoped = scopes.as_slice().iter().any(|s| {
+                    let str = s.build_string();
+                    str.starts_with("constant.") || str.starts_with("string.")
+                });
+                if scoped {
+                    saw_constant_or_string_at_quote = true;
+                }
+            }
+        }
+        assert!(
+            saw_constant_or_string_at_quote,
+            "char literal 'a' must receive a constant/string scope"
+        );
+    }
+
     /// `tree_sitter_for_syntect_name` handles the alias table + strict
     /// display-name match. The alias table catches syntect's verbose names;
     /// the strict match handles the common case.


### PR DESCRIPTION
## Summary

Fixes #1852.

The Julia grammar pushed a string context on every `'`, so the **adjoint** (conjugate-transpose) postfix operator `A'` swallowed everything until the next `'` — wrecking highlighting for whole functions (e.g. the next `end` keyword would render as a string).

This PR replaces the push/pop string context with a single atomic match for well-formed character literals. Any lone `'` (the adjoint operator) is now left unmatched and cannot bleed string state into the rest of the file. Invalid multi-char forms like `'abc'` fall through to plain text, which is visually distinct from valid char literals — addressing the secondary request in the issue.

### Cases now handled correctly

- `A'` (adjoint) — no longer starts a string
- `'a'` — recognized as a character constant
- `'\n'`, `'\t'`, `'\''`, `'\\'` — escape sequences
- `'\xff'`, `'é'`, `'\U0001F600'` — hex / short / long unicode escapes
- `'é'` — single unicode code point
- `'abc'` (invalid in Julia) — left as plain text, visually different from valid literals

### Approach

Sublime-syntax can't fully parse Julia's `'` ambiguity (it depends on whether the preceding token is an expression). Rather than try, the new rule matches only the *closed* character-literal form `'<char-or-escape>'` atomically. Anything else — including the bare `'` of the adjoint — passes through untouched. This is the same conservative approach used for similar postfix-operator ambiguity in other editors.

## Test plan

- [x] New regression test `test_julia_adjoint_does_not_start_string` — fails on master, passes with the fix (asserts the `function` keyword on a line after `A'` is not inside a `string.*` scope).
- [x] New regression test `test_julia_char_literal_is_recognized` — asserts `'a'` still receives a constant/string scope.
- [x] All 40 tests in `primitives::grammar` pass.
- [x] `cargo fmt`, `cargo clippy -p fresh-editor --all-targets` clean for the new code.
- [x] Manual validation: opened a Julia file in `fresh` via tmux with a function whose body returns `A'`. Before the fix, the `end` keyword after such a function rendered as string-colored; with the fix it renders as a keyword, and `'a'` renders as a character constant.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jwj8M5ogb6AV9b8BNvK9XS)_