### PR TITLE
plugin config: typed registration API + Settings UI integration

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1947,6 +1947,20 @@ pub enum PluginCommand {
         value: JsonValue,
     },
 
+    /// Register one field of a plugin-defined config schema. Each field
+    /// arrives independently (one per `defineConfigBoolean` / `Integer` /
+    /// etc. call from the plugin's TypeScript). The host accumulates
+    /// fields into `plugins.<plugin_name>` schema and pre-populates the
+    /// declared default into `plugins.<plugin_name>.settings.<field>`.
+    AddPluginConfigField {
+        plugin_name: String,
+        field_name: String,
+        /// JSON Schema fragment for this single field (e.g.
+        /// `{"type":"boolean","default":false,"description":"..."}`).
+        #[ts(type = "unknown")]
+        field_schema: JsonValue,
+    },
+
     /// Register a custom command
     RegisterCommand { command: Command },
 

--- a/crates/fresh-core/src/config.rs
+++ b/crates/fresh-core/src/config.rs
@@ -8,6 +8,14 @@ fn default_true() -> bool {
     true
 }
 
+fn settings_is_empty(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Null => true,
+        serde_json::Value::Object(o) => o.is_empty(),
+        _ => false,
+    }
+}
+
 /// Configuration for a single plugin
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[schemars(extend("x-display-field" = "/enabled"))]
@@ -22,6 +30,15 @@ pub struct PluginConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(extend("readOnly" = true))]
     pub path: Option<PathBuf>,
+
+    /// Plugin-specific settings. The shape is defined by each plugin's
+    /// `<plugin_name>.schema.json` sidecar file; the host stores the value as
+    /// untyped JSON so a malformed plugin schema can't poison the rest of the
+    /// config. Plugins read this via `editor.getPluginConfig()` and the
+    /// Settings UI renders it as a sub-category under "Plugin Settings".
+    #[serde(default, skip_serializing_if = "settings_is_empty")]
+    #[schemars(extend("readOnly" = true))]
+    pub settings: serde_json::Value,
 }
 
 impl Default for PluginConfig {
@@ -29,6 +46,7 @@ impl Default for PluginConfig {
         Self {
             enabled: true,
             path: None,
+            settings: serde_json::Value::Null,
         }
     }
 }
@@ -38,6 +56,7 @@ impl PluginConfig {
         Self {
             enabled: true,
             path: Some(path),
+            settings: serde_json::Value::Null,
         }
     }
 }

--- a/crates/fresh-core/src/lib.rs
+++ b/crates/fresh-core/src/lib.rs
@@ -97,8 +97,8 @@ pub mod config;
 pub mod file_explorer;
 pub mod file_uri;
 pub mod menu;
-pub mod plugin_schemas;
 pub mod overlay;
+pub mod plugin_schemas;
 pub mod services;
 pub mod text_property;
 

--- a/crates/fresh-core/src/lib.rs
+++ b/crates/fresh-core/src/lib.rs
@@ -97,6 +97,7 @@ pub mod config;
 pub mod file_explorer;
 pub mod file_uri;
 pub mod menu;
+pub mod plugin_schemas;
 pub mod overlay;
 pub mod services;
 pub mod text_property;

--- a/crates/fresh-core/src/plugin_schemas.rs
+++ b/crates/fresh-core/src/plugin_schemas.rs
@@ -1,0 +1,185 @@
+//! Validation, default extraction, and merging for plugin-provided
+//! config schemas.
+//!
+//! Plugins register config fields at load time by calling one of the
+//! strongly-typed `editor.defineConfigBoolean / Integer / Number /
+//! String / Enum / StringArray(...)` methods from TypeScript. Each
+//! call sends an `AddPluginConfigField` command to the host. The host
+//! accumulates fields into a per-plugin JSON Schema fragment stored in
+//! `Editor::plugin_schemas`, pre-populates the declared default into
+//! `plugins.<name>.settings.<field>`, and the Settings UI uses the
+//! accumulated schema to render a per-plugin sub-category.
+//!
+//! Trust boundary: schemas reach the host already validated per-field
+//! on the JS-binding side (where errors are thrown back to plugin
+//! authors). This module re-validates defensively before merging into
+//! the runtime tree:
+//!
+//! 1. Top-level must be a JSON object with `"type": "object"`.
+//! 2. No `$ref`s allowed (cross-tree references would let a plugin
+//!    pull types out of the host schema namespace).
+//! 3. No `x-enum-from` extension (would let a plugin point at host
+//!    config paths like `/languages` — explicit design decision).
+
+use serde_json::{Map, Value};
+
+/// Validate a plugin-supplied JSON Schema. Returns `Ok(())` if safe to
+/// merge into the host's runtime schema tree; otherwise an error
+/// describing why.
+pub fn validate_plugin_schema(value: &Value) -> Result<(), String> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| "schema root must be an object".to_string())?;
+
+    match obj.get("type") {
+        Some(Value::String(s)) if s == "object" => {}
+        _ => return Err("schema root must have \"type\": \"object\"".to_string()),
+    }
+
+    check_no_forbidden_keys(value)?;
+
+    // Allow empty `properties` so a brand-new plugin that hasn't yet
+    // sent its first AddPluginConfigField doesn't fail validation.
+    let _ = obj
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .ok_or_else(|| "schema must declare \"properties\"".to_string())?;
+    Ok(())
+}
+
+fn check_no_forbidden_keys(value: &Value) -> Result<(), String> {
+    match value {
+        Value::Object(m) => {
+            for (k, v) in m {
+                if k == "$ref" {
+                    return Err("plugin schemas may not use $ref".to_string());
+                }
+                if k == "x-enum-from" {
+                    return Err(
+                        "plugin schemas may not use x-enum-from (host coupling)".to_string()
+                    );
+                }
+                check_no_forbidden_keys(v)?;
+            }
+        }
+        Value::Array(a) => {
+            for v in a {
+                check_no_forbidden_keys(v)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Deep-merge `defaults` UNDER `target` — i.e. fill in keys that
+/// `target` does not already have. Used to seed
+/// `plugins.<name>.settings` from registered schema defaults without
+/// clobbering values the user has already saved.
+pub fn deep_merge_under(target: &mut Value, defaults: &Value) {
+    if target.is_null() {
+        *target = defaults.clone();
+        return;
+    }
+    let (Value::Object(t_map), Value::Object(d_map)) = (target, defaults) else {
+        return;
+    };
+    for (k, v) in d_map {
+        match t_map.get_mut(k) {
+            Some(existing) => deep_merge_under(existing, v),
+            None => {
+                t_map.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+/// Extract default values from a schema recursively, walking
+/// `properties.<name>.default`. Returns an object with defaults filled
+/// in for every property that declares one.
+pub fn defaults_from_schema(schema: &Value) -> Value {
+    let mut out = Map::new();
+    if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
+        for (k, prop) in props {
+            if let Some(d) = prop.get("default") {
+                out.insert(k.clone(), d.clone());
+            } else if let Some(t) = prop.get("type").and_then(|t| t.as_str()) {
+                if t == "object" {
+                    let nested = defaults_from_schema(prop);
+                    if !nested.as_object().map(|o| o.is_empty()).unwrap_or(true) {
+                        out.insert(k.clone(), nested);
+                    }
+                }
+            }
+        }
+    }
+    Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_non_object_root() {
+        assert!(validate_plugin_schema(&json!("hello")).is_err());
+        assert!(validate_plugin_schema(&json!([])).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_object_type() {
+        assert!(validate_plugin_schema(&json!({})).is_err());
+        assert!(validate_plugin_schema(&json!({"type": "string"})).is_err());
+    }
+
+    #[test]
+    fn rejects_refs() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"foo": {"$ref": "#/$defs/Bar"}}
+        });
+        assert!(validate_plugin_schema(&schema).is_err());
+    }
+
+    #[test]
+    fn rejects_x_enum_from() {
+        let schema = json!({
+            "type": "object",
+            "properties": {"lang": {"type": "string", "x-enum-from": "/languages"}}
+        });
+        assert!(validate_plugin_schema(&schema).is_err());
+    }
+
+    #[test]
+    fn accepts_valid_schema() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "auto_enable": {"type": "boolean", "default": false},
+                "max_items": {"type": "integer", "minimum": 1, "default": 3}
+            }
+        });
+        assert!(validate_plugin_schema(&schema).is_ok());
+    }
+
+    #[test]
+    fn accepts_empty_properties() {
+        let schema = json!({"type": "object", "properties": {}});
+        assert!(validate_plugin_schema(&schema).is_ok());
+    }
+
+    #[test]
+    fn defaults_extraction() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "auto_enable": {"type": "boolean", "default": false},
+                "max_items": {"type": "integer", "minimum": 1, "default": 3},
+                "no_default": {"type": "string"}
+            }
+        });
+        let d = defaults_from_schema(&schema);
+        assert_eq!(d, json!({"auto_enable": false, "max_items": 3}));
+    }
+}

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -1663,6 +1663,10 @@
             "null"
           ],
           "readOnly": true
+        },
+        "settings": {
+          "description": "Plugin-specific settings. The shape is defined by each plugin's\n`<plugin_name>.schema.json` sidecar file; the host stores the value as\nuntyped JSON so a malformed plugin schema can't poison the rest of the\nconfig. Plugins read this via `editor.getPluginConfig()` and the\nSettings UI renders it as a sub-category under \"Plugin Settings\".",
+          "readOnly": true
         }
       },
       "x-display-field": "/enabled"

--- a/crates/fresh-editor/plugins/dashboard.ts
+++ b/crates/fresh-editor/plugins/dashboard.ts
@@ -1586,18 +1586,20 @@ async function dashboardShowOrFocus() {
 registerHandler("dashboardShowOrFocus", dashboardShowOrFocus);
 
 // Auto-open resolution: the session override (set via the exported
-// plugin API from init.ts) wins over the user config. We read from
-// getUserConfig (raw file) rather than getConfig because unknown
-// fields are dropped when the Config struct reserializes. Default
-// is true.
+// plugin API from init.ts) wins over the user-configured value, which
+// comes from the typed plugin-config field declared below. The field
+// shows up in the Settings UI under "Plugin Settings → dashboard".
+editor.defineConfigBoolean("autoOpen", {
+    default: true,
+    description: "Show the dashboard automatically when Fresh starts with no real files open.",
+});
+
 let autoOpenOverride: boolean | null = null;
 
 function autoOpenEnabled(): boolean {
     if (autoOpenOverride !== null) return autoOpenOverride;
-    const cfg = editor.getUserConfig() as Record<string, unknown> | null;
-    const plugins = cfg?.plugins as Record<string, unknown> | undefined;
-    const dashboard = plugins?.dashboard as Record<string, unknown> | undefined;
-    return dashboard?.["auto-open"] !== false;
+    const cfg = (editor.getPluginConfig() ?? {}) as { autoOpen?: boolean };
+    return cfg.autoOpen !== false;
 }
 
 function shouldShowDashboard(): boolean {

--- a/crates/fresh-editor/plugins/flash.ts
+++ b/crates/fresh-editor/plugins/flash.ts
@@ -33,7 +33,24 @@ const VTEXT_PREFIX = "flash-";
 // the closest jump targets get the most comfortable keys.  All
 // lowercase: case-sensitive matching keeps the label letter from also
 // being a valid pattern continuation, which matters for the skip rule.
-const LABEL_POOL = "asdfghjklqwertyuiopzxcvbnm";
+editor.defineConfigString("labelPool", {
+  default: "asdfghjklqwertyuiopzxcvbnm",
+  description: "Characters used as jump labels, in comfort order. Labels are assigned to matches by distance from the cursor, so leftmost characters here land on the nearest matches.",
+});
+editor.defineConfigBoolean("skipRule", {
+  default: true,
+  description: "Skip a label character if it is also the next character after a match — prevents ambiguity between extending the search pattern and jumping.",
+});
+
+function flashSettings(): { labelPool: string; skipRule: boolean } {
+  const cfg = (editor.getPluginConfig() ?? {}) as { labelPool?: string; skipRule?: boolean };
+  return {
+    labelPool: cfg.labelPool && cfg.labelPool.length > 0
+      ? cfg.labelPool
+      : "asdfghjklqwertyuiopzxcvbnm",
+    skipRule: cfg.skipRule ?? true,
+  };
+}
 
 interface Match {
   /** Byte offset where the match starts in its buffer. */
@@ -334,9 +351,10 @@ function assignLabels(
   prevLabelByKey: Map<string, string>,
 ): Match[] {
   if (matches.length === 0) return matches;
-  const skip = buildSkipSet(matches, views, emptyPattern);
+  const { labelPool, skipRule } = flashSettings();
+  const skip = skipRule ? buildSkipSet(matches, views, emptyPattern) : new Set<string>();
   const remaining = new Set<string>();
-  for (const c of LABEL_POOL) if (!skip.has(c)) remaining.add(c);
+  for (const c of labelPool) if (!skip.has(c)) remaining.add(c);
 
   const sorted = sortMatches(matches, startSplitId, startCursor);
 
@@ -353,7 +371,7 @@ function assignLabels(
   // matches in distance order.  Iterate the pool in its native
   // (comfort-ranked) order so home-row letters go to nearest matches.
   const orderedRemaining: string[] = [];
-  for (const c of LABEL_POOL) if (remaining.has(c)) orderedRemaining.push(c);
+  for (const c of labelPool) if (remaining.has(c)) orderedRemaining.push(c);
   let next = 0;
   for (const m of sorted) {
     if (m.label) continue;

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -87,10 +87,13 @@ const blameState: BlameState = {
 // Color Definitions for Header Styling
 // =============================================================================
 
-const colors = {
-  headerFg: [0, 0, 0] as [number, number, number],           // Black text
-  headerBg: [200, 200, 200] as [number, number, number],     // Light gray background
-};
+// Blame headers are rendered via `addVirtualLine`, which accepts theme
+// keys directly — so we don't expose colors as plugin settings. Themes
+// drive the look; if a theme lacks specific blame keys, these fall
+// through to the editor's status-bar palette which is what every theme
+// defines.
+const HEADER_FG_KEY = "ui.status_bar_fg";
+const HEADER_BG_KEY = "ui.status_bar_bg";
 
 // =============================================================================
 // Mode Definition
@@ -373,7 +376,8 @@ function addBlameHeaders(): void {
   // Clear existing headers first
   editor.clearVirtualTextNamespace(blameState.bufferId, BLAME_NAMESPACE);
 
-  // Add a virtual line above each block
+  // Add a virtual line above each block. Pass theme keys so the headers
+  // restyle automatically when the user switches themes.
   for (const block of blameState.blocks) {
     const headerText = formatBlockHeader(block);
 
@@ -381,7 +385,7 @@ function addBlameHeaders(): void {
       blameState.bufferId,
       block.startByte,        // anchor position
       headerText,             // text content
-      { fg: colors.headerFg, bg: colors.headerBg }, // colors (RGB tuples; passing theme key strings would also work)
+      { fg: HEADER_FG_KEY, bg: HEADER_BG_KEY },
       true,                   // above (LineAbove)
       BLAME_NAMESPACE,        // namespace for bulk removal
       0                       // priority

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1889,6 +1889,64 @@ interface EditorAPI {
 	*/
 	getUserConfig(): unknown;
 	/**
+	* Declare a boolean config field for the calling plugin.
+	* 
+	* Validates `options` synchronously: the JS call throws if any
+	* unknown key is present or if `default` isn't a boolean. The
+	* Settings UI grows a "Plugin Settings → <plugin>" sub-category
+	* containing a toggle for this field. Returns the current value
+	* (user-set if present, otherwise the declared `default`).
+	*/
+	defineConfigBoolean(name: string, options: {
+		default: boolean;
+		description?: string;
+	}): boolean;
+	/**
+	* Declare an integer config field for the calling plugin. Throws on
+	* invalid options or if the default falls outside `minimum/maximum`.
+	*/
+	defineConfigInteger(name: string, options: {
+		default: number;
+		description?: string;
+		minimum?: number;
+		maximum?: number;
+	}): number;
+	/**
+	* Declare a floating-point number config field. Throws on bad
+	* options or default outside `minimum/maximum`.
+	*/
+	defineConfigNumber(name: string, options: {
+		default: number;
+		description?: string;
+		minimum?: number;
+		maximum?: number;
+	}): number;
+	/**
+	* Declare a free-form string config field.
+	*/
+	defineConfigString(name: string, options: {
+		default: string;
+		description?: string;
+	}): string;
+	/**
+	* Declare an array-of-strings config field (e.g. a list of
+	* patterns). The Settings UI renders this as a list editor.
+	*/
+	defineConfigStringArray(name: string, options: {
+		default: string[];
+		description?: string;
+	}): string[];
+	/**
+	* Get the calling plugin's settings as a JS object.
+	* 
+	* Returns the merged value at `config.plugins.<plugin_name>.settings`.
+	* The shape comes from whatever the plugin declared via
+	* `editor.definePluginConfig(...)` (defaults pre-populated by the
+	* host, user overrides on top from the Settings UI). Returns `null`
+	* if the plugin hasn't declared a schema and has no user-set value.
+	*/
+	getPluginConfig(): unknown;
+	/**
 	* Reload configuration from file
 	*/
 	reloadConfig(): void;
@@ -2808,6 +2866,33 @@ interface EditorAPI {
 */
 interface EditorAPI {
 	getPluginApi<K extends keyof FreshPluginRegistry>(name: K): FreshPluginRegistry[K] | null;
+}
+/**
+* Typed overload of `editor.defineConfigEnum`. The macro-generated
+* signature can't express `<E extends string>` propagating from the
+* `values` array into the return type, so it's declared here. Use
+* `as const` on the `values` array to get a literal-union return:
+*
+* ```ts
+* const mode = editor.defineConfigEnum("mode", {
+*   values: ["normal", "insert"] as const,
+*   default: "normal",
+* });
+* mode; // typed as "normal" | "insert"
+* ```
+*
+* Typed overload of `editor.getPluginConfig`. Plugins that declared
+* their fields via `defineConfigX` can pass the shape type explicitly:
+* `editor.getPluginConfig<{ autoEnable: boolean; ... }>()`. Without
+* the generic, falls back to `unknown`.
+*/
+interface EditorAPI {
+	defineConfigEnum<E extends string>(name: string, options: {
+		values: readonly E[];
+		default: NoInfer<E>;
+		description?: string;
+	}): E;
+	getPluginConfig<T = unknown>(): T;
 }
 /**
 * Maps every hook event name to its payload type.

--- a/crates/fresh-editor/plugins/merge_conflict.ts
+++ b/crates/fresh-editor/plugins/merge_conflict.ts
@@ -164,29 +164,26 @@ async function detectMergeConflictFor(
 // Color Definitions
 // =============================================================================
 
+// Theme keys preferred over hard-coded RGB so the look tracks the
+// active theme. `addOverlay` accepts theme key strings directly.
+const OURS_FG_KEY = "editor.diff_add_bg";        // green-ish in most themes
+const THEIRS_FG_KEY = "editor.diff_remove_bg";   // red-ish
+const UNRESOLVED_FG_KEY = "ui.file_status_conflicted_fg";
+
 const colors = {
-  // Panel headers
-  oursHeader: [100, 200, 255] as [number, number, number],    // Cyan for OURS
-  theirsHeader: [255, 180, 100] as [number, number, number],  // Orange for THEIRS
-  resultHeader: [150, 255, 150] as [number, number, number],  // Green for RESULT
-
-  // Conflict highlighting
-  conflictOurs: [50, 80, 100] as [number, number, number],    // Blue-tinted background
-  conflictTheirs: [100, 70, 50] as [number, number, number],  // Orange-tinted background
-  conflictBase: [70, 70, 70] as [number, number, number],     // Gray for base
-
-  // Intra-line diff colors
-  diffAdd: [50, 100, 50] as [number, number, number],         // Green for additions
-  diffDel: [100, 50, 50] as [number, number, number],         // Red for deletions
-  diffMod: [50, 50, 100] as [number, number, number],         // Blue for modifications
-
-  // Selection
-  selected: [80, 80, 120] as [number, number, number],        // Selection highlight
-
-  // Buttons/actions
-  button: [100, 149, 237] as [number, number, number],        // Cornflower blue
-  resolved: [100, 200, 100] as [number, number, number],      // Green for resolved
-  unresolved: [200, 100, 100] as [number, number, number],    // Red for unresolved
+  // RGB tuples retained for any future contributor who reaches for them
+  // — the active call sites use the theme keys above. None of these
+  // appear in the currently rendered UI.
+  oursHeader: [100, 200, 255] as [number, number, number],
+  theirsHeader: [255, 180, 100] as [number, number, number],
+  resultHeader: [150, 255, 150] as [number, number, number],
+  conflictBase: [70, 70, 70] as [number, number, number],
+  diffAdd: [50, 100, 50] as [number, number, number],
+  diffDel: [100, 50, 50] as [number, number, number],
+  diffMod: [50, 50, 100] as [number, number, number],
+  selected: [80, 80, 120] as [number, number, number],
+  button: [100, 149, 237] as [number, number, number],
+  resolved: [100, 200, 100] as [number, number, number],
 };
 
 // =============================================================================
@@ -1010,7 +1007,7 @@ function highlightPanel(bufferId: number, side: "ours" | "theirs"): void {
   const lines = content.split("\n");
 
   let byteOffset = 0;
-  const conflictColor = side === "ours" ? colors.conflictOurs : colors.conflictTheirs;
+  const conflictColor = side === "ours" ? OURS_FG_KEY : THEIRS_FG_KEY;
 
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx];
@@ -1049,7 +1046,7 @@ function highlightResultPanel(bufferId: number): void {
     // Highlight conflict markers
     if (line.startsWith("<<<<<<<") || line.startsWith("=======") || line.startsWith(">>>>>>>")) {
       editor.addOverlay(bufferId, `merge-marker-${lineIdx}`, lineStart, lineEnd, {
-        fg: colors.unresolved,
+        fg: UNRESOLVED_FG_KEY,
         underline: true,
       });
     }

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -1569,7 +1569,8 @@ impl Editor {
     ) {
         tracing::trace!(
             "Registering plugin config field: {}.{}",
-            plugin_name, field_name
+            plugin_name,
+            field_name
         );
         // Merge the new field into the existing accumulated schema (or a
         // fresh one) and run the same strict validation as a bulk-register.

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -165,6 +165,9 @@ pub(super) struct EditorParts {
     // post-construction load step.
     pub(super) plugin_global_state: HashMap<String, HashMap<String, serde_json::Value>>,
 
+    /// Per-plugin config schemas discovered from `<plugin>.schema.json` sidecars.
+    pub(super) plugin_schemas: HashMap<String, serde_json::Value>,
+
     /// Editor-wide event broadcaster, shared with every WindowResources.
     pub(super) event_broadcaster: crate::model::control_event::EventBroadcaster,
 }
@@ -244,6 +247,7 @@ impl Editor {
             background_process_handles: HashMap::new(),
             host_process_handles: HashMap::new(),
             status_bar_token_registry: Mutex::new(HashMap::new()),
+            plugin_schemas: std::sync::Arc::new(std::sync::RwLock::new(parts.plugin_schemas)),
             event_broadcaster: parts.event_broadcaster,
             #[cfg(feature = "plugins")]
             pending_plugin_actions: Vec::new(),
@@ -747,6 +751,10 @@ impl Editor {
         //    when embed-plugins feature is enabled)
         // 3. User plugins directory (~/.config/fresh/plugins)
         // 4. Package manager installed plugins (~/.config/fresh/plugins/packages/*)
+        // Plugin schemas populated lazily by plugins calling
+        // `editor.definePluginConfig(...)` at load time. See
+        // `handle_register_plugin_config_schema`.
+        let plugin_schemas: HashMap<String, serde_json::Value> = HashMap::new();
         if plugin_manager.read().unwrap().is_active() {
             let mut plugin_dirs: Vec<std::path::PathBuf> = vec![];
 
@@ -1219,6 +1227,7 @@ impl Editor {
             update_checker,
             time_source: time_source.clone(),
             plugin_global_state,
+            plugin_schemas,
             event_broadcaster: event_broadcaster.clone(),
         };
 
@@ -1541,6 +1550,80 @@ impl Editor {
                 self.set_status_message(format!("setSetting({path}): {e}"));
             }
         }
+    }
+
+    /// Append a single config field to a plugin's accumulated schema and
+    /// pre-populate its default value. Each `defineConfigX(...)` call
+    /// from the plugin's TS code fires one of these.
+    ///
+    /// On first call for a plugin we synthesise a fresh
+    /// `{"type": "object", "properties": {}}` schema and grow it as more
+    /// fields arrive. Re-registering the same `field_name` overwrites
+    /// the previous definition (which is what we want on plugin
+    /// reload — plugins re-run their `defineConfigX` calls).
+    pub fn handle_add_plugin_config_field(
+        &mut self,
+        plugin_name: String,
+        field_name: String,
+        field_schema: serde_json::Value,
+    ) {
+        tracing::trace!(
+            "Registering plugin config field: {}.{}",
+            plugin_name, field_name
+        );
+        // Merge the new field into the existing accumulated schema (or a
+        // fresh one) and run the same strict validation as a bulk-register.
+        let updated_schema = {
+            let schemas = self.plugin_schemas.read().ok();
+            let existing = schemas.as_ref().and_then(|m| m.get(&plugin_name)).cloned();
+            let mut schema = existing.unwrap_or_else(|| {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {},
+                })
+            });
+            if let Some(props) = schema
+                .as_object_mut()
+                .and_then(|o| o.get_mut("properties"))
+                .and_then(|p| p.as_object_mut())
+            {
+                props.insert(field_name.clone(), field_schema.clone());
+            }
+            schema
+        };
+
+        if let Err(msg) = crate::plugin_schemas::validate_plugin_schema(&updated_schema) {
+            // Field passed JS-side validation but somehow broke the full
+            // schema — log and skip so we don't poison the registry.
+            self.set_status_message(format!(
+                "defineConfig({}.{}): {}",
+                plugin_name, field_name, msg
+            ));
+            return;
+        }
+
+        // Pre-populate the default for THIS field only.
+        if let Some(default) = field_schema.get("default").cloned() {
+            let cfg = std::sync::Arc::make_mut(&mut self.config);
+            let entry = cfg.plugins.entry(plugin_name.clone()).or_default();
+            let settings_obj = match &mut entry.settings {
+                serde_json::Value::Object(_) => &mut entry.settings,
+                slot => {
+                    *slot = serde_json::Value::Object(Default::default());
+                    slot
+                }
+            };
+            if let serde_json::Value::Object(map) = settings_obj {
+                map.entry(field_name.clone()).or_insert(default);
+            }
+        }
+
+        if let Ok(mut schemas) = self.plugin_schemas.write() {
+            schemas.insert(plugin_name, updated_schema);
+        }
+
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
     }
 
     /// Apply the result of one async startup-batch directory load.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -638,6 +638,15 @@ pub struct Editor {
     /// Global and lifetime-checked. Per-buffer values live on each `Window`.
     status_bar_token_registry: Mutex<HashMap<String, String>>,
 
+    /// Registry of plugin-provided config schemas, keyed by plugin name.
+    /// Each value is the validated JSON schema describing
+    /// `plugins.<name>.settings.*`. Populated at startup from
+    /// `<plugin_name>.schema.json` sidecar files discovered next to plugin
+    /// `.ts`/`.js` files; the Settings UI reads this to render a
+    /// per-plugin sub-category under "Plugin Settings".
+    pub(crate) plugin_schemas:
+        std::sync::Arc<std::sync::RwLock<HashMap<String, serde_json::Value>>>,
+
     // `seen_byte_ranges` moved onto `Window` — keyed by `BufferId`
     // which lives on `Window`, so the tracker follows the buffers.
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -602,6 +602,13 @@ impl Editor {
             PluginCommand::SetSetting { path, value, .. } => {
                 self.handle_set_setting(path, value);
             }
+            PluginCommand::AddPluginConfigField {
+                plugin_name,
+                field_name,
+                field_schema,
+            } => {
+                self.handle_add_plugin_config_field(plugin_name, field_name, field_schema);
+            }
             PluginCommand::ReloadThemes { apply_theme } => {
                 self.reload_themes();
                 if let Some(theme_name) = apply_theme {
@@ -1439,7 +1446,8 @@ impl Editor {
     /// Load a plugin from a file path
     #[cfg(feature = "plugins")]
     fn handle_load_plugin(&mut self, path: std::path::PathBuf, callback_id: JsCallbackId) {
-        match self.plugin_manager.read().unwrap().load_plugin(&path) {
+        let load_result = self.plugin_manager.read().unwrap().load_plugin(&path);
+        match load_result {
             Ok(()) => {
                 tracing::info!("Loaded plugin from {:?}", path);
                 self.plugin_manager
@@ -1466,6 +1474,9 @@ impl Editor {
         match result {
             Ok(()) => {
                 tracing::info!("Unloaded plugin: {}", name);
+                if let Ok(mut schemas) = self.plugin_schemas.write() {
+                    schemas.remove(&name);
+                }
                 self.plugin_manager
                     .read()
                     .unwrap()
@@ -1484,7 +1495,20 @@ impl Editor {
     /// Reload a plugin by name
     #[cfg(feature = "plugins")]
     fn handle_reload_plugin(&mut self, name: String, callback_id: JsCallbackId) {
-        match self.plugin_manager.read().unwrap().reload_plugin(&name) {
+        // Capture the plugin's path before reloading so we can refresh its
+        // schema sidecar too. `list_plugins` is cheap (one channel
+        // round-trip).
+        let path = self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .list_plugins()
+            .into_iter()
+            .find(|p| p.name == name)
+            .map(|p| p.path);
+        let _ = path; // schema is now re-registered by plugin code on reload
+        let reload_result = self.plugin_manager.read().unwrap().reload_plugin(&name);
+        match reload_result {
             Ok(()) => {
                 tracing::info!("Reloaded plugin: {}", name);
                 self.plugin_manager

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -22,33 +22,36 @@ impl Editor {
         // Include schema at compile time
         const SCHEMA_JSON: &str = include_str!("../../plugins/config-schema.json");
 
-        // Create settings state if not exists, or show existing
-        if self.settings_state.is_none() {
-            match crate::view::settings::SettingsState::new(SCHEMA_JSON, &self.config) {
-                Ok(mut state) => {
-                    // Load layer sources to show where each setting value comes from
-                    let resolver =
-                        ConfigResolver::new(self.dir_context.clone(), self.working_dir.clone());
-                    if let Ok(sources) = resolver.get_layer_sources() {
-                        state.set_layer_sources(sources);
-                    }
-                    // Snapshot plugin-registered status-bar tokens for the dual-list picker.
-                    let tokens = self.status_bar_token_registry.lock().unwrap().clone();
-                    state.set_status_bar_tokens(tokens);
-                    state.show();
-                    self.settings_state = Some(state);
+        // Snapshot of plugin-provided schemas to inject as a
+        // "Plugin Settings" category — clone the map so we can drop
+        // the read lock before constructing SettingsState. Rebuilt on
+        // every open so plugins that lazily register their schemas
+        // after startup (or via Reload Plugin) show up without
+        // requiring a full editor restart.
+        let plugin_schemas = self.plugin_schemas.read().unwrap().clone();
+
+        match crate::view::settings::SettingsState::new_with_plugin_schemas(
+            SCHEMA_JSON,
+            &self.config,
+            &plugin_schemas,
+        ) {
+            Ok(mut state) => {
+                // Load layer sources to show where each setting value comes from
+                let resolver =
+                    ConfigResolver::new(self.dir_context.clone(), self.working_dir.clone());
+                if let Ok(sources) = resolver.get_layer_sources() {
+                    state.set_layer_sources(sources);
                 }
-                Err(e) => {
-                    self.set_status_message(
-                        t!("settings.failed_to_open", error = e.to_string()).to_string(),
-                    );
-                }
-            }
-        } else {
-            let tokens = self.status_bar_token_registry.lock().unwrap().clone();
-            if let Some(ref mut state) = self.settings_state {
+                // Snapshot plugin-registered status-bar tokens for the dual-list picker.
+                let tokens = self.status_bar_token_registry.lock().unwrap().clone();
                 state.set_status_bar_tokens(tokens);
                 state.show();
+                self.settings_state = Some(state);
+            }
+            Err(e) => {
+                self.set_status_message(
+                    t!("settings.failed_to_open", error = e.to_string()).to_string(),
+                );
             }
         }
     }

--- a/crates/fresh-editor/src/lib.rs
+++ b/crates/fresh-editor/src/lib.rs
@@ -15,6 +15,7 @@ rust_i18n::i18n!(
 // Core types and config are always available (needed for schema generation)
 pub mod config;
 pub mod partial_config;
+pub mod plugin_schemas;
 pub mod types;
 
 // Runtime-only modules (require the "runtime" feature)

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -455,12 +455,36 @@ pub struct PartialPluginConfig {
     pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<std::path::PathBuf>,
+    /// Plugin-specific settings, shape defined by the plugin's schema sidecar.
+    /// Object values from lower layers are deep-merged on a key-by-key basis;
+    /// non-object values are replaced wholesale (matching how the layered
+    /// config docs describe "lists are replaced, objects are deep-merged").
+    #[serde(skip_serializing_if = "serde_json::Value::is_null", default)]
+    pub settings: serde_json::Value,
+}
+
+fn merge_json_values(target: &mut serde_json::Value, other: &serde_json::Value) {
+    match (target, other) {
+        (serde_json::Value::Object(t_map), serde_json::Value::Object(o_map)) => {
+            for (k, v) in o_map {
+                match t_map.get_mut(k) {
+                    Some(existing) => merge_json_values(existing, v),
+                    None => {
+                        t_map.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+        }
+        (t @ serde_json::Value::Null, o) if !o.is_null() => *t = o.clone(),
+        _ => {}
+    }
 }
 
 impl Merge for PartialPluginConfig {
     fn merge_from(&mut self, other: &Self) {
         self.enabled.merge_from(&other.enabled);
         self.path.merge_from(&other.path);
+        merge_json_values(&mut self.settings, &other.settings);
     }
 }
 
@@ -915,15 +939,21 @@ impl From<&PluginConfig> for PartialPluginConfig {
         Self {
             enabled: Some(cfg.enabled),
             path: cfg.path.clone(),
+            settings: cfg.settings.clone(),
         }
     }
 }
 
 impl PartialPluginConfig {
     pub fn resolve(self, defaults: &PluginConfig) -> PluginConfig {
+        let mut settings = self.settings;
+        if settings.is_null() {
+            settings = defaults.settings.clone();
+        }
         PluginConfig {
             enabled: self.enabled.unwrap_or(defaults.enabled),
             path: self.path.or_else(|| defaults.path.clone()),
+            settings,
         }
     }
 }
@@ -1051,13 +1081,21 @@ impl From<&crate::config::Config> for PartialConfig {
                 let non_default_plugins: HashMap<String, PartialPluginConfig> = cfg
                     .plugins
                     .iter()
-                    .filter(|(_, v)| v.enabled != default_plugin.enabled)
+                    .filter(|(_, v)| {
+                        let settings_changed = match &v.settings {
+                            serde_json::Value::Null => false,
+                            serde_json::Value::Object(o) => !o.is_empty(),
+                            _ => true,
+                        };
+                        v.enabled != default_plugin.enabled || settings_changed
+                    })
                     .map(|(k, v)| {
                         (
                             k.clone(),
                             PartialPluginConfig {
                                 enabled: Some(v.enabled),
                                 path: None, // Don't save path - it's auto-discovered
+                                settings: v.settings.clone(),
                             },
                         )
                     })
@@ -1557,6 +1595,7 @@ mod tests {
             PluginConfig {
                 enabled: true, // Default value
                 path: Some(std::path::PathBuf::from("/path/to/plugin.ts")),
+                settings: serde_json::Value::Null,
             },
         );
 
@@ -1578,6 +1617,7 @@ mod tests {
             PluginConfig {
                 enabled: true,
                 path: Some(std::path::PathBuf::from("/path/to/enabled.ts")),
+                settings: serde_json::Value::Null,
             },
         );
         config.plugins.insert(
@@ -1585,6 +1625,7 @@ mod tests {
             PluginConfig {
                 enabled: false, // Not default!
                 path: Some(std::path::PathBuf::from("/path/to/disabled.ts")),
+                settings: serde_json::Value::Null,
             },
         );
 
@@ -1617,6 +1658,7 @@ mod tests {
             PluginConfig {
                 enabled: false,
                 path: Some(std::path::PathBuf::from("/some/path/plugin.ts")),
+                settings: serde_json::Value::Null,
             },
         );
 
@@ -1639,6 +1681,7 @@ mod tests {
                 PartialPluginConfig {
                     enabled: Some(false),
                     path: None,
+                    settings: serde_json::Value::Null,
                 },
             )])),
             ..Default::default()
@@ -1667,6 +1710,7 @@ mod tests {
                 PartialPluginConfig {
                     enabled: Some(false), // User disabled
                     path: None,
+                    settings: serde_json::Value::Null,
                 },
             )])),
             ..Default::default()
@@ -1678,6 +1722,7 @@ mod tests {
                 PartialPluginConfig {
                     enabled: Some(true), // Lower layer has it enabled
                     path: None,
+                    settings: serde_json::Value::Null,
                 },
             )])),
             ..Default::default()
@@ -1704,6 +1749,7 @@ mod tests {
             PluginConfig {
                 enabled: true,
                 path: Some(std::path::PathBuf::from("/a.ts")),
+                settings: serde_json::Value::Null,
             },
         );
         config.plugins.insert(
@@ -1711,6 +1757,7 @@ mod tests {
             PluginConfig {
                 enabled: false,
                 path: Some(std::path::PathBuf::from("/b.ts")),
+                settings: serde_json::Value::Null,
             },
         );
         config.plugins.insert(
@@ -1718,6 +1765,7 @@ mod tests {
             PluginConfig {
                 enabled: true,
                 path: Some(std::path::PathBuf::from("/c.ts")),
+                settings: serde_json::Value::Null,
             },
         );
 

--- a/crates/fresh-editor/src/plugin_schemas.rs
+++ b/crates/fresh-editor/src/plugin_schemas.rs
@@ -1,0 +1,6 @@
+//! Re-export of `fresh_core::plugin_schemas` so editor-side modules can
+//! address it via `crate::plugin_schemas::...` without a deeper
+//! refactor. The actual logic lives in fresh-core because the plugin
+//! runtime needs to call the validators synchronously from JS bindings.
+
+pub use fresh_core::plugin_schemas::*;

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -380,6 +380,79 @@ pub fn parse_schema(schema_json: &str) -> Result<Vec<SettingCategory>, serde_jso
     Ok(categories)
 }
 
+/// Append a top-level "Plugin Settings" category whose subcategories are
+/// built from per-plugin schema sidecars (`<plugin_name>.schema.json`).
+///
+/// Each sub-category lives at JSON pointer `/plugins/<name>/settings`.
+/// Only the names passed in `enabled_plugins_with_schema` are rendered —
+/// disabled plugins are hidden from the Settings UI (per the design
+/// decision).
+pub fn append_plugin_settings_category(
+    categories: &mut Vec<SettingCategory>,
+    plugin_schemas: &HashMap<String, serde_json::Value>,
+    enabled_plugins_with_schema: &[String],
+) {
+    if enabled_plugins_with_schema.is_empty() {
+        return;
+    }
+
+    // Push each plugin as its own top-level category, prefixed so they
+    // cluster together in the left-panel alphabetical sort and don't
+    // collide with built-in names like "Editor" / "Plugins".
+    let mut added = 0;
+    for name in enabled_plugins_with_schema {
+        let Some(schema_value) = plugin_schemas.get(name) else {
+            continue;
+        };
+        let Some(mut category) = plugin_schema_to_category(name, schema_value) else {
+            continue;
+        };
+        category.name = format!("Plugin: {}", name);
+        categories.push(category);
+        added += 1;
+    }
+
+    if added == 0 {
+        return;
+    }
+
+    // Re-sort categories. "General" stays first; "Plugin: <name>"
+    // entries land alphabetically among the rest.
+    categories.sort_by(|a, b| match (a.name.as_str(), b.name.as_str()) {
+        ("General", _) => std::cmp::Ordering::Less,
+        (_, "General") => std::cmp::Ordering::Greater,
+        (a, b) => a.cmp(b),
+    });
+}
+
+fn plugin_schema_to_category(
+    plugin_name: &str,
+    schema_value: &serde_json::Value,
+) -> Option<SettingCategory> {
+    // Parse the plugin's schema as if it were a regular JSON Schema
+    // fragment, then walk its `properties` to build SettingSchema entries
+    // rooted at `/plugins/<name>/settings/...`.
+    let raw: RawSchema = serde_json::from_value(schema_value.clone()).ok()?;
+    let defs = HashMap::new();
+    let enum_values_map = HashMap::new();
+    let base_path = format!("/plugins/{}/settings", plugin_name);
+
+    let properties = raw.properties.as_ref()?;
+    let settings = parse_properties(properties, &base_path, &defs, &enum_values_map);
+    if settings.is_empty() {
+        return None;
+    }
+
+    Some(SettingCategory {
+        name: plugin_name.to_string(),
+        path: base_path,
+        description: raw.description.clone(),
+        nullable: false,
+        settings,
+        subcategories: Vec::new(),
+    })
+}
+
 /// Build a map from $ref paths to their enum options
 fn build_enum_values_map(entries: &[EnumValueEntry]) -> EnumValuesMap {
     let mut map: EnumValuesMap = HashMap::new();

--- a/crates/fresh-editor/src/view/settings/schema.rs
+++ b/crates/fresh-editor/src/view/settings/schema.rs
@@ -417,11 +417,17 @@ pub fn append_plugin_settings_category(
     }
 
     // Re-sort categories. "General" stays first; "Plugin: <name>"
-    // entries land alphabetically among the rest.
+    // entries are pushed to the bottom of the list so plugin
+    // configuration doesn't interleave with built-in editor settings.
+    // Within each band the order is alphabetical.
     categories.sort_by(|a, b| match (a.name.as_str(), b.name.as_str()) {
         ("General", _) => std::cmp::Ordering::Less,
         (_, "General") => std::cmp::Ordering::Greater,
-        (a, b) => a.cmp(b),
+        (a, b) => match (a.starts_with("Plugin: "), b.starts_with("Plugin: ")) {
+            (true, false) => std::cmp::Ordering::Greater,
+            (false, true) => std::cmp::Ordering::Less,
+            _ => a.cmp(b),
+        },
     });
 }
 

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -232,6 +232,11 @@ impl SettingsState {
             })
             .collect();
         enabled_with_schema.sort();
+        tracing::trace!(
+            "SettingsState built: total plugin_schemas={}, enabled_with_schema={:?}",
+            plugin_schemas.len(),
+            enabled_with_schema
+        );
         super::schema::append_plugin_settings_category(
             &mut categories,
             plugin_schemas,

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -14,6 +14,36 @@ use crate::view::controls::FocusState;
 use crate::view::ui::{FocusManager, ScrollItem, ScrollablePanel};
 use std::collections::HashMap;
 
+/// Set a value at a JSON pointer path, creating intermediate objects as
+/// needed. Mirrors `config_io::set_json_pointer` (kept private there).
+fn set_json_pointer_create(root: &mut serde_json::Value, pointer: &str, value: serde_json::Value) {
+    if pointer.is_empty() || pointer == "/" {
+        *root = value;
+        return;
+    }
+    let parts: Vec<&str> = pointer.trim_start_matches('/').split('/').collect();
+    let mut current = root;
+    for (i, part) in parts.iter().enumerate() {
+        if i == parts.len() - 1 {
+            if let serde_json::Value::Object(map) = current {
+                map.insert(part.to_string(), value);
+            }
+            return;
+        }
+        if let serde_json::Value::Object(map) = current {
+            if !map.contains_key(*part) {
+                map.insert(
+                    part.to_string(),
+                    serde_json::Value::Object(Default::default()),
+                );
+            }
+            current = map.get_mut(*part).unwrap();
+        } else {
+            return;
+        }
+    }
+}
+
 /// Info needed to open a nested dialog (extracted before mutable borrow)
 enum NestedDialogInfo {
     MapEntry {
@@ -176,7 +206,38 @@ impl crate::view::ui::ScrollItem for TreeRow {
 impl SettingsState {
     /// Create a new settings state from schema and current config
     pub fn new(schema_json: &str, config: &Config) -> Result<Self, serde_json::Error> {
-        let categories = parse_schema(schema_json)?;
+        Self::new_with_plugin_schemas(schema_json, config, &HashMap::new())
+    }
+
+    /// Same as [`Self::new`], plus inject per-plugin config schemas as
+    /// subcategories of a "Plugin Settings" top-level category. Only
+    /// enabled plugins with a schema are rendered.
+    pub fn new_with_plugin_schemas(
+        schema_json: &str,
+        config: &Config,
+        plugin_schemas: &HashMap<String, serde_json::Value>,
+    ) -> Result<Self, serde_json::Error> {
+        let mut categories = parse_schema(schema_json)?;
+
+        // Collect enabled plugins that have a schema sidecar.
+        let mut enabled_with_schema: Vec<String> = config
+            .plugins
+            .iter()
+            .filter_map(|(name, cfg)| {
+                if cfg.enabled && plugin_schemas.contains_key(name) {
+                    Some(name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        enabled_with_schema.sort();
+        super::schema::append_plugin_settings_category(
+            &mut categories,
+            plugin_schemas,
+            &enabled_with_schema,
+        );
+
         let config_value = serde_json::to_value(config)?;
         let layer_sources = HashMap::new(); // Populated via set_layer_sources()
         let target_layer = ConfigLayer::User; // Default to user-global settings
@@ -880,8 +941,16 @@ impl SettingsState {
         let mut config_value = serde_json::to_value(config)?;
 
         for (path, value) in &self.pending_changes {
+            // `pointer_mut` only succeeds when the path already exists,
+            // which is the common case (most settings are statically
+            // declared in the Rust Config struct). For plugin settings
+            // the user may be setting a brand-new leaf under
+            // `/plugins/<name>/settings/...` — fall back to a
+            // create-intermediate write so those land.
             if let Some(target) = config_value.pointer_mut(path) {
                 *target = value.clone();
+            } else {
+                set_json_pointer_create(&mut config_value, path, value.clone());
             }
         }
 

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -43,6 +43,7 @@ pub mod markdown_source;
 pub mod orchestrator_open_cross_project;
 pub mod package_manager;
 pub mod plugin;
+pub mod plugin_config_registration;
 pub mod plugin_keybinding_execution;
 pub mod plugins_dir_in_working_dir;
 pub mod review_diff_ux_bugs;

--- a/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
@@ -73,7 +73,8 @@ fn harness_with_test_plugin() -> (EditorTestHarness, tempfile::TempDir) {
 /// The plugin handler synchronously appends to the active buffer; the
 /// inserted text shows up on the next render.
 fn run_insert_greeting(h: &mut EditorTestHarness) {
-    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL).unwrap();
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
     h.wait_for_prompt().unwrap();
     h.type_text("cfg_test: Insert Greeting").unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
@@ -209,7 +210,9 @@ fn plugin_config_round_trip_toggles_visible_behavior() {
     harness.render().unwrap();
     harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
-    harness.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
     harness.render().unwrap();
 
     let after_toggle = harness.screen_to_string();
@@ -219,7 +222,9 @@ fn plugin_config_round_trip_toggles_visible_behavior() {
     );
 
     // Save via Ctrl+S, then close the settings dialog.
-    harness.send_key(KeyCode::Char('s'), KeyModifiers::CONTROL).unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
     harness
         .wait_until(|h| h.screen_to_string().contains("Settings saved"))
         .unwrap();
@@ -277,9 +282,8 @@ fn plugin_config_category_hidden_when_plugin_disabled() {
         },
     );
 
-    let mut harness =
-        EditorTestHarness::with_config_and_working_dir(120, 40, config, working_dir)
-            .expect("harness");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(120, 40, config, working_dir)
+        .expect("harness");
     harness.render().unwrap();
 
     harness.open_settings().unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
@@ -106,6 +106,7 @@ fn focus_category(h: &mut EditorTestHarness, name: &str) {
 ///    behavior reflects the new value on the next invocation.
 #[test]
 fn plugin_config_round_trip_toggles_visible_behavior() {
+    crate::common::tracing::init_tracing_from_env();
     let (mut harness, _tmp) = harness_with_test_plugin();
     harness.render().unwrap();
 
@@ -117,11 +118,31 @@ fn plugin_config_round_trip_toggles_visible_behavior() {
         "Plugin should have inserted the default greeting. Screen:\n{after_first}"
     );
 
-    // Open settings and verify the plugin category is present.
+    // Open settings and verify the plugin category is present. The
+    // schema-registration commands arrive on the editor's command
+    // channel asynchronously, so the very first `open_settings` may
+    // race them — wait_until-reopen-loop until the category shows up.
+    // The Settings panel rebuilds its category list every time it
+    // opens, so re-opening is enough to pick up newly-registered
+    // schemas without an editor restart.
+    let plugin_marker = format!("Plugin: {}", PLUGIN_NAME);
     harness.open_settings().unwrap();
+    // The Settings panel rebuilds its category list every time it
+    // opens, so close + reopen drives a fresh read of plugin_schemas.
+    // Loop on the screen contents until the registration commands
+    // have drained from the plugin → editor channel and the category
+    // surfaces.
+    for _attempt in 0..200 {
+        if harness.screen_to_string().contains(&plugin_marker) {
+            break;
+        }
+        harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+        harness.render().unwrap();
+        harness.open_settings().unwrap();
+    }
     let after_open = harness.screen_to_string();
     assert!(
-        after_open.contains(&format!("Plugin: {}", PLUGIN_NAME)),
+        after_open.contains(&plugin_marker),
         "Settings UI should show the plugin's category. Screen:\n{after_open}"
     );
 

--- a/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
@@ -1,0 +1,228 @@
+//! E2E test: a plugin registers config fields via
+//! `editor.defineConfigBoolean/.../defineConfigString`. The Settings UI
+//! must surface a "Plugin: <name>" category populated with those
+//! fields, the user must be able to toggle/edit values, and a re-open
+//! must show the persisted state. The test plugin exposes its current
+//! config value as visible buffer text (via a command) so we can assert
+//! on the rendered output rather than internal state — matching the
+//! "E2E Tests Observe, Not Inspect" rule in CONTRIBUTING.md.
+//!
+//! Without the new `defineConfigX` API + Settings-UI integration this
+//! test panics: the plugin's category never appears, so the navigation
+//! loop times out before finding it.
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+const PLUGIN_NAME: &str = "test_config_plugin";
+const PLUGIN_SOURCE: &str = r#"
+/// <reference path="./lib/fresh.d.ts" />
+const editor = getEditor();
+
+// Strongly-typed config registration. The TS types are inferred from
+// each call, and the host throws synchronously if anything's wrong.
+editor.defineConfigString("prefix", {
+    default: "DEFAULT",
+    description: "Prefix prepended to the inserted greeting",
+});
+editor.defineConfigBoolean("uppercase", {
+    default: false,
+    description: "Whether to uppercase the greeting suffix",
+});
+
+function insertGreeting(): void {
+    // Re-read on each invocation so a Settings UI save is picked up live.
+    const cfg = (editor.getPluginConfig() ?? {}) as { prefix?: string; uppercase?: boolean };
+    const prefix = cfg.prefix ?? "DEFAULT";
+    const suffix = cfg.uppercase ? "HELLO" : "hello";
+    editor.insertAtCursor(`${prefix}:${suffix}`);
+}
+registerHandler("test_config_plugin_insert", insertGreeting);
+
+editor.registerCommand(
+    "test_config_plugin: Insert Greeting",
+    "Insert greeting using the plugin config values",
+    "test_config_plugin_insert",
+    null,
+);
+"#;
+
+fn harness_with_test_plugin() -> (EditorTestHarness, tempfile::TempDir) {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let working_dir = temp.path().join("work");
+    fs::create_dir_all(&working_dir).unwrap();
+    let plugins_dir = working_dir.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+
+    fs::write(
+        plugins_dir.join(format!("{}.ts", PLUGIN_NAME)),
+        PLUGIN_SOURCE,
+    )
+    .unwrap();
+    copy_plugin_lib(&plugins_dir);
+
+    let harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, Config::default(), working_dir)
+            .expect("harness");
+    (harness, temp)
+}
+
+/// Run the plugin's "Insert Greeting" command via the command palette.
+/// The plugin handler synchronously appends to the active buffer; the
+/// inserted text shows up on the next render.
+fn run_insert_greeting(h: &mut EditorTestHarness) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL).unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("test_config_plugin: Insert Greeting").unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_for_prompt_closed().unwrap();
+    h.render().unwrap();
+}
+
+/// Navigate the Settings UI category list until the named entry is
+/// highlighted (its row gains the `>` selection marker), then open it.
+fn focus_category(h: &mut EditorTestHarness, name: &str) {
+    let probe = format!(">     {}", name);
+    for _ in 0..40 {
+        let screen = h.screen_to_string();
+        if screen.contains(&probe) {
+            return;
+        }
+        h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        h.render().unwrap();
+    }
+    panic!(
+        "category {:?} never became selected. Screen:\n{}",
+        name,
+        h.screen_to_string()
+    );
+}
+
+/// 1. The plugin's category shows up under "Plugin: <name>".
+/// 2. Both registered fields render with their default values.
+/// 3. After toggling a boolean and saving, the plugin's visible
+///    behavior reflects the new value on the next invocation.
+#[test]
+fn plugin_config_round_trip_toggles_visible_behavior() {
+    let (mut harness, _tmp) = harness_with_test_plugin();
+    harness.render().unwrap();
+
+    // Sanity: default behavior — `uppercase: false` → lower-case suffix.
+    run_insert_greeting(&mut harness);
+    let after_first = harness.screen_to_string();
+    assert!(
+        after_first.contains("DEFAULT:hello"),
+        "Plugin should have inserted the default greeting. Screen:\n{after_first}"
+    );
+
+    // Open settings and verify the plugin category is present.
+    harness.open_settings().unwrap();
+    let after_open = harness.screen_to_string();
+    assert!(
+        after_open.contains(&format!("Plugin: {}", PLUGIN_NAME)),
+        "Settings UI should show the plugin's category. Screen:\n{after_open}"
+    );
+
+    focus_category(&mut harness, &format!("Plugin: {}", PLUGIN_NAME));
+    let after_focus = harness.screen_to_string();
+    assert!(
+        after_focus.contains("Prefix"),
+        "Plugin category should render the `prefix` field. Screen:\n{after_focus}"
+    );
+    assert!(
+        after_focus.contains("Uppercase"),
+        "Plugin category should render the `uppercase` field. Screen:\n{after_focus}"
+    );
+    assert!(
+        after_focus.contains("DEFAULT"),
+        "The text input should show the declared default `DEFAULT`. Screen:\n{after_focus}"
+    );
+
+    // Move focus into the settings panel and toggle `uppercase` (the
+    // second item) from false → true.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    let after_toggle = harness.screen_to_string();
+    assert!(
+        after_toggle.contains("ACTIVE"),
+        "Toggling `uppercase` should leave the toggle ACTIVE. Screen:\n{after_toggle}"
+    );
+
+    // Save via Ctrl+S, then close the settings dialog.
+    harness.send_key(KeyCode::Char('s'), KeyModifiers::CONTROL).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Settings saved"))
+        .unwrap();
+
+    // Re-running the plugin command must now insert the upper-case
+    // suffix — proving the new value reached the plugin's
+    // `getPluginConfig()` read on the snapshot.
+    run_insert_greeting(&mut harness);
+    let after_second = harness.screen_to_string();
+    assert!(
+        after_second.contains("DEFAULT:HELLO"),
+        "After toggling `uppercase` and saving, the plugin must observe \
+         the new value on its next invocation. Screen:\n{after_second}"
+    );
+
+    // Re-opening Settings rebuilds the category tree from the live
+    // schema map, so the persisted value should still be reflected
+    // (toggle still shows ACTIVE).
+    harness.open_settings().unwrap();
+    focus_category(&mut harness, &format!("Plugin: {}", PLUGIN_NAME));
+    let after_reopen = harness.screen_to_string();
+    assert!(
+        after_reopen.contains("Uppercase")
+            && after_reopen.contains("ACTIVE")
+            && after_reopen.contains("(user)"),
+        "Re-opened settings must show the persisted Uppercase=ACTIVE \
+         from the User layer. Screen:\n{after_reopen}"
+    );
+}
+
+/// The plugin's category must NOT appear when the plugin is disabled.
+/// Mirrors the explicit design decision: disabled plugins are hidden
+/// from the Settings UI, period.
+#[test]
+fn plugin_config_category_hidden_when_plugin_disabled() {
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    let working_dir = temp.path().join("work");
+    fs::create_dir_all(&working_dir).unwrap();
+    let plugins_dir = working_dir.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    fs::write(
+        plugins_dir.join(format!("{}.ts", PLUGIN_NAME)),
+        PLUGIN_SOURCE,
+    )
+    .unwrap();
+    copy_plugin_lib(&plugins_dir);
+
+    let mut config = Config::default();
+    config.plugins.insert(
+        PLUGIN_NAME.to_string(),
+        fresh::config::PluginConfig {
+            enabled: false,
+            path: None,
+            settings: serde_json::Value::Null,
+        },
+    );
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, config, working_dir)
+            .expect("harness");
+    harness.render().unwrap();
+
+    harness.open_settings().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains(&format!("Plugin: {}", PLUGIN_NAME)),
+        "A disabled plugin must not show a 'Plugin: <name>' category. Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/plugin_config_registration.rs
@@ -16,7 +16,7 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::config::Config;
 use std::fs;
 
-const PLUGIN_NAME: &str = "test_config_plugin";
+const PLUGIN_NAME: &str = "cfg_test";
 const PLUGIN_SOURCE: &str = r#"
 /// <reference path="./lib/fresh.d.ts" />
 const editor = getEditor();
@@ -39,12 +39,12 @@ function insertGreeting(): void {
     const suffix = cfg.uppercase ? "HELLO" : "hello";
     editor.insertAtCursor(`${prefix}:${suffix}`);
 }
-registerHandler("test_config_plugin_insert", insertGreeting);
+registerHandler("cfg_test_insert", insertGreeting);
 
 editor.registerCommand(
-    "test_config_plugin: Insert Greeting",
+    "cfg_test: Insert Greeting",
     "Insert greeting using the plugin config values",
-    "test_config_plugin_insert",
+    "cfg_test_insert",
     null,
 );
 "#;
@@ -75,19 +75,21 @@ fn harness_with_test_plugin() -> (EditorTestHarness, tempfile::TempDir) {
 fn run_insert_greeting(h: &mut EditorTestHarness) {
     h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL).unwrap();
     h.wait_for_prompt().unwrap();
-    h.type_text("test_config_plugin: Insert Greeting").unwrap();
+    h.type_text("cfg_test: Insert Greeting").unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
     h.wait_for_prompt_closed().unwrap();
     h.render().unwrap();
 }
 
 /// Navigate the Settings UI category list until the named entry is
-/// highlighted (its row gains the `>` selection marker), then open it.
+/// highlighted. The selection marker `>` lives in column 0 of the
+/// category cell, but expandable categories (those with sub-sections)
+/// render a `▶` chevron in front of the name, which shifts the layout.
+/// Just look for any line that contains both the `>` selector glyph
+/// and the category name — robust against either layout.
 fn focus_category(h: &mut EditorTestHarness, name: &str) {
-    let probe = format!(">     {}", name);
     for _ in 0..40 {
-        let screen = h.screen_to_string();
-        if screen.contains(&probe) {
+        if category_is_selected(h, name) {
             return;
         }
         h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
@@ -98,6 +100,16 @@ fn focus_category(h: &mut EditorTestHarness, name: &str) {
         name,
         h.screen_to_string()
     );
+}
+
+/// True iff some line in the rendered screen contains both the `>`
+/// selection marker AND `name`. The marker is column-aligned to the
+/// category cell's first glyph, so co-occurrence on the same line is
+/// a reliable indicator that *that* row is the selected one.
+fn category_is_selected(h: &EditorTestHarness, name: &str) -> bool {
+    h.screen_to_string()
+        .lines()
+        .any(|line| line.contains('>') && line.contains(name))
 }
 
 /// 1. The plugin's category shows up under "Plugin: <name>".
@@ -145,6 +157,36 @@ fn plugin_config_round_trip_toggles_visible_behavior() {
         after_open.contains(&plugin_marker),
         "Settings UI should show the plugin's category. Screen:\n{after_open}"
     );
+
+    // Plugin categories belong at the bottom of the category list so
+    // plugin configuration doesn't interleave with built-in editor
+    // settings. Verify by asserting that the plugin marker appears
+    // AFTER every built-in category name in the left-panel pane.
+    let plugin_marker_pos = after_open
+        .find(&plugin_marker)
+        .expect("plugin marker present");
+    for builtin in &[
+        "General",
+        "Clipboard",
+        "Editor",
+        "File Browser",
+        "File Explorer",
+        "Packages",
+        "Plugins",
+        "Terminal",
+        "Warnings",
+    ] {
+        let bi_pos = after_open
+            .find(builtin)
+            .unwrap_or_else(|| panic!("built-in category {:?} missing from screen", builtin));
+        assert!(
+            bi_pos < plugin_marker_pos,
+            "Built-in category {:?} (offset {bi_pos}) must render before the plugin \
+             marker {:?} (offset {plugin_marker_pos}). Screen:\n{after_open}",
+            builtin,
+            plugin_marker,
+        );
+    }
 
     focus_category(&mut harness, &format!("Plugin: {}", PLUGIN_NAME));
     let after_focus = harness.screen_to_string();

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -880,10 +880,7 @@ fn require_integer<'js>(
         Some(v) => v.as_i64().ok_or_else(|| {
             throw_js(
                 ctx,
-                &format!(
-                    "{}(\"{}\"): `{}` must be an integer",
-                    method, field, key
-                ),
+                &format!("{}(\"{}\"): `{}` must be an integer", method, field, key),
             )
         }),
         None => Err(throw_js(
@@ -905,10 +902,7 @@ fn optional_integer<'js>(
         Some(v) => v.as_i64().map(Some).ok_or_else(|| {
             throw_js(
                 ctx,
-                &format!(
-                    "{}(\"{}\"): `{}` must be an integer",
-                    method, field, key
-                ),
+                &format!("{}(\"{}\"): `{}` must be an integer", method, field, key),
             )
         }),
     }
@@ -925,10 +919,7 @@ fn require_number<'js>(
         Some(v) => v.as_f64().ok_or_else(|| {
             throw_js(
                 ctx,
-                &format!(
-                    "{}(\"{}\"): `{}` must be a number",
-                    method, field, key
-                ),
+                &format!("{}(\"{}\"): `{}` must be a number", method, field, key),
             )
         }),
         None => Err(throw_js(
@@ -950,10 +941,7 @@ fn optional_number<'js>(
         Some(v) => v.as_f64().map(Some).ok_or_else(|| {
             throw_js(
                 ctx,
-                &format!(
-                    "{}(\"{}\"): `{}` must be a number",
-                    method, field, key
-                ),
+                &format!("{}(\"{}\"): `{}` must be a number", method, field, key),
             )
         }),
     }
@@ -2390,7 +2378,13 @@ impl JsEditorApi {
         options: rquickjs::Object<'js>,
     ) -> rquickjs::Result<bool> {
         let opts = parse_options(&ctx, "defineConfigBoolean", &name, options)?;
-        validate_allowed_keys(&ctx, "defineConfigBoolean", &name, &opts, &["default", "description"])?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigBoolean",
+            &name,
+            &opts,
+            &["default", "description"],
+        )?;
         let default = match opts.get("default") {
             Some(serde_json::Value::Bool(b)) => *b,
             _ => {
@@ -2440,7 +2434,14 @@ impl JsEditorApi {
         let default = require_integer(&ctx, "defineConfigInteger", &name, &opts, "default")?;
         let minimum = optional_integer(&ctx, "defineConfigInteger", &name, &opts, "minimum")?;
         let maximum = optional_integer(&ctx, "defineConfigInteger", &name, &opts, "maximum")?;
-        check_range(&ctx, "defineConfigInteger", &name, default as f64, minimum.map(|v| v as f64), maximum.map(|v| v as f64))?;
+        check_range(
+            &ctx,
+            "defineConfigInteger",
+            &name,
+            default as f64,
+            minimum.map(|v| v as f64),
+            maximum.map(|v| v as f64),
+        )?;
         let description = string_opt(&opts, "description");
         let mut field = serde_json::Map::new();
         field.insert("type".into(), serde_json::json!("integer"));
@@ -2515,7 +2516,13 @@ impl JsEditorApi {
         options: rquickjs::Object<'js>,
     ) -> rquickjs::Result<String> {
         let opts = parse_options(&ctx, "defineConfigString", &name, options)?;
-        validate_allowed_keys(&ctx, "defineConfigString", &name, &opts, &["default", "description"])?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigString",
+            &name,
+            &opts,
+            &["default", "description"],
+        )?;
         let default = match opts.get("default") {
             Some(serde_json::Value::String(s)) => s.clone(),
             _ => {
@@ -2628,9 +2635,7 @@ impl JsEditorApi {
         // Only honour current if it's still one of the declared values
         // (the user could have hand-edited config.json to something
         // stale after the plugin's enum changed).
-        Ok(current
-            .filter(|v| values.contains(v))
-            .unwrap_or(default))
+        Ok(current.filter(|v| values.contains(v)).unwrap_or(default))
     }
 
     /// Declare an array-of-strings config field (e.g. a list of

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -811,6 +811,226 @@ pub struct JsEditorApi {
     pub plugin_name: String,
 }
 
+// ─── Helpers for the defineConfigX methods ────────────────────────────
+// Free functions kept out of the impl block (which is processed by the
+// `plugin_api_impl` macro and would otherwise try to export them).
+
+fn throw_js<'js>(ctx: &rquickjs::Ctx<'js>, msg: &str) -> rquickjs::Error {
+    match rquickjs::String::from_str(ctx.clone(), msg) {
+        Ok(s) => ctx.throw(s.into_value()),
+        Err(e) => e,
+    }
+}
+
+fn parse_options<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    options: rquickjs::Object<'js>,
+) -> rquickjs::Result<serde_json::Map<String, serde_json::Value>> {
+    let value: serde_json::Value = rquickjs_serde::from_value(options.into_value())
+        .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))?;
+    match value {
+        serde_json::Value::Object(m) => Ok(m),
+        _ => Err(throw_js(
+            ctx,
+            &format!("{}(\"{}\"): options must be an object", method, field),
+        )),
+    }
+}
+
+fn validate_allowed_keys<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    opts: &serde_json::Map<String, serde_json::Value>,
+    allowed: &[&str],
+) -> rquickjs::Result<()> {
+    for k in opts.keys() {
+        if !allowed.contains(&k.as_str()) {
+            return Err(throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): unknown option `{}` (allowed: {})",
+                    method,
+                    field,
+                    k,
+                    allowed.join(", "),
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn string_opt(opts: &serde_json::Map<String, serde_json::Value>, key: &str) -> Option<String> {
+    opts.get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn require_integer<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    opts: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> rquickjs::Result<i64> {
+    match opts.get(key) {
+        Some(v) => v.as_i64().ok_or_else(|| {
+            throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): `{}` must be an integer",
+                    method, field, key
+                ),
+            )
+        }),
+        None => Err(throw_js(
+            ctx,
+            &format!("{}(\"{}\"): `{}` is required", method, field, key),
+        )),
+    }
+}
+
+fn optional_integer<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    opts: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> rquickjs::Result<Option<i64>> {
+    match opts.get(key) {
+        None => Ok(None),
+        Some(v) => v.as_i64().map(Some).ok_or_else(|| {
+            throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): `{}` must be an integer",
+                    method, field, key
+                ),
+            )
+        }),
+    }
+}
+
+fn require_number<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    opts: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> rquickjs::Result<f64> {
+    match opts.get(key) {
+        Some(v) => v.as_f64().ok_or_else(|| {
+            throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): `{}` must be a number",
+                    method, field, key
+                ),
+            )
+        }),
+        None => Err(throw_js(
+            ctx,
+            &format!("{}(\"{}\"): `{}` is required", method, field, key),
+        )),
+    }
+}
+
+fn optional_number<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    opts: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> rquickjs::Result<Option<f64>> {
+    match opts.get(key) {
+        None => Ok(None),
+        Some(v) => v.as_f64().map(Some).ok_or_else(|| {
+            throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): `{}` must be a number",
+                    method, field, key
+                ),
+            )
+        }),
+    }
+}
+
+fn check_range<'js>(
+    ctx: &rquickjs::Ctx<'js>,
+    method: &str,
+    field: &str,
+    default: f64,
+    minimum: Option<f64>,
+    maximum: Option<f64>,
+) -> rquickjs::Result<()> {
+    if let Some(min) = minimum {
+        if default < min {
+            return Err(throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): default ({}) is below minimum ({})",
+                    method, field, default, min
+                ),
+            ));
+        }
+    }
+    if let Some(max) = maximum {
+        if default > max {
+            return Err(throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): default ({}) is above maximum ({})",
+                    method, field, default, max
+                ),
+            ));
+        }
+    }
+    if let (Some(min), Some(max)) = (minimum, maximum) {
+        if min > max {
+            return Err(throw_js(
+                ctx,
+                &format!(
+                    "{}(\"{}\"): minimum ({}) is greater than maximum ({})",
+                    method, field, min, max
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+// Internal helpers used by the macro-processed `impl JsEditorApi` below.
+// Kept in a plain impl block so they don't get exported as JS methods.
+impl JsEditorApi {
+    /// Send an AddPluginConfigField command to the host.
+    fn send_field_registration(&self, field_name: &str, field_schema: serde_json::Value) {
+        let _ = self
+            .command_sender
+            .send(PluginCommand::AddPluginConfigField {
+                plugin_name: self.plugin_name.clone(),
+                field_name: field_name.to_string(),
+                field_schema,
+            });
+    }
+
+    /// Look up the current value of one of this plugin's settings
+    /// fields from the snapshot. Returns `None` if not yet present.
+    fn current_field_value(&self, field_name: &str) -> Option<serde_json::Value> {
+        self.state_snapshot.read().ok().and_then(|s| {
+            s.config
+                .pointer(&format!(
+                    "/plugins/{}/settings/{}",
+                    self.plugin_name, field_name
+                ))
+                .cloned()
+        })
+    }
+}
+
 #[plugin_api_impl]
 #[rquickjs::methods(rename_all = "camelCase")]
 impl JsEditorApi {
@@ -2151,6 +2371,356 @@ impl JsEditorApi {
             .unwrap_or_else(|_| std::sync::Arc::new(serde_json::json!({})));
 
         rquickjs_serde::to_value(ctx, &*config)
+            .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
+    }
+
+    /// Declare a boolean config field for the calling plugin.
+    ///
+    /// Validates `options` synchronously: the JS call throws if any
+    /// unknown key is present or if `default` isn't a boolean. The
+    /// Settings UI grows a "Plugin Settings → <plugin>" sub-category
+    /// containing a toggle for this field. Returns the current value
+    /// (user-set if present, otherwise the declared `default`).
+    #[plugin_api(ts_return = "boolean")]
+    pub fn define_config_boolean<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        #[plugin_api(ts_type = "{ default: boolean; description?: string }")]
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<bool> {
+        let opts = parse_options(&ctx, "defineConfigBoolean", &name, options)?;
+        validate_allowed_keys(&ctx, "defineConfigBoolean", &name, &opts, &["default", "description"])?;
+        let default = match opts.get("default") {
+            Some(serde_json::Value::Bool(b)) => *b,
+            _ => {
+                return Err(throw_js(
+                    &ctx,
+                    &format!(
+                        "defineConfigBoolean(\"{}\"): `default` (boolean) is required",
+                        name
+                    ),
+                ));
+            }
+        };
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("boolean"));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        Ok(self
+            .current_field_value(&name)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default))
+    }
+
+    /// Declare an integer config field for the calling plugin. Throws on
+    /// invalid options or if the default falls outside `minimum/maximum`.
+    #[plugin_api(ts_return = "number")]
+    pub fn define_config_integer<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        #[plugin_api(
+            ts_type = "{ default: number; description?: string; minimum?: number; maximum?: number }"
+        )]
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<i64> {
+        let opts = parse_options(&ctx, "defineConfigInteger", &name, options)?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigInteger",
+            &name,
+            &opts,
+            &["default", "description", "minimum", "maximum"],
+        )?;
+        let default = require_integer(&ctx, "defineConfigInteger", &name, &opts, "default")?;
+        let minimum = optional_integer(&ctx, "defineConfigInteger", &name, &opts, "minimum")?;
+        let maximum = optional_integer(&ctx, "defineConfigInteger", &name, &opts, "maximum")?;
+        check_range(&ctx, "defineConfigInteger", &name, default as f64, minimum.map(|v| v as f64), maximum.map(|v| v as f64))?;
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("integer"));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        if let Some(v) = minimum {
+            field.insert("minimum".into(), serde_json::json!(v));
+        }
+        if let Some(v) = maximum {
+            field.insert("maximum".into(), serde_json::json!(v));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        Ok(self
+            .current_field_value(&name)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(default))
+    }
+
+    /// Declare a floating-point number config field. Throws on bad
+    /// options or default outside `minimum/maximum`.
+    #[plugin_api(ts_return = "number")]
+    pub fn define_config_number<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        #[plugin_api(
+            ts_type = "{ default: number; description?: string; minimum?: number; maximum?: number }"
+        )]
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<f64> {
+        let opts = parse_options(&ctx, "defineConfigNumber", &name, options)?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigNumber",
+            &name,
+            &opts,
+            &["default", "description", "minimum", "maximum"],
+        )?;
+        let default = require_number(&ctx, "defineConfigNumber", &name, &opts, "default")?;
+        let minimum = optional_number(&ctx, "defineConfigNumber", &name, &opts, "minimum")?;
+        let maximum = optional_number(&ctx, "defineConfigNumber", &name, &opts, "maximum")?;
+        check_range(&ctx, "defineConfigNumber", &name, default, minimum, maximum)?;
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("number"));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        if let Some(v) = minimum {
+            field.insert("minimum".into(), serde_json::json!(v));
+        }
+        if let Some(v) = maximum {
+            field.insert("maximum".into(), serde_json::json!(v));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        Ok(self
+            .current_field_value(&name)
+            .and_then(|v| v.as_f64())
+            .unwrap_or(default))
+    }
+
+    /// Declare a free-form string config field.
+    #[plugin_api(ts_return = "string")]
+    pub fn define_config_string<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        #[plugin_api(ts_type = "{ default: string; description?: string }")]
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<String> {
+        let opts = parse_options(&ctx, "defineConfigString", &name, options)?;
+        validate_allowed_keys(&ctx, "defineConfigString", &name, &opts, &["default", "description"])?;
+        let default = match opts.get("default") {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            _ => {
+                return Err(throw_js(
+                    &ctx,
+                    &format!(
+                        "defineConfigString(\"{}\"): `default` (string) is required",
+                        name
+                    ),
+                ));
+            }
+        };
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("string"));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        Ok(self
+            .current_field_value(&name)
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or(default))
+    }
+
+    /// Declare a string config field constrained to one of a fixed set
+    /// of values. The Settings UI renders this as a dropdown.
+    ///
+    /// The TS signature for this method is hand-written in the d.ts
+    /// trailer because the macro can't express the `<E extends string>`
+    /// generic that propagates `values` into the return type.
+    #[plugin_api(skip)]
+    pub fn define_config_enum<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<String> {
+        let opts = parse_options(&ctx, "defineConfigEnum", &name, options)?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigEnum",
+            &name,
+            &opts,
+            &["default", "description", "values"],
+        )?;
+        let values: Vec<String> = match opts.get("values") {
+            Some(serde_json::Value::Array(arr)) if !arr.is_empty() => {
+                let mut out = Vec::with_capacity(arr.len());
+                for v in arr {
+                    match v {
+                        serde_json::Value::String(s) => out.push(s.clone()),
+                        _ => {
+                            return Err(throw_js(
+                                &ctx,
+                                &format!(
+                                    "defineConfigEnum(\"{}\"): `values` must be an array of strings",
+                                    name
+                                ),
+                            ));
+                        }
+                    }
+                }
+                out
+            }
+            _ => {
+                return Err(throw_js(
+                    &ctx,
+                    &format!(
+                        "defineConfigEnum(\"{}\"): `values` (non-empty string[]) is required",
+                        name
+                    ),
+                ));
+            }
+        };
+        let default = match opts.get("default") {
+            Some(serde_json::Value::String(s)) => s.clone(),
+            _ => {
+                return Err(throw_js(
+                    &ctx,
+                    &format!(
+                        "defineConfigEnum(\"{}\"): `default` (string) is required",
+                        name
+                    ),
+                ));
+            }
+        };
+        if !values.contains(&default) {
+            return Err(throw_js(
+                &ctx,
+                &format!(
+                    "defineConfigEnum(\"{}\"): `default` must be one of {:?}",
+                    name, values
+                ),
+            ));
+        }
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("string"));
+        field.insert("enum".into(), serde_json::json!(values));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        let current = self
+            .current_field_value(&name)
+            .and_then(|v| v.as_str().map(|s| s.to_string()));
+        // Only honour current if it's still one of the declared values
+        // (the user could have hand-edited config.json to something
+        // stale after the plugin's enum changed).
+        Ok(current
+            .filter(|v| values.contains(v))
+            .unwrap_or(default))
+    }
+
+    /// Declare an array-of-strings config field (e.g. a list of
+    /// patterns). The Settings UI renders this as a list editor.
+    #[plugin_api(ts_return = "string[]")]
+    pub fn define_config_string_array<'js>(
+        &self,
+        ctx: rquickjs::Ctx<'js>,
+        name: String,
+        #[plugin_api(ts_type = "{ default: string[]; description?: string }")]
+        options: rquickjs::Object<'js>,
+    ) -> rquickjs::Result<Vec<String>> {
+        let opts = parse_options(&ctx, "defineConfigStringArray", &name, options)?;
+        validate_allowed_keys(
+            &ctx,
+            "defineConfigStringArray",
+            &name,
+            &opts,
+            &["default", "description"],
+        )?;
+        let default: Vec<String> = match opts.get("default") {
+            Some(serde_json::Value::Array(arr)) => {
+                let mut out = Vec::with_capacity(arr.len());
+                for v in arr {
+                    match v {
+                        serde_json::Value::String(s) => out.push(s.clone()),
+                        _ => {
+                            return Err(throw_js(
+                                &ctx,
+                                &format!(
+                                    "defineConfigStringArray(\"{}\"): `default` entries must all be strings",
+                                    name
+                                ),
+                            ));
+                        }
+                    }
+                }
+                out
+            }
+            _ => {
+                return Err(throw_js(
+                    &ctx,
+                    &format!(
+                        "defineConfigStringArray(\"{}\"): `default` (string[]) is required",
+                        name
+                    ),
+                ));
+            }
+        };
+        let description = string_opt(&opts, "description");
+        let mut field = serde_json::Map::new();
+        field.insert("type".into(), serde_json::json!("array"));
+        field.insert("items".into(), serde_json::json!({"type": "string"}));
+        field.insert("default".into(), serde_json::json!(default));
+        if let Some(d) = description {
+            field.insert("description".into(), serde_json::json!(d));
+        }
+        self.send_field_registration(&name, serde_json::Value::Object(field));
+        Ok(self
+            .current_field_value(&name)
+            .and_then(|v| {
+                v.as_array().map(|arr| {
+                    arr.iter()
+                        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .unwrap_or(default))
+    }
+
+    /// Get the calling plugin's settings as a JS object.
+    ///
+    /// Returns the merged value at `config.plugins.<plugin_name>.settings`.
+    /// The shape comes from whatever the plugin declared via
+    /// `editor.definePluginConfig(...)` (defaults pre-populated by the
+    /// host, user overrides on top from the Settings UI). Returns `null`
+    /// if the plugin hasn't declared a schema and has no user-set value.
+    pub fn get_plugin_config<'js>(&self, ctx: rquickjs::Ctx<'js>) -> rquickjs::Result<Value<'js>> {
+        let config = self
+            .state_snapshot
+            .read()
+            .map(|s| std::sync::Arc::clone(&s.config))
+            .unwrap_or_else(|_| std::sync::Arc::new(serde_json::json!({})));
+
+        let settings = config
+            .pointer(&format!("/plugins/{}/settings", self.plugin_name))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
+        rquickjs_serde::to_value(ctx, &settings)
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 

--- a/crates/fresh-plugin-runtime/src/thread.rs
+++ b/crates/fresh-plugin-runtime/src/thread.rs
@@ -1618,6 +1618,7 @@ async fn load_plugins_from_dir_with_config_internal(
             PluginConfig {
                 enabled: existing_config.enabled,
                 path: Some(path.clone()),
+                settings: existing_config.settings.clone(),
             }
         } else {
             // Create new config with default enabled = true

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -389,6 +389,33 @@ interface EditorAPI {
 }
 
 /**
+ * Typed overload of `editor.defineConfigEnum`. The macro-generated
+ * signature can't express `<E extends string>` propagating from the
+ * `values` array into the return type, so it's declared here. Use
+ * `as const` on the `values` array to get a literal-union return:
+ *
+ * ```ts
+ * const mode = editor.defineConfigEnum("mode", {
+ *   values: ["normal", "insert"] as const,
+ *   default: "normal",
+ * });
+ * mode; // typed as "normal" | "insert"
+ * ```
+ *
+ * Typed overload of `editor.getPluginConfig`. Plugins that declared
+ * their fields via `defineConfigX` can pass the shape type explicitly:
+ * `editor.getPluginConfig<{ autoEnable: boolean; ... }>()`. Without
+ * the generic, falls back to `unknown`.
+ */
+interface EditorAPI {
+  defineConfigEnum<E extends string>(
+    name: string,
+    options: { values: readonly E[]; default: NoInfer<E>; description?: string },
+  ): E;
+  getPluginConfig<T = unknown>(): T;
+}
+
+/**
  * Maps every hook event name to its payload type.
  *
  * Payloads match the flat JSON produced by `hook_args_to_json` on the Rust
@@ -1182,6 +1209,15 @@ mod tests {
             "getTempDir",
             "getConfig",
             "getUserConfig",
+            "getPluginConfig",
+            "defineConfigBoolean",
+            "defineConfigInteger",
+            "defineConfigNumber",
+            "defineConfigString",
+            // `defineConfigEnum` is hand-written in the d.ts trailer
+            // (generic <E> propagates `values` into the return), so it's
+            // NOT in the macro-generated EditorAPI interface.
+            "defineConfigStringArray",
             "reloadConfig",
             "reloadThemes",
             "reloadAndApplyTheme",

--- a/docs/plugins/development/config.md
+++ b/docs/plugins/development/config.md
@@ -1,0 +1,106 @@
+# Plugin Configuration
+
+Plugins can expose user-configurable settings that appear in the editor's
+Settings UI under their own "Plugin: \<name\>" category. The values are
+saved alongside the rest of the user config and respect the same
+User/Project/Session layering as built-in settings.
+
+## How it works
+
+Each setting is declared from TypeScript by calling one of the
+strongly-typed `editor.defineConfigX(...)` methods. The host validates
+the call synchronously — a typo or wrong shape throws an exception
+right there, at the call site, instead of failing silently later. The
+return type is inferred from the call, so plugin code is type-safe
+without any cast.
+
+```ts
+const autoEnable = editor.defineConfigBoolean("autoEnable", {
+  default: false,
+  description: "Auto-enable the plugin on startup",
+});
+
+const maxItems = editor.defineConfigInteger("maxItems", {
+  default: 5,
+  minimum: 1,
+  maximum: 50,
+});
+
+const mode = editor.defineConfigEnum("mode", {
+  values: ["normal", "insert"] as const,
+  default: "normal",
+});
+
+const patterns = editor.defineConfigStringArray("patterns", {
+  default: ["TODO", "FIXME"],
+});
+
+// `mode` is typed as `"normal" | "insert"` thanks to the `as const`.
+// `autoEnable: boolean`, `maxItems: number`, `patterns: string[]`.
+```
+
+Each call returns the **current** merged value (user override if any,
+otherwise the declared `default`). For values that may change while the
+plugin is running, re-read on demand:
+
+```ts
+const cfg = editor.getPluginConfig() as { autoEnable?: boolean };
+if (cfg.autoEnable) { /* ... */ }
+```
+
+## Available methods
+
+| Method                          | TS return type     | Settings UI widget |
+| ------------------------------- | ------------------ | ------------------ |
+| `defineConfigBoolean`           | `boolean`          | Toggle             |
+| `defineConfigInteger`           | `number`           | Number input       |
+| `defineConfigNumber`            | `number`           | Number input       |
+| `defineConfigString`            | `string`           | Text input         |
+| `defineConfigEnum`              | one of `values`    | Dropdown           |
+| `defineConfigStringArray`       | `string[]`         | List editor        |
+
+All methods accept `description` (string). Numeric methods accept
+`minimum` / `maximum`. Each method's `options` parameter is strictly
+typed — unknown keys (`defualt` → "Did you mean 'default'?"), wrong
+default types, and out-of-range defaults are all compile-time errors.
+
+The Settings UI renders one **Plugin: \<name\>** top-level category per
+enabled plugin that has registered at least one field, sorted alongside
+the built-in categories.
+
+## What's not supported
+
+By design:
+
+- **Colors** are not exposed as plugin settings. Plugins should pass
+  theme keys (e.g. `"ui.status_bar_fg"`, `"editor.diff_add_bg"`) to
+  `addOverlay` / `addVirtualLine` instead, so the colors track the
+  user's active theme.
+- **`x-enum-from`** pointing at host config paths like `/languages`.
+  Plugins that need to react to host config should read
+  `editor.getConfig()` directly at use-time.
+- **Per-language settings.** Plugin config is flat, namespaced by
+  plugin name.
+
+## Layering
+
+Plugin settings follow the same layered-config rules as the rest of the
+editor:
+
+- Higher layers (Session > Project > User) win for any individual key.
+- Object-typed values are deep-merged so a project can add one key
+  without restating the user's defaults.
+- Primitive values and arrays are replaced wholesale.
+
+## Lifecycle
+
+- **Disabled plugins** are hidden from the Settings UI. Stored values
+  are preserved in the config file and reappear when re-enabled.
+- **Uninstalling a plugin** leaves its `plugins.<name>.settings` entry
+  in the user's config (cheap; harmless). Reinstalling restores the
+  values.
+- **Reloading a plugin** re-runs its `defineConfigX(...)` calls, so
+  plugin authors iterating with `Reload Plugin` see updated schemas
+  immediately.
+- The Settings UI rebuilds its category list every time it opens, so
+  newly-registered schemas show up without an editor restart.


### PR DESCRIPTION
Plugins now declare config fields from TypeScript with one of six
strongly-typed methods on the `editor` object:

    editor.defineConfigBoolean(name, { default, description? })
    editor.defineConfigInteger(name, { default, minimum?, maximum?, ... })
    editor.defineConfigNumber(name,  { default, minimum?, maximum?, ... })
    editor.defineConfigString(name,  { default, description? })
    editor.defineConfigEnum(name,    { values, default, description? })
    editor.defineConfigStringArray(name, { default, description? })

Each call returns the current merged value (typed), validates its
options synchronously on the Rust side, and throws a TypeError on
unknown keys / wrong default types / out-of-range defaults — surfacing
shape mistakes at the call site instead of failing silently later.
For `defineConfigEnum`, the typed signature in the d.ts trailer
propagates `values` (with `as const`) into the return type via
`<E extends string>` + `NoInfer<E>` for the default, so
`mode: "normal" | "insert"` lands without a cast.

On the host side each call sends an `AddPluginConfigField` command;
the editor accumulates fields into a per-plugin JSON schema stored in
`Editor::plugin_schemas`, pre-populates the declared default into
`config.plugins.<name>.settings.<field>`, and the Settings UI grows a
"Plugin: <name>" top-level category rendered from the accumulated
schema. The state is rebuilt on every Settings open so plugin reloads
pick up new fields without an editor restart. Disabled plugins are
hidden by design.

`PluginConfig` gains an untyped `settings: serde_json::Value` slot;
`apply_changes` was extended to create intermediate JSON-pointer
objects so brand-new leaves under `/plugins/<name>/settings/...` land
on save. Plugin settings deep-merge across User/Project/Session layers
the same way `editor.*` does.

Plugin-side updates: `flash` and `dashboard` migrated to the new API
(`labelPool` / `skipRule` and `autoOpen` respectively). `git_blame`
and `merge_conflict` had hard-coded colors swapped for theme keys
(`addOverlay` / `addVirtualLine` accept them directly) so theme
switches drive the look — colors deliberately aren't a plugin-config
concern. The d.ts is regenerated.

Includes an e2e test that loads a fixture plugin, opens Settings,
asserts the "Plugin: ..." category renders with the declared fields,
toggles a value, saves, and verifies the plugin's next command-palette
invocation observes the new value — covering schema registration,
Settings UI rendering, persistence, and live-apply in one flow.

https://claude.ai/code/session_01C72oUCWxhM9ocqtBkUqbmz