### PR TITLE
Align submenu first item with its parent menu item (#2118)

### DIFF
--- a/crates/fresh-editor/src/view/ui/menu.rs
+++ b/crates/fresh-editor/src/view/ui/menu.rs
@@ -708,7 +708,11 @@ impl MenuRenderer {
                     current_x = dropdown_rect
                         .x
                         .saturating_add(dropdown_rect.width.saturating_sub(1));
-                    current_y = dropdown_rect.y.saturating_add(submenu_idx as u16 + 1); // +1 for border
+                    // Align the submenu's first item with the parent item it was
+                    // opened from. Items render at `dropdown_rect.y + 1 + idx`
+                    // (the `+ 1` skips the top border), so the submenu's top
+                    // border sits one row above the parent item's row.
+                    current_y = dropdown_rect.y.saturating_add(submenu_idx as u16);
 
                     // Adjust if submenu would go off screen to the right - flip to left side
                     let next_width = Self::calculate_dropdown_width(items);

--- a/crates/fresh-editor/tests/e2e/menu_bar.rs
+++ b/crates/fresh-editor/tests/e2e/menu_bar.rs
@@ -575,6 +575,43 @@ fn test_copy_with_formatting_submenu_activates_on_enter() {
     );
 }
 
+/// Regression test for #2118: when a submenu opens, its first item should be
+/// inline with the selected parent item (on the same screen row), not one row
+/// below it (which is where it lands if the submenu's top border is aligned
+/// with the parent item instead of the item itself).
+#[test]
+fn test_submenu_first_item_aligns_with_parent_item() {
+    let mut harness = EditorTestHarness::new(120, 40).unwrap();
+    harness.render().unwrap();
+
+    // Open the View menu, which contains the static "Terminal" submenu.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Locate the "Terminal" submenu parent item before opening it. At this
+    // point "Open Terminal" is not yet on screen, so this matches the parent.
+    let (term_col, parent_row) = harness
+        .find_text_on_screen("Terminal")
+        .expect("View menu should contain the Terminal submenu item");
+
+    // Hover over the parent item to open its submenu.
+    harness.mouse_move(term_col, parent_row).unwrap();
+
+    // The submenu's first item ("Open Terminal") must render on the same row
+    // as the parent item it was opened from.
+    let (_, first_item_row) = harness
+        .find_text_on_screen("Open Terminal")
+        .expect("Terminal submenu should show its first item 'Open Terminal'");
+
+    assert_eq!(
+        first_item_row, parent_row,
+        "Submenu's first item should be inline with the parent item row {}, but was on row {}",
+        parent_row, first_item_row
+    );
+}
+
 /// Test that Cut and Copy menu items are disabled when there's no selection
 #[test]
 fn test_cut_copy_disabled_without_selection() {


### PR DESCRIPTION
## Summary

Fixes #2118. When a submenu opened, its top border was aligned with the selected parent item, which pushed the submenu's first item one row *below* the parent item. This QOL fix shifts the submenu up by one row so its first item is inline with the parent item it was opened from (matching the behavior described in the issue, and how nested menus behave elsewhere).

## Root cause

In `render_dropdown_chain` (`crates/fresh-editor/src/view/ui/menu.rs`), menu items render at `dropdown.y + 1 + idx` (the `+ 1` skips the top border). The submenu's origin was computed as `dropdown_rect.y + submenu_idx + 1`, so the submenu's first item landed at `dropdown_rect.y + submenu_idx + 2` — one row below the parent item at `dropdown_rect.y + 1 + submenu_idx`. Dropping the extra `+ 1` places the submenu's top border one row above the parent item, so its first item sits exactly on the parent item's row. Hit-testing for submenu items derives from the same origin, so it stays consistent.

## Testing

- Added an e2e regression test `test_submenu_first_item_aligns_with_parent_item` that opens the View → Terminal submenu and asserts the first submenu item (`Open Terminal`) renders on the same row as the parent (`Terminal`). It fails before the fix (parent row 28, submenu item row 29) and passes after.
- All 113 menu e2e tests and 43 menu unit tests pass.
- `cargo fmt --check` clean; touched code passes clippy.

### Manual validation (tmux)

Opened the View menu and hovered the Terminal submenu — the first item is now inline with the parent:

```
│ ─────────────────────────────────────┌──────────────────────────────────────┐
│ Terminal                          >  │ Open Terminal                        │
│ ─────────────────────────────────────│ Close Terminal                       │
```

## Test plan

- [x] Regression test fails without the fix, passes with it
- [x] Existing menu unit + e2e suites pass
- [x] Manual tmux validation of submenu alignment

https://claude.ai/code/session_01LZHbvm9NK1dKCkQi7FqaTV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LZHbvm9NK1dKCkQi7FqaTV)_