### PR TITLE
fix(plugin-api): report real cursor line via CursorInfo.line (#2076)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -359,6 +359,12 @@ pub struct CursorInfo {
         ts(type = "{ start: number; end: number } | null")
     )]
     pub selection: Option<Range<usize>>,
+    /// 0-indexed line number of the cursor. `null` when the line index is
+    /// unavailable — e.g. a huge file whose line scan hasn't completed, where
+    /// the editor positions purely by byte offset. Plugins must treat `null`
+    /// as "unknown", never as line 0.
+    #[serde(default)]
+    pub line: Option<usize>,
 }
 
 /// Specification for an action to execute, with optional repeat count
@@ -5428,6 +5434,7 @@ mod tests {
             snapshot.primary_cursor = Some(CursorInfo {
                 position: 42,
                 selection: Some(10..42),
+                line: Some(3),
             });
         }
 
@@ -5454,14 +5461,17 @@ mod tests {
                 CursorInfo {
                     position: 10,
                     selection: None,
+                    line: Some(0),
                 },
                 CursorInfo {
                     position: 20,
                     selection: Some(15..20),
+                    line: Some(1),
                 },
                 CursorInfo {
                     position: 30,
                     selection: Some(25..30),
+                    line: Some(2),
                 },
             ];
         }

--- a/crates/fresh-editor/plugins/examples/bookmarks.ts
+++ b/crates/fresh-editor/plugins/examples/bookmarks.ts
@@ -46,8 +46,9 @@ function getCurrentLocation(): {
 
 // Helper: Get actual line number using the API
 function getCurrentLineCol(): { line: number; column: number } {
-  // Use the actual getCursorLine API for accurate line number
-  const lineNumber = editor.getCursorLine();
+  // Read the primary cursor's line from the snapshot. `line` is null when the
+  // buffer has no line index yet (huge files); fall back to 0 there.
+  const lineNumber = editor.getPrimaryCursor()?.line ?? 0;
 
   // Get cursor position within the line by reading buffer content
   const bufferId = editor.getActiveBufferId();

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -735,6 +735,13 @@ type CursorInfo = {
 		start: number;
 		end: number;
 	} | null;
+	/**
+	* 0-indexed line number of the cursor. `None` when the line index is
+	* unavailable — e.g. a huge file whose line scan hasn't completed, where
+	* the editor positions purely by byte offset. Plugins must treat `null`
+	* as "unknown", never as line 0.
+	*/
+	line: number | null;
 };
 type OverlayOptions = {
 	/**
@@ -1695,7 +1702,13 @@ interface EditorAPI {
 	*/
 	listSplits(): SplitSnapshot[];
 	/**
-	* Get the line number (0-indexed) of the primary cursor
+	* Get the line number (0-indexed) of the primary cursor.
+	* 
+	* @deprecated Use `getPrimaryCursor()?.line` instead. This accessor cannot
+	* represent "line index unavailable" (huge files before their line scan) —
+	* it returns `0` in that case, indistinguishable from a real first line.
+	* `getPrimaryCursor().line` is `number | null` and also covers every cursor
+	* via `getAllCursors()`.
 	*/
 	getCursorLine(): number;
 	/**
@@ -1864,38 +1877,17 @@ interface EditorAPI {
 	*/
 	getAuthorityLabel(): string;
 	/**
-	* Current Workspace Trust level for the active project:
-	* `"restricted"`, `"trusted"`, or `"blocked"` (empty `""` when trust
-	* state is unavailable, e.g. the default local authority).
-	*
-	* Trust is a per-project, user-granted decision. Plugins that run
-	* repo-controlled work (env activation, project tooling, repo-local
-	* binaries) MUST gate on this and treat anything other than
-	* `"trusted"` as "do not execute".
+	* Current Workspace Trust level for the active project: `"restricted"`,
+	* `"trusted"`, or `"blocked"` (empty when unavailable). Exposed to JS as
+	* `editor.workspaceTrustLevel()`. Plugins that run repo-controlled work
+	* should treat anything other than `"trusted"` as "do not execute".
 	*/
-	workspaceTrustLevel(): "restricted" | "trusted" | "blocked" | "";
+	workspaceTrustLevel(): string;
 	/**
-	* Activate an environment by setting the live env recipe: an activation
-	* shell `snippet` (e.g. `eval "$(direnv export bash)"`,
-	* `source .venv/bin/activate`, or `""` for a pure login shell) run in
-	* `dir` (defaults to the workspace). It is re-evaluated on demand on the
-	* active backend and applied to every spawn — language servers,
-	* formatters, `spawnProcess` — so they see the project environment. No
-	* authority rebuild; the LSP is restarted to pick it up.
-	*
-	* Honored only when `workspaceTrustLevel() === "trusted"` (it runs
-	* repo-controlled code). Call `clearEnv()` to deactivate.
-	*/
-	setEnv(snippet: string, dir?: string): void;
-	/**
-	* Deactivate the environment set by `setEnv` — spawns return to the
-	* inherited environment.
-	*/
-	clearEnv(): void;
-	/**
-	* Whether an environment is currently active (a recipe was set via
-	* `setEnv`). Survives the restart `setEnv` triggers, so a plugin can
-	* re-establish its file watch and reflect activation after reloading.
+	* Whether an environment is currently active (set via `editor.setEnv`).
+	* Exposed to JS as `editor.envActive()`. Lets the env-manager plugin
+	* reflect activation and re-establish its file watch after the restart
+	* that `setEnv` triggers.
 	*/
 	envActive(): boolean;
 	/**
@@ -2859,6 +2851,16 @@ interface EditorAPI {
 	* `setAuthority`.
 	*/
 	clearAuthority(): void;
+	/**
+	* Activate an environment: set the live env recipe (`snippet` run in
+	* `dir`). Applied to every spawn, re-evaluated on demand — no restart.
+	* Honored only when the workspace is Trusted.
+	*/
+	setEnv(snippet: string, dir: string | null): void;
+	/**
+	* Deactivate the environment — spawns return to the inherited env.
+	*/
+	clearEnv(): void;
 	/**
 	* Override the Remote Indicator's displayed state. Plugins call
 	* this to surface lifecycle transitions that the authority layer

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -395,7 +395,7 @@ registerHandler("vi_line_end", vi_line_end);
 async function vi_first_non_blank() : Promise<void> {
   consumeCount(); // Count doesn't apply
   // Get line start position directly (avoids stale snapshot from executeAction)
-  const line = editor.getCursorLine();
+  const line = editor.getPrimaryCursor()?.line ?? 0;
   const bufferId = editor.getActiveBufferId();
   const lineStart = await editor.getLineStartPosition(line);
   if (lineStart === null) {
@@ -939,7 +939,7 @@ async function vi_visual_block() : Promise<void> {
   // Calculate line and column for block anchor
   const cursorPos = editor.getCursorPosition();
   if (cursorPos !== null) {
-    const line = editor.getCursorLine() ?? 1;
+    const line = editor.getPrimaryCursor()?.line ?? 1;
     const lineStart = await editor.getLineStartPosition(line);
     const col = lineStart !== null ? cursorPos - lineStart : 0;
     state.visualBlockAnchor = { line, col };
@@ -2702,7 +2702,7 @@ async function executeCommand(
       if (info) {
         const modified = info.modified ? editor.t("info.modified") : "";
         const path = info.path || editor.t("info.no_name");
-        const line = editor.getCursorLine();
+        const line = editor.getPrimaryCursor()?.line ?? 0;
         return { message: editor.t("info.file", { path, modified, line: String(line), bytes: String(info.length) }) };
       }
       return { error: editor.t("error.no_buffer") };

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -6351,9 +6351,25 @@ impl Window {
                     let primary_position = primary.position;
                     let primary_selection = primary.selection_range();
 
+                    // Resolve a byte offset to its 0-indexed line, but only when the
+                    // active buffer has a line index. Huge files load without line
+                    // metadata (`line_count() == None`); reporting `0` there would be
+                    // a lie, so we surface `None` instead — the same guard the
+                    // viewport's `top_line` uses below.
+                    let line_of = |offset: usize| -> Option<usize> {
+                        buffers_mut.get(&active_buf_id).and_then(|state| {
+                            if state.buffer.line_count().is_some() {
+                                Some(state.buffer.get_line_number(offset))
+                            } else {
+                                None
+                            }
+                        })
+                    };
+
                     snapshot.primary_cursor = Some(CursorInfo {
                         position: primary_position,
                         selection: primary_selection.clone(),
+                        line: line_of(primary_position),
                     });
 
                     snapshot.all_cursors = active_cursors
@@ -6361,6 +6377,7 @@ impl Window {
                         .map(|(_, cursor)| CursorInfo {
                             position: cursor.position,
                             selection: cursor.selection_range(),
+                            line: line_of(cursor.position),
                         })
                         .collect();
 

--- a/crates/fresh-editor/tests/fixtures/large.rs
+++ b/crates/fresh-editor/tests/fixtures/large.rs
@@ -5344,9 +5344,21 @@ impl Editor {
                 let primary_position = primary.position;
                 let primary_selection = primary.selection_range();
 
+                let active_buf_id = self.active_buffer();
+                let line_of = |offset: usize| -> Option<usize> {
+                    self.buffers.get(&active_buf_id).and_then(|state| {
+                        if state.buffer.line_count().is_some() {
+                            Some(state.buffer.get_line_number(offset))
+                        } else {
+                            None
+                        }
+                    })
+                };
+
                 snapshot.primary_cursor = Some(CursorInfo {
                     position: primary_position,
                     selection: primary_selection.clone(),
+                    line: line_of(primary_position),
                 });
 
                 // All cursors
@@ -5355,6 +5367,7 @@ impl Editor {
                     .map(|(_, cursor)| CursorInfo {
                         position: cursor.position,
                         selection: cursor.selection_range(),
+                        line: line_of(cursor.position),
                     })
                     .collect();
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -1568,12 +1568,19 @@ impl JsEditorApi {
             .map_err(|e| rquickjs::Error::new_from_js_message("serialize", "", &e.to_string()))
     }
 
-    /// Get the line number (0-indexed) of the primary cursor
+    /// Get the line number (0-indexed) of the primary cursor.
+    ///
+    /// @deprecated Use `getPrimaryCursor()?.line` instead. This accessor cannot
+    /// represent "line index unavailable" (huge files before their line scan) —
+    /// it returns `0` in that case, indistinguishable from a real first line.
+    /// `getPrimaryCursor().line` is `number | null` and also covers every cursor
+    /// via `getAllCursors()`.
     pub fn get_cursor_line(&self) -> u32 {
-        // This would require line counting from the buffer
-        // For now, return 0 - proper implementation needs buffer access
-        // TODO: Add line number tracking to EditorStateSnapshot
-        0
+        self.state_snapshot
+            .read()
+            .ok()
+            .and_then(|s| s.primary_cursor.as_ref().and_then(|c| c.line))
+            .unwrap_or(0) as u32
     }
 
     /// Get the byte offset of the start of a line (0-indexed line number)
@@ -8194,6 +8201,7 @@ mod tests {
             state.primary_cursor = Some(CursorInfo {
                 position: 42,
                 selection: None,
+                line: Some(0),
             });
         }
 
@@ -8223,6 +8231,137 @@ mod tests {
                 let global = ctx.globals();
                 let result: u32 = global.get("_testResult").unwrap();
                 assert_eq!(result, 42);
+            });
+    }
+
+    /// Ad-hoc plugin probe for the cursor-line API (issue #2076).
+    ///
+    /// Exercises the real JS plugin surface (`getPrimaryCursor().line`,
+    /// `getAllCursors()`, and the deprecated `getCursorLine()`) against a
+    /// hand-built snapshot, covering both modes:
+    ///   * "small file": the buffer has a line index, so `line` is a real
+    ///     0-indexed number for every cursor.
+    ///   * "large file": the line index is unavailable (`line == None`), so
+    ///     `getPrimaryCursor().line` is `null` and the deprecated
+    ///     `getCursorLine()` collapses to its `0` fallback.
+    #[test]
+    fn test_api_get_cursor_line_small_and_large_file() {
+        // --- small-file mode: line index present -----------------------------
+        let (tx, _rx) = mpsc::channel();
+        let state_snapshot = Arc::new(RwLock::new(EditorStateSnapshot::new()));
+        {
+            let mut state = state_snapshot.write().unwrap();
+            state.primary_cursor = Some(CursorInfo {
+                position: 120,
+                selection: None,
+                line: Some(7),
+            });
+            state.all_cursors = vec![
+                CursorInfo {
+                    position: 120,
+                    selection: None,
+                    line: Some(7),
+                },
+                CursorInfo {
+                    position: 200,
+                    selection: None,
+                    line: Some(12),
+                },
+            ];
+        }
+
+        let services = Arc::new(fresh_core::services::NoopServiceBridge);
+        let mut backend = QuickJsBackend::with_state(state_snapshot, tx, services).unwrap();
+
+        backend
+            .execute_js(
+                r#"
+            const editor = getEditor();
+            const primary = editor.getPrimaryCursor();
+            globalThis._primaryLine = primary.line;
+            globalThis._cursorLine = editor.getCursorLine();
+            globalThis._allLines = editor.getAllCursors().map(c => c.line);
+        "#,
+                "probe_small.js",
+            )
+            .unwrap();
+
+        backend
+            .plugin_contexts
+            .borrow()
+            .get("probe_small")
+            .unwrap()
+            .clone()
+            .with(|ctx| {
+                let global = ctx.globals();
+                // getPrimaryCursor().line is the real 0-indexed line.
+                let primary_line: i32 = global.get("_primaryLine").unwrap();
+                assert_eq!(primary_line, 7);
+                // Deprecated getCursorLine() agrees in small-file mode.
+                let cursor_line: u32 = global.get("_cursorLine").unwrap();
+                assert_eq!(cursor_line, 7);
+                // Every cursor carries its own line (multi-cursor support).
+                let all_lines: Vec<i32> = global.get("_allLines").unwrap();
+                assert_eq!(all_lines, vec![7, 12]);
+            });
+
+        // --- large-file mode: line index unavailable --------------------------
+        let (tx2, _rx2) = mpsc::channel();
+        let state_snapshot2 = Arc::new(RwLock::new(EditorStateSnapshot::new()));
+        {
+            let mut state = state_snapshot2.write().unwrap();
+            state.primary_cursor = Some(CursorInfo {
+                position: 5_000_000,
+                selection: None,
+                line: None,
+            });
+            state.all_cursors = vec![CursorInfo {
+                position: 5_000_000,
+                selection: None,
+                line: None,
+            }];
+        }
+
+        let services2 = Arc::new(fresh_core::services::NoopServiceBridge);
+        let mut backend2 = QuickJsBackend::with_state(state_snapshot2, tx2, services2).unwrap();
+
+        backend2
+            .execute_js(
+                r#"
+            const editor = getEditor();
+            const primary = editor.getPrimaryCursor();
+            // null and undefined both serialize to JS null here; normalize to a
+            // sentinel so the Rust side can assert "unknown" unambiguously.
+            globalThis._primaryLineIsNull = (primary.line === null || primary.line === undefined);
+            globalThis._cursorLineFallback = editor.getCursorLine();
+            globalThis._allLineIsNull = (editor.getAllCursors()[0].line === null);
+        "#,
+                "probe_large.js",
+            )
+            .unwrap();
+
+        backend2
+            .plugin_contexts
+            .borrow()
+            .get("probe_large")
+            .unwrap()
+            .clone()
+            .with(|ctx| {
+                let global = ctx.globals();
+                // The honest API reports "unknown" as null in large-file mode.
+                let primary_null: bool = global.get("_primaryLineIsNull").unwrap();
+                assert!(
+                    primary_null,
+                    "primary.line should be null in large-file mode"
+                );
+                let all_null: bool = global.get("_allLineIsNull").unwrap();
+                assert!(
+                    all_null,
+                    "getAllCursors()[0].line should be null in large-file mode"
+                );
+                // The deprecated accessor cannot express null; it collapses to 0.
+                let fallback: u32 = global.get("_cursorLineFallback").unwrap();
+                assert_eq!(fallback, 0);
             });
     }
 


### PR DESCRIPTION
## Summary

`editor.getCursorLine()` always returned `0` — a stale stub that never read buffer state (#2076). The "needs buffer access" TODO was outdated: buffer access is already available at snapshot-build time (it's used for `viewport.topLine`).

- Add nullable `line` to `CursorInfo`, populated at snapshot-build time, guarded by `line_count().is_some()` like `viewport.top_line`. So `getPrimaryCursor()` / `getAllCursors()` now carry the 0-indexed line for **every** cursor, and report `null` in huge-file mode where the line index is unavailable.
- `getCursorLine()` now reads that field — **deprecated** in favor of `getPrimaryCursor()?.line` (it can't express `null`, so it falls back to `0` only when the line is unknown).
- Migrate the `bookmarks` example and `vi_mode` (`^`, visual-block, `:info`) to `getPrimaryCursor()?.line`.
- Regenerate `fresh.d.ts`.

## Test plan
- [x] New plugin-runtime probe `test_api_get_cursor_line_small_and_large_file` drives real JS through `QuickJsBackend`:
  - small-file: real line for primary + both cursors (multi-cursor)
  - large-file: `primary.line === null`, `getAllCursors()[0].line === null`, deprecated `getCursorLine()` → `0`
- [x] `fresh-core` + `fresh-plugin-runtime` cursor tests pass
- [x] `fresh-editor` test build compiles clean

https://claude.ai/code/session_013FASYNCLRx5Z5oBYgk9onb

---
_Generated by [Claude Code](https://claude.ai/code/session_013FASYNCLRx5Z5oBYgk9onb)_