### PR TITLE
Fix current-file search for files outside the workspace root

### DIFF
--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -2891,6 +2891,22 @@ impl Editor {
         let cwd = self.working_dir().to_path_buf();
         let query_len = pattern.len();
 
+        // The project walk below is rooted at `cwd`, so a source buffer backed
+        // by a file *outside* the workspace root (e.g. opened from /tmp) is
+        // never reached and a current-file search finds nothing. Queue that
+        // file explicitly so it flows through the same per-file search path
+        // (which also handles the dirty-buffer hybrid plan). In-root files are
+        // left to the walk to avoid searching them twice.
+        let out_of_root_source = (source_buffer_id != 0)
+            .then_some(BufferId(source_buffer_id))
+            .and_then(|bid| {
+                self.windows
+                    .get(&self.active_window)
+                    .and_then(|w| w.buffers.get(&bid))
+            })
+            .and_then(|state| state.buffer.file_path().map(|p| p.to_path_buf()))
+            .filter(|path| !path.starts_with(&cwd));
+
         let Some(runtime) = &self.tokio_runtime else {
             finish_with(
                 &handle,
@@ -2905,16 +2921,27 @@ impl Editor {
             let (path_tx, mut path_rx) = tokio::sync::mpsc::channel::<std::path::PathBuf>(256);
 
             let walker_handle = Arc::clone(&handle_for_task);
+            let walk_tx = path_tx.clone();
             tokio::task::spawn_blocking(move || {
                 if let Err(e) = filesystem_walker.walk_files(
                     &cwd,
                     IGNORED_DIRS,
                     &walker_handle.cancel,
-                    &mut |path, _rel| path_tx.blocking_send(path.to_path_buf()).is_ok(),
+                    &mut |path, _rel| walk_tx.blocking_send(path.to_path_buf()).is_ok(),
                 ) {
                     tracing::warn!("BeginSearch walk_files failed: {}", e);
                 }
             });
+
+            if let Some(path) = out_of_root_source {
+                // The receive loop below is the only consumer and is still
+                // alive, so a send error here just means the search was
+                // cancelled — discarding the path is correct.
+                path_tx.send(path).await.ok();
+            }
+            // Drop our retained sender so the receive loop terminates once the
+            // walker's clone is also dropped.
+            drop(path_tx);
 
             let semaphore = Arc::new(tokio::sync::Semaphore::new(8));
             let match_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -527,6 +527,82 @@ fn test_search_replace_current_file_unnamed_buffer() {
     );
 }
 
+/// Issue #2112: "Search and Replace in Current File" must work when the active
+/// buffer is a file located *outside* the project workspace root (e.g. opened
+/// from /tmp). The project file-walk is rooted at the working directory, so an
+/// out-of-root file is never reached — before the fix this reported "No matches
+/// found" even though the file clearly contained the pattern. The host must
+/// search the source buffer's file directly when it lies outside the walk root.
+#[test]
+fn test_search_replace_current_file_outside_workspace() {
+    init_tracing_from_env();
+    let (temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    // A file that is a sibling of the working dir, i.e. outside the project
+    // walk root. The walker rooted at `project_root` can never reach it.
+    let outside_file = temp_dir.path().join("outside.txt");
+    fs::write(&outside_file, "Line 1: testing the search\nplain line\n").unwrap();
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(160, 30, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&outside_file).unwrap();
+    harness.render().unwrap();
+
+    // Open via palette → "Search and Replace in Current File".
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness
+        .type_text("Search and Replace in Current File")
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string()
+                .contains("Search and Replace in Current File")
+        })
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Search:"))
+        .unwrap();
+
+    // The scope row must name the out-of-root file. It can't be made relative
+    // to the workspace root, so it shows the absolute path.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Only in:") && screen.contains("outside.txt"),
+        "Scope row should name the out-of-root file. Got:\n{}",
+        screen
+    );
+
+    // Search for text that exists in the out-of-root file.
+    harness.type_text("testing").unwrap();
+
+    // Wait for the search to settle — either the match-count header or the
+    // "No matches found" status appears once the backend reports `done`.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("Matches (1 in 1 files)") || s.contains("No matches found")
+        })
+        .unwrap();
+
+    // The match in the out-of-root file must be found (this is the
+    // regression: it used to read "No matches found").
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("Matches (1 in 1 files)"),
+        "Out-of-root current-file search must find the on-disk match, not \
+         report 'No matches'. Got:\n{}",
+        screen
+    );
+}
+
 /// Searching for a pattern with no matches shows the "No matches" message.
 #[test]
 fn test_search_replace_no_matches() {


### PR DESCRIPTION
## Summary

Fixes #2112. The Search & Replace **"current file"** scope returned *"No matches found"* whenever the active buffer's file lived **outside** the project workspace root (e.g. a file opened from `/tmp`), even though the file clearly contained the search text.

### Root cause

`handle_begin_search` (`crates/fresh-editor/src/app/plugin_commands.rs`) drives search by walking the filesystem starting at `working_dir()` (the session/workspace root). A file opened from outside that root is never visited by the walk, so the scoped current-file search saw zero results — leaving the contradictory "Searching…/No matches found" state described in the issue. (Unnamed/unsaved buffers were already special-cased; on-disk files outside the root were the remaining gap.)

### Fix

When the source buffer is backed by a file that lies outside the walk root, queue that file explicitly into the same per-file search pipeline (which already handles the dirty-buffer hybrid plan). In-root files are still left to the walk to avoid searching them twice. Implemented by retaining a clone of the path channel sender, pushing the out-of-root path, then dropping it so the receive loop still terminates cleanly.

## Test plan

- [x] Added e2e reproducer `test_search_replace_current_file_outside_workspace` that opens a sibling-of-workspace file and asserts the match is found. It **fails fast without the fix** ("No matches found") and **passes with it**.
- [x] Existing `e2e::search_replace` suite still green (31 sibling tests pass; no regressions).
- [x] `cargo fmt` clean.
- [x] Manual validation in a real `fresh` TUI (via tmux): opened `/tmp/test-files/sample.txt` with the workspace rooted at the repo, ran "Search and Replace in Current File" for `testing`, and the panel reported `Matches (2 in 1 files)` with both match rows and status `Found 2 matches`.

> Note: a pre-existing `clippy` `manual_str_repeat` lint in `view/ui/split_rendering/style.rs:279` (present on `master`, unrelated to this change) is left untouched.

https://claude.ai/code/session_01Tt3rSLVNCzPXWmX8bFHTxW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tt3rSLVNCzPXWmX8bFHTxW)_