### PR TITLE
Fix syntax highlighting artifacts in partial trailing lines

### DIFF
--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -431,6 +431,19 @@ impl TextMateEngine {
 
     /// Highlight the visible viewport. Path selection is documented in the
     /// module-level docs ("TextMate cache design").
+    /// Test-only: inspect the cache commit point (range.end) and
+    /// whether tail_state is populated. The cache must commit at a
+    /// newline boundary — anything past that risks streaming
+    /// forward-extension picking up where partial-line state poisoned
+    /// the parser, see `test_partial_trailing_line_not_committed_to_cache`.
+    #[cfg(test)]
+    pub fn cache_commit_for_test(&self) -> (usize, bool) {
+        match &self.cache {
+            Some(c) => (c.range.end, c.tail_state.is_some()),
+            None => (0, false),
+        }
+    }
+
     pub fn highlight_viewport(
         &mut self,
         buffer: &Buffer,
@@ -825,6 +838,18 @@ impl TextMateEngine {
         let mut pos = 0;
         let mut current_offset = extension_start;
         let mut bytes_since_checkpoint: usize = 0;
+        // Snapshot of the last newline-aligned cache commit point. We never
+        // commit parse state for a partial trailing line: with a streaming
+        // grammar like syntect's `Diff` (line-anchored `^\+.*` etc.) the
+        // state at end-of-input has already popped `markup.inserted`, so
+        // resuming from there parses the rest of the same line in
+        // `source.diff` with no scope — bytes of the line streamed in
+        // later get default editor bg, producing the dark-bar artifact
+        // inside `+` lines. Re-parsing the trailing partial line on every
+        // refresh costs at most one extra `parse_line` and is correct.
+        let mut safe_offset = extension_start;
+        let mut safe_state = state.clone();
+        let mut safe_scopes = current_scopes.clone();
 
         while pos < content_bytes.len() {
             if bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
@@ -871,7 +896,8 @@ impl TextMateEngine {
             };
 
             let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
-            let line_for_syntect = if line_end < content_bytes.len() || line_str.ends_with('\n') {
+            let line_ends_with_newline = line_str.ends_with('\n');
+            let line_for_syntect = if line_end < content_bytes.len() || line_ends_with_newline {
                 format!("{}\n", line_content)
             } else {
                 line_content.to_string()
@@ -925,23 +951,50 @@ impl TextMateEngine {
             pos = line_end;
             current_offset += actual_line_byte_len;
             bytes_since_checkpoint += actual_line_byte_len;
+
+            if line_ends_with_newline {
+                safe_offset = current_offset;
+                safe_state = state.clone();
+                safe_scopes = current_scopes.clone();
+            }
         }
 
         self.stats.bytes_parsed += parse_end - extension_start;
 
         Self::merge_adjacent_spans(&mut new_spans);
 
+        // Split spans into safe (fully before the trailing partial line,
+        // cacheable) and unsafe (overlap the partial line, render-only).
+        // Unsafe spans are returned in this pass so the partial line is
+        // still highlighted, but won't be cached — they'll be recomputed
+        // on the next refresh once more bytes (and a newline) stream in.
+        let (safe_spans, unsafe_spans): (Vec<_>, Vec<_>) = new_spans
+            .into_iter()
+            .partition(|s| s.range.end <= safe_offset);
+
         let cache = self
             .cache
             .as_mut()
             .expect("extend_cache_forward: cache must still exist");
-        cache.spans.extend(new_spans);
+        cache.spans.extend(safe_spans);
         Self::merge_adjacent_spans(&mut cache.spans);
-        cache.range.end = parse_end;
-        cache.tail_state = Some((state, current_scopes));
+        cache.range.end = safe_offset;
+        cache.tail_state = Some((safe_state, safe_scopes));
         self.last_buffer_len = buf_len;
 
-        self.filter_cached_spans(viewport_start, viewport_end, theme)
+        let mut result = self.filter_cached_spans(viewport_start, viewport_end, theme);
+        result.extend(
+            unsafe_spans
+                .into_iter()
+                .filter(|s| s.range.start < viewport_end && s.range.end > viewport_start)
+                .map(|s| HighlightSpan {
+                    range: s.range,
+                    color: highlight_color(s.category, theme),
+                    bg: highlight_bg(s.category, theme),
+                    category: Some(s.category),
+                }),
+        );
+        result
     }
 
     /// Full re-parse from desired_parse_start to parse_end. Used on cold start
@@ -979,6 +1032,14 @@ impl TextMateEngine {
         let mut pos = 0;
         let mut current_offset = actual_start;
         let mut bytes_since_checkpoint: usize = 0;
+        // See `extend_cache_forward` for rationale: never commit cache
+        // state past the last newline. `safe_offset` ends up == parse_end
+        // for buffers that end on `\n` (no behaviour change), and at the
+        // start of the trailing partial line otherwise so the next
+        // refresh re-parses it from scratch.
+        let mut safe_offset = actual_start;
+        let mut safe_state = state.clone();
+        let mut safe_scopes = current_scopes.clone();
 
         while pos < content_bytes.len() {
             if create_checkpoints && bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
@@ -1026,7 +1087,8 @@ impl TextMateEngine {
             };
 
             let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
-            let line_for_syntect = if line_end < content_bytes.len() || line_str.ends_with('\n') {
+            let line_ends_with_newline = line_str.ends_with('\n');
+            let line_for_syntect = if line_end < content_bytes.len() || line_ends_with_newline {
                 format!("{}\n", line_content)
             } else {
                 line_content.to_string()
@@ -1084,6 +1146,12 @@ impl TextMateEngine {
             current_offset += actual_line_byte_len;
             bytes_since_checkpoint += actual_line_byte_len;
 
+            if line_ends_with_newline {
+                safe_offset = current_offset;
+                safe_state = state.clone();
+                safe_scopes = current_scopes.clone();
+            }
+
             // Update checkpoint states as we pass them
             let markers_here: Vec<(MarkerId, usize)> = self
                 .checkpoint_markers
@@ -1104,10 +1172,22 @@ impl TextMateEngine {
 
         Self::merge_adjacent_spans(&mut spans);
 
+        // Cache only the prefix up to the last newline. Spans straddling
+        // or past the trailing partial line are returned for THIS render
+        // pass (so the partial line is highlighted now), but excluded
+        // from the cache — the next refresh re-parses them from
+        // `safe_state` once more bytes have streamed in.
+        let cache_range_end = safe_offset.max(desired_parse_start);
+        let cached_spans: Vec<CachedSpan> = spans
+            .iter()
+            .filter(|s| s.range.end <= cache_range_end)
+            .cloned()
+            .collect();
+
         self.cache = Some(TextMateCache {
-            range: desired_parse_start..parse_end,
-            spans: spans.clone(),
-            tail_state: Some((state, current_scopes)),
+            range: desired_parse_start..cache_range_end,
+            spans: cached_spans,
+            tail_state: Some((safe_state, safe_scopes)),
         });
         self.last_buffer_len = buffer.len();
 
@@ -1744,6 +1824,102 @@ mod tests {
             );
         } else {
             panic!("Expected TextMate engine for .java file");
+        }
+    }
+
+    /// When a buffer is parsed with no trailing newline (the streaming
+    /// case for `git show` output between writes), the engine must not
+    /// commit cache tail state at the end of the partial trailing line.
+    /// With syntect's `Diff` grammar (line-anchored `^\+.*` etc.), the
+    /// state at end-of-input has popped `markup.inserted`, so any
+    /// follow-up parse from there would see the rest of the line as a
+    /// new line in `source.diff` and emit no scope — losing the bg
+    /// inside otherwise-green `+` lines.
+    ///
+    /// This test pins the boundary the cache commits at: after parsing
+    /// a buffer ending mid-line, `cache.range.end` must be the last
+    /// newline (or `desired_parse_start` if no newline was seen), not
+    /// the end of the partial line.
+    #[test]
+    fn test_partial_trailing_line_not_committed_to_cache() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        // A complete `+` line followed by a partial `+` line (no \n).
+        let content = "+complete\n+partial";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        if let HighlightEngine::TextMate(ref mut tm) = engine {
+            let _ = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+            let (cache_end, has_tail) = tm.cache_commit_for_test();
+            assert_eq!(
+                cache_end,
+                "+complete\n".len(),
+                "cache should commit at the last newline, not into the partial \
+                 trailing line — committing past the newline causes streaming \
+                 forward-extension to parse the line's continuation in the wrong \
+                 grammar context, losing the diff bg."
+            );
+            assert!(has_tail, "tail state should be saved at the safe boundary");
+        }
+    }
+
+    /// Reproduce: artifacts inside `+` lines whose content contains
+    /// JS template literals — `\`...\`` with `${}` interpolation.
+    /// The whole `+` line should be one contiguous Inserted span
+    /// carrying `theme.diff_add_bg`, with no bg-less holes mid-line.
+    #[test]
+    fn test_diff_inserted_line_is_fully_covered() {
+        let registry =
+            GrammarRegistry::load(&crate::primitives::grammar::LocalGrammarLoader::embedded_only());
+        let mut engine = HighlightEngine::for_file(Path::new("commit.diff"), None, &registry);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        let content =
+            "diff --git a/file.ts b/file.ts\n\
+             index aaa..bbb 100644\n\
+             --- a/file.ts\n\
+             +++ b/file.ts\n\
+             @@ -1,3 +1,5 @@\n\
+             +${seen[g.subtree] > 1 ? `**Seen ${seen[g.subtree]}× — likely cross-subtree type seam.**` : \"\"}\n\
+             +              const k = `${b.fn}::${(b.what || \"\").slice(0, 80)}`;\n";
+        let buffer = Buffer::from_str(content, 0, test_fs());
+
+        if let HighlightEngine::TextMate(ref mut tm) = engine {
+            let spans = tm.highlight_viewport(&buffer, 0, content.len(), &theme, 0);
+
+            let bytes = content.as_bytes();
+            let mut line_start = 0;
+            while line_start < bytes.len() {
+                let mut line_end = line_start;
+                while line_end < bytes.len() && bytes[line_end] != b'\n' {
+                    line_end += 1;
+                }
+                if bytes[line_start] == b'+' && !content[line_start..line_end].starts_with("+++")
+                {
+                    for byte_pos in line_start..line_end {
+                        let span = spans
+                            .iter()
+                            .find(|s| s.range.start <= byte_pos && s.range.end > byte_pos);
+                        let bg = span.and_then(|s| s.bg);
+                        assert_eq!(
+                            bg,
+                            Some(theme.diff_add_bg),
+                            "byte {} (`{}`) of `+` line starting at {} should carry diff_add_bg; \
+                             got span={:?}",
+                            byte_pos,
+                            content[byte_pos..byte_pos + 1].escape_debug(),
+                            line_start,
+                            span,
+                        );
+                    }
+                }
+                line_start = line_end + 1;
+            }
+        } else {
+            panic!("Expected TextMate engine for .diff file");
         }
     }
 

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -318,6 +318,68 @@ const CHECKPOINT_INTERVAL: usize = 256;
 /// pathological edits whose effect doesn't converge.
 const CONVERGENCE_BUDGET: usize = 64 * 1024;
 
+/// Byte position one past the end of the line that starts at `pos`.
+/// Accepts `\n` and `\r\n` terminators; returns `content_bytes.len()`
+/// when the buffer ends without a terminator (the streaming tail).
+fn find_line_end(content_bytes: &[u8], pos: usize) -> usize {
+    let mut line_end = pos;
+    while line_end < content_bytes.len() {
+        if content_bytes[line_end] == b'\n' {
+            line_end += 1;
+            break;
+        } else if content_bytes[line_end] == b'\r' {
+            if line_end + 1 < content_bytes.len() && content_bytes[line_end + 1] == b'\n' {
+                line_end += 2;
+            } else {
+                line_end += 1;
+            }
+            break;
+        }
+        line_end += 1;
+    }
+    line_end
+}
+
+/// UTF-8-decoded line ready to feed `state.parse_line`.
+struct PreparedLine {
+    /// What `parse_line` sees: line content always terminated by `\n`,
+    /// EXCEPT for the buffer's final partial line where no `\n` has
+    /// arrived yet (caller must not commit cache state past such a
+    /// line — see `extend_cache_forward`).
+    line_for_syntect: String,
+    /// Byte length of the line excluding `\r` / `\n` terminator.
+    line_content_len: usize,
+    /// Whether the original line ended with `\n` (true for every line
+    /// except the streaming tail).
+    ends_with_newline: bool,
+}
+
+/// Slice the line starting at `pos` from `content_bytes` and prepare
+/// it for `parse_line`. Returns `(line_end, line_byte_len, prepared)`:
+/// callers always advance by `line_byte_len` to `line_end`; `prepared`
+/// is `None` only when the line wasn't valid UTF-8 (skip & continue).
+fn prepare_line_at(content_bytes: &[u8], pos: usize) -> (usize, usize, Option<PreparedLine>) {
+    let line_end = find_line_end(content_bytes, pos);
+    let line_bytes = &content_bytes[pos..line_end];
+    let line_byte_len = line_bytes.len();
+    let prepared = std::str::from_utf8(line_bytes).ok().map(|line_str| {
+        let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
+        let ends_with_newline = line_str.ends_with('\n');
+        let is_streaming_tail = line_end == content_bytes.len() && !ends_with_newline;
+        let line_for_syntect = if is_streaming_tail {
+            line_content.to_string()
+        } else {
+            format!("{}\n", line_content)
+        };
+        PreparedLine {
+            line_for_syntect,
+            line_content_len: line_content.len(),
+            ends_with_newline,
+        }
+    });
+    (line_end, line_byte_len, prepared)
+}
+
 impl TextMateEngine {
     /// Create a new TextMate engine for the given syntax
     pub fn new(syntax_set: Arc<SyntaxSet>, syntax_index: usize) -> Self {
@@ -427,6 +489,82 @@ impl TextMateEngine {
                 cache.tail_state = None;
             }
         }
+    }
+
+    /// Create a checkpoint at `current_offset` carrying the supplied
+    /// parse state, unless one already exists within half an interval
+    /// (which would shadow it). Callers gate on
+    /// `bytes_since_checkpoint >= CHECKPOINT_INTERVAL` to control
+    /// spacing.
+    fn maybe_create_checkpoint(
+        &mut self,
+        current_offset: usize,
+        state: &syntect::parsing::ParseState,
+        current_scopes: &syntect::parsing::ScopeStack,
+    ) {
+        let nearby = self.checkpoint_markers.query_range(
+            current_offset.saturating_sub(CHECKPOINT_INTERVAL / 2),
+            current_offset + CHECKPOINT_INTERVAL / 2,
+        );
+        if nearby.is_empty() {
+            let marker_id = self.checkpoint_markers.create(current_offset, true);
+            self.checkpoint_states
+                .insert(marker_id, (state.clone(), current_scopes.clone()));
+        }
+    }
+
+    /// Drive `state.parse_line(prepared.line_for_syntect)` and emit one
+    /// span per category-carrying byte range via `on_span(start, end,
+    /// category)`. Returns `false` when `parse_line` errored — caller
+    /// should advance past the line and continue (state may have been
+    /// mutated mid-parse but is left as-is, matching prior behaviour).
+    ///
+    /// Span emission is in two passes: the op iterator emits the
+    /// segment between consecutive ops with the scope-stack-active
+    /// category, and a trailing segment covers `[syntect_offset,
+    /// line_content_len)` when the final op didn't reach end-of-line.
+    fn parse_line_into_spans(
+        &mut self,
+        state: &mut syntect::parsing::ParseState,
+        current_scopes: &mut syntect::parsing::ScopeStack,
+        prepared: &PreparedLine,
+        current_offset: usize,
+        mut on_span: impl FnMut(usize, usize, HighlightCategory),
+    ) -> bool {
+        let ops = match state.parse_line(&prepared.line_for_syntect, &self.syntax_set) {
+            Ok(ops) => ops,
+            Err(_) => return false,
+        };
+
+        let line_content_len = prepared.line_content_len;
+        let mut syntect_offset = 0;
+
+        for (op_offset, op) in ops {
+            let clamped_op_offset = op_offset.min(line_content_len);
+            if clamped_op_offset > syntect_offset {
+                if let Some(category) = self.scope_stack_to_category(current_scopes) {
+                    on_span(
+                        current_offset + syntect_offset,
+                        current_offset + clamped_op_offset,
+                        category,
+                    );
+                }
+            }
+            syntect_offset = clamped_op_offset;
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = current_scopes.apply(&op);
+        }
+
+        if syntect_offset < line_content_len {
+            if let Some(category) = self.scope_stack_to_category(current_scopes) {
+                on_span(
+                    current_offset + syntect_offset,
+                    current_offset + line_content_len,
+                    category,
+                );
+            }
+        }
+        true
     }
 
     /// Highlight the visible viewport. Path selection is documented in the
@@ -626,77 +764,24 @@ impl TextMateEngine {
         while pos < content_bytes.len() {
             // Create checkpoints in new territory
             if bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                let nearby = self.checkpoint_markers.query_range(
-                    current_offset.saturating_sub(CHECKPOINT_INTERVAL / 2),
-                    current_offset + CHECKPOINT_INTERVAL / 2,
-                );
-                if nearby.is_empty() {
-                    let marker_id = self.checkpoint_markers.create(current_offset, true);
-                    self.checkpoint_states
-                        .insert(marker_id, (state.clone(), current_scopes.clone()));
-                }
+                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
                 bytes_since_checkpoint = 0;
             }
 
-            let line_start = pos;
-            let mut line_end = pos;
-            while line_end < content_bytes.len() {
-                if content_bytes[line_end] == b'\n' {
-                    line_end += 1;
-                    break;
-                } else if content_bytes[line_end] == b'\r' {
-                    if line_end + 1 < content_bytes.len() && content_bytes[line_end + 1] == b'\n' {
-                        line_end += 2;
-                    } else {
-                        line_end += 1;
-                    }
-                    break;
-                }
-                line_end += 1;
-            }
-
-            let line_bytes = &content_bytes[line_start..line_end];
-            let actual_line_byte_len = line_bytes.len();
-
-            let line_str = match std::str::from_utf8(line_bytes) {
-                Ok(s) => s,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
-            let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
-            let line_for_syntect = if line_end < content_bytes.len() || line_str.ends_with('\n') {
-                format!("{}\n", line_content)
-            } else {
-                line_content.to_string()
-            };
-
-            let ops = match state.parse_line(&line_for_syntect, &self.syntax_set) {
-                Ok(ops) => ops,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
+            let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
             // Collect spans for the dirty region
             let collect_spans =
-                current_offset + actual_line_byte_len > desired_parse_start.max(actual_start);
-            let mut syntect_offset = 0;
-            let line_content_len = line_content.len();
-
-            for (op_offset, op) in ops {
-                let clamped_op_offset = op_offset.min(line_content_len);
-                if collect_spans && clamped_op_offset > syntect_offset {
-                    if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                        let byte_start = current_offset + syntect_offset;
-                        let byte_end = current_offset + clamped_op_offset;
+                current_offset + line_byte_len > desired_parse_start.max(actual_start);
+            if let Some(prepared) = prepared {
+                let _ = self.parse_line_into_spans(
+                    &mut state,
+                    &mut current_scopes,
+                    &prepared,
+                    current_offset,
+                    |byte_start, byte_end, category| {
+                        if !collect_spans {
+                            return;
+                        }
                         let clamped_start = byte_start.max(actual_start);
                         if clamped_start < byte_end {
                             new_spans.push(CachedSpan {
@@ -704,30 +789,13 @@ impl TextMateEngine {
                                 category,
                             });
                         }
-                    }
-                }
-                syntect_offset = clamped_op_offset;
-                #[allow(clippy::let_underscore_must_use)]
-                let _ = current_scopes.apply(&op);
-            }
-
-            if collect_spans && syntect_offset < line_content_len {
-                if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                    let byte_start = current_offset + syntect_offset;
-                    let byte_end = current_offset + line_content_len;
-                    let clamped_start = byte_start.max(actual_start);
-                    if clamped_start < byte_end {
-                        new_spans.push(CachedSpan {
-                            range: clamped_start..byte_end,
-                            category,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             pos = line_end;
-            current_offset += actual_line_byte_len;
-            bytes_since_checkpoint += actual_line_byte_len;
+            current_offset += line_byte_len;
+            bytes_since_checkpoint += line_byte_len;
 
             // Check convergence at checkpoint markers
             while marker_idx < markers_ahead.len() && markers_ahead[marker_idx].1 <= current_offset
@@ -853,106 +921,35 @@ impl TextMateEngine {
 
         while pos < content_bytes.len() {
             if bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                let nearby = self.checkpoint_markers.query_range(
-                    current_offset.saturating_sub(CHECKPOINT_INTERVAL / 2),
-                    current_offset + CHECKPOINT_INTERVAL / 2,
-                );
-                if nearby.is_empty() {
-                    let marker_id = self.checkpoint_markers.create(current_offset, true);
-                    self.checkpoint_states
-                        .insert(marker_id, (state.clone(), current_scopes.clone()));
-                }
+                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
                 bytes_since_checkpoint = 0;
             }
 
-            let line_start = pos;
-            let mut line_end = pos;
-            while line_end < content_bytes.len() {
-                if content_bytes[line_end] == b'\n' {
-                    line_end += 1;
-                    break;
-                } else if content_bytes[line_end] == b'\r' {
-                    if line_end + 1 < content_bytes.len() && content_bytes[line_end + 1] == b'\n' {
-                        line_end += 2;
-                    } else {
-                        line_end += 1;
-                    }
-                    break;
-                }
-                line_end += 1;
-            }
-
-            let line_bytes = &content_bytes[line_start..line_end];
-            let actual_line_byte_len = line_bytes.len();
-
-            let line_str = match std::str::from_utf8(line_bytes) {
-                Ok(s) => s,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
-            let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
-            let line_ends_with_newline = line_str.ends_with('\n');
-            let line_for_syntect = if line_end < content_bytes.len() || line_ends_with_newline {
-                format!("{}\n", line_content)
-            } else {
-                line_content.to_string()
-            };
-
-            let ops = match state.parse_line(&line_for_syntect, &self.syntax_set) {
-                Ok(ops) => ops,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
-            let mut syntect_offset = 0;
-            let line_content_len = line_content.len();
-
-            for (op_offset, op) in ops {
-                let clamped_op_offset = op_offset.min(line_content_len);
-                if clamped_op_offset > syntect_offset {
-                    if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                        let byte_start = current_offset + syntect_offset;
-                        let byte_end = current_offset + clamped_op_offset;
-                        if byte_start < byte_end {
-                            new_spans.push(CachedSpan {
-                                range: byte_start..byte_end,
-                                category,
-                            });
-                        }
-                    }
-                }
-                syntect_offset = clamped_op_offset;
-                #[allow(clippy::let_underscore_must_use)]
-                let _ = current_scopes.apply(&op);
-            }
-
-            if syntect_offset < line_content_len {
-                if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                    let byte_start = current_offset + syntect_offset;
-                    let byte_end = current_offset + line_content_len;
-                    if byte_start < byte_end {
+            let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
+            let mut newline_terminated = false;
+            if let Some(prepared) = prepared {
+                let parse_ok = self.parse_line_into_spans(
+                    &mut state,
+                    &mut current_scopes,
+                    &prepared,
+                    current_offset,
+                    |byte_start, byte_end, category| {
                         new_spans.push(CachedSpan {
                             range: byte_start..byte_end,
                             category,
                         });
-                    }
+                    },
+                );
+                if parse_ok {
+                    newline_terminated = prepared.ends_with_newline;
                 }
             }
 
             pos = line_end;
-            current_offset += actual_line_byte_len;
-            bytes_since_checkpoint += actual_line_byte_len;
+            current_offset += line_byte_len;
+            bytes_since_checkpoint += line_byte_len;
 
-            if line_ends_with_newline {
+            if newline_terminated {
                 safe_offset = current_offset;
                 safe_state = state.clone();
                 safe_scopes = current_scopes.clone();
@@ -1043,77 +1040,26 @@ impl TextMateEngine {
 
         while pos < content_bytes.len() {
             if create_checkpoints && bytes_since_checkpoint >= CHECKPOINT_INTERVAL {
-                let nearby = self.checkpoint_markers.query_range(
-                    current_offset.saturating_sub(CHECKPOINT_INTERVAL / 2),
-                    current_offset + CHECKPOINT_INTERVAL / 2,
-                );
-                if nearby.is_empty() {
-                    let marker_id = self.checkpoint_markers.create(current_offset, true);
-                    self.checkpoint_states
-                        .insert(marker_id, (state.clone(), current_scopes.clone()));
-                }
+                self.maybe_create_checkpoint(current_offset, &state, &current_scopes);
                 bytes_since_checkpoint = 0;
             }
 
-            let line_start = pos;
-            let mut line_end = pos;
-
-            while line_end < content_bytes.len() {
-                if content_bytes[line_end] == b'\n' {
-                    line_end += 1;
-                    break;
-                } else if content_bytes[line_end] == b'\r' {
-                    if line_end + 1 < content_bytes.len() && content_bytes[line_end + 1] == b'\n' {
-                        line_end += 2;
-                    } else {
-                        line_end += 1;
-                    }
-                    break;
-                }
-                line_end += 1;
-            }
-
-            let line_bytes = &content_bytes[line_start..line_end];
-            let actual_line_byte_len = line_bytes.len();
-
-            let line_str = match std::str::from_utf8(line_bytes) {
-                Ok(s) => s,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
-            let line_content = line_str.trim_end_matches(&['\r', '\n'][..]);
-            let line_ends_with_newline = line_str.ends_with('\n');
-            let line_for_syntect = if line_end < content_bytes.len() || line_ends_with_newline {
-                format!("{}\n", line_content)
-            } else {
-                line_content.to_string()
-            };
-
-            let ops = match state.parse_line(&line_for_syntect, &self.syntax_set) {
-                Ok(ops) => ops,
-                Err(_) => {
-                    pos = line_end;
-                    current_offset += actual_line_byte_len;
-                    bytes_since_checkpoint += actual_line_byte_len;
-                    continue;
-                }
-            };
-
-            let collect_spans = current_offset + actual_line_byte_len > desired_parse_start;
-            let mut syntect_offset = 0;
-            let line_content_len = line_content.len();
-
-            for (op_offset, op) in ops {
-                let clamped_op_offset = op_offset.min(line_content_len);
-                if collect_spans && clamped_op_offset > syntect_offset {
-                    if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                        let byte_start = current_offset + syntect_offset;
-                        let byte_end = current_offset + clamped_op_offset;
+            let (line_end, line_byte_len, prepared) = prepare_line_at(content_bytes, pos);
+            // Skip span collection for lines that ended before the viewport's
+            // desired_parse_start — we still need to drive `parse_line` for
+            // state continuity, but their spans wouldn't be returned anyway.
+            let collect_spans = current_offset + line_byte_len > desired_parse_start;
+            let mut newline_terminated = false;
+            if let Some(prepared) = prepared {
+                let parse_ok = self.parse_line_into_spans(
+                    &mut state,
+                    &mut current_scopes,
+                    &prepared,
+                    current_offset,
+                    |byte_start, byte_end, category| {
+                        if !collect_spans {
+                            return;
+                        }
                         let clamped_start = byte_start.max(desired_parse_start);
                         if clamped_start < byte_end {
                             spans.push(CachedSpan {
@@ -1121,44 +1067,30 @@ impl TextMateEngine {
                                 category,
                             });
                         }
-                    }
-                }
-                syntect_offset = clamped_op_offset;
-                #[allow(clippy::let_underscore_must_use)]
-                let _ = current_scopes.apply(&op);
-            }
-
-            if collect_spans && syntect_offset < line_content_len {
-                if let Some(category) = self.scope_stack_to_category(&current_scopes) {
-                    let byte_start = current_offset + syntect_offset;
-                    let byte_end = current_offset + line_content_len;
-                    let clamped_start = byte_start.max(desired_parse_start);
-                    if clamped_start < byte_end {
-                        spans.push(CachedSpan {
-                            range: clamped_start..byte_end,
-                            category,
-                        });
-                    }
+                    },
+                );
+                if parse_ok {
+                    newline_terminated = prepared.ends_with_newline;
                 }
             }
 
             pos = line_end;
-            current_offset += actual_line_byte_len;
-            bytes_since_checkpoint += actual_line_byte_len;
+            current_offset += line_byte_len;
+            bytes_since_checkpoint += line_byte_len;
 
-            if line_ends_with_newline {
+            if newline_terminated {
                 safe_offset = current_offset;
                 safe_state = state.clone();
                 safe_scopes = current_scopes.clone();
             }
 
-            // Update checkpoint states as we pass them
+            // Update checkpoint states as we pass them. Done after the
+            // line is parsed (state now reflects end-of-line) so a
+            // checkpoint placed at the line's start position carries
+            // the state at that position, ready to feed the next line.
             let markers_here: Vec<(MarkerId, usize)> = self
                 .checkpoint_markers
-                .query_range(
-                    current_offset.saturating_sub(actual_line_byte_len),
-                    current_offset,
-                )
+                .query_range(current_offset.saturating_sub(line_byte_len), current_offset)
                 .into_iter()
                 .map(|(id, start, _)| (id, start))
                 .collect();

--- a/crates/fresh-editor/src/primitives/highlight_engine.rs
+++ b/crates/fresh-editor/src/primitives/highlight_engine.rs
@@ -1897,8 +1897,7 @@ mod tests {
                 while line_end < bytes.len() && bytes[line_end] != b'\n' {
                     line_end += 1;
                 }
-                if bytes[line_start] == b'+' && !content[line_start..line_end].starts_with("+++")
-                {
+                if bytes[line_start] == b'+' && !content[line_start..line_end].starts_with("+++") {
                     for byte_pos in line_start..line_end {
                         let span = spans
                             .iter()


### PR DESCRIPTION
## Summary
Fix a critical bug where syntax highlighting artifacts (dark bars) appeared inside diff `+` lines when content was streamed in without a trailing newline. The issue occurred because the cache was committing parser state at the end of partial lines, causing subsequent parses to resume in the wrong grammar context.

## Key Changes
- **Cache boundary enforcement**: Modified both `extend_cache_forward` and `full_parse` to only commit cache state at newline boundaries. Partial trailing lines are now tracked separately and re-parsed on the next refresh once more bytes arrive.

- **Span partitioning**: In `extend_cache_forward`, spans are now split into "safe" (fully before the trailing partial line, cacheable) and "unsafe" (overlapping the partial line, render-only). Safe spans are cached while unsafe spans are returned for immediate rendering but discarded after.

- **State tracking**: Added `safe_offset`, `safe_state`, and `safe_scopes` variables in both parsing functions to snapshot the last newline-aligned position, ensuring the cache never contains state from mid-line.

- **Test coverage**: Added two comprehensive tests:
  - `test_partial_trailing_line_not_committed_to_cache`: Verifies cache commits at newline boundaries, not into partial lines
  - `test_diff_inserted_line_is_fully_covered`: Ensures `+` lines with complex content (template literals, interpolation) maintain consistent background color throughout

## Implementation Details
- The fix handles streaming scenarios (e.g., `git show` output) where buffers arrive without trailing newlines
- Works with line-anchored grammars like syntect's `Diff` that rely on parser state to maintain scope context
- Minimal performance impact: re-parsing a partial trailing line costs at most one extra `parse_line` call per refresh
- Maintains backward compatibility: buffers ending with newlines see no behavior change

https://claude.ai/code/session_01DibzJwVTTpvEL6D8ARN33E