### PR TITLE
Fix completion dropdown UX: wrap in section and handle Enter key

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1593,6 +1593,14 @@ pub enum WidgetSpec {
         /// closes the popup.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         completions: Vec<String>,
+        /// How many candidate rows the popup paints at once
+        /// when it opens. Excess candidates stay reachable
+        /// via Up/Down (host auto-scrolls to keep selection
+        /// in view) or the mouse wheel; a thumb glyph paints
+        /// in the right edge of the popup whenever there's
+        /// more to scroll. `0` (default) falls back to `5`.
+        #[serde(default)]
+        completions_visible_rows: u32,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1568,6 +1568,31 @@ pub enum WidgetSpec {
         /// `LabeledSection` or a flexible row.
         #[serde(default)]
         full_width: bool,
+        /// Optional completion candidates. When non-empty AND
+        /// `label` is non-empty (the chrome trigger), the
+        /// renderer paints a popup directly under the input,
+        /// inside a unified box: the input's normal `╰─...─╯`
+        /// bottom border becomes a dimmed `┄` separator, the
+        /// labeled section's side borders extend down through
+        /// the candidate rows, and a single `╰─...─╯` bottom
+        /// closes the whole block. Candidates render left-
+        /// aligned with the input's text (the position right
+        /// after `[`), with the host-managed selected index
+        /// highlighted.
+        ///
+        /// Smart-key dispatch on a focused Text-with-completions:
+        /// Up/Down moves selection (host-internal, no event),
+        /// Tab fires `completion_accept` with the selected
+        /// candidate, Enter / Escape fire `completion_dismiss`
+        /// (the dispatcher's normal "Enter focus-advance / Esc
+        /// close panel" only runs once the popup is closed).
+        ///
+        /// Plugins push candidates in response to the text
+        /// widget's `change` event via
+        /// `WidgetMutation::SetCompletions`. An empty `items`
+        /// closes the popup.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        completions: Vec<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },
@@ -1817,6 +1842,16 @@ pub enum WidgetMutation {
         value: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cursor_byte: Option<i32>,
+    },
+    /// Set a `Text` widget's completion candidates (instance
+    /// state). Empty `items` closes the popup; non-empty opens
+    /// it and resets the selection to index 0. Plugins call
+    /// this from their `change` event handler after computing
+    /// candidates against the new value — same flow as
+    /// `setPromptSuggestions` for the legacy prompt UI.
+    SetCompletions {
+        widget_key: String,
+        items: Vec<String>,
     },
     /// Set a `Toggle`'s checked state. Mutates the Toggle's
     /// `checked` field in the spec.

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1007,6 +1007,15 @@ type WidgetSpec = {
 	* closes the popup.
 	*/
 	completions?: Array<string>;
+	/**
+	* How many candidate rows the popup paints at once
+	* when it opens. Excess candidates stay reachable
+	* via Up/Down (host auto-scrolls to keep selection
+	* in view) or the mouse wheel; a thumb glyph paints
+	* in the right edge of the popup whenever there's
+	* more to scroll. `0` (default) falls back to `5`.
+	*/
+	completionsVisibleRows: number;
 	key?: string | null;
 } | {
 	"kind": "labeledSection";

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -981,6 +981,32 @@ type WidgetSpec = {
 	* `LabeledSection` or a flexible row.
 	*/
 	fullWidth: boolean;
+	/**
+	* Optional completion candidates. When non-empty AND
+	* `label` is non-empty (the chrome trigger), the
+	* renderer paints a popup directly under the input,
+	* inside a unified box: the input's normal `╰─...─╯`
+	* bottom border becomes a dimmed `┄` separator, the
+	* labeled section's side borders extend down through
+	* the candidate rows, and a single `╰─...─╯` bottom
+	* closes the whole block. Candidates render left-
+	* aligned with the input's text (the position right
+	* after `[`), with the host-managed selected index
+	* highlighted.
+	*
+	* Smart-key dispatch on a focused Text-with-completions:
+	* Up/Down moves selection (host-internal, no event),
+	* Tab fires `completion_accept` with the selected
+	* candidate, Enter / Escape fire `completion_dismiss`
+	* (the dispatcher's normal "Enter focus-advance / Esc
+	* close panel" only runs once the popup is closed).
+	*
+	* Plugins push candidates in response to the text
+	* widget's `change` event via
+	* `WidgetMutation::SetCompletions`. An empty `items`
+	* closes the popup.
+	*/
+	completions?: Array<string>;
 	key?: string | null;
 } | {
 	"kind": "labeledSection";
@@ -1053,6 +1079,10 @@ type WidgetMutation = {
 	widgetKey: string;
 	value: string;
 	cursorByte?: number | null;
+} | {
+	"kind": "setCompletions";
+	widgetKey: string;
+	items: Array<string>;
 } | {
 	"kind": "setChecked";
 	widgetKey: string;

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -347,6 +347,13 @@ export function text(
      * with `labeledSection(...)` to get a uniformly full-width
      * fieldset look. */
     fullWidth?: boolean;
+    /** Initial completion candidates. Use the
+     * `setCompletions(widgetKey, items)` mutation for live
+     * updates — the spec field seeds the host's instance state
+     * on first render only. Empty = no popup. See
+     * `WidgetSpec::Text.completions` (Rust) for the rendering
+     * + keyboard semantics. */
+    completions?: string[];
     key?: string;
   } = {},
 ): WidgetSpec {
@@ -361,6 +368,7 @@ export function text(
     fieldWidth: options.fieldWidth ?? 0,
     maxVisibleChars: options.maxVisibleChars ?? 0,
     fullWidth: options.fullWidth ?? false,
+    completions: options.completions ?? [],
     key: options.key,
   };
 }
@@ -625,6 +633,15 @@ export class WidgetPanel {
     return this.mutate({ kind: "setSelectedIndex", widgetKey, index });
   }
 
+  /** Update a Text widget's completion popup candidates. Empty
+   * `items` closes the popup; non-empty opens it and resets the
+   * host-managed selection to index 0. The host repaints the
+   * popup on its own; the plugin doesn't need to follow up with
+   * an `update(spec)` call. */
+  setCompletions(widgetKey: string, items: string[]): boolean {
+    return this.mutate({ kind: "setCompletions", widgetKey, items });
+  }
+
   /** Replace a `List`'s items + parallel `itemKeys`. */
   setItems(
     widgetKey: string,
@@ -783,6 +800,13 @@ export class FloatingWidgetPanel {
 
   setSelectedIndex(widgetKey: string, index: number): boolean {
     return this.mutate({ kind: "setSelectedIndex", widgetKey, index });
+  }
+
+  /** Update a Text widget's completion popup candidates. Empty
+   * `items` closes the popup; non-empty opens it and resets the
+   * host-managed selection to index 0. */
+  setCompletions(widgetKey: string, items: string[]): boolean {
+    return this.mutate({ kind: "setCompletions", widgetKey, items });
   }
 
   setItems(

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2351,18 +2351,65 @@ function scheduleCompletionRefresh(
   const token = ++form.completion.token;
   form.completion.field = field;
   form.completion.anchor = anchor;
-  // Debounce: same 150ms feel as a snappy file picker. Don't
-  // collapse with the project-path probe (which runs at 200ms)
-  // because the completion list is interactive — every extra
-  // tick of latency reads as "the editor isn't keeping up".
+  // Path completion reads from `editor.readDir`, which is a
+  // synchronous host call (no IPC waiting). Run it inline so
+  // Tab pressed immediately after the last keystroke picks
+  // from the up-to-date candidate list rather than a stale
+  // one — the user reported that with the debounce in place,
+  // typing "repo" + Tab would accept the *previous* prefix's
+  // top match (e.g. "Desktop") because the popup hadn't
+  // refreshed yet.
+  if (field === "project_path") {
+    const items = computePathCompletions(anchor);
+    if (!form || form.completion.token !== token) return;
+    setCompletionItems(field, items);
+    return;
+  }
+  // Branch completion shells out to `git for-each-ref` — that
+  // *is* async, so a sync flush isn't possible. Keep the
+  // 150ms debounce so we coalesce rapid typing into a single
+  // subprocess invocation; Tab during the gap accepts the
+  // last known list, which is the same behaviour `bash`'s
+  // tab completion exhibits while a long-running compspec is
+  // catching up.
   void editor.delay(150).then(async () => {
     if (!form || form.completion.token !== token) return;
-    const items = field === "project_path"
-      ? await fetchPathCompletions(anchor)
-      : await fetchBranchCompletions(anchor);
+    const items = await fetchBranchCompletions(anchor);
     if (!form || form.completion.token !== token) return;
     setCompletionItems(field, items);
   });
+}
+
+/// Synchronous variant of `fetchPathCompletions` — same logic,
+/// but doesn't go through a `Promise` so it can run inline from
+/// the `change` event handler. `fetchPathCompletions` keeps the
+/// async signature for the legacy debounce path (in case the
+/// fetcher ever grows an async step), but delegates here so the
+/// two paths can't drift.
+function computePathCompletions(typed: string): string[] {
+  const slashIdx = typed.lastIndexOf("/");
+  let parent: string;
+  let basename: string;
+  if (slashIdx < 0) {
+    parent = typed ? "." : editor.getCwd();
+    basename = typed;
+  } else if (slashIdx === 0) {
+    parent = "/";
+    basename = typed.slice(1);
+  } else {
+    parent = typed.slice(0, slashIdx);
+    basename = typed.slice(slashIdx + 1);
+  }
+  const entries = editor.readDir(parent);
+  const matches = entries
+    .filter((e) => !basename || e.name.startsWith(basename))
+    .filter((e) => !e.name.startsWith(".") || basename.startsWith("."));
+  matches.sort((a, b) => {
+    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  const prefix = parent.endsWith("/") ? parent : `${parent}/`;
+  return matches.map((e) => `${prefix}${e.name}${e.is_dir ? "/" : ""}`);
 }
 
 function setCompletionItems(
@@ -2412,34 +2459,10 @@ async function fetchPathCompletions(typed: string): Promise<string[]> {
   // to and including the last `/`; `basename` is the unfinished
   // tail we filter on. `/foo/ba` → parent `/foo/`, basename
   // `ba`. `bar` (no slash) → parent `.`, basename `bar`. `/`
-  // → parent `/`, basename `""`.
-  const slashIdx = typed.lastIndexOf("/");
-  let parent: string;
-  let basename: string;
-  if (slashIdx < 0) {
-    parent = typed ? "." : editor.getCwd();
-    basename = typed;
-  } else if (slashIdx === 0) {
-    parent = "/";
-    basename = typed.slice(1);
-  } else {
-    parent = typed.slice(0, slashIdx);
-    basename = typed.slice(slashIdx + 1);
-  }
-  const entries = editor.readDir(parent);
-  const matches = entries
-    .filter((e) => !basename || e.name.startsWith(basename))
-    .filter((e) => !e.name.startsWith(".") || basename.startsWith(".")); // hide dotfiles unless asked
-  matches.sort((a, b) => {
-    // Dirs before files; then alphabetical.
-    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
-  // Render each item as the full path so accepting it
-  // overwrites the input cleanly (no string-stitching at
-  // accept time).
-  const prefix = parent.endsWith("/") ? parent : `${parent}/`;
-  return matches.map((e) => `${prefix}${e.name}${e.is_dir ? "/" : ""}`);
+  // → parent `/`, basename `""`. Delegates to the sync
+  // `computePathCompletions` so the two paths can't drift —
+  // see `scheduleCompletionRefresh` for the sync use case.
+  return computePathCompletions(typed);
 }
 
 /// List the project's local + remote branches and tags via

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2037,6 +2037,12 @@ function buildFormSpec(): WidgetSpec {
     // editor cwd for non-git launches). Empty submit uses the
     // placeholder verbatim, so the user can land on a sensible
     // default just by pressing Enter through the form.
+    // The completion popup hangs off the bottom of this Text
+    // widget — host-rendered chrome, no separate widget. The
+    // plugin pushes candidates via `formPanel.setCompletions`
+    // and reacts to the `completion_accept` event when the user
+    // hits Tab; the labeledSection wrapper extends its side
+    // borders down through the popup automatically.
     labeledSection({
       label: "Project Path",
       child: text({
@@ -2047,7 +2053,6 @@ function buildFormSpec(): WidgetSpec {
         key: "project_path",
       }),
     }),
-    ...maybeCompletionList("project_path"),
     // === Worktree toggle. ========================================
     // Enabled only when the Project Path resolves to a git work
     // tree. When disabled, render with a dim-fg `raw` row using
@@ -2126,7 +2131,6 @@ function buildFormSpec(): WidgetSpec {
         key: branchInert ? undefined : "branch",
       }),
     }),
-    ...maybeCompletionList("branch"),
   ];
   if (form.lastError) {
     children.push(spacer(0));
@@ -2369,14 +2373,13 @@ function setCompletionItems(
   form.completion.field = field;
   form.completion.items = items.slice(0, COMPLETION_MAX_ITEMS);
   form.completion.selectedIndex = 0;
-  // The list widget's `selectedIndex` from spec is initial-only
-  // after first render. Snap the host's instance state to 0 too
-  // so a refresh that shrinks / regrows the list always starts
-  // selection at the top of the new candidate set.
+  // Push the candidate list to the host's Text-widget instance
+  // state. The host repaints the popup chrome (dim separator,
+  // side borders, selected-row highlight) on its own — the
+  // plugin doesn't need to drive a re-render.
   if (formPanel) {
-    formPanel.setSelectedIndex("completion", 0);
+    formPanel.setCompletions(field, form.completion.items);
   }
-  renderForm();
 }
 
 function closeCompletion(): void {
@@ -2384,11 +2387,18 @@ function closeCompletion(): void {
   if (form.completion.field === null && form.completion.items.length === 0) {
     return;
   }
+  const prevField = form.completion.field;
   form.completion.field = null;
   form.completion.items = [];
   form.completion.selectedIndex = 0;
   form.completion.token += 1; // invalidate any in-flight fetch
-  renderForm();
+  // Mirror the close in host instance state so its popup goes
+  // away in the same frame. Without this the host would keep
+  // painting the candidate list until the next spec push
+  // happened to land for this widget.
+  if (formPanel && prevField) {
+    formPanel.setCompletions(prevField, []);
+  }
 }
 
 /// Split typed Project Path into (parent, basename), list
@@ -2487,104 +2497,33 @@ async function fetchBranchCompletions(typed: string): Promise<string[]> {
   return filtered;
 }
 
-/// Apply the highlighted completion to its field, dismiss the
-/// dropdown, and (for Project Path) re-probe defaults. Accepts
-/// the currently selected item; if the list is empty it's a
-/// no-op. For directories (path ends with `/`), the field stays
-/// open so the user can keep typing or `Tab` again to descend.
-function acceptCompletion(): boolean {
-  if (!form) return false;
-  const c = form.completion;
-  if (c.field === null || c.items.length === 0) return false;
-  const item = c.items[c.selectedIndex];
-  if (!item) return false;
-  const slot = c.field === "project_path" ? form.projectPath : form.branch;
+/// Apply the user-accepted completion candidate to its field.
+/// Fired in response to the host's `completion_accept` event
+/// (Tab on a Text-with-open-completions): the host has already
+/// figured out which row was selected — we just write it into
+/// the form model and update the field's value. For Project
+/// Path accepts that end in `/` (directory descent) we re-
+/// fetch the candidate list for the new path so the user can
+/// keep Tab-ing into deeper subdirs without first typing
+/// anything; the host preserves the open popup across the
+/// fetch, so it just refreshes in place.
+function applyAcceptedCompletion(
+  field: "project_path" | "branch",
+  item: string,
+): void {
+  if (!form) return;
+  const slot = field === "project_path" ? form.projectPath : form.branch;
   slot.value = item;
   slot.cursor = item.length;
-  if (formPanel) formPanel.setValue(c.field, slot.value, slot.cursor);
-  if (c.field === "project_path") {
-    // Re-trigger the is-git probe + default-branch / session-
-    // name placeholder probes for the new path. Also re-fetch
-    // path completions in case the user accepted a directory
-    // and wants to keep descending — they get a fresh list of
-    // children right away.
+  if (formPanel) formPanel.setValue(field, slot.value, slot.cursor);
+  if (field === "project_path") {
     scheduleProjectPathReprobe();
     if (item.endsWith("/")) {
       scheduleCompletionRefresh("project_path");
-      return true;
+      return;
     }
   }
   closeCompletion();
-  return true;
-}
-
-/// Build a `list` widget for the named field's completion
-/// dropdown. Returns an empty array when the dropdown shouldn't
-/// render — either no candidates fetched yet, the field isn't
-/// the one we're completing, or the input doesn't have focus
-/// (no point showing completions for an input the user isn't
-/// editing). Returned as an array so the caller can spread it
-/// into `children` for the conditional render.
-///
-/// The list is keyless (`focusable: false`, no `key`), so it
-/// stays out of the Tab cycle — it's a "suggestion strip"
-/// scoped to its input. Up/Down on the input route here via the
-/// `walkCompletion` helper instead of plain widget focus moves.
-function maybeCompletionList(field: "project_path" | "branch"): WidgetSpec[] {
-  if (!form) return [];
-  if (form.completion.field !== field) return [];
-  if (form.completion.items.length === 0) return [];
-  if (formFocusedKey() !== field) return [];
-  const sel = form.completion.selectedIndex;
-  // Render each row with an explicit selection highlight via
-  // styled segments — the floating-panel painter clobbers
-  // entry-level `style.bg` with the suggestion bg, so the
-  // List widget's own selected-row style doesn't carry colour
-  // through. A `segments` row turns into an inline overlay on
-  // the full text, which the painter's per-property merge
-  // honours.
-  const items = form.completion.items.map((s, i) => {
-    const isSelected = i === sel;
-    return styledRow([
-      {
-        text: s,
-        style: isSelected
-          ? {
-              fg: "ui.popup_selection_fg",
-              bg: "ui.popup_selection_bg",
-              bold: true,
-            }
-          : undefined,
-      },
-    ]);
-  });
-  return [
-    overlay(
-      // Wrap the list in an empty-labelled section so the dropdown
-      // gets the same `╭─...─╮ ... ╰─...─╯` chrome as the rest of
-      // the form. Without it the rows paint as bare text overlaid
-      // on whatever's underneath (the Worktree toggle / Session
-      // Name row), which reads as a rendering bug rather than a
-      // popup.
-      labeledSection({
-        label: "",
-        child: list({
-          items,
-          selectedIndex: sel,
-          visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
-          // Not in the Tab cycle (Up/Down on the focused INPUT
-          // walks the list via the smart-key handler). Keyed so
-          // mouse-click `select` events and `setSelectedIndex`
-          // mutations land on this list; the host's picker-Enter
-          // wiring used to route Enter here too, but the form's
-          // explicit Enter binding (see FORM_MODE_BINDINGS)
-          // intercepts that — Tab is the only accept path.
-          focusable: false,
-          key: "completion",
-        }),
-      }),
-    ),
-  ];
 }
 
 function closeForm(): void {
@@ -2788,36 +2727,33 @@ function dispatchFormKey(name: string): void {
   formPanel.command(widgetKey(name));
 }
 
+// Tab / Enter / Up / Down / Escape are all routed straight to
+// the host's smart-key dispatch via `dispatchFormKey`. The host
+// owns the completion popup state (instance state on the Text
+// widget), so when the popup is open it short-circuits these
+// keys to popup-specific behaviour (accept, dismiss, move
+// selection) and falls through to the widget's default key
+// handling otherwise. The plugin just reacts to the events the
+// host emits — `completion_accept` and `completion_dismiss`,
+// handled in the `widget_event` dispatch below.
 registerHandler("orchestrator_form_key_tab", () => {
-  // If the completion dropdown is showing for the focused
-  // input, Tab accepts the highlighted suggestion instead of
-  // advancing focus — matches the convention users expect from
-  // shell / IDE completion popups.
   if (completionVisibleForFocused()) {
-    acceptCompletion();
+    // Host fires completion_accept; plugin's widget_event
+    // handler applies the value. No focus advance.
+    dispatchFormKey("Tab");
     return;
   }
   advanceFormFocus(1);
   dispatchFormKey("Tab");
 });
 registerHandler("orchestrator_form_key_enter", () => {
-  // When the completion dropdown is open, drop it *without*
-  // accepting the highlighted item — Enter is "proceed with
-  // what's typed", not "accept the suggestion" (Tab does the
-  // latter). The host's picker-style Enter wiring otherwise
-  // overwrites the field with the highlighted entry the moment
-  // the user presses Enter on a partially-typed path.
-  //
-  // Render-then-dispatch ordering: `closeCompletion()` enqueues
-  // an `updateFloatingWidget` over the same command channel the
-  // subsequent `dispatchFormKey("Enter")` uses, so the host
-  // applies the spec update (list removed) before resolving the
-  // Enter dispatch. With no scrollable sibling left, the
-  // smart-key router falls through to its non-picker branches:
-  // focus-advance on a Text widget, activate on a Button.
-  if (completionVisibleForFocused()) {
-    closeCompletion();
-  }
+  // When the popup is open, the host's smart-key fires
+  // `completion_dismiss` (plugin syncs local state via that
+  // event) without firing the form's picker-Enter or focus
+  // advance — Enter is "dismiss the popup, stay focused on
+  // the text input". When the popup is closed, Enter falls
+  // through to the host's normal Text-widget Enter (picker
+  // activate or focus advance).
   dispatchFormKey("Enter");
 });
 registerHandler(
@@ -2833,11 +2769,12 @@ registerHandler(
   },
 );
 registerHandler("orchestrator_form_key_escape", () => {
-  // Esc closes the completion dropdown first; only when there's
-  // no dropdown does it cancel the dialog. Matches how popup-
-  // based UIs (browsers, shells) layer dismissal.
+  // When the popup is open, the host dismisses on Escape and
+  // emits `completion_dismiss`; the plugin's local state
+  // resync happens in the widget_event handler. Only when
+  // the popup is already closed does Escape cancel the form.
   if (completionVisibleForFocused()) {
-    closeCompletion();
+    dispatchFormKey("Escape");
     return;
   }
   if (form) cancelForm();
@@ -2852,12 +2789,12 @@ registerHandler("orchestrator_form_key_end", () => dispatchFormKey("End"));
 registerHandler("orchestrator_form_key_left", () => dispatchFormKey("Left"));
 registerHandler("orchestrator_form_key_right", () => dispatchFormKey("Right"));
 registerHandler("orchestrator_form_key_up", () => {
-  // Completion-list-aware navigation: when the dropdown is
-  // open for the focused input, ↑↓ navigates the list
-  // (overrides history). Otherwise ↑↓ walks history for
-  // history-bearing inputs; otherwise pass through.
+  // When the completion popup is open the host short-circuits
+  // Up/Down to its own selection navigation — dispatch
+  // straight through. Otherwise walk history for the history-
+  // bearing inputs; otherwise pass through.
   if (completionVisibleForFocused()) {
-    walkCompletion(-1);
+    dispatchFormKey("Up");
     return;
   }
   const histField = focusToHistoryField(formFocusedKey());
@@ -2869,7 +2806,7 @@ registerHandler("orchestrator_form_key_up", () => {
 });
 registerHandler("orchestrator_form_key_down", () => {
   if (completionVisibleForFocused()) {
-    walkCompletion(1);
+    dispatchFormKey("Down");
     return;
   }
   const histField = focusToHistoryField(formFocusedKey());
@@ -2880,31 +2817,20 @@ registerHandler("orchestrator_form_key_down", () => {
   }
 });
 
-/// Is the completion dropdown showing for the currently focused
-/// input? Returns false when there are no items, when the
-/// dropdown is for a different field, or when focus is on a
-/// non-input.
+/// Is the completion popup open for the currently focused
+/// input? Tracked plugin-side because the plugin still needs
+/// to know in order to gate history-walk (Up/Down on an empty-
+/// popup history-bearing input walks the history list, not
+/// the popup). The host's instance state is authoritative for
+/// the popup itself; the plugin mirrors the open/closed bit
+/// here by populating `form.completion.items` from
+/// `setCompletionItems` and clearing it from
+/// `closeCompletion` / on the `completion_dismiss` event.
 function completionVisibleForFocused(): boolean {
   if (!form) return false;
   const c = form.completion;
   if (c.field === null || c.items.length === 0) return false;
   return formFocusedKey() === c.field;
-}
-
-function walkCompletion(delta: -1 | 1): void {
-  if (!form) return;
-  const c = form.completion;
-  if (c.items.length === 0) return;
-  c.selectedIndex =
-    (c.selectedIndex + delta + c.items.length) % c.items.length;
-  // The List widget treats `selectedIndex` from the spec as
-  // initial-only after the first render — subsequent updates
-  // read instance state. Mutate the host's state directly so
-  // the selection highlight follows our cursor.
-  if (formPanel) {
-    formPanel.setSelectedIndex("completion", c.selectedIndex);
-  }
-  renderForm();
 }
 
 // Printable input arrives via the global `mode_text_input` action.
@@ -3031,31 +2957,31 @@ editor.on("widget_event", (e) => {
       renderForm();
       return;
     }
-    if (e.event_type === "activate") {
-      if (e.widget_key === "completion") {
-        // Enter on a focused Project Path / Branch input with
-        // an active dropdown lands here via the host's
-        // single-line-Text-+-sibling-list picker wiring.
-        acceptCompletion();
-        return;
+    if (e.event_type === "completion_accept") {
+      // Host fires this on Tab against a Text widget with an
+      // open completion popup. The payload carries the
+      // candidate that was highlighted.
+      const payload = (e.payload ?? {}) as Record<string, unknown>;
+      const value = payload.value;
+      if (typeof value !== "string") return;
+      if (e.widget_key === "project_path" || e.widget_key === "branch") {
+        applyAcceptedCompletion(e.widget_key, value);
       }
+      return;
+    }
+    if (e.event_type === "completion_dismiss") {
+      // Host fires this on Enter / Esc against a Text widget
+      // with an open popup. Sync plugin-side state so the
+      // history-walk gate (Up/Down on an empty-popup history-
+      // bearing field) reads `false` again.
+      closeCompletion();
+      return;
+    }
+    if (e.event_type === "activate") {
       if (e.widget_key === "create") {
         void submitForm();
       } else if (e.widget_key === "cancel") {
         cancelForm();
-      }
-      return;
-    }
-    if (e.event_type === "select" && e.widget_key === "completion") {
-      // Mouse click on a completion row: update our mirror
-      // and accept immediately (treating the click like a
-      // tap-to-pick rather than a tap-to-highlight). The
-      // host's select event carries the selected `index`.
-      const payload = (e.payload ?? {}) as Record<string, unknown>;
-      const idx = payload.index;
-      if (typeof idx === "number" && form.completion.items[idx]) {
-        form.completion.selectedIndex = idx;
-        acceptCompletion();
       }
       return;
     }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2157,7 +2157,7 @@ function buildFormSpec(): WidgetSpec {
     row(
       flexSpacer(),
       hintBar([
-        { keys: "Tab", label: "next" },
+        { keys: "Tab", label: "next / accept" },
         { keys: "S-Tab", label: "prev" },
         { keys: "↑↓", label: "history" },
         { keys: "Space", label: "toggle" },
@@ -2560,19 +2560,28 @@ function maybeCompletionList(field: "project_path" | "branch"): WidgetSpec[] {
   });
   return [
     overlay(
-      list({
-        items,
-        selectedIndex: sel,
-        visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
-        // Not in the Tab cycle (Up/Down on the focused INPUT
-        // walks the list via the smart-key handler) but keyed
-        // so the host's single-line-Text-+-sibling-list
-        // "picker Enter" wiring routes Enter on the focused
-        // input into an activate event on this list — which
-        // the form's widget_event handler turns into
-        // `acceptCompletion()`.
-        focusable: false,
-        key: "completion",
+      // Wrap the list in an empty-labelled section so the dropdown
+      // gets the same `╭─...─╮ ... ╰─...─╯` chrome as the rest of
+      // the form. Without it the rows paint as bare text overlaid
+      // on whatever's underneath (the Worktree toggle / Session
+      // Name row), which reads as a rendering bug rather than a
+      // popup.
+      labeledSection({
+        label: "",
+        child: list({
+          items,
+          selectedIndex: sel,
+          visibleRows: Math.min(COMPLETION_VISIBLE_ROWS, items.length),
+          // Not in the Tab cycle (Up/Down on the focused INPUT
+          // walks the list via the smart-key handler). Keyed so
+          // mouse-click `select` events and `setSelectedIndex`
+          // mutations land on this list; the host's picker-Enter
+          // wiring used to route Enter here too, but the form's
+          // explicit Enter binding (see FORM_MODE_BINDINGS)
+          // intercepts that — Tab is the only accept path.
+          focusable: false,
+          key: "completion",
+        }),
       }),
     ),
   ];
@@ -2747,18 +2756,20 @@ function startNewSession(): void {
 // Form key bindings — each delegates to smart-key dispatch on the
 // panel, which routes to the focused widget. `mode_text_input`
 // handles printable input outside this list.
-// Enter is intentionally NOT bound here: we want the host's
-// floating-widget smart-key dispatch to handle it natively. That
-// gives Enter-on-button → activate (so Cancel cancels and Create
-// Session submits via their respective `widget_event` "activate"
-// branches), and Enter-on-text-input → focus advance (next
-// field). Adding Enter to this list previously caused a regression
-// where pressing Enter on the focused Cancel button submitted
-// the form, because the plugin's handler always called
-// `submitForm` regardless of which widget the host had focused.
+// Enter is bound to a thin shim that closes the completion
+// dropdown without accepting (Tab is the only accept path —
+// matches bash / fish / readline path-completion conventions),
+// then forwards Enter to the host's smart-key dispatch so the
+// normal behaviour applies: Enter-on-button → activate (Cancel
+// cancels, Create Session submits via their `widget_event`
+// "activate" branches), Enter-on-text-input → focus advance.
+// Without the shim, the host's picker-style Enter wiring would
+// fire the sibling completion list's activate event and silently
+// overwrite the typed text with the highlighted suggestion.
 const FORM_MODE_BINDINGS: [string, string][] = [
   ["Tab", "orchestrator_form_key_tab"],
   ["S-Tab", "orchestrator_form_key_shift_tab"],
+  ["Enter", "orchestrator_form_key_enter"],
   ["Escape", "orchestrator_form_key_escape"],
   ["Backspace", "orchestrator_form_key_backspace"],
   ["Delete", "orchestrator_form_key_delete"],
@@ -2788,6 +2799,26 @@ registerHandler("orchestrator_form_key_tab", () => {
   }
   advanceFormFocus(1);
   dispatchFormKey("Tab");
+});
+registerHandler("orchestrator_form_key_enter", () => {
+  // When the completion dropdown is open, drop it *without*
+  // accepting the highlighted item — Enter is "proceed with
+  // what's typed", not "accept the suggestion" (Tab does the
+  // latter). The host's picker-style Enter wiring otherwise
+  // overwrites the field with the highlighted entry the moment
+  // the user presses Enter on a partially-typed path.
+  //
+  // Render-then-dispatch ordering: `closeCompletion()` enqueues
+  // an `updateFloatingWidget` over the same command channel the
+  // subsequent `dispatchFormKey("Enter")` uses, so the host
+  // applies the spec update (list removed) before resolving the
+  // Enter dispatch. With no scrollable sibling left, the
+  // smart-key router falls through to its non-picker branches:
+  // focus-advance on a Text widget, activate on a Button.
+  if (completionVisibleForFocused()) {
+    closeCompletion();
+  }
+  dispatchFormKey("Enter");
 });
 registerHandler(
   "orchestrator_form_key_shift_tab",

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -354,6 +354,11 @@ impl Editor {
             // file browser consumed the scroll
         } else if self.is_mouse_over_any_popup(col, row) {
             self.scroll_popup(delta);
+        } else if self.handle_floating_widget_panel_wheel(col, row, delta) {
+            // The floating widget panel (orchestrator New Session,
+            // ...) absorbed the wheel — its Text-widget
+            // completion popup uses this to scroll its candidate
+            // list when the user mouse-wheels over the popup.
         } else if self
             .active_window()
             .split_at_position(col, row)
@@ -3357,6 +3362,31 @@ impl Editor {
     /// Hit-test a click against the floating widget panel. Clicks
     /// inside the panel's inner rect resolve to a widget row/byte
     /// and fire `widget_event` via the same path
+    /// Forward a vertical-wheel scroll to the active floating
+    /// widget panel — same plumbing the orchestrator's
+    /// embedded-widget panels use, but the floating panel
+    /// doesn't show up in `split_at_position` so it needs its
+    /// own dispatch entry point. Returns `true` when the panel
+    /// is active AND the mouse is inside its inner rect (so the
+    /// caller knows the wheel was consumed and shouldn't fall
+    /// through to buffer scrolling).
+    fn handle_floating_widget_panel_wheel(&mut self, col: u16, row: u16, delta: i32) -> bool {
+        let inner = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => match fwp.last_inner_rect {
+                Some(rect) => rect,
+                None => return false,
+            },
+            None => return false,
+        };
+        if col < inner.x || col >= inner.x + inner.width {
+            return false;
+        }
+        if row < inner.y || row >= inner.y + inner.height {
+            return false;
+        }
+        self.handle_widget_panel_wheel(super::FLOATING_PANEL_BUFFER_ID, delta)
+    }
+
     /// `handle_editor_click` uses; clicks outside the rect are
     /// swallowed without dismissing the panel.
     fn handle_floating_widget_click(&mut self, col: u16, row: u16) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3571,20 +3571,22 @@ impl Editor {
                     // (if open) doesn't disappear on a value
                     // mutation that happens to land while the
                     // user is mid-keystroke.
-                    let (scroll, multiline, completions, sel_idx) =
+                    let (scroll, multiline, completions, sel_idx, scroll_off) =
                         match panel.instance_states.get(&widget_key) {
                             Some(crate::widgets::WidgetInstanceState::Text {
                                 editor,
                                 scroll,
                                 completions,
                                 completion_selected_index,
+                                completion_scroll_offset,
                             }) => (
                                 *scroll,
                                 editor.multiline,
                                 completions.clone(),
                                 *completion_selected_index,
+                                *completion_scroll_offset,
                             ),
-                            _ => (0u32, true, Vec::new(), 0usize),
+                            _ => (0u32, true, Vec::new(), 0usize, 0u32),
                         };
                     let mut editor = if multiline {
                         crate::primitives::text_edit::TextEdit::with_text(&value)
@@ -3603,6 +3605,7 @@ impl Editor {
                             scroll,
                             completions,
                             completion_selected_index: sel_idx,
+                            completion_scroll_offset: scroll_off,
                         },
                     );
                 }
@@ -3653,11 +3656,13 @@ impl Editor {
                     if let Some(crate::widgets::WidgetInstanceState::Text {
                         completions,
                         completion_selected_index,
+                        completion_scroll_offset,
                         ..
                     }) = panel.instance_states.get_mut(&widget_key)
                     {
                         *completions = items;
                         *completion_selected_index = 0;
+                        *completion_scroll_offset = 0;
                     }
                 }
             }
@@ -3813,18 +3818,29 @@ impl Editor {
             match key {
                 "Tab" => {
                     self.fire_completion_accept(panel_id);
+                    // The plugin's accept handler typically calls
+                    // setValue + (maybe) setCompletions — those
+                    // mutations re-render on their own, so we
+                    // don't force a render here.
                     return;
                 }
                 "Up" => {
                     self.move_focused_text_completion_index(panel_id, -1);
+                    // Selection moved host-side; force a repaint
+                    // so the highlight + scroll-into-view shift
+                    // is visible without waiting for the next
+                    // unrelated mutation.
+                    self.rerender_widget_panel(panel_id);
                     return;
                 }
                 "Down" => {
                     self.move_focused_text_completion_index(panel_id, 1);
+                    self.rerender_widget_panel(panel_id);
                     return;
                 }
                 "Enter" | "Escape" => {
                     self.dismiss_focused_text_completions(panel_id);
+                    self.rerender_widget_panel(panel_id);
                     return;
                 }
                 _ => {}
@@ -4462,6 +4478,16 @@ impl Editor {
         let panels = self.widget_registry.panels_for_buffer(buffer_id);
         let mut consumed = false;
         for panel_id in panels {
+            // First chance: a focused Text widget with an open
+            // completion popup absorbs the wheel — scrolling the
+            // candidate list when the popup is what the user is
+            // pointing at takes priority over scrolling a
+            // sibling List/Tree elsewhere on the panel.
+            if self.focused_text_completions_open(panel_id) {
+                self.scroll_focused_text_completions(panel_id, delta);
+                consumed = true;
+                continue;
+            }
             let spec = match self.widget_registry.get(panel_id) {
                 Some(p) => p.spec.clone(),
                 None => continue,
@@ -4483,6 +4509,53 @@ impl Editor {
             }
         }
         consumed
+    }
+
+    /// Shift the focused Text widget's completion popup scroll
+    /// offset by `delta` rows. The renderer reads the visible-
+    /// rows cap from the Text spec; we approximate it here as
+    /// "5 if zero / unset" to mirror the renderer's default —
+    /// the cap matters for clamping the max scroll so the
+    /// thumb doesn't drift past the end.
+    fn scroll_focused_text_completions(&mut self, panel_id: u64, delta: i32) {
+        let panel = match self.widget_registry.get(panel_id) {
+            Some(p) => p,
+            None => return,
+        };
+        let focus_key = panel.focus_key.clone();
+        if focus_key.is_empty() {
+            return;
+        }
+        let spec_visible_rows = match crate::widgets::find_widget_by_key(&panel.spec, &focus_key) {
+            Some(fresh_core::api::WidgetSpec::Text {
+                completions_visible_rows,
+                ..
+            }) => *completions_visible_rows,
+            _ => 0,
+        };
+        let visible = if spec_visible_rows == 0 {
+            5u32
+        } else {
+            spec_visible_rows
+        };
+        let panel = match self.widget_registry.get_mut(panel_id) {
+            Some(p) => p,
+            None => return,
+        };
+        if let Some(crate::widgets::WidgetInstanceState::Text {
+            completions,
+            completion_scroll_offset,
+            ..
+        }) = panel.instance_states.get_mut(&focus_key)
+        {
+            if completions.is_empty() {
+                return;
+            }
+            let total = completions.len() as u32;
+            let max_scroll = total.saturating_sub(visible.min(total));
+            let next = (*completion_scroll_offset as i32 + delta).clamp(0, max_scroll as i32);
+            *completion_scroll_offset = next as u32;
+        }
     }
 
     /// Shift a Tree's `scroll_offset` by `delta` rows. If the
@@ -5049,6 +5122,7 @@ impl Editor {
                 scroll: 0,
                 completions: Vec::new(),
                 completion_selected_index: 0,
+                completion_scroll_offset: 0,
             },
         );
         true

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4112,11 +4112,15 @@ impl Editor {
     }
 
     /// Move the selected-index cursor of the focused Text widget's
-    /// completion popup by `delta` (Up = -1, Down = +1). Wraps at
-    /// the ends so the user can cycle through candidates without
-    /// hitting a wall — same convention as `List`'s selection
-    /// wrap. No-op when the focused widget isn't a Text-with-
-    /// open-completions.
+    /// completion popup by `delta` (Up = -1, Down = +1). Clamps
+    /// at the ends rather than wrapping — Down past the last
+    /// candidate stays on the last candidate, Up past the first
+    /// stays on the first. Wraparound on a popup-style picker
+    /// reads as "I scrolled past the bottom and now I'm at the
+    /// top" which is jarring when the user is actively comparing
+    /// items they expect to be in monotonic positions. No-op
+    /// when the focused widget isn't a Text-with-open-
+    /// completions.
     fn move_focused_text_completion_index(&mut self, panel_id: u64, delta: i32) {
         let panel = match self.widget_registry.get_mut(panel_id) {
             Some(p) => p,
@@ -4135,9 +4139,9 @@ impl Editor {
             if completions.is_empty() {
                 return;
             }
-            let n = completions.len() as i32;
+            let max = (completions.len() - 1) as i32;
             let cur = *completion_selected_index as i32;
-            let next = ((cur + delta) % n + n) % n;
+            let next = (cur + delta).clamp(0, max);
             *completion_selected_index = next as usize;
         }
     }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4122,7 +4122,13 @@ impl Editor {
     /// when the focused widget isn't a Text-with-open-
     /// completions.
     fn move_focused_text_completion_index(&mut self, panel_id: u64, delta: i32) {
-        let panel = match self.widget_registry.get_mut(panel_id) {
+        // First read the spec's visible-rows cap so we can pull
+        // scroll back into view if the new selection lands above
+        // the current scroll offset. (The renderer only does
+        // forward-pull — it would otherwise fight the mouse-
+        // wheel handler which deliberately diverges scroll from
+        // selection.)
+        let panel = match self.widget_registry.get(panel_id) {
             Some(p) => p,
             None => return,
         };
@@ -4130,9 +4136,26 @@ impl Editor {
         if focus_key.is_empty() {
             return;
         }
+        let spec_visible_rows = match crate::widgets::find_widget_by_key(&panel.spec, &focus_key) {
+            Some(fresh_core::api::WidgetSpec::Text {
+                completions_visible_rows,
+                ..
+            }) => *completions_visible_rows,
+            _ => 0,
+        };
+        let visible = if spec_visible_rows == 0 {
+            5u32
+        } else {
+            spec_visible_rows
+        };
+        let panel = match self.widget_registry.get_mut(panel_id) {
+            Some(p) => p,
+            None => return,
+        };
         if let Some(crate::widgets::WidgetInstanceState::Text {
             completions,
             completion_selected_index,
+            completion_scroll_offset,
             ..
         }) = panel.instance_states.get_mut(&focus_key)
         {
@@ -4143,6 +4166,16 @@ impl Editor {
             let cur = *completion_selected_index as i32;
             let next = (cur + delta).clamp(0, max);
             *completion_selected_index = next as usize;
+            // Keyboard-driven selection move: if the new
+            // selection sits above the current scroll window,
+            // pull the scroll back so the selection stays
+            // visible. Forward-pull is handled by the renderer.
+            let next_u = next as u32;
+            if next_u < *completion_scroll_offset {
+                *completion_scroll_offset = next_u;
+            } else if next_u >= *completion_scroll_offset + visible {
+                *completion_scroll_offset = next_u + 1 - visible;
+            }
         }
     }
 
@@ -4489,6 +4522,15 @@ impl Editor {
             // sibling List/Tree elsewhere on the panel.
             if self.focused_text_completions_open(panel_id) {
                 self.scroll_focused_text_completions(panel_id, delta);
+                // The renderer reads `completion_scroll_offset`
+                // out of the Text widget's instance state on
+                // each paint, so flushing a rerender here is
+                // what actually puts the new scroll on screen
+                // — without this, the cached overlay rows on
+                // the floating panel stay pinned to the old
+                // offset until the user's next keystroke
+                // happens to re-render for some other reason.
+                self.rerender_widget_panel(panel_id);
                 consumed = true;
                 continue;
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3564,12 +3564,28 @@ impl Editor {
                 // plugin-driven update; the renderer re-clamps next
                 // render anyway.
                 if let Some(panel) = self.widget_registry.get_mut(panel_id) {
-                    let (scroll, multiline) = match panel.instance_states.get(&widget_key) {
-                        Some(crate::widgets::WidgetInstanceState::Text { editor, scroll }) => {
-                            (*scroll, editor.multiline)
-                        }
-                        _ => (0u32, true),
-                    };
+                    // Preserve `scroll` + `multiline` so plugin-
+                    // driven SetValue doesn't snap the viewport,
+                    // and preserve `completions` /
+                    // `completion_selected_index` so the popup
+                    // (if open) doesn't disappear on a value
+                    // mutation that happens to land while the
+                    // user is mid-keystroke.
+                    let (scroll, multiline, completions, sel_idx) =
+                        match panel.instance_states.get(&widget_key) {
+                            Some(crate::widgets::WidgetInstanceState::Text {
+                                editor,
+                                scroll,
+                                completions,
+                                completion_selected_index,
+                            }) => (
+                                *scroll,
+                                editor.multiline,
+                                completions.clone(),
+                                *completion_selected_index,
+                            ),
+                            _ => (0u32, true, Vec::new(), 0usize),
+                        };
                     let mut editor = if multiline {
                         crate::primitives::text_edit::TextEdit::with_text(&value)
                     } else {
@@ -3582,7 +3598,12 @@ impl Editor {
                     editor.set_cursor_from_flat(target);
                     panel.instance_states.insert(
                         widget_key,
-                        crate::widgets::WidgetInstanceState::Text { editor, scroll },
+                        crate::widgets::WidgetInstanceState::Text {
+                            editor,
+                            scroll,
+                            completions,
+                            completion_selected_index: sel_idx,
+                        },
                     );
                 }
             }
@@ -3617,6 +3638,27 @@ impl Editor {
                             selected_index: index,
                         },
                     );
+                }
+            }
+            WidgetMutation::SetCompletions { widget_key, items } => {
+                // Update completion popup state on a Text widget.
+                // Non-empty `items` opens the popup and resets the
+                // host-managed selection to the top candidate;
+                // empty closes it. The instance state has to
+                // exist first (a SetCompletions arriving before
+                // any render is dropped on the floor — Text
+                // instance state is seeded on first render of
+                // the spec).
+                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                    if let Some(crate::widgets::WidgetInstanceState::Text {
+                        completions,
+                        completion_selected_index,
+                        ..
+                    }) = panel.instance_states.get_mut(&widget_key)
+                    {
+                        *completions = items;
+                        *completion_selected_index = 0;
+                    }
                 }
             }
             WidgetMutation::SetItems {
@@ -3756,6 +3798,38 @@ impl Editor {
         } else {
             crate::widgets::find_widget_by_key(&panel.spec, &focus_key)
         };
+        // Completion-popup short-circuit: when the focused Text
+        // widget has an open completion popup, intercept Tab /
+        // Up / Down / Enter / Esc so they drive the popup instead
+        // of falling through to the widget's default key
+        // behaviour. Tab fires `completion_accept`, Enter/Esc
+        // dismiss, Up/Down move the host-managed selection. Any
+        // other key (printable, Backspace, etc.) still goes to
+        // the text editor, which lets the user keep typing to
+        // refine the candidate list.
+        let completions_open = matches!(key, "Tab" | "Up" | "Down" | "Enter" | "Escape")
+            && self.focused_text_completions_open(panel_id);
+        if completions_open {
+            match key {
+                "Tab" => {
+                    self.fire_completion_accept(panel_id);
+                    return;
+                }
+                "Up" => {
+                    self.move_focused_text_completion_index(panel_id, -1);
+                    return;
+                }
+                "Down" => {
+                    self.move_focused_text_completion_index(panel_id, 1);
+                    return;
+                }
+                "Enter" | "Escape" => {
+                    self.dismiss_focused_text_completions(panel_id);
+                    return;
+                }
+                _ => {}
+            }
+        }
         match key {
             "Tab" => self.handle_widget_focus_advance(panel_id, 1),
             "Shift+Tab" => self.handle_widget_focus_advance(panel_id, -1),
@@ -4000,6 +4074,159 @@ impl Editor {
     /// selection (or spec selection on first render). The plugin's
     /// activate handler does the actual user-visible thing — open
     /// the matched file, expand/collapse a tree node, etc.
+    /// True when the focused widget on `panel_id` is a Text input
+    /// whose host-managed completion popup is currently open
+    /// (instance state has at least one candidate). Lets the
+    /// smart-key dispatcher route Tab/Enter/Up/Down/Esc to the
+    /// popup-specific paths before falling through to the
+    /// widget's default key behaviour.
+    fn focused_text_completions_open(&self, panel_id: u64) -> bool {
+        let panel = match self.widget_registry.get(panel_id) {
+            Some(p) => p,
+            None => return false,
+        };
+        if panel.focus_key.is_empty() {
+            return false;
+        }
+        matches!(
+            panel.instance_states.get(&panel.focus_key),
+            Some(crate::widgets::WidgetInstanceState::Text { completions, .. })
+                if !completions.is_empty()
+        )
+    }
+
+    /// Move the selected-index cursor of the focused Text widget's
+    /// completion popup by `delta` (Up = -1, Down = +1). Wraps at
+    /// the ends so the user can cycle through candidates without
+    /// hitting a wall — same convention as `List`'s selection
+    /// wrap. No-op when the focused widget isn't a Text-with-
+    /// open-completions.
+    fn move_focused_text_completion_index(&mut self, panel_id: u64, delta: i32) {
+        let panel = match self.widget_registry.get_mut(panel_id) {
+            Some(p) => p,
+            None => return,
+        };
+        let focus_key = panel.focus_key.clone();
+        if focus_key.is_empty() {
+            return;
+        }
+        if let Some(crate::widgets::WidgetInstanceState::Text {
+            completions,
+            completion_selected_index,
+            ..
+        }) = panel.instance_states.get_mut(&focus_key)
+        {
+            if completions.is_empty() {
+                return;
+            }
+            let n = completions.len() as i32;
+            let cur = *completion_selected_index as i32;
+            let next = ((cur + delta) % n + n) % n;
+            *completion_selected_index = next as usize;
+        }
+    }
+
+    /// Clear the focused Text widget's completion popup (close it)
+    /// and fire a `completion_dismiss` event so the plugin can
+    /// sync its own state (e.g. invalidate any in-flight fetch
+    /// token, so a late-arriving result doesn't re-open the
+    /// popup the user just closed). Used by Enter and Escape on
+    /// a Text-with-open-completions.
+    fn dismiss_focused_text_completions(&mut self, panel_id: u64) {
+        let focus_key = {
+            let panel = match self.widget_registry.get_mut(panel_id) {
+                Some(p) => p,
+                None => return,
+            };
+            let focus_key = panel.focus_key.clone();
+            if focus_key.is_empty() {
+                return;
+            }
+            if let Some(crate::widgets::WidgetInstanceState::Text {
+                completions,
+                completion_selected_index,
+                ..
+            }) = panel.instance_states.get_mut(&focus_key)
+            {
+                if completions.is_empty() {
+                    return;
+                }
+                completions.clear();
+                *completion_selected_index = 0;
+            } else {
+                return;
+            }
+            focus_key
+        };
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                fresh_core::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key: focus_key,
+                    event_type: "completion_dismiss".into(),
+                    payload: serde_json::json!({}),
+                },
+            );
+        }
+    }
+
+    /// Fire `completion_accept` on the focused Text widget's
+    /// currently-selected candidate. Used by Tab on a Text-with-
+    /// open-completions — the plugin's handler is expected to
+    /// apply the accepted value to the field (typically via
+    /// `WidgetMutation::SetValue`). The host does NOT close the
+    /// popup automatically: directory-descent style flows (the
+    /// orchestrator's Project Path acceptance of `/foo/` re-
+    /// fetches children for the new path) want the popup to
+    /// stay alive so the user can keep Tab-ing. Plugins that
+    /// want a one-shot accept close the popup themselves with
+    /// `setCompletions(key, [])`.
+    fn fire_completion_accept(&mut self, panel_id: u64) {
+        let (focus_key, value) = {
+            let panel = match self.widget_registry.get(panel_id) {
+                Some(p) => p,
+                None => return,
+            };
+            let focus_key = panel.focus_key.clone();
+            if focus_key.is_empty() {
+                return;
+            }
+            match panel.instance_states.get(&focus_key) {
+                Some(crate::widgets::WidgetInstanceState::Text {
+                    completions,
+                    completion_selected_index,
+                    ..
+                }) if !completions.is_empty() => {
+                    let idx = (*completion_selected_index).min(completions.len() - 1);
+                    (focus_key, completions[idx].clone())
+                }
+                _ => return,
+            }
+        };
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                fresh_core::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key: focus_key,
+                    event_type: "completion_accept".into(),
+                    payload: serde_json::json!({ "value": value }),
+                },
+            );
+        }
+    }
+
     fn fire_list_activate(&mut self, panel_id: u64, focus_key: &str) {
         let panel = match self.widget_registry.get(panel_id) {
             Some(p) => p,
@@ -4817,7 +5044,12 @@ impl Editor {
         editor.set_cursor_from_flat(seed);
         panel.instance_states.insert(
             focus_key.to_string(),
-            crate::widgets::WidgetInstanceState::Text { editor, scroll: 0 },
+            crate::widgets::WidgetInstanceState::Text {
+                editor,
+                scroll: 0,
+                completions: Vec::new(),
+                completion_selected_index: 0,
+            },
         );
         true
     }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3652,7 +3652,19 @@ fn paint_text_property_entry(
 
     let base_bg = theme.suggestion_bg;
     let base_style = if let Some(opts) = normalized.style.as_ref() {
-        Editor::resolve_overlay_style(opts, theme).bg(base_bg)
+        // Resolve the entry's row-level style, then fill in the
+        // suggestion_bg only when the style didn't supply one
+        // of its own. Without this guard, calling `.bg(base_bg)`
+        // unconditionally would wipe out a row-level
+        // `popup_selection_bg` (the highlight on the completion
+        // popup's selected candidate) — `Style::bg` is a
+        // replacement, not a merge.
+        let resolved = Editor::resolve_overlay_style(opts, theme);
+        if resolved.bg.is_none() {
+            resolved.bg(base_bg)
+        } else {
+            resolved
+        }
     } else {
         Style::default().bg(base_bg)
     };

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -108,6 +108,11 @@ pub enum WidgetInstanceState {
         /// non-empty list; clamped on every render in case the
         /// list shrank.
         completion_selected_index: usize,
+        /// Index of the first candidate row currently painted.
+        /// Up/Down adjusts this implicitly (the renderer auto-
+        /// scrolls to keep selection in view); the mouse wheel
+        /// scrolls it directly without moving the selection.
+        completion_scroll_offset: u32,
     },
     /// `Tree` instance state: host-owned scroll offset, selected
     /// index, and the set of expanded item keys. All three become

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -92,7 +92,23 @@ pub enum WidgetInstanceState {
     /// navigation, and clipboard ops "for free" — every keybinding
     /// the legacy Settings UI accepted via `TextEdit` now applies
     /// to widget-backed text inputs too.
-    Text { editor: TextEdit, scroll: u32 },
+    Text {
+        editor: TextEdit,
+        scroll: u32,
+        /// Completion popup candidates the plugin most recently
+        /// pushed via `WidgetMutation::SetCompletions`. Empty =
+        /// popup closed. The list is stored host-side rather
+        /// than read from each `WidgetSpec` so the host can
+        /// keep painting the popup across renders that don't
+        /// re-push it, and so `Up`/`Down` selection survives a
+        /// spec refresh.
+        completions: Vec<String>,
+        /// Host-managed selection cursor into `completions`.
+        /// Reset to 0 every time `SetCompletions` runs with a
+        /// non-empty list; clamped on every render in case the
+        /// list shrank.
+        completion_selected_index: usize,
+    },
     /// `Tree` instance state: host-owned scroll offset, selected
     /// index, and the set of expanded item keys. All three become
     /// authoritative after first render — the spec's

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -89,6 +89,13 @@ const KEY_COMPLETION_DIM_FG: &str = "ui.menu_disabled_fg";
 // re-skin one re-skin the other.
 const KEY_COMPLETION_SEL_FG: &str = "ui.popup_selection_fg";
 const KEY_COMPLETION_SEL_BG: &str = "ui.popup_selection_bg";
+// Border chrome the popup paints around its own rows (the
+// `│ ... │` sides extending below the input + the `╰─...─╯`
+// closing border). Distinct theme key from the wrapping
+// labeled section's default (unstyled) chrome so the popup
+// reads as its own surface — matches the user's "use a theme
+// key for the popup border" expectation.
+const KEY_COMPLETION_BORDER_FG: &str = "ui.popup_border_fg";
 
 /// Where the host should place the buffer's hardware cursor — the
 /// terminal's blinking caret — when a `TextInput` is focused. Built
@@ -1656,28 +1663,43 @@ fn render_completion_dim_separator_overlay(total_cols: usize) -> TextPropertyEnt
     }
     text.push('│');
     text.push('\n');
-    // Sides paint in `popup_border_fg` (the labeled section's
-    // own border colour); the dashed run paints in the dim
-    // foreground so it reads as a recessed transition rather
-    // than chrome.
-    let border_bytes = "│".len();
+    // Side `│` chars paint in the popup's border theme key
+    // (`ui.popup_border_fg`) so the popup chrome reads as
+    // distinct from the wrapping labeled section's default
+    // border (per the "use a theme key for the popup border"
+    // requirement). The dashed run between them paints in the
+    // dim foreground so it reads as a recessed transition
+    // rather than chrome.
+    let left_border_bytes = "│".len();
     let dash_bytes = "┄".len() * inner;
+    let right_border_start = left_border_bytes + dash_bytes;
+    let right_border_end = right_border_start + "│".len();
     let inline_overlays = vec![
         InlineOverlay {
             start: 0,
-            end: border_bytes,
+            end: left_border_bytes,
             style: OverlayOptions {
-                fg: None, // inherit popup border colour from the renderer's default border style
+                fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_BORDER_FG)),
                 ..Default::default()
             },
             properties: Default::default(),
             unit: OffsetUnit::Byte,
         },
         InlineOverlay {
-            start: border_bytes,
-            end: border_bytes + dash_bytes,
+            start: left_border_bytes,
+            end: left_border_bytes + dash_bytes,
             style: OverlayOptions {
                 fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        },
+        InlineOverlay {
+            start: right_border_start,
+            end: right_border_end,
+            style: OverlayOptions {
+                fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_BORDER_FG)),
                 ..Default::default()
             },
             properties: Default::default(),
@@ -1709,10 +1731,18 @@ fn render_completion_bottom_border(total_cols: usize) -> TextPropertyEntry {
     }
     text.push('╯');
     text.push('\n');
+    // The whole row is chrome; stamp the popup-border theme key
+    // at the entry level so every glyph paints in the same
+    // colour (no hard-coded RGB or ratatui `Color` value
+    // anywhere in the popup rendering — every fg/bg goes
+    // through a `ui.*` theme key).
     TextPropertyEntry {
         text,
         properties: Default::default(),
-        style: None,
+        style: Some(OverlayOptions {
+            fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_BORDER_FG)),
+            ..Default::default()
+        }),
         inline_overlays: Vec::new(),
         segments: Vec::new(),
         pad_to_chars: None,
@@ -1748,9 +1778,16 @@ fn render_completion_item_overlay(
     text.push('\n');
     // Shift the body's inline overlays right by one byte
     // (the leading `│`) so the scrollbar tint still lands on
-    // the right cell.
+    // the right cell. Then add two more inline overlays for
+    // the side `│` chars themselves so they paint in the
+    // popup-border theme key — same key the dim separator and
+    // bottom border use, so the popup chrome reads as a
+    // single themed surface.
     let left_border_bytes = "│".len();
-    let inline_overlays = body_entry
+    let body_no_nl_bytes = body_no_nl.len();
+    let right_border_start = left_border_bytes + body_no_nl_bytes;
+    let right_border_end = right_border_start + "│".len();
+    let mut inline_overlays: Vec<InlineOverlay> = body_entry
         .inline_overlays
         .into_iter()
         .map(|mut io| {
@@ -1759,6 +1796,26 @@ fn render_completion_item_overlay(
             io
         })
         .collect();
+    inline_overlays.push(InlineOverlay {
+        start: 0,
+        end: left_border_bytes,
+        style: OverlayOptions {
+            fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_BORDER_FG)),
+            ..Default::default()
+        },
+        properties: Default::default(),
+        unit: OffsetUnit::Byte,
+    });
+    inline_overlays.push(InlineOverlay {
+        start: right_border_start,
+        end: right_border_end,
+        style: OverlayOptions {
+            fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_BORDER_FG)),
+            ..Default::default()
+        },
+        properties: Default::default(),
+        unit: OffsetUnit::Byte,
+    });
     TextPropertyEntry {
         text,
         properties: Default::default(),
@@ -3693,6 +3750,8 @@ mod tests {
                     field_width: 0,
                     max_visible_chars: 0,
                     full_width: false,
+                    completions: Vec::new(),
+                    completions_visible_rows: 0,
                     key: Some("ti".into()),
                 },
                 WidgetSpec::Toggle {
@@ -4936,6 +4995,8 @@ mod tests {
             field_width,
             max_visible_chars: 0,
             full_width: false,
+            completions: Vec::new(),
+            completions_visible_rows: 0,
             key: key.map(|s| s.into()),
         }
     }
@@ -5016,6 +5077,8 @@ mod tests {
             field_width: 6,
             max_visible_chars: 0,
             full_width: false,
+            completions: Vec::new(),
+            completions_visible_rows: 0,
             key: Some("ta".into()),
         };
         let prev = HashMap::new();
@@ -5048,7 +5111,16 @@ mod tests {
         let mut prev = HashMap::new();
         let mut editor = crate::primitives::text_edit::TextEdit::with_text("new");
         editor.set_cursor_from_flat(3);
-        prev.insert("ta".into(), WidgetInstanceState::Text { editor, scroll: 0 });
+        prev.insert(
+            "ta".into(),
+            WidgetInstanceState::Text {
+                editor,
+                scroll: 0,
+                completions: Vec::new(),
+                completion_selected_index: 0,
+                completion_scroll_offset: 0,
+            },
+        );
         let out = render_spec(&spec, &prev, "ta", 80);
         // The first row should now read "new" (not "old").
         assert!(out.entries[0].text.starts_with("new"));
@@ -5129,6 +5201,8 @@ mod tests {
             field_width,
             max_visible_chars: 0,
             full_width,
+            completions: Vec::new(),
+            completions_visible_rows: 0,
             key: key.map(|s| s.into()),
         }
     }

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1128,9 +1128,20 @@ fn render_collected(
             max_visible_chars,
             full_width,
             completions,
+            completions_visible_rows,
             key,
         } => {
             let _ = completions; // pulled from instance state below
+                                 // Default popup height: 5 visible rows. Plugins
+                                 // override per-widget by setting
+                                 // `completions_visible_rows`; 0 falls back to the
+                                 // default so the orchestrator's existing `text({...})`
+                                 // calls Just Work without opting in.
+            let effective_visible_rows = if *completions_visible_rows == 0 {
+                5u32
+            } else {
+                *completions_visible_rows
+            };
 
             let is_focused = match key.as_deref() {
                 Some(k) if !k.is_empty() => k == focus_key,
@@ -1153,6 +1164,7 @@ fn render_collected(
             // index to the current list size below.
             let mut prev_completions: Vec<String> = Vec::new();
             let mut prev_completion_idx: usize = 0;
+            let mut prev_completion_scroll: u32 = 0;
             match key
                 .as_deref()
                 .filter(|k| !k.is_empty())
@@ -1163,11 +1175,13 @@ fn render_collected(
                     scroll,
                     completions,
                     completion_selected_index,
+                    completion_scroll_offset,
                 }) => {
                     effective_editor = editor.clone();
                     prev_scroll = *scroll;
                     prev_completions = completions.clone();
                     prev_completion_idx = *completion_selected_index;
+                    prev_completion_scroll = *completion_scroll_offset;
                 }
                 _ => {
                     effective_editor = if multiline_spec {
@@ -1290,35 +1304,95 @@ fn render_collected(
             // auto-clamped first-visible-row for multi-line, or `0`
             // for single-line.
             //
-            // Emit the completion popup *after* the input row but
-            // *before* persisting state. The popup rides on the
-            // wrapping `LabeledSection`'s side borders: each row
-            // we push here gets `│ ... │` chrome added by the
-            // section, so the side borders naturally extend down
-            // through the candidates and the section's own
-            // `╰─...─╯` bottom border closes the unified block.
-            // See `render_completion_dim_separator` /
-            // `render_completion_item` for the chrome and the
-            // alignment rule (item text starts at the same column
-            // as the input value's first character).
+            // Emit the completion popup as *overlay rows* rather
+            // than regular entries so it floats — the rest of the
+            // form below the input keeps its layout position and
+            // the popup paints on top. The overlay anchors are
+            // chosen so the dim separator lands on top of the
+            // wrapping `LabeledSection`'s bottom border (visually
+            // replacing it), and the side borders + bottom
+            // border that follow paint over whatever sits below
+            // the section. See `render_completion_*` helpers for
+            // the chrome detail.
             if !prev_completions.is_empty() {
-                // `panel_width` here is whatever the enclosing
-                // container (typically a `LabeledSection`) handed
-                // us — i.e. the inner area width, before that
-                // container wraps each row with its own
-                // `│ ... │` chrome. The popup rows we emit get
-                // padded by the container to exactly this width,
-                // so the section's right border lines up with the
-                // input row's.
-                let row_cols = panel_width as usize;
-                entries.push(render_completion_dim_separator(row_cols));
-                for (i, item) in prev_completions.iter().enumerate() {
-                    entries.push(render_completion_item(
-                        item,
-                        i == prev_completion_idx,
-                        row_cols,
-                    ));
+                // `panel_width` here is the inner-area width the
+                // wrapping `LabeledSection` handed us (it has
+                // already subtracted its own 4 columns of chrome
+                // — `│ ` on the left + ` │` on the right). The
+                // overlay rows need to paint into the full panel
+                // width (including those `│ ... │` columns), so
+                // we widen by 4 here so the side borders the
+                // popup paints line up with the section's.
+                let popup_inner = panel_width as usize;
+                let popup_total = popup_inner.saturating_add(4); // re-add section chrome
+                let total = prev_completions.len() as u32;
+                let visible = effective_visible_rows.max(1).min(total);
+                // Auto-scroll: keep the selected row inside the
+                // visible window. Up/Down only ever moves the
+                // selection by ±1 (with wraparound), so a one-
+                // step adjustment is enough — unless the wrap
+                // landed at the other end of the list, in which
+                // case we still snap correctly because we clamp
+                // by computing `selected + 1 - visible` for the
+                // "scrolled past top" case.
+                let sel = prev_completion_idx as u32;
+                let mut scroll = prev_completion_scroll;
+                if sel < scroll {
+                    scroll = sel;
                 }
+                if sel >= scroll + visible {
+                    scroll = sel + 1 - visible;
+                }
+                let max_scroll = total.saturating_sub(visible);
+                if scroll > max_scroll {
+                    scroll = max_scroll;
+                }
+                prev_completion_scroll = scroll;
+
+                // Overlay anchors:
+                //   anchor 0 = the text widget's own row (input)
+                //   anchor 1 = labeledSection's bottom border row
+                //              (the dim separator paints here,
+                //              replacing the section's `╰─...─╯`
+                //              visually)
+                //   anchor 2..N+1 = item rows
+                //   anchor N+2 = popup's own bottom border
+                //              `╰─...─╯` (a `LabeledSection`
+                //              passes child overlays through
+                //              unchanged, see widgets/render.rs
+                //              `LabeledSection` branch).
+                let mut anchor: u32 = 1;
+                overlays.push(OverlayRow {
+                    buffer_row: anchor,
+                    entry: render_completion_dim_separator_overlay(popup_total),
+                });
+                anchor += 1;
+                let needs_scrollbar = total > visible;
+                let end = (scroll + visible).min(total) as usize;
+                for (visible_row, i) in (scroll as usize..end).enumerate() {
+                    let item = &prev_completions[i];
+                    let thumb = if needs_scrollbar {
+                        completion_scrollbar_glyph(visible_row as u32, visible, scroll, total)
+                    } else {
+                        None
+                    };
+                    overlays.push(OverlayRow {
+                        buffer_row: anchor,
+                        entry: render_completion_item_overlay(
+                            item,
+                            i == prev_completion_idx,
+                            popup_total,
+                            thumb,
+                        ),
+                    });
+                    anchor += 1;
+                }
+                overlays.push(OverlayRow {
+                    buffer_row: anchor,
+                    entry: render_completion_bottom_border(popup_total),
+                });
+            } else {
+                prev_completion_scroll = 0;
             }
             if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
                 next_state.insert(
@@ -1328,6 +1402,7 @@ fn render_collected(
                         scroll: new_scroll,
                         completions: prev_completions,
                         completion_selected_index: prev_completion_idx,
+                        completion_scroll_offset: prev_completion_scroll,
                     },
                 );
             }
@@ -1338,10 +1413,19 @@ fn render_collected(
             let inner_width = panel_width.saturating_sub(4).max(1);
             let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
                 render_collected(child, prev, next_state, focus_key, inner_width);
-            // Overlays bubble through the section unchanged —
-            // the section's chrome doesn't shift them and the
-            // anchor row is already relative to the inner area.
-            overlays.extend(child_overlays);
+            // Shift child overlays by 1 to account for the top
+            // border row this section emits — the child authored
+            // its anchors relative to its own row 0 (e.g. anchor 1
+            // = "one row below me"), so an unshifted forward
+            // would land them one row earlier than intended. The
+            // Text widget's completion-popup overlays rely on
+            // this: anchor 1 lands on the section's bottom
+            // border row (replacing it visually with the dim
+            // separator), anchor 2+ lands below the section.
+            overlays.extend(child_overlays.into_iter().map(|mut o| {
+                o.buffer_row += 1;
+                o
+            }));
 
             // Render the top border with the label embedded as a
             // legend: `╭─ <label> ─...─╮`. When the label is empty,
@@ -1555,28 +1639,131 @@ fn render_section_bottom_border(total_cols: usize) -> TextPropertyEntry {
     }
 }
 
-/// Dim `┄`-dashed row that takes the place of the input's normal
-/// `╰─...─╯` bottom border when the completion popup is open.
-/// `total_cols` is the width of the row *before* the wrapping
-/// `LabeledSection` adds its own `│ ... │` chrome — we fill the
-/// whole inner width with `┄` so the dashed line runs flush to
-/// the side borders, reading as a transition between the input
-/// and the candidate list rather than a chunky divider.
-fn render_completion_dim_separator(total_cols: usize) -> TextPropertyEntry {
-    let mut text = String::with_capacity(total_cols * 3 + 1);
-    for _ in 0..total_cols.max(1) {
+/// Dim-separator overlay row for the completion popup. Unlike
+/// `render_completion_dim_separator` (which targets a child of
+/// a `LabeledSection` and lets the section wrap the row with
+/// `│ ... │`), this one paints into the FULL panel width
+/// directly and supplies its own `│ ... │` chrome — overlay
+/// rows skip the wrapping section's per-row wrap and land on
+/// the parent col's row directly. `total_cols` is the section's
+/// outer width.
+fn render_completion_dim_separator_overlay(total_cols: usize) -> TextPropertyEntry {
+    let inner = total_cols.saturating_sub(2).max(1);
+    let mut text = String::with_capacity(total_cols * 4 + 2);
+    text.push('│');
+    for _ in 0..inner {
         text.push('┄');
     }
+    text.push('│');
     text.push('\n');
-    let style = OverlayOptions {
-        fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
-        ..Default::default()
-    };
+    // Sides paint in `popup_border_fg` (the labeled section's
+    // own border colour); the dashed run paints in the dim
+    // foreground so it reads as a recessed transition rather
+    // than chrome.
+    let border_bytes = "│".len();
+    let dash_bytes = "┄".len() * inner;
+    let inline_overlays = vec![
+        InlineOverlay {
+            start: 0,
+            end: border_bytes,
+            style: OverlayOptions {
+                fg: None, // inherit popup border colour from the renderer's default border style
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        },
+        InlineOverlay {
+            start: border_bytes,
+            end: border_bytes + dash_bytes,
+            style: OverlayOptions {
+                fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        },
+    ];
     TextPropertyEntry {
         text,
         properties: Default::default(),
-        style: Some(style),
+        style: None,
+        inline_overlays,
+        segments: Vec::new(),
+        pad_to_chars: None,
+        truncate_to_chars: None,
+    }
+}
+
+/// Completion-popup bottom border overlay row: `│╰─...─╯│`
+/// shape — wait no, the bottom-border row is exactly
+/// `╰─...─╯` (the side `│ ... │` columns become the corner
+/// glyphs at the very bottom of the popup). Paints at the row
+/// right after the last visible candidate, closing the
+/// unified box.
+fn render_completion_bottom_border(total_cols: usize) -> TextPropertyEntry {
+    let mut text = String::with_capacity(total_cols * 4 + 2);
+    text.push('╰');
+    for _ in 0..total_cols.saturating_sub(2).max(1) {
+        text.push('─');
+    }
+    text.push('╯');
+    text.push('\n');
+    TextPropertyEntry {
+        text,
+        properties: Default::default(),
+        style: None,
         inline_overlays: Vec::new(),
+        segments: Vec::new(),
+        pad_to_chars: None,
+        truncate_to_chars: None,
+    }
+}
+
+/// Overlay variant of `render_completion_item`. Same body
+/// (leading space + candidate text + optional scrollbar glyph
+/// + trailing pad), but wrapped with the popup's own
+/// `│ ... │` chrome since overlay rows paint at the panel
+/// width directly without going through a `LabeledSection`'s
+/// row wrapper.
+fn render_completion_item_overlay(
+    item: &str,
+    selected: bool,
+    total_cols: usize,
+    scrollbar: Option<char>,
+) -> TextPropertyEntry {
+    let inner = total_cols.saturating_sub(2).max(1);
+    // Reuse the inline-row builder for the body — same layout
+    // rules (1 leading space, item text, pad-to-(inner-1),
+    // scrollbar in the last column).
+    let body_entry = render_completion_item(item, selected, inner, scrollbar);
+    // Build the wrapped text: `│` + body content + `│`. We
+    // strip the body's trailing newline first so the borders
+    // sit on the same line.
+    let mut text = String::with_capacity(body_entry.text.len() + 8);
+    text.push('│');
+    let body_no_nl = body_entry.text.trim_end_matches('\n');
+    text.push_str(body_no_nl);
+    text.push('│');
+    text.push('\n');
+    // Shift the body's inline overlays right by one byte
+    // (the leading `│`) so the scrollbar tint still lands on
+    // the right cell.
+    let left_border_bytes = "│".len();
+    let inline_overlays = body_entry
+        .inline_overlays
+        .into_iter()
+        .map(|mut io| {
+            io.start += left_border_bytes;
+            io.end += left_border_bytes;
+            io
+        })
+        .collect();
+    TextPropertyEntry {
+        text,
+        properties: Default::default(),
+        style: body_entry.style,
+        inline_overlays,
         segments: Vec::new(),
         pad_to_chars: None,
         truncate_to_chars: None,
@@ -1595,12 +1782,58 @@ fn render_completion_dim_separator(total_cols: usize) -> TextPropertyEntry {
 /// fg/bg theme keys + `extend_to_line_end` so the highlight
 /// runs all the way to the right side border instead of
 /// stopping at the end of the candidate text.
-fn render_completion_item(item: &str, selected: bool, total_cols: usize) -> TextPropertyEntry {
-    let mut text = String::with_capacity(item.len() + 2);
+///
+/// `scrollbar` is `Some(glyph)` when the popup is scrollable
+/// AND this row owns a scrollbar character (thumb or track).
+/// The glyph paints at the right edge of the row, just inside
+/// the wrapping section's `│` border, so the scrollbar lives
+/// in the popup's chrome rather than crowding the candidate
+/// text. `None` rows leave the column blank — either because
+/// the popup fits without scrolling or because every row gets
+/// `None` when there's nothing to indicate.
+fn render_completion_item(
+    item: &str,
+    selected: bool,
+    total_cols: usize,
+    scrollbar: Option<char>,
+) -> TextPropertyEntry {
+    // Build the row up to `total_cols - 1` so the scrollbar (or
+    // a trailing space when there isn't one) lands at exactly
+    // `total_cols - 1`. The wrapping section pads/truncates the
+    // resulting row to `total_cols`, but we want the scrollbar
+    // glyph to keep its position regardless of how long the
+    // candidate text is, so we hand-pad rather than relying on
+    // entry-level `pad_to_chars`.
+    let text_budget = total_cols.saturating_sub(1).saturating_sub(1); // leading space + scrollbar col
+    let item_chars: Vec<char> = item.chars().collect();
+    let (visible_item, truncated): (String, bool) = if item_chars.len() <= text_budget {
+        (item.to_string(), false)
+    } else {
+        // Tail-truncate with `…` so the prefix the user typed
+        // stays anchored at the left, which is the common case
+        // for path / branch completions (the divergent part is
+        // at the end).
+        let keep = text_budget.saturating_sub(1);
+        let head: String = item_chars.iter().take(keep).collect();
+        (format!("{}…", head), true)
+    };
+    let _ = truncated;
+    let scrollbar_ch = scrollbar.unwrap_or(' ');
+    let mut text = String::with_capacity(total_cols * 4 + 2);
     text.push(' ');
-    text.push_str(item);
+    text.push_str(&visible_item);
+    // Pad with spaces between the candidate text and the
+    // scrollbar column so all rows have the scrollbar glyph in
+    // the same column regardless of candidate length.
+    let used_cols = 1 + visible_item.chars().count();
+    let pad_cols = total_cols.saturating_sub(used_cols).saturating_sub(1);
+    for _ in 0..pad_cols {
+        text.push(' ');
+    }
+    text.push(scrollbar_ch);
     text.push('\n');
-    let style = if selected {
+
+    let body_style = if selected {
         Some(OverlayOptions {
             fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_SEL_FG)),
             bg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_SEL_BG)),
@@ -1610,14 +1843,78 @@ fn render_completion_item(item: &str, selected: bool, total_cols: usize) -> Text
     } else {
         None
     };
+    // Scrollbar glyph paints in `popup_border_fg` so it reads as
+    // chrome rather than as part of the candidate text. We do
+    // this as an inline overlay over the last visible cell so
+    // the selection highlight on selected rows doesn't repaint
+    // the scrollbar in white-on-blue.
+    let mut inline_overlays: Vec<InlineOverlay> = Vec::new();
+    if scrollbar.is_some() {
+        let total_bytes = text.trim_end_matches('\n').len();
+        let scrollbar_byte_len = scrollbar_ch.len_utf8();
+        let start = total_bytes - scrollbar_byte_len;
+        let end = total_bytes;
+        inline_overlays.push(InlineOverlay {
+            start,
+            end,
+            style: OverlayOptions {
+                fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
+                ..Default::default()
+            },
+            properties: Default::default(),
+            unit: OffsetUnit::Byte,
+        });
+    }
+
     TextPropertyEntry {
         text,
         properties: Default::default(),
-        style,
-        inline_overlays: Vec::new(),
+        style: body_style,
+        inline_overlays,
         segments: Vec::new(),
-        pad_to_chars: Some(total_cols as u32),
+        pad_to_chars: None,
         truncate_to_chars: None,
+    }
+}
+
+/// Compute the scrollbar glyph for the given visible row
+/// position. Returns `Some(...)` for rows that overlap the
+/// thumb's vertical extent (rendered as a solid `█`); `None`
+/// otherwise (rendered as a blank track cell so the candidate
+/// row still aligns with the scrollbar column).
+///
+/// The thumb size is proportional to `visible / total` and
+/// snaps to at least one row. The thumb's top row is
+/// `floor(scroll / total * visible)` — first row of the
+/// visible window when scrolled to the top, last row when
+/// scrolled to the bottom.
+fn completion_scrollbar_glyph(
+    visible_row: u32,
+    visible: u32,
+    scroll: u32,
+    total: u32,
+) -> Option<char> {
+    if total <= visible || visible == 0 {
+        return None;
+    }
+    // Thumb size: at least 1 row, otherwise proportional. Float
+    // math is fine — `total` and `visible` are tiny (popup
+    // height capped to a handful of rows).
+    let thumb_size = ((visible as f32 * visible as f32) / total as f32).round() as u32;
+    let thumb_size = thumb_size.max(1).min(visible);
+    let max_scroll = total - visible;
+    let thumb_top = if max_scroll == 0 {
+        0
+    } else {
+        // `(scroll / max_scroll) * (visible - thumb_size)` —
+        // 0 when at the top, `visible - thumb_size` when at the
+        // bottom.
+        ((scroll as f32 / max_scroll as f32) * (visible - thumb_size) as f32).round() as u32
+    };
+    if visible_row >= thumb_top && visible_row < thumb_top + thumb_size {
+        Some('█')
+    } else {
+        None
     }
 }
 

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1334,19 +1334,21 @@ fn render_collected(
                 let popup_total = popup_inner.saturating_add(4); // re-add section chrome
                 let total = prev_completions.len() as u32;
                 let visible = effective_visible_rows.max(1).min(total);
-                // Auto-scroll: keep the selected row inside the
-                // visible window. Up/Down only ever moves the
-                // selection by ±1 (with wraparound), so a one-
-                // step adjustment is enough — unless the wrap
-                // landed at the other end of the list, in which
-                // case we still snap correctly because we clamp
-                // by computing `selected + 1 - visible` for the
-                // "scrolled past top" case.
+                // Forward-only auto-scroll: when the selection
+                // walks past the bottom of the visible window
+                // (Down past the last visible row), pull the
+                // scroll forward to keep selection in view. We
+                // deliberately do NOT pull the scroll *back* if
+                // the selection is above the window — the
+                // mouse-wheel scroll handler explicitly diverges
+                // scroll from selection (the user is scrolling
+                // the view, not the selection), and a back-pull
+                // here would undo the wheel's scroll on the very
+                // next render. The keyboard Up handler updates
+                // scroll itself when needed, so it doesn't rely
+                // on a back-pull from the renderer either.
                 let sel = prev_completion_idx as u32;
                 let mut scroll = prev_completion_scroll;
-                if sel < scroll {
-                    scroll = sel;
-                }
                 if sel >= scroll + visible {
                     scroll = sel + 1 - visible;
                 }

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -76,6 +76,19 @@ const KEY_PLACEHOLDER_FG: &str = "editor.whitespace_indicator_fg";
 // it's tuned for readability against the same surface a
 // LabeledSection sits on.
 const KEY_SECTION_LABEL_FG: &str = "ui.help_key_fg";
+// Dim separator that replaces the input's bottom border when the
+// completion popup is open. `ui.menu_disabled_fg` is the closest
+// "muted chrome" key already shipped by every theme (gray-ish in
+// dark themes, light gray in light themes) so the separator reads
+// as a recessed transition between the active input and the
+// candidate list rather than as a hard divider.
+const KEY_COMPLETION_DIM_FG: &str = "ui.menu_disabled_fg";
+// Selected completion row foreground/background. Same keys the
+// popup-driven selection highlight uses everywhere else (host
+// prompt suggestions, action-popup menu), so themes that
+// re-skin one re-skin the other.
+const KEY_COMPLETION_SEL_FG: &str = "ui.popup_selection_fg";
+const KEY_COMPLETION_SEL_BG: &str = "ui.popup_selection_bg";
 
 /// Where the host should place the buffer's hardware cursor — the
 /// terminal's blinking caret — when a `TextInput` is focused. Built
@@ -1114,8 +1127,11 @@ fn render_collected(
             field_width,
             max_visible_chars,
             full_width,
+            completions,
             key,
         } => {
+            let _ = completions; // pulled from instance state below
+
             let is_focused = match key.as_deref() {
                 Some(k) if !k.is_empty() => k == focus_key,
                 _ => *focused,
@@ -1130,14 +1146,28 @@ fn render_collected(
             let multiline_spec = *rows > 1;
             let mut effective_editor: crate::primitives::text_edit::TextEdit;
             let prev_scroll: u32;
+            // Completions + selected index ride along on the
+            // Text widget's instance state — neither comes from
+            // the spec (plugins push via `SetCompletions`), so we
+            // carry them across renders verbatim and clamp the
+            // index to the current list size below.
+            let mut prev_completions: Vec<String> = Vec::new();
+            let mut prev_completion_idx: usize = 0;
             match key
                 .as_deref()
                 .filter(|k| !k.is_empty())
                 .and_then(|k| prev.get(k))
             {
-                Some(WidgetInstanceState::Text { editor, scroll }) => {
+                Some(WidgetInstanceState::Text {
+                    editor,
+                    scroll,
+                    completions,
+                    completion_selected_index,
+                }) => {
                     effective_editor = editor.clone();
                     prev_scroll = *scroll;
+                    prev_completions = completions.clone();
+                    prev_completion_idx = *completion_selected_index;
                 }
                 _ => {
                     effective_editor = if multiline_spec {
@@ -1153,6 +1183,14 @@ fn render_collected(
                     effective_editor.set_cursor_from_flat(seed);
                     prev_scroll = 0;
                 }
+            }
+            // Clamp once per render so a list that shrank
+            // host-side (or arrived empty) doesn't keep a stale
+            // out-of-bounds index alive.
+            if !prev_completions.is_empty() {
+                prev_completion_idx = prev_completion_idx.min(prev_completions.len() - 1);
+            } else {
+                prev_completion_idx = 0;
             }
             let effective_value = effective_editor.value();
             let effective_cursor_byte = effective_editor.flat_cursor_byte() as i32;
@@ -1251,12 +1289,45 @@ fn render_collected(
             // selection); `scroll` carries the renderer's
             // auto-clamped first-visible-row for multi-line, or `0`
             // for single-line.
+            //
+            // Emit the completion popup *after* the input row but
+            // *before* persisting state. The popup rides on the
+            // wrapping `LabeledSection`'s side borders: each row
+            // we push here gets `│ ... │` chrome added by the
+            // section, so the side borders naturally extend down
+            // through the candidates and the section's own
+            // `╰─...─╯` bottom border closes the unified block.
+            // See `render_completion_dim_separator` /
+            // `render_completion_item` for the chrome and the
+            // alignment rule (item text starts at the same column
+            // as the input value's first character).
+            if !prev_completions.is_empty() {
+                // `panel_width` here is whatever the enclosing
+                // container (typically a `LabeledSection`) handed
+                // us — i.e. the inner area width, before that
+                // container wraps each row with its own
+                // `│ ... │` chrome. The popup rows we emit get
+                // padded by the container to exactly this width,
+                // so the section's right border lines up with the
+                // input row's.
+                let row_cols = panel_width as usize;
+                entries.push(render_completion_dim_separator(row_cols));
+                for (i, item) in prev_completions.iter().enumerate() {
+                    entries.push(render_completion_item(
+                        item,
+                        i == prev_completion_idx,
+                        row_cols,
+                    ));
+                }
+            }
             if let Some(k) = key.as_deref().filter(|k| !k.is_empty()) {
                 next_state.insert(
                     k.to_string(),
                     WidgetInstanceState::Text {
                         editor: effective_editor.clone(),
                         scroll: new_scroll,
+                        completions: prev_completions,
+                        completion_selected_index: prev_completion_idx,
                     },
                 );
             }
@@ -1480,6 +1551,72 @@ fn render_section_bottom_border(total_cols: usize) -> TextPropertyEntry {
         inline_overlays: Vec::new(),
         segments: Vec::new(),
         pad_to_chars: None,
+        truncate_to_chars: None,
+    }
+}
+
+/// Dim `┄`-dashed row that takes the place of the input's normal
+/// `╰─...─╯` bottom border when the completion popup is open.
+/// `total_cols` is the width of the row *before* the wrapping
+/// `LabeledSection` adds its own `│ ... │` chrome — we fill the
+/// whole inner width with `┄` so the dashed line runs flush to
+/// the side borders, reading as a transition between the input
+/// and the candidate list rather than a chunky divider.
+fn render_completion_dim_separator(total_cols: usize) -> TextPropertyEntry {
+    let mut text = String::with_capacity(total_cols * 3 + 1);
+    for _ in 0..total_cols.max(1) {
+        text.push('┄');
+    }
+    text.push('\n');
+    let style = OverlayOptions {
+        fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_DIM_FG)),
+        ..Default::default()
+    };
+    TextPropertyEntry {
+        text,
+        properties: Default::default(),
+        style: Some(style),
+        inline_overlays: Vec::new(),
+        segments: Vec::new(),
+        pad_to_chars: None,
+        truncate_to_chars: None,
+    }
+}
+
+/// One completion-candidate row. Renders as a single leading
+/// space followed by the candidate text, padded / truncated by
+/// the wrapping `LabeledSection` to `total_cols`. The leading
+/// space places the candidate's first character at the same
+/// column as the input value's first character (right after the
+/// input's `[` bracket), which is what the user expects from a
+/// "below the input, aligned with what you typed" popup.
+///
+/// `selected` rows paint with the standard popup-selection
+/// fg/bg theme keys + `extend_to_line_end` so the highlight
+/// runs all the way to the right side border instead of
+/// stopping at the end of the candidate text.
+fn render_completion_item(item: &str, selected: bool, total_cols: usize) -> TextPropertyEntry {
+    let mut text = String::with_capacity(item.len() + 2);
+    text.push(' ');
+    text.push_str(item);
+    text.push('\n');
+    let style = if selected {
+        Some(OverlayOptions {
+            fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_SEL_FG)),
+            bg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_SEL_BG)),
+            extend_to_line_end: true,
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+    TextPropertyEntry {
+        text,
+        properties: Default::default(),
+        style,
+        inline_overlays: Vec::new(),
+        segments: Vec::new(),
+        pad_to_chars: Some(total_cols as u32),
         truncate_to_chars: None,
     }
 }

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -40,6 +40,7 @@ pub mod live_diff;
 pub mod load_from_buffer;
 pub mod lsp_find_references;
 pub mod markdown_source;
+pub mod orchestrator_new_dialog;
 pub mod orchestrator_open_cross_project;
 pub mod package_manager;
 pub mod plugin;

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -45,6 +45,32 @@ fn set_up_workspace() -> (tempfile::TempDir, PathBuf) {
     (temp, workspace)
 }
 
+/// Workspace variant for the "popup with > visible_rows
+/// candidates" scenario. Creates 10 `alpha_NN` subdirs so the
+/// default-5 popup needs to scroll. Returns workspace path +
+/// the sorted candidate-name list so callers can spot-check
+/// which entries are visible / hidden in any given scroll
+/// position.
+fn set_up_workspace_many_alphas() -> (tempfile::TempDir, PathBuf, Vec<String>) {
+    fresh::i18n::set_locale("en");
+
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().canonicalize().unwrap();
+
+    let mut names: Vec<String> = (0..10).map(|i| format!("alpha_{:02}", i)).collect();
+    for n in &names {
+        fs::create_dir(workspace.join(n)).unwrap();
+    }
+    names.sort();
+
+    let plugins_dir = workspace.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    (temp, workspace, names)
+}
+
 fn wait_for_new_session_command(harness: &mut EditorTestHarness) {
     harness
         .wait_until(|h| {
@@ -217,5 +243,126 @@ fn enter_keeps_typed_text_when_completion_open() {
         "Enter must leave the typed text intact (not accept the highlighted suggestion). \
          Screen:\n{}",
         harness.screen_to_string(),
+    );
+}
+
+/// Type the `<workspace>/alpha_` prefix into Project Path and
+/// wait until the popup has surfaced at least the first
+/// candidate (`alpha_00/`). With 10 candidates the popup spans
+/// `total - visible = 5` extra rows that the user must scroll
+/// to reach.
+fn type_many_alphas_prefix_and_wait(harness: &mut EditorTestHarness, workspace: &std::path::Path) {
+    let prefix = format!("{}/alpha_", workspace.display());
+    harness.type_text(&prefix).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("alpha_00/"))
+        .unwrap();
+}
+
+/// With more candidates than the default visible-rows cap, the
+/// popup paints exactly `5` rows + scrollbar — never the whole
+/// list. The first batch of `alpha_NN/` directories sits in the
+/// window; the tail ones (`alpha_07/` … `alpha_09/`) are
+/// off-screen until the user scrolls. This pins the host's
+/// fixed visible-rows behaviour against accidental "render all
+/// candidates" regressions.
+#[test]
+fn completion_popup_caps_at_visible_rows() {
+    let (_temp, workspace, names) = set_up_workspace_many_alphas();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_many_alphas_prefix_and_wait(&mut harness, &workspace);
+
+    let screen = harness.screen_to_string();
+    let visible: Vec<&String> = names
+        .iter()
+        .filter(|n| screen.contains(&format!("{}/", n)))
+        .collect();
+    assert_eq!(
+        visible.len(),
+        5,
+        "default `completions_visible_rows = 5` should cap the painted candidates to 5; \
+         saw {} on screen ({:?}).\nScreen:\n{}",
+        visible.len(),
+        visible,
+        screen,
+    );
+    // The first five (`alpha_00` … `alpha_04`) should be the
+    // ones in view since the host starts the scroll at 0.
+    for n in names.iter().take(5) {
+        assert!(
+            screen.contains(&format!("{}/", n)),
+            "candidate `{}/` should be in the initial window. Screen:\n{}",
+            n,
+            screen,
+        );
+    }
+}
+
+/// Pressing Down past the bottom of the visible window scrolls
+/// the candidate list — earlier candidates fall out the top,
+/// later ones (`alpha_07/`, `alpha_08/`, `alpha_09/`) come into
+/// view. Verifies the host's auto-scroll-to-keep-selection-in-
+/// view path.
+#[test]
+fn completion_popup_scrolls_with_down_arrow() {
+    let (_temp, workspace, _names) = set_up_workspace_many_alphas();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_many_alphas_prefix_and_wait(&mut harness, &workspace);
+
+    // Sanity: tail candidate is off-screen before any Down.
+    assert!(
+        !harness.screen_to_string().contains("alpha_09/"),
+        "precondition: `alpha_09/` must be off-screen before scrolling",
+    );
+
+    // Press Down enough times to walk selection to the last
+    // candidate. Auto-scroll should snap the window so
+    // `alpha_09/` is visible at the bottom.
+    for _ in 0..9 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness
+        .wait_until(|h| h.screen_to_string().contains("alpha_09/"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("alpha_00/"),
+        "after scrolling to the bottom, the first candidate `alpha_00/` should fall \
+         off the top of the window. Screen:\n{}",
+        screen,
+    );
+}
+
+/// When the candidate count exceeds the visible-rows cap, the
+/// popup paints a scrollbar in the right edge — at minimum, a
+/// solid block (`█`) glyph appears somewhere inside the popup
+/// area. Pinning this prevents a future "the host stopped
+/// drawing the scrollbar" regression that would silently make
+/// the popup feel un-scrollable.
+#[test]
+fn completion_popup_renders_scrollbar_when_overflowing() {
+    let (_temp, workspace, _names) = set_up_workspace_many_alphas();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_many_alphas_prefix_and_wait(&mut harness, &workspace);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains('█'),
+        "scrollbar thumb glyph `█` should paint when the popup has more \
+         candidates than fit visible rows. Screen:\n{}",
+        screen,
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -95,26 +95,19 @@ fn project_path_field_value(screen: &str) -> String {
     );
 }
 
-/// True when the rendered screen contains the top border of a
-/// labeledSection chrome box nested inside the panel frame:
-/// `│╭───...───╮│`. The `│ ... │` is the outer panel's frame and
-/// `╭─...─╮` is the labeledSection's own top border — the popup's
-/// "wrapped" rendering. Used to distinguish the fixed bordered
-/// popup from the old bare-overlay rendering (where the
-/// completion items appeared as `│ /path/to/foo │` with no
-/// enclosing `╭─...─╮ / ╰─...─╯` chrome).
-///
-/// `contains` rather than `starts_with` because each screen row
-/// begins with editor placeholder columns (`~ `, gutter) that
-/// `trim()` doesn't strip.
-fn screen_has_dropdown_top_border(screen: &str) -> bool {
+/// True when the rendered screen contains a dim `┄┄┄...┄┄┄`
+/// separator row — the host-rendered popup's replacement for
+/// the input field's normal `╰─...─╯` bottom border. Its
+/// presence is the load-bearing visual cue that input + popup
+/// are part of one unified box: above the separator is the
+/// active input, below it (and inside the labeled section's
+/// side borders) are the candidate rows.
+fn screen_has_completion_dim_separator(screen: &str) -> bool {
     screen.lines().any(|l| {
-        if let Some(start) = l.find("│╭") {
-            let rest = &l[start + "│╭".len()..];
-            if let Some(end) = rest.find("╮│") {
-                let inner = &rest[..end];
-                return inner.chars().all(|c| c == '─') && inner.chars().count() >= 4;
-            }
+        if let Some(start) = l.find('┄') {
+            let rest = &l[start..];
+            let run: String = rest.chars().take_while(|c| *c == '┄').collect();
+            return run.chars().count() >= 8;
         }
         false
     })
@@ -139,11 +132,13 @@ fn type_alpha_prefix_and_wait(
     prefix
 }
 
-/// The completion list must render inside a `╭─...─╮ ... ╰─...─╯`
-/// chrome box — not as bare overlay rows painted directly on top
-/// of the form fields beneath it.
+/// The host-rendered popup integrates with the wrapping
+/// labeled-section chrome: the input field's normal bottom
+/// border becomes a dim `┄┄┄...┄┄┄` separator (cueing that the
+/// box has extended downward), and the side borders continue
+/// past the input through the candidate rows.
 #[test]
-fn completion_dropdown_renders_with_border() {
+fn completion_popup_renders_with_dim_separator() {
     let (_temp, workspace) = set_up_workspace();
     let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
     harness.tick_and_render().unwrap();
@@ -154,9 +149,9 @@ fn completion_dropdown_renders_with_border() {
 
     let screen = harness.screen_to_string();
     assert!(
-        screen_has_dropdown_top_border(&screen),
-        "completion dropdown must render with a `╭─...─╮` top border. \
-         Screen:\n{}",
+        screen_has_completion_dim_separator(&screen),
+        "completion popup must render with a dim `┄┄┄...┄┄┄` separator \
+         between input and candidates. Screen:\n{}",
         screen,
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -366,3 +366,58 @@ fn completion_popup_renders_scrollbar_when_overflowing() {
         screen,
     );
 }
+
+/// Mouse wheel over the popup scrolls its candidate list — same
+/// behaviour the user gets from Down arrow, except the selected
+/// index stays put (it's a scroll, not a selection move). Goes
+/// directly through `Editor::handle_mouse` since SGR mouse
+/// escape sequences sent via `tmux send-keys` get filtered by
+/// tmux's pane-input pipeline and never reach crossterm, so
+/// interactive tmux verification isn't possible without a real
+/// mouse device.
+#[test]
+fn completion_popup_scrolls_with_mouse_wheel() {
+    let (_temp, workspace, _names) = set_up_workspace_many_alphas();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_many_alphas_prefix_and_wait(&mut harness, &workspace);
+
+    // Sanity: bottom candidate is off-screen before scrolling.
+    assert!(
+        !harness.screen_to_string().contains("alpha_09/"),
+        "precondition: `alpha_09/` must be off-screen before scrolling",
+    );
+
+    // Locate a row owned by the popup so the wheel lands on its
+    // hit-test target. `alpha_00/` is the top candidate row when
+    // the popup just opened; find its on-screen row and scroll
+    // there. Column is irrelevant for the host's wheel routing
+    // (it only checks `last_inner_rect` containment), but pick
+    // a column inside the panel for realism.
+    let (col, row) = harness
+        .find_text_on_screen("alpha_00/")
+        .expect("`alpha_00/` should be visible before scrolling");
+    let _ = col;
+
+    // Each ScrollDown event ticks the popup's host-side scroll
+    // by 3 (the editor's default wheel step). 5 events is enough
+    // to reach the end of the 10-row list regardless of which
+    // direction the step is clamped from.
+    for _ in 0..5 {
+        harness.mouse_scroll_down(80, row).unwrap();
+    }
+    harness
+        .wait_until(|h| h.screen_to_string().contains("alpha_09/"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("alpha_00/"),
+        "after scrolling down with the mouse wheel, `alpha_00/` should fall off \
+         the top of the visible window. Screen:\n{}",
+        screen,
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -1,0 +1,229 @@
+//! E2E coverage for the Orchestrator "New Session" form's path-
+//! completion popup behaviour:
+//!
+//! 1. The dropdown renders inside a bordered box (it used to be bare
+//!    overlay rows painted on top of the worktree toggle).
+//! 2. Tab accepts the highlighted suggestion into the field.
+//! 3. Enter does NOT accept the suggestion — it leaves the typed
+//!    text intact and proceeds (matches bash / fish / readline
+//!    path-completion conventions). Before the fix, the host's
+//!    picker-style smart-key wiring fired the completion list's
+//!    activate event on Enter and silently overwrote the field.
+//!
+//! Each test sets up a workspace with two predictable subdirs
+//! (`alpha_dir/` and `alpha_two/`). The Project Path is driven via
+//! an absolute path (`<workspace>/al`) so the plugin's
+//! `fetchPathCompletions` reads the workspace directly — its
+//! `parent = "."` branch for un-slashed inputs would resolve
+//! against the cargo-test process cwd, not the harness workspace.
+
+#![cfg(feature = "plugins")]
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::path::PathBuf;
+
+/// Build a workspace with two `alpha*` subdirs and the orchestrator
+/// plugin installed. Returns (tempdir guard, canonicalized
+/// workspace path). The path is canonicalized so screen matching
+/// is stable on systems where `/tmp` is a symlink (e.g. macOS).
+fn set_up_workspace() -> (tempfile::TempDir, PathBuf) {
+    fresh::i18n::set_locale("en");
+
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().canonicalize().unwrap();
+
+    fs::create_dir(workspace.join("alpha_dir")).unwrap();
+    fs::create_dir(workspace.join("alpha_two")).unwrap();
+
+    let plugins_dir = workspace.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    (temp, workspace)
+}
+
+fn wait_for_new_session_command(harness: &mut EditorTestHarness) {
+    harness
+        .wait_until(|h| {
+            let reg = h.editor().command_registry().read().unwrap();
+            reg.get_all()
+                .iter()
+                .any(|c| c.get_localized_name() == "Orchestrator: New Session")
+        })
+        .unwrap();
+}
+
+fn open_new_session_form(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Orchestrator: New Session").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Orchestrator: New Session"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR :: New Session"))
+        .unwrap();
+}
+
+/// Read the bracketed text inside the Project Path field from the
+/// rendered screen. The field renders as `│ [<value>...] │` on the
+/// row after the `Project Path` label. Returns the trimmed value.
+fn project_path_field_value(screen: &str) -> String {
+    let lines: Vec<&str> = screen.lines().collect();
+    let label_row = lines
+        .iter()
+        .position(|l| l.contains("Project Path"))
+        .expect("Project Path label must appear on screen");
+    for next in lines.iter().skip(label_row + 1).take(3) {
+        if let Some(open) = next.find('[') {
+            if let Some(close_rel) = next[open + 1..].find(']') {
+                return next[open + 1..open + 1 + close_rel].trim().to_string();
+            }
+        }
+    }
+    panic!(
+        "Could not find [...] field after Project Path label.\nScreen:\n{}",
+        screen
+    );
+}
+
+/// True when the rendered screen contains the top border of a
+/// labeledSection chrome box nested inside the panel frame:
+/// `│╭───...───╮│`. The `│ ... │` is the outer panel's frame and
+/// `╭─...─╮` is the labeledSection's own top border — the popup's
+/// "wrapped" rendering. Used to distinguish the fixed bordered
+/// popup from the old bare-overlay rendering (where the
+/// completion items appeared as `│ /path/to/foo │` with no
+/// enclosing `╭─...─╮ / ╰─...─╯` chrome).
+///
+/// `contains` rather than `starts_with` because each screen row
+/// begins with editor placeholder columns (`~ `, gutter) that
+/// `trim()` doesn't strip.
+fn screen_has_dropdown_top_border(screen: &str) -> bool {
+    screen.lines().any(|l| {
+        if let Some(start) = l.find("│╭") {
+            let rest = &l[start + "│╭".len()..];
+            if let Some(end) = rest.find("╮│") {
+                let inner = &rest[..end];
+                return inner.chars().all(|c| c == '─') && inner.chars().count() >= 4;
+            }
+        }
+        false
+    })
+}
+
+/// Type `<workspace>/al` into the focused Project Path field and
+/// wait for the completion dropdown to surface both `alpha_dir/`
+/// and `alpha_two/` candidates. Returns the typed prefix so the
+/// caller can compare against the field value.
+fn type_alpha_prefix_and_wait(
+    harness: &mut EditorTestHarness,
+    workspace: &std::path::Path,
+) -> String {
+    let prefix = format!("{}/al", workspace.display());
+    harness.type_text(&prefix).unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("alpha_dir/") && s.contains("alpha_two/")
+        })
+        .unwrap();
+    prefix
+}
+
+/// The completion list must render inside a `╭─...─╮ ... ╰─...─╯`
+/// chrome box — not as bare overlay rows painted directly on top
+/// of the form fields beneath it.
+#[test]
+fn completion_dropdown_renders_with_border() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen_has_dropdown_top_border(&screen),
+        "completion dropdown must render with a `╭─...─╮` top border. \
+         Screen:\n{}",
+        screen,
+    );
+}
+
+/// Tab accepts the highlighted completion: the Project Path field
+/// must contain the first suggestion (`<workspace>/alpha_dir/`)
+/// after Tab is pressed with the dropdown open. Pins the
+/// already-working behaviour as a regression guard.
+#[test]
+fn tab_accepts_highlighted_completion() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    let typed = type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    // Precondition: typed text intact before Tab.
+    assert_eq!(
+        project_path_field_value(&harness.screen_to_string()),
+        typed,
+    );
+
+    // First item (`alpha_dir/`, sorted before `alpha_two/`) is
+    // highlighted by default — setCompletionItems resets
+    // selectedIndex to 0.
+    let expected = format!("{}/alpha_dir/", workspace.display());
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()) == expected)
+        .unwrap();
+}
+
+/// Enter must NOT accept the highlighted completion. Before the
+/// fix, Enter routed through the host's picker-style smart-key
+/// wiring and overwrote the field with the highlighted suggestion.
+/// After the fix, the form's explicit Enter binding closes the
+/// dropdown without accepting and forwards Enter through to the
+/// smart-key dispatcher's focus-advance branch — leaving the typed
+/// text intact.
+#[test]
+fn enter_keeps_typed_text_when_completion_open() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    let typed = type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Dropdown should close — neither `alpha_dir/` nor `alpha_two/`
+    // should remain on screen as suggestions. Wait for that so
+    // we're reading a steady state, not the in-flight render.
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("alpha_two/"))
+        .unwrap();
+
+    assert_eq!(
+        project_path_field_value(&harness.screen_to_string()),
+        typed,
+        "Enter must leave the typed text intact (not accept the highlighted suggestion). \
+         Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -176,10 +176,7 @@ fn tab_accepts_highlighted_completion() {
     let typed = type_alpha_prefix_and_wait(&mut harness, &workspace);
 
     // Precondition: typed text intact before Tab.
-    assert_eq!(
-        project_path_field_value(&harness.screen_to_string()),
-        typed,
-    );
+    assert_eq!(project_path_field_value(&harness.screen_to_string()), typed,);
 
     // First item (`alpha_dir/`, sorted before `alpha_two/`) is
     // highlighted by default — setCompletionItems resets


### PR DESCRIPTION
## Summary
Improves the completion dropdown UI/UX by wrapping it in a labeled section for consistent styling and adding explicit Enter key handling to prevent accidental acceptance of suggestions.

## Key Changes
- **Completion dropdown styling**: Wrapped the completion list in a `labeledSection` with an empty label so the dropdown renders with the same border chrome (`╭─...─╮ ... ╰─...─╯`) as the rest of the form, instead of appearing as bare text overlaid on the background
- **Enter key handling**: Added explicit Enter key binding (`orchestrator_form_key_enter`) that closes the completion dropdown without accepting the highlighted item, then forwards Enter to the host's smart-key dispatch for normal behavior (focus advance on text input, activate on buttons)
- **Tab hint update**: Updated the hint bar to clarify that Tab is used for both navigation and accepting completions ("next / accept")
- **Comment improvements**: Updated code comments to reflect the new Enter behavior and clarify that Tab is the only accept path for completions (matching bash/fish/readline conventions)

## Implementation Details
- The Enter handler uses `completionVisibleForFocused()` to check if a dropdown is open before closing it
- Render-then-dispatch ordering ensures the spec update (list removal) is applied before the Enter dispatch, so the smart-key router doesn't accidentally trigger the completion list's activate event
- The completion list remains non-focusable but keyed to receive mouse-click select events and mutations

https://claude.ai/code/session_015xqfmiGu2mPby4AzMsMAfd