### PR TITLE
Make macro replay a single undo unit (#2062)

### DIFF
--- a/crates/fresh-editor/src/app/macro_actions.rs
+++ b/crates/fresh-editor/src/app/macro_actions.rs
@@ -121,6 +121,14 @@ impl Editor {
         }
 
         self.active_window_mut().macros.begin_play();
+        // Bracket the replay so the whole macro is a single undo unit: one Undo
+        // reverts the entire playback (and one Redo re-applies it) rather than
+        // one event per replayed write action. The group is opened and closed
+        // on the same buffer's log even if the macro switches buffers mid-replay.
+        let group_buffer = self.active_buffer();
+        if let Some(log) = self.active_window_mut().event_logs.get_mut(&group_buffer) {
+            log.begin_undo_group();
+        }
         let action_count = actions.len();
         let width = self.active_chrome().last_frame_width;
         let height = self.active_chrome().last_frame_height;
@@ -129,6 +137,9 @@ impl Editor {
                 tracing::warn!("Macro action failed: {}", e);
             }
             self.recompute_layout(width, height);
+        }
+        if let Some(log) = self.active_window_mut().event_logs.get_mut(&group_buffer) {
+            log.end_undo_group();
         }
         self.active_window_mut().macros.end_play();
 

--- a/crates/fresh-editor/src/model/event.rs
+++ b/crates/fresh-editor/src/model/event.rs
@@ -568,6 +568,13 @@ pub struct LogEntry {
     /// to their exact original positions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub displaced_markers: Vec<(u64, usize)>,
+
+    /// Undo-group id. Entries sharing the same id are undone/redone as a
+    /// single atomic unit (e.g. a whole macro replay). `None` means the entry
+    /// stands on its own. Runtime-only — not persisted, so reloaded logs fall
+    /// back to per-entry undo.
+    #[serde(skip)]
+    pub group_id: Option<u64>,
 }
 
 impl LogEntry {
@@ -580,6 +587,7 @@ impl LogEntry {
                 .as_millis() as u64,
             description: None,
             displaced_markers: Vec::new(),
+            group_id: None,
         }
     }
 
@@ -624,6 +632,16 @@ pub struct EventLog {
     /// Index at which the buffer was last saved (for tracking modified status)
     /// When current_index equals saved_at_index, the buffer is not modified
     saved_at_index: Option<usize>,
+
+    /// Monotonic allocator for undo-group ids.
+    next_group_id: u64,
+
+    /// Id tagged onto appended entries while an undo group is open.
+    current_group: Option<u64>,
+
+    /// Nesting depth of open undo groups. The group is closed (and a fresh id
+    /// allocated for the next group) only when this returns to zero.
+    group_depth: u32,
 }
 
 impl EventLog {
@@ -637,6 +655,30 @@ impl EventLog {
             #[cfg(feature = "runtime")]
             stream_file: None,
             saved_at_index: Some(0), // New buffer starts at "saved" state (index 0)
+            next_group_id: 0,
+            current_group: None,
+            group_depth: 0,
+        }
+    }
+
+    /// Open an undo group. All write actions appended until the matching
+    /// [`Self::end_undo_group`] are reverted/reapplied together as one unit.
+    /// Nestable: only the outermost begin/end pair establishes the group.
+    pub fn begin_undo_group(&mut self) {
+        if self.group_depth == 0 {
+            self.current_group = Some(self.next_group_id);
+            self.next_group_id += 1;
+        }
+        self.group_depth += 1;
+    }
+
+    /// Close the undo group opened by [`Self::begin_undo_group`].
+    pub fn end_undo_group(&mut self) {
+        if self.group_depth > 0 {
+            self.group_depth -= 1;
+            if self.group_depth == 0 {
+                self.current_group = None;
+            }
         }
     }
 
@@ -799,7 +841,8 @@ impl EventLog {
             }
         }
 
-        let entry = LogEntry::new(event);
+        let mut entry = LogEntry::new(event);
+        entry.group_id = self.current_group;
         self.entries.push(entry);
         self.current_index = self.entries.len();
 
@@ -854,20 +897,36 @@ impl EventLog {
     pub fn undo(&mut self) -> Vec<(Event, Vec<(u64, usize)>)> {
         let mut inverse_events = Vec::new();
         let mut found_write_action = false;
+        // Group id of the write action that opened this undo unit, if any.
+        // While set, the walk keeps consuming entries belonging to the same
+        // group so a whole grouped edit (e.g. a macro replay) reverts at once.
+        let mut group: Option<u64> = None;
 
-        // Keep moving backward until we find a write action
-        while self.can_undo() && !found_write_action {
-            self.current_index -= 1;
-            let entry = &self.entries[self.current_index];
+        while self.can_undo() {
+            let idx = self.current_index - 1;
+            let is_write = self.entries[idx].event.is_write_action();
+            let entry_group = self.entries[idx].group_id;
 
-            // Check if this is a write action - we'll stop after processing it
-            if entry.event.is_write_action() {
+            if found_write_action {
+                match group {
+                    // Ungrouped edit: stop after the first write action.
+                    None => break,
+                    // Grouped edit: stop at the first entry outside the group.
+                    Some(g) if entry_group != Some(g) => break,
+                    Some(_) => {}
+                }
+            }
+
+            self.current_index = idx;
+
+            if is_write && !found_write_action {
                 found_write_action = true;
+                group = entry_group;
             }
 
             // Try to get the inverse of this event
-            if let Some(inverse) = entry.event.inverse() {
-                inverse_events.push((inverse, entry.displaced_markers.clone()));
+            if let Some(inverse) = self.entries[idx].event.inverse() {
+                inverse_events.push((inverse, self.entries[idx].displaced_markers.clone()));
             }
             // If no inverse exists (like MoveCursor), we just skip it
         }
@@ -881,25 +940,33 @@ impl EventLog {
     pub fn redo(&mut self) -> Vec<Event> {
         let mut events = Vec::new();
         let mut found_write_action = false;
+        // Mirror of `undo`'s grouping: once a grouped write action is reached,
+        // keep reapplying entries from the same group as one unit.
+        let mut group: Option<u64> = None;
 
         // Keep moving forward to collect write action and subsequent readonly events
         while self.can_redo() {
-            let event = self.entries[self.current_index].event.clone();
+            let idx = self.current_index;
+            let is_write = self.entries[idx].event.is_write_action();
+            let entry_group = self.entries[idx].group_id;
 
             // If we've already found a write action and this is another write action, stop
-            if found_write_action && event.is_write_action() {
-                // Don't include this event, it's the next write action
-                break;
+            // (unless it belongs to the same open undo group).
+            if found_write_action && is_write {
+                match group {
+                    None => break,
+                    Some(g) if entry_group != Some(g) => break,
+                    Some(_) => {}
+                }
             }
 
-            self.current_index += 1;
-
-            // Mark if we found a write action
-            if event.is_write_action() {
+            if is_write && !found_write_action {
                 found_write_action = true;
+                group = entry_group;
             }
 
-            events.push(event);
+            events.push(self.entries[idx].event.clone());
+            self.current_index = idx + 1;
         }
 
         events
@@ -1242,6 +1309,108 @@ mod tests {
             !redo_events.is_empty(),
             "Redo should return events after navigation"
         );
+    }
+
+    #[test]
+    fn test_undo_group_reverts_and_reapplies_atomically() {
+        // Three grouped inserts (e.g. a macro replay) collapse into one
+        // undo/redo unit (#2062).
+        let mut log = EventLog::new();
+
+        log.begin_undo_group();
+        for (i, ch) in ['a', 'b', 'c'].into_iter().enumerate() {
+            log.append(Event::Insert {
+                position: i,
+                text: ch.to_string(),
+                cursor_id: CursorId(0),
+            });
+        }
+        log.end_undo_group();
+        assert_eq!(log.current_index(), 3);
+
+        // One undo reverts the whole group.
+        let undo_events = log.undo();
+        assert_eq!(undo_events.len(), 3, "all three inserts revert in one undo");
+        assert_eq!(log.current_index(), 0);
+        assert!(!log.can_undo());
+
+        // One redo reapplies the whole group.
+        let redo_events = log.redo();
+        assert_eq!(
+            redo_events.len(),
+            3,
+            "all three inserts reapply in one redo"
+        );
+        assert_eq!(log.current_index(), 3);
+        assert!(!log.can_redo());
+    }
+
+    #[test]
+    fn test_ungrouped_edit_after_group_undoes_separately() {
+        // A standalone write after a group must NOT merge with it: the first
+        // undo reverts only the standalone edit, the second reverts the group.
+        let mut log = EventLog::new();
+
+        log.begin_undo_group();
+        log.append(Event::Insert {
+            position: 0,
+            text: "ab".to_string(),
+            cursor_id: CursorId(0),
+        });
+        log.append(Event::Insert {
+            position: 2,
+            text: "cd".to_string(),
+            cursor_id: CursorId(0),
+        });
+        log.end_undo_group();
+
+        // Standalone insert (not in any group).
+        log.append(Event::Insert {
+            position: 4,
+            text: "Z".to_string(),
+            cursor_id: CursorId(0),
+        });
+        assert_eq!(log.current_index(), 3);
+
+        // First undo: only the standalone "Z".
+        let first = log.undo();
+        assert_eq!(first.len(), 1);
+        assert_eq!(log.current_index(), 2);
+
+        // Second undo: the whole group ("ab" + "cd").
+        let second = log.undo();
+        assert_eq!(second.len(), 2);
+        assert_eq!(log.current_index(), 0);
+    }
+
+    #[test]
+    fn test_consecutive_groups_undo_independently() {
+        // Two back-to-back groups get distinct ids and undo as separate units.
+        let mut log = EventLog::new();
+
+        for _ in 0..2 {
+            log.begin_undo_group();
+            log.append(Event::Insert {
+                position: 0,
+                text: "xy".to_string(),
+                cursor_id: CursorId(0),
+            });
+            log.append(Event::Insert {
+                position: 2,
+                text: "zw".to_string(),
+                cursor_id: CursorId(0),
+            });
+            log.end_undo_group();
+        }
+        assert_eq!(log.current_index(), 4);
+
+        let first = log.undo();
+        assert_eq!(first.len(), 2, "second group reverts on its own");
+        assert_eq!(log.current_index(), 2);
+
+        let second = log.undo();
+        assert_eq!(second.len(), 2, "first group reverts on its own");
+        assert_eq!(log.current_index(), 0);
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/macros.rs
+++ b/crates/fresh-editor/tests/e2e/macros.rs
@@ -411,24 +411,21 @@ fn test_macro_playback_is_undoable() {
         screen
     );
 
-    // Now undo - should undo the entire macro playback
+    // Now undo - macro playback is a single undo unit (#2062), so ONE undo
+    // must remove the entire replayed "abc" in one step.
     harness
         .send_key(KeyCode::Char('z'), KeyModifiers::CONTROL)
         .unwrap();
     harness.render().unwrap();
 
-    // After one undo, the second "abc" should be gone
-    // (If macro playback is properly grouped, one undo removes all macro actions)
+    // After one undo exactly the recorded "abc" remains (the replayed one is
+    // gone wholesale — not just its last char).
     let screen_after_undo = harness.screen_to_string();
     let abc_count_after = screen_after_undo.matches("abc").count();
-
-    // We expect at most 1 "abc" after undo (the original one typed during recording)
-    // Note: The first "abc" was typed during recording, so it has its own undo entry
-    assert!(
-        abc_count_after < abc_count,
-        "Undo should have removed macro playback. Before: {} 'abc', after: {}. Screen:\n{}",
-        abc_count,
-        abc_count_after,
-        screen_after_undo
+    assert_eq!(
+        abc_count_after, 1,
+        "One undo should remove the whole macro replay, leaving exactly the recorded 'abc'. \
+         Before: {} 'abc', after: {}. Screen:\n{}",
+        abc_count, abc_count_after, screen_after_undo
     );
 }

--- a/crates/fresh-editor/tests/semantic/migrated_macros.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_macros.rs
@@ -39,29 +39,13 @@
 //! | `test_macro_move_line_end_uses_current_line_length`  | `migrated_macro_move_line_end_uses_current_line_length`                           |
 //! | `test_macro_playback_is_undoable`                    | `migrated_macro_playback_appends_replay`                                          |
 //!
-//! Note on `test_macro_playback_is_undoable`: the e2e test was
-//! NAMED for atomic undo and its inline comment said "If macro
-//! playback is properly grouped, one undo removes all macro
-//! actions" — i.e. the intended behaviour is that an entire
-//! macro replay collapses into a SINGLE undo unit. Its assertion
-//! was nonetheless weak (`abc_count_after < abc_count`, "at least
-//! some of the playback is undone"), which the per-char behaviour
-//! happens to satisfy.
-//!
-//! The current production behaviour (`play_macro` in
-//! `app/macro_actions.rs`) is per-char: the replay loop forwards
-//! each recorded action to `handle_action` with no undo-group /
-//! BulkEdit bracketing, so each replayed `InsertChar` lands as
-//! its own event-log entry and `EventLog::undo` (which stops at
-//! the first write action — see `model/event.rs`) reverts exactly
-//! one char per Undo. A 3-char replay therefore needs 3 Undos.
-//!
-//! This is the OPPOSITE of the intended atomic-undo semantics the
-//! original test name and comment describe — see
-//! FIXME(#2062) below. We pin the **observed** (defective)
-//! granularity so the regression is documented and so a future
-//! grouping FIX is loud (it will require updating sub-scenarios
-//! B/C below), not silent.
+//! Note on `test_macro_playback_is_undoable`: macro replay is a
+//! SINGLE undo unit (#2062). The `play_macro` loop in
+//! `app/macro_actions.rs` brackets the replay with
+//! `EventLog::begin_undo_group` / `end_undo_group`, so every
+//! replayed write action shares one undo-group id and
+//! `EventLog::undo` / `redo` (see `model/event.rs`) revert/reapply
+//! the whole replay atomically — one Undo, not one-per-char.
 
 use crate::common::scenario::buffer_scenario::{
     assert_buffer_scenario, BufferScenario, CursorExpect,
@@ -303,33 +287,17 @@ fn migrated_macro_move_line_end_uses_current_line_length() {
 // 5. Macro playback granularity (was: "is undoable")
 // ─────────────────────────────────────────────────────────────────────
 
-/// Original: `test_macro_playback_is_undoable`. Renamed away
-/// from `_is_undoable` because that name implies the *intended*
-/// atomic-undo semantics (one Undo reverts the whole replay),
-/// which production does NOT implement.
+/// Original: `test_macro_playback_is_undoable`.
 ///
-/// The e2e test asserted only that the post-undo `abc` count was
-/// *less than* the post-replay count — i.e. "at least some" of
-/// the replay was undone — but its name and inline comment ("If
-/// macro playback is properly grouped, one undo removes all macro
-/// actions") document the intended single-undo-unit behaviour.
-/// The actual production granularity is per-char: each replayed
-/// `InsertChar` lands as its own undo unit, so 3 Ctrl+Z's are
-/// needed to undo the replayed "abc".
+/// Macro replay is a single undo unit (#2062): one Undo reverts
+/// the whole replay, and one Redo re-applies it. The `play_macro`
+/// loop in `app/macro_actions.rs` brackets the replay with
+/// `EventLog::begin_undo_group` / `end_undo_group`, tagging every
+/// replayed write action with one undo-group id so `EventLog::undo`
+/// / `redo` treat them atomically.
 ///
-/// FIXME(#2062): macro replay should be a single undo unit. The
-/// `play_macro` loop in `app/macro_actions.rs` forwards each
-/// recorded action through `handle_action` with no undo-group /
-/// BulkEdit bracketing, so undo is per-char instead of atomic.
-/// Sub-scenarios B and C below pin the *current defective*
-/// per-char granularity; when the bug is fixed, B should leave
-/// "abc\n" (a single Undo reverting the whole replay) and C
-/// becomes redundant.
-///
-/// We pin both the playback-appends-replay claim and the
-/// per-char undo granularity in a single scenario so the
-/// regression is documented and a future grouping FIX is loud
-/// rather than silent.
+/// Sub-scenario A pins playback-appends-replay; B pins the
+/// single-Undo revert; C pins that Redo restores the whole replay.
 #[test]
 fn migrated_macro_playback_appends_replay() {
     // Sub-scenario A: post-playback the buffer is "abc\nabc".
@@ -350,12 +318,15 @@ fn migrated_macro_playback_appends_replay() {
         ..Default::default()
     });
 
-    // Sub-scenario B: one Undo removes one replayed char (per-char granularity).
-    // FIXME(#2062): macro replay should be a single undo unit — after the
-    // grouping fix this single Undo should revert the WHOLE replay, leaving
-    // "abc\n" (not "abc\nab").
+    // Sub-scenario B: macro replay is a single undo unit (#2062). One Undo
+    // reverts the WHOLE replayed "abc", leaving "abc\n" — not "abc\nab".
+    // The `play_macro` loop in `app/macro_actions.rs` brackets the replay with
+    // `EventLog::begin_undo_group` / `end_undo_group`, so every replayed write
+    // action shares one undo-group id and `EventLog::undo` reverts them all at
+    // once.
     assert_buffer_scenario(BufferScenario {
-        description: "First Undo after macro replay removes the last replayed char only".into(),
+        description: "One Undo after macro replay reverts the entire replay (single undo unit)"
+            .into(),
         initial_text: String::new(),
         actions: vec![
             Action::ToggleMacroRecording('0'),
@@ -365,35 +336,31 @@ fn migrated_macro_playback_appends_replay() {
             Action::ToggleMacroRecording('0'),
             Action::InsertNewline,
             Action::PlayLastMacro,
-            Action::Undo,
-        ],
-        expected_text: "abc\nab".into(),
-        expected_primary: CursorExpect::at("abc\nab".len()),
-        ..Default::default()
-    });
-
-    // Sub-scenario C: three Undos drain the rest of the replay,
-    // leaving only the recording + the newline.
-    // FIXME(#2062): this scenario only exists because replay is per-char;
-    // once macro replay is a single undo unit, one Undo (sub-scenario B)
-    // suffices and this becomes redundant.
-    assert_buffer_scenario(BufferScenario {
-        description: "Three Undos after macro replay leave the original recording + newline".into(),
-        initial_text: String::new(),
-        actions: vec![
-            Action::ToggleMacroRecording('0'),
-            Action::InsertChar('a'),
-            Action::InsertChar('b'),
-            Action::InsertChar('c'),
-            Action::ToggleMacroRecording('0'),
-            Action::InsertNewline,
-            Action::PlayLastMacro,
-            Action::Undo,
-            Action::Undo,
             Action::Undo,
         ],
         expected_text: "abc\n".into(),
         expected_primary: CursorExpect::at("abc\n".len()),
+        ..Default::default()
+    });
+
+    // Sub-scenario C: Redo after the atomic Undo re-applies the whole replay,
+    // restoring "abc\nabc" in one step.
+    assert_buffer_scenario(BufferScenario {
+        description: "Redo after the atomic Undo re-applies the entire macro replay".into(),
+        initial_text: String::new(),
+        actions: vec![
+            Action::ToggleMacroRecording('0'),
+            Action::InsertChar('a'),
+            Action::InsertChar('b'),
+            Action::InsertChar('c'),
+            Action::ToggleMacroRecording('0'),
+            Action::InsertNewline,
+            Action::PlayLastMacro,
+            Action::Undo,
+            Action::Redo,
+        ],
+        expected_text: "abc\nabc".into(),
+        expected_primary: CursorExpect::at("abc\nabc".len()),
         ..Default::default()
     });
 }

--- a/docs/internal/scenario-migration-findings.md
+++ b/docs/internal/scenario-migration-findings.md
@@ -211,32 +211,28 @@ non-obvious. Pinned in
 `migrated_multicursor_extras::migrated_add_cursor_next_match_with_*_selection`
 (case 3).
 
-## 13. Macro playback is per-action, not grouped as a single undo unit
+## 13. Macro playback is a single undo unit (FIXED, #2062)
 
 **Source:** `tests/e2e/macros.rs::test_macro_playback_is_undoable`.
 **Observation:** The e2e test was NAMED `test_macro_playback_is_undoable`
 and its inline comment said "If macro playback is properly
 grouped, one undo removes all macro actions" — i.e. the intended
 behaviour is that a whole macro replay collapses into a SINGLE
-undo unit. Its assertion was nonetheless weak
-(`abc_count_after < abc_count`, "at least some of the playback is
-undone"), which the per-char behaviour happens to satisfy. The
-current production behaviour in
-`crates/fresh-editor/src/app/macro_actions.rs::play_macro` is
-that each replayed action is forwarded to `handle_action` in a
-plain loop with no `BulkEdit` / undo-group wrapper, so each
-replayed `InsertChar` lands as its own event-log entry.
-`EventLog::undo` (`model/event.rs`) stops at the first write
-action, so one Undo reverts exactly one char. A 3-char macro
-replay therefore takes 3 Undos to fully revert.
-**Assessment:** This is a BUG — the actual per-char granularity
-is the OPPOSITE of the atomic-undo semantics the original test
-name and comment describe. Tracked as FIXME(#2062): macro replay
-should be wrapped as a single undo unit. The current defective
-behaviour is pinned (documented, not endorsed) in
+undo unit. Originally `play_macro` forwarded each replayed action
+to `handle_action` in a plain loop with no undo-group wrapper, so
+each replayed `InsertChar` landed as its own event-log entry and
+`EventLog::undo` (which stops at the first write action) reverted
+exactly one char per Undo — a 3-char replay took 3 Undos.
+**Resolution (#2062):** `EventLog` now supports undo groups
+(`begin_undo_group` / `end_undo_group`); appended entries are
+tagged with a group id and `EventLog::undo` / `redo` revert/reapply
+a whole group at once. `play_macro` brackets its replay loop with
+these calls, so a macro replay is reverted (and reapplied) in a
+single Undo/Redo. Pinned by
 `migrated_macros::migrated_macro_playback_appends_replay`
-sub-scenarios B and C so the eventual fix is loud rather than
-silent.
+(sub-scenario B = one Undo reverts the whole replay, C = one Redo
+restores it) and the `EventLog` unit tests
+`test_undo_group_*` in `model/event.rs`.
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #2062. Playing back a recorded macro produced **one undo unit per replayed write action** instead of a single atomic undo. After replaying N inserted characters, the user had to press Undo N times to revert the playback; one Undo should revert the whole replay.

### Root cause

`play_macro` (`crates/fresh-editor/src/app/macro_actions.rs`) forwarded each recorded action to `handle_action` in a plain loop with no undo-group bracketing, so every replayed `InsertChar` landed as its own event-log entry. `EventLog::undo` (`model/event.rs`) stops at the first write action, so one Undo reverted exactly one char.

### Fix

- Add an undo-group mechanism to `EventLog`: `begin_undo_group` / `end_undo_group` tag appended entries with a shared group id, and `undo` / `redo` revert/reapply a whole group as one unit. The group id is runtime-only (not persisted), nestable, and ungrouped edits behave exactly as before.
- `play_macro` brackets its replay loop with these calls. The group is opened and closed on the buffer that owned the active log at replay start, so a mid-replay buffer switch can't leave a group dangling. All per-action marker / highlighter / LSP updates still run unchanged — only undo/redo traversal is grouped.

## Tests

- **Unit** (`model/event.rs`): `test_undo_group_reverts_and_reapplies_atomically`, `test_ungrouped_edit_after_group_undoes_separately`, `test_consecutive_groups_undo_independently`.
- **Semantic** (`migrated_macros::migrated_macro_playback_appends_replay`): sub-scenario B now asserts one Undo reverts the whole replay (`abc\n`, was `abc\nab`); sub-scenario C asserts one Redo restores it (`abc\nabc`). These fail on the old per-char code.
- **E2E** (`e2e/macros.rs::test_macro_playback_is_undoable`): strengthened from the weak `abc_count_after < abc_count` to asserting exactly one `abc` remains after a single Undo.
- Updated finding #13 in `docs/internal/scenario-migration-findings.md` to mark it resolved.
- Regression: EventLog unit tests, undo/redo marker roundtrip, shadow-model and property suites all pass.

## Manual validation

Drove the real `fresh` binary in tmux: recorded `abc` on register 0, newline, F4 to replay (two `abc`), then a single Ctrl+Z removed the entire replayed `abc` in one step, and a single Ctrl+Y restored it.

## Test plan

- [x] `cargo test -p fresh-editor --lib event::`
- [x] `cargo test -p fresh-editor --test semantic_tests migrated_macro`
- [x] `cargo test -p fresh-editor --test e2e_tests macros::`
- [x] `cargo test -p fresh-editor --test undo_redo_marker_roundtrip_tests`
- [x] `cargo clippy -p fresh-editor --lib`
- [x] Manual tmux record → play → single Undo → single Redo

https://claude.ai/code/session_01JbQFMufuTUXAdnz4C7DF35

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbQFMufuTUXAdnz4C7DF35)_