### PR TITLE
fix(plugins): stop logging benign buffer races from snapshot lag

### DIFF
--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -978,7 +978,18 @@ async function recompute(bufferId: number): Promise<void> {
     }
 
     const length = editor.getBufferLength(bufferId);
-    const newText = await editor.getBufferText(bufferId, 0, length);
+    let newText: string;
+    try {
+      newText = await editor.getBufferText(bufferId, 0, length);
+    } catch (e) {
+      // The buffer can close between the awaits above (the git `show`
+      // for the reference is slow) and this fetch — e.g. the user
+      // closes the file, or an external process churns it while it's
+      // open. `buffer_closed` deletes our state, so if it's gone the
+      // recompute is moot: bail quietly instead of logging an error.
+      if (!states.has(bufferId)) return;
+      throw e;
+    }
 
     // Skip 1: same buffer text as last recompute. `lines_changed` fires
     // on viewport scrolls (cursor up/down past the visible area), and

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -809,7 +809,12 @@ impl Editor {
                 if let Err(e) =
                     self.set_status_bar_value(fresh_core::BufferId(buffer_id as usize), &key, value)
                 {
-                    tracing::warn!("Failed to set statusbar value: {}", e);
+                    // Plugins compute the value asynchronously off a lagging
+                    // state snapshot, then publish to the buffer that was
+                    // active when they started. If that buffer closed in the
+                    // meantime the value is simply discarded — an expected,
+                    // benign race, not a misuse worth warning about.
+                    tracing::debug!("Skipped statusbar value for stale buffer: {}", e);
                 }
             }
             PluginCommand::UnregisterCommand { name } => {
@@ -1657,7 +1662,10 @@ impl Editor {
         }
     }
 
-    /// Get text from a buffer range (for vi mode yank operations)
+    /// Get text from a buffer range (for vi mode yank operations).
+    ///
+    /// See [`clamp_buffer_text_range`] for why the requested range is
+    /// clamped rather than rejected.
     fn handle_get_buffer_text(
         &mut self,
         buffer_id: BufferId,
@@ -1672,16 +1680,15 @@ impl Editor {
             .expect("active window present")
             .get_mut(&buffer_id)
         {
-            // Get text from the buffer using the mutable get_text_range method
-            let len = state.buffer.len();
-            if start <= end && end <= len {
-                Ok(state.get_text_range(start, end))
-            } else {
-                Err(format!(
-                    "Invalid range {}..{} for buffer of length {}",
-                    start, end, len
-                ))
-            }
+            // Plugins derive `end` from a snapshot length (see
+            // `get_buffer_length`) that lags the live buffer, so when the
+            // buffer shrinks between the length read and this fetch — e.g.
+            // concurrent edits from the editor and an external process
+            // rewriting the file on disk — the requested end can briefly
+            // exceed the live length. Clamp to the current bounds and return
+            // what's there; the plugin recomputes on the next change event.
+            let (start, end) = clamp_buffer_text_range(start, end, state.buffer.len());
+            Ok(state.get_text_range(start, end))
         } else {
             Err(format!("Buffer {:?} not found", buffer_id))
         };
@@ -6042,6 +6049,22 @@ impl Editor {
     }
 }
 
+/// Clamp a plugin-requested `[start, end)` text range to a buffer's live
+/// length.
+///
+/// `getBufferText` callers size `end` from `getBufferLength`, which reads a
+/// state snapshot that lags the authoritative buffer. When the buffer shrinks
+/// in between (concurrent editor + external-process edits), the requested end
+/// briefly exceeds the live length. Returning the available text is the right
+/// behaviour — the plugin recomputes on the next change event — so clamp
+/// instead of rejecting. `start` is pinned to `end` so an over-large start
+/// yields an empty range rather than `start > end`.
+fn clamp_buffer_text_range(start: usize, end: usize, len: usize) -> (usize, usize) {
+    let end = end.min(len);
+    let start = start.min(end);
+    (start, end)
+}
+
 #[cfg(test)]
 mod tests {
     //! Focused tests for the SpawnHostProcess kill mechanism.
@@ -6177,6 +6200,30 @@ mod tests {
             // non-Unix builds.
             let _ = pid;
         }
+    }
+
+    use super::clamp_buffer_text_range;
+
+    #[test]
+    fn clamp_text_range_passes_through_in_bounds() {
+        assert_eq!(clamp_buffer_text_range(0, 165, 165), (0, 165));
+        assert_eq!(clamp_buffer_text_range(10, 50, 165), (10, 50));
+    }
+
+    /// The reported regression: `getBufferLength` returned a snapshot
+    /// length one byte ahead of the live buffer (the file was shrinking
+    /// under concurrent editor + external edits), so `getBufferText`
+    /// requested `0..len+1`. Pre-fix this produced "Invalid range
+    /// 0..165003 for buffer of length 165002"; now the end clamps down.
+    #[test]
+    fn clamp_text_range_clamps_stale_end_past_buffer() {
+        assert_eq!(clamp_buffer_text_range(0, 165_003, 165_002), (0, 165_002));
+    }
+
+    #[test]
+    fn clamp_text_range_pins_overlarge_start_to_empty() {
+        // start beyond the live length must not yield start > end.
+        assert_eq!(clamp_buffer_text_range(200, 250, 165), (165, 165));
     }
 }
 

--- a/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/dashboard.rs
@@ -7,9 +7,28 @@
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::Config;
+use fresh::config::{Config, PluginConfig};
 use std::fs;
 use std::path::PathBuf;
+
+/// Config that opts the dashboard back into auto-open.
+///
+/// `autoOpen` defaults to `false` (the dashboard no longer pops on
+/// startup), so tests that exercise the ambient open path must enable it
+/// explicitly via the same `plugins.dashboard.settings` channel a user
+/// would use in `config.json` / the Settings UI.
+fn config_with_dashboard_autoopen() -> Config {
+    let mut config = Config::default();
+    config.plugins.insert(
+        "dashboard".to_string(),
+        PluginConfig {
+            enabled: true,
+            path: None,
+            settings: serde_json::json!({ "autoOpen": true }),
+        },
+    );
+    config
+}
 
 /// Build a harness rooted at a scratch working directory that contains
 /// the real `dashboard` plugin (copied from the repo). The plugin loads
@@ -32,9 +51,13 @@ fn harness_with_dashboard_plugin_and_plugins_dir() -> (EditorTestHarness, tempfi
     copy_plugin(&plugins_dir, "dashboard");
     copy_plugin_lib(&plugins_dir);
 
-    let harness =
-        EditorTestHarness::with_config_and_working_dir(120, 40, Config::default(), working_dir)
-            .expect("harness");
+    let harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        config_with_dashboard_autoopen(),
+        working_dir,
+    )
+    .expect("harness");
     (harness, temp, plugins_dir)
 }
 
@@ -175,9 +198,13 @@ if (dash) {
     // scan and won't re-scan on its own.
     drop(harness);
     let working_dir = plugins_dir.parent().unwrap().to_path_buf();
-    harness =
-        EditorTestHarness::with_config_and_working_dir(120, 40, Config::default(), working_dir)
-            .expect("harness");
+    harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        config_with_dashboard_autoopen(),
+        working_dir,
+    )
+    .expect("harness");
 
     harness.editor_mut().fire_ready_hook();
 
@@ -322,9 +349,13 @@ fn keyboard_navigation_moves_focus_highlight() {
     // once when it constructed the first harness.
     drop(_harness_unused);
     let working_dir = plugins_dir.parent().unwrap().to_path_buf();
-    let mut harness =
-        EditorTestHarness::with_config_and_working_dir(120, 40, Config::default(), working_dir)
-            .expect("harness");
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        config_with_dashboard_autoopen(),
+        working_dir,
+    )
+    .expect("harness");
 
     harness.editor_mut().fire_ready_hook();
 


### PR DESCRIPTION
Plugins read buffer length/info from a state snapshot that lags the
authoritative buffer. When a file is edited concurrently from the editor
and an external process, the buffer can shrink (or close) between a
plugin's snapshot read and the live operation it drives, producing log
spam that isn't actionable:

- getBufferText: `end` is sized from the stale (larger) snapshot length,
  so the live buffer's range check rejected it with "Invalid range
  0..165003 for buffer of length 165002". Clamp the range to the live
  length and return what's there; the plugin recomputes on the next
  change event anyway.
- live-diff: the buffer can close during its slow `git show` reference
  load, so the follow-up getBufferText hits a closed buffer. Bail quietly
  when our state for the buffer is already gone, re-throwing anything
  unexpected.
- statusbar: a value published to a buffer that closed mid-compute is
  simply discarded. Downgrade the warning to debug.

https://claude.ai/code/session_018V1uH7XgUmefCpzZZjCB2Y