### PR TITLE
Fix search panel to clear "Searching…" on zero-match results

### DIFF
--- a/crates/fresh-editor/plugins/search_replace.ts
+++ b/crates/fresh-editor/plugins/search_replace.ts
@@ -921,12 +921,16 @@ function updatePanelContent(): void {
   //                                       trailing match-count stats.
   //   * `Row{ Toggle, Toggle, Toggle, Spacer, Button }`
   //                                       — case/regex/whole + Replace All.
+  //   * `HintBar{ ... }`                  — keyboard-hint row, sits
+  //                                       directly above the matches
+  //                                       section.
   //   * `Raw{ separator entry }`         — matches divider.
   //   * `List{ ... }` or `Raw{empty msg}` — virtual-scrolled match
   //                                       rows (host owns scroll +
   //                                       selection styling +
-  //                                       click routing).
-  //   * `HintBar{ ... }`                  — keyboard-hint footer.
+  //                                       click routing). Last child
+  //                                       so the match list is the
+  //                                       final thing in the buffer.
   if (!panel.widgetPanel) {
     panel.widgetPanel = new WidgetPanel(panel.resultsBufferId);
   }
@@ -935,9 +939,9 @@ function updatePanelContent(): void {
       buildLine1Spec(),
       buildOptionsRowSpec(),
       buildScopeRowSpec(),
+      hintBar(buildHelpHints()),
       raw(buildPanelEntries("postOptions"), "separator"),
       buildMatchListSpec(),
-      hintBar(buildHelpHints()),
     ),
   );
   // The Tree's `expandedKeys` field on the spec is initial-only —
@@ -1479,12 +1483,22 @@ async function rerunSearch(): Promise<void> {
   if (panel && currentSearchGeneration === myGen) {
     panel.busy = false;
     panel.searchPerformed = true;
-    // Only one tiny mutation needed: refresh matchStats since it
-    // depends on the busy flag and searchPerformed (showing
-    // "No matches" vs "Searching…"). The tree's nodes already
-    // reflect the final state — no full re-emit needed.
     if (panel.widgetPanel) {
-      panel.widgetPanel.setRawEntries("matchStats", buildMatchStatsEntries());
+      if (panel.searchResults.length === 0) {
+        // Zero matches: the match-list body is an empty-state `raw()`
+        // last rendered while `busy` was still true → "Searching…".
+        // `setRawEntries("matchStats", …)` only refreshes the small
+        // count label next to the inputs, not the body, so without a
+        // full re-emit the body stays stuck on "Searching…". Re-emit
+        // now that the flags are final so it shows "No matches".
+        // Cheap: the tree is empty (no per-node serialization cost).
+        updatePanelContent();
+      } else {
+        // Only one tiny mutation needed: refresh matchStats since it
+        // depends on the busy flag and searchPerformed. The tree's
+        // nodes already reflect the final state — no full re-emit.
+        panel.widgetPanel.setRawEntries("matchStats", buildMatchStatsEntries());
+      }
     }
   }
 }

--- a/crates/fresh-editor/tests/e2e/search_replace.rs
+++ b/crates/fresh-editor/tests/e2e/search_replace.rs
@@ -624,6 +624,100 @@ fn test_search_replace_no_matches() {
         .unwrap();
 }
 
+/// Regression: once a zero-match search settles, the match-list *body*
+/// must update from the transient "Searching…" placeholder to "No
+/// matches" — not stay stuck on "Searching…". The small count label
+/// next to the input fields flipped correctly even with the bug, so a
+/// plain `contains("No matches")` check passes either way; the body was
+/// the stuck part. Assert no "Searching" text remains after the screen
+/// stabilizes.
+#[test]
+fn test_search_replace_no_matches_clears_searching() {
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    enter_search_and_replace(&mut harness, "ZZZZNOTFOUND", "whatever");
+
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("No matches"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Searching"),
+        "match-list body must not stay on 'Searching…' after a zero-match \
+         search settles. Got:\n{}",
+        screen
+    );
+}
+
+/// The keyboard-hint row sits directly above the "Matches" separator, so
+/// the match list is the last thing in the panel buffer. Asserts on the
+/// relative line order of the rendered hint row, the separator, and the
+/// empty-state body.
+#[test]
+fn test_search_replace_help_row_above_matches() {
+    let (_temp_dir, project_root) = setup_search_replace_project();
+    create_test_files(&project_root);
+
+    let start_file = project_root.join("alpha.txt");
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, Default::default(), project_root)
+            .unwrap();
+    harness.open_file(&start_file).unwrap();
+    harness.render().unwrap();
+
+    open_search_replace_via_palette(&mut harness);
+    // No search typed yet: separator shows "Matches" and the body shows
+    // the "Type a search pattern above" empty state.
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("Matches") && s.contains("Type a search pattern")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    let lines: Vec<&str> = screen.lines().collect();
+    let help_idx = lines
+        .iter()
+        .position(|l| l.contains("include/exclude"))
+        .unwrap_or_else(|| panic!("help hint row not rendered. Got:\n{}", screen));
+    let sep_idx = lines
+        .iter()
+        .position(|l| l.contains("Matches") && l.contains('─'))
+        .unwrap_or_else(|| panic!("Matches separator not rendered. Got:\n{}", screen));
+    let body_idx = lines
+        .iter()
+        .position(|l| l.contains("Type a search pattern"))
+        .unwrap_or_else(|| panic!("empty-state body not rendered. Got:\n{}", screen));
+
+    assert!(
+        help_idx < sep_idx,
+        "help hint row (line {}) must render above the Matches separator \
+         (line {}). Got:\n{}",
+        help_idx,
+        sep_idx,
+        screen
+    );
+    assert!(
+        sep_idx < body_idx,
+        "Matches separator (line {}) and its list (body line {}) must be \
+         the last section in the panel. Got:\n{}",
+        sep_idx,
+        body_idx,
+        screen
+    );
+}
+
 /// Cancelling at the search field (before typing) closes the empty panel.
 #[test]
 fn test_search_replace_cancel_at_search_field() {


### PR DESCRIPTION
## Summary
Fixed a regression where the search-replace panel's match-list body would remain stuck on the "Searching…" placeholder after a zero-match search completed, instead of updating to show "No matches".

## Key Changes
- **Reordered panel layout**: Moved the keyboard-hint bar to sit directly above the "Matches" separator, making the match list the final section in the panel buffer (previously the hint bar was at the bottom).
- **Fixed zero-match state update**: When a search completes with zero results, the panel now performs a full content re-emit instead of a partial update. This ensures the empty-state body text updates from "Searching…" to "No matches" when the `busy` flag is cleared.
- **Optimized non-zero match updates**: Searches with results continue to use the efficient partial update path (`setRawEntries`), avoiding unnecessary full re-renders.

## Implementation Details
- The fix distinguishes between zero-match and non-zero-match completion paths in `rerunSearch()`.
- For zero matches, a full `updatePanelContent()` call is needed because the empty-state `raw()` entry depends on the `busy` and `searchPerformed` flags to determine which placeholder text to display.
- For non-zero matches, the existing partial update of match stats is sufficient since the tree nodes already contain the final match data.
- Added regression tests to verify the "Searching…" text clears and to validate the correct visual ordering of the help row, separator, and match list.

https://claude.ai/code/session_0135mMN4crhfrhRkDJoha1Q9