### PR TITLE
fix(view): adjacent tab indicators no longer double up (#1997)

### DIFF
--- a/crates/fresh-editor/src/view/ui/view_pipeline.rs
+++ b/crates/fresh-editor/src/view/ui/view_pipeline.rs
@@ -476,12 +476,15 @@ impl<'a> Iterator for ViewLineIterator<'a> {
                                 }
                                 col += spaces;
 
-                                for _ in 1..spaces {
+                                // Spaces 1..N of the tab expansion. The i-th
+                                // space sits at `col_before_tab + i`, where
+                                // `col_before_tab = col - spaces` (col was
+                                // already incremented above).
+                                for i in 1..spaces {
                                     text.push(' ');
                                     char_source_bytes.push(source);
                                     char_styles.push(token_style.clone());
-                                    char_visual_cols
-                                        .push(col - spaces + char_source_bytes.len() - char_idx);
+                                    char_visual_cols.push(col - spaces + i);
                                 }
                                 continue;
                             }
@@ -1276,6 +1279,42 @@ mod tests {
             vec![Some(10), Some(11), Some(12), Some(13)],
             "Line 3 char_source_bytes mismatch - CRLF offset drift accumulated"
         );
+    }
+
+    /// Issue #1997: adjacent tab characters caused the indicator arrow to be
+    /// rendered twice. Root cause: `char_visual_cols` entries for the 2nd..Nth
+    /// expansion-space of every tab were one column too high, so the
+    /// renderer's `col_offset` skipped column 1, hit `tab_starts` for the next
+    /// tab one iteration early, and emitted "→" both for the trailing space
+    /// of the previous tab and the leading space of the next.
+    #[test]
+    fn test_adjacent_tabs_visual_cols_monotonic() {
+        // Two adjacent tabs at the start of a line with tab_size = 4.
+        // Source bytes: \t=0, \t=1
+        // Each tab expands to 4 spaces, so we expect 8 expansion chars at
+        // visual columns 0,1,2,3,4,5,6,7 — exactly one column per char.
+        let tokens = vec![
+            make_text_token("\t\t", Some(0)),
+            make_newline_token(Some(2)),
+        ];
+
+        let lines: Vec<_> = ViewLineIterator::new(&tokens, false, false, 4, false).collect();
+        assert_eq!(lines.len(), 1);
+
+        // 8 spaces + 1 newline char
+        assert_eq!(lines[0].char_visual_cols.len(), 9);
+        assert_eq!(
+            &lines[0].char_visual_cols[..8],
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+            "Each expansion space must sit at its own visual column"
+        );
+
+        // tab_starts records the char indices where each tab begins.
+        // With both tabs at col 0 and col 4, the only valid tab-start char
+        // indices are 0 and 4.
+        let mut starts: Vec<usize> = lines[0].tab_starts.iter().copied().collect();
+        starts.sort();
+        assert_eq!(starts, vec![0, 4]);
     }
 
     /// Test CRLF visual column to source byte mapping.

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -488,34 +488,34 @@ fn completion_candidates_left_aligned_with_input_value() {
     let prefix = type_alpha_prefix_and_wait(&mut harness, &workspace);
     let _ = prefix;
 
-    // The typed value starts with the workspace path; its first
-    // char on the input row is the leading `/` of `/tmp/...`.
-    // The popup's first candidate row is `alpha_dir/` —
-    // however, both rows contain the workspace path as a prefix
-    // (we typed `<workspace>/al` and the popup echoes
-    // `<workspace>/alpha_dir/`), so the leading `/` is the
-    // common anchor we can locate on both rows.
+    // The typed value starts with the workspace path; the candidate
+    // popup row begins with the same workspace path followed by
+    // `alpha_dir/`. So the workspace path string is the natural
+    // anchor on both rows — locating its first occurrence on each
+    // gives the column of the first char of the value (input row)
+    // and of the candidate text (popup row).
+    //
+    // We must not anchor on `'/'` here: on Windows the workspace
+    // path is rendered as `\\?\C:\...` so the first `/` lands deep
+    // inside the path, far past the actual start of the candidate.
+    let workspace_str = workspace.display().to_string();
     let screen = harness.screen_to_string();
     let lines: Vec<&str> = screen.lines().collect();
     let input_row = lines
         .iter()
-        .position(|l| l.contains('[') && l.contains(']') && l.contains("/al"))
+        .position(|l| l.contains('[') && l.contains(']') && l.contains(&workspace_str))
         .expect("input row with [<typed path>] should be on screen");
     let popup_row = lines
         .iter()
-        .position(|l| l.contains("alpha_dir/"))
+        .position(|l| l.contains("alpha_dir/") && l.contains(&workspace_str))
         .expect("popup row with `alpha_dir/` should be on screen");
 
     let input_col = lines[input_row]
-        .find('[')
-        .map(|i| i + '['.len_utf8())
-        .expect("input row should contain `[`");
-    // First `/` on the popup row IS the candidate's first char
-    // (the candidate starts with the workspace path, which
-    // begins with `/`). Use that as the anchor.
+        .find(&workspace_str)
+        .expect("input row should contain the workspace path");
     let popup_col = lines[popup_row]
-        .find('/')
-        .expect("popup row should contain the candidate's leading `/`");
+        .find(&workspace_str)
+        .expect("popup row should contain the workspace path");
 
     assert_eq!(
         input_col, popup_col,

--- a/crates/fresh-editor/tests/e2e/tab_config.rs
+++ b/crates/fresh-editor/tests/e2e/tab_config.rs
@@ -32,6 +32,47 @@ fn test_show_whitespace_tabs_default_shows_arrow() {
     harness.assert_screen_contains("hello");
 }
 
+/// Issue #1997 — adjacent tab characters must not render their indicator arrow
+/// twice. Pre-fix, the off-by-one in tab-expansion column tracking caused
+/// `col_offset` to land on the next tab-start one cell early, so `→` was
+/// emitted both for the last expansion-space of the previous tab and for
+/// the first space of the next.
+#[test]
+fn test_issue_1997_adjacent_tabs_no_doubled_arrow() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+
+    // Two adjacent tabs followed by a unique marker. With tab_size = 4 the
+    // tabs occupy columns 0..4 and 4..8, so the rendered indicator pattern
+    // must be exactly: "→" then 3 spaces, "→" then 3 spaces, "X".
+    std::fs::write(&file_path, "\t\tX").unwrap();
+
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Screen content:\n{}", screen);
+
+    // The line that contains 'X' is the one we care about — locate it.
+    let line_with_x = screen
+        .lines()
+        .find(|line| line.contains('X'))
+        .expect("the marker 'X' must appear on screen");
+
+    // Count arrows and assert no two arrows are adjacent. Pre-fix this
+    // produced "→→" because both tabs' indicators landed on the same cell.
+    let arrow_count = line_with_x.matches('→').count();
+    assert_eq!(
+        arrow_count, 2,
+        "expected exactly 2 tab indicators for two tabs, got {arrow_count} in line: {line_with_x:?}"
+    );
+    assert!(
+        !line_with_x.contains("→→"),
+        "tab indicators must not appear back-to-back, got line: {line_with_x:?}"
+    );
+}
+
 /// Test that tab characters in Go files do NOT show → indicator
 /// (Go convention is to use tabs for indentation, so we hide the indicators)
 #[test]


### PR DESCRIPTION
Closes #1997.

## Root cause

`ViewLineIterator` expands each tab character into N space cells. The first space's `char_visual_cols` entry is correctly set to `col` (column before the tab). The remaining `N-1` spaces are pushed in a loop, and the column for each was computed as:

```rust
char_visual_cols.push(col - spaces + char_source_bytes.len() - char_idx);
```

But `char_source_bytes.len()` is read **after** the push, so it's one larger than the offset within the tab — the i-th space (i ≥ 1) ended up at `col_before_tab + i + 1` instead of `col_before_tab + i`. With two adjacent tabs at `tab_size = 4` this produced columns `[0, 2, 3, 4, 4, 6, 7, 8]` instead of `[0, 1, 2, 3, 4, 5, 6, 7]`.

Downstream in the renderer, `col_offset` advances via `char_visual_cols[next_idx]`, so it skipped column 1 and landed on column 4 one iteration early. `tab_starts.contains(&col_offset)` then fired for the *last* space of the previous tab as well as the *first* space of the next — emitting `→` twice. Visible symptom: lines with consecutive indentation tabs showed `→  →→   ` instead of `→   →   `, exactly the screenshot in the issue.

## Fix

Replace the post-push length arithmetic with the loop counter `i`. The i-th space sits at `col_before_tab + i`, full stop — no need to back-derive it from container lengths.

```rust
for i in 1..spaces {
    text.push(' ');
    char_source_bytes.push(source);
    char_styles.push(token_style.clone());
    char_visual_cols.push(col - spaces + i);
}
```

## Tests

- **Unit** (`view::ui::view_pipeline::tests::test_adjacent_tabs_visual_cols_monotonic`): pins per-char visual columns for two adjacent tabs to `[0..=7]` and checks `tab_starts == {0, 4}`. Fails without the fix.
- **E2E** (`e2e::tab_config::test_issue_1997_adjacent_tabs_no_doubled_arrow`): writes `\t\tX` to a buffer, renders it, locates the line containing `X`, and asserts exactly two `→` and no `→→`. Fails without the fix with the rendered line `"→  →→   X"`.

## Manual validation

Loaded a 27-line TypeScript file mirroring the issue's screenshot (indent uses tabs, multiple nesting levels). Captured in tmux post-fix:

```
 12 │ →   →   handle = window.setInterval(...);
 16 │ →   →   window.clearInterval(handle);
 21 │ →   →   if (value == 0)
 22 │ →   →   {
 23 │ →   →   →   stop();
 24 │ →   →   →   onExpired();
```

Each tab now occupies exactly one arrow + 3 spaces; no back-to-back arrows.

## Test plan
- [x] Unit test passes with fix, fails without
- [x] E2E test passes with fix, fails without
- [x] All 20 `e2e::tab_config::*` tests pass
- [x] All 747 `view::*` library tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean on touched files
- [x] `cargo check --all-targets` clean
- [x] Manual repro of the issue screenshot scenario renders correctly in tmux

https://claude.ai/code/session_01JLsAS7qhqdLmMHbdptbiLK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLsAS7qhqdLmMHbdptbiLK)_