### PR TITLE
Fix preview pane rendering of buffer groups (issue #2035)

### DIFF
--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1979,6 +1979,14 @@ impl Editor {
         let __preview_event_logs = &mut __win_for_preview.event_logs;
         let __preview_composite_buffers = &mut __win_for_preview.composite_buffers;
         let __preview_composite_view_states = &mut __win_for_preview.composite_view_states;
+        // Issue #2035: pass the previewed window's actual
+        // `grouped_subtrees` map. The previous code allocated an
+        // empty HashMap here, which made the split renderer unable
+        // to resolve any `active_group_tab` to its panel layout —
+        // so a session whose active tab was a buffer group (e.g.
+        // git_log's log/detail panels) silently fell through to
+        // rendering the split's underlying pre-group buffer.
+        let __preview_grouped_subtrees = &__win_for_preview.grouped_subtrees;
         let preview_tab_bar_visible = __win_for_preview.tab_bar_visible;
 
         // Per-call scratch — keeps the preview pass from
@@ -1987,10 +1995,6 @@ impl Editor {
         let mut scratch_cell_theme_map: Vec<crate::app::types::CellThemeInfo> = Vec::new();
         let mut scratch_pending_cursor: Option<(u16, u16)> = None;
         let lsp_waiting = false; // preview never shows LSP-waiting chrome
-        let no_grouped_subtrees: std::collections::HashMap<
-            crate::model::event::LeafId,
-            crate::view::split::SplitNode,
-        > = std::collections::HashMap::new();
 
         let mut preview_split_areas: Vec<(
             crate::model::event::LeafId,
@@ -2021,7 +2025,7 @@ impl Editor {
                     self.config.editor.estimated_line_length,
                     self.config.editor.highlight_context_bytes,
                     Some(view_states),
-                    &no_grouped_subtrees,
+                    __preview_grouped_subtrees,
                     true, // hide_cursor — the active session owns the hardware caret
                     None, // no tab-hover routing in the preview
                     None,

--- a/crates/fresh-editor/tests/e2e/issue_2035_preview_renders_buffer_groups.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2035_preview_renders_buffer_groups.rs
@@ -1,0 +1,153 @@
+//! Issue #2035 reproducer: the Orchestrator-style preview pane (any
+//! `windowEmbed` widget mounted inside a floating panel) used to skip
+//! virtual buffer GROUPS. Plugins like `git_log` build their UI as a
+//! `createBufferGroup` of virtual panels — so previewing a session
+//! whose active tab was `*Git Log*` rendered the previous file
+//! buffer instead of the log/detail panels.
+//!
+//! Root cause was a single line in
+//! `crates/fresh-editor/src/app/render.rs::render_session_preview_into_rect`:
+//! it passed a freshly-allocated empty `grouped_subtrees` map to
+//! `SplitRenderer::render_content`. When the split renderer asked
+//! "what's behind the `active_group_tab` of this split?", the empty
+//! map answered "nothing", and the renderer fell back to painting
+//! the split's underlying (pre-group) buffer.
+//!
+//! This test exercises the same code path the Orchestrator's
+//! `windowEmbed({windowId: s.id})` hits: a floating widget panel
+//! whose contents is a single `windowEmbed` aimed at the current
+//! window. The float is mounted at 100%×100% so the embed *is* the
+//! entire visible interior — no leakage from the underlying editor
+//! render. If the marker text from the buffer group's panels lands
+//! inside the float, the preview path resolved the group correctly.
+//!
+//! Per CONTRIBUTING.md §2 the assertion is on rendered output only.
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+const LEFT_MARKER: &str = "ISSUE2035-LEFT-MARKER";
+const RIGHT_MARKER: &str = "ISSUE2035-RIGHT-MARKER";
+
+/// Install the issue-2035 test plugin into the project's plugin
+/// directory. Mirrors the pattern in `e2e::buffer_groups`.
+fn install_plugin(project_root: &std::path::Path) {
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin_lib(&plugins_dir);
+
+    const SRC: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/plugins/test_issue_2035_preview_embed.ts"
+    ));
+    let dst = plugins_dir.join("test_issue_2035_preview_embed.ts");
+    fs::write(&dst, SRC).unwrap_or_else(|e| {
+        panic!(
+            "Failed to write test_issue_2035_preview_embed.ts to {:?}: {}",
+            dst, e
+        )
+    });
+}
+
+/// Drive a registered command via the command palette and wait for
+/// the plugin's status-message acknowledgement to appear.
+fn run_command_and_wait(harness: &mut EditorTestHarness, name: &str, ack: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(name).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(ack))
+        .unwrap();
+}
+
+#[test]
+fn floating_window_embed_renders_buffer_group_panels() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    install_plugin(&project_root);
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 40, Default::default(), project_root)
+            .unwrap();
+    harness.render().unwrap();
+
+    // Step 1: open a 2-panel buffer group in the active (and only)
+    // window. After this, both markers must be visible somewhere on
+    // screen — the panels render in the active split.
+    run_command_and_wait(&mut harness, "TestPrev: Setup", "TestPrev: SETUP_DONE");
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(LEFT_MARKER) && s.contains(RIGHT_MARKER)
+        })
+        .unwrap();
+
+    // Step 2: mount a 100%×100% floating widget whose content is a
+    // single `windowEmbed` pointing at the current window. The
+    // floating panel clears the entire visible area inside its
+    // border before painting, so any marker visible AFTER mount is
+    // a marker drawn by the embed — not leakage from the editor
+    // underneath.
+    run_command_and_wait(&mut harness, "TestPrev: Mount", "TestPrev: MOUNTED");
+
+    // Allow a render frame for the floating panel + embed to paint.
+    harness.render().unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+
+    // The float draws a box border (`┌─…─┐` top, `└─…─┘` bottom). The
+    // rows strictly between those two borders are the float's
+    // interior — any text on them was painted by the `windowEmbed`,
+    // not by the editor underneath (the underlying render at those
+    // rows was cleared before the embed paint).
+    //
+    // We must NOT use the full-screen text for the marker check:
+    // the active window still renders its buffer group in the
+    // narrow strips above/below the float, so the markers always
+    // appear *somewhere* on screen. The bug is that they don't
+    // appear *inside the float*.
+    let lines: Vec<&str> = screen.lines().collect();
+    let top_border = lines
+        .iter()
+        .position(|l| l.contains('┌') && l.contains('─'))
+        .expect("float top border must be on screen after mount");
+    let bottom_border = lines
+        .iter()
+        .rposition(|l| l.contains('└') && l.contains('─'))
+        .expect("float bottom border must be on screen after mount");
+    assert!(
+        bottom_border > top_border + 1,
+        "float must have an interior between its borders \
+         (top={top_border}, bottom={bottom_border})"
+    );
+    let interior: String = lines[top_border + 1..bottom_border].join("\n");
+
+    assert!(
+        interior.contains(LEFT_MARKER),
+        "issue #2035: LEFT panel marker must render INSIDE the \
+         floating `windowEmbed` (the embed should resolve the active \
+         window's buffer group). Without the fix, the embed renders \
+         the underlying pre-group buffer and the marker is absent \
+         from the float's interior.\nfloat interior:\n{interior}\n\
+         full screen:\n{screen}"
+    );
+    assert!(
+        interior.contains(RIGHT_MARKER),
+        "issue #2035: RIGHT panel marker must render INSIDE the \
+         floating `windowEmbed`.\nfloat interior:\n{interior}\n\
+         full screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -76,6 +76,7 @@ pub mod issue_1965_cursor_after_mouse_scroll;
 pub mod issue_2029_file_explorer_terminal_focus;
 pub mod issue_2030_quit_confirm_and_disable;
 pub mod issue_2031_next_prev_window;
+pub mod issue_2035_preview_renders_buffer_groups;
 pub mod issue_779_after_eof_shade;
 pub mod redraw_screen;
 pub mod suspend_process;

--- a/crates/fresh-editor/tests/plugins/test_issue_2035_preview_embed.ts
+++ b/crates/fresh-editor/tests/plugins/test_issue_2035_preview_embed.ts
@@ -1,0 +1,114 @@
+/// <reference path="../../plugins/lib/fresh.d.ts" />
+const editor = getEditor();
+
+/**
+ * Reproducer for issue #2035: the Orchestrator-style preview pane
+ * (`windowEmbed` inside a floating widget) failed to render virtual
+ * buffer GROUPS (the layout primitive that user-visible plugins like
+ * `git_log` rely on). The host's `render_session_preview_into_rect`
+ * passed an empty `grouped_subtrees` map to the split renderer, so
+ * the group's panel layout couldn't be resolved and the embed fell
+ * through to rendering the split's underlying (pre-group) buffer.
+ *
+ * This plugin gives the e2e test a deterministic surface:
+ *   1. `TestPrev: Setup` — opens a 2-panel buffer group with
+ *      distinctive markers (mirrors `test_buffer_groups.ts`).
+ *   2. `TestPrev: Mount` — mounts a near-fullscreen floating widget
+ *      whose only contents is a `windowEmbed` pointing at the
+ *      current window. With the bug, the embed renders the
+ *      underlying file buffer; with the fix, it renders the buffer
+ *      group's panel content (markers visible).
+ *
+ * The float is mounted at 100% width / 100% height so the underlying
+ * editor area is fully cleared inside the float — only what the
+ * embed paints is visible there. That makes the test assertion
+ * unambiguous: marker present ↔ the embed correctly resolved the
+ * group.
+ */
+
+interface State {
+  groupId: number | null;
+  panels: Record<string, number>;
+}
+
+const state: State = { groupId: null, panels: {} };
+const PANEL_ID = 991919; // arbitrary stable id for the float
+
+async function prev_setup(): Promise<void> {
+  if (state.groupId !== null) {
+    editor.setStatus("TestPrev: already set up");
+    return;
+  }
+  const layout = JSON.stringify({
+    type: "split",
+    direction: "h",
+    ratio: 0.5,
+    first: { type: "scrollable", id: "left" },
+    second: { type: "scrollable", id: "right" },
+  });
+  const result = await editor.createBufferGroup(
+    "*TestPrev*",
+    "test-prev",
+    layout,
+  );
+  state.groupId = result.groupId;
+  state.panels = result.panels;
+  editor.setVirtualBufferContent(state.panels["left"], [
+    { text: "ISSUE2035-LEFT-MARKER\n", properties: {} },
+    { text: "left line 2\n", properties: {} },
+  ]);
+  editor.setVirtualBufferContent(state.panels["right"], [
+    { text: "ISSUE2035-RIGHT-MARKER\n", properties: {} },
+    { text: "right line 2\n", properties: {} },
+  ]);
+  editor.setStatus("TestPrev: SETUP_DONE");
+}
+registerHandler("prev_setup", prev_setup);
+
+function prev_mount(): void {
+  // windowEmbed pointing back at the current window. The host's
+  // floating-widget-with-embed path bypasses the
+  // `PreviewWindowInRect` same-window guard (see `render.rs` near
+  // the `preview_window_id` swap), so this renders the active
+  // window into the embed even when it's the only window.
+  const winId = editor.activeWindow();
+  const spec = {
+    kind: "col",
+    children: [
+      {
+        kind: "windowEmbed",
+        windowId: winId,
+        rows: 20,
+        key: "issue-2035-embed",
+      },
+    ],
+  };
+  editor.mountFloatingWidget(PANEL_ID, spec, 100, 100);
+  editor.setStatus("TestPrev: MOUNTED");
+}
+registerHandler("prev_mount", prev_mount);
+
+function prev_unmount(): void {
+  editor.unmountFloatingWidget(PANEL_ID);
+  editor.setStatus("TestPrev: UNMOUNTED");
+}
+registerHandler("prev_unmount", prev_unmount);
+
+editor.registerCommand(
+  "TestPrev: Setup",
+  "Open a 2-panel buffer group with markers",
+  "prev_setup",
+  null,
+);
+editor.registerCommand(
+  "TestPrev: Mount",
+  "Mount a floating windowEmbed of the current window",
+  "prev_mount",
+  null,
+);
+editor.registerCommand(
+  "TestPrev: Unmount",
+  "Tear down the floating widget",
+  "prev_unmount",
+  null,
+);


### PR DESCRIPTION
## Summary
Fixed a bug where the Orchestrator-style preview pane (a `windowEmbed` widget mounted inside a floating panel) failed to render virtual buffer groups. When a session's active tab was a buffer group (e.g., git_log's log/detail panels), the preview would incorrectly render the underlying pre-group buffer instead of the group's panel layout.

## Root Cause
In `crates/fresh-editor/src/app/render.rs::render_session_preview_into_rect`, the code was passing a freshly-allocated empty `grouped_subtrees` map to `SplitRenderer::render_content`. When the split renderer tried to resolve the `active_group_tab`, the empty map returned nothing, causing the renderer to fall back to painting the split's underlying buffer.

## Key Changes
- **render.rs**: Changed `render_session_preview_into_rect` to pass the previewed window's actual `grouped_subtrees` map instead of an empty HashMap. This allows the split renderer to correctly resolve buffer group panel layouts during preview rendering.

## Testing
Added comprehensive end-to-end test coverage:
- **issue_2035_preview_renders_buffer_groups.rs**: E2E test that verifies a floating `windowEmbed` correctly renders buffer group panels. The test mounts a 100%×100% floating widget to ensure any rendered markers come from the embed, not from underlying editor leakage.
- **test_issue_2035_preview_embed.ts**: Test plugin that provides deterministic commands to set up a 2-panel buffer group with distinctive markers and mount a floating widget embed pointing at the current window.

The test validates that both left and right panel markers appear inside the floating widget's interior, confirming the buffer group is correctly resolved during preview rendering.

https://claude.ai/code/session_019qBb8gCDxupKtdBN564RjP