### PR TITLE
fix(search-replace): make "Search and Replace in Current File" work for unnamed buffers

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3529,6 +3529,11 @@ pub enum PluginCommand {
         max_results: usize,
         /// Whether to match whole words only
         whole_words: bool,
+        /// Source buffer id to additionally search in-memory when it has no
+        /// file path (an unnamed/unsaved buffer). The on-disk walk can't see
+        /// such a buffer, so the host searches its piece-tree content directly
+        /// and emits matches carrying this buffer id. 0 means "no such buffer".
+        source_buffer_id: usize,
         /// Handle ID — key into the shared `SearchHandleRegistry`
         handle_id: u64,
     },
@@ -3539,6 +3544,10 @@ pub enum PluginCommand {
     ReplaceInBuffer {
         /// File path to edit (will open if not already in a buffer)
         file_path: PathBuf,
+        /// Buffer id to edit directly when non-zero and still live. Used for
+        /// unnamed/unsaved buffers that have no path to resolve by. When 0, the
+        /// target is resolved via `file_path` (opening the file if needed).
+        buffer_id: usize,
         /// Matches to replace, each is (byte_offset, length)
         matches: Vec<(usize, usize)>,
         /// Replacement text

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2961,18 +2961,13 @@ interface EditorAPI {
 	* the consumer drains via `handle.take()` at its own cadence. Call
 	* `handle.cancel()` to abort.
 	*/
-	beginSearch(pattern: string, opts?: {
-		fixedString?: boolean;
-		caseSensitive?: boolean;
-		maxResults?: number;
-		wholeWords?: boolean;
-	}): SearchHandle;
+	beginSearch(pattern: string, opts?: { fixedString?: boolean; caseSensitive?: boolean; maxResults?: number; wholeWords?: boolean; sourceBufferId?: number }): SearchHandle;
 	/**
 	* Replace matches in a file's buffer (async)
 	* Opens the file if not already in a buffer, applies edits via the buffer model,
 	* and saves. All edits are grouped as a single undo action.
 	*/
-	replaceInFile(filePath: string, matches: number[][], replacement: string): Promise<ReplaceResult>;
+	replaceInFile(filePath: string, matches: number[][], replacement: string, bufferId?: number): Promise<ReplaceResult>;
 	/**
 	* Send LSP request (async, returns request_id)
 	*/

--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -68,16 +68,19 @@ interface PanelState {
   caseSensitive: boolean;
   useRegex: boolean;
   wholeWords: boolean;
-  // Scope (§1): when false, results are restricted to `sourceBufferPath`.
+  // Scope (§1): when false, results are restricted to the source buffer.
   // `sourceBufferPath` is the absolute path of the buffer that was
   // active when the panel opened; `sourceBufferRelPath` is the
-  // cwd-relative display form. Empty path means the source buffer was
-  // unsaved/virtual; in that case the "current file" mode degrades to
-  // "no matches" and the toggle visually still flips, but the user
-  // can't usefully restrict to an unnamed buffer.
+  // cwd-relative display form. An empty path means the source buffer is
+  // unnamed/unsaved — in that case scope filtering falls back to
+  // `sourceBufferId`, and the host searches that buffer's in-memory
+  // content directly (it has no on-disk file the project walk can find).
   allFiles: boolean;
   sourceBufferPath: string;
   sourceBufferRelPath: string;
+  // Buffer id of the source buffer, used to scope/replace unnamed buffers
+  // by id when there's no path to match on. 0 means "unknown".
+  sourceBufferId: number;
   // Layout
   viewportWidth: number;
   // State
@@ -1060,6 +1063,9 @@ async function performSearch(pattern: string, silent?: boolean): Promise<SearchR
       caseSensitive: panel.caseSensitive,
       maxResults: MAX_RESULTS,
       wholeWords: panel.wholeWords,
+      // Lets the host search an unnamed/unsaved source buffer in-memory;
+      // it has no on-disk file the project walk could otherwise reach.
+      sourceBufferId: panel.sourceBufferId,
     });
     activeSearchHandle = handle;
 
@@ -1108,10 +1114,15 @@ async function performSearch(pattern: string, silent?: boolean): Promise<SearchR
       const newExpandedKeys: string[] = []; // file rows added this batch
       for (const m of chunk) {
         // §1 scope filter: when scope is "current file only", drop
-        // matches from any other path. Done client-side because the
-        // host grep API is project-wide. Empty sourceBufferPath
-        // (unsaved buffer) filters everything out by design.
-        if (!panel.allFiles && m.file !== panel.sourceBufferPath) continue;
+        // matches from any other source. Done client-side because the
+        // host grep API is project-wide. A named buffer matches by path;
+        // an unnamed/unsaved buffer (empty sourceBufferPath) matches by
+        // buffer id instead — the host tags its in-memory matches with it.
+        if (!panel.allFiles) {
+          const sameFile = !!panel.sourceBufferPath && m.file === panel.sourceBufferPath;
+          const sameBuffer = !!panel.sourceBufferId && m.bufferId === panel.sourceBufferId;
+          if (!sameFile && !sameBuffer) continue;
+        }
         const result: SearchResult = { match: m, selected: true };
         allResults.push(result);
         let fileIdx = streamingFileIndexByPath?.get(m.file);
@@ -1276,8 +1287,10 @@ async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
   // Try to pre-fill search from editor selection
   let prefill = "";
   let sourceBufferPath = "";
+  let sourceBufferId = 0;
   try {
     const activeId = editor.getActiveBufferId();
+    sourceBufferId = activeId;
     sourceBufferPath = editor.getBufferPath(activeId) || "";
     const cursor = editor.getPrimaryCursor();
     if (cursor && cursor.selection) {
@@ -1304,6 +1317,7 @@ async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
     panel.allFiles = allFiles;
     panel.sourceBufferPath = sourceBufferPath;
     panel.sourceBufferRelPath = sourceBufferRelPath;
+    panel.sourceBufferId = sourceBufferId;
     updatePanelContent();
     if (panel.searchPattern) rerunSearchDebounced();
     return;
@@ -1329,6 +1343,7 @@ async function openPanel(opts?: { allFiles?: boolean }): Promise<void> {
     allFiles,
     sourceBufferPath,
     sourceBufferRelPath,
+    sourceBufferId,
     viewportWidth: DEFAULT_WIDTH,
     busy: false,
     searchPerformed: false,
@@ -1383,29 +1398,42 @@ async function executeReplacements(results?: SearchResult[]): Promise<string> {
     return editor.t("status.no_selected");
   }
 
-  const fileGroups: Map<string, Array<[number, number]>> = new Map();
+  // Group edits per target. Matches in an open buffer carry a non-zero
+  // bufferId; key by it so an unnamed buffer (whose `file` is a shared
+  // "[No Name]" label) still resolves to the right buffer rather than
+  // colliding with another unnamed buffer's matches. On-disk files
+  // (bufferId 0) key by path and are opened/saved by the host as before.
+  type Group = { filePath: string; bufferId: number; matches: Array<[number, number]> };
+  const groups: Map<string, Group> = new Map();
   for (const result of toReplace) {
-    const file = result.match.file;
-    if (!fileGroups.has(file)) {
-      fileGroups.set(file, []);
+    const bufferId = result.match.bufferId || 0;
+    const key = bufferId > 0 ? `buf:${bufferId}` : result.match.file;
+    let group = groups.get(key);
+    if (!group) {
+      group = { filePath: result.match.file, bufferId, matches: [] };
+      groups.set(key, group);
     }
-    fileGroups.get(file)!.push([result.match.byteOffset, result.match.length]);
+    group.matches.push([result.match.byteOffset, result.match.length]);
   }
 
   let filesModified = 0;
   let replacementsCount = 0;
   const errors: string[] = [];
 
-  const keys: string[] = [];
-  fileGroups.forEach((_v, k) => keys.push(k));
-  for (const filePath of keys) {
-    const matches = fileGroups.get(filePath)!;
+  const groupList: Group[] = [];
+  groups.forEach((g) => groupList.push(g));
+  for (const group of groupList) {
     try {
-      const result = await editor.replaceInFile(filePath, matches, panel.replaceText);
+      const result = await editor.replaceInFile(
+        group.filePath,
+        group.matches,
+        panel.replaceText,
+        group.bufferId
+      );
       replacementsCount += result.replacements;
       if (result.replacements > 0) filesModified++;
     } catch (e) {
-      errors.push(`${filePath}: ${e instanceof Error ? e.message : String(e)}`);
+      errors.push(`${group.filePath}: ${e instanceof Error ? e.message : String(e)}`);
     }
   }
 

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2746,6 +2746,7 @@ impl Editor {
         case_sensitive: bool,
         max_results: usize,
         whole_words: bool,
+        source_buffer_id: usize,
         handle_id: u64,
     ) {
         // Look up the handle the plugin pre-registered. If it's missing
@@ -2815,6 +2816,68 @@ impl Editor {
                     if let Some(plan) = state.buffer.search_hybrid_plan() {
                         dirty_plans.insert(path, (*bid, plan));
                     }
+                }
+            }
+        }
+
+        // An unnamed/unsaved buffer has no on-disk file, so the project walk
+        // below can never reach it (`search_hybrid_plan` also bails without a
+        // path). When the plugin passes the source buffer id and that buffer
+        // has no path, search its in-memory content here on the main thread
+        // (the piece tree isn't `Send`) and seed the results with matches that
+        // carry the buffer id so a later replace can target it directly.
+        if source_buffer_id != 0 {
+            let bid = BufferId(source_buffer_id);
+            let content = self
+                .windows
+                .get_mut(&self.active_window)
+                .and_then(|w| w.buffers.get_mut(&bid))
+                .filter(|state| state.buffer.file_path().is_none())
+                .and_then(|state| state.buffer.to_string());
+            if let Some(content) = content {
+                let bytes = content.as_bytes();
+                let mut grep_matches: Vec<GrepMatch> = Vec::new();
+                let mut running_line = 1usize;
+                let mut counted_to = 0usize;
+                for mat in regex.find_iter(bytes) {
+                    if grep_matches.len() >= max_results {
+                        break;
+                    }
+                    let start = mat.start();
+                    let end = mat.end();
+                    running_line += bytes[counted_to..start]
+                        .iter()
+                        .filter(|&&b| b == b'\n')
+                        .count();
+                    counted_to = start;
+                    let line_start = bytes[..start]
+                        .iter()
+                        .rposition(|&b| b == b'\n')
+                        .map(|p| p + 1)
+                        .unwrap_or(0);
+                    let line_end = bytes[start..]
+                        .iter()
+                        .position(|&b| b == b'\n')
+                        .map(|p| start + p)
+                        .unwrap_or(bytes.len());
+                    grep_matches.push(GrepMatch {
+                        file: "[No Name]".to_string(),
+                        buffer_id: source_buffer_id,
+                        byte_offset: start,
+                        length: end - start,
+                        line: running_line,
+                        column: start - line_start + 1,
+                        context: String::from_utf8_lossy(&bytes[line_start..line_end]).into_owned(),
+                    });
+                }
+                if !grep_matches.is_empty() {
+                    let count = grep_matches.len();
+                    let mut state = match handle.state.lock() {
+                        Ok(s) => s,
+                        Err(poisoned) => poisoned.into_inner(),
+                    };
+                    state.pending.extend(grep_matches);
+                    state.total_seen += count;
                 }
             }
         }
@@ -3025,6 +3088,7 @@ impl Editor {
     pub(super) fn handle_replace_in_buffer(
         &mut self,
         file_path: std::path::PathBuf,
+        buffer_id: usize,
         matches: Vec<(usize, usize)>,
         replacement: String,
         callback_id: JsCallbackId,
@@ -3042,8 +3106,16 @@ impl Editor {
             return;
         }
 
-        // Find or open the buffer for this file
-        let buffer_id = if let Some((&bid, _)) = self
+        // Resolve the target buffer. A non-zero, still-live `buffer_id` wins —
+        // this is how unnamed/unsaved buffers (which have no path to match on)
+        // are addressed. Otherwise fall back to matching the open buffer by
+        // path, opening the file when none is open.
+        let explicit_buffer = (buffer_id != 0)
+            .then(|| BufferId(buffer_id))
+            .filter(|bid| self.buffers().contains_key(bid));
+        let buffer_id = if let Some(bid) = explicit_buffer {
+            bid
+        } else if let Some((&bid, _)) = self
             .buffers()
             .iter()
             .find(|(_, state)| state.buffer.file_path() == Some(&file_path))
@@ -3219,7 +3291,12 @@ impl Editor {
                 // the modified flag — leaving the user with a reverted buffer
                 // that looks clean even though disk still has the XYZ
                 // content.  We want the tab to show `a.txt*` after undo.
-                event_log.mark_saved();
+                //
+                // Only when we actually saved, though: an unnamed buffer has
+                // no path and was left in memory, so it must stay modified.
+                if saved_path.is_some() {
+                    event_log.mark_saved();
+                }
             }
             self.active_window_mut()
                 .invalidate_layouts_for_buffer(buffer_id);

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1417,6 +1417,7 @@ impl Editor {
                 case_sensitive,
                 max_results,
                 whole_words,
+                source_buffer_id,
                 handle_id,
             } => {
                 self.handle_begin_search(
@@ -1425,17 +1426,25 @@ impl Editor {
                     case_sensitive,
                     max_results,
                     whole_words,
+                    source_buffer_id,
                     handle_id,
                 );
             }
 
             PluginCommand::ReplaceInBuffer {
                 file_path,
+                buffer_id,
                 matches,
                 replacement,
                 callback_id,
             } => {
-                self.handle_replace_in_buffer(file_path, matches, replacement, callback_id);
+                self.handle_replace_in_buffer(
+                    file_path,
+                    buffer_id,
+                    matches,
+                    replacement,
+                    callback_id,
+                );
             }
 
             PluginCommand::MountWidgetPanel {

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -440,6 +440,93 @@ fn test_search_replace_scope_after_close_reopen() {
     );
 }
 
+/// §1 regression: "Search and Replace in Current File" must work when the
+/// active buffer is an unnamed/unsaved buffer (no path on disk). The host
+/// can't reach such a buffer via the project file-walk, so it searches the
+/// buffer's in-memory content directly (addressed by buffer id). Before the
+/// fix this showed "No matches found" even when the buffer clearly contained
+/// the pattern, and Replace All was a no-op.
+#[test]
+fn test_search_replace_current_file_unnamed_buffer() {
+    init_tracing_from_env();
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    // Disk files also contain "hello" — they must NOT leak into a search
+    // scoped to the unnamed buffer.
+    create_test_files(&project_root);
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 30, Default::default(), project_root)
+            .unwrap();
+
+    // Create a fresh unnamed buffer and put three "hello" occurrences in it.
+    harness.new_buffer().unwrap();
+    harness.type_text("hello world hello there hello").unwrap();
+    harness.render().unwrap();
+
+    // Open via palette → "Search and Replace in Current File".
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .type_text("Search and Replace in Current File")
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("Search and Replace in Current File")
+        })
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // Search + replace term. The scope is the unnamed buffer.
+    enter_search_and_replace(&mut harness, "hello", "goodbye");
+
+    // The three in-buffer matches must be found (this is the regression:
+    // it used to read "No matches found").
+    harness
+        .wait_until(|h| h.screen_to_string().contains("3 matches"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("No matches"),
+        "Unnamed-buffer search must find the in-memory matches, not report \
+         'No matches'. Got:\n{}",
+        screen
+    );
+    // Disk files that also contain "hello" must stay out of the scoped results.
+    assert!(
+        !screen.contains("alpha.txt") && !screen.contains("beta.txt"),
+        "Disk files must not leak into a search scoped to the unnamed buffer. \
+         Got:\n{}",
+        screen
+    );
+
+    // Replace all three, then close the panel and confirm the buffer's
+    // visible content was actually rewritten in memory.
+    confirm_replace_all(&mut harness);
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("goodbye world goodbye there goodbye")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("hello world hello there hello"),
+        "Original text should be gone after replace. Got:\n{}",
+        screen
+    );
+}
+
 /// Searching for a pattern with no matches shows the "No matches" message.
 #[test]
 fn test_search_replace_no_matches() {

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5845,7 +5845,7 @@ impl JsEditorApi {
     /// `handle.cancel()` to abort.
     #[plugin_api(
         js_name = "beginSearch",
-        ts_raw = "beginSearch(pattern: string, opts?: { fixedString?: boolean; caseSensitive?: boolean; maxResults?: number; wholeWords?: boolean }): SearchHandle"
+        ts_raw = "beginSearch(pattern: string, opts?: { fixedString?: boolean; caseSensitive?: boolean; maxResults?: number; wholeWords?: boolean; sourceBufferId?: number }): SearchHandle"
     )]
     #[qjs(rename = "_beginSearch")]
     pub fn begin_search(
@@ -5856,6 +5856,7 @@ impl JsEditorApi {
         case_sensitive: bool,
         max_results: u32,
         whole_words: bool,
+        source_buffer_id: u32,
     ) -> u64 {
         let id = self.alloc_request_id();
         // Register the shared state before sending the command so the
@@ -5870,6 +5871,7 @@ impl JsEditorApi {
             case_sensitive,
             max_results: max_results as usize,
             whole_words,
+            source_buffer_id: source_buffer_id as usize,
             handle_id: id,
         });
         id
@@ -5943,7 +5945,11 @@ impl JsEditorApi {
     /// Replace matches in a file's buffer (async)
     /// Opens the file if not already in a buffer, applies edits via the buffer model,
     /// and saves. All edits are grouped as a single undo action.
-    #[plugin_api(async_promise, js_name = "replaceInFile", ts_return = "ReplaceResult")]
+    #[plugin_api(
+        async_promise,
+        js_name = "replaceInFile",
+        ts_raw = "replaceInFile(filePath: string, matches: number[][], replacement: string, bufferId?: number): Promise<ReplaceResult>"
+    )]
     #[qjs(rename = "_replaceInFileStart")]
     pub fn replace_in_file_start(
         &self,
@@ -5951,6 +5957,7 @@ impl JsEditorApi {
         file_path: String,
         matches: Vec<Vec<u32>>,
         replacement: String,
+        buffer_id: rquickjs::function::Opt<u32>,
     ) -> u64 {
         let id = self.alloc_request_id();
         // Convert [[offset, length], ...] to Vec<(usize, usize)>
@@ -5960,6 +5967,7 @@ impl JsEditorApi {
             .collect();
         let _ = self.command_sender.send(PluginCommand::ReplaceInBuffer {
             file_path: PathBuf::from(file_path),
+            buffer_id: buffer_id.0.unwrap_or(0) as usize,
             matches: match_pairs,
             replacement,
             callback_id: JsCallbackId::new(id),
@@ -6894,8 +6902,9 @@ impl QuickJsBackend {
                     const caseSensitive = opts.caseSensitive !== undefined ? opts.caseSensitive : true;
                     const maxResults = opts.maxResults || 10000;
                     const wholeWords = opts.wholeWords || false;
+                    const sourceBufferId = opts.sourceBufferId || 0;
                     const handleId = editor._beginSearch(
-                        pattern, fixedString, caseSensitive, maxResults, wholeWords
+                        pattern, fixedString, caseSensitive, maxResults, wholeWords, sourceBufferId
                     );
                     return {
                         searchId: handleId,

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -286,6 +286,8 @@ const DEPENDENCY_TYPES: &[&str] = &[
     // Streaming-search pull handle (referenced via ts_raw on beginSearch)
     "SearchTakeResult",
     "SearchHandle",
+    // Replace result (referenced via ts_raw on replaceInFile)
+    "ReplaceResult",
 ];
 
 /// Collect TypeScript type declarations based on referenced types from proc macro


### PR DESCRIPTION
The Search & Replace plugin runs a project-wide grep that walks files on
disk. An unnamed/unsaved buffer has no path, so the walk could never reach
it (`search_hybrid_plan` also bails without a path), and the plugin's
current-file scope filter — which matched by path — dropped everything.
The command therefore reported "No matches found" and Replace All was a
no-op on a buffer whose content plainly contained the pattern.

Thread the source buffer id through the search/replace pipeline so the
unnamed buffer can be addressed by id rather than path:

- `beginSearch` gains a `sourceBufferId`; when that buffer has no file
  path the host searches its in-memory piece-tree content directly and
  emits matches tagged with the buffer id.
- The plugin's scope filter falls back to buffer-id matching when the
  source path is empty, and groups replacements by buffer id so an
  unnamed buffer resolves to the right target.
- `replaceInFile` gains an optional `bufferId`; a non-zero, still-live id
  is preferred when resolving the target buffer. Unnamed buffers have no
  path, so the post-replace save is skipped and the event log is not
  marked saved — the buffer correctly stays modified.