### PR TITLE
Add git worktree discovery and attach-to-existing flows

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -263,10 +263,12 @@ interface OpenDialogState {
   // refresh. Bulk mode (the dedicated selection bar) engages once
   // two or more rows are checked.
   selectedIds: Set<number>;
-  // `true` hides the discovered on-disk `[○]` worktree rows from
-  // the list — the per-project filter checkbox below the scope
-  // control. Remembered across opens via `lastHideDiscovered`.
-  hideDiscovered: boolean;
+  // `true` shows the discovered on-disk worktree rows in the list.
+  // The "Show all worktrees" checkbox below the scope control toggles
+  // it (Alt+T / `orchestrator_toggle_worktrees`). Defaults to false
+  // (worktrees hidden) — discovery is opt-in. Remembered across opens
+  // via `lastShowWorktrees`.
+  showWorktrees: boolean;
   // Progress marker for an in-flight *bulk* action. While set, the
   // selection bar shows "Archiving 2/3…" and its buttons are
   // hidden so a second Enter can't re-fire mid-batch. Cleared when
@@ -327,9 +329,10 @@ let openPanel: FloatingWidgetPanel | null = null;
 // updates this and the next open honours it.
 let lastOpenScope: "current" | "all" = "all";
 // Remembered across opens, like `lastOpenScope`: whether the
-// discovered on-disk worktree rows are hidden. Defaults to false
-// (worktrees shown) so the discovery feature is visible by default.
-let lastHideDiscovered = false;
+// discovered on-disk worktree rows are shown. Defaults to false
+// (worktrees hidden) — surfacing them is opt-in via "Show all
+// worktrees" (Alt+T).
+let lastShowWorktrees = false;
 const OPEN_MODE = "orchestrator-open";
 
 // =============================================================================
@@ -557,12 +560,12 @@ function projectLabel(key: string): string {
 function filterSessions(needle: string): number[] {
   reconcileSessions();
   const scope = openDialog?.scope ?? "current";
-  const hideDiscovered = openDialog?.hideDiscovered ?? false;
+  const showWorktrees = openDialog?.showWorktrees ?? false;
   const cur = currentProjectKey();
   let allIds = Array.from(orchestratorSessions.keys());
-  // Per-project filter checkbox: drop the on-disk worktree rows
-  // entirely when the user has hidden them.
-  if (hideDiscovered) {
+  // "Show all worktrees" is opt-in: by default the discovered on-disk
+  // worktree rows are filtered out.
+  if (!showWorktrees) {
     allIds = allIds.filter((id) => !orchestratorSessions.get(id)!.discovered);
   }
 
@@ -668,7 +671,7 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   const checkbox = {
     text: isChecked ? "[x] " : "[ ] ",
     style: isChecked
-      ? { fg: "ui.tab_active_fg", bold: true }
+      ? { fg: "ui.help_key_fg", bold: true }
       : { fg: "ui.menu_disabled_fg" },
   };
 
@@ -677,7 +680,7 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
     {
       text: s.label,
       style: isActive
-        ? { fg: "ui.tab_active_fg", bold: true }
+        ? { fg: "ui.help_key_fg", bold: true }
         : isDiscovered
         ? { fg: "ui.menu_disabled_fg" }
         : undefined,
@@ -745,7 +748,7 @@ function buildPreviewEntries(
     {
       text: stateText,
       style: isActive
-        ? { fg: "ui.tab_active_fg", bold: true }
+        ? { fg: "ui.help_key_fg", bold: true }
         : { fg: "ui.menu_disabled_fg" },
     },
     { text: "  " },
@@ -1413,16 +1416,23 @@ function buildOpenSpec(): WidgetSpec {
     flexSpacer(),
   );
   // Per-project filter checkbox, on its own row under the Project
-  // control: hides the discovered on-disk `[○]` worktree rows. A
-  // button (not a Toggle) so it activates on Enter/click — Space is
-  // claimed mode-wide for row selection. Inert while a confirm
-  // prompt is up.
-  const hideWorktrees = openDialog.hideDiscovered;
+  // control: opt-in toggle that surfaces the discovered on-disk
+  // worktree rows. A `toggle` (single `[ ]`/`[v]` — no double
+  // bracket) that's clickable and bound to Alt+T
+  // (`orchestrator_toggle_worktrees`, rebindable). The label carries
+  // the live keybinding hint, mirroring the Project control's
+  // "(Alt+P)". Inert while a confirm prompt is up.
+  const worktreeKey = editor.getKeybindingLabel(
+    "orchestrator_toggle_worktrees",
+    OPEN_MODE,
+  );
+  const worktreeLabel = worktreeKey
+    ? `Show all worktrees   (${worktreeKey})`
+    : "Show all worktrees";
   const worktreeFilterRow = row(
-    button(
-      `${hideWorktrees ? "[x]" : "[ ]"} Hide on-disk worktrees`,
-      { key: openDialog.pendingConfirm !== null ? undefined : "worktree-hide" },
-    ),
+    toggle(openDialog.showWorktrees, worktreeLabel, {
+      key: openDialog.pendingConfirm !== null ? undefined : "worktree-show",
+    }),
     flexSpacer(),
   );
 
@@ -1626,7 +1636,7 @@ function openControlRoom(): void {
     // control / Alt+P updates it for next time.
     scope: lastOpenScope,
     selectedIds: new Set<number>(),
-    hideDiscovered: lastHideDiscovered,
+    showWorktrees: lastShowWorktrees,
     bulkInFlight: null,
   };
   openDialog.filteredIds = filterSessions("");
@@ -2223,6 +2233,10 @@ editor.defineMode(
     // filter while the picker is open; session names don't contain
     // spaces, so that's acceptable.
     ["Space", "orchestrator_toggle_select"],
+    // Alt+T toggles "Show all worktrees" — the opt-in filter that
+    // surfaces discovered on-disk worktree rows. Rebindable, same as
+    // the scope toggle.
+    ["M-t", "orchestrator_toggle_worktrees"],
   ],
   true,
   true,
@@ -2288,6 +2302,31 @@ function toggleScope(): void {
 }
 
 registerHandler("orchestrator_toggle_scope", toggleScope);
+
+// Flip "Show all worktrees" — reveal/hide the discovered on-disk
+// worktree rows. Preserves the highlighted row across the re-filter
+// where possible; drops now-hidden discovered rows from the bulk
+// selection. Shared by the Alt+T chord and the checkbox click.
+function toggleShowWorktrees(): void {
+  if (!openDialog) return;
+  openDialog.showWorktrees = !openDialog.showWorktrees;
+  lastShowWorktrees = openDialog.showWorktrees;
+  // Hiding worktrees shouldn't leave them lingering in the selection.
+  if (!openDialog.showWorktrees) {
+    for (const id of [...openDialog.selectedIds]) {
+      if (orchestratorSessions.get(id)?.discovered) {
+        openDialog.selectedIds.delete(id);
+      }
+    }
+  }
+  const prevId = openDialog.filteredIds[openDialog.selectedIndex];
+  openDialog.filteredIds = filterSessions(openDialog.filter.value);
+  const nextIdx = prevId !== undefined ? openDialog.filteredIds.indexOf(prevId) : -1;
+  openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
+  refreshOpenDialog();
+}
+
+registerHandler("orchestrator_toggle_worktrees", toggleShowWorktrees);
 
 // =============================================================================
 // New-session floating form
@@ -4123,18 +4162,10 @@ editor.on("widget_event", (e) => {
       refreshOpenDialog();
       return;
     }
-    if (e.event_type === "activate" && e.widget_key === "worktree-hide") {
-      openDialog.hideDiscovered = !openDialog.hideDiscovered;
-      lastHideDiscovered = openDialog.hideDiscovered;
-      // A hidden discovered row shouldn't linger in the selection.
-      if (openDialog.hideDiscovered) {
-        for (const id of [...openDialog.selectedIds]) {
-          if (orchestratorSessions.get(id)?.discovered) {
-            openDialog.selectedIds.delete(id);
-          }
-        }
-      }
-      refreshOpenDialog();
+    if (e.event_type === "toggle" && e.widget_key === "worktree-show") {
+      // The toggle widget reports the new checked state; route through
+      // the shared flip so the Alt+T chord and the click stay in sync.
+      toggleShowWorktrees();
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "stop") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -622,14 +622,15 @@ function filterSessions(needle: string): number[] {
   return matches.map((m) => m.id);
 }
 
-// Column widths for the tabular session list. ID holds `[NN] `;
-// NAME holds the label plus the BASE / ⇄ badges; PROJECT (filled
-// only for cross-project rows) trails. Kept in sync with
-// `sessionsColumnHeader`.
-const LIST_ID_W = 5;
-const LIST_NAME_W = 20;
+// Width of the NAME column before the trailing PROJECT column kicks
+// in (filled only for cross-project rows). Kept in sync with
+// `sessionsColumnHeader`. There is no id column — the numeric window
+// id is an internal handle the user never needs in the list; rows are
+// identified by name, the active one rendered bold and on-disk
+// worktrees flagged with a `· on-disk` tag.
+const LIST_NAME_W = 24;
 
-// Header row above the session list: `ID   NAME …   PROJECT`.
+// Header row above the session list: `NAME …   PROJECT`.
 function sessionsColumnHeader(): WidgetSpec {
   return {
     kind: "raw",
@@ -637,8 +638,7 @@ function sessionsColumnHeader(): WidgetSpec {
       styledRow([
         {
           // 4-space lead aligns under the per-row `[ ] ` checkbox.
-          text: "    " + "ID".padEnd(LIST_ID_W) + "NAME".padEnd(LIST_NAME_W) +
-            "PROJECT",
+          text: "    " + "NAME".padEnd(LIST_NAME_W) + "PROJECT",
           style: { fg: "ui.menu_disabled_fg" },
         },
       ]),
@@ -646,15 +646,16 @@ function sessionsColumnHeader(): WidgetSpec {
   };
 }
 
-// Build one rendered list-item row for `id`, laid out in columns:
-//   `[id]`  <name + BASE/⇄ badges>   <project basename>
-// The active session's id renders in the active-tab colour (the
-// list has no separate state column); the project column is filled
-// only for sessions that don't belong to the current project.
+// Build one rendered list-item row for `id`:
+//   `[ ] ` <name + BASE/⇄ badges + on-disk tag>   <project basename>
+// The active session's name renders bold; discovered (on-disk,
+// unopened) worktrees render dim with a `· on-disk` tag instead of a
+// glyph. The project column is filled only for sessions that don't
+// belong to the current project.
 function renderListItem(id: number, activeId: number): TextPropertyEntry {
   const s = orchestratorSessions.get(id);
   if (!s) {
-    return styledRow([{ text: `[${id}] (unknown)` }]);
+    return styledRow([{ text: "(unknown)" }]);
   }
   const isActive = id === activeId;
   const isBase = id === 1;
@@ -671,22 +672,12 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
       : { fg: "ui.menu_disabled_fg" },
   };
 
-  // Discovered (on-disk, unopened) worktrees have no window id —
-  // render a `[○]` glyph instead of the synthetic negative id so
-  // the row reads as "available to open", not "session #-2".
-  const idText = (isDiscovered ? "[○]" : `[${id}]`).padEnd(LIST_ID_W);
   const entries: { text: string; style?: Record<string, unknown> }[] = [
     checkbox,
     {
-      text: idText,
-      style: isActive
-        ? { fg: "ui.tab_active_fg", bold: true }
-        : { fg: isDiscovered ? "ui.menu_disabled_fg" : "ui.help_key_fg" },
-    },
-    {
       text: s.label,
       style: isActive
-        ? { bold: true }
+        ? { fg: "ui.tab_active_fg", bold: true }
         : isDiscovered
         ? { fg: "ui.menu_disabled_fg" }
         : undefined,
@@ -702,6 +693,13 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   if (s.sharedWorktree || countSiblingsAtRoot(s.root) > 1) {
     entries.push({ text: " ⇄", style: { fg: "ui.menu_disabled_fg" } });
     nameWidth += 2;
+  }
+  if (isDiscovered) {
+    entries.push({
+      text: " · on-disk",
+      style: { fg: "ui.menu_disabled_fg", italic: true },
+    });
+    nameWidth += 10;
   }
   // PROJECT column: basename for cross-project rows only; current-
   // project rows leave it blank (the whole list is one project when
@@ -1031,7 +1029,7 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       ]),
     ];
     return labeledSection({
-      label: `[○] ${s.label}  on-disk worktree`,
+      label: `${s.label}  —  on-disk worktree`,
       child: col(
         openButtonRow,
         spacer(0),
@@ -1096,8 +1094,8 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   // its worktree would close the editor / break the user's current
   // tree, so Stop / Archive / Delete refuse against it.
   const sectionLabel = isBase
-    ? `[${s.id}] ${s.label}  BASE — editor session`
-    : `[${s.id}] ${s.label}`;
+    ? `${s.label}  —  BASE (editor session)`
+    : s.label;
   return labeledSection({
     label: sectionLabel,
     child: body,
@@ -1146,8 +1144,8 @@ function buildConfirmPane(
   const cap = action[0].toUpperCase() + action.slice(1);
   const existing = ids.filter((id) => orchestratorSessions.has(id));
   const bulk = existing.length > 1;
-  const tagOf = (id: number): string =>
-    orchestratorSessions.get(id)?.discovered ? "[○]" : `[${id}]`;
+  const diskNote = (id: number): string =>
+    orchestratorSessions.get(id)?.discovered ? "  · on-disk" : "";
   const entries: TextPropertyEntry[] = [];
   if (bulk) {
     entries.push(
@@ -1158,7 +1156,12 @@ function buildConfirmPane(
     );
     for (const id of existing.slice(0, 8)) {
       const ss = orchestratorSessions.get(id)!;
-      entries.push(styledRow([{ text: `  ${tagOf(id)} ${ss.label}` }]));
+      entries.push(
+        styledRow([
+          { text: `  ${ss.label}` },
+          { text: diskNote(id), style: { fg: "ui.menu_disabled_fg", italic: true } },
+        ]),
+      );
     }
     if (existing.length > 8) {
       entries.push(
@@ -1175,10 +1178,7 @@ function buildConfirmPane(
     const ss = id !== undefined ? orchestratorSessions.get(id) : undefined;
     entries.push(
       styledRow([
-        {
-          text: `${cap} session ${id !== undefined ? tagOf(id) : ""} ${ss?.label ?? ""}?`,
-          style: { bold: true },
-        },
+        { text: `${cap} session ${ss?.label ?? ""}?`, style: { bold: true } },
       ]),
     );
   }
@@ -1226,16 +1226,13 @@ function buildBulkPane(): WidgetSpec {
   const stopN = eligibleSelected("stop").length;
   const archiveN = eligibleSelected("archive").length;
   const deleteN = eligibleSelected("delete").length;
-  const tagOf = (id: number): string =>
-    orchestratorSessions.get(id)?.discovered ? "[○]" : `[${id}]`;
 
   const entries: TextPropertyEntry[] = [];
   const cap = openDialog?.listVisibleRows ?? MIN_LIST_ROWS;
   for (const id of sel.slice(0, cap)) {
     const ss = orchestratorSessions.get(id)!;
     const rowParts: StyledSegment[] = [
-      { text: `  ${tagOf(id)} `, style: { fg: "ui.help_key_fg" } },
-      { text: ss.label },
+      { text: `  ${ss.label}` },
     ];
     // Flag rows a destructive bulk action will skip so the count
     // discrepancy is self-explanatory.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -247,10 +247,32 @@ interface OpenDialogState {
   // anchor it needs.
   originalActiveSession: number;
   // When non-null, the preview pane swaps to a confirmation
-  // panel for the named action against the named session id.
-  // Cleared on Cancel or after the action completes.
+  // panel for the named action against the listed session ids.
+  // A single-element `ids` is the per-row Stop/Archive/Delete
+  // path; a multi-element `ids` is a bulk action over the
+  // checkbox selection. Cleared on Cancel or after the action
+  // completes.
   pendingConfirm:
-    | { action: "stop" | "archive" | "delete"; sessionId: number }
+    | { action: "stop" | "archive" | "delete"; ids: number[] }
+    | null;
+  // Rows the user has checkbox-selected (Space, or click) for a
+  // bulk Stop/Archive/Delete. Holds session ids — positive for
+  // live windows, negative for discovered on-disk worktrees
+  // (which bulk-delete via `git worktree remove`). Survives filter
+  // and scope changes; pruned against the live set on every
+  // refresh. Bulk mode (the dedicated selection bar) engages once
+  // two or more rows are checked.
+  selectedIds: Set<number>;
+  // `true` hides the discovered on-disk `[○]` worktree rows from
+  // the list — the per-project filter checkbox below the scope
+  // control. Remembered across opens via `lastHideDiscovered`.
+  hideDiscovered: boolean;
+  // Progress marker for an in-flight *bulk* action. While set, the
+  // selection bar shows "Archiving 2/3…" and its buttons are
+  // hidden so a second Enter can't re-fire mid-batch. Cleared when
+  // the batch finishes.
+  bulkInFlight:
+    | { action: "stop" | "archive" | "delete"; total: number; done: number }
     | null;
   // Rows the embed reserves and rows the sessions list shows.
   // Captured once at dialog-open from the editor's viewport so
@@ -304,6 +326,10 @@ let openPanel: FloatingWidgetPanel | null = null;
 // showing every session; flipping it with the Project control / Alt+P
 // updates this and the next open honours it.
 let lastOpenScope: "current" | "all" = "all";
+// Remembered across opens, like `lastOpenScope`: whether the
+// discovered on-disk worktree rows are hidden. Defaults to false
+// (worktrees shown) so the discovery feature is visible by default.
+let lastHideDiscovered = false;
 const OPEN_MODE = "orchestrator-open";
 
 // =============================================================================
@@ -531,12 +557,23 @@ function projectLabel(key: string): string {
 function filterSessions(needle: string): number[] {
   reconcileSessions();
   const scope = openDialog?.scope ?? "current";
+  const hideDiscovered = openDialog?.hideDiscovered ?? false;
   const cur = currentProjectKey();
-  const allIds = Array.from(orchestratorSessions.keys());
+  let allIds = Array.from(orchestratorSessions.keys());
+  // Per-project filter checkbox: drop the on-disk worktree rows
+  // entirely when the user has hidden them.
+  if (hideDiscovered) {
+    allIds = allIds.filter((id) => !orchestratorSessions.get(id)!.discovered);
+  }
 
-  // Sort by (current-project-first, then id) so an "all" view
-  // groups the current project's sessions at the top and other
-  // projects' sessions below in a stable order.
+  const isDisc = (id: number): number =>
+    orchestratorSessions.get(id)!.discovered ? 1 : 0;
+
+  // Sort by (current-project-first, project, live-before-discovered,
+  // then id) so an "all" view groups the current project's sessions
+  // at the top and other projects' below, and within each project the
+  // pre-existing live sessions come first with the discovered on-disk
+  // worktrees listed after them.
   const byProjectThenId = (a: number, b: number): number => {
     const sa = orchestratorSessions.get(a)!;
     const sb = orchestratorSessions.get(b)!;
@@ -546,6 +583,9 @@ function filterSessions(needle: string): number[] {
     const ka = projectKeyOf(sa);
     const kb = projectKeyOf(sb);
     if (ka !== kb) return ka < kb ? -1 : 1;
+    const da = isDisc(a);
+    const db = isDisc(b);
+    if (da !== db) return da - db;
     return a - b;
   };
 
@@ -572,7 +612,13 @@ function filterSessions(needle: string): number[] {
       matches.push({ id, score: 2, len: label.length });
     }
   }
-  matches.sort((a, b) => a.score - b.score || a.len - b.len || a.id - b.id);
+  // Live sessions before discovered worktrees at equal relevance, so
+  // the on-disk rows still trail the real sessions in search results.
+  matches.sort(
+    (a, b) =>
+      a.score - b.score || isDisc(a.id) - isDisc(b.id) || a.len - b.len ||
+      a.id - b.id,
+  );
   return matches.map((m) => m.id);
 }
 
@@ -590,7 +636,9 @@ function sessionsColumnHeader(): WidgetSpec {
     entries: [
       styledRow([
         {
-          text: "ID".padEnd(LIST_ID_W) + "NAME".padEnd(LIST_NAME_W) + "PROJECT",
+          // 4-space lead aligns under the per-row `[ ] ` checkbox.
+          text: "    " + "ID".padEnd(LIST_ID_W) + "NAME".padEnd(LIST_NAME_W) +
+            "PROJECT",
           style: { fg: "ui.menu_disabled_fg" },
         },
       ]),
@@ -611,12 +659,24 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   const isActive = id === activeId;
   const isBase = id === 1;
   const isDiscovered = !!s.discovered;
+  const isChecked = openDialog?.selectedIds.has(id) ?? false;
+
+  // Leading multi-select checkbox. `[x]` when this row is in the
+  // bulk selection, `[ ]` otherwise — toggled with Space (the
+  // rebindable `orchestrator_toggle_select`) or a click.
+  const checkbox = {
+    text: isChecked ? "[x] " : "[ ] ",
+    style: isChecked
+      ? { fg: "ui.tab_active_fg", bold: true }
+      : { fg: "ui.menu_disabled_fg" },
+  };
 
   // Discovered (on-disk, unopened) worktrees have no window id —
   // render a `[○]` glyph instead of the synthetic negative id so
   // the row reads as "available to open", not "session #-2".
   const idText = (isDiscovered ? "[○]" : `[${id}]`).padEnd(LIST_ID_W);
   const entries: { text: string; style?: Record<string, unknown> }[] = [
+    checkbox,
     {
       text: idText,
       style: isActive
@@ -749,6 +809,72 @@ function countSiblingsAtRoot(root: string): number {
   return n;
 }
 
+// =============================================================================
+// Multi-select / bulk actions
+//
+// The user checkbox-selects rows (Space — the rebindable
+// `orchestrator_toggle_select` — or a click). Once two or more rows
+// are checked the preview pane swaps to the bulk selection bar
+// (`buildBulkPane`) offering Stop / Archive / Delete over the whole
+// set, with a single confirmation for the batch. Rows ineligible for
+// a given action (the base session; live sessions sharing a worktree)
+// are skipped, and each button's count reflects only the eligible
+// members.
+// =============================================================================
+
+type BulkAction = "stop" | "archive" | "delete";
+
+// Checked ids that still resolve to a known session, in the dialog's
+// current display order (so the bulk bar lists them the way the list
+// shows them). Selection persists across filter/scope changes, so an
+// id can be checked while filtered out of view — those still count.
+function selectedSessions(): number[] {
+  if (!openDialog) return [];
+  const order = openDialog.filteredIds;
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const id of order) {
+    if (openDialog.selectedIds.has(id) && orchestratorSessions.has(id)) {
+      out.push(id);
+      seen.add(id);
+    }
+  }
+  // Checked-but-filtered-out rows, appended in id order so the count
+  // stays honest even when a search hides part of the selection.
+  for (const id of openDialog.selectedIds) {
+    if (!seen.has(id) && orchestratorSessions.has(id)) out.push(id);
+  }
+  return out;
+}
+
+// Is `id` a legal target for `action`? Base session is never
+// touched. Stop only applies to live windows. Archive/Delete apply
+// to discovered worktrees (removable on disk) and to live sessions
+// that own their worktree outright (not shared with siblings or the
+// project root).
+function bulkEligible(action: BulkAction, id: number): boolean {
+  const s = orchestratorSessions.get(id);
+  if (!s) return false;
+  if (id === 1) return false;
+  if (action === "stop") return !s.discovered && id > 0;
+  if (s.discovered) return true;
+  const sharesRoot = countSiblingsAtRoot(s.root) > 1 || s.sharedWorktree;
+  return !sharesRoot;
+}
+
+function eligibleSelected(action: BulkAction): number[] {
+  return selectedSessions().filter((id) => bulkEligible(action, id));
+}
+
+// Drop checked ids whose session has vanished (closed window,
+// pruned worktree) so the selection can't grow stale references.
+function pruneSelection(): void {
+  if (!openDialog) return;
+  for (const id of [...openDialog.selectedIds]) {
+    if (!orchestratorSessions.has(id)) openDialog.selectedIds.delete(id);
+  }
+}
+
 // Blank-row separator used inside the Sessions column between
 // the filter, the new-session button, and the list.
 function sessionsSeparator(): WidgetSpec {
@@ -771,10 +897,10 @@ function maxListRowsForScreen(): number {
   const panelH = Math.floor(h * 0.9);
   // Chrome that isn't list rows: panel borders (2) + title (1) +
   // spacer (1) + footer (1) + sessions-section borders (2) +
-  // column chrome above the list (New + Project + Filter +
-  // separator + header = 5) = 12. Floor at MIN_LIST_ROWS so a tiny
-  // terminal still shows something.
-  return Math.max(MIN_LIST_ROWS, panelH - 12);
+  // column chrome above the list (New + Project + Worktree-filter +
+  // Filter + separator + header = 6) = 13. Floor at MIN_LIST_ROWS so
+  // a tiny terminal still shows something.
+  return Math.max(MIN_LIST_ROWS, panelH - 13);
 }
 
 // Compose the right-hand preview pane. Normally it shows info
@@ -819,130 +945,28 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       ),
     });
   }
-  if (openDialog?.pendingConfirm && s && openDialog.pendingConfirm.sessionId === s.id) {
-    const action = openDialog.pendingConfirm.action;
-    if (action === "stop") {
-      return labeledSection({
-        label: "Confirm Stop",
-        child: col(
-          {
-            kind: "raw",
-            entries: [
-              styledRow([
-                {
-                  text: `Stop session [${s.id}] ${s.label}?`,
-                  style: { bold: true },
-                },
-              ]),
-              styledRow([{ text: "" }]),
-              styledRow([{ text: "This will:" }]),
-              styledRow([{ text: "  • send SIGTERM to all session processes" }]),
-              styledRow([{ text: "  • SIGKILL after a short grace period" }]),
-              styledRow([{ text: "" }]),
-              styledRow([{ text: "The worktree and session record remain." }]),
-            ],
-          },
-          spacer(0),
-          row(
-            flexSpacer(),
-            button("Cancel", { key: "confirm-cancel" }),
-            spacer(2),
-            button("Confirm Stop", {
-              intent: "danger",
-              key: "confirm-stop",
-            }),
-          ),
-        ),
-      });
-    }
-    if (action === "archive") {
-      return labeledSection({
-        label: "Confirm Archive",
-        child: col(
-          {
-            kind: "raw",
-            entries: [
-              styledRow([
-                {
-                  text: `Archive session [${s.id}] ${s.label}?`,
-                  style: { bold: true },
-                },
-              ]),
-              styledRow([{ text: "" }]),
-              styledRow([{ text: "This will:" }]),
-              styledRow([{ text: "  • SIGKILL all session processes" }]),
-              styledRow([{ text: "  • close the editor session" }]),
-              styledRow([{ text: "  • move the worktree to .archived/" }]),
-              styledRow([{ text: "" }]),
-              styledRow([{ text: "Reversible via Unarchive." }]),
-            ],
-          },
-          spacer(0),
-          row(
-            flexSpacer(),
-            button("Cancel", { key: "confirm-cancel" }),
-            spacer(2),
-            button("Confirm Archive", {
-              intent: "danger",
-              key: "confirm-archive",
-            }),
-          ),
-        ),
-      });
-    }
-    if (action === "delete") {
-      return labeledSection({
-        label: "Confirm Delete",
-        child: col(
-          {
-            kind: "raw",
-            entries: [
-              styledRow([
-                {
-                  text: `Delete session [${s.id}] ${s.label}?`,
-                  style: { bold: true },
-                },
-              ]),
-              styledRow([{ text: "" }]),
-              styledRow([{ text: "This will:" }]),
-              styledRow([{ text: "  • stop all session processes" }]),
-              styledRow([{ text: "  • run `git worktree remove`" }]),
-              styledRow([{ text: "  • drop the session record" }]),
-              styledRow([{ text: "" }]),
-              styledRow([
-                {
-                  text: "Uncommitted changes will be lost.",
-                  style: {
-                    fg: "ui.status_error_indicator_fg",
-                    bold: true,
-                  },
-                },
-              ]),
-            ],
-          },
-          spacer(0),
-          row(
-            flexSpacer(),
-            button("Cancel", { key: "confirm-cancel" }),
-            spacer(2),
-            button("Confirm Delete", {
-              intent: "danger",
-              key: "confirm-delete",
-            }),
-          ),
-        ),
-      });
-    }
+  // Confirmation panel — single-row Stop/Archive/Delete or a bulk
+  // batch. Independent of the cursor row: the confirmed ids live in
+  // `pendingConfirm`, so it renders whenever a confirm is pending.
+  if (openDialog?.pendingConfirm) {
+    return buildConfirmPane(openDialog.pendingConfirm);
+  }
+  // Bulk selection bar: two or more rows checked (or a bulk action
+  // in flight) → operate on the whole batch rather than the cursor
+  // row.
+  if (selectedSessions().length >= 2 || openDialog?.bulkInFlight) {
+    return buildBulkPane();
   }
   // Match the sessions column's content height so the two panes'
   // bottom borders land on the same row. Sessions column inside its
-  // borders = New (1) + Project (1) + Filter (1) + separator (1) +
-  // header (1) + list (listVisibleRows) = listVisibleRows + 5.
-  // Preview inside its borders = button row (1) + spacer (1) +
-  // embedRows, so embedRows must equal listVisibleRows + 3. When
-  // details ARE shown, two info rows + a spacer eat three more
-  // lines — `_DETAILS_CHROME_ROWS` accounts for that.
-  const totalEmbedBase = (openDialog?.listVisibleRows ?? MIN_LIST_ROWS) + 3;
+  // borders = New (1) + Project (1) + Worktree-filter (1) +
+  // Filter (1) + separator (1) + header (1) + list (listVisibleRows)
+  // = listVisibleRows + 6. Preview inside its borders = button
+  // row (1) + spacer (1) + embedRows, so embedRows must equal
+  // listVisibleRows + 4. When details ARE shown, two info rows + a
+  // spacer eat three more lines — `_DETAILS_CHROME_ROWS` accounts
+  // for that.
+  const totalEmbedBase = (openDialog?.listVisibleRows ?? MIN_LIST_ROWS) + 4;
   const detailsOn = openDialog?.showDetails ?? false;
   const _DETAILS_CHROME_ROWS = 3; // 2 info rows + 1 spacer
   const embedRows = Math.max(
@@ -1080,6 +1104,204 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   });
 }
 
+// The per-action bullet lines shown in the confirmation panel.
+// `delete` adds a separate red "uncommitted changes" line in the
+// caller because it needs distinct styling.
+function confirmActionLines(action: BulkAction): string[] {
+  switch (action) {
+    case "stop":
+      return [
+        "  • send SIGTERM to all session processes",
+        "  • SIGKILL after a short grace period",
+        "",
+        "The worktree and session record remain.",
+      ];
+    case "archive":
+      return [
+        "  • SIGKILL all session processes",
+        "  • close the editor session",
+        "  • move the worktree to .archived/",
+        "",
+        "Reversible via Unarchive.",
+      ];
+    case "delete":
+      return [
+        "  • stop all session processes",
+        "  • run `git worktree remove`",
+        "  • drop the session record",
+      ];
+  }
+}
+
+// Confirmation panel for a Stop/Archive/Delete over one or many
+// sessions. A single id renders the familiar per-session prompt; two
+// or more render a batch prompt that lists the targets. The Confirm
+// button reuses the same `confirm-<action>` key the single path
+// always used, so the existing widget_event handlers fire for both —
+// they read `pendingConfirm.ids`.
+function buildConfirmPane(
+  confirm: { action: BulkAction; ids: number[] },
+): WidgetSpec {
+  const { action, ids } = confirm;
+  const cap = action[0].toUpperCase() + action.slice(1);
+  const existing = ids.filter((id) => orchestratorSessions.has(id));
+  const bulk = existing.length > 1;
+  const tagOf = (id: number): string =>
+    orchestratorSessions.get(id)?.discovered ? "[○]" : `[${id}]`;
+  const entries: TextPropertyEntry[] = [];
+  if (bulk) {
+    entries.push(
+      styledRow([
+        { text: `${cap} these ${existing.length} sessions?`, style: { bold: true } },
+      ]),
+      styledRow([{ text: "" }]),
+    );
+    for (const id of existing.slice(0, 8)) {
+      const ss = orchestratorSessions.get(id)!;
+      entries.push(styledRow([{ text: `  ${tagOf(id)} ${ss.label}` }]));
+    }
+    if (existing.length > 8) {
+      entries.push(
+        styledRow([
+          {
+            text: `  … and ${existing.length - 8} more`,
+            style: { fg: "ui.menu_disabled_fg", italic: true },
+          },
+        ]),
+      );
+    }
+  } else {
+    const id = existing[0];
+    const ss = id !== undefined ? orchestratorSessions.get(id) : undefined;
+    entries.push(
+      styledRow([
+        {
+          text: `${cap} session ${id !== undefined ? tagOf(id) : ""} ${ss?.label ?? ""}?`,
+          style: { bold: true },
+        },
+      ]),
+    );
+  }
+  entries.push(
+    styledRow([{ text: "" }]),
+    styledRow([{ text: bulk ? "For each session this will:" : "This will:" }]),
+  );
+  for (const line of confirmActionLines(action)) {
+    entries.push(styledRow([{ text: line }]));
+  }
+  if (action === "delete") {
+    entries.push(
+      styledRow([{ text: "" }]),
+      styledRow([
+        {
+          text: "Uncommitted changes will be lost.",
+          style: { fg: "ui.status_error_indicator_fg", bold: true },
+        },
+      ]),
+    );
+  }
+  return labeledSection({
+    label: bulk ? `Confirm ${cap} — ${existing.length} sessions` : `Confirm ${cap}`,
+    child: col(
+      { kind: "raw", entries },
+      spacer(0),
+      row(
+        flexSpacer(),
+        button("Cancel", { key: "confirm-cancel" }),
+        spacer(2),
+        button(`Confirm ${cap}`, { intent: "danger", key: `confirm-${action}` }),
+      ),
+    ),
+  });
+}
+
+// The dedicated bulk selection bar (Layout B). Shown in place of the
+// per-session preview when two or more rows are checked: lists the
+// selected sessions (flagging the ones a destructive action can't
+// touch) and offers Stop / Archive / Delete over the whole batch
+// plus a Clear-selection button. Each action's count is the number of
+// *eligible* members; an action with no eligible members is disabled.
+function buildBulkPane(): WidgetSpec {
+  const sel = selectedSessions();
+  const stopN = eligibleSelected("stop").length;
+  const archiveN = eligibleSelected("archive").length;
+  const deleteN = eligibleSelected("delete").length;
+  const tagOf = (id: number): string =>
+    orchestratorSessions.get(id)?.discovered ? "[○]" : `[${id}]`;
+
+  const entries: TextPropertyEntry[] = [];
+  const cap = openDialog?.listVisibleRows ?? MIN_LIST_ROWS;
+  for (const id of sel.slice(0, cap)) {
+    const ss = orchestratorSessions.get(id)!;
+    const rowParts: StyledSegment[] = [
+      { text: `  ${tagOf(id)} `, style: { fg: "ui.help_key_fg" } },
+      { text: ss.label },
+    ];
+    // Flag rows a destructive bulk action will skip so the count
+    // discrepancy is self-explanatory.
+    if (id === 1) {
+      rowParts.push({ text: "  · base (protected)", style: { fg: "ui.menu_disabled_fg", italic: true } });
+    } else if (!ss.discovered && (countSiblingsAtRoot(ss.root) > 1 || ss.sharedWorktree)) {
+      rowParts.push({ text: "  · shared worktree", style: { fg: "ui.menu_disabled_fg", italic: true } });
+    } else if (ss.discovered) {
+      rowParts.push({ text: "  · on-disk worktree", style: { fg: "ui.menu_disabled_fg", italic: true } });
+    }
+    entries.push(styledRow(rowParts));
+  }
+  if (sel.length > cap) {
+    entries.push(
+      styledRow([
+        {
+          text: `  … and ${sel.length - cap} more`,
+          style: { fg: "ui.menu_disabled_fg", italic: true },
+        },
+      ]),
+    );
+  }
+
+  const inflight = openDialog?.bulkInFlight ?? null;
+  const actionRow = inflight
+    ? row(
+        {
+          kind: "raw",
+          entries: [
+            styledRow([
+              {
+                text: `${inflight.action[0].toUpperCase()}${inflight.action.slice(1)}ing ${inflight.done}/${inflight.total}…`,
+                style: { fg: "ui.menu_disabled_fg", italic: true },
+              },
+            ]),
+          ],
+        },
+        flexSpacer(),
+      )
+    : row(
+        button(`Stop (${stopN})`, { key: "bulk-stop", disabled: stopN === 0 }),
+        spacer(2),
+        button(`Archive (${archiveN})`, {
+          key: "bulk-archive",
+          disabled: archiveN === 0,
+        }),
+        spacer(2),
+        button(`Delete (${deleteN})`, {
+          intent: "danger",
+          key: "bulk-delete",
+          disabled: deleteN === 0,
+        }),
+        flexSpacer(),
+        button("Clear", { key: "bulk-clear" }),
+      );
+
+  return labeledSection({
+    label: `Bulk actions — ${sel.length} selected`,
+    child: col(
+      { kind: "raw", entries },
+      spacer(0),
+      actionRow,
+    ),
+  });
+}
+
 function buildOpenSpec(): WidgetSpec {
   if (!openDialog) return col();
   const filtered = openDialog.filteredIds;
@@ -1179,6 +1401,19 @@ function buildOpenSpec(): WidgetSpec {
     scopeButton,
     flexSpacer(),
   );
+  // Per-project filter checkbox, on its own row under the Project
+  // control: hides the discovered on-disk `[○]` worktree rows. A
+  // button (not a Toggle) so it activates on Enter/click — Space is
+  // claimed mode-wide for row selection. Inert while a confirm
+  // prompt is up.
+  const hideWorktrees = openDialog.hideDiscovered;
+  const worktreeFilterRow = row(
+    button(
+      `${hideWorktrees ? "[x]" : "[ ]"} Hide on-disk worktrees`,
+      { key: openDialog.pendingConfirm !== null ? undefined : "worktree-hide" },
+    ),
+    flexSpacer(),
+  );
 
   return col(
     {
@@ -1233,6 +1468,7 @@ function buildOpenSpec(): WidgetSpec {
             flexSpacer(),
           ),
           projectControlRow,
+          worktreeFilterRow,
           filterInput,
           sessionsSeparator(),
           sessionsColumnHeader(),
@@ -1272,6 +1508,11 @@ function buildOpenSpec(): WidgetSpec {
       hintBar([
         { keys: "↑↓", label: "nav" },
         { keys: "Enter", label: "dive" },
+        {
+          keys: editor.getKeybindingLabel("orchestrator_toggle_select", OPEN_MODE) ||
+            "Space",
+          label: "select",
+        },
         {
           keys: scopeKey || "⌥P",
           label: scope === "current" ? "all projects" : "current only",
@@ -1332,6 +1573,7 @@ function clearDialogError(): void {
 
 function refreshOpenDialog(): void {
   if (!openPanel || !openDialog) return;
+  pruneSelection();
   openDialog.filteredIds = filterSessions(openDialog.filter.value);
   // Clamp the selection into range so a fresh filter or a
   // session vanishing under us doesn't leave us pointing past
@@ -1372,6 +1614,9 @@ function openControlRoom(): void {
     // Restore the last-used scope (defaults to "all"); the Project
     // control / Alt+P updates it for next time.
     scope: lastOpenScope,
+    selectedIds: new Set<number>(),
+    hideDiscovered: lastHideDiscovered,
+    bulkInFlight: null,
   };
   openDialog.filteredIds = filterSessions("");
   const activeIdx = openDialog.filteredIds.indexOf(activeId);
@@ -1410,33 +1655,27 @@ function closeOpenDialog(): void {
   editor.setEditorMode(null);
 }
 
-// Stop every process the highlighted session owns. Sends
-// SIGTERM first via the host's `signalWindow` (which fans
-// out through the window's process-group tracker), then
-// follows up with SIGKILL after a short grace period so
-// ill-behaved agents that ignore SIGTERM still get reaped.
-// The session record stays put — Stop only kills processes,
-// it doesn't touch the worktree or the editor session.
-function stopSelectedSession(): void {
-  if (!openDialog) return;
-  const id = openDialog.filteredIds[openDialog.selectedIndex];
-  if (typeof id !== "number" || id <= 0) return;
-  if (id === 1) {
-    setDialogError("cannot stop the base session");
-    refreshOpenDialog();
-    return;
-  }
+// Stop every process one session owns. Sends SIGTERM first via the
+// host's `signalWindow` (which fans out through the window's
+// process-group tracker), then follows up with SIGKILL after a short
+// grace period so ill-behaved agents that ignore SIGTERM still get
+// reaped. The session record stays put — Stop only kills processes,
+// it doesn't touch the worktree or the editor session. Returns false
+// for ids it can't stop (base session, discovered worktrees with no
+// live window).
+function stopOne(id: number): boolean {
+  const s = orchestratorSessions.get(id);
+  if (!s || id <= 0 || id === 1 || s.discovered) return false;
   editor.signalWindow(id, "SIGTERM");
-  // SIGKILL fallback for agents that ignore SIGTERM. The
-  // host's signalWindow is idempotent on already-exited
-  // process groups, so the second call is safe whether or
-  // not the first one took. QuickJS has no `setTimeout`;
-  // the host exposes `editor.delay(ms)` as the asynchronous
+  // SIGKILL fallback for agents that ignore SIGTERM. The host's
+  // signalWindow is idempotent on already-exited process groups, so
+  // the second call is safe whether or not the first one took.
+  // QuickJS has no `setTimeout`; `editor.delay(ms)` is the async
   // sleep primitive, which we kick off but don't await.
   void editor.delay(2000).then(() => {
     editor.signalWindow(id, "SIGKILL");
   });
-  editor.setStatus(`Orchestrator: stop signal sent to session [${id}]`);
+  return true;
 }
 
 // ---------------------------------------------------------------------
@@ -1519,136 +1758,97 @@ function pickNextActiveSession(excludeId: number): number {
   return 1;
 }
 
-// Archive flow: stop all processes (SIGKILL — archive is a
-// "I'm done with this for now" action, no graceful teardown
-// needed since the worktree stays on disk), close the editor
-// session, move the worktree to the `.archived/` graveyard,
-// and append a manifest entry so a future Unarchive flow can
-// reverse it.
-async function archiveSelectedSession(explicitId?: number): Promise<void> {
-  if (!openDialog) return;
-  // Prefer the explicit id from the confirm path. Otherwise read
-  // the currently selected row — used by the legacy direct-call
-  // entry points. Once the row is hidden synchronously after
-  // confirm, `filteredIds[selectedIndex]` no longer points at the
-  // session being archived (it shifts to whatever is now under
-  // the cursor).
-  const id = typeof explicitId === "number"
-    ? explicitId
-    : openDialog.filteredIds[openDialog.selectedIndex];
-  // Clear the in-flight marker so the preview pane stops showing
-  // "Archiving…" if the operation refuses or fails. After
-  // `closeWindow` succeeds the row is gone from `listWindows()`
-  // anyway, so clearing then is harmless.
-  const clearInFlight = () => {
-    if (
-      openDialog?.inFlight && typeof id === "number" &&
-      openDialog.inFlight.sessionId === id
-    ) {
-      openDialog.inFlight = null;
-      refreshOpenDialog();
+// Resolve the *main* repo root a session's worktree belongs to, so
+// `git worktree move/remove` runs from a stable directory (never from
+// inside the tree being moved/removed). Prefers the canonical
+// `projectPath` recorded at create/discovery time, falling back to
+// resolving from the worktree itself.
+async function worktreeRepoRoot(s: AgentSession): Promise<string | null> {
+  if (s.projectPath) {
+    const r = await resolveCanonicalRepoRoot(s.projectPath);
+    if (r) return r;
+  }
+  return await resolveCanonicalRepoRoot(s.root);
+}
+
+interface LifecycleResult {
+  ok: boolean;
+  err?: string;
+  repoRoot?: string;
+}
+
+// Archive a single session: SIGKILL its processes (archive is a
+// "done with this for now" action — no graceful teardown needed since
+// the worktree stays on disk), close the editor session, move the
+// worktree to the `.archived/` graveyard, and append a manifest
+// entry so Unarchive can reverse it. Handles both live sessions and
+// discovered on-disk worktrees (the latter have no window to close).
+// Does NOT trigger sync — the caller batches one sync per repo after
+// the whole run.
+async function archiveOne(id: number): Promise<LifecycleResult> {
+  const s = orchestratorSessions.get(id);
+  if (!s) return { ok: false, err: "session gone" };
+  if (id === 1) return { ok: false, err: "cannot archive the base session" };
+  const repoRoot = await worktreeRepoRoot(s);
+  if (!repoRoot) return { ok: false, err: "not a git repository" };
+
+  // Live session: close_window refuses to close the active window, so
+  // switch away first, then SIGKILL the process group (so pty
+  // children release worktree locks) and close the editor session.
+  if (!s.discovered && id > 0) {
+    if (id === editor.activeWindow()) {
+      editor.setActiveWindow(pickNextActiveSession(id));
     }
-  };
-  if (typeof id !== "number" || id <= 0) return;
-  if (id === 1) {
-    setDialogError("cannot archive the base session");
-    clearInFlight();
-    return;
-  }
-  // close_window refuses to close the active window; swap to a
-  // different session first. The pick prefers something already
-  // in the dialog's current filter, falls back to the base
-  // session — both always exist (base is undeletable, and we'd
-  // have nothing to archive without at least one session).
-  if (id === editor.activeWindow()) {
-    editor.setActiveWindow(pickNextActiveSession(id));
-  }
-  const session = orchestratorSessions.get(id);
-  if (!session) {
-    clearInFlight();
-    return;
+    editor.signalWindow(id, "SIGKILL");
+    editor.closeWindow(id);
+    // Brief settle so the filesystem reflects the pty's exit before
+    // we move the worktree out from under it.
+    await editor.delay(250);
   }
 
-  // Resolve the repo root from cwd (the user is in the
-  // umbrella session's tree).
-  const cwd = editor.getCwd();
-  const top = await spawnCollect(
-    "git",
-    ["rev-parse", "--show-toplevel"],
-    cwd,
-  );
-  if (top.exit_code !== 0) {
-    editor.setStatus("Orchestrator: archive failed — not a git repository");
-    clearInFlight();
-    return;
-  }
-  const repoRoot = (top.stdout || "").trim();
-
-  // SIGKILL the session's process group so the pty children
-  // release any locks on the worktree, then close the editor
-  // session. closeWindow already kills the pty via the child
-  // killer; signaling first via the window-level pg tracker
-  // catches stray subprocesses outside the pty.
-  editor.signalWindow(id, "SIGKILL");
-  editor.closeWindow(id);
-
-  // Brief settle so the filesystem reflects the pty's exit
-  // before we move the worktree out from under it.
-  await editor.delay(250);
-
-  // git worktree move keeps git's internal bookkeeping
-  // consistent (the new path stays registered as a worktree).
   const archivedRoot = editor.pathJoin(
     editor.getDataDir(),
     "orchestrator",
     slugify(repoRoot),
     ".archived",
-    session.label,
+    s.label,
   );
   const parent = editor.pathDirname(archivedRoot);
   if (!editor.createDir(parent)) {
-    editor.setStatus(
-      `Orchestrator: archive failed — could not create ${parent}`,
-    );
-    clearInFlight();
-    return;
+    return { ok: false, err: `could not create ${parent}`, repoRoot };
   }
+  // git worktree move keeps git's internal bookkeeping consistent
+  // (the new path stays registered as a worktree).
   const moveRes = await spawnCollect(
     "git",
-    ["-C", repoRoot, "worktree", "move", session.root, archivedRoot],
+    ["-C", repoRoot, "worktree", "move", s.root, archivedRoot],
     repoRoot,
   );
   if (moveRes.exit_code !== 0) {
-    editor.setStatus(
-      `Orchestrator: worktree move failed: ${
-        lastNonEmptyLine(moveRes.stderr) || "unknown error"
-      }`,
-    );
-    clearInFlight();
-    return;
+    return {
+      ok: false,
+      err: lastNonEmptyLine(moveRes.stderr) || "worktree move failed",
+      repoRoot,
+    };
   }
 
-  // Append manifest entry. The branch info is best-effort:
-  // we assume Orchestrator's convention of branch==label (set in
-  // the new-session form) until a session knows its branch
-  // separately.
   const manifest = loadArchiveManifest(repoRoot);
   manifest.sessions.push({
-    label: session.label,
+    label: s.label,
     root: archivedRoot,
-    original_root: session.root,
-    branch: session.label,
+    original_root: s.root,
+    branch: s.branch || s.label,
     archived_at: new Date().toISOString(),
   });
-  if (!saveArchiveManifest(repoRoot, manifest)) {
-    editor.setStatus(
-      "Orchestrator: archived, but failed to write archived.json",
-    );
-  } else {
-    editor.setStatus(`Orchestrator: archived [${id}] ${session.label}`);
+  saveArchiveManifest(repoRoot, manifest);
+
+  // A discovered row has no window_closed hook to drop it — remove it
+  // from the model directly.
+  if (s.discovered) {
+    orchestratorSessions.delete(id);
+    discoveredIdByPath.delete(s.root);
   }
-  clearInFlight();
-  triggerSyncAsync(repoRoot);
+  return { ok: true, repoRoot };
 }
 
 // ---------------------------------------------------------------------
@@ -1851,86 +2051,135 @@ async function buildSyncSnapshot(repoRoot: string): Promise<unknown> {
   };
 }
 
-// Delete flow: stop processes (SIGKILL), close the editor
-// session, then `git worktree remove --force` to drop the
-// worktree from disk. If the session was archived (manifest
-// entry exists), the manifest entry is dropped too. No
-// recovery after this point.
-async function deleteConfirmedSession(): Promise<void> {
-  if (!openDialog || !openDialog.pendingConfirm) return;
-  const { sessionId: id } = openDialog.pendingConfirm;
-  openDialog.pendingConfirm = null;
-  // Clear the in-flight marker on early failure. Mirrors the
-  // pattern in `archiveSelectedSession` — the confirm-delete
-  // handler set `inFlight` before kicking off this async work,
-  // and any path that aborts before `closeWindow` needs to undo
-  // it so the "Deleting…" overlay disappears.
-  const clearInFlight = () => {
-    if (openDialog?.inFlight && openDialog.inFlight.sessionId === id) {
-      openDialog.inFlight = null;
-      refreshOpenDialog();
+// Delete a single session: stop processes (SIGKILL), close the
+// editor session, then `git worktree remove --force` to drop the
+// worktree from disk. If the session was archived (manifest entry
+// exists), the manifest entry is dropped too. Handles discovered
+// on-disk worktrees (no window to close). No recovery after this
+// point. Does NOT trigger sync — the caller batches it.
+async function deleteOne(id: number): Promise<LifecycleResult> {
+  const s = orchestratorSessions.get(id);
+  if (!s) return { ok: false, err: "session gone" };
+  if (id === 1) return { ok: false, err: "cannot delete the base session" };
+  const repoRoot = await worktreeRepoRoot(s);
+  if (!repoRoot) return { ok: false, err: "not a git repository" };
+
+  if (!s.discovered && id > 0) {
+    // close_window refuses to close the active window, so swap away.
+    if (id === editor.activeWindow()) {
+      editor.setActiveWindow(pickNextActiveSession(id));
     }
-  };
-  const session = orchestratorSessions.get(id);
-  if (!session) {
-    clearInFlight();
-    return;
-  }
-  // Same auto-switch as archive — close_window refuses to close
-  // the active window, so swap to a different session first.
-  if (id === editor.activeWindow()) {
-    editor.setActiveWindow(pickNextActiveSession(id));
+    editor.signalWindow(id, "SIGKILL");
+    editor.closeWindow(id);
+    await editor.delay(250);
   }
 
-  const cwd = editor.getCwd();
-  const top = await spawnCollect(
-    "git",
-    ["rev-parse", "--show-toplevel"],
-    cwd,
-  );
-  if (top.exit_code !== 0) {
-    editor.setStatus("Orchestrator: delete failed — not a git repository");
-    clearInFlight();
-    return;
-  }
-  const repoRoot = (top.stdout || "").trim();
-
-  editor.signalWindow(id, "SIGKILL");
-  editor.closeWindow(id);
-  await editor.delay(250);
-
-  // `--force` because the worktree may have unstaged changes
-  // the user explicitly chose to discard via the confirm step.
+  // `--force` because the worktree may have unstaged changes the user
+  // explicitly chose to discard via the confirm step.
   const removeRes = await spawnCollect(
     "git",
-    ["-C", repoRoot, "worktree", "remove", "--force", session.root],
+    ["-C", repoRoot, "worktree", "remove", "--force", s.root],
     repoRoot,
   );
   if (removeRes.exit_code !== 0) {
-    editor.setStatus(
-      `Orchestrator: worktree remove failed: ${
-        lastNonEmptyLine(removeRes.stderr) || "unknown error"
-      }`,
-    );
-    clearInFlight();
-    return;
+    return {
+      ok: false,
+      err: lastNonEmptyLine(removeRes.stderr) || "worktree remove failed",
+      repoRoot,
+    };
   }
 
-  // Drop the matching manifest entry too, in case the session
-  // was already archived (delete-from-archived is the natural
-  // way to drop dormant sessions).
+  // Drop the matching manifest entry too, in case the session was
+  // already archived (delete-from-archived is the natural way to drop
+  // dormant sessions).
   const manifest = loadArchiveManifest(repoRoot);
   const before = manifest.sessions.length;
-  manifest.sessions = manifest.sessions.filter(
-    (e) => e.label !== session.label,
-  );
+  manifest.sessions = manifest.sessions.filter((e) => e.label !== s.label);
   if (manifest.sessions.length !== before) {
     saveArchiveManifest(repoRoot, manifest);
   }
 
-  editor.setStatus(`Orchestrator: deleted [${id}] ${session.label}`);
-  clearInFlight();
-  triggerSyncAsync(repoRoot);
+  if (s.discovered) {
+    orchestratorSessions.delete(id);
+    discoveredIdByPath.delete(s.root);
+  }
+  return { ok: true, repoRoot };
+}
+
+// Unified runner for a confirmed Stop / Archive / Delete over one or
+// many ids. Re-filters to eligible targets at execution time (the
+// selection or single row may have gone stale between confirm and
+// run), drives the in-flight progress markers, runs the per-id cores
+// sequentially, prunes acted-on ids from the selection, and triggers
+// one sync per touched repo at the end.
+async function runConfirmedAction(
+  action: BulkAction,
+  ids: number[],
+): Promise<void> {
+  if (!openDialog) return;
+  const targets = ids.filter((id) => bulkEligible(action, id));
+  if (targets.length === 0) {
+    setDialogError(`nothing eligible to ${action} in the selection`);
+    refreshOpenDialog();
+    return;
+  }
+
+  if (action === "stop") {
+    let n = 0;
+    for (const id of targets) if (stopOne(id)) n += 1;
+    editor.setStatus(`Orchestrator: stop signal sent to ${n} session(s)`);
+    // Stop leaves sessions in place; drop them from the selection so
+    // the bulk bar reflects that the action ran.
+    for (const id of targets) openDialog.selectedIds.delete(id);
+    refreshOpenDialog();
+    return;
+  }
+
+  const single = targets.length === 1;
+  if (single) {
+    openDialog.inFlight = { action, sessionId: targets[0] };
+  } else {
+    openDialog.bulkInFlight = { action, total: targets.length, done: 0 };
+  }
+  refreshOpenDialog();
+
+  const touchedRepos = new Set<string>();
+  let okCount = 0;
+  let lastErr = "";
+  for (let i = 0; i < targets.length; i++) {
+    const id = targets[i];
+    const res = action === "archive" ? await archiveOne(id) : await deleteOne(id);
+    if (res.ok) {
+      okCount += 1;
+      if (res.repoRoot) touchedRepos.add(res.repoRoot);
+    } else {
+      lastErr = res.err ?? "failed";
+    }
+    openDialog?.selectedIds.delete(id);
+    if (openDialog?.bulkInFlight) openDialog.bulkInFlight.done = i + 1;
+    refreshOpenDialog();
+  }
+  if (openDialog) {
+    openDialog.inFlight = null;
+    openDialog.bulkInFlight = null;
+  }
+
+  const verb = action === "archive" ? "archived" : "deleted";
+  if (okCount === 0) {
+    setDialogError(`${action} failed: ${lastErr || "unknown error"}`);
+  } else if (lastErr) {
+    setDialogError(`${verb} ${okCount}/${targets.length}; last error: ${lastErr}`);
+  } else {
+    editor.setStatus(`Orchestrator: ${verb} ${okCount} session(s)`);
+  }
+  for (const repo of touchedRepos) triggerSyncAsync(repo);
+  refreshOpenDialog();
+  // The batch emptied the selection, so the pane is back in
+  // single-preview mode — restore focus to Visit (the bulk buttons
+  // it may have been on are gone).
+  if (openPanel && selectedSessions().length < 2 && !openDialog.pendingConfirm) {
+    openPanel.setFocusKey("visit");
+  }
 }
 
 // `Alt+N` from inside the picker opens the new-session form — saves
@@ -1953,6 +2202,16 @@ editor.defineMode(
     // text; session names don't contain `/`, so that's an
     // acceptable trade for the quick-focus.)
     ["/", "orchestrator_focus_filter"],
+    // Space toggles the highlighted row's membership in the bulk
+    // selection. Bound as a mode chord (not a widget smart-key) so
+    // it's user-rebindable in the keybinding editor and fires
+    // regardless of which control holds focus — the host's
+    // `dispatch_floating_widget_key` defers any explicitly-bound
+    // mode key, including bare chars, before the text-input path.
+    // The trade (same as `/`) is that Space can't be typed into the
+    // filter while the picker is open; session names don't contain
+    // spaces, so that's acceptable.
+    ["Space", "orchestrator_toggle_select"],
   ],
   true,
   true,
@@ -1967,6 +2226,38 @@ registerHandler("orchestrator_open_new_from_picker", () => {
 registerHandler("orchestrator_focus_filter", () => {
   if (!openDialog || !openPanel) return;
   openPanel.setFocusKey("filter");
+});
+
+// Space (rebindable): toggle the highlighted row in/out of the bulk
+// selection. Manages focus across the single↔bulk transition: when
+// the second row is checked the preview pane swaps to the bulk bar
+// (so the now-absent "visit" focus would otherwise be clamped to a
+// random tabbable), and when the selection drops back below two the
+// per-session preview — with its "visit" button — returns.
+registerHandler("orchestrator_toggle_select", () => {
+  if (!openDialog || !openPanel) return;
+  // Inert while a confirm prompt is up — the selection is frozen
+  // behind the confirmation panel.
+  if (openDialog.pendingConfirm) return;
+  const id = openDialog.filteredIds[openDialog.selectedIndex];
+  if (typeof id !== "number") return;
+  const wasBulk = selectedSessions().length >= 2;
+  if (openDialog.selectedIds.has(id)) {
+    openDialog.selectedIds.delete(id);
+  } else {
+    openDialog.selectedIds.add(id);
+  }
+  clearDialogError();
+  refreshOpenDialog();
+  const isBulk = selectedSessions().length >= 2;
+  if (!wasBulk && isBulk) {
+    // Entering bulk mode — land focus on a bulk button (Up/Down from
+    // a button still drives the list, so navigation keeps working).
+    openPanel.setFocusKey("bulk-archive");
+  } else if (wasBulk && !isBulk) {
+    // Back to single preview — restore focus to Visit.
+    openPanel.setFocusKey("visit");
+  }
 });
 
 function toggleScope(): void {
@@ -3595,7 +3886,27 @@ function enterConfirm(action: "stop" | "archive" | "delete"): void {
       }
     }
   }
-  openDialog.pendingConfirm = { action, sessionId: id };
+  openDialog.pendingConfirm = { action, ids: [id] };
+  openPanel.update(buildOpenSpec());
+  openPanel.setFocusKey("confirm-cancel");
+}
+
+// Open the confirm panel for a *bulk* action over the current
+// checkbox selection. Filters to the eligible members up front (so
+// the confirm count matches what will actually run); refuses with a
+// banner when nothing is eligible.
+function enterBulkConfirm(action: BulkAction): void {
+  if (!openDialog || !openPanel) return;
+  const targets = eligibleSelected(action);
+  if (targets.length === 0) {
+    setDialogError(`no selected session can be ${action === "stop" ? "stopped" : action + "d"}`);
+    refreshOpenDialog();
+    return;
+  }
+  // All three actions confirm — even Stop, so a bulk Stop over a
+  // large selection isn't a single mis-key away. The confirm panel
+  // lists the targets and shows the eligible count.
+  openDialog.pendingConfirm = { action, ids: targets };
   openPanel.update(buildOpenSpec());
   openPanel.setFocusKey("confirm-cancel");
 }
@@ -3754,8 +4065,11 @@ editor.on("widget_event", (e) => {
         // on the button. Snap focus back to Visit so the user can
         // press Enter to open the newly-highlighted session — the
         // dialog's whole reason for being. Idempotent when focus
-        // is already on Visit.
-        openPanel.setFocusKey("visit");
+        // is already on Visit. Skipped in bulk mode and during a
+        // confirm, where "visit" isn't in the spec.
+        if (selectedSessions().length < 2 && !openDialog.pendingConfirm) {
+          openPanel.setFocusKey("visit");
+        }
       }
       return;
     }
@@ -3798,6 +4112,20 @@ editor.on("widget_event", (e) => {
       refreshOpenDialog();
       return;
     }
+    if (e.event_type === "activate" && e.widget_key === "worktree-hide") {
+      openDialog.hideDiscovered = !openDialog.hideDiscovered;
+      lastHideDiscovered = openDialog.hideDiscovered;
+      // A hidden discovered row shouldn't linger in the selection.
+      if (openDialog.hideDiscovered) {
+        for (const id of [...openDialog.selectedIds]) {
+          if (orchestratorSessions.get(id)?.discovered) {
+            openDialog.selectedIds.delete(id);
+          }
+        }
+      }
+      refreshOpenDialog();
+      return;
+    }
     if (e.event_type === "activate" && e.widget_key === "stop") {
       enterConfirm("stop");
       return;
@@ -3810,44 +4138,47 @@ editor.on("widget_event", (e) => {
       enterConfirm("delete");
       return;
     }
+    // Bulk action bar (Layout B) — Stop / Archive / Delete over the
+    // checkbox selection, plus Clear.
+    if (e.event_type === "activate" && e.widget_key === "bulk-stop") {
+      enterBulkConfirm("stop");
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "bulk-archive") {
+      enterBulkConfirm("archive");
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "bulk-delete") {
+      enterBulkConfirm("delete");
+      return;
+    }
+    if (e.event_type === "activate" && e.widget_key === "bulk-clear") {
+      openDialog.selectedIds.clear();
+      refreshOpenDialog();
+      openPanel.setFocusKey("visit");
+      return;
+    }
     if (e.event_type === "activate" && e.widget_key === "confirm-cancel") {
       openDialog.pendingConfirm = null;
       openPanel.update(buildOpenSpec());
       return;
     }
-    if (e.event_type === "activate" && e.widget_key === "confirm-stop") {
+    // Confirmed Stop / Archive / Delete — single row or bulk batch.
+    // The ids were captured into `pendingConfirm` by enterConfirm /
+    // enterBulkConfirm; `runConfirmedAction` re-checks eligibility,
+    // drives the in-flight markers, and triggers sync.
+    if (
+      e.event_type === "activate" &&
+      (e.widget_key === "confirm-stop" ||
+        e.widget_key === "confirm-archive" ||
+        e.widget_key === "confirm-delete")
+    ) {
+      const confirm = openDialog.pendingConfirm;
       openDialog.pendingConfirm = null;
-      stopSelectedSession();
+      if (confirm) {
+        void runConfirmedAction(confirm.action, confirm.ids);
+      }
       if (openPanel) openPanel.update(buildOpenSpec());
-      return;
-    }
-    if (e.event_type === "activate" && e.widget_key === "confirm-archive") {
-      const id = openDialog.filteredIds[openDialog.selectedIndex];
-      openDialog.pendingConfirm = null;
-      // Mark the session in-flight so the preview swaps to
-      // "Archiving…" and its action buttons disappear until git
-      // finishes. The row stays in the list — `editor.listWindows()`
-      // is still the source of truth and will drop it on
-      // `closeWindow`, which is intentional: a slightly-laggy real
-      // state beats a synchronously faked one that can desync from
-      // git reality (e.g. when `git worktree move` fails).
-      if (typeof id === "number" && id > 0) {
-        openDialog.inFlight = { action: "archive", sessionId: id };
-      }
-      void archiveSelectedSession(id);
-      refreshOpenDialog();
-      return;
-    }
-    if (e.event_type === "activate" && e.widget_key === "confirm-delete") {
-      const id = openDialog.pendingConfirm?.sessionId;
-      // Mark in-flight — see comment on confirm-archive above.
-      // `deleteConfirmedSession` clears `pendingConfirm` itself, so
-      // we capture the id here before it goes away.
-      if (typeof id === "number" && id > 0) {
-        openDialog.inFlight = { action: "delete", sessionId: id };
-      }
-      void deleteConfirmedSession();
-      refreshOpenDialog();
       return;
     }
     if (e.event_type === "cancel") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1216,45 +1216,18 @@ function buildConfirmPane(
 }
 
 // The dedicated bulk selection bar (Layout B). Shown in place of the
-// per-session preview when two or more rows are checked: lists the
-// selected sessions (flagging the ones a destructive action can't
-// touch) and offers Stop / Archive / Delete over the whole batch
-// plus a Clear-selection button. Each action's count is the number of
-// *eligible* members; an action with no eligible members is disabled.
+// per-session preview when two or more rows are checked. The bulk
+// action buttons sit at the *top* of the pane; the list of affected
+// sessions renders below as a scrollable `list` widget (so a long
+// selection scrolls — keyboard, wheel, and the draggable scrollbar —
+// rather than overflowing the pane). Each action's count is the
+// number of *eligible* members; an action with no eligible members is
+// disabled.
 function buildBulkPane(): WidgetSpec {
   const sel = selectedSessions();
   const stopN = eligibleSelected("stop").length;
   const archiveN = eligibleSelected("archive").length;
   const deleteN = eligibleSelected("delete").length;
-
-  const entries: TextPropertyEntry[] = [];
-  const cap = openDialog?.listVisibleRows ?? MIN_LIST_ROWS;
-  for (const id of sel.slice(0, cap)) {
-    const ss = orchestratorSessions.get(id)!;
-    const rowParts: StyledSegment[] = [
-      { text: `  ${ss.label}` },
-    ];
-    // Flag rows a destructive bulk action will skip so the count
-    // discrepancy is self-explanatory.
-    if (id === 1) {
-      rowParts.push({ text: "  · base (protected)", style: { fg: "ui.menu_disabled_fg", italic: true } });
-    } else if (!ss.discovered && (countSiblingsAtRoot(ss.root) > 1 || ss.sharedWorktree)) {
-      rowParts.push({ text: "  · shared worktree", style: { fg: "ui.menu_disabled_fg", italic: true } });
-    } else if (ss.discovered) {
-      rowParts.push({ text: "  · on-disk worktree", style: { fg: "ui.menu_disabled_fg", italic: true } });
-    }
-    entries.push(styledRow(rowParts));
-  }
-  if (sel.length > cap) {
-    entries.push(
-      styledRow([
-        {
-          text: `  … and ${sel.length - cap} more`,
-          style: { fg: "ui.menu_disabled_fg", italic: true },
-        },
-      ]),
-    );
-  }
 
   const inflight = openDialog?.bulkInFlight ?? null;
   const actionRow = inflight
@@ -1289,12 +1262,53 @@ function buildBulkPane(): WidgetSpec {
         button("Clear", { key: "bulk-clear" }),
       );
 
+  // Affected-sessions list. Flag the rows a destructive action will
+  // skip so the count discrepancy explains itself.
+  const items: TextPropertyEntry[] = sel.map((id) => {
+    const ss = orchestratorSessions.get(id)!;
+    const rowParts: StyledSegment[] = [{ text: `  ${ss.label}` }];
+    if (id === 1) {
+      rowParts.push({
+        text: "  · base (protected)",
+        style: { fg: "ui.menu_disabled_fg", italic: true },
+      });
+    } else if (!ss.discovered && (countSiblingsAtRoot(ss.root) > 1 || ss.sharedWorktree)) {
+      rowParts.push({
+        text: "  · shared worktree",
+        style: { fg: "ui.menu_disabled_fg", italic: true },
+      });
+    } else if (ss.discovered) {
+      rowParts.push({
+        text: "  · on-disk worktree",
+        style: { fg: "ui.menu_disabled_fg", italic: true },
+      });
+    }
+    return styledRow(rowParts);
+  });
+  const itemKeys = sel.map((id) => `bulksel-${id}`);
+  // Match the preview pane's height: content = action row (1) +
+  // spacer (1) + list, and the embed pane reserves `listVisibleRows
+  // + 4` for its body — so the list takes that height and the two
+  // panes' bottom borders line up.
+  const listRows = Math.max(3, (openDialog?.listVisibleRows ?? MIN_LIST_ROWS) + 4);
+
   return labeledSection({
     label: `Bulk actions — ${sel.length} selected`,
     child: col(
-      { kind: "raw", entries },
-      spacer(0),
       actionRow,
+      spacer(0),
+      list({
+        items,
+        itemKeys,
+        // Display-only: no highlighted row, and out of the Tab cycle
+        // (focus belongs on the action buttons). Up/Down still scroll
+        // it via the host's smart-key forwarding, and the scrollbar
+        // drags it.
+        selectedIndex: -1,
+        visibleRows: listRows,
+        focusable: false,
+        key: "bulk-list",
+      }),
     ),
   });
 }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -76,6 +76,18 @@ interface AgentSession {
   state: AgentState;
   // Wall-clock ms when orchestrator.new fired createWindow.
   createdAt: number;
+  // `true` when this row is a worktree discovered on disk (via
+  // `git worktree list`) that has no live editor window yet.
+  // Discovered rows carry a synthetic negative `id`, no
+  // `terminalId`, and dive by *attaching* a new session to
+  // `root` rather than switching to an existing window. They are
+  // dropped from `orchestratorSessions` the moment a real window
+  // is opened at the same `root`.
+  discovered?: boolean;
+  // Branch checked out in this worktree (best-effort, for
+  // display). Set for discovered rows; left undefined for live
+  // sessions where the tab/label already carries the identity.
+  branch?: string;
 }
 
 // =============================================================================
@@ -83,6 +95,25 @@ interface AgentSession {
 // =============================================================================
 
 const orchestratorSessions = new Map<number, AgentSession>();
+
+// Stable synthetic ids for discovered (on-disk, not-yet-opened)
+// worktrees, keyed by canonical path. Live windows own the
+// positive id space (editor `WindowId`s); discovered rows take
+// negative ids so the two never collide and the existing
+// `orchestratorSessions.get(id)` call sites keep working. Ids
+// stay stable across rescans so the dialog selection doesn't
+// jump when the worktree set is refreshed. `-1` is reserved as a
+// "no selection" sentinel elsewhere, so allocation starts at `-2`.
+const discoveredIdByPath = new Map<string, number>();
+let nextDiscoveredId = -2;
+function discoveredIdFor(path: string): number {
+  let id = discoveredIdByPath.get(path);
+  if (id === undefined) {
+    id = nextDiscoveredId--;
+    discoveredIdByPath.set(path, id);
+  }
+  return id;
+}
 
 // New-session form state. `null` ⇒ the floating form isn't
 // open. Each field's `value` + `cursor` mirrors what the host
@@ -118,6 +149,14 @@ interface NewSessionForm {
   // (checkbox disabled, branch field inert). `null`: probe
   // in flight (keep checkbox in its last-known state).
   projectPathIsGit: boolean | null;
+  // `true` when the resolved Project Path is itself an existing
+  // *linked* worktree (created by `git worktree add`). In that
+  // case leaving "Create a new git worktree" unchecked attaches
+  // the session to it as a managed worktree rather than treating
+  // it as a shared root. The probe defaults the checkbox to
+  // unchecked when it first detects this, and `buildFormSpec`
+  // surfaces an explanatory hint. `null` while the probe runs.
+  projectPathIsLinkedWorktree: boolean | null;
   // Concrete session name the auto-generator would produce
   // for the current Project Path (e.g. "session-3"). Surfaced
   // as the Session Name placeholder so the user sees the
@@ -298,9 +337,120 @@ function reconcileSessions(): void {
       if (s.shared_worktree != null) existing.sharedWorktree = s.shared_worktree;
     }
   }
+  // Live windows live in the positive id space; their absence from
+  // `listWindows()` means they were closed, so drop them. Discovered
+  // worktrees (negative ids) are NOT backed by a window and must
+  // survive this sweep — they're pruned separately, against the
+  // on-disk worktree set, by `refreshDiscoveredWorktrees`.
   for (const id of orchestratorSessions.keys()) {
-    if (!seen.has(id)) orchestratorSessions.delete(id);
+    if (id > 0 && !seen.has(id)) orchestratorSessions.delete(id);
   }
+  // A worktree that's now open as a live window must not also linger
+  // as a discovered row. Drop any discovered entry whose root a live
+  // session already occupies.
+  const liveRoots = new Set<string>();
+  for (const s of orchestratorSessions.values()) {
+    if (!s.discovered) liveRoots.add(s.root);
+  }
+  for (const [id, s] of orchestratorSessions) {
+    if (s.discovered && liveRoots.has(s.root)) orchestratorSessions.delete(id);
+  }
+}
+
+// =============================================================================
+// Discovered-worktree scan
+//
+// Surfaces worktrees that exist on disk but have no live editor
+// window, so the user doesn't have to add them by hand. Because
+// open sessions can span several repos, `git worktree list` must
+// run once *per project*: the scan set is the distinct canonical
+// repo roots of every live session, plus the editor's cwd repo.
+// Each linked worktree not already open (and not an
+// orchestrator-internal tree) becomes a discovered row that dives
+// by attaching a fresh session to it.
+// =============================================================================
+
+let discoveryInFlight = false;
+
+function isInternalWorktreePath(path: string): boolean {
+  // The sync-workspace and the `.archived/` graveyard are
+  // orchestrator bookkeeping, not user sessions.
+  return path.includes(".sync-workspace") || path.includes("/.archived/");
+}
+
+async function refreshDiscoveredWorktrees(): Promise<void> {
+  if (discoveryInFlight) return;
+  discoveryInFlight = true;
+  try {
+    reconcileSessions();
+
+    // (1) Candidate dirs: every live session's root + the editor
+    //     cwd. Resolve each to its canonical main repo root and
+    //     dedupe so a repo with N open worktrees is scanned once.
+    const candidates = new Set<string>([editor.getCwd()]);
+    for (const s of orchestratorSessions.values()) {
+      if (!s.discovered) candidates.add(s.root);
+    }
+    const mainRoots = new Set<string>();
+    for (const dir of candidates) {
+      const canonical = await resolveCanonicalRepoRoot(dir);
+      if (canonical) mainRoots.add(canonical);
+    }
+
+    // (2) Roots already occupied by a live session — discovered rows
+    //     for these would be duplicates.
+    const liveRoots = new Set<string>();
+    for (const s of orchestratorSessions.values()) {
+      if (!s.discovered) liveRoots.add(s.root);
+    }
+
+    // (3) Scan each repo and collect the linked worktrees worth
+    //     surfacing.
+    const foundPaths = new Set<string>();
+    for (const repoRoot of mainRoots) {
+      const listed = await listLinkedWorktrees(repoRoot);
+      if (!listed) continue;
+      for (const wt of listed.worktrees) {
+        if (liveRoots.has(wt.path)) continue;
+        if (isInternalWorktreePath(wt.path)) continue;
+        foundPaths.add(wt.path);
+        const id = discoveredIdFor(wt.path);
+        const label = wt.branch || editor.pathBasename(wt.path);
+        const existing = orchestratorSessions.get(id);
+        if (existing) {
+          existing.label = label;
+          existing.root = wt.path;
+          existing.projectPath = listed.mainRoot;
+          existing.branch = wt.branch;
+        } else {
+          orchestratorSessions.set(id, {
+            id,
+            label,
+            root: wt.path,
+            projectPath: listed.mainRoot,
+            sharedWorktree: false,
+            terminalId: null,
+            state: "ready",
+            createdAt: Date.now(),
+            discovered: true,
+            branch: wt.branch,
+          });
+        }
+      }
+    }
+
+    // (4) Prune discovered rows that vanished from disk (or got
+    //     opened, picked up by the liveRoots check above).
+    for (const [id, s] of orchestratorSessions) {
+      if (s.discovered && !foundPaths.has(s.root)) {
+        orchestratorSessions.delete(id);
+        discoveredIdByPath.delete(s.root);
+      }
+    }
+  } finally {
+    discoveryInFlight = false;
+  }
+  if (openPanel) refreshOpenDialog();
 }
 
 // =============================================================================
@@ -460,16 +610,27 @@ function renderListItem(id: number, activeId: number): TextPropertyEntry {
   }
   const isActive = id === activeId;
   const isBase = id === 1;
+  const isDiscovered = !!s.discovered;
 
-  const idText = `[${id}]`.padEnd(LIST_ID_W);
+  // Discovered (on-disk, unopened) worktrees have no window id —
+  // render a `[○]` glyph instead of the synthetic negative id so
+  // the row reads as "available to open", not "session #-2".
+  const idText = (isDiscovered ? "[○]" : `[${id}]`).padEnd(LIST_ID_W);
   const entries: { text: string; style?: Record<string, unknown> }[] = [
     {
       text: idText,
       style: isActive
         ? { fg: "ui.tab_active_fg", bold: true }
-        : { fg: "ui.help_key_fg" },
+        : { fg: isDiscovered ? "ui.menu_disabled_fg" : "ui.help_key_fg" },
     },
-    { text: s.label, style: isActive ? { bold: true } : undefined },
+    {
+      text: s.label,
+      style: isActive
+        ? { bold: true }
+        : isDiscovered
+        ? { fg: "ui.menu_disabled_fg" }
+        : undefined,
+    },
   ];
   // Visible width of the NAME column so far (label + badges), used
   // to pad out to LIST_NAME_W before the PROJECT column.
@@ -814,6 +975,48 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   // turns details on, pressing `[ Preview ]` turns them off
   // (back to compact).
   const detailsToggleLabel = detailsOn ? "Preview" : "Details";
+  // Discovered worktree: no live window to embed, so there's
+  // nothing to Stop / Archive / Delete yet. Offer only "Open"
+  // (Visit attaches a fresh session to the worktree) and describe
+  // what diving will do. The empty `windowId: 0` embed keeps the
+  // pane the same height as live-session previews so the dialog
+  // doesn't jump when the selection moves between row kinds.
+  if (s.discovered) {
+    const openButtonRow = row(
+      button("Open", { intent: "primary", key: "visit" }),
+      flexSpacer(),
+      button("Stop", { key: "stop", disabled: true }),
+      spacer(2),
+      button("Archive", { key: "archive", disabled: true }),
+      spacer(2),
+      button("Delete", { intent: "danger", key: "delete", disabled: true }),
+    );
+    const info: TextPropertyEntry[] = [
+      styledRow([
+        { text: "On-disk worktree (not open)", style: { fg: "ui.menu_disabled_fg", bold: true } },
+      ]),
+      styledRow([{ text: "" }]),
+      styledRow([{ text: "branch  ", style: { fg: "ui.menu_disabled_fg" } }, { text: s.branch || "(detached)" }]),
+      styledRow([{ text: "path    ", style: { fg: "ui.menu_disabled_fg" } }, { text: s.root }]),
+      styledRow([{ text: "" }]),
+      styledRow([
+        {
+          text: "Press Enter to open this worktree as a session.",
+          style: { fg: "ui.help_key_fg", italic: true },
+        },
+      ]),
+    ];
+    return labeledSection({
+      label: `[○] ${s.label}  on-disk worktree`,
+      child: col(
+        openButtonRow,
+        spacer(0),
+        { kind: "raw", entries: info },
+        spacer(0),
+        windowEmbed({ windowId: 0, rows: Math.max(3, embedRows - 6), key: "live-preview" }),
+      ),
+    });
+  }
   // Per-action availability. The row always renders all four
   // buttons (no layout shift between selections), but each is
   // marked disabled when its action would be refused against the
@@ -890,9 +1093,11 @@ function buildOpenSpec(): WidgetSpec {
   const selIdx = filtered.length === 0
     ? -1
     : Math.max(0, Math.min(openDialog.selectedIndex, filtered.length - 1));
-  const selectedId = selIdx >= 0 ? filtered[selIdx] : -1;
-  const selectedSession = selectedId > 0
-    ? orchestratorSessions.get(selectedId)
+  // Gate on the *index* (selIdx < 0 means "filter matched nothing"),
+  // not the sign of the id: discovered worktrees carry negative ids
+  // and must still resolve to their row here.
+  const selectedSession = selIdx >= 0
+    ? orchestratorSessions.get(filtered[selIdx])
     : undefined;
 
   // The "New Session" button advertises Alt+N (or whatever the
@@ -1188,6 +1393,12 @@ function openControlRoom(): void {
   // safe — there's nothing to act on then anyway.
   openPanel.setFocusKey("visit");
   editor.setEditorMode(OPEN_MODE);
+
+  // Discover worktrees that exist on disk but aren't open yet and
+  // fold them into the list. Async (it shells out to git per
+  // project); the dialog renders immediately with live sessions and
+  // gains the discovered rows when the scan lands.
+  void refreshDiscoveredWorktrees();
 }
 
 function closeOpenDialog(): void {
@@ -2078,6 +2289,130 @@ async function pathIsInsideGitWorkTree(
   return (res.stdout || "").trim() === "true";
 }
 
+// =============================================================================
+// Worktree classification & discovery
+//
+// Two distinct git facts drive the "attach to an existing worktree"
+// flows:
+//
+//   * `classifyWorktree(path)` answers "is this path a *linked*
+//     worktree, and if so what repo does it belong to?" — used by
+//     the new-session form to attach (rather than fork) when the
+//     user points Project Path at an existing worktree.
+//   * `listLinkedWorktrees(repoRoot)` enumerates every linked
+//     worktree of a repo (via `git worktree list --porcelain`) —
+//     used to surface on-disk worktrees in the Open dialog without
+//     the user adding them by hand.
+// =============================================================================
+
+interface WorktreeInfo {
+  // `git rev-parse --show-toplevel` for the path.
+  toplevel: string;
+  // Canonical main-worktree root (dirname of `--git-common-dir`).
+  // This is the repo the worktree belongs to, used as the
+  // session's `projectPath` so attached worktrees group under
+  // their repo in the picker.
+  mainRoot: string;
+  // `true` when the path is a *linked* worktree (its per-worktree
+  // git dir differs from the shared common dir), i.e. a tree
+  // created by `git worktree add` rather than the main checkout.
+  isLinked: boolean;
+  // Branch checked out there (`refs/heads/<name>` short form), or
+  // empty when detached.
+  branch: string;
+}
+
+/// Classify `path` as a git worktree. Returns `null` when `path`
+/// is not inside any git work tree (the caller then treats it as a
+/// plain directory / shared root).
+async function classifyWorktree(path: string): Promise<WorktreeInfo | null> {
+  if (!path) return null;
+  const top = await spawnCollect("git", ["-C", path, "rev-parse", "--show-toplevel"], path);
+  if (top.exit_code !== 0) return null;
+  const toplevel = (top.stdout || "").trim();
+  if (!toplevel) return null;
+
+  // The per-worktree git dir vs. the shared common dir: they are
+  // equal for the main worktree and differ for every linked
+  // worktree (`<common>/worktrees/<id>`). That difference is the
+  // canonical "is this a linked worktree?" test.
+  const [gitDir, commonDir] = await Promise.all([
+    spawnCollect("git", ["-C", toplevel, "rev-parse", "--path-format=absolute", "--git-dir"], toplevel),
+    spawnCollect(
+      "git",
+      ["-C", toplevel, "rev-parse", "--path-format=absolute", "--git-common-dir"],
+      toplevel,
+    ),
+  ]);
+  const gd = gitDir.exit_code === 0 ? (gitDir.stdout || "").trim() : "";
+  const cd = commonDir.exit_code === 0 ? (commonDir.stdout || "").trim() : "";
+  const isLinked = gd !== "" && cd !== "" && gd !== cd;
+  const mainRoot = cd ? editor.pathDirname(cd) : toplevel;
+
+  const head = await spawnCollect(
+    "git",
+    ["-C", toplevel, "rev-parse", "--abbrev-ref", "HEAD"],
+    toplevel,
+  );
+  let branch = head.exit_code === 0 ? (head.stdout || "").trim() : "";
+  if (branch === "HEAD") branch = ""; // detached
+
+  return { toplevel, mainRoot, isLinked, branch };
+}
+
+interface ParsedWorktree {
+  path: string;
+  branch: string;
+  detached: boolean;
+}
+
+/// Parse `git worktree list --porcelain` output. Blocks are
+/// separated by blank lines; the first block is the main worktree,
+/// the rest are linked. Each block has a `worktree <path>` line
+/// plus `branch refs/heads/<name>` or `detached`.
+function parseWorktreePorcelain(stdout: string): ParsedWorktree[] {
+  const out: ParsedWorktree[] = [];
+  let cur: ParsedWorktree | null = null;
+  for (const raw of (stdout || "").split(/\r?\n/)) {
+    const line = raw.trimEnd();
+    if (line.startsWith("worktree ")) {
+      if (cur) out.push(cur);
+      cur = { path: line.slice("worktree ".length), branch: "", detached: false };
+    } else if (cur && line.startsWith("branch ")) {
+      const ref = line.slice("branch ".length);
+      cur.branch = ref.replace(/^refs\/heads\//, "");
+    } else if (cur && line === "detached") {
+      cur.detached = true;
+    } else if (line === "" && cur) {
+      out.push(cur);
+      cur = null;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+/// Enumerate the *linked* worktrees of `repoRoot` (excludes the
+/// main worktree, which is the repo's own checkout). Returns the
+/// parsed entries with the main-repo root resolved so callers can
+/// tag discovered sessions with the right `projectPath`.
+async function listLinkedWorktrees(
+  repoRoot: string,
+): Promise<{ mainRoot: string; worktrees: ParsedWorktree[] } | null> {
+  const res = await spawnCollect(
+    "git",
+    ["-C", repoRoot, "worktree", "list", "--porcelain"],
+    repoRoot,
+  );
+  if (res.exit_code !== 0) return null;
+  const all = parseWorktreePorcelain(res.stdout || "");
+  if (all.length === 0) return null;
+  // The first entry is always the main worktree.
+  const mainRoot = all[0].path;
+  const worktrees = all.slice(1);
+  return { mainRoot, worktrees };
+}
+
 async function nextAutoSessionName(
   repoRoot: string,
   options?: { persist?: boolean },
@@ -2164,9 +2499,11 @@ function buildFormSpec(): WidgetSpec {
   // inert when worktree creation is off.
   let branchPlaceholder: string;
   if (branchInert) {
-    branchPlaceholder = worktreeEnabled
-      ? "shared worktree — N/A"
-      : "no git — N/A";
+    branchPlaceholder = !worktreeEnabled
+      ? "no git — N/A"
+      : form.projectPathIsLinkedWorktree === true
+      ? "existing worktree — N/A"
+      : "shared worktree — N/A";
   } else if (!form.defaultBranch) {
     branchPlaceholder = "detecting default branch…";
   } else if (form.defaultBranchIsHeadFallback) {
@@ -2241,6 +2578,24 @@ function buildFormSpec(): WidgetSpec {
             ]),
           ],
         },
+    // Existing-worktree hint: when Project Path points at a linked
+    // worktree, explain what the (un)checked box now means so the
+    // attach behaviour isn't a silent surprise.
+    ...(form.projectPathIsLinkedWorktree === true
+      ? [{
+          kind: "raw" as const,
+          entries: [
+            styledRow([
+              {
+                text: form.createWorktree
+                  ? "  ↳ existing worktree here — uncheck to attach instead of forking a new one"
+                  : "  ↳ existing worktree — this session will attach to it",
+                style: { fg: "ui.help_key_fg", italic: true },
+              },
+            ]),
+          ],
+        }]
+      : []),
     // === Form body: labeled, full-width inputs. ==================
     // Labels are plain — the `▸` glyph used to be baked into all
     // three strings and stayed put regardless of focus, which was
@@ -2380,6 +2735,7 @@ function openForm(options?: { fromPicker?: boolean }): void {
     lastError: null,
     defaultProjectPath: "",
     projectPathIsGit: null,
+    projectPathIsLinkedWorktree: null,
     defaultSessionName: "",
     defaultBranch: "",
     defaultBranchIsHeadFallback: false,
@@ -2441,6 +2797,24 @@ async function probeProjectPathDefaults(): Promise<void> {
   const isGit = await pathIsInsideGitWorkTree(effectivePath);
   if (!form || form.probeToken !== token) return;
   form.projectPathIsGit = isGit;
+
+  // (2b) Existing-linked-worktree detection. When the path is a
+  //      worktree created by `git worktree add` (not the repo's main
+  //      checkout), default the checkbox to *unchecked* so the
+  //      natural action is to attach to it. Only flip on the
+  //      detection transition so we don't fight a user who
+  //      deliberately re-checks "create a new worktree".
+  const wasLinked = form.projectPathIsLinkedWorktree;
+  if (isGit) {
+    const info = await classifyWorktree(effectivePath);
+    if (!form || form.probeToken !== token) return;
+    form.projectPathIsLinkedWorktree = info?.isLinked === true;
+  } else {
+    form.projectPathIsLinkedWorktree = false;
+  }
+  if (form.projectPathIsLinkedWorktree && wasLinked !== true) {
+    form.createWorktree = false;
+  }
 
   // (3) Default branch + session name probes only make sense on
   //     a git path. On non-git, leave both empty (the renderer
@@ -2861,14 +3235,28 @@ async function submitForm(): Promise<void> {
     editor.setGlobalState("orchestrator.last_cmd", cmd);
   }
 
+  // Attach-to-existing-worktree: when the user opted out of
+  // creating a worktree but pointed Project Path at an *existing
+  // linked worktree* (one created by `git worktree add`, possibly
+  // for a repo Fresh has never opened before), treat it as the
+  // dedicated worktree it is rather than a shared root. That means
+  // `shared_worktree = false` (so Archive / Delete can
+  // `git worktree move` / `remove` it) and a `project_path` of the
+  // owning repo so the session groups with its siblings. A path
+  // that's the repo's *main* worktree, or a non-git directory, stays
+  // shared — you can't `git worktree remove` either of those.
+  const attachInfo = !createWorktree ? await classifyWorktree(root) : null;
+  if (!form) return;
+  const isLinkedAttach = attachInfo?.isLinked === true;
+  const effectiveProjectPath = isLinkedAttach ? attachInfo!.mainRoot : projectPath;
+
   // Branch / cmd values used for the per-window state record —
-  // `branchName` only exists in the worktree-create flow above;
-  // for the shared-worktree / non-git case we report whatever's
-  // currently checked out (best-effort) so the new session record
-  // matches the situation on disk.
+  // `branchName` only exists in the worktree-create flow above; for
+  // an attached linked worktree we report its checked-out branch;
+  // for the shared-worktree / non-git case we leave it blank.
   const reportedBranch = createWorktree
     ? (branchInput || sessionName)
-    : "";
+    : (isLinkedAttach ? attachInfo!.branch : "");
 
   // Append the user-effective values to per-field input
   // history so ↑/↓ can recall them on the next form open.
@@ -2886,7 +3274,9 @@ async function submitForm(): Promise<void> {
   // terminal IS the new window's seed buffer, so the window is
   // born with a single tab.
   const argv = splitAgentCmd(cmd);
-  const sharedWorktree = !createWorktree;
+  // Shared only when we neither created a worktree nor attached to an
+  // existing linked one (i.e. a non-git dir or the repo's main tree).
+  const sharedWorktree = !createWorktree && !isLinkedAttach;
   try {
     const result = await editor.createWindowWithTerminal({
       root,
@@ -2898,22 +3288,79 @@ async function submitForm(): Promise<void> {
     const id = result.windowId;
     // `createWindowWithTerminal` already dove into the new window,
     // so `setWindowState` writes to it.
-    editor.setWindowState("project_path", projectPath);
+    editor.setWindowState("project_path", effectiveProjectPath);
     editor.setWindowState("shared_worktree", sharedWorktree);
+    // If we attached to a worktree that was sitting in the picker as
+    // a discovered row, drop that placeholder — this live window
+    // supersedes it.
+    const discId = discoveredIdByPath.get(root);
+    if (discId !== undefined) {
+      orchestratorSessions.delete(discId);
+      discoveredIdByPath.delete(root);
+    }
     const tracked: AgentSession = {
       id,
       label: sessionName,
       root,
-      projectPath,
+      projectPath: effectiveProjectPath,
       sharedWorktree,
       terminalId: result.terminalId,
       state: "running",
       createdAt: Date.now(),
+      branch: reportedBranch || undefined,
     };
     orchestratorSessions.set(id, tracked);
   } catch (e) {
     editor.setStatus(
       `Orchestrator: failed to start session — ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+  }
+}
+
+/// Open a session in an existing worktree without creating one —
+/// the dive action for a discovered row, and the building block the
+/// new-session form reuses when the user points Project Path at an
+/// existing linked worktree. Spawns a bare terminal (no agent
+/// command) rooted at the worktree, tags the window with its
+/// canonical project + `shared_worktree = false` so Archive / Delete
+/// manage it as the real worktree it is, then drops the discovered
+/// placeholder (the live window supersedes it).
+async function attachToWorktree(opts: {
+  root: string;
+  projectPath: string;
+  label: string;
+  branch?: string;
+  discoveredId?: number;
+}): Promise<void> {
+  try {
+    const result = await editor.createWindowWithTerminal({
+      root: opts.root,
+      label: opts.label,
+      cwd: opts.root,
+    });
+    const id = result.windowId;
+    editor.setWindowState("project_path", opts.projectPath);
+    editor.setWindowState("shared_worktree", false);
+    if (opts.discoveredId !== undefined) {
+      orchestratorSessions.delete(opts.discoveredId);
+      discoveredIdByPath.delete(opts.root);
+    }
+    orchestratorSessions.set(id, {
+      id,
+      label: opts.label,
+      root: opts.root,
+      projectPath: opts.projectPath,
+      sharedWorktree: false,
+      terminalId: result.terminalId,
+      state: "running",
+      createdAt: Date.now(),
+      branch: opts.branch,
+    });
+  } catch (e) {
+    editor.setStatus(
+      `Orchestrator: failed to attach session — ${
         e instanceof Error ? e.message : String(e)
       }`,
     );
@@ -3317,6 +3764,20 @@ editor.on("widget_event", (e) => {
       (e.widget_key === "sessions" || e.widget_key === "visit")
     ) {
       const id = openDialog.filteredIds[openDialog.selectedIndex];
+      const sel = typeof id === "number" ? orchestratorSessions.get(id) : undefined;
+      if (sel && sel.discovered) {
+        // Discovered worktree: there's no window to switch to —
+        // open one by attaching a fresh session to the worktree.
+        closeOpenDialog();
+        void attachToWorktree({
+          root: sel.root,
+          projectPath: sel.projectPath ?? sel.root,
+          label: sel.label,
+          branch: sel.branch,
+          discoveredId: sel.id,
+        });
+        return;
+      }
       if (typeof id === "number" && id > 0 && id !== editor.activeWindow()) {
         editor.setActiveWindow(id);
       }

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -963,9 +963,33 @@ pub(crate) struct FloatingWidgetState {
     /// widget without reflowing the rest of the panel when
     /// they show or hide.
     pub overlays: Vec<crate::widgets::OverlayRow>,
+    /// Scrollable `List` widgets that overflowed, with the geometry
+    /// the draw pass uses to paint a scrollbar. Refreshed on every
+    /// render alongside `entries`/`embeds`.
+    pub scroll_regions: Vec<crate::widgets::ScrollRegion>,
+    /// Screen-space scrollbar tracks computed at the last draw — used
+    /// by the mouse hit-test to start/continue a scrollbar drag. One
+    /// per overflowing list.
+    pub scrollbar_tracks: Vec<WidgetScrollbarTrack>,
+    /// Shared press/drag/release state for the panel's list
+    /// scrollbars (the canonical `ScrollbarMouse`).
+    pub scrollbar_mouse: crate::view::ui::scrollbar::ScrollbarMouse,
+    /// `list_key` of the scrollbar currently being drag-scrolled.
+    pub scrollbar_drag_key: Option<String>,
     /// Inner rect (frame interior) of the last draw — used by the
     /// click hit-test to map terminal coords back to buffer coords.
     pub last_inner_rect: Option<ratatui::layout::Rect>,
+}
+
+/// A list scrollbar's screen rect + scroll state, captured at draw
+/// time so mouse press/drag can hit-test and drive `ScrollbarMouse`.
+#[derive(Debug, Clone)]
+pub(crate) struct WidgetScrollbarTrack {
+    pub list_key: String,
+    pub rect: ratatui::layout::Rect,
+    pub total: usize,
+    pub visible: usize,
+    pub scroll: usize,
 }
 
 /// A file that should be opened after the TUI starts

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -179,6 +179,7 @@ impl Editor {
                 }
 
                 // Stop dragging and clear drag state
+                self.release_widget_scrollbar();
                 self.active_window_mut().mouse_state.dragging_scrollbar = None;
                 self.active_window_mut().mouse_state.drag_start_row = None;
                 self.active_window_mut().mouse_state.drag_start_top_byte = None;
@@ -2358,6 +2359,12 @@ impl Editor {
 
     /// Handle mouse drag event
     pub(super) fn handle_mouse_drag(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
+        // Floating-panel list scrollbar drag takes precedence — the
+        // modal panel owns the input channel while it's up.
+        if self.try_widget_scrollbar_drag(row) {
+            let _ = col;
+            return Ok(());
+        }
         // If dragging scrollbar, update scroll position
         if let Some(dragging_split_id) = self.active_window_mut().mouse_state.dragging_scrollbar {
             // Snapshot split_areas so we don't borrow `self.active_layout()` and
@@ -3446,9 +3453,121 @@ impl Editor {
         self.handle_widget_panel_wheel(super::FLOATING_PANEL_BUFFER_ID, delta)
     }
 
+    /// Try to start a floating-panel list scrollbar drag. Returns
+    /// true if the press landed on a scrollbar track (so the caller
+    /// skips row hit-testing — the bar overlaps the list's rightmost
+    /// column). Reuses the canonical `ScrollbarMouse`/`ScrollbarState`.
+    fn try_widget_scrollbar_press(&mut self, col: u16, row: u16) -> bool {
+        use crate::view::ui::scrollbar::ScrollbarState;
+        let (panel_id, tracks) = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => (fwp.panel_id, fwp.scrollbar_tracks.clone()),
+            None => return false,
+        };
+        for t in &tracks {
+            let state = ScrollbarState::new(t.total, t.visible, t.scroll);
+            let pressed = self
+                .floating_widget_panel
+                .as_mut()
+                .and_then(|fwp| fwp.scrollbar_mouse.press(state, t.rect, col, row));
+            if let Some(new_offset) = pressed {
+                if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                    fwp.scrollbar_drag_key = Some(t.list_key.clone());
+                }
+                self.apply_widget_scroll(panel_id, &t.list_key, new_offset, t.visible);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Continue an in-flight floating-panel scrollbar drag. Returns
+    /// true if a drag is active (the press captured a `list_key`).
+    fn try_widget_scrollbar_drag(&mut self, row: u16) -> bool {
+        use crate::view::ui::scrollbar::ScrollbarState;
+        let (panel_id, key) = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => match &fwp.scrollbar_drag_key {
+                Some(k) => (fwp.panel_id, k.clone()),
+                None => return false,
+            },
+            None => return false,
+        };
+        // The track geometry for the dragged list (its rect may have
+        // shifted if the panel re-rendered between events).
+        let track = self.floating_widget_panel.as_ref().and_then(|fwp| {
+            fwp.scrollbar_tracks
+                .iter()
+                .find(|t| t.list_key == key)
+                .cloned()
+        });
+        let Some(t) = track else {
+            return false;
+        };
+        let state = ScrollbarState::new(t.total, t.visible, t.scroll);
+        let new_offset = self
+            .floating_widget_panel
+            .as_mut()
+            .and_then(|fwp| fwp.scrollbar_mouse.drag(state, t.rect, row));
+        if let Some(off) = new_offset {
+            self.apply_widget_scroll(panel_id, &key, off, t.visible);
+        }
+        true
+    }
+
+    /// End any in-flight floating-panel scrollbar drag.
+    pub(super) fn release_widget_scrollbar(&mut self) {
+        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            fwp.scrollbar_mouse.release();
+            fwp.scrollbar_drag_key = None;
+        }
+    }
+
+    /// Apply a host-driven scroll to a panel list (scrollbar press /
+    /// drag): update the registry's instance state, re-render, and —
+    /// when the list has a live selection that moved into the new
+    /// window — notify the plugin so its own selection mirror +
+    /// preview stay in sync with the thumb.
+    fn apply_widget_scroll(
+        &mut self,
+        panel_id: u64,
+        list_key: &str,
+        new_offset: usize,
+        visible: usize,
+    ) {
+        let moved_sel = self.widget_registry.set_list_scroll(
+            panel_id,
+            list_key,
+            new_offset as u32,
+            visible as u32,
+        );
+        self.rerender_widget_panel(panel_id);
+        if let Some(sel) = moved_sel {
+            if self
+                .plugin_manager
+                .read()
+                .unwrap()
+                .has_hook_handlers("widget_event")
+            {
+                self.plugin_manager.read().unwrap().run_hook(
+                    "widget_event",
+                    crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                        panel_id,
+                        widget_key: list_key.to_string(),
+                        event_type: "select".to_string(),
+                        payload: serde_json::json!({ "index": sel as i64 }),
+                    },
+                );
+            }
+        }
+    }
+
     /// `handle_editor_click` uses; clicks outside the rect are
     /// swallowed without dismissing the panel.
     fn handle_floating_widget_click(&mut self, col: u16, row: u16) {
+        // Scrollbar press wins over row hit-testing (the bar overlaps
+        // the list's rightmost column).
+        if self.try_widget_scrollbar_press(col, row) {
+            return;
+        }
         let (panel_id, inner) = match self.floating_widget_panel.as_ref() {
             Some(fwp) => match fwp.last_inner_rect {
                 Some(rect) => (fwp.panel_id, rect),

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3710,6 +3710,7 @@ impl Editor {
         let entries = out_pieces.entries;
         let embeds = out_pieces.embeds;
         let overlays = out_pieces.overlays;
+        let scroll_regions = out_pieces.scroll_regions;
         if self
             .widget_registry
             .update_side_effects(
@@ -3731,6 +3732,7 @@ impl Editor {
                     fwp.focus_cursor = focus_cursor;
                     fwp.embeds = embeds;
                     fwp.overlays = overlays;
+                    fwp.scroll_regions = scroll_regions;
                 }
             }
             return;
@@ -5595,6 +5597,10 @@ impl Editor {
             focus_cursor: None,
             embeds: Vec::new(),
             overlays: Vec::new(),
+            scroll_regions: Vec::new(),
+            scrollbar_tracks: Vec::new(),
+            scrollbar_mouse: Default::default(),
+            scrollbar_drag_key: None,
             last_inner_rect: None,
         });
         let prev = std::collections::HashMap::new();
@@ -5605,6 +5611,7 @@ impl Editor {
         let entries = out.entries;
         let embeds = out.embeds;
         let overlays = out.overlays;
+        let scroll_regions = out.scroll_regions;
         self.widget_registry.mount(
             panel_id,
             FLOATING_PANEL_BUFFER_ID,
@@ -5619,6 +5626,7 @@ impl Editor {
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
             fwp.overlays = overlays;
+            fwp.scroll_regions = scroll_regions;
         }
         tracing::debug!(
             "Mounted floating widget panel {} ({}%x{}%)",
@@ -5655,6 +5663,7 @@ impl Editor {
         let entries = out.entries;
         let embeds = out.embeds;
         let overlays = out.overlays;
+        let scroll_regions = out.scroll_regions;
         if self
             .widget_registry
             .update(
@@ -5678,6 +5687,7 @@ impl Editor {
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
             fwp.overlays = overlays;
+            fwp.scroll_regions = scroll_regions;
         }
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3493,7 +3493,7 @@ impl Editor {
     ) {
         use ratatui::widgets::{Block, Borders, Clear};
 
-        let (width_pct, height_pct, entries, focus_cursor, embeds, overlays) =
+        let (width_pct, height_pct, entries, focus_cursor, embeds, overlays, scroll_regions) =
             match self.floating_widget_panel.as_ref() {
                 Some(fwp) => (
                     fwp.width_pct,
@@ -3502,6 +3502,7 @@ impl Editor {
                     fwp.focus_cursor,
                     fwp.embeds.clone(),
                     fwp.overlays.clone(),
+                    fwp.scroll_regions.clone(),
                 ),
                 None => return,
             };
@@ -3595,6 +3596,51 @@ impl Editor {
         }
         self.preview_window_id = saved_preview;
 
+        // Paint a draggable scrollbar over the rightmost column of each
+        // overflowing list, reusing the canonical `render_scrollbar` /
+        // `ScrollbarState` (same path as the keybinding editor &
+        // settings dialog). Record each track's screen rect + state so
+        // the mouse handlers can hit-test press/drag against it.
+        let mut scrollbar_tracks: Vec<super::WidgetScrollbarTrack> = Vec::new();
+        {
+            use crate::view::ui::scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
+            let colors = ScrollbarColors::from_theme(&theme);
+            for region in &scroll_regions {
+                // Scrollbar column = right edge of the list's column,
+                // clamped inside the panel. Height = visible rows,
+                // clamped to the panel bottom.
+                let sb_x = inner
+                    .x
+                    .saturating_add(region.col_in_row as u16)
+                    .saturating_add((region.width_cols.saturating_sub(1)) as u16)
+                    .min(inner.x + inner.width.saturating_sub(1));
+                let sb_y = inner.y.saturating_add(region.buffer_row as u16);
+                if sb_y >= inner.y + inner.height {
+                    continue;
+                }
+                let max_h = inner.y + inner.height - sb_y;
+                let sb_h = (region.height_rows as u16).min(max_h);
+                if sb_h == 0 {
+                    continue;
+                }
+                let sb_rect = ratatui::layout::Rect {
+                    x: sb_x,
+                    y: sb_y,
+                    width: 1,
+                    height: sb_h,
+                };
+                let state = ScrollbarState::new(region.total, region.visible, region.scroll);
+                render_scrollbar(frame, sb_rect, &state, &colors);
+                scrollbar_tracks.push(super::WidgetScrollbarTrack {
+                    list_key: region.list_key.clone(),
+                    rect: sb_rect,
+                    total: region.total,
+                    visible: region.visible,
+                    scroll: region.scroll,
+                });
+            }
+        }
+
         // Paint overlay rows AFTER the main entries + embeds. Each
         // overlay row sits on top of whatever's at its
         // `buffer_row` (the row it would have occupied if it
@@ -3654,6 +3700,7 @@ impl Editor {
 
         if let Some(fwp) = self.floating_widget_panel.as_mut() {
             fwp.last_inner_rect = Some(inner);
+            fwp.scrollbar_tracks = scrollbar_tracks;
         }
     }
 

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -24,4 +24,4 @@ pub use actions::{
     tree_parent_index,
 };
 pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
-pub use render::{render_spec, EmbedRect, FocusCursor, OverlayRow, RenderOutput};
+pub use render::{render_spec, EmbedRect, FocusCursor, OverlayRow, RenderOutput, ScrollRegion};

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -256,6 +256,49 @@ impl WidgetRegistry {
         }
     }
 
+    /// Host-driven scroll of a `List` widget (e.g. a scrollbar drag).
+    /// Sets the list's `scroll_offset` and, when the list has a live
+    /// selection, clamps `selected_index` into the new visible window
+    /// `[scroll, scroll + visible)` so the next render's
+    /// ensure-selected-visible doesn't snap the thumb back.
+    ///
+    /// Returns the post-clamp `selected_index` when the list has a
+    /// selection that moved (so the caller can notify the plugin to
+    /// keep its own selection mirror + preview in sync), else `None`.
+    pub fn set_list_scroll(
+        &mut self,
+        panel_id: PanelId,
+        list_key: &str,
+        scroll_offset: u32,
+        visible: u32,
+    ) -> Option<i32> {
+        let state = self.panels.get_mut(&panel_id)?;
+        let WidgetInstanceState::List {
+            scroll_offset: so,
+            selected_index,
+        } = state.instance_states.get_mut(list_key)?
+        else {
+            return None;
+        };
+        *so = scroll_offset;
+        if *selected_index < 0 || visible == 0 {
+            return None;
+        }
+        let prev = *selected_index;
+        let lo = scroll_offset as i32;
+        let hi = (scroll_offset + visible).saturating_sub(1) as i32;
+        if *selected_index < lo {
+            *selected_index = lo;
+        } else if *selected_index > hi {
+            *selected_index = hi;
+        }
+        if *selected_index != prev {
+            Some(*selected_index)
+        } else {
+            None
+        }
+    }
+
     /// Update side-effects (hits, instance_states, focus_key, tabbable)
     /// without taking ownership of the spec. Used by `rerender_widget_panel`
     /// after an in-place spec mutation: the spec in the registry is already
@@ -426,6 +469,70 @@ mod tests {
         assert!(reg.hit_test(BufferId(0), 0, 100).is_none());
         assert!(reg.hit_test(BufferId(0), 1, 0).is_none(), "wrong row");
         assert!(reg.hit_test(BufferId(99), 0, 0).is_none(), "wrong buffer");
+    }
+
+    fn mount_with_list(reg: &mut WidgetRegistry, scroll: u32, sel: i32) {
+        let mut states = HashMap::new();
+        states.insert(
+            "lst".to_string(),
+            WidgetInstanceState::List {
+                scroll_offset: scroll,
+                selected_index: sel,
+            },
+        );
+        reg.mount(
+            7,
+            BufferId(0),
+            empty_spec(),
+            Vec::new(),
+            states,
+            String::new(),
+            Vec::new(),
+        );
+    }
+
+    fn list_state(reg: &WidgetRegistry) -> (u32, i32) {
+        match reg.instance_states(7).unwrap().get("lst").unwrap() {
+            WidgetInstanceState::List {
+                scroll_offset,
+                selected_index,
+            } => (*scroll_offset, *selected_index),
+            _ => panic!("not a list"),
+        }
+    }
+
+    #[test]
+    fn set_list_scroll_sets_offset_and_clamps_selection_into_view() {
+        // Selection (row 2) is above the dragged-to window [10, 18);
+        // it should clamp up to the new top (10) and report the move.
+        let mut reg = WidgetRegistry::new();
+        mount_with_list(&mut reg, 0, 2);
+        let moved = reg.set_list_scroll(7, "lst", 10, 8);
+        assert_eq!(moved, Some(10));
+        assert_eq!(list_state(&reg), (10, 10));
+    }
+
+    #[test]
+    fn set_list_scroll_leaves_in_view_selection_untouched() {
+        // Selection already inside the new window — offset updates,
+        // selection stays, and no move is reported (no plugin sync
+        // needed).
+        let mut reg = WidgetRegistry::new();
+        mount_with_list(&mut reg, 0, 12);
+        let moved = reg.set_list_scroll(7, "lst", 10, 8); // window [10,18)
+        assert_eq!(moved, None);
+        assert_eq!(list_state(&reg), (10, 12));
+    }
+
+    #[test]
+    fn set_list_scroll_ignores_selectionless_list() {
+        // A display-only list (selected_index < 0) just scrolls; no
+        // selection clamp, no reported move.
+        let mut reg = WidgetRegistry::new();
+        mount_with_list(&mut reg, 0, -1);
+        let moved = reg.set_list_scroll(7, "lst", 5, 8);
+        assert_eq!(moved, None);
+        assert_eq!(list_state(&reg), (5, -1));
     }
 
     #[test]

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -149,6 +149,10 @@ pub struct RenderOutput {
     /// widget without reflowing the rest of the layout when it
     /// shows or hides.
     pub overlays: Vec<OverlayRow>,
+    /// Scrollable `List` widgets that overflowed their visible height,
+    /// with the geometry + state the host needs to paint and drag a
+    /// scrollbar. Empty for lists that fit.
+    pub scroll_regions: Vec<ScrollRegion>,
 }
 
 /// One row produced by an `Overlay` widget. `buffer_row` is the
@@ -175,6 +179,26 @@ pub struct EmbedRect {
     pub col_in_row: u32,
     pub width_cols: u32,
     pub height_rows: u32,
+}
+
+/// A scrollable `List` widget's geometry + scroll state, surfaced so
+/// the host can paint a draggable scrollbar over the list's rightmost
+/// column and hit-test mouse press/drag against it. Threaded through
+/// the compositor (Row/Col/Section) identically to [`EmbedRect`] —
+/// `buffer_row`/`col_in_row` are panel-relative display coordinates.
+/// `width_cols` spans the list's column so `col_in_row + width_cols -
+/// 1` is the scrollbar column; `height_rows` is the visible track
+/// height. `total`/`visible`/`scroll` feed `ScrollbarState`.
+#[derive(Debug, Clone)]
+pub struct ScrollRegion {
+    pub list_key: String,
+    pub buffer_row: u32,
+    pub col_in_row: u32,
+    pub width_cols: u32,
+    pub height_rows: u32,
+    pub total: usize,
+    pub visible: usize,
+    pub scroll: usize,
 }
 
 /// Render a spec to a [`RenderOutput`].
@@ -204,7 +228,7 @@ pub fn render_spec(
     };
 
     let mut next_state = HashMap::new();
-    let (entries, hits, focus_cursor, embeds, overlays) =
+    let (entries, hits, focus_cursor, embeds, overlays, scroll_regions) =
         render_collected(spec, prev, &mut next_state, &focus_key, panel_width);
     RenderOutput {
         entries,
@@ -215,6 +239,7 @@ pub fn render_spec(
         focus_cursor,
         embeds,
         overlays,
+        scroll_regions,
     }
 }
 
@@ -277,6 +302,8 @@ enum RowPiece {
         /// pinned to that row. Rare but worth carrying through
         /// rather than dropping.
         embeds: Vec<EmbedRect>,
+        /// Scroll regions propagated up from this inline child.
+        scroll_regions: Vec<ScrollRegion>,
     },
     Block {
         /// Allocated column width for the zip path. May differ
@@ -292,6 +319,9 @@ enum RowPiece {
         /// own row 0; the zip pass shifts row by `starting_row`
         /// and byte_in_row by the block's `byte_shift`.
         embeds: Vec<EmbedRect>,
+        /// Scroll regions propagated up from this block child,
+        /// shifted by the zip pass identically to `embeds`.
+        scroll_regions: Vec<ScrollRegion>,
     },
     Flex,
 }
@@ -375,6 +405,7 @@ fn render_collected(
     Option<FocusCursor>,
     Vec<EmbedRect>,
     Vec<OverlayRow>,
+    Vec<ScrollRegion>,
 ) {
     let mut entries: Vec<TextPropertyEntry> = Vec::new();
     let mut hits: Vec<HitArea> = Vec::new();
@@ -383,6 +414,7 @@ fn render_collected(
     let mut focus_cursor: Option<FocusCursor> = None;
     let mut embeds: Vec<EmbedRect> = Vec::new();
     let mut overlays: Vec<OverlayRow> = Vec::new();
+    let mut scroll_regions: Vec<ScrollRegion> = Vec::new();
     match spec {
         WidgetSpec::Row { children, .. } => {
             // Two-pass layout for Row:
@@ -448,8 +480,14 @@ fn render_collected(
                     continue;
                 }
                 let child_panel_width = per_child_width[idx];
-                let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
-                    render_collected(child, prev, next_state, focus_key, child_panel_width);
+                let (
+                    child_entries,
+                    child_hits,
+                    child_focus,
+                    child_embeds,
+                    child_overlays,
+                    child_scroll,
+                ) = render_collected(child, prev, next_state, focus_key, child_panel_width);
                 // Rows can host overlays in principle (e.g. a
                 // tooltip on a button); forward them up without
                 // a row-offset adjustment — Row pieces all sit
@@ -471,6 +509,7 @@ fn render_collected(
                         hits: child_hits,
                         focus_cursor: child_focus,
                         embeds: child_embeds,
+                        scroll_regions: child_scroll,
                     });
                 } else {
                     row_pieces.push(RowPiece::Block {
@@ -479,6 +518,7 @@ fn render_collected(
                         hits: child_hits,
                         focus_cursor: child_focus,
                         embeds: child_embeds,
+                        scroll_regions: child_scroll,
                     });
                 }
             }
@@ -496,6 +536,7 @@ fn render_collected(
                     &mut hits,
                     &mut focus_cursor,
                     &mut embeds,
+                    &mut scroll_regions,
                 );
             } else {
                 // Compute flex sizing.
@@ -532,6 +573,7 @@ fn render_collected(
                             hits: child_hits,
                             focus_cursor: child_focus,
                             embeds: child_embeds,
+                            scroll_regions: child_scroll,
                         } => {
                             let inline_shift = match acc.as_ref() {
                                 Some(e) => e.text.len(),
@@ -555,6 +597,10 @@ fn render_collected(
                                 // rare).
                                 emb.col_in_row += inline_shift as u32;
                                 embeds.push(emb);
+                            }
+                            for mut sr in child_scroll {
+                                sr.col_in_row += inline_shift as u32;
+                                scroll_regions.push(sr);
                             }
                             match acc.as_mut() {
                                 Some(merged) => merge_inline(merged, &mut entry),
@@ -611,8 +657,14 @@ fn render_collected(
                 // afterwards without pushing the rest of the
                 // col downward.
                 let is_overlay = matches!(child, WidgetSpec::Overlay { .. });
-                let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
-                    render_collected(child, prev, next_state, focus_key, panel_width);
+                let (
+                    child_entries,
+                    child_hits,
+                    child_focus,
+                    child_embeds,
+                    child_overlays,
+                    child_scroll,
+                ) = render_collected(child, prev, next_state, focus_key, panel_width);
                 let row_offset = entries.len() as u32;
                 if is_overlay {
                     // Promote the overlay child's regular
@@ -651,6 +703,10 @@ fn render_collected(
                         emb.buffer_row += row_offset;
                         embeds.push(emb);
                     }
+                    for mut sr in child_scroll {
+                        sr.buffer_row += row_offset;
+                        scroll_regions.push(sr);
+                    }
                     continue;
                 }
                 for mut h in child_hits {
@@ -664,6 +720,10 @@ fn render_collected(
                 for mut emb in child_embeds {
                     emb.buffer_row += row_offset;
                     embeds.push(emb);
+                }
+                for mut sr in child_scroll {
+                    sr.buffer_row += row_offset;
+                    scroll_regions.push(sr);
                 }
                 overlays.extend(child_overlays.into_iter().map(|mut o| {
                     o.buffer_row += row_offset;
@@ -901,6 +961,28 @@ fn render_collected(
                 };
                 ensure_trailing_newline(&mut padding);
                 entries.push(padding);
+            }
+
+            // Surface a scroll region for the host to paint a draggable
+            // scrollbar when the list overflows its visible height. The
+            // region is panel-relative-from-this-render: buffer_row 0 is
+            // the first list row, col 0 the list's left edge; the
+            // compositor (Row/Col/Section) offsets both as it places the
+            // list. The scrollbar lives in the rightmost column
+            // (`col_in_row + width_cols - 1`).
+            if total > visible {
+                if let Some(k) = list_key.as_deref() {
+                    scroll_regions.push(ScrollRegion {
+                        list_key: k.to_string(),
+                        buffer_row: 0,
+                        col_in_row: 0,
+                        width_cols: panel_width,
+                        height_rows: visible,
+                        total: total as usize,
+                        visible: visible as usize,
+                        scroll: scroll as usize,
+                    });
+                }
             }
         }
         WidgetSpec::Tree {
@@ -1426,8 +1508,14 @@ fn render_collected(
             // Inner area: 1 column of border + 1 column of
             // padding on each side ⇒ 4 columns of chrome.
             let inner_width = panel_width.saturating_sub(4).max(1);
-            let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
-                render_collected(child, prev, next_state, focus_key, inner_width);
+            let (
+                child_entries,
+                child_hits,
+                child_focus,
+                child_embeds,
+                child_overlays,
+                child_scroll,
+            ) = render_collected(child, prev, next_state, focus_key, inner_width);
             // Shift child overlays by 1 to account for the top
             // border row this section emits — the child authored
             // its anchors relative to its own row 0 (e.g. anchor 1
@@ -1486,6 +1574,15 @@ fn render_collected(
                 emb.buffer_row += 1;
                 emb.col_in_row += prefix_cols;
                 embeds.push(emb);
+            }
+            for mut sr in child_scroll {
+                sr.buffer_row += 1;
+                sr.col_in_row += prefix_cols;
+                // The section padded the child to `inner_width`, so the
+                // scroll region's usable width is the inner width (not
+                // the child's requested width).
+                sr.width_cols = inner_width;
+                scroll_regions.push(sr);
             }
 
             entries.push(render_section_bottom_border(total_cols));
@@ -1552,8 +1649,14 @@ fn render_collected(
             // flow through unchanged. This keeps the
             // Overlay-as-root case (no enclosing Col) sane:
             // it just renders inline.
-            let (child_entries, child_hits, child_focus, child_embeds, child_overlays) =
-                render_collected(child, prev, next_state, focus_key, panel_width);
+            let (
+                child_entries,
+                child_hits,
+                child_focus,
+                child_embeds,
+                child_overlays,
+                child_scroll,
+            ) = render_collected(child, prev, next_state, focus_key, panel_width);
             entries.extend(child_entries);
             hits.extend(child_hits);
             if focus_cursor.is_none() {
@@ -1561,9 +1664,17 @@ fn render_collected(
             }
             embeds.extend(child_embeds);
             overlays.extend(child_overlays);
+            scroll_regions.extend(child_scroll);
         }
     }
-    (entries, hits, focus_cursor, embeds, overlays)
+    (
+        entries,
+        hits,
+        focus_cursor,
+        embeds,
+        overlays,
+        scroll_regions,
+    )
 }
 
 // =========================================================================
@@ -3153,6 +3264,7 @@ fn zip_row_blocks(
     out_hits: &mut Vec<HitArea>,
     out_focus_cursor: &mut Option<FocusCursor>,
     out_embeds: &mut Vec<EmbedRect>,
+    out_scroll: &mut Vec<ScrollRegion>,
 ) {
     let starting_row = out_entries.len() as u32;
     let _ = panel_width;
@@ -3180,6 +3292,7 @@ fn zip_row_blocks(
                     hits,
                     focus_cursor,
                     embeds: inline_embeds,
+                    scroll_regions: inline_scroll,
                 } => {
                     let inline_cols = entry.text.chars().count();
                     let byte_shift = text.len();
@@ -3197,6 +3310,12 @@ fn zip_row_blocks(
                                 width_cols: emb.width_cols,
                                 height_rows: emb.height_rows,
                             });
+                        }
+                        for sr in inline_scroll {
+                            let mut sr = sr.clone();
+                            sr.buffer_row += starting_row;
+                            sr.col_in_row += col_shift;
+                            out_scroll.push(sr);
                         }
                         for overlay in &entry.inline_overlays {
                             overlays.push(InlineOverlay {
@@ -3235,6 +3354,7 @@ fn zip_row_blocks(
                     hits,
                     focus_cursor,
                     embeds: block_embeds,
+                    scroll_regions: block_scroll,
                 } => {
                     let block_w = *column_width as usize;
                     let byte_shift = text.len();
@@ -3254,6 +3374,12 @@ fn zip_row_blocks(
                                 width_cols: emb.width_cols,
                                 height_rows: emb.height_rows,
                             });
+                        }
+                        for sr in block_scroll {
+                            let mut sr = sr.clone();
+                            sr.buffer_row += starting_row;
+                            sr.col_in_row += col_shift;
+                            out_scroll.push(sr);
                         }
                     }
                     if let Some(line) = entries.get(row_idx) {

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -40,6 +40,7 @@ pub mod live_diff;
 pub mod load_from_buffer;
 pub mod lsp_find_references;
 pub mod markdown_source;
+pub mod orchestrator_attach_worktree;
 pub mod orchestrator_new_dialog;
 pub mod orchestrator_new_session_renders;
 pub mod orchestrator_open_cross_project;

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -156,6 +156,22 @@ fn open_orchestrator_dialog(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
+/// Discovered on-disk worktrees are hidden by default; flip the "Show
+/// all worktrees" toggle on via its Alt+T chord so the worktree-
+/// dependent assertions have rows to find. Idempotent — a no-op when
+/// the toggle already reads checked (`[v]`).
+fn ensure_worktrees_shown(harness: &mut EditorTestHarness) {
+    if harness
+        .screen_to_string()
+        .contains("[ ] Show all worktrees")
+    {
+        harness
+            .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+            .unwrap();
+        harness.tick_and_render().ok();
+    }
+}
+
 fn open_new_session_form(harness: &mut EditorTestHarness) {
     harness
         .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
@@ -206,6 +222,7 @@ fn open_dialog_discovers_existing_worktree() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
 
     // The discovered worktree row carries the `· on-disk` tag and its
     // branch name. The async per-project `git worktree list` scan
@@ -235,6 +252,7 @@ fn discovered_worktree_preview_offers_open() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     harness
         .wait_until(|h| h.screen_to_string().contains("· on-disk"))
         .unwrap();
@@ -274,6 +292,7 @@ fn diving_discovered_worktree_attaches_managed_session() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     // Discovered worktrees now sort *after* the live sessions, so the
     // `· on-disk` row isn't the default selection. Wait for it, then
     // move the highlight down onto it (Down routes to the list even
@@ -296,6 +315,7 @@ fn diving_discovered_worktree_attaches_managed_session() {
     // Reopen the dialog. The worktree is now a live session, so the
     // discovery scan no longer surfaces it as a `· on-disk` row.
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
@@ -362,6 +382,7 @@ fn discovered_rows_sort_after_live_sessions() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     harness
         .wait_until(|h| h.screen_to_string().contains("· on-disk"))
         .unwrap();
@@ -395,6 +416,7 @@ fn space_selects_rows_and_shows_bulk_bar() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     // Wait for both discovered worktrees to land.
     harness
         .wait_until(|h| {
@@ -441,6 +463,7 @@ fn bulk_delete_removes_selected_worktrees() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
@@ -563,6 +586,7 @@ fn scrollbar_click_scrolls_the_session_list() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
+    ensure_worktrees_shown(&mut harness);
     // Wait for the discovery scan to fold in the on-disk worktrees,
     // and for the screen to settle, so the full set is present before
     // we snapshot.
@@ -614,6 +638,72 @@ fn scrollbar_click_scrolls_the_session_list() {
                  scroll the session list to a different set of rows.\n\
                  before={:?}\nScreen:\n{}",
                 before,
+                harness.screen_to_string()
+            )
+        });
+}
+
+/// On-disk worktrees are hidden by default; the "Show all worktrees"
+/// checkbox (unchecked at open) reveals them, and its Alt+T chord
+/// toggles it. Verifies the inverted default + rebindable keybinding.
+#[test]
+fn worktrees_hidden_by_default_until_show_toggled() {
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    // NB: open WITHOUT `ensure_worktrees_shown` — we're testing the
+    // default-hidden state here.
+    open_orchestrator_dialog(&mut harness);
+
+    // The toggle renders unchecked (`[ ]`), and no on-disk row shows.
+    assert!(
+        harness
+            .screen_to_string()
+            .contains("[ ] Show all worktrees"),
+        "the worktree toggle should default to unchecked.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+    // Give the discovery scan time to run; it finds the worktree but
+    // the filter keeps it hidden while the toggle is off.
+    harness
+        .wait_until(|h| h.editor().session_count() >= 1)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    assert!(
+        !harness.screen_to_string().contains("· on-disk"),
+        "discovered worktrees must stay hidden while the toggle is off.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Alt+T (the rebindable `orchestrator_toggle_worktrees`) reveals
+    // them, and the toggle flips to checked.
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("· on-disk") && s.contains("[v] Show all worktrees")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Alt+T should reveal the on-disk worktree and check the toggle.\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Alt+T again hides them.
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("· on-disk"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "Alt+T again should hide the on-disk worktree.\nScreen:\n{}",
                 harness.screen_to_string()
             )
         });

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -3,7 +3,7 @@
 //!
 //! 1. **Discovery**: opening the Orchestrator Open dialog scans the
 //!    worktrees of every known project (`git worktree list`, run
-//!    per repo) and lists the ones that aren't open yet as `[○]`
+//!    per repo) and lists the ones that aren't open yet as `· on-disk`
 //!    rows. The user can dive one to open a session there without
 //!    creating it by hand.
 //!
@@ -173,7 +173,7 @@ fn open_new_session_form(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
-/// Move the list highlight down onto the discovered `[○]` worktree
+/// Move the list highlight down onto the discovered on-disk worktree
 /// row (which now sorts after the live sessions). Down routes to the
 /// list via the host's smart-key dispatch even though focus sits on a
 /// button. Stops once the on-disk preview pane is showing.
@@ -189,14 +189,14 @@ fn navigate_to_discovered_row(harness: &mut EditorTestHarness) {
         .wait_until(|h| h.screen_to_string().contains("On-disk worktree"))
         .unwrap_or_else(|_| {
             panic!(
-                "could not navigate to the discovered `[○]` row.\nScreen:\n{}",
+                "could not navigate to the discovered on-disk row.\nScreen:\n{}",
                 harness.screen_to_string()
             )
         });
 }
 
 /// Opening the dialog discovers the on-disk `feature-x` worktree and
-/// lists it as an `[○]` row labelled with its branch — even though no
+/// lists it as an on-disk row labelled with its branch — even though no
 /// session was ever opened there.
 #[test]
 fn open_dialog_discovers_existing_worktree() {
@@ -207,18 +207,18 @@ fn open_dialog_discovers_existing_worktree() {
 
     open_orchestrator_dialog(&mut harness);
 
-    // The discovered worktree row carries the `[○]` on-disk glyph and
-    // its branch name. The async per-project `git worktree list` scan
+    // The discovered worktree row carries the `· on-disk` tag and its
+    // branch name. The async per-project `git worktree list` scan
     // lands a beat after the dialog opens, so wait for it.
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("feature-x") && s.contains("[○]")
+            s.contains("feature-x") && s.contains("· on-disk")
         })
         .unwrap_or_else(|_| {
             panic!(
-                "Open dialog should discover the on-disk `feature-x` worktree as an \
-                 `[○]` row.\nScreen:\n{}",
+                "Open dialog should discover the on-disk `feature-x` worktree as a \
+                 `· on-disk` row.\nScreen:\n{}",
                 harness.screen_to_string()
             )
         });
@@ -236,7 +236,7 @@ fn discovered_worktree_preview_offers_open() {
 
     open_orchestrator_dialog(&mut harness);
     harness
-        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .wait_until(|h| h.screen_to_string().contains("· on-disk"))
         .unwrap();
 
     // The discovered row sorts after the live sessions now; navigate
@@ -258,9 +258,9 @@ fn discovered_worktree_preview_offers_open() {
 }
 
 /// Diving a discovered worktree opens a real session there: the
-/// `[○]` placeholder is replaced by a live, numeric-id row at the
-/// worktree (no `⇄` shared badge — it's managed as the worktree it
-/// is). Reproduces the headline "attach to existing worktree" flow.
+/// `· on-disk` row is replaced by a live session row at the worktree
+/// (no `⇄` shared badge — it's managed as the worktree it is).
+/// Reproduces the headline "attach to existing worktree" flow.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
 fn diving_discovered_worktree_attaches_managed_session() {
@@ -275,11 +275,11 @@ fn diving_discovered_worktree_attaches_managed_session() {
 
     open_orchestrator_dialog(&mut harness);
     // Discovered worktrees now sort *after* the live sessions, so the
-    // `[○]` row isn't the default selection. Wait for it, then move
-    // the highlight down onto it (Down routes to the list even though
-    // focus sits on a button) until its on-disk preview shows.
+    // `· on-disk` row isn't the default selection. Wait for it, then
+    // move the highlight down onto it (Down routes to the list even
+    // though focus sits on a button) until its on-disk preview shows.
     harness
-        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .wait_until(|h| h.screen_to_string().contains("· on-disk"))
         .unwrap();
     navigate_to_discovered_row(&mut harness);
     harness
@@ -293,19 +293,18 @@ fn diving_discovered_worktree_attaches_managed_session() {
         .wait_until(|h| h.editor().session_count() >= 2)
         .unwrap();
 
-    // Reopen the dialog. The worktree is now a live session, so it
-    // lists with a numeric id and the discovery scan no longer
-    // surfaces it as `[○]`.
+    // Reopen the dialog. The worktree is now a live session, so the
+    // discovery scan no longer surfaces it as a `· on-disk` row.
     open_orchestrator_dialog(&mut harness);
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("feature-x") && !s.contains("[○]")
+            s.contains("feature-x") && !s.contains("· on-disk")
         })
         .unwrap_or_else(|_| {
             panic!(
                 "After diving the discovered worktree it should appear as a live \
-                 (non-`[○]`) session.\nScreen:\n{}",
+                 (non-`· on-disk`) session.\nScreen:\n{}",
                 harness.screen_to_string()
             )
         });
@@ -314,7 +313,7 @@ fn diving_discovered_worktree_attaches_managed_session() {
     let screen = harness.screen_to_string();
     let feature_line = screen
         .lines()
-        .find(|l| l.contains("feature-x") && l.contains('['))
+        .find(|l| l.contains("feature-x") && l.contains("[ ]"))
         .unwrap_or("");
     assert!(
         !feature_line.contains('⇄'),
@@ -351,7 +350,10 @@ fn new_session_form_hints_existing_worktree() {
 }
 
 /// Discovered on-disk worktree rows sort *after* the live sessions:
-/// the base session `[1]` row appears above the discovered `[○]` row.
+/// the base session's list row appears above the discovered worktree
+/// row. The base list row is identified by the `[ ]` checkbox + the
+/// `BASE` badge (both unique to that list row); the discovered row by
+/// its `· on-disk` tag.
 #[test]
 fn discovered_rows_sort_after_live_sessions() {
     let (_temp, repo, _wt) = set_up_repo_with_worktree();
@@ -361,16 +363,18 @@ fn discovered_rows_sort_after_live_sessions() {
 
     open_orchestrator_dialog(&mut harness);
     harness
-        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .wait_until(|h| h.screen_to_string().contains("· on-disk"))
         .unwrap();
 
     let screen = harness.screen_to_string();
     let lines: Vec<&str> = screen.lines().collect();
-    let base_idx = lines.iter().position(|l| l.contains("[1]"));
-    let disc_idx = lines.iter().position(|l| l.contains("[○]"));
+    let base_idx = lines
+        .iter()
+        .position(|l| l.contains("[ ]") && l.contains("BASE"));
+    let disc_idx = lines.iter().position(|l| l.contains("· on-disk"));
     assert!(
         base_idx.is_some() && disc_idx.is_some() && base_idx < disc_idx,
-        "live `[1]` session must list above the discovered `[○]` worktree.\n\
+        "live base session must list above the discovered worktree.\n\
          base_idx={:?} disc_idx={:?}\nScreen:\n{}",
         base_idx,
         disc_idx,
@@ -395,7 +399,7 @@ fn space_selects_rows_and_shows_bulk_bar() {
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("feature-x") && s.contains("feature-y") && s.contains("[○]")
+            s.contains("feature-x") && s.contains("feature-y") && s.contains("· on-disk")
         })
         .unwrap();
 
@@ -440,7 +444,7 @@ fn bulk_delete_removes_selected_worktrees() {
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("feature-x") && s.contains("feature-y") && s.contains("[○]")
+            s.contains("feature-x") && s.contains("feature-y") && s.contains("· on-disk")
         })
         .unwrap();
 

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -596,9 +596,13 @@ fn scrollbar_click_scrolls_the_session_list() {
         .position(|l| l.contains('╰'))
         .map(|p| p + top_border_row + 1)
         .expect("Sessions box bottom border");
-    // Scrollbar column = just inside the right border; click row =
-    // last track row (just above the bottom border).
-    let sb_col = (border_col.saturating_sub(1)) as u16;
+    // Scrollbar column = the last content column. The section wraps
+    // its child as `│ <content> │` — a 2-column ` │` suffix — so the
+    // scrollbar sits at `border_col - 2`, not directly under the
+    // border. Click row = last track row (just above the bottom
+    // border). (Verified interactively: border `╮` at col N ⇒ thumb at
+    // col N-2.)
+    let sb_col = (border_col.saturating_sub(2)) as u16;
     let click_row = (bottom_border_row.saturating_sub(1)) as u16;
 
     harness.mouse_click(sb_col, click_row).unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -498,3 +498,119 @@ fn bulk_delete_removes_selected_worktrees() {
             )
         });
 }
+
+/// Build a repo with `n` linked worktrees `feat-1..feat-n`, plus the
+/// orchestrator plugin installed. Used to overflow the session list so
+/// it grows a scrollbar.
+fn set_up_repo_with_many_worktrees(n: usize) -> (tempfile::TempDir, PathBuf) {
+    fresh::i18n::set_locale("en");
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let repo = root.join("mainrepo");
+    std::fs::create_dir(&repo).unwrap();
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["config", "user.name", "Test User"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    git(&repo, &["add", "file.txt"]);
+    git(&repo, &["commit", "-qm", "init"]);
+    for i in 1..=n {
+        let branch = format!("feat-{i}");
+        git(&repo, &["branch", &branch]);
+        let wt = root.join(format!("wt-{i}"));
+        git(&repo, &["worktree", "add", wt.to_str().unwrap(), &branch]);
+    }
+    let plugins_dir = repo.join("plugins");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+    (temp, repo)
+}
+
+/// The set of `feat-N` labels currently rendered in the Sessions
+/// list column (the left pane). At open, nothing is selected so the
+/// preview pane shows the base session — `feat-` only appears in the
+/// list rows.
+fn visible_feats(screen: &str) -> std::collections::BTreeSet<String> {
+    let mut out = std::collections::BTreeSet::new();
+    for line in screen.lines() {
+        // Each "feat-<n>" token followed by a space/non-digit.
+        let mut rest = line;
+        while let Some(pos) = rest.find("feat-") {
+            let after = &rest[pos + "feat-".len()..];
+            let digits: String = after.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if !digits.is_empty() {
+                out.insert(format!("feat-{digits}"));
+            }
+            rest = &after[digits.len().max(1).min(after.len())..];
+        }
+    }
+    out
+}
+
+/// A long session list grows a draggable scrollbar; clicking near the
+/// bottom of its track scrolls the list (the canonical `ScrollbarMouse`
+/// press path), surfacing rows that were hidden at the top. Runs in a
+/// short terminal so the ~16 rows overflow the visible height.
+#[test]
+fn scrollbar_click_scrolls_the_session_list() {
+    let (_temp, repo) = set_up_repo_with_many_worktrees(15);
+    // 24 rows ⇒ list visible height well under the 16 rows, so it
+    // overflows and a scrollbar is drawn.
+    let mut harness = EditorTestHarness::with_working_dir(160, 24, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    // Wait for the discovery scan to fold in the on-disk worktrees,
+    // and for the screen to settle, so the full set is present before
+    // we snapshot.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().matches("· on-disk").count() >= 5)
+        .unwrap();
+
+    let before = visible_feats(&harness.screen_to_string());
+    assert!(
+        !before.is_empty(),
+        "expected discovered feat- rows.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Locate the Sessions box: its top-border `╮` marks the right
+    // edge; the scrollbar sits in the column just inside it. Click one
+    // row above the box's bottom border — the bottom of the track.
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+    let top_border_row = lines
+        .iter()
+        .position(|l| l.contains("╭─ Sessions"))
+        .expect("Sessions box top border");
+    let border_col = lines[top_border_row]
+        .chars()
+        .position(|c| c == '╮')
+        .expect("Sessions box right corner");
+    let bottom_border_row = lines
+        .iter()
+        .skip(top_border_row + 1)
+        .position(|l| l.contains('╰'))
+        .map(|p| p + top_border_row + 1)
+        .expect("Sessions box bottom border");
+    // Scrollbar column = just inside the right border; click row =
+    // last track row (just above the bottom border).
+    let sb_col = (border_col.saturating_sub(1)) as u16;
+    let click_row = (bottom_border_row.saturating_sub(1)) as u16;
+
+    harness.mouse_click(sb_col, click_row).unwrap();
+    harness
+        .wait_until(|h| visible_feats(&h.screen_to_string()) != before)
+        .unwrap_or_else(|_| {
+            panic!(
+                "clicking the scrollbar track (col {sb_col}, row {click_row}) should \
+                 scroll the session list to a different set of rows.\n\
+                 before={:?}\nScreen:\n{}",
+                before,
+                harness.screen_to_string()
+            )
+        });
+}

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -86,6 +86,47 @@ fn set_up_repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
     (temp, repo, worktree)
 }
 
+/// Like `set_up_repo_with_worktree` but adds two linked worktrees
+/// (`feature-x`, `feature-y`) so multi-select / bulk flows have more
+/// than one discovered row to work with. Returns (guard, repo, wt1,
+/// wt2).
+fn set_up_repo_with_two_worktrees() -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+    fresh::i18n::set_locale("en");
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let repo = root.join("mainrepo");
+    std::fs::create_dir(&repo).unwrap();
+
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["config", "user.name", "Test User"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    git(&repo, &["add", "file.txt"]);
+    git(&repo, &["commit", "-qm", "init"]);
+    git(&repo, &["branch", "feature-x"]);
+    git(&repo, &["branch", "feature-y"]);
+
+    let wt1 = root.join("existing-wt-x");
+    git(
+        &repo,
+        &["worktree", "add", wt1.to_str().unwrap(), "feature-x"],
+    );
+    let wt2 = root.join("existing-wt-y");
+    git(
+        &repo,
+        &["worktree", "add", wt2.to_str().unwrap(), "feature-y"],
+    );
+
+    let plugins_dir = repo.join("plugins");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    (temp, repo, wt1, wt2)
+}
+
 fn wait_for_command(harness: &mut EditorTestHarness, name: &str) {
     let owned = name.to_string();
     harness
@@ -132,6 +173,28 @@ fn open_new_session_form(harness: &mut EditorTestHarness) {
         .unwrap();
 }
 
+/// Move the list highlight down onto the discovered `[○]` worktree
+/// row (which now sorts after the live sessions). Down routes to the
+/// list via the host's smart-key dispatch even though focus sits on a
+/// button. Stops once the on-disk preview pane is showing.
+fn navigate_to_discovered_row(harness: &mut EditorTestHarness) {
+    for _ in 0..12 {
+        if harness.screen_to_string().contains("On-disk worktree") {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness.tick_and_render().ok();
+    }
+    harness
+        .wait_until(|h| h.screen_to_string().contains("On-disk worktree"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "could not navigate to the discovered `[○]` row.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
 /// Opening the dialog discovers the on-disk `feature-x` worktree and
 /// lists it as an `[○]` row labelled with its branch — even though no
 /// session was ever opened there.
@@ -176,8 +239,10 @@ fn discovered_worktree_preview_offers_open() {
         .wait_until(|h| h.screen_to_string().contains("[○]"))
         .unwrap();
 
-    // The discovered row is the only non-base session; navigate to it
-    // and confirm its preview pane describes the open-by-attach flow.
+    // The discovered row sorts after the live sessions now; navigate
+    // onto it and confirm its preview pane describes the open-by-attach
+    // flow.
+    navigate_to_discovered_row(&mut harness);
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
@@ -209,11 +274,14 @@ fn diving_discovered_worktree_attaches_managed_session() {
     wait_for_command(&mut harness, "Orchestrator: Open");
 
     open_orchestrator_dialog(&mut harness);
-    // The discovered row sorts to the top (synthetic negative id);
-    // wait for it, then dive it.
+    // Discovered worktrees now sort *after* the live sessions, so the
+    // `[○]` row isn't the default selection. Wait for it, then move
+    // the highlight down onto it (Down routes to the list even though
+    // focus sits on a button) until its on-disk preview shows.
     harness
         .wait_until(|h| h.screen_to_string().contains("[○]"))
         .unwrap();
+    navigate_to_discovered_row(&mut harness);
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
@@ -277,6 +345,151 @@ fn new_session_form_hints_existing_worktree() {
             panic!(
                 "New Session form should hint that Project Path is an existing \
                  worktree.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
+/// Discovered on-disk worktree rows sort *after* the live sessions:
+/// the base session `[1]` row appears above the discovered `[○]` row.
+#[test]
+fn discovered_rows_sort_after_live_sessions() {
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+    let base_idx = lines.iter().position(|l| l.contains("[1]"));
+    let disc_idx = lines.iter().position(|l| l.contains("[○]"));
+    assert!(
+        base_idx.is_some() && disc_idx.is_some() && base_idx < disc_idx,
+        "live `[1]` session must list above the discovered `[○]` worktree.\n\
+         base_idx={:?} disc_idx={:?}\nScreen:\n{}",
+        base_idx,
+        disc_idx,
+        screen
+    );
+}
+
+/// Space-selecting two rows shows the dedicated bulk selection bar
+/// (Layout B) with per-action counts. Uses the two discovered
+/// worktree rows (selectable, no PTY needed). Space is the rebindable
+/// `orchestrator_toggle_select` mode chord, so it fires regardless of
+/// which control holds focus.
+#[test]
+fn space_selects_rows_and_shows_bulk_bar() {
+    let (_temp, repo, _wt1, _wt2) = set_up_repo_with_two_worktrees();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    // Wait for both discovered worktrees to land.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("feature-y") && s.contains("[○]")
+        })
+        .unwrap();
+
+    // Highlight the first discovered row and check it; move down and
+    // check the second.
+    navigate_to_discovered_row(&mut harness);
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::NONE)
+        .unwrap();
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("Bulk actions") && s.contains("2 selected") && s.contains("Delete (2)")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Selecting two rows should show the bulk bar with `Delete (2)`.\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
+/// Bulk-deleting two checked discovered worktrees runs `git worktree
+/// remove` on both, so their directories disappear from disk. Drives
+/// the selection → Delete (2) → Confirm Delete flow entirely from the
+/// keyboard.
+#[test]
+fn bulk_delete_removes_selected_worktrees() {
+    let (_temp, repo, wt1, wt2) = set_up_repo_with_two_worktrees();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("feature-y") && s.contains("[○]")
+        })
+        .unwrap();
+
+    // Check both discovered rows.
+    navigate_to_discovered_row(&mut harness);
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Char(' '), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Delete (2)"))
+        .unwrap();
+
+    // Entering bulk mode lands focus on `Archive`; Tab to `Delete`
+    // (Stop is disabled for discovered rows, so it's out of the Tab
+    // cycle), Enter to open the confirm panel.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "Delete (2) should open the bulk Confirm Delete panel.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Confirm panel defaults focus to Cancel; Tab to `Confirm Delete`
+    // and activate.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Both worktree directories should be removed from disk.
+    harness
+        .wait_until(|_| !wt1.exists() && !wt2.exists())
+        .unwrap_or_else(|_| {
+            panic!(
+                "bulk delete should `git worktree remove` both worktrees.\n\
+                 wt1.exists()={} wt2.exists()={}\nScreen:\n{}",
+                wt1.exists(),
+                wt2.exists(),
                 harness.screen_to_string()
             )
         });

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -35,6 +35,27 @@ fn pty_available() -> bool {
         .is_ok()
 }
 
+/// Canonicalize a path to the form git and the editor both accept.
+///
+/// `std::fs::canonicalize` returns a `\\?\C:\…` *verbatim* path on
+/// Windows; git refuses it (`git worktree add` can't create leading
+/// directories under `//?/C:/…`). Strip the verbatim prefix so we get
+/// a plain `C:\…` path. On Unix this is just `canonicalize` (which
+/// also resolves the macOS `/var → /private/var` symlink so the test
+/// path matches what `git rev-parse` reports).
+fn canonical_dir(p: &Path) -> PathBuf {
+    let c = std::fs::canonicalize(p).expect("canonicalize tempdir");
+    #[cfg(windows)]
+    {
+        // Tempdirs are always local-disk, so the verbatim form is
+        // `\\?\C:\…`; dropping the 4-char prefix yields `C:\…`.
+        if let Some(rest) = c.to_str().and_then(|s| s.strip_prefix(r"\\?\")) {
+            return PathBuf::from(rest);
+        }
+    }
+    c
+}
+
 /// Run a git subcommand in `cwd`, panicking with stderr on failure.
 fn git(cwd: &Path, args: &[&str]) {
     let out = Command::new("git")
@@ -59,7 +80,7 @@ fn set_up_repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
     fresh::i18n::set_locale("en");
 
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().canonicalize().unwrap();
+    let root = canonical_dir(temp.path());
     let repo = root.join("mainrepo");
     std::fs::create_dir(&repo).unwrap();
 
@@ -94,7 +115,7 @@ fn set_up_repo_with_two_worktrees() -> (tempfile::TempDir, PathBuf, PathBuf, Pat
     fresh::i18n::set_locale("en");
 
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().canonicalize().unwrap();
+    let root = canonical_dir(temp.path());
     let repo = root.join("mainrepo");
     std::fs::create_dir(&repo).unwrap();
 
@@ -528,7 +549,7 @@ fn bulk_delete_removes_selected_worktrees() {
 fn set_up_repo_with_many_worktrees(n: usize) -> (tempfile::TempDir, PathBuf) {
     fresh::i18n::set_locale("en");
     let temp = tempfile::tempdir().unwrap();
-    let root = temp.path().canonicalize().unwrap();
+    let root = canonical_dir(temp.path());
     let repo = root.join("mainrepo");
     std::fs::create_dir(&repo).unwrap();
     git(&repo, &["init", "-q"]);

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -1,0 +1,283 @@
+//! E2E coverage for attaching Orchestrator sessions to *existing*
+//! git worktrees — both ways the feature surfaces:
+//!
+//! 1. **Discovery**: opening the Orchestrator Open dialog scans the
+//!    worktrees of every known project (`git worktree list`, run
+//!    per repo) and lists the ones that aren't open yet as `[○]`
+//!    rows. The user can dive one to open a session there without
+//!    creating it by hand.
+//!
+//! 2. **Form attach hint**: pointing the New Session form's Project
+//!    Path at an existing linked worktree surfaces an "existing
+//!    worktree" hint, signalling that submitting will attach to it
+//!    (managed) rather than fork a fresh worktree.
+//!
+//! Both behaviours are new: on the pre-change plugin the dialog only
+//! ever listed live windows, and the form had no notion of an
+//! existing worktree, so these screens never appeared.
+
+#![cfg(feature = "plugins")]
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use portable_pty::{native_pty_system, PtySize};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// Run a git subcommand in `cwd`, panicking with stderr on failure.
+fn git(cwd: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to spawn git {:?}: {}", args, e));
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Build a git repo with one extra linked worktree on branch
+/// `feature-x`, plus the orchestrator plugin installed in the repo's
+/// `plugins/` dir. Returns (tempdir guard, repo path, worktree path).
+/// The worktree is a sibling of the repo so it sits outside the
+/// editor's working dir (discovery finds it via git, not the tree).
+fn set_up_repo_with_worktree() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    fresh::i18n::set_locale("en");
+
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path().canonicalize().unwrap();
+    let repo = root.join("mainrepo");
+    std::fs::create_dir(&repo).unwrap();
+
+    git(&repo, &["init", "-q"]);
+    git(&repo, &["config", "user.name", "Test User"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(repo.join("file.txt"), "hello\n").unwrap();
+    git(&repo, &["add", "file.txt"]);
+    git(&repo, &["commit", "-qm", "init"]);
+    git(&repo, &["branch", "feature-x"]);
+
+    let worktree = root.join("existing-wt");
+    git(
+        &repo,
+        &["worktree", "add", worktree.to_str().unwrap(), "feature-x"],
+    );
+
+    let plugins_dir = repo.join("plugins");
+    std::fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+
+    (temp, repo, worktree)
+}
+
+fn wait_for_command(harness: &mut EditorTestHarness, name: &str) {
+    let owned = name.to_string();
+    harness
+        .wait_until(|h| {
+            let reg = h.editor().command_registry().read().unwrap();
+            reg.get_all()
+                .iter()
+                .any(|c| c.get_localized_name() == owned)
+        })
+        .unwrap();
+}
+
+fn open_orchestrator_dialog(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Orchestrator: Open").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Orchestrator: Open"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR :: Sessions"))
+        .unwrap();
+}
+
+fn open_new_session_form(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Orchestrator: New Session").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Orchestrator: New Session"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR :: New Session"))
+        .unwrap();
+}
+
+/// Opening the dialog discovers the on-disk `feature-x` worktree and
+/// lists it as an `[○]` row labelled with its branch — even though no
+/// session was ever opened there.
+#[test]
+fn open_dialog_discovers_existing_worktree() {
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+
+    // The discovered worktree row carries the `[○]` on-disk glyph and
+    // its branch name. The async per-project `git worktree list` scan
+    // lands a beat after the dialog opens, so wait for it.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("[○]")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Open dialog should discover the on-disk `feature-x` worktree as an \
+                 `[○]` row.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
+/// Selecting the discovered worktree row shows the on-disk preview
+/// panel — the "On-disk worktree" header and the "Press Enter to
+/// open" affordance — rather than a live window embed.
+#[test]
+fn discovered_worktree_preview_offers_open() {
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    harness
+        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .unwrap();
+
+    // The discovered row is the only non-base session; navigate to it
+    // and confirm its preview pane describes the open-by-attach flow.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("On-disk worktree") && s.contains("Press Enter to open")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Discovered-worktree preview pane should describe the open-by-attach \
+                 flow.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
+/// Diving a discovered worktree opens a real session there: the
+/// `[○]` placeholder is replaced by a live, numeric-id row at the
+/// worktree (no `⇄` shared badge — it's managed as the worktree it
+/// is). Reproduces the headline "attach to existing worktree" flow.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
+fn diving_discovered_worktree_attaches_managed_session() {
+    if !pty_available() {
+        eprintln!("skipping: no PTY available in this environment");
+        return;
+    }
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    // The discovered row sorts to the top (synthetic negative id);
+    // wait for it, then dive it.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("[○]"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Attach is async (`createWindowWithTerminal`). Synchronize on the
+    // new window existing before reopening so the dialog's one-shot
+    // discovery scan sees the worktree as live, not on-disk.
+    harness
+        .wait_until(|h| h.editor().session_count() >= 2)
+        .unwrap();
+
+    // Reopen the dialog. The worktree is now a live session, so it
+    // lists with a numeric id and the discovery scan no longer
+    // surfaces it as `[○]`.
+    open_orchestrator_dialog(&mut harness);
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && !s.contains("[○]")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "After diving the discovered worktree it should appear as a live \
+                 (non-`[○]`) session.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // The attached worktree is managed, not shared: no `⇄` badge.
+    let screen = harness.screen_to_string();
+    let feature_line = screen
+        .lines()
+        .find(|l| l.contains("feature-x") && l.contains('['))
+        .unwrap_or("");
+    assert!(
+        !feature_line.contains('⇄'),
+        "attached worktree session must not be flagged shared (`⇄`).\nRow: {}\nScreen:\n{}",
+        feature_line,
+        screen,
+    );
+}
+
+/// Pointing the New Session form's Project Path at an existing linked
+/// worktree surfaces the "existing worktree" attach hint.
+#[test]
+fn new_session_form_hints_existing_worktree() {
+    let (_temp, repo, wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: New Session");
+
+    open_new_session_form(&mut harness);
+
+    // Type the worktree path into the focused Project Path field. The
+    // debounced probe classifies it as a linked worktree and renders
+    // the attach hint.
+    harness.type_text(wt.to_str().unwrap()).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("existing worktree"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "New Session form should hint that Project Path is an existing \
+                 worktree.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}


### PR DESCRIPTION
## Summary

This change adds support for discovering and attaching to existing git worktrees in the Orchestrator plugin. Users can now see on-disk worktrees that aren't yet open as sessions in the Open dialog, and can attach to them without manually creating new worktrees. The New Session form also detects when the Project Path points to an existing linked worktree and hints at the attach behavior.

## Key Changes

- **Worktree Discovery**: When opening the Orchestrator dialog, the plugin now scans all known project repositories via `git worktree list --porcelain` and surfaces linked worktrees that don't have live sessions as `[○]` rows in the session list.

- **Discovered Worktree Rows**: Added `discovered` and `branch` fields to `AgentSession` to track on-disk worktrees. Discovered rows use synthetic negative IDs (starting at -2) to distinguish them from live windows (positive IDs), preventing collisions while keeping existing lookup code working.

- **Attach-to-Worktree Flow**: Implemented `attachToWorktree()` function that opens a session in an existing worktree without creating a new one. This is the action triggered when diving a discovered row, and is also used when the New Session form detects an existing linked worktree.

- **Worktree Classification**: Added `classifyWorktree()` to determine if a path is a linked worktree and extract its metadata (main repo root, branch, etc.). Added `listLinkedWorktrees()` to enumerate linked worktrees of a repo via git porcelain output.

- **Form Attach Hint**: The New Session form now detects when Project Path points to an existing linked worktree via `projectPathIsLinkedWorktree` field and surfaces an explanatory hint. When detected, the form defaults "Create a new git worktree" to unchecked, signaling that submission will attach rather than fork.

- **Session Lifecycle**: Updated `reconcileSessions()` to preserve discovered rows (negative IDs) during cleanup while removing closed live windows. Added logic to drop discovered rows when their worktree is opened as a live session.

- **Stable IDs**: Implemented `discoveredIdFor()` to maintain stable synthetic IDs across rescans so dialog selection doesn't jump when the worktree set is refreshed.

## Notable Implementation Details

- Discovery runs asynchronously when the Open dialog opens, scanning once per distinct canonical repo root to avoid redundant git calls.
- Discovered worktrees are filtered to exclude orchestrator-internal paths (`.sync-workspace`, `/.archived/`).
- The preview pane for discovered rows shows branch/path info and an "Open" button, with disabled Stop/Archive/Delete buttons since there's no live window yet.
- Attaching a discovered worktree sets `shared_worktree = false` so Archive/Delete can manage it as a real worktree via `git worktree move`/`remove`.
- Added comprehensive E2E tests covering discovery, preview rendering, attach flow, and form hint detection.

https://claude.ai/code/session_01MryiNCyuFDhaELmmpP3EAv