### PR TITLE
fix(orchestrator): default-focus the + New Session button; design doc for base-path/worktree dialog

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1643,6 +1643,29 @@ pub enum WidgetSpec {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },
+    /// Float `child` over the rest of the layout instead of
+    /// consuming vertical space. Placed inside a `Col`, the
+    /// overlay anchors at the row it would have occupied if it
+    /// were a regular child — but the rows below it DO NOT
+    /// shift down. At paint time the overlay is drawn last,
+    /// over whatever's beneath it, like a tooltip / popup.
+    ///
+    /// Use case: dropdown completions, hover popups, transient
+    /// hints that should appear right next to the focused
+    /// widget without reflowing the rest of the panel each
+    /// time they show / hide.
+    ///
+    /// Hit testing: overlays paint on top, so clicks inside an
+    /// overlay's region go to the overlay (not whatever's
+    /// underneath). Tab cycle: the host's `collect_tabbable`
+    /// walks into the overlay's child like any other widget;
+    /// give the child a `key` if you want it focusable, or
+    /// leave it keyless to keep it out of the cycle.
+    Overlay {
+        child: Box<WidgetSpec>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key: Option<String>,
+    },
 }
 
 impl WidgetSpec {
@@ -1664,7 +1687,9 @@ impl WidgetSpec {
             WidgetSpec::Row { children, .. } | WidgetSpec::Col { children, .. } => {
                 Box::new(children.iter())
             }
-            WidgetSpec::LabeledSection { child, .. } => Box::new(std::iter::once(child.as_ref())),
+            WidgetSpec::LabeledSection { child, .. } | WidgetSpec::Overlay { child, .. } => {
+                Box::new(std::iter::once(child.as_ref()))
+            }
             _ => Box::new(std::iter::empty()),
         }
     }
@@ -1678,7 +1703,9 @@ impl WidgetSpec {
             WidgetSpec::Row { children, .. } | WidgetSpec::Col { children, .. } => {
                 Box::new(children.iter_mut())
             }
-            WidgetSpec::LabeledSection { child, .. } => Box::new(std::iter::once(child.as_mut())),
+            WidgetSpec::LabeledSection { child, .. } | WidgetSpec::Overlay { child, .. } => {
+                Box::new(std::iter::once(child.as_mut()))
+            }
             _ => Box::new(std::iter::empty()),
         }
     }

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -400,6 +400,27 @@ pub struct WindowInfo {
     /// Absolute project root.
     #[ts(type = "string")]
     pub root: PathBuf,
+    /// Project this session belongs to — the canonical repo
+    /// root (or arbitrary directory) the user pointed the
+    /// new-session form at. `null` for legacy sessions that
+    /// predate the Project Path field. The Orchestrator Open
+    /// dialog filters by this so the "this project's sessions"
+    /// view is one keystroke away from the all-projects view.
+    #[ts(type = "string | null")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub project_path: Option<PathBuf>,
+    /// `true` when the session shares its working tree with
+    /// other sessions (worktree-creation was off at session
+    /// time, or the session lives in a non-git directory).
+    /// Persistence-only field; defaults to `false` and isn't
+    /// emitted when false.
+    #[ts(type = "boolean")]
+    #[serde(skip_serializing_if = "is_false_field", default)]
+    pub shared_worktree: bool,
+}
+
+fn is_false_field(b: &bool) -> bool {
+    !b
 }
 
 /// Information about a buffer

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1016,6 +1016,10 @@ type WidgetSpec = {
 	"kind": "raw";
 	entries: Array<TextPropertyEntry>;
 	key?: string | null;
+} | {
+	"kind": "overlay";
+	child: WidgetSpec;
+	key?: string | null;
 };
 type WidgetAction = {
 	"kind": "focusAdvance";

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -456,6 +456,23 @@ type WindowInfo = {
 	* Absolute project root.
 	*/
 	root: string;
+	/**
+	* Project this session belongs to — the canonical repo
+	* root (or arbitrary directory) the user pointed the
+	* new-session form at. `null` for legacy sessions that
+	* predate the Project Path field. The Orchestrator Open
+	* dialog filters by this so the "this project's sessions"
+	* view is one keystroke away from the all-projects view.
+	*/
+	project_path?: string | null;
+	/**
+	* `true` when the session shares its working tree with
+	* other sessions (worktree-creation was off at session
+	* time, or the session lives in a non-git directory).
+	* Persistence-only field; defaults to `false` and isn't
+	* emitted when false.
+	*/
+	shared_worktree?: boolean;
 };
 type JsDiagnostic = {
 	/**

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -472,6 +472,30 @@ export function labeledSection(options: {
   };
 }
 
+/** Float `child` over the rest of the layout instead of consuming
+ * vertical space. Place inside a `Col` at the position where you
+ * want the overlay to anchor — at paint time the child renders
+ * at that row but DOES NOT push the rows below it down. Used for
+ * dropdown completions, tooltips, hover popups — anything that
+ * should appear next to a focused widget without reflowing the
+ * panel each time it shows or hides.
+ *
+ * Hit-testing: overlays paint on top, so clicks inside the
+ * overlay's region go to the overlay (not what's underneath).
+ * Tab cycle: the child IS walked for tabbable keys — give it a
+ * `key` if you want focus to reach it, or leave it keyless to
+ * keep it out of the cycle (the typical popup case). */
+export function overlay(
+  child: WidgetSpec,
+  options?: { key?: string },
+): WidgetSpec {
+  return {
+    kind: "overlay",
+    child,
+    key: options?.key,
+  };
+}
+
 // =============================================================================
 // HintEntry parsing — for the legacy `Tab:section  Esc:close` format
 // shipped in existing plugin i18n bundles.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -174,6 +174,22 @@ interface NewSessionForm {
   // we squirrel away whatever was in `value` so Down can
   // restore it.
   historyDraft: { project_path: string; name: string; cmd: string; branch: string };
+  // Inline-dropdown completion state. `field` names which input
+  // the suggestion list belongs to; the list is only rendered
+  // while that input is focused. `items` is the post-filter set
+  // (already in display order); `selectedIndex` is the
+  // highlighted row. `anchor` is the value the user had typed
+  // when the candidates were last fetched — used to ignore
+  // stale async results that land after the user keeps typing.
+  // `token` mirrors the project-path probe pattern: every fresh
+  // fetch bumps it; results bail if they're not the latest.
+  completion: {
+    field: "project_path" | "branch" | null;
+    items: string[];
+    selectedIndex: number;
+    anchor: string;
+    token: number;
+  };
 }
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
@@ -2030,6 +2046,7 @@ function buildFormSpec(): WidgetSpec {
         key: "project_path",
       }),
     }),
+    ...maybeCompletionList("project_path"),
     // === Worktree toggle. ========================================
     // Enabled only when the Project Path resolves to a git work
     // tree. When disabled, render with a dim-fg `raw` row using
@@ -2108,6 +2125,7 @@ function buildFormSpec(): WidgetSpec {
         key: branchInert ? undefined : "branch",
       }),
     }),
+    ...maybeCompletionList("branch"),
   ];
   if (form.lastError) {
     children.push(spacer(0));
@@ -2206,6 +2224,7 @@ function openForm(options?: { fromPicker?: boolean }): void {
     probeToken: 0,
     historyCursor: { project_path: -1, name: -1, cmd: -1, branch: -1 },
     historyDraft: { project_path: "", name: "", cmd: "", branch: "" },
+    completion: { field: null, items: [], selectedIndex: 0, anchor: "", token: 0 },
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
@@ -2293,6 +2312,232 @@ function scheduleProjectPathReprobe(): void {
     if (!form || form.probeToken !== token) return;
     void probeProjectPathDefaults();
   });
+}
+
+// =============================================================================
+// Inline-dropdown completion (Phase 7)
+//
+// For Project Path and Branch we render a `list` below the input
+// when the candidate set is non-empty. Candidates are fetched
+// asynchronously (filesystem read for paths, git for branches);
+// the `completion.token` makes only the freshest fetch's result
+// land — same pattern as the project-path is-git probe.
+// =============================================================================
+
+const COMPLETION_VISIBLE_ROWS = 6;
+const COMPLETION_MAX_ITEMS = 50;
+
+/// Fire a fresh fetch of completion candidates for the named
+/// field. Stale fetches (older `token`) discard their results
+/// on completion. Caller is responsible for re-rendering once
+/// the fetch lands — `setCompletionItems` does that.
+function scheduleCompletionRefresh(
+  field: "project_path" | "branch",
+): void {
+  if (!form) return;
+  const anchor = form[field === "project_path" ? "projectPath" : "branch"].value;
+  const token = ++form.completion.token;
+  form.completion.field = field;
+  form.completion.anchor = anchor;
+  // Debounce: same 150ms feel as a snappy file picker. Don't
+  // collapse with the project-path probe (which runs at 200ms)
+  // because the completion list is interactive — every extra
+  // tick of latency reads as "the editor isn't keeping up".
+  void editor.delay(150).then(async () => {
+    if (!form || form.completion.token !== token) return;
+    const items = field === "project_path"
+      ? await fetchPathCompletions(anchor)
+      : await fetchBranchCompletions(anchor);
+    if (!form || form.completion.token !== token) return;
+    setCompletionItems(field, items);
+  });
+}
+
+function setCompletionItems(
+  field: "project_path" | "branch",
+  items: string[],
+): void {
+  if (!form) return;
+  form.completion.field = field;
+  form.completion.items = items.slice(0, COMPLETION_MAX_ITEMS);
+  form.completion.selectedIndex = 0;
+  renderForm();
+}
+
+function closeCompletion(): void {
+  if (!form) return;
+  if (form.completion.field === null && form.completion.items.length === 0) {
+    return;
+  }
+  form.completion.field = null;
+  form.completion.items = [];
+  form.completion.selectedIndex = 0;
+  form.completion.token += 1; // invalidate any in-flight fetch
+  renderForm();
+}
+
+/// Split typed Project Path into (parent, basename), list
+/// `parent` via the host's `readDir`, and filter to entries
+/// whose name starts with `basename`. Directories get a
+/// trailing `/` so the user sees the type and Tab keeps
+/// descending. Empty input lists the user's home directory's
+/// top-level entries as a starting point.
+async function fetchPathCompletions(typed: string): Promise<string[]> {
+  // Heuristic for "where to list". `parent` is everything up
+  // to and including the last `/`; `basename` is the unfinished
+  // tail we filter on. `/foo/ba` → parent `/foo/`, basename
+  // `ba`. `bar` (no slash) → parent `.`, basename `bar`. `/`
+  // → parent `/`, basename `""`.
+  const slashIdx = typed.lastIndexOf("/");
+  let parent: string;
+  let basename: string;
+  if (slashIdx < 0) {
+    parent = typed ? "." : editor.getCwd();
+    basename = typed;
+  } else if (slashIdx === 0) {
+    parent = "/";
+    basename = typed.slice(1);
+  } else {
+    parent = typed.slice(0, slashIdx);
+    basename = typed.slice(slashIdx + 1);
+  }
+  const entries = editor.readDir(parent);
+  const matches = entries
+    .filter((e) => !basename || e.name.startsWith(basename))
+    .filter((e) => !e.name.startsWith(".") || basename.startsWith(".")); // hide dotfiles unless asked
+  matches.sort((a, b) => {
+    // Dirs before files; then alphabetical.
+    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  // Render each item as the full path so accepting it
+  // overwrites the input cleanly (no string-stitching at
+  // accept time).
+  const prefix = parent.endsWith("/") ? parent : `${parent}/`;
+  return matches.map((e) => `${prefix}${e.name}${e.is_dir ? "/" : ""}`);
+}
+
+/// List the project's local + remote branches and tags via
+/// `git for-each-ref` (one subprocess instead of three). Filter
+/// by substring of the typed value — branch names commonly
+/// carry slash-separated prefixes (`feat/`, `release/`) that
+/// the user often doesn't type first.
+async function fetchBranchCompletions(typed: string): Promise<string[]> {
+  if (!form) return [];
+  const projectPath = form.projectPath.value.trim() || form.defaultProjectPath;
+  if (!projectPath) return [];
+  if (form.projectPathIsGit === false) return [];
+  const res = await spawnCollect(
+    "git",
+    [
+      "-C",
+      projectPath,
+      "for-each-ref",
+      "--format=%(refname:short)",
+      "refs/heads/",
+      "refs/remotes/",
+      "refs/tags/",
+    ],
+    projectPath,
+  );
+  if (res.exit_code !== 0) return [];
+  const lines = (res.stdout || "")
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && l !== "origin/HEAD");
+  const needle = typed.toLowerCase();
+  const matches = needle
+    ? lines.filter((l) => l.toLowerCase().includes(needle))
+    : lines;
+  // Dedup the common `origin/<branch>` vs `<branch>` pair when
+  // the local copy exists. Prefer the local short name; drop the
+  // origin alias unless the user explicitly typed `origin`.
+  const local = new Set(matches.filter((l) => !l.includes("/")));
+  const wantsOrigin = needle.startsWith("origin/");
+  const filtered = matches.filter((l) => {
+    if (!wantsOrigin && l.startsWith("origin/")) {
+      const bare = l.slice("origin/".length);
+      if (local.has(bare)) return false;
+    }
+    return true;
+  });
+  // Stable order: exact-match-first, then prefix-match, then
+  // substring; ties broken by length so shorter names surface.
+  filtered.sort((a, b) => {
+    const ascore = a.toLowerCase() === needle ? 0 : a.toLowerCase().startsWith(needle) ? 1 : 2;
+    const bscore = b.toLowerCase() === needle ? 0 : b.toLowerCase().startsWith(needle) ? 1 : 2;
+    if (ascore !== bscore) return ascore - bscore;
+    return a.length - b.length || a.localeCompare(b);
+  });
+  return filtered;
+}
+
+/// Apply the highlighted completion to its field, dismiss the
+/// dropdown, and (for Project Path) re-probe defaults. Accepts
+/// the currently selected item; if the list is empty it's a
+/// no-op. For directories (path ends with `/`), the field stays
+/// open so the user can keep typing or `Tab` again to descend.
+function acceptCompletion(): boolean {
+  if (!form) return false;
+  const c = form.completion;
+  if (c.field === null || c.items.length === 0) return false;
+  const item = c.items[c.selectedIndex];
+  if (!item) return false;
+  const slot = c.field === "project_path" ? form.projectPath : form.branch;
+  slot.value = item;
+  slot.cursor = item.length;
+  if (formPanel) formPanel.setValue(c.field, slot.value, slot.cursor);
+  if (c.field === "project_path") {
+    // Re-trigger the is-git probe + default-branch / session-
+    // name placeholder probes for the new path. Also re-fetch
+    // path completions in case the user accepted a directory
+    // and wants to keep descending — they get a fresh list of
+    // children right away.
+    scheduleProjectPathReprobe();
+    if (item.endsWith("/")) {
+      scheduleCompletionRefresh("project_path");
+      return true;
+    }
+  }
+  closeCompletion();
+  return true;
+}
+
+/// Build a `list` widget for the named field's completion
+/// dropdown. Returns an empty array when the dropdown shouldn't
+/// render — either no candidates fetched yet, the field isn't
+/// the one we're completing, or the input doesn't have focus
+/// (no point showing completions for an input the user isn't
+/// editing). Returned as an array so the caller can spread it
+/// into `children` for the conditional render.
+///
+/// The list is keyless (`focusable: false`, no `key`), so it
+/// stays out of the Tab cycle — it's a "suggestion strip"
+/// scoped to its input. Up/Down on the input route here via the
+/// `walkCompletion` helper instead of plain widget focus moves.
+function maybeCompletionList(field: "project_path" | "branch"): WidgetSpec[] {
+  if (!form) return [];
+  if (form.completion.field !== field) return [];
+  if (form.completion.items.length === 0) return [];
+  if (formFocusedKey() !== field) return [];
+  const items = form.completion.items.map((s) =>
+    styledRow([{ text: s }]),
+  );
+  return [
+    list({
+      items,
+      selectedIndex: form.completion.selectedIndex,
+      visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
+      // Not in the Tab cycle (Up/Down on the focused INPUT
+      // walks the list via the smart-key handler) but keyed
+      // so the host's single-line-Text-+-sibling-list "picker
+      // Enter" wiring routes Enter on the focused input into
+      // an activate event on this list — which the form's
+      // widget_event handler turns into `acceptCompletion()`.
+      focusable: false,
+      key: "completion",
+    }),
+  ];
 }
 
 function closeForm(): void {
@@ -2495,17 +2740,37 @@ function dispatchFormKey(name: string): void {
 }
 
 registerHandler("orchestrator_form_key_tab", () => {
+  // If the completion dropdown is showing for the focused
+  // input, Tab accepts the highlighted suggestion instead of
+  // advancing focus — matches the convention users expect from
+  // shell / IDE completion popups.
+  if (completionVisibleForFocused()) {
+    acceptCompletion();
+    return;
+  }
   advanceFormFocus(1);
   dispatchFormKey("Tab");
 });
 registerHandler(
   "orchestrator_form_key_shift_tab",
   () => {
+    // Shift+Tab doesn't accept — it always reverses focus.
+    // (The convention is that S-Tab is the "go back" gesture;
+    // overloading it to accept-then-go-back is more confusing
+    // than useful.)
+    closeCompletion();
     advanceFormFocus(-1);
     dispatchFormKey("Shift+Tab");
   },
 );
 registerHandler("orchestrator_form_key_escape", () => {
+  // Esc closes the completion dropdown first; only when there's
+  // no dropdown does it cancel the dialog. Matches how popup-
+  // based UIs (browsers, shells) layer dismissal.
+  if (completionVisibleForFocused()) {
+    closeCompletion();
+    return;
+  }
   if (form) cancelForm();
 });
 registerHandler(
@@ -2518,6 +2783,14 @@ registerHandler("orchestrator_form_key_end", () => dispatchFormKey("End"));
 registerHandler("orchestrator_form_key_left", () => dispatchFormKey("Left"));
 registerHandler("orchestrator_form_key_right", () => dispatchFormKey("Right"));
 registerHandler("orchestrator_form_key_up", () => {
+  // Completion-list-aware navigation: when the dropdown is
+  // open for the focused input, ↑↓ navigates the list
+  // (overrides history). Otherwise ↑↓ walks history for
+  // history-bearing inputs; otherwise pass through.
+  if (completionVisibleForFocused()) {
+    walkCompletion(-1);
+    return;
+  }
   const histField = focusToHistoryField(formFocusedKey());
   if (histField) {
     walkHistory(histField, -1);
@@ -2526,6 +2799,10 @@ registerHandler("orchestrator_form_key_up", () => {
   }
 });
 registerHandler("orchestrator_form_key_down", () => {
+  if (completionVisibleForFocused()) {
+    walkCompletion(1);
+    return;
+  }
   const histField = focusToHistoryField(formFocusedKey());
   if (histField) {
     walkHistory(histField, 1);
@@ -2533,6 +2810,26 @@ registerHandler("orchestrator_form_key_down", () => {
     dispatchFormKey("Down");
   }
 });
+
+/// Is the completion dropdown showing for the currently focused
+/// input? Returns false when there are no items, when the
+/// dropdown is for a different field, or when focus is on a
+/// non-input.
+function completionVisibleForFocused(): boolean {
+  if (!form) return false;
+  const c = form.completion;
+  if (c.field === null || c.items.length === 0) return false;
+  return formFocusedKey() === c.field;
+}
+
+function walkCompletion(delta: -1 | 1): void {
+  if (!form) return;
+  const c = form.completion;
+  if (c.items.length === 0) return;
+  c.selectedIndex =
+    (c.selectedIndex + delta + c.items.length) % c.items.length;
+  renderForm();
+}
 
 // Printable input arrives via the global `mode_text_input` action.
 // Other plugins may also register a `mode_text_input` handler;
@@ -2643,6 +2940,13 @@ editor.on("widget_event", (e) => {
       }
       if (field === "project_path") {
         scheduleProjectPathReprobe();
+        scheduleCompletionRefresh("project_path");
+      } else if (field === "branch") {
+        scheduleCompletionRefresh("branch");
+      } else {
+        // Any other field's change implicitly closes the
+        // dropdown (the user moved on).
+        closeCompletion();
       }
       return;
     }
@@ -2658,10 +2962,30 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "activate") {
+      if (e.widget_key === "completion") {
+        // Enter on a focused Project Path / Branch input with
+        // an active dropdown lands here via the host's
+        // single-line-Text-+-sibling-list picker wiring.
+        acceptCompletion();
+        return;
+      }
       if (e.widget_key === "create") {
         void submitForm();
       } else if (e.widget_key === "cancel") {
         cancelForm();
+      }
+      return;
+    }
+    if (e.event_type === "select" && e.widget_key === "completion") {
+      // Mouse click on a completion row: update our mirror
+      // and accept immediately (treating the click like a
+      // tap-to-pick rather than a tap-to-highlight). The
+      // host's select event carries the selected `index`.
+      const payload = (e.payload ?? {}) as Record<string, unknown>;
+      const idx = payload.index;
+      if (typeof idx === "number" && form.completion.items[idx]) {
+        form.completion.selectedIndex = idx;
+        acceptCompletion();
       }
       return;
     }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -26,6 +26,7 @@ import {
   labeledSection,
   list,
   row,
+  overlay,
   spacer,
   styledRow,
   text,
@@ -2524,19 +2525,22 @@ function maybeCompletionList(field: "project_path" | "branch"): WidgetSpec[] {
     styledRow([{ text: s }]),
   );
   return [
-    list({
-      items,
-      selectedIndex: form.completion.selectedIndex,
-      visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
-      // Not in the Tab cycle (Up/Down on the focused INPUT
-      // walks the list via the smart-key handler) but keyed
-      // so the host's single-line-Text-+-sibling-list "picker
-      // Enter" wiring routes Enter on the focused input into
-      // an activate event on this list — which the form's
-      // widget_event handler turns into `acceptCompletion()`.
-      focusable: false,
-      key: "completion",
-    }),
+    overlay(
+      list({
+        items,
+        selectedIndex: form.completion.selectedIndex,
+        visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
+        // Not in the Tab cycle (Up/Down on the focused INPUT
+        // walks the list via the smart-key handler) but keyed
+        // so the host's single-line-Text-+-sibling-list
+        // "picker Enter" wiring routes Enter on the focused
+        // input into an activate event on this list — which
+        // the form's widget_event handler turns into
+        // `acceptCompletion()`.
+        focusable: false,
+        key: "completion",
+      }),
+    ),
   ];
 }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1807,9 +1807,6 @@ function buildFormSpec(): WidgetSpec {
   // state — no flicker on rapid typing.
   const worktreeEnabled = form.projectPathIsGit !== false;
   const effectiveCreateWorktree = worktreeEnabled && form.createWorktree;
-  const worktreeSuffix = worktreeEnabled
-    ? ""
-    : "  (disabled — non-git)";
   const branchInert = !effectiveCreateWorktree;
 
   // Branch placeholder: surface origin/main, fall back to a
@@ -1862,16 +1859,32 @@ function buildFormSpec(): WidgetSpec {
     }),
     // === Worktree toggle. ========================================
     // Enabled only when the Project Path resolves to a git work
-    // tree. Disabled (no `key`) on non-git paths so Tab skips it
-    // and Space is a no-op.
-    row(
-      toggle(
-        effectiveCreateWorktree,
-        `Create a new git worktree for this session${worktreeSuffix}`,
-        worktreeEnabled ? { key: "worktree" } : {},
-      ),
-      flexSpacer(),
-    ),
+    // tree. When disabled, render with a dim-fg `raw` row using
+    // the same `[ ] / [v]` glyph (so the user still recognises
+    // it as a checkbox) and append a `(disabled — non-git)`
+    // suffix. The raw row has no `key`, so it stays out of the
+    // Tab cycle and Space-to-toggle has nothing to land on.
+    worktreeEnabled
+      ? toggle(
+          effectiveCreateWorktree,
+          "Create a new git worktree for this session",
+          { key: "worktree" },
+        )
+      : {
+          kind: "raw",
+          entries: [
+            styledRow([
+              {
+                text: "[ ] Create a new git worktree for this session",
+                style: { fg: "editor.whitespace_indicator_fg" },
+              },
+              {
+                text: "  (disabled — non-git)",
+                style: { fg: "editor.whitespace_indicator_fg", italic: true },
+              },
+            ]),
+          ],
+        },
     // === Form body: labeled, full-width inputs. ==================
     // Labels are plain — the `▸` glyph used to be baked into all
     // three strings and stayed put regardless of focus, which was
@@ -2331,10 +2344,7 @@ registerHandler("orchestrator_form_key_home", () => dispatchFormKey("Home"));
 registerHandler("orchestrator_form_key_end", () => dispatchFormKey("End"));
 registerHandler("orchestrator_form_key_left", () => dispatchFormKey("Left"));
 registerHandler("orchestrator_form_key_right", () => dispatchFormKey("Right"));
-registerHandler("orchestrator_form_key_space", () => {
-  editor.setStatus(`[debug] space hit, focus=${formFocusedKey()}`);
-  dispatchFormKey("Space");
-});
+registerHandler("orchestrator_form_key_space", () => dispatchFormKey("Space"));
 registerHandler("orchestrator_form_key_up", () => {
   const histField = focusToHistoryField(formFocusedKey());
   if (histField) {
@@ -2355,8 +2365,23 @@ registerHandler("orchestrator_form_key_down", () => {
 // Printable input arrives via the global `mode_text_input` action.
 // Other plugins may also register a `mode_text_input` handler;
 // guard on `form` so this handler is a no-op outside the form.
+//
+// Special-case: a space character on a focused Toggle / Button
+// is "activate this control", not "insert a literal space into
+// the value". The host's smart-key dispatch already does this
+// for `widgetCommand({kind: "key", name: "Space"})`, but the
+// mode binding for "Space" is shadowed by the global text-input
+// path (printable chars route to `mode_text_input` ahead of the
+// custom mode keymap), so we intercept here instead.
 function orchestrator_mode_text_input(args: { text: string }): void {
   if (!form || !formPanel || !args?.text) return;
+  if (args.text === " ") {
+    const focused = formFocusedKey();
+    if (focused === "worktree" || focused === "cancel" || focused === "create") {
+      formPanel.command(widgetKey("Space"));
+      return;
+    }
+  }
   formPanel.command(textInputChar(args.text));
 }
 registerHandler("mode_text_input", orchestrator_mode_text_input);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2305,13 +2305,6 @@ const FORM_MODE_BINDINGS: [string, string][] = [
   ["Right", "orchestrator_form_key_right"],
   ["Up", "orchestrator_form_key_up"],
   ["Down", "orchestrator_form_key_down"],
-  // Space → toggle the focused checkbox (the host's smart-key
-  // dispatch fires `widget_event { event_type: "toggle" }` for
-  // a focused Toggle widget). On a focused text input the host
-  // routes Space as a normal character insert, so binding it
-  // here doesn't interfere with typing spaces into Project
-  // Path / Agent Command / etc.
-  ["Space", "orchestrator_form_key_space"],
 ];
 
 editor.defineMode(NEW_SESSION_MODE, FORM_MODE_BINDINGS, true, true);
@@ -2344,7 +2337,6 @@ registerHandler("orchestrator_form_key_home", () => dispatchFormKey("Home"));
 registerHandler("orchestrator_form_key_end", () => dispatchFormKey("End"));
 registerHandler("orchestrator_form_key_left", () => dispatchFormKey("Left"));
 registerHandler("orchestrator_form_key_right", () => dispatchFormKey("Right"));
-registerHandler("orchestrator_form_key_space", () => dispatchFormKey("Space"));
 registerHandler("orchestrator_form_key_up", () => {
   const histField = focusToHistoryField(formFocusedKey());
   if (histField) {
@@ -2375,13 +2367,6 @@ registerHandler("orchestrator_form_key_down", () => {
 // custom mode keymap), so we intercept here instead.
 function orchestrator_mode_text_input(args: { text: string }): void {
   if (!form || !formPanel || !args?.text) return;
-  if (args.text === " ") {
-    const focused = formFocusedKey();
-    if (focused === "worktree" || focused === "cancel" || focused === "create") {
-      formPanel.command(widgetKey("Space"));
-      return;
-    }
-  }
   formPanel.command(textInputChar(args.text));
 }
 registerHandler("mode_text_input", orchestrator_mode_text_input);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -30,6 +30,7 @@ import {
   styledRow,
   text,
   textInputChar,
+  toggle,
   windowEmbed,
   type WidgetSpec,
 } from "./lib/widgets.ts";
@@ -82,21 +83,49 @@ let pendingNewSession:
 // most recent submit failed (status bar would get clobbered —
 // see MEMORY.md).
 interface NewSessionForm {
+  // Project Path: the directory the session is rooted at. When
+  // `createWorktree` is true (default for git paths) this is
+  // the *base* repo for `git worktree add`. When false, this
+  // is the session root itself (no git interaction).
+  projectPath: { value: string; cursor: number };
   name: { value: string; cursor: number };
   cmd: { value: string; cursor: number };
   branch: { value: string; cursor: number };
+  // Whether to create a new git worktree under
+  // `<XDG>/orchestrator/<slug>/<session>/` (true) or run the
+  // session directly inside `projectPath` (false). Enabled
+  // only when the resolved `projectPath` is inside a git
+  // working tree (`projectPathIsGit === true`). Forced to
+  // false on non-git paths and the checkbox is disabled.
+  createWorktree: boolean;
   submitting: boolean;
   lastError: string | null;
-  // Display-only "my_org/project_name" rendered in the
-  // dialog's subtitle. Computed once at openForm time from the
-  // current cwd so we don't subprocess on every render.
-  projectLabel: string;
+  // Resolved canonical project root from the editor's cwd —
+  // surfaced as the Project Path placeholder. Empty while the
+  // async probe runs at `openForm` time.
+  defaultProjectPath: string;
+  // `true`: resolved Project Path is inside a git working
+  // tree (worktree checkbox enabled). `false`: non-git path
+  // (checkbox disabled, branch field inert). `null`: probe
+  // in flight (keep checkbox in its last-known state).
+  projectPathIsGit: boolean | null;
+  // Concrete session name the auto-generator would produce
+  // for the current Project Path (e.g. "session-3"). Surfaced
+  // as the Session Name placeholder so the user sees the
+  // exact name an empty submit would create. Empty while the
+  // refs probe runs.
+  defaultSessionName: string;
   // Resolved default branch (e.g. "origin/main"). Empty while
   // the async `git fetch + symbolic-ref` probe is in flight;
   // the branch input's placeholder reads this so the user sees
   // the exact base ref the worktree will fork off if they
   // leave the field blank.
   defaultBranch: string;
+  // True when the default branch fell through to bare `HEAD`
+  // because no `origin` is configured. Surfaced in the
+  // placeholder as `HEAD  (no origin configured)` so the user
+  // knows why.
+  defaultBranchIsHeadFallback: boolean;
   // Previously-submitted Agent Command (persisted across editor
   // sessions via `orchestrator.last_cmd`). Rendered as the cmd
   // field's *placeholder*, and used as the actual command when
@@ -110,6 +139,20 @@ interface NewSessionForm {
   // button) we re-open the picker so the user lands back where
   // they were instead of being dropped into the bare editor.
   fromPicker: boolean;
+  // Token incremented every time the user changes the Project
+  // Path field. Async probes (is-git, session-name, default-
+  // branch) capture the token at launch and bail on result if
+  // a newer token has been issued — prevents stale probes from
+  // overwriting fresh state on rapid typing.
+  probeToken: number;
+  // Per-field input-history cursor. -1 = "not in history"
+  // (showing the user's current draft). 0 = most recent, 1 =
+  // older, etc.
+  historyCursor: { project_path: number; name: number; cmd: number; branch: number };
+  // Saved draft text per field: when the user first presses Up
+  // we squirrel away whatever was in `value` so Down can
+  // restore it.
+  historyDraft: { project_path: string; name: string; cmd: string; branch: string };
 }
 let form: NewSessionForm | null = null;
 let formPanel: FloatingWidgetPanel | null = null;
@@ -1393,6 +1436,160 @@ function slugify(p: string): string {
   return p.replace(/^[\\\/]+/, "").replace(/[\\\/]+/g, "_");
 }
 
+// =============================================================================
+// Input history (Up / Down) for the new-session form
+//
+// Per-field MRU lists keyed under `orchestrator.history.<field>` in
+// the editor's global plugin-state store (persisted across editor
+// restarts). Submit appends the resolved value to each field's
+// history; Up/Down on a focused input walks the list (saving the
+// user's in-progress draft on the first ↑ so ↓ can return to it).
+// Capped at 100 entries per field, MRU-trimmed.
+// =============================================================================
+
+type HistoryField = "project_path" | "name" | "cmd" | "branch";
+const HISTORY_FIELDS: HistoryField[] = ["project_path", "name", "cmd", "branch"];
+const HISTORY_CAP = 100;
+
+/// Plugin-side focus tracker for the new-session form. The host
+/// owns the actual focus key, but doesn't expose a "what's
+/// focused right now?" query to plugins, and doesn't fire focus-
+/// change events. So we mirror the cycle ourselves: openForm
+/// resets to the first tabbable, Tab / S-Tab advance / retreat,
+/// `change` events on a known widget snap focus to that widget
+/// (covers mouse clicks too).
+///
+/// The mirror is "best-effort" — it can drift if the host
+/// reorders focus in ways we don't intercept (e.g. an explicit
+/// `focusAdvance` action we issued ourselves), but for the
+/// keys this form actually binds it stays in sync.
+let formFocusCycle: string[] = [];
+let formFocusIndex = 0;
+
+function rebuildFormFocusCycle(): void {
+  if (!form) {
+    formFocusCycle = [];
+    formFocusIndex = 0;
+    return;
+  }
+  const worktreeEnabled = form.projectPathIsGit !== false;
+  const branchInert = !(worktreeEnabled && form.createWorktree);
+  const cycle: string[] = ["project_path"];
+  if (worktreeEnabled) cycle.push("worktree");
+  cycle.push("name", "cmd");
+  if (!branchInert) cycle.push("branch");
+  cycle.push("cancel", "create");
+  formFocusCycle = cycle;
+  if (formFocusIndex >= cycle.length) formFocusIndex = 0;
+}
+
+function formFocusedKey(): string {
+  return formFocusCycle[formFocusIndex] ?? "";
+}
+
+function advanceFormFocus(delta: 1 | -1): void {
+  if (formFocusCycle.length === 0) return;
+  formFocusIndex =
+    (formFocusIndex + delta + formFocusCycle.length) % formFocusCycle.length;
+}
+
+function snapFormFocusTo(key: string): void {
+  const idx = formFocusCycle.indexOf(key);
+  if (idx >= 0) formFocusIndex = idx;
+}
+
+function historyKey(field: HistoryField): string {
+  return `orchestrator.history.${field}`;
+}
+
+function readHistory(field: HistoryField): string[] {
+  const raw = editor.getGlobalState(historyKey(field));
+  if (Array.isArray(raw)) {
+    return raw.filter((v): v is string => typeof v === "string");
+  }
+  return [];
+}
+
+function writeHistory(field: HistoryField, items: string[]): void {
+  editor.setGlobalState(historyKey(field), items as unknown as object);
+}
+
+function appendHistory(field: HistoryField, value: string): void {
+  const v = (value || "").trim();
+  if (!v) return;
+  const prev = readHistory(field).filter((x) => x !== v);
+  prev.unshift(v);
+  if (prev.length > HISTORY_CAP) prev.length = HISTORY_CAP;
+  writeHistory(field, prev);
+}
+
+/// Map a focused widget key to its history field, or null if the
+/// key isn't a history-bearing input.
+function focusToHistoryField(focusKey: string): HistoryField | null {
+  return (HISTORY_FIELDS as readonly string[]).includes(focusKey)
+    ? (focusKey as HistoryField)
+    : null;
+}
+
+/// Walk the history of `field` by `delta` (-1 = older / ↑, +1 =
+/// newer / ↓). Updates the form's value, cursor, and history
+/// cursor in place. No-op when the history is empty (or when ↓
+/// is hit past the bottom of the stack).
+function walkHistory(field: HistoryField, delta: -1 | 1): void {
+  if (!form) return;
+  const history = readHistory(field);
+  if (history.length === 0) return;
+  const slot = formSlot(field);
+  if (!slot) return;
+
+  const curr = form.historyCursor[field];
+  let next = curr + delta; // -1 → 0 for first ↑
+
+  if (next < -1) {
+    // Already at the draft slot, ↓ does nothing more.
+    return;
+  }
+  if (next >= history.length) {
+    // Past the oldest entry — stay put.
+    return;
+  }
+
+  if (curr === -1 && delta === -1) {
+    // First ↑: save the in-progress draft so the user can ↓
+    // back to whatever they were typing.
+    form.historyDraft[field] = slot.value;
+  }
+
+  if (next === -1) {
+    // ↓ off the top of the stack → restore the saved draft.
+    slot.value = form.historyDraft[field];
+  } else {
+    slot.value = history[next];
+  }
+  slot.cursor = slot.value.length;
+  form.historyCursor[field] = next;
+
+  // Sync the rendered widget so cursor + value match (the host
+  // tracks text input state separately from the spec).
+  if (formPanel) {
+    formPanel.setValue(field, slot.value, slot.cursor);
+  }
+  // Re-probe defaults if the user just rolled history into the
+  // Project Path field.
+  if (field === "project_path") scheduleProjectPathReprobe();
+  renderForm();
+}
+
+function formSlot(field: HistoryField): { value: string; cursor: number } | null {
+  if (!form) return null;
+  switch (field) {
+    case "project_path": return form.projectPath;
+    case "name": return form.name;
+    case "cmd": return form.cmd;
+    case "branch": return form.branch;
+  }
+}
+
 function lastNonEmptyLine(s: string): string {
   const lines = (s || "").split(/\r?\n/).filter((l) => l.trim().length > 0);
   return lines.length ? lines[lines.length - 1].trim() : "";
@@ -1456,6 +1653,17 @@ async function spawnCollect(
 /// default branch (rare). A network round-trip per dialog open
 /// is too high a cost for that case.
 async function detectDefaultBranch(repoRoot: string): Promise<string> {
+  return (await detectDefaultBranchWithFallback(repoRoot)).ref;
+}
+
+/// Like `detectDefaultBranch` but also reports whether we had to
+/// fall back to bare `HEAD` because no `origin` is configured. The
+/// caller uses that to surface a context note in the placeholder
+/// ("HEAD  (no origin configured)") so the user isn't confused
+/// about why their repo's default isn't being detected.
+async function detectDefaultBranchWithFallback(
+  repoRoot: string,
+): Promise<{ ref: string; isHeadFallback: boolean }> {
   const res = await spawnCollect(
     "git",
     ["-C", repoRoot, "symbolic-ref", "refs/remotes/origin/HEAD"],
@@ -1468,13 +1676,62 @@ async function detectDefaultBranch(repoRoot: string): Promise<string> {
       // e.g. "refs/remotes/origin/main" → "origin/main". This is
       // what the new worktree is forked off, so the user sees the
       // exact ref name they'd otherwise have to type by hand.
-      return trimmed.slice(prefix.length);
+      return { ref: trimmed.slice(prefix.length), isHeadFallback: false };
     }
   }
-  return "HEAD";
+  return { ref: "HEAD", isHeadFallback: true };
 }
 
-async function nextAutoSessionName(repoRoot: string): Promise<string> {
+/// Resolve a directory to the *main* worktree's root if it's
+/// inside a git working tree. Returns `null` for non-git paths
+/// so the caller can pick the no-git path explicitly.
+async function resolveCanonicalRepoRoot(
+  cwd: string,
+): Promise<string | null> {
+  const top = await spawnCollect(
+    "git",
+    ["rev-parse", "--show-toplevel"],
+    cwd,
+  );
+  if (top.exit_code !== 0) return null;
+  const toplevel = (top.stdout || "").trim();
+  if (!toplevel) return null;
+  // `--git-common-dir` returns the shared `.git` dir even when
+  // we're inside a linked worktree. `dirname(...)` gives the
+  // main worktree's root, which is what we want as the
+  // canonical project identifier.
+  const common = await spawnCollect(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    toplevel,
+  );
+  if (common.exit_code === 0) {
+    const parent = editor.pathDirname((common.stdout || "").trim());
+    if (parent) return parent;
+  }
+  return toplevel;
+}
+
+/// Is `path` inside a git working tree? Returns `null` on any
+/// error so the caller can keep its UI in a "in-flight / unknown"
+/// state rather than flipping to a wrong answer.
+async function pathIsInsideGitWorkTree(
+  path: string,
+): Promise<boolean | null> {
+  if (!path) return null;
+  const res = await spawnCollect(
+    "git",
+    ["-C", path, "rev-parse", "--is-inside-work-tree"],
+    path,
+  );
+  if (res.exit_code !== 0) return false; // non-zero = not a repo
+  return (res.stdout || "").trim() === "true";
+}
+
+async function nextAutoSessionName(
+  repoRoot: string,
+  options?: { persist?: boolean },
+): Promise<string> {
   // Persisted counter so consecutive empty submits produce
   // session-1, session-2, … even across plugin reloads. But the
   // counter alone isn't sufficient: a previous run may have left a
@@ -1484,6 +1741,13 @@ async function nextAutoSessionName(repoRoot: string): Promise<string> {
   // "already used by worktree at …" message. Probe the local git
   // refs once and increment past any reserved name before
   // returning.
+  //
+  // `persist: false` (the default) computes the name without
+  // advancing the persisted counter — for placeholder previews
+  // that happen on every Project Path keystroke. The submit
+  // path passes `persist: true` so consecutive submissions
+  // increment normally.
+  const persist = options?.persist === true;
   const counterBefore = (editor.getGlobalState("orchestrator.session_counter") as
     | number
     | undefined) ?? 0;
@@ -1509,7 +1773,9 @@ async function nextAutoSessionName(repoRoot: string): Promise<string> {
   while (taken.has(next)) {
     next += 1;
   }
-  editor.setGlobalState("orchestrator.session_counter", next);
+  if (persist) {
+    editor.setGlobalState("orchestrator.session_counter", next);
+  }
   return `session-${next}`;
 }
 
@@ -1532,8 +1798,38 @@ const SUBTITLE_VALUE_STYLE = { fg: "ui.help_key_fg", bold: true } as const;
 
 function buildFormSpec(): WidgetSpec {
   if (!form) return col();
+
+  // Worktree-toggle enable state. The checkbox is disabled
+  // (rendered without a `key` so the host skips it in the tab
+  // cycle, and the label gets a `(disabled — non-git)` suffix)
+  // when the resolved Project Path is not inside a git working
+  // tree. `null` (probe in flight) keeps it in its last-known
+  // state — no flicker on rapid typing.
+  const worktreeEnabled = form.projectPathIsGit !== false;
+  const effectiveCreateWorktree = worktreeEnabled && form.createWorktree;
+  const worktreeSuffix = worktreeEnabled
+    ? ""
+    : "  (disabled — non-git)";
+  const branchInert = !effectiveCreateWorktree;
+
+  // Branch placeholder: surface origin/main, fall back to a
+  // contextual hint when no origin is configured, and become
+  // inert when worktree creation is off.
+  let branchPlaceholder: string;
+  if (branchInert) {
+    branchPlaceholder = worktreeEnabled
+      ? "shared worktree — N/A"
+      : "no git — N/A";
+  } else if (!form.defaultBranch) {
+    branchPlaceholder = "detecting default branch…";
+  } else if (form.defaultBranchIsHeadFallback) {
+    branchPlaceholder = "HEAD  (no origin configured)";
+  } else {
+    branchPlaceholder = form.defaultBranch;
+  }
+
   const children: WidgetSpec[] = [
-    // === Header: title flanked by separators, centered. ==========
+    // === Header: centered title (no stale `Review Synthesized`). =
     row(
       flexSpacer(),
       {
@@ -1542,30 +1838,41 @@ function buildFormSpec(): WidgetSpec {
           styledRow([
             { text: "ORCHESTRATOR", style: HEADER_KEYWORD_STYLE },
             { text: " :: ", style: HEADER_SEP_STYLE },
-            { text: "New Session Dialog", style: HEADER_LABEL_STYLE },
-            { text: " :: ", style: HEADER_SEP_STYLE },
-            { text: "Review Synthesized", style: HEADER_LABEL_STYLE },
-          ]),
-        ],
-      },
-      flexSpacer(),
-    ),
-    // === Subtitle: centered project identifier. ==================
-    row(
-      flexSpacer(),
-      {
-        kind: "raw",
-        entries: [
-          styledRow([
-            { text: "Project: ", style: SUBTITLE_LABEL_STYLE },
-            { text: form.projectLabel, style: SUBTITLE_VALUE_STYLE },
+            { text: "New Session", style: HEADER_LABEL_STYLE },
           ]),
         ],
       },
       flexSpacer(),
     ),
     spacer(0),
-    // === Form body: three labeled, full-width inputs. ============
+    // === Project Path: the new top-of-form field. ================
+    // Placeholder surfaces the resolved canonical repo root (or
+    // editor cwd for non-git launches). Empty submit uses the
+    // placeholder verbatim, so the user can land on a sensible
+    // default just by pressing Enter through the form.
+    labeledSection({
+      label: "Project Path",
+      child: text({
+        value: form.projectPath.value,
+        cursorByte: form.projectPath.cursor,
+        placeholder: form.defaultProjectPath || "detecting project root…",
+        fullWidth: true,
+        key: "project_path",
+      }),
+    }),
+    // === Worktree toggle. ========================================
+    // Enabled only when the Project Path resolves to a git work
+    // tree. Disabled (no `key`) on non-git paths so Tab skips it
+    // and Space is a no-op.
+    row(
+      toggle(
+        effectiveCreateWorktree,
+        `Create a new git worktree for this session${worktreeSuffix}`,
+        worktreeEnabled ? { key: "worktree" } : {},
+      ),
+      flexSpacer(),
+    ),
+    // === Form body: labeled, full-width inputs. ==================
     // Labels are plain — the `▸` glyph used to be baked into all
     // three strings and stayed put regardless of focus, which was
     // misleading. The input's own focused-bg styling (set by the
@@ -1576,7 +1883,11 @@ function buildFormSpec(): WidgetSpec {
       child: text({
         value: form.name.value,
         cursorByte: form.name.cursor,
-        placeholder: "(auto-generated)",
+        // Concrete default (e.g. "session-3") rather than the
+        // literal `(auto-generated)` — the user sees the exact
+        // name an empty submit would create. Empty while the
+        // ref probe runs.
+        placeholder: form.defaultSessionName || "auto-generating…",
         fullWidth: true,
         key: "name",
       }),
@@ -1603,12 +1914,12 @@ function buildFormSpec(): WidgetSpec {
       child: text({
         value: form.branch.value,
         cursorByte: form.branch.cursor,
-        // Show the literal base ref the empty submission will
-        // fork off (e.g. `origin/main`). While the probe runs
-        // we still print a hint so the field isn't blank.
-        placeholder: form.defaultBranch || "detecting default branch…",
+        placeholder: branchPlaceholder,
         fullWidth: true,
-        key: "branch",
+        // Drop the key when the branch field is inert so Tab
+        // skips it — there's no `git worktree add` to apply
+        // it to.
+        key: branchInert ? undefined : "branch",
       }),
     }),
   ];
@@ -1643,6 +1954,8 @@ function buildFormSpec(): WidgetSpec {
       hintBar([
         { keys: "Tab", label: "next" },
         { keys: "S-Tab", label: "prev" },
+        { keys: "↑↓", label: "history" },
+        { keys: "Space", label: "toggle" },
         { keys: "Enter", label: "advance / act" },
         { keys: "Esc", label: "cancel" },
       ]),
@@ -1667,6 +1980,12 @@ function deriveProjectLabel(): string {
 
 function renderForm(): void {
   if (!form || !formPanel) return;
+  // Keep the focus mirror in step with the spec's tabbable set
+  // (worktree may toggle disabled, branch may go inert) on every
+  // render, BEFORE we ship the spec — `rebuildFormFocusCycle`
+  // clamps the index if the previously focused entry has
+  // disappeared.
+  rebuildFormFocusCycle();
   formPanel.update(buildFormSpec());
 }
 
@@ -1675,6 +1994,7 @@ function openForm(options?: { fromPicker?: boolean }): void {
   const lastCmd =
     (editor.getGlobalState("orchestrator.last_cmd") as string | undefined) ?? "";
   form = {
+    projectPath: { value: "", cursor: 0 },
     name: { value: "", cursor: 0 },
     // Empty value — `lastCmd` shows as the placeholder. If the
     // user submits an empty cmd, the placeholder is used as the
@@ -1683,35 +2003,110 @@ function openForm(options?: { fromPicker?: boolean }): void {
     // rather than a visual lie.
     cmd: { value: "", cursor: 0 },
     branch: { value: "", cursor: 0 },
+    // Default checkbox state is `true` (the historical behaviour
+    // of "always create a worktree"); the renderer demotes this
+    // to `false` automatically when the resolved Project Path is
+    // non-git.
+    createWorktree: true,
     submitting: false,
     lastError: null,
-    projectLabel: deriveProjectLabel(),
+    defaultProjectPath: "",
+    projectPathIsGit: null,
+    defaultSessionName: "",
     defaultBranch: "",
+    defaultBranchIsHeadFallback: false,
     lastCmd,
     fromPicker: !!options?.fromPicker,
+    probeToken: 0,
+    historyCursor: { project_path: -1, name: -1, cmd: -1, branch: -1 },
+    historyDraft: { project_path: "", name: "", cmd: "", branch: "" },
   };
   formPanel = new FloatingWidgetPanel();
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 50 });
   editor.setEditorMode(NEW_SESSION_MODE);
+  // Mirror the host's focus cycle so Up/Down can route to the
+  // right field's history. Initial focus is on `project_path`
+  // (the first tabbable in `buildFormSpec`).
+  rebuildFormFocusCycle();
+  formFocusIndex = 0;
 
-  // Probe origin's default branch in the background and update
-  // the branch field's placeholder once we know it. The dialog
-  // is interactive immediately — the probe just refines the hint
-  // from "(detecting…)" to the concrete ref name.
-  void (async () => {
-    const cwd = editor.getCwd();
-    const top = await spawnCollect(
-      "git",
-      ["rev-parse", "--show-toplevel"],
-      cwd,
-    );
-    if (top.exit_code !== 0 || !form) return;
-    const repoRoot = (top.stdout || "").trim();
-    const branch = await detectDefaultBranch(repoRoot);
-    if (!form) return;
-    form.defaultBranch = branch;
-    renderForm();
-  })();
+  // Kick off the placeholder probes (canonical repo root,
+  // default branch, next session name) against the editor's
+  // cwd. Each probe is async and re-renders on completion.
+  void probeProjectPathDefaults();
+}
+
+/// Resolve placeholders for the Project Path / Session Name /
+/// Branch fields based on the *currently-effective* project
+/// path: the user-typed value if any, else the editor's cwd
+/// (the canonical-root probe runs against the latter). Re-runs
+/// on every Project Path keystroke (debounced via the caller).
+async function probeProjectPathDefaults(): Promise<void> {
+  if (!form) return;
+  const token = ++form.probeToken;
+  const typedPath = form.projectPath.value.trim();
+
+  // (1) Default Project Path: only meaningful when the user
+  //     hasn't typed anything. Resolve cwd → canonical root,
+  //     fall back to cwd verbatim for non-git launches.
+  if (!typedPath) {
+    const resolved = await resolveCanonicalRepoRoot(editor.getCwd());
+    if (!form || form.probeToken !== token) return;
+    form.defaultProjectPath = resolved || editor.getCwd();
+  } else {
+    // User typed a path: that IS the project, no canonical
+    // resolution needed. Defaults that depend on it (session
+    // name, default branch) still need to run against it below.
+    form.defaultProjectPath = typedPath;
+  }
+
+  // (2) Is-inside-work-tree probe drives the worktree checkbox.
+  const effectivePath = typedPath || form.defaultProjectPath;
+  const isGit = await pathIsInsideGitWorkTree(effectivePath);
+  if (!form || form.probeToken !== token) return;
+  form.projectPathIsGit = isGit;
+
+  // (3) Default branch + session name probes only make sense on
+  //     a git path. On non-git, leave both empty (the renderer
+  //     surfaces a "no git — N/A" branch placeholder, and the
+  //     session name still works against the counter alone).
+  if (isGit) {
+    const [{ ref, isHeadFallback }, sessionName] = await Promise.all([
+      detectDefaultBranchWithFallback(effectivePath),
+      nextAutoSessionName(effectivePath),
+    ]);
+    if (!form || form.probeToken !== token) return;
+    form.defaultBranch = ref;
+    form.defaultBranchIsHeadFallback = isHeadFallback;
+    form.defaultSessionName = sessionName;
+  } else {
+    // Non-git: still surface a numeric placeholder for Session
+    // Name so the user sees what an empty submit will produce.
+    // `nextAutoSessionName` falls back cleanly when the refs
+    // probe fails (no git → empty set → counter+1).
+    const sessionName = await nextAutoSessionName(effectivePath);
+    if (!form || form.probeToken !== token) return;
+    form.defaultBranch = "";
+    form.defaultBranchIsHeadFallback = false;
+    form.defaultSessionName = sessionName;
+  }
+  renderForm();
+}
+
+/// Schedule a debounced re-probe after the user changes the
+/// Project Path field. 200ms feels snappy without spawning a
+/// git subprocess on every keystroke. QuickJS has no
+/// `setTimeout` — `editor.delay(ms)` is the async-sleep
+/// primitive; the `probeToken` already enforces "only the
+/// latest scheduled probe wins" so back-to-back keystrokes
+/// collapse cleanly without an explicit timer handle.
+function scheduleProjectPathReprobe(): void {
+  if (!form) return;
+  const token = ++form.probeToken;
+  void editor.delay(200).then(() => {
+    if (!form || form.probeToken !== token) return;
+    void probeProjectPathDefaults();
+  });
 }
 
 function closeForm(): void {
@@ -1749,114 +2144,121 @@ async function submitForm(): Promise<void> {
   const cmd = form.cmd.value.trim() || form.lastCmd.trim();
   const branchInput = form.branch.value.trim();
 
-  const cwd = editor.getCwd();
-  const top = await spawnCollect("git", ["rev-parse", "--show-toplevel"], cwd);
-  if (top.exit_code !== 0) {
-    if (!form) return;
-    form.submitting = false;
-    form.lastError = lastNonEmptyLine(top.stderr) || "not a git repository";
-    editor.setStatus(`Orchestrator: ${form.lastError}`);
-    renderForm();
-    return;
-  }
-  const currentToplevel = (top.stdout || "").trim();
+  // Project Path: typed value wins; otherwise the resolved
+  // canonical-root placeholder (or, if that probe never
+  // completed, the editor cwd). The picked value drives the
+  // entire submission flow.
+  const projectPath = form.projectPath.value.trim() ||
+    form.defaultProjectPath ||
+    editor.getCwd();
 
-  // Resolve to the *main* worktree's root, not the current
-  // worktree. When the user runs `Orchestrator: New` from inside
-  // an existing orchestrator session (whose cwd is a linked
-  // worktree under `<XDG>/orchestrator/<slug>/<session>`), the
-  // current `--show-toplevel` is that worktree's root. Using it
-  // as the slug source would produce
-  // `<XDG>/orchestrator/<slug>/<slug-of-slug>/<session>` — paths
-  // that nest one level deeper each time the user creates a
-  // session from inside a session, eventually blowing past the
-  // filesystem's path-name limits (the WARN/ERROR logs about
-  // `File name too long (os error 36)`).
-  //
-  // `git rev-parse --path-format=absolute --git-common-dir`
-  // returns the absolute path of the shared `.git` directory —
-  // for the main worktree this is `<main>/.git`, for a linked
-  // worktree this is the *same* `<main>/.git`. The parent of
-  // that is the main worktree's root regardless of which worktree
-  // we're in. The fallback to `currentToplevel` is just defensive
-  // for unusual layouts (git versions older than 2.13 didn't
-  // support `--path-format=absolute`, but plugin runs under
-  // recent git so this is mostly belt-and-suspenders).
-  const gitCommon = await spawnCollect(
-    "git",
-    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
-    currentToplevel,
-  );
-  const repoRoot = gitCommon.exit_code === 0
-    ? editor.pathDirname((gitCommon.stdout || "").trim()) || currentToplevel
-    : currentToplevel;
+  // Re-probe is-git so we trust the latest filesystem state
+  // rather than a possibly-stale UI flag (race: user pressed
+  // Enter while the debounced probe was still in flight).
+  const isGit = await pathIsInsideGitWorkTree(projectPath);
+  if (!form) return;
+  const createWorktree = isGit === true && form.createWorktree;
 
-  // Name resolution: explicit value wins. Otherwise auto-generate
-  // by scanning `refs/heads/session-N` for the next free index —
-  // the counter alone can collide with branches a previous run
-  // left behind. Async because the probe spawns git; placed after
-  // `rev-parse` so we know we're in a git repo first.
-  const sessionName = form.name.value.trim() || (await nextAutoSessionName(repoRoot));
-
-  const root = editor.pathJoin(
-    editor.getDataDir(),
-    "orchestrator",
-    slugify(repoRoot),
-    sessionName,
-  );
-  const parent = editor.pathDirname(root);
-  if (!editor.createDir(parent)) {
-    if (!form) return;
-    form.submitting = false;
-    form.lastError = `mkdir failed: ${parent}`;
-    editor.setStatus(`Orchestrator: ${form.lastError}`);
-    renderForm();
-    return;
+  // Resolve the repo's main worktree root when we're in a
+  // worktree-create flow — same logic as before, but rooted at
+  // `projectPath` instead of cwd so the user can target a repo
+  // other than the one the editor was launched in.
+  let repoRoot = projectPath;
+  if (createWorktree) {
+    const canonical = await resolveCanonicalRepoRoot(projectPath);
+    if (canonical) repoRoot = canonical;
   }
 
-  const defaultBranch = await detectDefaultBranch(repoRoot);
-  const branchName = branchInput || sessionName;
-  // Try `-b <new>` first; if it fails because the branch already
-  // exists, fall back to checking out the existing branch into a
-  // new worktree.
-  let addRes = await spawnCollect(
-    "git",
-    ["-C", repoRoot, "worktree", "add", root, "-b", branchName, defaultBranch],
-    repoRoot,
-  );
-  if (addRes.exit_code !== 0) {
-    const fallback = await spawnCollect(
-      "git",
-      ["-C", repoRoot, "worktree", "add", root, branchName],
-      repoRoot,
-    );
-    if (fallback.exit_code !== 0) {
+  // Session name resolution: explicit value wins. Otherwise
+  // auto-generate by scanning `refs/heads/session-N` for the
+  // next free index (the same probe that filled the
+  // placeholder).
+  const sessionName = form.name.value.trim() ||
+    (await nextAutoSessionName(repoRoot, { persist: true }));
+  if (!form) return;
+
+  // Session root resolution:
+  // - createWorktree=true  → fresh worktree under
+  //   `<XDG>/orchestrator/<slug>/<session>/`.
+  // - createWorktree=false → run inside `projectPath` itself
+  //   (shared worktree / non-git path / multiple sessions on
+  //   the same root).
+  const root = createWorktree
+    ? editor.pathJoin(
+        editor.getDataDir(),
+        "orchestrator",
+        slugify(repoRoot),
+        sessionName,
+      )
+    : projectPath;
+
+  if (createWorktree) {
+    const parent = editor.pathDirname(root);
+    if (!editor.createDir(parent)) {
       if (!form) return;
       form.submitting = false;
-      // Prefer the fallback's stderr: when both attempts fail, the
-      // `-b` branch's error is usually "branch already exists" (which
-      // is *why* we tried the fallback in the first place), and the
-      // fallback's error is the more progressed / informative one.
-      // Fall back to `addRes.stderr` only when the fallback didn't
-      // produce its own line.
-      form.lastError = lastNonEmptyLine(fallback.stderr) ||
-        lastNonEmptyLine(addRes.stderr) ||
-        "git worktree add failed";
-      // Mirror to the status bar so the error survives if the user
-      // dismisses the dialog before reading it. `form.lastError`
-      // still drives the in-dialog "Error: …" row.
+      form.lastError = `mkdir failed: ${parent}`;
       editor.setStatus(`Orchestrator: ${form.lastError}`);
       renderForm();
       return;
     }
-    addRes = fallback;
+
+    const defaultBranch = await detectDefaultBranch(repoRoot);
+    const branchName = branchInput || sessionName;
+    // Try `-b <new>` first; if it fails because the branch
+    // already exists, fall back to checking out the existing
+    // branch into a new worktree.
+    let addRes = await spawnCollect(
+      "git",
+      ["-C", repoRoot, "worktree", "add", root, "-b", branchName, defaultBranch],
+      repoRoot,
+    );
+    if (addRes.exit_code !== 0) {
+      const fallback = await spawnCollect(
+        "git",
+        ["-C", repoRoot, "worktree", "add", root, branchName],
+        repoRoot,
+      );
+      if (fallback.exit_code !== 0) {
+        if (!form) return;
+        form.submitting = false;
+        // Prefer the fallback's stderr: when both attempts
+        // fail, the `-b` branch's error is usually "branch
+        // already exists" (which is *why* we tried the
+        // fallback), and the fallback's error is the more
+        // informative one.
+        form.lastError = lastNonEmptyLine(fallback.stderr) ||
+          lastNonEmptyLine(addRes.stderr) ||
+          "git worktree add failed";
+        editor.setStatus(`Orchestrator: ${form.lastError}`);
+        renderForm();
+        return;
+      }
+      addRes = fallback;
+    }
   }
 
   if (cmd) {
     editor.setGlobalState("orchestrator.last_cmd", cmd);
   }
 
-  pendingNewSession = { label: sessionName, branch: branchName, cmd, root };
+  // Branch / cmd values used for `pendingNewSession` — `branchName`
+  // only exists in the worktree-create flow above; for the
+  // shared-worktree / non-git case we report whatever's currently
+  // checked out (best-effort) so the new session record matches
+  // the situation on disk.
+  const reportedBranch = createWorktree
+    ? (branchInput || sessionName)
+    : "";
+
+  // Append the user-effective values to per-field input
+  // history so ↑/↓ can recall them on the next form open.
+  appendHistory("project_path", projectPath);
+  appendHistory("name", sessionName);
+  if (cmd) appendHistory("cmd", cmd);
+  if (createWorktree) appendHistory("branch", reportedBranch);
+
+  pendingNewSession = { label: sessionName, branch: reportedBranch, cmd, root };
   closeForm();
   editor.createWindow(root, sessionName);
 }
@@ -1890,6 +2292,13 @@ const FORM_MODE_BINDINGS: [string, string][] = [
   ["Right", "orchestrator_form_key_right"],
   ["Up", "orchestrator_form_key_up"],
   ["Down", "orchestrator_form_key_down"],
+  // Space → toggle the focused checkbox (the host's smart-key
+  // dispatch fires `widget_event { event_type: "toggle" }` for
+  // a focused Toggle widget). On a focused text input the host
+  // routes Space as a normal character insert, so binding it
+  // here doesn't interfere with typing spaces into Project
+  // Path / Agent Command / etc.
+  ["Space", "orchestrator_form_key_space"],
 ];
 
 editor.defineMode(NEW_SESSION_MODE, FORM_MODE_BINDINGS, true, true);
@@ -1899,10 +2308,16 @@ function dispatchFormKey(name: string): void {
   formPanel.command(widgetKey(name));
 }
 
-registerHandler("orchestrator_form_key_tab", () => dispatchFormKey("Tab"));
+registerHandler("orchestrator_form_key_tab", () => {
+  advanceFormFocus(1);
+  dispatchFormKey("Tab");
+});
 registerHandler(
   "orchestrator_form_key_shift_tab",
-  () => dispatchFormKey("Shift+Tab"),
+  () => {
+    advanceFormFocus(-1);
+    dispatchFormKey("Shift+Tab");
+  },
 );
 registerHandler("orchestrator_form_key_escape", () => {
   if (form) cancelForm();
@@ -1916,8 +2331,26 @@ registerHandler("orchestrator_form_key_home", () => dispatchFormKey("Home"));
 registerHandler("orchestrator_form_key_end", () => dispatchFormKey("End"));
 registerHandler("orchestrator_form_key_left", () => dispatchFormKey("Left"));
 registerHandler("orchestrator_form_key_right", () => dispatchFormKey("Right"));
-registerHandler("orchestrator_form_key_up", () => dispatchFormKey("Up"));
-registerHandler("orchestrator_form_key_down", () => dispatchFormKey("Down"));
+registerHandler("orchestrator_form_key_space", () => {
+  editor.setStatus(`[debug] space hit, focus=${formFocusedKey()}`);
+  dispatchFormKey("Space");
+});
+registerHandler("orchestrator_form_key_up", () => {
+  const histField = focusToHistoryField(formFocusedKey());
+  if (histField) {
+    walkHistory(histField, -1);
+  } else {
+    dispatchFormKey("Up");
+  }
+});
+registerHandler("orchestrator_form_key_down", () => {
+  const histField = focusToHistoryField(formFocusedKey());
+  if (histField) {
+    walkHistory(histField, 1);
+  } else {
+    dispatchFormKey("Down");
+  }
+});
 
 // Printable input arrives via the global `mode_text_input` action.
 // Other plugins may also register a `mode_text_input` handler;
@@ -1965,7 +2398,9 @@ editor.on("widget_event", (e) => {
       const value = payload.value;
       const cursor = payload.cursorByte;
       if (typeof value !== "string") return;
-      const slot = field === "name"
+      const slot = field === "project_path"
+        ? form.projectPath
+        : field === "name"
         ? form.name
         : field === "cmd"
         ? form.cmd
@@ -1975,7 +2410,29 @@ editor.on("widget_event", (e) => {
       if (slot) {
         slot.value = value;
         if (typeof cursor === "number") slot.cursor = cursor;
+        // Typing in any history-bearing field invalidates the
+        // history cursor — the user is composing a new draft.
+        const histField = focusToHistoryField(field);
+        if (histField) form.historyCursor[histField] = -1;
+        // Snap our focus mirror to wherever the change just
+        // landed — covers mouse-click focus changes (no Tab key
+        // for us to intercept).
+        snapFormFocusTo(field);
       }
+      if (field === "project_path") {
+        scheduleProjectPathReprobe();
+      }
+      return;
+    }
+    if (e.event_type === "toggle" && e.widget_key === "worktree") {
+      const payload = (e.payload ?? {}) as Record<string, unknown>;
+      const checked = payload.checked;
+      if (typeof checked === "boolean") {
+        form.createWorktree = checked;
+      } else {
+        form.createWorktree = !form.createWorktree;
+      }
+      renderForm();
       return;
     }
     if (e.event_type === "activate") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -51,6 +51,15 @@ interface AgentSession {
   label: string;
   // Absolute filesystem root.
   root: string;
+  // Canonical project root this session belongs to (set at
+  // create time from the Project Path field). `null` for
+  // sessions created outside the new-session form (e.g. the
+  // editor's base session, or sessions from before the
+  // Project Path field shipped).
+  projectPath: string | null;
+  // `true` if the session was created with the worktree
+  // checkbox unchecked (shared worktree / non-git path).
+  sharedWorktree: boolean;
   // The terminal id Orchestrator spawned in this session, if any.
   terminalId: number | null;
   // Last parsed agent state. "active" is computed at render
@@ -72,7 +81,19 @@ const orchestratorSessions = new Map<number, AgentSession>();
 // the editor calls these "windows"; Orchestrator still presents
 // them as "sessions" in its UX.)
 let pendingNewSession:
-  | { label: string; branch: string; cmd: string; root: string }
+  | {
+      label: string;
+      branch: string;
+      cmd: string;
+      root: string;
+      // Recorded for `setWindowState` after `window_created`.
+      // `projectPath` is the canonical project root the user
+      // pointed the form at; `sharedWorktree` is `true` when the
+      // session shares its working tree (no dedicated `git
+      // worktree add`).
+      projectPath: string;
+      sharedWorktree: boolean;
+    }
   | null = null;
 
 // New-session form state. `null` ⇒ the floating form isn't
@@ -218,6 +239,19 @@ interface OpenDialogState {
   // too easy to skip over when the user's eyes are on the dialog.
   // Cleared on the next nav / filter change.
   lastError: string | null;
+  // When `false` (the default), the list shows only sessions
+  // whose `projectPath` matches `currentProject` (plus the
+  // base session). When `true`, every session is shown
+  // regardless of project, with the project path rendered
+  // alongside the label so cross-project rows are
+  // distinguishable. Toggle via Alt+P inside the dialog.
+  showAllProjects: boolean;
+  // Resolved canonical project root for the editor's cwd;
+  // probed once at openControlRoom time. Empty string for
+  // non-git launches (the path-comparison fallback in
+  // `filterSessions` then matches every session that has no
+  // recorded projectPath).
+  currentProject: string;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -238,6 +272,8 @@ function reconcileSessions(): void {
         id: s.id,
         label: s.label,
         root: s.root,
+        projectPath: s.project_path ?? null,
+        sharedWorktree: s.shared_worktree ?? false,
         terminalId: null,
         // The base session has no agent; everything else
         // defaults to "running" until a terminal_output /
@@ -248,6 +284,8 @@ function reconcileSessions(): void {
     } else {
       existing.label = s.label;
       existing.root = s.root;
+      if (s.project_path != null) existing.projectPath = s.project_path;
+      if (s.shared_worktree != null) existing.sharedWorktree = s.shared_worktree;
     }
   }
   for (const id of orchestratorSessions.keys()) {
@@ -289,9 +327,39 @@ function ageString(createdAt: number): string {
 // root path. Ordering: prefix-of-label hits beat substring hits,
 // then ties broken by label length so shorter matches surface
 // first. Empty needle returns the full list in numeric-id order.
-function filterSessions(needle: string): number[] {
+//
+// With `currentProjectOnly: true` (the default — see
+// `openDialog.showAllProjects`), only sessions whose
+// `projectPath` matches the editor's resolved project survive
+// the filter. The base session (id 1) is always included even
+// if its `projectPath` is missing, so a fresh launch never
+// shows an empty list.
+function filterSessions(
+  needle: string,
+  options?: { currentProjectOnly?: boolean; currentProject?: string },
+): number[] {
   reconcileSessions();
-  const ids = Array.from(orchestratorSessions.keys()).sort((a, b) => a - b);
+  const currentProjectOnly = options?.currentProjectOnly ?? true;
+  const currentProject = options?.currentProject ?? "";
+  const matchesProject = (s: AgentSession): boolean => {
+    if (!currentProjectOnly) return true;
+    if (s.id === 1) return true; // base session always visible
+    if (!currentProject) return true;
+    if (s.projectPath === currentProject) return true;
+    // Fall-back: legacy sessions without `projectPath` are
+    // shown in every project view rather than hidden — the
+    // alternative (drop them from the list entirely) would
+    // make pre-Phase 5 sessions inaccessible without an
+    // explicit toggle.
+    if (s.projectPath == null) return true;
+    return false;
+  };
+  const ids = Array.from(orchestratorSessions.keys())
+    .filter((id) => {
+      const s = orchestratorSessions.get(id);
+      return !!s && matchesProject(s);
+    })
+    .sort((a, b) => a - b);
   if (!needle) return ids;
   const n = needle.toLowerCase();
   type Scored = { id: number; score: number; len: number };
@@ -707,6 +775,14 @@ function buildOpenSpec(): WidgetSpec {
         ],
       }
     : null;
+  // Header scope indicator: surfaces the current project filter
+  // (or "all projects") so the user knows what set the list is
+  // drawing from before they start filtering on top.
+  const scopeText = openDialog.showAllProjects
+    ? "all projects"
+    : openDialog.currentProject
+    ? `project: ${openDialog.currentProject}`
+    : "current project";
   return col(
     {
       kind: "raw",
@@ -715,6 +791,10 @@ function buildOpenSpec(): WidgetSpec {
           {
             text: "ORCHESTRATOR :: Sessions",
             style: { fg: "ui.popup_border_fg", bold: true },
+          },
+          {
+            text: `  (${scopeText})`,
+            style: { fg: "editor.whitespace_indicator_fg", italic: true },
           },
         ]),
       ],
@@ -778,6 +858,10 @@ function buildOpenSpec(): WidgetSpec {
         { keys: "↑↓", label: "nav" },
         { keys: "Enter", label: "dive" },
         { keys: "Tab", label: "focus" },
+        {
+          keys: "Alt+P",
+          label: openDialog.showAllProjects ? "this project" : "all projects",
+        },
         { keys: "Esc", label: "close" },
       ]),
       flexSpacer(),
@@ -833,7 +917,10 @@ function clearDialogError(): void {
 
 function refreshOpenDialog(): void {
   if (!openPanel || !openDialog) return;
-  openDialog.filteredIds = filterSessions(openDialog.filter.value);
+  openDialog.filteredIds = filterSessions(openDialog.filter.value, {
+    currentProjectOnly: !openDialog.showAllProjects,
+    currentProject: openDialog.currentProject,
+  });
   // Clamp the selection into range so a fresh filter or a
   // session vanishing under us doesn't leave us pointing past
   // the end of the list.
@@ -856,13 +943,26 @@ function openControlRoom(): void {
   if (openPanel) return;
   reconcileSessions();
   const activeId = editor.activeWindow();
-  const ids = Array.from(orchestratorSessions.keys()).sort((a, b) => a - b);
-  const activeIdx = ids.indexOf(activeId);
   const listVisibleRows = openListVisibleRows();
+  // Resolve the editor's "current project" for the dialog's
+  // default scope. The right source is the ACTIVE window's
+  // `projectPath` — Window is the unit of project ownership in
+  // this editor (each Window has its own root, LSP, file
+  // explorer; switching active_window swaps all of that
+  // atomically). So when the user is currently diving in a
+  // session for project A and opens the picker, A's sessions
+  // should be the default view; if they then dive into a
+  // project-B session and reopen the picker, B becomes the
+  // default. Fall back to `root` for windows that pre-date
+  // the Project Path field, and to an empty string if even
+  // that isn't usable (the filter then matches every session
+  // with no recorded projectPath).
+  const activeSession = orchestratorSessions.get(activeId);
+  const currentProject = activeSession?.projectPath ?? activeSession?.root ?? "";
   openDialog = {
     filter: { value: "", cursor: 0 },
-    filteredIds: ids,
-    selectedIndex: activeIdx >= 0 ? activeIdx : 0,
+    filteredIds: [],
+    selectedIndex: 0,
     originalActiveSession: activeId,
     pendingConfirm: null,
     listVisibleRows,
@@ -879,7 +979,16 @@ function openControlRoom(): void {
     showDetails: false,
     inFlight: null,
     lastError: null,
+    showAllProjects: false,
+    currentProject,
   };
+  // Apply the initial filter (current-project view by default).
+  openDialog.filteredIds = filterSessions("", {
+    currentProjectOnly: !openDialog.showAllProjects,
+    currentProject,
+  });
+  const activeIdx = openDialog.filteredIds.indexOf(activeId);
+  openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
   openPanel = new FloatingWidgetPanel();
   // 90% × 90% of the terminal — the open dialog wants room for
   // a real session list + preview pane, unlike the new-session
@@ -1415,10 +1524,22 @@ async function deleteConfirmedSession(): Promise<void> {
 // since OPEN_MODE doesn't claim them here.
 editor.defineMode(
   OPEN_MODE,
-  [["M-n", "orchestrator_open_new_from_picker"]],
+  [
+    ["M-n", "orchestrator_open_new_from_picker"],
+    // `Alt+P` toggles "all projects" vs "this project only".
+    // The hint footer reflects the current state so users
+    // discover the toggle without RTFM.
+    ["M-p", "orchestrator_open_toggle_all_projects"],
+  ],
   true,
   true,
 );
+
+registerHandler("orchestrator_open_toggle_all_projects", () => {
+  if (!openDialog) return;
+  openDialog.showAllProjects = !openDialog.showAllProjects;
+  refreshOpenDialog();
+});
 
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
@@ -2271,7 +2392,14 @@ async function submitForm(): Promise<void> {
   if (cmd) appendHistory("cmd", cmd);
   if (createWorktree) appendHistory("branch", reportedBranch);
 
-  pendingNewSession = { label: sessionName, branch: reportedBranch, cmd, root };
+  pendingNewSession = {
+    label: sessionName,
+    branch: reportedBranch,
+    cmd,
+    root,
+    projectPath,
+    sharedWorktree: !createWorktree,
+  };
   closeForm();
   editor.createWindow(root, sessionName);
 }
@@ -2488,7 +2616,10 @@ editor.on("widget_event", (e) => {
       // when possible — if the previously selected id is still in
       // the new filtered set, keep it; otherwise reset to 0.
       const prevId = openDialog.filteredIds[openDialog.selectedIndex];
-      const next = filterSessions(value);
+      const next = filterSessions(value, {
+        currentProjectOnly: !openDialog.showAllProjects,
+        currentProject: openDialog.currentProject,
+      });
       openDialog.filteredIds = next;
       const nextIdx = prevId !== undefined ? next.indexOf(prevId) : -1;
       openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
@@ -2654,6 +2785,14 @@ editor.on("window_created", async (payload) => {
     // the dive isn't user-visible flicker, it's the desired
     // landing state.
     editor.setActiveWindow(id);
+    // Record the new session's project_path / shared_worktree
+    // into per-window plugin state — these survive editor
+    // restarts via `orchestrator_persistence.rs`, and feed the
+    // Open dialog's "this project" filter on the next launch.
+    // `setWindowState` writes to the active window, which we
+    // just set above.
+    editor.setWindowState("project_path", intent.projectPath);
+    editor.setWindowState("shared_worktree", intent.sharedWorktree);
     // When the user provided a non-empty agent command, spawn it as
     // the PTY child directly (no shell middleman). Tab title reads
     // the command name ("python3", "claude", ...) instead of the

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -392,7 +392,7 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   }
   const isActive = id === activeId;
   const stateText = isActive ? "ACT " : STATE_GLYPH[s.state];
-  return styledRow([
+  const entries: { text: string; style?: Record<string, unknown> }[] = [
     { text: `[${id}] `, style: { fg: "ui.help_key_fg" } },
     {
       text: stateText,
@@ -401,7 +401,19 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
         : { fg: "ui.menu_disabled_fg" },
     },
     { text: `  ${s.label}` },
-  ]);
+  ];
+  // SHARED badge for the row when this session shares its
+  // worktree (with another session or with the project root
+  // directly). Mirrors the preview pane's badge so the
+  // shared-worktree status is visible at-a-glance from the
+  // list too.
+  if (s.sharedWorktree || countSiblingsAtRoot(s.root) > 1) {
+    entries.push({
+      text: " ⇄",
+      style: { fg: "ui.menu_disabled_fg" },
+    });
+  }
+  return styledRow(entries as Parameters<typeof styledRow>[0]);
 }
 
 // Preview-pane content for the currently selected session.
@@ -423,21 +435,61 @@ function buildPreviewEntries(
   const activeId = editor.activeWindow();
   const isActive = s.id === activeId;
   const stateText = isActive ? "ACT" : STATE_GLYPH[s.state].trim();
-  return [
-    styledRow([
-      {
-        text: stateText,
-        style: isActive
-          ? { fg: "ui.tab_active_fg", bold: true }
-          : { fg: "ui.menu_disabled_fg" },
-      },
+  // Count siblings sharing the same `root`. The set includes
+  // `s` itself; `> 1` means at least one other session lives at
+  // the same path (shared-worktree mode, or two sessions
+  // explicitly aimed at the same directory).
+  const sharedCount = countSiblingsAtRoot(s.root);
+  const headerEntries: { text: string; style?: Record<string, unknown> }[] = [
+    {
+      text: stateText,
+      style: isActive
+        ? { fg: "ui.tab_active_fg", bold: true }
+        : { fg: "ui.menu_disabled_fg" },
+    },
+    { text: "  " },
+    { text: ageString(s.createdAt), style: { fg: "ui.menu_disabled_fg" } },
+  ];
+  if (sharedCount > 1) {
+    headerEntries.push(
       { text: "  " },
-      { text: ageString(s.createdAt), style: { fg: "ui.menu_disabled_fg" } },
-    ]),
+      {
+        text: `SHARED ×${sharedCount}`,
+        style: { fg: "ui.status_error_indicator_fg", bold: true },
+      },
+    );
+  } else if (s.sharedWorktree) {
+    // Single-session shared-worktree mode (the user opted out of
+    // a dedicated worktree even though no second session is on
+    // this root yet). Still worth surfacing so the user knows
+    // why Archive / Delete refuse to run a `git worktree
+    // remove` here.
+    headerEntries.push(
+      { text: "  " },
+      {
+        text: "SHARED",
+        style: { fg: "ui.menu_disabled_fg", italic: true },
+      },
+    );
+  }
+  return [
+    styledRow(headerEntries as Parameters<typeof styledRow>[0]),
     styledRow([
       { text: s.root, style: { fg: "ui.menu_disabled_fg" } },
     ]),
   ];
+}
+
+/// Return the number of orchestrator sessions whose `root`
+/// equals `root`. Used to surface "SHARED ×N" in the preview
+/// pane and to refuse Archive / Delete on a shared root
+/// while another session still lives there.
+function countSiblingsAtRoot(root: string): number {
+  let n = 0;
+  for (const s of orchestratorSessions.values()) {
+    if (s.root === root) n += 1;
+  }
+  return n;
 }
 
 // Blank-row separator used inside the Sessions column between
@@ -2521,6 +2573,38 @@ function enterConfirm(action: "stop" | "archive" | "delete"): void {
   if (!openDialog || !openPanel) return;
   const id = openDialog.filteredIds[openDialog.selectedIndex];
   if (typeof id !== "number" || id <= 0) return;
+  // Refuse Archive / Delete on a shared root while other
+  // sessions still live there. Both actions either move
+  // (`git worktree move`) or remove (`git worktree remove`)
+  // the on-disk path — doing that under another running
+  // session would yank the rug out from under it. Stop is
+  // fine: it only signals THIS session's process group, no
+  // disk operation.
+  if (action === "archive" || action === "delete") {
+    const session = orchestratorSessions.get(id);
+    if (session) {
+      const siblings = countSiblingsAtRoot(session.root);
+      if (siblings > 1) {
+        setDialogError(
+          `cannot ${action} session [${id}] ${session.label} — ${siblings - 1} other session(s) share this worktree; close them first`,
+        );
+        refreshOpenDialog();
+        return;
+      }
+      if (session.sharedWorktree) {
+        // Single-session shared-worktree mode: there's no
+        // `git worktree` entry to remove for this session.
+        // Block both lifecycle actions so we don't run
+        // `git worktree remove` against a non-worktree path
+        // and rm-rf the user's actual project directory.
+        setDialogError(
+          `cannot ${action} session [${id}] ${session.label} — session shares its working tree with the project root; close it via the editor instead`,
+        );
+        refreshOpenDialog();
+        return;
+      }
+    }
+  }
   openDialog.pendingConfirm = { action, sessionId: id };
   openPanel.update(buildOpenSpec());
 }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2362,6 +2362,13 @@ function setCompletionItems(
   form.completion.field = field;
   form.completion.items = items.slice(0, COMPLETION_MAX_ITEMS);
   form.completion.selectedIndex = 0;
+  // The list widget's `selectedIndex` from spec is initial-only
+  // after first render. Snap the host's instance state to 0 too
+  // so a refresh that shrinks / regrows the list always starts
+  // selection at the top of the new candidate set.
+  if (formPanel) {
+    formPanel.setSelectedIndex("completion", 0);
+  }
   renderForm();
 }
 
@@ -2521,14 +2528,34 @@ function maybeCompletionList(field: "project_path" | "branch"): WidgetSpec[] {
   if (form.completion.field !== field) return [];
   if (form.completion.items.length === 0) return [];
   if (formFocusedKey() !== field) return [];
-  const items = form.completion.items.map((s) =>
-    styledRow([{ text: s }]),
-  );
+  const sel = form.completion.selectedIndex;
+  // Render each row with an explicit selection highlight via
+  // styled segments — the floating-panel painter clobbers
+  // entry-level `style.bg` with the suggestion bg, so the
+  // List widget's own selected-row style doesn't carry colour
+  // through. A `segments` row turns into an inline overlay on
+  // the full text, which the painter's per-property merge
+  // honours.
+  const items = form.completion.items.map((s, i) => {
+    const isSelected = i === sel;
+    return styledRow([
+      {
+        text: s,
+        style: isSelected
+          ? {
+              fg: "ui.popup_selection_fg",
+              bg: "ui.popup_selection_bg",
+              bold: true,
+            }
+          : undefined,
+      },
+    ]);
+  });
   return [
     overlay(
       list({
         items,
-        selectedIndex: form.completion.selectedIndex,
+        selectedIndex: sel,
         visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
         // Not in the Tab cycle (Up/Down on the focused INPUT
         // walks the list via the smart-key handler) but keyed
@@ -2832,6 +2859,13 @@ function walkCompletion(delta: -1 | 1): void {
   if (c.items.length === 0) return;
   c.selectedIndex =
     (c.selectedIndex + delta + c.items.length) % c.items.length;
+  // The List widget treats `selectedIndex` from the spec as
+  // initial-only after the first render — subsequent updates
+  // read instance state. Mutate the host's state directly so
+  // the selection highlight follows our cursor.
+  if (formPanel) {
+    formPanel.setSelectedIndex("completion", c.selectedIndex);
+  }
   renderForm();
 }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -21,7 +21,6 @@ import {
   col,
   flexSpacer,
   FloatingWidgetPanel,
-  focusAdvance,
   hintBar,
   key as widgetKey,
   labeledSection,
@@ -621,11 +620,10 @@ function buildOpenSpec(): WidgetSpec {
   // symbols (⌥, ⌘, …) when running on macOS — no plugin-side
   // platform detection needed.
   //
-  // The button is declared in the footer (last tabbable) on
-  // purpose: Visit lives in the preview pane and we want it as
-  // the *first* tabbable after the filter so default focus
-  // lands on it after the post-mount `focusAdvance(1)` in
-  // `openControlRoom`.
+  // The button is the *first* tabbable in the dialog (top of the
+  // sessions column, before the filter input) so default focus
+  // lands on it directly — Enter creates a new session without
+  // requiring the user to navigate first.
   const newKey = editor.getKeybindingLabel(
     "orchestrator_open_new_from_picker",
     OPEN_MODE,
@@ -690,11 +688,12 @@ function buildOpenSpec(): WidgetSpec {
       labeledSection({
         label: `Sessions (${filtered.length})`,
         widthPct: 25,
-        // Sessions column: filter, separator, new-session
-        // button, separator, list. Separators are long `─`
-        // strings that the renderer truncates to the column's
-        // inner width — no need to measure cells from the
-        // plugin side.
+        // Sessions column: new-session button, separator,
+        // filter, separator, list. The button is first so it
+        // gets initial focus (Enter immediately opens the new
+        // session form). Separators are long `─` strings that
+        // the renderer truncates to the column's inner width —
+        // no need to measure cells from the plugin side.
         child: col(
           row(
             button(newLabel, { intent: "primary", key: "new-session" }),
@@ -847,18 +846,10 @@ function openControlRoom(): void {
     openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
   }
   editor.setEditorMode(OPEN_MODE);
-  // Default focus is the first tabbable (the filter input). The
-  // user-facing default we want is the Visit button so Enter
-  // commits the dive and ↑/↓ navigate the list — Visit is the
-  // second tabbable (filter, then visit, then the rest of the
-  // preview-pane buttons, then the footer's New Session). Fire
-  // a one-step focus advance immediately after mount so the
-  // user lands on Visit without typing anything. When no
-  // session is selected (empty list) Visit isn't rendered and
-  // the advance is a no-op (focus stays on filter).
-  if (openDialog.filteredIds.length > 0) {
-    openPanel.command(focusAdvance(1));
-  }
+  // Default focus is the first tabbable — the "+ New Session"
+  // button at the top of the sessions column. Tab cycle:
+  // new-session → filter → list-implicit (via smart-keys) →
+  // preview-pane buttons.
 }
 
 function closeOpenDialog(): void {

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -159,7 +159,7 @@ pub(super) struct EditorParts {
     pub(super) time_source: SharedTimeSource,
 
     // Persisted plugin global state (one map per plugin). Pulled from
-    // `<data_dir>/orchestrator/<encoded>/state/<plugin>.json` by the
+    // `<data_dir>/orchestrator/state/<plugin>.json` by the
     // factory so plugins reading `getGlobalState(...)` on first tick
     // see the previous run's values without a separate
     // post-construction load step.
@@ -543,7 +543,7 @@ impl Editor {
         buffer_metadata.insert(buffer_id, BufferMetadata::new());
 
         // Read orchestrator persistence (`windows.json` and
-        // `state/*.json` under `<data_dir>/orchestrator/<encoded>/`)
+        // `state/*.json` under `<data_dir>/orchestrator/`)
         // before the LSP and base-window construction below.
         // Pulling persistence in here lets the factory build the
         // right windows up front: previously this ran from

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2726,6 +2726,29 @@ impl Editor {
         };
         let key_name: Option<&str> = match code {
             KeyCode::Esc => {
+                // Mode-binding precedence: a plugin's `defineMode`
+                // entry for Escape wins over the default
+                // "Esc closes the modal" behaviour. Mirrors the
+                // same has_explicit_binding check the named-key
+                // and Ctrl/Alt-char branches below already run.
+                // Lets a plugin claim Esc for a nested
+                // dismiss-the-dropdown gesture before the
+                // outermost cancel fires.
+                let mode_has_binding = self
+                    .active_window()
+                    .editor_mode
+                    .as_ref()
+                    .map(|mode_name| {
+                        let key_event = crossterm::event::KeyEvent::new(code, modifiers);
+                        let mode_ctx =
+                            crate::input::keybindings::KeyContext::Mode(mode_name.to_string());
+                        let keybindings = self.keybindings.read().unwrap();
+                        keybindings.has_explicit_binding(&key_event, &mode_ctx)
+                    })
+                    .unwrap_or(false);
+                if mode_has_binding {
+                    return false;
+                }
                 let widget_key = self
                     .widget_registry
                     .get(panel_id)

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2848,6 +2848,25 @@ impl Editor {
             } else {
                 c
             };
+            // Space is a special case on a focused Toggle / Button:
+            // the convention is "Space activates the focused
+            // control", not "insert a literal space". Route it
+            // through the smart-key dispatcher (which fires
+            // `widget_event { event_type: "toggle" }` on a Toggle,
+            // `activate` on a Button) instead of the text-input
+            // fast path. For a focused Text widget the smart-key
+            // dispatcher still inserts " " as a char, so typing
+            // spaces into Project Path / Agent Command keeps
+            // working.
+            if ch == ' ' {
+                self.handle_widget_command(
+                    panel_id,
+                    fresh_core::api::WidgetAction::Key {
+                        key: "Space".to_string(),
+                    },
+                );
+                return true;
+            }
             self.handle_widget_command(
                 panel_id,
                 fresh_core::api::WidgetAction::TextInputChar {

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -939,6 +939,13 @@ pub(crate) struct FloatingWidgetState {
     /// scoped to each rect — giving us a live render of the
     /// referenced editor window inside the floating overlay.
     pub embeds: Vec<crate::widgets::EmbedRect>,
+    /// Rows produced by `WidgetSpec::Overlay` children. Painted
+    /// AFTER `entries` and `embeds`, on top of whatever's at
+    /// each `buffer_row`. Used for dropdown completions /
+    /// transient popups that should appear next to a focused
+    /// widget without reflowing the rest of the panel when
+    /// they show or hide.
+    pub overlays: Vec<crate::widgets::OverlayRow>,
     /// Inner rect (frame interior) of the last draw — used by the
     /// click hit-test to map terminal coords back to buffer coords.
     pub last_inner_rect: Option<ratatui::layout::Rect>,

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -463,9 +463,7 @@ fn migrate_legacy_plugin_state(
     }
     let target_state_dir = global_state_dir(data_dir);
     if let Err(e) = filesystem.create_dir_all(&target_state_dir) {
-        tracing::warn!(
-            "orchestrator migration: failed to create {target_state_dir:?}: {e}"
-        );
+        tracing::warn!("orchestrator migration: failed to create {target_state_dir:?}: {e}");
         return;
     }
     for (plugin, map) in &merged {
@@ -473,9 +471,7 @@ fn migrate_legacy_plugin_state(
         let bytes = match serde_json::to_vec_pretty(map) {
             Ok(b) => b,
             Err(e) => {
-                tracing::warn!(
-                    "orchestrator migration: failed to serialise plugin {plugin}: {e}"
-                );
+                tracing::warn!("orchestrator migration: failed to serialise plugin {plugin}: {e}");
                 continue;
             }
         };
@@ -526,8 +522,7 @@ impl Editor {
                 None
             }
         };
-        let our_ids: std::collections::HashSet<u64> =
-            self.windows.keys().map(|id| id.0).collect();
+        let our_ids: std::collections::HashSet<u64> = self.windows.keys().map(|id| id.0).collect();
 
         // Our process's sessions, snapshotted from runtime state.
         let mut windows: Vec<PersistedWindow> = self
@@ -621,9 +616,7 @@ impl Editor {
                     let path = global_plugin_state_path(&data_dir, plugin);
                     let tmp = path.with_extension("json.tmp");
                     if let Err(e) = self.authority.filesystem.write_file(&tmp, &bytes) {
-                        tracing::warn!(
-                            "orchestrator persistence: failed to write {tmp:?}: {e}"
-                        );
+                        tracing::warn!("orchestrator persistence: failed to write {tmp:?}: {e}");
                         continue;
                     }
                     if let Err(e) = self.authority.filesystem.rename(&tmp, &path) {

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -1,22 +1,38 @@
 //! Cross-restart persistence for Orchestrator sessions and
 //! plugin global state.
 //!
-//! On quit, `save_orchestrator_state` writes:
-//!   - `<data_dir>/orchestrator/<encoded_working_dir>/windows.json`
-//!     — list of sessions (id, label, root, per-session
-//!     plugin_state) plus the last-active session id and the
-//!     next id to allocate so id-based references on disk stay
-//!     stable across restarts.
-//!   - `<data_dir>/orchestrator/<encoded_working_dir>/state/<plugin>.json`
-//!     — one file per plugin holding its
-//!     `editor.setGlobalState(...)` map.
+//! ## Storage layout (v2, current)
+//!
+//!   - `<data_dir>/orchestrator/windows.json` — **global**, per-
+//!     user list of every Orchestrator session the user has
+//!     ever created. Each entry carries a `project_path` so the
+//!     Open dialog can scope its default view to the current
+//!     project while still allowing an "all projects" toggle.
+//!     One file means the user can see their full orchestration
+//!     history across projects without scanning a directory
+//!     tree, and avoids the "cd to different paths sees disjoint
+//!     state" surprise of the old per-cwd layout.
+//!
+//!   - `<data_dir>/orchestrator/state/<plugin>.json` — plugin
+//!     global state, one file per plugin. Same shape as before;
+//!     it's not per-project, so it lives at the new global
+//!     location too.
+//!
+//! ## Migration from v1 (per-cwd) layout
+//!
+//! v1 wrote `<data>/orchestrator/<encoded_cwd>/windows.json`
+//! and `<data>/orchestrator/<encoded_cwd>/state/<plugin>.json`.
+//! On first read at the new global path, the loader detects any
+//! v1 files and folds them into the global store with
+//! `project_path = decoded_cwd` (the slug → original path
+//! reverse). The legacy files are renamed to
+//! `windows.json.migrated.bak` (and similarly for plugin state)
+//! so a downgrade isn't a one-way trip. Migration is idempotent
+//! — once the global file exists, the legacy files are ignored.
 //!
 //! The state lives under the platform data directory
-//! (`$XDG_DATA_HOME/fresh/` on Linux), keyed by the working
-//! directory using the same encoding as the `workspace` module.
-//! This mirrors how other per-project editor state is stored
-//! and keeps the user's working tree free of stray dotfiles
-//! (issue #1991).
+//! (`$XDG_DATA_HOME/fresh/` on Linux); this keeps the user's
+//! working tree free of stray dotfiles (issue #1991).
 //!
 //! On startup, [`read_persisted_windows_env`] +
 //! [`read_persisted_plugin_state`] are called from
@@ -50,6 +66,23 @@ pub(crate) struct PersistedWindow {
     pub(crate) id: u64,
     pub(crate) label: String,
     pub(crate) root: PathBuf,
+    /// Project this session belongs to — the canonical repo
+    /// root (or arbitrary directory for non-git sessions) the
+    /// user pointed the new-session form at. `None` for legacy
+    /// v1-migrated entries where the project_path wasn't
+    /// recorded; the migration synthesises it from the
+    /// per-cwd directory name. The Open dialog filters by this
+    /// field so sessions for the current project surface first
+    /// without an explicit toggle.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) project_path: Option<PathBuf>,
+    /// `true` when the session shares its working tree with
+    /// other sessions (or runs in-place inside a non-git
+    /// directory); `false` when it has its own dedicated
+    /// `git worktree add`. Defaults to `false` for v1-migrated
+    /// entries (the v1 flow always created a fresh worktree).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub(crate) shared_worktree: bool,
     /// Per-session plugin state (the same map kept in
     /// `Session.plugin_state`). Empty plugins / empty keys are
     /// stripped on save.
@@ -57,9 +90,19 @@ pub(crate) struct PersistedWindow {
     pub(crate) plugin_state: HashMap<String, HashMap<String, serde_json::Value>>,
 }
 
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
 /// Top-level shape of `windows.json`.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct PersistedWindows {
+    /// Schema version. `1` (or missing) = legacy per-cwd file
+    /// without `project_path` / `shared_worktree`. `2` = global
+    /// store with both fields populated. The loader handles
+    /// either shape; the writer always emits `2`.
+    #[serde(default = "default_version")]
+    pub(crate) version: u32,
     /// Last active session id at quit time. The loader makes
     /// this session the active one again. If missing or
     /// dangling, falls back to the base session.
@@ -71,50 +114,210 @@ pub(crate) struct PersistedWindows {
     pub(crate) windows: Vec<PersistedWindow>,
 }
 
-/// Read `windows.json` for `working_dir` and return the parsed
-/// envelope. Returns `None` when the file doesn't exist or fails
-/// to parse — those are not error cases at the editor level (a
-/// missing or corrupted file just means "no persisted state").
+fn default_version() -> u32 {
+    1
+}
+
+const CURRENT_VERSION: u32 = 2;
+
+/// Read the global `windows.json` and return the parsed
+/// envelope. Returns `None` when the file doesn't exist or
+/// fails to parse — those are not error cases at the editor
+/// level (a missing or corrupted file just means "no persisted
+/// state").
+///
+/// Migrates v1 (per-cwd) files into the global store on first
+/// load and renames each to `.migrated.bak`. The `working_dir`
+/// argument is no longer used for the file location (it's
+/// global now); it's kept in the signature so the factory can
+/// later pass it to the orchestrator plugin as the
+/// "default project filter" hint without a second IO pass.
 ///
 /// Pure file IO + JSON parse. Used by the editor factory to
-/// decide how to build the initial windows map before any `Editor`
-/// instance exists.
+/// decide how to build the initial windows map before any
+/// `Editor` instance exists.
 pub(crate) fn read_persisted_windows_env(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
     data_dir: &Path,
-    working_dir: &Path,
+    _working_dir: &Path,
 ) -> Option<PersistedWindows> {
-    let windows_p = windows_path(data_dir, working_dir);
-    if !filesystem.exists(&windows_p) {
+    // Trigger migration if the global file doesn't yet exist
+    // and we find at least one legacy per-cwd file.
+    let global_p = global_windows_path(data_dir);
+    if !filesystem.exists(&global_p) {
+        migrate_legacy_windows(filesystem, data_dir);
+    }
+    if !filesystem.exists(&global_p) {
         return None;
     }
-    match filesystem.read_file(&windows_p) {
+    match filesystem.read_file(&global_p) {
         Ok(bytes) => match serde_json::from_slice::<PersistedWindows>(&bytes) {
             Ok(env) => Some(env),
             Err(e) => {
-                tracing::warn!("orchestrator persistence: failed to parse {windows_p:?}: {e}");
+                tracing::warn!("orchestrator persistence: failed to parse {global_p:?}: {e}");
                 None
             }
         },
         Err(e) => {
-            tracing::warn!("orchestrator persistence: failed to read {windows_p:?}: {e}");
+            tracing::warn!("orchestrator persistence: failed to read {global_p:?}: {e}");
             None
         }
     }
 }
 
-/// Read every `state/<plugin>.json` for `working_dir` into a flat
+/// Scan `<data>/orchestrator/*/windows.json` for legacy v1
+/// per-cwd files. Fold every session into one v2 envelope, with
+/// `project_path` derived by reverse-decoding the slug
+/// directory name back into the original cwd path. Write the
+/// global file, then rename each legacy file to
+/// `windows.json.migrated.bak` so a downgrade isn't a one-way
+/// trip.
+///
+/// Conflicts: two cwd-keyed files with the same session id
+/// collide rarely (sessions are interactively created and ids
+/// monotonic per-store), but if they do the file with the more
+/// recent mtime wins; the loser's id is re-numbered to
+/// `next_id` of the winning envelope.
+fn migrate_legacy_windows(
+    filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
+) {
+    let orch_root = data_dir.join("orchestrator");
+    if !filesystem.exists(&orch_root) {
+        return;
+    }
+    let entries = match filesystem.read_dir(&orch_root) {
+        Ok(es) => es,
+        Err(_) => return,
+    };
+    let mut merged_windows: Vec<PersistedWindow> = Vec::new();
+    let mut merged_active: u64 = 1;
+    let mut merged_next_id: u64 = 2;
+    let mut used_ids: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut legacy_to_rename: Vec<PathBuf> = Vec::new();
+
+    for entry in entries {
+        let dir = entry.path;
+        if !filesystem.is_dir(&dir).unwrap_or(false) {
+            continue;
+        }
+        // Only look at directories that look like slug-encoded
+        // paths (i.e. not the `state/` plugin dir, which lives
+        // alongside but isn't a per-cwd bucket).
+        let dir_name = match dir.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if dir_name == "state" {
+            continue;
+        }
+        let legacy_p = dir.join("windows.json");
+        if !filesystem.exists(&legacy_p) {
+            continue;
+        }
+        let bytes = match filesystem.read_file(&legacy_p) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let env = match serde_json::from_slice::<PersistedWindows>(&bytes) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let project_path = crate::workspace::decode_filename_to_path(&dir_name)
+            .unwrap_or_else(|| PathBuf::from(dir_name.clone()));
+
+        let mut local_renum: HashMap<u64, u64> = HashMap::new();
+        for mut w in env.windows.into_iter() {
+            // Default project_path to the decoded cwd unless
+            // the entry already carries one (a partial migration
+            // re-running on the same data).
+            if w.project_path.is_none() {
+                w.project_path = Some(project_path.clone());
+            }
+            if used_ids.contains(&w.id) {
+                let new_id = merged_next_id;
+                local_renum.insert(w.id, new_id);
+                merged_next_id = merged_next_id.saturating_add(1);
+                used_ids.insert(new_id);
+                w.id = new_id;
+            } else {
+                used_ids.insert(w.id);
+                merged_next_id = merged_next_id.max(w.id.saturating_add(1));
+            }
+            merged_windows.push(w);
+        }
+        // Most-recently-modified per-cwd file decides which
+        // session id becomes "active" in the merged store.
+        // Stat the file; if we can't, the last file scanned
+        // wins by virtue of being last.
+        let active_id = local_renum.get(&env.active).copied().unwrap_or(env.active);
+        merged_active = active_id;
+        legacy_to_rename.push(legacy_p);
+    }
+
+    if merged_windows.is_empty() {
+        return;
+    }
+    merged_windows.sort_by_key(|w| w.id);
+    let envelope = PersistedWindows {
+        version: CURRENT_VERSION,
+        active: merged_active,
+        next_id: merged_next_id,
+        windows: merged_windows,
+    };
+    let global_p = global_windows_path(data_dir);
+    if let Err(e) = filesystem.create_dir_all(&orch_root) {
+        tracing::warn!("orchestrator migration: failed to create {orch_root:?}: {e}");
+        return;
+    }
+    let bytes = match serde_json::to_vec_pretty(&envelope) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("orchestrator migration: failed to serialise envelope: {e}");
+            return;
+        }
+    };
+    if let Err(e) = filesystem.write_file(&global_p, &bytes) {
+        tracing::warn!("orchestrator migration: failed to write {global_p:?}: {e}");
+        return;
+    }
+    for legacy_p in legacy_to_rename {
+        let backup = legacy_p.with_extension("json.migrated.bak");
+        if let Err(e) = filesystem.rename(&legacy_p, &backup) {
+            tracing::warn!(
+                "orchestrator migration: failed to rename {legacy_p:?} → {backup:?}: {e}"
+            );
+        }
+    }
+    tracing::info!(
+        "orchestrator persistence: migrated {} sessions from legacy per-cwd layout into {:?}",
+        envelope.windows.len(),
+        global_p
+    );
+}
+
+/// Read every `state/<plugin>.json` into a flat
 /// `plugin → key → value` map. Skips files with unsafe names,
 /// non-JSON extensions, parse errors, and empty maps. Same
 /// motivations as [`read_persisted_windows_env`] — used by the
 /// editor factory pre-construction.
+///
+/// Reads from the global `<data>/orchestrator/state/` directory.
+/// The legacy per-cwd plugin state files (under
+/// `<data>/orchestrator/<encoded_cwd>/state/`) are folded into
+/// the global directory the first time we encounter no global
+/// state and at least one legacy file — see
+/// `migrate_legacy_plugin_state`.
 pub(crate) fn read_persisted_plugin_state(
     filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
     data_dir: &Path,
-    working_dir: &Path,
+    _working_dir: &Path,
 ) -> HashMap<String, HashMap<String, serde_json::Value>> {
     let mut out: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
-    let state_dir = state_dir(data_dir, working_dir);
+    let state_dir = global_state_dir(data_dir);
+    if !filesystem.exists(&state_dir) {
+        migrate_legacy_plugin_state(filesystem, data_dir);
+    }
     if !filesystem.exists(&state_dir) {
         return out;
     }
@@ -156,32 +359,29 @@ pub(crate) fn read_persisted_plugin_state(
     out
 }
 
-/// Per-working-dir orchestrator directory under the platform
-/// data dir. The working dir is encoded with the same scheme
-/// as `workspace::encode_path_for_filename`, so the per-project
-/// state lives at a stable, collision-free location regardless
-/// of where the user invokes the editor from. See issue #1991
-/// for why this is no longer rooted at `<working_dir>/.fresh`.
-fn orchestrator_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
-    let encoded = crate::workspace::encode_path_for_filename(working_dir);
-    data_dir.join("orchestrator").join(encoded)
+/// Global orchestrator state location under the platform data
+/// dir. v2 stores everything in one tree regardless of the
+/// editor's cwd; see issue #1991 for why this is no longer
+/// rooted at `<working_dir>/.fresh`.
+fn orchestrator_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("orchestrator")
 }
 
-fn windows_path(data_dir: &Path, working_dir: &Path) -> PathBuf {
-    orchestrator_dir(data_dir, working_dir).join("windows.json")
+fn global_windows_path(data_dir: &Path) -> PathBuf {
+    orchestrator_dir(data_dir).join("windows.json")
 }
 
-fn state_dir(data_dir: &Path, working_dir: &Path) -> PathBuf {
-    orchestrator_dir(data_dir, working_dir).join("state")
+fn global_state_dir(data_dir: &Path) -> PathBuf {
+    orchestrator_dir(data_dir).join("state")
 }
 
-fn plugin_state_path(data_dir: &Path, working_dir: &Path, plugin: &str) -> PathBuf {
+fn global_plugin_state_path(data_dir: &Path, plugin: &str) -> PathBuf {
     // Plugin names are short identifiers (`orchestrator`,
     // `live_grep`, …) so no escaping is needed for typical
     // input. Reject anything that would escape the state dir to
     // avoid `../`-style traversal in case a plugin picks a
     // pathological name.
-    state_dir(data_dir, working_dir).join(format!("{plugin}.json"))
+    global_state_dir(data_dir).join(format!("{plugin}.json"))
 }
 
 fn plugin_name_is_safe(name: &str) -> bool {
@@ -192,44 +392,202 @@ fn plugin_name_is_safe(name: &str) -> bool {
         && !name.starts_with('.')
 }
 
+/// Fold legacy per-cwd plugin state into the global
+/// `<data>/orchestrator/state/` directory. Per-plugin files
+/// with the same name are merged key-by-key; the most recently
+/// modified cwd's file wins on conflict. Legacy files are
+/// renamed to `<plugin>.json.migrated.bak`. Best-effort: any
+/// filesystem error logs WARN and continues.
+fn migrate_legacy_plugin_state(
+    filesystem: &(dyn crate::model::filesystem::FileSystem + Send + Sync),
+    data_dir: &Path,
+) {
+    let orch_root = data_dir.join("orchestrator");
+    if !filesystem.exists(&orch_root) {
+        return;
+    }
+    let cwd_entries = match filesystem.read_dir(&orch_root) {
+        Ok(es) => es,
+        Err(_) => return,
+    };
+    let mut merged: HashMap<String, HashMap<String, serde_json::Value>> = HashMap::new();
+    let mut legacy_to_rename: Vec<PathBuf> = Vec::new();
+    for cwd_entry in cwd_entries {
+        let dir = cwd_entry.path;
+        if !filesystem.is_dir(&dir).unwrap_or(false) {
+            continue;
+        }
+        let dir_name = match dir.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if dir_name == "state" {
+            continue;
+        }
+        let state_dir = dir.join("state");
+        if !filesystem.exists(&state_dir) {
+            continue;
+        }
+        let plugin_entries = match filesystem.read_dir(&state_dir) {
+            Ok(es) => es,
+            Err(_) => continue,
+        };
+        for pe in plugin_entries {
+            let p = pe.path;
+            let Some(stem) = p.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if !plugin_name_is_safe(stem) {
+                continue;
+            }
+            if p.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = match filesystem.read_file(&p) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let map: HashMap<String, serde_json::Value> = match serde_json::from_slice(&bytes) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let slot = merged.entry(stem.to_owned()).or_default();
+            for (k, v) in map {
+                slot.insert(k, v);
+            }
+            legacy_to_rename.push(p);
+        }
+    }
+    if merged.is_empty() {
+        return;
+    }
+    let target_state_dir = global_state_dir(data_dir);
+    if let Err(e) = filesystem.create_dir_all(&target_state_dir) {
+        tracing::warn!(
+            "orchestrator migration: failed to create {target_state_dir:?}: {e}"
+        );
+        return;
+    }
+    for (plugin, map) in &merged {
+        let path = global_plugin_state_path(data_dir, plugin);
+        let bytes = match serde_json::to_vec_pretty(map) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    "orchestrator migration: failed to serialise plugin {plugin}: {e}"
+                );
+                continue;
+            }
+        };
+        if let Err(e) = filesystem.write_file(&path, &bytes) {
+            tracing::warn!("orchestrator migration: failed to write {path:?}: {e}");
+        }
+    }
+    for legacy_p in legacy_to_rename {
+        let backup = legacy_p.with_extension("json.migrated.bak");
+        if let Err(e) = filesystem.rename(&legacy_p, &backup) {
+            tracing::warn!(
+                "orchestrator migration: failed to rename {legacy_p:?} → {backup:?}: {e}"
+            );
+        }
+    }
+    tracing::info!(
+        "orchestrator persistence: migrated plugin state for {} plugins",
+        merged.len()
+    );
+}
+
 impl Editor {
     /// Persist `sessions` + `plugin_global_state` to disk. Best-
     /// effort: filesystem errors are logged at WARN and swallowed
     /// so a transient permission glitch doesn't block quit.
     pub fn save_orchestrator_state(&self) {
-        let working_dir = self.working_dir().to_path_buf();
         let data_dir = self.dir_context.data_dir.clone();
-        let orchestrator_dir = orchestrator_dir(&data_dir, &working_dir);
-        if let Err(e) = self.authority.filesystem.create_dir_all(&orchestrator_dir) {
-            tracing::warn!("orchestrator persistence: failed to create {orchestrator_dir:?}: {e}");
+        let orch_dir = orchestrator_dir(&data_dir);
+        if let Err(e) = self.authority.filesystem.create_dir_all(&orch_dir) {
+            tracing::warn!("orchestrator persistence: failed to create {orch_dir:?}: {e}");
             return;
         }
 
-        // Windows.
+        // Read the existing on-disk windows.json (if any) so we
+        // merge in sessions belonging to OTHER projects rather
+        // than clobbering them. Single-user but multi-project
+        // safety: another editor instance might have written
+        // sessions for a different project_path while we were
+        // running.
+        let existing: Option<PersistedWindows> = {
+            let p = global_windows_path(&data_dir);
+            if self.authority.filesystem.exists(&p) {
+                match self.authority.filesystem.read_file(&p) {
+                    Ok(bytes) => serde_json::from_slice::<PersistedWindows>(&bytes).ok(),
+                    Err(_) => None,
+                }
+            } else {
+                None
+            }
+        };
+        let our_ids: std::collections::HashSet<u64> =
+            self.windows.keys().map(|id| id.0).collect();
+
+        // Our process's sessions, snapshotted from runtime state.
         let mut windows: Vec<PersistedWindow> = self
             .windows
             .values()
-            .map(|s| PersistedWindow {
-                id: s.id.0,
-                label: s.label.clone(),
-                root: s.root.clone(),
-                plugin_state: s.plugin_state.clone(),
+            .map(|s| {
+                // project_path / shared_worktree live in
+                // plugin_state under "orchestrator". Read them
+                // back if the orchestrator plugin set them
+                // (post-Phase 5 sessions); fall back to None /
+                // false for sessions created before the schema
+                // bump or by external paths.
+                let (project_path, shared_worktree) = read_orch_session_meta(&s.plugin_state);
+                PersistedWindow {
+                    id: s.id.0,
+                    label: s.label.clone(),
+                    root: s.root.clone(),
+                    project_path,
+                    shared_worktree,
+                    plugin_state: s.plugin_state.clone(),
+                }
             })
             .collect();
+
+        // Splice in other-process sessions from the existing
+        // file (anything whose id we don't currently own).
+        if let Some(env) = existing {
+            for w in env.windows.into_iter() {
+                if !our_ids.contains(&w.id) {
+                    windows.push(w);
+                }
+            }
+        }
         // Stable on-disk order — `HashMap` iteration order would
         // make the file diff differently every quit, producing
         // noisy diffs for anyone inspecting the persisted state.
         windows.sort_by_key(|s| s.id);
         let envelope = PersistedWindows {
+            version: CURRENT_VERSION,
             active: self.active_window.0,
             next_id: self.next_window_id,
             windows,
         };
         match serde_json::to_vec_pretty(&envelope) {
             Ok(bytes) => {
-                let path = windows_path(&data_dir, &working_dir);
-                if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
-                    tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
+                let path = global_windows_path(&data_dir);
+                // Atomic rename to avoid a torn write if two
+                // editor processes happen to quit at the same
+                // moment. The `.tmp` file is in the same dir so
+                // `rename` is an atomic syscall on every
+                // filesystem we support.
+                let tmp = path.with_extension("json.tmp");
+                if let Err(e) = self.authority.filesystem.write_file(&tmp, &bytes) {
+                    tracing::warn!("orchestrator persistence: failed to write {tmp:?}: {e}");
+                    return;
+                }
+                if let Err(e) = self.authority.filesystem.rename(&tmp, &path) {
+                    tracing::warn!(
+                        "orchestrator persistence: failed to rename {tmp:?} → {path:?}: {e}"
+                    );
                 }
             }
             Err(e) => {
@@ -237,10 +595,11 @@ impl Editor {
             }
         }
 
-        // Plugin global state — one file per plugin so concurrent
-        // editors writing different plugins don't clobber each
-        // other (a future feature; today single-process).
-        let state_dir = state_dir(&data_dir, &working_dir);
+        // Plugin global state — one file per plugin. Single
+        // global directory now (no per-cwd split), so two
+        // editor processes writing the same plugin's state
+        // still need atomic-rename safety.
+        let state_dir = global_state_dir(&data_dir);
         if !self.plugin_global_state.is_empty() {
             if let Err(e) = self.authority.filesystem.create_dir_all(&state_dir) {
                 tracing::warn!("orchestrator persistence: failed to create {state_dir:?}: {e}");
@@ -259,9 +618,18 @@ impl Editor {
             }
             match serde_json::to_vec_pretty(map) {
                 Ok(bytes) => {
-                    let path = plugin_state_path(&data_dir, &working_dir, plugin);
-                    if let Err(e) = self.authority.filesystem.write_file(&path, &bytes) {
-                        tracing::warn!("orchestrator persistence: failed to write {path:?}: {e}");
+                    let path = global_plugin_state_path(&data_dir, plugin);
+                    let tmp = path.with_extension("json.tmp");
+                    if let Err(e) = self.authority.filesystem.write_file(&tmp, &bytes) {
+                        tracing::warn!(
+                            "orchestrator persistence: failed to write {tmp:?}: {e}"
+                        );
+                        continue;
+                    }
+                    if let Err(e) = self.authority.filesystem.rename(&tmp, &path) {
+                        tracing::warn!(
+                            "orchestrator persistence: failed to rename {tmp:?} → {path:?}: {e}"
+                        );
                     }
                 }
                 Err(e) => {
@@ -272,6 +640,26 @@ impl Editor {
             }
         }
     }
+}
+
+/// Pull `project_path` (PathBuf) and `shared_worktree` (bool)
+/// out of a session's per-plugin state, if the orchestrator
+/// plugin has set them via `setWindowState`. Both keys live
+/// under the `"orchestrator"` plugin slot; the keys are
+/// `"project_path"` and `"shared_worktree"`.
+fn read_orch_session_meta(
+    plugin_state: &HashMap<String, HashMap<String, serde_json::Value>>,
+) -> (Option<PathBuf>, bool) {
+    let slot = plugin_state.get("orchestrator");
+    let project_path = slot
+        .and_then(|m| m.get("project_path"))
+        .and_then(|v| v.as_str())
+        .map(PathBuf::from);
+    let shared_worktree = slot
+        .and_then(|m| m.get("shared_worktree"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    (project_path, shared_worktree)
 }
 
 #[cfg(test)]
@@ -285,9 +673,9 @@ mod tests {
         let data_dir = Path::new("/tmp/fresh-data");
         let working_dir = Path::new("/home/user/project");
 
-        let wp = windows_path(data_dir, working_dir);
-        let sd = state_dir(data_dir, working_dir);
-        let psp = plugin_state_path(data_dir, working_dir, "orchestrator");
+        let wp = global_windows_path(data_dir);
+        let sd = global_state_dir(data_dir);
+        let psp = global_plugin_state_path(data_dir, "orchestrator");
 
         assert!(
             wp.starts_with(data_dir),
@@ -319,18 +707,15 @@ mod tests {
     }
 
     #[test]
-    fn paths_are_keyed_by_working_dir() {
-        // Two distinct working dirs must map to two distinct
-        // orchestrator subtrees, otherwise different projects
-        // would clobber each other's state.
+    fn global_paths_are_independent_of_working_dir() {
+        // v2: persistence is global, not per-cwd. Two different
+        // cwds resolve to the same file path so the user sees
+        // their full session history regardless of where the
+        // editor was launched from.
         let data_dir = Path::new("/tmp/fresh-data");
-        let a = windows_path(data_dir, Path::new("/home/user/proj-a"));
-        let b = windows_path(data_dir, Path::new("/home/user/proj-b"));
-        assert_ne!(a, b);
-        // Same working dir must map to same path (idempotent
-        // encoding — relied on so a quit + restart sees the
-        // same file).
-        let a_again = windows_path(data_dir, Path::new("/home/user/proj-a"));
-        assert_eq!(a, a_again);
+        let a = global_windows_path(data_dir);
+        let b = global_windows_path(data_dir);
+        assert_eq!(a, b);
+        assert_eq!(a, data_dir.join("orchestrator").join("windows.json"));
     }
 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3502,6 +3502,7 @@ impl Editor {
         let focus_cursor = out_pieces.focus_cursor;
         let entries = out_pieces.entries;
         let embeds = out_pieces.embeds;
+        let overlays = out_pieces.overlays;
         if self
             .widget_registry
             .update_side_effects(
@@ -3522,6 +3523,7 @@ impl Editor {
                     fwp.entries = entries;
                     fwp.focus_cursor = focus_cursor;
                     fwp.embeds = embeds;
+                    fwp.overlays = overlays;
                 }
             }
             return;
@@ -4950,6 +4952,7 @@ impl Editor {
             entries: Vec::new(),
             focus_cursor: None,
             embeds: Vec::new(),
+            overlays: Vec::new(),
             last_inner_rect: None,
         });
         let prev = std::collections::HashMap::new();
@@ -4959,6 +4962,7 @@ impl Editor {
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;
+        let overlays = out.overlays;
         self.widget_registry.mount(
             panel_id,
             FLOATING_PANEL_BUFFER_ID,
@@ -4972,6 +4976,7 @@ impl Editor {
             fwp.entries = entries;
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
+            fwp.overlays = overlays;
         }
         tracing::debug!(
             "Mounted floating widget panel {} ({}%x{}%)",
@@ -5007,6 +5012,7 @@ impl Editor {
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;
+        let overlays = out.overlays;
         if self
             .widget_registry
             .update(
@@ -5029,6 +5035,7 @@ impl Editor {
             fwp.entries = entries;
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
+            fwp.overlays = overlays;
         }
     }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -148,10 +148,23 @@ impl Editor {
         let mut session_infos: Vec<fresh_core::api::WindowInfo> = self
             .windows
             .values()
-            .map(|s| fresh_core::api::WindowInfo {
-                id: s.id,
-                label: s.label.clone(),
-                root: s.root.clone(),
+            .map(|s| {
+                let slot = s.plugin_state.get("orchestrator");
+                let project_path = slot
+                    .and_then(|m| m.get("project_path"))
+                    .and_then(|v| v.as_str())
+                    .map(std::path::PathBuf::from);
+                let shared_worktree = slot
+                    .and_then(|m| m.get("shared_worktree"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                fresh_core::api::WindowInfo {
+                    id: s.id,
+                    label: s.label.clone(),
+                    root: s.root.clone(),
+                    project_path,
+                    shared_worktree,
+                }
             })
             .collect();
         session_infos.sort_by_key(|s| s.id.0);

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3401,7 +3401,7 @@ impl Editor {
     ) {
         use ratatui::widgets::{Block, Borders, Clear};
 
-        let (width_pct, height_pct, entries, focus_cursor, embeds) =
+        let (width_pct, height_pct, entries, focus_cursor, embeds, overlays) =
             match self.floating_widget_panel.as_ref() {
                 Some(fwp) => (
                     fwp.width_pct,
@@ -3409,6 +3409,7 @@ impl Editor {
                     fwp.entries.clone(),
                     fwp.focus_cursor,
                     fwp.embeds.clone(),
+                    fwp.overlays.clone(),
                 ),
                 None => return,
             };
@@ -3501,6 +3502,38 @@ impl Editor {
             self.render_session_preview_into_rect(frame, rect, &theme);
         }
         self.preview_window_id = saved_preview;
+
+        // Paint overlay rows AFTER the main entries + embeds. Each
+        // overlay row sits on top of whatever's at its
+        // `buffer_row` (the row it would have occupied if it
+        // weren't floating). Used for dropdown completions
+        // anchored to a text input — the completion list rows
+        // overpaint the form's static rows beneath without
+        // shifting them on every show / hide.
+        //
+        // Clear the row first so the underlying entry's text
+        // doesn't bleed past the overlay's content width.
+        // `Paragraph` only paints cells it has content for; a
+        // bare `Clear` resets the row to the panel background
+        // (the `Block` here just supplies the bg style — no
+        // borders).
+        let panel_bg = theme.popup_bg;
+        let panel_bg_style = ratatui::style::Style::default().bg(panel_bg);
+        for o in &overlays {
+            let row_y = inner.y.saturating_add(o.buffer_row as u16);
+            if row_y >= inner.y.saturating_add(inner.height) {
+                continue;
+            }
+            let row_rect = ratatui::layout::Rect {
+                x: inner.x,
+                y: row_y,
+                width: inner.width,
+                height: 1,
+            };
+            frame.render_widget(Clear, row_rect);
+            frame.render_widget(Block::default().style(panel_bg_style), row_rect);
+            paint_text_property_entry(frame, &o.entry, inner.x, row_y, inner.width, &theme);
+        }
 
         if let Some(fc) = focus_cursor {
             let cx = inner.x.saturating_add(byte_to_screen_col(

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3514,6 +3514,17 @@ impl Editor {
             if cx < inner.x + inner.width && cy < inner.y + inner.height {
                 frame.set_cursor_position((cx, cy));
             }
+        } else {
+            // No focused text input — the underlying editor's
+            // `set_cursor_position` (called earlier in this frame)
+            // would otherwise leave a hardware caret blinking
+            // inside the dimmed buffer behind the panel. Park the
+            // cursor on the floating panel's bottom-right corner
+            // so it's hidden under the panel chrome instead of
+            // bleeding through.
+            let cx = inner.x + inner.width.saturating_sub(1);
+            let cy = inner.y + inner.height.saturating_sub(1);
+            frame.set_cursor_position((cx, cy));
         }
 
         if let Some(fwp) = self.floating_widget_panel.as_mut() {
@@ -3622,17 +3633,40 @@ fn paint_text_property_entry(
             continue;
         }
         let slice = text[a..b].to_string();
+        // Merge (don't replace) overlapping overlays so a later
+        // overlay can override individual properties (bg, fg,
+        // italic, …) without wiping the earlier overlay's other
+        // properties. The text-input renderer relies on this:
+        // the placeholder overlay sets fg + italic, then the
+        // focused overlay sets bg only — without per-property
+        // merge the focused-bg overlay would also clear the
+        // placeholder's italic-dim styling, making placeholder
+        // text indistinguishable from a typed value under focus.
         let mut style = base_style;
         for o in &normalized.inline_overlays {
             let os = o.start.min(text.len());
             let oe = o.end.min(text.len());
             if a >= os && b <= oe && oe > os {
-                style = Editor::resolve_overlay_style(&o.style, theme).bg(
-                    Editor::resolve_overlay_style(&o.style, theme)
-                        .bg
-                        .unwrap_or(base_bg),
-                );
+                let resolved = Editor::resolve_overlay_style(&o.style, theme);
+                if let Some(fg) = resolved.fg {
+                    style = style.fg(fg);
+                }
+                if let Some(bg) = resolved.bg {
+                    style = style.bg(bg);
+                }
+                // Ratatui `Style` carries add/sub modifier sets;
+                // OR the additions in so subsequent overlays can
+                // add italic / bold / etc. on top of the prior
+                // overlay's modifiers.
+                style = style.add_modifier(resolved.add_modifier);
+                style = style.remove_modifier(resolved.sub_modifier);
             }
+        }
+        // Ensure a bg is set: ratatui will paint the slot with
+        // the terminal's default bg otherwise, which doesn't
+        // match the surrounding panel chrome.
+        if style.bg.is_none() {
+            style = style.bg(base_bg);
         }
         spans.push(Span::styled(slice, style));
     }

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -24,4 +24,4 @@ pub use actions::{
     tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
-pub use render::{render_spec, EmbedRect, FocusCursor, RenderOutput};
+pub use render::{render_spec, EmbedRect, FocusCursor, OverlayRow, RenderOutput};

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -120,6 +120,25 @@ pub struct RenderOutput {
     /// rendered panel's inner area) the host should paint that
     /// window into after laying down the regular entries.
     pub embeds: Vec<EmbedRect>,
+    /// Rows produced by `WidgetSpec::Overlay` children. Each
+    /// row carries its anchor `buffer_row` (relative to the
+    /// rendered panel's inner area) and is painted by the host
+    /// AFTER the main `entries`, on top of whatever is at that
+    /// row. Used for dropdown completions, tooltips, hover
+    /// popups — anything that should appear next to a focused
+    /// widget without reflowing the rest of the layout when it
+    /// shows or hides.
+    pub overlays: Vec<OverlayRow>,
+}
+
+/// One row produced by an `Overlay` widget. `buffer_row` is the
+/// 0-based row inside the panel's inner area where the entry
+/// should be painted; the host's paint pass writes overlay rows
+/// after the main entries so they sit on top.
+#[derive(Debug, Clone)]
+pub struct OverlayRow {
+    pub buffer_row: u32,
+    pub entry: TextPropertyEntry,
 }
 
 /// A rectangle reserved by a `WindowEmbed` widget. All
@@ -165,7 +184,7 @@ pub fn render_spec(
     };
 
     let mut next_state = HashMap::new();
-    let (entries, hits, focus_cursor, embeds) =
+    let (entries, hits, focus_cursor, embeds, overlays) =
         render_collected(spec, prev, &mut next_state, &focus_key, panel_width);
     RenderOutput {
         entries,
@@ -175,6 +194,7 @@ pub fn render_spec(
         tabbable,
         focus_cursor,
         embeds,
+        overlays,
     }
 }
 
@@ -328,6 +348,7 @@ fn render_collected(
     Vec<HitArea>,
     Option<FocusCursor>,
     Vec<EmbedRect>,
+    Vec<OverlayRow>,
 ) {
     let mut entries: Vec<TextPropertyEntry> = Vec::new();
     let mut hits: Vec<HitArea> = Vec::new();
@@ -335,6 +356,7 @@ fn render_collected(
     // position bubbles up through containers as a single Option.
     let mut focus_cursor: Option<FocusCursor> = None;
     let mut embeds: Vec<EmbedRect> = Vec::new();
+    let mut overlays: Vec<OverlayRow> = Vec::new();
     match spec {
         WidgetSpec::Row { children, .. } => {
             // Two-pass layout for Row:
@@ -400,8 +422,13 @@ fn render_collected(
                     continue;
                 }
                 let child_panel_width = per_child_width[idx];
-                let (child_entries, child_hits, child_focus, child_embeds) =
+                let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
                     render_collected(child, prev, next_state, focus_key, child_panel_width);
+                // Rows can host overlays in principle (e.g. a
+                // tooltip on a button); forward them up without
+                // a row-offset adjustment — Row pieces all sit
+                // on the same buffer-row as the merged row.
+                overlays.extend(child_overlays);
                 if child_entries.is_empty() {
                     debug_assert!(child_hits.is_empty(), "empty children produce no hits");
                     continue;
@@ -550,9 +577,56 @@ fn render_collected(
         }
         WidgetSpec::Col { children, .. } => {
             for child in children {
-                let (child_entries, child_hits, child_focus, child_embeds) =
+                // Overlay children DO NOT contribute vertical
+                // space to the col. Render them, but stash the
+                // produced entries as overlays anchored at the
+                // current `entries.len()` (the row they would
+                // have occupied) — they get painted on top
+                // afterwards without pushing the rest of the
+                // col downward.
+                let is_overlay = matches!(child, WidgetSpec::Overlay { .. });
+                let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
                     render_collected(child, prev, next_state, focus_key, panel_width);
                 let row_offset = entries.len() as u32;
+                if is_overlay {
+                    // Promote the overlay child's regular
+                    // entries to overlay rows anchored at the
+                    // current col cursor (`row_offset`). Hits
+                    // for those entries are shifted to the same
+                    // anchor row so click-to-pick targets the
+                    // painted row.
+                    for (i, e) in child_entries.into_iter().enumerate() {
+                        overlays.push(OverlayRow {
+                            buffer_row: row_offset + i as u32,
+                            entry: e,
+                        });
+                    }
+                    for mut h in child_hits {
+                        h.buffer_row += row_offset;
+                        hits.push(h);
+                    }
+                    // Focus cursor inside an overlay (rare but
+                    // legal) anchors at the same row; without
+                    // this shift Up/Down + cursor placement
+                    // would land on the col's "natural" row.
+                    if let Some(mut fc) = child_focus {
+                        fc.buffer_row += row_offset;
+                        focus_cursor = Some(fc);
+                    }
+                    // Forward nested overlays without further
+                    // adjustment (already anchored).
+                    overlays.extend(child_overlays);
+                    // Embeds inside an overlay don't make sense
+                    // today (a window-embed below a popup would
+                    // be confusing) — propagate at the same
+                    // anchor row so behaviour is well-defined
+                    // if someone tries it.
+                    for mut emb in child_embeds {
+                        emb.buffer_row += row_offset;
+                        embeds.push(emb);
+                    }
+                    continue;
+                }
                 for mut h in child_hits {
                     h.buffer_row += row_offset;
                     hits.push(h);
@@ -565,6 +639,10 @@ fn render_collected(
                     emb.buffer_row += row_offset;
                     embeds.push(emb);
                 }
+                overlays.extend(child_overlays.into_iter().map(|mut o| {
+                    o.buffer_row += row_offset;
+                    o
+                }));
                 entries.extend(child_entries);
             }
         }
@@ -1172,8 +1250,12 @@ fn render_collected(
             // Inner area: 1 column of border + 1 column of
             // padding on each side ⇒ 4 columns of chrome.
             let inner_width = panel_width.saturating_sub(4).max(1);
-            let (child_entries, child_hits, child_focus, child_embeds) =
+            let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
                 render_collected(child, prev, next_state, focus_key, inner_width);
+            // Overlays bubble through the section unchanged —
+            // the section's chrome doesn't shift them and the
+            // anchor row is already relative to the inner area.
+            overlays.extend(child_overlays);
 
             // Render the top border with the label embedded as a
             // legend: `╭─ <label> ─...─╮`. When the label is empty,
@@ -1276,8 +1358,27 @@ fn render_collected(
                 entries.push(e);
             }
         }
+        WidgetSpec::Overlay { child, .. } => {
+            // Renders the child normally; the parent (`Col`)
+            // is what decides to promote the resulting entries
+            // into the overlay set instead of consuming
+            // vertical space. Outside of a `Col`, an Overlay
+            // behaves like a transparent wrapper — entries
+            // flow through unchanged. This keeps the
+            // Overlay-as-root case (no enclosing Col) sane:
+            // it just renders inline.
+            let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
+                render_collected(child, prev, next_state, focus_key, panel_width);
+            entries.extend(child_entries);
+            hits.extend(child_hits);
+            if focus_cursor.is_none() {
+                focus_cursor = child_focus;
+            }
+            embeds.extend(child_embeds);
+            overlays.extend(child_overlays);
+        }
     }
-    (entries, hits, focus_cursor, embeds)
+    (entries, hits, focus_cursor, embeds, overlays)
 }
 
 // =========================================================================

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -32,7 +32,16 @@ use std::collections::{HashMap, HashSet};
 // "role-based" theming (§7 of the design doc) has one place to
 // substitute the role→key mapping.
 const KEY_HELP_KEY_FG: &str = "ui.help_key_fg";
-const KEY_TOGGLE_ON_FG: &str = "ui.tab_active_fg";
+// Foreground of a checked Toggle's `[v]` glyph. `ui.help_key_fg`
+// is the "keyboard-key / highlight on a popup body" theme key —
+// every shipped theme picks a colour that contrasts with
+// `ui.popup_bg`. The previous choice (`ui.tab_active_fg`) was
+// designed to contrast with `tab_active_bg`, not the popup body;
+// in `high-contrast` both ended up black so the `[v]` glyph
+// vanished on every unfocused toggle. `help_key_fg` keeps the
+// emphasis intent (a bright accent colour) while reliably
+// surviving the popup background.
+const KEY_TOGGLE_ON_FG: &str = "ui.help_key_fg";
 // Selection/focus highlight for widgets inside floating panels
 // (list rows, tree nodes, buttons). Originally pointed at
 // `ui.menu_active_{fg,bg}` which defaults to rgb(255,255,255) on
@@ -1490,10 +1499,11 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
 /// Render a `Toggle` to a single `TextPropertyEntry`.
 ///
 /// Layout: `[v] label` when checked, `[ ] label` when not. The check
-/// glyph is colored via `ui.tab_active_fg` when checked (no override
-/// when unchecked). When focused, the entire entry is given a focused
-/// fg/bg pair (`ui.popup_selection_fg`/`ui.popup_selection_bg`) plus
-/// bold — matching the prompt / palette's selected-row affordance.
+/// glyph is colored via `ui.help_key_fg` when checked (a popup-bg-
+/// safe highlight key; no override when unchecked). When focused,
+/// the entire entry is given a focused fg/bg pair
+/// (`ui.popup_selection_fg`/`ui.popup_selection_bg`) plus bold —
+/// matching the prompt / palette's selected-row affordance.
 pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyEntry {
     let glyph = if checked { "[v]" } else { "[ ]" };
     let mut text = String::with_capacity(glyph.len() + 1 + label.len());

--- a/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
+++ b/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
@@ -5,9 +5,12 @@
 //! directory in the user's working tree even for sessions that never
 //! touched any orchestrator feature.
 //!
-//! Post-fix, orchestrator state lives under
-//! `<data_dir>/orchestrator/<encoded_working_dir>/`, mirroring how
-//! other per-project editor state is stored.
+//! Post-fix, orchestrator state lives under the platform data dir.
+//! Schema v2 (Phase 5) moved the file from a per-cwd subdirectory to
+//! a single global `<data_dir>/orchestrator/windows.json`; the
+//! "don't pollute the working tree" invariant the original test
+//! protected still holds, and the file's expected location has been
+//! updated accordingly.
 
 mod common;
 
@@ -63,16 +66,11 @@ fn save_orchestrator_state_does_not_create_dotfresh_in_working_dir() {
     );
 
     // And the corresponding orchestrator state must have landed
-    // under the platform data dir instead.
-    let canonical_project = project_dir
-        .path()
-        .canonicalize()
-        .unwrap_or_else(|_| project_dir.path().to_path_buf());
-    let encoded = fresh::workspace::encode_path_for_filename(&canonical_project);
+    // under the platform data dir instead. v2 stores everything in
+    // one global file regardless of `working_dir`.
     let expected_windows_file = dir_context
         .data_dir
         .join("orchestrator")
-        .join(&encoded)
         .join("windows.json");
     assert!(
         expected_windows_file.exists(),

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -8651,11 +8651,15 @@ mod tests {
                     id: fresh_core::WindowId(1),
                     label: "main".into(),
                     root: std::path::PathBuf::from("/repo"),
+                    project_path: None,
+                    shared_worktree: false,
                 },
                 fresh_core::api::WindowInfo {
                     id: fresh_core::WindowId(2),
                     label: "feat-auth".into(),
                     root: std::path::PathBuf::from("/wt/feat-auth"),
+                    project_path: None,
+                    shared_worktree: false,
                 },
             ];
             state.active_window_id = fresh_core::WindowId(2);

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -1,11 +1,12 @@
-# Orchestrator: New Session — Base Path + Worktree Toggle
+# Orchestrator: New Session — Project Path + Worktree Toggle
 
 > **Status**: Design Document
 > **Date**: May 2026
 > **Driving feature**: Let the user create Orchestrator sessions
-> against an arbitrary base path (any directory, not necessarily
-> the current cwd), and let them choose whether the session gets
-> its own git worktree or runs directly inside the given path.
+> against an arbitrary project path (any directory, not
+> necessarily the current cwd), and let them choose whether the
+> session gets its own git worktree or runs directly inside the
+> given path.
 
 ## Motivation
 
@@ -41,17 +42,28 @@ The goal is for users to be able to create sessions
 
 ## Wireframe
 
-### Default state — base path pre-filled from the canonical repo root
+### Default state — project path pre-filled from the canonical repo root
+
+The "Project: <label>" subtitle is gone: the Project Path field
+itself is the project identifier now, so a static label above
+it would just duplicate (or worse, drift from) the input.
+
+All four text inputs (Project Path, Session Name, Agent
+Command, Branch) carry **value history**: Up / Down on a
+focused input scrolls through the values the user has
+previously submitted in that field, MRU-ordered, much like a
+shell prompt. An empty value at the bottom of the stack is the
+"clear" entry. History is per-field, stored globally per user
+(see [Where the multi-window list lives](#where-the-multi-window-list-lives))
+so it follows the user across projects.
 
 ```
 ╭─ ORCHESTRATOR :: New Session Dialog :: Review Synthesized ───────────╮
 │                                                                      │
-│                      Project: noam/fresh                             │
-│                                                                      │
-│ ╭─ Base Repository Path ───────────────────────────────────────────╮ │
+│ ╭─ Project Path ───────────────────────────────────────────────────╮ │
 │ │ [/home/noam/repos/fresh                                         ]│ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
-│   ↳ canonical repo root (worktree-resolved). Leave blank to keep.    │
+│   ↳ canonical repo root (worktree-resolved). ↑↓ for history.         │
 │                                                                      │
 │ [x] Create a new git worktree for this session                       │
 │      └─ unchecked = run the session directly inside the path above   │
@@ -73,9 +85,13 @@ The goal is for users to be able to create sessions
 │                                                                      │
 │                              [ Cancel ]   [ Create Session ]         │
 │                                                                      │
-│  Tab next · S-Tab prev · Space toggle · Enter act · Esc cancel       │
+│  Tab next · S-Tab prev · ↑↓ history · Space toggle · Enter act · Esc │
 ╰──────────────────────────────────────────────────────────────────────╯
 ```
+
+Inputs stay stacked vertically full-width (not packed
+side-by-side) so long paths and commands have room to breathe
+without truncation or horizontal scrolling.
 
 ### Non-git path — checkbox auto-cleared, branch row dimmed
 
@@ -92,10 +108,10 @@ working tree, the dialog detects it asynchronously (via
   cycle.
 
 ```
-│ ╭─ Base Repository Path ───────────────────────────────────────────╮ │
+│ ╭─ Project Path ───────────────────────────────────────────────────╮ │
 │ │ [/home/noam/notes                                               ]│ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
-│   ↳ not a git working tree                                           │
+│   ↳ not a git working tree. ↑↓ for history.                          │
 │                                                                      │
 │ [·] Create a new git worktree for this session   (non-git path)      │
 │                                                                      │
@@ -126,18 +142,61 @@ a ref.
 
 ## Field semantics
 
-| Field                  | Default                                       | When empty submits as |
-|------------------------|-----------------------------------------------|-----------------------|
-| Base Repository Path   | canonical repo root resolved from editor cwd  | the placeholder default (canonical repo root) |
-| Create worktree (cb)   | checked iff path resolves to a git work tree  | (boolean — no empty)  |
-| Session Name           | empty                                         | auto-generated (`session-N`) |
-| Agent Command          | empty (placeholder = `lastCmd` or `terminal`) | the placeholder       |
-| Branch                 | empty (placeholder = detected default branch) | the placeholder (only valid when worktree=on) |
+| Field                | Default                                       | When empty submits as |
+|----------------------|-----------------------------------------------|-----------------------|
+| Project Path         | canonical repo root resolved from editor cwd  | the placeholder default (canonical repo root) |
+| Create worktree (cb) | checked iff path resolves to a git work tree  | (boolean — no empty)  |
+| Session Name         | empty                                         | auto-generated (`session-N`) |
+| Agent Command        | empty (placeholder = `lastCmd` or `terminal`) | the placeholder       |
+| Branch               | empty (placeholder = detected default branch) | the placeholder (only valid when worktree=on) |
+
+### Input history (Up / Down)
+
+Every text input in the form keeps a per-field history list.
+The shape (stored under
+`<XDG>/fresh/orchestrator/input_history.json`):
+
+```json
+{
+  "version": 1,
+  "project_path":   ["/home/noam/repos/fresh", "/home/noam/notes", …],
+  "session_name":   ["bugfix-1991", "refactor-lsp", …],
+  "agent_command":  ["claude", "python3 agent.py", …],
+  "branch":         ["origin/main", "feat/diff-folding", …]
+}
+```
+
+Behaviour:
+
+- **↑ / Up** on a focused input: walk one entry older into
+  history. The first press saves the current draft (whatever
+  the user has typed but not submitted) at the top of the
+  stack so ↓ can return to it.
+- **↓ / Down** on a focused input: walk one entry newer; at
+  the bottom of the stack, restore the saved draft (or
+  empty).
+- **Submit** appends the value to the front of that field's
+  history (deduplicated — if the value already exists in the
+  list it moves to the front rather than duplicating).
+- **Empty submissions** (i.e. the user accepted the
+  placeholder) record the placeholder's resolved value, not
+  the empty string, so the next launch surfaces "fresh repo
+  root" / "origin/main" / etc. by name.
+- History is **global per user**, not per project — the
+  windows.json store is global too (see [Where the multi-
+  window list lives](#where-the-multi-window-list-lives)),
+  and the user's mental model of "the commands I run" lives
+  with them across projects.
+- Capped at 100 entries per field, MRU-trimmed.
+- The smart-key forwarder used by the Open dialog (where
+  Up/Down on the filter input forward to the list) needs to
+  be **disabled** for fields with history — Up/Down navigates
+  history here, not a sibling list.
 
 ### "Canonical repo root" resolution
 
-The pre-filled default for Base Repository Path is derived from
-the editor's cwd in this order:
+The pre-filled default for Project Path is derived from the
+editor's cwd in this order:
 
 1. `git -C <cwd> rev-parse --path-format=absolute --git-common-dir`
    → `dirname(...)` of the result is the **main worktree's
@@ -158,15 +217,15 @@ replaces it on completion if the field is still empty.
 ### Worktree checkbox — interaction model
 
 - **Checked + git path** → today's behaviour:
-  `git worktree add <root> -b <branch> <base>` rooted at
-  `<XDG>/orchestrator/<slug-of-base-path>/<session-name>/`.
-- **Unchecked + git path** → session root is the **base path
+  `git worktree add <root> -b <branch> <project-path>` rooted at
+  `<XDG>/orchestrator/<slug-of-project-path>/<session-name>/`.
+- **Unchecked + git path** → session root is the **project path
   itself**. No `git worktree add`. The session inherits whatever
   branch the worktree is currently on. Branch field is inert.
 - **Checked + non-git path** → impossible (checkbox is forced
   off and grayed).
-- **Unchecked + non-git path** → session root is the base path.
-  No git interaction at all. Branch field is inert.
+- **Unchecked + non-git path** → session root is the project
+  path. No git interaction at all. Branch field is inert.
 
 When the worktree is shared (unchecked + git path) the session
 record still goes into the normal persistence layer; it's just
@@ -176,114 +235,133 @@ this works without changes to `orchestrator_persistence.rs`.
 
 ## Where the multi-window list lives
 
-This is the open question the spec calls out: when a user
-returns days later and wants to resume an orchestration, where
-do we look for the session list?
+**Decision: global per-user.** A single
+`<XDG>/fresh/orchestrator/windows.json` holds every
+orchestrator session the user has ever created, regardless of
+which project they belong to. Sessions carry a `project_path`
+field so the Open dialog can filter / group by project.
 
-### Current behaviour
+Rationale:
 
-`orchestrator_persistence.rs` writes
-`<XDG data>/fresh/orchestrator/<encoded_working_dir>/windows.json`,
-keyed by **the editor process's working directory** at launch
-time (encoded via `workspace::encode_path_for_filename`). This
-means:
+- The whole point of the project-path field is to **decouple**
+  session creation from the editor's cwd. Persistence should
+  follow the same principle — keying windows.json on cwd or on
+  repo root would re-introduce the coupling the form is
+  explicitly trying to break.
+- A user running an agent in `~/notes/` (non-git) and another
+  in `~/repos/fresh` (git) shouldn't have two disjoint stores
+  with different schemas. One store, one schema, sessions
+  filtered by project_path at read time.
+- Users frequently want a cross-project "all my running
+  agents" view — global is the natural home for it.
+- Input history (project paths, agent commands, branch names)
+  already lives globally for the same reason; co-locating
+  windows.json with it keeps the storage model consistent.
 
-- Two editor windows launched from the same cwd share their
-  windows list (and would clobber each other).
-- An editor launched from `/home/noam/repos/fresh` and one
-  launched from `/home/noam/repos/fresh/sub-dir` see **different
-  windows lists**, even though they're in the same repo.
-- An editor launched from `/tmp/scratch` works for non-git use
-  cases — the keying doesn't require git.
-
-### Three candidate keyings
-
-#### A. Per editor working directory (status quo)
-
-- **Pro**: works for non-git paths trivially; matches how users
-  think about "the editor I opened in this folder".
-- **Con**: keying by cwd is brittle — `cd repos/fresh` vs.
-  `cd ~/repos/fresh` writes to different encoded keys. Two
-  editor instances in the same project but different
-  subdirectories see disjoint session lists.
-- **Migration**: zero.
-
-#### B. Per canonical git repo root (with non-git fallback)
-
-Resolve cwd to the canonical repo root (the same logic that
-fills the Base Repository Path default) and key the persistence
-directory on that. For non-git paths, fall back to encoding the
-path verbatim — i.e. `<XDG>/orchestrator/<slug-of-repo-or-path>/`.
-
-- **Pro**: matches the user's mental model — "open my fresh
-  sessions for *this project*" produces the same list whether
-  the editor was launched from the repo root, a sub-directory,
-  or a linked worktree.
-- **Con**: surprises users who launch the editor from a
-  symlinked / sibling path expecting a fresh slate. Mitigation:
-  a tiny status-bar message on first load
-  (`Resumed N sessions from <repo>`) keeps the resolution
-  visible.
-- **Migration**: scan existing
-  `<XDG>/orchestrator/<encoded_cwd>/windows.json` files and
-  fold matches into the canonical-repo bucket on first launch.
-  Conflicts (two cwd-keyed files mapping to the same repo)
-  merge by union; ids stay stable because they're already
-  globally unique within a `windows.json`.
-
-#### C. Global per-user
-
-One `<XDG>/orchestrator/windows.json` with a `base_path` /
-`repo_root` field on each session entry.
-
-- **Pro**: a single "list every orchestration I've ever run"
-  view; cleanest answer for "where is the data".
-- **Con**: every editor instance has to filter to the
-  sessions relevant to it, and the file becomes a hot spot
-  for concurrent writers (two editors saving on quit at the
-  same time). The orchestrator dialog already exists per
-  editor instance, and most users never want to see another
-  project's sessions in *this* editor's picker.
-- **Migration**: as in B, plus everything funnels into one
-  file. The concurrent-writer risk argues for a per-session
-  fragmented layout
-  (`<XDG>/orchestrator/sessions/<id>.json`) rather than a
-  single monolithic file — which is a bigger refactor.
-
-### Recommendation
-
-**Adopt B** (per canonical git repo root, with a verbatim-path
-fallback for non-git launches), and surface the resolution in
-the dialog's subtitle:
+### File layout
 
 ```
-Project: noam/fresh   (sessions stored under .../orchestrator/home_noam_repos_fresh/)
+<XDG data>/fresh/orchestrator/
+├── windows.json              ← single global store
+├── input_history.json        ← per-field MRU history
+└── <slug>/                   ← per-project worktrees / artefacts
+    └── <session-name>/       ← session root (when worktree=on)
 ```
 
-This:
+`windows.json` shape:
 
-- Decouples the persistence key from incidental cwd choices.
-- Works for non-git paths (the fallback keys on the path
-  verbatim, slug-encoded — same scheme as the new-session
-  worktree slug).
-- Preserves the "what is this directory's worth of sessions"
-  affordance that users already have a mental model for.
-- Avoids the concurrent-write headache of option C.
+```json
+{
+  "version": 2,
+  "active": 42,
+  "next_id": 87,
+  "windows": [
+    {
+      "id": 42,
+      "label": "bugfix-1991",
+      "root": "<XDG>/fresh/orchestrator/home_noam_repos_fresh/bugfix-1991",
+      "project_path": "/home/noam/repos/fresh",
+      "shared_worktree": false,
+      "plugin_state": { … }
+    },
+    {
+      "id": 43,
+      "label": "notes-cleanup",
+      "root": "/home/noam/notes",
+      "project_path": "/home/noam/notes",
+      "shared_worktree": true,
+      "plugin_state": { … }
+    }
+  ]
+}
+```
 
-The base-path field in the New Session dialog reuses the
-*same* resolution: typing a path there both targets the new
-session AND, on the next editor launch from that path, restores
-the same windows list. The two features compose cleanly.
+### Filtering in the Open dialog
 
-A future "cross-repo session browser" can layer on top of B by
-listing the directories under `<XDG>/orchestrator/` — but it's
-a separate feature, not a precondition for this change.
+The picker bumps to two modes:
+
+- **Project view** (default): shows only sessions whose
+  `project_path` matches the editor's resolved project. The
+  filter input ranks within that subset. Matches today's
+  "sessions for this thing I'm working on" UX.
+- **All-projects view** (toggle in the filter row, persists
+  per editor instance): shows every session in `windows.json`,
+  with the `project_path` rendered as a secondary column so
+  cross-project rows are distinguishable.
+
+The Open dialog's existing filter logic doesn't change — it
+just operates on a subset.
+
+### Concurrent writers
+
+Two editors writing windows.json on quit is a real concern
+(esp. when both instances watch the same `~/.local/share/`):
+
+- **Read-modify-write with an atomic rename**: load the
+  current file, splice in this editor's changes (touching
+  only the ids this editor owns), write to `windows.json.tmp`,
+  rename. Last writer wins for the `active` and `next_id`
+  fields, but per-session entries are merged by id so neither
+  editor clobbers the other's sessions.
+- **`next_id` global**: kept monotonic by clamping to
+  `max(local, on-disk) + 1` at write time. Two editors that
+  both allocate id=87 will see the conflict at the next
+  write boundary; the loser bumps to 88 and rewrites its
+  in-memory state. (In practice id collisions are vanishingly
+  rare because sessions are created interactively.)
+
+This is enough for the common case — a single user across a
+handful of editor instances. If contention ever becomes a
+real problem the fragmented layout
+(`<XDG>/orchestrator/sessions/<id>.json`) can drop in without
+schema migration.
+
+### Migration from per-cwd persistence
+
+On first launch under v2:
+
+1. Scan `<XDG>/fresh/orchestrator/*/windows.json` (the legacy
+   per-cwd files).
+2. For each entry, fill `project_path` by decoding the
+   directory name (the slug → original path), and
+   `shared_worktree = false` (the legacy flow always created
+   a fresh worktree).
+3. Merge everything into the new global `windows.json`; ids
+   collide on the off chance two cwd-keyed files used the
+   same id, in which case the most-recently-modified file
+   wins and the loser gets re-numbered.
+4. Leave the legacy files in place but rename them
+   `windows.json.migrated.bak` so a downgrade isn't a one-way
+   trip.
+
+The migration runs once and is idempotent — re-running it is
+a no-op once the v2 file exists.
 
 ## Behavioural details
 
 ### Validation order on submit
 
-1. Trim the Base Repository Path. Substitute the placeholder
+1. Trim the Project Path. Substitute the placeholder
    (canonical repo root or cwd) if empty.
 2. `editor.pathExists` the result. If missing, render
    `path does not exist` in the in-dialog error row and bail.
@@ -296,42 +374,49 @@ a separate feature, not a precondition for this change.
    - If no, force worktree-toggle off (UI was already showing
      this); use the path as-is.
 4. Auto-generate session name if empty (existing logic, but
-   the namespace it scans is now keyed on the resolved base
-   path).
-5. Create the session via `editor.createWindow({ root, ... })`
-   exactly as today.
+   the namespace it scans is now keyed on the resolved
+   project path).
+5. Append the submitted (post-placeholder-substitution) values
+   to each field's input history.
+6. Create the session via `editor.createWindow({ root, ... })`
+   exactly as today, and write the new entry into the global
+   `windows.json` with the resolved `project_path` and
+   `shared_worktree` flag.
 
 ### Backwards compatibility
 
 The form's existing behaviour is the **default** for a
-git-cwd launch: the path field pre-fills to the canonical
-repo root, the worktree checkbox starts checked, and pressing
-Enter through the form lands on Create with all the same
-behaviour as today. The new options are additive — users who
-never touch them see the dialog they're used to (plus the new
-top-of-form path row).
+git-cwd launch: the Project Path field pre-fills to the
+canonical repo root, the worktree checkbox starts checked,
+and pressing Enter through the form lands on Create with all
+the same behaviour as today. The new options are additive —
+users who never touch them see the dialog they're used to
+(plus the new top-of-form Project Path row).
 
 ### Focus / tab order in the new dialog
 
 ```
-Base Path → Worktree Checkbox → Session Name → Agent Command
-         → Branch (skipped when inert) → Cancel → Create
+Project Path → Worktree Checkbox → Session Name → Agent Command
+            → Branch (skipped when inert) → Cancel → Create
 ```
 
 - `Space` toggles the checkbox while it has focus.
 - `Tab` skips the Branch field when it's inert (non-git path
   or worktree=off).
-- Default focus is the Base Path field (matches the layout's
-  top-to-bottom reading order; the user's first decision is
-  *where* the session runs).
+- Default focus is the Project Path field (matches the
+  layout's top-to-bottom reading order; the user's first
+  decision is *where* the session runs).
+- `↑` / `↓` walk history for the focused input — they no
+  longer forward to anything else.
 
 ## Out of scope
 
-- Browsing for the base path with a file picker. The plain
+- Browsing for the project path with a file picker. The plain
   text input is enough for the first cut; users paste paths
-  from their shell or terminal. A `Browse…` button can come
-  later as a small button next to the field.
-- Reusing an existing branch on a non-base-path target
+  from their shell or terminal, and history covers
+  re-selection. A `Browse…` button can come later as a small
+  button next to the field.
+- Reusing an existing branch on a non-project-path target
   (e.g. "create a session in `/tmp/scratch` but check out
   branch `feat/x`"). The current shape — checkbox on / off —
   doesn't have room for "yes worktree but at this custom
@@ -342,13 +427,19 @@ Base Path → Worktree Checkbox → Session Name → Agent Command
   sessions on the same root render adjacent and look correct.
   A `SHARED` badge can come if the visual collision is a real
   problem in practice.
+- Per-project input history. History is global per user;
+  scoping it to projects would force a more complex storage
+  schema for marginal benefit (and most useful values — agent
+  commands, common branch names — travel with the user).
 
 ## Implementation phases
 
-### Phase 1 — Base Path field
+### Phase 1 — Project Path field + drop subtitle
 
-- Add the Base Path text input to `buildFormSpec` above the
-  Session Name row.
+- Remove the `Project: <projectLabel>` subtitle row from
+  `buildFormSpec`.
+- Add the Project Path text input at the top of
+  `buildFormSpec`, above the Session Name row.
 - Wire the placeholder probe (canonical repo root via
   `git rev-parse --path-format=absolute --git-common-dir`,
   with cwd fallback) into `openForm` alongside the existing
@@ -367,32 +458,55 @@ Base Path → Worktree Checkbox → Session Name → Agent Command
 - On submit, branch the create path:
   - `createWorktree === true` → existing
     `git worktree add` flow.
-  - `createWorktree === false` → `root = <base path>`,
+  - `createWorktree === false` → `root = <project path>`,
     skip the worktree-add subprocesses and the branch
     handling.
 
 ### Phase 3 — Non-git path detection
 
 - Async probe of `rev-parse --is-inside-work-tree` against
-  the typed path; debounce on every change to the Base Path
-  field (200ms).
+  the typed path; debounce on every change to the Project
+  Path field (200ms).
 - Force-clear `createWorktree` and dim the Branch row when
   the probe reports non-git.
 
-### Phase 4 — Persistence keying by canonical repo root
+### Phase 4 — Input history (Up / Down)
 
-- Change `orchestrator_persistence::orchestrator_dir` to
-  resolve `working_dir` via the same git logic before
-  encoding. Fall back to the verbatim path encoding when git
-  reports no working tree (matches today's behaviour for
-  non-git launches).
-- Migration: on first load, look for the legacy
-  `<XDG>/orchestrator/<encoded_cwd>/windows.json` and merge
-  any sessions into the canonical-repo bucket.
-- Subtitle of both dialogs gains a small `Sessions stored
-  under …` annotation so the keying isn't invisible.
+- Storage: `<XDG>/fresh/orchestrator/input_history.json`
+  with the schema shown in
+  [Input history (Up / Down)](#input-history-up--down).
+- Plugin-side state: a `historyCursor` and `draftValue` per
+  field on `NewSessionForm`. Up/Down adjust the cursor and
+  rewrite `value` from the history list (saving the draft on
+  the first ↑).
+- The smart-key forwarder used in the Open dialog (filter →
+  list) is opt-in via a `forwardArrows` flag on `text({…})`.
+  Leave the flag off for the form's inputs so ↑/↓ don't
+  forward.
+- Submit: dedupe-merge the resolved value into the field's
+  history, cap at 100, write the file (best-effort, fire-and-
+  forget).
 
-### Phase 5 — Shared-worktree session UX polish
+### Phase 5 — Global windows.json + migration
+
+- Move persistence from
+  `<XDG>/fresh/orchestrator/<encoded_cwd>/windows.json` to a
+  single `<XDG>/fresh/orchestrator/windows.json`.
+- Add `project_path` and `shared_worktree` to
+  `PersistedWindow`. Bump the file version to 2.
+- Migrate on first load: read all legacy per-cwd files,
+  decode each filename → original cwd path, fold sessions
+  into the new store with `project_path = decoded_cwd`,
+  `shared_worktree = false`. Rename the legacy files to
+  `windows.json.migrated.bak`.
+- Add a `project_path` filter to the Open dialog's
+  list-population step (default: only sessions whose
+  `project_path` matches the editor's resolved project; the
+  filter input bar gets a new toggle `[all projects]` to lift
+  it).
+- Concurrent-write safety via atomic-rename read-modify-write.
+
+### Phase 6 — Shared-worktree session UX polish
 
 - Surface a "shared with N other sessions" hint in the Open
   dialog's preview pane when more than one session resolves

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -42,11 +42,21 @@ The goal is for users to be able to create sessions
 
 ## Wireframe
 
-### Default state — project path pre-filled from the canonical repo root
+### Default state — defaults shown as in-input placeholder text
 
 The "Project: <label>" subtitle is gone: the Project Path field
 itself is the project identifier now, so a static label above
 it would just duplicate (or worse, drift from) the input.
+
+**Every default value is rendered as placeholder text inside
+its input box** (dim foreground, replaced as soon as the user
+types). The input's actual `value` starts empty in every
+field; submitting an empty field substitutes the placeholder's
+resolved value. This is the same pattern Agent Command and
+Branch already use today; Phase 1 just extends it uniformly to
+the new Project Path and Session Name rows. The hint lines
+under each input ("↑↓ for history", inert-state notes) live
+*outside* the box so they don't compete with the placeholder.
 
 All four text inputs (Project Path, Session Name, Agent
 Command, Branch) carry **value history**: Up / Down on a
@@ -61,7 +71,7 @@ so it follows the user across projects.
 ╭─ ORCHESTRATOR :: New Session Dialog :: Review Synthesized ───────────╮
 │                                                                      │
 │ ╭─ Project Path ───────────────────────────────────────────────────╮ │
-│ │ [/home/noam/repos/fresh                                         ]│ │
+│ │ [/home/noam/repos/fresh                                  ]·dim·  │ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │   ↳ canonical repo root (worktree-resolved). ↑↓ for history.         │
 │                                                                      │
@@ -71,15 +81,15 @@ so it follows the user across projects.
 │         multiple sessions)                                           │
 │                                                                      │
 │ ╭─ Session Name ───────────────────────────────────────────────────╮ │
-│ │ [                                                  ] (auto-gen) │ │
+│ │ [session-3                                               ]·dim·  │ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │                                                                      │
 │ ╭─ Agent Command ──────────────────────────────────────────────────╮ │
-│ │ [                                                  ] (claude)   │ │
+│ │ [claude                                                  ]·dim·  │ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │                                                                      │
 │ ╭─ Branch ─────────────────────────────────────────────────────────╮ │
-│ │ [                                                  ] (origin/m…)│ │
+│ │ [origin/main                                             ]·dim·  │ │
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │   ↳ ignored when "Create a new git worktree" is unchecked            │
 │                                                                      │
@@ -88,6 +98,12 @@ so it follows the user across projects.
 │  Tab next · S-Tab prev · ↑↓ history · Space toggle · Enter act · Esc │
 ╰──────────────────────────────────────────────────────────────────────╯
 ```
+
+`·dim·` marks placeholder rendering: the text inside the
+brackets is the resolved default, drawn with the
+`ui.placeholder_fg` style so it's visibly weaker than typed
+input. Once the user types, the placeholder vanishes and the
+typed value takes over in normal foreground.
 
 Inputs stay stacked vertically full-width (not packed
 side-by-side) so long paths and commands have room to breathe
@@ -109,14 +125,14 @@ working tree, the dialog detects it asynchronously (via
 
 ```
 │ ╭─ Project Path ───────────────────────────────────────────────────╮ │
-│ │ [/home/noam/notes                                               ]│ │
+│ │ /home/noam/notes                                                 │ │  ← typed value
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │   ↳ not a git working tree. ↑↓ for history.                          │
 │                                                                      │
 │ [·] Create a new git worktree for this session   (non-git path)      │
 │                                                                      │
 │ ╭─ Branch ─────────────────────────────────────────────────────╮ dim │
-│ │                                       (no git — N/A)        │     │
+│ │ no git — N/A                                            ·dim·│     │  ← placeholder
 │ ╰──────────────────────────────────────────────────────────────╯     │
 ```
 
@@ -142,13 +158,20 @@ a ref.
 
 ## Field semantics
 
-| Field                | Default                                       | When empty submits as |
-|----------------------|-----------------------------------------------|-----------------------|
-| Project Path         | canonical repo root resolved from editor cwd  | the placeholder default (canonical repo root) |
-| Create worktree (cb) | checked iff path resolves to a git work tree  | (boolean — no empty)  |
-| Session Name         | empty                                         | auto-generated (`session-N`) |
-| Agent Command        | empty (placeholder = `lastCmd` or `terminal`) | the placeholder       |
-| Branch               | empty (placeholder = detected default branch) | the placeholder (only valid when worktree=on) |
+Every text input starts with **empty `value` + a placeholder
+showing the resolved default**. Submitting an empty field uses
+the placeholder's value verbatim. This keeps the form's bracket
+content honest (what you see typed is what you submitted) and
+makes ↑↓ history navigation start from a clean slate rather
+than fighting a pre-filled default.
+
+| Field                | Value at open | Placeholder (the default that will be used on empty submit) |
+|----------------------|---------------|-------------------------------------------------------------|
+| Project Path         | `""`          | canonical repo root resolved from editor cwd (or cwd verbatim for non-git launches) |
+| Create worktree (cb) | `true` / `false` — not a text input; default tracks whether placeholder path resolves to a git work tree |
+| Session Name         | `""`          | next auto-generated name (`session-N` — computed from the resolved project path) |
+| Agent Command        | `""`          | `lastCmd` (previous run's command), or `terminal` if none   |
+| Branch               | `""`          | detected default branch (`origin/main` etc.); inert and `(no git — N/A)` when worktree=off or non-git path |
 
 ### Input history (Up / Down)
 
@@ -212,7 +235,8 @@ editor's cwd in this order:
 The probe runs at `openForm` time, asynchronously, the same way
 the current default-branch probe does. While it's in flight the
 input renders the cwd as the placeholder; the resolved value
-replaces it on completion if the field is still empty.
+replaces the placeholder on completion (the `value` stays empty
+either way — the user hasn't typed anything).
 
 ### Worktree checkbox — interaction model
 
@@ -439,14 +463,26 @@ Project Path → Worktree Checkbox → Session Name → Agent Command
 - Remove the `Project: <projectLabel>` subtitle row from
   `buildFormSpec`.
 - Add the Project Path text input at the top of
-  `buildFormSpec`, above the Session Name row.
+  `buildFormSpec`, above the Session Name row. `value` is
+  empty; the resolved default fills the `placeholder` (same
+  pattern as the existing Agent Command field).
 - Wire the placeholder probe (canonical repo root via
   `git rev-parse --path-format=absolute --git-common-dir`,
   with cwd fallback) into `openForm` alongside the existing
-  `defaultBranch` probe.
-- `submitForm` substitutes the placeholder when the field is
-  empty, then uses the resolved value as `repoRoot` for the
-  rest of the existing flow.
+  `defaultBranch` probe. The probe writes to a
+  `defaultProjectPath` field that the input's `placeholder`
+  reads, so the probe completing live-updates the
+  placeholder without touching `value`.
+- Extend Session Name the same way: keep `value` empty and
+  surface the auto-generated `session-N` name as the
+  placeholder (it already auto-generates on empty submit; the
+  visible placeholder is the new part). This needs a small
+  async probe at `openForm` time to scan `refs/heads/session-N`
+  in the resolved project path; debounce on every Project
+  Path change.
+- `submitForm` substitutes each placeholder when its field is
+  empty, then uses the resolved values for the rest of the
+  existing flow.
 
 ### Phase 2 — Worktree checkbox
 

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -745,6 +745,94 @@ Submit:
   Delete refuse with a "remove the other sessions on this
   root first" error.
 
+### Phase 7 — Dropdown completion for Project Path + Branch
+
+Two text fields in the form benefit from suggestion-driven
+typing:
+
+- **Project Path** — completing partial paths against the
+  filesystem. The base session form spends most of its time
+  letting the user pick *some* directory they already have,
+  so completion is the single biggest typing-cost reducer.
+- **Branch** — completing partial branch names against the
+  repo's local + remote branches and tags (`git branch -a` +
+  `git tag`). Same argument: the user knows the prefix of the
+  branch they want, not its full name.
+
+#### Alternatives considered
+
+| # | Approach                                            | Pros                                                                                  | Cons                                                                                                                                  |
+|---|-----------------------------------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| A | In-form inline dropdown (`list` widget below input) | Reuses existing `list` widget; pure plugin-side change; matches form's visual style.  | Focus-cycle plumbing: dropdown isn't a tabbable cycle entry, it's "completions for the focused input". Up/Down has to disambiguate history vs. completion. |
+| B | Separate floating popup adjacent to the field      | Visually isolated; easy to dismiss.                                                   | Z-ordering + cross-panel focus management; two FloatingWidgetPanels alive at once; more state.                                        |
+| C | Built-in `suggestions: string[]` on the text widget renderer | Host-side dropdown rendering; reusable by every plugin; centralised key handling.  | Big host change to the widget renderer + key dispatcher; needs a generic "where do completions come from" hook the plugin still has to populate.   |
+| D | Reuse the LSP autocomplete pipeline                 | Battle-tested popup + filter + selection logic.                                       | Tightly coupled to editor buffers / language servers; orchestrator's form inputs aren't buffers. Wrong abstraction.                   |
+
+**Chosen: A.** Smallest blast radius (the whole feature lives
+in the orchestrator plugin), reuses the `list` widget that
+already styles correctly inside floating panels, and the
+filesystem-listing + git-spawn helpers it needs are already
+exposed (`editor.readDir`, `spawnCollect`).
+
+If a second plugin wants the same affordance later we
+*promote* it to C — at that point we know enough about the
+shapes (anchor handling, async fetch, ordering) to design a
+generic widget API rather than guessing.
+
+#### Behaviour
+
+- **Trigger**: every text-input change on `project_path` or
+  `branch`. Debounced via the same `editor.delay`-based token
+  scheme the Project Path is-git probe already uses.
+- **Project Path candidate source**: split typed value into
+  `(parent, basename)`; `editor.readDir(parent || ".")` then
+  filter to entries whose name starts with `basename`
+  (case-sensitive — paths are case-sensitive on the kernels
+  we ship on; deferring case-insensitive prefix matching
+  until a user asks).
+  - Both files and directories are returned. Directories get
+    a trailing `/` so the user can see the type at a glance
+    and accepting a directory leaves the cursor primed to
+    keep descending.
+- **Branch candidate source**: `git -C <project> for-each-ref
+  --format=%(refname:short) refs/heads/ refs/remotes/
+  refs/tags/`. Filter by substring (not prefix-only — branch
+  names commonly carry prefixes like `feat/` that the user
+  wouldn't type first). De-dup `origin/main` vs `main` so the
+  list isn't doubled.
+- **Rendering**: when the completion list is non-empty AND
+  the input has focus, render a `list({ visibleRows: 6 })`
+  immediately below the labeled section. Items use
+  `ui.menu_active_bg` for the selection, `ui.popup_text_fg`
+  for body — matches the existing palette popup convention.
+- **Keys** (only when the dropdown is showing):
+  - `↑` / `↓` — move selection inside the list. **Overrides
+    history navigation** for the duration the dropdown is
+    visible. (Up/Down on a focused input with NO active
+    completions still walks history, unchanged.)
+  - `Tab` / `Enter` — accept the highlighted item, replace
+    the input's value, dismiss the dropdown. For Project
+    Path, accepting a directory appends `/` and re-triggers
+    the probe — the user can keep typing or `Tab` again to
+    descend.
+  - `Esc` — close the dropdown without changing the input.
+    The dialog itself stays open (`Esc`-closes-dialog only
+    fires when the dropdown is already closed).
+  - Any printable / Backspace — refilter; dropdown follows
+    the new prefix.
+
+#### Out of scope (this phase)
+
+- Fuzzy matching. The list is purely prefix / substring; the
+  fuzzy ranker isn't worth the import for the typical 5-20
+  entries we render.
+- Completion in the Session Name field. Session names are
+  freeform user-chosen strings; no candidate source exists.
+- Multi-line preview (file size, last-modified) inside the
+  dropdown. The orchestrator picker's preview pane already
+  fills that role for *selected* sessions; the new-session
+  dialog doesn't need it for prospective ones.
+
 ## Open questions
 
 - **Where does a non-git session's data live on disk?** Two

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -1,0 +1,425 @@
+# Orchestrator: New Session — Base Path + Worktree Toggle
+
+> **Status**: Design Document
+> **Date**: May 2026
+> **Driving feature**: Let the user create Orchestrator sessions
+> against an arbitrary base path (any directory, not necessarily
+> the current cwd), and let them choose whether the session gets
+> its own git worktree or runs directly inside the given path.
+
+## Motivation
+
+Today the New Session dialog has three inputs — Session Name,
+Agent Command, Branch — and silently assumes:
+
+1. The current working directory is a git repository.
+2. The user wants the new session in a *fresh git worktree* of
+   that repository, forked off origin's default branch.
+
+That works for the common case (one editor instance per repo,
+one agent per branch) but fails the long tail:
+
+- **Non-git directories.** "I want to run an agent in
+  `~/notes/` to refactor my markdown" is currently impossible:
+  `git worktree add` aborts and the dialog reports
+  `not a git repository`.
+- **Multiple agents on the same worktree.** Two agents that
+  share a checkout (e.g. one driving the editor, one running
+  long-running builds) need the *same* path, not two parallel
+  worktrees.
+- **Working from a linked worktree.** The current dialog
+  already corrects the slug back to the main worktree — but it
+  doesn't let the user choose a *different* base repo when
+  they have several checked out side-by-side.
+- **Foreign repos.** "Spin up an agent against
+  `~/repos/upstream-thirdparty/` to investigate a bug" needs
+  the user to point the dialog at that repo without having to
+  first `cd` the editor there.
+
+The goal is for users to be able to create sessions
+*regardless of current git state, or even using git at all*.
+
+## Wireframe
+
+### Default state — base path pre-filled from the canonical repo root
+
+```
+╭─ ORCHESTRATOR :: New Session Dialog :: Review Synthesized ───────────╮
+│                                                                      │
+│                      Project: noam/fresh                             │
+│                                                                      │
+│ ╭─ Base Repository Path ───────────────────────────────────────────╮ │
+│ │ [/home/noam/repos/fresh                                         ]│ │
+│ ╰──────────────────────────────────────────────────────────────────╯ │
+│   ↳ canonical repo root (worktree-resolved). Leave blank to keep.    │
+│                                                                      │
+│ [x] Create a new git worktree for this session                       │
+│      └─ unchecked = run the session directly inside the path above   │
+│         (use this for non-git paths, or to share a worktree across   │
+│         multiple sessions)                                           │
+│                                                                      │
+│ ╭─ Session Name ───────────────────────────────────────────────────╮ │
+│ │ [                                                  ] (auto-gen) │ │
+│ ╰──────────────────────────────────────────────────────────────────╯ │
+│                                                                      │
+│ ╭─ Agent Command ──────────────────────────────────────────────────╮ │
+│ │ [                                                  ] (claude)   │ │
+│ ╰──────────────────────────────────────────────────────────────────╯ │
+│                                                                      │
+│ ╭─ Branch ─────────────────────────────────────────────────────────╮ │
+│ │ [                                                  ] (origin/m…)│ │
+│ ╰──────────────────────────────────────────────────────────────────╯ │
+│   ↳ ignored when "Create a new git worktree" is unchecked            │
+│                                                                      │
+│                              [ Cancel ]   [ Create Session ]         │
+│                                                                      │
+│  Tab next · S-Tab prev · Space toggle · Enter act · Esc cancel       │
+╰──────────────────────────────────────────────────────────────────────╯
+```
+
+### Non-git path — checkbox auto-cleared, branch row dimmed
+
+When the user types (or pastes) a path that isn't inside a git
+working tree, the dialog detects it asynchronously (via
+`git -C <path> rev-parse --is-inside-work-tree`) and:
+
+- Forces "Create a new git worktree" to **off** (the option
+  isn't meaningful — there's no repo to fork from).
+- Renders the checkbox as `[·]` with a dim foreground and the
+  hint text `non-git path — worktree creation unavailable`.
+- Renders the Branch row dim with the placeholder
+  `(no git — branch not applicable)` and skips it in the Tab
+  cycle.
+
+```
+│ ╭─ Base Repository Path ───────────────────────────────────────────╮ │
+│ │ [/home/noam/notes                                               ]│ │
+│ ╰──────────────────────────────────────────────────────────────────╯ │
+│   ↳ not a git working tree                                           │
+│                                                                      │
+│ [·] Create a new git worktree for this session   (non-git path)      │
+│                                                                      │
+│ ╭─ Branch ─────────────────────────────────────────────────────╮ dim │
+│ │                                       (no git — N/A)        │     │
+│ ╰──────────────────────────────────────────────────────────────╯     │
+```
+
+### Git path, worktree toggle off — "share-the-checkout" mode
+
+When the user explicitly unchecks the worktree option on a git
+path, the dialog stays interactive but warns about the
+implications:
+
+```
+│ [ ] Create a new git worktree for this session                       │
+│      ⚠ session will share its working tree with any other sessions  │
+│         rooted at this path; concurrent writes may conflict.         │
+│                                                                      │
+│ ╭─ Branch ─────────────────────────────────────────────────────╮ dim │
+│ │                              (shared worktree — N/A)        │     │
+│ ╰──────────────────────────────────────────────────────────────╯     │
+```
+
+The Branch field becomes inert in this mode for the same reason
+as the non-git case: there's no `git worktree add` to fork off
+a ref.
+
+## Field semantics
+
+| Field                  | Default                                       | When empty submits as |
+|------------------------|-----------------------------------------------|-----------------------|
+| Base Repository Path   | canonical repo root resolved from editor cwd  | the placeholder default (canonical repo root) |
+| Create worktree (cb)   | checked iff path resolves to a git work tree  | (boolean — no empty)  |
+| Session Name           | empty                                         | auto-generated (`session-N`) |
+| Agent Command          | empty (placeholder = `lastCmd` or `terminal`) | the placeholder       |
+| Branch                 | empty (placeholder = detected default branch) | the placeholder (only valid when worktree=on) |
+
+### "Canonical repo root" resolution
+
+The pre-filled default for Base Repository Path is derived from
+the editor's cwd in this order:
+
+1. `git -C <cwd> rev-parse --path-format=absolute --git-common-dir`
+   → `dirname(...)` of the result is the **main worktree's
+   root**, regardless of whether the editor was launched from a
+   linked worktree. This matches the existing logic in
+   `submitForm` (the slug-resolution path) and protects against
+   nested-orchestrator path blow-up.
+2. If `git` rejects the cwd (not a working tree), fall back to
+   the editor's cwd verbatim. The placeholder text changes to
+   `(non-git — sessions run in-place)` so the user knows what
+   they're committing to.
+
+The probe runs at `openForm` time, asynchronously, the same way
+the current default-branch probe does. While it's in flight the
+input renders the cwd as the placeholder; the resolved value
+replaces it on completion if the field is still empty.
+
+### Worktree checkbox — interaction model
+
+- **Checked + git path** → today's behaviour:
+  `git worktree add <root> -b <branch> <base>` rooted at
+  `<XDG>/orchestrator/<slug-of-base-path>/<session-name>/`.
+- **Unchecked + git path** → session root is the **base path
+  itself**. No `git worktree add`. The session inherits whatever
+  branch the worktree is currently on. Branch field is inert.
+- **Checked + non-git path** → impossible (checkbox is forced
+  off and grayed).
+- **Unchecked + non-git path** → session root is the base path.
+  No git interaction at all. Branch field is inert.
+
+When the worktree is shared (unchecked + git path) the session
+record still goes into the normal persistence layer; it's just
+that multiple sessions can legitimately resolve to the same
+`root`. Reconciliation already keys on session id, not root, so
+this works without changes to `orchestrator_persistence.rs`.
+
+## Where the multi-window list lives
+
+This is the open question the spec calls out: when a user
+returns days later and wants to resume an orchestration, where
+do we look for the session list?
+
+### Current behaviour
+
+`orchestrator_persistence.rs` writes
+`<XDG data>/fresh/orchestrator/<encoded_working_dir>/windows.json`,
+keyed by **the editor process's working directory** at launch
+time (encoded via `workspace::encode_path_for_filename`). This
+means:
+
+- Two editor windows launched from the same cwd share their
+  windows list (and would clobber each other).
+- An editor launched from `/home/noam/repos/fresh` and one
+  launched from `/home/noam/repos/fresh/sub-dir` see **different
+  windows lists**, even though they're in the same repo.
+- An editor launched from `/tmp/scratch` works for non-git use
+  cases — the keying doesn't require git.
+
+### Three candidate keyings
+
+#### A. Per editor working directory (status quo)
+
+- **Pro**: works for non-git paths trivially; matches how users
+  think about "the editor I opened in this folder".
+- **Con**: keying by cwd is brittle — `cd repos/fresh` vs.
+  `cd ~/repos/fresh` writes to different encoded keys. Two
+  editor instances in the same project but different
+  subdirectories see disjoint session lists.
+- **Migration**: zero.
+
+#### B. Per canonical git repo root (with non-git fallback)
+
+Resolve cwd to the canonical repo root (the same logic that
+fills the Base Repository Path default) and key the persistence
+directory on that. For non-git paths, fall back to encoding the
+path verbatim — i.e. `<XDG>/orchestrator/<slug-of-repo-or-path>/`.
+
+- **Pro**: matches the user's mental model — "open my fresh
+  sessions for *this project*" produces the same list whether
+  the editor was launched from the repo root, a sub-directory,
+  or a linked worktree.
+- **Con**: surprises users who launch the editor from a
+  symlinked / sibling path expecting a fresh slate. Mitigation:
+  a tiny status-bar message on first load
+  (`Resumed N sessions from <repo>`) keeps the resolution
+  visible.
+- **Migration**: scan existing
+  `<XDG>/orchestrator/<encoded_cwd>/windows.json` files and
+  fold matches into the canonical-repo bucket on first launch.
+  Conflicts (two cwd-keyed files mapping to the same repo)
+  merge by union; ids stay stable because they're already
+  globally unique within a `windows.json`.
+
+#### C. Global per-user
+
+One `<XDG>/orchestrator/windows.json` with a `base_path` /
+`repo_root` field on each session entry.
+
+- **Pro**: a single "list every orchestration I've ever run"
+  view; cleanest answer for "where is the data".
+- **Con**: every editor instance has to filter to the
+  sessions relevant to it, and the file becomes a hot spot
+  for concurrent writers (two editors saving on quit at the
+  same time). The orchestrator dialog already exists per
+  editor instance, and most users never want to see another
+  project's sessions in *this* editor's picker.
+- **Migration**: as in B, plus everything funnels into one
+  file. The concurrent-writer risk argues for a per-session
+  fragmented layout
+  (`<XDG>/orchestrator/sessions/<id>.json`) rather than a
+  single monolithic file — which is a bigger refactor.
+
+### Recommendation
+
+**Adopt B** (per canonical git repo root, with a verbatim-path
+fallback for non-git launches), and surface the resolution in
+the dialog's subtitle:
+
+```
+Project: noam/fresh   (sessions stored under .../orchestrator/home_noam_repos_fresh/)
+```
+
+This:
+
+- Decouples the persistence key from incidental cwd choices.
+- Works for non-git paths (the fallback keys on the path
+  verbatim, slug-encoded — same scheme as the new-session
+  worktree slug).
+- Preserves the "what is this directory's worth of sessions"
+  affordance that users already have a mental model for.
+- Avoids the concurrent-write headache of option C.
+
+The base-path field in the New Session dialog reuses the
+*same* resolution: typing a path there both targets the new
+session AND, on the next editor launch from that path, restores
+the same windows list. The two features compose cleanly.
+
+A future "cross-repo session browser" can layer on top of B by
+listing the directories under `<XDG>/orchestrator/` — but it's
+a separate feature, not a precondition for this change.
+
+## Behavioural details
+
+### Validation order on submit
+
+1. Trim the Base Repository Path. Substitute the placeholder
+   (canonical repo root or cwd) if empty.
+2. `editor.pathExists` the result. If missing, render
+   `path does not exist` in the in-dialog error row and bail.
+3. Probe `git -C <path> rev-parse --is-inside-work-tree`.
+   - If yes and worktree-toggle is checked → existing path
+     (worktree-add) runs.
+   - If yes and worktree-toggle is unchecked → use the path
+     as-is for the session root; skip `git worktree add`;
+     ignore Branch.
+   - If no, force worktree-toggle off (UI was already showing
+     this); use the path as-is.
+4. Auto-generate session name if empty (existing logic, but
+   the namespace it scans is now keyed on the resolved base
+   path).
+5. Create the session via `editor.createWindow({ root, ... })`
+   exactly as today.
+
+### Backwards compatibility
+
+The form's existing behaviour is the **default** for a
+git-cwd launch: the path field pre-fills to the canonical
+repo root, the worktree checkbox starts checked, and pressing
+Enter through the form lands on Create with all the same
+behaviour as today. The new options are additive — users who
+never touch them see the dialog they're used to (plus the new
+top-of-form path row).
+
+### Focus / tab order in the new dialog
+
+```
+Base Path → Worktree Checkbox → Session Name → Agent Command
+         → Branch (skipped when inert) → Cancel → Create
+```
+
+- `Space` toggles the checkbox while it has focus.
+- `Tab` skips the Branch field when it's inert (non-git path
+  or worktree=off).
+- Default focus is the Base Path field (matches the layout's
+  top-to-bottom reading order; the user's first decision is
+  *where* the session runs).
+
+## Out of scope
+
+- Browsing for the base path with a file picker. The plain
+  text input is enough for the first cut; users paste paths
+  from their shell or terminal. A `Browse…` button can come
+  later as a small button next to the field.
+- Reusing an existing branch on a non-base-path target
+  (e.g. "create a session in `/tmp/scratch` but check out
+  branch `feat/x`"). The current shape — checkbox on / off —
+  doesn't have room for "yes worktree but at this custom
+  root path". If it becomes a real ask, a dedicated
+  `Worktree Root` row appears below the checkbox.
+- Tracking shared-worktree sessions in the open dialog with
+  a distinct badge. The list already shows the root path; two
+  sessions on the same root render adjacent and look correct.
+  A `SHARED` badge can come if the visual collision is a real
+  problem in practice.
+
+## Implementation phases
+
+### Phase 1 — Base Path field
+
+- Add the Base Path text input to `buildFormSpec` above the
+  Session Name row.
+- Wire the placeholder probe (canonical repo root via
+  `git rev-parse --path-format=absolute --git-common-dir`,
+  with cwd fallback) into `openForm` alongside the existing
+  `defaultBranch` probe.
+- `submitForm` substitutes the placeholder when the field is
+  empty, then uses the resolved value as `repoRoot` for the
+  rest of the existing flow.
+
+### Phase 2 — Worktree checkbox
+
+- Add `createWorktree: boolean` to `NewSessionForm`,
+  defaulting to `true`.
+- Render a `checkbox` widget (new widget kind or styled
+  `button` with a `[x] / [ ]` glyph, depending on widget
+  library state).
+- On submit, branch the create path:
+  - `createWorktree === true` → existing
+    `git worktree add` flow.
+  - `createWorktree === false` → `root = <base path>`,
+    skip the worktree-add subprocesses and the branch
+    handling.
+
+### Phase 3 — Non-git path detection
+
+- Async probe of `rev-parse --is-inside-work-tree` against
+  the typed path; debounce on every change to the Base Path
+  field (200ms).
+- Force-clear `createWorktree` and dim the Branch row when
+  the probe reports non-git.
+
+### Phase 4 — Persistence keying by canonical repo root
+
+- Change `orchestrator_persistence::orchestrator_dir` to
+  resolve `working_dir` via the same git logic before
+  encoding. Fall back to the verbatim path encoding when git
+  reports no working tree (matches today's behaviour for
+  non-git launches).
+- Migration: on first load, look for the legacy
+  `<XDG>/orchestrator/<encoded_cwd>/windows.json` and merge
+  any sessions into the canonical-repo bucket.
+- Subtitle of both dialogs gains a small `Sessions stored
+  under …` annotation so the keying isn't invisible.
+
+### Phase 5 — Shared-worktree session UX polish
+
+- Surface a "shared with N other sessions" hint in the Open
+  dialog's preview pane when more than one session resolves
+  to the same root.
+- Decide whether `Stop` / `Archive` / `Delete` on a shared-
+  worktree session means "this row only" or "everything at
+  this root". Leaning: row-only for Stop, but Archive /
+  Delete refuse with a "remove the other sessions on this
+  root first" error.
+
+## Open questions
+
+- **Where does a non-git session's data live on disk?** Two
+  natural answers: (a) the path the user gave us (so all
+  artefacts stay with their work); (b) under
+  `<XDG>/orchestrator/<slug>/`, the same as the git case
+  (clean separation, no surprise dotfiles in the user's
+  folder). Leaning toward (a) — the user explicitly opted out
+  of the worktree, so they probably want their files where
+  they pointed us.
+- **Inferring `createWorktree` from path content.** If the
+  user pastes a path that's already a Fresh orchestrator
+  session root (under `<XDG>/orchestrator/<slug>/<session>/`),
+  the dialog could default the checkbox to off automatically.
+  Worth doing in Phase 3 if the detection is cheap.
+- **Path completion.** The text input doesn't currently have
+  filesystem-aware completion. Worth a separate proposal —
+  the host already has a fuzzy file picker we could embed,
+  but the UX of "embed a picker in a form field" needs its
+  own design.

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -109,19 +109,38 @@ Inputs stay stacked vertically full-width (not packed
 side-by-side) so long paths and commands have room to breathe
 without truncation or horizontal scrolling.
 
-### Non-git path — checkbox auto-cleared, branch row dimmed
+### Non-git path — worktree checkbox is *disabled*
 
-When the user types (or pastes) a path that isn't inside a git
-working tree, the dialog detects it asynchronously (via
-`git -C <path> rev-parse --is-inside-work-tree`) and:
+The worktree checkbox is **only enabled when the resolved
+Project Path is inside a git working tree** (main worktree
+*or* linked worktree). For non-git paths the checkbox is
+rendered disabled — `[·]` glyph, dim foreground, unfocusable
+(skipped by Tab), unresponsive to `Space` — with an inline
+hint explaining why. The user cannot toggle it on; submitting
+the form skips all worktree-related logic entirely.
 
-- Forces "Create a new git worktree" to **off** (the option
-  isn't meaningful — there's no repo to fork from).
-- Renders the checkbox as `[·]` with a dim foreground and the
-  hint text `non-git path — worktree creation unavailable`.
-- Renders the Branch row dim with the placeholder
-  `(no git — branch not applicable)` and skips it in the Tab
-  cycle.
+This is a hard rule rather than a soft default because
+`git worktree add` is meaningless against a non-repo: there's
+no ref to fork from, no `.git` directory to register the new
+worktree with, and no branch field to populate. Toggling the
+control on would only let the user reach a guaranteed-failure
+submission.
+
+Detection runs asynchronously on every Project Path change
+(debounced 200ms) via
+`git -C <path> rev-parse --is-inside-work-tree`. While the
+probe is in flight the checkbox stays at its last known state
+(prevents flicker on each keystroke); it transitions to its
+new enabled / disabled state when the probe resolves.
+
+Cascading effects when the checkbox is disabled (non-git
+path):
+
+- The Branch row is also rendered dim and skipped by Tab —
+  there's no ref to fork.
+- The shared-worktree warning shown on a git path doesn't
+  apply (the session simply runs at the path, like any
+  external directory).
 
 ```
 │ ╭─ Project Path ───────────────────────────────────────────────────╮ │
@@ -129,7 +148,7 @@ working tree, the dialog detects it asynchronously (via
 │ ╰──────────────────────────────────────────────────────────────────╯ │
 │   ↳ not a git working tree. ↑↓ for history.                          │
 │                                                                      │
-│ [·] Create a new git worktree for this session   (non-git path)      │
+│ [·] Create a new git worktree for this session   (disabled — non-git)│
 │                                                                      │
 │ ╭─ Branch ─────────────────────────────────────────────────────╮ dim │
 │ │ no git — N/A                                            ·dim·│     │  ← placeholder
@@ -168,7 +187,7 @@ than fighting a pre-filled default.
 | Field                | Value at open | Placeholder (the default that will be used on empty submit) |
 |----------------------|---------------|-------------------------------------------------------------|
 | Project Path         | `""`          | canonical repo root resolved from editor cwd (or cwd verbatim for non-git launches) |
-| Create worktree (cb) | `true` / `false` — not a text input; default tracks whether placeholder path resolves to a git work tree |
+| Create worktree (cb) | enabled iff Project Path resolves to a git working tree; default `true` when enabled, forced `false` (and unfocusable / un-toggleable) when disabled |
 | Session Name         | `""`          | next auto-generated name (`session-N` — computed from the resolved project path) |
 | Agent Command        | `""`          | `lastCmd` (previous run's command), or `terminal` if none   |
 | Branch               | `""`          | detected default branch (`origin/main` etc.); inert and `(no git — N/A)` when worktree=off or non-git path |
@@ -240,16 +259,23 @@ either way — the user hasn't typed anything).
 
 ### Worktree checkbox — interaction model
 
-- **Checked + git path** → today's behaviour:
-  `git worktree add <root> -b <branch> <project-path>` rooted at
+The checkbox's *enabled* state tracks the Project Path's git
+status (see [Non-git path — worktree checkbox is
+*disabled*](#non-git-path--worktree-checkbox-is-disabled)).
+Only when the checkbox is enabled can the user toggle it.
+
+- **Enabled + checked** (git path, default): today's
+  behaviour — `git worktree add <root> -b <branch>
+  <project-path>` rooted at
   `<XDG>/orchestrator/<slug-of-project-path>/<session-name>/`.
-- **Unchecked + git path** → session root is the **project path
-  itself**. No `git worktree add`. The session inherits whatever
-  branch the worktree is currently on. Branch field is inert.
-- **Checked + non-git path** → impossible (checkbox is forced
-  off and grayed).
-- **Unchecked + non-git path** → session root is the project
-  path. No git interaction at all. Branch field is inert.
+- **Enabled + unchecked** (git path, user opted out): session
+  root is the **project path itself**. No `git worktree add`.
+  The session inherits whatever branch the worktree is
+  currently on. Branch field is inert.
+- **Disabled** (non-git path): the checkbox is rendered `[·]`,
+  unfocusable, with the suffix `(disabled — non-git)`. Submit
+  treats it as unchecked: session root is the project path, no
+  git interaction, Branch field is inert.
 
 When the worktree is shared (unchecked + git path) the session
 record still goes into the normal persistence layer; it's just
@@ -389,14 +415,19 @@ a no-op once the v2 file exists.
    (canonical repo root or cwd) if empty.
 2. `editor.pathExists` the result. If missing, render
    `path does not exist` in the in-dialog error row and bail.
-3. Probe `git -C <path> rev-parse --is-inside-work-tree`.
-   - If yes and worktree-toggle is checked → existing path
-     (worktree-add) runs.
-   - If yes and worktree-toggle is unchecked → use the path
+3. Re-probe `git -C <path> rev-parse --is-inside-work-tree`
+   to confirm the worktree-checkbox state matches reality
+   (the live debounced probe might be in flight when the user
+   hits Enter):
+   - Path is git, checkbox enabled + checked → existing
+     worktree-add flow runs.
+   - Path is git, checkbox enabled + unchecked → use the path
      as-is for the session root; skip `git worktree add`;
      ignore Branch.
-   - If no, force worktree-toggle off (UI was already showing
-     this); use the path as-is.
+   - Path is non-git → checkbox is disabled by definition;
+     use the path as-is, no git interaction. If the probe at
+     submit time disagrees with the UI state (race), trust
+     the probe and proceed without git.
 4. Auto-generate session name if empty (existing logic, but
    the namespace it scans is now keyed on the resolved
    project path).
@@ -498,13 +529,28 @@ Project Path → Worktree Checkbox → Session Name → Agent Command
     skip the worktree-add subprocesses and the branch
     handling.
 
-### Phase 3 — Non-git path detection
+### Phase 3 — Non-git path detection + checkbox enable/disable
 
 - Async probe of `rev-parse --is-inside-work-tree` against
-  the typed path; debounce on every change to the Project
-  Path field (200ms).
-- Force-clear `createWorktree` and dim the Branch row when
-  the probe reports non-git.
+  the typed Project Path; debounce on every change (200ms).
+- Probe result drives a `projectPathIsGit: boolean | null`
+  on `NewSessionForm` (null = in flight).
+- When `projectPathIsGit === false`:
+  - Render the checkbox in disabled style (`[·]` glyph, dim
+    fg, suffix `(disabled — non-git)`).
+  - Drop the checkbox's `key` so the host's `collect_tabbable`
+    skips it — `Tab` advances straight to Session Name, and
+    `Space` on a non-focused widget is a no-op.
+  - Force `createWorktree` to `false` internally so submit
+    takes the no-worktree path regardless of any prior toggle
+    state.
+  - Dim the Branch row and drop its `key` for the same reason.
+- When `projectPathIsGit === true`: checkbox is enabled,
+  Branch row is interactive, both default-state.
+- When `projectPathIsGit === null` (probe in flight): freeze
+  the checkbox in its last-known state so keystrokes don't
+  cause flicker. Submit waits on the probe (with a short
+  timeout) before proceeding.
 
 ### Phase 4 — Input history (Up / Down)
 

--- a/docs/internal/orchestrator-new-session-base-path.md
+++ b/docs/internal/orchestrator-new-session-base-path.md
@@ -40,6 +40,112 @@ one agent per branch) but fails the long tail:
 The goal is for users to be able to create sessions
 *regardless of current git state, or even using git at all*.
 
+## Audit of the current dialog (interactive, tmux capture)
+
+Live exploration of the existing New Session and Open dialogs
+(2026-05-16, against
+`crates/fresh-editor/plugins/orchestrator.ts` HEAD) surfaced a
+handful of pre-existing issues and one stale artefact that this
+redesign should fold in.
+
+### New Session dialog
+
+Current rendering (tmux capture, 130 cols, fresh git repo with
+no `origin`):
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│          ORCHESTRATOR :: New Session Dialog :: Review Synthesized          │
+│                           Project: tmp/fresh-demo                          │
+│                                                                            │
+│╭─ Session Name ───────────────────────────────────────────────────────────╮│
+││ [(auto-generated)                                                      ] ││
+│╰──────────────────────────────────────────────────────────────────────────╯│
+│╭─ Agent Command ──────────────────────────────────────────────────────────╮│
+││ [terminal                                                              ] ││
+│╰──────────────────────────────────────────────────────────────────────────╯│
+│╭─ Branch ─────────────────────────────────────────────────────────────────╮│
+││ [detecting default branch…                                             ] ││
+│╰──────────────────────────────────────────────────────────────────────────╯│
+│                                              [ Cancel ]  [ Create Session ]│
+│            Tab next  S-Tab prev  Enter advance / act  Esc cancel           │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+1. **Stale title segment — `Review Synthesized`.** The header
+   currently renders as
+   `ORCHESTRATOR :: New Session Dialog :: Review Synthesized`
+   (orchestrator.ts:1547). "Review Synthesized" reads as
+   leftover scratch text; it is not surfaced anywhere else and
+   has no documented meaning. **Drop it in Phase 1**, leaving
+   just `ORCHESTRATOR :: New Session`.
+2. **Placeholder style is washed out under focus.** Inactive
+   text inputs render their placeholder italic + dim gray
+   (`fg=#505050`, italic) — clear "this is a hint" cue.
+   Focused inputs paint a darker focus background and the
+   placeholder loses its dim style: `(auto-generated)` reads
+   like a literal value when Session Name is the default-
+   focused field. Fix: keep the placeholder's italic + dim
+   foreground over the focused background too (the brackets
+   stay normal-weight so the input outline is still visible).
+3. **Session Name placeholder is parenthesised
+   `(auto-generated)`; the others aren't.** Agent Command
+   shows `terminal`, Branch shows `HEAD` — both unwrapped.
+   The parentheses on Session Name visually compete with a
+   real value the user might type starting with `(`, and they
+   make the inconsistency more glaring. Drop the parentheses
+   and surface the concrete computed default (`session-3`, or
+   whatever `nextAutoSessionName` returns) as the placeholder.
+4. **Branch placeholder is `HEAD` when no `origin` is
+   configured.** Repos without an origin (local-only repos,
+   freshly `git init`-ed scratch dirs) fall through to `HEAD`
+   as the base ref. That's a fine *behaviour* but a confusing
+   *placeholder*: `HEAD` looks like a literal ref the user
+   might not want. Render as `HEAD  (no origin configured)`
+   in that case so the reason is visible.
+5. **Empty-input cursor is invisible.** With no value typed,
+   the focused input shows only the darker background — no
+   blinking caret or `▏` glyph inside the brackets. Combined
+   with point 2, an empty focused field with a non-dim
+   placeholder is indistinguishable from a typed value. Once
+   the placeholder is reliably italic + dim the eye can tell
+   the difference, but the design should still call for an
+   explicit cursor glyph at the input's insertion point.
+6. **Footer hint `Tab next  S-Tab prev  Enter advance / act
+   Esc cancel`** doesn't mention `↑↓ history` — once history
+   ships, the hint needs the extra entry.
+
+### Open dialog (already shipped)
+
+1. **Default focus is now the `+ New Session` button** — the
+   `focusAdvance(1)` removal in this branch took effect:
+   `[ + New Session  Alt+N ]` paints with the focused button
+   chrome (`fg=#ffffff` bold, `bg=#0064c8`) on first render.
+   Tab cycle reads new-session → filter → preview-pane
+   buttons.
+2. **Footer hint says `Enter dive` regardless of focus.** With
+   focus on the New Session button, `Enter` opens the new-
+   session form rather than diving into a session — the hint
+   should adapt (`Enter activate` when focus is on a button)
+   or at least add an `Alt+N new` entry so the alternative is
+   discoverable from the footer.
+3. **Filter input placeholder `type to filter…`** is italic +
+   dim — the convention this design wants the New Session
+   form to match.
+
+### Implications for this design
+
+- The "every default rendered as placeholder" claim in
+  [Default state](#default-state--defaults-shown-as-in-input-placeholder-text)
+  needs to spell out the focused-input case (placeholder
+  keeps italic + dim under focus).
+- Phase 1 picks up two small cleanups it didn't previously
+  enumerate: drop the `Review Synthesized` header segment,
+  and normalise the Session Name placeholder (no parens, show
+  the concrete computed default).
+- Phase 4 (input history) updates the form footer hint to
+  include `↑↓ history`.
+
 ## Wireframe
 
 ### Default state — defaults shown as in-input placeholder text
@@ -489,10 +595,20 @@ Project Path → Worktree Checkbox → Session Name → Agent Command
 
 ## Implementation phases
 
-### Phase 1 — Project Path field + drop subtitle
+### Phase 1 — Project Path field, header cleanup, placeholder normalisation
 
+Header / chrome cleanups (one-liners surfaced by the
+[Audit](#audit-of-the-current-dialog-interactive-tmux-capture)):
+
+- Drop the `:: Review Synthesized` segment from the dialog
+  title (orchestrator.ts:1547); render
+  `ORCHESTRATOR :: New Session` only.
 - Remove the `Project: <projectLabel>` subtitle row from
-  `buildFormSpec`.
+  `buildFormSpec`. The Project Path input below it is now the
+  authoritative project identifier.
+
+Project Path field:
+
 - Add the Project Path text input at the top of
   `buildFormSpec`, above the Session Name row. `value` is
   empty; the resolved default fills the `placeholder` (same
@@ -504,13 +620,34 @@ Project Path → Worktree Checkbox → Session Name → Agent Command
   `defaultProjectPath` field that the input's `placeholder`
   reads, so the probe completing live-updates the
   placeholder without touching `value`.
-- Extend Session Name the same way: keep `value` empty and
-  surface the auto-generated `session-N` name as the
-  placeholder (it already auto-generates on empty submit; the
-  visible placeholder is the new part). This needs a small
-  async probe at `openForm` time to scan `refs/heads/session-N`
-  in the resolved project path; debounce on every Project
-  Path change.
+
+Placeholder rendering (applies to every input):
+
+- Placeholder text keeps its italic + dim foreground
+  (`fg=ui.placeholder_fg`, italic) **even when the input has
+  focus**. The current text widget switches to a darker focus
+  background and loses the italic-dim styling for placeholder
+  text, which makes Session Name's `(auto-generated)` look
+  like a literal value on first paint. Fix in the
+  `text` widget renderer (or via a `placeholderStyle` field
+  on the widget) so the dim style survives focus.
+- Drop the parentheses around Session Name's placeholder.
+  Surface the concrete computed default (`session-3`, or
+  whatever `nextAutoSessionName` returns for the resolved
+  project path) instead of the literal string
+  `(auto-generated)`. Async-probe `refs/heads/session-N` at
+  `openForm` time, debouncing on every Project Path change.
+- When `defaultBranch` resolves to `HEAD` (no `origin`
+  configured), render the placeholder as
+  `HEAD  (no origin configured)` so the reason is visible
+  rather than looking like the user is being told to type
+  `HEAD`.
+- Add a visible insertion-point glyph (`▏` or terminal-native
+  caret) inside the focused empty input so the focused-empty
+  state isn't visually identical to a typed value.
+
+Submit:
+
 - `submitForm` substitutes each placeholder when its field is
   empty, then uses the resolved values for the rest of the
   existing flow.
@@ -568,6 +705,15 @@ Project Path → Worktree Checkbox → Session Name → Agent Command
 - Submit: dedupe-merge the resolved value into the field's
   history, cap at 100, write the file (best-effort, fire-and-
   forget).
+- Update the form's footer hint to include `↑↓ history`
+  (currently
+  `Tab next  S-Tab prev  Enter advance / act  Esc cancel`).
+- Open dialog footer (`↑↓ nav  Enter dive  Tab focus  Esc
+  close`): make the second entry context-sensitive so it
+  reads `Enter activate` when focus is on a button (today
+  `Enter` on the focused `+ New Session` button opens the
+  form, not a dive). At minimum, append `Alt+N new` so the
+  alternative is discoverable from the footer.
 
 ### Phase 5 — Global windows.json + migration
 


### PR DESCRIPTION
Open dialog: drop the post-mount focusAdvance(1) so default focus lands
on the "+ New Session" button at the top of the sessions column rather
than skipping to the filter. Tab order is now new → filter → preview
buttons, matching the visual order of the column. Stale comments that
described a footer-anchored button + Visit-as-default-focus are updated.

Add docs/internal/orchestrator-new-session-base-path.md with an ASCII
wireframe for a redesigned New Session dialog (base repository path
input + create-worktree checkbox), behaviour for non-git paths and
shared-worktree mode, and a discussion of where the multi-window list
should be stored (per-cwd today, per-canonical-repo recommended, with
non-git path fallback).