### PR TITLE
fix: Fixed cursor column calculation in statusbar elements

### DIFF
--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
@@ -460,12 +460,12 @@
   <rect x="378" y="54" width="9" height="18" fill="#000000"/>
   <text x="379" y="68" fill="#ffff00" class="terminal" style="">n</text>
   <rect x="387" y="54" width="9" height="18" fill="#000000"/>
-  <text x="388" y="68" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="388" y="68" fill="#8be9fd" class="terminal" style="">(</text>
   <rect x="396" y="54" width="9" height="18" fill="#000000"/>
-  <text x="397" y="68" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="397" y="68" fill="#8be9fd" class="terminal" style="">)</text>
   <rect x="405" y="54" width="9" height="18" fill="#000000"/>
   <rect x="414" y="54" width="9" height="18" fill="#000000"/>
-  <text x="415" y="68" fill="#d4d4d4" class="terminal" style="">{</text>
+  <text x="415" y="68" fill="#8be9fd" class="terminal" style="">{</text>
   <rect x="423" y="54" width="9" height="18" fill="#000000"/>
   <rect x="432" y="54" width="9" height="18" fill="#000000"/>
   <rect x="441" y="54" width="9" height="18" fill="#000000"/>
@@ -972,13 +972,13 @@
   <rect x="423" y="126" width="9" height="18" fill="#000000"/>
   <text x="424" y="140" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="126" width="9" height="18" fill="#000000"/>
-  <text x="433" y="140" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="140" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="126" width="9" height="18" fill="#000000"/>
   <text x="442" y="140" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="126" width="9" height="18" fill="#000000"/>
-  <text x="451" y="140" fill="#00cd00" class="terminal" style="">{</text>
+  <text x="451" y="140" fill="#f1fa8c" class="terminal" style="">{</text>
   <rect x="459" y="126" width="9" height="18" fill="#000000"/>
-  <text x="460" y="140" fill="#00cd00" class="terminal" style="">}</text>
+  <text x="460" y="140" fill="#f1fa8c" class="terminal" style="">}</text>
   <rect x="468" y="126" width="9" height="18" fill="#000000"/>
   <text x="469" y="140" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="477" y="126" width="9" height="18" fill="#000000"/>
@@ -995,7 +995,7 @@
   <rect x="531" y="126" width="9" height="18" fill="#000000"/>
   <text x="532" y="140" fill="#ffffff" class="terminal" style="">o</text>
   <rect x="540" y="126" width="9" height="18" fill="#000000"/>
-  <text x="541" y="140" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="541" y="140" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="549" y="126" width="9" height="18" fill="#000000"/>
   <text x="550" y="140" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="558" y="126" width="9" height="18" fill="#000000"/>
@@ -1077,7 +1077,7 @@
   <text x="307" y="158" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="144" width="9" height="18" fill="#000000"/>
   <rect x="324" y="144" width="9" height="18" fill="#000000"/>
-  <text x="325" y="158" fill="#d4d4d4" class="terminal" style="">}</text>
+  <text x="325" y="158" fill="#8be9fd" class="terminal" style="">}</text>
   <rect x="333" y="144" width="9" height="18" fill="#000000"/>
   <rect x="342" y="144" width="9" height="18" fill="#000000"/>
   <rect x="351" y="144" width="9" height="18" fill="#000000"/>
@@ -1425,7 +1425,7 @@
   <rect x="396" y="198" width="9" height="18" fill="#000000"/>
   <text x="397" y="212" fill="#ffff00" class="terminal" style="">r</text>
   <rect x="405" y="198" width="9" height="18" fill="#000000"/>
-  <text x="406" y="212" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="406" y="212" fill="#8be9fd" class="terminal" style="">(</text>
   <rect x="414" y="198" width="9" height="18" fill="#000000"/>
   <text x="415" y="212" fill="#ffffff" class="terminal" style="">x</text>
   <rect x="423" y="198" width="9" height="18" fill="#000000"/>
@@ -1438,12 +1438,12 @@
   <rect x="459" y="198" width="9" height="18" fill="#000000"/>
   <text x="460" y="212" fill="#ff55ff" class="terminal" style="">2</text>
   <rect x="468" y="198" width="9" height="18" fill="#000000"/>
-  <text x="469" y="212" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="469" y="212" fill="#8be9fd" class="terminal" style="">)</text>
   <rect x="477" y="198" width="9" height="18" fill="#000000"/>
   <rect x="486" y="198" width="9" height="18" fill="#000000"/>
   <text x="487" y="212" fill="#ffffff" class="terminal" style="">-</text>
   <rect x="495" y="198" width="9" height="18" fill="#000000"/>
-  <text x="496" y="212" fill="#ffffff" class="terminal" style="">&gt;</text>
+  <text x="496" y="212" fill="#8be9fd" class="terminal" style="">&gt;</text>
   <rect x="504" y="198" width="9" height="18" fill="#000000"/>
   <rect x="513" y="198" width="9" height="18" fill="#000000"/>
   <text x="514" y="212" fill="#ff55ff" class="terminal" style="">i</text>
@@ -1453,7 +1453,7 @@
   <text x="532" y="212" fill="#ff55ff" class="terminal" style="">2</text>
   <rect x="540" y="198" width="9" height="18" fill="#000000"/>
   <rect x="549" y="198" width="9" height="18" fill="#000000"/>
-  <text x="550" y="212" fill="#d4d4d4" class="terminal" style="">{</text>
+  <text x="550" y="212" fill="#8be9fd" class="terminal" style="">{</text>
   <rect x="558" y="198" width="9" height="18" fill="#000000"/>
   <rect x="567" y="198" width="9" height="18" fill="#000000"/>
   <rect x="576" y="198" width="9" height="18" fill="#000000"/>
@@ -1890,7 +1890,7 @@
   <text x="307" y="284" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="270" width="9" height="18" fill="#000000"/>
   <rect x="324" y="270" width="9" height="18" fill="#000000"/>
-  <text x="325" y="284" fill="#d4d4d4" class="terminal" style="">}</text>
+  <text x="325" y="284" fill="#8be9fd" class="terminal" style="">}</text>
   <rect x="333" y="270" width="9" height="18" fill="#000000"/>
   <rect x="342" y="270" width="9" height="18" fill="#000000"/>
   <rect x="351" y="270" width="9" height="18" fill="#000000"/>
@@ -2265,12 +2265,12 @@
   <rect x="459" y="324" width="9" height="18" fill="#000000"/>
   <text x="460" y="338" fill="#ffff00" class="terminal" style="">n</text>
   <rect x="468" y="324" width="9" height="18" fill="#000000"/>
-  <text x="469" y="338" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="469" y="338" fill="#8be9fd" class="terminal" style="">(</text>
   <rect x="477" y="324" width="9" height="18" fill="#000000"/>
-  <text x="478" y="338" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="478" y="338" fill="#8be9fd" class="terminal" style="">)</text>
   <rect x="486" y="324" width="9" height="18" fill="#000000"/>
   <rect x="495" y="324" width="9" height="18" fill="#000000"/>
-  <text x="496" y="338" fill="#d4d4d4" class="terminal" style="">{</text>
+  <text x="496" y="338" fill="#8be9fd" class="terminal" style="">{</text>
   <rect x="504" y="324" width="9" height="18" fill="#000000"/>
   <rect x="513" y="324" width="9" height="18" fill="#000000"/>
   <rect x="522" y="324" width="9" height="18" fill="#000000"/>
@@ -2377,7 +2377,7 @@
   <rect x="423" y="342" width="9" height="18" fill="#000000"/>
   <text x="424" y="356" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="342" width="9" height="18" fill="#000000"/>
-  <text x="433" y="356" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="356" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="342" width="9" height="18" fill="#000000"/>
   <text x="442" y="356" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="342" width="9" height="18" fill="#000000"/>
@@ -2394,7 +2394,7 @@
   <rect x="504" y="342" width="9" height="18" fill="#000000"/>
   <text x="505" y="356" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="513" y="342" width="9" height="18" fill="#000000"/>
-  <text x="514" y="356" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="514" y="356" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="342" width="9" height="18" fill="#000000"/>
   <text x="523" y="356" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="531" y="342" width="9" height="18" fill="#000000"/>
@@ -2500,7 +2500,7 @@
   <rect x="423" y="360" width="9" height="18" fill="#141414"/>
   <text x="424" y="374" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="360" width="9" height="18" fill="#141414"/>
-  <text x="433" y="374" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="374" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="360" width="9" height="18" fill="#141414"/>
   <text x="442" y="374" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="360" width="9" height="18" fill="#141414"/>
@@ -2517,7 +2517,7 @@
   <rect x="504" y="360" width="9" height="18" fill="#141414"/>
   <text x="505" y="374" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="513" y="360" width="9" height="18" fill="#141414"/>
-  <text x="514" y="374" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="514" y="374" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="360" width="9" height="18" fill="#141414"/>
   <text x="523" y="374" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="531" y="360" width="9" height="18" fill="#141414"/>
@@ -2623,7 +2623,7 @@
   <rect x="423" y="378" width="9" height="18" fill="#000000"/>
   <text x="424" y="392" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="378" width="9" height="18" fill="#000000"/>
-  <text x="433" y="392" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="392" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="378" width="9" height="18" fill="#000000"/>
   <text x="442" y="392" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="378" width="9" height="18" fill="#000000"/>
@@ -2640,7 +2640,7 @@
   <rect x="504" y="378" width="9" height="18" fill="#000000"/>
   <text x="505" y="392" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="513" y="378" width="9" height="18" fill="#000000"/>
-  <text x="514" y="392" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="514" y="392" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="378" width="9" height="18" fill="#000000"/>
   <text x="523" y="392" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="531" y="378" width="9" height="18" fill="#000000"/>
@@ -2746,7 +2746,7 @@
   <rect x="423" y="396" width="9" height="18" fill="#000000"/>
   <text x="424" y="410" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="396" width="9" height="18" fill="#000000"/>
-  <text x="433" y="410" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="410" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="396" width="9" height="18" fill="#000000"/>
   <text x="442" y="410" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="396" width="9" height="18" fill="#000000"/>
@@ -2763,7 +2763,7 @@
   <rect x="504" y="396" width="9" height="18" fill="#000000"/>
   <text x="505" y="410" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="513" y="396" width="9" height="18" fill="#000000"/>
-  <text x="514" y="410" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="514" y="410" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="396" width="9" height="18" fill="#000000"/>
   <text x="523" y="410" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="531" y="396" width="9" height="18" fill="#000000"/>
@@ -2869,7 +2869,7 @@
   <rect x="423" y="414" width="9" height="18" fill="#000000"/>
   <text x="424" y="428" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="432" y="414" width="9" height="18" fill="#000000"/>
-  <text x="433" y="428" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="433" y="428" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="441" y="414" width="9" height="18" fill="#000000"/>
   <text x="442" y="428" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="450" y="414" width="9" height="18" fill="#000000"/>
@@ -2886,7 +2886,7 @@
   <rect x="504" y="414" width="9" height="18" fill="#000000"/>
   <text x="505" y="428" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="513" y="414" width="9" height="18" fill="#000000"/>
-  <text x="514" y="428" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="514" y="428" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="522" y="414" width="9" height="18" fill="#000000"/>
   <text x="523" y="428" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="531" y="414" width="9" height="18" fill="#000000"/>
@@ -2972,7 +2972,7 @@
   <text x="307" y="446" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="315" y="432" width="9" height="18" fill="#000000"/>
   <rect x="324" y="432" width="9" height="18" fill="#000000"/>
-  <text x="325" y="446" fill="#d4d4d4" class="terminal" style="">}</text>
+  <text x="325" y="446" fill="#8be9fd" class="terminal" style="">}</text>
   <rect x="333" y="432" width="9" height="18" fill="#000000"/>
   <rect x="342" y="432" width="9" height="18" fill="#000000"/>
   <rect x="351" y="432" width="9" height="18" fill="#000000"/>

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -583,10 +583,7 @@ fn cursor_column(
         Some(b) => b,
         None => return 0,
     };
-    let line_text = match std::str::from_utf8(&line_bytes) {
-        Ok(s) => s,
-        Err(_) => return 0,
-    };
+    let line_text = String::from_utf8_lossy(&line_bytes);
     let line_start = buffer.line_start_offset(line).unwrap_or(0);
     let byte_col = cursor_position.saturating_sub(line_start);
     line_text
@@ -2253,5 +2250,33 @@ mod tests {
         let top = format_cursor_position(1, 1, 10_000);
         let high = format_cursor_position(9_999, 999, 10_000);
         assert_eq!(top.len(), high.len());
+    }
+
+    #[test]
+    fn test_cursor_column_counts_chars_not_bytes() {
+        let buf = crate::model::buffer::TextBuffer::from_str_test("hello\ncafé résumé\nworld\n");
+        let line = 1;
+        let line_start = buf.line_start_offset(line).unwrap();
+
+        let at_r = line_start + 6;
+        let col = cursor_column(&buf, at_r, line);
+        assert_eq!(col, 5, "cursor at 'r' should be char column 5, not byte offset 6");
+
+        let at_e_acute = line_start + 3;
+        let col = cursor_column(&buf, at_e_acute, line);
+        assert_eq!(col, 3, "cursor at 'é' should be char column 3, not byte offset 3");
+
+        let at_u = line_start + 10;
+        let col = cursor_column(&buf, at_u, line);
+        assert_eq!(col, 8, "cursor at 'u' should be char column 8");
+
+        assert_ne!(at_r - line_start, 5, "byte offset != char column for multibyte text");
+    }
+
+    #[test]
+    fn test_cursor_column_out_of_range_line_returns_zero() {
+        let buf = crate::model::buffer::TextBuffer::from_str_test("hello\nworld\n");
+        let col = cursor_column(&buf, 0, 999);
+        assert_eq!(col, 0, "out-of-range line should return 0");
     }
 }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -574,7 +574,11 @@ fn truncate_to_width(s: &str, max_width: usize) -> String {
 const CURSOR_COL_RESERVE: usize = 3;
 
 /// Compute the cursor column (number of Unicode characters from line start)
-fn cursor_column(buffer: &crate::model::buffer::TextBuffer, cursor_position: usize, line: usize) -> usize {
+fn cursor_column(
+    buffer: &crate::model::buffer::TextBuffer,
+    cursor_position: usize,
+    line: usize,
+) -> usize {
     let line_bytes = match buffer.get_line(line) {
         Some(b) => b,
         None => return 0,
@@ -585,7 +589,8 @@ fn cursor_column(buffer: &crate::model::buffer::TextBuffer, cursor_position: usi
     };
     let line_start = buffer.line_start_offset(line).unwrap_or(0);
     let byte_col = cursor_position.saturating_sub(line_start);
-    line_text.char_indices()
+    line_text
+        .char_indices()
         .take_while(|(i, _)| *i < byte_col)
         .count()
 }

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -2260,17 +2260,27 @@ mod tests {
 
         let at_r = line_start + 6;
         let col = cursor_column(&buf, at_r, line);
-        assert_eq!(col, 5, "cursor at 'r' should be char column 5, not byte offset 6");
+        assert_eq!(
+            col, 5,
+            "cursor at 'r' should be char column 5, not byte offset 6"
+        );
 
         let at_e_acute = line_start + 3;
         let col = cursor_column(&buf, at_e_acute, line);
-        assert_eq!(col, 3, "cursor at 'é' should be char column 3, not byte offset 3");
+        assert_eq!(
+            col, 3,
+            "cursor at 'é' should be char column 3, not byte offset 3"
+        );
 
         let at_u = line_start + 10;
         let col = cursor_column(&buf, at_u, line);
         assert_eq!(col, 8, "cursor at 'u' should be char column 8");
 
-        assert_ne!(at_r - line_start, 5, "byte offset != char column for multibyte text");
+        assert_ne!(
+            at_r - line_start,
+            5,
+            "byte offset != char column for multibyte text"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -573,6 +573,23 @@ fn truncate_to_width(s: &str, max_width: usize) -> String {
 /// common single-digit case (the text is suffix-padded, not number-padded).
 const CURSOR_COL_RESERVE: usize = 3;
 
+/// Compute the cursor column (number of Unicode characters from line start)
+fn cursor_column(buffer: &crate::model::buffer::TextBuffer, cursor_position: usize, line: usize) -> usize {
+    let line_bytes = match buffer.get_line(line) {
+        Some(b) => b,
+        None => return 0,
+    };
+    let line_text = match std::str::from_utf8(&line_bytes) {
+        Ok(s) => s,
+        Err(_) => return 0,
+    };
+    let line_start = buffer.line_start_offset(line).unwrap_or(0);
+    let byte_col = cursor_position.saturating_sub(line_start);
+    line_text.char_indices()
+        .take_while(|(i, _)| *i < byte_col)
+        .count()
+}
+
 /// Format the cursor's `Ln X, Col Y` indicator so its rendered width is
 /// stable as the cursor moves. The numbers themselves are emitted with
 /// their natural width — preserving the format existing tests and screen-
@@ -867,10 +884,8 @@ impl StatusBarRenderer {
                 let cursor = *ctx.cursors.primary();
                 let line_count = ctx.state.buffer.line_count();
                 let text = if let Some(lc) = line_count {
-                    let cursor_iter = ctx.state.buffer.line_iterator(cursor.position, 80);
-                    let line_start = cursor_iter.current_position();
-                    let col = cursor.position.saturating_sub(line_start);
                     let line = ctx.state.primary_cursor_line_number.value();
+                    let col = cursor_column(&ctx.state.buffer, cursor.position, line);
                     format_cursor_position(line + 1, col + 1, lc)
                 } else {
                     format!("Byte {}", cursor.position)
@@ -887,10 +902,8 @@ impl StatusBarRenderer {
                 let cursor = *ctx.cursors.primary();
                 let line_count = ctx.state.buffer.line_count();
                 let text = if let Some(lc) = line_count {
-                    let cursor_iter = ctx.state.buffer.line_iterator(cursor.position, 80);
-                    let line_start = cursor_iter.current_position();
-                    let col = cursor.position.saturating_sub(line_start);
                     let line = ctx.state.primary_cursor_line_number.value();
+                    let col = cursor_column(&ctx.state.buffer, cursor.position, line);
                     format_cursor_position_compact(line + 1, col + 1, lc)
                 } else {
                     format!("{}", cursor.position)

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -573,23 +573,34 @@ fn truncate_to_width(s: &str, max_width: usize) -> String {
 /// common single-digit case (the text is suffix-padded, not number-padded).
 const CURSOR_COL_RESERVE: usize = 3;
 
-/// Compute the cursor column (number of Unicode characters from line start)
-fn cursor_column(
-    buffer: &crate::model::buffer::TextBuffer,
-    cursor_position: usize,
-    line: usize,
-) -> usize {
-    let line_bytes = match buffer.get_line(line) {
-        Some(b) => b,
-        None => return 0,
-    };
-    let line_text = String::from_utf8_lossy(&line_bytes);
-    let line_start = buffer.line_start_offset(line).unwrap_or(0);
+/// Compute the cursor column as the number of grapheme clusters between the
+/// start of the cursor's line and the cursor. The line start is derived from
+/// the live cursor byte position (not a cached line number), so it stays
+/// correct in diff/split views where the two can disagree. Counting graphemes
+/// — rather than bytes or code points — keeps the reported column consistent
+/// with the editor's grapheme-based cursor movement.
+fn cursor_column(buffer: &mut crate::model::buffer::TextBuffer, cursor_position: usize) -> usize {
+    let mut iter = buffer.line_iterator(cursor_position, 80);
+    let line_start = iter.current_position();
     let byte_col = cursor_position.saturating_sub(line_start);
-    line_text
-        .char_indices()
-        .take_while(|(i, _)| *i < byte_col)
-        .count()
+    if byte_col == 0 {
+        return 0;
+    }
+    // Prefer counting grapheme clusters over the line's text so multi-byte
+    // characters advance the column by one (issue #2090). Composite/diff
+    // buffers don't expose readable line content here; in that case fall back
+    // to the byte distance, which equals the grapheme count for the ASCII
+    // content those views render and matches the prior behavior.
+    match iter.next_line() {
+        Some((_, text)) if text.len() >= byte_col => {
+            let mut end = byte_col;
+            while end > 0 && !text.is_char_boundary(end) {
+                end -= 1;
+            }
+            crate::primitives::grapheme::grapheme_count(&text[..end])
+        }
+        _ => byte_col,
+    }
 }
 
 /// Format the cursor's `Ln X, Col Y` indicator so its rendered width is
@@ -887,7 +898,7 @@ impl StatusBarRenderer {
                 let line_count = ctx.state.buffer.line_count();
                 let text = if let Some(lc) = line_count {
                     let line = ctx.state.primary_cursor_line_number.value();
-                    let col = cursor_column(&ctx.state.buffer, cursor.position, line);
+                    let col = cursor_column(&mut ctx.state.buffer, cursor.position);
                     format_cursor_position(line + 1, col + 1, lc)
                 } else {
                     format!("Byte {}", cursor.position)
@@ -905,7 +916,7 @@ impl StatusBarRenderer {
                 let line_count = ctx.state.buffer.line_count();
                 let text = if let Some(lc) = line_count {
                     let line = ctx.state.primary_cursor_line_number.value();
-                    let col = cursor_column(&ctx.state.buffer, cursor.position, line);
+                    let col = cursor_column(&mut ctx.state.buffer, cursor.position);
                     format_cursor_position_compact(line + 1, col + 1, lc)
                 } else {
                     format!("{}", cursor.position)
@@ -2254,39 +2265,58 @@ mod tests {
 
     #[test]
     fn test_cursor_column_counts_chars_not_bytes() {
-        let buf = crate::model::buffer::TextBuffer::from_str_test("hello\ncafé résumé\nworld\n");
-        let line = 1;
-        let line_start = buf.line_start_offset(line).unwrap();
+        let mut buf =
+            crate::model::buffer::TextBuffer::from_str_test("hello\ncafé résumé\nworld\n");
+        let line_start = buf.line_start_offset(1).unwrap();
 
-        let at_r = line_start + 6;
-        let col = cursor_column(&buf, at_r, line);
+        // 'r' starts at byte 6 ("café " = 5 chars / 6 bytes), char column 5.
+        let col = cursor_column(&mut buf, line_start + 6);
         assert_eq!(
             col, 5,
-            "cursor at 'r' should be char column 5, not byte offset 6"
+            "cursor at 'r' should be column 5, not byte offset 6"
         );
 
-        let at_e_acute = line_start + 3;
-        let col = cursor_column(&buf, at_e_acute, line);
+        // 'é' starts at byte 3 (after "caf"), column 3.
+        let col = cursor_column(&mut buf, line_start + 3);
+        assert_eq!(col, 3, "cursor at 'é' should be column 3");
+
+        // 'u' in "résumé" sits at byte 10, column 8.
+        let col = cursor_column(&mut buf, line_start + 10);
+        assert_eq!(col, 8, "cursor at 'u' should be column 8");
+    }
+
+    #[test]
+    fn test_cursor_column_counts_grapheme_clusters() {
+        // Line 1 is "e + combining acute" followed by 'x'. The accented 'e' is
+        // two code points but one grapheme; counting graphemes (not chars or
+        // bytes) keeps the column aligned with grapheme-based cursor movement.
+        let mut buf = crate::model::buffer::TextBuffer::from_str_test("ab\ne\u{0301}x\n");
+        let line_start = buf.line_start_offset(1).unwrap();
+
+        // 'x' sits after the 1-byte 'e' and 2-byte combining accent (byte 3),
+        // which is char column 2 but grapheme column 1.
+        let col = cursor_column(&mut buf, line_start + 3);
         assert_eq!(
-            col, 3,
-            "cursor at 'é' should be char column 3, not byte offset 3"
-        );
-
-        let at_u = line_start + 10;
-        let col = cursor_column(&buf, at_u, line);
-        assert_eq!(col, 8, "cursor at 'u' should be char column 8");
-
-        assert_ne!(
-            at_r - line_start,
-            5,
-            "byte offset != char column for multibyte text"
+            col, 1,
+            "accented 'e' is one grapheme; 'x' should be column 1, not 2"
         );
     }
 
     #[test]
-    fn test_cursor_column_out_of_range_line_returns_zero() {
-        let buf = crate::model::buffer::TextBuffer::from_str_test("hello\nworld\n");
-        let col = cursor_column(&buf, 0, 999);
-        assert_eq!(col, 0, "out-of-range line should return 0");
+    fn test_cursor_column_zwj_emoji_is_one_grapheme() {
+        // Family emoji is several code points joined by ZWJ but a single
+        // grapheme cluster (18 bytes).
+        let mut buf = crate::model::buffer::TextBuffer::from_str_test("👨\u{200D}👩\u{200D}👧z\n");
+        let line_start = buf.line_start_offset(0).unwrap();
+
+        let col = cursor_column(&mut buf, line_start + 18);
+        assert_eq!(col, 1, "ZWJ family emoji should count as one column");
+    }
+
+    #[test]
+    fn test_cursor_column_at_line_start_is_zero() {
+        let mut buf = crate::model::buffer::TextBuffer::from_str_test("hello\nworld\n");
+        let line_start = buf.line_start_offset(1).unwrap();
+        assert_eq!(cursor_column(&mut buf, line_start), 0);
     }
 }

--- a/crates/fresh-editor/tests/e2e/multibyte_characters.rs
+++ b/crates/fresh-editor/tests/e2e/multibyte_characters.rs
@@ -2172,3 +2172,37 @@ fn test_mouse_select_multiline_multibyte() {
         );
     }
 }
+
+/// The status bar's `Col` must count grapheme clusters, not bytes (issue
+/// #2090: box-drawing / accented lines showed an inflated column). This
+/// drives Right one step at a time over a multi-byte line and asserts the
+/// rendered column advances by exactly one per keypress.
+#[test]
+fn test_status_bar_column_counts_graphemes_not_bytes() {
+    let mut harness = EditorTestHarness::new(120, 24).unwrap();
+
+    // 4 Chinese characters, 3 bytes each (12 bytes). The pre-fix byte count
+    // would report Col 13 at the end; the grapheme count is Col 5.
+    harness.type_text("你好世界").unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.get_status_bar().contains("Col 5"),
+        "end of 4-char line should render Col 5, got: {}",
+        harness.get_status_bar()
+    );
+
+    // Step from line start; each Right crosses one 3-byte character and must
+    // advance the column by exactly one.
+    harness.send_key(KeyCode::Home, KeyModifiers::NONE).unwrap();
+    for expected_col in 2..=5 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+        let status = harness.get_status_bar();
+        assert!(
+            status.contains(&format!("Col {expected_col}")),
+            "after crossing one multi-byte char column should be {expected_col}, got: {status}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/sinelaw/fresh/issues/2090

`Cursor` and `Cursor (compact)` statusbar elements calculate column count incorrectly (characters byte length instead of characters position).