### PR TITLE
Cut idle CPU: throttle git plugins, dedup status-bar writes, gate hooks

### DIFF
--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -7,31 +7,45 @@ const GIT_BRANCH = "branch";
 let lastDetectedTimestamp = 0;
 let lastDetectedBranch = editor.t("status.detecting_branch");
 
+let inFlight: Promise<string> | null = null;
+
 async function getCurrentGitBranch(): Promise<string> {
   const now = Date.now();
 
   if (now - lastDetectedTimestamp < 5000) {
     return lastDetectedBranch;
   }
-
-  const cwd = editor.getCwd();
-  const result = await editor.spawnProcess(
-    "git",
-    ["rev-parse", "--abbrev-ref", "HEAD"],
-    cwd,
-  );
-
-  if (result.exit_code === 0) {
-    const branch = result.stdout.trim();
-
-    lastDetectedBranch = branch || "HEAD";
-  } else {
-    lastDetectedBranch = editor.t("status.not_in_git");
+  // Coalesce concurrent callers onto a single spawn. Without this, every
+  // event handler that fires during the in-flight `git rev-parse` re-enters
+  // here, sees the still-stale timestamp, and spawns its own copy.
+  if (inFlight) {
+    return inFlight;
   }
 
-  lastDetectedTimestamp = now;
+  inFlight = (async () => {
+    try {
+      const cwd = editor.getCwd();
+      const result = await editor.spawnProcess(
+        "git",
+        ["rev-parse", "--abbrev-ref", "HEAD"],
+        cwd,
+      );
 
-  return lastDetectedBranch;
+      if (result.exit_code === 0) {
+        const branch = result.stdout.trim();
+        lastDetectedBranch = branch || "HEAD";
+      } else {
+        lastDetectedBranch = editor.t("status.not_in_git");
+      }
+
+      lastDetectedTimestamp = Date.now();
+      return lastDetectedBranch;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
 }
 
 editor.registerStatusBarElement(GIT_BRANCH, editor.t("status.git_branch"));

--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -4,24 +4,65 @@ const editor = getEditor();
 
 const GIT_BRANCH = "branch";
 
-let lastDetectedTimestamp = 0;
 let lastDetectedBranch = editor.t("status.detecting_branch");
-
 let inFlight: Promise<string> | null = null;
 
+// HEAD-file watcher. Branch changes correspond exactly to mutations of
+// the `HEAD` file inside the relevant git dir (resolved by
+// `git rev-parse --git-path HEAD` so worktrees / submodules / `--git-dir`
+// setups work). When HEAD changes we re-spawn `git rev-parse --abbrev-ref`
+// and push the new value; otherwise we never spawn git on the hot path.
+let headWatchHandle: number | null = null;
+let watchedCwd: string | null = null;
+let watchedHeadPath: string | null = null;
+let ensureWatchInFlight: Promise<void> | null = null;
+
+async function discoverHeadPath(cwd: string): Promise<string | null> {
+  const result = await editor.spawnProcess(
+    "git",
+    ["rev-parse", "--git-path", "HEAD"],
+    cwd,
+  );
+  if (result.exit_code !== 0) return null;
+  const headPath = result.stdout.trim();
+  if (!headPath) return null;
+  // `--git-path` returns a path relative to cwd unless the git dir is
+  // outside (e.g. worktree). Make absolute so notify gets a stable target.
+  return headPath.startsWith("/") ? headPath : `${cwd}/${headPath}`;
+}
+
+async function ensureHeadWatch(): Promise<void> {
+  const cwd = editor.getCwd();
+  if (watchedCwd === cwd && headWatchHandle !== null) return;
+  if (ensureWatchInFlight) return ensureWatchInFlight;
+
+  ensureWatchInFlight = (async () => {
+    try {
+      if (headWatchHandle !== null) {
+        editor.unwatchPath(headWatchHandle);
+        headWatchHandle = null;
+        watchedHeadPath = null;
+      }
+      watchedCwd = cwd;
+      const headPath = await discoverHeadPath(cwd);
+      if (!headPath) return;
+      try {
+        headWatchHandle = await editor.watchPath(headPath, false);
+        watchedHeadPath = headPath;
+      } catch (_e) {
+        // Watch registration failed (path missing, kernel limit). Fall
+        // back to event-driven refresh — getCurrentGitBranch is still
+        // gated by inFlight + the per-event invocation pattern below.
+      }
+    } finally {
+      ensureWatchInFlight = null;
+    }
+  })();
+  return ensureWatchInFlight;
+}
+
 async function getCurrentGitBranch(): Promise<string> {
-  const now = Date.now();
-
-  if (now - lastDetectedTimestamp < 5000) {
-    return lastDetectedBranch;
-  }
-  // Coalesce concurrent callers onto a single spawn. Without this, every
-  // event handler that fires during the in-flight `git rev-parse` re-enters
-  // here, sees the still-stale timestamp, and spawns its own copy.
-  if (inFlight) {
-    return inFlight;
-  }
-
+  if (inFlight) return inFlight;
   inFlight = (async () => {
     try {
       const cwd = editor.getCwd();
@@ -30,42 +71,63 @@ async function getCurrentGitBranch(): Promise<string> {
         ["rev-parse", "--abbrev-ref", "HEAD"],
         cwd,
       );
-
       if (result.exit_code === 0) {
         const branch = result.stdout.trim();
         lastDetectedBranch = branch || "HEAD";
       } else {
         lastDetectedBranch = editor.t("status.not_in_git");
       }
-
-      lastDetectedTimestamp = Date.now();
       return lastDetectedBranch;
     } finally {
       inFlight = null;
     }
   })();
-
   return inFlight;
+}
+
+async function refreshForActiveBuffer(): Promise<void> {
+  // Lazy: pick up cwd changes (Orchestrator window switch, etc.) the next
+  // time anything triggers us.
+  ensureHeadWatch();
+  const bufferId = editor.getActiveBufferId();
+  if (bufferId === 0) return;
+  const branch = await getCurrentGitBranch();
+  editor.setStatusBarValue(bufferId, GIT_BRANCH, branch);
 }
 
 editor.registerStatusBarElement(GIT_BRANCH, editor.t("status.git_branch"));
 
+// Refresh the branch label when:
+// - The user switches to a different buffer (the per-buffer value may not
+//   be set yet for that buffer).
+// - A file is freshly opened (same reason).
+// - A file is saved (best-effort UX: the user may have committed via an
+//   external terminal between events; the watchPath below catches actual
+//   HEAD mutations).
+// - The editor regains focus from another window — covers the case of
+//   running `git checkout` in an external terminal while fresh was unfocused.
+//
+// Notably *not* in this list (compared to the legacy version): render_start,
+// cursor_moved, after_insert, after_delete, buffer_deactivated, buffer_closed.
+// None of them can change the current branch, and render_start was being
+// fired ~300/s — see #2009 for the feedback-loop investigation.
 [
   "buffer_activated",
-  "buffer_deactivated",
-  "buffer_closed",
   "after_file_open",
   "after_file_save",
-  "after_insert",
-  "after_delete",
-  "cursor_moved",
-  "render_start",
+  "focus_gained",
 ].forEach((event) => {
   editor.on(event, async () => {
-    const bufferId = editor.getActiveBufferId();
-    if (bufferId === 0) {
-      return;
-    }
-    editor.setStatusBarValue(bufferId, GIT_BRANCH, await getCurrentGitBranch());
+    await refreshForActiveBuffer();
   });
 });
+
+// path_changed → HEAD file mutated → branch may have changed.
+editor.on("path_changed", async (args) => {
+  if (args.handle !== headWatchHandle) return;
+  await refreshForActiveBuffer();
+});
+
+// Kick off the first detection at load time so the status bar populates
+// before any user event fires.
+refreshForActiveBuffer();

--- a/crates/fresh-editor/plugins/merge_conflict.ts
+++ b/crates/fresh-editor/plugins/merge_conflict.ts
@@ -100,6 +100,66 @@ const mergeState: MergeState = {
   resultContent: "",
 };
 
+// Caches for the buffer_activated / after_file_open detection path.
+// Without these, every tab switch re-spawns `git rev-parse` + `git ls-files`
+// even though their answers rarely change. The detection path is purely a
+// status-bar hint, so a stale answer for a few seconds is harmless.
+const inGitRepoCache: Map<string, boolean> = new Map();
+const detectionLastCheck: Map<string, number> = new Map();
+const DETECTION_TTL_MS = 30_000;
+const detectionInFlight: Map<string, Promise<void>> = new Map();
+
+async function isInGitRepo(fileDir: string): Promise<boolean> {
+  const cached = inGitRepoCache.get(fileDir);
+  if (cached !== undefined) return cached;
+  const gitCheck = await editor.spawnProcess(
+    "git",
+    ["rev-parse", "--is-inside-work-tree"],
+    fileDir,
+  );
+  const ok = gitCheck.exit_code === 0;
+  inGitRepoCache.set(fileDir, ok);
+  return ok;
+}
+
+async function detectMergeConflictFor(
+  path: string,
+  statusOnDetect: () => string,
+): Promise<void> {
+  if (mergeState.isActive) return;
+  if (!path) return;
+
+  const last = detectionLastCheck.get(path);
+  if (last !== undefined && Date.now() - last < DETECTION_TTL_MS) return;
+
+  // Coalesce concurrent callers for the same path onto one in-flight check
+  // (e.g. buffer_activated + after_file_open firing back-to-back).
+  const existing = detectionInFlight.get(path);
+  if (existing) return existing;
+
+  const fileDir = editor.pathDirname(path);
+  const promise = (async () => {
+    try {
+      if (!(await isInGitRepo(fileDir))) return;
+      const lsFiles = await editor.spawnProcess(
+        "git",
+        ["ls-files", "-u", path],
+        fileDir,
+      );
+      if (lsFiles.exit_code === 0 && lsFiles.stdout.trim().length > 0) {
+        editor.setStatus(statusOnDetect());
+      }
+      detectionLastCheck.set(path, Date.now());
+    } catch (_e) {
+      // Not in git repo or other error, ignore
+    } finally {
+      detectionInFlight.delete(path);
+    }
+  })();
+  detectionInFlight.set(path, promise);
+  return promise;
+}
+
 // =============================================================================
 // Color Definitions
 // =============================================================================
@@ -1712,50 +1772,18 @@ registerHandler("merge_show_help", merge_show_help);
 // =============================================================================
 
 editor.on("buffer_activated", async (data) => {
-  // Don't trigger if already in merge mode
-  if (mergeState.isActive) return;
-
-  // Don't trigger for virtual buffers
   const info = editor.getBufferInfo(data.buffer_id);
   if (!info || !info.path) return;
-
-  // Get the directory of the file for running git commands
-  const fileDir = editor.pathDirname(info.path);
-
-  // Check if we're in a git repo first
-  try {
-    const gitCheck = await editor.spawnProcess("git", ["rev-parse", "--is-inside-work-tree"], fileDir);
-    if (gitCheck.exit_code !== 0) return;
-
-    // Check for unmerged entries
-    const lsFiles = await editor.spawnProcess("git", ["ls-files", "-u", info.path], fileDir);
-    if (lsFiles.exit_code === 0 && lsFiles.stdout.trim().length > 0) {
-      editor.setStatus(editor.t("status.detected"));
-    }
-  } catch (e) {
-    // Not in git repo or other error, ignore
-  }
+  await detectMergeConflictFor(info.path, () => editor.t("status.detected"));
 });
 editor.on("after_file_open", async (data) => {
-  // Don't trigger if already in merge mode
-  if (mergeState.isActive) return;
-
-  // Get the directory of the file for running git commands
-  const fileDir = editor.pathDirname(data.path);
-
-  // Check if we're in a git repo first
-  try {
-    const gitCheck = await editor.spawnProcess("git", ["rev-parse", "--is-inside-work-tree"], fileDir);
-    if (gitCheck.exit_code !== 0) return;
-
-    // Check for unmerged entries
-    const lsFiles = await editor.spawnProcess("git", ["ls-files", "-u", data.path], fileDir);
-    if (lsFiles.exit_code === 0 && lsFiles.stdout.trim().length > 0) {
-      editor.setStatus(editor.t("status.detected_file", { path: data.path }));
-    }
-  } catch (e) {
-    // Not in git repo or other error, ignore
-  }
+  // File-open is a strong signal that state may have changed externally
+  // (e.g. user ran `git merge` then opened the conflicted file). Bypass the
+  // per-path TTL so the detection still runs.
+  detectionLastCheck.delete(data.path);
+  await detectMergeConflictFor(data.path, () =>
+    editor.t("status.detected_file", { path: data.path }),
+  );
 });
 
 // =============================================================================

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1489,10 +1489,8 @@ impl Editor {
                 key,
                 value,
             } => {
-                self.current_status_bar_value(
-                    fresh_core::BufferId(*buffer_id as usize),
-                    key,
-                ) != Some(value.as_str())
+                self.current_status_bar_value(fresh_core::BufferId(*buffer_id as usize), key)
+                    != Some(value.as_str())
             }
             _ => true,
         });

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1476,9 +1476,26 @@ impl Editor {
             return false;
         }
 
-        let has_visual_commands = commands
-            .iter()
-            .any(|c| !matches!(c, fresh_core::api::PluginCommand::HookCompleted { .. }));
+        // Classify each command as visual (needs re-render) or not.
+        // `HookCompleted` is a pure ack. `SetStatusBarValue` is treated as
+        // visual only when the value actually differs from what's stored —
+        // many plugins (e.g. git_statusbar) re-publish the same value on
+        // every `render_start` hook, which would otherwise create a
+        // render → hook → ack → render feedback loop at ~13Hz forever.
+        let has_visual_commands = commands.iter().any(|c| match c {
+            fresh_core::api::PluginCommand::HookCompleted { .. } => false,
+            fresh_core::api::PluginCommand::SetStatusBarValue {
+                buffer_id,
+                key,
+                value,
+            } => {
+                self.current_status_bar_value(
+                    fresh_core::BufferId(*buffer_id as usize),
+                    key,
+                ) != Some(value.as_str())
+            }
+            _ => true,
+        });
 
         let cmd_names: Vec<String> = commands.iter().map(|c| c.debug_variant_name()).collect();
         tracing::trace!(

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1252,6 +1252,21 @@ impl Editor {
         HashMap::new()
     }
 
+    /// Current value of a single status-bar token for the given buffer, if any.
+    /// Used by the plugin command dispatcher to detect no-op `SetStatusBarValue`
+    /// commands (i.e. plugins re-publishing an unchanged value on every render).
+    pub fn current_status_bar_value(&self, buffer_id: BufferId, key: &str) -> Option<&str> {
+        for window in self.windows.values() {
+            if let Some(values) = window.status_bar_values.get(&buffer_id) {
+                if let Some(v) = values.get(key) {
+                    return Some(v.as_str());
+                }
+                return None;
+            }
+        }
+        None
+    }
+
     /// Remove every registry entry and per-buffer value belonging to a plugin.
     /// Called when a plugin is unloaded.
     fn remove_plugin_status_bar_elements(&mut self, plugin_name: &str) {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -394,49 +394,62 @@ impl Editor {
                 let added = __win
                     .buffers
                     .with_buffer_and_view_states(buffer_id, |state, vs_map| {
-                        plugin_manager.read().unwrap().run_hook(
+                        // `render_start` has a tiny payload (just the
+                        // buffer id) — fire unconditionally so third-party
+                        // plugins listening for it still work.
+                        let pm_guard = plugin_manager.read().unwrap();
+                        pm_guard.run_hook(
                             "render_start",
                             crate::services::plugins::hooks::HookArgs::RenderStart { buffer_id },
                         );
 
                         let visible_count = split_area.height as usize;
-                        let is_binary = state.buffer.is_binary();
-                        let line_ending = state.buffer.line_ending();
-                        let base_tokens =
-                            crate::view::ui::split_rendering::SplitRenderer::build_base_tokens_for_hook(
-                                &mut state.buffer,
-                                viewport_top_byte,
-                                estimated_line_length,
-                                visible_count,
-                                is_binary,
-                                line_ending,
-                            );
-                        let viewport_start = viewport_top_byte;
-                        let viewport_end = base_tokens
-                            .last()
-                            .and_then(|t| t.source_offset)
-                            .unwrap_or(viewport_start);
-                        let cursor_positions: Vec<usize> = vs_map
-                            .get(&split_id)
-                            .map(|vs| vs.cursors.iter().map(|(_, c)| c.position).collect())
-                            .unwrap_or_default();
-                        plugin_manager.read().unwrap().run_hook(
-                            "view_transform_request",
-                            crate::services::plugins::hooks::HookArgs::ViewTransformRequest {
-                                buffer_id,
-                                split_id: split_id.into(),
-                                viewport_start,
-                                viewport_end,
-                                tokens: base_tokens,
-                                cursor_positions,
-                            },
-                        );
 
-                        // Plugin saw fresh base tokens; future
-                        // SubmitViewTransform from this request is valid.
-                        if let Some(vs) = vs_map.get_mut(&split_id) {
-                            vs.view_transform_stale = false;
+                        // `view_transform_request` carries the full
+                        // tokenized viewport in its args. Building those
+                        // tokens (`build_base_tokens_for_hook`) is the
+                        // expensive part — see #2009. Skip the whole
+                        // pipeline when no plugin subscribes.
+                        if pm_guard.has_subscribers("view_transform_request") {
+                            let is_binary = state.buffer.is_binary();
+                            let line_ending = state.buffer.line_ending();
+                            let base_tokens =
+                                crate::view::ui::split_rendering::SplitRenderer::build_base_tokens_for_hook(
+                                    &mut state.buffer,
+                                    viewport_top_byte,
+                                    estimated_line_length,
+                                    visible_count,
+                                    is_binary,
+                                    line_ending,
+                                );
+                            let viewport_start = viewport_top_byte;
+                            let viewport_end = base_tokens
+                                .last()
+                                .and_then(|t| t.source_offset)
+                                .unwrap_or(viewport_start);
+                            let cursor_positions: Vec<usize> = vs_map
+                                .get(&split_id)
+                                .map(|vs| vs.cursors.iter().map(|(_, c)| c.position).collect())
+                                .unwrap_or_default();
+                            pm_guard.run_hook(
+                                "view_transform_request",
+                                crate::services::plugins::hooks::HookArgs::ViewTransformRequest {
+                                    buffer_id,
+                                    split_id: split_id.into(),
+                                    viewport_start,
+                                    viewport_end,
+                                    tokens: base_tokens,
+                                    cursor_positions,
+                                },
+                            );
+
+                            // Plugin saw fresh base tokens; future
+                            // SubmitViewTransform from this request is valid.
+                            if let Some(vs) = vs_map.get_mut(&split_id) {
+                                vs.view_transform_stale = false;
+                            }
                         }
+                        drop(pm_guard);
 
                         let top_byte = viewport_top_byte;
                         let seen_byte_ranges =

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -437,12 +437,34 @@ impl PluginManager {
     }
 
     /// Check if any handlers are registered for a hook.
+    ///
+    /// Blocking call (round-trips through the plugin thread). Suitable for
+    /// rare events (mouse clicks, command dispatch). For per-render gating
+    /// use `has_subscribers` instead — it reads a shared registry directly.
     pub fn has_hook_handlers(&self, hook_name: &str) -> bool {
         #[cfg(feature = "plugins")]
         {
             self.inner
                 .as_ref()
                 .map(|m| m.has_hook_handlers(hook_name))
+                .unwrap_or(false)
+        }
+        #[cfg(not(feature = "plugins"))]
+        {
+            let _ = hook_name;
+            false
+        }
+    }
+
+    /// Non-blocking variant of `has_hook_handlers`. Reads the shared
+    /// `event_handlers` registry directly — safe to call on the hot
+    /// render path. Returns `false` when plugins are disabled.
+    pub fn has_subscribers(&self, hook_name: &str) -> bool {
+        #[cfg(feature = "plugins")]
+        {
+            self.inner
+                .as_ref()
+                .map(|m| m.has_subscribers(hook_name))
                 .unwrap_or(false)
         }
         #[cfg(not(feature = "plugins"))]

--- a/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/git_statusbar.rs
@@ -104,17 +104,12 @@ fn test_status_bar_shows_custom_branch_token() {
     harness
         .send_key(KeyCode::Right, KeyModifiers::NONE)
         .unwrap();
-    harness.render().unwrap();
 
-    // Verify status bar contains expected elements
-    let status_bar = harness.get_status_bar();
-
-    // The branch token value comes from the plugin at runtime.
-    // With the plugin loaded, the status bar should show "Not in git"
-    // since we're not in a git repository.
-    assert!(
-        status_bar.contains("Not in git"),
-        "Status bar should contain 'Not in git' from plugin. Got: {}",
-        status_bar
-    );
+    // The branch token value is published asynchronously by the plugin
+    // (after_file_open → spawnProcess("git") → setStatusBarValue). Wait
+    // for it to land in the rendered status bar rather than snapshotting
+    // once and racing the round-trip.
+    harness
+        .wait_until(|h| h.get_status_bar().contains("Not in git"))
+        .unwrap();
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5703,8 +5703,7 @@ impl QuickJsBackend {
         let async_resource_owners: AsyncResourceOwners =
             Arc::new(std::sync::Mutex::new(HashMap::new()));
         let search_handles: SearchHandleRegistry = Arc::new(std::sync::Mutex::new(HashMap::new()));
-        let event_handlers: EventHandlerRegistry =
-            Arc::new(RwLock::new(HashMap::new()));
+        let event_handlers: EventHandlerRegistry = Arc::new(RwLock::new(HashMap::new()));
         Self::with_state_responses_and_resources(
             state_snapshot,
             command_sender,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -702,6 +702,15 @@ pub struct PluginTrackedState {
 /// Shared between QuickJsBackend (plugin thread) and PluginThreadHandle (main thread).
 pub type AsyncResourceOwners = Arc<std::sync::Mutex<HashMap<u64, String>>>;
 
+/// Plugin event handler registry shared between the plugin thread (which
+/// reads + mutates on `on` / `off` / `emit` / `cleanup_plugin`) and the
+/// editor thread (which only does cheap "does anyone listen?" lookups
+/// via `has_subscribers` to gate expensive per-render hook arg building).
+///
+/// Switched from `Rc<RefCell<...>>` to `Arc<RwLock<...>>` so the editor
+/// thread can read it lock-free in the uncontended case (read fast path).
+pub type EventHandlerRegistry = Arc<RwLock<HashMap<String, Vec<PluginHandler>>>>;
+
 #[derive(Debug, Clone)]
 pub struct PluginHandler {
     pub plugin_name: String,
@@ -766,7 +775,7 @@ pub struct JsEditorApi {
     #[qjs(skip_trace)]
     registered_actions: Rc<RefCell<HashMap<String, PluginHandler>>>,
     #[qjs(skip_trace)]
-    event_handlers: Rc<RefCell<HashMap<String, Vec<PluginHandler>>>>,
+    event_handlers: EventHandlerRegistry,
     #[qjs(skip_trace)]
     next_request_id: Rc<RefCell<u64>>,
     #[qjs(skip_trace)]
@@ -1756,7 +1765,8 @@ impl JsEditorApi {
             let _ = self.command_sender.send(PluginCommand::RefreshAllLines);
         }
         self.event_handlers
-            .borrow_mut()
+            .write()
+            .expect("event_handlers poisoned")
             .entry(event_name)
             .or_default()
             .push(PluginHandler {
@@ -1767,7 +1777,12 @@ impl JsEditorApi {
 
     /// Unsubscribe from an event
     pub fn off(&self, event_name: String, handler_name: String) {
-        if let Some(list) = self.event_handlers.borrow_mut().get_mut(&event_name) {
+        if let Some(list) = self
+            .event_handlers
+            .write()
+            .expect("event_handlers poisoned")
+            .get_mut(&event_name)
+        {
             list.retain(|h| h.handler_name != handler_name);
         }
     }
@@ -4349,7 +4364,8 @@ impl JsEditorApi {
     /// Get registered event handlers for an event
     pub fn get_handlers(&self, event_name: String) -> Vec<String> {
         self.event_handlers
-            .borrow()
+            .read()
+            .expect("event_handlers poisoned")
             .get(&event_name)
             .cloned()
             .unwrap_or_default()
@@ -5607,8 +5623,10 @@ pub struct QuickJsBackend {
     main_context: Context,
     /// Plugin-specific contexts: plugin_name -> Context
     plugin_contexts: Rc<RefCell<HashMap<String, Context>>>,
-    /// Event handlers: event_name -> list of PluginHandler
-    event_handlers: Rc<RefCell<HashMap<String, Vec<PluginHandler>>>>,
+    /// Event handlers: event_name -> list of PluginHandler.
+    /// Shared with the editor thread so it can cheaply check
+    /// "does anyone listen to this hook?" — see `EventHandlerRegistry`.
+    event_handlers: EventHandlerRegistry,
     /// Registered actions: action_name -> PluginHandler
     registered_actions: Rc<RefCell<HashMap<String, PluginHandler>>>,
     /// Editor state snapshot (read-only access)
@@ -5685,6 +5703,8 @@ impl QuickJsBackend {
         let async_resource_owners: AsyncResourceOwners =
             Arc::new(std::sync::Mutex::new(HashMap::new()));
         let search_handles: SearchHandleRegistry = Arc::new(std::sync::Mutex::new(HashMap::new()));
+        let event_handlers: EventHandlerRegistry =
+            Arc::new(RwLock::new(HashMap::new()));
         Self::with_state_responses_and_resources(
             state_snapshot,
             command_sender,
@@ -5692,6 +5712,7 @@ impl QuickJsBackend {
             services,
             async_resource_owners,
             search_handles,
+            event_handlers,
         )
     }
 
@@ -5704,6 +5725,7 @@ impl QuickJsBackend {
         services: Arc<dyn fresh_core::services::PluginServiceBridge>,
         async_resource_owners: AsyncResourceOwners,
         search_handles: SearchHandleRegistry,
+        event_handlers: EventHandlerRegistry,
     ) -> Result<Self> {
         tracing::debug!("QuickJsBackend::new: creating QuickJS runtime");
 
@@ -5741,7 +5763,6 @@ impl QuickJsBackend {
             .map_err(|e| anyhow!("Failed to create QuickJS context: {}", e))?;
 
         let plugin_contexts = Rc::new(RefCell::new(HashMap::new()));
-        let event_handlers = Rc::new(RefCell::new(HashMap::new()));
         let registered_actions = Rc::new(RefCell::new(HashMap::new()));
         let next_request_id = Rc::new(RefCell::new(1u64));
         let callback_contexts = Rc::new(RefCell::new(HashMap::new()));
@@ -5785,7 +5806,7 @@ impl QuickJsBackend {
     fn setup_context_api(&self, context: &Context, plugin_name: &str) -> Result<()> {
         let state_snapshot = Arc::clone(&self.state_snapshot);
         let command_sender = self.command_sender.clone();
-        let event_handlers = Rc::clone(&self.event_handlers);
+        let event_handlers = Arc::clone(&self.event_handlers);
         let registered_actions = Rc::clone(&self.registered_actions);
         let next_request_id = Rc::clone(&self.next_request_id);
         let registered_command_names = Rc::clone(&self.registered_command_names);
@@ -5806,7 +5827,7 @@ impl QuickJsBackend {
                 state_snapshot: Arc::clone(&state_snapshot),
                 command_sender: command_sender.clone(),
                 registered_actions: Rc::clone(&registered_actions),
-                event_handlers: Rc::clone(&event_handlers),
+                event_handlers: Arc::clone(&event_handlers),
                 next_request_id: Rc::clone(&next_request_id),
                 callback_contexts: Rc::clone(&self.callback_contexts),
                 services: self.services.clone(),
@@ -6300,8 +6321,18 @@ impl QuickJsBackend {
         self.plugin_contexts.borrow_mut().remove(plugin_name);
 
         // 2. Remove event handlers for this plugin
-        for handlers in self.event_handlers.borrow_mut().values_mut() {
-            handlers.retain(|h| h.plugin_name != plugin_name);
+        {
+            let mut handlers_map = self
+                .event_handlers
+                .write()
+                .expect("event_handlers poisoned");
+            for handlers in handlers_map.values_mut() {
+                handlers.retain(|h| h.plugin_name != plugin_name);
+            }
+            // Drop any keys whose lists are now empty so a future
+            // `has_subscribers(name)` check returns the right answer
+            // without scanning a stale empty Vec.
+            handlers_map.retain(|_, list| !list.is_empty());
         }
 
         // 3. Remove registered actions for this plugin
@@ -6486,7 +6517,12 @@ impl QuickJsBackend {
         self.services
             .set_js_execution_state(format!("hook '{}'", event_name));
 
-        let handlers = self.event_handlers.borrow().get(event_name).cloned();
+        let handlers = self
+            .event_handlers
+            .read()
+            .expect("event_handlers poisoned")
+            .get(event_name)
+            .cloned();
         if let Some(handler_pairs) = handlers {
             let plugin_contexts = self.plugin_contexts.borrow();
             for handler in &handler_pairs {
@@ -6506,7 +6542,8 @@ impl QuickJsBackend {
     /// Check if any handlers are registered for an event
     pub fn has_handlers(&self, event_name: &str) -> bool {
         self.event_handlers
-            .borrow()
+            .read()
+            .expect("event_handlers poisoned")
             .get(event_name)
             .map(|v| !v.is_empty())
             .unwrap_or(false)
@@ -6946,7 +6983,8 @@ mod tests {
         // Register a handler
         backend
             .event_handlers
-            .borrow_mut()
+            .write()
+            .unwrap()
             .entry("test_event".to_string())
             .or_default()
             .push(PluginHandler {

--- a/crates/fresh-plugin-runtime/src/thread.rs
+++ b/crates/fresh-plugin-runtime/src/thread.rs
@@ -217,6 +217,12 @@ pub struct PluginThreadHandle {
     /// write directly into the same shared state the JS side drains via
     /// `_searchHandleTake`.
     search_handles: SearchHandleRegistry,
+
+    /// Shared registry of `event_handlers` so the editor thread can
+    /// cheaply ask "does any plugin subscribe to hook X?" before doing
+    /// expensive per-render work (e.g. building hook args). See
+    /// `EventHandlerRegistry` in `quickjs_backend.rs`.
+    event_handlers: crate::backend::quickjs_backend::EventHandlerRegistry,
 }
 
 impl PluginThreadHandle {
@@ -244,6 +250,13 @@ impl PluginThreadHandle {
         let search_handles: SearchHandleRegistry =
             Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
         let thread_search_handles = Arc::clone(&search_handles);
+
+        // Plugin event-handler registry, shared with the editor thread so
+        // the renderer can skip expensive hook arg building when no plugin
+        // subscribes.
+        let event_handlers: crate::backend::quickjs_backend::EventHandlerRegistry =
+            Arc::new(RwLock::new(std::collections::HashMap::new()));
+        let thread_event_handlers = Arc::clone(&event_handlers);
 
         // Create channel for requests (unbounded allows sync send, async recv)
         let (request_sender, request_receiver) = tokio::sync::mpsc::unbounded_channel();
@@ -279,6 +292,7 @@ impl PluginThreadHandle {
                 services.clone(),
                 thread_async_resource_owners,
                 thread_search_handles,
+                thread_event_handlers,
             ) {
                 Ok(rt) => {
                     tracing::debug!("Plugin thread: QuickJS runtime created successfully");
@@ -317,12 +331,25 @@ impl PluginThreadHandle {
             command_receiver,
             async_resource_owners,
             search_handles,
+            event_handlers,
         })
     }
 
     /// Accessor for the streaming-search handle registry.
     pub fn search_handles_handle(&self) -> SearchHandleRegistry {
         Arc::clone(&self.search_handles)
+    }
+
+    /// Non-blocking check: does any loaded plugin subscribe to `hook_name`?
+    /// Used by the renderer to skip building expensive hook args (e.g.
+    /// the full tokenized viewport for `view_transform_request`) when
+    /// nothing would consume them. Reads from the shared
+    /// `event_handlers` registry directly — no channel round-trip.
+    pub fn has_subscribers(&self, hook_name: &str) -> bool {
+        self.event_handlers
+            .read()
+            .map(|h| h.get(hook_name).is_some_and(|v| !v.is_empty()))
+            .unwrap_or(false)
     }
 
     /// Check if the plugin thread is still alive


### PR DESCRIPTION
## Summary

Fixes the runaway idle CPU usage in Fresh (#2009, #2012). Three layered fixes:

- **Throttle built-in git plugins** (`git_statusbar`, `merge_conflict`) so they don't spawn `git` subprocesses on every editor event. Net: ~4× fewer `git rev-parse` calls per refresh in `git_statusbar`, and tab switches no longer re-run `git rev-parse --is-inside-work-tree` + `git ls-files -u` for the same path.
- **Break the render → plugin-ack → render feedback loop** by treating no-op `SetStatusBarValue` commands as non-visual at the engine command dispatcher. Plugins re-publishing the same value (very common pattern) no longer trigger a fresh redraw.
- **Drive `git_statusbar` off `watchPath(.git/HEAD)`** instead of `render_start`, and skip the `view_transform_request` hook + its tokenized-viewport payload entirely when no plugin subscribes (none do today).

Closes #2009. Closes #2012.

## Commits

- `4bbcbc053` — `git_statusbar` race-on-debounce fix; `merge_conflict` per-directory git-repo cache + 30s per-path TTL.
- `90b664c8a` — `process_plugin_commands` classifier ignores `SetStatusBarValue` writes that match the current stored value.
- `3beda6b7f` — `git_statusbar` rewritten to use `watchPath` on the HEAD file (worktree / submodule-safe via `git rev-parse --git-path HEAD`); `event_handlers` upgraded to `Arc<RwLock<...>>` so the renderer can lock-free check subscribers and skip `view_transform_request` (with its heavy token-build) when no plugin listens.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `cargo nextest run -p fresh-plugin-runtime` — 109/109 passing.
- [ ] Open Fresh in a git repo, leave idle for ~30s, confirm CPU drops to ~0 (was 40-75% of one core).
- [ ] Run `git checkout other-branch` in an external terminal while Fresh is unfocused; refocus and confirm the branch label in the status bar updates.
- [ ] Switch between several open tabs quickly; confirm no flurry of `git` subprocesses in `htop`.
- [ ] Open a file with merge conflicts; confirm `merge_conflict` plugin still detects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)