### PR TITLE
Fix Review Diff hunk discard for unterminated final lines (#2117)

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -537,7 +537,12 @@ function parseDiffOutput(stdout: string, gitStatus: 'staged' | 'unstaged' | 'unt
                 };
                 hunks.push(currentHunk);
             }
-        } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' '))) {
+        } else if (currentHunk && (line.startsWith('+') || line.startsWith('-') || line.startsWith(' ') || line.startsWith('\\'))) {
+            // Keep the "\ No newline at end of file" marker (starts with
+            // a backslash) so buildHunkPatch can reproduce the exact
+            // end-of-file newline state; without it git refuses to apply
+            // the reconstructed patch (e.g. discarding a hunk that adds an
+            // unterminated final line).
             if (!line.startsWith('---') && !line.startsWith('+++')) {
                  currentHunk.lines.push(line);
             }
@@ -921,6 +926,21 @@ function buildDiffLines(_rightWidth: number): DiffLine[] {
         // Diff content lines with word-level highlighting for adjacent -/+ pairs
         for (let li = 0; li < hunk.lines.length; li++) {
             const line = hunk.lines[li];
+            if (line[0] === '\\') {
+                // "\ No newline at end of file": informational marker, not a
+                // real line. Render it dim with no line numbers and don't
+                // advance the line counters. It still occupies exactly one
+                // row so hunk.lines stays 1:1 with displayed rows (which
+                // selectionLineRange relies on).
+                lines.push({
+                    text: line, type: 'context',
+                    hunkId: hunk.id, file: hunk.file,
+                    lineType: 'context', oldLine: undefined, newLine: undefined,
+                    lineContent: line,
+                    style: { fg: STYLE_LINE_NUM_FG },
+                });
+                continue;
+            }
             const nextLine = hunk.lines[li + 1];
             const prefix = line[0];
             const lineType: 'add' | 'remove' | 'context' =
@@ -2209,20 +2229,32 @@ function buildHunkPatch(filePath: string, hunk: Hunk, lineRange?: { start: numbe
     const filtered: string[] = [];
     let oldCount = 0;
     let newCount = 0;
+    // Whether the preceding diff line produced output. A trailing
+    // "\ No newline at end of file" marker annotates the line just above
+    // it, so it is only meaningful when that line was kept.
+    let lastEmitted = false;
 
     for (let i = 0; i < hunk.lines.length; i++) {
         const line = hunk.lines[i];
         const ch = line[0];
+        if (ch === '\\') {
+            // "\ No newline at end of file": travels with its annotated
+            // line and never counts toward the @@ line totals.
+            if (lastEmitted) filtered.push(line);
+            continue;
+        }
         const inRange = !lineRange || (i >= lineRange.start && i <= lineRange.end);
         if (ch === '+') {
             if (inRange) {
                 filtered.push(line);
                 newCount++;
+                lastEmitted = true;
             } else {
                 // An out-of-range '+' line means: this addition isn't being
                 // applied, so it shouldn't appear in either side. Drop it
                 // entirely (don't convert to context — there's nothing to
                 // match in the source file).
+                lastEmitted = false;
             }
         } else if (ch === '-') {
             if (inRange) {
@@ -2235,10 +2267,12 @@ function buildHunkPatch(filePath: string, hunk: Hunk, lineRange?: { start: numbe
                 oldCount++;
                 newCount++;
             }
+            lastEmitted = true;
         } else {
             filtered.push(line);
             oldCount++;
             newCount++;
+            lastEmitted = true;
         }
     }
 

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -13,23 +13,27 @@ use tempfile::TempDir;
 /// system git config of whatever machine runs the suite (a developer's box, a
 /// Linux CI runner, a Windows CI runner). That config can enable signing
 /// programs, background `gc`/`maintenance`, `init.templateDir` hooks,
-/// `core.autocrlf`, `fsmonitor`, etc. — any of which can make a commit fail or
-/// silently change behavior in environment-specific ways. The
-/// `git_log_commit_list_scrolls_with_wheel` flake ("fatal: unable to read
-/// <hash>" during commit) and the Windows CRLF discard failure were both
-/// symptoms of this leakage.
+/// `fsmonitor`, etc. — any of which can make a commit fail in
+/// environment-specific ways. The `git_log_commit_list_scrolls_with_wheel`
+/// flake ("fatal: unable to read <hash>" during commit) was a symptom of this
+/// leakage.
 ///
 /// We therefore:
 ///   * ignore system config (`GIT_CONFIG_NOSYSTEM`) and point global config at
 ///     a nonexistent file (`GIT_CONFIG_GLOBAL`), which git treats as empty —
 ///     cross-platform, unlike `/dev/null`;
-///   * pin every setting the tests rely on via `-c` so it applies to *every*
-///     subcommand including `init` (identity, no signing, LF endings);
+///   * pin identity and disable signing via `-c` so it applies to *every*
+///     subcommand including `init`;
 ///   * disable automatic `gc`/`maintenance` so loose objects are never
 ///     repacked mid-operation;
 ///   * force durable loose-object writes (`core.fsync`) so an object written by
 ///     one commit is guaranteed readable by the next, even on CI filesystems
 ///     with weaker write-then-read coherency.
+///
+/// We deliberately do NOT pin `core.autocrlf` / `core.eol`: line-ending
+/// behavior is left at git's platform default so the editor under test is
+/// exercised the way a real user's git would behave. Tests that read files
+/// back must therefore be line-ending-agnostic rather than assuming LF.
 pub fn git_command(path: &Path) -> Command {
     let mut cmd = Command::new("git");
     cmd.current_dir(path)
@@ -42,8 +46,6 @@ pub fn git_command(path: &Path) -> Command {
         .args(["-c", "tag.gpgsign=false"])
         .args(["-c", "gc.auto=0"])
         .args(["-c", "maintenance.auto=false"])
-        .args(["-c", "core.autocrlf=false"])
-        .args(["-c", "core.eol=lf"])
         .args(["-c", "core.fsync=loose-object,index,reference"])
         .args(["-c", "core.fsyncMethod=fsync"]);
     cmd
@@ -63,11 +65,12 @@ impl GitTestRepo {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let path = temp_dir.path().to_path_buf();
 
-        // Initialize git repository. All git settings the tests rely on are
-        // pinned per-invocation by `git_command` (identity, no signing, LF
-        // endings, no auto gc/maintenance, durable writes), and the host's
-        // global/system config is ignored — so behavior is identical on every
-        // machine.
+        // Initialize git repository. The test's own git invocations are
+        // isolated by `git_command` so the host's signing program / background
+        // gc can't break commits, but we deliberately leave line-ending config
+        // (core.autocrlf / core.eol) at git's defaults — the editor under test
+        // must behave correctly for a normal user's git, whatever their
+        // platform default is, rather than relying on the test pinning LF.
         let output = git_command(&path)
             .arg("init")
             .output()

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -30,7 +30,7 @@ use tempfile::TempDir;
 ///   * force durable loose-object writes (`core.fsync`) so an object written by
 ///     one commit is guaranteed readable by the next, even on CI filesystems
 ///     with weaker write-then-read coherency.
-fn git_command(path: &Path) -> Command {
+pub fn git_command(path: &Path) -> Command {
     let mut cmd = Command::new("git");
     cmd.current_dir(path)
         .env("GIT_CONFIG_NOSYSTEM", "1")

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -2,9 +2,52 @@
 
 use super::harness::{copy_plugin, copy_plugin_lib};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
+
+/// Build a `git` command for a test repo that is fully isolated from the host
+/// machine's git configuration.
+///
+/// Why this matters: without isolation, every test repo inherits the global /
+/// system git config of whatever machine runs the suite (a developer's box, a
+/// Linux CI runner, a Windows CI runner). That config can enable signing
+/// programs, background `gc`/`maintenance`, `init.templateDir` hooks,
+/// `core.autocrlf`, `fsmonitor`, etc. — any of which can make a commit fail or
+/// silently change behavior in environment-specific ways. The
+/// `git_log_commit_list_scrolls_with_wheel` flake ("fatal: unable to read
+/// <hash>" during commit) and the Windows CRLF discard failure were both
+/// symptoms of this leakage.
+///
+/// We therefore:
+///   * ignore system config (`GIT_CONFIG_NOSYSTEM`) and point global config at
+///     a nonexistent file (`GIT_CONFIG_GLOBAL`), which git treats as empty —
+///     cross-platform, unlike `/dev/null`;
+///   * pin every setting the tests rely on via `-c` so it applies to *every*
+///     subcommand including `init` (identity, no signing, LF endings);
+///   * disable automatic `gc`/`maintenance` so loose objects are never
+///     repacked mid-operation;
+///   * force durable loose-object writes (`core.fsync`) so an object written by
+///     one commit is guaranteed readable by the next, even on CI filesystems
+///     with weaker write-then-read coherency.
+fn git_command(path: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(path)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", path.join("nonexistent-gitconfig"))
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .args(["-c", "user.name=Test User"])
+        .args(["-c", "user.email=test@example.com"])
+        .args(["-c", "commit.gpgsign=false"])
+        .args(["-c", "tag.gpgsign=false"])
+        .args(["-c", "gc.auto=0"])
+        .args(["-c", "maintenance.auto=false"])
+        .args(["-c", "core.autocrlf=false"])
+        .args(["-c", "core.eol=lf"])
+        .args(["-c", "core.fsync=loose-object,index,reference"])
+        .args(["-c", "core.fsyncMethod=fsync"]);
+    cmd
+}
 
 /// A hermetic git repository for testing
 pub struct GitTestRepo {
@@ -20,10 +63,13 @@ impl GitTestRepo {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         let path = temp_dir.path().to_path_buf();
 
-        // Initialize git repository
-        let output = Command::new("git")
+        // Initialize git repository. All git settings the tests rely on are
+        // pinned per-invocation by `git_command` (identity, no signing, LF
+        // endings, no auto gc/maintenance, durable writes), and the host's
+        // global/system config is ignored — so behavior is identical on every
+        // machine.
+        let output = git_command(&path)
             .arg("init")
-            .current_dir(&path)
             .output()
             .expect("Failed to initialize git repository");
 
@@ -33,52 +79,6 @@ impl GitTestRepo {
                 String::from_utf8_lossy(&output.stderr)
             );
         }
-
-        // Configure git user for commits
-        Command::new("git")
-            .args(["config", "user.name", "Test User"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to configure git user.name");
-
-        Command::new("git")
-            .args(["config", "user.email", "test@example.com"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to configure git user.email");
-
-        // Disable GPG signing for test commits
-        Command::new("git")
-            .args(["config", "commit.gpgsign", "false"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to disable GPG signing");
-
-        // Disable automatic GC/repacking to prevent "unable to read <hash>"
-        // failures when many test repos run in parallel: auto-gc can move loose
-        // objects into pack files mid-operation, making them temporarily
-        // unreadable by a concurrent git command in the same repo.
-        Command::new("git")
-            .args(["config", "gc.auto", "0"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to disable auto gc");
-
-        // Force LF line endings regardless of platform git configuration
-        // (e.g. core.autocrlf=true on Windows). Tests write files with \n and
-        // assert they come back with \n after a git checkout/restore; CRLF
-        // conversion would break those assertions on Windows.
-        Command::new("git")
-            .args(["config", "core.autocrlf", "false"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to set core.autocrlf");
-
-        Command::new("git")
-            .args(["config", "core.eol", "lf"])
-            .current_dir(&path)
-            .output()
-            .expect("Failed to set core.eol");
 
         GitTestRepo {
             _temp_dir: temp_dir,
@@ -102,9 +102,8 @@ impl GitTestRepo {
     /// Add files to git staging area
     pub fn git_add(&self, paths: &[&str]) {
         for path in paths {
-            let output = Command::new("git")
+            let output = git_command(&self.path)
                 .args(["add", path])
-                .current_dir(&self.path)
                 .output()
                 .expect("Failed to run git add");
 
@@ -119,9 +118,8 @@ impl GitTestRepo {
 
     /// Add all files to git
     pub fn git_add_all(&self) {
-        let output = Command::new("git")
+        let output = git_command(&self.path)
             .args(["add", "."])
-            .current_dir(&self.path)
             .output()
             .expect("Failed to run git add .");
 
@@ -135,9 +133,8 @@ impl GitTestRepo {
 
     /// Commit staged changes
     pub fn git_commit(&self, message: &str) {
-        let output = Command::new("git")
+        let output = git_command(&self.path)
             .args(["commit", "-m", message])
-            .current_dir(&self.path)
             .output()
             .expect("Failed to run git commit");
 

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -54,6 +54,32 @@ impl GitTestRepo {
             .output()
             .expect("Failed to disable GPG signing");
 
+        // Disable automatic GC/repacking to prevent "unable to read <hash>"
+        // failures when many test repos run in parallel: auto-gc can move loose
+        // objects into pack files mid-operation, making them temporarily
+        // unreadable by a concurrent git command in the same repo.
+        Command::new("git")
+            .args(["config", "gc.auto", "0"])
+            .current_dir(&path)
+            .output()
+            .expect("Failed to disable auto gc");
+
+        // Force LF line endings regardless of platform git configuration
+        // (e.g. core.autocrlf=true on Windows). Tests write files with \n and
+        // assert they come back with \n after a git checkout/restore; CRLF
+        // conversion would break those assertions on Windows.
+        Command::new("git")
+            .args(["config", "core.autocrlf", "false"])
+            .current_dir(&path)
+            .output()
+            .expect("Failed to set core.autocrlf");
+
+        Command::new("git")
+            .args(["config", "core.eol", "lf"])
+            .current_dir(&path)
+            .output()
+            .expect("Failed to set core.eol");
+
         GitTestRepo {
             _temp_dir: temp_dir,
             path,

--- a/crates/fresh-editor/tests/e2e/live_grep.rs
+++ b/crates/fresh-editor/tests/e2e/live_grep.rs
@@ -1,4 +1,5 @@
 use crate::common::fixtures::TestFixture;
+use crate::common::git_test_helper::git_command;
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crossterm::event::{KeyCode, KeyModifiers};
 use fresh::input::commands::Suggestion;
@@ -26,15 +27,7 @@ fn test_live_grep_git_grep_flow_finds_match_in_repo() {
     // Initialise a real git repo so `git rev-parse --is-inside-work-tree`
     // succeeds and `isAvailable` returns true for git-grep.
     let run_git = |args: &[&str]| {
-        let out = std::process::Command::new("git")
-            .args(args)
-            .current_dir(&project_root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@t")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@t")
-            .output()
-            .unwrap();
+        let out = git_command(&project_root).args(args).output().unwrap();
         assert!(
             out.status.success(),
             "git {:?} failed: {}",

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -1,6 +1,6 @@
 //! E2E tests for audit_mode (Review Diff) plugin
 
-use crate::common::git_test_helper::GitTestRepo;
+use crate::common::git_test_helper::{git_command, GitTestRepo};
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
@@ -1943,18 +1943,16 @@ fn test_review_diff_scrolling_many_files() {
         repo.create_file(&path, &format!("fn staged_func_{}() {{}}\n", i));
     }
     // Stage them
-    let output = std::process::Command::new("git")
+    let output = git_command(&repo.path)
         .args(["add", "src/"])
-        .current_dir(&repo.path)
         .output()
         .expect("git add failed");
     assert!(output.status.success(), "git add failed");
 
     // Create 5 unstaged modified files (modify existing tracked files or create new ones)
     // First commit the staged files
-    let output = std::process::Command::new("git")
+    let output = git_command(&repo.path)
         .args(["commit", "-m", "Add staged files"])
-        .current_dir(&repo.path)
         .output()
         .expect("git commit failed");
     assert!(output.status.success(), "git commit failed");
@@ -2250,9 +2248,8 @@ fn test_review_diff_renamed_file_message() {
     repo.git_commit("Initial commit");
 
     // Rename a file via git mv (staged rename)
-    let output = std::process::Command::new("git")
+    let output = git_command(&repo.path)
         .args(["mv", "src/utils.rs", "src/helpers.rs"])
-        .current_dir(&repo.path)
         .output()
         .expect("git mv failed");
     assert!(output.status.success(), "git mv failed");
@@ -4099,9 +4096,8 @@ fn test_review_diff_capital_s_stages_whole_file() {
 
 /// Run `git` with the given args in the given repo and panic on failure.
 fn run_git(repo: &GitTestRepo, args: &[&str]) {
-    let out = std::process::Command::new("git")
+    let out = git_command(&repo.path)
         .args(args)
-        .current_dir(&repo.path)
         .output()
         .unwrap_or_else(|e| panic!("git {:?} failed to spawn: {}", args, e));
     if !out.status.success() {

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1979,11 +1979,16 @@ fn test_issue2117_discard_hunk_with_no_trailing_newline() {
         screen
     );
 
-    // The discard must actually revert the working tree on disk.
+    // The discard must actually revert the working tree on disk: the
+    // unterminated added line is gone and the committed lines are restored.
+    // Compare line-ending-agnostically — whether git writes the restored file
+    // back as LF or CRLF depends on the user's core.autocrlf, which the test
+    // leaves at its platform default; that's git's choice, not the feature's.
     let after = fs::read_to_string(&notes).unwrap();
     assert_eq!(
-        after, original,
+        after.replace("\r\n", "\n"),
+        original,
         "Issue #2117: discarding the hunk should restore the committed \
-         content (removing the unterminated added line)."
+         content (removing the unterminated added line). Got: {after:?}"
     );
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_ux_bugs.rs
@@ -1906,3 +1906,84 @@ fn test_issue2036_range_refresh_explains_working_tree_excluded() {
         })
         .unwrap();
 }
+
+/// Issue #2117: discarding a hunk whose change adds an *unterminated* final
+/// line (no trailing newline) failed with "patch does not apply". The
+/// reconstructed patch dropped git's "\ No newline at end of file" marker, so
+/// `git apply --reverse` refused it even though the equivalent `git diff |
+/// git apply --reverse` succeeds. With the marker preserved the discard
+/// succeeds and the working tree is restored.
+#[test]
+fn test_issue2117_discard_hunk_with_no_trailing_newline() {
+    init_tracing_from_env();
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+
+    // Commit a file that ends with a newline.
+    let original = "alpha\nbeta\ngamma\n";
+    let notes = repo.create_file("notes.txt", original);
+    repo.git_add_all();
+    repo.git_commit("Initial commit");
+
+    // Working-tree change: append a final line WITHOUT a trailing newline,
+    // which git renders with a "\ No newline at end of file" marker.
+    fs::write(&notes, "alpha\nbeta\ngamma\nNO_NEWLINE_LINE").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&notes).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("NO_NEWLINE_LINE"))
+        .unwrap();
+
+    open_review_diff(&mut harness);
+
+    // Focus the diff panel and land the cursor on the hunk (not the file
+    // header) so `d` performs a *hunk*-level discard — the path that builds
+    // and reverse-applies a patch.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    for _ in 0..10 {
+        harness.tick_and_render().unwrap();
+    }
+
+    // `d` opens the confirmation prompt; Enter accepts the default
+    // ("Discard hunk").
+    harness
+        .send_key(KeyCode::Char('d'), KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    for _ in 0..20 {
+        harness.tick_and_render().unwrap();
+    }
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Patch failed") && !screen.contains("does not apply"),
+        "Issue #2117: discarding a hunk that adds an unterminated final line \
+         must not fail with a patch error. Screen:\n{}",
+        screen
+    );
+
+    // The discard must actually revert the working tree on disk.
+    let after = fs::read_to_string(&notes).unwrap();
+    assert_eq!(
+        after, original,
+        "Issue #2117: discarding the hunk should restore the committed \
+         content (removing the unterminated added line)."
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2117. In the **Review Diff** view, discarding a hunk whose change adds (or touches) a file's final line when that line has **no trailing newline** failed with:

```
Patch failed: error: patch failed: <file>:Nerror: <file>: patch does not apply
```

…even though the equivalent `git diff HEAD -- <file> | git apply --reverse` succeeds from the shell.

## Root cause

`audit_mode.ts` reconstructs a unified diff for the targeted hunk (`buildHunkPatch`) and reverse-applies it with `git apply --reverse`. The parser (`parseDiffOutput`) only kept lines beginning with `+`, `-`, or space, so it **silently dropped git's `\ No newline at end of file` marker**. The rebuilt patch therefore asserted a trailing newline that the working tree doesn't have, and `git apply` rejected it (most visibly on `--reverse`, the discard path).

Verified at the git level: a reconstructed patch missing the marker fails `git apply --check --reverse` with the exact error from the issue, while the same patch *with* the marker applies cleanly and restores the file.

## Fix

- **Preserve** the `\ No newline at end of file` marker through `parseDiffOutput`.
- In `buildHunkPatch`, pass the marker through verbatim — it never counts toward the `@@` line totals and travels with the line it annotates (dropped only if that line was itself dropped, e.g. an out-of-range `+` in a line-level selection).
- Render the marker as a dim, line-number-less row so the displayed diff stays one-to-one with `hunk.lines` (which `selectionLineRange` relies on). This also matches how git/magit/GitHub display it.

## Testing

- New e2e reproducer `test_issue2117_discard_hunk_with_no_trailing_newline`: commits a file ending in a newline, appends an unterminated final line, opens Review Diff, discards the hunk, and asserts no patch error on screen **and** that the working tree is restored on disk. Confirmed it **fails without** the fix (the "Patch failed" assertion fires) and **passes with** it.
- Full `audit_mode` (43) and active `review_diff_ux_bugs` suites pass; `cargo fmt --check` clean; plugin `tsc` type-check clean.
- Manually validated in a real `fresh` TUI session via tmux: the `\ No newline at end of file` marker now renders in the panel, the discard succeeds ("No changes to review."), and the file is restored to its committed contents.

## Test plan

- [x] Reproducer fails before fix, passes after
- [x] `audit_mode` + `review_diff_ux_bugs` e2e suites pass
- [x] `cargo fmt --check`, plugin `tsc` type-check
- [x] Manual TUI validation (tmux)

https://claude.ai/code/session_01QutMmdizaPXBQU8Hw37eyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QutMmdizaPXBQU8Hw37eyK)_