### PR TITLE
fix(live-grep): correct overlay preview & input-box undo/redo

### DIFF
--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -207,22 +207,15 @@ impl Editor {
             }
             PromptType::LiveGrep => {
                 // Confirm navigates to the selected suggestion's
-                // file:line:col. Suggestions for LiveGrep prompts pack
-                // location info into the suggestion text using the
-                // standard "path:line:col" format used elsewhere
-                // (parse_path_line_col).
+                // file:line:col. `confirm_prompt` has already resolved
+                // `input` to the selected suggestion's `value` (which
+                // packs the location in the standard "path:line:col"
+                // format), so parse it directly. (The prompt itself has
+                // been taken by `confirm_prompt` and can no longer be
+                // read here — relying on `self.prompt` made Resume open
+                // the raw query as a file path.)
                 use crate::input::quick_open::parse_path_line_col;
-                let target = if let Some(idx) = selected_index {
-                    self.active_window()
-                        .prompt
-                        .as_ref()
-                        .and_then(|p| p.suggestions.get(idx))
-                        .map(|s| s.value.clone().unwrap_or_else(|| s.text.clone()))
-                        .unwrap_or_else(|| input.clone())
-                } else {
-                    input.clone()
-                };
-                let (path_str, line, column) = parse_path_line_col(&target);
+                let (path_str, line, column) = parse_path_line_col(&input);
                 if !path_str.is_empty() {
                     let expanded = expand_tilde(&path_str);
                     let resolved = if expanded.is_absolute() {

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -900,6 +900,13 @@ impl Editor {
                     | PromptType::SetEncoding
                     | PromptType::SetLineEnding
                     | PromptType::Plugin { .. }
+                    // Resume re-opens Live Grep as a core-driven
+                    // PromptType::LiveGrep whose suggestions carry the
+                    // match location in `value`. Resolve to the selected
+                    // suggestion's value here, while the prompt still
+                    // exists — the confirm handler runs after the prompt
+                    // is taken and can no longer look it up.
+                    | PromptType::LiveGrep
             ) {
                 // Use the selected suggestion if any
                 if let Some(selected_idx) = prompt.selected_suggestion {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -2162,32 +2162,39 @@ impl Editor {
     fn prepare_overlay_preview(&mut self) {
         use crate::input::quick_open::parse_path_line_col;
 
-        let (path_str, line, col) = {
-            let Some(prompt) = self.active_window().prompt.as_ref() else {
+        let parsed = {
+            self.active_window()
+                .prompt
+                .as_ref()
+                .and_then(|prompt| {
+                    let idx = prompt.selected_suggestion?;
+                    prompt.suggestions.get(idx)
+                })
+                .map(|s| {
+                    // Suggestions emitted by the Finder library use `value`
+                    // as an opaque index; the parseable label lives in
+                    // `text`. Resume-replay is the inverse: `value` carries
+                    // the full path:line:col triple.
+                    let from_text = parse_path_line_col(&s.text);
+                    if !from_text.0.is_empty() && from_text.1.is_some() {
+                        from_text
+                    } else if let Some(v) = s.value.as_deref() {
+                        parse_path_line_col(v)
+                    } else {
+                        from_text
+                    }
+                })
+        };
+        // No selectable result (empty list, no selection, or an
+        // unparseable entry): blank the preview so the previous match's
+        // content doesn't linger after the result list clears.
+        let (path_str, line, col) = match parsed {
+            Some((path, line, col)) if !path.is_empty() => (path, line, col),
+            _ => {
+                self.blank_overlay_preview();
                 return;
-            };
-            let Some(idx) = prompt.selected_suggestion else {
-                return;
-            };
-            let Some(s) = prompt.suggestions.get(idx) else {
-                return;
-            };
-            // Suggestions emitted by the Finder library use `value` as
-            // an opaque index; the parseable label lives in `text`.
-            // Resume-replay is the inverse: `value` carries the full
-            // path:line:col triple.
-            let from_text = parse_path_line_col(&s.text);
-            if !from_text.0.is_empty() && from_text.1.is_some() {
-                from_text
-            } else if let Some(v) = s.value.as_deref() {
-                parse_path_line_col(v)
-            } else {
-                from_text
             }
         };
-        if path_str.is_empty() {
-            return;
-        }
         let line = line.unwrap_or(1).saturating_sub(1);
         let col = col.unwrap_or(1).saturating_sub(1);
 
@@ -2366,6 +2373,7 @@ impl Editor {
                     buffer_id,
                     view_state,
                     loaded_buffers,
+                    blanked: false,
                 });
         } else {
             // Pre-compute hidden flag (immutable borrow on self.windows)
@@ -2378,6 +2386,12 @@ impl Editor {
             if let Some(state) = self.active_window_mut().overlay_preview_state.as_mut() {
                 if state.buffer_id != buffer_id {
                     state.view_state.switch_buffer(buffer_id);
+                    // Keep the struct's `buffer_id` in lockstep with the
+                    // view-state's active buffer: the renderer looks up the
+                    // buffer to draw via this field, so a stale value here
+                    // renders the *previous* file's text at the new file's
+                    // scroll offset (wrong content, or blank past EOF).
+                    state.buffer_id = buffer_id;
                     if hidden_from_tabs {
                         state.loaded_buffers.insert(buffer_id);
                     }
@@ -2419,7 +2433,30 @@ impl Editor {
             .unwrap_or(line_start);
         if let Some(state) = self.active_window_mut().overlay_preview_state.as_mut() {
             state.view_state.cursors.primary_mut().position = byte_offset;
+            // Force line wrapping on for the preview regardless of the
+            // global `editor.line_wrap` setting (and of a switched-in
+            // buffer's fresh default): the preview pane has no horizontal
+            // scroll affordance, so without wrapping a match deep in a long
+            // line scrolls the start of the line off-screen and the context
+            // is unreadable. Wrapping also moots horizontal scroll, so reset
+            // it to the left edge. `view_state` derefs to the active
+            // buffer's `BufferViewState`, so this targets the buffer that's
+            // actually rendered.
+            state.view_state.viewport.line_wrap_enabled = true;
+            state.view_state.viewport.left_column = 0;
+            state.view_state.viewport.horizontal_scroll_offset = 0;
             state.view_state.viewport.top_byte = top_byte;
+            // We have a live target: ensure the pane is shown.
+            state.blanked = false;
+        }
+    }
+
+    /// Blank the Live Grep preview pane: it renders just its frame until
+    /// the next selectable result. Keeps `overlay_preview_state` (and its
+    /// `loaded_buffers` cleanup tracking) intact.
+    fn blank_overlay_preview(&mut self) {
+        if let Some(state) = self.active_window_mut().overlay_preview_state.as_mut() {
+            state.blanked = true;
         }
     }
 
@@ -2867,6 +2904,12 @@ impl Editor {
                 let Some(preview_state) = __win.overlay_preview_state.as_mut() else {
                     return;
                 };
+                // Blanked: the current query has no selectable result, so
+                // leave the framed pane empty rather than rendering a stale
+                // match.
+                if preview_state.blanked {
+                    return;
+                }
                 preview_state
                     .view_state
                     .viewport

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -1659,6 +1659,13 @@ pub struct OverlayPreviewState {
     /// Buffers the user already had open are *not* in this set —
     /// dismissing the overlay never disturbs them.
     pub loaded_buffers: HashSet<BufferId>,
+    /// When true, the preview pane renders empty (just its frame). Set
+    /// when the current query has no selectable result so a stale match
+    /// doesn't keep showing after the result list clears. Kept as a flag
+    /// (rather than dropping the whole state) so `loaded_buffers` stays
+    /// tracked for cleanup and the buffer can be re-shown on the next
+    /// match without reloading.
+    pub blanked: bool,
 }
 
 #[cfg(test)]

--- a/crates/fresh-editor/src/view/prompt.rs
+++ b/crates/fresh-editor/src/view/prompt.rs
@@ -242,6 +242,13 @@ pub struct Prompt {
     /// session_preview delegate region was already provided by
     /// Primitive #1 — `editor.previewWindowInRect`).
     pub footer: Vec<fresh_core::api::StyledText>,
+    /// Undo history for the input field: `(input, cursor_pos)` snapshots
+    /// captured before each text mutation. Ctrl+Z pops from here. Kept
+    /// local to the prompt so undo edits the query box rather than the
+    /// underlying (modal-inaccessible) buffer.
+    undo_stack: Vec<(String, usize)>,
+    /// Redo counterpart to `undo_stack`. Cleared on any fresh mutation.
+    redo_stack: Vec<(String, usize)>,
 }
 
 /// Maximum number of suggestion rows shown at once. Mirrors the cap used by
@@ -267,6 +274,8 @@ impl Prompt {
             overlay: false,
             title: Vec::new(),
             footer: Vec::new(),
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         }
     }
 
@@ -299,6 +308,8 @@ impl Prompt {
             overlay: false,
             title: Vec::new(),
             footer: Vec::new(),
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         }
     }
 
@@ -350,6 +361,8 @@ impl Prompt {
             overlay: false,
             title: Vec::new(),
             footer: Vec::new(),
+            undo_stack: Vec::new(),
+            redo_stack: Vec::new(),
         }
     }
 
@@ -373,8 +386,57 @@ impl Prompt {
         }
     }
 
+    /// Capture the current `(input, cursor_pos)` for undo, and drop any
+    /// redo history. Call at the start of every text-mutating operation.
+    /// No-ops if the input is unchanged from the most recent snapshot so
+    /// repeated no-op edits don't bloat the stack.
+    fn push_undo_snapshot(&mut self) {
+        if self
+            .undo_stack
+            .last()
+            .is_some_and(|(text, _)| *text == self.input)
+        {
+            return;
+        }
+        // Bound the history so a very long editing session can't grow it
+        // without limit.
+        const MAX_UNDO: usize = 500;
+        if self.undo_stack.len() >= MAX_UNDO {
+            self.undo_stack.remove(0);
+        }
+        self.undo_stack.push((self.input.clone(), self.cursor_pos));
+        self.redo_stack.clear();
+    }
+
+    /// Undo the last input edit. Returns true if the input changed.
+    pub fn undo_input(&mut self) -> bool {
+        if let Some((text, cursor)) = self.undo_stack.pop() {
+            self.redo_stack.push((self.input.clone(), self.cursor_pos));
+            self.input = text;
+            self.cursor_pos = cursor.min(self.input.len());
+            self.selection_anchor = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Redo the last undone input edit. Returns true if the input changed.
+    pub fn redo_input(&mut self) -> bool {
+        if let Some((text, cursor)) = self.redo_stack.pop() {
+            self.undo_stack.push((self.input.clone(), self.cursor_pos));
+            self.input = text;
+            self.cursor_pos = cursor.min(self.input.len());
+            self.selection_anchor = None;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Insert a character at the cursor position
     pub fn insert_char(&mut self, ch: char) {
+        self.push_undo_snapshot();
         self.input.insert(self.cursor_pos, ch);
         self.cursor_pos += ch.len_utf8();
     }
@@ -386,6 +448,7 @@ impl Prompt {
     /// tone mark without removing the base consonant.
     pub fn backspace(&mut self) {
         if self.cursor_pos > 0 {
+            self.push_undo_snapshot();
             // Find the previous character (code point) boundary, not grapheme boundary
             // This allows layer-by-layer deletion of combining marks
             let prev_boundary = self.input[..self.cursor_pos]
@@ -403,6 +466,7 @@ impl Prompt {
     /// Deletes the entire grapheme cluster, handling combining characters properly.
     pub fn delete(&mut self) {
         if self.cursor_pos < self.input.len() {
+            self.push_undo_snapshot();
             let next_boundary = grapheme::next_grapheme_boundary(&self.input, self.cursor_pos);
             self.input.drain(self.cursor_pos..next_boundary);
         }
@@ -435,6 +499,7 @@ impl Prompt {
     /// assert_eq!(prompt.cursor_pos, 12); // At end
     /// ```
     pub fn set_input(&mut self, text: String) {
+        self.push_undo_snapshot();
         self.cursor_pos = text.len();
         self.input = text;
         self.clear_selection();
@@ -603,6 +668,7 @@ impl Prompt {
     pub fn delete_word_forward(&mut self) {
         let word_end = find_word_end_bytes(self.input.as_bytes(), self.cursor_pos);
         if word_end > self.cursor_pos {
+            self.push_undo_snapshot();
             self.input.drain(self.cursor_pos..word_end);
             // Cursor stays at same position
         }
@@ -626,6 +692,7 @@ impl Prompt {
     pub fn delete_word_backward(&mut self) {
         let word_start = find_word_start_bytes(self.input.as_bytes(), self.cursor_pos);
         if word_start < self.cursor_pos {
+            self.push_undo_snapshot();
             self.input.drain(word_start..self.cursor_pos);
             self.cursor_pos = word_start;
         }
@@ -647,6 +714,7 @@ impl Prompt {
     /// ```
     pub fn delete_to_end(&mut self) {
         if self.cursor_pos < self.input.len() {
+            self.push_undo_snapshot();
             self.input.truncate(self.cursor_pos);
         }
     }
@@ -742,6 +810,7 @@ impl Prompt {
     /// Delete the current selection and return the deleted text
     pub fn delete_selection(&mut self) -> Option<String> {
         if let Some((start, end)) = self.selection_range() {
+            self.push_undo_snapshot();
             let deleted = self.input[start..end].to_string();
             self.input.drain(start..end);
             self.cursor_pos = start;

--- a/crates/fresh-editor/src/view/prompt_input.rs
+++ b/crates/fresh-editor/src/view/prompt_input.rs
@@ -145,6 +145,7 @@ impl InputHandler for Prompt {
                                 self.prompt_type,
                                 crate::view::prompt::PromptType::Plugin { .. }
                                     | crate::view::prompt::PromptType::QuickOpen
+                                    | crate::view::prompt::PromptType::LiveGrep
                             );
                         if should_sync {
                             if let Some(suggestion) = self.suggestions.get(new_selected) {
@@ -189,6 +190,7 @@ impl InputHandler for Prompt {
                                 self.prompt_type,
                                 crate::view::prompt::PromptType::Plugin { .. }
                                     | crate::view::prompt::PromptType::QuickOpen
+                                    | crate::view::prompt::PromptType::LiveGrep
                             );
                         if should_sync {
                             if let Some(suggestion) = self.suggestions.get(new_selected) {

--- a/crates/fresh-editor/src/view/prompt_input.rs
+++ b/crates/fresh-editor/src/view/prompt_input.rs
@@ -322,6 +322,23 @@ impl Prompt {
                 ctx.defer(DeferredAction::UpdatePromptSuggestions);
                 InputResult::Consumed
             }
+            'z' => {
+                // Undo the last input edit. Operates on the prompt's own
+                // history so undo edits the query box, not the underlying
+                // (modal-inaccessible) buffer. Consumed unconditionally so
+                // it never falls through to the global buffer undo.
+                if self.undo_input() {
+                    ctx.defer(DeferredAction::UpdatePromptSuggestions);
+                }
+                InputResult::Consumed
+            }
+            'y' => {
+                // Redo the last undone input edit.
+                if self.redo_input() {
+                    ctx.defer(DeferredAction::UpdatePromptSuggestions);
+                }
+                InputResult::Consumed
+            }
             // Pass through other Ctrl+key combinations to global keybindings (e.g., Ctrl+P to toggle Quick Open)
             _ => InputResult::Ignored,
         }

--- a/crates/fresh-editor/tests/e2e/live_grep.rs
+++ b/crates/fresh-editor/tests/e2e/live_grep.rs
@@ -990,3 +990,142 @@ fn test_live_grep_preview_wraps_long_lines() {
          off. Screen:\n{screen}"
     );
 }
+
+/// Build a temp project, seed the Resume cache with `matches` under
+/// `query`, then dispatch `ResumeLiveGrep` to re-open the overlay from
+/// the cache (no plugin / no grep — the core replay path). Returns the
+/// harness (overlay open) plus the `TempDir` guard.
+fn open_resumed_live_grep(
+    files: &[(&str, &str)],
+    query: &str,
+    matches: &[(&str, usize, usize, &str)],
+    selected: Option<usize>,
+) -> (EditorTestHarness, tempfile::TempDir) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    for (name, content) in files {
+        fs::write(project_root.join(name), content).unwrap();
+    }
+    let start_file = project_root.join("start.txt");
+    fs::write(&start_file, "start\n").unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(200, 44, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    let cached_results = matches
+        .iter()
+        .map(|(file, line, column, content)| GrepMatch {
+            file: file.to_string(),
+            line: *line,
+            column: *column,
+            content: content.to_string(),
+        })
+        .collect();
+    harness
+        .editor_mut()
+        .set_live_grep_last_state_for_tests(Some(LiveGrepLastState {
+            query: query.to_string(),
+            selected_index: selected,
+            cached_results: Some(cached_results),
+            cached_at: None,
+            last_results_snapshot_id: None,
+        }));
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::ResumeLiveGrep);
+    harness.render().unwrap();
+
+    (harness, temp_dir)
+}
+
+/// Resume bug A: navigating the *resumed* Live Grep overlay must not
+/// overwrite the filter query. The resumed prompt is `PromptType::LiveGrep`
+/// whose suggestions carry the match location (`path:line:col`) in their
+/// `value`; arrow-key navigation syncs the input to that value, so the
+/// query box turns into a file path. After the next confirm that path is
+/// re-cached, so subsequent resumes show the path instead of the query.
+#[test]
+fn test_resume_live_grep_navigation_preserves_query() {
+    let files = &[("aaa.txt", "match in aaa\n"), ("bbb.txt", "match in bbb\n")];
+    let (mut harness, _tmp) = open_resumed_live_grep(
+        files,
+        "menu_bg",
+        &[
+            ("aaa.txt", 1, 1, "match in aaa"),
+            ("bbb.txt", 1, 1, "match in bbb"),
+        ],
+        Some(0),
+    );
+
+    assert!(
+        harness.screen_to_string().contains("Live grep: menu_bg"),
+        "resumed overlay should show the original query; got:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Arrow down to the second result.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.screen_to_string().contains("Live grep: menu_bg"),
+        "navigating the resumed overlay must keep the query in the filter \
+         box; pre-fix it synced the input to the selected result's \
+         path:line:col. Input row:\n{}",
+        harness
+            .screen_to_string()
+            .lines()
+            .find(|l| l.contains("Live grep:"))
+            .unwrap_or("")
+    );
+}
+
+/// Resume bug B: pressing Enter on a resumed Live Grep result must open
+/// the selected match's file, not a file named after the query. Pre-fix,
+/// `confirm_prompt` took the prompt before the `LiveGrep` confirm handler
+/// read `self.prompt.suggestions[idx]`, so the lookup failed and it fell
+/// back to opening the raw query string as a path (creating an empty
+/// buffer named e.g. "menu_bg").
+#[test]
+fn test_resume_live_grep_enter_opens_selected_result() {
+    // The match line carries a unique marker so we can tell the real file
+    // opened (marker visible in the editor) from the bogus query-named
+    // buffer (empty).
+    let files = &[("aaa.txt", "RESUMEMATCHCONTENT_A unique line\n")];
+    let (mut harness, _tmp) = open_resumed_live_grep(
+        files,
+        "menu_bg",
+        &[("aaa.txt", 1, 1, "RESUMEMATCHCONTENT_A unique line")],
+        Some(0),
+    );
+
+    assert!(
+        harness.screen_to_string().contains("Live grep: menu_bg"),
+        "precondition: resumed overlay shows the query; got:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Confirm the selected result.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // The overlay closes on confirm in both the buggy and fixed cases —
+    // wait for that (deterministic) rather than for content that the bug
+    // never produces, so the test fails fast instead of timing out.
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("Live grep:"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("RESUMEMATCHCONTENT_A"),
+        "Enter on a resumed result must open the match file (aaa.txt) so its \
+         content is visible; pre-fix the confirm handler couldn't read the \
+         (already-taken) prompt's suggestions and fell back to opening the \
+         raw query 'menu_bg' as a path, leaving an empty buffer. Screen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/live_grep.rs
+++ b/crates/fresh-editor/tests/e2e/live_grep.rs
@@ -789,3 +789,204 @@ fn test_open_terminal_in_dock_has_only_terminal_tab() {
     let leaf_buffer = sm.get_buffer_id(dock_leaf.into()).expect("leaf has buffer");
     assert_eq!(tabs[0], leaf_buffer);
 }
+
+// ===================================================================
+// Floating-overlay preview / input bug reproductions
+//
+// These exercise the centred Live Grep overlay (issue #1796): the
+// filter input box and the right-hand preview pane.
+//
+// They deliberately do NOT drive the async grep backend (ripgrep / git
+// grep): the live search path is debounced + spawns a subprocess and is
+// known to time out intermittently under the test harness (see the
+// `#[ignore = "flaky test"]` tags on the search-driven tests above).
+// Instead they open the overlay and seed the result list directly — the
+// same pattern the Resume tests use — then drive real keyboard events
+// and assert only on rendered screen output. This keeps the preview /
+// input behaviour under test deterministic and decoupled from grep.
+// ===================================================================
+
+/// Open the editor in a fresh temp project containing `files`, then
+/// launch the Live Grep floating overlay (issue #1796). The overlay is
+/// wide enough (200 cols) that the right-hand preview pane is shown.
+/// Returns the harness plus the `TempDir` guard — keep it alive.
+fn open_live_grep_overlay(
+    files: &[(&str, &str)],
+    config: fresh::config::Config,
+) -> (EditorTestHarness, tempfile::TempDir) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    for (name, content) in files {
+        fs::write(project_root.join(name), content).unwrap();
+    }
+    let start_file = project_root.join("start.txt");
+    fs::write(&start_file, "start\n").unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(200, 44, config, project_root).unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .start_prompt("Live grep: ".to_string(), PromptType::LiveGrep);
+    // The `floatingOverlay` flag is what triggers the preview-pane layout
+    // and `prepare_overlay_preview`; the plugin sets it at runtime, so we
+    // set it directly here.
+    harness.editor_mut().prompt_mut().unwrap().overlay = true;
+    harness.render().unwrap();
+
+    (harness, temp_dir)
+}
+
+/// Seed the overlay's result list with `labels` (each a parseable
+/// `path:line` string, resolved against the working dir) and select
+/// `selected`. Mirrors the streamed-results shape the Finder produces.
+fn seed_overlay_results(harness: &mut EditorTestHarness, labels: &[&str], selected: Option<usize>) {
+    let prompt = harness.editor_mut().prompt_mut().unwrap();
+    prompt.suggestions = labels
+        .iter()
+        .map(|l| Suggestion::new(l.to_string()))
+        .collect();
+    prompt.selected_suggestion = selected;
+}
+
+/// Issue #1: undo/redo must operate on the filter input box, not the
+/// underlying buffer. Pre-fix, Ctrl+Z/Ctrl+Y returned `Ignored` from the
+/// prompt input handler and fell through to the global buffer
+/// undo/redo, so the typed query was never reverted/restored.
+#[test]
+fn test_live_grep_input_undo_redo() {
+    let (mut harness, _tmp) = open_live_grep_overlay(&[], Default::default());
+
+    harness.type_text("ZQXJV").unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("Live grep: ZQXJV"),
+        "input box should show the typed query; got:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Undo must revert the typed input.
+    harness
+        .send_key(KeyCode::Char('z'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        !harness.screen_to_string().contains("ZQXJV"),
+        "Ctrl+Z must undo the input edit; pre-fix it fell through to the \
+         buffer's undo and left the query untouched. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Redo must restore it.
+    harness
+        .send_key(KeyCode::Char('y'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("ZQXJV"),
+        "Ctrl+Y must redo the input edit. Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Issue #2: when the query stops matching anything (result list goes
+/// empty), the preview pane must clear too. Pre-fix,
+/// `prepare_overlay_preview` early-returned without dropping the stale
+/// `overlay_preview_state`, so the previous match's file content kept
+/// rendering in the preview.
+#[test]
+fn test_live_grep_preview_clears_when_no_matches() {
+    // PREVIEWMARKERAAA sits on a context line, so it only ever appears in
+    // the preview pane — the result-list label is the parseable
+    // `path:line`, never the file's contents.
+    let files = &[("aaa.txt", "PREVIEWMARKERAAA\nmatch line here\n")];
+    let (mut harness, _tmp) = open_live_grep_overlay(files, Default::default());
+
+    seed_overlay_results(&mut harness, &["aaa.txt:2"], Some(0));
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("PREVIEWMARKERAAA"),
+        "preview should show the selected file's context; got:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Query now matches nothing: the result list clears.
+    seed_overlay_results(&mut harness, &[], None);
+    harness.render().unwrap();
+    assert!(
+        !harness.screen_to_string().contains("PREVIEWMARKERAAA"),
+        "preview must clear when there are no results; pre-fix the stale \
+         match content kept rendering. Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Issue #3: navigating between results in *different* files must update
+/// the preview to the newly-selected file. Pre-fix, the buffer switch
+/// updated the preview view-state but not `OverlayPreviewState.buffer_id`,
+/// so the renderer drew the previous file's text at the new file's scroll
+/// offset (wrong content, or blank past EOF).
+#[test]
+fn test_live_grep_preview_follows_selection_across_files() {
+    // Each file has a unique context marker on line 1; the marker only
+    // appears in the preview pane.
+    let files = &[
+        ("aaa.txt", "PREVIEWMARKERAAA\nmatch in aaa\n"),
+        ("bbb.txt", "PREVIEWMARKERBBB\nmatch in bbb\n"),
+    ];
+    let (mut harness, _tmp) = open_live_grep_overlay(files, Default::default());
+
+    seed_overlay_results(&mut harness, &["aaa.txt:2", "bbb.txt:2"], Some(0));
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("PREVIEWMARKERAAA") && !screen.contains("PREVIEWMARKERBBB"),
+        "preview should start on aaa.txt; got:\n{screen}"
+    );
+
+    // Arrow-key down to the second result (bbb.txt).
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    assert!(
+        harness.screen_to_string().contains("PREVIEWMARKERBBB"),
+        "preview must follow the selection to bbb.txt; pre-fix it rendered \
+         aaa.txt's buffer at bbb.txt's scroll offset (wrong content or \
+         blank). Screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Issue #4: the preview must wrap long lines so the full match context
+/// is visible, rather than horizontally scrolling and pushing earlier
+/// parts of the line off-screen. A marker near the middle of a very long
+/// line and the token near its end must both be visible at once. The
+/// global `line_wrap` is disabled so the bug is exercised: the preview
+/// must wrap regardless, since it has no horizontal scroll affordance.
+#[test]
+fn test_live_grep_preview_wraps_long_lines() {
+    // One very long line: padding, MIDMARKERWORD (~col 70), more padding,
+    // ENDMATCHWORD (~col 185). Both markers are far past the preview's
+    // visible width, so only wrapping can show them together.
+    let long_line = format!(
+        "{} MIDMARKERWORD {} ENDMATCHWORD\n",
+        "x".repeat(70),
+        "y".repeat(100)
+    );
+    let files = &[("long.txt", long_line.as_str())];
+    let mut config = fresh::config::Config::default();
+    config.editor.line_wrap = false;
+    let (mut harness, _tmp) = open_live_grep_overlay(files, config);
+
+    seed_overlay_results(&mut harness, &["long.txt:1"], Some(0));
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("MIDMARKERWORD") && screen.contains("ENDMATCHWORD"),
+        "preview must wrap the long match line so both the mid-line marker \
+         and the end token are visible; without wrapping the start scrolls \
+         off. Screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
The centred Live Grep overlay (issue #1796) had four defects in its
filter input box and preview pane:

1. Undo/redo did nothing in the filter box — Ctrl+Z/Ctrl+Y fell through
   the prompt input handler to the global buffer undo. Give the prompt
   its own per-input undo/redo history (snapshots captured before each
   text mutation) and handle the keys in the prompt.

2. The preview kept showing the previous match after the result list
   emptied (non-matching query). `prepare_overlay_preview` early-returned
   without dropping the stale state; now it blanks the pane when there is
   no selectable result.

3. Navigating to a result in a different file rendered the wrong file's
   text (or blank past EOF): the buffer switch updated the preview
   view-state but not `OverlayPreviewState.buffer_id`, which the renderer
   uses to look up content. Keep the two in lockstep.

4. Long match lines horizontally scrolled to the cursor column, pushing
   the start of the line off-screen with no way to see the full context.
   Force line wrapping on in the preview (it has no horizontal scroll
   affordance) regardless of the global `editor.line_wrap` setting.

Adds deterministic e2e reproductions that drive keyboard events / seed
the result list and assert on rendered output, avoiding the flaky async
grep path.

https://claude.ai/code/session_01ELWivnfsn7MpYs3cp49tCn