### PR TITLE
Reduce serial console lag by avoiding unnecessary repaints

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -42,7 +42,21 @@ impl Editor {
         for window in self.windows.values() {
             messages.extend(window.bridge.try_recv_all());
         }
-        let needs_render = !messages.is_empty();
+        // A render is only warranted if a message can actually change the
+        // screen. A `DelayComplete` just resolves a debounced
+        // `editor.delay()` callback in the plugin runtime; on its own it
+        // paints nothing. Any visual outcome of the resumed plugin code
+        // arrives as a follow-up plugin *command* and is caught by
+        // `process_plugin_commands`'s `has_visual_commands` check below (or
+        // on the next tick). Forcing a render for the bare completion made
+        // live_diff's per-keystroke debounce repaint the screen with no
+        // change — invisible locally, but real lag over serial (#2100).
+        let needs_render = messages.iter().any(|m| {
+            !matches!(
+                m,
+                AsyncMessage::Plugin(fresh_core::api::PluginAsyncMessage::DelayComplete { .. })
+            )
+        });
         tracing::trace!(
             async_message_count = messages.len(),
             "received async messages"

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1482,9 +1482,31 @@ impl Editor {
         // many plugins (e.g. git_statusbar) re-publish the same value on
         // every `render_start` hook, which would otherwise create a
         // render → hook → ack → render feedback loop at ~13Hz forever.
+        //
+        // The remaining `=> false` arms are side-effecting commands that
+        // never touch the rendered buffer: scheduling a timer, spawning
+        // processes / HTTP, watching paths, and writing plugin-private
+        // state. Any *visual* result they eventually produce arrives as its
+        // own command (overlay, virtual text, status value, …) and is
+        // counted then. Treating these as visual forced a redraw on every
+        // debounce tick — e.g. live_diff's 75ms `editor.delay()` recompute
+        // repainted the screen twice per keystroke with no change. Invisible
+        // on a fast terminal, but real lag over a serial console (#2100).
+        use fresh_core::api::PluginCommand as Pc;
         let has_visual_commands = commands.iter().any(|c| match c {
-            fresh_core::api::PluginCommand::HookCompleted { .. } => false,
-            fresh_core::api::PluginCommand::SetStatusBarValue {
+            Pc::HookCompleted { .. }
+            | Pc::Delay { .. }
+            | Pc::SpawnProcess { .. }
+            | Pc::SpawnBackgroundProcess { .. }
+            | Pc::KillBackgroundProcess { .. }
+            | Pc::SpawnProcessWait { .. }
+            | Pc::HttpFetch { .. }
+            | Pc::WatchPath { .. }
+            | Pc::UnwatchPath { .. }
+            | Pc::SetGlobalState { .. }
+            | Pc::SetWindowState { .. }
+            | Pc::SetViewState { .. } => false,
+            Pc::SetStatusBarValue {
                 buffer_id,
                 key,
                 value,

--- a/scripts/serial_lag_bench.py
+++ b/scripts/serial_lag_bench.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+Empirically measure terminal output traffic for TUI editors, to reproduce and
+quantify "lag over a serial console".
+
+A serial line at 115200 8N1 carries ~11,520 bytes/sec (10 bits/byte incl.
+start+stop). Therefore the number of bytes an editor writes to the terminal in
+response to a keystroke is, to first order, the floor on the latency the user
+feels on that link:
+
+    serial_ms(n_bytes) = n_bytes * 10 / 115200 * 1000  ~=  n_bytes * 0.0868 ms
+
+We run the editor under a pseudo-terminal, feed it a scripted, identical
+sequence of input events, and for each event count the bytes it emits back to
+the "terminal" (the pty master = what would physically go down the wire). We
+also measure idle output (does it stream bytes with no input? e.g. cursor
+blink / periodic repaint -- that alone saturates a slow serial link).
+"""
+
+import os, pty, select, time, sys, fcntl, struct, termios, json, argparse, tempfile, signal
+
+BAUD = 115200
+BITS_PER_BYTE = 10  # 8 data + 1 start + 1 stop, no parity
+
+
+def serial_ms(nbytes, baud=BAUD):
+    return nbytes * BITS_PER_BYTE / baud * 1000.0
+
+
+def spawn(argv, env, cols=80, rows=24):
+    pid, fd = pty.fork()
+    if pid == 0:
+        for k, v in env.items():
+            os.environ[k] = v
+        try:
+            os.execvp(argv[0], argv)
+        except Exception as e:
+            sys.stderr.write("exec failed: %r\n" % (e,))
+        os._exit(127)
+    # parent: force a known window size on the tty
+    winsize = struct.pack("HHHH", rows, cols, 0, 0)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, winsize)
+    return pid, fd
+
+
+def drain(fd, quiet=0.35, maxwait=8.0):
+    """Read until no bytes arrive for `quiet` seconds (or maxwait elapses)."""
+    buf = bytearray()
+    start = time.time()
+    while True:
+        timeout = quiet
+        r, _, _ = select.select([fd], [], [], timeout)
+        if r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            buf += data
+        else:
+            break  # quiescent
+        if time.time() - start > maxwait:
+            break
+    return bytes(buf)
+
+
+def idle_collect(fd, seconds):
+    """Collect everything emitted over a fixed window with no input."""
+    buf = bytearray()
+    end = time.time() + seconds
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], end - time.time())
+        if r:
+            try:
+                data = os.read(fd, 65536)
+            except OSError:
+                break
+            if not data:
+                break
+            buf += data
+    return bytes(buf)
+
+
+import re
+def analyze_escapes(data):
+    """Characterize a chunk of terminal output: how many cursor moves, color
+    changes, clears -- i.e. what the editor is spending bytes on."""
+    text = data
+    return {
+        "bytes": len(data),
+        "cursor_pos": len(re.findall(rb"\x1b\[[0-9;]*[Hf]", text)),   # CUP
+        "sgr_color": len(re.findall(rb"\x1b\[[0-9;]*m", text)),       # set graphics
+        "erase_line": len(re.findall(rb"\x1b\[[0-9]*K", text)),       # EL
+        "erase_disp": len(re.findall(rb"\x1b\[[0-9]*J", text)),       # ED (clear screen)
+        "cursor_updn": len(re.findall(rb"\x1b\[[0-9]*[ABCD]", text)), # rel moves
+        "printable": sum(1 for b in text if 0x20 <= b < 0x7f),
+    }
+
+
+def run_scenario(name, argv, env, testfile, cols=80, rows=24):
+    pid, fd = spawn(argv, env, cols, rows)
+    try:
+        # settle startup; ignore the initial paint for per-key numbers but record it
+        startup = drain(fd, quiet=0.6, maxwait=10.0)
+        results = {"editor": name, "argv": argv, "cols": cols, "rows": rows}
+        results["startup_bytes"] = len(startup)
+
+        captures = {}
+        def event(label, data, quiet=0.35, reps=1):
+            tot = 0
+            last = b""
+            for _ in range(reps):
+                os.write(fd, data)
+                out = drain(fd, quiet=quiet)
+                tot += len(out)
+                last = out
+            captures[label] = last  # keep last sample for escape analysis
+            return {"bytes_total": tot, "reps": reps,
+                    "bytes_per_event": tot / reps,
+                    "serial_ms_per_event": serial_ms(tot / reps),
+                    "sample_analysis": analyze_escapes(last)}
+
+        steps = {}
+        # 1) Type characters one at a time (the dominant typing feel)
+        steps["type_char"] = event("type_char", b"a", reps=20)
+        # 2) Arrow-key cursor movement
+        steps["arrow_down"] = event("arrow_down", b"\x1b[B", reps=20)
+        steps["arrow_right"] = event("arrow_right", b"\x1b[C", reps=20)
+        # 3) Page down (scrolling -- forces large region redraw)
+        steps["page_down"] = event("page_down", b"\x1b[6~", reps=10)
+        # 4) Backspace
+        steps["backspace"] = event("backspace", b"\x7f", reps=20)
+        results["steps"] = steps
+        # keep a hex sample of one keystroke's output for the report
+        results["sample_type_char_hex"] = captures.get("type_char", b"")[:400].hex()
+
+        # 5) Idle: no input, measure streamed bytes over 3 s (cursor blink etc.)
+        idle = idle_collect(fd, 3.0)
+        results["idle_bytes_3s"] = len(idle)
+        results["idle_bytes_per_sec"] = len(idle) / 3.0
+        return results
+    finally:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except Exception:
+            pass
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+
+
+def make_testfile():
+    fd, path = tempfile.mkstemp(suffix=".txt", prefix="seriallag_")
+    with os.fdopen(fd, "w") as f:
+        for i in range(1, 401):
+            f.write("line %4d: the quick brown fox jumps over the lazy dog 0123456789\n" % i)
+    return path
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fresh", default="target/release/fresh")
+    ap.add_argument("--nano", default="nano")
+    ap.add_argument("--cols", type=int, default=80)
+    ap.add_argument("--rows", type=int, default=24)
+    args = ap.parse_args()
+
+    testfile = make_testfile()
+    home = tempfile.mkdtemp(prefix="seriallag_home_")
+    base_env = {
+        "TERM": "xterm-256color",
+        "HOME": home,
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "NO_COLOR": "",  # leave colors on; serial terminals do support them
+    }
+
+    editors = []
+    if os.path.exists(args.fresh):
+        editors.append(("fresh", [args.fresh, testfile]))
+    editors.append(("nano", [args.nano, testfile]))
+
+    all_results = []
+    for name, argv in editors:
+        try:
+            res = run_scenario(name, argv, base_env, testfile, args.cols, args.rows)
+            all_results.append(res)
+        except Exception as e:
+            all_results.append({"editor": name, "error": repr(e)})
+
+    print(json.dumps(all_results, indent=2))
+
+    # Human-readable comparison table
+    print("\n=== Serial-lag comparison @ %d baud (%.1f bytes/sec) ===" %
+          (BAUD, BAUD / BITS_PER_BYTE))
+    print("File: 400 lines, terminal %dx%d, TERM=xterm-256color\n" % (args.cols, args.rows))
+    hdr = "%-12s %12s %12s %12s %12s %12s" % (
+        "metric", "fresh B", "fresh ms", "nano B", "nano ms", "ratio")
+    print(hdr)
+    print("-" * len(hdr))
+
+    def get(res, *keys):
+        for k in keys:
+            res = res.get(k, {}) if isinstance(res, dict) else {}
+        return res
+
+    rmap = {r["editor"]: r for r in all_results if "editor" in r and "steps" in r}
+    fr = rmap.get("fresh"); na = rmap.get("nano")
+    if fr and na:
+        def row(label, fb, nb):
+            ratio = (fb / nb) if nb else float("inf")
+            print("%-12s %12.0f %12.1f %12.0f %12.1f %11.1fx" % (
+                label, fb, serial_ms(fb), nb, serial_ms(nb), ratio))
+        print("%-12s %12.0f %12.1f %12.0f %12.1f %11.1fx" % (
+            "startup", fr["startup_bytes"], serial_ms(fr["startup_bytes"]),
+            na["startup_bytes"], serial_ms(na["startup_bytes"]),
+            fr["startup_bytes"] / max(na["startup_bytes"], 1)))
+        for key in ["type_char", "arrow_down", "arrow_right", "page_down", "backspace"]:
+            row(key, fr["steps"][key]["bytes_per_event"], na["steps"][key]["bytes_per_event"])
+        print("%-12s %12.0f %12.1f %12.0f %12.1f %11s" % (
+            "idle/sec", fr["idle_bytes_per_sec"], serial_ms(fr["idle_bytes_per_sec"]),
+            na["idle_bytes_per_sec"], serial_ms(na["idle_bytes_per_sec"]), "-"))
+
+        # Why: escape-sequence breakdown for a single keystroke / arrow press
+        for key in ["type_char", "arrow_down", "page_down"]:
+            fa = fr["steps"][key]["sample_analysis"]
+            naa = na["steps"][key]["sample_analysis"]
+            print("\n[%s] per-event escape breakdown (one sample):" % key)
+            print("   %-10s fresh=%-6d nano=%-6d" % ("bytes", fa["bytes"], naa["bytes"]))
+            for m in ["cursor_pos", "sgr_color", "erase_line", "erase_disp",
+                      "cursor_updn", "printable"]:
+                print("   %-10s fresh=%-6d nano=%-6d" % (m, fa[m], naa[m]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/serial_lag_diagnose.py
+++ b/scripts/serial_lag_diagnose.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Diagnose *where* Fresh's per-keystroke serial traffic goes (companion to
+serial_lag_bench.py). Two empirical probes, no serial hardware required:
+
+  1. config sweep  -- toggle individual settings and measure bytes/keystroke,
+                      isolating which feature drives the output volume.
+  2. frame audit   -- count synchronized-update frames (ESC[?2026h..l) emitted
+                      per single keystroke, splitting them into "content" frames
+                      (real cell changes) vs "empty" frames (no-op repaints that
+                      still cost ~48 bytes of wrapper + cursor reposition + SGR
+                      reset). Empty frames are pure waste on a slow link.
+
+Usage:
+  python3 scripts/serial_lag_diagnose.py sweep
+  python3 scripts/serial_lag_diagnose.py frames
+"""
+import os, pty, select, time, struct, fcntl, termios, signal, tempfile, json, re, sys
+
+FRESH = os.environ.get("FRESH_BIN", "target/release/fresh")
+CSI = re.compile(rb"\x1b\[[0-9;?]*[A-Za-z]")
+OSC = re.compile(rb"\x1b\][^\x07]*\x07")
+
+
+def spawn(config=None, rows=24, cols=80):
+    home = tempfile.mkdtemp(prefix="freshdiag_")
+    os.makedirs(os.path.join(home, ".config", "fresh"), exist_ok=True)
+    if config is not None:
+        with open(os.path.join(home, ".config", "fresh", "config.json"), "w") as f:
+            json.dump(config, f)
+    tf = os.path.join(home, "t.txt")
+    with open(tf, "w") as f:
+        for i in range(1, 401):
+            f.write("line %4d: the quick brown fox jumps over the lazy dog 0123456789\n" % i)
+    env = dict(TERM="xterm-256color", HOME=home, PATH=os.environ["PATH"],
+               LANG="C.UTF-8", LC_ALL="C.UTF-8",
+               XDG_STATE_HOME=os.path.join(home, "state"))
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.environ.update(env)
+        os.execvp(FRESH, [FRESH, tf])
+        os._exit(127)
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    return pid, fd
+
+
+def drain(fd, quiet=0.4, maxwait=8.0):
+    buf = bytearray()
+    start = time.time()
+    while True:
+        r, _, _ = select.select([fd], [], [], quiet)
+        if r:
+            try:
+                d = os.read(fd, 65536)
+            except OSError:
+                break
+            if not d:
+                break
+            buf += d
+        else:
+            break
+        if time.time() - start > maxwait:
+            break
+    return bytes(buf)
+
+
+def kill(pid, fd):
+    try:
+        os.kill(pid, signal.SIGKILL); os.waitpid(pid, 0)
+    except Exception:
+        pass
+    try:
+        os.close(fd)
+    except Exception:
+        pass
+
+
+def measure(config):
+    pid, fd = spawn(config)
+    try:
+        drain(fd, 0.8, 10)
+
+        def ev(data, reps):
+            t = 0
+            for _ in range(reps):
+                os.write(fd, data); t += len(drain(fd))
+            return t / reps
+        return {"type": ev(b"a", 20), "down": ev(b"\x1b[B", 20),
+                "right": ev(b"\x1b[C", 20), "pgdn": ev(b"\x1b[6~", 10)}
+    finally:
+        kill(pid, fd)
+
+
+def sweep():
+    configs = {
+        "baseline(default)": None,
+        "no_cursorline": {"editor": {"highlight_current_line": False}},
+        "no_syntax": {"editor": {"syntax_highlighting": False}},
+        "no_whitespace": {"editor": {"whitespace_show": False}},
+        "no_linenum": {"editor": {"line_numbers": False}},
+        "no_scrollbar": {"editor": {"show_vertical_scrollbar": False}},
+        "minimal_all": {"editor": {
+            "highlight_current_line": False, "syntax_highlighting": False,
+            "whitespace_show": False, "line_numbers": False,
+            "show_vertical_scrollbar": False, "show_status_bar": False,
+            "show_menu_bar": False, "show_tab_bar": False}},
+    }
+    print("%-20s %8s %8s %8s %8s   (bytes/keystroke)" % ("config", "type", "down", "right", "pgdn"))
+    print("-" * 64)
+    for name, cfg in configs.items():
+        r = measure(cfg)
+        print("%-20s %8.0f %8.0f %8.0f %8.0f" % (name, r["type"], r["down"], r["right"], r["pgdn"]))
+
+
+def frames():
+    pid, fd = spawn(None)
+    try:
+        drain(fd, 0.8, 10)
+
+        def strip(s):
+            return OSC.sub(b"", CSI.sub(b"", s))
+
+        def one(data, label):
+            os.write(fd, data)
+            out = drain(fd, 0.5)
+            segs = re.findall(rb"\x1b\[\?2026h(.*?)\x1b\[\?2026l", out, re.S)
+            content = empty = empty_bytes = 0
+            for s in segs:
+                if strip(s).strip():
+                    content += 1
+                else:
+                    empty += 1
+                    empty_bytes += len(s) + len(b"\x1b[?2026h\x1b[?2026l")
+            print("%-9s total=%-4d frames=%-2d content=%-2d empty=%-2d empty_overhead=%dB"
+                  % (label, len(out), len(segs), content, empty, empty_bytes))
+        print("Per single keystroke: synchronized-update frames (ESC[?2026h..l)")
+        print("content = real cell changes; empty = no-op repaint (pure waste)\n")
+        for _ in range(3):
+            one(b"a", "type a")
+        for _ in range(3):
+            one(b"\x1b[B", "arrow_dn")
+        idle = drain(fd, 2.0, 2.5)
+        print("\nidle 2s after input: bytes=%d (should be 0)" % len(idle))
+    finally:
+        kill(pid, fd)
+
+
+if __name__ == "__main__":
+    mode = sys.argv[1] if len(sys.argv) > 1 else "sweep"
+    if mode == "sweep":
+        sweep()
+    elif mode == "frames":
+        frames()
+    else:
+        print("usage: serial_lag_diagnose.py [sweep|frames]")


### PR DESCRIPTION
## Summary
This PR reduces terminal output traffic for Fresh when running over slow serial connections (e.g., 115200 baud) by eliminating unnecessary screen repaints that produce no visual changes.

## Changes

### New Diagnostic Tools
- **`scripts/serial_lag_bench.py`**: Benchmarking tool that measures terminal output bytes per keystroke by running editors under a pseudo-terminal and comparing Fresh against nano. Calculates equivalent serial latency at 115200 baud and analyzes escape sequence usage.
- **`scripts/serial_lag_diagnose.py`**: Diagnostic companion tool with two modes:
  - `sweep`: Tests individual feature toggles (syntax highlighting, line numbers, cursor line, etc.) to isolate which settings drive output volume
  - `frames`: Audits synchronized-update frames (ESC[?2026h..l) to identify "empty" frames that repaint with no actual cell changes

### Core Rendering Optimizations
- **`async_messages.rs`**: Refined `has_visual_commands` check to exclude side-effecting commands that don't produce visual output:
  - Timers (`Delay`), process spawning, HTTP requests, path watching, and state updates no longer trigger redraws
  - Previously, plugins like `live_diff` would repaint on every debounce tick (~75ms) even when no visual changes occurred
  - Only commands that directly modify rendered content (overlays, virtual text, status values) now force repaints

- **`async_dispatch.rs`**: Optimized `DelayComplete` message handling to skip render when a debounced callback completes:
  - `DelayComplete` alone doesn't paint anything; any visual result arrives as a follow-up plugin command
  - Prevents double-repaints where the completion message + subsequent visual command would both trigger screen updates
  - Eliminates per-keystroke repaints with zero visual change

## Impact
On a 115200 baud serial link (~11,520 bytes/sec), unnecessary repaints directly translate to user-visible lag. These changes eliminate wasteful output while preserving all visual functionality, making Fresh significantly more responsive over slow serial consoles.

https://claude.ai/code/session_011fE5QjeJsZTNLTcf3EHrdi