### PR TITLE
feat(file-explorer): make tree expand/collapse indicators configurable (#1940)

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -135,7 +135,9 @@
         "side": "left",
         "auto_open_on_last_buffer_close": true,
         "follow_active_buffer": false,
-        "compact_directories": true
+        "compact_directories": true,
+        "tree_indicator_collapsed": ">",
+        "tree_indicator_expanded": "▼"
       }
     },
     "file_browser": {
@@ -966,6 +968,16 @@
           "description": "Render single-child directory chains on a single line, e.g.\n`src/main/java/com/example`. Only applies when each intermediate\ndirectory in the chain is expanded and has exactly one visible\nchild that is itself a directory. Mirrors VSCode's\n`explorer.compactFolders`.\nDefault: true",
           "type": "boolean",
           "default": true
+        },
+        "tree_indicator_collapsed": {
+          "description": "Symbol shown next to a collapsed (closed) directory in the file\nexplorer tree. A short string (single character recommended).\nA trailing space is added automatically during rendering; the\nrenderer pads narrower indicators so collapsed/expanded rows align.\nDefault: \">\"",
+          "type": "string",
+          "default": ">"
+        },
+        "tree_indicator_expanded": {
+          "description": "Symbol shown next to an expanded (open) directory in the file\nexplorer tree. A short string (single character recommended).\nA trailing space is added automatically during rendering; the\nrenderer pads narrower indicators so collapsed/expanded rows align.\nDefault: \"▼\"",
+          "type": "string",
+          "default": "▼"
         }
       }
     },

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -337,6 +337,8 @@ impl Editor {
                     close_button_hovered,
                     remote_connection.as_deref(),
                     cut_paths,
+                    &self.config.file_explorer.tree_indicator_collapsed,
+                    &self.config.file_explorer.tree_indicator_expanded,
                 );
             }
             // Note: if file_explorer is None but sync_in_progress is true,

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1550,6 +1550,22 @@ pub struct FileExplorerConfig {
     /// Default: true
     #[serde(default = "default_true")]
     pub compact_directories: bool,
+
+    /// Symbol shown next to a collapsed (closed) directory in the file
+    /// explorer tree. A short string (single character recommended).
+    /// A trailing space is added automatically during rendering; the
+    /// renderer pads narrower indicators so collapsed/expanded rows align.
+    /// Default: ">"
+    #[serde(default = "default_tree_indicator_collapsed")]
+    pub tree_indicator_collapsed: String,
+
+    /// Symbol shown next to an expanded (open) directory in the file
+    /// explorer tree. A short string (single character recommended).
+    /// A trailing space is added automatically during rendering; the
+    /// renderer pads narrower indicators so collapsed/expanded rows align.
+    /// Default: "▼"
+    #[serde(default = "default_tree_indicator_expanded")]
+    pub tree_indicator_expanded: String,
 }
 
 /// Width configuration for the file explorer.
@@ -1708,6 +1724,14 @@ fn default_explorer_width() -> ExplorerWidth {
 
 fn default_explorer_side() -> FileExplorerSide {
     FileExplorerSide::default()
+}
+
+fn default_tree_indicator_collapsed() -> String {
+    ">".to_string()
+}
+
+fn default_tree_indicator_expanded() -> String {
+    "▼".to_string()
 }
 
 /// Public default used by the workspace state deserializer.
@@ -1908,6 +1932,8 @@ impl Default for FileExplorerConfig {
             auto_open_on_last_buffer_close: true,
             follow_active_buffer: false,
             compact_directories: true,
+            tree_indicator_collapsed: default_tree_indicator_collapsed(),
+            tree_indicator_expanded: default_tree_indicator_expanded(),
         }
     }
 }
@@ -6585,6 +6611,35 @@ mod tests {
     fn test_file_explorer_width_default_is_percent_30() {
         let cfg = FileExplorerConfig::default();
         assert_eq!(cfg.width, ExplorerWidth::Percent(30));
+    }
+
+    #[test]
+    fn test_tree_indicators_defaults_preserve_current_glyphs() {
+        // Defaults must match the historically rendered symbols so the
+        // baseline file-explorer appearance is unchanged when no config
+        // override is set.
+        let cfg = FileExplorerConfig::default();
+        assert_eq!(cfg.tree_indicator_collapsed, ">");
+        assert_eq!(cfg.tree_indicator_expanded, "▼");
+    }
+
+    #[test]
+    fn test_tree_indicators_can_be_overridden_from_json() {
+        let cfg: FileExplorerConfig = serde_json::from_str(
+            r#"{"tree_indicator_collapsed": "▸", "tree_indicator_expanded": "▾"}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.tree_indicator_collapsed, "▸");
+        assert_eq!(cfg.tree_indicator_expanded, "▾");
+    }
+
+    #[test]
+    fn test_tree_indicators_partial_override_keeps_default_for_unset() {
+        let cfg: FileExplorerConfig =
+            serde_json::from_str(r#"{"tree_indicator_collapsed": "+"}"#).unwrap();
+        assert_eq!(cfg.tree_indicator_collapsed, "+");
+        // Expanded was not set; should fall back to default.
+        assert_eq!(cfg.tree_indicator_expanded, "▼");
     }
 
     // --- Wire format acceptance ---------------------------------------

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -348,6 +348,8 @@ pub struct PartialFileExplorerConfig {
     pub auto_open_on_last_buffer_close: Option<bool>,
     pub follow_active_buffer: Option<bool>,
     pub compact_directories: Option<bool>,
+    pub tree_indicator_collapsed: Option<String>,
+    pub tree_indicator_expanded: Option<String>,
 }
 
 impl Merge for PartialFileExplorerConfig {
@@ -366,6 +368,10 @@ impl Merge for PartialFileExplorerConfig {
             .merge_from(&other.follow_active_buffer);
         self.compact_directories
             .merge_from(&other.compact_directories);
+        self.tree_indicator_collapsed
+            .merge_from(&other.tree_indicator_collapsed);
+        self.tree_indicator_expanded
+            .merge_from(&other.tree_indicator_expanded);
     }
 }
 
@@ -774,6 +780,8 @@ impl From<&FileExplorerConfig> for PartialFileExplorerConfig {
             auto_open_on_last_buffer_close: Some(cfg.auto_open_on_last_buffer_close),
             follow_active_buffer: Some(cfg.follow_active_buffer),
             compact_directories: Some(cfg.compact_directories),
+            tree_indicator_collapsed: Some(cfg.tree_indicator_collapsed.clone()),
+            tree_indicator_expanded: Some(cfg.tree_indicator_expanded.clone()),
         }
     }
 }
@@ -799,6 +807,12 @@ impl PartialFileExplorerConfig {
             compact_directories: self
                 .compact_directories
                 .unwrap_or(defaults.compact_directories),
+            tree_indicator_collapsed: self
+                .tree_indicator_collapsed
+                .unwrap_or_else(|| defaults.tree_indicator_collapsed.clone()),
+            tree_indicator_expanded: self
+                .tree_indicator_expanded
+                .unwrap_or_else(|| defaults.tree_indicator_expanded.clone()),
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -44,6 +44,8 @@ impl FileExplorerRenderer {
         close_button_hovered: bool,
         remote_connection: Option<&str>,
         cut_paths: &[PathBuf],
+        tree_indicator_collapsed: &str,
+        tree_indicator_expanded: &str,
     ) {
         let search_active = view.is_search_active();
 
@@ -97,6 +99,8 @@ impl FileExplorerRenderer {
                     content_width,
                     fuzzy_match.as_ref(),
                     cut_paths,
+                    tree_indicator_collapsed,
+                    tree_indicator_expanded,
                 )
             })
             .collect();
@@ -233,6 +237,8 @@ impl FileExplorerRenderer {
         content_width: usize,
         fuzzy_match: Option<&FuzzyMatch>,
         cut_paths: &[PathBuf],
+        tree_indicator_collapsed: &str,
+        tree_indicator_expanded: &str,
     ) -> ListItem<'static> {
         let node = view.tree().get_node(node_id).expect("Node should exist");
 
@@ -248,10 +254,19 @@ impl FileExplorerRenderer {
             .filter_map(|id| view.tree().get_node(id).map(|n| n.entry.name.clone()))
             .collect();
 
+        // Width reserved for the indicator column. Computed from the
+        // configured collapsed/expanded indicators (plus a trailing space)
+        // so files and dirs line up regardless of glyph width. The
+        // built-in loading ("⟳ ") and error ("! ") states are 2 cols
+        // wide and so is the default; we still take the max so a wider
+        // user glyph doesn't truncate them.
+        let collapsed_w = str_width(tree_indicator_collapsed);
+        let expanded_w = str_width(tree_indicator_expanded);
+        let indicator_width = collapsed_w.max(expanded_w).max(1) + 1;
+
         // Calculate the left side width for padding calculation
         let indent_width = indent * 2;
-        let indicator_width = 2; // "▼ " or "  "
-                                 // Chain prefix contributes each name plus a "/" separator.
+        // Chain prefix contributes each name plus a "/" separator.
         let chain_prefix_width: usize = chain_prefix_names.iter().map(|s| str_width(s) + 1).sum();
         let name_width = str_width(&node.entry.name);
         let left_side_width = indent_width + indicator_width + chain_prefix_width + name_width;
@@ -263,22 +278,26 @@ impl FileExplorerRenderer {
 
         // Tree expansion indicator (only for directories)
         if node.is_dir() {
-            let indicator = if node.is_expanded() {
-                "▼ "
+            let (indicator, glyph_width) = if node.is_expanded() {
+                (format!("{} ", tree_indicator_expanded), expanded_w + 1)
             } else if node.is_collapsed() {
-                "> "
+                (format!("{} ", tree_indicator_collapsed), collapsed_w + 1)
             } else if node.is_loading() {
-                "⟳ "
+                ("⟳ ".to_string(), 2)
             } else {
-                "! "
+                ("! ".to_string(), 2)
             };
             spans.push(Span::styled(
                 indicator,
                 Style::default().fg(theme.diagnostic_warning_fg),
             ));
+            let pad = indicator_width.saturating_sub(glyph_width);
+            if pad > 0 {
+                spans.push(Span::raw(" ".repeat(pad)));
+            }
         } else {
-            // For files, add spacing to align with directory names
-            spans.push(Span::raw("  "));
+            // For files, pad to align with directory names
+            spans.push(Span::raw(" ".repeat(indicator_width)));
         }
 
         // Name styling using theme colors

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -3824,3 +3824,64 @@ fn explorer_tree_contains(harness: &EditorTestHarness, name: &str) -> bool {
         .lines()
         .any(|line| line.contains(name) && line.contains('│'))
 }
+
+/// Custom tree indicators (issue #1940) — the collapsed/expanded glyphs
+/// rendered next to directories must come from
+/// `file_explorer.tree_indicator_collapsed/expanded` config, falling back
+/// to the historical `>` / `▼` when unset. We verify by rendering the
+/// explorer with a directory at the root, then asserting on screen text.
+#[test]
+fn test_file_explorer_custom_tree_indicators() {
+    let mut config = Config::default();
+    // Use single ASCII chars so the assertion is robust against unicode
+    // width quirks in the test backend.
+    config.file_explorer.tree_indicator_collapsed = "+".to_string();
+    config.file_explorer.tree_indicator_expanded = "-".to_string();
+    // Make the explorer wide enough to comfortably render `+ subdir`.
+    config.file_explorer.width = fresh::config::ExplorerWidth::Columns(30);
+
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    // Two sibling subdirs so the root never reduces to a single child
+    // (some auto-expand heuristics short-circuit on degenerate trees).
+    fs::create_dir(project_root.join("subdir")).unwrap();
+    fs::write(project_root.join("subdir/inner.txt"), "x").unwrap();
+    fs::create_dir(project_root.join("other")).unwrap();
+    fs::write(project_root.join("other/y.txt"), "y").unwrap();
+
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    // The root may or may not be auto-expanded depending on harness
+    // state. If `subdir` isn't visible yet, expand by sending Right.
+    if !harness.screen_to_string().contains("subdir") {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("subdir"))
+            .unwrap();
+    }
+
+    // Locate the line that contains "subdir" and confirm the configured
+    // collapsed indicator ("+") precedes the name on that row.
+    let screen = harness.screen_to_string();
+    let subdir_line = screen
+        .lines()
+        .find(|l| l.contains("subdir"))
+        .unwrap_or_else(|| panic!("subdir not found in:\n{screen}"));
+    assert!(
+        subdir_line.contains("+ subdir"),
+        "expected '+ subdir' on the row for the collapsed directory.\n\
+         Got line: {subdir_line:?}\nFull screen:\n{screen}"
+    );
+    // Default expanded glyph "▼" must not appear when overridden.
+    assert!(
+        !subdir_line.contains('▼'),
+        "default expanded glyph leaked through when collapsed.\nLine: {subdir_line:?}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -1382,8 +1382,8 @@ fn test_settings_file_explorer_width_shows_percent_suffix() {
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
     // Compact Directories, Custom Ignore Patterns, Follow Active Buffer,
     // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden,
-    // Side, Width.
-    for _ in 0..9 {
+    // Side, Tree Indicator Collapsed, Tree Indicator Expanded, Width.
+    for _ in 0..11 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();
@@ -1431,8 +1431,8 @@ fn test_settings_file_explorer_width_applies_live() {
     // File Explorer items (alphabetical): Auto Open On Last Buffer Close,
     // Compact Directories, Custom Ignore Patterns, Follow Active Buffer,
     // Preview Tabs, Respect Gitignore, Show Gitignored, Show Hidden,
-    // Side, Width.
-    for _ in 0..9 {
+    // Side, Tree Indicator Collapsed, Tree Indicator Expanded, Width.
+    for _ in 0..11 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness.render().unwrap();


### PR DESCRIPTION
Closes #1940.

## Summary

The file explorer's tree expand/collapse markers (`▼` / `>`) were hard-coded, which left users on nerd-font or custom-icon setups without a way to match the glyphs to the rest of their file explorer iconography. This PR adds two opt-in `file_explorer` config fields and threads them through the renderer.

```json
{
  "file_explorer": {
    "tree_indicator_collapsed": "▸",
    "tree_indicator_expanded":  "▾"
  }
}
```

Defaults are unchanged (`">"` collapsed, `"▼"` expanded) — purely opt-in.

## Design

- New fields on `FileExplorerConfig` with `#[serde(default = "...")]` so unset keys still deserialize cleanly from existing user configs.
- Mirrored on `PartialFileExplorerConfig` (merge + resolve) so they participate in the layered partial-config system.
- The renderer derives the indicator column width from the configured strings (`max(width(collapsed), width(expanded)) + 1` for the trailing space) and pads narrower glyphs, so wider nerd-font icons don't shift sibling rows out of column.
- The built-in loading (`⟳`) and error (`!`) indicators remain non-configurable.
- Generated `plugins/config-schema.json` via `./scripts/gen_schema.sh`.

## Tests

**Unit (`config::tests`):**
- `test_tree_indicators_defaults_preserve_current_glyphs` — defaults match historical rendering
- `test_tree_indicators_can_be_overridden_from_json` — both fields override
- `test_tree_indicators_partial_override_keeps_default_for_unset` — partial override

**E2E (`tests/e2e/file_explorer.rs`):**
- `test_file_explorer_custom_tree_indicators` — observes rendered screen, asserts custom `+` indicator precedes a collapsed subdir name and the default `▼` glyph does not appear.

**Pre-existing tests touched:**
- `test_settings_file_explorer_width_shows_percent_suffix` and `test_settings_file_explorer_width_applies_live` — both step through the File Explorer settings list by index; the two new fields land alphabetically between "Side" and "Width", so the down-arrow count was bumped from 9 to 11. Comments updated accordingly.

## Manual validation

Built `target/debug/fresh` and exercised it under `tmux` against a project with two sibling subdirs:

| Config | Collapsed row | Expanded row |
|---|---|---|
| (none — defaults) | `> other` | `▼ subdir` |
| `"+"` / `"-"` | `+ other` | `- subdir` |
| `"▸"` / `"▾"` | `▸ other` | `▾ subdir` |

All three behaviors match expectations; sibling rows stay aligned in every case.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo check --all-targets --features gui`
- [x] `cargo fmt --all --check`
- [x] `cargo test -p fresh-editor --lib config` (142 passed)
- [x] `cargo test -p fresh-editor --test e2e_tests file_explorer` (80 passed)
- [x] `cargo test -p fresh-editor --test e2e_tests settings` (117 passed)
- [x] Manual tmux validation with default + custom indicator configs


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2xqGZtkPTiLsyaGBtjScx)_