### PR TITLE
Fix diagnostics panel q/a/r shortcuts tripping "Editing disabled"

### DIFF
--- a/crates/fresh-editor/plugins/diagnostics_panel.ts
+++ b/crates/fresh-editor/plugins/diagnostics_panel.ts
@@ -130,6 +130,16 @@ const finder = new Finder<DiagnosticItem>(editor, {
   // the shared Utility Dock so it shares space with Quickfix,
   // search-replace results, etc. See issue #1796.
   useUtilityDock: true,
+  // Keys advertised in the panel's status hint
+  // ("a: toggle filter | RET: goto | q: close"). RET/Esc are bound by
+  // the Finder itself; these wire up the diagnostics-specific actions
+  // so they no longer fall through to the read-only text layer and
+  // trip "Editing disabled in this buffer" (issue #2125).
+  panelKeys: [
+    ["q", "diagnostics_close"],
+    ["a", "diagnostics_toggle_all"],
+    ["r", "diagnostics_refresh"],
+  ],
   onClose: () => {
     isOpen = false;
     sourceBufferId = null;

--- a/crates/fresh-editor/plugins/lib/finder.ts
+++ b/crates/fresh-editor/plugins/lib/finder.ts
@@ -120,6 +120,19 @@ export interface FinderConfig<T> {
   onClose?: () => void;
 
   /**
+   * Panel-specific: extra key bindings active while the panel buffer
+   * is focused, as `[key, command]` pairs (e.g. `["q", "my_close"]`).
+   * `command` is dispatched as a plugin action, so it should name a
+   * handler registered via `registerHandler`. These augment the
+   * built-in `Return` (select) and `Escape` (close) bindings.
+   *
+   * Without this, keys a plugin advertises in its panel UI (e.g.
+   * "q: close") fall through to the read-only text layer and trip
+   * "Editing disabled in this buffer" (issue #2125).
+   */
+  panelKeys?: Array<[string, string]>;
+
+  /**
    * When true, panels created by this Finder are routed into the
    * shared Utility Dock (issue #1796 / Section 2 of
    * `docs/internal/tui-editor-layout-design.md`). The first
@@ -1111,12 +1124,17 @@ export class Finder<T> {
   private registerPanelHandlers(): void {
     const self = this;
 
-    // Define panel mode
+    // Define panel mode. The built-in Return/Escape bindings are
+    // augmented with any caller-supplied `panelKeys` so plugin-specific
+    // shortcuts (e.g. Diagnostics' "q: close | a: toggle filter") resolve
+    // to their handlers instead of falling through to the read-only text
+    // layer (issue #2125).
     this.editor.defineMode(
       this.modeName,
       [
         ["Return", `${this.handlerPrefix}_panel_select`],
         ["Escape", `${this.handlerPrefix}_panel_close`],
+        ...(this.config.panelKeys ?? []),
       ],
       true
     );

--- a/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/diagnostics_panel_bugs.rs
@@ -257,3 +257,82 @@ fn test_diagnostics_panel_jump_to_correct_line() {
         after_jump
     );
 }
+
+// ─── Bug 3: Panel shortcuts (q / a) are advertised but not bound ────────────
+
+/// The panel's status hint advertises `q: close`, but pressing `q` in the
+/// diagnostics panel does nothing useful — the key falls through to the
+/// read-only text layer and shows "Editing disabled in this buffer" while the
+/// panel stays open (issue #2125). With the fix, `q` runs the close handler.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_diagnostics_panel_q_closes() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn_many_diagnostics(temp_dir.path(), 3).unwrap();
+    let (mut harness, _test_file) = setup_harness(&temp_dir);
+
+    open_diagnostics_panel(&mut harness);
+    assert!(
+        harness.screen_to_string().contains("Esc:close"),
+        "Panel should be open before pressing q.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Press `q` — should close the panel, not edit the read-only buffer.
+    harness
+        .send_key(KeyCode::Char('q'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("Esc:close"))
+        .unwrap();
+
+    let after = harness.screen_to_string();
+    assert!(
+        !after.contains("Editing disabled"),
+        "Pressing q should close the panel, not trip 'Editing disabled'.\nScreen:\n{}",
+        after
+    );
+    assert!(
+        !after.contains("Diagnostics ("),
+        "Panel should be closed after pressing q.\nScreen:\n{}",
+        after
+    );
+}
+
+/// The panel's status hint advertises `a: toggle filter`. Pressing `a` should
+/// flip the title between "Current File" and "All Files". Before the fix, `a`
+/// fell through to the read-only text layer ("Editing disabled") and the title
+/// never changed (issue #2125).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_diagnostics_panel_a_toggles_filter() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let _fake_server = FakeLspServer::spawn_many_diagnostics(temp_dir.path(), 3).unwrap();
+    let (mut harness, _test_file) = setup_harness(&temp_dir);
+
+    open_diagnostics_panel(&mut harness);
+    assert!(
+        harness.screen_to_string().contains("Current File"),
+        "Panel should start filtered to the current file.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Press `a` — should toggle the filter title to "All Files".
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("All Files"))
+        .unwrap();
+
+    let after = harness.screen_to_string();
+    assert!(
+        !after.contains("Editing disabled"),
+        "Pressing a should toggle the filter, not trip 'Editing disabled'.\nScreen:\n{}",
+        after
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2125. The diagnostics panel's status hint advertises `a: toggle filter | RET: goto | q: close`, but pressing `q`, `a` (or `r`) produced **"Editing disabled in this buffer"** and did nothing.

**Root cause:** The shared `Finder` panel mode (`lib/finder.ts`) only bound `Return` (select) and `Escape` (close). The diagnostics plugin already had `diagnostics_close` / `diagnostics_toggle_all` / `diagnostics_refresh` handlers, but they were never mapped to keys — so `q`/`a`/`r` fell through to the read-only text-editing layer, which refuses input on the `[RO]` buffer.

## Changes

- **`lib/finder.ts`**: Added an optional `panelKeys` to `FinderConfig`. These `[key, command]` pairs augment the panel mode's built-in `Return`/`Escape` bindings. Backward-compatible (defaults to none), so other Finder consumers are unaffected.
- **`diagnostics_panel.ts`**: Wired `q`→close, `a`→toggle filter, `r`→refresh through `panelKeys` to the existing handlers.
- **`diagnostics_panel_bugs.rs`**: Added two e2e reproducers (`q` closes the panel; `a` toggles the filter title). Without the fix they hang/fail (the panel never closes); with it they pass.

## Test plan

- [x] `cargo test -p fresh-editor --test e2e_tests plugins::diagnostics_panel_bugs` — all 4 pass
- [x] Confirmed the new tests **hang/time out without the fix** (q never closes the panel)
- [x] `cargo fmt --check` clean; clippy clean on the changed files
- [x] Manual tmux validation (no LSP, 0 diagnostics — the exact repro from the issue):
  - `q` → panel closes, status "Diagnostics panel closed"
  - `a` → status "Showing: All Files" ↔ "Showing: Current File"
  - `r` → "Diagnostics refreshed"
  - `Enter` (no items) → "No item selected"
  - None produce "Editing disabled"

https://claude.ai/code/session_01L7KkhBMitZcSrKkgQ5Yyqb

---
_Generated by [Claude Code](https://claude.ai/code/session_01L7KkhBMitZcSrKkgQ5Yyqb)_