### PR TITLE
docs: drop Homebrew tap step now that fresh-editor is in homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ On macOS and some linux distros (Bazzite/Bluefin/Aurora):
 > **Note:** On macOS, see [macOS Terminal Tips](https://getfresh.dev/docs/configuration/keyboard#macos-terminal-tips) for recommended terminal configuration.
 
 ```bash
-brew tap sinelaw/fresh
 brew install fresh-editor
 ```
 

--- a/crates/fresh-editor/src/services/release_checker.rs
+++ b/crates/fresh-editor/src/services/release_checker.rs
@@ -40,7 +40,7 @@ impl InstallMethod {
     /// Get the update command for this installation method
     pub fn update_command(&self) -> Option<&'static str> {
         Some(match self {
-            Self::Homebrew => " brew upgrade fresh-editor",
+            Self::Homebrew => "brew upgrade fresh-editor",
             Self::Cargo => "cargo install --locked fresh-editor",
             Self::Npm => "npm update -g @fresh-editor/fresh-editor",
             Self::Aur => "yay -Syu fresh-editor  # or use your AUR helper",

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -1506,7 +1506,7 @@
                 <div class="install-card">
                     <h3>macOS (Homebrew)</h3>
                     <div class="copyable">
-                        <code id="cmd-brew">brew install sinelaw/fresh/fresh-editor</code>
+                        <code id="cmd-brew">brew install fresh-editor</code>
                         <button class="copy-btn" onclick="copyCode('cmd-brew', this)">
                             <img src="public/copy-icon.svg" alt="Copy">
                         </button>
@@ -1699,7 +1699,7 @@
 
         const INSTALL_COMMANDS = {
             linux: 'curl https://raw.githubusercontent.com/sinelaw/fresh/refs/heads/master/scripts/install.sh | sh',
-            mac: 'brew install sinelaw/fresh/fresh-editor',
+            mac: 'brew install fresh-editor',
             windows: 'winget install fresh-editor'
         };
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,7 +69,6 @@ run_privileged() {
 install_macos() {
     if check_cmd brew; then
         log_info "macOS detected. Installing via Homebrew..."
-        brew tap "${REPO_OWNER}/${REPO_NAME}"
         brew install "${BIN_NAME}"
     else
         log_warn "Homebrew not found."


### PR DESCRIPTION
fresh-editor ships in homebrew-core, so `brew install fresh-editor` resolves without tapping. Remove the `brew tap sinelaw/fresh` step from the README, homepage install card/JS, and install.sh; also strip a stray leading space in the Homebrew upgrade command.