### PR TITLE
fix(orchestrator): scope sessions per project + redesign the Open picker

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -480,10 +480,12 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   }
   // Project tag: in the "all projects" view, label every row with
   // its project so a cross-project session is obvious at a glance
-  // rather than blending into the current project's sessions.
+  // rather than blending into the current project's sessions. Use
+  // the project's basename (not the full parent/base label) so it
+  // fits the sessions column without truncating.
   if (openDialog?.scope === "all" && projectKeyOf(s) !== currentProjectKey()) {
     entries.push({
-      text: `  · ${projectLabel(projectKeyOf(s))}`,
+      text: `  · ${editor.pathBasename(projectKeyOf(s))}`,
       style: { fg: "ui.menu_disabled_fg", italic: true },
     });
   }
@@ -962,6 +964,14 @@ function buildOpenSpec(): WidgetSpec {
   const sectionLabel = scope === "current"
     ? `${curName} · this project (${filtered.length})`
     : `Sessions (${filtered.length})`;
+  // Visible, clickable scope toggle. The chevrons mark it as a
+  // cycle; clicking (or Alt+P) flips between this-project and
+  // all-projects. Inert while a confirm prompt is up (drop the key)
+  // so it can't steal focus from Cancel/Confirm.
+  const scopeToggleLabel = scope === "current" ? "‹ This project ›" : "‹ All projects ›";
+  const scopeToggleButton = button(scopeToggleLabel, {
+    key: openDialog.pendingConfirm !== null ? undefined : "scope-toggle",
+  });
   const otherCount = otherProjectSessionCount();
   const otherAffordance: WidgetSpec[] = scope === "current" && otherCount > 0
     ? [
@@ -1007,9 +1017,13 @@ function buildOpenSpec(): WidgetSpec {
     row(
       labeledSection({
         label: sectionLabel,
-        widthPct: 25,
-        // Sessions column: new-session button, separator,
-        // filter, separator, list. The button is first so it
+        // 34% (was 25%): wide enough that the per-row project tag in
+        // the all-projects view (`· <project>`) and longer session
+        // labels render without truncating to `· tmp_o…`. The preview
+        // pane still keeps the majority for the live window embed.
+        widthPct: 34,
+        // Sessions column: new-session button, separator, filter,
+        // scope toggle, separator, list. The button is first so it
         // gets initial focus (Enter immediately opens the new
         // session form). Separators are long `─` strings that
         // the renderer truncates to the column's inner width —
@@ -1030,18 +1044,28 @@ function buildOpenSpec(): WidgetSpec {
           ),
           sessionsSeparator(),
           filterInput,
+          // Scope toggle: a visible, clickable control for the
+          // current-project ↔ all-projects switch (Alt+P also flips
+          // it). The chevrons hint it cycles; the footer + the "N in
+          // other projects" affordance spell out the alternative.
+          row(scopeToggleButton, flexSpacer()),
           sessionsSeparator(),
           list({
             items,
             itemKeys,
             selectedIndex: selIdx,
-            // The "N in other projects" affordance (separator + line)
-            // sits below the list and eats into the column's height
-            // budget. Shrink the list's reserved rows by exactly those
-            // rows so the sessions column keeps the same total height
-            // as the preview pane — otherwise the extra rows push the
-            // footer hint bar off the bottom of the fixed-height panel.
-            visibleRows: Math.max(1, openDialog.listVisibleRows - otherAffordance.length),
+            // The scope-toggle row (always present) and the "N in
+            // other projects" affordance (separator + line, scoped
+            // view only) sit outside the list but inside the sessions
+            // column, eating into its height budget. Shrink the list's
+            // reserved rows by exactly those rows so the sessions
+            // column keeps the same total height as the preview pane —
+            // otherwise the extra rows push the footer hint bar off the
+            // bottom of the fixed-height panel.
+            visibleRows: Math.max(
+              1,
+              openDialog.listVisibleRows - 1 - otherAffordance.length,
+            ),
             // Excluded from the Tab cycle — Up/Down on the
             // filter input forwards to this list via host
             // smart-keys, so Tab jumps straight to the action
@@ -1759,7 +1783,7 @@ registerHandler("orchestrator_open_new_from_picker", () => {
   openForm({ fromPicker: true });
 });
 
-registerHandler("orchestrator_toggle_scope", () => {
+function toggleScope(): void {
   if (!openDialog) return;
   openDialog.scope = openDialog.scope === "current" ? "all" : "current";
   // Keep the highlighted session selected across the scope flip
@@ -1771,7 +1795,9 @@ registerHandler("orchestrator_toggle_scope", () => {
   const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
   openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
   refreshOpenDialog();
-});
+}
+
+registerHandler("orchestrator_toggle_scope", toggleScope);
 
 // =============================================================================
 // New-session floating form
@@ -3323,6 +3349,10 @@ editor.on("widget_event", (e) => {
     if (e.event_type === "activate" && e.widget_key === "new-session") {
       closeOpenDialog();
       openForm({ fromPicker: true });
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "scope-toggle") {
+      toggleScope();
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "toggle-details") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -246,6 +246,17 @@ interface OpenDialogState {
   // too easy to skip over when the user's eyes are on the dialog.
   // Cleared on the next nav / filter change.
   lastError: string | null;
+  // Which sessions the list foregrounds:
+  //   - "current": only sessions belonging to the active window's
+  //     project (the default — launching in project B shouldn't
+  //     bury you under project A's sessions). A trailing affordance
+  //     row advertises how many sessions live in other projects.
+  //   - "all": every session, across every project, each row
+  //     labeled with its project so cross-project rows are obvious.
+  // Toggled with the scope key (⌥P by default). The filter input
+  // always searches globally regardless of scope, so typing a name
+  // from another project still surfaces it.
+  scope: "current" | "all";
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -325,14 +336,88 @@ function ageString(createdAt: number): string {
 // The picker is cross-project by design — every session is a
 // candidate regardless of which project the active window
 // points at — so there is no project-scope filter here.
+// Project a session belongs to, as a comparison key. Prefer the
+// canonical `projectPath` recorded at create time; fall back to
+// the session root for sessions that predate the field (the base
+// session, externally-created windows).
+function projectKeyOf(s: AgentSession): string {
+  return s.projectPath ?? s.root;
+}
+
+// The project the user is currently "in" — the active window's
+// project. Falls back to the editor cwd when the active window
+// isn't a tracked session (shouldn't normally happen, but keeps
+// scoping well-defined).
+function currentProjectKey(): string {
+  const s = orchestratorSessions.get(editor.activeWindow());
+  return s ? projectKeyOf(s) : editor.getCwd();
+}
+
+// Short, human-readable label for a project key — the trailing
+// `parent/base` of the path, matching the new-session form's
+// `deriveProjectLabel` style.
+function projectLabel(key: string): string {
+  const base = editor.pathBasename(key);
+  const parent = editor.pathBasename(editor.pathDirname(key));
+  if (parent && parent !== base) return `${parent}/${base}`;
+  return base || key;
+}
+
+// Count sessions that do NOT belong to the current project —
+// surfaced as the "N in other projects" affordance when the
+// dialog is scoped to the current project.
+function otherProjectSessionCount(): number {
+  const cur = currentProjectKey();
+  let n = 0;
+  for (const s of orchestratorSessions.values()) {
+    if (projectKeyOf(s) !== cur) n += 1;
+  }
+  return n;
+}
+
+// Resolve the id list for the current filter + scope.
+//
+// Scope only constrains the *empty-filter* view: with no needle
+// and `scope === "current"`, the list shows just the active
+// project's sessions (current project first, by id). As soon as
+// the user types, the search goes global regardless of scope —
+// hiding a session the user is explicitly searching for would be
+// the worse surprise. `scope === "all"` always shows everything,
+// sorted by project (current project first) so rows are grouped
+// rather than interleaved.
 function filterSessions(needle: string): number[] {
   reconcileSessions();
-  const ids = Array.from(orchestratorSessions.keys()).sort((a, b) => a - b);
-  if (!needle) return ids;
+  const scope = openDialog?.scope ?? "current";
+  const cur = currentProjectKey();
+  const allIds = Array.from(orchestratorSessions.keys());
+
+  // Sort by (current-project-first, then id) so an "all" view
+  // groups the current project's sessions at the top and other
+  // projects' sessions below in a stable order.
+  const byProjectThenId = (a: number, b: number): number => {
+    const sa = orchestratorSessions.get(a)!;
+    const sb = orchestratorSessions.get(b)!;
+    const aCur = projectKeyOf(sa) === cur ? 0 : 1;
+    const bCur = projectKeyOf(sb) === cur ? 0 : 1;
+    if (aCur !== bCur) return aCur - bCur;
+    const ka = projectKeyOf(sa);
+    const kb = projectKeyOf(sb);
+    if (ka !== kb) return ka < kb ? -1 : 1;
+    return a - b;
+  };
+
+  if (!needle) {
+    const ids = allIds.slice().sort(byProjectThenId);
+    if (scope === "current") {
+      return ids.filter((id) => projectKeyOf(orchestratorSessions.get(id)!) === cur);
+    }
+    return ids;
+  }
+
   const n = needle.toLowerCase();
   type Scored = { id: number; score: number; len: number };
   const matches: Scored[] = [];
-  for (const id of ids) {
+  for (const id of allIds) {
     const s = orchestratorSessions.get(id)!;
     const label = s.label.toLowerCase();
     const root = s.root.toLowerCase();
@@ -391,6 +476,15 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
     entries.push({
       text: " ⇄",
       style: { fg: "ui.menu_disabled_fg" },
+    });
+  }
+  // Project tag: in the "all projects" view, label every row with
+  // its project so a cross-project session is obvious at a glance
+  // rather than blending into the current project's sessions.
+  if (openDialog?.scope === "all" && projectKeyOf(s) !== currentProjectKey()) {
+    entries.push({
+      text: `  · ${projectLabel(projectKeyOf(s))}`,
+      style: { fg: "ui.menu_disabled_fg", italic: true },
     });
   }
   return styledRow(entries as Parameters<typeof styledRow>[0]);
@@ -853,6 +947,39 @@ function buildOpenSpec(): WidgetSpec {
         ],
       }
     : null;
+
+  // Scope chrome. The title and the sessions-section label both
+  // advertise what the list is currently showing so the user is
+  // never confused about which project's sessions they're looking
+  // at. When scoped to the current project, a trailing affordance
+  // row reports how many sessions live elsewhere and how to reveal
+  // them — nothing is hidden, just not foregrounded.
+  const scope = openDialog.scope;
+  const curKey = currentProjectKey();
+  const curName = projectLabel(curKey);
+  const scopeKey = editor.getKeybindingLabel("orchestrator_toggle_scope", OPEN_MODE);
+  const titleSuffix = scope === "current" ? `  —  ${curName}` : "  —  all projects";
+  const sectionLabel = scope === "current"
+    ? `${curName} · this project (${filtered.length})`
+    : `Sessions (${filtered.length})`;
+  const otherCount = otherProjectSessionCount();
+  const otherAffordance: WidgetSpec[] = scope === "current" && otherCount > 0
+    ? [
+        sessionsSeparator(),
+        {
+          kind: "raw",
+          entries: [
+            styledRow([
+              {
+                text: `${otherCount} in other projects${scopeKey ? `  ·  ${scopeKey}` : ""}`,
+                style: { fg: "ui.menu_disabled_fg", italic: true },
+              },
+            ]),
+          ],
+        },
+      ]
+    : [];
+
   return col(
     {
       kind: "raw",
@@ -861,6 +988,10 @@ function buildOpenSpec(): WidgetSpec {
           {
             text: "ORCHESTRATOR :: Sessions",
             style: { fg: "ui.popup_border_fg", bold: true },
+          },
+          {
+            text: titleSuffix,
+            style: { fg: "ui.menu_disabled_fg" },
           },
         ]),
       ],
@@ -875,7 +1006,7 @@ function buildOpenSpec(): WidgetSpec {
     // the dialog.
     row(
       labeledSection({
-        label: `Sessions (${filtered.length})`,
+        label: sectionLabel,
         widthPct: 25,
         // Sessions column: new-session button, separator,
         // filter, separator, list. The button is first so it
@@ -920,6 +1051,7 @@ function buildOpenSpec(): WidgetSpec {
             // `pendingConfirm.sessionId`).
             key: inConfirm ? undefined : "sessions",
           }),
+          ...otherAffordance,
         ),
       }),
       // Preview pane has no explicit width — picks up the
@@ -932,6 +1064,10 @@ function buildOpenSpec(): WidgetSpec {
       hintBar([
         { keys: "↑↓", label: "nav" },
         { keys: "Enter", label: "dive" },
+        {
+          keys: scopeKey || "⌥P",
+          label: scope === "current" ? "all projects" : "current only",
+        },
         { keys: "Tab", label: "focus" },
         { keys: "Esc", label: "close" },
       ]),
@@ -1032,6 +1168,11 @@ function openControlRoom(): void {
     showDetails: false,
     inFlight: null,
     lastError: null,
+    // Default to the current project's sessions so re-opening the
+    // editor in project B doesn't dump project A's whole history on
+    // the user. Cross-project sessions stay one keystroke away via
+    // the scope toggle / the "N in other projects" affordance.
+    scope: "current",
   };
   openDialog.filteredIds = filterSessions("");
   const activeIdx = openDialog.filteredIds.indexOf(activeId);
@@ -1595,7 +1736,13 @@ async function deleteConfirmedSession(): Promise<void> {
 // since OPEN_MODE doesn't claim them here.
 editor.defineMode(
   OPEN_MODE,
-  [["M-n", "orchestrator_open_new_from_picker"]],
+  [
+    ["M-n", "orchestrator_open_new_from_picker"],
+    // Scope toggle: flip the list between "current project only"
+    // and "all projects". Registered as a mode chord so it's
+    // user-rebindable and renders cross-platform (⌥P / Alt+P).
+    ["M-p", "orchestrator_toggle_scope"],
+  ],
   true,
   true,
 );
@@ -1604,6 +1751,20 @@ registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
   closeOpenDialog();
   openForm({ fromPicker: true });
+});
+
+registerHandler("orchestrator_toggle_scope", () => {
+  if (!openDialog) return;
+  openDialog.scope = openDialog.scope === "current" ? "all" : "current";
+  // Keep the highlighted session selected across the scope flip
+  // when it survives into the new list; otherwise fall back to the
+  // top. The filter value is untouched — toggling scope with an
+  // active filter just widens/narrows the global-search base.
+  const prevId = openDialog.filteredIds[openDialog.selectedIndex];
+  openDialog.filteredIds = filterSessions(openDialog.filter.value);
+  const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
+  openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
+  refreshOpenDialog();
 });
 
 // =============================================================================

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1035,7 +1035,13 @@ function buildOpenSpec(): WidgetSpec {
             items,
             itemKeys,
             selectedIndex: selIdx,
-            visibleRows: openDialog.listVisibleRows,
+            // The "N in other projects" affordance (separator + line)
+            // sits below the list and eats into the column's height
+            // budget. Shrink the list's reserved rows by exactly those
+            // rows so the sessions column keeps the same total height
+            // as the preview pane — otherwise the extra rows push the
+            // footer hint bar off the bottom of the fixed-height panel.
+            visibleRows: Math.max(1, openDialog.listVisibleRows - otherAffordance.length),
             // Excluded from the Tab cycle — Up/Down on the
             // filter input forwards to this list via host
             // smart-keys, so Tab jumps straight to the action

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -611,14 +611,6 @@ function maxListRowsForScreen(): number {
   return Math.max(MIN_LIST_ROWS, panelH - 12);
 }
 
-// Actual list height: fit the session count, clamped between
-// MIN_LIST_ROWS and the screen budget, so a handful of sessions
-// gives a compact panel (the host shrinks the floating panel to
-// content height) instead of a tall box padded with blank rows.
-function fitListRows(itemCount: number): number {
-  return Math.min(maxListRowsForScreen(), Math.max(MIN_LIST_ROWS, itemCount));
-}
-
 // Compose the right-hand preview pane. Normally it shows info
 // + action buttons (Stop, Archive, Delete); when a destructive
 // action is pending confirmation it swaps to a "Confirm
@@ -883,10 +875,10 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
 function buildOpenSpec(): WidgetSpec {
   if (!openDialog) return col();
   const filtered = openDialog.filteredIds;
-  // Fit the list (and therefore the whole floating panel) to the
-  // session count, bounded by the screen budget — few sessions give
-  // a compact panel instead of a tall box padded with blank rows.
-  openDialog.listVisibleRows = fitListRows(filtered.length);
+  // Fill the panel's full height budget (the list pads with blank
+  // rows when there are few sessions) so the dialog stays
+  // vertically full rather than collapsing to a short floating box.
+  openDialog.listVisibleRows = maxListRowsForScreen();
   const activeId = editor.activeWindow();
   const items = filtered.map((id) => renderListItem(id, activeId));
   const itemKeys = filtered.map(String);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -363,18 +363,6 @@ function projectLabel(key: string): string {
   return base || key;
 }
 
-// Count sessions that do NOT belong to the current project —
-// surfaced as the "N in other projects" affordance when the
-// dialog is scoped to the current project.
-function otherProjectSessionCount(): number {
-  const cur = currentProjectKey();
-  let n = 0;
-  for (const s of orchestratorSessions.values()) {
-    if (projectKeyOf(s) !== cur) n += 1;
-  }
-  return n;
-}
-
 // Resolve the id list for the current filter + scope.
 //
 // Scope only constrains the *empty-filter* view: with no needle
@@ -433,11 +421,33 @@ function filterSessions(needle: string): number[] {
   return matches.map((m) => m.id);
 }
 
-// Build one rendered list-item row for `id`. Style cues:
-//   * `[id]` in `ui.help_key_fg`
-//   * `ACT` (active session) in `ui.tab_active_fg` + bold
-//   * other states use the default fg
-//   * label in default fg
+// Column widths for the tabular session list. ID holds `[NN] `;
+// NAME holds the label plus the BASE / ⇄ badges; PROJECT (filled
+// only for cross-project rows) trails. Kept in sync with
+// `sessionsColumnHeader`.
+const LIST_ID_W = 5;
+const LIST_NAME_W = 20;
+
+// Header row above the session list: `ID   NAME …   PROJECT`.
+function sessionsColumnHeader(): WidgetSpec {
+  return {
+    kind: "raw",
+    entries: [
+      styledRow([
+        {
+          text: "ID".padEnd(LIST_ID_W) + "NAME".padEnd(LIST_NAME_W) + "PROJECT",
+          style: { fg: "ui.menu_disabled_fg" },
+        },
+      ]),
+    ],
+  };
+}
+
+// Build one rendered list-item row for `id`, laid out in columns:
+//   `[id]`  <name + BASE/⇄ badges>   <project basename>
+// The active session's id renders in the active-tab colour (the
+// list has no separate state column); the project column is filled
+// only for sessions that don't belong to the current project.
 function renderListItem(id: number, activeId: number): TextPropertyEntry {
   const s = orchestratorSessions.get(id);
   if (!s) {
@@ -445,47 +455,37 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   }
   const isActive = id === activeId;
   const isBase = id === 1;
-  const stateText = isActive ? "ACT " : STATE_GLYPH[s.state];
+
+  const idText = `[${id}]`.padEnd(LIST_ID_W);
   const entries: { text: string; style?: Record<string, unknown> }[] = [
-    { text: `[${id}] `, style: { fg: "ui.help_key_fg" } },
     {
-      text: stateText,
+      text: idText,
       style: isActive
         ? { fg: "ui.tab_active_fg", bold: true }
-        : { fg: "ui.menu_disabled_fg" },
+        : { fg: "ui.help_key_fg" },
     },
-    { text: `  ${s.label}` },
+    { text: s.label, style: isActive ? { bold: true } : undefined },
   ];
-  // BASE badge: the base session is the editor process itself —
-  // archive / delete would close the editor (and possibly destroy
-  // the user's current worktree), so the host refuses both. The
-  // badge makes that special status visible up-front instead of
-  // surfacing as "Archive disabled, why?" after a Tab.
+  // Visible width of the NAME column so far (label + badges), used
+  // to pad out to LIST_NAME_W before the PROJECT column.
+  let nameWidth = s.label.length;
   if (isBase) {
-    entries.push({
-      text: " BASE",
-      style: { fg: "ui.help_key_fg", bold: true },
-    });
+    entries.push({ text: " BASE", style: { fg: "ui.help_key_fg", bold: true } });
+    nameWidth += 5;
   }
-  // SHARED badge for the row when this session shares its
-  // worktree (with another session or with the project root
-  // directly). Mirrors the preview pane's badge so the
-  // shared-worktree status is visible at-a-glance from the
-  // list too.
   if (s.sharedWorktree || countSiblingsAtRoot(s.root) > 1) {
-    entries.push({
-      text: " ⇄",
-      style: { fg: "ui.menu_disabled_fg" },
-    });
+    entries.push({ text: " ⇄", style: { fg: "ui.menu_disabled_fg" } });
+    nameWidth += 2;
   }
-  // Project tag: in the "all projects" view, label every row with
-  // its project so a cross-project session is obvious at a glance
-  // rather than blending into the current project's sessions. Use
-  // the project's basename (not the full parent/base label) so it
-  // fits the sessions column without truncating.
-  if (openDialog?.scope === "all" && projectKeyOf(s) !== currentProjectKey()) {
+  // PROJECT column: basename for cross-project rows only; current-
+  // project rows leave it blank (the whole list is one project when
+  // scoped, so this column is empty then).
+  const proj = projectKeyOf(s);
+  if (proj !== currentProjectKey()) {
+    const pad = Math.max(1, LIST_NAME_W - nameWidth);
+    entries.push({ text: " ".repeat(pad) });
     entries.push({
-      text: `  · ${editor.pathBasename(projectKeyOf(s))}`,
+      text: editor.pathBasename(proj),
       style: { fg: "ui.menu_disabled_fg", italic: true },
     });
   }
@@ -589,20 +589,34 @@ function sessionsSeparator(): WidgetSpec {
   return spacer(0);
 }
 
-// Approximate number of session rows the picker's list pane
-// should show. Sized off the full terminal (not the active
-// buffer's viewport — that shrinks with vertical splits and made
-// the picker collapse to ~half its `heightPct: 90` budget).
-function openListVisibleRows(): number {
+// Smallest list height we'll show even when there are only a
+// couple of sessions — keeps the preview pane (which matches the
+// list height) usable rather than collapsing to a sliver.
+const MIN_LIST_ROWS = 6;
+
+// Upper bound on session rows for this terminal — the list height
+// when the panel is at its full `heightPct: 90` budget. Sized off
+// the full terminal (not the active buffer's viewport — that
+// shrinks with vertical splits and made the picker collapse to
+// ~half its budget).
+function maxListRowsForScreen(): number {
   const screen = editor.getScreenSize();
   const h = screen.height > 0 ? screen.height : 30;
   const panelH = Math.floor(h * 0.9);
-  // panel borders (2) + header (1) + spacer (1) + sessions
-  // section borders (2) + filter row (1) + separator (1) +
-  // new-session button row (1) + separator (1) + footer (1) =
-  // 11 rows of chrome. Floor at 4 so a tiny terminal still
-  // shows something.
-  return Math.max(4, panelH - 11);
+  // Chrome that isn't list rows: panel borders (2) + title (1) +
+  // spacer (1) + footer (1) + sessions-section borders (2) +
+  // column chrome above the list (New + Project + Filter +
+  // separator + header = 5) = 12. Floor at MIN_LIST_ROWS so a tiny
+  // terminal still shows something.
+  return Math.max(MIN_LIST_ROWS, panelH - 12);
+}
+
+// Actual list height: fit the session count, clamped between
+// MIN_LIST_ROWS and the screen budget, so a handful of sessions
+// gives a compact panel (the host shrinks the floating panel to
+// content height) instead of a tall box padded with blank rows.
+function fitListRows(itemCount: number): number {
+  return Math.min(maxListRowsForScreen(), Math.max(MIN_LIST_ROWS, itemCount));
 }
 
 // Compose the right-hand preview pane. Normally it shows info
@@ -763,14 +777,14 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
     }
   }
   // Match the sessions column's content height so the two panes'
-  // bottom borders land on the same row. Sessions column inside
-  // its borders = filter (1) + separator (1) + new-session button
-  // (1) + separator (1) + list (listVisibleRows) = listVisibleRows
-  // + 4. Preview inside its borders = button row (1) + spacer (1)
-  // + embedRows, so embedRows must equal listVisibleRows + 2.
-  // When details ARE shown, two info rows + a spacer eat three
-  // more lines — `_DETAILS_CHROME_ROWS` accounts for that.
-  const totalEmbedBase = (openDialog?.listVisibleRows ?? 6) + 2;
+  // bottom borders land on the same row. Sessions column inside its
+  // borders = New (1) + Project (1) + Filter (1) + separator (1) +
+  // header (1) + list (listVisibleRows) = listVisibleRows + 5.
+  // Preview inside its borders = button row (1) + spacer (1) +
+  // embedRows, so embedRows must equal listVisibleRows + 3. When
+  // details ARE shown, two info rows + a spacer eat three more
+  // lines — `_DETAILS_CHROME_ROWS` accounts for that.
+  const totalEmbedBase = (openDialog?.listVisibleRows ?? MIN_LIST_ROWS) + 3;
   const detailsOn = openDialog?.showDetails ?? false;
   const _DETAILS_CHROME_ROWS = 3; // 2 info rows + 1 spacer
   const embedRows = Math.max(
@@ -868,24 +882,11 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
 
 function buildOpenSpec(): WidgetSpec {
   if (!openDialog) return col();
-  // Re-derive row counts on every spec build as a fallback for the
-  // resize hook not always firing reliably through tmux's SIGWINCH
-  // propagation (Finding I). **One-way ratchet**: only adopt the
-  // new value when it's *larger* than the current one. The
-  // `editor.getViewport()` height shrinks while the picker is
-  // mounted (the floating panel covers part of the buffer area),
-  // and naively re-reading it on every refresh fed that shrink
-  // back into the dialog size — pressing Up/Down caused the
-  // picker to oscillate smaller on every keystroke. A real
-  // terminal-grow event still flows through because the new
-  // viewport height exceeds the cached value; a spurious shrink
-  // (because the panel itself is up) is ignored.
-  const liveListVisibleRows = openListVisibleRows();
-  if (liveListVisibleRows > openDialog.listVisibleRows) {
-    openDialog.listVisibleRows = liveListVisibleRows;
-    openDialog.embedRows = Math.max(3, liveListVisibleRows - 5);
-  }
   const filtered = openDialog.filteredIds;
+  // Fit the list (and therefore the whole floating panel) to the
+  // session count, bounded by the screen budget — few sessions give
+  // a compact panel instead of a tall box padded with blank rows.
+  openDialog.listVisibleRows = fitListRows(filtered.length);
   const activeId = editor.activeWindow();
   const items = filtered.map((id) => renderListItem(id, activeId));
   const itemKeys = filtered.map(String);
@@ -913,9 +914,7 @@ function buildOpenSpec(): WidgetSpec {
     "orchestrator_open_new_from_picker",
     OPEN_MODE,
   );
-  const newLabel = newKey
-    ? `+ New Session  ${newKey}`
-    : "+ New Session";
+  const newLabel = newKey ? `+ New  ${newKey}` : "+ New";
   const inConfirm = openDialog.pendingConfirm !== null;
   // While a confirmation prompt is up the filter is rendered
   // without a `key`. The host's `collect_tabbable` only adds
@@ -928,7 +927,8 @@ function buildOpenSpec(): WidgetSpec {
   const filterInput = text({
     value: openDialog.filter.value,
     cursorByte: openDialog.filter.cursor,
-    placeholder: "type to filter…",
+    label: "Filter",
+    placeholder: "type to search… ( / )",
     fullWidth: true,
     key: inConfirm ? undefined : "filter",
   });
@@ -950,45 +950,33 @@ function buildOpenSpec(): WidgetSpec {
       }
     : null;
 
-  // Scope chrome. The title and the sessions-section label both
-  // advertise what the list is currently showing so the user is
-  // never confused about which project's sessions they're looking
-  // at. When scoped to the current project, a trailing affordance
-  // row reports how many sessions live elsewhere and how to reveal
-  // them — nothing is hidden, just not foregrounded.
+  // Scope chrome. The title keeps the active project visible; the
+  // `Project:` control below is the clickable scope switch.
   const scope = openDialog.scope;
   const curKey = currentProjectKey();
   const curName = projectLabel(curKey);
   const scopeKey = editor.getKeybindingLabel("orchestrator_toggle_scope", OPEN_MODE);
   const titleSuffix = scope === "current" ? `  —  ${curName}` : "  —  all projects";
-  const sectionLabel = scope === "current"
-    ? `${curName} · this project (${filtered.length})`
-    : `Sessions (${filtered.length})`;
-  // Visible, clickable scope toggle. The chevrons mark it as a
-  // cycle; clicking (or Alt+P) flips between this-project and
-  // all-projects. Inert while a confirm prompt is up (drop the key)
-  // so it can't steal focus from Cancel/Confirm.
-  const scopeToggleLabel = scope === "current" ? "‹ This project ›" : "‹ All projects ›";
-  const scopeToggleButton = button(scopeToggleLabel, {
+  const sectionLabel = "Sessions";
+  // `Project:` control — a visible, clickable scope switch with the
+  // Alt+P hint baked into the button label. Shows the current
+  // project's name when scoped, "All" when showing every project.
+  // Inert while a confirm prompt is up so it can't steal focus.
+  const scopeWord = scope === "current" ? editor.pathBasename(curKey) : "All";
+  const scopeButtonLabel = scopeKey ? `${scopeWord} ▾   (${scopeKey})` : `${scopeWord} ▾`;
+  const scopeButton = button(scopeButtonLabel, {
     key: openDialog.pendingConfirm !== null ? undefined : "scope-toggle",
   });
-  const otherCount = otherProjectSessionCount();
-  const otherAffordance: WidgetSpec[] = scope === "current" && otherCount > 0
-    ? [
-        sessionsSeparator(),
-        {
-          kind: "raw",
-          entries: [
-            styledRow([
-              {
-                text: `${otherCount} in other projects${scopeKey ? `  ·  ${scopeKey}` : ""}`,
-                style: { fg: "ui.menu_disabled_fg", italic: true },
-              },
-            ]),
-          ],
-        },
-      ]
-    : [];
+  const projectControlRow = row(
+    {
+      kind: "raw",
+      entries: [
+        styledRow([{ text: "Project: ", style: { fg: "ui.menu_disabled_fg" } }]),
+      ],
+    },
+    scopeButton,
+    flexSpacer(),
+  );
 
   return col(
     {
@@ -1022,12 +1010,12 @@ function buildOpenSpec(): WidgetSpec {
         // labels render without truncating to `· tmp_o…`. The preview
         // pane still keeps the majority for the live window embed.
         widthPct: 34,
-        // Sessions column: new-session button, separator, filter,
-        // scope toggle, separator, list. The button is first so it
-        // gets initial focus (Enter immediately opens the new
-        // session form). Separators are long `─` strings that
-        // the renderer truncates to the column's inner width —
-        // no need to measure cells from the plugin side.
+        // Sessions column: New button, Project (scope) control,
+        // Filter, separator, column header, list. The button is
+        // first so it gets initial focus (Enter immediately opens the
+        // new session form). Separators are long `─` strings that the
+        // renderer truncates to the column's inner width — no need to
+        // measure cells from the plugin side.
         child: col(
           row(
             button(newLabel, {
@@ -1042,30 +1030,20 @@ function buildOpenSpec(): WidgetSpec {
             }),
             flexSpacer(),
           ),
-          sessionsSeparator(),
+          projectControlRow,
           filterInput,
-          // Scope toggle: a visible, clickable control for the
-          // current-project ↔ all-projects switch (Alt+P also flips
-          // it). The chevrons hint it cycles; the footer + the "N in
-          // other projects" affordance spell out the alternative.
-          row(scopeToggleButton, flexSpacer()),
           sessionsSeparator(),
+          sessionsColumnHeader(),
           list({
             items,
             itemKeys,
             selectedIndex: selIdx,
-            // The scope-toggle row (always present) and the "N in
-            // other projects" affordance (separator + line, scoped
-            // view only) sit outside the list but inside the sessions
-            // column, eating into its height budget. Shrink the list's
-            // reserved rows by exactly those rows so the sessions
-            // column keeps the same total height as the preview pane —
-            // otherwise the extra rows push the footer hint bar off the
-            // bottom of the fixed-height panel.
-            visibleRows: Math.max(
-              1,
-              openDialog.listVisibleRows - 1 - otherAffordance.length,
-            ),
+            // `listVisibleRows` is the fitted list height; the 5 rows
+            // of column chrome above it (New / Project / Filter /
+            // separator / header) and the matching preview embed are
+            // accounted for separately so both panes stay the same
+            // height and the footer hint stays on-screen.
+            visibleRows: openDialog.listVisibleRows,
             // Excluded from the Tab cycle — Up/Down on the
             // filter input forwards to this list via host
             // smart-keys, so Tab jumps straight to the action
@@ -1081,12 +1059,10 @@ function buildOpenSpec(): WidgetSpec {
             // `pendingConfirm.sessionId`).
             key: inConfirm ? undefined : "sessions",
           }),
-          ...otherAffordance,
         ),
       }),
       // Preview pane has no explicit width — picks up the
-      // remaining 75% by default since the sessions list took
-      // 25%.
+      // remaining width by default since the sessions list took 34%.
       buildPreviewPane(selectedSession),
     ),
     row(
@@ -1177,7 +1153,9 @@ function openControlRoom(): void {
   if (openPanel) return;
   reconcileSessions();
   const activeId = editor.activeWindow();
-  const listVisibleRows = openListVisibleRows();
+  // Seed with the screen-max; buildOpenSpec refits to the session
+  // count on the first render (and every render after).
+  const listVisibleRows = maxListRowsForScreen();
   openDialog = {
     filter: { value: "", cursor: 0 },
     filteredIds: [],
@@ -1185,23 +1163,14 @@ function openControlRoom(): void {
     originalActiveSession: activeId,
     pendingConfirm: null,
     listVisibleRows,
-    // Mirror buildPreviewPane's chrome: 1 button row + 1 spacer
-    // + 2 info rows + 1 spacer = 4 rows reserved above the embed.
-    // Preview chrome above the embed: 1 button row + 1 spacer + 2
-    // info rows + 1 spacer = 5 rows. The labeledSection's top/bottom
-    // borders match the sessions list's, so subtracting just the
-    // chrome makes the preview pane's apparent height match the
-    // list pane's (`visible_rows + 2 borders`) exactly. Floored at
-    // 3 so a tiny terminal still leaves enough rows for the embed
-    // to paint something meaningful.
-    embedRows: Math.max(3, listVisibleRows - 5),
+    embedRows: Math.max(3, listVisibleRows + 3),
     showDetails: false,
     inFlight: null,
     lastError: null,
     // Default to the current project's sessions so re-opening the
     // editor in project B doesn't dump project A's whole history on
     // the user. Cross-project sessions stay one keystroke away via
-    // the scope toggle / the "N in other projects" affordance.
+    // the Project scope control / Alt+P.
     scope: "current",
   };
   openDialog.filteredIds = filterSessions("");
@@ -1772,6 +1741,12 @@ editor.defineMode(
     // and "all projects". Registered as a mode chord so it's
     // user-rebindable and renders cross-platform (⌥P / Alt+P).
     ["M-p", "orchestrator_toggle_scope"],
+    // `/` jumps focus to the filter input — the familiar
+    // search-focus shortcut. (As a mode chord it's intercepted even
+    // while the filter has focus, so `/` can't be typed as filter
+    // text; session names don't contain `/`, so that's an
+    // acceptable trade for the quick-focus.)
+    ["/", "orchestrator_focus_filter"],
   ],
   true,
   true,
@@ -1781,6 +1756,11 @@ registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
   closeOpenDialog();
   openForm({ fromPicker: true });
+});
+
+registerHandler("orchestrator_focus_filter", () => {
+  if (!openDialog || !openPanel) return;
+  openPanel.setFocusKey("filter");
 });
 
 function toggleScope(): void {
@@ -3498,9 +3478,8 @@ editor.on("active_window_changed", () => {
 // viewport at the same time.
 editor.on("resize", () => {
   if (openDialog && openPanel) {
-    const listVisibleRows = openListVisibleRows();
-    openDialog.listVisibleRows = listVisibleRows;
-    openDialog.embedRows = Math.max(3, listVisibleRows - 5);
+    // buildOpenSpec refits `listVisibleRows` to the session count
+    // (bounded by the new screen budget) on the refresh below.
     refreshOpenDialog();
   }
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -260,6 +260,11 @@ interface OpenDialogState {
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
+// Scope is remembered across opens of the picker (module state
+// survives dialog close). Defaults to "all" so the picker opens
+// showing every session; flipping it with the Project control / Alt+P
+// updates this and the next open honours it.
+let lastOpenScope: "current" | "all" = "all";
 const OPEN_MODE = "orchestrator-open";
 
 // =============================================================================
@@ -1159,11 +1164,9 @@ function openControlRoom(): void {
     showDetails: false,
     inFlight: null,
     lastError: null,
-    // Default to the current project's sessions so re-opening the
-    // editor in project B doesn't dump project A's whole history on
-    // the user. Cross-project sessions stay one keystroke away via
-    // the Project scope control / Alt+P.
-    scope: "current",
+    // Restore the last-used scope (defaults to "all"); the Project
+    // control / Alt+P updates it for next time.
+    scope: lastOpenScope,
   };
   openDialog.filteredIds = filterSessions("");
   const activeIdx = openDialog.filteredIds.indexOf(activeId);
@@ -1758,6 +1761,8 @@ registerHandler("orchestrator_focus_filter", () => {
 function toggleScope(): void {
   if (!openDialog) return;
   openDialog.scope = openDialog.scope === "current" ? "all" : "current";
+  // Remember the choice for the next time the picker opens.
+  lastOpenScope = openDialog.scope;
   // Keep the highlighted session selected across the scope flip
   // when it survives into the new list; otherwise fall back to the
   // top. The filter value is untouched — toggling scope with an

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -693,7 +693,11 @@ impl Editor {
                     // Flush any plugin grammars that arrived during the build
                     self.flush_pending_grammars();
                 }
-                AsyncMessage::QuickOpenFilesLoaded { files, complete } => {
+                AsyncMessage::QuickOpenFilesLoaded {
+                    cwd,
+                    files,
+                    complete,
+                } => {
                     // Update the file provider cache and refresh suggestions
                     // if Quick Open is currently showing file mode (empty prefix).
                     if let Some((provider, _)) = self.quick_open_registry.get_provider_for_input("")
@@ -703,9 +707,9 @@ impl Editor {
                             .downcast_ref::<crate::input::quick_open::providers::FileProvider>(
                         ) {
                             if complete {
-                                fp.set_cache(files);
+                                fp.set_cache(&cwd, files);
                             } else {
-                                fp.set_partial_cache(files);
+                                fp.set_partial_cache(&cwd, files);
                             }
                         }
                     }

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -569,20 +569,21 @@ impl Editor {
             &working_dir,
         );
 
-        // Determine the active window's id and root. Persisted
-        // `env.active` is *cross-project* — it just names the last
-        // session the user touched anywhere. Honoring it blindly
-        // when the user re-launches inside a different project
-        // strands the editor with an LSP and Open-Terminal default
-        // pointed at the wrong tree (see issue #2026). Prefer a
-        // persisted window that actually belongs to `working_dir`,
-        // and fall back to the boot-time defaults (id 1, process
-        // cwd) when no persisted window matches.
-        let (active_window_id, active_window_root) =
-            crate::app::orchestrator_persistence::pick_active_window_for_cwd(
-                persisted_env.as_ref(),
-                &working_dir,
-            )
+        // Reopen the session the user last used *in this project*, if
+        // any — never a session from another project. Cross-project
+        // restore is what dragged yesterday's directories/files into a
+        // different project's window; `pick_active_window_for_cwd` only
+        // ever returns a window rooted at `working_dir`, so launching
+        // elsewhere can't pull this project's sessions in (and vice
+        // versa). When the cwd has no sessions, fall back to a clean
+        // base window (id 1) at the launch cwd. This also keeps the LSP
+        // / Open-Terminal default pointed at the launch cwd (issue
+        // #2026).
+        let picked_active = crate::app::orchestrator_persistence::pick_active_window_for_cwd(
+            persisted_env.as_ref(),
+            &working_dir,
+        );
+        let (active_window_id, active_window_root) = picked_active
             .map(|w| (fresh_core::WindowId(w.id), w.root.clone()))
             .unwrap_or((fresh_core::WindowId(1), working_dir.clone()));
 
@@ -1067,13 +1068,15 @@ impl Editor {
 
         // Build the active window — the one that holds the seed
         // buffer, the SplitManager, the LSP, and the
-        // already-configured per-window bridge. Its label/root
-        // come from persistence when present so a restored session
-        // looks correct from frame zero; otherwise it falls back to
-        // the boot defaults.
-        let (active_label, active_root, active_plugin_state) = persisted_env
-            .as_ref()
-            .and_then(|env| env.windows.iter().find(|w| w.id == active_window_id.0))
+        // already-configured per-window bridge. Its label / root /
+        // plugin state come from the persisted session we chose to
+        // reopen (the last-used one for this cwd). When there was none
+        // we boot a clean base: empty label, cwd root, no inherited
+        // state. We deliberately key off the *picked* window, not a
+        // lookup by `active_window_id` — a clean base reuses id 1, and
+        // a stale persisted id-1 window (a different project's old
+        // base) must not lend its label/root/state to it.
+        let (active_label, active_root, active_plugin_state) = picked_active
             .map(|w| (w.label.clone(), w.root.clone(), w.plugin_state.clone()))
             .unwrap_or_else(|| (String::new(), working_dir.clone(), HashMap::new()));
 

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2845,19 +2845,17 @@ impl Editor {
             return true;
         }
         if let KeyCode::Char(c) = code {
-            // Ctrl/Alt-modified chords are swallowed by the floating
-            // panel without further action — a modal dialog must
-            // not leak keys to global bindings like Ctrl-P or
-            // Alt-F. Plain (or Shift-only) chars feed printable
-            // text into the focused TextInput.
-            //
-            // Exception: the active editor mode may have explicitly
-            // claimed the chord via `defineMode` (the Orchestrator
-            // picker binds `Alt+N` to its new-session shortcut, for
-            // example). Defer to that path so plugin-declared
-            // modal shortcuts work, mirroring the same precedence
-            // check the named-key branch above uses.
-            if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+            // The active editor mode may have explicitly claimed this
+            // char via `defineMode` — e.g. the Orchestrator picker
+            // binds `Alt+N` (new session), `Alt+P` (scope), and `/`
+            // (focus filter). Defer to that path so plugin-declared
+            // modal shortcuts work. This now covers *plain* chars too
+            // (not just Ctrl/Alt chords): a plugin that binds a bare
+            // key like `/` gets it before the text-input fast path.
+            // The trade-off is that a bound bare key can't also be
+            // typed as text in that mode, which is what the plugin
+            // asked for by binding it.
+            {
                 let mode_has_binding = self
                     .active_window()
                     .editor_mode
@@ -2873,6 +2871,13 @@ impl Editor {
                 if mode_has_binding {
                     return false;
                 }
+            }
+            // Ctrl/Alt-modified chords with no mode binding are
+            // swallowed by the floating panel without further action —
+            // a modal dialog must not leak keys to global bindings
+            // like Ctrl-P or Alt-F. Plain (or Shift-only) chars feed
+            // printable text into the focused TextInput.
+            if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
                 return true;
             }
             let ch = if modifiers.contains(KeyModifiers::SHIFT) {

--- a/crates/fresh-editor/src/app/orchestrator_persistence.rs
+++ b/crates/fresh-editor/src/app/orchestrator_persistence.rs
@@ -37,15 +37,20 @@
 //! On startup, [`read_persisted_windows_env`] +
 //! [`read_persisted_plugin_state`] are called from
 //! `Editor::with_options` (see `editor_init.rs`) *before* the
-//! editor struct is built. The factory uses the parsed envelope
-//! to pick the active window's id and root (so the spawned LSP
-//! targets the right project), to attach the seed buffer +
-//! split layout to the active window directly, and to populate
-//! `plugin_global_state` so plugins reading `getGlobalState`
-//! during their on-load handler see the previous run's values.
-//! All non-active persisted windows come back as inert shells
-//! (no splits, no LSP); first dive into one re-warms it on
-//! demand exactly like a freshly-`createWindow`-ed session.
+//! editor struct is built. The factory reopens the session the user
+//! last used **in the launch cwd's project** (see
+//! [`pick_active_window_for_cwd`]) and uses it for the active window's
+//! id / root / label / plugin state, so the spawned LSP targets the
+//! right project. Crucially the pick is cwd-scoped: a session from a
+//! *different* project is never activated, which is what kept one
+//! day's directories/files from bleeding into another project's
+//! window. When the cwd has no sessions, the active window is a clean
+//! base (id 1) rooted at the cwd. All other persisted windows come
+//! back as inert shells (no splits, no LSP); first dive into one
+//! re-warms it on demand exactly like a freshly-`createWindow`-ed
+//! session. The factory also populates `plugin_global_state` so
+//! plugins reading `getGlobalState` during their on-load handler see
+//! the previous run's values.
 //!
 //! The "warm" half of warm-swap (split layout, LSP, file
 //! explorer state) is intentionally *not* persisted: the only
@@ -165,24 +170,30 @@ pub(crate) fn read_persisted_windows_env(
     }
 }
 
-/// Pick which persisted window the active-window slot should be
-/// restored to at boot time, scoped to the editor's launch cwd.
+/// Pick which persisted session to bring up at boot, scoped to the
+/// editor's launch cwd.
 ///
-/// The persisted `env.active` is cross-project: it names the last
-/// window the user touched anywhere, not necessarily one rooted at
-/// the cwd. Honoring it blindly when the user re-launches inside a
-/// different project leaves the active window pointed at an
-/// unrelated tree — "Open Terminal" spawns a shell in the other
-/// project, the LSP starts under the wrong root. So we re-pick:
+/// The rule the user expects: re-opening the editor in a project
+/// should reopen the session they last used **in that project** —
+/// but never a session from a *different* project (that cross-project
+/// bleed is what made one day's work leak into the next). So we only
+/// ever consider windows that belong to `cwd`:
 ///
-///   1. If `env.active`'s window belongs to `cwd`, keep it.
-///   2. Else, pick any persisted window that belongs to `cwd`.
-///   3. Else, `None` — caller falls back to a fresh window at cwd.
+///   1. If `env.active` (the globally last-used session at quit)
+///      belongs to `cwd`, that's the last-used session for this
+///      project — bring it up.
+///   2. Else pick the most-recently-*created* window belonging to
+///      `cwd` (highest id — orchestrator ids are monotonic). This is
+///      the fallback for "your last-used session was in another
+///      project, but this one has sessions of its own."
+///   3. Else `None` — the caller boots a clean base window at `cwd`.
 ///
-/// A window "belongs to" `cwd` when its `project_path` (preferred
-/// for orchestrator sessions, which always carry one) or its
-/// `root` (legacy / non-orchestrator windows) equals `cwd` after
-/// canonicalization.
+/// A window "belongs to" `cwd` when its `project_path` (preferred for
+/// orchestrator sessions, which always carry one) or its `root`
+/// (legacy / non-orchestrator windows) equals `cwd` after
+/// canonicalization. The previous base (id 1) is eligible too — if it
+/// was the user's last-used window in this cwd, reopening it is just a
+/// clean editor at the cwd.
 pub(crate) fn pick_active_window_for_cwd<'a>(
     env: Option<&'a PersistedWindows>,
     cwd: &Path,
@@ -195,7 +206,10 @@ pub(crate) fn pick_active_window_for_cwd<'a>(
     {
         return Some(w);
     }
-    env.windows.iter().find(|w| window_matches_cwd(w, cwd))
+    env.windows
+        .iter()
+        .filter(|w| window_matches_cwd(w, cwd))
+        .max_by_key(|w| w.id)
 }
 
 fn window_matches_cwd(w: &PersistedWindow, cwd: &Path) -> bool {
@@ -764,41 +778,66 @@ mod tests {
     }
 
     #[test]
-    fn pick_active_falls_through_when_persisted_active_belongs_to_another_project() {
-        // Regression for issue #2026: launching fresh in /repoA must
-        // not activate a persisted window rooted at /repoB just
-        // because it was the last window the user touched anywhere.
-        let env = env_with(
-            2,
-            vec![
-                make_window(1, "/repoA", Some("/repoA")),
-                make_window(2, "/repoB", Some("/repoB")),
-            ],
-        );
-        let cwd = Path::new("/repoA");
-        let picked = pick_active_window_for_cwd(Some(&env), cwd).expect("should pick a window");
-        assert_eq!(
-            picked.id, 1,
-            "must pick the /repoA-rooted window, not env.active=2"
-        );
-    }
-
-    #[test]
-    fn pick_active_keeps_env_active_when_it_matches_cwd() {
+    fn pick_active_never_crosses_projects() {
+        // Regression for the orchestration bug: launching in /repoB
+        // must never bring up a session rooted in /repoA, even when
+        // /repoA holds the globally last-used session (env.active).
         let env = env_with(
             2,
             vec![
                 make_window(1, "/repoA", Some("/repoA")),
                 make_window(2, "/repoA", Some("/repoA")),
+                make_window(3, "/repoB", Some("/repoB")),
+            ],
+        );
+        let picked = pick_active_window_for_cwd(Some(&env), Path::new("/repoB"))
+            .expect("a /repoB session exists");
+        assert_eq!(
+            picked.id, 3,
+            "must pick the /repoB session, not env.active=2"
+        );
+    }
+
+    #[test]
+    fn pick_active_reopens_last_used_for_cwd() {
+        // env.active points at this project's last-used session — it
+        // wins even though it isn't the highest id.
+        let env = env_with(
+            2,
+            vec![
+                make_window(2, "/repoA", Some("/repoA")),
+                make_window(5, "/repoA", Some("/repoA")),
             ],
         );
         let picked =
             pick_active_window_for_cwd(Some(&env), Path::new("/repoA")).expect("matching window");
-        assert_eq!(picked.id, 2, "env.active wins when it matches");
+        assert_eq!(
+            picked.id, 2,
+            "env.active is the last-used session for the cwd"
+        );
+    }
+
+    #[test]
+    fn pick_active_falls_back_to_most_recent_session_for_cwd() {
+        // The globally last-used session (env.active=9) is in another
+        // project, so for /repoA we fall back to the most-recently-
+        // created /repoA session (highest id), not the first.
+        let env = env_with(
+            9,
+            vec![
+                make_window(2, "/repoA", Some("/repoA")),
+                make_window(7, "/repoA", Some("/repoA")),
+                make_window(9, "/repoB", Some("/repoB")),
+            ],
+        );
+        let picked =
+            pick_active_window_for_cwd(Some(&env), Path::new("/repoA")).expect("matching window");
+        assert_eq!(picked.id, 7, "fall back to the most recent /repoA session");
     }
 
     #[test]
     fn pick_active_returns_none_when_no_window_matches_cwd() {
+        // No session for this cwd → caller boots a clean base window.
         let env = env_with(
             1,
             vec![

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -290,6 +290,15 @@ impl crate::app::Editor {
             }
         }
 
+        // Refresh the plugin state snapshot so `getCwd()` (and every
+        // other snapshot field) reflects the window we just switched
+        // to *before* the `active_window_changed` hook runs. Without
+        // this, plugins that read `editor.getCwd()` — Live Grep, file
+        // finders, etc. — keep targeting the previous window's project
+        // after a dive, surfacing the wrong project's files.
+        #[cfg(feature = "plugins")]
+        self.update_plugin_state_snapshot();
+
         self.plugin_manager.read().unwrap().run_hook(
             "active_window_changed",
             HookArgs::ActiveWindowChanged {

--- a/crates/fresh-editor/src/input/quick_open/providers.rs
+++ b/crates/fresh-editor/src/input/quick_open/providers.rs
@@ -293,6 +293,12 @@ struct FileCache {
     files: Option<std::sync::Arc<Vec<FileEntry>>>,
     /// Whether a background load is in progress.
     loading: bool,
+    /// The cwd the cached `files` (and the in-progress load) belong
+    /// to. A cache hit only counts when this matches the requested
+    /// cwd — otherwise switching windows/projects would keep serving
+    /// the first project's files. Late-arriving results for a stale
+    /// cwd are dropped on the same check.
+    loaded_cwd: Option<String>,
 }
 
 /// Provider for finding files in the project.
@@ -329,6 +335,7 @@ impl FileProvider {
             cache: std::sync::Arc::new(std::sync::Mutex::new(FileCache {
                 files: None,
                 loading: false,
+                loaded_cwd: None,
             })),
             frecency: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
             filesystem,
@@ -346,6 +353,7 @@ impl FileProvider {
         if let Ok(mut c) = self.cache.lock() {
             c.files = None;
             c.loading = false;
+            c.loaded_cwd = None;
         }
     }
 
@@ -359,9 +367,15 @@ impl FileProvider {
         }
     }
 
-    /// Update the file cache with final results from a completed background load.
-    pub fn set_cache(&self, files: std::sync::Arc<Vec<FileEntry>>) {
+    /// Update the file cache with final results from a completed
+    /// background load. Dropped if `cwd` no longer matches the cache's
+    /// in-flight cwd — i.e. the user switched projects mid-load, so
+    /// these results are stale.
+    pub fn set_cache(&self, cwd: &str, files: std::sync::Arc<Vec<FileEntry>>) {
         if let Ok(mut c) = self.cache.lock() {
+            if c.loaded_cwd.as_deref() != Some(cwd) {
+                return;
+            }
             c.files = Some(files);
             c.loading = false;
         }
@@ -369,8 +383,11 @@ impl FileProvider {
 
     /// Update the file cache with partial results while the background scan
     /// is still running.  Unlike [`set_cache`], this keeps `loading = true`.
-    pub fn set_partial_cache(&self, files: std::sync::Arc<Vec<FileEntry>>) {
+    pub fn set_partial_cache(&self, cwd: &str, files: std::sync::Arc<Vec<FileEntry>>) {
         if let Ok(mut c) = self.cache.lock() {
+            if c.loaded_cwd.as_deref() != Some(cwd) {
+                return;
+            }
             c.files = Some(files);
             // Keep c.loading = true — the walk is still in progress.
         }
@@ -486,15 +503,29 @@ impl FileProvider {
     fn get_or_start_loading(&self, cwd: &str) -> Option<std::sync::Arc<Vec<FileEntry>>> {
         let mut cache = self.cache.lock().ok()?;
 
-        if let Some(files) = &cache.files {
-            return Some(std::sync::Arc::clone(files));
+        // A cache hit only counts for the cwd the files were loaded
+        // under. When the cwd changed (the user switched windows /
+        // projects), drop the stale list and reload — otherwise the
+        // picker keeps showing the first project's files.
+        let cwd_matches = cache.loaded_cwd.as_deref() == Some(cwd);
+        if cwd_matches {
+            if let Some(files) = &cache.files {
+                return Some(std::sync::Arc::clone(files));
+            }
+            if cache.loading {
+                return None; // already loading this cwd
+            }
+        } else {
+            // Stale cwd: cancel any in-flight load for the old cwd and
+            // reset so the load below starts fresh for `cwd`.
+            self.cancel
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+            cache.files = None;
+            cache.loading = false;
         }
 
-        if cache.loading {
-            return None; // already loading
-        }
-
-        // No cache, not loading — kick off background load
+        // No cache for this cwd, not loading — kick off background load
+        cache.loaded_cwd = Some(cwd.to_string());
         let (sender, handle) = match (&self.async_sender, &self.runtime_handle) {
             (Some(s), Some(h)) => (s.clone(), h.clone()),
             _ => {
@@ -536,6 +567,7 @@ impl FileProvider {
                 // shutting down); nothing more to do since we return below.
                 drop(sender.send(
                     crate::services::async_bridge::AsyncMessage::QuickOpenFilesLoaded {
+                        cwd: cwd.clone(),
                         files: std::sync::Arc::new(entries),
                         complete: true,
                     },
@@ -567,7 +599,7 @@ impl FileProvider {
             .collect();
 
         let files = std::sync::Arc::new(entries);
-        self.set_cache(std::sync::Arc::clone(&files));
+        self.set_cache(cwd, std::sync::Arc::clone(&files));
         Some(files)
     }
 
@@ -702,6 +734,7 @@ fn walk_dir_with_updates(
             if sender
                 .send(
                     crate::services::async_bridge::AsyncMessage::QuickOpenFilesLoaded {
+                        cwd: cwd.to_string(),
                         files: std::sync::Arc::new(entries),
                         complete: false,
                     },
@@ -743,6 +776,7 @@ fn walk_dir_with_updates(
         .collect();
     drop(sender.send(
         crate::services::async_bridge::AsyncMessage::QuickOpenFilesLoaded {
+            cwd: cwd.to_string(),
             files: std::sync::Arc::new(entries),
             complete: true,
         },
@@ -1334,10 +1368,11 @@ mod tests {
     fn test_set_partial_cache_keeps_loading() {
         let provider = make_file_provider();
 
-        // Simulate background loading start
+        // Simulate background loading start for a specific cwd.
         {
             let mut cache = provider.cache.lock().unwrap();
             cache.loading = true;
+            cache.loaded_cwd = Some("/proj".to_string());
         }
 
         // Partial cache update should keep loading = true
@@ -1345,7 +1380,7 @@ mod tests {
             relative_path: "foo.rs".to_string(),
             frecency_score: 0.0,
         }]);
-        provider.set_partial_cache(partial);
+        provider.set_partial_cache("/proj", partial);
 
         assert!(provider.is_loading());
         assert!(provider.cache.lock().unwrap().files.is_some());
@@ -1355,8 +1390,20 @@ mod tests {
             relative_path: "foo.rs".to_string(),
             frecency_score: 0.0,
         }]);
-        provider.set_cache(final_files);
+        provider.set_cache("/proj", final_files);
 
         assert!(!provider.is_loading());
+
+        // A stale-cwd update is ignored.
+        let stale = std::sync::Arc::new(vec![FileEntry {
+            relative_path: "other.rs".to_string(),
+            frecency_score: 0.0,
+        }]);
+        provider.set_cache("/different", stale);
+        assert_eq!(
+            provider.cache.lock().unwrap().files.as_ref().unwrap()[0].relative_path,
+            "foo.rs",
+            "results for a different cwd must not overwrite the current cache"
+        );
     }
 }

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -302,6 +302,10 @@ pub enum AsyncMessage {
     /// `complete` is `true` when the scan is finished, `false` for incremental
     /// partial updates sent while the walk is still in progress.
     QuickOpenFilesLoaded {
+        /// The working directory the files were enumerated under. Lets
+        /// the editor drop results that arrive after the user has
+        /// switched windows/projects (the cache is keyed by cwd).
+        cwd: String,
         files: std::sync::Arc<Vec<crate::input::quick_open::providers::FileEntry>>,
         complete: bool,
     },

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -3111,6 +3111,19 @@ fn pad_or_truncate_cols(text: &mut String, cols: usize) {
     }
 }
 
+/// Clamp `idx` to `s.len()`, then walk it down to the nearest
+/// char boundary. Byte-unit inline overlays computed against a
+/// pre-truncation line must pass through this after the line is
+/// column-truncated, so they can never index inside a multi-byte
+/// char (the panic the span splitter raises on `text[a..b]`).
+fn snap_down_to_char_boundary(s: &str, idx: usize) -> usize {
+    let mut i = idx.min(s.len());
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
 /// Horizontal-zip pass for a Row that contains ≥1 multi-line
 /// (Block) child. Each block has already been rendered with its
 /// per-column budget (`block_width`); this helper walks the
@@ -3250,7 +3263,6 @@ fn zip_row_blocks(
                         if line_text.ends_with('\n') {
                             line_text.pop();
                         }
-                        let original_byte_len = line_text.len();
                         pad_or_truncate_cols(&mut line_text, block_w);
                         let padded_byte_len = line_text.len();
                         text.push_str(&line_text);
@@ -3273,16 +3285,22 @@ fn zip_row_blocks(
                             });
                         }
                         for overlay in &line.inline_overlays {
-                            // Overlays whose end exceeds the
-                            // truncated byte length get clamped to
-                            // the truncation point.
-                            let new_end = overlay.end.min(original_byte_len);
-                            if overlay.start >= original_byte_len {
+                            // `pad_or_truncate_cols` may have cut the
+                            // line (and appended a multi-byte `…`), so
+                            // an overlay computed against the original
+                            // line can now point past — or *inside* — a
+                            // char of the truncated text. Clamp both
+                            // ends to the truncated length and snap to a
+                            // char boundary; otherwise the downstream
+                            // span splitter slices mid-char and panics.
+                            let start = snap_down_to_char_boundary(&line_text, overlay.start);
+                            let end = snap_down_to_char_boundary(&line_text, overlay.end);
+                            if start >= end {
                                 continue;
                             }
                             overlays.push(InlineOverlay {
-                                start: overlay.start + byte_shift,
-                                end: new_end + byte_shift,
+                                start: start + byte_shift,
+                                end: end + byte_shift,
                                 style: overlay.style.clone(),
                                 properties: overlay.properties.clone(),
                                 unit: overlay.unit,
@@ -5342,6 +5360,53 @@ mod tests {
         // Bottom border is a plain run.
         assert!(out.entries[2].text.starts_with("╰"));
         assert!(out.entries[2].text.ends_with("╯\n"));
+    }
+
+    #[test]
+    fn zip_row_blocks_keeps_overlays_on_char_boundaries() {
+        // Regression for the orchestrator picker panic: a two-pane
+        // `row(labeledSection, labeledSection)` whose left label is
+        // long and contains a multi-byte `·`. The column is narrow
+        // enough that `pad_or_truncate_cols` cuts the label and
+        // appends a multi-byte `…`. Before the fix, the label's
+        // byte-unit overlay end was clamped to the *pre*-truncation
+        // length, leaving it pointing inside the `…` — and the app
+        // span splitter then sliced `text[a..b]` mid-char and
+        // panicked. Every emitted overlay offset must land on a char
+        // boundary of its row text.
+        let left = WidgetSpec::LabeledSection {
+            label: "alpha/beta · this project (2)".into(),
+            child: Box::new(make_text_input("x", -1, false, false, 4, Some("a"))),
+            width_pct: Some(40),
+            key: None,
+        };
+        let right = WidgetSpec::LabeledSection {
+            label: "preview".into(),
+            child: Box::new(make_text_input("y", -1, false, false, 4, Some("b"))),
+            width_pct: None,
+            key: None,
+        };
+        let spec = WidgetSpec::Row {
+            children: vec![left, right],
+            key: None,
+        };
+        let out = render_spec(&spec, &HashMap::new(), "", 40);
+        for e in &out.entries {
+            for o in &e.inline_overlays {
+                assert!(
+                    e.text.is_char_boundary(o.start.min(e.text.len())),
+                    "overlay start {} not on a char boundary of {:?}",
+                    o.start,
+                    e.text,
+                );
+                assert!(
+                    e.text.is_char_boundary(o.end.min(e.text.len())),
+                    "overlay end {} not on a char boundary of {:?}",
+                    o.end,
+                    e.text,
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -91,6 +91,11 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
          foregrounding so nothing feels hidden.\nScreen:\n{}",
         screen,
     );
+    assert!(
+        screen.contains("This project"),
+        "Scoped view must render the visible scope-toggle control.\nScreen:\n{}",
+        screen,
+    );
 
     // Toggle scope (Alt+P) → every session, across every project.
     harness
@@ -110,6 +115,11 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
     assert!(
         screen.contains(LABEL_B),
         "Project B's session must still be listed in the all-projects view.\nScreen:\n{}",
+        screen,
+    );
+    assert!(
+        screen.contains("All projects"),
+        "All-projects view must show the scope-toggle in its 'all' state.\nScreen:\n{}",
         screen,
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -1,13 +1,13 @@
-//! The Orchestrator Open dialog must list every session, regardless of
-//! which project the active window happens to point at.
+//! The Orchestrator Open dialog scopes to the current project by
+//! default, and reveals every project on the scope toggle (Alt+P).
 //!
 //! Sessions are inherently cross-project — each row can have its own
-//! `project_path` — so scoping the picker to "current project" hides
-//! exactly the rows the user came to switch into. The visible symptom
-//! is that opening the dialog, visiting a session in another project,
-//! then reopening the dialog changes the visible row count, because
-//! the dialog's notion of "current project" is recomputed from the
-//! newly-active window every time it opens.
+//! `project_path` — but surfacing all of them at once means launching
+//! the editor in project B buries the user under project A's history
+//! (the orchestration bug this scoping fixes). So the default view
+//! lists only the active window's project, with an "N in other
+//! projects" affordance, and the scope toggle brings the rest into a
+//! single grouped list. Nothing is hidden; it's just not foregrounded.
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -46,7 +46,7 @@ fn set_orch_project_path(harness: &mut EditorTestHarness, project_path: &Path) {
 }
 
 #[test]
-fn open_dialog_lists_sessions_from_all_projects() {
+fn open_dialog_scopes_to_current_project_then_reveals_all() {
     let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
 
     // Project A: the harness's temp project root, owned by the base
@@ -65,28 +65,51 @@ fn open_dialog_lists_sessions_from_all_projects() {
     harness.editor_mut().set_active_window(win_b);
     set_orch_project_path(&mut harness, &proj_b);
 
-    // Switch back to A so the dialog opens with currentProject = A —
-    // the case the bug repro turns on.
-    harness.editor_mut().set_active_window(WindowId(1));
+    // Active window stays in Project B — the dialog should default to
+    // B's sessions only.
     harness.render().unwrap();
 
     run_palette(&mut harness, "Orchestrator: Open");
     harness
-        .wait_until(|h| h.screen_to_string().contains("Sessions ("))
-        .expect("Orchestrator Open dialog should appear");
+        .wait_until(|h| h.screen_to_string().contains("this project"))
+        .expect("Orchestrator Open dialog should appear scoped to the current project");
 
     let screen = harness.screen_to_string();
     assert!(
         screen.contains(LABEL_B),
-        "Project B's session must be listed in the open dialog while the \
-         active window is in Project A — the picker is cross-project by \
-         design.\nScreen:\n{}",
+        "Project B's session must be listed — it's the current project.\nScreen:\n{}",
         screen,
     );
     assert!(
+        screen.contains("this project"),
+        "Scoped section must be captioned as the current project.\nScreen:\n{}",
+        screen,
+    );
+    assert!(
+        screen.contains("in other projects"),
+        "Scoped view must advertise the cross-project sessions it isn't \
+         foregrounding so nothing feels hidden.\nScreen:\n{}",
+        screen,
+    );
+
+    // Toggle scope (Alt+P) → every session, across every project.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("all projects"))
+        .expect("scope toggle should switch the dialog to the all-projects view");
+
+    let screen = harness.screen_to_string();
+    assert!(
         screen.contains("Sessions (2)"),
-        "Header count must reflect every session, not the project-filtered \
-         subset.\nScreen:\n{}",
+        "All-projects view must count every session.\nScreen:\n{}",
+        screen,
+    );
+    assert!(
+        screen.contains(LABEL_B),
+        "Project B's session must still be listed in the all-projects view.\nScreen:\n{}",
         screen,
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -107,4 +107,26 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
         "Project B's session must still be listed in the all-projects view.\nScreen:\n{}",
         screen,
     );
+
+    // `/` focuses the filter; typing then narrows the list live. A
+    // query that matches nothing must filter LABEL_B out — proving
+    // both that `/` moved focus to the filter and that printable
+    // input reaches it.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    for ch in "qzqz".chars() {
+        harness
+            .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains(LABEL_B),
+        "Typing a non-matching filter (after `/` focuses it) must hide \
+         unmatched sessions.\nScreen:\n{}",
+        screen,
+    );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -71,8 +71,8 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
 
     run_palette(&mut harness, "Orchestrator: Open");
     harness
-        .wait_until(|h| h.screen_to_string().contains("this project"))
-        .expect("Orchestrator Open dialog should appear scoped to the current project");
+        .wait_until(|h| h.screen_to_string().contains("Project:"))
+        .expect("Orchestrator Open dialog should appear with the Project scope control");
 
     let screen = harness.screen_to_string();
     assert!(
@@ -81,19 +81,9 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
         screen,
     );
     assert!(
-        screen.contains("this project"),
-        "Scoped section must be captioned as the current project.\nScreen:\n{}",
-        screen,
-    );
-    assert!(
-        screen.contains("in other projects"),
-        "Scoped view must advertise the cross-project sessions it isn't \
-         foregrounding so nothing feels hidden.\nScreen:\n{}",
-        screen,
-    );
-    assert!(
-        screen.contains("This project"),
-        "Scoped view must render the visible scope-toggle control.\nScreen:\n{}",
+        screen.contains("Project:") && screen.contains("(Alt+P)"),
+        "Scoped view must render the visible Project scope control with its \
+         Alt+P hint.\nScreen:\n{}",
         screen,
     );
 
@@ -108,18 +98,13 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
 
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains("Sessions (2)"),
-        "All-projects view must count every session.\nScreen:\n{}",
+        screen.contains("All ▾"),
+        "All-projects view must flip the Project control to 'All'.\nScreen:\n{}",
         screen,
     );
     assert!(
         screen.contains(LABEL_B),
         "Project B's session must still be listed in the all-projects view.\nScreen:\n{}",
-        screen,
-    );
-    assert!(
-        screen.contains("All projects"),
-        "All-projects view must show the scope-toggle in its 'all' state.\nScreen:\n{}",
         screen,
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_open_cross_project.rs
@@ -1,13 +1,12 @@
-//! The Orchestrator Open dialog scopes to the current project by
-//! default, and reveals every project on the scope toggle (Alt+P).
+//! The Orchestrator Open dialog defaults to showing every project's
+//! sessions, and the scope toggle (Alt+P) narrows to the current
+//! project. The Project control + Alt+P switch between the two, and
+//! the choice is remembered across opens (module state).
 //!
-//! Sessions are inherently cross-project — each row can have its own
-//! `project_path` — but surfacing all of them at once means launching
-//! the editor in project B buries the user under project A's history
-//! (the orchestration bug this scoping fixes). So the default view
-//! lists only the active window's project, with an "N in other
-//! projects" affordance, and the scope toggle brings the rest into a
-//! single grouped list. Nothing is hidden; it's just not foregrounded.
+//! Sessions are inherently cross-project — each row can carry its own
+//! `project_path`. The picker foregrounds all of them by default; the
+//! current-project scope is one keystroke away for when project A's
+//! history is in the way.
 
 use crate::common::harness::EditorTestHarness;
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -46,7 +45,7 @@ fn set_orch_project_path(harness: &mut EditorTestHarness, project_path: &Path) {
 }
 
 #[test]
-fn open_dialog_scopes_to_current_project_then_reveals_all() {
+fn open_dialog_defaults_to_all_projects_then_scopes_to_current() {
     let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
 
     // Project A: the harness's temp project root, owned by the base
@@ -65,46 +64,49 @@ fn open_dialog_scopes_to_current_project_then_reveals_all() {
     harness.editor_mut().set_active_window(win_b);
     set_orch_project_path(&mut harness, &proj_b);
 
-    // Active window stays in Project B — the dialog should default to
-    // B's sessions only.
     harness.render().unwrap();
 
     run_palette(&mut harness, "Orchestrator: Open");
     harness
-        .wait_until(|h| h.screen_to_string().contains("Project:"))
-        .expect("Orchestrator Open dialog should appear with the Project scope control");
+        .wait_until(|h| h.screen_to_string().contains("all projects"))
+        .expect("Orchestrator Open dialog should default to the all-projects view");
 
+    // Default scope is "all": every session is listed and the Project
+    // control shows "All".
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains(LABEL_B),
-        "Project B's session must be listed — it's the current project.\nScreen:\n{}",
-        screen,
-    );
-    assert!(
         screen.contains("Project:") && screen.contains("(Alt+P)"),
-        "Scoped view must render the visible Project scope control with its \
+        "Picker must render the visible Project scope control with its \
          Alt+P hint.\nScreen:\n{}",
         screen,
     );
+    assert!(
+        screen.contains("All ▾"),
+        "Default view must show the Project control in its 'All' state.\nScreen:\n{}",
+        screen,
+    );
+    assert!(
+        screen.contains(LABEL_B),
+        "Project B's session must be listed in the all-projects view.\nScreen:\n{}",
+        screen,
+    );
 
-    // Toggle scope (Alt+P) → every session, across every project.
+    // Toggle scope (Alt+P) → current project only (Project B, the
+    // active window). B's session stays; the title drops "all
+    // projects".
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::ALT)
         .unwrap();
     harness.render().unwrap();
     harness
-        .wait_until(|h| h.screen_to_string().contains("all projects"))
-        .expect("scope toggle should switch the dialog to the all-projects view");
+        .wait_until(|h| !h.screen_to_string().contains("all projects"))
+        .expect("scope toggle should switch the dialog to the current-project view");
 
     let screen = harness.screen_to_string();
     assert!(
-        screen.contains("All ▾"),
-        "All-projects view must flip the Project control to 'All'.\nScreen:\n{}",
-        screen,
-    );
-    assert!(
         screen.contains(LABEL_B),
-        "Project B's session must still be listed in the all-projects view.\nScreen:\n{}",
+        "Project B's session must remain listed when scoped to its own \
+         project.\nScreen:\n{}",
         screen,
     );
 

--- a/docs/internal/orchestrator-open-dialog-and-lifecycle.md
+++ b/docs/internal/orchestrator-open-dialog-and-lifecycle.md
@@ -521,58 +521,72 @@ total.
 
 ### Wireframe — new, default (scoped to current project)
 
+_As shipped (the title carries the project; a clickable scope
+toggle sits under the filter; the "N in other projects" affordance
+spells out the alternative):_
+
 ```
-╭─ ORCHESTRATOR :: Sessions ─ projB ──────────────────────────────╮
-│ ╭ [type to filter…      ]  Scope: ‹ current › ⌥P  searches all ╮│
-│ ╰───────────────────────────────────────────────────────────────╯│
+╭─ ORCHESTRATOR :: Sessions  —  projB ────────────────────────────╮
 │ ╭─ projB · this project (2) ─╮ ╭─ [3] blog-redesign ──────────╮ │
-│ │ [ + New Session  ⌥N ]      │ │ Project: /…/projB            │ │
-│ │ ▸ [3] ACT  blog-redesign   │ │ State:   ACT       Age: 3m   │ │
-│ │   [4] RUN  hotfix-2031     │ │ ──────────────────────────── │ │
-│ │ ── 2 in other projects ─── │ │ ▸ Dive · Stop⌥S · Arch⌥A …   │ │
-│ │      press ⌥P to show      │ │                              │ │
+│ │ [ + New Session  ⌥N ]      │ │ [ Visit ]  [Details][Stop]…  │ │
+│ │ [type to filter…         ] │ │                              │ │
+│ │ [ ‹ This project › ]       │ │   (live session preview)     │ │
+│ │ [3] ACT  blog-redesign     │ │                              │ │
+│ │ [4] RUN  hotfix-2031       │ │                              │ │
+│ │ 2 in other projects · ⌥P   │ │                              │ │
 │ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
-│  ↑↓ nav · Enter dive · ⌥P all projects · ⌥N new · Esc close     │
+│  ↑↓ nav · Enter dive · ⌥P all projects · Tab focus · Esc close  │
 ╰──────────────────────────────────────────────────────────────────╯
 ```
 
-### Wireframe — new, all-projects view (`⌥P`, grouped)
+### Wireframe — new, all-projects view (`⌥P`)
 
 ```
-╭─ ORCHESTRATOR :: Sessions ─ all projects ───────────────────────╮
-│ ╭ [type to filter…      ]  Scope: ‹ all ›    ⌥P current only   ╮│
-│ ╰───────────────────────────────────────────────────────────────╯│
-│ ╭─ Sessions (4) ─────────────╮ ╭─ [1] fresh ──────────────────╮ │
-│ │ [ + New Session  ⌥N ]      │ │ Project: /…/projA            │ │
-│ │ ▾ projB  · current         │ │ ⚠ different project than this │ │
-│ │   [3] ACT  blog-redesign   │ │   window                     │ │
-│ │   [4] RUN  hotfix-2031     │ │ State:   RUN (BASE)  Age: 1d  │ │
-│ │ ▾ projA                    │ │ ──────────────────────────── │ │
-│ │   [1] RUN  fresh    BASE   │ │ ▸ Dive (switches project) ·… │ │
-│ │   [2] RUN  feature-login   │ │                              │ │
+╭─ ORCHESTRATOR :: Sessions  —  all projects ─────────────────────╮
+│ ╭─ Sessions (4) ─────────────╮ ╭─ [3] blog-redesign ──────────╮ │
+│ │ [ + New Session  ⌥N ]      │ │ [ Visit ]  [Details][Stop]…  │ │
+│ │ [type to filter…         ] │ │                              │ │
+│ │ [ ‹ All projects › ]       │ │   (live session preview)     │ │
+│ │ [3] ACT  blog-redesign     │ │                              │ │
+│ │ [4] RUN  hotfix-2031       │ │                              │ │
+│ │ [1] RUN  fresh BASE · A    │ │                              │ │
+│ │ [2] RUN  feature-login · A │ │                              │ │
 │ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
-│  ↑↓ nav · Enter dive · ⌥P current only · ⌥N new · Esc close     │
+│  ↑↓ nav · Enter dive · ⌥P current only · Tab focus · Esc close  │
 ╰──────────────────────────────────────────────────────────────────╯
 ```
+
+Sessions sort current-project-first; cross-project rows carry an
+inline `· <project>` basename tag rather than separator-row group
+headers (the list widget has no non-selectable rows, and threading
+headers through the selection/lifecycle indexing wasn't worth the
+regression risk). Current-first ordering already clusters each
+project, and the wider sessions column keeps the tags from
+truncating.
 
 ### Interaction notes
 
-- **Scope toggle** (`⌥P`) flips current ↔ all and is rendered in
-  the filter row through `format_keybinding` (chord registered in
-  the `orchestrator-open` mode, same pipeline as Stop/Archive/
-  Delete). Persist the last-used scope per editor session.
+- **Scope toggle**: a visible, clickable `[ ‹ This project › ]` /
+  `[ ‹ All projects › ]` button under the filter, plus the `⌥P`
+  chord (registered in the `orchestrator-open` mode, rendered via
+  `format_keybinding`, same pipeline as Stop/Archive/Delete). Both
+  call the same `toggleScope()`. Scope is also legible from the
+  title suffix and the section caption; the scoped view's "N in
+  other projects · ⌥P" affordance advertises the alternative.
 - **Filter is always global**: typing in the scoped view still
-  matches sessions in other projects and auto-reveals them under
-  their project header (so search never hides a session the user
-  is clearly looking for).
-- **Grouping** reuses the existing list widget: project headers
-  are non-selectable separator rows; the current project's group
-  sorts first and is labeled `· current`.
-- **Boot behavior** (separate from the dialog): replace the
-  cross-project auto-activate in `pick_active_window_for_cwd` with
-  "clean base window for the cwd + optional Resume affordance."
-  This is the single highest-impact fix and is independent of the
-  dialog redesign.
+  matches sessions in other projects (search never hides a session
+  the user is clearly looking for).
+- **Height budget**: the scope-toggle row (always) and the
+  affordance row (scoped view) are subtracted from the list
+  widget's `visibleRows` so the sessions column stays the same
+  height as the preview pane — otherwise the extra rows push the
+  footer hint off the fixed-height panel.
+- **Boot behavior** (separate from the dialog, shipped): the editor
+  reopens the session last used **in the launch cwd's project**
+  (`pick_active_window_for_cwd` — `env.active` if it belongs to the
+  cwd, else the most-recent session for the cwd, else a clean base
+  window). The pick is strictly cwd-scoped, so a different project's
+  session is never auto-activated.
 
 ## Open questions
 

--- a/docs/internal/orchestrator-open-dialog-and-lifecycle.md
+++ b/docs/internal/orchestrator-open-dialog-and-lifecycle.md
@@ -458,11 +458,138 @@ existing swallow-don't-leak rule.
   performs the worktree fetch / create lazily).
 - `fresh.orchestrator.sync = false` config opt-out.
 
+## Project scoping (cross-project confusion)
+
+> **Status**: Design addition, May 2026
+> **Driving bug**: After the v2 persistence change (one global
+> `<data>/orchestrator/windows.json` instead of per-cwd files),
+> launching Fresh in project B surfaces every session from every
+> project the user ever created. The picker lists them in one
+> flat, unlabeled list, and `pick_active_window_for_cwd` can boot
+> straight into yesterday's session when its `project_path`
+> matches today's cwd. Users read this as "it's combining
+> yesterday's directories/tabs into today's project."
+
+### Principles
+
+1. **Scope by default, global on demand.** Open scoped to the
+   current project. Cross-project is an explicit, always-visible
+   gesture (`⌥P` / a Scope toggle), never the landing view.
+2. **All sessions stay reachable.** The orchestrator is still the
+   one place to reach every session everywhere — scoping changes
+   what's *foregrounded*, not what's *reachable*. The scoped view
+   always shows a `── N in other projects · ⌥P ──` affordance, and
+   the filter searches globally even while scoped.
+3. **Never silently inherit a session across projects.** Booting
+   in project X lands on a clean base window for X. Do not
+   auto-activate a persisted session just because its
+   `project_path` matches the cwd; if we restore, make it a
+   visible, dismissible "Resume last session?" affordance.
+4. **Scope is legible.** Current project shows in the dialog
+   title and the editor status bar. The list is grouped by
+   project (never flat), with the current project marked. A dive
+   into another project is labeled (`Dive (switches project)`).
+5. **Consistent boundaries.** Workspaces (tabs/explorer) are
+   per-cwd but orchestrator windows are global — that mismatch is
+   what makes state feel "combined." Apply one boundary (project
+   root) uniformly to sessions, per-window plugin state, and
+   workspace.
+6. **Migrations are visible and reversible.** When the storage
+   model changes (per-cwd → global), show a one-time notice
+   rather than silently folding everyone's history together on
+   first launch.
+
+### Wireframe — current (flat, unscoped)
+
+```
+╭─ ORCHESTRATOR :: Sessions ──────────────────────────────────────╮
+│ ╭─ Sessions (4) ─────────╮ ╭─ [3] blog-redesign ──────────────╮ │
+│ │ [ + New Session  Alt+N]│ │ [ Visit ] [Details][Stop][Arch…] │ │
+│ │ [type to filter…     ] │ │                                  │ │
+│ │ [1] RUN  fresh BASE ⇄  │ │        (preview of session)      │ │
+│ │ [2] RUN  feature-login │ │                                  │ │
+│ │ [3] ACT  blog-redesign │ │                                  │ │
+│ │ [4] RUN  hotfix-2031 ⇄ │ │                                  │ │
+│ ╰────────────────────────╯ ╰──────────────────────────────────╯ │
+│  ↑↓ nav · Enter dive · Tab focus · Esc close                    │
+╰──────────────────────────────────────────────────────────────────╯
+```
+
+Launched in projB, but `fresh` / `feature-login` (projA) are
+mixed in with no project label and the count `(4)` is the global
+total.
+
+### Wireframe — new, default (scoped to current project)
+
+```
+╭─ ORCHESTRATOR :: Sessions ─ projB ──────────────────────────────╮
+│ ╭ [type to filter…      ]  Scope: ‹ current › ⌥P  searches all ╮│
+│ ╰───────────────────────────────────────────────────────────────╯│
+│ ╭─ projB · this project (2) ─╮ ╭─ [3] blog-redesign ──────────╮ │
+│ │ [ + New Session  ⌥N ]      │ │ Project: /…/projB            │ │
+│ │ ▸ [3] ACT  blog-redesign   │ │ State:   ACT       Age: 3m   │ │
+│ │   [4] RUN  hotfix-2031     │ │ ──────────────────────────── │ │
+│ │ ── 2 in other projects ─── │ │ ▸ Dive · Stop⌥S · Arch⌥A …   │ │
+│ │      press ⌥P to show      │ │                              │ │
+│ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
+│  ↑↓ nav · Enter dive · ⌥P all projects · ⌥N new · Esc close     │
+╰──────────────────────────────────────────────────────────────────╯
+```
+
+### Wireframe — new, all-projects view (`⌥P`, grouped)
+
+```
+╭─ ORCHESTRATOR :: Sessions ─ all projects ───────────────────────╮
+│ ╭ [type to filter…      ]  Scope: ‹ all ›    ⌥P current only   ╮│
+│ ╰───────────────────────────────────────────────────────────────╯│
+│ ╭─ Sessions (4) ─────────────╮ ╭─ [1] fresh ──────────────────╮ │
+│ │ [ + New Session  ⌥N ]      │ │ Project: /…/projA            │ │
+│ │ ▾ projB  · current         │ │ ⚠ different project than this │ │
+│ │   [3] ACT  blog-redesign   │ │   window                     │ │
+│ │   [4] RUN  hotfix-2031     │ │ State:   RUN (BASE)  Age: 1d  │ │
+│ │ ▾ projA                    │ │ ──────────────────────────── │ │
+│ │   [1] RUN  fresh    BASE   │ │ ▸ Dive (switches project) ·… │ │
+│ │   [2] RUN  feature-login   │ │                              │ │
+│ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
+│  ↑↓ nav · Enter dive · ⌥P current only · ⌥N new · Esc close     │
+╰──────────────────────────────────────────────────────────────────╯
+```
+
+### Interaction notes
+
+- **Scope toggle** (`⌥P`) flips current ↔ all and is rendered in
+  the filter row through `format_keybinding` (chord registered in
+  the `orchestrator-open` mode, same pipeline as Stop/Archive/
+  Delete). Persist the last-used scope per editor session.
+- **Filter is always global**: typing in the scoped view still
+  matches sessions in other projects and auto-reveals them under
+  their project header (so search never hides a session the user
+  is clearly looking for).
+- **Grouping** reuses the existing list widget: project headers
+  are non-selectable separator rows; the current project's group
+  sorts first and is labeled `· current`.
+- **Boot behavior** (separate from the dialog): replace the
+  cross-project auto-activate in `pick_active_window_for_cwd` with
+  "clean base window for the cwd + optional Resume affordance."
+  This is the single highest-impact fix and is independent of the
+  dialog redesign.
+
 ## Open questions
 
+- **Project scope default**: per-project default scope is the
+  recommendation, but should the very first open in a brand-new
+  project (zero sessions) auto-expand to all-projects so the list
+  isn't empty, or show an empty state with a clear `⌥P` hint?
+  Leaning toward the empty state — an empty scoped list with a
+  visible toggle teaches the model better than silently widening.
 - **Stop with no live processes**: silent no-op or status-bar
   feedback? Leaning toward status-bar — surprise-no-op feels
   broken.
+- **Diving into an archived session**: implicit unarchive
+  (today's plan), or refuse and require the user to
+  explicitly unarchive first? Implicit is more ergonomic but
+  hides the worktree move under what reads as a navigation
+  action.
 - **Diving into an archived session**: implicit unarchive
   (today's plan), or refuse and require the user to
   explicitly unarchive first? Implicit is more ergonomic but

--- a/docs/internal/orchestrator-open-dialog-and-lifecycle.md
+++ b/docs/internal/orchestrator-open-dialog-and-lifecycle.md
@@ -521,58 +521,66 @@ total.
 
 ### Wireframe — new, default (scoped to current project)
 
-_As shipped (the title carries the project; a clickable scope
-toggle sits under the filter; the "N in other projects" affordance
-spells out the alternative):_
+_As shipped — tabular rows (`ID / NAME / PROJECT`), a labelled
+`Project:` scope control with the `Alt+P` hint baked in, a labelled
+`Filter` field (`/` focuses it), and a panel that fits the session
+count:_
 
 ```
 ╭─ ORCHESTRATOR :: Sessions  —  projB ────────────────────────────╮
-│ ╭─ projB · this project (2) ─╮ ╭─ [3] blog-redesign ──────────╮ │
-│ │ [ + New Session  ⌥N ]      │ │ [ Visit ]  [Details][Stop]…  │ │
-│ │ [type to filter…         ] │ │                              │ │
-│ │ [ ‹ This project › ]       │ │   (live session preview)     │ │
-│ │ [3] ACT  blog-redesign     │ │                              │ │
-│ │ [4] RUN  hotfix-2031       │ │                              │ │
-│ │ 2 in other projects · ⌥P   │ │                              │ │
+│ ╭─ Sessions ─────────────────╮ ╭─ [3] blog-redesign ──────────╮ │
+│ │ [ + New  Alt+N ]           │ │ [ Visit ]  [Details][Stop]…  │ │
+│ │ Project: [ projB ▾ (Alt+P)]│ │                              │ │
+│ │ Filter [type to search…/]  │ │   (live session preview)     │ │
+│ │ ────────────────────────── │ │                              │ │
+│ │ ID   NAME          PROJECT │ │                              │ │
+│ │ [3]  blog-redesign         │ │                              │ │
+│ │ [4]  hotfix-2031           │ │                              │ │
 │ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
-│  ↑↓ nav · Enter dive · ⌥P all projects · Tab focus · Esc close  │
+│  ↑↓ nav · Enter dive · Alt+P all projects · Tab focus · Esc     │
 ╰──────────────────────────────────────────────────────────────────╯
 ```
 
-### Wireframe — new, all-projects view (`⌥P`)
+### Wireframe — new, all-projects view (`Alt+P`)
 
 ```
 ╭─ ORCHESTRATOR :: Sessions  —  all projects ─────────────────────╮
-│ ╭─ Sessions (4) ─────────────╮ ╭─ [3] blog-redesign ──────────╮ │
-│ │ [ + New Session  ⌥N ]      │ │ [ Visit ]  [Details][Stop]…  │ │
-│ │ [type to filter…         ] │ │                              │ │
-│ │ [ ‹ All projects › ]       │ │   (live session preview)     │ │
-│ │ [3] ACT  blog-redesign     │ │                              │ │
-│ │ [4] RUN  hotfix-2031       │ │                              │ │
-│ │ [1] RUN  fresh BASE · A    │ │                              │ │
-│ │ [2] RUN  feature-login · A │ │                              │ │
+│ ╭─ Sessions ─────────────────╮ ╭─ [3] blog-redesign ──────────╮ │
+│ │ [ + New  Alt+N ]           │ │ [ Visit ]  [Details][Stop]…  │ │
+│ │ Project: [ All ▾  (Alt+P) ]│ │                              │ │
+│ │ Filter [type to search…/]  │ │   (live session preview)     │ │
+│ │ ────────────────────────── │ │                              │ │
+│ │ ID   NAME          PROJECT │ │                              │ │
+│ │ [3]  blog-redesign         │ │                              │ │
+│ │ [4]  hotfix-2031           │ │                              │ │
+│ │ [1]  fresh BASE    projA   │ │                              │ │
+│ │ [2]  feature-login projA   │ │                              │ │
 │ ╰────────────────────────────╯ ╰──────────────────────────────╯ │
-│  ↑↓ nav · Enter dive · ⌥P current only · Tab focus · Esc close  │
+│  ↑↓ nav · Enter dive · Alt+P current only · Tab focus · Esc     │
 ╰──────────────────────────────────────────────────────────────────╯
 ```
 
-Sessions sort current-project-first; cross-project rows carry an
-inline `· <project>` basename tag rather than separator-row group
-headers (the list widget has no non-selectable rows, and threading
-headers through the selection/lifecycle indexing wasn't worth the
-regression risk). Current-first ordering already clusters each
-project, and the wider sessions column keeps the tags from
-truncating.
+Sessions sort current-project-first; the PROJECT column carries the
+project basename only for cross-project rows (current-project rows
+leave it blank) rather than separator-row group headers — the list
+widget has no non-selectable rows, and threading headers through the
+selection/lifecycle indexing wasn't worth the regression risk. The
+active session's `[id]` renders in the active-tab colour (there's no
+separate state column).
 
 ### Interaction notes
 
-- **Scope toggle**: a visible, clickable `[ ‹ This project › ]` /
-  `[ ‹ All projects › ]` button under the filter, plus the `⌥P`
-  chord (registered in the `orchestrator-open` mode, rendered via
-  `format_keybinding`, same pipeline as Stop/Archive/Delete). Both
-  call the same `toggleScope()`. Scope is also legible from the
-  title suffix and the section caption; the scoped view's "N in
-  other projects · ⌥P" affordance advertises the alternative.
+- **Scope control**: a labelled, clickable `Project: [ <name> ▾
+  (Alt+P) ]` button — clicking it or pressing `Alt+P` flips
+  current ↔ all (both call `toggleScope()`). The chord is registered
+  in the `orchestrator-open` mode and rendered via
+  `format_keybinding`. Scope is also legible from the title suffix.
+- **`/` focuses the filter**: bound as a plain-char chord in the
+  picker mode. The host's floating-panel key dispatch now defers
+  plain chars to an explicit mode binding before feeding them to the
+  focused text input (it already did this for named keys and
+  Ctrl/Alt chords), so a bare key like `/` reaches the plugin — at
+  the cost of not being typeable as filter text in that mode.
 - **Filter is always global**: typing in the scoped view still
   matches sessions in other projects (search never hides a session
   the user is clearly looking for).


### PR DESCRIPTION
## Summary

Fixes the reported orchestration bug where launching in one project pulled in **another day's / another project's** directories, files, and sessions, and reworks the Open picker around per-project scoping.

**Root cause.** In 0.3.7 orchestrator persistence moved from per-cwd files to a single global `windows.json`. Two surfaces then leaked across projects:
1. the Open picker listed *every* session from *every* project in one flat, unlabeled list; and
2. at boot the editor could drop you straight into a previous session (its worktree root / label / plugin state) rather than a clean editor for the project you launched in.

## Changes

**Boot (no cross-project bleed):**
- `pick_active_window_for_cwd` is now strictly cwd-scoped: reopen the session last used **in the launch cwd's project** (`env.active` if it belongs to the cwd, else the most-recent session for that cwd, else a clean base window). A different project's session is never auto-activated. Honors a directory passed on the CLI (`fresh /path`), not just the shell cwd.
- A clean base keys off the *picked* window, so a stale persisted id-1 window from another project can't lend its label/root/state to it.

**Open picker:**
- Scopes to the current project by default; an `Alt+P` toggle reveals all projects. Filtering is always global.
- Tabular rows `[id]  NAME …  PROJECT` with a column header; the PROJECT column labels cross-project rows; sessions sort current-project-first. Active session's `[id]` renders in the active-tab colour.
- Labelled `Project: [ <name> ▾  (Alt+P) ]` scope control and a labelled `Filter` field; `/` focuses the filter.
- The floating panel now fits the session count instead of a tall box padded with blank rows.

**Host fixes (found while testing):**
- Widget row-zip clamped byte-unit overlays to the pre-truncation length, so a multi-byte ellipsis from column truncation could land mid-char and panic the span splitter — now snaps overlays to a char boundary.
- The floating-panel key dispatcher fed plain chars straight to the focused text input, consulting mode bindings only for named/Ctrl/Alt keys — so a bare key like `/` bound in a picker mode was dead. Plain chars now defer to an explicit mode binding first.

**Docs:** design doc updated with the scoping principles, wireframes, and the shipped layout.

## Test plan

- [x] `cargo test -p fresh-editor --lib orchestrator_persistence::tests` (cwd-scoped boot pick: never-crosses-projects, last-used, most-recent fallback, clean-base)
- [x] `cargo test -p fresh-editor --lib widgets::render` (char-boundary regression test)
- [x] `cargo test -p fresh-editor --test orchestrator_persistence_paths`
- [x] `cargo test -p fresh-editor --test e2e_tests orchestrator` (scoping default + `Alt+P` reveal-all + `/`-focus live filtering; form typing unaffected)
- [x] Widget / search_replace text-input e2e (host key-dispatch change is non-regressive)
- [x] Manual tmux walkthrough: created git-worktree sessions across `webapp`/`api-service` + an in-place session in non-git `data`; verified scoped vs all-projects views, the Project control, `/`-focus + filtering, clean per-cwd boot, and compact panel sizing

https://claude.ai/code/session_01UhCtdAe4SYg6QUsXuYKc9y