### PR TITLE
fix(input): match Shift+letter bindings when terminal omits SHIFT modifier

### DIFF
--- a/crates/fresh-editor/src/app/event_debug.rs
+++ b/crates/fresh-editor/src/app/event_debug.rs
@@ -13,14 +13,30 @@ const MAX_HISTORY: usize = 10;
 pub struct RecordedEvent {
     /// The raw key event
     pub event: KeyEvent,
-    /// Human-readable description
+    /// Human-readable description of the raw event
     pub description: String,
+    /// Human-readable description of the key *after* `normalize_key` — i.e.
+    /// the form keybinding lookup actually matches against. `None` when
+    /// normalization leaves the event unchanged (no extra line to show).
+    pub normalized: Option<String>,
 }
 
 impl RecordedEvent {
     fn new(event: KeyEvent) -> Self {
         let description = format_key_event(&event);
-        Self { event, description }
+        let (norm_code, norm_mods) =
+            crate::input::keybindings::normalize_key(event.code, event.modifiers);
+        let normalized = if norm_code == event.code && norm_mods == event.modifiers {
+            None
+        } else {
+            let norm_event = KeyEvent::new(norm_code, norm_mods);
+            Some(format_key_event(&norm_event))
+        };
+        Self {
+            event,
+            description,
+            normalized,
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/keybinding_editor/editor.rs
+++ b/crates/fresh-editor/src/app/keybinding_editor/editor.rs
@@ -4,7 +4,9 @@ use super::helpers::{format_chord_keys, key_code_to_config_name, modifiers_to_co
 use super::types::*;
 use crate::config::{Config, Keybinding};
 use crate::input::command_registry::CommandRegistry;
-use crate::input::keybindings::{format_keybinding, Action, KeyContext, KeybindingResolver};
+use crate::input::keybindings::{
+    format_keybinding, normalize_key, Action, KeyContext, KeybindingResolver,
+};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use rust_i18n::t;
 use std::collections::{HashMap, HashSet};
@@ -742,9 +744,13 @@ impl KeybindingEditor {
 
     /// Record a search key
     pub fn record_search_key(&mut self, event: &KeyEvent) {
-        self.search_key_code = Some(event.code);
-        self.search_modifiers = event.modifiers;
-        self.search_key_display = format_keybinding(&event.code, &event.modifiers);
+        // Normalize so search-by-key behaves consistently with binding lookup
+        // (in particular: uppercase letters without an explicit SHIFT modifier
+        // are folded to lowercase + SHIFT).
+        let (norm_code, norm_mods) = normalize_key(event.code, event.modifiers);
+        self.search_key_code = Some(norm_code);
+        self.search_modifiers = norm_mods;
+        self.search_key_display = format_keybinding(&norm_code, &norm_mods);
         self.apply_filters();
     }
 
@@ -1267,6 +1273,29 @@ mod tests {
                 .iter()
                 .any(|a| a == "switch_keybinding_map"),
             "bare `switch_keybinding_map` must not appear"
+        );
+    }
+
+    #[test]
+    fn record_search_key_normalizes_uppercase_letter_to_shift() {
+        // Regression for https://github.com/sinelaw/fresh/issues/1899
+        // Many terminals don't report SHIFT when sending an uppercase letter
+        // — they encode the case in the character itself. `record_search_key`
+        // (used by the key-search ":record" mode) must still capture this as
+        // "Shift+letter" so it can find bindings stored that way.
+        let mut editor = make_editor(&[]);
+        // Simulate the typical terminal event: Char('P') with no SHIFT modifier.
+        let event = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::empty());
+        editor.record_search_key(&event);
+        assert_eq!(
+            editor.search_key_code,
+            Some(KeyCode::Char('p')),
+            "uppercase letter should be folded to lowercase for lookup"
+        );
+        assert!(
+            editor.search_modifiers.contains(KeyModifiers::SHIFT),
+            "uppercase letter should imply SHIFT (got modifiers={:?})",
+            editor.search_modifiers
         );
     }
 

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -11,12 +11,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///   strip the redundant SHIFT so bindings defined as "BackTab" match.
 /// - Shift+Backspace has no distinct semantics from plain Backspace — strip
 ///   the redundant SHIFT so bindings defined as "Backspace" match both.
-/// - Uppercase letters may arrive as `Char('P')` + SHIFT (real Shift press)
-///   or `Char('A')` without SHIFT (CapsLock on, kitty keyboard protocol).
-///   In both cases, lowercase the character and preserve the existing
-///   modifiers. This ensures CapsLock+Ctrl+A matches the `Ctrl+A` binding,
-///   while Shift+P still matches the `Shift+P` binding.
-fn normalize_key(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
+/// - Uppercase letters may arrive as `Char('P')` + SHIFT (real Shift press
+///   with kitty keyboard protocol), `Char('P')` without SHIFT (typical
+///   terminal — the case carries the shift information, including with ALT:
+///   Alt+Shift+F arrives as `Char('F')` + ALT), or `Char('A')` with only
+///   CONTROL (CapsLock+Ctrl+A in some terminals). Lowercase the character and
+///   infer SHIFT so that a binding defined as `Shift+P` / `Alt+Shift+F`
+///   matches whether or not the terminal reports the modifier. The one
+///   exception is CONTROL: an uppercase letter with Ctrl is ambiguous between
+///   CapsLock+Ctrl+letter and Shift+Ctrl+letter, and treating it as the
+///   former preserves the long-standing intent that CapsLock+Ctrl+A still
+///   triggers the `Ctrl+A` binding — so don't infer SHIFT when CONTROL is set.
+pub(crate) fn normalize_key(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifiers) {
     if code == KeyCode::BackTab {
         return (code, modifiers.difference(KeyModifiers::SHIFT));
     }
@@ -25,7 +31,12 @@ fn normalize_key(code: KeyCode, modifiers: KeyModifiers) -> (KeyCode, KeyModifie
     }
     if let KeyCode::Char(c) = code {
         if c.is_ascii_uppercase() {
-            return (KeyCode::Char(c.to_ascii_lowercase()), modifiers);
+            let new_modifiers = if modifiers.contains(KeyModifiers::CONTROL) {
+                modifiers
+            } else {
+                modifiers | KeyModifiers::SHIFT
+            };
+            return (KeyCode::Char(c.to_ascii_lowercase()), new_modifiers);
         }
     }
     (code, modifiers)
@@ -3147,6 +3158,143 @@ mod tests {
             resolver.resolve(&shift_backspace, KeyContext::FileExplorer),
             Action::FileExplorerSearchBackspace,
             "Shift+Backspace should resolve to FileExplorerSearchBackspace (same as Backspace) in FileExplorer context"
+        );
+    }
+
+    #[test]
+    fn test_shift_letter_binding_works_without_terminal_shift_modifier() {
+        // Regression test for https://github.com/sinelaw/fresh/issues/1899
+        // Most terminals don't report the SHIFT modifier when sending an
+        // uppercase letter — the case carries the shift information instead.
+        // A binding defined as `Shift+P` (key=p, modifiers=[shift]) must
+        // still trigger when the terminal sends `Char('P')` with no modifiers.
+        let mut config = Config::default();
+        config.keybindings.push(crate::config::Keybinding {
+            key: "p".to_string(),
+            modifiers: vec!["shift".to_string()],
+            keys: Vec::new(),
+            action: "save".to_string(),
+            args: HashMap::new(),
+            when: Some("normal".to_string()),
+        });
+        let resolver = KeybindingResolver::new(&config);
+
+        // Case 1: kitty keyboard protocol — explicit SHIFT modifier alongside uppercase.
+        let kitty_upper_shift = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT);
+        assert_eq!(
+            resolver.resolve(&kitty_upper_shift, KeyContext::Normal),
+            Action::Save,
+            "Char('P')+SHIFT should match Shift+P binding"
+        );
+
+        // Case 2: kitty protocol with lowercased char (caps lock or some terminals).
+        let kitty_lower_shift = KeyEvent::new(KeyCode::Char('p'), KeyModifiers::SHIFT);
+        assert_eq!(
+            resolver.resolve(&kitty_lower_shift, KeyContext::Normal),
+            Action::Save,
+            "Char('p')+SHIFT should match Shift+P binding"
+        );
+
+        // Case 3: typical terminal without kitty protocol — uppercase only, no modifier.
+        // This is the case that failed before the fix.
+        let plain_upper = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&plain_upper, KeyContext::Normal),
+            Action::Save,
+            "Char('P') with no modifier should match Shift+P binding \
+             (typical terminal behavior — case alone carries shift)"
+        );
+    }
+
+    #[test]
+    fn test_alt_shift_letter_binding_matches_across_terminal_encodings() {
+        // Alt+Shift+F is encoded differently by different terminals: some send
+        // `Char('F')` + ALT (no SHIFT bit — the case carries the shift), others
+        // send `Char('F')` + ALT + SHIFT. Both must match an `Alt+Shift+F`
+        // binding, and both must stay distinct from a plain `Alt+F` (Alt+f).
+        let mut config = Config::default();
+        config.keybindings.push(crate::config::Keybinding {
+            key: "f".to_string(),
+            modifiers: vec!["alt".to_string(), "shift".to_string()],
+            keys: Vec::new(),
+            action: "save".to_string(),
+            args: HashMap::new(),
+            when: Some("normal".to_string()),
+        });
+        let resolver = KeybindingResolver::new(&config);
+
+        // Encoding A: uppercase + ALT, terminal omits the SHIFT bit.
+        let no_shift_bit = KeyEvent::new(KeyCode::Char('F'), KeyModifiers::ALT);
+        assert_eq!(
+            resolver.resolve(&no_shift_bit, KeyContext::Normal),
+            Action::Save,
+            "Char('F')+ALT (no SHIFT bit) should match Alt+Shift+F"
+        );
+
+        // Encoding B: uppercase + ALT + SHIFT, terminal reports the SHIFT bit.
+        let with_shift_bit =
+            KeyEvent::new(KeyCode::Char('F'), KeyModifiers::ALT | KeyModifiers::SHIFT);
+        assert_eq!(
+            resolver.resolve(&with_shift_bit, KeyContext::Normal),
+            Action::Save,
+            "Char('F')+ALT+SHIFT should match Alt+Shift+F"
+        );
+
+        // Plain Alt+f (no shift) must NOT match the Alt+Shift+F binding.
+        let alt_f = KeyEvent::new(KeyCode::Char('f'), KeyModifiers::ALT);
+        assert_ne!(
+            resolver.resolve(&alt_f, KeyContext::Normal),
+            Action::Save,
+            "Alt+f (lowercase, no shift) must stay distinct from Alt+Shift+F"
+        );
+    }
+
+    #[test]
+    fn test_capslock_ctrl_letter_still_matches_ctrl_letter_binding() {
+        // The fix above must not regress the long-standing behavior where
+        // CapsLock+Ctrl+A is treated equivalently to Ctrl+A. When the
+        // character arrives uppercase with another modifier (CONTROL), we
+        // don't infer SHIFT — that case is ambiguous and the existing intent
+        // is to fold caps lock away.
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+
+        // Ctrl+A (lowercase, real key press).
+        let ctrl_a = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        let action_ctrl_a = resolver.resolve(&ctrl_a, KeyContext::Normal);
+
+        // CapsLock+Ctrl+A (uppercase from caps, CONTROL modifier only).
+        let caps_ctrl_a = KeyEvent::new(KeyCode::Char('A'), KeyModifiers::CONTROL);
+        let action_caps_ctrl_a = resolver.resolve(&caps_ctrl_a, KeyContext::Normal);
+
+        assert_eq!(
+            action_ctrl_a, action_caps_ctrl_a,
+            "CapsLock+Ctrl+A must resolve to the same action as Ctrl+A"
+        );
+    }
+
+    #[test]
+    fn test_uppercase_without_binding_falls_through_to_insert_char() {
+        // When there's no binding for a Shift+letter, an uppercase letter must
+        // still be inserted as text. The fix to normalize uppercase → SHIFT
+        // for lookup must not interfere with the InsertChar fallback (which
+        // uses the original event, not the normalized one).
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+
+        // 'Z' has no Shift+z binding in the default config.
+        let upper_z_no_mod = KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&upper_z_no_mod, KeyContext::Normal),
+            Action::InsertChar('Z'),
+            "Char('Z') with no modifier should still be inserted as 'Z'"
+        );
+
+        let upper_z_shift = KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::SHIFT);
+        assert_eq!(
+            resolver.resolve(&upper_z_shift, KeyContext::Normal),
+            Action::InsertChar('Z'),
+            "Char('Z')+SHIFT should still be inserted as 'Z'"
         );
     }
 

--- a/crates/fresh-editor/src/view/event_debug.rs
+++ b/crates/fresh-editor/src/view/event_debug.rs
@@ -103,10 +103,23 @@ pub fn render_event_debug(frame: &mut Frame, area: Rect, debug: &EventDebug, the
             };
 
             let prefix = if i == 0 { "> " } else { "  " };
-            history_lines.push(Line::from(vec![
+            let label_style = Style::default().fg(theme.line_number_fg);
+            let mut spans = vec![
                 Span::styled(prefix, style),
+                Span::styled("Raw: ", label_style),
                 Span::styled(&recorded.description, style),
-            ]));
+            ];
+            // The form keybinding lookup actually matches against. Shown only
+            // when normalization changes the key (e.g. raw Alt+F → Alt+Shift+F).
+            if let Some(normalized) = &recorded.normalized {
+                spans.push(Span::styled("    (Normalized: ", label_style));
+                spans.push(Span::styled(
+                    normalized,
+                    Style::default().fg(theme.diagnostic_hint_fg),
+                ));
+                spans.push(Span::styled(")", label_style));
+            }
+            history_lines.push(Line::from(spans));
         }
     }
 

--- a/crates/fresh-editor/src/view/keybinding_editor.rs
+++ b/crates/fresh-editor/src/view/keybinding_editor.rs
@@ -6,7 +6,7 @@ use crate::app::keybinding_editor::{
     BindingSource, ContextFilter, DeleteResult, DisplayRow, EditMode, KeybindingEditor, SearchMode,
     SourceFilter,
 };
-use crate::input::keybindings::{format_keybinding, KeybindingResolver};
+use crate::input::keybindings::{format_keybinding, normalize_key, KeybindingResolver};
 use crate::view::dimming::apply_dimming;
 use crate::view::theme::Theme;
 use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors};
@@ -1444,11 +1444,16 @@ fn handle_edit_dialog_input(
         match event.code {
             KeyCode::Modifier(_) => {} // ignore bare modifier presses
             _ => {
-                dialog.key_code = Some(event.code);
-                dialog.modifiers = event.modifiers;
-                dialog.key_display = format_keybinding(&event.code, &event.modifiers);
-                dialog.conflicts =
-                    editor.find_conflicts(event.code, event.modifiers, &dialog.context);
+                // Normalize the event so terminals that don't report SHIFT for
+                // uppercase letters still produce a "Shift+letter" binding (e.g.
+                // Shift+P stored as `key=p, modifiers=[shift]` rather than just
+                // `key=p`). This mirrors the lookup-time normalization so the
+                // recorded binding will match at runtime.
+                let (norm_code, norm_mods) = normalize_key(event.code, event.modifiers);
+                dialog.key_code = Some(norm_code);
+                dialog.modifiers = norm_mods;
+                dialog.key_display = format_keybinding(&norm_code, &norm_mods);
+                dialog.conflicts = editor.find_conflicts(norm_code, norm_mods, &dialog.context);
                 dialog.capturing_special = false;
             }
         }
@@ -1720,6 +1725,10 @@ fn handle_confirm_input(editor: &mut KeybindingEditor, event: &KeyEvent) -> Keyb
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::keybinding_editor::EditBindingState;
+    use crate::config::Config;
+    use crate::input::buffer_mode::ModeRegistry;
+    use crate::input::command_registry::CommandRegistry;
 
     /// The modal must stay fully inside the area it is handed and be
     /// horizontally centred within it. Regression test for the
@@ -1771,5 +1780,74 @@ mod tests {
         );
         assert!(modal.x + modal.width <= area.width);
         assert!(modal.y + modal.height <= area.height);
+    }
+
+    fn make_editor() -> KeybindingEditor {
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+        let mode_registry = ModeRegistry::new();
+        let cmd_registry = CommandRegistry::new();
+        let menu_names: Vec<String> = ["File", "Edit", "View"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        KeybindingEditor::new(
+            &config,
+            &resolver,
+            &mode_registry,
+            &cmd_registry,
+            String::from("/tmp/fresh-config.toml"),
+            &menu_names,
+        )
+    }
+
+    /// Drive the add-binding dialog through one "capture key" flow and
+    /// return the resulting (key_code, modifiers).
+    fn capture_in_add_dialog(event: KeyEvent) -> (Option<KeyCode>, KeyModifiers) {
+        let mut editor = make_editor();
+        editor.edit_dialog = Some(EditBindingState::new_add());
+        // Enter the "press a key" capture mode by sending Enter on the key
+        // field, then send the simulated event.
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        handle_keybinding_editor_input(&mut editor, &enter);
+        handle_keybinding_editor_input(&mut editor, &event);
+        let dialog = editor.edit_dialog.as_ref().expect("dialog still open");
+        (dialog.key_code, dialog.modifiers)
+    }
+
+    #[test]
+    fn add_dialog_records_shift_when_terminal_omits_shift_modifier() {
+        // Regression for https://github.com/sinelaw/fresh/issues/1899
+        // When a non-kitty terminal sends Char('P') with no modifier (the
+        // typical case for Shift+P), the add-binding dialog must still
+        // capture this as a "Shift+P" binding rather than just "p".
+        let plain_upper = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::empty());
+        let (code, mods) = capture_in_add_dialog(plain_upper);
+        assert_eq!(code, Some(KeyCode::Char('p')));
+        assert!(
+            mods.contains(KeyModifiers::SHIFT),
+            "Shift+P (sent as plain 'P') must capture SHIFT (got modifiers={:?})",
+            mods
+        );
+    }
+
+    #[test]
+    fn add_dialog_records_shift_when_terminal_includes_shift_modifier() {
+        // The fix must not regress the kitty-protocol path either.
+        let kitty_shift = KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT);
+        let (code, mods) = capture_in_add_dialog(kitty_shift);
+        assert_eq!(code, Some(KeyCode::Char('p')));
+        assert!(mods.contains(KeyModifiers::SHIFT));
+    }
+
+    #[test]
+    fn add_dialog_preserves_ctrl_when_capturing_upper_letter() {
+        // CapsLock+Ctrl+A — uppercase letter with CONTROL modifier — should
+        // record as plain Ctrl+A (no inferred SHIFT) so the long-standing
+        // caps-lock-tolerant lookup keeps working.
+        let caps_ctrl_a = KeyEvent::new(KeyCode::Char('A'), KeyModifiers::CONTROL);
+        let (code, mods) = capture_in_add_dialog(caps_ctrl_a);
+        assert_eq!(code, Some(KeyCode::Char('a')));
+        assert_eq!(mods, KeyModifiers::CONTROL);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1899.

Without kitty keyboard protocol, terminals typically encode `Shift+letter` by sending the uppercase character alone — no `SHIFT` modifier accompanies it. The previous `normalize_key` lowercased the char but kept the empty modifier set, so a binding stored as `(Char('p'), SHIFT)` never matched the incoming `(Char('P'), NONE)` event.

As reported in #1899, this made `Shift+letter` shortcuts only fire while **Caps Lock was on** (which causes some terminals to invert the case and re-introduce the `SHIFT` modifier on lowercase letters). The same root cause meant the **keybinding editor's add-binding dialog** captured `Shift+P` as plain `p`, losing the shift information at save time.

## Approach

- `normalize_key` now infers `SHIFT` when an uppercase letter arrives with no other modifiers. The `CapsLock+Ctrl+letter` → `Ctrl+letter` collapse is preserved (uppercase + `CONTROL` is intentionally not given a `SHIFT` because that case is ambiguous between caps lock and a real shift, and the existing behavior is to fold caps lock away).
- The add-binding dialog (`view/keybinding_editor.rs`) and the record-key search (`app/keybinding_editor/editor.rs`) route the recorded event through `normalize_key` so they capture `Shift+P` consistently — no matter whether the terminal reported `SHIFT`.
- The fallback to `InsertChar` is unaffected: it uses the original event, so typing capital `Z` in a buffer still inserts `Z`.

## Tests

- `test_shift_letter_binding_works_without_terminal_shift_modifier` — the core regression: `Char('P')` with no modifier now matches a `Shift+P` binding.
- `test_capslock_ctrl_letter_still_matches_ctrl_letter_binding` — guards the existing CapsLock+Ctrl+A → Ctrl+A behavior.
- `test_uppercase_without_binding_falls_through_to_insert_char` — confirms typing capital letters still inserts them when no binding exists.
- `record_search_key_normalizes_uppercase_letter_to_shift` — the record-key search captures the `SHIFT` modifier even when the terminal omits it.
- `add_dialog_records_shift_when_terminal_omits_shift_modifier` / `add_dialog_records_shift_when_terminal_includes_shift_modifier` / `add_dialog_preserves_ctrl_when_capturing_upper_letter` — full end-to-end dialog drive: send the simulated event through `handle_keybinding_editor_input` and assert the captured `(key_code, modifiers)`.

Full lib test suite: **2468 passed, 0 failed**.

## Manual validation

Reproduced and verified the fix end-to-end:

1. Added a `Shift+P → save` binding in `~/.config/fresh/config.json`.
2. Opened a modified buffer (`Xinitial content`) in `fresh` under tmux.
3. Pressed `P`. The status bar transitioned to `Saved`, the unsaved-changes marker `[+]` and the buffer's `*` cleared, and the file on disk reflects the new content.

## Test plan

- [x] `cargo test -p fresh-editor --lib`
- [x] `cargo check --all-targets`
- [x] `cargo check --all-targets --features gui`
- [x] `cargo fmt --check`
- [x] Manual smoke test: `Shift+P` triggers `save` via custom binding.

https://claude.ai/code/session_01H6FpwGdLrCA7zquAbVrhX9

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6FpwGdLrCA7zquAbVrhX9)_