### PR TITLE
refactor(window): move open_file core + LSP/watch helpers onto Window

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -150,7 +150,7 @@ pub(super) struct EditorParts {
     pub(super) command_registry: Arc<RwLock<CommandRegistry>>,
     pub(super) quick_open_registry: QuickOpenRegistry,
     pub(super) plugin_manager: Arc<RwLock<PluginManager>>,
-    pub(super) recovery_service: RecoveryService,
+    pub(super) recovery_service: Arc<std::sync::Mutex<RecoveryService>>,
     pub(super) key_translator: crate::input::key_translator::KeyTranslator,
     pub(super) update_checker: Option<crate::services::release_checker::PeriodicUpdateChecker>,
 
@@ -1049,6 +1049,31 @@ impl Editor {
         let local_filesystem: Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> =
             Arc::new(crate::model::filesystem::StdFileSystem);
 
+        // Hot-exit recovery service, shared (Arc<Mutex>) into every
+        // `Window` via `WindowResources` so per-window restore/auto-save
+        // can reach it without an active-window flip.
+        let recovery_service = {
+            let recovery_config = RecoveryConfig {
+                enabled: recovery_enabled,
+                ..RecoveryConfig::default()
+            };
+            // Default to a CWD-scoped recovery directory so each working
+            // directory keeps its own hot-exit recovery files. If this
+            // editor is later promoted to session mode, `set_session_name`
+            // re-creates the service with `RecoveryScope::Session`.
+            // Issue #1550: without per-CWD scoping, opening Fresh in a
+            // second folder would clobber the first folder's unsaved
+            // unnamed buffers on shutdown.
+            let scope = crate::services::recovery::RecoveryScope::Standalone {
+                working_dir: working_dir.clone(),
+            };
+            std::sync::Arc::new(std::sync::Mutex::new(RecoveryService::with_scope(
+                recovery_config,
+                &dir_context.recovery_dir(),
+                &scope,
+            )))
+        };
+
         // Build the resource bundle every `Window` gets a clone of. The
         // base window receives one clone here; subsequent windows
         // (created via `Editor::create_window_at` or first-dive seeding
@@ -1072,6 +1097,7 @@ impl Editor {
             plugin_manager: Arc::clone(&plugin_manager),
             theme: Arc::clone(&theme),
             event_broadcaster: event_broadcaster.clone(),
+            recovery_service: Arc::clone(&recovery_service),
         };
 
         // Build the active window — the one that holds the seed
@@ -1179,6 +1205,7 @@ impl Editor {
                     plugin_manager: Arc::clone(&plugin_manager),
                     theme: Arc::clone(&theme),
                     event_broadcaster: event_broadcaster.clone(),
+                    recovery_service: Arc::clone(&recovery_service),
                 };
                 let mut shell = crate::app::window::Window::new(
                     id,
@@ -1204,24 +1231,6 @@ impl Editor {
             .as_ref()
             .map(|env| env.next_id.max(max_existing + 1))
             .unwrap_or(2);
-
-        let recovery_service = {
-            let recovery_config = RecoveryConfig {
-                enabled: recovery_enabled,
-                ..RecoveryConfig::default()
-            };
-            // Default to a CWD-scoped recovery directory so each working
-            // directory keeps its own hot-exit recovery files. If this
-            // editor is later promoted to session mode, `set_session_name`
-            // re-creates the service with `RecoveryScope::Session`.
-            // Issue #1550: without per-CWD scoping, opening Fresh in a
-            // second folder would clobber the first folder's unsaved
-            // unnamed buffers on shutdown.
-            let scope = crate::services::recovery::RecoveryScope::Standalone {
-                working_dir: working_dir.clone(),
-            };
-            RecoveryService::with_scope(recovery_config, &dir_context.recovery_dir(), &scope)
-        };
 
         let key_translator = crate::input::key_translator::KeyTranslator::load_from_config_dir(
             &dir_context.config_dir,

--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -48,7 +48,7 @@ impl Editor {
             .and_then(|s| s.buffer.file_path())
             .is_some();
 
-        let buffer_id = self.open_file_no_focus(path)?;
+        let buffer_id = self.active_window_mut().open_file_no_focus(path)?;
 
         // Check if this was an already-open buffer or a new one
         // For already-open buffers, just switch to them
@@ -135,335 +135,19 @@ impl Editor {
     /// but does not change the active buffer. Useful for opening files in background tabs.
     ///
     /// If the file doesn't exist, creates an unsaved buffer with that filename.
+    ///
+    /// Thin delegator: the open-file core lives on `impl Window` (rooted
+    /// at the window's own `root` / `resources`). The editor forwards to
+    /// the active window.
     pub fn open_file_no_focus(&mut self, path: &Path) -> anyhow::Result<BufferId> {
-        self.open_file_no_focus_inner(path, true)
+        self.active_window_mut().open_file_no_focus(path)
     }
 
     /// Open a file without switching focus AND without ever
-    /// repurposing the active "no name" buffer.
-    ///
-    /// `open_file_no_focus`'s `replace_current` heuristic reuses the
-    /// initial empty unnamed buffer for the *first* file the user
-    /// opens — convenient for the normal "fresh launch → open file"
-    /// flow. The Live Grep floating overlay's preview pane needs the
-    /// opposite: the user's current buffer (often the empty unnamed
-    /// scratch) must stay untouched as preview cycles through
-    /// results. This variant always allocates a fresh BufferId so the
-    /// background buffer never gets repurposed.
+    /// repurposing the active "no name" buffer. Thin delegator to the
+    /// active window's `Window::open_file_for_preview`.
     pub(super) fn open_file_for_preview(&mut self, path: &Path) -> anyhow::Result<BufferId> {
-        self.open_file_no_focus_inner(path, false)
-    }
-
-    fn open_file_no_focus_inner(
-        &mut self,
-        path: &Path,
-        allow_replace_empty: bool,
-    ) -> anyhow::Result<BufferId> {
-        // Fail fast if the remote connection is down — don't attempt I/O that
-        // would either timeout or return confusing errors.
-        if !self.authority.filesystem.is_remote_connected() {
-            anyhow::bail!(
-                "Cannot open file: remote connection lost ({})",
-                self.authority
-                    .filesystem
-                    .remote_connection_info()
-                    .unwrap_or("unknown host")
-            );
-        }
-
-        // Resolve relative paths against appropriate base directory
-        // For remote mode, use the remote home directory; for local, use working_dir
-        let base_dir = if self.authority.filesystem.remote_connection_info().is_some() {
-            self.authority
-                .filesystem
-                .home_dir()
-                .unwrap_or_else(|_| self.working_dir().to_path_buf())
-        } else {
-            self.working_dir().to_path_buf()
-        };
-
-        let resolved_path = if path.is_relative() {
-            base_dir.join(path)
-        } else {
-            path.to_path_buf()
-        };
-
-        // Determine if we're opening a non-existent file (for creating new files)
-        // Use filesystem trait method to support remote files
-        let file_exists = self.authority.filesystem.exists(&resolved_path);
-
-        // Save the user-visible (non-canonicalized) path for language detection.
-        // Glob patterns in language config should match the path as the user sees it,
-        // not the canonical path (e.g., on macOS /var -> /private/var symlinks).
-        let display_path = resolved_path.clone();
-
-        // Canonicalize the path to resolve symlinks and normalize path components
-        // This ensures consistent path representation throughout the editor
-        // For non-existent files, we need to canonicalize the parent directory and append the filename
-        let canonical_path = if file_exists {
-            self.authority
-                .filesystem
-                .canonicalize(&resolved_path)
-                .unwrap_or_else(|_| resolved_path.clone())
-        } else {
-            // For non-existent files, canonicalize parent dir and append filename
-            if let Some(parent) = resolved_path.parent() {
-                let canonical_parent = if parent.as_os_str().is_empty() {
-                    // No parent means just a filename, use base dir
-                    base_dir.clone()
-                } else {
-                    self.authority
-                        .filesystem
-                        .canonicalize(parent)
-                        .unwrap_or_else(|_| parent.to_path_buf())
-                };
-                if let Some(filename) = resolved_path.file_name() {
-                    canonical_parent.join(filename)
-                } else {
-                    resolved_path
-                }
-            } else {
-                resolved_path
-            }
-        };
-        let path = canonical_path.as_path();
-
-        // Check if the path is a directory (after following symlinks via canonicalize)
-        // Directories cannot be opened as files in the editor
-        // Use filesystem trait method to support remote files
-        if self.authority.filesystem.is_dir(path).unwrap_or(false) {
-            anyhow::bail!(t!("buffer.cannot_open_directory"));
-        }
-
-        // Check if file is already open - return existing buffer without switching
-        let already_open = self
-            .buffers()
-            .iter()
-            .find(|(_, state)| state.buffer.file_path() == Some(path))
-            .map(|(id, _)| *id);
-
-        if let Some(id) = already_open {
-            return Ok(id);
-        }
-
-        // If the current buffer is empty and unmodified, replace it instead of creating a new one
-        // Note: Don't replace composite buffers (they appear empty but are special views).
-        // Suppressed when `allow_replace_empty` is false — see
-        // `open_file_for_preview` for the rationale.
-        let replace_current = allow_replace_empty && {
-            let current_state = self
-                .windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-                .get(&self.active_buffer())
-                .unwrap();
-            !current_state.is_composite_buffer
-                && current_state.buffer.is_empty()
-                && !current_state.buffer.is_modified()
-                && current_state.buffer.file_path().is_none()
-        };
-
-        let buffer_id = if replace_current {
-            // Reuse the current empty buffer
-            self.active_buffer()
-        } else {
-            // Create new buffer for this file
-            let id = self.alloc_buffer_id();
-            id
-        };
-
-        // Create the editor state - either load from file or create empty buffer
-        tracing::info!(
-            "[SYNTAX DEBUG] open_file_no_focus: path={:?}, extension={:?}, catalog={}",
-            path,
-            path.extension(),
-            self.grammar_registry.catalog().len(),
-        );
-        let mut state = if file_exists {
-            // Load from canonical path (for I/O and dedup), detect language from
-            // display path (for glob pattern matching against user-visible names).
-            let buffer = crate::model::buffer::Buffer::load_from_file(
-                &canonical_path,
-                self.config.editor.large_file_threshold_bytes as usize,
-                Arc::clone(&self.authority.filesystem),
-            )?;
-            let first_line = buffer.first_line_lossy();
-            let detected =
-                crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
-                    &display_path,
-                    first_line.as_deref(),
-                    &self.grammar_registry,
-                    &self.config.languages,
-                    self.config.default_language.as_deref(),
-                );
-            EditorState::from_buffer_with_language(buffer, detected)
-        } else {
-            // File doesn't exist - create empty buffer with the file path set
-            EditorState::new_with_path(
-                self.config.editor.large_file_threshold_bytes as usize,
-                Arc::clone(&self.authority.filesystem),
-                path.to_path_buf(),
-            )
-        };
-        // Note: line_wrap_enabled is set on SplitViewState.viewport when the split is created
-
-        // Check if the buffer contains binary content
-        let is_binary = state.buffer.is_binary();
-        if is_binary {
-            // Make binary buffers read-only
-            state.editing_disabled = true;
-            tracing::info!("Detected binary file: {}", path.display());
-        }
-
-        // Set whitespace visibility, use_tabs, and tab_size based on language config
-        // with fallback to global editor config for tab_size
-        // Use the buffer's stored language (already set by from_file_with_languages)
-        let mut whitespace =
-            crate::config::WhitespaceVisibility::from_editor_config(&self.config.editor);
-        state.buffer_settings.auto_close = self.config.editor.auto_close;
-        state.buffer_settings.auto_surround = self.config.editor.auto_surround;
-        if let Some(lang_config) = self.config.languages.get(&state.language) {
-            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
-            state.buffer_settings.use_tabs =
-                lang_config.use_tabs.unwrap_or(self.config.editor.use_tabs);
-            // Use language-specific tab_size if set, otherwise fall back to global
-            state.buffer_settings.tab_size =
-                lang_config.tab_size.unwrap_or(self.config.editor.tab_size);
-            // Auto close: language override (only if globally enabled)
-            if state.buffer_settings.auto_close {
-                if let Some(lang_auto_close) = lang_config.auto_close {
-                    state.buffer_settings.auto_close = lang_auto_close;
-                }
-            }
-            // Auto surround: language override (only if globally enabled)
-            if state.buffer_settings.auto_surround {
-                if let Some(lang_auto_surround) = lang_config.auto_surround {
-                    state.buffer_settings.auto_surround = lang_auto_surround;
-                }
-            }
-        } else {
-            state.buffer_settings.tab_size = self.config.editor.tab_size;
-            state.buffer_settings.use_tabs = self.config.editor.use_tabs;
-        }
-        state.buffer_settings.whitespace = whitespace;
-
-        // Apply line_numbers default from config
-        state
-            .margins
-            .configure_for_line_numbers(self.config.editor.line_numbers);
-
-        self.windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.buffers)
-            .expect("active window present")
-            .insert(buffer_id, state);
-        self.active_window_mut()
-            .event_logs
-            .insert(buffer_id, crate::model::event::EventLog::new());
-
-        // Create metadata for this buffer
-        let mut metadata = super::types::BufferMetadata::with_file(
-            path.to_path_buf(),
-            &display_path,
-            self.working_dir(),
-            self.authority.path_translation.as_ref(),
-        );
-
-        // Mark binary files in metadata and disable LSP
-        if is_binary {
-            metadata.binary = true;
-            metadata.read_only = true;
-            metadata.disable_lsp(t!("buffer.binary_file").to_string());
-        }
-
-        // Check if the file is read-only on disk (filesystem permissions)
-        if file_exists && !metadata.read_only && !self.authority.filesystem.is_writable(path) {
-            metadata.read_only = true;
-        }
-
-        // Mark read-only files (library, binary, or filesystem-readonly) as editing-disabled
-        if metadata.read_only {
-            if let Some(state) = self
-                .windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .get_mut(&buffer_id)
-            {
-                state.editing_disabled = true;
-            }
-        }
-
-        // Notify LSP about the newly opened file (skip for binary files)
-        if !is_binary {
-            self.notify_lsp_file_opened(path, buffer_id, &mut metadata);
-        }
-
-        // Store metadata for this buffer
-        self.active_window_mut()
-            .buffer_metadata
-            .insert(buffer_id, metadata);
-
-        // Add buffer to the preferred split's tabs (but don't switch to it)
-        // Uses preferred_split_for_file() to avoid opening in labeled splits (e.g., sidebars)
-        let target_split = self.active_window().preferred_split_for_file();
-        let line_wrap = self.active_window().resolve_line_wrap_for_buffer(buffer_id);
-        let wrap_column = self
-            .active_window()
-            .resolve_wrap_column_for_buffer(buffer_id);
-        let page_view = self.active_window().resolve_page_view_for_buffer(buffer_id);
-        if let Some(view_state) = self
-            .windows
-            .get_mut(&self.active_window)
-            .and_then(|w| w.split_view_states_mut())
-            .expect("active window must have a populated split layout")
-            .get_mut(&target_split)
-        {
-            view_state.add_buffer(buffer_id);
-            // Initialize per-buffer view state for the new buffer with config defaults
-            let buf_state = view_state.ensure_buffer_state(buffer_id);
-            buf_state.apply_config_defaults(
-                self.config.editor.line_numbers,
-                self.config.editor.highlight_current_line,
-                line_wrap,
-                self.config.editor.wrap_indent,
-                wrap_column,
-                self.config.editor.rulers.clone(),
-            );
-            // Auto-activate page view if configured for this language
-            if let Some(page_width) = page_view {
-                buf_state.activate_page_view(page_width);
-            }
-        }
-
-        // Restore global file state (scroll/cursor position) if available
-        // This persists file positions across projects and editor instances
-        self.active_window_mut()
-            .restore_global_file_state(buffer_id, path, target_split);
-
-        // Emit control event
-        self.emit_event(
-            crate::model::control_event::events::FILE_OPENED.name,
-            serde_json::json!({
-                "path": path.display().to_string(),
-                "buffer_id": buffer_id.0
-            }),
-        );
-
-        // Track file for auto-revert and conflict detection
-        self.watch_file(path);
-
-        // Fire AfterFileOpen hook for plugins
-        self.plugin_manager.read().unwrap().run_hook(
-            "after_file_open",
-            crate::services::plugins::hooks::HookArgs::AfterFileOpen {
-                buffer_id,
-                path: path.to_path_buf(),
-            },
-        );
-
-        Ok(buffer_id)
+        self.active_window_mut().open_file_for_preview(path)
     }
 
     // `open_local_file` lives on `impl Window` — call it via
@@ -1038,6 +722,348 @@ impl Editor {
                 self.config.editor.rulers.clone(),
             );
         }
+
+        Ok(buffer_id)
+    }
+}
+
+impl crate::app::window::Window {
+    /// Open a file without switching focus to it.
+    ///
+    /// Window-scoped core of the open-file path: creates a new buffer
+    /// for the file (or returns the existing buffer id if already open)
+    /// without changing the active buffer. Rooted at this window's own
+    /// `root` / `resources` so it can open files directly into a
+    /// non-active window (e.g. workspace restore) with no active-window
+    /// flip. If the file doesn't exist, creates an unsaved buffer with
+    /// that filename.
+    pub fn open_file_no_focus(&mut self, path: &Path) -> anyhow::Result<BufferId> {
+        self.open_file_no_focus_inner(path, true)
+    }
+
+    /// Open a file without switching focus AND without ever
+    /// repurposing the active "no name" buffer.
+    ///
+    /// `open_file_no_focus`'s `replace_current` heuristic reuses the
+    /// initial empty unnamed buffer for the *first* file the user
+    /// opens — convenient for the normal "fresh launch → open file"
+    /// flow. The Live Grep floating overlay's preview pane needs the
+    /// opposite: the user's current buffer (often the empty unnamed
+    /// scratch) must stay untouched as preview cycles through
+    /// results. This variant always allocates a fresh BufferId so the
+    /// background buffer never gets repurposed.
+    pub(crate) fn open_file_for_preview(&mut self, path: &Path) -> anyhow::Result<BufferId> {
+        self.open_file_no_focus_inner(path, false)
+    }
+
+    fn open_file_no_focus_inner(
+        &mut self,
+        path: &Path,
+        allow_replace_empty: bool,
+    ) -> anyhow::Result<BufferId> {
+        // Fail fast if the remote connection is down — don't attempt I/O that
+        // would either timeout or return confusing errors.
+        if !self.resources.authority.filesystem.is_remote_connected() {
+            anyhow::bail!(
+                "Cannot open file: remote connection lost ({})",
+                self.resources
+                    .authority
+                    .filesystem
+                    .remote_connection_info()
+                    .unwrap_or("unknown host")
+            );
+        }
+
+        // Resolve relative paths against appropriate base directory.
+        // For remote mode, use the remote home directory; for local, use
+        // this window's root.
+        let base_dir = if self
+            .resources
+            .authority
+            .filesystem
+            .remote_connection_info()
+            .is_some()
+        {
+            self.resources
+                .authority
+                .filesystem
+                .home_dir()
+                .unwrap_or_else(|_| self.root.clone())
+        } else {
+            self.root.clone()
+        };
+
+        let resolved_path = if path.is_relative() {
+            base_dir.join(path)
+        } else {
+            path.to_path_buf()
+        };
+
+        // Determine if we're opening a non-existent file (for creating new files)
+        // Use filesystem trait method to support remote files
+        let file_exists = self.resources.authority.filesystem.exists(&resolved_path);
+
+        // Save the user-visible (non-canonicalized) path for language detection.
+        // Glob patterns in language config should match the path as the user sees it,
+        // not the canonical path (e.g., on macOS /var -> /private/var symlinks).
+        let display_path = resolved_path.clone();
+
+        // Canonicalize the path to resolve symlinks and normalize path components
+        // This ensures consistent path representation throughout the editor
+        // For non-existent files, we need to canonicalize the parent directory and append the filename
+        let canonical_path = if file_exists {
+            self.resources
+                .authority
+                .filesystem
+                .canonicalize(&resolved_path)
+                .unwrap_or_else(|_| resolved_path.clone())
+        } else {
+            // For non-existent files, canonicalize parent dir and append filename
+            if let Some(parent) = resolved_path.parent() {
+                let canonical_parent = if parent.as_os_str().is_empty() {
+                    // No parent means just a filename, use base dir
+                    base_dir.clone()
+                } else {
+                    self.resources
+                        .authority
+                        .filesystem
+                        .canonicalize(parent)
+                        .unwrap_or_else(|_| parent.to_path_buf())
+                };
+                if let Some(filename) = resolved_path.file_name() {
+                    canonical_parent.join(filename)
+                } else {
+                    resolved_path
+                }
+            } else {
+                resolved_path
+            }
+        };
+        let path = canonical_path.as_path();
+
+        // Check if the path is a directory (after following symlinks via canonicalize)
+        // Directories cannot be opened as files in the editor
+        // Use filesystem trait method to support remote files
+        if self
+            .resources
+            .authority
+            .filesystem
+            .is_dir(path)
+            .unwrap_or(false)
+        {
+            anyhow::bail!(t!("buffer.cannot_open_directory"));
+        }
+
+        // Check if file is already open - return existing buffer without switching
+        let already_open = self
+            .buffers
+            .iter()
+            .find(|(_, state)| state.buffer.file_path() == Some(path))
+            .map(|(id, _)| *id);
+
+        if let Some(id) = already_open {
+            return Ok(id);
+        }
+
+        // If the current buffer is empty and unmodified, replace it instead of creating a new one
+        // Note: Don't replace composite buffers (they appear empty but are special views).
+        // Suppressed when `allow_replace_empty` is false — see
+        // `open_file_for_preview` for the rationale.
+        let replace_current = allow_replace_empty && {
+            let current_state = self.buffers.get(&self.active_buffer()).unwrap();
+            !current_state.is_composite_buffer
+                && current_state.buffer.is_empty()
+                && !current_state.buffer.is_modified()
+                && current_state.buffer.file_path().is_none()
+        };
+
+        let buffer_id = if replace_current {
+            // Reuse the current empty buffer
+            self.active_buffer()
+        } else {
+            // Create new buffer for this file
+            self.alloc_buffer_id()
+        };
+
+        // Create the editor state - either load from file or create empty buffer
+        tracing::info!(
+            "[SYNTAX DEBUG] open_file_no_focus: path={:?}, extension={:?}, catalog={}",
+            path,
+            path.extension(),
+            self.resources.grammar_registry.catalog().len(),
+        );
+        let mut state = if file_exists {
+            // Load from canonical path (for I/O and dedup), detect language from
+            // display path (for glob pattern matching against user-visible names).
+            let buffer = crate::model::buffer::Buffer::load_from_file(
+                &canonical_path,
+                self.resources.config.editor.large_file_threshold_bytes as usize,
+                Arc::clone(&self.resources.authority.filesystem),
+            )?;
+            let first_line = buffer.first_line_lossy();
+            let detected =
+                crate::primitives::detected_language::DetectedLanguage::from_path_with_fallback(
+                    &display_path,
+                    first_line.as_deref(),
+                    &self.resources.grammar_registry,
+                    &self.resources.config.languages,
+                    self.resources.config.default_language.as_deref(),
+                );
+            EditorState::from_buffer_with_language(buffer, detected)
+        } else {
+            // File doesn't exist - create empty buffer with the file path set
+            EditorState::new_with_path(
+                self.resources.config.editor.large_file_threshold_bytes as usize,
+                Arc::clone(&self.resources.authority.filesystem),
+                path.to_path_buf(),
+            )
+        };
+        // Note: line_wrap_enabled is set on SplitViewState.viewport when the split is created
+
+        // Check if the buffer contains binary content
+        let is_binary = state.buffer.is_binary();
+        if is_binary {
+            // Make binary buffers read-only
+            state.editing_disabled = true;
+            tracing::info!("Detected binary file: {}", path.display());
+        }
+
+        // Set whitespace visibility, use_tabs, and tab_size based on language config
+        // with fallback to global editor config for tab_size
+        // Use the buffer's stored language (already set by from_file_with_languages)
+        let mut whitespace =
+            crate::config::WhitespaceVisibility::from_editor_config(&self.resources.config.editor);
+        state.buffer_settings.auto_close = self.resources.config.editor.auto_close;
+        state.buffer_settings.auto_surround = self.resources.config.editor.auto_surround;
+        if let Some(lang_config) = self.resources.config.languages.get(&state.language) {
+            whitespace = whitespace.with_language_tab_override(lang_config.show_whitespace_tabs);
+            state.buffer_settings.use_tabs = lang_config
+                .use_tabs
+                .unwrap_or(self.resources.config.editor.use_tabs);
+            // Use language-specific tab_size if set, otherwise fall back to global
+            state.buffer_settings.tab_size = lang_config
+                .tab_size
+                .unwrap_or(self.resources.config.editor.tab_size);
+            // Auto close: language override (only if globally enabled)
+            if state.buffer_settings.auto_close {
+                if let Some(lang_auto_close) = lang_config.auto_close {
+                    state.buffer_settings.auto_close = lang_auto_close;
+                }
+            }
+            // Auto surround: language override (only if globally enabled)
+            if state.buffer_settings.auto_surround {
+                if let Some(lang_auto_surround) = lang_config.auto_surround {
+                    state.buffer_settings.auto_surround = lang_auto_surround;
+                }
+            }
+        } else {
+            state.buffer_settings.tab_size = self.resources.config.editor.tab_size;
+            state.buffer_settings.use_tabs = self.resources.config.editor.use_tabs;
+        }
+        state.buffer_settings.whitespace = whitespace;
+
+        // Apply line_numbers default from config
+        state
+            .margins
+            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
+
+        self.buffers.insert(buffer_id, state);
+        self.event_logs
+            .insert(buffer_id, crate::model::event::EventLog::new());
+
+        // Create metadata for this buffer
+        let mut metadata = crate::app::types::BufferMetadata::with_file(
+            path.to_path_buf(),
+            &display_path,
+            &self.root,
+            self.resources.authority.path_translation.as_ref(),
+        );
+
+        // Mark binary files in metadata and disable LSP
+        if is_binary {
+            metadata.binary = true;
+            metadata.read_only = true;
+            metadata.disable_lsp(t!("buffer.binary_file").to_string());
+        }
+
+        // Check if the file is read-only on disk (filesystem permissions)
+        if file_exists
+            && !metadata.read_only
+            && !self.resources.authority.filesystem.is_writable(path)
+        {
+            metadata.read_only = true;
+        }
+
+        // Mark read-only files (library, binary, or filesystem-readonly) as editing-disabled
+        if metadata.read_only {
+            if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                state.editing_disabled = true;
+            }
+        }
+
+        // Notify LSP about the newly opened file (skip for binary files)
+        if !is_binary {
+            self.notify_lsp_file_opened(path, buffer_id, &mut metadata);
+        }
+
+        // Store metadata for this buffer
+        self.buffer_metadata.insert(buffer_id, metadata);
+
+        // Add buffer to the preferred split's tabs (but don't switch to it)
+        // Uses preferred_split_for_file() to avoid opening in labeled splits (e.g., sidebars)
+        let target_split = self.preferred_split_for_file();
+        let line_wrap = self.resolve_line_wrap_for_buffer(buffer_id);
+        let wrap_column = self.resolve_wrap_column_for_buffer(buffer_id);
+        let page_view = self.resolve_page_view_for_buffer(buffer_id);
+        // Snapshot config values before taking the mutable view-states borrow
+        // so the closure body doesn't have to re-borrow `self.resources`.
+        let cfg = self.resources.config.editor.clone();
+        if let Some(view_state) = self
+            .split_view_states_mut()
+            .expect("active window must have a populated split layout")
+            .get_mut(&target_split)
+        {
+            view_state.add_buffer(buffer_id);
+            // Initialize per-buffer view state for the new buffer with config defaults
+            let buf_state = view_state.ensure_buffer_state(buffer_id);
+            buf_state.apply_config_defaults(
+                cfg.line_numbers,
+                cfg.highlight_current_line,
+                line_wrap,
+                cfg.wrap_indent,
+                wrap_column,
+                cfg.rulers,
+            );
+            // Auto-activate page view if configured for this language
+            if let Some(page_width) = page_view {
+                buf_state.activate_page_view(page_width);
+            }
+        }
+
+        // Restore global file state (scroll/cursor position) if available
+        // This persists file positions across projects and editor instances
+        self.restore_global_file_state(buffer_id, path, target_split);
+
+        // Emit control event
+        self.resources.event_broadcaster.emit_named(
+            crate::model::control_event::events::FILE_OPENED.name,
+            serde_json::json!({
+                "path": path.display().to_string(),
+                "buffer_id": buffer_id.0
+            }),
+        );
+
+        // Track file for auto-revert and conflict detection
+        self.watch_file(path);
+
+        // Fire AfterFileOpen hook for plugins
+        self.resources.plugin_manager.read().unwrap().run_hook(
+            "after_file_open",
+            crate::services::plugins::hooks::HookArgs::AfterFileOpen {
+                buffer_id,
+                path: path.to_path_buf(),
+            },
+        );
 
         Ok(buffer_id)
     }

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -960,223 +960,28 @@ impl Editor {
 
     /// Notify LSP server about a newly opened file
     /// Handles language detection, spawning LSP clients, and sending didOpen notifications
+    ///
+    /// Thin delegator: the LSP-notify core lives on `impl Window` (it
+    /// reads only the window's own `lsp` / `buffers` /
+    /// `diagnostic_result_ids` + `self.resources`). Editor callers
+    /// forward to the active window.
     pub(crate) fn notify_lsp_file_opened(
         &mut self,
         path: &Path,
         buffer_id: BufferId,
         metadata: &mut BufferMetadata,
     ) {
-        // Get language from buffer state
-        let Some(language) = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
-            .get(&buffer_id)
-            .map(|s| s.language.clone())
-        else {
-            tracing::debug!("No buffer state for file: {}", path.display());
-            return;
-        };
-
-        let Some(uri) = metadata.file_uri().cloned() else {
-            tracing::warn!(
-                "No URI in metadata for file: {} (failed to compute absolute path)",
-                path.display()
-            );
-            return;
-        };
-
-        // Check file size
-        let file_size = self
-            .authority
-            .filesystem
-            .metadata(path)
-            .ok()
-            .map(|m| m.size)
-            .unwrap_or(0);
-        if file_size > self.config.editor.large_file_threshold_bytes {
-            let reason = format!("File too large ({} bytes)", file_size);
-            tracing::debug!(
-                "Skipping LSP for large file: {} ({})",
-                path.display(),
-                reason
-            );
-            metadata.disable_lsp(reason);
-            return;
-        }
-
-        // Get text before borrowing lsp
-        let text = match self
-            .buffers()
-            .get(&buffer_id)
-            .and_then(|state| state.buffer.to_string())
-        {
-            Some(t) => t,
-            None => {
-                tracing::debug!("Buffer not fully loaded for LSP notification");
-                return;
-            }
-        };
-
-        let enable_inlay_hints = self.config.editor.enable_inlay_hints;
-        let previous_result_id = self
-            .active_window()
-            .diagnostic_result_ids
-            .get(uri.as_str())
-            .cloned();
-
-        // Get buffer line count and version for inlay hints
-        let (last_line, last_char, buffer_version) = self
-            .buffers()
-            .get(&buffer_id)
-            .map(|state| {
-                let line_count = state.buffer.line_count().unwrap_or(1000);
-                (
-                    line_count.saturating_sub(1) as u32,
-                    10000u32,
-                    state.buffer.version(),
-                )
-            })
-            .unwrap_or((999, 10000, 0));
-
-        // Now borrow lsp and do all LSP operations
-        let __active_id = self.active_window;
-        let Some(__win) = self.windows.get_mut(&__active_id) else {
-            tracing::debug!("No LSP manager available");
-            return;
-        };
-        let Some(lsp) = __win.lsp.as_mut() else {
-            tracing::debug!("No LSP manager available");
-            return;
-        };
-        let __next_id = &mut __win.next_lsp_request_id;
-
-        tracing::debug!("LSP manager available for file: {}", path.display());
-        tracing::debug!(
-            "Detected language: {} for file: {}",
-            language,
-            path.display()
-        );
-        tracing::debug!("Using URI from metadata: {}", uri.as_str());
-        tracing::debug!("Attempting to spawn LSP client for language: {}", language);
-
-        match lsp.try_spawn(&language, Some(path)) {
-            LspSpawnResult::Spawned => {
-                // Send didOpen to ALL server handles for this language,
-                // not just the first one.  With multiple servers configured
-                // (e.g. error-server + warning-server) each needs to know
-                // about the open document.
-                for sh in lsp.get_handles_mut(&language) {
-                    tracing::info!("Sending didOpen to LSP '{}' for: {}", sh.name, uri.as_str());
-                    if let Err(e) =
-                        sh.handle
-                            .did_open(uri.as_uri().clone(), text.clone(), language.clone())
-                    {
-                        tracing::warn!("Failed to send didOpen to LSP '{}': {}", sh.name, e);
-                    } else {
-                        metadata.lsp_opened_with.insert(sh.handle.id());
-                    }
-                }
-
-                // Route each follow-up request through capability-aware
-                // routing so we never send an optional method to a server
-                // that didn't advertise it. On a cold spawn the capability
-                // check returns `None` (capabilities aren't known until the
-                // `initialize` response arrives); the `LspInitialized`
-                // handler replays these requests once capabilities land.
-                if let Some(sh) =
-                    lsp.handle_for_feature_mut(&language, crate::types::LspFeature::Diagnostics)
-                {
-                    let request_id = {
-                        let id = *__next_id;
-                        *__next_id += 1;
-                        id
-                    };
-                    if let Err(e) = sh.handle.document_diagnostic(
-                        request_id,
-                        uri.as_uri().clone(),
-                        previous_result_id,
-                    ) {
-                        tracing::debug!("Failed to request pull diagnostics: {}", e);
-                    } else {
-                        tracing::info!(
-                            "Requested pull diagnostics for {} (request_id={})",
-                            uri.as_str(),
-                            request_id
-                        );
-                    }
-                }
-
-                if enable_inlay_hints {
-                    if let Some(sh) =
-                        lsp.handle_for_feature_mut(&language, crate::types::LspFeature::InlayHints)
-                    {
-                        let request_id = {
-                            let id = *__next_id;
-                            *__next_id += 1;
-                            id
-                        };
-
-                        if let Err(e) = sh.handle.inlay_hints(
-                            request_id,
-                            uri.as_uri().clone(),
-                            0,
-                            0,
-                            last_line,
-                            last_char,
-                        ) {
-                            tracing::debug!("Failed to request inlay hints: {}", e);
-                        } else {
-                            self.active_window_mut()
-                                .pending_inlay_hints_requests
-                                .insert(
-                                    request_id,
-                                    super::InlayHintsRequest {
-                                        buffer_id,
-                                        version: buffer_version,
-                                    },
-                                );
-                            tracing::info!(
-                                "Requested inlay hints for {} (request_id={})",
-                                uri.as_str(),
-                                request_id
-                            );
-                        }
-                    }
-                }
-
-                // Schedule folding range refresh
-                self.active_window_mut()
-                    .schedule_folding_ranges_refresh(buffer_id);
-            }
-            LspSpawnResult::NotAutoStart => {
-                tracing::debug!(
-                    "LSP for {} not auto-starting (auto_start=false). Click the LSP indicator to start manually.",
-                    language
-                );
-            }
-            LspSpawnResult::NotConfigured => {
-                tracing::debug!("No LSP server configured for language: {}", language);
-            }
-            LspSpawnResult::Disabled => {
-                tracing::debug!("LSP disabled in config for language: {}", language);
-            }
-            LspSpawnResult::Failed => {
-                tracing::warn!("Failed to spawn LSP client for language: {}", language);
-            }
-        }
+        self.active_window_mut()
+            .notify_lsp_file_opened(path, buffer_id, metadata);
     }
 
     /// Record a file's modification time (called when opening files)
-    /// This is used by the polling-based auto-revert to detect external changes
+    /// This is used by the polling-based auto-revert to detect external changes.
+    ///
+    /// Thin delegator: `watch_file` is window-local (records into the
+    /// active window's `file_mod_times`); forwards to the active window.
     pub(crate) fn watch_file(&mut self, path: &Path) {
-        // Record current modification time for polling
-        if let Ok(metadata) = self.authority.filesystem.metadata(path) {
-            if let Some(mtime) = metadata.modified {
-                self.file_mod_times_mut().insert(path.to_path_buf(), mtime);
-            }
-        }
+        self.active_window_mut().watch_file(path);
     }
 
     /// Notify LSP that a file's contents changed (e.g., after revert)
@@ -1569,4 +1374,212 @@ pub(crate) fn load_gitignore_via_fs(fs: &dyn FileSystem, explorer: &mut FileTree
         }
     };
     explorer.load_gitignore_from_bytes(dir, &bytes, meta.modified);
+}
+
+impl crate::app::window::Window {
+    /// Notify this window's LSP servers about a newly opened file.
+    ///
+    /// Window-scoped: reads only the window's own `lsp`, `buffers`,
+    /// `diagnostic_result_ids`, and `self.resources.{authority,config}`.
+    /// Handles language detection, spawning LSP clients, and sending
+    /// didOpen notifications + follow-up pull-diagnostics / inlay-hints.
+    pub(crate) fn notify_lsp_file_opened(
+        &mut self,
+        path: &Path,
+        buffer_id: BufferId,
+        metadata: &mut BufferMetadata,
+    ) {
+        // Get language from buffer state
+        let Some(language) = self.buffers.get(&buffer_id).map(|s| s.language.clone()) else {
+            tracing::debug!("No buffer state for file: {}", path.display());
+            return;
+        };
+
+        let Some(uri) = metadata.file_uri().cloned() else {
+            tracing::warn!(
+                "No URI in metadata for file: {} (failed to compute absolute path)",
+                path.display()
+            );
+            return;
+        };
+
+        // Check file size
+        let file_size = self
+            .resources
+            .authority
+            .filesystem
+            .metadata(path)
+            .ok()
+            .map(|m| m.size)
+            .unwrap_or(0);
+        if file_size > self.resources.config.editor.large_file_threshold_bytes {
+            let reason = format!("File too large ({} bytes)", file_size);
+            tracing::debug!(
+                "Skipping LSP for large file: {} ({})",
+                path.display(),
+                reason
+            );
+            metadata.disable_lsp(reason);
+            return;
+        }
+
+        // Get text before borrowing lsp
+        let text = match self
+            .buffers
+            .get(&buffer_id)
+            .and_then(|state| state.buffer.to_string())
+        {
+            Some(t) => t,
+            None => {
+                tracing::debug!("Buffer not fully loaded for LSP notification");
+                return;
+            }
+        };
+
+        let enable_inlay_hints = self.resources.config.editor.enable_inlay_hints;
+        let previous_result_id = self.diagnostic_result_ids.get(uri.as_str()).cloned();
+
+        // Get buffer line count and version for inlay hints
+        let (last_line, last_char, buffer_version) = self
+            .buffers
+            .get(&buffer_id)
+            .map(|state| {
+                let line_count = state.buffer.line_count().unwrap_or(1000);
+                (
+                    line_count.saturating_sub(1) as u32,
+                    10000u32,
+                    state.buffer.version(),
+                )
+            })
+            .unwrap_or((999, 10000, 0));
+
+        // Now borrow lsp and do all LSP operations
+        let Some(lsp) = self.lsp.as_mut() else {
+            tracing::debug!("No LSP manager available");
+            return;
+        };
+        let __next_id = &mut self.next_lsp_request_id;
+
+        tracing::debug!("LSP manager available for file: {}", path.display());
+        tracing::debug!(
+            "Detected language: {} for file: {}",
+            language,
+            path.display()
+        );
+        tracing::debug!("Using URI from metadata: {}", uri.as_str());
+        tracing::debug!("Attempting to spawn LSP client for language: {}", language);
+
+        match lsp.try_spawn(&language, Some(path)) {
+            LspSpawnResult::Spawned => {
+                // Send didOpen to ALL server handles for this language,
+                // not just the first one.  With multiple servers configured
+                // (e.g. error-server + warning-server) each needs to know
+                // about the open document.
+                for sh in lsp.get_handles_mut(&language) {
+                    tracing::info!("Sending didOpen to LSP '{}' for: {}", sh.name, uri.as_str());
+                    if let Err(e) =
+                        sh.handle
+                            .did_open(uri.as_uri().clone(), text.clone(), language.clone())
+                    {
+                        tracing::warn!("Failed to send didOpen to LSP '{}': {}", sh.name, e);
+                    } else {
+                        metadata.lsp_opened_with.insert(sh.handle.id());
+                    }
+                }
+
+                // Route each follow-up request through capability-aware
+                // routing so we never send an optional method to a server
+                // that didn't advertise it. On a cold spawn the capability
+                // check returns `None` (capabilities aren't known until the
+                // `initialize` response arrives); the `LspInitialized`
+                // handler replays these requests once capabilities land.
+                if let Some(sh) =
+                    lsp.handle_for_feature_mut(&language, crate::types::LspFeature::Diagnostics)
+                {
+                    let request_id = {
+                        let id = *__next_id;
+                        *__next_id += 1;
+                        id
+                    };
+                    if let Err(e) = sh.handle.document_diagnostic(
+                        request_id,
+                        uri.as_uri().clone(),
+                        previous_result_id,
+                    ) {
+                        tracing::debug!("Failed to request pull diagnostics: {}", e);
+                    } else {
+                        tracing::info!(
+                            "Requested pull diagnostics for {} (request_id={})",
+                            uri.as_str(),
+                            request_id
+                        );
+                    }
+                }
+
+                if enable_inlay_hints {
+                    if let Some(sh) =
+                        lsp.handle_for_feature_mut(&language, crate::types::LspFeature::InlayHints)
+                    {
+                        let request_id = {
+                            let id = *__next_id;
+                            *__next_id += 1;
+                            id
+                        };
+
+                        if let Err(e) = sh.handle.inlay_hints(
+                            request_id,
+                            uri.as_uri().clone(),
+                            0,
+                            0,
+                            last_line,
+                            last_char,
+                        ) {
+                            tracing::debug!("Failed to request inlay hints: {}", e);
+                        } else {
+                            self.pending_inlay_hints_requests.insert(
+                                request_id,
+                                super::InlayHintsRequest {
+                                    buffer_id,
+                                    version: buffer_version,
+                                },
+                            );
+                            tracing::info!(
+                                "Requested inlay hints for {} (request_id={})",
+                                uri.as_str(),
+                                request_id
+                            );
+                        }
+                    }
+                }
+
+                // Schedule folding range refresh
+                self.schedule_folding_ranges_refresh(buffer_id);
+            }
+            LspSpawnResult::NotAutoStart => {
+                tracing::debug!(
+                    "LSP for {} not auto-starting (auto_start=false). Click the LSP indicator to start manually.",
+                    language
+                );
+            }
+            LspSpawnResult::NotConfigured => {
+                tracing::debug!("No LSP server configured for language: {}", language);
+            }
+            LspSpawnResult::Disabled => {
+                tracing::debug!("LSP disabled in config for language: {}", language);
+            }
+            LspSpawnResult::Failed => {
+                tracing::warn!("Failed to spawn LSP client for language: {}", language);
+            }
+        }
+    }
+
+    /// Record a file's modification time (called when opening files).
+    /// Window-local: records into this window's own `file_mod_times`.
+    pub(crate) fn watch_file(&mut self, path: &Path) {
+        if let Ok(metadata) = self.resources.authority.filesystem.metadata(path) {
+            if let Some(mtime) = metadata.modified {
+                self.file_mod_times.insert(path.to_path_buf(), mtime);
+            }
+        }
+    }
 }

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -59,10 +59,13 @@ impl Editor {
                 name: session_name.clone(),
             };
             let recovery_config = RecoveryConfig {
-                enabled: self.recovery_service.is_enabled(),
+                enabled: self.recovery_service.lock().unwrap().is_enabled(),
                 ..RecoveryConfig::default()
             };
-            self.recovery_service =
+            // Replace the shared service's contents in place — the
+            // `Arc<Mutex>` is cloned into every window, so we must not
+            // swap the `Arc` itself (that would desync the windows).
+            *self.recovery_service.lock().unwrap() =
                 RecoveryService::with_scope(recovery_config, &base_recovery_dir, &scope);
         }
         self.session_name = name;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -739,8 +739,11 @@ pub struct Editor {
     /// Cached layout for file browser (for mouse hit testing)
     // `file_browser_layout` moved onto `Window`.
 
-    /// Recovery service for auto-recovery-save and crash recovery
-    recovery_service: RecoveryService,
+    /// Recovery service for auto-recovery-save and crash recovery.
+    /// `Arc<Mutex>` because it is shared into every `Window` via
+    /// `WindowResources` so per-window restore / auto-save can reach it
+    /// without an active-window flip.
+    recovery_service: std::sync::Arc<std::sync::Mutex<RecoveryService>>,
 
     /// Request a full terminal clear and redraw on the next frame
     full_redraw_requested: bool,

--- a/crates/fresh-editor/src/app/recovery_actions.rs
+++ b/crates/fresh-editor/src/app/recovery_actions.rs
@@ -22,39 +22,13 @@ impl Editor {
     /// the on-disk content, the server is left on a stale base and every
     /// position it returns is offset by the net byte delta.
     pub(crate) fn sync_lsp_after_recovery_replay(&mut self, buffer_id: BufferId) {
-        self.sync_lsp_after_recovery_replay_for(self.active_window, buffer_id);
-    }
-
-    /// As [`Self::sync_lsp_after_recovery_replay`] but targets a specific
-    /// window's buffer + LSP, so the workspace-restore path can replay
-    /// hot-exit changes into a non-active window without an active-window
-    /// flip.
-    pub(crate) fn sync_lsp_after_recovery_replay_for(
-        &mut self,
-        id: fresh_core::WindowId,
-        buffer_id: BufferId,
-    ) {
-        let Some(text) = self
-            .windows
-            .get(&id)
-            .and_then(|w| w.buffers.get(&buffer_id))
-            .and_then(|state| state.buffer.to_string())
-        else {
-            return;
-        };
-        let full_change = lsp_types::TextDocumentContentChangeEvent {
-            range: None,
-            range_length: None,
-            text,
-        };
-        if let Some(w) = self.windows.get_mut(&id) {
-            w.send_lsp_changes_for_buffer(buffer_id, vec![full_change]);
-        }
+        self.active_window_mut()
+            .sync_lsp_after_recovery_replay(buffer_id);
     }
 
     /// Start the recovery session (call on editor startup after recovery check)
     pub fn start_recovery_session(&mut self) -> AnyhowResult<()> {
-        Ok(self.recovery_service.start_session()?)
+        Ok(self.recovery_service.lock().unwrap().start_session()?)
     }
 
     /// End the recovery session cleanly (call on normal shutdown)
@@ -80,9 +54,11 @@ impl Editor {
             let preserve_ids = self.recovery_ids_to_preserve();
             Ok(self
                 .recovery_service
+                .lock()
+                .unwrap()
                 .end_session_preserving(&preserve_ids)?)
         } else {
-            Ok(self.recovery_service.end_session()?)
+            Ok(self.recovery_service.lock().unwrap().end_session()?)
         }
     }
 
@@ -117,7 +93,12 @@ impl Editor {
                 // Use stored recovery_id, or compute from path for file-backed buffers
                 meta.recovery_id.clone().or_else(|| {
                     let file_path = state.buffer.file_path().map(|p| p.to_path_buf());
-                    Some(self.recovery_service.get_buffer_id(file_path.as_deref()))
+                    Some(
+                        self.recovery_service
+                            .lock()
+                            .unwrap()
+                            .get_buffer_id(file_path.as_deref()),
+                    )
                 })
             })
             .collect()
@@ -125,14 +106,18 @@ impl Editor {
 
     /// Check if there are files to recover from a crash
     pub fn has_recovery_files(&self) -> AnyhowResult<bool> {
-        Ok(self.recovery_service.should_offer_recovery()?)
+        Ok(self
+            .recovery_service
+            .lock()
+            .unwrap()
+            .should_offer_recovery()?)
     }
 
     /// Get list of recoverable files
     pub fn list_recoverable_files(
         &self,
     ) -> AnyhowResult<Vec<crate::services::recovery::RecoveryEntry>> {
-        Ok(self.recovery_service.list_recoverable()?)
+        Ok(self.recovery_service.lock().unwrap().list_recoverable()?)
     }
 
     /// Recover all buffers from recovery files
@@ -140,11 +125,16 @@ impl Editor {
     pub fn recover_all_buffers(&mut self) -> AnyhowResult<usize> {
         use crate::services::recovery::RecoveryResult;
 
-        let entries = self.recovery_service.list_recoverable()?;
+        let entries = self.recovery_service.lock().unwrap().list_recoverable()?;
         let mut recovered_count = 0;
 
         for entry in entries {
-            match self.recovery_service.accept_recovery(&entry) {
+            let accepted = self
+                .recovery_service
+                .lock()
+                .unwrap()
+                .accept_recovery(&entry);
+            match accepted {
                 Ok(RecoveryResult::Recovered {
                     original_path,
                     content,
@@ -269,7 +259,11 @@ impl Editor {
     /// Discard all recovery files (user decided not to recover)
     /// Returns the number of recovery files deleted
     pub fn discard_all_recovery(&mut self) -> AnyhowResult<usize> {
-        Ok(self.recovery_service.discard_all_recovery()?)
+        Ok(self
+            .recovery_service
+            .lock()
+            .unwrap()
+            .discard_all_recovery()?)
     }
 
     /// Restore only the hot-exit content from the previous clean exit:
@@ -293,14 +287,15 @@ impl Editor {
             return Ok(0);
         }
 
-        let entries = self.recovery_service.list_recoverable()?;
+        let entries = self.recovery_service.lock().unwrap().list_recoverable()?;
         if entries.is_empty() {
             return Ok(0);
         }
 
         let mut restored = 0;
         for entry in entries {
-            match self.recovery_service.load_recovery(&entry) {
+            let loaded = self.recovery_service.lock().unwrap().load_recovery(&entry);
+            match loaded {
                 Ok(RecoveryResult::Recovered {
                     original_path,
                     content,
@@ -424,7 +419,7 @@ impl Editor {
     /// Perform auto-recovery-save for all modified buffers if needed.
     /// Called frequently (every frame); rate-limited by `auto_recovery_save_interval_secs`.
     pub fn auto_recovery_save_dirty_buffers(&mut self) -> AnyhowResult<usize> {
-        if !self.recovery_service.is_enabled() {
+        if !self.recovery_service.lock().unwrap().is_enabled() {
             return Ok(0);
         }
 
@@ -447,7 +442,7 @@ impl Editor {
     /// Save all buffers marked `recovery_pending` to recovery storage.
     /// Shared by the periodic auto-save and the exit flush.
     fn save_pending_recovery_buffers(&mut self) -> AnyhowResult<usize> {
-        if !self.recovery_service.is_enabled() {
+        if !self.recovery_service.lock().unwrap().is_enabled() {
             return Ok(0);
         }
 
@@ -509,11 +504,16 @@ impl Editor {
                 let recovery_id = if let Some(ref stored_id) = meta.recovery_id {
                     stored_id.clone()
                 } else {
-                    self.recovery_service.get_buffer_id(path.as_deref())
+                    self.recovery_service
+                        .lock()
+                        .unwrap()
+                        .get_buffer_id(path.as_deref())
                 };
                 let recovery_pending = state.buffer.is_recovery_pending();
                 if self
                     .recovery_service
+                    .lock()
+                    .unwrap()
                     .needs_auto_recovery_save(&recovery_id, recovery_pending)
                 {
                     Some((buffer_id, recovery_id, path))
@@ -564,13 +564,19 @@ impl Editor {
                 stored_id
             } else if let Some(state) = state {
                 let path = state.buffer.file_path().map(|p| p.to_path_buf());
-                self.recovery_service.get_buffer_id(path.as_deref())
+                self.recovery_service
+                    .lock()
+                    .unwrap()
+                    .get_buffer_id(path.as_deref())
             } else {
                 return Ok(());
             }
         };
 
-        self.recovery_service.delete_buffer_recovery(&recovery_id)?;
+        self.recovery_service
+            .lock()
+            .unwrap()
+            .delete_buffer_recovery(&recovery_id)?;
 
         // Clear recovery_pending since buffer is now saved
         if let Some(state) = self
@@ -622,7 +628,7 @@ impl Editor {
                 .collect();
             let original_size = state.buffer.original_file_size().unwrap_or(0);
             let final_size = state.buffer.total_bytes();
-            self.recovery_service.save_buffer(
+            self.recovery_service.lock().unwrap().save_buffer(
                 recovery_id,
                 recovery_chunks,
                 path,
@@ -643,7 +649,7 @@ impl Editor {
             let chunks = vec![crate::services::recovery::types::RecoveryChunk::new(
                 0, 0, content,
             )];
-            self.recovery_service.save_buffer(
+            self.recovery_service.lock().unwrap().save_buffer(
                 recovery_id,
                 chunks,
                 path,

--- a/crates/fresh-editor/src/app/recovery_actions.rs
+++ b/crates/fresh-editor/src/app/recovery_actions.rs
@@ -22,9 +22,22 @@ impl Editor {
     /// the on-disk content, the server is left on a stale base and every
     /// position it returns is offset by the net byte delta.
     pub(crate) fn sync_lsp_after_recovery_replay(&mut self, buffer_id: BufferId) {
+        self.sync_lsp_after_recovery_replay_for(self.active_window, buffer_id);
+    }
+
+    /// As [`Self::sync_lsp_after_recovery_replay`] but targets a specific
+    /// window's buffer + LSP, so the workspace-restore path can replay
+    /// hot-exit changes into a non-active window without an active-window
+    /// flip.
+    pub(crate) fn sync_lsp_after_recovery_replay_for(
+        &mut self,
+        id: fresh_core::WindowId,
+        buffer_id: BufferId,
+    ) {
         let Some(text) = self
-            .buffers()
-            .get(&buffer_id)
+            .windows
+            .get(&id)
+            .and_then(|w| w.buffers.get(&buffer_id))
             .and_then(|state| state.buffer.to_string())
         else {
             return;
@@ -34,8 +47,9 @@ impl Editor {
             range_length: None,
             text,
         };
-        self.active_window_mut()
-            .send_lsp_changes_for_buffer(buffer_id, vec![full_change]);
+        if let Some(w) = self.windows.get_mut(&id) {
+            w.send_lsp_changes_for_buffer(buffer_id, vec![full_change]);
+        }
     }
 
     /// Start the recovery session (call on editor startup after recovery check)

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -596,13 +596,6 @@ impl Window {
 }
 
 impl Editor {
-    /// Editor-side thin wrapper. Delegates to the active window. New code
-    /// on `impl Window` should call `Window::resolved_terminal_wrapper`
-    /// directly.
-    pub(crate) fn resolved_terminal_wrapper(&self) -> TerminalWrapper {
-        self.active_window().resolved_terminal_wrapper()
-    }
-
     /// Spawn a new PTY-backed terminal session in the active window
     /// using its `root` as cwd. Editor-side thin wrapper; per-window
     /// body lives in `Window::spawn_terminal_session`.

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -42,6 +42,7 @@ impl crate::app::Editor {
             plugin_manager: std::sync::Arc::clone(&self.plugin_manager),
             theme: std::sync::Arc::clone(&self.theme),
             event_broadcaster: self.event_broadcaster.clone(),
+            recovery_service: std::sync::Arc::clone(&self.recovery_service),
         }
     }
 

--- a/crates/fresh-editor/src/app/window_resources.rs
+++ b/crates/fresh-editor/src/app/window_resources.rs
@@ -25,8 +25,6 @@
 //! - `clipboard: Clipboard` — owned value; pending Tier-2 migration
 //! - `mode_registry: ModeRegistry` — owned value; pending wrap
 //! - `quick_open_registry: QuickOpenRegistry` — owned value; pending wrap
-//! - `recovery_service: RecoveryService` — owned value; needs `Arc`
-//!   wrapping when `recovery_actions.rs` migrates
 //! - `event_broadcaster: EventBroadcaster` — owned value; needs check
 //! - `plugin_manager: PluginManager` — needs `Arc<Mutex<…>>` wrapping
 //!   when the first hook-firing handler migrates to `impl Window`
@@ -185,4 +183,10 @@ pub struct WindowResources {
 
     /// Editor-wide event broadcaster (cloneable, Arc inside).
     pub event_broadcaster: crate::model::control_event::EventBroadcaster,
+
+    /// Hot-exit / crash recovery service. `Arc<Mutex>` because it carries
+    /// mutable session state (`session_started`, per-buffer save times)
+    /// and is shared by every window — per-window restore and auto-save
+    /// reach it directly (no active-window flip).
+    pub recovery_service: Arc<std::sync::Mutex<crate::services::recovery::RecoveryService>>,
 }

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -183,7 +183,7 @@ impl Editor {
             return Ok(0);
         }
 
-        let entries = self.recovery_service.list_recoverable()?;
+        let entries = self.recovery_service.lock().unwrap().list_recoverable()?;
         if entries.is_empty() {
             return Ok(0);
         }
@@ -203,10 +203,15 @@ impl Editor {
 
         let mut recovered = 0;
         for (buffer_id, file_path) in buffer_files {
-            let recovery_id = self.recovery_service.get_buffer_id(Some(&file_path));
+            let recovery_id = self
+                .recovery_service
+                .lock()
+                .unwrap()
+                .get_buffer_id(Some(&file_path));
             let entry = entries.iter().find(|e| e.id == recovery_id);
             if let Some(entry) = entry {
-                match self.recovery_service.load_recovery(entry) {
+                let loaded = self.recovery_service.lock().unwrap().load_recovery(entry);
+                match loaded {
                     Ok(crate::services::recovery::RecoveryResult::Recovered {
                         content, ..
                     }) => {
@@ -344,208 +349,6 @@ impl Editor {
         // See issue #1156.
     }
 
-    /// Replay hot-exit recovery data onto file-backed buffers in
-    /// `windows[id]` that were modified when the editor last exited.
-    /// Stays on `Editor` because it needs `recovery_service`; targets
-    /// `windows[id]` explicitly so it works for any window without an
-    /// active-window flip.
-    fn restore_hot_exit_changes(
-        &mut self,
-        id: fresh_core::WindowId,
-        path_to_buffer: &HashMap<PathBuf, BufferId>,
-    ) {
-        if !self.config.editor.hot_exit {
-            return;
-        }
-        let entries = self.recovery_service.list_recoverable().unwrap_or_default();
-        if entries.is_empty() {
-            return;
-        }
-        let buffer_ids: Vec<BufferId> = path_to_buffer.values().copied().collect();
-        for buffer_id in buffer_ids {
-            let file_path = self
-                .windows
-                .get(&id)
-                .and_then(|w| w.buffers.get(&buffer_id))
-                .and_then(|s| s.buffer.file_path().map(|p| p.to_path_buf()));
-            let Some(file_path) = file_path else { continue };
-
-            let recovery_id = self.recovery_service.get_buffer_id(Some(&file_path));
-            let Some(entry) = entries.iter().find(|e| e.id == recovery_id) else {
-                continue;
-            };
-            match self.recovery_service.load_recovery(entry) {
-                Ok(crate::services::recovery::RecoveryResult::Recovered { content, .. }) => {
-                    let mut mutated = false;
-                    if let Some(state) = self
-                        .windows
-                        .get_mut(&id)
-                        .and_then(|w| w.buffers.get_mut(&buffer_id))
-                    {
-                        let current_len = state.buffer.total_bytes();
-                        let text = String::from_utf8_lossy(&content).into_owned();
-                        let current = state.buffer.get_text_range_mut(0, current_len).ok();
-                        let current_text = current
-                            .as_ref()
-                            .map(|b| String::from_utf8_lossy(b).into_owned());
-                        if current_text.as_deref() != Some(&text) {
-                            state.buffer.delete(0..current_len);
-                            state.buffer.insert(0, &text);
-                            state.buffer.set_modified(true);
-                            state.buffer.set_recovery_pending(false);
-                            mutated = true;
-                            tracing::info!(
-                                "Restored unsaved changes for {:?} from hot exit recovery",
-                                file_path
-                            );
-                        }
-                    }
-                    if let Some(log) = self
-                        .windows
-                        .get_mut(&id)
-                        .and_then(|w| w.event_logs.get_mut(&buffer_id))
-                    {
-                        log.clear_saved_position();
-                    }
-                    if mutated {
-                        self.sync_lsp_after_recovery_replay_for(id, buffer_id);
-                    }
-                }
-                Ok(crate::services::recovery::RecoveryResult::RecoveredChunks {
-                    chunks, ..
-                }) => {
-                    let mut mutated = false;
-                    if let Some(state) = self
-                        .windows
-                        .get_mut(&id)
-                        .and_then(|w| w.buffers.get_mut(&buffer_id))
-                    {
-                        for chunk in chunks.into_iter().rev() {
-                            let text = String::from_utf8_lossy(&chunk.content).into_owned();
-                            if chunk.original_len > 0 {
-                                state
-                                    .buffer
-                                    .delete(chunk.offset..chunk.offset + chunk.original_len);
-                            }
-                            state.buffer.insert(chunk.offset, &text);
-                        }
-                        state.buffer.set_modified(true);
-                        state.buffer.set_recovery_pending(false);
-                        mutated = true;
-                        tracing::info!(
-                            "Restored unsaved changes (chunked) for {:?} from hot exit recovery",
-                            file_path
-                        );
-                    }
-                    if let Some(log) = self
-                        .windows
-                        .get_mut(&id)
-                        .and_then(|w| w.event_logs.get_mut(&buffer_id))
-                    {
-                        log.clear_saved_position();
-                    }
-                    if mutated {
-                        self.sync_lsp_after_recovery_replay_for(id, buffer_id);
-                    }
-                }
-                Ok(crate::services::recovery::RecoveryResult::OriginalFileModified {
-                    original_path,
-                    ..
-                }) => {
-                    let name = original_path
-                        .file_name()
-                        .unwrap_or_default()
-                        .to_string_lossy();
-                    tracing::warn!("{} changed on disk; unsaved changes not restored", name);
-                    if let Some(w) = self.windows.get_mut(&id) {
-                        w.set_status_message(format!(
-                            "{} changed on disk; unsaved changes not restored",
-                            name
-                        ));
-                    }
-                }
-                Ok(_) => {} // Corrupted, NotFound — skip
-                Err(e) => {
-                    tracing::debug!(
-                        "Failed to load hot exit recovery for {:?}: {}",
-                        file_path,
-                        e
-                    );
-                }
-            }
-        }
-    }
-
-    /// Restore unnamed (unsaved) buffers into `windows[id]` from their
-    /// hot-exit recovery files. Returns a map from `recovery_id` to the
-    /// newly created `BufferId`. Stays on `Editor` (needs
-    /// `recovery_service`) but creates the buffers directly in
-    /// `windows[id]` — no active-window flip.
-    fn restore_unnamed_buffers(
-        &mut self,
-        id: fresh_core::WindowId,
-        unnamed_buffers: &[UnnamedBufferRef],
-    ) -> HashMap<String, BufferId> {
-        let mut unnamed_buffer_map: HashMap<String, BufferId> = HashMap::new();
-        if !self.config.editor.hot_exit || unnamed_buffers.is_empty() {
-            return unnamed_buffer_map;
-        }
-        tracing::debug!(
-            "Restoring {} unnamed buffers from recovery",
-            unnamed_buffers.len()
-        );
-        for unnamed_ref in unnamed_buffers {
-            let entries = match self.recovery_service.list_recoverable() {
-                Ok(e) => e,
-                Err(e) => {
-                    tracing::warn!("Failed to list recovery entries: {}", e);
-                    continue;
-                }
-            };
-            let Some(entry) = entries.iter().find(|e| e.id == unnamed_ref.recovery_id) else {
-                tracing::debug!(
-                    "Recovery file not found for unnamed buffer {}",
-                    unnamed_ref.recovery_id
-                );
-                continue;
-            };
-            match self.recovery_service.load_recovery(entry) {
-                Ok(crate::services::recovery::RecoveryResult::Recovered { content, .. }) => {
-                    let text = String::from_utf8_lossy(&content).into_owned();
-                    let Some(w) = self.windows.get_mut(&id) else {
-                        continue;
-                    };
-                    let buffer_id = w.create_unnamed_recovery_buffer(
-                        &text,
-                        unnamed_ref.recovery_id.clone(),
-                        unnamed_ref.display_name.clone(),
-                    );
-                    unnamed_buffer_map.insert(unnamed_ref.recovery_id.clone(), buffer_id);
-                    tracing::info!(
-                        "Restored unnamed buffer '{}' (recovery_id={})",
-                        unnamed_ref.display_name,
-                        unnamed_ref.recovery_id
-                    );
-                }
-                Ok(other) => {
-                    tracing::warn!(
-                        "Unexpected recovery result for unnamed buffer {}: {:?}",
-                        unnamed_ref.recovery_id,
-                        std::mem::discriminant(&other)
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        "Failed to load recovery for unnamed buffer {}: {}",
-                        unnamed_ref.recovery_id,
-                        e
-                    );
-                }
-            }
-        }
-        unnamed_buffer_map
-    }
-
     /// Save a specific window's workspace to disk, keyed by its own
     /// `root`. No active-window flip: reads `windows[id]` directly,
     /// snapshots via `Window::capture_workspace`, and injects the
@@ -595,14 +398,12 @@ impl Editor {
 
     /// Restore a specific window's workspace from disk into
     /// `windows[id]`, keyed by its own `root`. No active-window flip:
-    /// the window-local layout restore runs on `windows[id]` via
-    /// `Window::apply_workspace_layout`; the genuinely editor-global
-    /// steps are layered on here:
+    /// the entire window-local layout AND hot-exit recovery now run on
+    /// `windows[id]` via `Window::apply_workspace_layout` (the recovery
+    /// service is shared into the window via `WindowResources`). Only
+    /// genuinely editor-global steps are layered on here:
     /// - `restore_config_overrides` (mutates the shared `Config`),
     /// - `plugin_global_state` assignment,
-    /// - hot-exit recovery (`restore_unnamed_buffers` before the layout
-    ///   so the split tree can reference the restored buffers;
-    ///   `restore_hot_exit_changes` after), which needs `recovery_service`,
     /// - and, for the active window ONLY, the post-restore plugin
     ///   snapshot + `buffer_activated` hook (background restores must not
     ///   fire focus side-effects).
@@ -642,18 +443,14 @@ impl Editor {
             .unwrap_or(false);
 
         let session = self.session_name.clone();
-        let path_to_buffer = if populated {
+        if populated {
             // Normal path: editor_init has already seeded windows[id], so
-            // restore the layout into the existing window. Unnamed-buffer
-            // recovery must precede the split layout (the layout
-            // references those buffers); it needs the editor's
-            // recovery_service but creates buffers directly in windows[id].
-            let unnamed_buffer_map = self.restore_unnamed_buffers(id, &workspace.unnamed_buffers);
+            // restore the layout (incl. hot-exit recovery) into it.
             let win = self
                 .windows
                 .get_mut(&id)
                 .expect("window present for restore");
-            win.apply_workspace_layout(&workspace, &unnamed_buffer_map, session.as_deref())
+            win.apply_workspace_layout(&workspace, session.as_deref());
         } else {
             // Never-seeded shell: build the whole window from the
             // workspace via the `Window::from_workspace` factory, carrying
@@ -675,11 +472,7 @@ impl Editor {
             built.terminal_height = th;
             built.plugin_state = pstate;
             self.windows.insert(id, built);
-            HashMap::new()
-        };
-
-        // Replay hot-exit changes onto the file-backed buffers we opened.
-        self.restore_hot_exit_changes(id, &path_to_buffer);
+        }
 
         // Active-window only: refresh the plugin snapshot and fire
         // buffer_activated for the restored active buffer. Background
@@ -1834,26 +1627,247 @@ impl crate::app::window::Window {
             .insert(buf, crate::model::event::EventLog::new());
     }
 
-    /// Apply a loaded workspace's **window-local** layout onto this
-    /// window: search options, prompt histories, file-explorer settings,
-    /// the opened files (`open_file_no_focus`, no focus side-effects),
-    /// external + read-only files, terminals, the split tree + per-split
-    /// view state, bookmarks, orphan cleanup, and the restore summary.
+    /// Push a recovered buffer's full content to this window's LSP after
+    /// an out-of-band hot-exit replay (the replay edits the buffer
+    /// directly, bypassing the event log's `didChange`).
+    pub(crate) fn sync_lsp_after_recovery_replay(&mut self, buffer_id: BufferId) {
+        let Some(text) = self
+            .buffers
+            .get(&buffer_id)
+            .and_then(|state| state.buffer.to_string())
+        else {
+            return;
+        };
+        let full_change = lsp_types::TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text,
+        };
+        self.send_lsp_changes_for_buffer(buffer_id, vec![full_change]);
+    }
+
+    /// Restore unnamed (unsaved) buffers into this window from their
+    /// hot-exit recovery files (via the shared recovery service in
+    /// `self.resources`). Returns a map from `recovery_id` to the new
+    /// `BufferId`. No focus side-effects — the split-layout restore wires
+    /// each buffer into a tab afterwards.
+    fn restore_unnamed_buffers(
+        &mut self,
+        unnamed_buffers: &[UnnamedBufferRef],
+    ) -> HashMap<String, BufferId> {
+        let mut unnamed_buffer_map: HashMap<String, BufferId> = HashMap::new();
+        if !self.resources.config.editor.hot_exit || unnamed_buffers.is_empty() {
+            return unnamed_buffer_map;
+        }
+        tracing::debug!(
+            "Restoring {} unnamed buffers from recovery",
+            unnamed_buffers.len()
+        );
+        for unnamed_ref in unnamed_buffers {
+            let entries = match self
+                .resources
+                .recovery_service
+                .lock()
+                .unwrap()
+                .list_recoverable()
+            {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("Failed to list recovery entries: {}", e);
+                    continue;
+                }
+            };
+            let Some(entry) = entries.iter().find(|e| e.id == unnamed_ref.recovery_id) else {
+                tracing::debug!(
+                    "Recovery file not found for unnamed buffer {}",
+                    unnamed_ref.recovery_id
+                );
+                continue;
+            };
+            let loaded = self
+                .resources
+                .recovery_service
+                .lock()
+                .unwrap()
+                .load_recovery(entry);
+            match loaded {
+                Ok(crate::services::recovery::RecoveryResult::Recovered { content, .. }) => {
+                    let text = String::from_utf8_lossy(&content).into_owned();
+                    let buffer_id = self.create_unnamed_recovery_buffer(
+                        &text,
+                        unnamed_ref.recovery_id.clone(),
+                        unnamed_ref.display_name.clone(),
+                    );
+                    unnamed_buffer_map.insert(unnamed_ref.recovery_id.clone(), buffer_id);
+                    tracing::info!(
+                        "Restored unnamed buffer '{}' (recovery_id={})",
+                        unnamed_ref.display_name,
+                        unnamed_ref.recovery_id
+                    );
+                }
+                Ok(other) => {
+                    tracing::warn!(
+                        "Unexpected recovery result for unnamed buffer {}: {:?}",
+                        unnamed_ref.recovery_id,
+                        std::mem::discriminant(&other)
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to load recovery for unnamed buffer {}: {}",
+                        unnamed_ref.recovery_id,
+                        e
+                    );
+                }
+            }
+        }
+        unnamed_buffer_map
+    }
+
+    /// Replay hot-exit recovery data onto this window's file-backed
+    /// buffers that were modified when the editor last exited (via the
+    /// shared recovery service in `self.resources`).
+    fn restore_hot_exit_changes(&mut self, path_to_buffer: &HashMap<PathBuf, BufferId>) {
+        if !self.resources.config.editor.hot_exit {
+            return;
+        }
+        let entries = self
+            .resources
+            .recovery_service
+            .lock()
+            .unwrap()
+            .list_recoverable()
+            .unwrap_or_default();
+        if entries.is_empty() {
+            return;
+        }
+        let buffer_ids: Vec<BufferId> = path_to_buffer.values().copied().collect();
+        for buffer_id in buffer_ids {
+            let file_path = self
+                .buffers
+                .get(&buffer_id)
+                .and_then(|s| s.buffer.file_path().map(|p| p.to_path_buf()));
+            let Some(file_path) = file_path else { continue };
+
+            let recovery_id = self
+                .resources
+                .recovery_service
+                .lock()
+                .unwrap()
+                .get_buffer_id(Some(&file_path));
+            let Some(entry) = entries.iter().find(|e| e.id == recovery_id) else {
+                continue;
+            };
+            let loaded = self
+                .resources
+                .recovery_service
+                .lock()
+                .unwrap()
+                .load_recovery(entry);
+            match loaded {
+                Ok(crate::services::recovery::RecoveryResult::Recovered { content, .. }) => {
+                    let mut mutated = false;
+                    if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                        let current_len = state.buffer.total_bytes();
+                        let text = String::from_utf8_lossy(&content).into_owned();
+                        let current = state.buffer.get_text_range_mut(0, current_len).ok();
+                        let current_text = current
+                            .as_ref()
+                            .map(|b| String::from_utf8_lossy(b).into_owned());
+                        if current_text.as_deref() != Some(&text) {
+                            state.buffer.delete(0..current_len);
+                            state.buffer.insert(0, &text);
+                            state.buffer.set_modified(true);
+                            state.buffer.set_recovery_pending(false);
+                            mutated = true;
+                            tracing::info!(
+                                "Restored unsaved changes for {:?} from hot exit recovery",
+                                file_path
+                            );
+                        }
+                    }
+                    if let Some(log) = self.event_logs.get_mut(&buffer_id) {
+                        log.clear_saved_position();
+                    }
+                    if mutated {
+                        self.sync_lsp_after_recovery_replay(buffer_id);
+                    }
+                }
+                Ok(crate::services::recovery::RecoveryResult::RecoveredChunks {
+                    chunks, ..
+                }) => {
+                    let mut mutated = false;
+                    if let Some(state) = self.buffers.get_mut(&buffer_id) {
+                        for chunk in chunks.into_iter().rev() {
+                            let text = String::from_utf8_lossy(&chunk.content).into_owned();
+                            if chunk.original_len > 0 {
+                                state
+                                    .buffer
+                                    .delete(chunk.offset..chunk.offset + chunk.original_len);
+                            }
+                            state.buffer.insert(chunk.offset, &text);
+                        }
+                        state.buffer.set_modified(true);
+                        state.buffer.set_recovery_pending(false);
+                        mutated = true;
+                        tracing::info!(
+                            "Restored unsaved changes (chunked) for {:?} from hot exit recovery",
+                            file_path
+                        );
+                    }
+                    if let Some(log) = self.event_logs.get_mut(&buffer_id) {
+                        log.clear_saved_position();
+                    }
+                    if mutated {
+                        self.sync_lsp_after_recovery_replay(buffer_id);
+                    }
+                }
+                Ok(crate::services::recovery::RecoveryResult::OriginalFileModified {
+                    original_path,
+                    ..
+                }) => {
+                    let name = original_path
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy();
+                    tracing::warn!("{} changed on disk; unsaved changes not restored", name);
+                    self.set_status_message(format!(
+                        "{} changed on disk; unsaved changes not restored",
+                        name
+                    ));
+                }
+                Ok(_) => {} // Corrupted, NotFound — skip
+                Err(e) => {
+                    tracing::debug!(
+                        "Failed to load hot exit recovery for {:?}: {}",
+                        file_path,
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    /// Apply a loaded workspace's layout onto this window — now fully
+    /// window-scoped: search options, prompt histories, file-explorer
+    /// settings, unnamed-buffer hot-exit recovery (before the split tree,
+    /// which references those buffers), the opened files
+    /// (`open_file_no_focus`, no focus side-effects), external + read-only
+    /// files, terminals, the split tree + per-split view state, bookmarks,
+    /// orphan cleanup, the restore summary, and finally hot-exit replay
+    /// onto the opened file buffers. Recovery reaches the shared service
+    /// via `self.resources.recovery_service`, so no `Editor` involvement
+    /// is needed.
     ///
-    /// `unnamed_buffer_map` is the result of the editor-global
-    /// `restore_unnamed_buffers` (run beforehand because the split tree
-    /// references those buffers). Returns the path→`BufferId` map so the
-    /// caller can replay editor-global hot-exit changes onto the opened
-    /// files. The editor-global steps (config overrides beyond
-    /// `mouse_enabled`, plugin global state, hot-exit recovery, and the
-    /// active-window plugin snapshot + `buffer_activated`) live on
-    /// `Editor::restore_workspace_for`.
+    /// The only steps that stay on `Editor::restore_workspace_for` are the
+    /// genuinely editor-global ones: config overrides beyond
+    /// `mouse_enabled`, plugin global state, and the active-window plugin
+    /// snapshot + `buffer_activated`.
     pub(crate) fn apply_workspace_layout(
         &mut self,
         workspace: &Workspace,
-        unnamed_buffer_map: &HashMap<String, BufferId>,
         session_name: Option<&str>,
-    ) -> HashMap<PathBuf, BufferId> {
+    ) {
         tracing::debug!(
             "Applying workspace layout with {} split states",
             workspace.split_states.len()
@@ -1869,6 +1883,10 @@ impl crate::app::window::Window {
         self.restore_prompt_histories(&workspace.histories);
         self.restore_file_explorer_settings(&workspace.file_explorer);
 
+        // Unnamed-buffer recovery must precede the split layout (the tree
+        // references those buffers).
+        let unnamed_buffer_map = self.restore_unnamed_buffers(&workspace.unnamed_buffers);
+
         let mut path_to_buffer = self.open_workspace_files(&workspace.split_states);
         self.restore_external_files(&workspace.external_files, &mut path_to_buffer);
         self.apply_read_only_flags(&workspace.read_only_files, &path_to_buffer);
@@ -1880,7 +1898,7 @@ impl crate::app::window::Window {
             &workspace.split_layout,
             &path_to_buffer,
             &terminal_buffer_map,
-            unnamed_buffer_map,
+            &unnamed_buffer_map,
             &workspace.split_states,
             &mut split_id_map,
             true,
@@ -1897,17 +1915,15 @@ impl crate::app::window::Window {
         self.clean_orphaned_buffers();
         self.log_restore_summary(session_name);
 
-        path_to_buffer
+        // Replay hot-exit changes onto the file-backed buffers we opened.
+        self.restore_hot_exit_changes(&path_to_buffer);
     }
 
     /// Build a `Window` directly from a persisted `Workspace`: construct
     /// a fresh window, seed its initial layout, then apply the workspace
-    /// layout into it. The realized "restore is a Window factory" design
-    /// (the `open_file` move in this branch removed the prior blocker
-    /// that kept restore on `Editor`). Editor-global recovery
-    /// (hot-exit / unnamed buffers via `recovery_service`) is layered on
-    /// by `Editor::restore_workspace_for`; this factory restores the pure
-    /// window-local layout.
+    /// layout into it. The realized "restore is a Window factory" design —
+    /// moving the `open_file` core and the recovery service onto `Window`
+    /// removed the prior blockers that kept restore on `Editor`.
     pub(crate) fn from_workspace(
         id: fresh_core::WindowId,
         label: impl Into<String>,
@@ -1917,7 +1933,7 @@ impl crate::app::window::Window {
     ) -> Self {
         let mut window = Self::new(id, label, root, resources);
         window.seed_initial_layout();
-        window.apply_workspace_layout(workspace, &HashMap::new(), None);
+        window.apply_workspace_layout(workspace, None);
         window
     }
 

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -159,215 +159,18 @@ impl Editor {
         ws
     }
 
-    /// Save the current workspace to disk
-    ///
-    /// Ensures all active terminals have their visible screen synced to
-    /// backing files before capturing the workspace.
-    /// Also saves global file states (scroll/cursor positions per file).
+    /// Save the current (active) window's workspace to disk. Thin
+    /// active-window wrapper over [`Editor::save_workspace_for`].
     pub fn save_workspace(&mut self) -> Result<(), WorkspaceError> {
-        // Ensure all terminal backing files have complete state before saving
-        self.sync_all_terminal_backing_files();
-
-        // Save global file states for all open file buffers
-        self.save_all_global_file_states();
-
-        let workspace = self.capture_workspace();
-
-        // Refuse to overwrite a non-empty on-disk workspace with an
-        // all-virtual snapshot. When the only live buffers are virtual
-        // (Dashboard, plugin scratch buffers), the serializer strips
-        // them and produces an empty workspace; before this guard,
-        // quitting from a Dashboard-only tab silently wiped the user's
-        // saved file list (see issue #2027). Genuinely-empty quits
-        // (no buffers at all) still pass through and clear the file.
-        //
-        // The protection is for FILE/unnamed content only. Terminals are
-        // live runtime state: once the user closes a restored terminal, the
-        // on-disk terminal entry is stale, so a terminal-only on-disk
-        // workspace must NOT block this save — otherwise the closed terminal
-        // is resurrected on the next restart (terminal-reappears bug).
-        if workspace.has_no_real_content() && self.has_any_virtual_buffer() {
-            let on_disk = if let Some(ref session_name) = self.session_name {
-                Workspace::load_session(session_name, self.working_dir())
-                    .ok()
-                    .flatten()
-            } else {
-                Workspace::load(self.working_dir()).ok().flatten()
-            };
-            if let Some(existing) = on_disk {
-                if !existing.has_no_preservable_content() {
-                    tracing::info!(
-                        "Skipping workspace save: only virtual buffers are open, \
-                         on-disk workspace already has preservable file content"
-                    );
-                    return Ok(());
-                }
-            }
-        }
-
-        // For named sessions, save to session-scoped workspace file
-        if let Some(ref session_name) = self.session_name {
-            workspace.save_session(session_name)
-        } else {
-            workspace.save()
-        }
+        self.save_workspace_for(self.active_window)
     }
 
-    /// True when the active window has any virtual buffer (Dashboard,
-    /// plugin scratch buffers, etc.) — used by `save_workspace` to
-    /// detect the Dashboard-only-quit case where the serializer
-    /// produces an empty snapshot.
-    fn has_any_virtual_buffer(&self) -> bool {
-        self.active_window()
-            .buffer_metadata
-            .values()
-            .any(|m| matches!(m.kind, crate::app::types::BufferKind::Virtual { .. }))
-    }
-
-    /// Save global file states for all open file buffers
-    fn save_all_global_file_states(&self) {
-        // Collect all file states from all splits
-        for (leaf_id, view_state) in self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.buffers.splits())
-            .map(|(_, vs)| vs)
-            .expect("active window must have a populated split layout")
-        {
-            // Get the active buffer for this split
-            let active_buffer = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .root()
-                .get_leaves_with_rects(ratatui::layout::Rect::default())
-                .into_iter()
-                .find(|(sid, _, _)| *sid == *leaf_id)
-                .map(|(_, buffer_id, _)| buffer_id);
-
-            if let Some(buffer_id) = active_buffer {
-                self.save_buffer_file_state(buffer_id, view_state);
-            }
-        }
-    }
-
-    /// Save file state for a specific buffer (used when closing files and saving workspace)
-    fn save_buffer_file_state(&self, buffer_id: BufferId, view_state: &SplitViewState) {
-        // Get the file path for this buffer
-        let abs_path = match self.active_window().buffer_metadata.get(&buffer_id) {
-            Some(metadata) => match metadata.file_path() {
-                Some(path) => path.to_path_buf(),
-                None => return, // Not a file buffer
-            },
-            None => return,
-        };
-
-        // Capture the current state
-        let primary_cursor = view_state.cursors.primary();
-        let file_state = SerializedFileState {
-            cursor: SerializedCursor {
-                position: primary_cursor.position,
-                anchor: primary_cursor.anchor,
-                sticky_column: primary_cursor.sticky_column,
-            },
-            additional_cursors: view_state
-                .cursors
-                .iter()
-                .skip(1)
-                .map(|(_, cursor)| SerializedCursor {
-                    position: cursor.position,
-                    anchor: cursor.anchor,
-                    sticky_column: cursor.sticky_column,
-                })
-                .collect(),
-            scroll: SerializedScroll {
-                top_byte: view_state.viewport.top_byte,
-                top_view_line_offset: view_state.viewport.top_view_line_offset,
-                left_column: view_state.viewport.left_column,
-            },
-            view_mode: Default::default(),
-            compose_width: None,
-            plugin_state: std::collections::HashMap::new(),
-            folds: Vec::new(),
-        };
-
-        // Save to disk immediately
-        PersistedFileWorkspace::save(&abs_path, file_state);
-    }
-
-    /// Sync all active terminal visible screens to their backing files.
-    ///
-    /// Called before workspace save to ensure backing files contain complete
-    /// terminal state (scrollback + visible screen).
-    fn sync_all_terminal_backing_files(&mut self) {
-        use std::io::BufWriter;
-
-        // Collect terminal IDs and their backing paths
-        let terminals_to_sync: Vec<_> = self
-            .active_window()
-            .terminal_buffers
-            .values()
-            .copied()
-            .filter_map(|terminal_id| {
-                self.active_window()
-                    .terminal_backing_files
-                    .get(&terminal_id)
-                    .map(|path| (terminal_id, path.clone()))
-            })
-            .collect();
-
-        for (terminal_id, backing_path) in terminals_to_sync {
-            if let Some(handle) = self.active_window().terminal_manager.get(terminal_id) {
-                if let Ok(state) = handle.state.lock() {
-                    // Append visible screen to backing file
-                    if let Ok(mut file) = self
-                        .authority
-                        .filesystem
-                        .open_file_for_append(&backing_path)
-                    {
-                        let mut writer = BufWriter::new(&mut *file);
-                        if let Err(e) = state.append_visible_screen(&mut writer) {
-                            tracing::warn!(
-                                "Failed to sync terminal {:?} to backing file: {}",
-                                terminal_id,
-                                e
-                            );
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// Try to load and apply a workspace for the current working directory
+    /// Try to load and apply a workspace for the active window. Thin
+    /// active-window wrapper over [`Editor::restore_workspace_for`].
     ///
     /// Returns true if a workspace was successfully loaded and applied.
     pub fn try_restore_workspace(&mut self) -> Result<bool, WorkspaceError> {
-        tracing::debug!(
-            "Attempting to restore workspace for {:?}",
-            self.working_dir()
-        );
-
-        // For named sessions, load from session-scoped workspace file
-        let workspace = if let Some(ref session_name) = self.session_name {
-            Workspace::load_session(session_name, self.working_dir())?
-        } else {
-            Workspace::load(self.working_dir())?
-        };
-
-        match workspace {
-            Some(workspace) => {
-                tracing::info!("Found workspace, applying...");
-                self.apply_workspace(&workspace)?;
-                Ok(true)
-            }
-            None => {
-                tracing::debug!("No workspace found for {:?}", self.working_dir());
-                Ok(false)
-            }
-        }
+        self.restore_workspace_for(self.active_window)
     }
 
     /// Apply hot exit recovery to all currently open file-backed buffers.
@@ -515,75 +318,10 @@ impl Editor {
         Ok(recovered)
     }
 
-    /// Apply a loaded workspace to the editor
-    pub fn apply_workspace(&mut self, workspace: &Workspace) -> Result<(), WorkspaceError> {
-        tracing::debug!(
-            "Applying workspace with {} split states",
-            workspace.split_states.len()
-        );
-
-        self.restore_config_overrides(&workspace.config_overrides);
-
-        if !workspace.plugin_global_state.is_empty() {
-            tracing::debug!(
-                "Restoring plugin global state for {} plugins",
-                workspace.plugin_global_state.len()
-            );
-            self.plugin_global_state = workspace.plugin_global_state.clone();
-        }
-
-        self.restore_search_options(&workspace.search_options);
-        self.restore_prompt_histories(&workspace.histories);
-        self.restore_file_explorer_settings(&workspace.file_explorer);
-
-        let mut path_to_buffer = self.open_workspace_files(&workspace.split_states);
-        self.restore_external_files(&workspace.external_files, &mut path_to_buffer);
-        self.apply_read_only_flags(&workspace.read_only_files, &path_to_buffer);
-        self.restore_hot_exit_changes(&path_to_buffer);
-
-        let unnamed_buffer_map = self.restore_unnamed_buffers(&workspace.unnamed_buffers);
-        let terminal_buffer_map = self.restore_terminals_from_workspace(&workspace.terminals);
-
-        let mut split_id_map: HashMap<usize, SplitId> = HashMap::new();
-        self.restore_split_node(
-            &workspace.split_layout,
-            &path_to_buffer,
-            &terminal_buffer_map,
-            &unnamed_buffer_map,
-            &workspace.split_states,
-            &mut split_id_map,
-            true,
-        );
-
-        if let Some(&new_active_split) = split_id_map.get(&workspace.active_split_id) {
-            self.windows
-                .get_mut(&self.active_window)
-                .and_then(|w| w.split_manager_mut())
-                .expect("active window must have a populated split layout")
-                .set_active_split(LeafId(new_active_split));
-        }
-
-        self.restore_bookmarks_from_workspace(&workspace.bookmarks, &path_to_buffer);
-        self.clean_orphaned_buffers();
-        self.log_restore_summary();
-
-        #[cfg(feature = "plugins")]
-        {
-            let buffer_id = self.active_buffer();
-            self.update_plugin_state_snapshot();
-            tracing::debug!(
-                "Firing buffer_activated for active buffer {:?} after workspace restore",
-                buffer_id
-            );
-            self.plugin_manager.read().unwrap().run_hook(
-                "buffer_activated",
-                crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
-            );
-        }
-
-        Ok(())
-    }
-
+    /// Apply only the **editor-global** config overrides from a
+    /// workspace (the global `Config`). The window-local override
+    /// (`mouse_enabled`) is applied by
+    /// `Window::apply_workspace_layout`.
     fn restore_config_overrides(&mut self, overrides: &WorkspaceConfigOverrides) {
         if let Some(line_numbers) = overrides.line_numbers {
             self.config_mut().editor.line_numbers = line_numbers;
@@ -600,154 +338,22 @@ impl Editor {
         if let Some(enable_inlay_hints) = overrides.enable_inlay_hints {
             self.config_mut().editor.enable_inlay_hints = enable_inlay_hints;
         }
-        if let Some(mouse_enabled) = overrides.mouse_enabled {
-            self.active_window_mut().mouse_enabled = mouse_enabled;
-        }
         // `overrides.menu_bar_hidden` is a legacy field — kept for serde
         // compatibility with workspaces written by older builds, but no
         // longer applied: menu bar visibility is now a global preference.
         // See issue #1156.
     }
 
-    fn restore_search_options(&mut self, opts: &SearchOptions) {
-        self.active_window_mut().search_case_sensitive = opts.case_sensitive;
-        self.active_window_mut().search_whole_word = opts.whole_word;
-        self.active_window_mut().search_use_regex = opts.use_regex;
-        self.active_window_mut().search_confirm_each = opts.confirm_each;
-    }
-
-    fn restore_prompt_histories(&mut self, histories: &WorkspaceHistories) {
-        tracing::debug!(
-            "Restoring histories: {} search, {} replace, {} goto_line",
-            histories.search.len(),
-            histories.replace.len(),
-            histories.goto_line.len()
-        );
-        for item in &histories.search {
-            self.get_or_create_prompt_history("search")
-                .push(item.clone());
-        }
-        for item in &histories.replace {
-            self.get_or_create_prompt_history("replace")
-                .push(item.clone());
-        }
-        for item in &histories.goto_line {
-            self.get_or_create_prompt_history("goto_line")
-                .push(item.clone());
-        }
-    }
-
-    fn restore_file_explorer_settings(&mut self, fe: &FileExplorerState) {
-        self.active_window_mut().file_explorer_visible = fe.visible;
-        self.active_window_mut().file_explorer_width = fe.width;
-        self.active_window_mut().file_explorer_side = fe.side;
-
-        // Store pending settings (fixes #569); applied when explorer initialises (async).
-        if fe.show_hidden {
-            self.active_window_mut().pending_file_explorer_show_hidden = Some(true);
-        }
-        if fe.show_gitignored {
-            self.active_window_mut()
-                .pending_file_explorer_show_gitignored = Some(true);
-        }
-
-        // Keep key_context as Normal so the editor (not the explorer) has focus.
-        if self.file_explorer_visible() && self.file_explorer().is_none() {
-            self.init_file_explorer();
-        }
-    }
-
-    /// Open every file referenced by the saved split states, returning a map
-    /// from relative (or absolute) path to the new `BufferId`.
-    fn open_workspace_files(
+    /// Replay hot-exit recovery data onto file-backed buffers in
+    /// `windows[id]` that were modified when the editor last exited.
+    /// Stays on `Editor` because it needs `recovery_service`; targets
+    /// `windows[id]` explicitly so it works for any window without an
+    /// active-window flip.
+    fn restore_hot_exit_changes(
         &mut self,
-        split_states: &HashMap<usize, SerializedSplitViewState>,
-    ) -> HashMap<PathBuf, BufferId> {
-        let file_paths = collect_file_paths_from_states(split_states);
-        tracing::debug!(
-            "Workspace has {} files to restore: {:?}",
-            file_paths.len(),
-            file_paths
-        );
-        let mut path_to_buffer: HashMap<PathBuf, BufferId> = HashMap::new();
-        for rel_path in file_paths {
-            let abs_path = self.working_dir().join(&rel_path);
-            tracing::trace!(
-                "Checking file: {:?} (exists: {})",
-                abs_path,
-                abs_path.exists()
-            );
-            if abs_path.exists() {
-                match self.open_file_internal(&abs_path) {
-                    Ok(buffer_id) => {
-                        tracing::debug!("Opened file {:?} as buffer {:?}", rel_path, buffer_id);
-                        path_to_buffer.insert(rel_path, buffer_id);
-                    }
-                    Err(e) => tracing::warn!("Failed to open file {:?}: {}", abs_path, e),
-                }
-            } else {
-                tracing::debug!("Skipping non-existent file: {:?}", abs_path);
-            }
-        }
-        tracing::debug!("Opened {} files from workspace", path_to_buffer.len());
-        path_to_buffer
-    }
-
-    /// Restore files that live outside the working directory (stored as absolute paths).
-    fn restore_external_files(
-        &mut self,
-        external_files: &[PathBuf],
-        path_to_buffer: &mut HashMap<PathBuf, BufferId>,
-    ) {
-        if external_files.is_empty() {
-            return;
-        }
-        tracing::debug!(
-            "Restoring {} external files: {:?}",
-            external_files.len(),
-            external_files
-        );
-        for abs_path in external_files {
-            if !abs_path.exists() {
-                tracing::debug!("Skipping non-existent external file: {:?}", abs_path);
-                continue;
-            }
-            match self.open_file_internal(abs_path) {
-                Ok(buffer_id) => {
-                    path_to_buffer.insert(abs_path.clone(), buffer_id);
-                    tracing::debug!(
-                        "Restored external file {:?} as buffer {:?}",
-                        abs_path,
-                        buffer_id
-                    );
-                }
-                Err(e) => tracing::warn!("Failed to restore external file {:?}: {}", abs_path, e),
-            }
-        }
-    }
-
-    /// Re-apply read-only flags for files that were locked in the saved session.
-    /// Paths may be relative (under `working_dir`) or absolute.
-    fn apply_read_only_flags(
-        &mut self,
-        read_only_files: &[PathBuf],
+        id: fresh_core::WindowId,
         path_to_buffer: &HashMap<PathBuf, BufferId>,
     ) {
-        for ro_path in read_only_files {
-            let buffer_id = path_to_buffer.get(ro_path).copied().or_else(|| {
-                path_to_buffer
-                    .get(&self.working_dir().join(ro_path))
-                    .copied()
-            });
-            if let Some(id) = buffer_id {
-                self.active_window_mut().mark_buffer_read_only(id, true);
-            }
-        }
-    }
-
-    /// Replay hot-exit recovery data onto file-backed buffers that were modified
-    /// when the editor last exited.
-    fn restore_hot_exit_changes(&mut self, path_to_buffer: &HashMap<PathBuf, BufferId>) {
         if !self.config.editor.hot_exit {
             return;
         }
@@ -758,8 +364,9 @@ impl Editor {
         let buffer_ids: Vec<BufferId> = path_to_buffer.values().copied().collect();
         for buffer_id in buffer_ids {
             let file_path = self
-                .buffers()
-                .get(&buffer_id)
+                .windows
+                .get(&id)
+                .and_then(|w| w.buffers.get(&buffer_id))
                 .and_then(|s| s.buffer.file_path().map(|p| p.to_path_buf()));
             let Some(file_path) = file_path else { continue };
 
@@ -772,10 +379,8 @@ impl Editor {
                     let mut mutated = false;
                     if let Some(state) = self
                         .windows
-                        .get_mut(&self.active_window)
-                        .map(|w| &mut w.buffers)
-                        .expect("active window present")
-                        .get_mut(&buffer_id)
+                        .get_mut(&id)
+                        .and_then(|w| w.buffers.get_mut(&buffer_id))
                     {
                         let current_len = state.buffer.total_bytes();
                         let text = String::from_utf8_lossy(&content).into_owned();
@@ -795,11 +400,15 @@ impl Editor {
                             );
                         }
                     }
-                    if let Some(log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {
+                    if let Some(log) = self
+                        .windows
+                        .get_mut(&id)
+                        .and_then(|w| w.event_logs.get_mut(&buffer_id))
+                    {
                         log.clear_saved_position();
                     }
                     if mutated {
-                        self.sync_lsp_after_recovery_replay(buffer_id);
+                        self.sync_lsp_after_recovery_replay_for(id, buffer_id);
                     }
                 }
                 Ok(crate::services::recovery::RecoveryResult::RecoveredChunks {
@@ -808,10 +417,8 @@ impl Editor {
                     let mut mutated = false;
                     if let Some(state) = self
                         .windows
-                        .get_mut(&self.active_window)
-                        .map(|w| &mut w.buffers)
-                        .expect("active window present")
-                        .get_mut(&buffer_id)
+                        .get_mut(&id)
+                        .and_then(|w| w.buffers.get_mut(&buffer_id))
                     {
                         for chunk in chunks.into_iter().rev() {
                             let text = String::from_utf8_lossy(&chunk.content).into_owned();
@@ -830,11 +437,15 @@ impl Editor {
                             file_path
                         );
                     }
-                    if let Some(log) = self.active_window_mut().event_logs.get_mut(&buffer_id) {
+                    if let Some(log) = self
+                        .windows
+                        .get_mut(&id)
+                        .and_then(|w| w.event_logs.get_mut(&buffer_id))
+                    {
                         log.clear_saved_position();
                     }
                     if mutated {
-                        self.sync_lsp_after_recovery_replay(buffer_id);
+                        self.sync_lsp_after_recovery_replay_for(id, buffer_id);
                     }
                 }
                 Ok(crate::services::recovery::RecoveryResult::OriginalFileModified {
@@ -846,10 +457,12 @@ impl Editor {
                         .unwrap_or_default()
                         .to_string_lossy();
                     tracing::warn!("{} changed on disk; unsaved changes not restored", name);
-                    self.set_status_message(format!(
-                        "{} changed on disk; unsaved changes not restored",
-                        name
-                    ));
+                    if let Some(w) = self.windows.get_mut(&id) {
+                        w.set_status_message(format!(
+                            "{} changed on disk; unsaved changes not restored",
+                            name
+                        ));
+                    }
                 }
                 Ok(_) => {} // Corrupted, NotFound — skip
                 Err(e) => {
@@ -863,10 +476,14 @@ impl Editor {
         }
     }
 
-    /// Restore unnamed (unsaved) buffers from their hot-exit recovery files.
-    /// Returns a map from `recovery_id` to the newly created `BufferId`.
+    /// Restore unnamed (unsaved) buffers into `windows[id]` from their
+    /// hot-exit recovery files. Returns a map from `recovery_id` to the
+    /// newly created `BufferId`. Stays on `Editor` (needs
+    /// `recovery_service`) but creates the buffers directly in
+    /// `windows[id]` — no active-window flip.
     fn restore_unnamed_buffers(
         &mut self,
+        id: fresh_core::WindowId,
         unnamed_buffers: &[UnnamedBufferRef],
     ) -> HashMap<String, BufferId> {
         let mut unnamed_buffer_map: HashMap<String, BufferId> = HashMap::new();
@@ -895,19 +512,14 @@ impl Editor {
             match self.recovery_service.load_recovery(entry) {
                 Ok(crate::services::recovery::RecoveryResult::Recovered { content, .. }) => {
                     let text = String::from_utf8_lossy(&content).into_owned();
-                    let buffer_id = self.new_buffer();
-                    {
-                        let state = self.active_state_mut();
-                        state.buffer.insert(0, &text);
-                        state.buffer.set_modified(true);
-                        state.buffer.set_recovery_pending(false);
-                    }
-                    self.active_event_log_mut().clear_saved_position();
-                    if let Some(meta) = self.active_window_mut().buffer_metadata.get_mut(&buffer_id)
-                    {
-                        meta.recovery_id = Some(unnamed_ref.recovery_id.clone());
-                        meta.display_name = unnamed_ref.display_name.clone();
-                    }
+                    let Some(w) = self.windows.get_mut(&id) else {
+                        continue;
+                    };
+                    let buffer_id = w.create_unnamed_recovery_buffer(
+                        &text,
+                        unnamed_ref.recovery_id.clone(),
+                        unnamed_ref.display_name.clone(),
+                    );
                     unnamed_buffer_map.insert(unnamed_ref.recovery_id.clone(), buffer_id);
                     tracing::info!(
                         "Restored unnamed buffer '{}' (recovery_id={})",
@@ -934,7 +546,231 @@ impl Editor {
         unnamed_buffer_map
     }
 
-    /// Restore all serialized terminals and return a map from terminal index to `BufferId`.
+    /// Save a specific window's workspace to disk, keyed by its own
+    /// `root`. No active-window flip: reads `windows[id]` directly,
+    /// snapshots via `Window::capture_workspace`, and injects the
+    /// editor-global `plugin_global_state`.
+    pub fn save_workspace_for(&mut self, id: fresh_core::WindowId) -> Result<(), WorkspaceError> {
+        let Some(win) = self.windows.get(&id) else {
+            return Ok(());
+        };
+
+        // Ensure terminal backing files have complete state, and persist
+        // per-file global states, before snapshotting.
+        win.sync_terminal_backing_files();
+        win.save_all_global_file_states();
+
+        let mut workspace = win.capture_workspace();
+        workspace.plugin_global_state = self.plugin_global_state.clone();
+
+        // Refuse to overwrite a non-empty on-disk workspace with an
+        // all-virtual snapshot (issue #2027). The protection is for
+        // FILE/unnamed content only — terminals are live runtime state, so
+        // a terminal-only on-disk workspace must NOT block this save.
+        if workspace.has_no_real_content() && win.has_any_virtual_buffer() {
+            let root = win.root.clone();
+            let on_disk = if let Some(ref session_name) = self.session_name {
+                Workspace::load_session(session_name, &root).ok().flatten()
+            } else {
+                Workspace::load(&root).ok().flatten()
+            };
+            if let Some(existing) = on_disk {
+                if !existing.has_no_preservable_content() {
+                    tracing::info!(
+                        "Skipping workspace save: only virtual buffers are open, \
+                         on-disk workspace already has preservable file content"
+                    );
+                    return Ok(());
+                }
+            }
+        }
+
+        // For named sessions, save to session-scoped workspace file
+        if let Some(ref session_name) = self.session_name {
+            workspace.save_session(session_name)
+        } else {
+            workspace.save()
+        }
+    }
+
+    /// Restore a specific window's workspace from disk into
+    /// `windows[id]`, keyed by its own `root`. No active-window flip:
+    /// the window-local layout restore runs on `windows[id]` via
+    /// `Window::apply_workspace_layout`; the genuinely editor-global
+    /// steps are layered on here:
+    /// - `restore_config_overrides` (mutates the shared `Config`),
+    /// - `plugin_global_state` assignment,
+    /// - hot-exit recovery (`restore_unnamed_buffers` before the layout
+    ///   so the split tree can reference the restored buffers;
+    ///   `restore_hot_exit_changes` after), which needs `recovery_service`,
+    /// - and, for the active window ONLY, the post-restore plugin
+    ///   snapshot + `buffer_activated` hook (background restores must not
+    ///   fire focus side-effects).
+    pub fn restore_workspace_for(
+        &mut self,
+        id: fresh_core::WindowId,
+    ) -> Result<bool, WorkspaceError> {
+        let Some(root) = self.windows.get(&id).map(|w| w.root.clone()) else {
+            return Ok(false);
+        };
+
+        let workspace = if let Some(ref session_name) = self.session_name {
+            Workspace::load_session(session_name, &root)?
+        } else {
+            Workspace::load(&root)?
+        };
+        let Some(workspace) = workspace else {
+            tracing::debug!("No workspace found for {:?}", root);
+            return Ok(false);
+        };
+        tracing::info!("Found workspace for {:?}, applying...", root);
+
+        // Editor-global config overrides (the shared `Config`).
+        self.restore_config_overrides(&workspace.config_overrides);
+        if !workspace.plugin_global_state.is_empty() {
+            tracing::debug!(
+                "Restoring plugin global state for {} plugins",
+                workspace.plugin_global_state.len()
+            );
+            self.plugin_global_state = workspace.plugin_global_state.clone();
+        }
+
+        let populated = self
+            .windows
+            .get(&id)
+            .map(|w| w.buffers.splits().is_some() && w.buffers.len() > 0)
+            .unwrap_or(false);
+
+        let session = self.session_name.clone();
+        let path_to_buffer = if populated {
+            // Normal path: editor_init has already seeded windows[id], so
+            // restore the layout into the existing window. Unnamed-buffer
+            // recovery must precede the split layout (the layout
+            // references those buffers); it needs the editor's
+            // recovery_service but creates buffers directly in windows[id].
+            let unnamed_buffer_map = self.restore_unnamed_buffers(id, &workspace.unnamed_buffers);
+            let win = self
+                .windows
+                .get_mut(&id)
+                .expect("window present for restore");
+            win.apply_workspace_layout(&workspace, &unnamed_buffer_map, session.as_deref())
+        } else {
+            // Never-seeded shell: build the whole window from the
+            // workspace via the `Window::from_workspace` factory, carrying
+            // over the shell's identity fields.
+            let (label, root2, resources, tw, th, pstate) = {
+                let w = self.windows.get(&id).expect("window present for restore");
+                (
+                    w.label.clone(),
+                    w.root.clone(),
+                    w.resources.clone(),
+                    w.terminal_width,
+                    w.terminal_height,
+                    w.plugin_state.clone(),
+                )
+            };
+            let mut built =
+                crate::app::window::Window::from_workspace(id, label, root2, resources, &workspace);
+            built.terminal_width = tw;
+            built.terminal_height = th;
+            built.plugin_state = pstate;
+            self.windows.insert(id, built);
+            HashMap::new()
+        };
+
+        // Replay hot-exit changes onto the file-backed buffers we opened.
+        self.restore_hot_exit_changes(id, &path_to_buffer);
+
+        // Active-window only: refresh the plugin snapshot and fire
+        // buffer_activated for the restored active buffer. Background
+        // (inactive) window restores must NOT fire these focus effects.
+        if id == self.active_window {
+            #[cfg(feature = "plugins")]
+            {
+                let buffer_id = self.active_buffer();
+                self.update_plugin_state_snapshot();
+                tracing::debug!(
+                    "Firing buffer_activated for active buffer {:?} after workspace restore",
+                    buffer_id
+                );
+                self.plugin_manager.read().unwrap().run_hook(
+                    "buffer_activated",
+                    crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
+                );
+            }
+        }
+
+        Ok(true)
+    }
+
+    /// Save workspaces for every window whose split layout is populated.
+    /// Each window's workspace is keyed by its own `root`.
+    ///
+    /// Returns the first error encountered, if any; logs and continues
+    /// past per-window failures so a single bad window can't block the
+    /// other quits.
+    pub fn save_all_windows_workspaces(&mut self) -> Result<(), WorkspaceError> {
+        let targets: Vec<fresh_core::WindowId> = self
+            .windows
+            .iter()
+            .filter(|(_, w)| w.buffers.splits().is_some())
+            .map(|(id, _)| *id)
+            .collect();
+
+        let mut first_err = None;
+        for id in targets {
+            if let Err(e) = self.save_workspace_for(id) {
+                tracing::warn!("Failed to save workspace for window {id}: {e}");
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+
+        match first_err {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+
+    /// Restore workspaces for every persisted window that isn't the
+    /// already-restored active one, each from its own `root`.
+    ///
+    /// `plugin_global_state` is editor-wide and would otherwise be
+    /// clobbered by the last window we touch, so we snapshot it once and
+    /// restore it after the loop — the active window's restore (run
+    /// before this) is the one whose plugin state we keep.
+    ///
+    /// Best-effort: per-window failures are logged but don't stop the
+    /// loop, so one corrupt workspace file can't blank the others.
+    pub fn restore_inactive_window_workspaces(&mut self) {
+        let active = self.active_window;
+        let saved_plugin_state = self.plugin_global_state.clone();
+
+        let targets: Vec<fresh_core::WindowId> = self
+            .windows
+            .keys()
+            .copied()
+            .filter(|id| *id != active)
+            .collect();
+
+        for id in targets {
+            match self.restore_workspace_for(id) {
+                Ok(true) => tracing::debug!("Restored workspace for inactive window {id}"),
+                Ok(false) => tracing::trace!(
+                    "No persisted workspace for inactive window {id}; seed layout kept"
+                ),
+                Err(e) => {
+                    tracing::warn!("Failed to restore workspace for inactive window {id}: {e}")
+                }
+            }
+        }
+
+        self.plugin_global_state = saved_plugin_state;
+    }
+}
+
+impl crate::app::window::Window {
     fn restore_terminals_from_workspace(
         &mut self,
         terminals: &[SerializedTerminalWorkspace],
@@ -943,10 +779,8 @@ impl Editor {
         if terminals.is_empty() {
             return terminal_buffer_map;
         }
-        let __window_bridge = self.active_window().bridge.clone();
-        self.active_window_mut()
-            .terminal_manager
-            .set_async_bridge(__window_bridge);
+        let __window_bridge = self.bridge.clone();
+        self.terminal_manager.set_async_bridge(__window_bridge);
         for terminal in terminals {
             if let Some(buffer_id) = self.restore_terminal_from_workspace(terminal) {
                 terminal_buffer_map.insert(terminal.terminal_index, buffer_id);
@@ -965,15 +799,9 @@ impl Editor {
             let Some(&buffer_id) = path_to_buffer.get(&bookmark.file_path) else {
                 continue;
             };
-            if let Some(buffer) = self
-                .windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-                .get(&buffer_id)
-            {
+            if let Some(buffer) = self.buffers.get(&buffer_id) {
                 let pos = bookmark.position.min(buffer.buffer.len());
-                self.active_window_mut().bookmarks.set(
+                self.bookmarks.set(
                     *key,
                     Bookmark {
                         buffer_id,
@@ -988,19 +816,15 @@ impl Editor {
     /// split after the workspace has been applied.
     fn clean_orphaned_buffers(&mut self) {
         let referenced: HashSet<BufferId> = self
-            .windows
-            .get(&self.active_window)
-            .and_then(|w| w.buffers.splits())
+            .buffers
+            .splits()
             .map(|(_, vs)| vs)
             .expect("active window must have a populated split layout")
             .values()
             .flat_map(|vs| vs.buffer_tab_ids())
             .collect();
         let orphans: Vec<BufferId> = self
-            .windows
-            .get(&self.active_window)
-            .map(|w| &w.buffers)
-            .expect("active window present")
+            .buffers
             .iter()
             .filter(|(id, state)| {
                 !referenced.contains(id)
@@ -1011,48 +835,33 @@ impl Editor {
             .collect();
         for id in orphans {
             tracing::debug!("Removing orphaned empty unnamed buffer {:?}", id);
-            self.windows
-                .get_mut(&self.active_window)
-                .map(|w| &mut w.buffers)
-                .expect("active window present")
-                .remove(&id);
-            self.detach_buffer_from_all_windows(id);
-            self.active_window_mut().event_logs.remove(&id);
-            self.active_window_mut().buffer_metadata.remove(&id);
+            self.buffers.remove(&id);
+            self.event_logs.remove(&id);
+            self.buffer_metadata.remove(&id);
         }
     }
 
     /// Set a status-bar message summarising how many buffers were restored and from
     /// which session, then emit a debug log with split/buffer counts.
-    fn log_restore_summary(&mut self) {
+    fn log_restore_summary(&mut self, session_name: Option<&str>) {
         tracing::debug!(
             "Workspace restore complete: {} splits, {} buffers",
-            self.windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
+            self.buffers
+                .splits()
                 .map(|(_, vs)| vs)
                 .expect("active window must have a populated split layout")
                 .len(),
-            self.windows
-                .get(&self.active_window)
-                .map(|w| &w.buffers)
-                .expect("active window present")
-                .len()
+            self.buffers.len()
         );
-        let restored_count = self.buffers().count_where(|id, _| {
-            self.active_window()
-                .buffer_metadata
+        let restored_count = self.buffers.count_where(|id, _| {
+            self.buffer_metadata
                 .get(&id)
                 .is_some_and(|m| !m.hidden_from_tabs && !m.is_virtual())
         });
         if restored_count == 0 {
             return;
         }
-        let msg = match self
-            .session_name
-            .as_ref()
-            .map(|n| format!("session '{}'", n))
-        {
+        let msg = match session_name.map(|n| format!("session '{}'", n)) {
             Some(label) => format!("Restored {} ({} buffer(s))", label, restored_count),
             None => format!(
                 "Restored {} buffer(s) from previous session",
@@ -1075,7 +884,10 @@ impl Editor {
         terminal: &SerializedTerminalWorkspace,
     ) -> Option<BufferId> {
         // Resolve paths (accept absolute; otherwise treat as relative to terminals dir)
-        let terminals_root = self.dir_context.terminal_dir_for(self.working_dir());
+        let terminals_root = self
+            .resources
+            .dir_context
+            .terminal_dir_for(self.root.as_path());
         let log_path = if terminal.log_path.is_absolute() {
             terminal.log_path.clone()
         } else {
@@ -1089,7 +901,7 @@ impl Editor {
 
         // Best-effort directory creation for terminal backing files
         #[allow(clippy::let_underscore_must_use)]
-        let _ = self.authority.filesystem.create_dir_all(
+        let _ = self.resources.authority.filesystem.create_dir_all(
             log_path
                 .parent()
                 .or_else(|| backing_path.parent())
@@ -1097,29 +909,22 @@ impl Editor {
         );
 
         // Record paths using the predicted ID so buffer creation can reuse them
-        let predicted_id = self.active_window().terminal_manager.next_terminal_id();
-        self.active_window_mut()
-            .terminal_log_files
+        let predicted_id = self.terminal_manager.next_terminal_id();
+        self.terminal_log_files
             .insert(predicted_id, log_path.clone());
-        self.active_window_mut()
-            .terminal_backing_files
+        self.terminal_backing_files
             .insert(predicted_id, backing_path.clone());
 
         // Spawn the terminal with backing file for incremental scrollback
         let wrapper_for_spawn = self.resolved_terminal_wrapper();
-        let terminal_id = match self
-            .windows
-            .get_mut(&self.active_window)
-            .map(|w| &mut w.terminal_manager)
-            .expect("active window present")
-            .spawn(
-                terminal.cols,
-                terminal.rows,
-                terminal.cwd.clone(),
-                Some(log_path.clone()),
-                Some(backing_path.clone()),
-                wrapper_for_spawn,
-            ) {
+        let terminal_id = match self.terminal_manager.spawn(
+            terminal.cols,
+            terminal.rows,
+            terminal.cwd.clone(),
+            Some(log_path.clone()),
+            Some(backing_path.clone()),
+            wrapper_for_spawn,
+        ) {
             Ok(id) => id,
             Err(e) => {
                 tracing::warn!(
@@ -1133,18 +938,12 @@ impl Editor {
 
         // Ensure maps keyed by actual ID
         if terminal_id != predicted_id {
-            self.active_window_mut()
-                .terminal_log_files
+            self.terminal_log_files
                 .insert(terminal_id, log_path.clone());
-            self.active_window_mut()
-                .terminal_backing_files
+            self.terminal_backing_files
                 .insert(terminal_id, backing_path.clone());
-            self.active_window_mut()
-                .terminal_log_files
-                .remove(&predicted_id);
-            self.active_window_mut()
-                .terminal_backing_files
-                .remove(&predicted_id);
+            self.terminal_log_files.remove(&predicted_id);
+            self.terminal_backing_files.remove(&predicted_id);
         }
 
         // Create buffer for this terminal
@@ -1167,25 +966,24 @@ impl Editor {
             return;
         }
 
-        let large_file_threshold = self.config.editor.large_file_threshold_bytes as usize;
+        let large_file_threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
         if let Ok(new_state) = EditorState::from_file_with_languages(
             backing_path,
             self.terminal_width,
             self.terminal_height,
             large_file_threshold,
-            &self.grammar_registry,
-            &self.config.languages,
-            std::sync::Arc::clone(&self.authority.filesystem),
+            &self.resources.grammar_registry,
+            &self.resources.config.languages,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
         ) {
-            self.active_window_mut()
-                .install_terminal_buffer_state(buffer_id, new_state);
+            self.install_terminal_buffer_state(buffer_id, new_state);
         }
     }
 
     /// Internal helper to open a file and return its buffer ID
     fn open_file_internal(&mut self, path: &Path) -> Result<BufferId, WorkspaceError> {
         // Check if file is already open
-        for (buffer_id, metadata) in &self.active_window().buffer_metadata {
+        for (buffer_id, metadata) in &self.buffer_metadata {
             if let Some(file_path) = metadata.file_path() {
                 if file_path == path {
                     return Ok(*buffer_id);
@@ -1194,7 +992,7 @@ impl Editor {
         }
 
         // File not open, open it using the Editor's open_file method
-        self.open_file(path).map_err(WorkspaceError::Io)
+        self.open_file_no_focus(path).map_err(WorkspaceError::Io)
     }
 
     /// Recursively restore the split layout from a serialized tree
@@ -1231,19 +1029,17 @@ impl Editor {
                 let current_leaf_id = if is_first_leaf {
                     // First leaf reuses the existing split
                     let leaf_id = self
-                        .windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.buffers.splits())
+                        .buffers
+                        .splits()
                         .map(|(mgr, _)| mgr)
                         .expect("active window must have a populated split layout")
                         .active_split();
-                    self.active_window_mut().set_pane_buffer(leaf_id, buffer_id);
+                    self.set_pane_buffer(leaf_id, buffer_id);
                     leaf_id
                 } else {
                     // Non-first leaves use the active split (created by split_active)
-                    self.windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.buffers.splits())
+                    self.buffers
+                        .splits()
                         .map(|(mgr, _)| mgr)
                         .expect("active window must have a populated split layout")
                         .active_split()
@@ -1254,9 +1050,8 @@ impl Editor {
 
                 // Restore label if present
                 if let Some(label) = label {
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .set_label(current_leaf_id, label.clone());
                 }
@@ -1264,14 +1059,12 @@ impl Editor {
                 // Restore role tag if present (clearing any prior holder
                 // first to preserve the at-most-one-leaf-per-role invariant).
                 if let Some(role) = role {
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .clear_role(*role);
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .set_leaf_role(current_leaf_id, Some(*role));
                 }
@@ -1299,18 +1092,16 @@ impl Editor {
 
                 let current_leaf_id = if is_first_leaf {
                     let leaf_id = self
-                        .windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.buffers.splits())
+                        .buffers
+                        .splits()
                         .map(|(mgr, _)| mgr)
                         .expect("active window must have a populated split layout")
                         .active_split();
-                    self.active_window_mut().set_pane_buffer(leaf_id, buffer_id);
+                    self.set_pane_buffer(leaf_id, buffer_id);
                     leaf_id
                 } else {
-                    self.windows
-                        .get(&self.active_window)
-                        .and_then(|w| w.buffers.splits())
+                    self.buffers
+                        .splits()
                         .map(|(mgr, _)| mgr)
                         .expect("active window must have a populated split layout")
                         .active_split()
@@ -1320,9 +1111,8 @@ impl Editor {
 
                 // Restore label if present
                 if let Some(label) = label {
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .set_label(current_leaf_id, label.clone());
                 }
@@ -1330,21 +1120,18 @@ impl Editor {
                 // Restore role tag for terminal leaves (same one-per-role
                 // invariant as the file-leaf branch above).
                 if let Some(role) = role {
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .clear_role(*role);
-                    self.windows
-                        .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                    self.buffers
+                        .split_manager_mut()
                         .expect("active window must have a populated split layout")
                         .set_leaf_role(current_leaf_id, Some(*role));
                 }
 
-                self.windows
-                    .get_mut(&self.active_window)
-                    .and_then(|w| w.split_manager_mut())
+                self.buffers
+                    .split_manager_mut()
                     .expect("active window must have a populated split layout")
                     .set_split_buffer(current_leaf_id, buffer_id);
 
@@ -1391,11 +1178,12 @@ impl Editor {
                 };
 
                 // Create the split for the second child
-                match self.split_manager_mut().split_active(
-                    split_direction,
-                    second_buffer_id,
-                    *ratio,
-                ) {
+                match self
+                    .buffers
+                    .split_manager_mut()
+                    .expect("active window must have a populated split layout")
+                    .split_active(split_direction, second_buffer_id, *ratio)
+                {
                     Ok(new_leaf_id) => {
                         // Create view state for the new split
                         let mut view_state = SplitViewState::with_buffer(
@@ -1404,18 +1192,15 @@ impl Editor {
                             second_buffer_id,
                         );
                         view_state.apply_config_defaults(
-                            self.config.editor.line_numbers,
-                            self.config.editor.highlight_current_line,
-                            self.active_window()
-                                .resolve_line_wrap_for_buffer(second_buffer_id),
-                            self.config.editor.wrap_indent,
-                            self.active_window()
-                                .resolve_wrap_column_for_buffer(second_buffer_id),
-                            self.config.editor.rulers.clone(),
+                            self.resources.config.editor.line_numbers,
+                            self.resources.config.editor.highlight_current_line,
+                            self.resolve_line_wrap_for_buffer(second_buffer_id),
+                            self.resources.config.editor.wrap_indent,
+                            self.resolve_wrap_column_for_buffer(second_buffer_id),
+                            self.resources.config.editor.rulers.clone(),
                         );
-                        self.windows
-                            .get_mut(&self.active_window)
-                            .and_then(|w| w.split_view_states_mut())
+                        self.buffers
+                            .split_view_states_mut()
                             .expect("active window must have a populated split layout")
                             .insert(new_leaf_id, view_state);
 
@@ -1459,12 +1244,12 @@ impl Editor {
         // Resolve the split-manager-assigned buffer before taking the
         // &mut borrow on windows so the borrow stays disjoint from
         // any subsequent reads.
-        let split_buf_for_current = self.split_manager().buffer_for_split(current_split_id);
-        let active_id = self.active_window;
+        let split_buf_for_current = self
+            .buffers
+            .split_manager()
+            .expect("active window must have a populated split layout")
+            .buffer_for_split(current_split_id);
         let active_buffer_id = self
-            .windows
-            .get_mut(&active_id)
-            .expect("active window must exist")
             .buffers
             .with_all_mut(|__buffers_mut, _mgr, vs_map| {
                 let Some(view_state) = vs_map.get_mut(&current_split_id) else {
@@ -1704,119 +1489,438 @@ impl Editor {
         // hook). Done after the view_state borrow ends so we can take a
         // second &mut borrow on self.windows for the split manager.
         if let Some(active_buf_id) = active_buffer_id {
-            self.windows
-                .get_mut(&active_id)
-                .and_then(|w| w.split_manager_mut())
+            self.buffers
+                .split_manager_mut()
                 .expect("active window must have a populated split layout")
                 .set_split_buffer(current_split_id, active_buf_id);
         }
     }
 
-    /// Run `f` with `id` temporarily set as the active window, then
-    /// restore the previous active window. The single, guarded home for
-    /// the "act as another window" redirect the batch save/restore need:
-    /// the per-window workspace helpers (and `working_dir()`, which
-    /// derives from the active window's root) all key off
-    /// `self.active_window`, and the file-open machinery they call
-    /// (`Editor::open_file` → LSP / buffer alloc) is active-window-scoped,
-    /// so a `WindowId`-parameterized restore is implemented by this
-    /// redirect rather than threading an id through `open_file`.
-    ///
-    /// This is a transient internal redirect — it deliberately does NOT
-    /// fire `active_window_changed` hooks (unlike `set_active_window`).
-    fn with_active_window<R>(
+    fn restore_search_options(&mut self, opts: &SearchOptions) {
+        self.search_case_sensitive = opts.case_sensitive;
+        self.search_whole_word = opts.whole_word;
+        self.search_use_regex = opts.use_regex;
+        self.search_confirm_each = opts.confirm_each;
+    }
+
+    fn restore_prompt_histories(&mut self, histories: &WorkspaceHistories) {
+        tracing::debug!(
+            "Restoring histories: {} search, {} replace, {} goto_line",
+            histories.search.len(),
+            histories.replace.len(),
+            histories.goto_line.len()
+        );
+        for item in &histories.search {
+            self.prompt_histories
+                .entry("search".to_string())
+                .or_default()
+                .push(item.clone());
+        }
+        for item in &histories.replace {
+            self.prompt_histories
+                .entry("replace".to_string())
+                .or_default()
+                .push(item.clone());
+        }
+        for item in &histories.goto_line {
+            self.prompt_histories
+                .entry("goto_line".to_string())
+                .or_default()
+                .push(item.clone());
+        }
+    }
+
+    fn restore_file_explorer_settings(&mut self, fe: &FileExplorerState) {
+        self.file_explorer_visible = fe.visible;
+        self.file_explorer_width = fe.width;
+        self.file_explorer_side = fe.side;
+
+        // Store pending settings (fixes #569); applied when explorer initialises (async).
+        if fe.show_hidden {
+            self.pending_file_explorer_show_hidden = Some(true);
+        }
+        if fe.show_gitignored {
+            self.pending_file_explorer_show_gitignored = Some(true);
+        }
+
+        // Keep key_context as Normal so the editor (not the explorer) has focus.
+        if self.file_explorer_visible && self.file_explorer.is_none() {
+            self.init_file_explorer();
+        }
+    }
+
+    /// Open every file referenced by the saved split states, returning a map
+    /// from relative (or absolute) path to the new `BufferId`.
+    fn open_workspace_files(
         &mut self,
-        id: fresh_core::WindowId,
-        f: impl FnOnce(&mut Self) -> R,
-    ) -> R {
-        let prev = self.active_window;
-        self.active_window = id;
-        let result = f(self);
-        self.active_window = prev;
-        result
-    }
-
-    /// Save a specific window's workspace (keyed by its `root`).
-    pub fn save_workspace_for(&mut self, id: fresh_core::WindowId) -> Result<(), WorkspaceError> {
-        self.with_active_window(id, |e| e.save_workspace())
-    }
-
-    /// Restore a specific window's workspace from disk.
-    pub fn restore_workspace_for(
-        &mut self,
-        id: fresh_core::WindowId,
-    ) -> Result<bool, WorkspaceError> {
-        self.with_active_window(id, |e| e.try_restore_workspace())
-    }
-
-    /// Save workspaces for every window whose split layout is populated.
-    /// Each window's workspace is keyed by its own `root`.
-    ///
-    /// Returns the first error encountered, if any; logs and continues
-    /// past per-window failures so a single bad window can't block the
-    /// other quits.
-    pub fn save_all_windows_workspaces(&mut self) -> Result<(), WorkspaceError> {
-        let targets: Vec<fresh_core::WindowId> = self
-            .windows
-            .iter()
-            .filter(|(_, w)| w.buffers.splits().is_some())
-            .map(|(id, _)| *id)
-            .collect();
-
-        let mut first_err = None;
-        for id in targets {
-            if let Err(e) = self.save_workspace_for(id) {
-                tracing::warn!("Failed to save workspace for window {id}: {e}");
-                if first_err.is_none() {
-                    first_err = Some(e);
+        split_states: &HashMap<usize, SerializedSplitViewState>,
+    ) -> HashMap<PathBuf, BufferId> {
+        let file_paths = collect_file_paths_from_states(split_states);
+        tracing::debug!(
+            "Workspace has {} files to restore: {:?}",
+            file_paths.len(),
+            file_paths
+        );
+        let mut path_to_buffer: HashMap<PathBuf, BufferId> = HashMap::new();
+        for rel_path in file_paths {
+            let abs_path = self.root.join(&rel_path);
+            tracing::trace!(
+                "Checking file: {:?} (exists: {})",
+                abs_path,
+                abs_path.exists()
+            );
+            if abs_path.exists() {
+                match self.open_file_internal(&abs_path) {
+                    Ok(buffer_id) => {
+                        tracing::debug!("Opened file {:?} as buffer {:?}", rel_path, buffer_id);
+                        path_to_buffer.insert(rel_path, buffer_id);
+                    }
+                    Err(e) => tracing::warn!("Failed to open file {:?}: {}", abs_path, e),
                 }
+            } else {
+                tracing::debug!("Skipping non-existent file: {:?}", abs_path);
             }
         }
+        tracing::debug!("Opened {} files from workspace", path_to_buffer.len());
+        path_to_buffer
+    }
 
-        match first_err {
-            Some(e) => Err(e),
-            None => Ok(()),
+    /// Restore files that live outside the working directory (stored as absolute paths).
+    fn restore_external_files(
+        &mut self,
+        external_files: &[PathBuf],
+        path_to_buffer: &mut HashMap<PathBuf, BufferId>,
+    ) {
+        if external_files.is_empty() {
+            return;
+        }
+        tracing::debug!(
+            "Restoring {} external files: {:?}",
+            external_files.len(),
+            external_files
+        );
+        for abs_path in external_files {
+            if !abs_path.exists() {
+                tracing::debug!("Skipping non-existent external file: {:?}", abs_path);
+                continue;
+            }
+            match self.open_file_internal(abs_path) {
+                Ok(buffer_id) => {
+                    path_to_buffer.insert(abs_path.clone(), buffer_id);
+                    tracing::debug!(
+                        "Restored external file {:?} as buffer {:?}",
+                        abs_path,
+                        buffer_id
+                    );
+                }
+                Err(e) => tracing::warn!("Failed to restore external file {:?}: {}", abs_path, e),
+            }
         }
     }
 
-    /// Restore workspaces for every persisted window that isn't the
-    /// already-restored active one, each from its own `root`.
-    ///
-    /// `plugin_global_state` is editor-wide and would otherwise be
-    /// clobbered by the last window we touch, so we snapshot it once and
-    /// restore it after the loop — the active window's restore (run
-    /// before this) is the one whose plugin state we keep.
-    ///
-    /// Best-effort: per-window failures are logged but don't stop the
-    /// loop, so one corrupt workspace file can't blank the others.
-    pub fn restore_inactive_window_workspaces(&mut self) {
-        let active = self.active_window;
-        let saved_plugin_state = self.plugin_global_state.clone();
+    /// Re-apply read-only flags for files that were locked in the saved session.
+    /// Paths may be relative (under this window's `root`) or absolute.
+    fn apply_read_only_flags(
+        &mut self,
+        read_only_files: &[PathBuf],
+        path_to_buffer: &HashMap<PathBuf, BufferId>,
+    ) {
+        for ro_path in read_only_files {
+            let buffer_id = path_to_buffer
+                .get(ro_path)
+                .copied()
+                .or_else(|| path_to_buffer.get(&self.root.join(ro_path)).copied());
+            if let Some(id) = buffer_id {
+                self.mark_buffer_read_only(id, true);
+            }
+        }
+    }
 
-        let targets: Vec<fresh_core::WindowId> = self
-            .windows
-            .keys()
+    /// True when this window has any virtual buffer (Dashboard, plugin
+    /// scratch buffers, etc.) — used by the save path to detect the
+    /// Dashboard-only-quit case where the serializer produces an empty
+    /// snapshot.
+    pub(crate) fn has_any_virtual_buffer(&self) -> bool {
+        self.buffer_metadata
+            .values()
+            .any(|m| matches!(m.kind, crate::app::types::BufferKind::Virtual { .. }))
+    }
+
+    /// Persist per-file global state (cursor/scroll) for every file
+    /// buffer in this window's splits.
+    pub(crate) fn save_all_global_file_states(&self) {
+        for (leaf_id, view_state) in self
+            .buffers
+            .splits()
+            .map(|(_, vs)| vs)
+            .expect("window must have a populated split layout")
+        {
+            let active_buffer = self
+                .buffers
+                .splits()
+                .map(|(mgr, _)| mgr)
+                .expect("window must have a populated split layout")
+                .root()
+                .get_leaves_with_rects(ratatui::layout::Rect::default())
+                .into_iter()
+                .find(|(sid, _, _)| *sid == *leaf_id)
+                .map(|(_, buffer_id, _)| buffer_id);
+
+            if let Some(buffer_id) = active_buffer {
+                self.save_buffer_file_state(buffer_id, view_state);
+            }
+        }
+    }
+
+    /// Save per-file global state (cursor/scroll) for a specific buffer.
+    fn save_buffer_file_state(&self, buffer_id: BufferId, view_state: &SplitViewState) {
+        let abs_path = match self.buffer_metadata.get(&buffer_id) {
+            Some(metadata) => match metadata.file_path() {
+                Some(path) => path.to_path_buf(),
+                None => return,
+            },
+            None => return,
+        };
+
+        let primary_cursor = view_state.cursors.primary();
+        let file_state = SerializedFileState {
+            cursor: SerializedCursor {
+                position: primary_cursor.position,
+                anchor: primary_cursor.anchor,
+                sticky_column: primary_cursor.sticky_column,
+            },
+            additional_cursors: view_state
+                .cursors
+                .iter()
+                .skip(1)
+                .map(|(_, cursor)| SerializedCursor {
+                    position: cursor.position,
+                    anchor: cursor.anchor,
+                    sticky_column: cursor.sticky_column,
+                })
+                .collect(),
+            scroll: SerializedScroll {
+                top_byte: view_state.viewport.top_byte,
+                top_view_line_offset: view_state.viewport.top_view_line_offset,
+                left_column: view_state.viewport.left_column,
+            },
+            view_mode: Default::default(),
+            compose_width: None,
+            plugin_state: std::collections::HashMap::new(),
+            folds: Vec::new(),
+        };
+
+        PersistedFileWorkspace::save(&abs_path, file_state);
+    }
+
+    /// Sync this window's active terminal visible screens to their
+    /// backing files (so the snapshot captures complete terminal state).
+    pub(crate) fn sync_terminal_backing_files(&self) {
+        use std::io::BufWriter;
+
+        let terminals_to_sync: Vec<_> = self
+            .terminal_buffers
+            .values()
             .copied()
-            .filter(|id| *id != active)
+            .filter_map(|terminal_id| {
+                self.terminal_backing_files
+                    .get(&terminal_id)
+                    .map(|path| (terminal_id, path.clone()))
+            })
             .collect();
 
-        for id in targets {
-            match self.restore_workspace_for(id) {
-                Ok(true) => tracing::debug!("Restored workspace for inactive window {id}"),
-                Ok(false) => tracing::trace!(
-                    "No persisted workspace for inactive window {id}; seed layout kept"
-                ),
-                Err(e) => {
-                    tracing::warn!("Failed to restore workspace for inactive window {id}: {e}")
+        for (terminal_id, backing_path) in terminals_to_sync {
+            if let Some(handle) = self.terminal_manager.get(terminal_id) {
+                if let Ok(state) = handle.state.lock() {
+                    if let Ok(mut file) = self
+                        .resources
+                        .authority
+                        .filesystem
+                        .open_file_for_append(&backing_path)
+                    {
+                        let mut writer = BufWriter::new(&mut *file);
+                        if let Err(e) = state.append_visible_screen(&mut writer) {
+                            tracing::warn!(
+                                "Failed to sync terminal {:?} to backing file: {}",
+                                terminal_id,
+                                e
+                            );
+                        }
+                    }
                 }
             }
         }
-
-        self.plugin_global_state = saved_plugin_state;
     }
-}
 
-impl crate::app::window::Window {
+    /// Create an unnamed (unsaved) buffer in this window from recovered
+    /// hot-exit content. Window-scoped, no focus side-effects — the
+    /// split-layout restore wires it into a tab afterwards.
+    pub(crate) fn create_unnamed_recovery_buffer(
+        &mut self,
+        text: &str,
+        recovery_id: String,
+        display_name: String,
+    ) -> BufferId {
+        let buffer_id = self.alloc_buffer_id();
+        let mut state = EditorState::new(
+            self.terminal_width,
+            self.terminal_height,
+            self.resources.config.editor.large_file_threshold_bytes as usize,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
+        );
+        state
+            .margins
+            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
+        state.buffer.set_default_line_ending(
+            self.resources
+                .config
+                .editor
+                .default_line_ending
+                .to_line_ending(),
+        );
+        state.buffer.insert(0, text);
+        state.buffer.set_modified(true);
+        state.buffer.set_recovery_pending(false);
+        self.buffers.insert(buffer_id, state);
+
+        let mut log = crate::model::event::EventLog::new();
+        log.clear_saved_position();
+        self.event_logs.insert(buffer_id, log);
+
+        let mut meta = crate::app::types::BufferMetadata::new();
+        meta.recovery_id = Some(recovery_id);
+        meta.display_name = display_name;
+        self.buffer_metadata.insert(buffer_id, meta);
+
+        buffer_id
+    }
+
+    /// Seed this window with the initial empty buffer + single-leaf split
+    /// layout, if it doesn't already have a populated layout. Mirrors
+    /// `Editor::build_fresh_layout_if_needed`, rooted on `self`.
+    pub(crate) fn seed_initial_layout(&mut self) {
+        if self.buffers.splits().is_some() && self.buffers.len() > 0 {
+            return;
+        }
+        let buf = self.alloc_buffer_id();
+        let mut state = EditorState::new(
+            self.terminal_width,
+            self.terminal_height,
+            self.resources.config.editor.large_file_threshold_bytes as usize,
+            std::sync::Arc::clone(&self.resources.authority.filesystem),
+        );
+        state
+            .margins
+            .configure_for_line_numbers(self.resources.config.editor.line_numbers);
+        state.buffer.set_default_line_ending(
+            self.resources
+                .config
+                .editor
+                .default_line_ending
+                .to_line_ending(),
+        );
+        let manager = crate::view::split::SplitManager::new(buf);
+        let active_leaf = manager.active_split();
+        let mut view_states = HashMap::new();
+        view_states.insert(
+            active_leaf,
+            SplitViewState::with_buffer(self.terminal_width, self.terminal_height, buf),
+        );
+        self.buffers.set_splits((manager, view_states));
+        self.buffers.insert(buf, state);
+        self.buffer_metadata
+            .insert(buf, crate::app::types::BufferMetadata::new());
+        self.event_logs
+            .insert(buf, crate::model::event::EventLog::new());
+    }
+
+    /// Apply a loaded workspace's **window-local** layout onto this
+    /// window: search options, prompt histories, file-explorer settings,
+    /// the opened files (`open_file_no_focus`, no focus side-effects),
+    /// external + read-only files, terminals, the split tree + per-split
+    /// view state, bookmarks, orphan cleanup, and the restore summary.
+    ///
+    /// `unnamed_buffer_map` is the result of the editor-global
+    /// `restore_unnamed_buffers` (run beforehand because the split tree
+    /// references those buffers). Returns the path→`BufferId` map so the
+    /// caller can replay editor-global hot-exit changes onto the opened
+    /// files. The editor-global steps (config overrides beyond
+    /// `mouse_enabled`, plugin global state, hot-exit recovery, and the
+    /// active-window plugin snapshot + `buffer_activated`) live on
+    /// `Editor::restore_workspace_for`.
+    pub(crate) fn apply_workspace_layout(
+        &mut self,
+        workspace: &Workspace,
+        unnamed_buffer_map: &HashMap<String, BufferId>,
+        session_name: Option<&str>,
+    ) -> HashMap<PathBuf, BufferId> {
+        tracing::debug!(
+            "Applying workspace layout with {} split states",
+            workspace.split_states.len()
+        );
+
+        // Window-local config override (the rest of the overrides mutate
+        // the editor-global `Config` and are applied by the caller).
+        if let Some(mouse_enabled) = workspace.config_overrides.mouse_enabled {
+            self.mouse_enabled = mouse_enabled;
+        }
+
+        self.restore_search_options(&workspace.search_options);
+        self.restore_prompt_histories(&workspace.histories);
+        self.restore_file_explorer_settings(&workspace.file_explorer);
+
+        let mut path_to_buffer = self.open_workspace_files(&workspace.split_states);
+        self.restore_external_files(&workspace.external_files, &mut path_to_buffer);
+        self.apply_read_only_flags(&workspace.read_only_files, &path_to_buffer);
+
+        let terminal_buffer_map = self.restore_terminals_from_workspace(&workspace.terminals);
+
+        let mut split_id_map: HashMap<usize, SplitId> = HashMap::new();
+        self.restore_split_node(
+            &workspace.split_layout,
+            &path_to_buffer,
+            &terminal_buffer_map,
+            unnamed_buffer_map,
+            &workspace.split_states,
+            &mut split_id_map,
+            true,
+        );
+
+        if let Some(&new_active_split) = split_id_map.get(&workspace.active_split_id) {
+            self.buffers
+                .split_manager_mut()
+                .expect("window must have a populated split layout")
+                .set_active_split(LeafId(new_active_split));
+        }
+
+        self.restore_bookmarks_from_workspace(&workspace.bookmarks, &path_to_buffer);
+        self.clean_orphaned_buffers();
+        self.log_restore_summary(session_name);
+
+        path_to_buffer
+    }
+
+    /// Build a `Window` directly from a persisted `Workspace`: construct
+    /// a fresh window, seed its initial layout, then apply the workspace
+    /// layout into it. The realized "restore is a Window factory" design
+    /// (the `open_file` move in this branch removed the prior blocker
+    /// that kept restore on `Editor`). Editor-global recovery
+    /// (hot-exit / unnamed buffers via `recovery_service`) is layered on
+    /// by `Editor::restore_workspace_for`; this factory restores the pure
+    /// window-local layout.
+    pub(crate) fn from_workspace(
+        id: fresh_core::WindowId,
+        label: impl Into<String>,
+        root: PathBuf,
+        resources: crate::app::window_resources::WindowResources,
+        workspace: &Workspace,
+    ) -> Self {
+        let mut window = Self::new(id, label, root, resources);
+        window.seed_initial_layout();
+        window.apply_workspace_layout(workspace, &HashMap::new(), None);
+        window
+    }
+
     /// Snapshot THIS window's restorable state into a `Workspace`,
     /// rooted at `self.root` and reading only window-owned state +
     /// `self.resources`. The inverse of restore. `plugin_global_state`

--- a/docs/internal/orchestrator-bringup-dataflow-review.md
+++ b/docs/internal/orchestrator-bringup-dataflow-review.md
@@ -218,10 +218,12 @@ In order of leverage (✅ = landed on this branch):
 4. ✅ **Derive `working_dir` from `active_window().root`** (§2) — the
    field is deleted; the boot invariant is unconditional; the two
    batch-workspace functions no longer flip a `working_dir` copy.
-5. 🟡 **Workspace capture/restore off the active-window flip** (§10) —
-   capture moved onto `Window` (done); restore stays editor-coupled
-   (opens files via `Editor::open_file`/LSP) and is parameterized by
-   `WindowId` to drop the flip (remaining).
+5. ✅ **Workspace capture/restore off the active-window flip** (§10) —
+   the `open_file` core moved onto `Window`, so both capture and restore
+   are window-scoped: `Window::capture_workspace` +
+   `Window::apply_workspace_layout` + the `Window::from_workspace`
+   factory. `with_active_window` and every `self.active_window = …` write
+   in the save/restore path are deleted.
 6. ⬜ **Unify the restore path** (§6) — first-run vs restart vs harness.
 
 Net effect on the branch/state matrix (✅ already realized):
@@ -229,7 +231,7 @@ Net effect on the branch/state matrix (✅ already realized):
 - ✅ `working_dir` vs `active_window().root` divergence → unrepresentable.
 - ✅ id-1 fallback collision special-case → gone.
 - ✅ explorer "first-init sticky at working_dir" hazard → gone.
-- ⬜ active-window-flip dance in workspace save/restore → §10.
+- ✅ active-window-flip dance in workspace save/restore → gone (§10).
 - ⬜ two restore implementations → one (§6).
 
 ---
@@ -259,68 +261,80 @@ helpers). To save/restore a *non-active* window, the two batch functions
 temporarily flip the global `active_window` pointer. That flip is a
 window-scoped operation faked with editor-global state.
 
-### Finding: capture is window-pure, restore is editor-coupled
+### Finding: both capture AND restore are now window-scoped ✅
 
-Implementation surfaced an asymmetry:
+The original implementation surfaced an asymmetry — capture was
+window-pure but restore reached into `Editor::open_file` (LSP attach,
+buffer allocation, grammar/syntax). That made a `Window::from_workspace`
+constructor look impossible **as long as `open_file` stayed on `Editor`.**
 
-- **Capture (save) is pure window-read.** ✅ Moved:
-  `Window::capture_workspace(&self) -> Workspace` reads only the window's
-  own state + `self.resources` (no editor reach). `Editor::capture_workspace`
+That condition has since been removed. The `open_file` core
+(`open_file_no_focus` / `open_file_for_preview` /
+`open_file_no_focus_inner`) plus its window-local helpers
+(`notify_lsp_file_opened`, `watch_file`) were moved onto `impl Window`
+(rooted at `self.root` / `self.resources`); `Editor::open_file` is now a
+thin active-window **focus** wrapper. With the file-open core
+window-scoped, the whole restore path moved onto `Window` too:
+
+- **Capture (save):** `Window::capture_workspace(&self) -> Workspace`
+  (reads only window state + `self.resources`). `Editor::capture_workspace`
   delegates and injects the editor-global `plugin_global_state`.
 
-- **Restore (apply) is editor-coupled and CANNOT be a pure `Window`
-  constructor.** Restoring opens files via
-  `open_workspace_files → open_file_internal → Editor::open_file`, which
-  pulls in **LSP attach, buffer allocation, grammar/syntax** — all
-  editor-level (LSP is editor-spawned, per-window). A
-  `Window::from_workspace(...)` constructor would require relocating the
-  whole file-open subsystem onto `Window`, which is out of scope and not
-  desirable. So **there is no `from_workspace` constructor.**
+- **Restore (apply):** `Window::apply_workspace_layout(&mut self, ws,
+  unnamed_buffer_map, session_name) -> path_to_buffer` does every
+  window-local step (search options, prompt histories, file-explorer
+  settings, `open_workspace_files`/`restore_external_files` via
+  `open_file_no_focus`, read-only flags, terminals, the split tree +
+  per-split view state, bookmarks, orphan cleanup, restore summary). The
+  ~14 helpers it calls are all `impl Window` methods now.
 
-### Revised restore-side plan: parameterize by `WindowId` (no flip)
+- **`Window::from_workspace(id, label, root, resources, ws) -> Window`
+  IS the realized factory** (`Window::new(...)` → `seed_initial_layout()`
+  → `apply_workspace_layout(...)`). `restore_workspace_for` uses it to
+  build a never-seeded shell from disk.
 
-`apply_workspace` / `try_restore_workspace` stay on `Editor` but take an
-explicit target window instead of implicitly using the active one — that
-removes the active-pointer flip without moving the file-open machinery:
+### Realized restore-side design: window factory, no flip
+
+`save_workspace_for` / `restore_workspace_for` take an explicit target
+window and operate on `windows[id]` directly — **the `with_active_window`
+active-pointer flip is deleted** (along with every `self.active_window =
+…` write in the save/restore path):
 
 ```rust
-impl Window { pub(crate) fn capture_workspace(&self) -> Workspace; }   // DONE
+impl Window {
+    pub(crate) fn capture_workspace(&self) -> Workspace;                                  // DONE
+    pub(crate) fn apply_workspace_layout(&mut self, ws, unnamed_map, session) -> PathMap; // DONE
+    pub(crate) fn from_workspace(id, label, root, resources, ws) -> Window;               // DONE
+}
 
 impl Editor {
-    pub fn save_workspace_for(&mut self, id: WindowId) -> Result<(), WorkspaceError>;     // windows[id].capture_workspace() + disk + plugin_global
-    pub fn restore_workspace_for(&mut self, id: WindowId) -> Result<bool, WorkspaceError>; // apply into windows[id] via editor services
-    // existing names become thin active-window wrappers:
+    pub fn save_workspace_for(&mut self, id: WindowId) -> Result<(), WorkspaceError>;      // windows[id].capture_workspace() + disk + plugin_global
+    pub fn restore_workspace_for(&mut self, id: WindowId) -> Result<bool, WorkspaceError>; // apply into windows[id]; no flip
+    // existing names are thin active-window wrappers:
     pub fn save_workspace(&mut self)        -> Result<(), WorkspaceError> { self.save_workspace_for(self.active_window) }
     pub fn try_restore_workspace(&mut self) -> Result<bool, WorkspaceError> { self.restore_workspace_for(self.active_window) }
-    // batch ops become plain loops — the active_window flip is deleted:
+    // batch ops are plain loops — the active_window flip is gone:
     pub fn save_all_windows_workspaces(&mut self) -> Result<(), WorkspaceError>;
     pub fn restore_inactive_window_workspaces(&mut self);
 }
 ```
 
-`restore_workspace_for(id)` threads `id` through the ~12 window-scoped
-restore helpers (`open_workspace_files`, `restore_split_node`,
-`restore_external_files`, `restore_terminals_from_workspace`,
-`restore_bookmarks_from_workspace`, `restore_file_explorer_settings`,
-`restore_search_options`, `restore_prompt_histories`,
-`apply_read_only_flags`, `clean_orphaned_buffers`, `log_restore_summary`,
-view-state restore) — changing `self.active_window()/active_window_mut()`
-to `self.windows.get(&id)/get_mut(&id)`. The editor-global steps
-(`restore_config_overrides`, `plugin_global_state`,
-`restore_hot_exit_changes`/`restore_unnamed_buffers` via `recovery_service`,
-the `buffer_activated` hook) stay where they are.
+The genuinely editor-global steps stay on `Editor::restore_workspace_for`
+as thin pre/post-steps around the window layout call:
+`restore_config_overrides` (mutates the shared `Config`),
+`plugin_global_state` assignment, hot-exit recovery
+(`restore_unnamed_buffers` before the layout so the split tree can
+reference the restored buffers, `restore_hot_exit_changes` after) via
+`recovery_service` — both parameterized by `id`, no flip — and, for the
+**active window only**, the post-restore plugin snapshot +
+`buffer_activated` (background restores must NOT fire focus side-effects).
 
-### Acceptance
-- Round-trip property test (committed: `orchestrator_workspace_roundtrip`)
-  stays green — that is the de-risking gate.
-- `save_all_windows_workspaces` / `restore_inactive_window_workspaces`
-  contain **no** `self.active_window = …` writes.
-- All existing `orchestrator_bringup_*` specs stay green.
-
-### Status / why the rest is deferred
-Save side (capture → `Window`) is **done**. The restore-side
-`WindowId`-parameterization removes the last flip but has **no
-correctness payoff** (post-§2 the flip is transient and restored) and
-threads an id through ~12 behavior-sensitive helpers. It's safe to do
-incrementally now that the round-trip property test guards it; deferred
-only by appetite for churn, not by risk of a missing safety net.
+### Acceptance — met
+- `with_active_window` and every `self.active_window = …` write in the
+  workspace save/restore path are **gone**.
+- `restore_workspace_for(id)` opens files into `windows[id]` with no flip.
+- `Window::from_workspace` exists and is used by restore;
+  `Editor::open_file` is a thin focus wrapper.
+- Round-trip property test (`orchestrator_workspace_roundtrip`) +
+  `orchestrator_bringup_*` + persistence/e2e file-open specs stay green;
+  `cargo fmt` + `cargo check` clean.


### PR DESCRIPTION
Move open_file_no_focus / open_file_for_preview / the ~310-line
open_file_no_focus_inner core, plus the window-local helpers
notify_lsp_file_opened and watch_file, onto `impl Window` (rooted at
self.root / self.resources). Editor keeps thin delegators for every
existing caller; Editor::open_file stays the active-window FOCUS wrapper
(set_active_buffer + position history + plugin snapshot + status).

This makes the file-open core genuinely window-scoped so a background /
restore open can target a non-active window directly, with no
active-window pointer flip. Pure architecture; behavior unchanged.

https://claude.ai/code/session_01L2ittieNAgHZUNtSfdUUWF