### PR TITLE
Replace explicit queries directory with .scm file extension filter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,10 @@
               (lib.fileset.fileFilter (file: file.hasExt "py") unfilteredRoot)
               # Keep sublime-syntax grammar files (used by include_str! in grammar_registry.rs)
               (lib.fileset.fileFilter (file: file.hasExt "sublime-syntax") unfilteredRoot)
+              # Tree-sitter query files (used by include_str! in fresh-languages and shipped
+              # as runtime assets by fresh-editor). Filtering by extension covers query files
+              # under any crate without needing to enumerate per-crate query directories.
+              (lib.fileset.fileFilter (file: file.hasExt "scm") unfilteredRoot)
               # Font files (used by include_bytes! in fresh-gui and fresh-editor)
               (lib.fileset.fileFilter (file: file.hasExt "ttf") unfilteredRoot)
               # Icon files (used by include_bytes! in fresh-gui)
@@ -65,7 +69,6 @@
               ./crates/fresh-editor/keymaps
               ./crates/fresh-editor/locales
               ./crates/fresh-editor/plugins
-              ./crates/fresh-editor/queries
               ./crates/fresh-editor/themes
               ./crates/fresh-editor/types
               # Test files


### PR DESCRIPTION
## Summary
Refactored the Nix flake configuration to use a more generic approach for including Tree-sitter query files in the build, replacing an explicit directory path with an extension-based filter.

## Key Changes
- Added a new file filter for `.scm` (Scheme) files, which are Tree-sitter query files used by `fresh-languages` and shipped as runtime assets by `fresh-editor`
- Removed the explicit `./crates/fresh-editor/queries` directory from the included paths
- The extension-based filter approach automatically covers query files under any crate without requiring per-crate directory enumeration

## Implementation Details
The new filter uses `lib.fileset.fileFilter` with `file.hasExt "scm"` to match all Tree-sitter query files across the repository. This is more maintainable than hardcoding specific directory paths, as it will automatically include query files regardless of where they're located in the crate structure. The change maintains the same functionality while improving the flexibility and scalability of the build configuration.

https://claude.ai/code/session_01AVvNTZYT5LsJfgrXCdcxZM