### PR TITLE
Fix mouse-wheel scrolling in File Explorer, Live Grep, and Git Log

### DIFF
--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -364,8 +364,12 @@ impl Editor {
         if modifiers.contains(crossterm::event::KeyModifiers::SHIFT) {
             self.active_window_mut()
                 .handle_horizontal_scroll(col, row, delta)?;
+        } else if self.handle_overlay_prompt_scroll(col, row, delta) {
+            // Floating-overlay prompt (Live Grep): the wheel scrolls the pane
+            // under the pointer — the preview when over it, otherwise the
+            // result list (without moving the selection). See issue #2119.
         } else if self.handle_prompt_scroll(delta) {
-            // prompt consumed the scroll
+            // bottom-anchored prompt consumed the scroll (moves selection)
         } else if self.is_file_open_active()
             && self.is_mouse_over_file_browser(col, row)
             && self.handle_file_open_scroll(delta)
@@ -404,6 +408,39 @@ impl Editor {
                 .handle_mouse_scroll(col, row, delta)?;
         }
         Ok(())
+    }
+
+    /// Route a wheel event inside the floating-overlay prompt (Live Grep).
+    ///
+    /// The overlay is mouse-modal, so it always consumes the wheel (returns
+    /// true) when active — the event must never leak to the buffer below.
+    /// * Over the preview pane → scroll the preview.
+    /// * Anywhere else (result list, input, toolbar, frame) → scroll the
+    ///   result list *without* moving the selection.
+    ///
+    /// Bottom-anchored prompts (command palette, file finder) are left to
+    /// `handle_prompt_scroll`, which keeps their wheel-moves-selection UX.
+    fn handle_overlay_prompt_scroll(&mut self, col: u16, row: u16, delta: i32) -> bool {
+        if !self.overlay_prompt_active() {
+            return false;
+        }
+        let preview_area = self.active_chrome().prompt_preview_area;
+        let results_visible = self
+            .active_chrome()
+            .prompt_results_area
+            .map(|r| r.height as usize)
+            .unwrap_or(0);
+        if let Some(preview) = preview_area {
+            if in_rect(col, row, preview) {
+                self.active_window_mut()
+                    .scroll_overlay_preview_by_lines(delta);
+                return true;
+            }
+        }
+        if let Some(prompt) = self.active_window_mut().prompt.as_mut() {
+            prompt.scroll_results(delta, results_visible);
+        }
+        true
     }
 
     /// Update the current hover target based on mouse position

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2072,6 +2072,10 @@ impl Editor {
             } else {
                 Some(0)
             };
+            // A fresh result list re-engages keep-selection-visible scrolling
+            // (issue #2119): a stale manual-scroll latch from the previous
+            // query must not suppress it.
+            prompt.manual_scroll = false;
             // Track that suggestions were set for this input value.
             // If filter_suggestions is called with the same input, we skip filtering
             // because the plugin has already provided filtered results.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4842,12 +4842,17 @@ impl Editor {
             let widget = crate::widgets::find_widget_by_key(&spec, &widget_key);
             match widget {
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                    self.handle_widget_tree_wheel(panel_id, &widget_key, delta);
-                    consumed = true;
+                    // Only claim the wheel if the widget actually scrolled.
+                    // A List/Tree that declares `visible_rows >= total`
+                    // (e.g. Git Log, which renders every row and relies on
+                    // its scrollable region's buffer scroll instead) has
+                    // nothing to scroll here; swallowing the event would
+                    // leave the wheel dead. Falling through lets the
+                    // underlying buffer scroll handle it.
+                    consumed |= self.handle_widget_tree_wheel(panel_id, &widget_key, delta);
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                    self.handle_widget_list_wheel(panel_id, &widget_key, delta);
-                    consumed = true;
+                    consumed |= self.handle_widget_list_wheel(panel_id, &widget_key, delta);
                 }
                 _ => {}
             }
@@ -4906,10 +4911,10 @@ impl Editor {
     /// selection would fall outside the new viewport, drag it to
     /// the edge so the renderer's keep-selection-visible logic
     /// doesn't snap the offset back.
-    fn handle_widget_tree_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) {
+    fn handle_widget_tree_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) -> bool {
         let panel = match self.widget_registry.get(panel_id) {
             Some(p) => p,
-            None => return,
+            None => return false,
         };
         let widget = crate::widgets::find_widget_by_key(&panel.spec, widget_key);
         let (visible_rows, nodes, item_keys) = match widget {
@@ -4919,10 +4924,10 @@ impl Editor {
                 item_keys,
                 ..
             }) => (*visible_rows, nodes.clone(), item_keys.clone()),
-            _ => return,
+            _ => return false,
         };
         if nodes.is_empty() {
-            return;
+            return false;
         }
         let (cur_sel, cur_scroll, expanded) = match panel.instance_states.get(widget_key) {
             Some(crate::widgets::WidgetInstanceState::Tree {
@@ -4934,14 +4939,14 @@ impl Editor {
         };
         let visible_indices = collect_visible_tree_indices(&nodes, &item_keys, &expanded);
         if visible_indices.is_empty() {
-            return;
+            return false;
         }
         let visible = visible_rows.max(1);
         let total_visible = visible_indices.len() as u32;
         let max_scroll = total_visible.saturating_sub(visible);
         let new_scroll = (cur_scroll as i32 + delta).clamp(0, max_scroll as i32) as u32;
         if new_scroll == cur_scroll {
-            return;
+            return false;
         }
         // Drag selection to stay inside the new viewport.
         let cur_pos: Option<u32> = if cur_sel >= 0 {
@@ -4970,13 +4975,15 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
+        true
     }
 
-    /// List counterpart of `handle_widget_tree_wheel`.
-    fn handle_widget_list_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) {
+    /// List counterpart of `handle_widget_tree_wheel`. Returns true if the
+    /// list's scroll offset actually changed (the wheel was consumed).
+    fn handle_widget_list_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) -> bool {
         let panel = match self.widget_registry.get(panel_id) {
             Some(p) => p,
-            None => return,
+            None => return false,
         };
         let widget = crate::widgets::find_widget_by_key(&panel.spec, widget_key);
         let (visible_rows, total) = match widget {
@@ -4985,10 +4992,10 @@ impl Editor {
                 items,
                 ..
             }) => (*visible_rows, items.len() as u32),
-            _ => return,
+            _ => return false,
         };
         if total == 0 {
-            return;
+            return false;
         }
         let (cur_sel, cur_scroll) = match panel.instance_states.get(widget_key) {
             Some(crate::widgets::WidgetInstanceState::List {
@@ -5001,7 +5008,7 @@ impl Editor {
         let max_scroll = total.saturating_sub(visible);
         let new_scroll = (cur_scroll as i32 + delta).clamp(0, max_scroll as i32) as u32;
         if new_scroll == cur_scroll {
-            return;
+            return false;
         }
         let new_sel = if cur_sel < 0 {
             cur_sel
@@ -5022,6 +5029,7 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
+        true
     }
 
     /// Right/Left arrow on a focused Tree.

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -950,6 +950,8 @@ impl Editor {
         // Initialize popup/suggestion layout state (rendered after status bar below)
         self.active_chrome_mut().suggestions_area = None;
         self.active_chrome_mut().suggestions_outer_area = None;
+        self.active_chrome_mut().prompt_results_area = None;
+        self.active_chrome_mut().prompt_preview_area = None;
         self.active_window_mut().file_browser_layout = None;
 
         // Clone all immutable values before the mutable borrow
@@ -2374,6 +2376,7 @@ impl Editor {
                     view_state,
                     loaded_buffers,
                     blanked: false,
+                    centered_byte: None,
                 });
         } else {
             // Pre-compute hidden flag (immutable borrow on self.windows)
@@ -2392,6 +2395,8 @@ impl Editor {
                     // renders the *previous* file's text at the new file's
                     // scroll offset (wrong content, or blank past EOF).
                     state.buffer_id = buffer_id;
+                    // New file in the preview ⇒ force a recenter below.
+                    state.centered_byte = None;
                     if hidden_from_tabs {
                         state.loaded_buffers.insert(buffer_id);
                     }
@@ -2443,9 +2448,16 @@ impl Editor {
             // buffer's `BufferViewState`, so this targets the buffer that's
             // actually rendered.
             state.view_state.viewport.line_wrap_enabled = true;
-            state.view_state.viewport.left_column = 0;
-            state.view_state.viewport.horizontal_scroll_offset = 0;
-            state.view_state.viewport.top_byte = top_byte;
+            // Recentre the viewport only when the selected match changed
+            // (issue #2119). Re-seeding every frame would undo a mouse-wheel
+            // scroll of the preview; gating on `centered_byte` preserves the
+            // user's scroll while still recentering on a new selection.
+            if state.centered_byte != Some(byte_offset) {
+                state.view_state.viewport.left_column = 0;
+                state.view_state.viewport.horizontal_scroll_offset = 0;
+                state.view_state.viewport.top_byte = top_byte;
+                state.centered_byte = Some(byte_offset);
+            }
             // We have a live target: ensure the pane is shown.
             state.blanked = false;
         }
@@ -2541,7 +2553,11 @@ impl Editor {
         let chrome_rows: usize = 4 + toolbar_rows + usize::from(footer_visible);
         let suggestions_visible_rows = (overlay_rect.height as usize).saturating_sub(chrome_rows);
         if let Some(prompt) = self.active_window_mut().prompt.as_mut() {
-            prompt.ensure_selected_visible_within(suggestions_visible_rows);
+            // Skip when the user has wheel-scrolled the list — keeping the
+            // selection pinned in view would undo their scroll (issue #2119).
+            if !prompt.manual_scroll {
+                prompt.ensure_selected_visible_within(suggestions_visible_rows);
+            }
         }
         let Some(prompt) = self.active_window().prompt.as_ref() else {
             return;
@@ -2707,6 +2723,11 @@ impl Editor {
         } else {
             (body, None)
         };
+
+        // Cache the result/preview rects so the mouse-wheel handler can route
+        // the wheel to the pane under the pointer (issue #2119).
+        self.active_chrome_mut().prompt_results_area = Some(results_area);
+        self.active_chrome_mut().prompt_preview_area = preview_area;
 
         // The prompt input is the full-width top row of the header band.
         let input_row = Rect {

--- a/crates/fresh-editor/src/app/scrollbar_input.rs
+++ b/crates/fresh-editor/src/app/scrollbar_input.rs
@@ -37,30 +37,24 @@ impl crate::app::window::Window {
                 && row >= explorer_area.y
                 && row < explorer_area.y + explorer_area.height
             {
-                // Scroll the file explorer
+                // Scroll the file explorer's viewport. The wheel moves the
+                // view, not the selection — moving the selected entry (and
+                // letting it drag the viewport) is jumpy and surprising.
                 if let Some(explorer) = self.file_explorer.as_mut() {
                     let count = explorer.visible_count();
                     if count == 0 {
                         return Ok(());
                     }
 
-                    // Get current selected index
-                    let current_index = explorer.get_selected_index().unwrap_or(0);
-
-                    // Calculate new index based on scroll delta
-                    let new_index = if delta < 0 {
-                        // Scroll up (negative delta)
-                        current_index.saturating_sub(delta.unsigned_abs() as usize)
+                    let viewport = explorer.viewport_height.max(1);
+                    let max_scroll = count.saturating_sub(viewport);
+                    let current_offset = explorer.get_scroll_offset();
+                    let new_offset = if delta < 0 {
+                        current_offset.saturating_sub(delta.unsigned_abs() as usize)
                     } else {
-                        // Scroll down (positive delta)
-                        (current_index + delta as usize).min(count - 1)
+                        (current_offset + delta as usize).min(max_scroll)
                     };
-
-                    // Set the new selection
-                    if let Some(node_id) = explorer.get_node_at_index(new_index) {
-                        explorer.set_selected(Some(node_id));
-                        explorer.update_scroll_for_selection();
-                    }
+                    explorer.set_scroll_offset(new_offset);
                 }
                 return Ok(());
             }

--- a/crates/fresh-editor/src/app/types.rs
+++ b/crates/fresh-editor/src/app/types.rs
@@ -1192,6 +1192,16 @@ pub(crate) struct ChromeLayout {
     /// `toolbar_widget`; a click inside one fires the matching
     /// `live_grep_toggle_<key>` action. Empty otherwise.
     pub prompt_toolbar_hits: Vec<(String, Rect)>,
+    /// Screen rect of the floating-overlay prompt's results list (issue
+    /// #2119). `None` when no overlay is open. The mouse-wheel handler reads
+    /// this to scroll the result list (without moving the selection) when the
+    /// pointer is over it.
+    pub prompt_results_area: Option<Rect>,
+    /// Screen rect of the floating-overlay prompt's preview pane (issue
+    /// #2119). `None` when no overlay is open or the overlay is too narrow to
+    /// show a preview. The mouse-wheel handler reads this to scroll the
+    /// preview (rather than the result list) when the pointer is over it.
+    pub prompt_preview_area: Option<Rect>,
     /// Settings modal layout for hit testing
     pub settings_layout: Option<crate::view::settings::SettingsLayout>,
     /// Workspace-trust dialog click layout (radios + OK/Quit) for hit testing.
@@ -1671,6 +1681,11 @@ pub struct OverlayPreviewState {
     /// tracked for cleanup and the buffer can be re-shown on the next
     /// match without reloading.
     pub blanked: bool,
+    /// The match byte-offset the preview viewport was last centred on
+    /// (issue #2119). The renderer recentres only when this changes (a new
+    /// selected result), so a mouse-wheel scroll of the preview isn't undone
+    /// by the next frame's recenter.
+    pub centered_byte: Option<usize>,
 }
 
 #[cfg(test)]

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1411,6 +1411,47 @@ impl Window {
             });
     }
 
+    /// Scroll the Live Grep overlay's preview pane by `delta` lines
+    /// (issue #2119). The preview lives in `overlay_preview_state` (not in
+    /// the split tree), so it needs its own scroll path rather than going
+    /// through `scroll_split_by_lines`. Returns true if a preview was present
+    /// and scrolled.
+    pub fn scroll_overlay_preview_by_lines(&mut self, delta: i32) -> bool {
+        let buffer_id = match self.overlay_preview_state.as_ref() {
+            Some(ps) if !ps.blanked => ps.buffer_id,
+            _ => return false,
+        };
+        // Gather buffer-derived inputs first so the mutable borrows below stay
+        // disjoint (buffer store vs. overlay preview state).
+        let (soft_breaks, virtual_lines) = match self.buffers.get(&buffer_id) {
+            Some(s) => (
+                s.collect_soft_break_positions(),
+                s.collect_virtual_line_positions(),
+            ),
+            None => return false,
+        };
+        let Some(state) = self.buffers.get_mut(&buffer_id) else {
+            return false;
+        };
+        let buffer = &mut state.buffer;
+        let Some(ps) = self.overlay_preview_state.as_mut() else {
+            return false;
+        };
+        let viewport = &mut ps.view_state.active_state_mut().viewport;
+        if delta < 0 {
+            viewport.scroll_up(
+                buffer,
+                &soft_breaks,
+                &virtual_lines,
+                delta.unsigned_abs() as usize,
+            );
+        } else {
+            viewport.scroll_down(buffer, &soft_breaks, &virtual_lines, delta as usize);
+        }
+        viewport.set_skip_ensure_visible();
+        true
+    }
+
     /// Clear LSP-related overlays (diagnostics, virtual texts,
     /// folding ranges, and folds) for `buffer_id`, used when LSP is
     /// being disabled for the buffer. Pure window-state mutation.

--- a/crates/fresh-editor/src/view/prompt.rs
+++ b/crates/fresh-editor/src/view/prompt.rs
@@ -209,6 +209,12 @@ pub struct Prompt {
     /// visible — selection changes inside the viewport never scroll
     /// (issue #1660).
     pub scroll_offset: usize,
+    /// When true, the user has scrolled the result list with the mouse wheel,
+    /// so the renderer must NOT pull `scroll_offset` back to keep the
+    /// selection in view (issue #2119). Reset whenever the selection moves by
+    /// keyboard or the suggestion list is rebuilt, so normal navigation
+    /// re-engages the keep-selection-visible behaviour.
+    pub manual_scroll: bool,
     /// Selection anchor position (for Shift+Arrow selection)
     /// When Some(pos), there's a selection from anchor to cursor_pos
     pub selection_anchor: Option<usize>,
@@ -283,6 +289,7 @@ impl Prompt {
             original_suggestions: None,
             selected_suggestion: None,
             scroll_offset: 0,
+            manual_scroll: false,
             selection_anchor: None,
             suggestions_set_for_input: None,
             sync_input_on_navigate: false,
@@ -320,6 +327,7 @@ impl Prompt {
             suggestions,
             selected_suggestion,
             scroll_offset: 0,
+            manual_scroll: false,
             selection_anchor: None,
             suggestions_set_for_input: None,
             sync_input_on_navigate: false,
@@ -376,6 +384,7 @@ impl Prompt {
             original_suggestions: None,
             selected_suggestion: None,
             scroll_offset: 0,
+            manual_scroll: false,
             selection_anchor,
             suggestions_set_for_input: None,
             sync_input_on_navigate: false,
@@ -532,6 +541,8 @@ impl Prompt {
     /// Select next suggestion
     pub fn select_next_suggestion(&mut self) {
         if !self.suggestions.is_empty() {
+            // Keyboard navigation re-engages keep-selection-visible scrolling.
+            self.manual_scroll = false;
             self.selected_suggestion = Some(match self.selected_suggestion {
                 Some(idx) if idx + 1 < self.suggestions.len() => idx + 1,
                 Some(_) => 0, // Wrap to start
@@ -543,12 +554,32 @@ impl Prompt {
     /// Select previous suggestion
     pub fn select_prev_suggestion(&mut self) {
         if !self.suggestions.is_empty() {
+            self.manual_scroll = false;
             self.selected_suggestion = Some(match self.selected_suggestion {
                 Some(0) => self.suggestions.len() - 1, // Wrap to end
                 Some(idx) => idx - 1,
                 None => 0,
             });
         }
+    }
+
+    /// Scroll the result list by `delta` rows without moving the selection
+    /// (mouse wheel over the Live Grep overlay results pane, issue #2119).
+    /// `visible` is the number of result rows currently on screen, used to
+    /// clamp the offset so it can't scroll past the end of the list.
+    pub fn scroll_results(&mut self, delta: i32, visible: usize) {
+        let total = self.suggestions.len();
+        if total == 0 {
+            return;
+        }
+        let max_offset = total.saturating_sub(visible.max(1));
+        let next = (self.scroll_offset as i32 + delta).clamp(0, max_offset as i32) as usize;
+        if next != self.scroll_offset {
+            self.scroll_offset = next;
+        }
+        // Latch manual scroll even when clamped at an edge, so a follow-up
+        // render doesn't immediately yank the offset back to the selection.
+        self.manual_scroll = true;
     }
 
     /// Get the currently selected suggestion value
@@ -616,6 +647,7 @@ impl Prompt {
             Some(0)
         };
         self.scroll_offset = 0;
+        self.manual_scroll = false;
     }
 
     /// Adjust `scroll_offset` so that `selected_suggestion` is inside the

--- a/crates/fresh-editor/src/view/prompt_input.rs
+++ b/crates/fresh-editor/src/view/prompt_input.rs
@@ -133,6 +133,9 @@ impl InputHandler for Prompt {
             // hardcoded prompt type checks here. This would make the suggestion UI more flexible
             // and allow custom handling for any prompt type without modifying this code.
             KeyCode::Up => {
+                // Keyboard navigation re-engages keep-selection-visible
+                // scrolling after a mouse-wheel scroll of the list (#2119).
+                self.manual_scroll = false;
                 if !self.suggestions.is_empty() {
                     // Don't wrap around - stay at 0 if already at the beginning
                     if let Some(selected) = self.selected_suggestion {
@@ -178,6 +181,7 @@ impl InputHandler for Prompt {
                 InputResult::Consumed
             }
             KeyCode::Down => {
+                self.manual_scroll = false;
                 if !self.suggestions.is_empty() {
                     // Don't wrap around - stay at end if already at the last item
                     if let Some(selected) = self.selected_suggestion {
@@ -223,12 +227,14 @@ impl InputHandler for Prompt {
                 InputResult::Consumed
             }
             KeyCode::PageUp => {
+                self.manual_scroll = false;
                 if let Some(selected) = self.selected_suggestion {
                     self.selected_suggestion = Some(selected.saturating_sub(10));
                 }
                 InputResult::Consumed
             }
             KeyCode::PageDown => {
+                self.manual_scroll = false;
                 if let Some(selected) = self.selected_suggestion {
                     let len = self.suggestions.len();
                     let new_pos = selected + 10;

--- a/crates/fresh-editor/tests/e2e/issue_2119_wheel_scroll.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2119_wheel_scroll.rs
@@ -346,3 +346,95 @@ fn git_log_commit_list_scrolls_with_wheel() {
          (top commit should change from {top_before}). Screen:\n{after}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Keyboard navigation after a wheel scroll must re-reveal the selection
+// ---------------------------------------------------------------------------
+
+/// In Live Grep, after the result list is wheel-scrolled so the selected
+/// result is off-screen, the next keyboard navigation (Down) must scroll the
+/// list so the (newly) selected result is visible again.
+#[test]
+fn live_grep_keyboard_nav_scrolls_selection_back_into_view() {
+    let mut harness = open_live_grep_with_results(160, 40, 60);
+
+    // Selection starts on the first result.
+    let initial = harness.screen_to_string();
+    assert!(
+        initial.contains("match_00.txt"),
+        "first result should be visible initially. Screen:\n{initial}"
+    );
+
+    // Wheel the results down until the selected result (match_00) scrolls off.
+    for _ in 0..5 {
+        harness.mouse_scroll_down(10, 12).unwrap();
+    }
+    settle(&mut harness);
+    let scrolled = harness.screen_to_string();
+    assert!(
+        !scrolled.contains("match_00.txt"),
+        "precondition: the selected result should have scrolled out of view. \
+         Screen:\n{scrolled}"
+    );
+
+    // Keyboard Down moves the selection (0 → 1) and must bring it back in view.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    settle(&mut harness);
+    let after = harness.screen_to_string();
+    assert!(
+        after.contains("match_01.txt"),
+        "keyboard navigation after a wheel scroll should scroll the selected \
+         result back into view. Screen:\n{after}"
+    );
+}
+
+/// In the File Explorer, after the tree is wheel-scrolled so the selected
+/// entry is off-screen, the next keyboard navigation (Down) must scroll the
+/// view so the (newly) selected entry is visible again (its `▌` cursor shows).
+#[test]
+fn file_explorer_keyboard_nav_scrolls_selection_back_into_view() {
+    let mut harness = EditorTestHarness::with_temp_project(100, 30).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    for i in 0..60 {
+        fs::write(project_root.join(format!("file_{i:02}.txt")), "x").unwrap();
+    }
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("file_00.txt").unwrap();
+
+    // Select an entry near the top of the list.
+    for _ in 0..5 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+    let selected = token_on_line_with(&harness.screen_to_string(), "▌", "file_")
+        .expect("an entry should be selected before scrolling");
+
+    // Wheel the explorer down until the selected entry scrolls off the top
+    // (its `▌` cursor is no longer drawn).
+    for _ in 0..10 {
+        harness.mouse_scroll_down(3, 8).unwrap();
+    }
+    harness.render().unwrap();
+    assert!(
+        token_on_line_with(&harness.screen_to_string(), "▌", "file_").is_none(),
+        "precondition: the selected entry should have scrolled out of view. \
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Keyboard Down moves the selection and must scroll it back into view.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    let after = harness.screen_to_string();
+    let selected_after = token_on_line_with(&after, "▌", "file_").unwrap_or_else(|| {
+        panic!(
+            "keyboard navigation should scroll the selected entry back into view. Screen:\n{after}"
+        )
+    });
+    assert_ne!(
+        selected_after, selected,
+        "selection should have advanced by one entry (was {selected})"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/issue_2119_wheel_scroll.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2119_wheel_scroll.rs
@@ -1,0 +1,348 @@
+//! Regression tests for issue #2119: mouse-wheel scrolling is broken in the
+//! File Explorer, Live Grep overlay, and Git Log panel.
+//!
+//! These tests are written to FAIL against the current implementation and
+//! PASS once the corresponding fix lands. Each drives a real mouse-wheel
+//! event and asserts on rendered output only (CONTRIBUTING §2).
+//!
+//! Bugs covered:
+//!  1. File Explorer — the wheel moves the *selected* entry (in jumps of the
+//!     wheel step), dragging the viewport, instead of scrolling the view and
+//!     leaving the selection alone.
+//!  2. Live Grep results list — the wheel moves the selected result (in
+//!     jumps), instead of scrolling the list smoothly.
+//!  3. Live Grep preview pane — the wheel over the preview moves the *results*
+//!     selection instead of scrolling the preview.
+//!  4. Git Log commit list — the wheel does not scroll the list at all.
+
+use crate::common::git_test_helper::GitTestRepo;
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+/// Pump async work until the screen stops changing.
+fn settle(harness: &mut EditorTestHarness) {
+    harness.wait_until_stable(|_| true).unwrap();
+}
+
+/// The first non-whitespace token at/after `prefix` on the line, e.g. for
+/// prefix "file_" on "│▌   file_11.txt  ●" returns "file_11.txt".
+fn token_after(line: &str, prefix: &str) -> Option<String> {
+    let idx = line.find(prefix)?;
+    let tok: String = line[idx..]
+        .chars()
+        .take_while(|c| !c.is_whitespace())
+        .collect();
+    Some(tok)
+}
+
+/// The `prefix`-token on the first screen line that also contains `marker`.
+fn token_on_line_with(screen: &str, marker: &str, prefix: &str) -> Option<String> {
+    screen
+        .lines()
+        .find(|l| l.contains(marker))
+        .and_then(|l| token_after(l, prefix))
+}
+
+/// The `prefix`-token on the first screen line that carries it (reading order).
+fn first_token(screen: &str, prefix: &str) -> Option<String> {
+    screen.lines().find_map(|l| token_after(l, prefix))
+}
+
+/// The `prefix`-token on the first *file-explorer body* row (those start with
+/// the explorer's left border `│`), so we read the top tree entry rather than
+/// a tab title or status-bar mention of the same name.
+fn first_explorer_token(screen: &str, prefix: &str) -> Option<String> {
+    screen
+        .lines()
+        .filter(|l| l.starts_with('│'))
+        .find_map(|l| token_after(l, prefix))
+}
+
+// ---------------------------------------------------------------------------
+// Bug 1: File Explorer wheel moves the selection instead of scrolling the view
+// ---------------------------------------------------------------------------
+
+/// With the explorer focused and more entries than fit on screen, one
+/// wheel-down over the explorer should scroll the view while leaving the
+/// selected entry unchanged. The buggy behaviour moves the selection by the
+/// wheel step (so the `▌` cursor jumps to a different file) and only scrolls
+/// to follow it.
+#[test]
+fn file_explorer_wheel_scrolls_view_without_moving_selection() {
+    let mut harness = EditorTestHarness::with_temp_project(100, 30).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    // Flat list of zero-padded names so the sort order is numeric and there
+    // are far more entries than the explorer viewport can show.
+    for i in 0..40 {
+        fs::write(project_root.join(format!("file_{i:02}.txt")), "x").unwrap();
+    }
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("file_00.txt").unwrap();
+
+    // Move the selection down into the middle of the viewport so there are
+    // entries both above (to scroll off the top) and below it.
+    for _ in 0..12 {
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    harness.render().unwrap();
+
+    let before = harness.screen_to_string();
+    let selected_before = token_on_line_with(&before, "▌", "file_")
+        .expect("a file should be selected (▌ marker) before scrolling");
+    let top_before =
+        first_explorer_token(&before, "file_").expect("at least one file visible before scrolling");
+
+    // One wheel notch over the explorer (column 3 is inside the left sidebar).
+    harness.mouse_scroll_down(3, 8).unwrap();
+    harness.render().unwrap();
+
+    let after = harness.screen_to_string();
+    let selected_after = token_on_line_with(&after, "▌", "file_")
+        .expect("a file should still be selected after scrolling");
+    let top_after =
+        first_explorer_token(&after, "file_").expect("at least one file visible after scrolling");
+
+    assert_eq!(
+        selected_after, selected_before,
+        "wheel over the file explorer must NOT move the selection \
+         (was {selected_before}, now {selected_after}). Screen:\n{after}"
+    );
+    assert_ne!(
+        top_after, top_before,
+        "wheel over the file explorer should scroll the view \
+         (top entry should change from {top_before}). Screen:\n{after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Live Grep helpers
+// ---------------------------------------------------------------------------
+
+/// A unique token on line 1 of each grep target, shown in the *preview* pane
+/// (the matched line is line 2). Identifies which result is selected/previewed
+/// while the preview is at the top of the file.
+const PREVIEW_MARKER: &str = "ZTOPMARKER";
+/// A unique token deep inside each grep target (well below the preview's
+/// initial viewport). Only becomes visible after the preview scrolls down, and
+/// — being per-file — also confirms which file is still selected.
+const DEEP_MARKER: &str = "ZDEEPMARKER";
+const NEEDLE: &str = "NEEDLEZZ";
+
+/// Build a git repo with `n` files, each matching NEEDLE, plus the live_grep
+/// plugin, and open the Live Grep overlay on a NEEDLE search. Returns the
+/// harness with results showing.
+fn open_live_grep_with_results(width: u16, height: u16, n: usize) -> EditorTestHarness {
+    let repo = GitTestRepo::new();
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "live_grep");
+
+    for i in 0..n {
+        // Line 1: preview-only top marker. Line 2: the searchable needle.
+        // Many filler lines, then a deep per-file marker far below the
+        // preview's initial viewport so it only appears once the preview
+        // scrolls down.
+        let mut content = format!("{PREVIEW_MARKER}{i:02}\n{NEEDLE} on line two\n");
+        for f in 0..80 {
+            content.push_str(&format!("filler line {f:02}\n"));
+        }
+        content.push_str(&format!("{DEEP_MARKER}{i:02}\n"));
+        repo.create_file(&format!("match_{i:02}.txt"), &content);
+    }
+    repo.git_add_all();
+    repo.git_commit("seed matches");
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        width,
+        height,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    // Keep the repo alive for the lifetime of the harness.
+    std::mem::forget(repo);
+
+    // Open palette → run Live Grep.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Live Grep").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Live Grep"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search in:"))
+        .unwrap();
+
+    // Type the needle and wait for results + a preview to render.
+    harness.type_text(NEEDLE).unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("match_00.txt") && s.contains(PREVIEW_MARKER)
+        })
+        .unwrap();
+    settle(&mut harness);
+    harness
+}
+
+// ---------------------------------------------------------------------------
+// Bug 2: Live Grep results-list wheel moves the selection
+// ---------------------------------------------------------------------------
+
+/// Wheeling over the results list should scroll the list, not move the
+/// selected result. The preview reflects the selected result, so a stable
+/// preview marker before/after the wheel proves the selection did not move.
+#[test]
+fn live_grep_results_wheel_scrolls_without_moving_selection() {
+    // More results than the result pane can show, so the list is scrollable.
+    let mut harness = open_live_grep_with_results(160, 40, 60);
+
+    let before = harness.screen_to_string();
+    let selected_before = first_token(&before, PREVIEW_MARKER)
+        .expect("the preview should show the selected result's marker");
+    let top_result_before =
+        first_token(&before, "match_").expect("the result list should show results");
+
+    // Wheel over the results list (left pane).
+    harness.mouse_scroll_down(10, 12).unwrap();
+    settle(&mut harness);
+
+    let after = harness.screen_to_string();
+    let selected_after = first_token(&after, PREVIEW_MARKER)
+        .expect("the preview should still show a marker after scrolling");
+    let top_result_after =
+        first_token(&after, "match_").expect("the result list should still show results");
+
+    assert_eq!(
+        selected_after, selected_before,
+        "wheel over the Live Grep results list must NOT move the selected \
+         result (preview was {selected_before}, now {selected_after}). Screen:\n{after}"
+    );
+    assert_ne!(
+        top_result_after, top_result_before,
+        "wheel over the Live Grep results list should scroll the list \
+         (top result should change from {top_result_before}). Screen:\n{after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 3: Live Grep preview wheel moves the results selection
+// ---------------------------------------------------------------------------
+
+/// Wheeling while the pointer is over the preview pane should scroll the
+/// preview, not the results list. The bug routes the wheel to the results
+/// selection, so the preview jumps to a different file. We assert the
+/// previewed file (its marker) is unchanged.
+#[test]
+fn live_grep_preview_wheel_scrolls_preview_not_results() {
+    let mut harness = open_live_grep_with_results(160, 40, 60);
+
+    let before = harness.screen_to_string();
+    // Which file is selected/previewed (from the top marker, visible before
+    // any preview scroll). The deep marker must NOT be visible yet.
+    let selected = first_token(&before, PREVIEW_MARKER)
+        .expect("the preview should show the selected result's top marker");
+    let idx = &selected[PREVIEW_MARKER.len()..]; // e.g. "00"
+    assert!(
+        !before.contains(DEEP_MARKER),
+        "deep marker must be below the preview's initial viewport. Screen:\n{before}"
+    );
+
+    // Wheel over the preview pane (right half of the overlay), enough to bring
+    // the deep marker into view.
+    for _ in 0..20 {
+        harness.mouse_scroll_down(140, 12).unwrap();
+    }
+    settle(&mut harness);
+
+    let after = harness.screen_to_string();
+    // The preview scrolled (deep marker now visible) AND it's still the SAME
+    // file's deep marker — i.e. the results selection did not move. A single
+    // assertion captures both: a different file would show a different index,
+    // and an unscrolled preview wouldn't show any deep marker.
+    let expected_deep = format!("{DEEP_MARKER}{idx}");
+    assert!(
+        after.contains(&expected_deep),
+        "wheel over the preview should scroll the preview to reveal {expected_deep} \
+         (same file, scrolled) — not move the results selection. Screen:\n{after}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bug 4: Git Log commit list does not scroll with the wheel
+// ---------------------------------------------------------------------------
+
+/// With more commits than fit on screen, wheeling over the Git Log commit
+/// list (left pane) should scroll it. The bug ignores the wheel entirely, so
+/// the topmost visible commit never changes.
+#[test]
+fn git_log_commit_list_scrolls_with_wheel() {
+    let repo = GitTestRepo::new();
+    repo.setup_typical_project();
+    repo.setup_git_log_plugin();
+
+    // Many uniquely-named commits so the list overflows the viewport.
+    for i in 0..40 {
+        repo.create_file("churn.txt", &format!("rev {i}\n"));
+        repo.git_add_all();
+        repo.git_commit(&format!("wheelcommit_{i:02}"));
+    }
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        24,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+    harness.open_file(&repo.path.join("src/main.rs")).unwrap();
+    harness.render().unwrap();
+
+    // Open Git Log via the command palette.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Git Log").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("switch pane") && s.contains("wheelcommit_")
+        })
+        .unwrap();
+    settle(&mut harness);
+
+    let before = harness.screen_to_string();
+    let top_before = first_token(&before, "wheelcommit_")
+        .expect("a commit should be visible in the git log list");
+
+    // Wheel down over the commit list (left pane).
+    for _ in 0..4 {
+        harness.mouse_scroll_down(10, 8).unwrap();
+    }
+    settle(&mut harness);
+
+    let after = harness.screen_to_string();
+    let top_after = first_token(&after, "wheelcommit_")
+        .expect("a commit should still be visible after scrolling");
+
+    assert_ne!(
+        top_after, top_before,
+        "wheel over the Git Log commit list should scroll it \
+         (top commit should change from {top_before}). Screen:\n{after}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -64,6 +64,7 @@ pub mod issue_2029_file_explorer_terminal_focus;
 pub mod issue_2030_quit_confirm_and_disable;
 pub mod issue_2031_next_prev_window;
 pub mod issue_2035_preview_renders_buffer_groups;
+pub mod issue_2119_wheel_scroll;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod suspend_process;


### PR DESCRIPTION
## Summary

This PR fixes four mouse-wheel scrolling bugs across the File Explorer, Live Grep overlay, and Git Log panel (issue #2119). The core problems were:

1. **File Explorer**: Wheel moved the selection instead of scrolling the viewport
2. **Live Grep results list**: Wheel moved the selected result instead of scrolling smoothly
3. **Live Grep preview pane**: Wheel over the preview moved the results selection instead of scrolling the preview
4. **Git Log commit list**: Wheel didn't scroll at all

## Key Changes

- **File Explorer scrolling** (`scrollbar_input.rs`): Changed from moving the selection to scrolling the viewport offset directly, providing smooth scrolling without selection jumps.

- **Live Grep overlay scrolling** (`mouse_input.rs`): Added `handle_overlay_prompt_scroll()` to route wheel events correctly:
  - Over the preview pane → scroll the preview buffer
  - Elsewhere → scroll the results list without moving selection

- **Preview pane scroll state** (`render.rs`): Added `centered_byte` tracking to prevent the preview from re-centering on every frame, preserving user-initiated scrolls while still recentering when the selection changes.

- **Prompt result list scrolling** (`prompt.rs`): 
  - Added `manual_scroll` flag to distinguish user wheel-scrolls from keyboard navigation
  - Implemented `scroll_results()` method to adjust `scroll_offset` without moving selection
  - Reset `manual_scroll` on keyboard navigation to re-engage keep-selection-visible behavior

- **Widget wheel handling** (`plugin_dispatch.rs`): Changed Tree and List wheel handlers to return `bool` indicating whether they actually scrolled, allowing fallthrough to buffer scrolling when widgets have nothing to scroll (e.g., Git Log rendering all rows).

- **Overlay preview state** (`types.rs`): Added `centered_byte` field to track which byte offset the preview is centered on, enabling scroll preservation across renders.

- **Chrome layout** (`types.rs`): Added `prompt_results_area` and `prompt_preview_area` fields for mouse-wheel hit testing in the floating overlay.

- **Comprehensive regression tests** (`issue_2119_wheel_scroll.rs`): Added 4 end-to-end tests covering all fixed bugs, driving real mouse-wheel events and asserting on rendered output.

## Implementation Details

- The fix preserves the existing "keep-selection-visible" scrolling behavior for keyboard navigation while enabling independent viewport scrolling via mouse wheel.
- The overlay prompt's wheel handling is modal—when active, it always consumes the wheel event to prevent leaking to the buffer below.
- Git Log's wheel support works by allowing the widget's scroll handler to return false (no scroll occurred), which then falls through to the underlying buffer's scroll mechanism.

https://claude.ai/code/session_01K5cGe1ACZkGrcpGifpWBpd