### PR TITLE
Suppress column rulers on virtual buffers

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -564,6 +564,19 @@ pub(crate) fn render_content(
             let effective_highlight_current_line =
                 view_prefs.highlight_current_line && state.show_cursors;
 
+            // Column rulers are a source-code editing aid; virtual buffers
+            // (dashboard, *Diagnostics*, grep results, ...) aren't code, so
+            // the config-driven rulers would just paint stripes over plugin
+            // chrome. Suppress them for any virtual buffer.
+            let is_virtual_buffer = buffer_metadata
+                .get(&buffer_id)
+                .is_some_and(|m| m.is_virtual());
+            let effective_rulers: &[usize] = if is_virtual_buffer {
+                &[]
+            } else {
+                &view_prefs.rulers
+            };
+
             let mut empty_folds = FoldManager::new();
             let folds = split_view_states
                 .as_deref_mut()
@@ -597,7 +610,7 @@ pub(crate) fn render_content(
                 use_terminal_bg,
                 session_mode,
                 software_cursor_only,
-                &view_prefs.rulers,
+                effective_rulers,
                 view_prefs.show_line_numbers,
                 effective_highlight_current_line,
                 diagnostics_inline_text,

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -167,11 +167,10 @@ fn test_no_rulers_on_virtual_buffer() {
 
     let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
 
-    let dashboard_buffer = harness.editor_mut().active_window_mut().create_virtual_buffer(
-        "Dashboard".to_string(),
-        "dashboard".to_string(),
-        true,
-    );
+    let dashboard_buffer = harness
+        .editor_mut()
+        .active_window_mut()
+        .create_virtual_buffer("Dashboard".to_string(), "dashboard".to_string(), true);
     harness
         .editor_mut()
         .set_virtual_buffer_content(

--- a/crates/fresh-editor/tests/e2e/vertical_rulers.rs
+++ b/crates/fresh-editor/tests/e2e/vertical_rulers.rs
@@ -157,6 +157,46 @@ fn test_no_rulers_by_default() {
     }
 }
 
+/// Regression: virtual buffers (Dashboard, *Diagnostics*, grep results, ...)
+/// must not paint the config-driven column rulers. They aren't source code,
+/// and the ruler stripes would otherwise overlay plugin chrome.
+#[test]
+fn test_no_rulers_on_virtual_buffer() {
+    let mut config = Config::default();
+    config.editor.rulers = vec![10, 20];
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+
+    let dashboard_buffer = harness.editor_mut().active_window_mut().create_virtual_buffer(
+        "Dashboard".to_string(),
+        "dashboard".to_string(),
+        true,
+    );
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            dashboard_buffer,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                &"X".repeat(60),
+            )],
+        )
+        .unwrap();
+    harness.editor_mut().switch_buffer(dashboard_buffer);
+    harness.render().unwrap();
+
+    let (content_first_row, _) = harness.content_area_rows();
+    let row = content_first_row as u16;
+
+    assert!(
+        !has_ruler_bg(&harness, gutter_width(&harness) + 10, row),
+        "Virtual buffer should not paint a ruler at column 10"
+    );
+    assert!(
+        !has_ruler_bg(&harness, gutter_width(&harness) + 20, row),
+        "Virtual buffer should not paint a ruler at column 20"
+    );
+}
+
 /// Test that ruler uses the theme's ruler_bg color.
 #[test]
 fn test_ruler_uses_theme_color() {


### PR DESCRIPTION
## Summary
Column rulers configured in the editor settings are now suppressed when rendering virtual buffers (Dashboard, Diagnostics, grep results, etc.). These buffers are not source code and should not display the ruler stripes, which would otherwise overlay plugin UI chrome.

## Changes
- **Rendering logic**: Modified `render_content()` in `split_rendering/orchestration/mod.rs` to detect virtual buffers and pass an empty rulers list to the rendering pipeline instead of the configured rulers
- **Test coverage**: Added regression test `test_no_rulers_on_virtual_buffer()` to verify that configured column rulers (at columns 10 and 20) are not painted on virtual buffers

## Implementation Details
The fix checks the buffer metadata to determine if a buffer is virtual using `is_virtual()`. When rendering a virtual buffer, an empty slice is used for the rulers parameter instead of the user-configured rulers from view preferences. This ensures virtual buffers remain clean without ruler overlays while preserving ruler behavior for regular source code buffers.

https://claude.ai/code/session_01HWz1rNK3hAW3TFWuSRiZrp