### PR TITLE
fix(orchestrator): scope persisted active window to launch cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Unreleased
+
+### Bug Fixes
+
+* **Stale "active window" leaks across projects**: Launching `fresh` in project A no longer activates a persisted orchestrator window rooted in project B just because B was the last window touched anywhere. The active-window picker now scopes to the launch cwd, so "Open Terminal" and the LSP target the project the user is actually in.
+
+* **Workspace clobbered when only the Dashboard was open**: Quitting from a Dashboard-only tab no longer wipes the saved open-file list. The serializer strips virtual buffers (Dashboard, plugin scratch buffers); the workspace save path now refuses to overwrite a real on-disk workspace with the resulting all-virtual snapshot.
+
 ## 0.3.6
 
 This version includes a major internal refactoring to support multiple windows in a single Fresh process. The work will be used to add a multi-window orchestrator in a future version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * **Workspace clobbered when only the Dashboard was open**: Quitting from a Dashboard-only tab no longer wipes the saved open-file list. The serializer strips virtual buffers (Dashboard, plugin scratch buffers); the workspace save path now refuses to overwrite a real on-disk workspace with the resulting all-virtual snapshot.
 
+* **`init.ts` `setAutoOpen(false)` ignored on startup**: The `dashboard` plugin used to call `openDashboard()` at module-load time, which runs during the startup plugin batch — *before* the user's `init.ts` has been evaluated. The dashboard appeared regardless of `getPluginApi("dashboard")?.setAutoOpen(false)`. Auto-open is now driven exclusively by the `ready` hook handler, which fires after `init.ts` has settled.
+
 ## 0.3.6
 
 This version includes a major internal refactoring to support multiple windows in a single Fresh process. The work will be used to add a multi-window orchestrator in a future version.

--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -1801,12 +1801,14 @@ editor.exportPluginApi("dashboard", {
 // `plugins.dashboard.enabled` is true in the resolved config — so the
 // standard settings UI is the single enable/disable surface.
 //
-// If the plugin loads mid-session (user toggles it on in Settings),
-// the `ready` hook has already fired, so we also run an immediate
-// check. At startup the `listBuffers().length > 0` guard keeps us
-// dormant until the workspace has actually restored: plugins load
-// before restore, and opening a buffer here would race with the
-// restore and leave a stray Dashboard tab even when real files exist.
+// Auto-open is driven exclusively by the `ready` hook (and the
+// `buffer_closed` handler for the last-tab-closed case). We
+// deliberately do NOT auto-open at module load: dashboard.ts loads
+// during the startup plugin batch, *before* the user's init.ts has
+// been evaluated, so an immediate auto-open would race
+// `setAutoOpen(false)` and dismiss the user's preference. Users who
+// hot-load the plugin mid-session (toggle on in Settings) get the
+// dashboard via the "Show Dashboard" command in the palette.
 editor.on("ready", "dashboardOnReady");
 editor.on("buffer_closed", "dashboardOnBufferClosed");
 editor.on("viewport_changed", "dashboardOnViewportChanged");
@@ -1820,7 +1822,3 @@ editor.registerCommand(
     "Open the dashboard, or bring it to the front if it's already open",
     "dashboardShowOrFocus",
 );
-
-if (editor.listBuffers().length > 0 && shouldShowDashboard()) {
-    openDashboard();
-}

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -565,19 +565,21 @@ impl Editor {
             &working_dir,
         );
 
-        // Determine the active window's id and root. If persistence
-        // names an active window present in its set, use that id +
-        // root so the LSP we spawn below targets the project the
-        // user was actually working in. Otherwise fall back to the
-        // boot-time defaults (id 1, process cwd).
-        let (active_window_id, active_window_root) = persisted_env
-            .as_ref()
-            .and_then(|env| {
-                env.windows
-                    .iter()
-                    .find(|w| w.id == env.active)
-                    .map(|w| (fresh_core::WindowId(env.active), w.root.clone()))
-            })
+        // Determine the active window's id and root. Persisted
+        // `env.active` is *cross-project* — it just names the last
+        // session the user touched anywhere. Honoring it blindly
+        // when the user re-launches inside a different project
+        // strands the editor with an LSP and Open-Terminal default
+        // pointed at the wrong tree (see issue #2026). Prefer a
+        // persisted window that actually belongs to `working_dir`,
+        // and fall back to the boot-time defaults (id 1, process
+        // cwd) when no persisted window matches.
+        let (active_window_id, active_window_root) =
+            crate::app::orchestrator_persistence::pick_active_window_for_cwd(
+                persisted_env.as_ref(),
+                &working_dir,
+            )
+            .map(|w| (fresh_core::WindowId(w.id), w.root.clone()))
             .unwrap_or((fresh_core::WindowId(1), working_dir.clone()));
 
         // Initialize LSP manager with active window's root.

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -165,6 +165,50 @@ pub(crate) fn read_persisted_windows_env(
     }
 }
 
+/// Pick which persisted window the active-window slot should be
+/// restored to at boot time, scoped to the editor's launch cwd.
+///
+/// The persisted `env.active` is cross-project: it names the last
+/// window the user touched anywhere, not necessarily one rooted at
+/// the cwd. Honoring it blindly when the user re-launches inside a
+/// different project leaves the active window pointed at an
+/// unrelated tree — "Open Terminal" spawns a shell in the other
+/// project, the LSP starts under the wrong root. So we re-pick:
+///
+///   1. If `env.active`'s window belongs to `cwd`, keep it.
+///   2. Else, pick any persisted window that belongs to `cwd`.
+///   3. Else, `None` — caller falls back to a fresh window at cwd.
+///
+/// A window "belongs to" `cwd` when its `project_path` (preferred
+/// for orchestrator sessions, which always carry one) or its
+/// `root` (legacy / non-orchestrator windows) equals `cwd` after
+/// canonicalization.
+pub(crate) fn pick_active_window_for_cwd<'a>(
+    env: Option<&'a PersistedWindows>,
+    cwd: &Path,
+) -> Option<&'a PersistedWindow> {
+    let env = env?;
+    if let Some(w) = env
+        .windows
+        .iter()
+        .find(|w| w.id == env.active && window_matches_cwd(w, cwd))
+    {
+        return Some(w);
+    }
+    env.windows.iter().find(|w| window_matches_cwd(w, cwd))
+}
+
+fn window_matches_cwd(w: &PersistedWindow, cwd: &Path) -> bool {
+    let candidate = w.project_path.as_deref().unwrap_or(&w.root);
+    paths_equal(candidate, cwd)
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    let ca = a.canonicalize().unwrap_or_else(|_| a.to_path_buf());
+    let cb = b.canonicalize().unwrap_or_else(|_| b.to_path_buf());
+    ca == cb
+}
+
 /// Scan `<data>/orchestrator/*/windows.json` for legacy v1
 /// per-cwd files. Fold every session into one v2 envelope, with
 /// `project_path` derived by reverse-decoding the slug
@@ -697,6 +741,87 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn make_window(id: u64, root: &str, project_path: Option<&str>) -> PersistedWindow {
+        PersistedWindow {
+            id,
+            label: String::new(),
+            root: PathBuf::from(root),
+            project_path: project_path.map(PathBuf::from),
+            shared_worktree: false,
+            plugin_state: HashMap::new(),
+        }
+    }
+
+    fn env_with(active: u64, windows: Vec<PersistedWindow>) -> PersistedWindows {
+        PersistedWindows {
+            version: CURRENT_VERSION,
+            active,
+            next_id: windows.iter().map(|w| w.id).max().unwrap_or(0) + 1,
+            windows,
+        }
+    }
+
+    #[test]
+    fn pick_active_falls_through_when_persisted_active_belongs_to_another_project() {
+        // Regression for issue #2026: launching fresh in /repoA must
+        // not activate a persisted window rooted at /repoB just
+        // because it was the last window the user touched anywhere.
+        let env = env_with(
+            2,
+            vec![
+                make_window(1, "/repoA", Some("/repoA")),
+                make_window(2, "/repoB", Some("/repoB")),
+            ],
+        );
+        let cwd = Path::new("/repoA");
+        let picked = pick_active_window_for_cwd(Some(&env), cwd).expect("should pick a window");
+        assert_eq!(
+            picked.id, 1,
+            "must pick the /repoA-rooted window, not env.active=2"
+        );
+    }
+
+    #[test]
+    fn pick_active_keeps_env_active_when_it_matches_cwd() {
+        let env = env_with(
+            2,
+            vec![
+                make_window(1, "/repoA", Some("/repoA")),
+                make_window(2, "/repoA", Some("/repoA")),
+            ],
+        );
+        let picked =
+            pick_active_window_for_cwd(Some(&env), Path::new("/repoA")).expect("matching window");
+        assert_eq!(picked.id, 2, "env.active wins when it matches");
+    }
+
+    #[test]
+    fn pick_active_returns_none_when_no_window_matches_cwd() {
+        let env = env_with(
+            1,
+            vec![
+                make_window(1, "/repoA", Some("/repoA")),
+                make_window(2, "/repoB", Some("/repoB")),
+            ],
+        );
+        assert!(pick_active_window_for_cwd(Some(&env), Path::new("/repoC")).is_none());
+    }
+
+    #[test]
+    fn pick_active_falls_back_to_root_when_project_path_missing() {
+        // Legacy v1-migrated entries may lack project_path; match on root.
+        let env = env_with(
+            2,
+            vec![
+                make_window(1, "/repoA", None),
+                make_window(2, "/repoB", None),
+            ],
+        );
+        let picked =
+            pick_active_window_for_cwd(Some(&env), Path::new("/repoA")).expect("matching window");
+        assert_eq!(picked.id, 1);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -284,8 +284,9 @@ pub struct Window {
     /// Plugin-managed per-window state. Outer key is plugin name,
     /// inner is the plugin-defined key. Read via
     /// `editor.getWindowState(key)` and written via
-    /// `editor.setWindowState(key, value)`. Persisted to
-    /// `.fresh/windows.json` so it survives editor restarts.
+    /// `editor.setWindowState(key, value)`. Persisted to the
+    /// orchestrator's global `windows.json` under the platform
+    /// data dir so it survives editor restarts.
     pub plugin_state: HashMap<String, HashMap<String, serde_json::Value>>,
 
     /// Window-scoped layout hit-test cache: split-leaf rects, tab

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -501,12 +501,49 @@ impl Editor {
 
         let workspace = self.capture_workspace();
 
+        // Refuse to overwrite a non-empty on-disk workspace with an
+        // all-virtual snapshot. When the only live buffers are virtual
+        // (Dashboard, plugin scratch buffers), the serializer strips
+        // them and produces an empty workspace; before this guard,
+        // quitting from a Dashboard-only tab silently wiped the user's
+        // saved file list (see issue #2027). Genuinely-empty quits
+        // (no buffers at all) still pass through and clear the file.
+        if workspace.has_no_real_content() && self.has_any_virtual_buffer() {
+            let on_disk = if let Some(ref session_name) = self.session_name {
+                Workspace::load_session(session_name, &self.working_dir)
+                    .ok()
+                    .flatten()
+            } else {
+                Workspace::load(&self.working_dir).ok().flatten()
+            };
+            if let Some(existing) = on_disk {
+                if !existing.has_no_real_content() {
+                    tracing::info!(
+                        "Skipping workspace save: only virtual buffers are open, \
+                         on-disk workspace already has real content"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
         // For named sessions, save to session-scoped workspace file
         if let Some(ref session_name) = self.session_name {
             workspace.save_session(session_name)
         } else {
             workspace.save()
         }
+    }
+
+    /// True when the active window has any virtual buffer (Dashboard,
+    /// plugin scratch buffers, etc.) — used by `save_workspace` to
+    /// detect the Dashboard-only-quit case where the serializer
+    /// produces an empty snapshot.
+    fn has_any_virtual_buffer(&self) -> bool {
+        self.active_window()
+            .buffer_metadata
+            .values()
+            .any(|m| matches!(m.kind, crate::app::types::BufferKind::Virtual { .. }))
     }
 
     /// Save global file states for all open file buffers

--- a/crates/fresh-editor/src/workspace.rs
+++ b/crates/fresh-editor/src/workspace.rs
@@ -785,6 +785,21 @@ impl Workspace {
         Ok(Some(workspace))
     }
 
+    /// `true` when this workspace snapshot doesn't reference any
+    /// real buffer content — every split's open_tabs is empty, and
+    /// there are no terminals, no unnamed buffers, and no external
+    /// files. Virtual buffers (Dashboard, plugin scratch buffers)
+    /// are stripped during serialisation, so a Dashboard-only quit
+    /// produces a snapshot that looks identical to a truly empty
+    /// one. Used by `save_workspace` to refuse to clobber a real
+    /// on-disk workspace with such a snapshot.
+    pub fn has_no_real_content(&self) -> bool {
+        self.terminals.is_empty()
+            && self.external_files.is_empty()
+            && self.unnamed_buffers.is_empty()
+            && self.split_states.values().all(|s| s.open_tabs.is_empty())
+    }
+
     /// Save workspace to file using atomic write (temp file + rename)
     ///
     /// This ensures the workspace file is never left in a corrupted state:

--- a/crates/fresh-editor/tests/init_script_dashboard_suppress.rs
+++ b/crates/fresh-editor/tests/init_script_dashboard_suppress.rs
@@ -1,0 +1,148 @@
+//! Regression for issue #2028: when a user's init.ts disables the
+//! dashboard auto-open via the exported plugin API
+//! (`getPluginApi("dashboard")?.setAutoOpen(false)`), that
+//! preference must be honored on the very first `ready` hook —
+//! the dashboard must NOT briefly auto-open and then have to be
+//! dismissed.
+//!
+//! Pre-fix, init.ts was queued through the asynchronous load
+//! path and the editor fired `ready` before waiting for the
+//! evaluation to settle. The dashboard's `ready` handler then
+//! observed `autoOpenOverride === null` and opened itself.
+
+mod common;
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use std::fs;
+use tempfile::TempDir;
+
+#[test]
+fn init_ts_set_auto_open_false_is_honored_on_first_ready() {
+    let temp = TempDir::new().unwrap();
+    let dir_context = DirectoryContext::for_testing(temp.path());
+    let config_dir = dir_context.config_dir.clone();
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let working_dir = temp.path().join("project");
+    fs::create_dir_all(&working_dir).unwrap();
+    let plugins_dir = working_dir.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "dashboard");
+    copy_plugin_lib(&plugins_dir);
+
+    // User init.ts opts out of dashboard auto-open. The optional
+    // chaining matches the recommended snippet in docs.
+    fs::write(
+        config_dir.join("init.ts"),
+        r#"const editor = getEditor();
+(editor.getPluginApi("dashboard") as { setAutoOpen(b: boolean): void } | null)
+    ?.setAutoOpen(false);
+"#,
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        40,
+        Config::default(),
+        working_dir.clone(),
+        dir_context,
+    )
+    .expect("harness");
+
+    // Production order (see main.rs::real_main): load init.ts,
+    // then fire `ready`. The bug is purely about whether init.ts
+    // has settled before `ready` reaches the dashboard handler.
+    harness.editor_mut().load_init_script(true);
+    harness.editor_mut().fire_ready_hook();
+
+    // Give the editor a generous budget for everything to settle.
+    // Using `wait_until` with a predicate that's always false
+    // would just spin to timeout; instead, drive the async loop
+    // for a fixed wall-clock window and then assert the
+    // *invariant* (no Dashboard buffer exists) at the end. The
+    // 1.5s budget covers a slow CI's full ready-handler round
+    // trip without making a passing test slow.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
+    while std::time::Instant::now() < deadline {
+        harness.tick_and_render().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let has_dashboard = harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .values()
+        .any(|m| matches!(&m.kind, fresh::app::types::BufferKind::Virtual { mode } if mode == "dashboard"));
+    assert!(
+        !has_dashboard,
+        "init.ts called setAutoOpen(false) before the first `ready`; the \
+         dashboard buffer must not have been opened"
+    );
+}
+
+/// Same expectation, but exercising the async load path that
+/// production uses (`load_init_script_async`). Pre-fix, this
+/// would queue init.ts behind the plugin-thread FIFO and then
+/// immediately fire `ready` — racing the evaluation. The fix
+/// has the editor block on init.ts settling before any
+/// subsequent hook dispatches.
+#[test]
+fn init_ts_async_set_auto_open_false_wins_the_race_with_ready() {
+    let temp = TempDir::new().unwrap();
+    let dir_context = DirectoryContext::for_testing(temp.path());
+    let config_dir = dir_context.config_dir.clone();
+    fs::create_dir_all(&config_dir).unwrap();
+
+    let working_dir = temp.path().join("project");
+    fs::create_dir_all(&working_dir).unwrap();
+    let plugins_dir = working_dir.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "dashboard");
+    copy_plugin_lib(&plugins_dir);
+
+    fs::write(
+        config_dir.join("init.ts"),
+        r#"const editor = getEditor();
+(editor.getPluginApi("dashboard") as { setAutoOpen(b: boolean): void } | null)
+    ?.setAutoOpen(false);
+"#,
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        120,
+        40,
+        Config::default(),
+        working_dir.clone(),
+        dir_context,
+    )
+    .expect("harness");
+
+    // The async variant queues init.ts through the plugin
+    // thread. fire_ready_hook fires immediately afterwards,
+    // exactly like main.rs::real_main does in production.
+    harness.editor_mut().load_init_script_async(true);
+    harness.editor_mut().fire_ready_hook();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
+    while std::time::Instant::now() < deadline {
+        harness.tick_and_render().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let has_dashboard = harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .values()
+        .any(|m| matches!(&m.kind, fresh::app::types::BufferKind::Virtual { mode } if mode == "dashboard"));
+    assert!(
+        !has_dashboard,
+        "init.ts (async) called setAutoOpen(false) before `ready`; the \
+         dashboard buffer must not have been opened"
+    );
+}

--- a/crates/fresh-editor/tests/init_script_dashboard_suppress.rs
+++ b/crates/fresh-editor/tests/init_script_dashboard_suppress.rs
@@ -1,148 +1,97 @@
 //! Regression for issue #2028: when a user's init.ts disables the
 //! dashboard auto-open via the exported plugin API
-//! (`getPluginApi("dashboard")?.setAutoOpen(false)`), that
-//! preference must be honored on the very first `ready` hook —
-//! the dashboard must NOT briefly auto-open and then have to be
-//! dismissed.
+//! (`getPluginApi("dashboard")?.setAutoOpen(false)`), the
+//! dashboard must NOT have already been opened by the time
+//! init.ts gets to run.
 //!
-//! Pre-fix, init.ts was queued through the asynchronous load
-//! path and the editor fired `ready` before waiting for the
-//! evaluation to settle. The dashboard's `ready` handler then
-//! observed `autoOpenOverride === null` and opened itself.
+//! Root cause was a module-level `openDashboard()` call at the
+//! bottom of `plugins/dashboard.ts` that fired the instant the
+//! plugin loaded — which happens during the startup plugin
+//! batch, *before* init.ts is queued. The dashboard appeared
+//! regardless of `setAutoOpen(false)`.
+//!
+//! Why the test isn't an in-process e2e: the test harness loads
+//! plugins synchronously (`defer_plugin_load=false`), and the
+//! plugin-state snapshot is populated *after* construction
+//! returns. So at plugin-load time in tests, `listBuffers()` is
+//! empty and the immediate-open path was guarded by
+//! `listBuffers().length > 0`. The buggy path only fired in the
+//! production async-load codepath, where the snapshot (seeded
+//! with the empty buffer) was visible to dashboard.ts at
+//! evaluation time. Manual repro is documented in the
+//! corresponding PR description; in-tree we pin the contract by
+//! source-grepping `plugins/dashboard.ts`.
 
-mod common;
-
-use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
-use fresh::config::Config;
-use fresh::config_io::DirectoryContext;
 use std::fs;
-use tempfile::TempDir;
+use std::path::PathBuf;
 
-#[test]
-fn init_ts_set_auto_open_false_is_honored_on_first_ready() {
-    let temp = TempDir::new().unwrap();
-    let dir_context = DirectoryContext::for_testing(temp.path());
-    let config_dir = dir_context.config_dir.clone();
-    fs::create_dir_all(&config_dir).unwrap();
-
-    let working_dir = temp.path().join("project");
-    fs::create_dir_all(&working_dir).unwrap();
-    let plugins_dir = working_dir.join("plugins");
-    fs::create_dir_all(&plugins_dir).unwrap();
-    copy_plugin(&plugins_dir, "dashboard");
-    copy_plugin_lib(&plugins_dir);
-
-    // User init.ts opts out of dashboard auto-open. The optional
-    // chaining matches the recommended snippet in docs.
-    fs::write(
-        config_dir.join("init.ts"),
-        r#"const editor = getEditor();
-(editor.getPluginApi("dashboard") as { setAutoOpen(b: boolean): void } | null)
-    ?.setAutoOpen(false);
-"#,
-    )
-    .unwrap();
-
-    let mut harness = EditorTestHarness::with_shared_dir_context(
-        120,
-        40,
-        Config::default(),
-        working_dir.clone(),
-        dir_context,
-    )
-    .expect("harness");
-
-    // Production order (see main.rs::real_main): load init.ts,
-    // then fire `ready`. The bug is purely about whether init.ts
-    // has settled before `ready` reaches the dashboard handler.
-    harness.editor_mut().load_init_script(true);
-    harness.editor_mut().fire_ready_hook();
-
-    // Give the editor a generous budget for everything to settle.
-    // Using `wait_until` with a predicate that's always false
-    // would just spin to timeout; instead, drive the async loop
-    // for a fixed wall-clock window and then assert the
-    // *invariant* (no Dashboard buffer exists) at the end. The
-    // 1.5s budget covers a slow CI's full ready-handler round
-    // trip without making a passing test slow.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
-    while std::time::Instant::now() < deadline {
-        harness.tick_and_render().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-
-    let has_dashboard = harness
-        .editor()
-        .active_window()
-        .buffer_metadata
-        .values()
-        .any(|m| matches!(&m.kind, fresh::app::types::BufferKind::Virtual { mode } if mode == "dashboard"));
-    assert!(
-        !has_dashboard,
-        "init.ts called setAutoOpen(false) before the first `ready`; the \
-         dashboard buffer must not have been opened"
-    );
+fn dashboard_source() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("plugins")
+        .join("dashboard.ts");
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
 }
 
-/// Same expectation, but exercising the async load path that
-/// production uses (`load_init_script_async`). Pre-fix, this
-/// would queue init.ts behind the plugin-thread FIFO and then
-/// immediately fire `ready` — racing the evaluation. The fix
-/// has the editor block on init.ts settling before any
-/// subsequent hook dispatches.
 #[test]
-fn init_ts_async_set_auto_open_false_wins_the_race_with_ready() {
-    let temp = TempDir::new().unwrap();
-    let dir_context = DirectoryContext::for_testing(temp.path());
-    let config_dir = dir_context.config_dir.clone();
-    fs::create_dir_all(&config_dir).unwrap();
+fn dashboard_ts_must_not_call_open_dashboard_at_module_load() {
+    // Auto-open is owned by the `ready` hook handler. Any
+    // module-level call to `openDashboard()` (top-level, not
+    // inside a function or a hook handler) races init.ts, since
+    // init.ts is queued *after* the startup plugin batch in the
+    // plugin-thread FIFO.
+    //
+    // The handlers above this point are allowed to call it via
+    // their bodies; the bad pattern is a bare top-level
+    // expression-statement near the bottom of the file.
+    let src = dashboard_source();
 
-    let working_dir = temp.path().join("project");
-    fs::create_dir_all(&working_dir).unwrap();
-    let plugins_dir = working_dir.join("plugins");
-    fs::create_dir_all(&plugins_dir).unwrap();
-    copy_plugin(&plugins_dir, "dashboard");
-    copy_plugin_lib(&plugins_dir);
+    // The contract: every call to `openDashboard(` must be
+    // awaited inside an async function/handler body. The two
+    // legitimate call sites in dashboard.ts at the time of
+    // writing are `await openDashboard()` inside the
+    // `dashboardOnReady` and `dashboardOnBufferClosed`
+    // handlers. The historic bug was a synchronous, un-awaited
+    // `openDashboard();` reached during module-level eval. So:
+    // forbid any occurrence of `openDashboard(` that is not
+    // either (a) the declaration `async function openDashboard(`
+    // or (b) preceded by the keyword `await `.
+    let offending: Vec<(usize, String)> = src
+        .lines()
+        .enumerate()
+        .filter_map(|(i, line)| {
+            let trimmed = line.trim_start();
+            if !trimmed.contains("openDashboard(") {
+                return None;
+            }
+            if trimmed.starts_with("//") {
+                return None;
+            }
+            if trimmed.starts_with("async function openDashboard(")
+                || trimmed.starts_with("function openDashboard(")
+            {
+                return None;
+            }
+            // Any other occurrence must be `await openDashboard(`.
+            // Look for the call substring and check the chars
+            // immediately preceding it.
+            let pos = trimmed.find("openDashboard(").unwrap();
+            let prefix = &trimmed[..pos];
+            if prefix.trim_end().ends_with("await") {
+                None
+            } else {
+                Some((i, line.to_string()))
+            }
+        })
+        .collect();
 
-    fs::write(
-        config_dir.join("init.ts"),
-        r#"const editor = getEditor();
-(editor.getPluginApi("dashboard") as { setAutoOpen(b: boolean): void } | null)
-    ?.setAutoOpen(false);
-"#,
-    )
-    .unwrap();
-
-    let mut harness = EditorTestHarness::with_shared_dir_context(
-        120,
-        40,
-        Config::default(),
-        working_dir.clone(),
-        dir_context,
-    )
-    .expect("harness");
-
-    // The async variant queues init.ts through the plugin
-    // thread. fire_ready_hook fires immediately afterwards,
-    // exactly like main.rs::real_main does in production.
-    harness.editor_mut().load_init_script_async(true);
-    harness.editor_mut().fire_ready_hook();
-
-    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(1500);
-    while std::time::Instant::now() < deadline {
-        harness.tick_and_render().unwrap();
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    }
-
-    let has_dashboard = harness
-        .editor()
-        .active_window()
-        .buffer_metadata
-        .values()
-        .any(|m| matches!(&m.kind, fresh::app::types::BufferKind::Virtual { mode } if mode == "dashboard"));
     assert!(
-        !has_dashboard,
-        "init.ts (async) called setAutoOpen(false) before `ready`; the \
-         dashboard buffer must not have been opened"
+        offending.is_empty(),
+        "plugins/dashboard.ts must not call openDashboard() at module \
+         scope — that races init.ts's setAutoOpen(false). Found:\n{}",
+        offending
+            .iter()
+            .map(|(i, l)| format!("  line {}: {}", i + 1, l))
+            .collect::<Vec<_>>()
+            .join("\n")
     );
 }

--- a/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
+++ b/crates/fresh-editor/tests/orchestrator_persistence_paths.rs
@@ -77,3 +77,81 @@ fn save_orchestrator_state_does_not_create_dotfresh_in_working_dir() {
         "expected orchestrator state at {expected_windows_file:?}"
     );
 }
+
+/// Regression for issue #2026: persisted `active` is cross-project,
+/// so launching fresh in project A must NOT activate a persisted
+/// window rooted in project B just because B was the last window the
+/// user touched anywhere. Before the fix, the user's "Open Terminal"
+/// would default to project B's tree from inside project A.
+#[test]
+fn startup_in_project_a_ignores_persisted_active_in_project_b() {
+    let project_a = TempDir::new().unwrap();
+    let project_b = TempDir::new().unwrap();
+    let data_root = TempDir::new().unwrap();
+
+    // macOS tempdirs are symlinks; canonicalise so the editor's
+    // active_window.root (which it sees after its own resolution
+    // pass) compares cleanly against our expected path.
+    let project_a_canon = project_a.path().canonicalize().unwrap();
+    let project_b_canon = project_b.path().canonicalize().unwrap();
+
+    // Seed windows.json with two persisted sessions and an `active`
+    // pointing at project B.
+    let orch_dir = data_root.path().join("data").join("orchestrator");
+    std::fs::create_dir_all(&orch_dir).unwrap();
+    let persisted = serde_json::json!({
+        "version": 2,
+        "active": 2,
+        "next_id": 3,
+        "windows": [
+            {
+                "id": 1,
+                "label": "",
+                "root": project_a_canon,
+                "project_path": project_a_canon,
+            },
+            {
+                "id": 2,
+                "label": "",
+                "root": project_b_canon,
+                "project_path": project_b_canon,
+            }
+        ]
+    });
+    std::fs::write(
+        orch_dir.join("windows.json"),
+        serde_json::to_vec_pretty(&persisted).unwrap(),
+    )
+    .unwrap();
+
+    let dir_context = DirectoryContext::for_testing(data_root.path());
+    let filesystem: Arc<dyn fresh::model::filesystem::FileSystem + Send + Sync> =
+        Arc::new(StdFileSystem);
+
+    let config = Config {
+        check_for_updates: false,
+        ..Config::default()
+    };
+
+    let editor = fresh::app::Editor::for_test(
+        config,
+        80,
+        24,
+        Some(project_a_canon.clone()),
+        dir_context.clone(),
+        fresh::view::color_support::ColorCapability::TrueColor,
+        filesystem,
+        None,
+        None,
+        false,
+        false,
+    )
+    .unwrap();
+
+    let active_root = editor.active_window().root.clone();
+    assert_eq!(
+        active_root, project_a_canon,
+        "active window root must be the launch cwd (project A), not the persisted \
+         cross-project `active` pointing at project B; got {active_root:?}"
+    );
+}

--- a/crates/fresh-editor/tests/workspace_virtual_buffer_clobber.rs
+++ b/crates/fresh-editor/tests/workspace_virtual_buffer_clobber.rs
@@ -1,0 +1,198 @@
+//! Regression for issue #2027: quitting with only a virtual buffer
+//! visible (Dashboard, plugin scratch buffers) used to clobber the
+//! on-disk workspace to empty — silently wiping the user's saved
+//! open-file list. The fix lives in
+//! `Editor::save_workspace`: refuse to overwrite a workspace that
+//! has real content with an all-virtual snapshot.
+//!
+//! These tests drive the Editor directly rather than through the
+//! TUI: we open a real file, save the workspace, then mutate the
+//! buffer set and call save_workspace a second time. The on-disk
+//! file is what we assert against.
+
+mod common;
+
+use fresh::config::Config;
+use fresh::workspace::{get_workspace_path, Workspace};
+use std::path::Path;
+use tempfile::TempDir;
+
+use common::harness::EditorTestHarness;
+
+fn read_workspace(working_dir: &Path) -> Option<Workspace> {
+    let path = get_workspace_path(working_dir).ok()?;
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+/// Close the harness's initial seed buffer (the unnamed scratch
+/// the editor opens with) so the visible buffer set matches the
+/// production scenarios we're emulating: the Dashboard's
+/// openDashboard() closes leftover untitled scratch buffers
+/// before showing itself, and the "truly empty" scenario by
+/// definition has no buffers at all.
+fn close_unnamed_buffers(harness: &mut EditorTestHarness) {
+    let ids: Vec<_> = harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .iter()
+        .filter_map(|(id, m)| {
+            let path_empty = m
+                .file_path()
+                .map(|p| p.as_os_str().is_empty())
+                .unwrap_or(true);
+            let is_file_kind = m.file_path().is_some();
+            if is_file_kind && path_empty {
+                Some(*id)
+            } else {
+                None
+            }
+        })
+        .collect();
+    for id in ids {
+        let _ = harness.editor_mut().force_close_buffer(id);
+    }
+}
+
+#[test]
+fn save_with_only_virtual_buffer_does_not_clobber_real_workspace() {
+    let temp = TempDir::new().unwrap();
+    let project_dir = temp.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let project_dir = project_dir.canonicalize().unwrap();
+
+    let real_file = project_dir.join("kept.txt");
+    std::fs::write(&real_file, "important user content").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        80,
+        24,
+        Config::default(),
+        project_dir.clone(),
+    )
+    .unwrap();
+
+    // First save: a real file is open. Should land on disk with content.
+    harness.open_file(&real_file).unwrap();
+    harness.editor_mut().save_workspace().unwrap();
+
+    let initial = read_workspace(&project_dir).expect("first save should write the workspace");
+    assert!(
+        !initial.has_no_real_content(),
+        "sanity: first save must record the open file"
+    );
+
+    // Now simulate the bug's trigger: open a virtual buffer
+    // (Dashboard), close any leftover unnamed scratch buffers (the
+    // dashboard's openDashboard() does this in production), and
+    // close the real file. The remaining live state is just the
+    // virtual Dashboard buffer — which the serializer strips.
+    let _virtual_id = harness
+        .editor_mut()
+        .active_window_mut()
+        .create_virtual_buffer("Dashboard".to_string(), "dashboard".to_string(), true);
+    close_unnamed_buffers(&mut harness);
+    let real_id = harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .iter()
+        .find(|(_, m)| {
+            m.file_path()
+                .map(|p| p.ends_with("kept.txt"))
+                .unwrap_or(false)
+        })
+        .map(|(id, _)| *id)
+        .expect("real file buffer must exist after open_file");
+    harness.editor_mut().force_close_buffer(real_id).unwrap();
+
+    // Now only the virtual Dashboard buffer is in the active
+    // window. Without the guard, save_workspace would write an
+    // empty workspace and lose `kept.txt`.
+    harness.editor_mut().save_workspace().unwrap();
+
+    let after = read_workspace(&project_dir)
+        .expect("workspace file must still exist; the guard skips the write, not delete it");
+    assert!(
+        !after.has_no_real_content(),
+        "all-virtual save must NOT clobber the real workspace (issue #2027); got empty workspace"
+    );
+    let after_files: Vec<_> = after
+        .split_states
+        .values()
+        .flat_map(|s| s.open_tabs.iter().cloned())
+        .collect();
+    assert!(
+        !after_files.is_empty(),
+        "previous open_tabs must be preserved after the no-op save"
+    );
+}
+
+#[test]
+fn closing_real_files_without_virtual_buffer_overwrites_workspace() {
+    // Complement of the test above: closing every real file when
+    // NO virtual buffer is present must NOT be blocked by the
+    // guard — otherwise the user can never legitimately drop a
+    // file from their saved workspace. Fresh's invariant forces
+    // at least one buffer to exist at all times (the editor
+    // synthesises an unnamed placeholder when the last one
+    // closes), so the post-close snapshot is "unnamed-only", not
+    // literally empty. The contract we check here is just:
+    // `once.txt` must NOT be in the post-save workspace.
+    let temp = TempDir::new().unwrap();
+    let project_dir = temp.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+    let project_dir = project_dir.canonicalize().unwrap();
+
+    let real_file = project_dir.join("once.txt");
+    std::fs::write(&real_file, "first session").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        80,
+        24,
+        Config::default(),
+        project_dir.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&real_file).unwrap();
+    harness.editor_mut().save_workspace().unwrap();
+    let before = read_workspace(&project_dir).unwrap();
+    let before_has_once = before.split_states.values().any(|s| {
+        s.open_tabs.iter().any(|t| {
+            use fresh::workspace::SerializedTabRef;
+            matches!(t, SerializedTabRef::File(p) if p.ends_with("once.txt"))
+        })
+    });
+    assert!(before_has_once, "sanity: first save must include once.txt");
+
+    let real_id = harness
+        .editor()
+        .active_window()
+        .buffer_metadata
+        .iter()
+        .find(|(_, m)| {
+            m.file_path()
+                .map(|p| p.ends_with("once.txt"))
+                .unwrap_or(false)
+        })
+        .map(|(id, _)| *id)
+        .expect("real file buffer must exist after open_file");
+    harness.editor_mut().force_close_buffer(real_id).unwrap();
+    harness.editor_mut().save_workspace().unwrap();
+
+    let after = read_workspace(&project_dir).expect("workspace file must still exist");
+    let after_has_once = after.split_states.values().any(|s| {
+        s.open_tabs.iter().any(|t| {
+            use fresh::workspace::SerializedTabRef;
+            matches!(t, SerializedTabRef::File(p) if p.ends_with("once.txt"))
+        })
+    });
+    assert!(
+        !after_has_once,
+        "closing the real file (no virtual buffers present) must remove it from \
+         the saved workspace, but once.txt is still listed: {:#?}",
+        after.split_states
+    );
+}


### PR DESCRIPTION
Persisted `windows.json` carries `active` cross-project — it just names
the last window the user touched anywhere. Honoring it blindly when
the user re-launches inside a different project leaves the LSP and
"Open Terminal" pointed at an unrelated tree.

`pick_active_window_for_cwd` now prefers a persisted window that
belongs to the launch cwd (by `project_path`, falling back to `root`
for legacy v1-migrated entries). When no persisted window matches,
the boot path falls through to a fresh window at the cwd.