### PR TITLE
Stop search highlights from growing over adjacent typing (#2053)

### DIFF
--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -196,7 +196,7 @@ impl Editor {
                 .zip(match_lengths.iter())
             {
                 let search_style = ratatui::style::Style::default().fg(search_fg).bg(search_bg);
-                let overlay = crate::view::overlay::Overlay::with_namespace(
+                let overlay = crate::view::overlay::Overlay::with_namespace_fixed_end(
                     &mut state.marker_list,
                     pos..(pos + len),
                     crate::view::overlay::OverlayFace::Style {
@@ -310,7 +310,7 @@ impl Editor {
 
         for (pos, len) in &viewport_matches {
             let search_style = ratatui::style::Style::default().fg(search_fg).bg(search_bg);
-            let overlay = crate::view::overlay::Overlay::with_namespace(
+            let overlay = crate::view::overlay::Overlay::with_namespace_fixed_end(
                 &mut state.marker_list,
                 *pos..(*pos + *len),
                 crate::view::overlay::OverlayFace::Style {

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2640,7 +2640,7 @@ impl Window {
             let absolute_pos = visible_start + mat.start();
             let match_len = mat.end() - mat.start();
             let search_style = ratatui::style::Style::default().fg(search_fg).bg(search_bg);
-            let overlay = crate::view::overlay::Overlay::with_namespace(
+            let overlay = crate::view::overlay::Overlay::with_namespace_fixed_end(
                 &mut state.marker_list,
                 absolute_pos..(absolute_pos + match_len),
                 crate::view::overlay::OverlayFace::Style {

--- a/crates/fresh-editor/src/model/marker.rs
+++ b/crates/fresh-editor/src/model/marker.rs
@@ -93,6 +93,20 @@ impl MarkerList {
         id
     }
 
+    /// Create a new left-gravity point marker at the given position.
+    ///
+    /// Unlike [`create`], text inserted exactly at the marker's position leaves
+    /// it in place instead of pushing it forward. Used as the end marker of a
+    /// fixed-width highlight (e.g. a search match) so the highlight does not
+    /// grow when text is typed immediately after it.
+    pub fn create_left_gravity(&mut self, position: usize) -> MarkerId {
+        let pos = position as u64;
+        let tree_id = self.tree.insert_left_gravity(pos, pos);
+        let id = MarkerId(tree_id);
+        self._affinity_map.insert(id, true);
+        id
+    }
+
     /// Delete a marker
     pub fn delete(&mut self, id: MarkerId) {
         self.tree.delete(id.0);
@@ -678,11 +692,18 @@ mod tests {
                 unique_positions.sort_unstable();
                 unique_positions.dedup();
 
-                // Shadow: Vec<(MarkerId, Option<usize>)>. None means deleted.
-                let mut shadow: Vec<(MarkerId, Option<usize>)> = Vec::new();
+                // Shadow: Vec<(MarkerId, Option<usize>, right_gravity)>.
+                // None means deleted. Half the markers are created left-gravity
+                // (issue #2053) so the model also covers the sticky-end path.
+                let mut shadow: Vec<(MarkerId, Option<usize>, bool)> = Vec::new();
                 for (i, &p) in unique_positions.iter().enumerate() {
-                    let id = list.create(p, i % 2 == 0);
-                    shadow.push((id, Some(p)));
+                    let right_gravity = i % 2 == 0;
+                    let id = if right_gravity {
+                        list.create(p, i % 2 == 0)
+                    } else {
+                        list.create_left_gravity(p)
+                    };
+                    shadow.push((id, Some(p), right_gravity));
                 }
 
                 // Delete some markers (by shadow index modulo len).
@@ -691,7 +712,7 @@ mod tests {
                         break;
                     }
                     let i = idx % shadow.len();
-                    if let (id, Some(_)) = shadow[i] {
+                    if let (id, Some(_), _) = shadow[i] {
                         list.delete(id);
                         shadow[i].1 = None;
                     }
@@ -702,9 +723,18 @@ mod tests {
                     match op {
                         EditOp::Insert { position, length } => {
                             list.adjust_for_insert(position, length);
-                            for (_id, pos) in shadow.iter_mut() {
+                            for (_id, pos, right_gravity) in shadow.iter_mut() {
                                 if let Some(p) = pos {
-                                    if *p >= position {
+                                    // Right-gravity markers shift when the
+                                    // insertion is at or before them; left-gravity
+                                    // markers only shift for insertions strictly
+                                    // before, staying put at the exact boundary.
+                                    let shifts = if *right_gravity {
+                                        *p >= position
+                                    } else {
+                                        *p > position
+                                    };
+                                    if shifts {
                                         *p += length;
                                     }
                                 }
@@ -715,13 +745,14 @@ mod tests {
                                 continue;
                             }
                             list.adjust_for_delete(position, length);
-                            for (_id, pos) in shadow.iter_mut() {
+                            for (_id, pos, _right_gravity) in shadow.iter_mut() {
                                 if let Some(p) = pos {
                                     // Markers inside the deleted range
                                     // clamp to the deletion start in
                                     // MarkerList's semantics (see
                                     // adjust_recursive's `.max(pos)`),
                                     // so mirror that in the shadow.
+                                    // Gravity does not affect deletions.
                                     if *p >= position + length {
                                         *p -= length;
                                     } else if *p > position {
@@ -734,7 +765,7 @@ mod tests {
 
                     // Every live marker's tree position must match its
                     // shadow position after every operation.
-                    for (id, shadow_pos) in &shadow {
+                    for (id, shadow_pos, _right_gravity) in &shadow {
                         match shadow_pos {
                             Some(expected) => {
                                 let actual = list.get_position(*id);

--- a/crates/fresh-editor/src/model/marker_tree.rs
+++ b/crates/fresh-editor/src/model/marker_tree.rs
@@ -45,6 +45,17 @@ pub struct Marker {
     pub id: MarkerId,
     pub interval: Interval,
     pub marker_type: MarkerType,
+    /// Insertion gravity at the marker's exact position.
+    /// - `true` (right gravity, default): text inserted exactly at the marker
+    ///   position pushes the marker forward (the marker moves after the text).
+    /// - `false` (left gravity): text inserted exactly at the marker position
+    ///   leaves it in place (the marker stays before the text).
+    ///
+    /// Only matters for insertions landing on the marker's own position;
+    /// insertions strictly before always shift it, insertions strictly after
+    /// never do. Used to keep search-match highlights from growing when text
+    /// is typed immediately after a match (issue #2053).
+    pub right_gravity: bool,
 }
 
 /// A Strong pointer to a tree node (child/sibling/map reference)
@@ -166,9 +177,23 @@ impl IntervalTree {
         self.insert_with_type(start, end, MarkerType::Position)
     }
 
+    /// Inserts a new left-gravity marker interval: text inserted exactly at the
+    /// marker's position leaves it in place rather than pushing it forward.
+    /// Performance: O(log n)
+    pub fn insert_left_gravity(&mut self, start: u64, end: u64) -> MarkerId {
+        self.insert_full(start, end, MarkerType::Position, false)
+    }
+
     /// Insert a marker with a specific ID and type (for set_position).
     /// The caller must ensure the ID is not already in use.
-    fn insert_with_id(&mut self, id: MarkerId, start: u64, end: u64, marker_type: MarkerType) {
+    fn insert_with_id(
+        &mut self,
+        id: MarkerId,
+        start: u64,
+        end: u64,
+        marker_type: MarkerType,
+        right_gravity: bool,
+    ) {
         debug_assert!(
             id < self.next_id,
             "insert_with_id: id {} must be < next_id {}",
@@ -184,6 +209,7 @@ impl IntervalTree {
             id,
             interval: Interval { start, end },
             marker_type,
+            right_gravity,
         };
 
         let new_node = Node::new(marker.clone(), Weak::new());
@@ -191,14 +217,26 @@ impl IntervalTree {
         self.marker_map.insert(id, new_node);
     }
 
-    /// Insert a marker with a specific type
+    /// Insert a marker with a specific type (right gravity).
     pub fn insert_with_type(&mut self, start: u64, end: u64, marker_type: MarkerType) -> MarkerId {
+        self.insert_full(start, end, marker_type, true)
+    }
+
+    /// Insert a marker with a specific type and gravity.
+    fn insert_full(
+        &mut self,
+        start: u64,
+        end: u64,
+        marker_type: MarkerType,
+        right_gravity: bool,
+    ) -> MarkerId {
         let id = self.next_id;
         self.next_id += 1;
         let marker = Marker {
             id,
             interval: Interval { start, end },
             marker_type,
+            right_gravity,
         };
 
         let new_node = Node::new(marker.clone(), Weak::new());
@@ -272,9 +310,9 @@ impl IntervalTree {
     /// Returns false if the marker doesn't exist.
     /// Performance: O(log n)
     pub fn set_position(&mut self, id: MarkerId, new_start: u64, new_end: u64) -> bool {
-        // Get the marker's type before deleting
-        let marker_type = match self.get_marker(id) {
-            Some(m) => m.marker_type,
+        // Get the marker's type and gravity before deleting
+        let (marker_type, right_gravity) = match self.get_marker(id) {
+            Some(m) => (m.marker_type, m.right_gravity),
             None => return false,
         };
 
@@ -284,7 +322,7 @@ impl IntervalTree {
         }
 
         // Reinsert with same ID
-        self.insert_with_id(id, new_start, new_end, marker_type);
+        self.insert_with_id(id, new_start, new_end, marker_type, right_gravity);
         true
     }
 
@@ -501,29 +539,41 @@ impl IntervalTree {
 
         let mut node = node_rc.borrow_mut();
         let start = node.marker.interval.start;
+        // Left-gravity markers stay put when text is inserted exactly at their
+        // position (the insertion goes after them); right-gravity markers (the
+        // default) are pushed forward. Gravity only changes behaviour for
+        // insertions (delta > 0) landing exactly on the boundary.
+        let left_gravity = !node.marker.right_gravity;
 
         if pos <= start {
             // CASE 1: Edit is at or before this node's start.
             // This node and everything to its right must be shifted.
 
+            // Whether this node's own start should shift. A left-gravity marker
+            // does NOT move when the insertion lands exactly on it.
+            let stay_put = left_gravity && delta > 0 && pos == start;
+
             // 1. Shift the current node's start position directly, clamping at `pos` if needed.
-            if delta < 0 {
-                node.marker.interval.start = (start as i64 + delta).max(pos as i64) as u64;
-            } else {
-                node.marker.interval.start = (start as i64 + delta) as u64;
+            if !stay_put {
+                if delta < 0 {
+                    node.marker.interval.start = (start as i64 + delta).max(pos as i64) as u64;
+                } else {
+                    node.marker.interval.start = (start as i64 + delta) as u64;
+                }
             }
 
             // 2. Handle the right subtree.
-            // For insertions (delta > 0): can use lazy propagation since all nodes shift uniformly
-            // For deletions (delta < 0): must recurse to provide position-aware clamping
-            if delta < 0 {
-                // Deletion: recurse immediately so nodes can clamp to `pos`
+            // For insertions strictly before this node's start, every node to
+            // the right has start > pos and shifts uniformly, so lazy
+            // propagation is safe and efficient. When the insertion lands
+            // exactly on this node's start (pos == start), the right subtree may
+            // contain other markers also sitting at `pos` whose gravity must be
+            // respected individually, so recurse instead of shifting them all.
+            // Deletions always recurse so nodes can clamp to `pos`.
+            if delta < 0 || pos == start {
                 Self::adjust_recursive(&mut node.right, pos, delta);
-            } else {
-                // Insertion: lazy propagation is safe and efficient
-                if let Some(ref right) = node.right {
-                    right.borrow_mut().lazy_delta += delta;
-                }
+            } else if let Some(ref right) = node.right {
+                right.borrow_mut().lazy_delta += delta;
             }
 
             // 3. Recurse left, as it may contain markers spanning the edit pos.
@@ -536,11 +586,18 @@ impl IntervalTree {
             Self::adjust_recursive(&mut node.right, pos, delta);
         }
 
-        // Always handle the interval span case (where end >= pos)
-        if node.marker.interval.end >= pos {
-            node.marker.interval.end = (node.marker.interval.end as i64 + delta)
-                .max(node.marker.interval.start as i64)
-                as u64;
+        // Handle the interval span case (where the edit falls inside [start, end]).
+        // A left-gravity marker's end stays put for an insertion landing exactly
+        // on it, matching its start behaviour above.
+        let end = node.marker.interval.end;
+        let shift_end = if left_gravity && delta > 0 {
+            end > pos
+        } else {
+            end >= pos
+        };
+        if shift_end {
+            node.marker.interval.end =
+                (end as i64 + delta).max(node.marker.interval.start as i64) as u64;
         }
 
         drop(node);
@@ -664,6 +721,92 @@ mod tests {
     fn get_pos(tree: &IntervalTree, id: MarkerId) -> (u64, u64) {
         tree.get_position(id)
             .unwrap_or_else(|| panic!("Marker ID {} not found.", id))
+    }
+
+    // --- Insertion gravity (issue #2053) ---
+
+    #[test]
+    fn test_left_gravity_marker_stays_on_insert_at_position() {
+        // A left-gravity point marker models the end of a fixed-width
+        // highlight (e.g. a search match). Inserting text exactly at its
+        // position must NOT move it, so the highlight does not grow.
+        let mut tree = IntervalTree::new();
+        let m = tree.insert_left_gravity(3, 3);
+
+        // Insert 4 bytes immediately at the marker.
+        tree.adjust_for_edit(3, 4);
+
+        assert_eq!(
+            get_pos(&tree, m),
+            (3, 3),
+            "left-gravity marker must stay put when text is inserted at its position"
+        );
+    }
+
+    #[test]
+    fn test_right_gravity_marker_moves_on_insert_at_position() {
+        // The default (right gravity) point marker moves forward when text is
+        // inserted exactly at its position.
+        let mut tree = IntervalTree::new();
+        let m = tree.insert(3, 3);
+
+        tree.adjust_for_edit(3, 4);
+
+        assert_eq!(get_pos(&tree, m), (7, 7));
+    }
+
+    #[test]
+    fn test_left_gravity_marker_still_shifts_on_insert_before() {
+        // Left gravity only changes the exact-boundary case; insertions
+        // strictly before the marker still shift it.
+        let mut tree = IntervalTree::new();
+        let m = tree.insert_left_gravity(5, 5);
+
+        tree.adjust_for_edit(2, 3);
+
+        assert_eq!(get_pos(&tree, m), (8, 8));
+    }
+
+    #[test]
+    fn test_search_match_does_not_grow_on_adjacent_insert() {
+        // Reproduces #2053 at the marker level: a match highlight spanning
+        // [0, 3) is modelled by a right-gravity start marker at 0 and a
+        // left-gravity end marker at 3. Typing immediately after the match
+        // (at position 3) must leave both markers anchored to the match.
+        let mut tree = IntervalTree::new();
+        let start = tree.insert(0, 0);
+        let end = tree.insert_left_gravity(3, 3);
+
+        // User types "X" right after the match.
+        tree.adjust_for_edit(3, 1);
+
+        assert_eq!(get_pos(&tree, start), (0, 0));
+        assert_eq!(
+            get_pos(&tree, end),
+            (3, 3),
+            "highlight end must not extend over text typed after the match"
+        );
+    }
+
+    #[test]
+    fn test_adjacent_matches_keep_independent_gravity_at_shared_boundary() {
+        // Two adjacent matches (e.g. searching "ab" in "abab") share a
+        // boundary at position 2: the first match's left-gravity end and the
+        // second match's right-gravity start both sit at 2. Inserting there
+        // must keep the first match fixed while the second match shifts.
+        let mut tree = IntervalTree::new();
+        let m1_start = tree.insert(0, 0);
+        let m1_end = tree.insert_left_gravity(2, 2);
+        let m2_start = tree.insert(2, 2);
+        let m2_end = tree.insert_left_gravity(4, 4);
+
+        // Insert 3 bytes exactly at the shared boundary.
+        tree.adjust_for_edit(2, 3);
+
+        assert_eq!(get_pos(&tree, m1_start), (0, 0));
+        assert_eq!(get_pos(&tree, m1_end), (2, 2), "first match must not grow");
+        assert_eq!(get_pos(&tree, m2_start), (5, 5), "second match shifts");
+        assert_eq!(get_pos(&tree, m2_end), (7, 7));
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -206,6 +206,36 @@ impl Overlay {
         overlay
     }
 
+    /// Like [`with_namespace`], but the end marker uses left gravity so the
+    /// overlay does not grow when text is inserted immediately after it.
+    ///
+    /// Used for search-match highlights, which must stay anchored to the matched
+    /// text and not absorb adjacent typing (issue #2053).
+    ///
+    /// [`with_namespace`]: Overlay::with_namespace
+    pub fn with_namespace_fixed_end(
+        marker_list: &mut MarkerList,
+        range: Range<usize>,
+        face: OverlayFace,
+        namespace: OverlayNamespace,
+    ) -> Self {
+        let start_marker = marker_list.create(range.start, true); // left affinity
+        let end_marker = marker_list.create_left_gravity(range.end);
+
+        Self {
+            handle: OverlayHandle::new(),
+            namespace: Some(namespace),
+            start_marker,
+            end_marker,
+            face,
+            priority: 0,
+            message: None,
+            extend_to_line_end: false,
+            url: None,
+            theme_key: None,
+        }
+    }
+
     /// Create an overlay with a specific priority
     pub fn with_priority(
         marker_list: &mut MarkerList,

--- a/crates/fresh-editor/tests/e2e/search.rs
+++ b/crates/fresh-editor/tests/e2e/search.rs
@@ -299,6 +299,65 @@ fn test_incremental_search_highlighting() {
     assert!(screen.contains("test line three"));
 }
 
+/// Regression test for issue #2053: a committed search highlight must not
+/// extend over text that is typed immediately after a match.
+#[test]
+fn test_search_highlight_does_not_extend_on_adjacent_insert() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "abc def ghi\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Search for "def" and commit, leaving a persistent highlight on the match.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("def").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Locate the highlighted match on screen. The cursor lands on the match
+    // start, so the highlighted background of the last match character is our
+    // reference color.
+    let (col, row) = harness
+        .find_text_on_screen("def")
+        .expect("match text should be visible");
+    let match_bg = harness
+        .get_cell_style(col + 2, row)
+        .and_then(|s| s.bg)
+        .expect("matched char should have a highlight background");
+
+    // Move just past the match and type a character.
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.type_text("X").unwrap();
+    harness.render().unwrap();
+
+    // The typed character must sit immediately after the match...
+    assert_eq!(
+        harness.get_cell(col + 3, row).as_deref(),
+        Some("X"),
+        "typed character should render right after the match"
+    );
+    // ...and must NOT inherit the search-match highlight.
+    let typed_bg = harness.get_cell_style(col + 3, row).and_then(|s| s.bg);
+    assert_ne!(
+        typed_bg,
+        Some(match_bg),
+        "search highlight must not extend over text typed after the match"
+    );
+}
+
 /// Test that search highlighting only applies to visible viewport
 #[test]
 fn test_search_highlighting_visible_only() {


### PR DESCRIPTION
## Summary

Fixes #2053: typing immediately after a search match caused the match highlight to extend over the freshly typed text.

A committed search highlight is anchored by a start/end marker pair in the interval tree. Both markers were effectively *right-gravity*, so text inserted exactly at the match's end position pushed the end marker forward and the highlight swallowed the new characters.

### Fix
- Add per-marker **insertion gravity** to the interval tree (`Marker.right_gravity`), defaulting to the existing right-gravity behaviour so nothing else changes. A left-gravity marker stays put when text is inserted exactly at its position.
- The lazy-propagation path now recurses when an insertion lands exactly on a node's start, so markers sharing a boundary (e.g. adjacent matches) each apply their own gravity.
- Search-match overlays now use a new `Overlay::with_namespace_fixed_end` constructor whose **end marker is left-gravity**, so a match stays anchored to its matched text. The three search-overlay creation sites (committed search, viewport refresh, incremental highlight) all use it.

Insertions *before* a match still shift it, and the start boundary already behaved correctly — only the end boundary needed to stop growing.

## Testing
- New unit tests in `marker_tree.rs` covering left/right gravity, the #2053 scenario, and the shared-boundary case for adjacent matches.
- New e2e regression test `test_search_highlight_does_not_extend_on_adjacent_insert` (search "def", type a char right after it, assert the typed cell does not inherit the highlight background). Verified it **fails on the pre-fix code** and passes with the fix.
- Manually validated in a tmux session: highlight stays on the match, typed text is not highlighted.
- Existing marker, overlay, undo/redo-marker-roundtrip, and the full 45-test search e2e suite pass.

## Test plan
- [x] `cargo test -p fresh-editor --lib -- overlay model:: diagnostic`
- [x] `cargo test -p fresh-editor --test e2e_tests search::`
- [x] `cargo test -p fresh-editor --test undo_redo_marker_roundtrip_tests`
- [x] `cargo fmt` / `cargo clippy` clean on changed files
- [x] Manual tmux validation

https://claude.ai/code/session_01B9yHNfNTmZHiRMHoGpUVWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9yHNfNTmZHiRMHoGpUVWJ)_