### PR TITLE
fix(window): keep session working trees under the data dir editable

### DIFF
--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -756,18 +756,25 @@ impl crate::app::window::Window {
         self.open_file_no_focus_inner(path, false)
     }
 
-    /// True if `path` resolves to a location under the app data dir.
-    /// Both sides are canonicalized so a symlinked home (e.g. macOS
-    /// `/var` → `/private/var`) doesn't defeat the prefix check.
-    fn path_under_data_dir(&self, path: &Path) -> bool {
-        let data_dir = &self.resources.dir_context.data_dir;
-        let canonical_data = self
-            .resources
-            .authority
-            .filesystem
-            .canonicalize(data_dir)
-            .unwrap_or_else(|_| data_dir.clone());
-        path.starts_with(&canonical_data)
+    /// True if `path` is an internal app artifact (terminal scrollback,
+    /// git-show output, etc.) that the user is inspecting rather than
+    /// editing — i.e. it lives under the app data dir but outside this
+    /// window's own project root. A session working tree can itself live
+    /// under the data dir (conductor / orchestrator sessions); files under
+    /// the window root are real working files, not artifacts.
+    /// Paths are canonicalized so a symlinked home (e.g. macOS
+    /// `/var` → `/private/var`) doesn't defeat the prefix checks.
+    fn is_internal_data_artifact(&self, path: &Path) -> bool {
+        let canonicalize = |p: &Path| {
+            self.resources
+                .authority
+                .filesystem
+                .canonicalize(p)
+                .unwrap_or_else(|_| p.to_path_buf())
+        };
+        let canonical_data = canonicalize(&self.resources.dir_context.data_dir);
+        let canonical_root = canonicalize(&self.root);
+        path.starts_with(&canonical_data) && !path.starts_with(&canonical_root)
     }
 
     fn open_file_no_focus_inner(
@@ -942,11 +949,13 @@ impl crate::app::window::Window {
             tracing::info!("Detected binary file: {}", path.display());
         }
 
-        // Files under the app data dir (e.g. terminal scrollback backing
-        // files surfaced by Universal Search) are internal artifacts the
-        // user is inspecting, not editing — open them read-only so an
-        // accidental keystroke can't corrupt persisted state.
-        if self.path_under_data_dir(&canonical_path) {
+        // Internal app artifacts under the data dir (e.g. terminal scrollback
+        // backing files surfaced by Universal Search) are things the user is
+        // inspecting, not editing — open them read-only so an accidental
+        // keystroke can't corrupt persisted state. Files inside the window's
+        // own root are excluded so session working trees that live under the
+        // data dir stay editable.
+        if self.is_internal_data_artifact(&canonical_path) {
             state.editing_disabled = true;
         }
 

--- a/crates/fresh-editor/tests/e2e/binary_file.rs
+++ b/crates/fresh-editor/tests/e2e/binary_file.rs
@@ -66,6 +66,43 @@ fn test_file_outside_data_dir_is_editable() {
     );
 }
 
+/// A session working tree (conductor / orchestrator) physically lives under
+/// the data dir, but its files are real working files — opening one must stay
+/// editable. The read-only rule applies only to artifacts outside the window's
+/// own root. Drives real keystrokes and observes the typed text on screen.
+#[test]
+fn test_file_in_session_tree_under_data_dir_is_editable() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Project root sits under the data dir, mirroring a conductor session.
+    let project = dir_context
+        .data_dir
+        .join("conductor")
+        .join("proj")
+        .join("session-1");
+    std::fs::create_dir_all(&project).unwrap();
+    let changelog = project.join("CHANGELOG.md");
+    std::fs::write(&changelog, "# Release Notes\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_shared_dir_context(
+        100,
+        24,
+        Config::default(),
+        project,
+        dir_context,
+    )
+    .unwrap();
+    harness.open_file(&changelog).unwrap();
+    harness.render().unwrap();
+
+    // Typing must land in the buffer: if the data-dir guard wrongly disabled
+    // editing, the keystrokes are dropped and the marker never renders.
+    harness.type_text("ZZEDITABLEZZ").unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("ZZEDITABLEZZ");
+}
+
 /// Test that PNG files are detected as binary and opened in read-only mode
 #[test]
 fn test_png_file_detected_as_binary() {


### PR DESCRIPTION
The "open data-dir files read-only" guard matched on a bare data-dir path prefix, so it disabled editing for any file opened from a conductor or orchestrator session whose working tree physically lives under ~/.local/share/fresh/. Those are real working files, not internal artifacts, so the editor silently dropped every keystroke.

Narrow the guard: a file is an internal artifact only if it is under the data dir AND outside the window's own project root. Genuine artifacts (terminal scrollback, git-show output surfaced by Universal Search) are always opened outside the project root, so they stay read-only; session trees rooted under the data dir become editable again.