### PR TITLE
fix(pkg): support direct file URLs in "Install from URL"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
  "android-properties",
  "bitflags 2.11.1",
  "cc",
- "jni",
+ "jni 0.22.4",
  "libc",
  "log",
  "ndk",
@@ -494,6 +494,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -2292,6 +2298,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3288,6 +3310,12 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -4717,6 +4745,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,6 +4764,33 @@ checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4788,6 +4855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4835,6 +4911,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6135,6 +6234,7 @@ dependencies = [
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "ureq-proto",
  "utf8-zero",
  "webpki-roots",
@@ -6493,6 +6593,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6931,6 +7040,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6963,6 +7081,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7009,6 +7142,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7021,6 +7160,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7030,6 +7175,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7057,6 +7208,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7066,6 +7223,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7081,6 +7244,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7090,6 +7259,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2220,6 +2220,20 @@ pub enum PluginCommand {
         duration_ms: u64,
     },
 
+    /// Fetch a URL over HTTP(S) and write the response body to a file.
+    ///
+    /// Streams the response body directly to `target_path` rather than
+    /// buffering in memory, so large downloads stay off the JS bridge. The
+    /// callback resolves with a `SpawnResult`-shaped value: `exit_code` is
+    /// `0` on 2xx, the HTTP status code on non-2xx responses, and `-1` on
+    /// transport errors; `stderr` carries any error message; `stdout` is
+    /// always empty.
+    HttpFetch {
+        url: String,
+        target_path: PathBuf,
+        callback_id: JsCallbackId,
+    },
+
     /// Spawn a long-running background process
     /// Unlike SpawnProcess, this returns immediately with a process handle
     /// and provides streaming output via hooks

--- a/crates/fresh-editor/Cargo.toml
+++ b/crates/fresh-editor/Cargo.toml
@@ -174,7 +174,7 @@ arboard = { version = "3.6", default-features = false, features = ["wayland-data
 # runtime uses onig (faster), wasm uses fancy-regex (pure Rust, WASM-compatible)
 syntect = { version = "5.3", default-features = false, optional = true }
 
-ureq = { version = "3.1.4", default-features = false, features = ["rustls"], optional = true }
+ureq = { version = "3.1.4", default-features = false, features = ["rustls", "platform-verifier"], optional = true }
 # Unicode handling - always needed for primitives
 unicode-width = { version = "0.2" }
 unicode-segmentation = { version = "1.12" }

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1006,7 +1006,7 @@ type WidgetSpec = {
 	* `WidgetMutation::SetCompletions`. An empty `items`
 	* closes the popup.
 	*/
-	completions?: Array<string>;
+	completions?: Array<string | CompletionItem>;
 	/**
 	* How many candidate rows the popup paints at once
 	* when it opens. Excess candidates stay reachable
@@ -1091,7 +1091,7 @@ type WidgetMutation = {
 } | {
 	"kind": "setCompletions";
 	widgetKey: string;
-	items: Array<string>;
+	items: Array<string | CompletionItem>;
 } | {
 	"kind": "setChecked";
 	widgetKey: string;
@@ -2798,6 +2798,19 @@ interface EditorAPI {
 	* without a prior `setRemoteIndicatorState`.
 	*/
 	clearRemoteIndicatorState(): void;
+	/**
+	* Fetch a URL over HTTP(S) and stream the response body into `target_path`.
+	* 
+	* Resolves with a `SpawnResult`-shaped value: `exit_code` is `0` on a
+	* 2xx response (file written), the HTTP status code on non-2xx
+	* (target file untouched), and `-1` on transport errors. `stderr`
+	* carries an error message in the non-success cases; `stdout` is
+	* always empty.
+	* 
+	* This uses the editor's built-in HTTP client (`ureq`), so plugins
+	* don't need `curl`/`wget` on PATH.
+	*/
+	httpFetch(url: string, targetPath: string): ProcessHandle<SpawnResult>;
 	/**
 	* Wait for a process to complete and get its result (async)
 	*/

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -875,20 +875,16 @@ async function installFromDirectFile(
   );
 
   editor.setStatus(`Downloading ${url}...`);
-  const result = await editor.spawnProcess("curl", [
-    "-fsSL",
-    "--max-time", "30",
-    "-o", tempFile,
-    url,
-  ]);
+  const result = await editor.httpFetch(url, tempFile);
 
   if (result.exit_code !== 0) {
-    const stderr = result.stderr || "";
-    const errorMsg = stderr.includes("404") || /not found/i.test(stderr)
+    // exit_code mirrors editor.httpFetch's contract: 0 on 2xx, the HTTP
+    // status code on non-2xx, -1 on transport errors.
+    const errorMsg = result.exit_code === 404
       ? "File not found"
-      : stderr.includes("Could not resolve host") || stderr.includes("resolve")
-      ? "Network error"
-      : stderr.split("\n")[0] || `curl exited ${result.exit_code}`;
+      : result.exit_code > 0
+      ? `HTTP ${result.exit_code}`
+      : result.stderr.split("\n")[0] || "Download failed";
     editor.setStatus(`Failed to download ${packageName}: ${errorMsg}`);
     editor.removePath(tempFile);
     return false;

--- a/crates/fresh-editor/plugins/pkg.ts
+++ b/crates/fresh-editor/plugins/pkg.ts
@@ -232,6 +232,12 @@ interface ParsedPackageUrl {
   name: string;
   /** Whether this is a local file path (not a remote URL) */
   isLocal: boolean;
+  /**
+   * Whether the URL points directly to a single downloadable file (e.g. a
+   * theme JSON) rather than to a git repository. When true, the URL should
+   * be fetched over HTTP instead of cloned with git.
+   */
+  isDirectFile: boolean;
 }
 
 // =============================================================================
@@ -297,6 +303,24 @@ function isLocalPath(str: string): boolean {
 }
 
 /**
+ * File extensions that indicate a URL points to a single downloadable file
+ * (e.g. a Fresh theme JSON) rather than to a git repository.
+ */
+const DIRECT_FILE_EXTENSIONS = /\.(jsonc?|JSONC?)$/;
+
+/**
+ * Check if a URL points directly to a single downloadable file rather than
+ * to a git repository. Examples:
+ * - `https://github.com/user-attachments/files/123/synthwave-84.json` → true
+ * - `https://github.com/user/repo` → false
+ */
+function isDirectFileUrl(url: string): boolean {
+  // Strip query string for extension check
+  const pathOnly = url.split("?")[0];
+  return DIRECT_FILE_EXTENSIONS.test(pathOnly);
+}
+
+/**
  * Parse a package URL that may contain a subpath fragment.
  *
  * Supported formats:
@@ -305,6 +329,7 @@ function isLocalPath(str: string): boolean {
  * - `https://github.com/user/repo.git#packages/my-plugin` - with .git suffix
  * - `/path/to/local/repo#subdir` - local path with subpath
  * - `/path/to/local/package` - direct local package path
+ * - `https://example.com/path/to/theme.json` - direct file (downloaded over HTTP)
  *
  * The fragment (after #) specifies a subdirectory within the repo.
  */
@@ -329,19 +354,28 @@ function parsePackageUrl(url: string): ParsedPackageUrl {
   // Determine if this is a local path
   const isLocal = isLocalPath(repoUrl);
 
+  // A remote URL ending in a recognized file extension (and without a
+  // subpath fragment) is treated as a direct file download, not a git repo.
+  const isDirectFile = !isLocal && !subpath && isDirectFileUrl(repoUrl);
+
   // Extract package name
   let name: string;
   if (subpath) {
     // For monorepo/directory, use the last component of the subpath
     const parts = subpath.split("/");
     name = parts[parts.length - 1].replace(/^fresh-/, "");
+  } else if (isDirectFile) {
+    // For direct file downloads, use the filename without the extension
+    const pathOnly = repoUrl.split("?")[0];
+    const match = pathOnly.match(/\/([^\/]+?)\.(jsonc?|JSONC?)$/);
+    name = match ? match[1].replace(/^fresh-/, "") : "unknown";
   } else {
     // For regular repo/path, use the last component
     const match = repoUrl.match(/\/([^\/]+?)(\.git)?$/);
     name = match ? match[1].replace(/^fresh-/, "") : "unknown";
   }
 
-  return { repoUrl, subpath, name, isLocal };
+  return { repoUrl, subpath, name, isLocal, isDirectFile };
 }
 
 /**
@@ -784,11 +818,12 @@ function validatePackage(packageDir: string, packageName: string): ValidationRes
 }
 
 /**
- * Install a package from git URL or local path.
+ * Install a package from a git URL, direct file URL, or local path.
  *
  * Supports:
  * - `https://github.com/user/repo` - standard git repo
  * - `https://github.com/user/repo#packages/my-plugin` - monorepo with subpath
+ * - `https://example.com/path/to/theme.json` - direct file download (theme JSON)
  * - `/path/to/local/repo#subdir` - local path with subpath
  * - `/path/to/local/package` - direct local package path
  *
@@ -808,6 +843,9 @@ async function installPackage(
   if (parsed.isLocal) {
     // Local path installation: copy directly
     return await installFromLocalPath(parsed, packageName);
+  } else if (parsed.isDirectFile) {
+    // Direct file URL (e.g. theme JSON): download with curl, not git clone
+    return await installFromDirectFile(parsed.repoUrl, packageName);
   } else if (parsed.subpath) {
     // Remote monorepo installation: clone to temp, copy subdirectory
     return await installFromMonorepo(parsed, packageName, version);
@@ -815,6 +853,137 @@ async function installPackage(
     // Standard git installation: clone directly
     return await installFromRepo(parsed.repoUrl, packageName, version);
   }
+}
+
+/**
+ * Install from a direct file URL (e.g. a single theme JSON hosted on a CDN
+ * or GitHub user-attachments). Downloads the file with curl, validates it
+ * looks like a Fresh package (currently themes only), and writes it into
+ * the appropriate packages directory with a synthetic package.json manifest.
+ *
+ * Supported file types:
+ * - `.json` / `.jsonc` containing a Fresh theme (object with a `name` field
+ *   and at least one theme section like `editor`, `ui`, `syntax`, etc.)
+ */
+async function installFromDirectFile(
+  url: string,
+  packageName: string
+): Promise<boolean> {
+  const tempFile = editor.pathJoin(
+    editor.getTempDir(),
+    `fresh-pkg-file-${hashString(url)}-${Date.now()}.json`
+  );
+
+  editor.setStatus(`Downloading ${url}...`);
+  const result = await editor.spawnProcess("curl", [
+    "-fsSL",
+    "--max-time", "30",
+    "-o", tempFile,
+    url,
+  ]);
+
+  if (result.exit_code !== 0) {
+    const stderr = result.stderr || "";
+    const errorMsg = stderr.includes("404") || /not found/i.test(stderr)
+      ? "File not found"
+      : stderr.includes("Could not resolve host") || stderr.includes("resolve")
+      ? "Network error"
+      : stderr.split("\n")[0] || `curl exited ${result.exit_code}`;
+    editor.setStatus(`Failed to download ${packageName}: ${errorMsg}`);
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  const content = editor.readFile(tempFile);
+  if (!content) {
+    editor.setStatus(`Failed to read downloaded file`);
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(content) as Record<string, unknown>;
+  } catch (e) {
+    editor.setStatus(`Downloaded file is not valid JSON: ${e}`);
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  // Heuristic: a Fresh theme JSON has a `name` string and at least one of
+  // the recognized theme sections. This rules out arbitrary JSON files
+  // (configs, package manifests, etc.) being installed as themes.
+  const themeName = typeof parsed.name === "string" ? parsed.name : null;
+  const looksLikeTheme = themeName !== null && (
+    parsed.editor !== undefined ||
+    parsed.ui !== undefined ||
+    parsed.syntax !== undefined ||
+    parsed.search !== undefined ||
+    parsed.diagnostics !== undefined ||
+    parsed.base !== undefined
+  );
+
+  if (!looksLikeTheme) {
+    editor.setStatus(
+      `Unrecognized file format at ${url} - direct file install currently supports Fresh theme JSON only`
+    );
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  // Use the theme's own name as the package name when available.
+  if (themeName) packageName = themeName;
+
+  // Sanitize for use as a directory name.
+  const safeName = packageName.replace(/[^a-zA-Z0-9_.-]/g, "-");
+  const targetDir = editor.pathJoin(THEMES_PACKAGES_DIR, safeName);
+
+  if (editor.fileExists(targetDir)) {
+    editor.setStatus(`Package '${safeName}' is already installed`);
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  ensureDir(THEMES_PACKAGES_DIR);
+  if (!ensureDir(targetDir)) {
+    editor.setStatus(`Failed to create package directory ${targetDir}`);
+    editor.removePath(tempFile);
+    return false;
+  }
+
+  const themeFileName = "theme.json";
+  if (!editor.writeFile(editor.pathJoin(targetDir, themeFileName), content)) {
+    editor.setStatus(`Failed to write theme file`);
+    editor.removePath(tempFile);
+    editor.removePath(targetDir);
+    return false;
+  }
+
+  const manifest: PackageManifest = {
+    name: safeName,
+    version: "1.0.0",
+    description: `Theme installed from ${url}`,
+    type: "theme",
+    fresh: {
+      themes: [{ file: themeFileName, name: themeName ?? safeName }],
+    },
+  };
+  if (!await writeJsonFile(editor.pathJoin(targetDir, "package.json"), manifest)) {
+    editor.setStatus(`Failed to write package manifest`);
+    editor.removePath(tempFile);
+    editor.removePath(targetDir);
+    return false;
+  }
+
+  await writeJsonFile(editor.pathJoin(targetDir, ".fresh-source.json"), {
+    url,
+    installed_at: new Date().toISOString(),
+  });
+
+  editor.removePath(tempFile);
+  editor.reloadThemes();
+  editor.setStatus(`Installed theme ${themeName ?? safeName}`);
+  return true;
 }
 
 /**
@@ -2748,7 +2917,7 @@ async function pkg_install_theme() : Promise<void> {
 registerHandler("pkg_install_theme", pkg_install_theme);
 
 /**
- * Install from git URL or local path
+ * Install from git URL, direct file URL, or local path
  */
 function pkg_install_url() : void {
   editor.startPrompt("Git URL or local path:", "pkg-install-url");

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -6314,9 +6314,17 @@ const HTTP_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
 /// as their status code without writing to the target file. Transport
 /// errors (DNS, TLS, timeout, …) are returned as `Err`.
 fn fetch_url_to_file(url: &str, target: &std::path::Path) -> Result<u16, String> {
+    // Use the platform's native certificate verifier so requests work in
+    // environments with TLS-intercepting proxies or custom enterprise root
+    // CAs that aren't in Mozilla's bundled webpki-roots.
+    let tls_config = ureq::tls::TlsConfig::builder()
+        .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+        .build();
+
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(std::time::Duration::from_secs(30)))
         .http_status_as_error(false)
+        .tls_config(tls_config)
         .build()
         .new_agent();
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -949,6 +949,14 @@ impl Editor {
                 self.handle_delay(callback_id, duration_ms);
             }
 
+            PluginCommand::HttpFetch {
+                url,
+                target_path,
+                callback_id,
+            } => {
+                self.handle_http_fetch(url, target_path, callback_id);
+            }
+
             PluginCommand::SpawnBackgroundProcess {
                 process_id,
                 command,
@@ -3284,6 +3292,54 @@ impl Editor {
                 .read()
                 .unwrap()
                 .resolve_callback(callback_id, "null".to_string());
+        }
+    }
+
+    fn handle_http_fetch(
+        &mut self,
+        url: String,
+        target_path: std::path::PathBuf,
+        callback_id: fresh_core::api::JsCallbackId,
+    ) {
+        if let (Some(runtime), Some(bridge)) = (&self.tokio_runtime, &self.async_bridge) {
+            let sender = bridge.sender();
+            let process_id = callback_id.as_u64();
+
+            runtime.spawn(async move {
+                let fetch = tokio::task::spawn_blocking(move || {
+                    fetch_url_to_file(&url, &target_path)
+                })
+                .await;
+
+                let (stdout, stderr, exit_code) = match fetch {
+                    Ok(Ok(status)) => {
+                        if (200..300).contains(&status) {
+                            (String::new(), String::new(), 0)
+                        } else {
+                            (
+                                String::new(),
+                                format!("HTTP {}", status),
+                                i32::from(status),
+                            )
+                        }
+                    }
+                    Ok(Err(e)) => (String::new(), e, -1),
+                    Err(e) => (String::new(), format!("fetch task failed: {}", e), -1),
+                };
+
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = sender.send(AsyncMessage::PluginProcessOutput {
+                    process_id,
+                    stdout,
+                    stderr,
+                    exit_code,
+                });
+            });
+        } else {
+            self.plugin_manager
+                .read()
+                .unwrap()
+                .reject_callback(callback_id, "Async runtime not available".to_string());
         }
     }
 
@@ -6245,4 +6301,47 @@ impl Window {
             }
         }
     }
+}
+
+/// Maximum size of a body downloaded via `editor.httpFetch`. 64 MB is well
+/// above any reasonable theme/plugin asset (themes are tens of KB) while
+/// still capping a misbehaving server's blast radius.
+const HTTP_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Fetch a URL over HTTP(S) and stream the response body into `target`.
+///
+/// Returns the HTTP status code on success. Non-2xx responses are returned
+/// as their status code without writing to the target file. Transport
+/// errors (DNS, TLS, timeout, …) are returned as `Err`.
+fn fetch_url_to_file(url: &str, target: &std::path::Path) -> Result<u16, String> {
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(30)))
+        .http_status_as_error(false)
+        .build()
+        .new_agent();
+
+    let response = agent
+        .get(url)
+        .header("User-Agent", "fresh-editor")
+        .call()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    let status = response.status().as_u16();
+    if !(200..300).contains(&status) {
+        return Ok(status);
+    }
+
+    let mut file = std::fs::File::create(target)
+        .map_err(|e| format!("failed to create {}: {}", target.display(), e))?;
+
+    let mut reader = response
+        .into_body()
+        .into_with_config()
+        .limit(HTTP_FETCH_MAX_BYTES)
+        .reader();
+
+    std::io::copy(&mut reader, &mut file)
+        .map_err(|e| format!("failed to write response body: {}", e))?;
+
+    Ok(status)
 }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3306,21 +3306,16 @@ impl Editor {
             let process_id = callback_id.as_u64();
 
             runtime.spawn(async move {
-                let fetch = tokio::task::spawn_blocking(move || {
-                    fetch_url_to_file(&url, &target_path)
-                })
-                .await;
+                let fetch =
+                    tokio::task::spawn_blocking(move || fetch_url_to_file(&url, &target_path))
+                        .await;
 
                 let (stdout, stderr, exit_code) = match fetch {
                     Ok(Ok(status)) => {
                         if (200..300).contains(&status) {
                             (String::new(), String::new(), 0)
                         } else {
-                            (
-                                String::new(),
-                                format!("HTTP {}", status),
-                                i32::from(status),
-                            )
+                            (String::new(), format!("HTTP {}", status), i32::from(status))
                         }
                     }
                     Ok(Err(e)) => (String::new(), e, -1),

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6704,6 +6704,7 @@ impl QuickJsBackend {
                 editor.createBufferGroup = _wrapAsync("_createBufferGroupStart", "createBufferGroup");
                 editor.sendLspRequest = _wrapAsync("_sendLspRequestStart", "sendLspRequest");
                 editor.spawnBackgroundProcess = _wrapAsyncThenable("_spawnBackgroundProcessStart", "spawnBackgroundProcess");
+                editor.httpFetch = _wrapAsyncThenable("_httpFetchStart", "httpFetch");
                 editor.spawnProcessWait = _wrapAsync("_spawnProcessWaitStart", "spawnProcessWait");
                 editor.getBufferText = _wrapAsync("_getBufferTextStart", "getBufferText");
                 editor.createCompositeBuffer = _wrapAsync("_createCompositeBufferStart", "createCompositeBuffer");

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5609,6 +5609,40 @@ impl JsEditorApi {
             .send(PluginCommand::ClearRemoteIndicatorState);
     }
 
+    /// Fetch a URL over HTTP(S) and stream the response body into `target_path`.
+    ///
+    /// Resolves with a `SpawnResult`-shaped value: `exit_code` is `0` on a
+    /// 2xx response (file written), the HTTP status code on non-2xx
+    /// (target file untouched), and `-1` on transport errors. `stderr`
+    /// carries an error message in the non-success cases; `stdout` is
+    /// always empty.
+    ///
+    /// This uses the editor's built-in HTTP client (`ureq`), so plugins
+    /// don't need `curl`/`wget` on PATH.
+    #[plugin_api(async_thenable, js_name = "httpFetch", ts_return = "SpawnResult")]
+    #[qjs(rename = "_httpFetchStart")]
+    pub fn http_fetch_start(
+        &self,
+        _ctx: rquickjs::Ctx<'_>,
+        url: String,
+        target_path: String,
+    ) -> u64 {
+        let id = self.alloc_request_id();
+        tracing::info!(
+            "http_fetch_start: plugin='{}', url='{}', target='{}', callback_id={}",
+            self.plugin_name,
+            url,
+            target_path,
+            id
+        );
+        let _ = self.command_sender.send(PluginCommand::HttpFetch {
+            url,
+            target_path: std::path::PathBuf::from(target_path),
+            callback_id: JsCallbackId::new(id),
+        });
+        id
+    }
+
     /// Wait for a process to complete and get its result (async)
     #[plugin_api(async_promise, js_name = "spawnProcessWait", ts_return = "SpawnResult")]
     #[qjs(rename = "_spawnProcessWaitStart")]

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1315,6 +1315,7 @@ mod tests {
             "spawnProcess",
             "spawnProcessWait",
             "spawnHostProcess",
+            "httpFetch",
             "setAuthority",
             "clearAuthority",
             "setRemoteIndicatorState",


### PR DESCRIPTION
URLs pointing to a single downloadable file (e.g. a theme JSON hosted
on GitHub user-attachments) were sent through git clone and failed
with "Repository not found". Detect URLs ending in `.json`/`.jsonc`
and download them with curl instead, then validate the payload looks
like a Fresh theme and install it as a synthetic theme package.