### PR TITLE
Move orchestrator persistence from working dir to data dir

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -541,8 +541,9 @@ impl Editor {
         let mut buffer_metadata: HashMap<BufferId, BufferMetadata> = HashMap::new();
         buffer_metadata.insert(buffer_id, BufferMetadata::new());
 
-        // Read orchestrator persistence (`.fresh/windows.json` and
-        // `.fresh/state/*.json`) before the LSP and base-window
+        // Read orchestrator persistence (windows.json + plugin
+        // state files under `data_dir/orchestrator/<encoded
+        // working dir>/`) before the LSP and base-window
         // construction below. Pulling persistence in here lets the
         // factory build the right windows up front: previously this
         // ran from `main.rs` after construction, so the freshly
@@ -554,10 +555,12 @@ impl Editor {
         // sees a well-formed windows map.
         let persisted_env = crate::app::orchestrator_persistence::read_persisted_windows_env(
             filesystem.as_ref(),
+            &dir_context.data_dir,
             &working_dir,
         );
         let plugin_global_state = crate::app::orchestrator_persistence::read_persisted_plugin_state(
             filesystem.as_ref(),
+            &dir_context.data_dir,
             &working_dir,
         );
 

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -1,13 +1,21 @@
 //! Cross-restart persistence for Orchestrator sessions and
 //! plugin global state.
 //!
+//! State lives under `DirectoryContext::data_dir` (i.e.
+//! `$XDG_DATA_HOME/fresh/...` on Linux), keyed by an encoded
+//! representation of the working directory — same convention as
+//! `workspace.rs`. The editor never writes anything to the user's
+//! working directory.
+//!
 //! On quit, `save_orchestrator_state` writes:
-//!   - `<working_dir>/.fresh/windows.json` — list of sessions
-//!     (id, label, root, per-session plugin_state) plus the
-//!     last-active session id and the next id to allocate so
-//!     id-based references on disk stay stable across restarts.
-//!   - `<working_dir>/.fresh/state/<plugin>.json` — one file per
-//!     plugin holding its `editor.setGlobalState(...)` map.
+//!   - `<data_dir>/orchestrator/<encoded_working_dir>/windows.json`
+//!     — list of sessions (id, label, root, per-session
+//!     plugin_state) plus the last-active session id and the next
+//!     id to allocate so id-based references on disk stay stable
+//!     across restarts.
+//!   - `<data_dir>/orchestrator/<encoded_working_dir>/state/<plugin>.json`
+//!     — one file per plugin holding its
+//!     `editor.setGlobalState(...)` map.
 //!
 //! On startup, [`read_persisted_windows_env`] +
 //! [`read_persisted_plugin_state`] are called from
@@ -48,7 +56,7 @@ pub(crate) struct PersistedWindow {
     pub(crate) plugin_state: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 
-/// Top-level shape of `.fresh/windows.json`.
+/// Top-level shape of `windows.json`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct PersistedWindows {
     /// Last active session id at quit time. The loader makes
@@ -62,19 +70,21 @@ pub(crate) struct PersistedWindows {
     pub(crate) windows: Vec<PersistedWindow>,
 }
 
-/// Read `.fresh/windows.json` from `working_dir` and return the
-/// parsed envelope. Returns `None` when the file doesn't exist or
-/// fails to parse — those are not error cases at the editor level
-/// (a missing or corrupted file just means "no persisted state").
+/// Read `windows.json` for `working_dir` (from under `data_dir`)
+/// and return the parsed envelope. Returns `None` when the file
+/// doesn't exist or fails to parse — those are not error cases at
+/// the editor level (a missing or corrupted file just means "no
+/// persisted state").
 ///
 /// Pure file IO + JSON parse. Used by the editor factory to
 /// decide how to build the initial windows map before any `Editor`
 /// instance exists.
 pub(crate) fn read_persisted_windows_env(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
     working_dir: &Path,
 ) -> Option<PersistedWindows> {
-    let windows_p = windows_path(working_dir);
+    let windows_p = windows_path(data_dir, working_dir);
     if !filesystem.exists(&windows_p) {
         return None;
     }
@@ -93,17 +103,18 @@ pub(crate) fn read_persisted_windows_env(
     }
 }
 
-/// Read every `.fresh/state/<plugin>.json` from `working_dir` into
-/// a flat `plugin → key → value` map. Skips files with unsafe
-/// names, non-JSON extensions, parse errors, and empty maps. Same
-/// motivations as [`read_persisted_windows_env`] — used by the
-/// editor factory pre-construction.
+/// Read every `state/<plugin>.json` for `working_dir` (from under
+/// `data_dir`) into a flat `plugin → key → value` map. Skips files
+/// with unsafe names, non-JSON extensions, parse errors, and empty
+/// maps. Same motivations as [`read_persisted_windows_env`] — used
+/// by the editor factory pre-construction.
 pub(crate) fn read_persisted_plugin_state(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
     working_dir: &Path,
 ) -> HashMap<String, HashMap<String, serde_json::Value>> {
     let mut out: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
-    let state_dir = state_dir(working_dir);
+    let state_dir = state_dir(data_dir, working_dir);
     if !filesystem.exists(&state_dir) {
         return out;
     }
@@ -145,21 +156,34 @@ pub(crate) fn read_persisted_plugin_state(
     out
 }
 
-fn windows_path(working_dir: &Path) -> PathBuf {
-    working_dir.join(".fresh").join("windows.json")
+/// Root for all orchestrator persistence belonging to a given
+/// working directory. Keyed by `encode_path_for_filename` so two
+/// projects with different roots don't collide and so the path
+/// stays a single flat directory under `data_dir/orchestrator/`.
+fn project_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    let canonical = working_dir
+        .canonicalize()
+        .unwrap_or_else(|_| working_dir.to_path_buf());
+    data_dir
+        .join("orchestrator")
+        .join(crate::workspace::encode_path_for_filename(&canonical))
 }
 
-fn state_dir(working_dir: &Path) -> PathBuf {
-    working_dir.join(".fresh").join("state")
+fn windows_path(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    project_dir(data_dir, working_dir).join("windows.json")
 }
 
-fn plugin_state_path(working_dir: &Path, plugin: &str) -> PathBuf {
+fn state_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
+    project_dir(data_dir, working_dir).join("state")
+}
+
+fn plugin_state_path(data_dir: &Path, working_dir: &Path, plugin: &str) -> PathBuf {
     // Plugin names are short identifiers (`orchestrator`,
     // `live_grep`, …) so no escaping is needed for typical
     // input. Reject anything that would escape the state dir to
     // avoid `../`-style traversal in case a plugin picks a
     // pathological name.
-    state_dir(working_dir).join(format!("{plugin}.json"))
+    state_dir(data_dir, working_dir).join(format!("{plugin}.json"))
 }
 
 fn plugin_name_is_safe(name: &str) -> bool {
@@ -173,13 +197,13 @@ fn plugin_name_is_safe(name: &str) -> bool {
 impl Editor {
     /// Persist `sessions` + `plugin_global_state` to disk. Best-
     /// effort: filesystem errors are logged at WARN and swallowed
-    /// so a transient `.fresh/` permission glitch doesn't block
-    /// quit.
+    /// so a transient permission glitch doesn't block quit.
     pub fn save_orchestrator_state(&self) {
         let working_dir = self.working_dir().to_path_buf();
-        let fresh_dir = working_dir.join(".fresh");
-        if let Err(e) = self.authority.filesystem.create_dir_all(&fresh_dir) {
-            tracing::warn!("orchestrator persistence: failed to create {fresh_dir:?}: {e}");
+        let data_dir = self.dir_context.data_dir.clone();
+        let project_dir = project_dir(&data_dir, &working_dir);
+        if let Err(e) = self.authority.filesystem.create_dir_all(&project_dir) {
+            tracing::warn!("orchestrator persistence: failed to create {project_dir:?}: {e}");
             return;
         }
 
@@ -195,8 +219,7 @@ impl Editor {
             })
             .collect();
         // Stable on-disk order — `HashMap` iteration order would
-        // make the file diff differently every quit, which is
-        // ugly for users who keep `.fresh/` in version control.
+        // make the file diff differently every quit.
         windows.sort_by_key(|s| s.id);
         let envelope = PersistedWindows {
             active: self.active_window.0,
@@ -205,7 +228,7 @@ impl Editor {
         };
         match serde_json::to_vec_pretty(&envelope) {
             Ok(bytes) => {
-                let path = windows_path(&working_dir);
+                let path = windows_path(&data_dir, &working_dir);
                 if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
                     tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
                 }
@@ -218,7 +241,7 @@ impl Editor {
         // Plugin global state — one file per plugin so concurrent
         // editors writing different plugins don't clobber each
         // other (a future feature; today single-process).
-        let state_dir = state_dir(&working_dir);
+        let state_dir = state_dir(&data_dir, &working_dir);
         if !self.plugin_global_state.is_empty() {
             if let Err(e) = self.authority.filesystem.create_dir_all(&state_dir) {
                 tracing::warn!("orchestrator persistence: failed to create {state_dir:?}: {e}");
@@ -237,7 +260,7 @@ impl Editor {
             }
             match serde_json::to_vec_pretty(map) {
                 Ok(bytes) => {
-                    let path = plugin_state_path(&working_dir, plugin);
+                    let path = plugin_state_path(&data_dir, &working_dir, plugin);
                     if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
                         tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
                     }
@@ -249,5 +272,80 @@ impl Editor {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::config_io::DirectoryContext;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    /// Regression for the v0.3.6 bug where orchestrator persistence
+    /// dumped a `.fresh/windows.json` into the user's working
+    /// directory (e.g. their git project root). Persisted state must
+    /// live under `DirectoryContext::data_dir`; nothing should be
+    /// written under `working_dir`.
+    #[test]
+    fn save_orchestrator_state_does_not_touch_working_dir() {
+        let working = TempDir::new().unwrap();
+        let data = TempDir::new().unwrap();
+
+        // Build a `DirectoryContext` whose `data_dir` points at our
+        // temp `data/` dir. `for_testing` would put data under
+        // `<working>/data` — too close to the working dir to make a
+        // clean assertion — so we hand-roll one.
+        let dir_context = DirectoryContext {
+            data_dir: data.path().to_path_buf(),
+            config_dir: working.path().join("_cfg"),
+            home_dir: None,
+            documents_dir: None,
+            downloads_dir: None,
+        };
+
+        let filesystem: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> =
+            Arc::new(crate::model::filesystem::StdFileSystem);
+
+        let editor = Editor::with_working_dir(
+            Config::default(),
+            80,
+            24,
+            Some(working.path().to_path_buf()),
+            dir_context,
+            false,
+            crate::view::color_support::ColorCapability::TrueColor,
+            filesystem,
+        )
+        .unwrap();
+
+        editor.save_orchestrator_state();
+
+        // Nothing must land in the user's working directory.
+        assert!(
+            !working.path().join(".fresh").exists(),
+            "save_orchestrator_state created `.fresh/` in the user's working dir at {:?}",
+            working.path().join(".fresh"),
+        );
+
+        // The persisted envelope must live under `data_dir`.
+        let project_dir = project_dir(data.path(), working.path());
+        assert!(
+            project_dir.join("windows.json").exists(),
+            "expected windows.json under {:?}",
+            project_dir,
+        );
+    }
+
+    #[test]
+    fn project_dir_isolates_distinct_working_dirs() {
+        let data = TempDir::new().unwrap();
+        let a = TempDir::new().unwrap();
+        let b = TempDir::new().unwrap();
+        assert_ne!(
+            project_dir(data.path(), a.path()),
+            project_dir(data.path(), b.path()),
+        );
     }
 }

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3588,8 +3588,9 @@ fn real_main() -> AnyhowResult<()> {
 
         // Orchestrator cross-restart persistence is now loaded by
         // `Editor::with_options` before construction — it reads
-        // `.fresh/windows.json` + `.fresh/state/*.json` and builds
-        // the initial windows map / `plugin_global_state` directly
+        // the persisted windows.json + plugin state files (under
+        // `data_dir/orchestrator/<encoded working dir>/`) and
+        // builds the initial windows map / `plugin_global_state` directly
         // into the constructor's inputs. This used to happen here
         // as a post-construction swap, which left the active window
         // in an inert-shell state until something re-seeded it (see


### PR DESCRIPTION
## Summary
Fixes a v0.3.6 regression where orchestrator persistence files (`.fresh/windows.json` and plugin state) were being written to the user's working directory (e.g., git project root) instead of the proper XDG data directory. This change ensures the editor never writes anything to the user's working directory.

## Key Changes
- **Relocated persistence storage**: Moved from `<working_dir>/.fresh/` to `<data_dir>/orchestrator/<encoded_working_dir>/`, following the same convention as `workspace.rs`
- **Updated function signatures**: Added `data_dir` parameter to `read_persisted_windows_env()` and `read_persisted_plugin_state()` functions
- **New helper function**: Added `project_dir()` to compute the root directory for a given working directory's persistence, using `encode_path_for_filename()` to safely key by working directory path
- **Updated path helpers**: Modified `windows_path()`, `state_dir()`, and `plugin_state_path()` to accept and use `data_dir` parameter
- **Updated callers**: Modified `Editor::save_orchestrator_state()` and `Editor::with_options()` to pass `data_dir` from `DirectoryContext`
- **Added regression tests**: 
  - `save_orchestrator_state_does_not_touch_working_dir()` verifies no `.fresh/` directory is created in the working directory
  - `project_dir_isolates_distinct_working_dirs()` ensures different working directories get isolated persistence directories

## Implementation Details
- The `project_dir()` function canonicalizes the working directory path before encoding it to ensure consistent keying across symlinks and relative paths
- Path encoding uses the existing `workspace::encode_path_for_filename()` utility to safely flatten the directory structure
- All documentation comments were updated to reflect the new storage location and XDG conventions
- The change maintains backward compatibility at the API level while fixing the storage location issue

https://claude.ai/code/session_015CaqE7ahS1HdvbChMjoww8