### PR TITLE
plugin config: typed registration API + Settings UI integration

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -2942,5 +2942,16 @@ editor.exportPluginApi("vi-mode", {
 // Initialization
 // ============================================================================
 
+// User-configurable opt-in: when enabled, vi mode kicks in for every
+// session without the user having to run the toggle command. Surfaces
+// in Settings UI under "Plugin: vi_mode".
+const autoStart = editor.defineConfigBoolean("autoStart", {
+  default: false,
+  description:
+    "Automatically enable vi mode when the editor starts. Default off — users opt in.",
+});
+if (autoStart) {
+  enableVi();
+}
 
 registerHandler("vi_to_brace", vi_to_brace);

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -745,6 +745,20 @@ impl Editor {
             // "prompt")` gets null even though Alt+P is bound, and
             // ends up hardcoding the key in its UI.
             populate_builtin_keybinding_labels(&mut snapshot, &keybindings);
+            // Seed the snapshot's `config` view with the resolved
+            // initial config so plugins reading
+            // `editor.getPluginConfig()` (and the lower-level
+            // `defineConfigX` snapshot-lookups) see user-set values
+            // on their very first call. Without this seed the
+            // synchronous test path runs plugin scripts BEFORE the
+            // first `update_plugin_state_snapshot` tick, so a
+            // preset `plugins.<name>.settings.<field>` is invisible
+            // to the plugin until much later — defeating any
+            // "react to user config at startup" pattern (e.g.
+            // vi_mode's `autoStart`).
+            if let Ok(json) = serde_json::to_value(&config) {
+                snapshot.config = std::sync::Arc::new(json);
+            }
         }
 
         // Load TypeScript plugins from multiple directories:

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -52,4 +52,5 @@ pub mod tab_actions;
 pub mod terminal_hooks;
 pub mod theme_editor;
 pub mod unified_keybindings;
+pub mod vi_mode_autostart;
 pub mod watch_path;

--- a/crates/fresh-editor/tests/e2e/plugins/vi_mode_autostart.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/vi_mode_autostart.rs
@@ -1,0 +1,126 @@
+//! E2E: the vi_mode plugin's `autoStart` config field.
+//!
+//! When `plugins.vi_mode.settings.autoStart = true` lands in the
+//! resolved config BEFORE the plugin runs, the plugin's
+//! `editor.defineConfigBoolean("autoStart", { default: false })` call
+//! sees the user-set `true` (via the snapshot) and enables vi mode
+//! immediately.
+//!
+//! The observable: with vi-normal active, typing `i` enters insert
+//! mode without inserting the letter `i`. So `iX<Esc>` on an empty
+//! buffer leaves just `X`. Without vi, `iX<Esc>` leaves `iX`. We
+//! distinguish the two by scanning the rendered buffer for the
+//! literal `iX` substring.
+
+use crate::common::fixtures::TestFixture;
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, PluginConfig};
+use std::fs;
+
+fn build_harness(auto_start: bool) -> (EditorTestHarness, tempfile::TempDir) {
+    init_tracing_from_env();
+    let temp = tempfile::TempDir::new().unwrap();
+    let project_root = temp.path().join("project_root");
+    fs::create_dir_all(&project_root).unwrap();
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "vi_mode");
+    copy_plugin_lib(&plugins_dir);
+
+    let mut config = Config::default();
+    // Preset the plugin's config slot so `editor.defineConfigBoolean`
+    // sees `autoStart=<auto_start>` via the state snapshot the first
+    // time the plugin runs.
+    config.plugins.insert(
+        "vi_mode".to_string(),
+        PluginConfig {
+            enabled: true,
+            path: None,
+            settings: serde_json::json!({ "autoStart": auto_start }),
+        },
+    );
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, config, project_root).unwrap();
+    harness.editor_mut().set_clipboard_for_test(String::new());
+    (harness, temp)
+}
+
+/// Drive `iX<Esc>` on an open empty file and return the rendered
+/// screen. Includes a `wait_until` for the vi_mode plugin command to
+/// be registered, so the plugin's top-level body (including the
+/// `if (autoStart) enableVi()` line) is guaranteed to have run.
+fn rendered_after_ix_esc(h: &mut EditorTestHarness) -> String {
+    use fresh::input::keybindings::Action::PluginAction;
+    h.wait_until(|h| {
+        let cmds = h.editor().command_registry().read().unwrap().get_all();
+        cmds.iter()
+            .any(|c| c.action == PluginAction("vi_mode_toggle".to_string()))
+    })
+    .unwrap();
+    h.send_key(KeyCode::Char('i'), KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Char('X'), KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.render().unwrap();
+    h.screen_to_string()
+}
+
+/// autoStart=true → vi mode is on at first render; `iX<Esc>` leaves
+/// just `X` in the buffer (the `i` was the vi insert command).
+#[test]
+fn vi_mode_autostart_true_enables_vi_immediately() {
+    let (mut harness, _tmp) = build_harness(true);
+
+    let fixture = TestFixture::new("scratch.txt", "").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    let screen = rendered_after_ix_esc(&mut harness);
+    // The buffer area renders content after ` N │ `. Pull the first
+    // line's content.
+    // The buffer row renders as `... N │ <content>`. There may be a
+    // border `│` from the chrome on the same line, so take everything
+    // after the LAST `│` rather than the first.
+    let line1 = screen
+        .lines()
+        .find(|l| l.contains("1 │"))
+        .expect("expected line 1 in render");
+    let content = line1.rsplit('│').next().unwrap_or("").trim();
+    assert_eq!(
+        content, "X",
+        "autoStart=true: vi-normal `i` should swallow the keystroke, \
+         leaving only the trailing `X`. Got buffer content {content:?}. \
+         Screen:\n{screen}"
+    );
+}
+
+/// autoStart=false (default) → vi mode stays dormant; the same
+/// keystrokes type both letters: `iX<Esc>` leaves `iX` in the buffer.
+/// Same plugin, same harness setup, just the opposite flag — proves
+/// the autoStart field is wired and isn't a no-op.
+#[test]
+fn vi_mode_autostart_false_leaves_vi_dormant() {
+    let (mut harness, _tmp) = build_harness(false);
+
+    let fixture = TestFixture::new("scratch.txt", "").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    let screen = rendered_after_ix_esc(&mut harness);
+    // The buffer row renders as `... N │ <content>`. There may be a
+    // border `│` from the chrome on the same line, so take everything
+    // after the LAST `│` rather than the first.
+    let line1 = screen
+        .lines()
+        .find(|l| l.contains("1 │"))
+        .expect("expected line 1 in render");
+    let content = line1.rsplit('│').next().unwrap_or("").trim();
+    assert_eq!(
+        content, "iX",
+        "autoStart=false: vi mode should stay off, both `i` and `X` \
+         get inserted as text. Got buffer content {content:?}. \
+         Screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a plugin API for declaring user-configurable settings from TypeScript, rendered as per-plugin sections in the Settings UI and persisted in the layered config like any built-in setting.

Plugin authors write code, not schema files:

```ts
const autoEnable = editor.defineConfigBoolean("autoEnable", {
  default: false,
  description: "Auto-enable the plugin on startup",
});
const maxItems = editor.defineConfigInteger("maxItems", {
  default: 5, minimum: 1, maximum: 50,
});
const mode = editor.defineConfigEnum("mode", {
  values: ["normal", "insert"] as const,
  default: "normal",
});
```

Six strongly-typed methods (`defineConfigBoolean / Integer / Number / String / Enum / StringArray`). Each:

- Returns the current merged value (typed — `mode` is `"normal" | "insert"`, not `string`).
- Validates options synchronously on the Rust side and throws a TypeError on unknown keys (typos like `defualt` → "Did you mean 'default'?"), wrong default types, out-of-range defaults, or enum defaults outside `values`.
- Sends an `AddPluginConfigField` command to the host; the editor accumulates fields into a per-plugin JSON schema in `Editor::plugin_schemas` and pre-populates the declared default into `config.plugins.<name>.settings.<field>`.

The Settings UI grows a "Plugin: \<name\>" top-level category per enabled plugin that has registered at least one field, sorted to the **bottom** of the left-panel list so plugin config doesn't interleave with built-in editor settings. The state rebuilds on every Settings open so plugin reloads / fresh registrations pick up without an editor restart. Disabled plugins are hidden from the UI by design.

## Migrations

- **vi_mode**: new `autoStart` boolean — when on, vi-normal kicks in at session start without the user running the toggle command.
- **dashboard**: replaces the ad-hoc `getUserConfig()` lookup of `auto-open` with `defineConfigBoolean("autoOpen", ...)`.
- **flash**: `labelPool` (string) + `skipRule` (boolean).
- **git_blame** / **merge_conflict**: hard-coded RGB tuples swapped for theme keys (`addOverlay` / `addVirtualLine` accept them directly), so theme switches drive the look — colors deliberately aren't a plugin-config concern.

## Notable implementation details

- `PluginConfig` gains a passthrough `settings: serde_json::Value` slot. `apply_changes` was extended to create intermediate JSON-pointer objects so brand-new leaves under `/plugins/<name>/settings/...` land on save.
- Plugin settings deep-merge across User/Project/Session layers the same way `editor.*` does.
- TS-side enum literal narrowing works via `<E extends string>` + `NoInfer<E>` for the default param, so `as const` on `values` is the only ceremony.
- `EditorStateSnapshot.config` is now seeded from the resolved initial config in the existing pre-plugin-load setup block. Without this seed, plugins reading user-set settings at script-top-level (e.g. vi_mode's `autoStart`) got `null` in the synchronous test/server/GUI load paths.

## Test plan

- [x] Unit tests for schema validation, deep-merge, defaults extraction (`fresh-core::plugin_schemas`).
- [x] `test_all_editor_api_methods_present` covers the new TS API surface.
- [x] E2E `plugin_config_round_trip_toggles_visible_behavior`: fixture plugin registers two fields, test asserts the "Plugin: ..." category renders with both labels, toggles a value via Settings UI, saves, and verifies the plugin's next command-palette invocation observes the new value via inserted buffer text.
- [x] E2E `plugin_config_category_hidden_when_plugin_disabled`: same fixture with `enabled: false` → no "Plugin: ..." category in the rendered Settings panel.
- [x] E2E `vi_mode_autostart_true_enables_vi_immediately`: preset `autoStart=true`, send `iX<Esc>` on empty buffer, assert rendered first line is `X` (vi-normal swallowed the `i`).
- [x] E2E `vi_mode_autostart_false_leaves_vi_dormant`: same flow with `autoStart=false`, rendered first line is `iX` (vi never activated).
- [x] Interactive tmux: launch fresh → Settings UI → toggle `Plugin: vi_mode → AutoStart` → save → quit → relaunch → status bar shows "Vi mode enabled - NORMAL" without any user toggle; flip back → restart → vi off.
- [x] All 328 plugin e2e tests pass (1 unrelated LSP failure pre-existing).
- [x] All 2479 `fresh-editor --lib` tests pass.
- [x] All 109 `fresh-plugin-runtime --lib` tests pass.
- [x] `cargo fmt` clean.
- [x] `tsc --strict` clean on all migrated plugins.

https://claude.ai/code/session_01C72oUCWxhM9ocqtBkUqbmz

---
_Generated by [Claude Code](https://claude.ai/code/session_01C72oUCWxhM9ocqtBkUqbmz)_