### PR TITLE
Fix stale search highlights when editing inside matches

### DIFF
--- a/crates/fresh-editor/src/app/event_apply.rs
+++ b/crates/fresh-editor/src/app/event_apply.rs
@@ -148,17 +148,61 @@ impl Editor {
         self.active_window_mut()
             .adjust_other_split_cursors_for_event(event);
 
-        // 3. Clear search highlights on edit (Insert/Delete events)
-        // This preserves highlights while navigating but clears them when modifying text
-        // EXCEPT during interactive replace where we want to keep highlights visible
-        let in_interactive_replace = self.active_window().interactive_replace_state.is_some();
-
-        // Note: We intentionally do NOT clear search overlays on buffer modification.
-        // Overlays have markers that automatically track position changes through edits,
-        // which allows F3/Shift+F3 to find matches at their updated positions.
-        // The visual highlights may be on text that no longer matches the query,
-        // but that's acceptable - user can see where original matches were.
-        let _ = in_interactive_replace; // silence unused warning
+        // 3. Re-evaluate search highlights around the edited region.
+        // Overlays have markers that automatically track position changes
+        // through edits (so F3/Shift+F3 find matches at their updated
+        // positions), but the markers never re-check whether the covered
+        // text still matches the query. Without this, editing inside a
+        // highlighted match — or typing against its boundary so a
+        // whole-word `\b` rule no longer holds — would leave a stale
+        // highlight on text that no longer matches. We skip during
+        // interactive replace, which manages its own highlight lifecycle.
+        if self.active_window().interactive_replace_state.is_none() {
+            let search_bg = self.theme.read().unwrap().search_match_bg;
+            let search_fg = self.theme.read().unwrap().search_match_fg;
+            match event {
+                Event::Insert { position, text, .. } => {
+                    self.active_window_mut().reevaluate_search_overlays_around(
+                        *position,
+                        text.len(),
+                        search_fg,
+                        search_bg,
+                    );
+                }
+                Event::Delete { range, .. } => {
+                    self.active_window_mut().reevaluate_search_overlays_around(
+                        range.start,
+                        0,
+                        search_fg,
+                        search_bg,
+                    );
+                }
+                Event::Batch { events, .. } => {
+                    for e in events {
+                        match e {
+                            Event::Insert { position, text, .. } => {
+                                self.active_window_mut().reevaluate_search_overlays_around(
+                                    *position,
+                                    text.len(),
+                                    search_fg,
+                                    search_bg,
+                                );
+                            }
+                            Event::Delete { range, .. } => {
+                                self.active_window_mut().reevaluate_search_overlays_around(
+                                    range.start,
+                                    0,
+                                    search_fg,
+                                    search_bg,
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
 
         // 3. Trigger plugin hooks for this event (with pre-calculated line info)
         self.trigger_plugin_hooks_for_event(event, line_info);

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2653,6 +2653,103 @@ impl Window {
         }
     }
 
+    /// Re-evaluate committed search highlights around an edited region.
+    ///
+    /// Search-match overlays are anchored by markers that merely *track*
+    /// byte positions through edits; they never re-check whether the text
+    /// they cover still matches the query. So editing inside a highlighted
+    /// match (or typing against its boundary, which can break a `\b`
+    /// whole-word rule) would leave a stale highlight on text that no
+    /// longer matches. This recomputes matches on just the line(s) touched
+    /// by the edit and swaps the search overlays in that span, so highlights
+    /// drop and appear exactly where the text starts/stops matching.
+    ///
+    /// `edit_start` / `edit_new_len` are in post-edit byte coordinates (for
+    /// a deletion, `edit_new_len` is 0). Bounded to the affected lines to
+    /// keep it viewport-localized rather than a full-buffer rescan.
+    pub fn reevaluate_search_overlays_around(
+        &mut self,
+        edit_start: usize,
+        edit_new_len: usize,
+        search_fg: ratatui::style::Color,
+        search_bg: ratatui::style::Color,
+    ) {
+        let query = match self.search_state.as_ref() {
+            Some(ss) if !ss.query.is_empty() => ss.query.clone(),
+            _ => return,
+        };
+
+        let case_sensitive = self.search_case_sensitive;
+        let whole_word = self.search_whole_word;
+        let use_regex = self.search_use_regex;
+        let ns = self.search_namespace.clone();
+
+        let regex_pattern = if use_regex {
+            if whole_word {
+                format!(r"\b{}\b", query)
+            } else {
+                query
+            }
+        } else {
+            let escaped = regex::escape(&query);
+            if whole_word {
+                format!(r"\b{}\b", escaped)
+            } else {
+                escaped
+            }
+        };
+
+        let regex = match regex::RegexBuilder::new(&regex_pattern)
+            .case_insensitive(!case_sensitive)
+            .build()
+        {
+            Ok(r) => r,
+            Err(_) => return,
+        };
+
+        let state = self.active_state_mut();
+        let buf_len = state.buffer.len();
+        let edit_end = edit_start.saturating_add(edit_new_len).min(buf_len);
+
+        // Expand the edited byte span to the full line(s) it touches so that
+        // word-boundary context on either side of the edit is included.
+        let start_line = state.buffer.get_line_number(edit_start.min(buf_len));
+        let end_line = state.buffer.get_line_number(edit_end);
+        let win_start = state.buffer.line_start_offset(start_line).unwrap_or(0);
+        let win_end = state
+            .buffer
+            .line_start_offset(end_line + 1)
+            .unwrap_or(buf_len)
+            .min(buf_len);
+
+        let text = state.get_text_range(win_start, win_end);
+
+        let mut new_overlays = Vec::new();
+        for mat in regex.find_iter(&text) {
+            let absolute_pos = win_start + mat.start();
+            let match_len = mat.end() - mat.start();
+            let search_style = ratatui::style::Style::default().fg(search_fg).bg(search_bg);
+            new_overlays.push(
+                crate::view::overlay::Overlay::with_namespace_fixed_end(
+                    &mut state.marker_list,
+                    absolute_pos..(absolute_pos + match_len),
+                    crate::view::overlay::OverlayFace::Style {
+                        style: search_style,
+                    },
+                    ns.clone(),
+                )
+                .with_priority_value(10),
+            );
+        }
+
+        state.overlays.replace_range_in_namespace(
+            &ns,
+            &(win_start..win_end),
+            new_overlays,
+            &mut state.marker_list,
+        );
+    }
+
     // ---- File-explorer leaf delegators ----
 
     /// Whether this window's file-explorer panel is visible.

--- a/crates/fresh-editor/tests/e2e/search.rs
+++ b/crates/fresh-editor/tests/e2e/search.rs
@@ -358,6 +358,112 @@ fn test_search_highlight_does_not_extend_on_adjacent_insert() {
     );
 }
 
+/// Regression test for issue #2133: editing inside a highlighted search
+/// match must drop the highlight, because the text no longer matches.
+#[test]
+fn test_search_highlight_clears_when_edit_breaks_match() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "abc def ghi\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Search for "def" and commit, leaving a persistent highlight.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("def").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // Confirm the match is highlighted: capture the highlight background of
+    // the first match character.
+    let (col, row) = harness
+        .find_text_on_screen("def")
+        .expect("match text should be visible");
+    let match_bg = harness
+        .get_cell_style(col, row)
+        .and_then(|s| s.bg)
+        .expect("matched char should have a highlight background");
+
+    // Move one char into the match and type a character, breaking the match
+    // ("def" -> "dXef").
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("X").unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The first match character must no longer carry the search highlight.
+    let after_bg = harness.get_cell_style(col, row).and_then(|s| s.bg);
+    assert_ne!(
+        after_bg,
+        Some(match_bg),
+        "search highlight must clear when an edit breaks the match"
+    );
+}
+
+/// Regression test for issue #2133: with Whole Word enabled, typing right
+/// after a match breaks the `\b` boundary, so the highlight must clear.
+#[test]
+fn test_search_highlight_clears_when_whole_word_boundary_breaks() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, "one def two\n").unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Search for whole-word "def" and commit.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    // Toggle Whole Word with Alt+W.
+    harness
+        .send_key(KeyCode::Char('w'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text("def").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    let (col, row) = harness
+        .find_text_on_screen("def")
+        .expect("match text should be visible");
+    let match_bg = harness
+        .get_cell_style(col, row)
+        .and_then(|s| s.bg)
+        .expect("matched char should have a highlight background");
+
+    // Move just past the match (3 chars) and type a character. "def" -> "defX"
+    // is no longer a whole word, so the highlight must clear.
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+    harness.type_text("X").unwrap();
+    harness.process_async_and_render().unwrap();
+
+    let after_bg = harness.get_cell_style(col, row).and_then(|s| s.bg);
+    assert_ne!(
+        after_bg,
+        Some(match_bg),
+        "whole-word search highlight must clear when the boundary is broken"
+    );
+}
+
 /// Test that search highlighting only applies to visible viewport
 #[test]
 fn test_search_highlighting_visible_only() {


### PR DESCRIPTION
## Summary
Fixes issue #2133 where search highlights would remain visible on text that no longer matches the query after editing inside a highlighted match or breaking a whole-word boundary.

## Problem
Search-match overlays use markers that automatically track byte positions through edits, but they never re-check whether the covered text still matches the search query. This caused stale highlights to persist when:
1. Editing inside a highlighted match (e.g., "def" → "dXef")
2. Typing after a match with whole-word search enabled, breaking the `\b` boundary (e.g., "def" → "defX")

## Solution
Implemented `reevaluate_search_overlays_around()` in the Window to re-evaluate search matches on the affected line(s) after each edit:

- **New method in `window/mod.rs`**: `reevaluate_search_overlays_around()` re-scans the edited region (expanded to full lines for word-boundary context) and replaces search overlays with fresh matches
- **Updated `event_apply.rs`**: Calls the new method for Insert/Delete events (including batched events), skipping during interactive replace which manages its own highlight lifecycle
- **Added regression tests**: Two new e2e tests verify highlights clear when matches break due to editing

## Key Changes
- Overlays are now dynamically updated to reflect actual text matches after edits
- The re-evaluation is scoped to affected lines only for performance
- Interactive replace mode is excluded to avoid interfering with its own highlight management

https://claude.ai/code/session_01LcaxKqLSUEGyXxr2a6HbVf