### PR TITLE
feat: Add move to next/previous paragraph actions

### DIFF
--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Přesunout o stránku dolů",
   "action.move_page_up": "Přesunout o stránku nahoru",
   "action.move_right": "Přesunout kurzor vpravo",
+  "action.move_to_paragraph_down": "Přesunout na další prázdný řádek",
+  "action.move_to_paragraph_up": "Přesunout na předchozí prázdný řádek",
   "action.move_up": "Přesunout kurzor nahoru",
   "action.move_word_end": "Přesunout na konec slova",
   "action.move_word_left": "Přesunout o slovo vlevo",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Seite nach unten bewegen",
   "action.move_page_up": "Seite nach oben bewegen",
   "action.move_right": "Cursor nach rechts bewegen",
+  "action.move_to_paragraph_down": "Zur nächsten leeren Zeile bewegen",
+  "action.move_to_paragraph_up": "Zur vorherigen leeren Zeile bewegen",
   "action.move_up": "Cursor nach oben bewegen",
   "action.move_word_end": "Zum Wortende bewegen",
   "action.move_word_left": "Wort nach links bewegen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -287,6 +287,8 @@
   "action.select_theme": "Select theme",
   "action.select_to_paragraph_down": "Select to next empty line",
   "action.select_to_paragraph_up": "Select to previous empty line",
+  "action.move_to_paragraph_down": "Move to next empty line",
+  "action.move_to_paragraph_up": "Move to previous empty line",
   "action.select_up": "Select up",
   "action.select_word": "Select word under cursor",
   "action.select_word_end": "Select to word end",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Mover página abajo",
   "action.move_page_up": "Mover página arriba",
   "action.move_right": "Mover cursor a la derecha",
+  "action.move_to_paragraph_down": "Mover hasta la siguiente línea vacía",
+  "action.move_to_paragraph_up": "Mover hasta la línea vacía anterior",
   "action.move_up": "Mover cursor arriba",
   "action.move_word_end": "Mover al final de palabra",
   "action.move_word_left": "Mover palabra a la izquierda",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Page suivante",
   "action.move_page_up": "Page précédente",
   "action.move_right": "Déplacer le curseur vers la droite",
+  "action.move_to_paragraph_down": "Déplacer jusqu'à la ligne vide suivante",
+  "action.move_to_paragraph_up": "Déplacer jusqu'à la ligne vide précédente",
   "action.move_up": "Déplacer le curseur vers le haut",
   "action.move_word_end": "Aller à la fin du mot",
   "action.move_word_left": "Déplacer d'un mot vers la gauche",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Vai alla pagina successiva",
   "action.move_page_up": "Vai alla pagina precedente",
   "action.move_right": "Sposta cursore a destra",
+  "action.move_to_paragraph_down": "Sposta fino alla prossima riga vuota",
+  "action.move_to_paragraph_up": "Sposta fino alla riga vuota precedente",
   "action.move_up": "Sposta cursore su",
   "action.move_word_end": "Vai a fine parola",
   "action.move_word_left": "Sposta parola a sinistra",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "ページダウン",
   "action.move_page_up": "ページアップ",
   "action.move_right": "カーソルを右へ移動",
+  "action.move_to_paragraph_down": "次の空行まで移動",
+  "action.move_to_paragraph_up": "前の空行まで移動",
   "action.move_up": "カーソルを上へ移動",
   "action.move_word_end": "単語末尾へ移動",
   "action.move_word_left": "左の単語へ移動",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "페이지 아래로 이동",
   "action.move_page_up": "페이지 위로 이동",
   "action.move_right": "커서 오른쪽으로 이동",
+  "action.move_to_paragraph_down": "다음 빈 줄까지 이동",
+  "action.move_to_paragraph_up": "이전 빈 줄까지 이동",
   "action.move_up": "커서 위로 이동",
   "action.move_word_end": "단어 끝으로 이동",
   "action.move_word_left": "단어 왼쪽으로 이동",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Mover página para baixo",
   "action.move_page_up": "Mover página para cima",
   "action.move_right": "Mover cursor para a direita",
+  "action.move_to_paragraph_down": "Mover até a próxima linha vazia",
+  "action.move_to_paragraph_up": "Mover até a linha vazia anterior",
   "action.move_up": "Mover cursor para cima",
   "action.move_word_end": "Mover para fim da palavra",
   "action.move_word_left": "Mover palavra para a esquerda",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Страница вниз",
   "action.move_page_up": "Страница вверх",
   "action.move_right": "Переместить курсор вправо",
+  "action.move_to_paragraph_down": "Перейти к следующей пустой строке",
+  "action.move_to_paragraph_up": "Перейти к предыдущей пустой строке",
   "action.move_up": "Переместить курсор вверх",
   "action.move_word_end": "Перейти в конец слова",
   "action.move_word_left": "Переместиться на слово влево",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "เลื่อนลงหนึ่งหน้า",
   "action.move_page_up": "เลื่อนขึ้นหนึ่งหน้า",
   "action.move_right": "เลื่อนเคอร์เซอร์ไปทางขวา",
+  "action.move_to_paragraph_down": "เลื่อนไปถึงบรรทัดว่างถัดไป",
+  "action.move_to_paragraph_up": "เลื่อนไปถึงบรรทัดว่างก่อนหน้า",
   "action.move_up": "เลื่อนเคอร์เซอร์ขึ้น",
   "action.move_word_end": "เลื่อนไปท้ายคำ",
   "action.move_word_left": "เลื่อนไปทางซ้ายหนึ่งคำ",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Перейти на сторінку вниз",
   "action.move_page_up": "Перейти на сторінку вгору",
   "action.move_right": "Перемістити курсор вправо",
+  "action.move_to_paragraph_down": "Перейти до наступного порожнього рядка",
+  "action.move_to_paragraph_up": "Перейти до попереднього порожнього рядка",
   "action.move_up": "Перемістити курсор вгору",
   "action.move_word_end": "Перейти до кінця слова",
   "action.move_word_left": "Перемістити слово вліво",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "Di chuyển xuống một trang",
   "action.move_page_up": "Di chuyển lên một trang",
   "action.move_right": "Di chuyển con trỏ sang phải",
+  "action.move_to_paragraph_down": "Di chuyển đến dòng trống tiếp theo",
+  "action.move_to_paragraph_up": "Di chuyển đến dòng trống trước đó",
   "action.move_up": "Di chuyển con trỏ lên",
   "action.move_word_end": "Di chuyển đến cuối từ",
   "action.move_word_left": "Di chuyển sang trái một từ",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -171,6 +171,8 @@
   "action.move_page_down": "向下翻页",
   "action.move_page_up": "向上翻页",
   "action.move_right": "光标向右移动",
+  "action.move_to_paragraph_down": "移动到下一个空行",
+  "action.move_to_paragraph_up": "移动到上一个空行",
   "action.move_up": "光标向上移动",
   "action.move_word_end": "移动到单词末尾",
   "action.move_word_left": "向左移动一个单词",

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -56,6 +56,33 @@ fn content_len_without_line_ending(content: &str) -> usize {
     content.trim_end_matches(LINE_ENDING_CHARS).len()
 }
 
+fn find_paragraph_up(buffer: &mut Buffer, pos: usize, estimated_line_length: usize) -> usize {
+    let mut iter = buffer.line_iterator(pos, estimated_line_length);
+    let mut found_pos = None;
+    while let Some((line_start, line_content)) = iter.prev() {
+        let trimmed = line_content.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
+            found_pos = Some(line_start);
+            break;
+        }
+    }
+    found_pos.unwrap_or(0)
+}
+
+fn find_paragraph_down(buffer: &mut Buffer, pos: usize, estimated_line_length: usize) -> usize {
+    let mut iter = buffer.line_iterator(pos, estimated_line_length);
+    iter.next_line();
+    let mut found_pos = None;
+    while let Some((line_start, line_content)) = iter.next_line() {
+        let trimmed = line_content.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
+            found_pos = Some(line_start);
+            break;
+        }
+    }
+    found_pos.unwrap_or(buffer.len())
+}
+
 /// Adjust position after moving left in CRLF mode.
 /// If we land on \n that's preceded by \r, skip back to the \r.
 /// This ensures the cursor never sits between \r and \n.
@@ -2216,36 +2243,25 @@ pub fn action_to_events(
 
         Action::SelectToParagraphUp => {
             select_each_cursor(cursors, &mut events, |c| {
-                let mut iter = state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length);
-                let mut found_pos = None;
-                while let Some((line_start, line_content)) = iter.prev() {
-                    let trimmed = line_content.trim_end_matches(['\n', '\r']);
-                    if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
-                        found_pos = Some(line_start);
-                        break;
-                    }
-                }
-                found_pos.unwrap_or(0)
+                find_paragraph_up(&mut state.buffer, c.position, estimated_line_length)
             });
         }
 
         Action::SelectToParagraphDown => {
             select_each_cursor(cursors, &mut events, |c| {
-                let mut iter = state
-                    .buffer
-                    .line_iterator(c.position, estimated_line_length);
-                iter.next_line();
-                let mut found_pos = None;
-                while let Some((line_start, line_content)) = iter.next_line() {
-                    let trimmed = line_content.trim_end_matches(['\n', '\r']);
-                    if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
-                        found_pos = Some(line_start);
-                        break;
-                    }
-                }
-                found_pos.unwrap_or(state.buffer.len())
+                find_paragraph_down(&mut state.buffer, c.position, estimated_line_length)
+            });
+        }
+
+        Action::MoveToParagraphUp => {
+            move_each_cursor(cursors, &mut events, |c| {
+                find_paragraph_up(&mut state.buffer, c.position, estimated_line_length)
+            });
+        }
+
+        Action::MoveToParagraphDown => {
+            move_each_cursor(cursors, &mut events, |c| {
+                find_paragraph_down(&mut state.buffer, c.position, estimated_line_length)
             });
         }
 

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -341,6 +341,8 @@ pub enum Action {
     MoveLineEnd,
     MoveLineUp,
     MoveLineDown,
+    MoveToParagraphUp,
+    MoveToParagraphDown,
     MovePageUp,
     MovePageDown,
     MoveDocumentStart,
@@ -880,6 +882,8 @@ impl Action {
             "move_page_down" => MovePageDown,
             "move_document_start" => MoveDocumentStart,
             "move_document_end" => MoveDocumentEnd,
+            "move_to_paragraph_up" => MoveToParagraphUp,
+            "move_to_paragraph_down" => MoveToParagraphDown,
 
             "select_left" => SelectLeft,
             "select_right" => SelectRight,
@@ -1331,6 +1335,8 @@ impl Action {
                 | Action::MovePageDown
                 | Action::MoveDocumentStart
                 | Action::MoveDocumentEnd
+                | Action::MoveToParagraphUp
+                | Action::MoveToParagraphDown
                 // Selection actions
                 | Action::SelectLeft
                 | Action::SelectRight
@@ -2274,6 +2280,8 @@ impl KeybindingResolver {
             Action::SelectDown => t!("action.select_down"),
             Action::SelectToParagraphUp => t!("action.select_to_paragraph_up"),
             Action::SelectToParagraphDown => t!("action.select_to_paragraph_down"),
+            Action::MoveToParagraphUp => t!("action.move_to_paragraph_up"),
+            Action::MoveToParagraphDown => t!("action.move_to_paragraph_down"),
             Action::SelectWordLeft => t!("action.select_word_left"),
             Action::SelectWordRight => t!("action.select_word_right"),
             Action::SelectWordEnd => t!("action.select_word_end"),

--- a/crates/fresh-editor/tests/semantic/migrated_select_to_paragraph_full.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_select_to_paragraph_full.rs
@@ -166,3 +166,43 @@ fn anti_select_to_paragraph_up_at_start_dropping_action_yields_check_err() {
          with no selection; the (7, 0) range expectation must NOT match"
     );
 }
+
+#[test]
+fn migrated_move_to_paragraph_down_from_first_line() {
+    assert_buffer_scenario(BufferScenario {
+        description: "MoveToParagraphDown from line 1 moves to empty line without selecting".into(),
+        initial_text:
+            "paragraph 1 line 1\nparagraph 1 line 2\n\nparagraph 2 line 1\nparagraph 2 line 2\n"
+                .into(),
+        actions: vec![Action::MoveLineStart, Action::MoveToParagraphDown],
+        expected_text:
+            "paragraph 1 line 1\nparagraph 1 line 2\n\nparagraph 2 line 1\nparagraph 2 line 2\n"
+                .into(),
+        // Cursor at the empty-line position (38), no selection.
+        expected_primary: CursorExpect::at(38),
+        ..Default::default()
+    });
+}
+
+#[test]
+fn migrated_move_to_paragraph_up_from_paragraph_2() {
+    assert_buffer_scenario(BufferScenario {
+        description: "MoveToParagraphUp from paragraph 2 moves to empty line without selecting"
+            .into(),
+        initial_text:
+            "paragraph 1 line 1\nparagraph 1 line 2\n\nparagraph 2 line 1\nparagraph 2 line 2\n"
+                .into(),
+        actions: vec![
+            Action::MoveDown,
+            Action::MoveDown,
+            Action::MoveDown,
+            Action::MoveToParagraphUp,
+        ],
+        expected_text:
+            "paragraph 1 line 1\nparagraph 1 line 2\n\nparagraph 2 line 1\nparagraph 2 line 2\n"
+                .into(),
+        // Cursor at the empty-line position (38), no selection.
+        expected_primary: CursorExpect::at(38),
+        ..Default::default()
+    });
+}


### PR DESCRIPTION
Closes https://github.com/sinelaw/fresh/issues/2083

Added `move to next/previous paragraph` move actions (no corresponding commands, just like `select next/previous paragraph` provide action only with no palette commands - they are not needed just like `move left` command is not needed).


https://github.com/user-attachments/assets/63b4bfb6-c2b5-4134-b752-16aaf972a356

