### PR TITLE
Add global orchestrator dock: non-modal left panel with live window switching

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -406,15 +406,19 @@ pub struct WindowInfo {
     /// Absolute project root.
     #[ts(type = "string")]
     pub root: PathBuf,
-    /// Project this session belongs to — the canonical repo
-    /// root (or arbitrary directory) the user pointed the
-    /// new-session form at. `null` for legacy sessions that
-    /// predate the Project Path field. The Orchestrator Open
-    /// dialog filters by this so the "this project's sessions"
-    /// view is one keystroke away from the all-projects view.
-    #[ts(type = "string | null")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub project_path: Option<PathBuf>,
+    /// Project this session belongs to — the canonical repo root
+    /// (or arbitrary directory) the user pointed the new-session
+    /// form at. For sessions without an explicit project (legacy
+    /// sessions, the launch session, sessions created outside the
+    /// orchestrator's new-session form) this equals `root` — the
+    /// host normalises at the API boundary so plugins never have
+    /// to deal with `null`/`undefined`/`""` ambiguity (`??` only
+    /// falls through on `null`, but the orchestrator's
+    /// `WindowInfo` round-trips a `Some(PathBuf::new())` as `""`,
+    /// which then becomes a poisoned lex sort key — observed as
+    /// the Windows-only dock reorder).
+    #[ts(type = "string")]
+    pub project_path: PathBuf,
     /// `true` when the session shares its working tree with
     /// other sessions (worktree-creation was off at session
     /// time, or the session lives in a non-git directory).

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3720,6 +3720,10 @@ pub enum PluginCommand {
         spec: WidgetSpec,
         width_pct: u8,
         height_pct: u8,
+        /// When true, mount into the editor-global left **dock** slot
+        /// (persists alongside a centered modal) rather than as a
+        /// centered overlay.
+        as_dock: bool,
     },
 
     /// Replace the spec of the currently-mounted floating widget

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2188,6 +2188,13 @@ pub enum PluginCommand {
     /// `editor.activeWindow()` after.
     SetActiveWindow { id: WindowId },
 
+    /// Like `SetActiveWindow`, but plays a directional wipe on the
+    /// newly-active window's editor content as it appears. `from_edge`
+    /// is "top" | "bottom" | "left" | "right" (the edge the incoming
+    /// content slides in from). Used by the orchestrator dock so that
+    /// arrowing up/down the session list wipes the window up/down.
+    SetActiveWindowAnimated { id: WindowId, from_edge: String },
+
     /// Close a session and drop its associated state. Refuses to
     /// close the currently active session — the caller must switch
     /// first. Fires `session_closed` on success.
@@ -3723,6 +3730,17 @@ pub enum PluginCommand {
     /// Tear down the floating widget panel. No-op when no floating
     /// panel is mounted, or when the `panel_id` doesn't match.
     UnmountFloatingWidget { panel_id: u64 },
+
+    /// Control a mounted floating widget panel's placement / focus
+    /// without re-sending its spec. `op` is one of:
+    /// - "dock"   — re-anchor as a full-height left dock; `arg` is the
+    ///   dock width in columns. The dock is non-modal: the editor
+    ///   underneath stays rendered and (when blurred) keyboard-usable.
+    /// - "center" — restore the default centered-overlay placement.
+    /// - "focus"  — route keys to the panel (modal-ish capture).
+    /// - "blur"   — stop routing keys to the panel; it stays rendered
+    ///   so focus returns to the editor while the dock remains visible.
+    FloatingPanelControl { panel_id: u64, op: String, arg: f64 },
 }
 
 impl PluginCommand {

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2566,6 +2566,13 @@ interface EditorAPI {
 	*/
 	setActiveWindow(id: number): boolean;
 	/**
+	* Like `setActiveWindow`, but plays a directional wipe on the
+	* newly-active window's editor content as it appears. `fromEdge`
+	* is the edge the incoming content slides in from — use "bottom"
+	* when moving down a list and "top" when moving up.
+	*/
+	setActiveWindowAnimated(id: number, fromEdge: "top" | "bottom" | "left" | "right"): boolean;
+	/**
 	* Close session `id`. Refuses to close the active session or
 	* the base session (id 1). Logs and no-ops on failure.
 	*/
@@ -2866,6 +2873,18 @@ interface EditorAPI {
 	* Tear down the floating widget panel.
 	*/
 	unmountFloatingWidget(panelId: number): boolean;
+	/**
+	* Control a mounted floating panel's placement / focus without
+	* re-sending its spec.
+	* - `op="dock"`   — re-anchor as a full-height left dock; `arg` is
+	*   the dock width in columns. Non-modal: the editor underneath
+	*   stays rendered, and keyboard-usable while the dock is blurred.
+	* - `op="center"` — restore the default centered-overlay placement.
+	* - `op="focus"`  — route keys to the panel.
+	* - `op="blur"`   — stop routing keys to the panel (it stays
+	*   visible); focus returns to the editor.
+	*/
+	floatingPanelControl(panelId: number, op: "dock" | "center" | "focus" | "blur", arg?: number): boolean;
 	/**
 	* Spawn a process (async, returns request_id)
 	* 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2566,12 +2566,11 @@ interface EditorAPI {
 	*/
 	setActiveWindow(id: number): boolean;
 	/**
-	* Like `setActiveWindow`, but plays a directional wipe on the
-	* newly-active window's editor content as it appears. `fromEdge`
-	* is the edge the incoming content slides in from — use "bottom"
-	* when moving down a list and "top" when moving up.
+	* Switch the active window with a directional wipe on the
+	* incoming content. `from_edge`: "top" | "bottom" | "left" |
+	* "right". See `PluginCommand::SetActiveWindowAnimated`.
 	*/
-	setActiveWindowAnimated(id: number, fromEdge: "top" | "bottom" | "left" | "right"): boolean;
+	setActiveWindowAnimated(id: number, fromEdge: string): boolean;
 	/**
 	* Close session `id`. Refuses to close the active session or
 	* the base session (id 1). Logs and no-ops on failure.
@@ -2875,16 +2874,10 @@ interface EditorAPI {
 	unmountFloatingWidget(panelId: number): boolean;
 	/**
 	* Control a mounted floating panel's placement / focus without
-	* re-sending its spec.
-	* - `op="dock"`   — re-anchor as a full-height left dock; `arg` is
-	*   the dock width in columns. Non-modal: the editor underneath
-	*   stays rendered, and keyboard-usable while the dock is blurred.
-	* - `op="center"` — restore the default centered-overlay placement.
-	* - `op="focus"`  — route keys to the panel.
-	* - `op="blur"`   — stop routing keys to the panel (it stays
-	*   visible); focus returns to the editor.
+	* re-sending its spec. `op`: "dock" (`arg` = width in columns),
+	* "center", "focus", "blur". See `PluginCommand::FloatingPanelControl`.
 	*/
-	floatingPanelControl(panelId: number, op: "dock" | "center" | "focus" | "blur", arg?: number): boolean;
+	floatingPanelControl(panelId: number, op: string, arg: number): boolean;
 	/**
 	* Spawn a process (async, returns request_id)
 	* 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2863,7 +2863,7 @@ interface EditorAPI {
 	* Mount a declarative widget panel as a centered floating
 	* overlay (not bound to any virtual buffer).
 	*/
-	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number): boolean;
+	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number, asDock?: boolean): boolean;
 	/**
 	* Replace the spec of the currently-mounted floating widget panel.
 	*/

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -755,14 +755,20 @@ export class FloatingWidgetPanel {
    * existing panel. */
   mount(
     spec: WidgetSpec,
-    options: { widthPct?: number; heightPct?: number } = {},
+    options: { widthPct?: number; heightPct?: number; asDock?: boolean } = {},
   ): boolean {
     // deno-lint-ignore no-explicit-any
     const editor = (globalThis as any).editor;
     const wp = options.widthPct ?? 60;
     const hp = options.heightPct ?? 40;
     this.mounted = true;
-    return editor.mountFloatingWidget(this.panelId, spec, wp, hp);
+    return editor.mountFloatingWidget(
+      this.panelId,
+      spec,
+      wp,
+      hp,
+      options.asDock ?? false,
+    );
   }
 
   /** Re-render the panel against the given spec; instance state on

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1995,7 +1995,22 @@ function buildDockSpec(): WidgetSpec {
       kind: "raw",
       entries: [
         styledRow([
-          { text: "ORCHESTRATOR", style: { fg: "ui.popup_border_fg", bold: true } },
+          {
+            // TEMPORARY DIAGNOSTIC for the Windows-only
+            // `dock_initial_sort_…` / `dock_list_order_…` failure.
+            // Embed `dockMode`, the basename's first 3 chars of `cur`,
+            // and `filteredIds` into the dock header so the CI screen
+            // dump tells us whether the plugin sees `dockMode=true` (the
+            // fix is taking effect) and what `currentProjectKey()` it
+            // believes is current at filter time. Use only the first 3
+            // chars of the basename so it doesn't collide with the
+            // tests' `row_of("aaa_project")` / `row_of("zzz_project")`
+            // substring matches. Revert once the root cause is fixed.
+            text: `ORCHESTRATOR dm=${dockMode ? "T" : "F"} c=${(
+              currentProjectKey().split(/[/\\]/).pop() ?? ""
+            ).slice(0, 3)} f=[${filtered.join(",")}]`,
+            style: { fg: "ui.popup_border_fg", bold: true },
+          },
         ]),
       ],
     },

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1903,6 +1903,11 @@ function buildDockSpec(): WidgetSpec {
   const newLabel = newKey ? `+ New ${newKey}` : "+ New";
   const worktreeKey = editor.getKeybindingLabel("orchestrator_toggle_worktrees", OPEN_MODE);
   const worktreeLabel = worktreeKey ? `worktrees (${worktreeKey})` : "worktrees";
+  // Checked = show trivial (empty / single-file) sessions; unchecked
+  // (default) hides them so the dock focuses on real work. Same
+  // `hide-trivial` widget key the modal uses, so the existing
+  // `widget_event` toggle handler fires for the dock too.
+  const trivialLabel = "show empty/1-file";
 
   // Pinned bottom block: a confirm prompt (separator + 2 rows) OR
   // detail + actions (separator + 0–2 rows), then the hint bar. The
@@ -1942,12 +1947,13 @@ function buildDockSpec(): WidgetSpec {
     bottom.push(hintRow);
   }
 
-  // Size the list to fill the dock. Inner height = screen rows − dock
-  // borders (2); fixed top chrome is 6 rows (title, New/scope,
-  // worktrees toggle, filter, separator, column header).
+  // Size the list to fill the dock. The dock draws only a right border
+  // (no top/bottom), so its content area is the full terminal height.
+  // Fixed top chrome is 7 rows (title, New/scope, worktrees toggle,
+  // empty/1-file toggle, filter, separator, header).
   const screen = editor.getScreenSize();
-  const innerH = Math.max(8, (screen.height > 0 ? screen.height : 30) - 2);
-  const listRows = Math.max(MIN_LIST_ROWS, innerH - 6 - bottomRows);
+  const innerH = Math.max(8, screen.height > 0 ? screen.height : 30);
+  const listRows = Math.max(MIN_LIST_ROWS, innerH - 7 - bottomRows);
   openDialog.listVisibleRows = listRows;
 
   return col(
@@ -1972,6 +1978,12 @@ function buildDockSpec(): WidgetSpec {
     row(
       toggle(openDialog.showWorktrees, worktreeLabel, {
         key: inConfirm ? undefined : "worktree-show",
+      }),
+      flexSpacer(),
+    ),
+    row(
+      toggle(!openDialog.hideTrivial, trivialLabel, {
+        key: inConfirm ? undefined : "hide-trivial",
       }),
       flexSpacer(),
     ),

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -331,6 +331,19 @@ interface OpenDialogState {
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
+// When the open panel is mounted as the persistent left dock rather
+// than the centered modal picker. The dock reuses the same panel +
+// `openDialog` state; these flags drive the dock-only behaviours
+// (live-switch on nav, Enter/Esc blur instead of close).
+let dockMode = false;
+// True while the dock is visible but blurred — keyboard focus is in
+// the editor and the dock just reflects the active session. The
+// toggle command re-focuses; Enter/Esc blur.
+let dockBlurred = false;
+// Monotonic token so a rapid run of ↑/↓ only commits the *last*
+// selection after the debounce window (30ms) — see `scheduleDockSwitch`.
+let dockSwitchToken = 0;
+const DOCK_WIDTH_COLS = 32;
 // Scope is remembered across opens of the picker (module state
 // survives dialog close). Defaults to "all" so the picker opens
 // showing every session; flipping it with the Project control / Alt+P
@@ -1684,7 +1697,7 @@ function refreshOpenDialog(): void {
   } else if (openDialog.selectedIndex < 0) {
     openDialog.selectedIndex = 0;
   }
-  openPanel.update(buildOpenSpec());
+  openPanel.update(dockMode ? buildDockSpec() : buildOpenSpec());
   // The list widget's `selectedIndex` in the spec is initial-only;
   // pin it via mutation so re-renders don't snap back to 0.
   if (openDialog.filteredIds.length > 0) {
@@ -1692,8 +1705,9 @@ function refreshOpenDialog(): void {
   }
 }
 
-function openControlRoom(): void {
+function openControlRoom(opts: { dock?: boolean } = {}): void {
   if (openPanel) return;
+  const asDock = opts?.dock === true;
   reconcileSessions();
   // Summarise on-disk session content up front so the trivial filter
   // has data on the first render.
@@ -1725,10 +1739,22 @@ function openControlRoom(): void {
   const activeIdx = openDialog.filteredIds.indexOf(activeId);
   openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
   openPanel = new FloatingWidgetPanel();
-  // 90% × 90% of the terminal — the open dialog wants room for
-  // a real session list + preview pane, unlike the new-session
-  // form which stays compact.
-  openPanel.mount(buildOpenSpec(), { widthPct: 90, heightPct: 90 });
+  if (asDock) {
+    // Persistent, non-modal full-height left column. Mount, then
+    // re-anchor to the dock (which sets the content-wrap width to the
+    // dock columns) and re-render so the spec lays out at dock width.
+    dockMode = true;
+    dockBlurred = false;
+    openPanel.mount(buildDockSpec(), { widthPct: 100, heightPct: 100 });
+    editor.floatingPanelControl(openPanel.id(), "dock", DOCK_WIDTH_COLS);
+    openPanel.update(buildDockSpec());
+  } else {
+    dockMode = false;
+    // 90% × 90% of the terminal — the open dialog wants room for
+    // a real session list + preview pane, unlike the new-session
+    // form which stays compact.
+    openPanel.mount(buildOpenSpec(), { widthPct: 90, heightPct: 90 });
+  }
   if (openDialog.filteredIds.length > 0) {
     openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
   }
@@ -1755,8 +1781,138 @@ function closeOpenDialog(): void {
     openPanel = null;
   }
   openDialog = null;
+  dockMode = false;
+  dockBlurred = false;
   editor.setEditorMode(null);
 }
+
+// ---------------------------------------------------------------------
+// Global left dock
+//
+// The dock reuses the open-dialog state/panel but is mounted as a
+// full-height, non-modal left column (host `floatingPanelControl`
+// "dock"). It renders a single-column session list (the modal's
+// two-pane picker would be unreadable at dock width). Navigating the
+// list switches the active window live (debounced), so the editor to
+// the dock's right *is* the preview.
+// ---------------------------------------------------------------------
+
+// Compact single-column spec for the dock. Reuses the same `sessions`
+// list key + filter/scope/action keys as the modal so the existing
+// `widget_event` handlers fire unchanged.
+function buildDockSpec(): WidgetSpec {
+  if (!openDialog) return col();
+  const filtered = openDialog.filteredIds;
+  const activeId = editor.activeWindow();
+  const items = filtered.map((id) => renderListItem(id, activeId));
+  const itemKeys = filtered.map(String);
+  const selIdx = filtered.length === 0
+    ? -1
+    : Math.max(0, Math.min(openDialog.selectedIndex, filtered.length - 1));
+  const inConfirm = openDialog.pendingConfirm !== null;
+  const scope = openDialog.scope;
+  const newKey = editor.getKeybindingLabel(
+    "orchestrator_open_new_from_picker",
+    OPEN_MODE,
+  );
+  const newLabel = newKey ? `+ New ${newKey}` : "+ New";
+
+  return col(
+    {
+      kind: "raw",
+      entries: [
+        styledRow([
+          { text: "ORCHESTRATOR", style: { fg: "ui.popup_border_fg", bold: true } },
+        ]),
+      ],
+    },
+    row(
+      button(newLabel, {
+        intent: "primary",
+        key: inConfirm ? undefined : "new-session",
+      }),
+      flexSpacer(),
+      button(scope === "current" ? "this ▾" : "all ▾", {
+        key: inConfirm ? undefined : "scope-toggle",
+      }),
+    ),
+    text({
+      value: openDialog.filter.value,
+      cursorByte: openDialog.filter.cursor,
+      label: "Filter",
+      placeholder: "/ to search",
+      fullWidth: true,
+      key: inConfirm ? undefined : "filter",
+    }),
+    sessionsSeparator(),
+    sessionsColumnHeader(),
+    list({
+      items,
+      itemKeys,
+      selectedIndex: selIdx,
+      visibleRows: openDialog.listVisibleRows,
+      focusable: false,
+      key: inConfirm ? undefined : "sessions",
+    }),
+    row(
+      flexSpacer(),
+      hintBar([
+        { keys: "↑↓", label: "switch" },
+        { keys: "Enter", label: "edit" },
+        { keys: "Esc", label: "editor" },
+      ]),
+      flexSpacer(),
+    ),
+  );
+}
+
+function refreshDock(): void {
+  if (openPanel && dockMode && openDialog) {
+    openPanel.update(buildDockSpec());
+    if (openDialog.filteredIds.length > 0) {
+      openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+    }
+  }
+}
+
+// Commit the highlighted session as the active window after a short
+// debounce, so holding ↑/↓ to traverse the list doesn't thrash through
+// every session in between. `fromEdge` drives the directional wipe.
+function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
+  const token = ++dockSwitchToken;
+  void (async () => {
+    await editor.delay(30);
+    if (token !== dockSwitchToken) return;
+    if (!openDialog || !openPanel || !dockMode || dockBlurred) return;
+    const id = openDialog.filteredIds[openDialog.selectedIndex];
+    if (typeof id !== "number" || id <= 0) return;
+    if (orchestratorSessions.get(id)?.discovered) return;
+    if (id === editor.activeWindow()) return;
+    if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
+    else editor.setActiveWindow(id);
+  })();
+}
+
+// Toggle command (bind to a key of choice; reachable as
+// "Orchestrator: Toggle Dock" in the command palette). hidden → show
+// + focus; focused → hide; blurred → re-focus.
+function toggleDock(): void {
+  if (openPanel && dockMode) {
+    if (dockBlurred) {
+      editor.floatingPanelControl(openPanel.id(), "focus");
+      dockBlurred = false;
+      editor.setEditorMode(OPEN_MODE);
+    } else {
+      closeOpenDialog();
+    }
+    return;
+  }
+  // A centered modal picker is open — leave it alone.
+  if (openPanel) return;
+  openControlRoom({ dock: true });
+}
+
+registerHandler("orchestrator_dock_toggle", toggleDock);
 
 // Stop every process one session owns. Sends SIGTERM first via the
 // host's `signalWindow` (which fans out through the window's
@@ -4220,7 +4376,17 @@ editor.on("widget_event", (e) => {
   // Open dialog (session picker)
   // ---------------------------------------------------------------------
   if (openPanel && openDialog && e.panel_id === openPanel.id()) {
-    if (e.event_type === "change" && e.widget_key === "filter") {
+    if (e.event_type === "blur") {
+      // Host fired this because Esc was pressed while the dock was
+      // focused — focus has returned to the editor; the dock stays
+      // visible. Drop the dock's editor-mode so its chords (/, Space,
+      // …) don't intercept keys meant for the buffer.
+      if (dockMode) {
+        dockBlurred = true;
+        editor.setEditorMode(null);
+      }
+      return;
+    }
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const value = payload.value;
       const cursor = payload.cursorByte;
@@ -4255,8 +4421,20 @@ editor.on("widget_event", (e) => {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const idx = payload.index;
       if (typeof idx === "number") {
+        const prevIdx = openDialog.selectedIndex;
         openDialog.selectedIndex = idx;
         clearDialogError();
+        if (dockMode) {
+          // The editor to the dock's right is the preview: arrowing
+          // the list switches the active window live (debounced),
+          // wiping down when moving down the list and up when moving
+          // up. Re-render the dock list to move the highlight now.
+          openPanel.update(buildDockSpec());
+          openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+          const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
+          scheduleDockSwitch(fromEdge);
+          return;
+        }
         // Update preview pane.
         openPanel.update(buildOpenSpec());
         // Re-pin the list selection so the spec re-emit doesn't
@@ -4297,6 +4475,14 @@ editor.on("widget_event", (e) => {
       }
       if (typeof id === "number" && id > 0 && id !== editor.activeWindow()) {
         editor.setActiveWindow(id);
+      }
+      if (dockMode && openPanel) {
+        // Dock stays visible; Enter just hands keyboard focus to the
+        // editor (the session is already active via live-switch).
+        editor.floatingPanelControl(openPanel.id(), "blur");
+        dockBlurred = true;
+        editor.setEditorMode(null);
+        return;
       }
       closeOpenDialog();
       return;
@@ -4547,6 +4733,13 @@ editor.registerCommand(
   "Orchestrator: Kill Selected",
   "Close the session highlighted in the open Orchestrator prompt",
   "orchestrator_kill",
+  null,
+  { terminalBypass: true },
+);
+editor.registerCommand(
+  "Orchestrator: Toggle Dock",
+  "Show/hide the persistent left session dock (↑↓ switches windows live)",
+  "orchestrator_dock_toggle",
   null,
   { terminalBypass: true },
 );

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1765,7 +1765,9 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
   // selection. The host clamps to the first tabbable when "visit"
   // isn't in the spec (empty filter result, no session), which is
   // safe — there's nothing to act on then anyway.
-  openPanel.setFocusKey("visit");
+  // In the dock the focusable session list is the default focus
+  // (↑↓ switch, Enter blurs to editor). The modal lands on Visit.
+  openPanel.setFocusKey(asDock ? "sessions" : "visit");
   editor.setEditorMode(OPEN_MODE);
 
   // Discover worktrees that exist on disk but aren't open yet and
@@ -1851,7 +1853,10 @@ function buildDockSpec(): WidgetSpec {
       itemKeys,
       selectedIndex: selIdx,
       visibleRows: openDialog.listVisibleRows,
-      focusable: false,
+      // Focusable in the dock (unlike the modal, where Up/Down forward
+      // from the filter): the list itself is the default focus so
+      // ↑↓ drive live-switch and Enter blurs to the editor.
+      focusable: !inConfirm,
       key: inConfirm ? undefined : "sessions",
     }),
     row(
@@ -4387,6 +4392,7 @@ editor.on("widget_event", (e) => {
       }
       return;
     }
+    if (e.event_type === "change" && e.widget_key === "filter") {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const value = payload.value;
       const cursor = payload.cursorByte;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1799,9 +1799,72 @@ function closeOpenDialog(): void {
 // the dock's right *is* the preview.
 // ---------------------------------------------------------------------
 
+// Single-line compact detail for the selected session, pinned just
+// above the action row. One line keeps the list-fill maths exact.
+function dockDetailLine(s: AgentSession | undefined): WidgetSpec | null {
+  if (!s || s.discovered) return null;
+  return {
+    kind: "raw",
+    entries: [
+      styledRow([
+        { text: "▸ ", style: { fg: "ui.help_key_fg" } },
+        { text: s.branch || "(detached)", style: { fg: "ui.menu_disabled_fg" } },
+      ]),
+    ],
+  };
+}
+
+// Action buttons for the selected live session — same keys as the
+// modal's preview pane so the existing widget_event handlers fire.
+function dockActionRow(s: AgentSession | undefined): WidgetSpec | null {
+  if (!s || s.discovered) return null;
+  const hasWorktree = ownsWorktree(s);
+  const isLastWindow = s.id > 0 && liveWindowCount() <= 1;
+  return row(
+    button("Stop", { key: "stop", disabled: !s.terminalId }),
+    spacer(1),
+    button("Arch", { key: "archive", disabled: !hasWorktree || isLastWindow }),
+    spacer(1),
+    button("Del", { intent: "danger", key: "delete", disabled: isLastWindow }),
+    flexSpacer(),
+  );
+}
+
+// Compact in-place confirmation for the dock (Delete is the only
+// action that confirms). Reuses `confirm-cancel` / `confirm-<action>`
+// keys so the modal's handlers run unchanged. Two lines.
+function dockConfirmRows(
+  confirm: { action: BulkAction; ids: number[] },
+): WidgetSpec[] {
+  const cap = confirm.action[0].toUpperCase() + confirm.action.slice(1);
+  const id = confirm.ids[0];
+  const label = orchestratorSessions.get(id)?.label ?? `#${id}`;
+  return [
+    {
+      kind: "raw",
+      entries: [
+        styledRow([
+          {
+            text: `${cap} ${label}?`,
+            style: { fg: "ui.status_error_indicator_fg", bold: true },
+          },
+        ]),
+      ],
+    },
+    row(
+      button("Cancel", { key: "confirm-cancel" }),
+      spacer(1),
+      button(`${cap}`, { intent: "danger", key: `confirm-${confirm.action}` }),
+      flexSpacer(),
+    ),
+  ];
+}
+
 // Compact single-column spec for the dock. Reuses the same `sessions`
 // list key + filter/scope/action keys as the modal so the existing
-// `widget_event` handlers fire unchanged.
+// `widget_event` handlers fire unchanged. The session list fills the
+// available height; the hint bar is pinned to the bottom by sizing the
+// list to consume everything above the fixed bottom block.
 function buildDockSpec(): WidgetSpec {
   if (!openDialog) return col();
   const filtered = openDialog.filteredIds;
@@ -1811,13 +1874,63 @@ function buildDockSpec(): WidgetSpec {
   const selIdx = filtered.length === 0
     ? -1
     : Math.max(0, Math.min(openDialog.selectedIndex, filtered.length - 1));
-  const inConfirm = openDialog.pendingConfirm !== null;
+  const selected = selIdx >= 0 ? orchestratorSessions.get(filtered[selIdx]) : undefined;
+  const confirm = openDialog.pendingConfirm;
+  const inConfirm = confirm !== null;
   const scope = openDialog.scope;
   const newKey = editor.getKeybindingLabel(
     "orchestrator_open_new_from_picker",
     OPEN_MODE,
   );
   const newLabel = newKey ? `+ New ${newKey}` : "+ New";
+  const worktreeKey = editor.getKeybindingLabel("orchestrator_toggle_worktrees", OPEN_MODE);
+  const worktreeLabel = worktreeKey ? `worktrees (${worktreeKey})` : "worktrees";
+
+  // Pinned bottom block: a confirm prompt (separator + 2 rows) OR
+  // detail + actions (separator + 0–2 rows), then the hint bar. The
+  // list is sized to consume the height above so the hint stays glued
+  // to the bottom.
+  const hintRow = row(
+    flexSpacer(),
+    hintBar([
+      { keys: "↑↓", label: "switch" },
+      { keys: "Enter", label: "edit" },
+      { keys: "Esc", label: "editor" },
+    ]),
+    flexSpacer(),
+  );
+  let bottom: WidgetSpec[];
+  let bottomRows: number;
+  if (inConfirm && confirm) {
+    bottom = [sessionsSeparator(), ...dockConfirmRows(confirm), hintRow];
+    bottomRows = 1 + 2 + 1;
+  } else {
+    const detail = dockDetailLine(selected);
+    const actions = dockActionRow(selected);
+    bottom = [];
+    bottomRows = 1; // hint
+    if (detail || actions) {
+      bottom.push(sessionsSeparator());
+      bottomRows += 1;
+    }
+    if (detail) {
+      bottom.push(detail);
+      bottomRows += 1;
+    }
+    if (actions) {
+      bottom.push(actions);
+      bottomRows += 1;
+    }
+    bottom.push(hintRow);
+  }
+
+  // Size the list to fill the dock. Inner height = screen rows − dock
+  // borders (2); fixed top chrome is 6 rows (title, New/scope,
+  // worktrees toggle, filter, separator, column header).
+  const screen = editor.getScreenSize();
+  const innerH = Math.max(8, (screen.height > 0 ? screen.height : 30) - 2);
+  const listRows = Math.max(MIN_LIST_ROWS, innerH - 6 - bottomRows);
+  openDialog.listVisibleRows = listRows;
 
   return col(
     {
@@ -1838,6 +1951,12 @@ function buildDockSpec(): WidgetSpec {
         key: inConfirm ? undefined : "scope-toggle",
       }),
     ),
+    row(
+      toggle(openDialog.showWorktrees, worktreeLabel, {
+        key: inConfirm ? undefined : "worktree-show",
+      }),
+      flexSpacer(),
+    ),
     text({
       value: openDialog.filter.value,
       cursorByte: openDialog.filter.cursor,
@@ -1852,32 +1971,15 @@ function buildDockSpec(): WidgetSpec {
       items,
       itemKeys,
       selectedIndex: selIdx,
-      visibleRows: openDialog.listVisibleRows,
+      visibleRows: listRows,
       // Focusable in the dock (unlike the modal, where Up/Down forward
       // from the filter): the list itself is the default focus so
       // ↑↓ drive live-switch and Enter blurs to the editor.
       focusable: !inConfirm,
       key: inConfirm ? undefined : "sessions",
     }),
-    row(
-      flexSpacer(),
-      hintBar([
-        { keys: "↑↓", label: "switch" },
-        { keys: "Enter", label: "edit" },
-        { keys: "Esc", label: "editor" },
-      ]),
-      flexSpacer(),
-    ),
+    ...bottom,
   );
-}
-
-function refreshDock(): void {
-  if (openPanel && dockMode && openDialog) {
-    openPanel.update(buildDockSpec());
-    if (openDialog.filteredIds.length > 0) {
-      openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
-    }
-  }
 }
 
 // Commit the highlighted session as the active window after a short

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -344,6 +344,14 @@ let dockBlurred = false;
 // selection after the debounce window (30ms) — see `scheduleDockSwitch`.
 let dockSwitchToken = 0;
 const DOCK_WIDTH_COLS = 32;
+// The dock's own editor mode. Unlike the modal picker (OPEN_MODE), the
+// dock binds Up/Down/Enter/Esc explicitly so navigation + dive + leave
+// are deterministic regardless of which inner widget holds focus.
+const DOCK_MODE = "orchestrator-dock";
+// Which dock zone has keyboard focus: the session list (default) or the
+// filter input. `/` switches to the filter; Enter/Esc from the filter
+// return to the list (rather than diving / leaving).
+let dockFocus: "list" | "filter" = "list";
 // Scope is remembered across opens of the picker (module state
 // survives dialog close). Defaults to "all" so the picker opens
 // showing every session; flipping it with the Project control / Alt+P
@@ -1773,7 +1781,12 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
   // In the dock the focusable session list is the default focus
   // (↑↓ switch, Enter blurs to editor). The modal lands on Visit.
   openPanel.setFocusKey(asDock ? "sessions" : "visit");
-  editor.setEditorMode(OPEN_MODE);
+  if (asDock) {
+    dockFocus = "list";
+    editor.setEditorMode(DOCK_MODE);
+  } else {
+    editor.setEditorMode(OPEN_MODE);
+  }
 
   // Discover worktrees that exist on disk but aren't open yet and
   // fold them into the list. Async (it shells out to git per
@@ -2632,6 +2645,75 @@ editor.defineMode(
   true,
 );
 
+// The dock's mode: list navigation + dive/leave are explicit bindings.
+// `/`, Space, and the M-* chords reuse the picker handlers (they operate
+// on the shared `openDialog`).
+editor.defineMode(
+  DOCK_MODE,
+  [
+    ["Up", "orchestrator_dock_up"],
+    ["Down", "orchestrator_dock_down"],
+    ["Enter", "orchestrator_dock_enter"],
+    ["Escape", "orchestrator_dock_escape"],
+    ["/", "orchestrator_focus_filter"],
+    ["Space", "orchestrator_toggle_select"],
+    ["M-n", "orchestrator_open_new_from_picker"],
+    ["M-p", "orchestrator_toggle_scope"],
+    ["M-t", "orchestrator_toggle_worktrees"],
+  ],
+  true,
+  true,
+);
+
+// Move the dock's session-list selection and live-switch the active
+// window. Works whether the list or the filter holds focus (so you can
+// type a filter and arrow through results without leaving the input).
+function dockMove(delta: number): void {
+  if (!openDialog || !openPanel || !dockMode) return;
+  const n = openDialog.filteredIds.length;
+  if (n === 0) return;
+  const prev = openDialog.selectedIndex;
+  let next = prev + delta;
+  if (next < 0) next = 0;
+  if (next >= n) next = n - 1;
+  if (next === prev) return;
+  openDialog.selectedIndex = next;
+  openPanel.update(buildDockSpec());
+  openPanel.setSelectedIndex("sessions", next);
+  scheduleDockSwitch(delta > 0 ? "bottom" : "top");
+}
+registerHandler("orchestrator_dock_up", () => dockMove(-1));
+registerHandler("orchestrator_dock_down", () => dockMove(1));
+
+// Enter: from the filter, return to the list; from the list, dive into
+// the selected (already-active) window — focus leaves the dock, which
+// stays visible.
+registerHandler("orchestrator_dock_enter", () => {
+  if (!openPanel || !dockMode) return;
+  if (dockFocus === "filter") {
+    dockFocus = "list";
+    openPanel.setFocusKey("sessions");
+    return;
+  }
+  editor.floatingPanelControl(openPanel.id(), "blur");
+  dockBlurred = true;
+  editor.setEditorMode(null);
+});
+
+// Esc: from the filter, return to the list; from the list, leave the
+// dock (focus the editor; the dock stays visible).
+registerHandler("orchestrator_dock_escape", () => {
+  if (!openPanel || !dockMode) return;
+  if (dockFocus === "filter") {
+    dockFocus = "list";
+    openPanel.setFocusKey("sessions");
+    return;
+  }
+  editor.floatingPanelControl(openPanel.id(), "blur");
+  dockBlurred = true;
+  editor.setEditorMode(null);
+});
+
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
   closeOpenDialog();
@@ -2641,6 +2723,7 @@ registerHandler("orchestrator_open_new_from_picker", () => {
 registerHandler("orchestrator_focus_filter", () => {
   if (!openDialog || !openPanel) return;
   openPanel.setFocusKey("filter");
+  if (dockMode) dockFocus = "filter";
 });
 
 // Space (rebindable): toggle the highlighted row in/out of the bulk
@@ -2664,6 +2747,12 @@ registerHandler("orchestrator_toggle_select", () => {
   }
   clearDialogError();
   refreshOpenDialog();
+  // The dock has no bulk preview pane / Visit button; just toggle the
+  // checkbox and keep focus on the list.
+  if (dockMode) {
+    openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+    return;
+  }
   const isBulk = selectedSessions().length >= 2;
   if (!wasBulk && isBulk) {
     // Entering bulk mode — land focus on a bulk button (Up/Down from
@@ -4486,13 +4575,24 @@ editor.on("widget_event", (e) => {
   // ---------------------------------------------------------------------
   if (openPanel && openDialog && e.panel_id === openPanel.id()) {
     if (e.event_type === "blur") {
-      // Host fired this because Esc was pressed while the dock was
-      // focused — focus has returned to the editor; the dock stays
-      // visible. Drop the dock's editor-mode so its chords (/, Space,
-      // …) don't intercept keys meant for the buffer.
+      // Host fired this because focus left the dock (Esc/Enter dive,
+      // editor click, or an unhandled chord like Ctrl+P). The dock
+      // stays visible; drop its editor-mode so its chords (/, Space,
+      // Up/Down, …) don't intercept keys meant for the buffer.
       if (dockMode) {
         dockBlurred = true;
         editor.setEditorMode(null);
+      }
+      return;
+    }
+    if (e.event_type === "focus") {
+      // Focus (re-)entered the dock — e.g. a mouse click on a row or
+      // the filter. Re-arm the dock's editor-mode so the keyboard
+      // works again, and track which zone was focused.
+      if (dockMode) {
+        dockBlurred = false;
+        editor.setEditorMode(DOCK_MODE);
+        dockFocus = e.widget_key === "filter" ? "filter" : "list";
       }
       return;
     }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2666,6 +2666,14 @@ editor.defineMode(
 
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
+  // TODO(dock): opening the new-session form closes the dock because the
+  // host allows only one mounted floating panel at a time, so the
+  // centered form replaces the left dock. The dock (left column) and a
+  // centered modal occupy disjoint regions and SHOULD be able to coexist
+  // — i.e. "+ New" from the dock should leave the dock visible. Fixing
+  // this needs the host to hold two panels (a dock slot + a centered
+  // slot) and route input/mouse to the focused one. Deferred to a future
+  // branch; see docs/internal/orchestrator-dock-gaps.md.
   closeOpenDialog();
   openForm({ fromPicker: true });
 });

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1755,7 +1755,15 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     // dock columns) and re-render so the spec lays out at dock width.
     dockMode = true;
     dockBlurred = false;
-    openPanel.mount(buildDockSpec(), { widthPct: 100, heightPct: 100 });
+    // Mount straight into the host's dedicated dock slot so it
+    // coexists with a centered modal (the New-Session form) instead
+    // of being replaced by it. `asDock` carves the left column and
+    // wraps the content to the dock width.
+    openPanel.mount(buildDockSpec(), {
+      widthPct: 100,
+      heightPct: 100,
+      asDock: true,
+    });
     editor.floatingPanelControl(openPanel.id(), "dock", DOCK_WIDTH_COLS);
     openPanel.update(buildDockSpec());
   } else {
@@ -2666,14 +2674,17 @@ editor.defineMode(
 
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
-  // TODO(dock): opening the new-session form closes the dock because the
-  // host allows only one mounted floating panel at a time, so the
-  // centered form replaces the left dock. The dock (left column) and a
-  // centered modal occupy disjoint regions and SHOULD be able to coexist
-  // — i.e. "+ New" from the dock should leave the dock visible. Fixing
-  // this needs the host to hold two panels (a dock slot + a centered
-  // slot) and route input/mouse to the focused one. Deferred to a future
-  // branch; see docs/internal/orchestrator-dock-gaps.md.
+  // The New-Session form is a centered modal in the host's dedicated
+  // floating slot, which coexists with the dock's own slot. From the
+  // dock, leave the dock mounted underneath (it keeps showing the live
+  // session list); from the centered picker, replace it with the form.
+  if (dockMode) {
+    // Hand keyboard focus to the form by blurring the dock; the host
+    // routes keys to the focused centered modal first.
+    dockBlurred = true;
+    openForm({ fromPicker: true });
+    return;
+  }
   closeOpenDialog();
   openForm({ fromPicker: true });
 });
@@ -3914,13 +3925,29 @@ function closeForm(): void {
   editor.setEditorMode(null);
 }
 
+// When the New-Session form was opened on top of a still-mounted dock,
+// closing the form returns keyboard focus to the dock (rather than
+// reopening a centered picker). Returns true when it handled the
+// restore — i.e. the dock is live.
+function restoreDockAfterForm(): boolean {
+  if (!openPanel || !dockMode) return false;
+  dockBlurred = false;
+  dockFocus = "list";
+  editor.floatingPanelControl(openPanel.id(), "focus", 0);
+  openPanel.setFocusKey("sessions");
+  refreshOpenDialog();
+  return true;
+}
+
 // Cancel path: tear down the form, and if it was reached via the
 // picker (Alt+N or "+ New Session" button), reopen the picker so
 // Esc behaves like a true "back" rather than dropping the user
-// into the bare editor.
+// into the bare editor. When the dock is still mounted underneath,
+// just hand focus back to it instead.
 function cancelForm(): void {
   const wasFromPicker = !!form?.fromPicker;
   closeForm();
+  if (restoreDockAfterForm()) return;
   if (wasFromPicker) {
     openControlRoom();
   }
@@ -4069,6 +4096,13 @@ async function submitForm(): Promise<void> {
   if (createWorktree) appendHistory("branch", reportedBranch);
 
   closeForm();
+  // When the form was opened over the dock, the new session dives in
+  // below — hand keyboard focus to the dived-into terminal by blurring
+  // the dock (it stays visible and refreshes to show the new row).
+  if (openPanel && dockMode) {
+    dockBlurred = true;
+    editor.floatingPanelControl(openPanel.id(), "blur", 0);
+  }
 
   // Spawn the new window + agent terminal atomically. Compared to
   // the legacy `createWindow → window_created hook → createTerminal`
@@ -4113,6 +4147,8 @@ async function submitForm(): Promise<void> {
       branch: reportedBranch || undefined,
     };
     orchestratorSessions.set(id, tracked);
+    // Refresh the dock so the freshly-created session shows up.
+    if (openPanel && dockMode) refreshOpenDialog();
   } catch (e) {
     editor.setStatus(
       `Orchestrator: failed to start session — ${
@@ -4521,6 +4557,7 @@ editor.on("widget_event", (e) => {
       form = null;
       formPanel = null;
       editor.setEditorMode(null);
+      if (restoreDockAfterForm()) return;
       if (wasFromPicker) {
         openControlRoom();
       }
@@ -4554,6 +4591,15 @@ editor.on("widget_event", (e) => {
       // Host Space on the dock → toggle the highlighted row's
       // multi-select checkbox.
       if (dockMode) toggleSelectCurrent();
+      return;
+    }
+    if (e.event_type === "dock_new") {
+      // Host Alt+N on the dock → open the new-session form. The form is
+      // a centered modal in a separate slot, so the dock stays visible.
+      if (dockMode) {
+        dockBlurred = true;
+        openForm({ fromPicker: true });
+      }
       return;
     }
     if (e.event_type === "change" && e.widget_key === "filter") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -349,6 +349,15 @@ const DOCK_WIDTH_COLS = 32;
 // (dispatch_floating_widget_key) reads the panel focus directly to route
 // Enter/Esc/Space//'; this mirror is informational for the plugin.
 let dockFocus: "list" | "filter" = "list";
+// Full focused-widget mirror for the open dialog (both dock and
+// centered-picker modes). Updated from every `focus` widget_event.
+// Used by `toggleSelectCurrent` so a Space keypress while focus is
+// on a filter checkbox toggles *that* checkbox rather than the list
+// — see the OPEN_MODE `["Space", "orchestrator_toggle_select"]`
+// binding below for why the mode binding can't be made conditional
+// upstream (it has to swallow Space unconditionally to keep it out
+// of the filter text-input).
+let pickerFocusKey: string = "sessions";
 // Scope is remembered across opens of the picker (module state
 // survives dialog close). Defaults to "all" so the picker opens
 // showing every session; flipping it with the Project control / Alt+P
@@ -1785,7 +1794,12 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
   // safe — there's nothing to act on then anyway.
   // In the dock the focusable session list is the default focus
   // (↑↓ switch, Enter blurs to editor). The modal lands on Visit.
-  openPanel.setFocusKey(asDock ? "sessions" : "visit");
+  const initialFocus = asDock ? "sessions" : "visit";
+  openPanel.setFocusKey(initialFocus);
+  // Seed the `pickerFocusKey` mirror — `setFocusKey` only fires the
+  // `focus` widget_event when the inner key actually *changes*, so on
+  // a fresh mount it may not fire (no previous focus to differ from).
+  pickerFocusKey = initialFocus;
   if (asDock) {
     // The dock has no editor mode — its keys are handled at the host
     // floating-panel layer (mode bindings would be shadowed by the
@@ -2706,6 +2720,27 @@ function toggleSelectCurrent(): void {
   // Inert while a confirm prompt is up — the selection is frozen
   // behind the confirmation panel.
   if (openDialog.pendingConfirm) return;
+  // Context-sensitive Space dispatch. OPEN_MODE binds Space to
+  // `orchestrator_toggle_select` *unconditionally* — it must, to keep
+  // Space out of the filter text input (the host's
+  // dispatch_floating_widget_key defers any explicitly-bound mode key
+  // before the text-input path). We branch on the focused widget so
+  // Space on the filter checkboxes / scope chip toggles *that*
+  // control rather than the list multi-select. Other focused widgets
+  // (sessions list, Visit button, +New, the filter input itself) fall
+  // through to the list multi-select — preserving today's behaviour
+  // for widgets that don't expose a natural toggle.
+  switch (pickerFocusKey) {
+    case "worktree-show":
+      toggleShowWorktrees();
+      return;
+    case "hide-trivial":
+      toggleHideTrivial();
+      return;
+    case "scope-toggle":
+      toggleScope();
+      return;
+  }
   const id = openDialog.filteredIds[openDialog.selectedIndex];
   if (typeof id !== "number") return;
   const wasBulk = selectedSessions().length >= 2;
@@ -4578,9 +4613,14 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "focus") {
-      // Focus (re-)entered the dock — a mouse click on a row/filter, or
-      // a host-driven focus move. Track the zone so Up/Down + filter
-      // behave; mark the dock active again.
+      // Focus (re-)entered the dock / picker — a mouse click on a
+      // row/filter, a host-driven focus move, or the symmetric
+      // refocus_floating_panel notification fired by the host's
+      // un-dive mouse handler. Track the zone (dockFocus) and the
+      // exact focused widget (pickerFocusKey); mark the dock active.
+      if (typeof e.widget_key === "string" && e.widget_key.length > 0) {
+        pickerFocusKey = e.widget_key;
+      }
       if (dockMode) {
         dockBlurred = false;
         dockFocus = e.widget_key === "filter" ? "filter" : "list";

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -344,13 +344,10 @@ let dockBlurred = false;
 // selection after the debounce window (30ms) — see `scheduleDockSwitch`.
 let dockSwitchToken = 0;
 const DOCK_WIDTH_COLS = 32;
-// The dock's own editor mode. Unlike the modal picker (OPEN_MODE), the
-// dock binds Up/Down/Enter/Esc explicitly so navigation + dive + leave
-// are deterministic regardless of which inner widget holds focus.
-const DOCK_MODE = "orchestrator-dock";
 // Which dock zone has keyboard focus: the session list (default) or the
-// filter input. `/` switches to the filter; Enter/Esc from the filter
-// return to the list (rather than diving / leaving).
+// filter input. Tracked from the host's `focus` widget_event. The host
+// (dispatch_floating_widget_key) reads the panel focus directly to route
+// Enter/Esc/Space//'; this mirror is informational for the plugin.
 let dockFocus: "list" | "filter" = "list";
 // Scope is remembered across opens of the picker (module state
 // survives dialog close). Defaults to "all" so the picker opens
@@ -1782,8 +1779,11 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
   // (↑↓ switch, Enter blurs to editor). The modal lands on Visit.
   openPanel.setFocusKey(asDock ? "sessions" : "visit");
   if (asDock) {
+    // The dock has no editor mode — its keys are handled at the host
+    // floating-panel layer (mode bindings would be shadowed by the
+    // active session's buffer mode).
     dockFocus = "list";
-    editor.setEditorMode(DOCK_MODE);
+    editor.setEditorMode(null);
   } else {
     editor.setEditorMode(OPEN_MODE);
   }
@@ -2645,74 +2645,12 @@ editor.defineMode(
   true,
 );
 
-// The dock's mode: list navigation + dive/leave are explicit bindings.
-// `/`, Space, and the M-* chords reuse the picker handlers (they operate
-// on the shared `openDialog`).
-editor.defineMode(
-  DOCK_MODE,
-  [
-    ["Up", "orchestrator_dock_up"],
-    ["Down", "orchestrator_dock_down"],
-    ["Enter", "orchestrator_dock_enter"],
-    ["Escape", "orchestrator_dock_escape"],
-    ["/", "orchestrator_focus_filter"],
-    ["Space", "orchestrator_toggle_select"],
-    ["M-n", "orchestrator_open_new_from_picker"],
-    ["M-p", "orchestrator_toggle_scope"],
-    ["M-t", "orchestrator_toggle_worktrees"],
-  ],
-  true,
-  true,
-);
-
-// Move the dock's session-list selection and live-switch the active
-// window. Works whether the list or the filter holds focus (so you can
-// type a filter and arrow through results without leaving the input).
-function dockMove(delta: number): void {
-  if (!openDialog || !openPanel || !dockMode) return;
-  const n = openDialog.filteredIds.length;
-  if (n === 0) return;
-  const prev = openDialog.selectedIndex;
-  let next = prev + delta;
-  if (next < 0) next = 0;
-  if (next >= n) next = n - 1;
-  if (next === prev) return;
-  openDialog.selectedIndex = next;
-  openPanel.update(buildDockSpec());
-  openPanel.setSelectedIndex("sessions", next);
-  scheduleDockSwitch(delta > 0 ? "bottom" : "top");
-}
-registerHandler("orchestrator_dock_up", () => dockMove(-1));
-registerHandler("orchestrator_dock_down", () => dockMove(1));
-
-// Enter: from the filter, return to the list; from the list, dive into
-// the selected (already-active) window — focus leaves the dock, which
-// stays visible.
-registerHandler("orchestrator_dock_enter", () => {
-  if (!openPanel || !dockMode) return;
-  if (dockFocus === "filter") {
-    dockFocus = "list";
-    openPanel.setFocusKey("sessions");
-    return;
-  }
-  editor.floatingPanelControl(openPanel.id(), "blur");
-  dockBlurred = true;
-  editor.setEditorMode(null);
-});
-
-// Esc: from the filter, return to the list; from the list, leave the
-// dock (focus the editor; the dock stays visible).
-registerHandler("orchestrator_dock_escape", () => {
-  if (!openPanel || !dockMode) return;
-  if (dockFocus === "filter") {
-    dockFocus = "list";
-    openPanel.setFocusKey("sessions");
-    return;
-  }
-  editor.floatingPanelControl(openPanel.id(), "blur");
-  dockBlurred = true;
-  editor.setEditorMode(null);
-});
+// The dock's Enter / Esc / Space / "/" are handled at the host's
+// floating-panel layer (see dispatch_floating_widget_key), not via an
+// editor mode — `defineMode` bindings resolve against the active
+// buffer's mode, which the dock floats over, so a session with a
+// buffer-local mode would shadow them. Up/Down use the host's generic
+// list smart-keys, which fire the `select` event we live-switch on.
 
 registerHandler("orchestrator_open_new_from_picker", () => {
   if (!openDialog) return;
@@ -2732,7 +2670,7 @@ registerHandler("orchestrator_focus_filter", () => {
 // (so the now-absent "visit" focus would otherwise be clamped to a
 // random tabbable), and when the selection drops back below two the
 // per-session preview — with its "visit" button — returns.
-registerHandler("orchestrator_toggle_select", () => {
+function toggleSelectCurrent(): void {
   if (!openDialog || !openPanel) return;
   // Inert while a confirm prompt is up — the selection is frozen
   // behind the confirmation panel.
@@ -2762,7 +2700,8 @@ registerHandler("orchestrator_toggle_select", () => {
     // Back to single preview — restore focus to Visit.
     openPanel.setFocusKey("visit");
   }
-});
+}
+registerHandler("orchestrator_toggle_select", toggleSelectCurrent);
 
 function toggleScope(): void {
   if (!openDialog) return;
@@ -4575,25 +4514,26 @@ editor.on("widget_event", (e) => {
   // ---------------------------------------------------------------------
   if (openPanel && openDialog && e.panel_id === openPanel.id()) {
     if (e.event_type === "blur") {
-      // Host fired this because focus left the dock (Esc/Enter dive,
-      // editor click, or an unhandled chord like Ctrl+P). The dock
-      // stays visible; drop its editor-mode so its chords (/, Space,
-      // Up/Down, …) don't intercept keys meant for the buffer.
-      if (dockMode) {
-        dockBlurred = true;
-        editor.setEditorMode(null);
-      }
+      // Host fired this because focus left the dock (Enter/Esc dive or
+      // leave, editor click, or an unhandled chord like Ctrl+P). The
+      // dock stays visible; the host stops routing keys to it.
+      if (dockMode) dockBlurred = true;
       return;
     }
     if (e.event_type === "focus") {
-      // Focus (re-)entered the dock — e.g. a mouse click on a row or
-      // the filter. Re-arm the dock's editor-mode so the keyboard
-      // works again, and track which zone was focused.
+      // Focus (re-)entered the dock — a mouse click on a row/filter, or
+      // a host-driven focus move. Track the zone so Up/Down + filter
+      // behave; mark the dock active again.
       if (dockMode) {
         dockBlurred = false;
-        editor.setEditorMode(DOCK_MODE);
         dockFocus = e.widget_key === "filter" ? "filter" : "list";
       }
+      return;
+    }
+    if (e.event_type === "dock_space") {
+      // Host Space on the dock → toggle the highlighted row's
+      // multi-select checkbox.
+      if (dockMode) toggleSelectCurrent();
       return;
     }
     if (e.event_type === "change" && e.widget_key === "filter") {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -641,7 +641,17 @@ function ageString(createdAt: number): string {
 // the session root for sessions that predate the field (the base
 // session, externally-created windows).
 function projectKeyOf(s: AgentSession): string {
-  return s.projectPath ?? s.root;
+  // Use `||`, not `??`, so an empty-string `projectPath` also falls
+  // through to `root`. The host serialises `WindowInfo.project_path:
+  // Option<PathBuf>`: `None` is skipped (so plugin sees `undefined`),
+  // but a `Some(PathBuf::new())` — or any path that round-trips as the
+  // empty string — would survive `??` as `""` and become the sort key.
+  // That made `byProjectThenId` compare two sessions as `"" < real path`
+  // (empty lex-sorts first), reversing the dock list on Windows CI
+  // where one session's projectPath was emerging as "". Treating empty
+  // as "no projectPath" is correct anyway: an empty path is meaningless
+  // as a project identifier.
+  return s.projectPath || s.root;
 }
 
 // The project the user is currently "in" — the active window's
@@ -1995,22 +2005,7 @@ function buildDockSpec(): WidgetSpec {
       kind: "raw",
       entries: [
         styledRow([
-          {
-            // TEMPORARY DIAGNOSTIC for the Windows-only
-            // `dock_initial_sort_…` / `dock_list_order_…` failure.
-            // Embed `dockMode`, the basename's first 3 chars of `cur`,
-            // and `filteredIds` into the dock header so the CI screen
-            // dump tells us whether the plugin sees `dockMode=true` (the
-            // fix is taking effect) and what `currentProjectKey()` it
-            // believes is current at filter time. Use only the first 3
-            // chars of the basename so it doesn't collide with the
-            // tests' `row_of("aaa_project")` / `row_of("zzz_project")`
-            // substring matches. Revert once the root cause is fixed.
-            text: `ORCHESTRATOR dm=${dockMode ? "T" : "F"} c=${(
-              currentProjectKey().split(/[/\\]/).pop() ?? ""
-            ).slice(0, 3)} f=[${filtered.join(",")}]`,
-            style: { fg: "ui.popup_border_fg", bold: true },
-          },
+          { text: "ORCHESTRATOR", style: { fg: "ui.popup_border_fg", bold: true } },
         ]),
       ],
     },

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1754,16 +1754,29 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     hideTrivial: lastHideTrivial,
     bulkInFlight: null,
   };
+  // Set `dockMode` BEFORE the initial `filterSessions("")`. The sort
+  // inside `filterSessions` keys off `pinCurrentFirst = !dockMode`: the
+  // dock wants stable lex order, the modal picker wants current-first.
+  // Doing the filter first (when `dockMode` is still its previous /
+  // initial `false` value) made the dock's INITIAL render use current-
+  // first ordering, while every subsequent `refreshOpenDialog`
+  // (active_window_changed, window_created, …) used the stable lex
+  // sort. Switching the active project then visibly reordered the
+  // dock list — precisely what the dock comment forbids.
+  openPanel = new FloatingWidgetPanel();
+  if (asDock) {
+    dockMode = true;
+    dockBlurred = false;
+  } else {
+    dockMode = false;
+  }
   openDialog.filteredIds = filterSessions("");
   const activeIdx = openDialog.filteredIds.indexOf(activeId);
   openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
-  openPanel = new FloatingWidgetPanel();
   if (asDock) {
     // Persistent, non-modal full-height left column. Mount, then
     // re-anchor to the dock (which sets the content-wrap width to the
     // dock columns) and re-render so the spec lays out at dock width.
-    dockMode = true;
-    dockBlurred = false;
     // Mount straight into the host's dedicated dock slot so it
     // coexists with a centered modal (the New-Session form) instead
     // of being replaced by it. `asDock` carves the left column and
@@ -1776,7 +1789,6 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     editor.floatingPanelControl(openPanel.id(), "dock", DOCK_WIDTH_COLS);
     openPanel.update(buildDockSpec());
   } else {
-    dockMode = false;
     // 90% × 90% of the terminal — the open dialog wants room for
     // a real session list + preview pane, unlike the new-session
     // form which stays compact.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2060,14 +2060,33 @@ function buildDockSpec(): WidgetSpec {
 // every session in between. `fromEdge` drives the directional wipe.
 function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
   const token = ++dockSwitchToken;
+  console.log(`[dock-switch] scheduled token=${token} fromEdge=${fromEdge}`);
   void (async () => {
     await editor.delay(30);
-    if (token !== dockSwitchToken) return;
-    if (!openDialog || !openPanel || !dockMode || dockBlurred) return;
+    if (token !== dockSwitchToken) {
+      console.log(`[dock-switch] token=${token} superseded by ${dockSwitchToken}`);
+      return;
+    }
+    if (!openDialog || !openPanel || !dockMode || dockBlurred) {
+      console.log(
+        `[dock-switch] token=${token} skipped: openDialog=${!!openDialog} openPanel=${!!openPanel} dockMode=${dockMode} dockBlurred=${dockBlurred}`,
+      );
+      return;
+    }
     const id = openDialog.filteredIds[openDialog.selectedIndex];
-    if (typeof id !== "number" || id <= 0) return;
-    if (orchestratorSessions.get(id)?.discovered) return;
-    if (id === editor.activeWindow()) return;
+    if (typeof id !== "number" || id <= 0) {
+      console.log(`[dock-switch] token=${token} no valid id: ${id}`);
+      return;
+    }
+    if (orchestratorSessions.get(id)?.discovered) {
+      console.log(`[dock-switch] token=${token} id=${id} is discovered, skipping`);
+      return;
+    }
+    if (id === editor.activeWindow()) {
+      console.log(`[dock-switch] token=${token} id=${id} already active`);
+      return;
+    }
+    console.log(`[dock-switch] token=${token} firing setActiveWindow(${id}) fromEdge=${fromEdge}`);
     if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
     else editor.setActiveWindow(id);
   })();

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2060,33 +2060,33 @@ function buildDockSpec(): WidgetSpec {
 // every session in between. `fromEdge` drives the directional wipe.
 function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
   const token = ++dockSwitchToken;
-  console.log(`[dock-switch] scheduled token=${token} fromEdge=${fromEdge}`);
+  console.warn(`[dock-switch] scheduled token=${token} fromEdge=${fromEdge}`);
   void (async () => {
     await editor.delay(30);
     if (token !== dockSwitchToken) {
-      console.log(`[dock-switch] token=${token} superseded by ${dockSwitchToken}`);
+      console.warn(`[dock-switch] token=${token} superseded by ${dockSwitchToken}`);
       return;
     }
     if (!openDialog || !openPanel || !dockMode || dockBlurred) {
-      console.log(
+      console.warn(
         `[dock-switch] token=${token} skipped: openDialog=${!!openDialog} openPanel=${!!openPanel} dockMode=${dockMode} dockBlurred=${dockBlurred}`,
       );
       return;
     }
     const id = openDialog.filteredIds[openDialog.selectedIndex];
     if (typeof id !== "number" || id <= 0) {
-      console.log(`[dock-switch] token=${token} no valid id: ${id}`);
+      console.warn(`[dock-switch] token=${token} no valid id: ${id}`);
       return;
     }
     if (orchestratorSessions.get(id)?.discovered) {
-      console.log(`[dock-switch] token=${token} id=${id} is discovered, skipping`);
+      console.warn(`[dock-switch] token=${token} id=${id} is discovered, skipping`);
       return;
     }
     if (id === editor.activeWindow()) {
-      console.log(`[dock-switch] token=${token} id=${id} already active`);
+      console.warn(`[dock-switch] token=${token} id=${id} already active`);
       return;
     }
-    console.log(`[dock-switch] token=${token} firing setActiveWindow(${id}) fromEdge=${fromEdge}`);
+    console.warn(`[dock-switch] token=${token} firing setActiveWindow(${id}) fromEdge=${fromEdge}`);
     if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
     else editor.setActiveWindow(id);
   })();
@@ -4722,6 +4722,9 @@ editor.on("widget_event", (e) => {
     ) {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const idx = payload.index;
+      console.warn(
+        `[dock-select] event reached plugin: idx=${idx} widget_key=${e.widget_key} dockMode=${dockMode} dockBlurred=${dockBlurred}`,
+      );
       if (typeof idx === "number") {
         const prevIdx = openDialog.selectedIndex;
         openDialog.selectedIndex = idx;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -61,11 +61,11 @@ interface AgentSession {
   // Absolute filesystem root.
   root: string;
   // Canonical project root this session belongs to (set at
-  // create time from the Project Path field). `null` for
-  // sessions created outside the new-session form (e.g. the
-  // editor's base session, or sessions from before the
-  // Project Path field shipped).
-  projectPath: string | null;
+  // create time from the Project Path field). Equals `root`
+  // for sessions without an explicit project — the host
+  // normalises at the API boundary so plugins never have to
+  // distinguish `null`/`undefined`/`""`.
+  projectPath: string;
   // `true` if the session was created with the worktree
   // checkbox unchecked (shared worktree / non-git path).
   sharedWorktree: boolean;
@@ -466,7 +466,7 @@ function reconcileSessions(): void {
         id: s.id,
         label: s.label,
         root: s.root,
-        projectPath: s.project_path ?? null,
+        projectPath: s.project_path,
         sharedWorktree: s.shared_worktree ?? false,
         terminalId: null,
         // The base session has no agent; everything else
@@ -478,7 +478,7 @@ function reconcileSessions(): void {
     } else {
       existing.label = s.label;
       existing.root = s.root;
-      if (s.project_path != null) existing.projectPath = s.project_path;
+      existing.projectPath = s.project_path;
       if (s.shared_worktree != null) existing.sharedWorktree = s.shared_worktree;
     }
   }
@@ -641,17 +641,10 @@ function ageString(createdAt: number): string {
 // the session root for sessions that predate the field (the base
 // session, externally-created windows).
 function projectKeyOf(s: AgentSession): string {
-  // Use `||`, not `??`, so an empty-string `projectPath` also falls
-  // through to `root`. The host serialises `WindowInfo.project_path:
-  // Option<PathBuf>`: `None` is skipped (so plugin sees `undefined`),
-  // but a `Some(PathBuf::new())` — or any path that round-trips as the
-  // empty string — would survive `??` as `""` and become the sort key.
-  // That made `byProjectThenId` compare two sessions as `"" < real path`
-  // (empty lex-sorts first), reversing the dock list on Windows CI
-  // where one session's projectPath was emerging as "". Treating empty
-  // as "no projectPath" is correct anyway: an empty path is meaningless
-  // as a project identifier.
-  return s.projectPath || s.root;
+  // The host guarantees `projectPath` is always a non-empty string
+  // (defaults to `root` when no explicit project is set), so no
+  // `?? root` / `|| root` defence is needed here.
+  return s.projectPath;
 }
 
 // The project the user is currently "in" — the active window's
@@ -910,7 +903,13 @@ function buildPreviewEntries(
 // a real checkout, so Archive (which moves the worktree) doesn't apply
 // and Delete simply forgets the session without touching the directory.
 function ownsWorktree(s: AgentSession): boolean {
-  return !!s.discovered || (!!s.projectPath && !s.sharedWorktree);
+  // "Has an explicit project that's separate from this session's
+  // root" means the session is a worktree of that project — Archive
+  // / Delete apply. `projectPath === root` is the "no separate
+  // project" case (host normalises absence → root); skip those too.
+  return (
+    !!s.discovered || (s.projectPath !== s.root && !s.sharedWorktree)
+  );
 }
 
 // =============================================================================
@@ -2215,11 +2214,17 @@ function liveWindowCount(): number {
 // `projectPath` recorded at create/discovery time, falling back to
 // resolving from the worktree itself.
 async function worktreeRepoRoot(s: AgentSession): Promise<string | null> {
-  if (s.projectPath) {
-    const r = await resolveCanonicalRepoRoot(s.projectPath);
-    if (r) return r;
+  // `projectPath` is the canonical repo root when the session is a
+  // worktree of a separate project, and equals `root` otherwise (the
+  // host normalises absence → root). Resolve once; if the canonical
+  // path is unavailable (non-git, etc.), fall back to `root` so the
+  // caller still gets something to dedupe against.
+  const r = await resolveCanonicalRepoRoot(s.projectPath);
+  if (r) return r;
+  if (s.projectPath !== s.root) {
+    return await resolveCanonicalRepoRoot(s.root);
   }
-  return await resolveCanonicalRepoRoot(s.root);
+  return null;
 }
 
 interface LifecycleResult {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2004,24 +2004,7 @@ function buildDockSpec(): WidgetSpec {
       kind: "raw",
       entries: [
         styledRow([
-          {
-            // TEMPORARY Windows-CI diagnostic. Show, in dock-list order,
-            // the FIRST 3 chars of each session's `projectPath` basename
-            // — what `byProjectThenId`'s lex comparison actually sees.
-            // Width-constrained: 3 chars per session, joined by `>` so
-            // the order is unambiguous in the screen dump. Doesn't
-            // collide with row_of("aaa_project") / row_of("zzz_project").
-            text: `ORCHESTRATOR ${filtered
-              .map((id) => {
-                const s = orchestratorSessions.get(id);
-                if (!s) return "?";
-                const base =
-                  s.projectPath.split(/[/\\]/).pop() ?? s.projectPath;
-                return base.slice(0, 3);
-              })
-              .join(">")}`,
-            style: { fg: "ui.popup_border_fg", bold: true },
-          },
+          { text: "ORCHESTRATOR", style: { fg: "ui.popup_border_fg", bold: true } },
         ]),
       ],
     },

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2006,17 +2006,14 @@ function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
 }
 
 // Toggle command (bind to a key of choice; reachable as
-// "Orchestrator: Toggle Dock" in the command palette). hidden → show
-// + focus; focused → hide; blurred → re-focus.
+// "Orchestrator: Toggle Dock" in the command palette). Simple
+// 2-state: visible → hide, hidden → show + focus. (A blurred-but-
+// visible dock is re-focused by clicking it.) A 3-state toggle can't
+// work reliably because invoking the toggle via a chord first blurs
+// the focused dock — the toggle would then always see "blurred".
 function toggleDock(): void {
   if (openPanel && dockMode) {
-    if (dockBlurred) {
-      editor.floatingPanelControl(openPanel.id(), "focus");
-      dockBlurred = false;
-      editor.setEditorMode(OPEN_MODE);
-    } else {
-      closeOpenDialog();
-    }
+    closeOpenDialog();
     return;
   }
   // A centered modal picker is open — leave it alone.
@@ -4540,13 +4537,9 @@ editor.on("widget_event", (e) => {
         if (dockMode) {
           // The editor to the dock's right is the preview: arrowing
           // the list switches the active window live (debounced),
-          // wiping down when moving down the list and up when moving
-          // up. Re-render the dock list to move the highlight now, and
-          // keep focus pinned to the list so Enter activates it (→ blur
-          // to the editor) rather than drifting to the New button.
+          // wiping down when moving down the list and up when moving up.
           openPanel.update(buildDockSpec());
           openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
-          openPanel.setFocusKey("sessions");
           const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
           scheduleDockSwitch(fromEdge);
           return;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2004,7 +2004,24 @@ function buildDockSpec(): WidgetSpec {
       kind: "raw",
       entries: [
         styledRow([
-          { text: "ORCHESTRATOR", style: { fg: "ui.popup_border_fg", bold: true } },
+          {
+            // TEMPORARY Windows-CI diagnostic. Show, in dock-list order,
+            // the FIRST 3 chars of each session's `projectPath` basename
+            // — what `byProjectThenId`'s lex comparison actually sees.
+            // Width-constrained: 3 chars per session, joined by `>` so
+            // the order is unambiguous in the screen dump. Doesn't
+            // collide with row_of("aaa_project") / row_of("zzz_project").
+            text: `ORCHESTRATOR ${filtered
+              .map((id) => {
+                const s = orchestratorSessions.get(id);
+                if (!s) return "?";
+                const base =
+                  s.projectPath.split(/[/\\]/).pop() ?? s.projectPath;
+                return base.slice(0, 3);
+              })
+              .join(">")}`,
+            style: { fg: "ui.popup_border_fg", bold: true },
+          },
         ]),
       ],
     },

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -694,12 +694,17 @@ function filterSessions(needle: string): number[] {
   // at the top and other projects' below, and within each project the
   // pre-existing live sessions come first with the discovered on-disk
   // worktrees listed after them.
+  // The dock is persistent and switches the active session constantly,
+  // so it must NOT reorder as the active project changes — pin a stable
+  // order (project, then id). The modal picker, opened fresh each time,
+  // keeps the current-project-first grouping.
+  const pinCurrentFirst = !dockMode;
   const byProjectThenId = (a: number, b: number): number => {
     const sa = orchestratorSessions.get(a)!;
     const sb = orchestratorSessions.get(b)!;
     const aCur = projectKeyOf(sa) === cur ? 0 : 1;
     const bCur = projectKeyOf(sb) === cur ? 0 : 1;
-    if (aCur !== bCur) return aCur - bCur;
+    if (pinCurrentFirst && aCur !== bCur) return aCur - bCur;
     const ka = projectKeyOf(sa);
     const kb = projectKeyOf(sb);
     if (ka !== kb) return ka < kb ? -1 : 1;
@@ -4536,9 +4541,12 @@ editor.on("widget_event", (e) => {
           // The editor to the dock's right is the preview: arrowing
           // the list switches the active window live (debounced),
           // wiping down when moving down the list and up when moving
-          // up. Re-render the dock list to move the highlight now.
+          // up. Re-render the dock list to move the highlight now, and
+          // keep focus pinned to the list so Enter activates it (→ blur
+          // to the editor) rather than drifting to the New button.
           openPanel.update(buildDockSpec());
           openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+          openPanel.setFocusKey("sessions");
           const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
           scheduleDockSwitch(fromEdge);
           return;

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -669,6 +669,43 @@ impl Editor {
         }
     }
 
+    /// Mutable handle to the slot *option* itself (for take/assign).
+    pub(crate) fn panel_opt_mut(
+        &mut self,
+        slot: crate::app::PanelSlot,
+    ) -> &mut Option<crate::app::FloatingWidgetState> {
+        match slot {
+            crate::app::PanelSlot::Floating => &mut self.floating_widget_panel,
+            crate::app::PanelSlot::Dock => &mut self.dock,
+        }
+    }
+
+    /// Which slot currently holds the panel with this id, if any.
+    pub(crate) fn slot_of_panel(&self, panel_id: u64) -> Option<crate::app::PanelSlot> {
+        if self
+            .floating_widget_panel
+            .as_ref()
+            .is_some_and(|f| f.panel_id == panel_id)
+        {
+            Some(crate::app::PanelSlot::Floating)
+        } else if self.dock.as_ref().is_some_and(|f| f.panel_id == panel_id) {
+            Some(crate::app::PanelSlot::Dock)
+        } else {
+            None
+        }
+    }
+
+    /// Map a panel sentinel buffer-id back to its slot.
+    pub(crate) fn slot_for_panel_buffer(buffer_id: BufferId) -> Option<crate::app::PanelSlot> {
+        if buffer_id == crate::app::FLOATING_PANEL_BUFFER_ID {
+            Some(crate::app::PanelSlot::Floating)
+        } else if buffer_id == crate::app::DOCK_PANEL_BUFFER_ID {
+            Some(crate::app::PanelSlot::Dock)
+        } else {
+            None
+        }
+    }
+
     /// The active window's layout-cache (split-leaf rects, tab rects,
     /// file-explorer rect, view-line mappings). Mouse hit-testing and
     /// visual-line motion read from here.

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -531,6 +531,16 @@ impl Editor {
         self.active_window
     }
 
+    /// True iff the editor-global dock is open AND currently holds
+    /// keyboard focus. Test helpers use this to wait for `Toggle Dock`'s
+    /// async focus-grab to settle before dispatching subsequent keys;
+    /// without that readiness check, keys can race into the editor
+    /// during the gap and the test silently waits for a dock response
+    /// that never comes.
+    pub fn is_dock_focused(&self) -> bool {
+        self.dock.as_ref().is_some_and(|d| d.focused)
+    }
+
     /// Allocate the next globally-unique `BufferId`. Use this in
     /// `impl Editor` handler bodies that mint new buffer ids. Handlers
     /// that have already moved to `impl Window` use

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -646,6 +646,29 @@ impl Editor {
             .expect("active_window id must be a member of sessions")
     }
 
+    /// Borrow one of the two coexisting widget-panel slots (centered
+    /// modal vs. left dock). See `PanelSlot`.
+    pub(crate) fn panel(
+        &self,
+        slot: crate::app::PanelSlot,
+    ) -> Option<&crate::app::FloatingWidgetState> {
+        match slot {
+            crate::app::PanelSlot::Floating => self.floating_widget_panel.as_ref(),
+            crate::app::PanelSlot::Dock => self.dock.as_ref(),
+        }
+    }
+
+    /// Mutable handle to one of the two widget-panel slots.
+    pub(crate) fn panel_mut(
+        &mut self,
+        slot: crate::app::PanelSlot,
+    ) -> Option<&mut crate::app::FloatingWidgetState> {
+        match slot {
+            crate::app::PanelSlot::Floating => self.floating_widget_panel.as_mut(),
+            crate::app::PanelSlot::Dock => self.dock.as_mut(),
+        }
+    }
+
     /// The active window's layout-cache (split-leaf rects, tab rects,
     /// file-explorer rect, view-line mappings). Mouse hit-testing and
     /// visual-line motion read from here.

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -275,6 +275,8 @@ impl Editor {
             pending_vb_animations: Vec::new(),
             widget_registry: crate::widgets::WidgetRegistry::new(),
             floating_widget_panel: None,
+            dock_width: None,
+            dock_resizing: false,
         }
     }
 

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -463,18 +463,8 @@ impl Editor {
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
         // Canonicalize working_dir to resolve symlinks and normalize path components
-        // This ensures consistent path comparisons throughout the editor.
+        // This ensures consistent path comparisons throughout the editor
         let working_dir = working_dir.canonicalize().unwrap_or(working_dir);
-        // Strip Windows' `\\?\` verbatim prefix so this path is byte-equal to
-        // ones produced by ordinary `Path::join` elsewhere in the editor.
-        #[cfg(windows)]
-        let working_dir = {
-            let s = working_dir.to_string_lossy();
-            match s.strip_prefix(r"\\?\") {
-                Some(stripped) => PathBuf::from(stripped),
-                None => working_dir.clone(),
-            }
-        };
 
         t.phase("preamble");
         // Load all themes into registry

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -463,8 +463,18 @@ impl Editor {
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
         // Canonicalize working_dir to resolve symlinks and normalize path components
-        // This ensures consistent path comparisons throughout the editor
+        // This ensures consistent path comparisons throughout the editor.
         let working_dir = working_dir.canonicalize().unwrap_or(working_dir);
+        // Strip Windows' `\\?\` verbatim prefix so this path is byte-equal to
+        // ones produced by ordinary `Path::join` elsewhere in the editor.
+        #[cfg(windows)]
+        let working_dir = {
+            let s = working_dir.to_string_lossy();
+            match s.strip_prefix(r"\\?\") {
+                Some(stripped) => PathBuf::from(stripped),
+                None => working_dir.clone(),
+            }
+        };
 
         t.phase("preamble");
         // Load all themes into registry

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -275,6 +275,7 @@ impl Editor {
             pending_vb_animations: Vec::new(),
             widget_registry: crate::widgets::WidgetRegistry::new(),
             floating_widget_panel: None,
+            dock: None,
             dock_width: None,
             dock_resizing: false,
         }

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2648,8 +2648,26 @@ impl Editor {
         use crossterm::event::{KeyCode, KeyModifiers};
         let panel_id = match self.panel(slot) {
             Some(fwp) => fwp.panel_id,
-            None => return false,
+            None => {
+                tracing::warn!(
+                    target: "fresh::dock",
+                    ?slot,
+                    ?code,
+                    "dispatch_floating_widget_key: no panel mounted in slot — returning false"
+                );
+                return false;
+            }
         };
+        tracing::warn!(
+            target: "fresh::dock",
+            panel_id,
+            ?slot,
+            ?code,
+            modifiers = ?modifiers,
+            placement = ?self.panel(slot).map(|f| f.placement),
+            focused = ?self.panel(slot).map(|f| f.focused),
+            "dispatch_floating_widget_key: entry"
+        );
         // The left dock handles Enter / Esc / Space / "/" here, at the
         // floating-panel layer, *independent of editor modes*. Editor
         // modes (`defineMode`) resolve against the active buffer's mode,
@@ -2709,12 +2727,19 @@ impl Editor {
                 KeyCode::Char(' ') => {
                     // Toggle the highlighted row's multi-select checkbox
                     // (plugin owns the selection set).
-                    if self
+                    let has_handler = self
                         .plugin_manager
                         .read()
                         .unwrap()
-                        .has_hook_handlers("widget_event")
-                    {
+                        .has_hook_handlers("widget_event");
+                    tracing::warn!(
+                        target: "fresh::dock",
+                        panel_id,
+                        has_handler,
+                        focus_key = ?self.widget_registry.focus_key(panel_id),
+                        "dispatch_floating_widget_key: Space on LeftDock — firing dock_space widget_event"
+                    );
+                    if has_handler {
                         self.plugin_manager.read().unwrap().run_hook(
                             "widget_event",
                             crate::services::plugins::hooks::HookArgs::WidgetEvent {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -249,8 +249,12 @@ impl Editor {
             && (self.global_popups.is_visible() || self.active_state().popups.is_visible())
         {
             KeyContext::Popup
-        } else if self.floating_widget_panel.is_some() {
-            // A modal floating panel (picker / new-session form /
+        } else if self
+            .floating_widget_panel
+            .as_ref()
+            .is_some_and(|f| f.focused)
+        {
+            // A focused floating panel (picker / new-session form /
             // plugin overlay) is the keyboard owner. Resolve keys
             // as Normal regardless of the underlying buffer's stale
             // `key_context` (which can still be Terminal when the
@@ -259,6 +263,11 @@ impl Editor {
             // Normal)` skipped the mode-keybinding lookup for any
             // Ctrl/Alt chord the plugin had bound on the panel's
             // mode, e.g. `Alt+N` for "new session from the picker".
+            //
+            // A *blurred* panel (the orchestrator dock after Enter)
+            // falls through to the editor's own context so the buffer
+            // underneath stays keyboard-usable while the dock stays
+            // visible.
             KeyContext::Normal
         } else if self
             .active_window()
@@ -324,7 +333,10 @@ impl Editor {
         // command dispatcher; printable chars feed `textInputChar` to
         // the focused TextInput. Mouse clicks outside the panel are
         // swallowed (handled in `mouse_input`).
-        if self.floating_widget_panel.is_some()
+        if self
+            .floating_widget_panel
+            .as_ref()
+            .is_some_and(|f| f.focused)
             && self.dispatch_floating_widget_key(code, modifiers)
         {
             return Ok(());
@@ -2503,6 +2515,43 @@ impl Editor {
             Some(fwp) => fwp.panel_id,
             None => return false,
         };
+        // A left-dock panel is non-modal: Esc returns focus to the
+        // editor (blur) and leaves the dock visible, rather than
+        // tearing the panel down. The plugin is told via a "blur"
+        // widget_event so it can update its own focus mirror. Hiding
+        // the dock entirely is the toggle command's job.
+        if code == KeyCode::Esc
+            && matches!(
+                self.floating_widget_panel.as_ref().map(|f| f.placement),
+                Some(super::PanelPlacement::LeftDock { .. })
+            )
+        {
+            let widget_key = self
+                .widget_registry
+                .get(panel_id)
+                .map(|p| p.focus_key.clone())
+                .unwrap_or_default();
+            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                fwp.focused = false;
+            }
+            if self
+                .plugin_manager
+                .read()
+                .unwrap()
+                .has_hook_handlers("widget_event")
+            {
+                self.plugin_manager.read().unwrap().run_hook(
+                    "widget_event",
+                    crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                        panel_id,
+                        widget_key,
+                        event_type: "blur".to_string(),
+                        payload: serde_json::json!({}),
+                    },
+                );
+            }
+            return true;
+        }
         let key_name: Option<&str> = match code {
             KeyCode::Esc => {
                 // Mode-binding precedence: a plugin's `defineMode`

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2520,42 +2520,11 @@ impl Editor {
         // tearing the panel down. The plugin is told via a "blur"
         // widget_event so it can update its own focus mirror. Hiding
         // the dock entirely is the toggle command's job.
-        // A left-dock panel is non-modal. While the session list (or
-        // nothing) holds focus, Esc and Enter both return focus to the
-        // editor — Enter is "dive into the selected window" and Esc is
-        // "leave the dock" — leaving the dock visible (the toggle
-        // command hides it). When focus is on a Button/Toggle (the
-        // action row, a confirm prompt), Enter/Esc fall through to the
-        // widget system so those controls stay keyboard-operable.
-        if matches!(
-            self.floating_widget_panel.as_ref().map(|f| f.placement),
-            Some(super::PanelPlacement::LeftDock { .. })
-        ) && matches!(code, KeyCode::Esc | KeyCode::Enter)
-        {
-            let on_button = self
-                .widget_registry
-                .get(panel_id)
-                .map(|p| (p.focus_key.clone(), p.spec.clone()))
-                .and_then(|(key, spec)| {
-                    if key.is_empty() {
-                        None
-                    } else {
-                        crate::widgets::find_widget_by_key(&spec, &key).cloned()
-                    }
-                })
-                .map(|w| {
-                    matches!(
-                        w,
-                        fresh_core::api::WidgetSpec::Button { .. }
-                            | fresh_core::api::WidgetSpec::Toggle { .. }
-                    )
-                })
-                .unwrap_or(false);
-            if !on_button {
-                self.blur_floating_panel();
-                return true;
-            }
-        }
+        // The left dock drives Enter/Esc/Up/Down/Space//' through its
+        // own editor mode (`DOCK_MODE` in orchestrator.ts), so they are
+        // handled by the mode-binding precedence path below rather than
+        // the generic floating-panel smart keys. Nothing dock-specific
+        // is needed here.
         let key_name: Option<&str> = match code {
             KeyCode::Esc => {
                 // Mode-binding precedence: a plugin's `defineMode`

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -254,21 +254,26 @@ impl Editor {
             .as_ref()
             .is_some_and(|f| f.focused)
         {
-            // A focused floating panel (picker / new-session form /
-            // plugin overlay) is the keyboard owner. Resolve keys
-            // as Normal regardless of the underlying buffer's stale
-            // `key_context` (which can still be Terminal when the
-            // panel was opened from a python3 session). Without
-            // this, `should_check_mode_bindings = matches!(ctx,
-            // Normal)` skipped the mode-keybinding lookup for any
-            // Ctrl/Alt chord the plugin had bound on the panel's
-            // mode, e.g. `Alt+N` for "new session from the picker".
-            //
-            // A *blurred* panel (the orchestrator dock after Enter)
-            // falls through to the editor's own context so the buffer
-            // underneath stays keyboard-usable while the dock stays
-            // visible.
+            // A focused centered modal (picker / new-session form /
+            // plugin overlay) is the keyboard owner. It takes
+            // precedence over a focused dock: when "+ New" opens the
+            // form on top of the dock, the modal owns input. Resolve
+            // keys as Normal regardless of the underlying buffer's
+            // stale `key_context` (which can still be Terminal when the
+            // panel was opened from a python3 session). Without this,
+            // `should_check_mode_bindings = matches!(ctx, Normal)`
+            // skipped the mode-keybinding lookup for any Ctrl/Alt chord
+            // the plugin had bound on the panel's mode, e.g. `Alt+N`.
             KeyContext::Normal
+        } else if self.dock.as_ref().is_some_and(|f| f.focused) {
+            // A focused dock (the orchestrator's global side panel) is
+            // the keyboard owner, but it lives *outside* the active
+            // window's chrome. Its own context lets dock keybindings
+            // (when="dock") resolve while still allowing UI fallthrough.
+            // A *blurred* dock falls through to the editor's own context
+            // so the buffer underneath stays keyboard-usable while the
+            // dock stays visible.
+            KeyContext::Dock
         } else if self
             .active_window()
             .is_composite_buffer(self.active_buffer())
@@ -333,11 +338,18 @@ impl Editor {
         // command dispatcher; printable chars feed `textInputChar` to
         // the focused TextInput. Mouse clicks outside the panel are
         // swallowed (handled in `mouse_input`).
+        // A focused centered modal takes keyboard precedence over the
+        // dock (e.g. the New-Session form opened on top of the dock).
         if self
             .floating_widget_panel
             .as_ref()
             .is_some_and(|f| f.focused)
-            && self.dispatch_floating_widget_key(code, modifiers)
+            && self.dispatch_floating_widget_key(super::PanelSlot::Floating, code, modifiers)
+        {
+            return Ok(());
+        }
+        if self.dock.as_ref().is_some_and(|f| f.focused)
+            && self.dispatch_floating_widget_key(super::PanelSlot::Dock, code, modifiers)
         {
             return Ok(());
         }
@@ -2507,11 +2519,12 @@ impl Editor {
     /// currently focused TextInput.
     fn dispatch_floating_widget_key(
         &mut self,
+        slot: super::PanelSlot,
         code: crossterm::event::KeyCode,
         modifiers: crossterm::event::KeyModifiers,
     ) -> bool {
         use crossterm::event::{KeyCode, KeyModifiers};
-        let panel_id = match self.floating_widget_panel.as_ref() {
+        let panel_id = match self.panel(slot) {
             Some(fwp) => fwp.panel_id,
             None => return false,
         };
@@ -2523,7 +2536,7 @@ impl Editor {
         // through to the generic smart-key list nav below (which fires
         // the `select` event the plugin live-switches on).
         if matches!(
-            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            self.panel(slot).map(|f| f.placement),
             Some(super::PanelPlacement::LeftDock { .. })
         ) {
             let on_filter = self
@@ -2539,12 +2552,36 @@ impl Editor {
                     } else {
                         // Dive into / leave the dock — focus the editor;
                         // the dock stays visible.
-                        self.blur_floating_panel();
+                        self.blur_floating_panel(slot);
                     }
                     return true;
                 }
                 KeyCode::Char('/') if modifiers.is_empty() => {
                     self.set_panel_focus_and_notify(panel_id, "filter".to_string());
+                    return true;
+                }
+                KeyCode::Char('n' | 'N') if modifiers.contains(KeyModifiers::ALT) => {
+                    // Alt+N opens the new-session form. Handled here (not
+                    // via an editor mode) because the dock floats over the
+                    // active buffer's mode; fire a `dock_new` widget_event
+                    // the plugin turns into "+ New" — and which now leaves
+                    // the dock mounted (the form is a separate slot).
+                    if self
+                        .plugin_manager
+                        .read()
+                        .unwrap()
+                        .has_hook_handlers("widget_event")
+                    {
+                        self.plugin_manager.read().unwrap().run_hook(
+                            "widget_event",
+                            crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                                panel_id,
+                                widget_key: "sessions".to_string(),
+                                event_type: "dock_new".to_string(),
+                                payload: serde_json::json!({}),
+                            },
+                        );
+                    }
                     return true;
                 }
                 KeyCode::Char(' ') => {
@@ -2617,7 +2654,7 @@ impl Editor {
                         },
                     );
                 }
-                self.floating_widget_panel = None;
+                *self.panel_opt_mut(slot) = None;
                 let _ = self.widget_registry.unmount(panel_id);
                 return true;
             }
@@ -2718,10 +2755,10 @@ impl Editor {
             // (e.g. Ctrl-P opens the command palette).
             if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
                 if matches!(
-                    self.floating_widget_panel.as_ref().map(|f| f.placement),
+                    self.panel(slot).map(|f| f.placement),
                     Some(super::PanelPlacement::LeftDock { .. })
                 ) {
-                    self.blur_floating_panel();
+                    self.blur_floating_panel(slot);
                     return false;
                 }
                 return true;

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2526,30 +2526,7 @@ impl Editor {
                 Some(super::PanelPlacement::LeftDock { .. })
             )
         {
-            let widget_key = self
-                .widget_registry
-                .get(panel_id)
-                .map(|p| p.focus_key.clone())
-                .unwrap_or_default();
-            if let Some(fwp) = self.floating_widget_panel.as_mut() {
-                fwp.focused = false;
-            }
-            if self
-                .plugin_manager
-                .read()
-                .unwrap()
-                .has_hook_handlers("widget_event")
-            {
-                self.plugin_manager.read().unwrap().run_hook(
-                    "widget_event",
-                    crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                        panel_id,
-                        widget_key,
-                        event_type: "blur".to_string(),
-                        payload: serde_json::json!({}),
-                    },
-                );
-            }
+            self.blur_floating_panel();
             return true;
         }
         let key_name: Option<&str> = match code {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -244,12 +244,12 @@ impl Editor {
     /// keyboard-focus precedence first), ending with the always-present
     /// editor base layer.
     ///
-    /// This is the single source of truth for focus precedence: it
-    /// reproduces the historical ladder (Settings > Menu > Prompt > Popup
-    /// (only when capturing) > focused centered modal > focused dock >
-    /// CompositeBuffer / current context) as a list of
-    /// [`crate::app::overlay::Layer`]s. `get_key_context` walks it; render
-    /// and mouse dispatch are migrated onto the same list in later steps.
+    /// This is the single source of truth for overlay precedence: focus
+    /// resolution (`get_key_context`), the unfocused-popup modal guard
+    /// (`resolve_unfocused_popup_action`) and the terminal-input gate
+    /// (`dispatch_terminal_input`) all read from this list rather than
+    /// keeping their own conditional ladders. Render and mouse dispatch
+    /// are migrated onto it in later steps.
     pub(crate) fn overlay_layers(&self) -> Vec<crate::app::overlay::Layer> {
         use crate::app::overlay::{FocusPolicy, Layer, LayerKind, LayerRegion};
         use crate::input::keybindings::KeyContext;
@@ -263,7 +263,33 @@ impl Editor {
                 region: LayerRegion::FullScreen,
                 policy: FocusPolicy::Modal,
                 owns_keyboard: true,
-                key_context: KeyContext::Settings,
+                key_context: Some(KeyContext::Settings),
+                blocks_terminal_input: true,
+            });
+        }
+        // Keybinding editor and calibration wizard install their *own*
+        // input dispatchers (see `input_dispatch.rs`), so they are
+        // transparent to `KeyContext`-driven keybinding resolution
+        // (`key_context: None`) — but they fully own the keyboard while
+        // present and block PTY routing.
+        if self.keybinding_editor.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::KeybindingEditor,
+                region: LayerRegion::FullScreen,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
+        if self.calibration_wizard.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::CalibrationWizard,
+                region: LayerRegion::FullScreen,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
             });
         }
         if self.menu_state.active_menu.is_some() {
@@ -272,7 +298,8 @@ impl Editor {
                 region: LayerRegion::FullScreen,
                 policy: FocusPolicy::Modal,
                 owns_keyboard: true,
-                key_context: KeyContext::Menu,
+                key_context: Some(KeyContext::Menu),
+                blocks_terminal_input: true,
             });
         }
         if self.is_prompting() {
@@ -281,44 +308,52 @@ impl Editor {
                 region: LayerRegion::FullScreen,
                 policy: FocusPolicy::Modal,
                 owns_keyboard: true,
-                key_context: KeyContext::Prompt,
+                key_context: Some(KeyContext::Prompt),
+                blocks_terminal_input: true,
             });
         }
         // A popup is *present* whenever visible, but only *owns* the
         // keyboard while capturing (`popups_capture_keys`); a merely-visible
-        // unfocused popup falls through to the layers below it.
+        // unfocused popup falls through to the layers below it. Either way
+        // a visible popup blocks PTY routing — it covers the active buffer.
         if self.global_popups.is_visible() || self.active_state().popups.is_visible() {
             layers.push(Layer {
                 kind: LayerKind::Popup,
                 region: LayerRegion::Anchored,
                 policy: FocusPolicy::NonModal,
                 owns_keyboard: self.popups_capture_keys(),
-                key_context: KeyContext::Popup,
+                key_context: Some(KeyContext::Popup),
+                blocks_terminal_input: true,
             });
         }
         // The centered widget modal (picker / new-session form / plugin
         // overlay) owns the keyboard when focused. It resolves as `Normal`
         // regardless of the underlying buffer's (possibly stale) context so
         // mode-keybinding lookups still fire for the panel's own chords.
+        // It blocks PTY routing whenever present — the modal sits on top of
+        // (and obscures) the active terminal buffer.
         if let Some(f) = self.floating_widget_panel.as_ref() {
             layers.push(Layer {
                 kind: LayerKind::FloatingModal,
                 region: LayerRegion::Centered,
                 policy: FocusPolicy::Modal,
                 owns_keyboard: f.focused,
-                key_context: KeyContext::Normal,
+                key_context: Some(KeyContext::Normal),
+                blocks_terminal_input: true,
             });
         }
         // The editor-global dock owns the keyboard only while focused; a
         // blurred dock stays visible but lets the buffer underneath keep
-        // the keyboard.
+        // the keyboard *and* receive PTY routing (the dock lives beside the
+        // chrome, not over it).
         if let Some(d) = self.dock.as_ref() {
             layers.push(Layer {
                 kind: LayerKind::Dock,
                 region: LayerRegion::LeftDock,
                 policy: FocusPolicy::NonModal,
                 owns_keyboard: d.focused,
-                key_context: KeyContext::Dock,
+                key_context: Some(KeyContext::Dock),
+                blocks_terminal_input: d.focused,
             });
         }
         // The editor content is the keyboard owner of last resort.
@@ -335,10 +370,18 @@ impl Editor {
             region: LayerRegion::EditorContent,
             policy: FocusPolicy::Base,
             owns_keyboard: true,
-            key_context: base_context,
+            key_context: Some(base_context),
+            blocks_terminal_input: false,
         });
 
         layers
+    }
+
+    /// True iff any overlay layer is currently blocking key routing to a
+    /// terminal buffer's PTY child. The single source of truth for the
+    /// "is anything modal up?" question.
+    pub(crate) fn presents_blocking_overlay(&self) -> bool {
+        crate::app::overlay::any_layer_blocks_terminal_input(&self.overlay_layers())
     }
 
     /// Determine the current keybinding context based on UI state.

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -246,28 +246,37 @@ impl Editor {
     ///
     /// This is the single source of truth for overlay precedence: focus
     /// resolution (`get_key_context`), the unfocused-popup modal guard
-    /// (`resolve_unfocused_popup_action`) and the terminal-input gate
-    /// (`dispatch_terminal_input`) all read from this list rather than
-    /// keeping their own conditional ladders. Render and mouse dispatch
-    /// are migrated onto it in later steps.
+    /// (`resolve_unfocused_popup_action`), the terminal-input gate
+    /// (`dispatch_terminal_input`), and the mouse early-capture ladder
+    /// (`handle_mouse`) all read from this list rather than keeping their
+    /// own conditional ladders.
     pub(crate) fn overlay_layers(&self) -> Vec<crate::app::overlay::Layer> {
-        use crate::app::overlay::{FocusPolicy, Layer, LayerKind, LayerRegion};
+        use crate::app::overlay::{Layer, LayerKind};
         use crate::input::keybindings::KeyContext;
 
         let mut layers = Vec::new();
 
+        // Event-debug dialog intercepts every key event ahead of every
+        // other path (see `handle_key_event`), so it sits at the top of
+        // the stack. Its dispatcher is custom (no `KeyContext`).
+        if self.active_window().is_event_debug_active() {
+            layers.push(Layer {
+                kind: LayerKind::EventDebug,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
         // Full-screen modals own the keyboard whenever they are present.
         if self.settings_state.as_ref().is_some_and(|s| s.visible) {
             layers.push(Layer {
                 kind: LayerKind::Settings,
-                region: LayerRegion::FullScreen,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: true,
                 key_context: Some(KeyContext::Settings),
                 blocks_terminal_input: true,
             });
         }
-        // Keybinding editor and calibration wizard install their *own*
+        // Keybinding editor and calibration wizard install their own
         // input dispatchers (see `input_dispatch.rs`), so they are
         // transparent to `KeyContext`-driven keybinding resolution
         // (`key_context: None`) — but they fully own the keyboard while
@@ -275,8 +284,6 @@ impl Editor {
         if self.keybinding_editor.is_some() {
             layers.push(Layer {
                 kind: LayerKind::KeybindingEditor,
-                region: LayerRegion::FullScreen,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: true,
                 key_context: None,
                 blocks_terminal_input: true,
@@ -285,18 +292,33 @@ impl Editor {
         if self.calibration_wizard.is_some() {
             layers.push(Layer {
                 kind: LayerKind::CalibrationWizard,
-                region: LayerRegion::FullScreen,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: true,
                 key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
+        // The workspace-trust prompt is a `global_popups` entry with its
+        // own modal z-band, key handler and mouse handler. When it's the
+        // top of the global stack it takes the place of the generic
+        // `Popup` layer so the dedicated handlers can be reached by
+        // top-down kind dispatch (`handle_mouse`, `input_dispatch`).
+        let trust_on_top = self.global_popups.top().is_some_and(|p| {
+            matches!(
+                p.resolver,
+                crate::view::popup::PopupResolver::WorkspaceTrust
+            )
+        });
+        if trust_on_top {
+            layers.push(Layer {
+                kind: LayerKind::WorkspaceTrust,
+                owns_keyboard: self.popups_capture_keys(),
+                key_context: Some(KeyContext::Popup),
                 blocks_terminal_input: true,
             });
         }
         if self.menu_state.active_menu.is_some() {
             layers.push(Layer {
                 kind: LayerKind::Menu,
-                region: LayerRegion::FullScreen,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: true,
                 key_context: Some(KeyContext::Menu),
                 blocks_terminal_input: true,
@@ -305,22 +327,20 @@ impl Editor {
         if self.is_prompting() {
             layers.push(Layer {
                 kind: LayerKind::Prompt,
-                region: LayerRegion::FullScreen,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: true,
                 key_context: Some(KeyContext::Prompt),
                 blocks_terminal_input: true,
             });
         }
-        // A popup is *present* whenever visible, but only *owns* the
-        // keyboard while capturing (`popups_capture_keys`); a merely-visible
-        // unfocused popup falls through to the layers below it. Either way
-        // a visible popup blocks PTY routing — it covers the active buffer.
-        if self.global_popups.is_visible() || self.active_state().popups.is_visible() {
+        // A non-trust popup is *present* whenever visible, but only *owns*
+        // the keyboard while capturing (`popups_capture_keys`); a
+        // merely-visible unfocused popup falls through. Either way a
+        // visible popup blocks PTY routing — it covers the active buffer.
+        if !trust_on_top
+            && (self.global_popups.is_visible() || self.active_state().popups.is_visible())
+        {
             layers.push(Layer {
                 kind: LayerKind::Popup,
-                region: LayerRegion::Anchored,
-                policy: FocusPolicy::NonModal,
                 owns_keyboard: self.popups_capture_keys(),
                 key_context: Some(KeyContext::Popup),
                 blocks_terminal_input: true,
@@ -330,13 +350,11 @@ impl Editor {
         // overlay) owns the keyboard when focused. It resolves as `Normal`
         // regardless of the underlying buffer's (possibly stale) context so
         // mode-keybinding lookups still fire for the panel's own chords.
-        // It blocks PTY routing whenever present — the modal sits on top of
-        // (and obscures) the active terminal buffer.
+        // It blocks PTY routing whenever present — the modal sits on top
+        // of (and obscures) the active terminal buffer.
         if let Some(f) = self.floating_widget_panel.as_ref() {
             layers.push(Layer {
                 kind: LayerKind::FloatingModal,
-                region: LayerRegion::Centered,
-                policy: FocusPolicy::Modal,
                 owns_keyboard: f.focused,
                 key_context: Some(KeyContext::Normal),
                 blocks_terminal_input: true,
@@ -344,13 +362,11 @@ impl Editor {
         }
         // The editor-global dock owns the keyboard only while focused; a
         // blurred dock stays visible but lets the buffer underneath keep
-        // the keyboard *and* receive PTY routing (the dock lives beside the
-        // chrome, not over it).
+        // the keyboard *and* receive PTY routing (the dock lives beside
+        // the chrome, not over it).
         if let Some(d) = self.dock.as_ref() {
             layers.push(Layer {
                 kind: LayerKind::Dock,
-                region: LayerRegion::LeftDock,
-                policy: FocusPolicy::NonModal,
                 owns_keyboard: d.focused,
                 key_context: Some(KeyContext::Dock),
                 blocks_terminal_input: d.focused,
@@ -367,8 +383,6 @@ impl Editor {
         };
         layers.push(Layer {
             kind: LayerKind::Editor,
-            region: LayerRegion::EditorContent,
-            policy: FocusPolicy::Base,
             owns_keyboard: true,
             key_context: Some(base_context),
             blocks_terminal_input: false,

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -232,57 +232,114 @@ impl Editor {
         }
     }
 
-    /// Determine the current keybinding context based on UI state
-    pub fn get_key_context(&self) -> crate::input::keybindings::KeyContext {
+    /// Build the editor's overlay stack, ordered top-first (highest
+    /// keyboard-focus precedence first), ending with the always-present
+    /// editor base layer.
+    ///
+    /// This is the single source of truth for focus precedence: it
+    /// reproduces the historical ladder (Settings > Menu > Prompt > Popup
+    /// (only when capturing) > focused centered modal > focused dock >
+    /// CompositeBuffer / current context) as a list of
+    /// [`crate::app::overlay::Layer`]s. `get_key_context` walks it; render
+    /// and mouse dispatch are migrated onto the same list in later steps.
+    pub(crate) fn overlay_layers(&self) -> Vec<crate::app::overlay::Layer> {
+        use crate::app::overlay::{FocusPolicy, Layer, LayerKind, LayerRegion};
         use crate::input::keybindings::KeyContext;
 
-        // Priority order: Settings > Menu > Prompt > Popup (only when
-        // editor-pane focused) > CompositeBuffer > Current context
-        // (FileExplorer or Normal).
+        let mut layers = Vec::new();
+
+        // Full-screen modals own the keyboard whenever they are present.
         if self.settings_state.as_ref().is_some_and(|s| s.visible) {
-            KeyContext::Settings
-        } else if self.menu_state.active_menu.is_some() {
-            KeyContext::Menu
-        } else if self.is_prompting() {
-            KeyContext::Prompt
-        } else if self.popups_capture_keys()
-            && (self.global_popups.is_visible() || self.active_state().popups.is_visible())
-        {
-            KeyContext::Popup
-        } else if self
-            .floating_widget_panel
-            .as_ref()
-            .is_some_and(|f| f.focused)
-        {
-            // A focused centered modal (picker / new-session form /
-            // plugin overlay) is the keyboard owner. It takes
-            // precedence over a focused dock: when "+ New" opens the
-            // form on top of the dock, the modal owns input. Resolve
-            // keys as Normal regardless of the underlying buffer's
-            // stale `key_context` (which can still be Terminal when the
-            // panel was opened from a python3 session). Without this,
-            // `should_check_mode_bindings = matches!(ctx, Normal)`
-            // skipped the mode-keybinding lookup for any Ctrl/Alt chord
-            // the plugin had bound on the panel's mode, e.g. `Alt+N`.
-            KeyContext::Normal
-        } else if self.dock.as_ref().is_some_and(|f| f.focused) {
-            // A focused dock (the orchestrator's global side panel) is
-            // the keyboard owner, but it lives *outside* the active
-            // window's chrome. Its own context lets dock keybindings
-            // (when="dock") resolve while still allowing UI fallthrough.
-            // A *blurred* dock falls through to the editor's own context
-            // so the buffer underneath stays keyboard-usable while the
-            // dock stays visible.
-            KeyContext::Dock
-        } else if self
+            layers.push(Layer {
+                kind: LayerKind::Settings,
+                region: LayerRegion::FullScreen,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: true,
+                key_context: KeyContext::Settings,
+            });
+        }
+        if self.menu_state.active_menu.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::Menu,
+                region: LayerRegion::FullScreen,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: true,
+                key_context: KeyContext::Menu,
+            });
+        }
+        if self.is_prompting() {
+            layers.push(Layer {
+                kind: LayerKind::Prompt,
+                region: LayerRegion::FullScreen,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: true,
+                key_context: KeyContext::Prompt,
+            });
+        }
+        // A popup is *present* whenever visible, but only *owns* the
+        // keyboard while capturing (`popups_capture_keys`); a merely-visible
+        // unfocused popup falls through to the layers below it.
+        if self.global_popups.is_visible() || self.active_state().popups.is_visible() {
+            layers.push(Layer {
+                kind: LayerKind::Popup,
+                region: LayerRegion::Anchored,
+                policy: FocusPolicy::NonModal,
+                owns_keyboard: self.popups_capture_keys(),
+                key_context: KeyContext::Popup,
+            });
+        }
+        // The centered widget modal (picker / new-session form / plugin
+        // overlay) owns the keyboard when focused. It resolves as `Normal`
+        // regardless of the underlying buffer's (possibly stale) context so
+        // mode-keybinding lookups still fire for the panel's own chords.
+        if let Some(f) = self.floating_widget_panel.as_ref() {
+            layers.push(Layer {
+                kind: LayerKind::FloatingModal,
+                region: LayerRegion::Centered,
+                policy: FocusPolicy::Modal,
+                owns_keyboard: f.focused,
+                key_context: KeyContext::Normal,
+            });
+        }
+        // The editor-global dock owns the keyboard only while focused; a
+        // blurred dock stays visible but lets the buffer underneath keep
+        // the keyboard.
+        if let Some(d) = self.dock.as_ref() {
+            layers.push(Layer {
+                kind: LayerKind::Dock,
+                region: LayerRegion::LeftDock,
+                policy: FocusPolicy::NonModal,
+                owns_keyboard: d.focused,
+                key_context: KeyContext::Dock,
+            });
+        }
+        // The editor content is the keyboard owner of last resort.
+        let base_context = if self
             .active_window()
             .is_composite_buffer(self.active_buffer())
         {
             KeyContext::CompositeBuffer
         } else {
-            // Use the current context (can be FileExplorer or Normal)
             self.active_window().key_context.clone()
-        }
+        };
+        layers.push(Layer {
+            kind: LayerKind::Editor,
+            region: LayerRegion::EditorContent,
+            policy: FocusPolicy::Base,
+            owns_keyboard: true,
+            key_context: base_context,
+        });
+
+        layers
+    }
+
+    /// Determine the current keybinding context based on UI state.
+    ///
+    /// Returns the `KeyContext` of the topmost overlay layer that owns the
+    /// keyboard (see [`Editor::overlay_layers`]).
+    pub fn get_key_context(&self) -> crate::input::keybindings::KeyContext {
+        crate::app::overlay::resolve_focus_context(&self.overlay_layers())
+            .expect("editor base layer always owns the keyboard")
     }
 
     /// Handle a key event and return whether it was handled

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -160,10 +160,18 @@ impl Editor {
         // visible underneath. Skip the unfocused-popup interception so
         // pressing Esc in a settings dialog still closes the dialog
         // rather than reaching past it to dismiss a stale popup.
-        if self.settings_state.as_ref().is_some_and(|s| s.visible)
-            || self.menu_state.active_menu.is_some()
-            || self.is_prompting()
-        {
+        //
+        // Ask the overlay stack directly rather than re-listing the modal
+        // fields: any layer ranked *above* the popup layer that owns the
+        // keyboard is exactly Settings / Menu / Prompt (the only layers
+        // above Popup). `popup_visible` above guarantees a Popup layer is
+        // present, so `take_while` stops before the editor base layer.
+        let blocked_by_higher_modal = self
+            .overlay_layers()
+            .iter()
+            .take_while(|l| l.kind != crate::app::overlay::LayerKind::Popup)
+            .any(|l| l.owns_keyboard);
+        if blocked_by_higher_modal {
             return None;
         }
 

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2515,16 +2515,62 @@ impl Editor {
             Some(fwp) => fwp.panel_id,
             None => return false,
         };
-        // A left-dock panel is non-modal: Esc returns focus to the
-        // editor (blur) and leaves the dock visible, rather than
-        // tearing the panel down. The plugin is told via a "blur"
-        // widget_event so it can update its own focus mirror. Hiding
-        // the dock entirely is the toggle command's job.
-        // The left dock drives Enter/Esc/Up/Down/Space//' through its
-        // own editor mode (`DOCK_MODE` in orchestrator.ts), so they are
-        // handled by the mode-binding precedence path below rather than
-        // the generic floating-panel smart keys. Nothing dock-specific
-        // is needed here.
+        // The left dock handles Enter / Esc / Space / "/" here, at the
+        // floating-panel layer, *independent of editor modes*. Editor
+        // modes (`defineMode`) resolve against the active buffer's mode,
+        // which the dock floats over — so a session whose buffer has a
+        // local mode would shadow any global dock mode. Up/Down fall
+        // through to the generic smart-key list nav below (which fires
+        // the `select` event the plugin live-switches on).
+        if matches!(
+            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            Some(super::PanelPlacement::LeftDock { .. })
+        ) {
+            let on_filter = self
+                .widget_registry
+                .focus_key(panel_id)
+                .map(|k| k == "filter")
+                .unwrap_or(false);
+            match code {
+                KeyCode::Enter | KeyCode::Esc => {
+                    if on_filter {
+                        // Return from the filter to the session list.
+                        self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
+                    } else {
+                        // Dive into / leave the dock — focus the editor;
+                        // the dock stays visible.
+                        self.blur_floating_panel();
+                    }
+                    return true;
+                }
+                KeyCode::Char('/') if modifiers.is_empty() => {
+                    self.set_panel_focus_and_notify(panel_id, "filter".to_string());
+                    return true;
+                }
+                KeyCode::Char(' ') => {
+                    // Toggle the highlighted row's multi-select checkbox
+                    // (plugin owns the selection set).
+                    if self
+                        .plugin_manager
+                        .read()
+                        .unwrap()
+                        .has_hook_handlers("widget_event")
+                    {
+                        self.plugin_manager.read().unwrap().run_hook(
+                            "widget_event",
+                            crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                                panel_id,
+                                widget_key: "sessions".to_string(),
+                                event_type: "dock_space".to_string(),
+                                payload: serde_json::json!({}),
+                            },
+                        );
+                    }
+                    return true;
+                }
+                _ => {}
+            }
+        }
         let key_name: Option<&str> = match code {
             KeyCode::Esc => {
                 // Mode-binding precedence: a plugin's `defineMode`

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2668,12 +2668,20 @@ impl Editor {
                     return false;
                 }
             }
-            // Ctrl/Alt-modified chords with no mode binding are
-            // swallowed by the floating panel without further action —
-            // a modal dialog must not leak keys to global bindings
-            // like Ctrl-P or Alt-F. Plain (or Shift-only) chars feed
-            // printable text into the focused TextInput.
+            // Ctrl/Alt-modified chords with no mode binding: a centered
+            // modal swallows them (it must not leak keys to global
+            // bindings like Ctrl-P). The non-modal dock does the
+            // opposite — an unhandled shortcut returns focus to the
+            // editor (blur) and falls through so the editor handles it
+            // (e.g. Ctrl-P opens the command palette).
             if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+                if matches!(
+                    self.floating_widget_panel.as_ref().map(|f| f.placement),
+                    Some(super::PanelPlacement::LeftDock { .. })
+                ) {
+                    self.blur_floating_panel();
+                    return false;
+                }
                 return true;
             }
             let ch = if modifiers.contains(KeyModifiers::SHIFT) {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2520,14 +2520,41 @@ impl Editor {
         // tearing the panel down. The plugin is told via a "blur"
         // widget_event so it can update its own focus mirror. Hiding
         // the dock entirely is the toggle command's job.
-        if code == KeyCode::Esc
-            && matches!(
-                self.floating_widget_panel.as_ref().map(|f| f.placement),
-                Some(super::PanelPlacement::LeftDock { .. })
-            )
+        // A left-dock panel is non-modal. While the session list (or
+        // nothing) holds focus, Esc and Enter both return focus to the
+        // editor — Enter is "dive into the selected window" and Esc is
+        // "leave the dock" — leaving the dock visible (the toggle
+        // command hides it). When focus is on a Button/Toggle (the
+        // action row, a confirm prompt), Enter/Esc fall through to the
+        // widget system so those controls stay keyboard-operable.
+        if matches!(
+            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            Some(super::PanelPlacement::LeftDock { .. })
+        ) && matches!(code, KeyCode::Esc | KeyCode::Enter)
         {
-            self.blur_floating_panel();
-            return true;
+            let on_button = self
+                .widget_registry
+                .get(panel_id)
+                .map(|p| (p.focus_key.clone(), p.spec.clone()))
+                .and_then(|(key, spec)| {
+                    if key.is_empty() {
+                        None
+                    } else {
+                        crate::widgets::find_widget_by_key(&spec, &key).cloned()
+                    }
+                })
+                .map(|w| {
+                    matches!(
+                        w,
+                        fresh_core::api::WidgetSpec::Button { .. }
+                            | fresh_core::api::WidgetSpec::Toggle { .. }
+                    )
+                })
+                .unwrap_or(false);
+            if !on_button {
+                self.blur_floating_panel();
+                return true;
+            }
         }
         let key_name: Option<&str> = match code {
             KeyCode::Esc => {

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -34,7 +34,10 @@ impl Editor {
             || self.settings_state.as_ref().is_some_and(|s| s.visible)
             || self.calibration_wizard.is_some()
             || self.keybinding_editor.is_some()
-            || self.floating_widget_panel.is_some();
+            || self.floating_widget_panel.is_some()
+            // The dock blocks PTY routing only while it owns the keyboard;
+            // a blurred dock leaves the dived-into terminal usable.
+            || self.dock.as_ref().is_some_and(|f| f.focused);
 
         if in_modal {
             return None;

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -119,49 +119,76 @@ impl Editor {
         None
     }
 
+    /// Walk the overlay stack top-down and, if a *capture-all* modal
+    /// (Settings / KeybindingEditor / CalibrationWizard / Menu) is the
+    /// keyboard owner, dispatch to its handler and return its result.
+    /// Returns `None` when no such modal is up, letting the caller fall
+    /// through to the Prompt / Popup blocks (which have their own
+    /// fall-through semantics that don't fit a top-down kind-walk).
+    ///
+    /// The mouse counterpart is `Editor::dispatch_modal_mouse`.
+    fn dispatch_modal_keyboard(&mut self, event: &KeyEvent) -> Option<InputResult> {
+        use crate::app::overlay::LayerKind;
+
+        // Snapshot the capturing kind first so the stack borrow ends
+        // before any `&mut self` handler runs.
+        let kind = self.overlay_layers().iter().find_map(|l| match l.kind {
+            LayerKind::Settings
+            | LayerKind::KeybindingEditor
+            | LayerKind::CalibrationWizard
+            | LayerKind::Menu => Some(l.kind),
+            _ => None,
+        })?;
+        let mut ctx = InputContext::new();
+        Some(match kind {
+            LayerKind::Settings => {
+                let result = {
+                    let settings = self
+                        .settings_state
+                        .as_mut()
+                        .expect("Settings layer implies settings_state present");
+                    settings.dispatch_input(event, &mut ctx)
+                };
+                self.process_deferred_actions(ctx);
+                result
+            }
+            LayerKind::KeybindingEditor => self.handle_keybinding_editor_input(event),
+            LayerKind::CalibrationWizard => self.handle_calibration_input(event),
+            LayerKind::Menu => {
+                let all_menus: Vec<crate::config::Menu> = self
+                    .menus
+                    .menus
+                    .iter()
+                    .chain(self.menu_state.plugin_menus.iter())
+                    .cloned()
+                    .collect();
+                let result = {
+                    let mut handler = MenuInputHandler::new(&mut self.menu_state, &all_menus);
+                    handler.dispatch_input(event, &mut ctx)
+                };
+                self.process_deferred_actions(ctx);
+                result
+            }
+            _ => unreachable!("find_map only returns the four capture-all kinds"),
+        })
+    }
+
     /// Dispatch input to the appropriate modal handler.
     ///
     /// Returns `Some(InputResult)` if a modal handled the input,
     /// `None` if no modal is active and input should be handled normally.
     pub fn dispatch_modal_input(&mut self, event: &KeyEvent) -> Option<InputResult> {
+        // Always-early-return modals (Settings, KeybindingEditor,
+        // CalibrationWizard, Menu) dispatch through the overlay stack so
+        // their precedence matches `get_key_context()`, the terminal-input
+        // gate and the mouse modal-capture path. The Prompt and Popup
+        // blocks below have fall-through (`Ignored`) semantics and
+        // multi-arm internal logic, so they stay as explicit blocks.
+        if let Some(result) = self.dispatch_modal_keyboard(event) {
+            return Some(result);
+        }
+
         let mut ctx = InputContext::new();
-
-        // Settings has highest priority
-        if let Some(ref mut settings) = self.settings_state {
-            if settings.visible {
-                let result = settings.dispatch_input(event, &mut ctx);
-                self.process_deferred_actions(ctx);
-                return Some(result);
-            }
-        }
-
-        // Keybinding editor is next
-        if self.keybinding_editor.is_some() {
-            let result = self.handle_keybinding_editor_input(event);
-            return Some(result);
-        }
-
-        // Calibration wizard is next (modal, blocks all other input)
-        if self.calibration_wizard.is_some() {
-            let result = self.handle_calibration_input(event);
-            return Some(result);
-        }
-
-        // Menu is next
-        if self.menu_state.active_menu.is_some() {
-            let all_menus: Vec<crate::config::Menu> = self
-                .menus
-                .menus
-                .iter()
-                .chain(self.menu_state.plugin_menus.iter())
-                .cloned()
-                .collect();
-
-            let mut handler = MenuInputHandler::new(&mut self.menu_state, &all_menus);
-            let result = handler.dispatch_input(event, &mut ctx);
-            self.process_deferred_actions(ctx);
-            return Some(result);
-        }
 
         // Prompt is next
         if self.active_window().prompt.is_some() {

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -20,26 +20,14 @@ impl Editor {
     /// Returns `Some(InputResult)` if terminal mode handled the input,
     /// `None` if not in terminal mode or if a modal is active.
     pub fn dispatch_terminal_input(&mut self, event: &KeyEvent) -> Option<InputResult> {
-        // Skip if we're in a prompt/popup (those need to handle keys normally)
-        // — including the floating widget panel (Orchestrator picker,
-        // new-session form, plugin overlays), which is the editor-wide
-        // modal owner of the keyboard while it's up. Without this skip,
-        // a terminal-buffer-active window with `terminal_mode=true` would
-        // route keys to the PTY child even when the user's keystrokes
-        // are meant for the picker on top of it.
-        let in_modal = self.is_prompting()
-            || self.global_popups.is_visible()
-            || self.active_state().popups.is_visible()
-            || self.menu_state.active_menu.is_some()
-            || self.settings_state.as_ref().is_some_and(|s| s.visible)
-            || self.calibration_wizard.is_some()
-            || self.keybinding_editor.is_some()
-            || self.floating_widget_panel.is_some()
-            // The dock blocks PTY routing only while it owns the keyboard;
-            // a blurred dock leaves the dived-into terminal usable.
-            || self.dock.as_ref().is_some_and(|f| f.focused);
-
-        if in_modal {
+        // Skip if any overlay layer is blocking — a prompt, popup, menu,
+        // settings/calibration/keybinding modal, the floating widget panel
+        // (Orchestrator picker / new-session form / plugin overlays), or a
+        // *focused* dock. A blurred dock leaves the dived-into terminal
+        // usable, which is why this is a per-layer `blocks_terminal_input`
+        // property and not just "any overlay present." See
+        // `Editor::overlay_layers` for the per-layer rationale.
+        if self.presents_blocking_overlay() {
             return None;
         }
 

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -304,7 +304,13 @@ impl Editor {
         // dimensions (Bug 13). The hook above lets plugins update
         // their spec; this rerender picks up either the updated
         // spec or the existing spec at the new width.
-        if let Some(panel_id) = self.floating_widget_panel.as_ref().map(|f| f.panel_id) {
+        for panel_id in [
+            self.dock.as_ref().map(|f| f.panel_id),
+            self.floating_widget_panel.as_ref().map(|f| f.panel_id),
+        ]
+        .into_iter()
+        .flatten()
+        {
             self.rerender_widget_panel(panel_id);
         }
     }

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -934,6 +934,14 @@ pub struct Editor {
     /// floaters would obscure each other without a usable focus
     /// model. Mounting a second one replaces the first.
     pub(crate) floating_widget_panel: Option<FloatingWidgetState>,
+
+    /// Persisted width (columns) of the orchestrator left dock after the
+    /// user drags its right border. `None` until first resized; when set,
+    /// `FloatingPanelControl{op:"dock"}` restores this instead of the
+    /// plugin's default so the width survives toggling the dock off/on.
+    pub(crate) dock_width: Option<u16>,
+    /// True while the user is dragging the dock's right border to resize.
+    pub(crate) dock_resizing: bool,
 }
 
 /// Sentinel `BufferId` registered with the widget registry for the

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -933,6 +933,13 @@ pub struct Editor {
     /// overlay is modal-ish (input is routed to it) and stacking
     /// floaters would obscure each other without a usable focus
     /// model. Mounting a second one replaces the first.
+    ///
+    /// TODO(dock): the non-modal left dock (`PanelPlacement::LeftDock`)
+    /// and a centered modal (the new-session form, etc.) occupy disjoint
+    /// screen regions and should be able to coexist — today mounting the
+    /// form replaces the dock. Reconsider this as two slots (one dock,
+    /// one centered) with input/mouse routed to the focused one. See
+    /// docs/internal/orchestrator-dock-gaps.md.
     pub(crate) floating_widget_panel: Option<FloatingWidgetState>,
 
     /// Persisted width (columns) of the orchestrator left dock after the

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -949,11 +949,32 @@ pub(crate) const FLOATING_PANEL_BUFFER_ID: BufferId = BufferId(usize::MAX);
 /// mutate paths apply), but its rendered entries are painted into
 /// the overlay rect at draw time instead of being written into a
 /// virtual buffer.
+/// Where a floating widget panel is anchored on screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PanelPlacement {
+    /// Centered modal overlay sized by `width_pct`/`height_pct`
+    /// (the historical default; dims the background, captures keys).
+    Centered,
+    /// Full-height column pinned to the left of the entire editor
+    /// chrome (left of the menu bar, splits, and status bar). The
+    /// chrome is laid out in the remaining width; no background
+    /// dimming. Non-modal — see `FloatingWidgetState::focused`.
+    LeftDock { width_cols: u16 },
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct FloatingWidgetState {
     pub panel_id: crate::widgets::PanelId,
     pub width_pct: u8,
     pub height_pct: u8,
+    /// On-screen anchor. Defaults to `Centered` on mount; a plugin
+    /// re-anchors to a dock via `FloatingPanelControl{op:"dock"}`.
+    pub placement: PanelPlacement,
+    /// Whether keys route to this panel. Always true for `Centered`
+    /// (modal). For `LeftDock` a plugin toggles this via
+    /// `FloatingPanelControl{op:"focus"|"blur"}` so the editor
+    /// underneath stays keyboard-usable while the dock is visible.
+    pub focused: bool,
     /// Most-recently rendered entries. Refreshed on every spec /
     /// command / mutate; painted into the overlay rect at draw
     /// time.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1598,7 +1598,10 @@ mod tests {
         use crate::input::keybindings::KeyContext;
 
         let mut editor = default_test_editor();
-        editor.dock = Some(test_panel(PanelPlacement::LeftDock { width_cols: 30 }, true));
+        editor.dock = Some(test_panel(
+            PanelPlacement::LeftDock { width_cols: 30 },
+            true,
+        ));
         assert_eq!(editor.get_key_context(), KeyContext::Dock);
 
         editor.dock.as_mut().unwrap().focused = false;
@@ -1612,7 +1615,10 @@ mod tests {
         use crate::input::keybindings::KeyContext;
 
         let mut editor = default_test_editor();
-        editor.dock = Some(test_panel(PanelPlacement::LeftDock { width_cols: 30 }, true));
+        editor.dock = Some(test_panel(
+            PanelPlacement::LeftDock { width_cols: 30 },
+            true,
+        ));
         editor.floating_widget_panel = Some(test_panel(PanelPlacement::Centered, true));
         // The centered modal resolves as Normal (not Dock).
         assert_eq!(editor.get_key_context(), KeyContext::Normal);

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1578,15 +1578,15 @@ mod tests {
     /// window's context.
     #[test]
     fn overlay_stack_base_layer_owns_keyboard() {
-        use crate::app::overlay::{FocusPolicy, LayerKind};
+        use crate::app::overlay::LayerKind;
         use crate::input::keybindings::KeyContext;
 
         let editor = default_test_editor();
         let layers = editor.overlay_layers();
         let base = layers.last().expect("at least the base layer");
         assert_eq!(base.kind, LayerKind::Editor);
-        assert_eq!(base.policy, FocusPolicy::Base);
         assert!(base.owns_keyboard);
+        assert!(!base.blocks_terminal_input);
         assert_eq!(editor.get_key_context(), KeyContext::Normal);
     }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -49,6 +49,7 @@ mod mouse_input;
 mod navigation;
 mod on_save_actions;
 mod orchestrator_persistence;
+mod overlay;
 mod path_utils;
 mod plugin_commands;
 mod plugin_dispatch;
@@ -1536,6 +1537,85 @@ mod tests {
 
         assert_eq!(editor.buffers().len(), 1);
         assert!(!editor.should_quit());
+    }
+
+    fn default_test_editor() -> Editor {
+        let (dir_context, temp) = test_dir_context();
+        // Keep the temp dir alive for the editor's lifetime.
+        std::mem::forget(temp);
+        Editor::new(
+            Config::default(),
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap()
+    }
+
+    fn test_panel(placement: PanelPlacement, focused: bool) -> FloatingWidgetState {
+        FloatingWidgetState {
+            panel_id: 1,
+            width_pct: 50,
+            height_pct: 50,
+            placement,
+            focused,
+            entries: Vec::new(),
+            focus_cursor: None,
+            embeds: Vec::new(),
+            overlays: Vec::new(),
+            scroll_regions: Vec::new(),
+            scrollbar_tracks: Vec::new(),
+            scrollbar_mouse: Default::default(),
+            scrollbar_drag_key: None,
+            last_inner_rect: None,
+        }
+    }
+
+    /// The overlay layer stack always terminates in the editor base layer,
+    /// which owns the keyboard, so a fresh editor resolves to its active
+    /// window's context.
+    #[test]
+    fn overlay_stack_base_layer_owns_keyboard() {
+        use crate::app::overlay::{FocusPolicy, LayerKind};
+        use crate::input::keybindings::KeyContext;
+
+        let editor = default_test_editor();
+        let layers = editor.overlay_layers();
+        let base = layers.last().expect("at least the base layer");
+        assert_eq!(base.kind, LayerKind::Editor);
+        assert_eq!(base.policy, FocusPolicy::Base);
+        assert!(base.owns_keyboard);
+        assert_eq!(editor.get_key_context(), KeyContext::Normal);
+    }
+
+    /// P1 invariant preserved through the P2 layer walk: a *focused* dock
+    /// owns the keyboard (`KeyContext::Dock`); once blurred it falls
+    /// through to the editor underneath so the buffer stays usable.
+    #[test]
+    fn focused_dock_owns_keyboard_blurred_falls_through() {
+        use crate::input::keybindings::KeyContext;
+
+        let mut editor = default_test_editor();
+        editor.dock = Some(test_panel(PanelPlacement::LeftDock { width_cols: 30 }, true));
+        assert_eq!(editor.get_key_context(), KeyContext::Dock);
+
+        editor.dock.as_mut().unwrap().focused = false;
+        assert_eq!(editor.get_key_context(), KeyContext::Normal);
+    }
+
+    /// A focused centered modal outranks a focused dock — when the
+    /// new-session form opens on top of the dock, the modal owns input.
+    #[test]
+    fn centered_modal_outranks_dock() {
+        use crate::input::keybindings::KeyContext;
+
+        let mut editor = default_test_editor();
+        editor.dock = Some(test_panel(PanelPlacement::LeftDock { width_cols: 30 }, true));
+        editor.floating_widget_panel = Some(test_panel(PanelPlacement::Centered, true));
+        // The centered modal resolves as Normal (not Dock).
+        assert_eq!(editor.get_key_context(), KeyContext::Normal);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -934,13 +934,17 @@ pub struct Editor {
     /// floaters would obscure each other without a usable focus
     /// model. Mounting a second one replaces the first.
     ///
-    /// TODO(dock): the non-modal left dock (`PanelPlacement::LeftDock`)
-    /// and a centered modal (the new-session form, etc.) occupy disjoint
-    /// screen regions and should be able to coexist — today mounting the
-    /// form replaces the dock. Reconsider this as two slots (one dock,
-    /// one centered) with input/mouse routed to the focused one. See
-    /// docs/internal/orchestrator-dock-gaps.md.
+    /// This is the **centered modal** slot (`PanelSlot::Floating`): the
+    /// orchestrator picker, the new-session form, and other plugin
+    /// modals. The persistent left dock lives in a separate slot
+    /// (`dock`) so the two can coexist (a modal opens *over* the editor
+    /// while the dock stays visible). Routing is by `PanelSlot`.
     pub(crate) floating_widget_panel: Option<FloatingWidgetState>,
+
+    /// The editor-global left **dock** panel (`PanelSlot::Dock`), if
+    /// shown. Independent of `floating_widget_panel` so the dock persists
+    /// while a centered modal is open. Always rendered as a `LeftDock`.
+    pub(crate) dock: Option<FloatingWidgetState>,
 
     /// Persisted width (columns) of the orchestrator left dock after the
     /// user drags its right border. `None` until first resized; when set,
@@ -957,6 +961,31 @@ pub struct Editor {
 /// rerender paths special-case this id and paint into the overlay
 /// rect instead.
 pub(crate) const FLOATING_PANEL_BUFFER_ID: BufferId = BufferId(usize::MAX);
+
+/// Sentinel `BufferId` for the editor-global **dock** panel — distinct
+/// from `FLOATING_PANEL_BUFFER_ID` so the dock and a centered modal can
+/// both live in the widget registry (and be hit-tested) at the same
+/// time. See `Editor::dock` and `PanelSlot`.
+pub(crate) const DOCK_PANEL_BUFFER_ID: BufferId = BufferId(usize::MAX - 1);
+
+/// Selects which of the two coexisting widget-panel slots an operation
+/// targets: the centered modal overlay (`Floating`, the picker /
+/// new-session form / plugin modals) or the persistent editor-global
+/// left `Dock`. They occupy disjoint screen regions and render together.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PanelSlot {
+    Floating,
+    Dock,
+}
+
+impl PanelSlot {
+    pub(crate) fn buffer_id(self) -> BufferId {
+        match self {
+            PanelSlot::Floating => FLOATING_PANEL_BUFFER_ID,
+            PanelSlot::Dock => DOCK_PANEL_BUFFER_ID,
+        }
+    }
+}
 
 /// A widget panel rendered as a centered floating overlay rather
 /// than into a virtual buffer. The panel still lives in the shared

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -158,6 +158,17 @@ impl Editor {
                 needs_render = true;
             }
             MouseEventKind::Up(MouseButton::Left) => {
+                // End a dock-resize drag and persist the chosen width so
+                // it survives toggling the dock off/on.
+                if self.dock_resizing {
+                    self.dock_resizing = false;
+                    if let Some(super::PanelPlacement::LeftDock { width_cols }) =
+                        self.floating_widget_panel.as_ref().map(|f| f.placement)
+                    {
+                        self.dock_width = Some(width_cols);
+                    }
+                    return Ok(true);
+                }
                 // Check if we were dragging a separator to trigger terminal resize
                 let was_dragging_separator = self
                     .active_window_mut()
@@ -1477,6 +1488,18 @@ impl Editor {
         row: u16,
         modifiers: crossterm::event::KeyModifiers,
     ) -> AnyhowResult<()> {
+        // Dock resize: a press on the dock's right border (its rightmost
+        // column) starts a drag that resizes the dock width. Checked
+        // before the click-routing below so the border column is a
+        // resize handle, not a widget hit.
+        if let Some(super::PanelPlacement::LeftDock { width_cols }) =
+            self.floating_widget_panel.as_ref().map(|f| f.placement)
+        {
+            if col == width_cols.saturating_sub(1) {
+                self.dock_resizing = true;
+                return Ok(());
+            }
+        }
         // Floating widget panel click routing. A centered panel is
         // modal: clicks inside hit-test its widgets, clicks outside are
         // swallowed (the form has explicit Cancel / Esc). A left dock
@@ -2480,6 +2503,19 @@ impl Editor {
 
     /// Handle mouse drag event
     pub(super) fn handle_mouse_drag(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
+        // Dock resize drag: track the pointer column as the new dock
+        // width (the right border follows the cursor), clamped so it
+        // can't swallow the chrome.
+        if self.dock_resizing {
+            let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
+            let new_w = col.saturating_add(1).clamp(10, max_cols);
+            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                if let super::PanelPlacement::LeftDock { width_cols } = &mut fwp.placement {
+                    *width_cols = new_w;
+                }
+            }
+            return Ok(());
+        }
         // Floating-panel list scrollbar drag takes precedence — the
         // modal panel owns the input channel while it's up.
         if self.try_widget_scrollbar_drag(row) {

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1537,6 +1537,14 @@ impl Editor {
             self.dock.as_ref().map(|f| (f.placement, f.focused))
         {
             if col < width_cols {
+                tracing::warn!(
+                    target: "fresh::dock",
+                    col,
+                    row,
+                    width_cols,
+                    focused,
+                    "handle_mouse_click: click in dock column"
+                );
                 if !focused {
                     // Symmetric with `blur_floating_panel`: the un-blur
                     // must notify the plugin via a `focus` widget_event
@@ -1552,6 +1560,13 @@ impl Editor {
                 return Ok(());
             }
             if focused {
+                tracing::warn!(
+                    target: "fresh::dock",
+                    col,
+                    row,
+                    width_cols,
+                    "handle_mouse_click: click outside dock — blurring"
+                );
                 self.blur_floating_panel(super::PanelSlot::Dock);
             }
         }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1477,14 +1477,39 @@ impl Editor {
         row: u16,
         modifiers: crossterm::event::KeyModifiers,
     ) -> AnyhowResult<()> {
-        // Floating widget panel is modal: clicks inside hit-test
-        // against its widget hits; clicks outside are swallowed so
-        // the user can't accidentally focus another split while the
-        // form is up. Auto-dismiss on outside-click is deliberately
-        // NOT done — the form has explicit Cancel / Esc.
-        if self.floating_widget_panel.is_some() {
-            self.handle_floating_widget_click(col, row);
-            return Ok(());
+        // Floating widget panel click routing. A centered panel is
+        // modal: clicks inside hit-test its widgets, clicks outside are
+        // swallowed (the form has explicit Cancel / Esc). A left dock
+        // is non-modal: clicks inside its column hit-test (and re-focus
+        // it if blurred); clicks in the editor blur the dock and fall
+        // through to normal editor handling.
+        if let Some((placement, focused)) = self
+            .floating_widget_panel
+            .as_ref()
+            .map(|f| (f.placement, f.focused))
+        {
+            match placement {
+                super::PanelPlacement::Centered => {
+                    self.handle_floating_widget_click(col, row);
+                    return Ok(());
+                }
+                super::PanelPlacement::LeftDock { width_cols } => {
+                    if col < width_cols {
+                        if !focused {
+                            if let Some(f) = self.floating_widget_panel.as_mut() {
+                                f.focused = true;
+                            }
+                        }
+                        self.handle_floating_widget_click(col, row);
+                        return Ok(());
+                    }
+                    // Click landed in the editor: hand focus back so the
+                    // dock stops capturing keys, then fall through.
+                    if focused {
+                        self.blur_floating_panel();
+                    }
+                }
+            }
         }
         if let Some(r) = self.handle_click_context_menus(col, row) {
             return r;
@@ -3556,7 +3581,15 @@ impl Editor {
         if row < inner.y || row >= inner.y + inner.height {
             return false;
         }
-        self.handle_widget_panel_wheel(super::FLOATING_PANEL_BUFFER_ID, delta)
+        let scrolled = self.handle_widget_panel_wheel(super::FLOATING_PANEL_BUFFER_ID, delta);
+        // The non-modal dock must swallow the wheel whenever the pointer
+        // is over it, even when the list is too short to scroll — the
+        // scroll must never leak through to the active window beneath.
+        let is_dock = matches!(
+            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            Some(super::PanelPlacement::LeftDock { .. })
+        );
+        scrolled || is_dock
     }
 
     /// Try to start a floating-panel list scrollbar drag. Returns

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -163,7 +163,7 @@ impl Editor {
                 if self.dock_resizing {
                     self.dock_resizing = false;
                     if let Some(super::PanelPlacement::LeftDock { width_cols }) =
-                        self.floating_widget_panel.as_ref().map(|f| f.placement)
+                        self.dock.as_ref().map(|f| f.placement)
                     {
                         self.dock_width = Some(width_cols);
                     }
@@ -389,13 +389,17 @@ impl Editor {
         } else if self.is_mouse_over_any_popup(col, row) {
             self.scroll_popup(delta);
         } else if self.floating_widget_panel.is_some() {
-            // The floating widget panel (orchestrator picker, New
-            // Session form, ...) is modal: scroll it when the pointer is
-            // over it (e.g. a Text-widget completion popup scrolls its
-            // candidate list), and otherwise swallow the wheel so it
-            // can't leak through to the buffer behind the modal. Either
-            // way the event is consumed here — never falls through.
-            self.handle_floating_widget_panel_wheel(col, row, delta);
+            // A centered modal (orchestrator picker, New-Session form,
+            // ...) is modal and takes precedence: scroll it when the
+            // pointer is over it, otherwise swallow the wheel so it
+            // can't leak through to the buffer (or the dock) behind it.
+            // Either way the event is consumed here — never falls through.
+            self.handle_floating_widget_panel_wheel(super::PanelSlot::Floating, col, row, delta);
+        } else if self.dock.is_some()
+            && self.handle_floating_widget_panel_wheel(super::PanelSlot::Dock, col, row, delta)
+        {
+            // The dock swallows the wheel whenever the pointer is over
+            // its column (never leaks to the window beneath).
         } else if self
             .active_window()
             .split_at_position(col, row)
@@ -1488,50 +1492,42 @@ impl Editor {
         row: u16,
         modifiers: crossterm::event::KeyModifiers,
     ) -> AnyhowResult<()> {
+        // A centered modal takes click precedence over the dock: while
+        // the New-Session form is up over the dock, clicks hit-test the
+        // modal (clicks outside it are swallowed — it has Cancel / Esc).
+        if self.floating_widget_panel.is_some() {
+            self.handle_floating_widget_click(super::PanelSlot::Floating, col, row);
+            return Ok(());
+        }
         // Dock resize: a press on the dock's right border (its rightmost
         // column) starts a drag that resizes the dock width. Checked
         // before the click-routing below so the border column is a
         // resize handle, not a widget hit.
         if let Some(super::PanelPlacement::LeftDock { width_cols }) =
-            self.floating_widget_panel.as_ref().map(|f| f.placement)
+            self.dock.as_ref().map(|f| f.placement)
         {
             if col == width_cols.saturating_sub(1) {
                 self.dock_resizing = true;
                 return Ok(());
             }
         }
-        // Floating widget panel click routing. A centered panel is
-        // modal: clicks inside hit-test its widgets, clicks outside are
-        // swallowed (the form has explicit Cancel / Esc). A left dock
-        // is non-modal: clicks inside its column hit-test (and re-focus
-        // it if blurred); clicks in the editor blur the dock and fall
-        // through to normal editor handling.
-        if let Some((placement, focused)) = self
-            .floating_widget_panel
-            .as_ref()
-            .map(|f| (f.placement, f.focused))
+        // Dock click routing (non-modal): clicks inside its column
+        // hit-test (and re-focus it if blurred); clicks in the editor
+        // blur the dock and fall through to normal editor handling.
+        if let Some((super::PanelPlacement::LeftDock { width_cols }, focused)) =
+            self.dock.as_ref().map(|f| (f.placement, f.focused))
         {
-            match placement {
-                super::PanelPlacement::Centered => {
-                    self.handle_floating_widget_click(col, row);
-                    return Ok(());
-                }
-                super::PanelPlacement::LeftDock { width_cols } => {
-                    if col < width_cols {
-                        if !focused {
-                            if let Some(f) = self.floating_widget_panel.as_mut() {
-                                f.focused = true;
-                            }
-                        }
-                        self.handle_floating_widget_click(col, row);
-                        return Ok(());
-                    }
-                    // Click landed in the editor: hand focus back so the
-                    // dock stops capturing keys, then fall through.
-                    if focused {
-                        self.blur_floating_panel();
+            if col < width_cols {
+                if !focused {
+                    if let Some(f) = self.dock.as_mut() {
+                        f.focused = true;
                     }
                 }
+                self.handle_floating_widget_click(super::PanelSlot::Dock, col, row);
+                return Ok(());
+            }
+            if focused {
+                self.blur_floating_panel(super::PanelSlot::Dock);
             }
         }
         if let Some(r) = self.handle_click_context_menus(col, row) {
@@ -2509,7 +2505,7 @@ impl Editor {
         if self.dock_resizing {
             let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
             let new_w = col.saturating_add(1).clamp(10, max_cols);
-            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            if let Some(fwp) = self.dock.as_mut() {
                 if let super::PanelPlacement::LeftDock { width_cols } = &mut fwp.placement {
                     *width_cols = new_w;
                 }
@@ -2518,7 +2514,9 @@ impl Editor {
         }
         // Floating-panel list scrollbar drag takes precedence — the
         // modal panel owns the input channel while it's up.
-        if self.try_widget_scrollbar_drag(row) {
+        if self.try_widget_scrollbar_drag(super::PanelSlot::Dock, row)
+            || self.try_widget_scrollbar_drag(super::PanelSlot::Floating, row)
+        {
             let _ = col;
             return Ok(());
         }
@@ -3603,8 +3601,14 @@ impl Editor {
     /// is active AND the mouse is inside its inner rect (so the
     /// caller knows the wheel was consumed and shouldn't fall
     /// through to buffer scrolling).
-    fn handle_floating_widget_panel_wheel(&mut self, col: u16, row: u16, delta: i32) -> bool {
-        let inner = match self.floating_widget_panel.as_ref() {
+    fn handle_floating_widget_panel_wheel(
+        &mut self,
+        slot: super::PanelSlot,
+        col: u16,
+        row: u16,
+        delta: i32,
+    ) -> bool {
+        let inner = match self.panel(slot) {
             Some(fwp) => match fwp.last_inner_rect {
                 Some(rect) => rect,
                 None => return false,
@@ -3617,12 +3621,12 @@ impl Editor {
         if row < inner.y || row >= inner.y + inner.height {
             return false;
         }
-        let scrolled = self.handle_widget_panel_wheel(super::FLOATING_PANEL_BUFFER_ID, delta);
+        let scrolled = self.handle_widget_panel_wheel(slot.buffer_id(), delta);
         // The non-modal dock must swallow the wheel whenever the pointer
         // is over it, even when the list is too short to scroll — the
         // scroll must never leak through to the active window beneath.
         let is_dock = matches!(
-            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            self.panel(slot).map(|f| f.placement),
             Some(super::PanelPlacement::LeftDock { .. })
         );
         scrolled || is_dock
@@ -3632,20 +3636,19 @@ impl Editor {
     /// true if the press landed on a scrollbar track (so the caller
     /// skips row hit-testing — the bar overlaps the list's rightmost
     /// column). Reuses the canonical `ScrollbarMouse`/`ScrollbarState`.
-    fn try_widget_scrollbar_press(&mut self, col: u16, row: u16) -> bool {
+    fn try_widget_scrollbar_press(&mut self, slot: super::PanelSlot, col: u16, row: u16) -> bool {
         use crate::view::ui::scrollbar::ScrollbarState;
-        let (panel_id, tracks) = match self.floating_widget_panel.as_ref() {
+        let (panel_id, tracks) = match self.panel(slot) {
             Some(fwp) => (fwp.panel_id, fwp.scrollbar_tracks.clone()),
             None => return false,
         };
         for t in &tracks {
             let state = ScrollbarState::new(t.total, t.visible, t.scroll);
             let pressed = self
-                .floating_widget_panel
-                .as_mut()
+                .panel_mut(slot)
                 .and_then(|fwp| fwp.scrollbar_mouse.press(state, t.rect, col, row));
             if let Some(new_offset) = pressed {
-                if let Some(fwp) = self.floating_widget_panel.as_mut() {
+                if let Some(fwp) = self.panel_mut(slot) {
                     fwp.scrollbar_drag_key = Some(t.list_key.clone());
                 }
                 self.apply_widget_scroll(panel_id, &t.list_key, new_offset, t.visible);
@@ -3657,9 +3660,9 @@ impl Editor {
 
     /// Continue an in-flight floating-panel scrollbar drag. Returns
     /// true if a drag is active (the press captured a `list_key`).
-    fn try_widget_scrollbar_drag(&mut self, row: u16) -> bool {
+    fn try_widget_scrollbar_drag(&mut self, slot: super::PanelSlot, row: u16) -> bool {
         use crate::view::ui::scrollbar::ScrollbarState;
-        let (panel_id, key) = match self.floating_widget_panel.as_ref() {
+        let (panel_id, key) = match self.panel(slot) {
             Some(fwp) => match &fwp.scrollbar_drag_key {
                 Some(k) => (fwp.panel_id, k.clone()),
                 None => return false,
@@ -3668,7 +3671,7 @@ impl Editor {
         };
         // The track geometry for the dragged list (its rect may have
         // shifted if the panel re-rendered between events).
-        let track = self.floating_widget_panel.as_ref().and_then(|fwp| {
+        let track = self.panel(slot).and_then(|fwp| {
             fwp.scrollbar_tracks
                 .iter()
                 .find(|t| t.list_key == key)
@@ -3679,8 +3682,7 @@ impl Editor {
         };
         let state = ScrollbarState::new(t.total, t.visible, t.scroll);
         let new_offset = self
-            .floating_widget_panel
-            .as_mut()
+            .panel_mut(slot)
             .and_then(|fwp| fwp.scrollbar_mouse.drag(state, t.rect, row));
         if let Some(off) = new_offset {
             self.apply_widget_scroll(panel_id, &key, off, t.visible);
@@ -3690,7 +3692,10 @@ impl Editor {
 
     /// End any in-flight floating-panel scrollbar drag.
     pub(super) fn release_widget_scrollbar(&mut self) {
-        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+        for fwp in [self.dock.as_mut(), self.floating_widget_panel.as_mut()]
+            .into_iter()
+            .flatten()
+        {
             fwp.scrollbar_mouse.release();
             fwp.scrollbar_drag_key = None;
         }
@@ -3737,13 +3742,13 @@ impl Editor {
 
     /// `handle_editor_click` uses; clicks outside the rect are
     /// swallowed without dismissing the panel.
-    fn handle_floating_widget_click(&mut self, col: u16, row: u16) {
+    fn handle_floating_widget_click(&mut self, slot: super::PanelSlot, col: u16, row: u16) {
         // Scrollbar press wins over row hit-testing (the bar overlaps
         // the list's rightmost column).
-        if self.try_widget_scrollbar_press(col, row) {
+        if self.try_widget_scrollbar_press(slot, col, row) {
             return;
         }
-        let (panel_id, inner) = match self.floating_widget_panel.as_ref() {
+        let (panel_id, inner) = match self.panel(slot) {
             Some(fwp) => match fwp.last_inner_rect {
                 Some(rect) => (fwp.panel_id, rect),
                 None => return,
@@ -3758,8 +3763,7 @@ impl Editor {
         }
         let brow = (row - inner.y) as u32;
         let entries = self
-            .floating_widget_panel
-            .as_ref()
+            .panel(slot)
             .map(|f| f.entries.clone())
             .unwrap_or_default();
         let local_screen_col = (col - inner.x) as usize;
@@ -3770,7 +3774,7 @@ impl Editor {
         let (hit_payload, hit_event, hit_key, hit_kind) =
             match self
                 .widget_registry
-                .hit_test(super::FLOATING_PANEL_BUFFER_ID, brow, bcol as u32)
+                .hit_test(slot.buffer_id(), brow, bcol as u32)
             {
                 Some((_, hit)) => (
                     hit.payload.clone(),

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1538,9 +1538,15 @@ impl Editor {
         {
             if col < width_cols {
                 if !focused {
-                    if let Some(f) = self.dock.as_mut() {
-                        f.focused = true;
-                    }
+                    // Symmetric with `blur_floating_panel`: the un-blur
+                    // must notify the plugin via a `focus` widget_event
+                    // so any mirror of dock-focus state updates before
+                    // the click's row-select event fires its scheduling
+                    // logic. Without this, the orchestrator's
+                    // `dockBlurred` mirror stayed `true` and its
+                    // debounced live-switch aborted on the first
+                    // un-dive click.
+                    self.refocus_floating_panel(super::PanelSlot::Dock);
                 }
                 self.handle_floating_widget_click(super::PanelSlot::Dock, col, row);
                 return Ok(());

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -24,6 +24,43 @@ fn in_rect(col: u16, row: u16, rect: Rect) -> bool {
 }
 
 impl Editor {
+    /// If any overlay layer captures mouse events, dispatch to its
+    /// dedicated handler and return its result; otherwise return `None`
+    /// so the caller continues with the normal click/wheel pipeline.
+    ///
+    /// This is the mouse counterpart of `resolve_focus_context` /
+    /// `presents_blocking_overlay`: precedence is the order of
+    /// `overlay_layers()`, top-first. Only the kinds whose modal
+    /// handlers exist need an arm here — non-capturing layers fall
+    /// through.
+    fn dispatch_modal_mouse(
+        &mut self,
+        mouse_event: crossterm::event::MouseEvent,
+        is_double_click: bool,
+    ) -> Option<AnyhowResult<bool>> {
+        use crate::app::overlay::LayerKind;
+
+        // Snapshot the capturing kinds first so the borrow ends before
+        // any `&mut self` handler runs.
+        let capturing_kind = self.overlay_layers().iter().find_map(|l| match l.kind {
+            LayerKind::Settings
+            | LayerKind::KeybindingEditor
+            | LayerKind::CalibrationWizard
+            | LayerKind::WorkspaceTrust => Some(l.kind),
+            _ => None,
+        })?;
+        Some(match capturing_kind {
+            LayerKind::KeybindingEditor => self.handle_keybinding_editor_mouse(mouse_event),
+            LayerKind::Settings => self.handle_settings_mouse(mouse_event, is_double_click),
+            // The calibration wizard owns the modal z-band but ignores
+            // every mouse event (its UI is keyboard-driven). Swallowing
+            // here matches the previous explicit `return Ok(false)`.
+            LayerKind::CalibrationWizard => Ok(false),
+            LayerKind::WorkspaceTrust => self.handle_workspace_trust_mouse(mouse_event),
+            _ => unreachable!("find_map only returns capturing kinds"),
+        })
+    }
+
     /// Handle a mouse event.
     /// Returns true if a re-render is needed.
     pub fn handle_mouse(
@@ -37,31 +74,13 @@ impl Editor {
 
         let (is_double_click, is_triple_click) = self.detect_multi_click(&mouse_event, col, row);
 
-        // When keybinding editor is open, capture all mouse events
-        if self.keybinding_editor.is_some() {
-            return self.handle_keybinding_editor_mouse(mouse_event);
-        }
-
-        // When settings modal is open, capture all mouse events
-        if self.settings_state.as_ref().is_some_and(|s| s.visible) {
-            return self.handle_settings_mouse(mouse_event, is_double_click);
-        }
-
-        // When calibration wizard is active, ignore all mouse events
-        if self.calibration_wizard.is_some() {
-            return Ok(false);
-        }
-
-        // The workspace-trust modal captures every mouse event: clicks act on
-        // its controls (and are otherwise absorbed), the wheel scrolls it. None
-        // of it may leak to the buffer behind (which would move the cursor).
-        if self.global_popups.top().is_some_and(|p| {
-            matches!(
-                p.resolver,
-                crate::view::popup::PopupResolver::WorkspaceTrust
-            )
-        }) {
-            return self.handle_workspace_trust_mouse(mouse_event);
+        // Modal mouse-capture: walk the overlay stack top-down (the same
+        // list `get_key_context` / `dispatch_terminal_input` consult) and
+        // dispatch to the first layer that captures mouse. This replaces
+        // a hand-listed ladder that had drifted out of order with the
+        // keyboard dispatcher.
+        if let Some(result) = self.dispatch_modal_mouse(mouse_event, is_double_click) {
+            return result;
         }
 
         // Cancel LSP rename prompt on any mouse interaction

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -1,0 +1,165 @@
+//! Unified overlay **layer** model (P2 — staged migration).
+//!
+//! The editor paints a stack of overlays on top of the editor content:
+//! full-screen modals (settings, the keybinding editor, …), the menu, the
+//! prompt, popups, the centered widget modal, and the left dock.
+//! Historically each was an independent field with its own
+//! focus-precedence, paint-order and mouse-routing logic scattered across
+//! `render.rs`, `input.rs` and `mouse_input.rs`. The eventual destination
+//! (see `docs/internal/orchestrator-dock-gaps.md`, "Design: dock + modal
+//! coexistence", option P2) is to make this stack a first-class *ordered
+//! list of layers* so precedence, z-order and hit-testing are *properties
+//! of layers* rather than duplicated conditionals.
+//!
+//! This module is the seed of that model. **Step 1** makes the layer stack
+//! the single source of truth for keyboard-focus precedence: `get_key_context`
+//! now builds the ordered layer list (`Editor::overlay_layers`) and returns
+//! the `KeyContext` of the topmost layer that owns the keyboard, instead of a
+//! hand-written if/else ladder. Render and mouse dispatch are migrated onto
+//! the same list in later steps.
+
+use crate::input::keybindings::KeyContext;
+
+/// Where a layer is anchored on screen. Determines its hit-testing region
+/// and, for modal layers, what is dimmed underneath. Not all consumers use
+/// this yet (step 1 only resolves keyboard focus); it is carried on every
+/// layer so the render/mouse migrations can switch onto it without
+/// reshaping the model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayerRegion {
+    /// Covers the whole frame — really the *chrome area* beside the dock,
+    /// which is the full frame when no dock is present. Full-screen modals
+    /// (settings, keybinding editor) and the menu/prompt live here.
+    FullScreen,
+    /// A centered modal box sized by a percentage of the frame (the
+    /// orchestrator picker / new-session form / plugin modals).
+    Centered,
+    /// A full-height column pinned to the left of the chrome (the dock).
+    LeftDock,
+    /// Anchored near the cursor or a focused widget (popups, completions).
+    Anchored,
+    /// The editor content / window splits — the bottom-most layer.
+    EditorContent,
+}
+
+/// How a layer participates in keyboard focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FocusPolicy {
+    /// Owns the keyboard whenever the layer is present, blocking every
+    /// layer below it (settings, menu, prompt, a focused centered modal).
+    Modal,
+    /// Focusable, but only owns the keyboard while *focused*; when blurred
+    /// it coexists with the editor underneath (the dock; an unfocused
+    /// popup that is merely visible).
+    NonModal,
+    /// Never the keyboard target — the bottom editor-content layer, which
+    /// is the terminal's default key sink.
+    Base,
+}
+
+/// Identifies a concrete overlay. The ordering of `overlay_layers` — not
+/// this enum's declaration order — defines precedence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayerKind {
+    Settings,
+    Menu,
+    Prompt,
+    Popup,
+    /// The centered widget modal (`floating_widget_panel`).
+    FloatingModal,
+    /// The editor-global left dock (`dock`).
+    Dock,
+    /// The editor content / window splits.
+    Editor,
+}
+
+/// One entry in the overlay stack: a present overlay (or the always-present
+/// editor base), with the data the dispatchers need to make precedence,
+/// focus and (later) paint/hit-test decisions.
+#[derive(Debug, Clone)]
+pub(crate) struct Layer {
+    // `kind` / `region` / `policy` describe the layer for the paint-order
+    // and mouse-hit-test migrations (later steps of P2); step 1 resolves
+    // only keyboard focus, which reads `owns_keyboard` + `key_context`.
+    #[allow(dead_code)]
+    pub kind: LayerKind,
+    #[allow(dead_code)]
+    pub region: LayerRegion,
+    #[allow(dead_code)]
+    pub policy: FocusPolicy,
+    /// Whether this layer currently owns the keyboard. For `Modal` layers
+    /// this is always true while present; for `NonModal` it tracks the
+    /// layer's focused/capturing state; the `Base` layer sets it true so a
+    /// top-down walk always terminates.
+    pub owns_keyboard: bool,
+    /// The keybinding context to resolve against when this layer is the
+    /// keyboard owner.
+    pub key_context: KeyContext,
+}
+
+/// Resolve the keyboard-owning context from an ordered (top-first) layer
+/// list: the first layer that owns the keyboard wins. The editor base
+/// layer always owns the keyboard, so this never returns `None` for a
+/// well-formed stack.
+pub(crate) fn resolve_focus_context(layers: &[Layer]) -> Option<KeyContext> {
+    layers
+        .iter()
+        .find(|l| l.owns_keyboard)
+        .map(|l| l.key_context.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn layer(kind: LayerKind, owns: bool, ctx: KeyContext) -> Layer {
+        Layer {
+            kind,
+            region: LayerRegion::FullScreen,
+            policy: if owns {
+                FocusPolicy::Modal
+            } else {
+                FocusPolicy::NonModal
+            },
+            owns_keyboard: owns,
+            key_context: ctx,
+        }
+    }
+
+    fn base() -> Layer {
+        Layer {
+            kind: LayerKind::Editor,
+            region: LayerRegion::EditorContent,
+            policy: FocusPolicy::Base,
+            owns_keyboard: true,
+            key_context: KeyContext::Normal,
+        }
+    }
+
+    #[test]
+    fn topmost_owning_layer_wins() {
+        let layers = [
+            layer(LayerKind::Settings, false, KeyContext::Settings),
+            layer(LayerKind::Popup, true, KeyContext::Popup),
+            layer(LayerKind::Dock, true, KeyContext::Dock),
+            base(),
+        ];
+        assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Popup));
+    }
+
+    #[test]
+    fn falls_through_unfocused_layers_to_base() {
+        let layers = [
+            layer(LayerKind::FloatingModal, false, KeyContext::Normal),
+            layer(LayerKind::Dock, false, KeyContext::Dock),
+            base(),
+        ];
+        assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
+    }
+
+    #[test]
+    fn base_layer_terminates_the_walk() {
+        let layers = [base()];
+        assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
+    }
+}

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -78,11 +78,10 @@ pub(crate) enum LayerKind {
 /// focus and (later) paint/hit-test decisions.
 #[derive(Debug, Clone)]
 pub(crate) struct Layer {
-    // `kind` / `region` / `policy` describe the layer for the paint-order
-    // and mouse-hit-test migrations (later steps of P2); step 1 resolves
-    // only keyboard focus, which reads `owns_keyboard` + `key_context`.
-    #[allow(dead_code)]
     pub kind: LayerKind,
+    // `region` / `policy` describe the layer for the paint-order and
+    // mouse-hit-test migrations (later steps of P2); keyboard-focus
+    // resolution reads `kind` / `owns_keyboard` / `key_context`.
     #[allow(dead_code)]
     pub region: LayerRegion,
     #[allow(dead_code)]

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -1,35 +1,39 @@
 //! Unified overlay **layer** model (P2 — staged migration).
 //!
 //! The editor paints a stack of overlays on top of the editor content:
-//! full-screen modals (settings, the keybinding editor, …), the menu, the
-//! prompt, popups, the centered widget modal, and the left dock.
-//! Historically each was an independent field with its own
-//! focus-precedence, paint-order and mouse-routing logic scattered across
-//! `render.rs`, `input.rs` and `mouse_input.rs`. The eventual destination
+//! full-screen modals (settings, the keybinding editor, the calibration
+//! wizard, …), the menu, the prompt, popups, the centered widget modal,
+//! and the left dock. Historically each was an independent field with its
+//! own focus-precedence, paint-order and mouse-routing logic scattered
+//! across `render.rs`, `input.rs`, `input_dispatch.rs` and
+//! `mouse_input.rs`. The eventual destination
 //! (see `docs/internal/orchestrator-dock-gaps.md`, "Design: dock + modal
 //! coexistence", option P2) is to make this stack a first-class *ordered
 //! list of layers* so precedence, z-order and hit-testing are *properties
 //! of layers* rather than duplicated conditionals.
 //!
-//! This module is the seed of that model. **Step 1** makes the layer stack
-//! the single source of truth for keyboard-focus precedence: `get_key_context`
-//! now builds the ordered layer list (`Editor::overlay_layers`) and returns
-//! the `KeyContext` of the topmost layer that owns the keyboard, instead of a
-//! hand-written if/else ladder. Render and mouse dispatch are migrated onto
-//! the same list in later steps.
+//! Status of the staged migration:
+//! - Step 1: `get_key_context` resolved through the stack.
+//! - Step 2: the duplicate "higher-priority modal owns the keyboard" guard
+//!   in `resolve_unfocused_popup_action` is a stack query.
+//! - Step 3 (this revision): the stack includes the full-screen modal zoo
+//!   (calibration / keybinding editor) and tracks `blocks_terminal_input`
+//!   per layer, letting `dispatch_terminal_input`'s `in_modal` predicate
+//!   become a single stack query.
+//! - Later: render paint-order and mouse hit-testing.
 
 use crate::input::keybindings::KeyContext;
 
 /// Where a layer is anchored on screen. Determines its hit-testing region
-/// and, for modal layers, what is dimmed underneath. Not all consumers use
-/// this yet (step 1 only resolves keyboard focus); it is carried on every
-/// layer so the render/mouse migrations can switch onto it without
-/// reshaping the model.
+/// and, for modal layers, what is dimmed underneath. Step 1–3 only resolve
+/// focus and terminal-blocking; it is carried on every layer so the
+/// render/mouse migrations can switch onto it without reshaping the model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LayerRegion {
     /// Covers the whole frame — really the *chrome area* beside the dock,
     /// which is the full frame when no dock is present. Full-screen modals
-    /// (settings, keybinding editor) and the menu/prompt live here.
+    /// (settings, calibration wizard, keybinding editor) and the menu/prompt
+    /// live here.
     FullScreen,
     /// A centered modal box sized by a percentage of the frame (the
     /// orchestrator picker / new-session form / plugin modals).
@@ -46,7 +50,8 @@ pub(crate) enum LayerRegion {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FocusPolicy {
     /// Owns the keyboard whenever the layer is present, blocking every
-    /// layer below it (settings, menu, prompt, a focused centered modal).
+    /// layer below it (settings, calibration wizard, keybinding editor,
+    /// menu, prompt, a focused centered modal).
     Modal,
     /// Focusable, but only owns the keyboard while *focused*; when blurred
     /// it coexists with the editor underneath (the dock; an unfocused
@@ -62,6 +67,12 @@ pub(crate) enum FocusPolicy {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LayerKind {
     Settings,
+    /// The keybinding editor (`keybinding_editor`) — a full-screen modal
+    /// with its own input dispatcher; transparent to `KeyContext`-driven
+    /// keybinding resolution.
+    KeybindingEditor,
+    /// The calibration wizard (`calibration_wizard`) — same as above.
+    CalibrationWizard,
     Menu,
     Prompt,
     Popup,
@@ -75,13 +86,13 @@ pub(crate) enum LayerKind {
 
 /// One entry in the overlay stack: a present overlay (or the always-present
 /// editor base), with the data the dispatchers need to make precedence,
-/// focus and (later) paint/hit-test decisions.
+/// focus, terminal-blocking and (later) paint/hit-test decisions.
 #[derive(Debug, Clone)]
 pub(crate) struct Layer {
     pub kind: LayerKind,
     // `region` / `policy` describe the layer for the paint-order and
-    // mouse-hit-test migrations (later steps of P2); keyboard-focus
-    // resolution reads `kind` / `owns_keyboard` / `key_context`.
+    // mouse-hit-test migrations (later steps of P2). Reading is via
+    // `kind` / `owns_keyboard` / `key_context` / `blocks_terminal_input`.
     #[allow(dead_code)]
     pub region: LayerRegion,
     #[allow(dead_code)]
@@ -92,26 +103,46 @@ pub(crate) struct Layer {
     /// top-down walk always terminates.
     pub owns_keyboard: bool,
     /// The keybinding context to resolve against when this layer is the
-    /// keyboard owner.
-    pub key_context: KeyContext,
+    /// keyboard owner. `None` for layers whose keys are intercepted by a
+    /// custom dispatcher (calibration wizard, keybinding editor) and never
+    /// reach `KeyContext`-driven resolution — they are *transparent* to
+    /// `resolve_focus_context`, which keeps walking below them.
+    pub key_context: Option<KeyContext>,
+    /// Whether this layer, while present, blocks routing of keys to the
+    /// PTY child of a terminal buffer underneath. A blurred dock leaves the
+    /// terminal usable; a merely-visible popup does not (it covers the
+    /// active buffer and the user's keystrokes belong to the popup).
+    pub blocks_terminal_input: bool,
 }
 
-/// Resolve the keyboard-owning context from an ordered (top-first) layer
-/// list: the first layer that owns the keyboard wins. The editor base
-/// layer always owns the keyboard, so this never returns `None` for a
-/// well-formed stack.
+/// Resolve the keyboard-owning `KeyContext` from an ordered (top-first)
+/// layer list: the first owning layer that *has* a `KeyContext` wins.
+/// Layers without a `KeyContext` (custom-dispatch modals) are skipped —
+/// not because they don't own the keyboard but because they don't
+/// participate in `KeyContext`-driven keybinding resolution; their input
+/// dispatcher has already intercepted the keys upstream.
+///
+/// The editor base layer always owns and has a `KeyContext`, so this
+/// never returns `None` for a well-formed stack.
 pub(crate) fn resolve_focus_context(layers: &[Layer]) -> Option<KeyContext> {
     layers
         .iter()
-        .find(|l| l.owns_keyboard)
-        .map(|l| l.key_context.clone())
+        .find(|l| l.owns_keyboard && l.key_context.is_some())
+        .and_then(|l| l.key_context.clone())
+}
+
+/// True iff any layer in the stack currently blocks routing to the PTY
+/// child of a terminal buffer underneath. Used by `dispatch_terminal_input`
+/// to decide whether to drop into PTY-passthrough mode.
+pub(crate) fn any_layer_blocks_terminal_input(layers: &[Layer]) -> bool {
+    layers.iter().any(|l| l.blocks_terminal_input)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn layer(kind: LayerKind, owns: bool, ctx: KeyContext) -> Layer {
+    fn modal(kind: LayerKind, owns: bool, ctx: Option<KeyContext>, blocks: bool) -> Layer {
         Layer {
             kind,
             region: LayerRegion::FullScreen,
@@ -122,6 +153,7 @@ mod tests {
             },
             owns_keyboard: owns,
             key_context: ctx,
+            blocks_terminal_input: blocks,
         }
     }
 
@@ -131,16 +163,22 @@ mod tests {
             region: LayerRegion::EditorContent,
             policy: FocusPolicy::Base,
             owns_keyboard: true,
-            key_context: KeyContext::Normal,
+            key_context: Some(KeyContext::Normal),
+            blocks_terminal_input: false,
         }
     }
 
     #[test]
     fn topmost_owning_layer_wins() {
         let layers = [
-            layer(LayerKind::Settings, false, KeyContext::Settings),
-            layer(LayerKind::Popup, true, KeyContext::Popup),
-            layer(LayerKind::Dock, true, KeyContext::Dock),
+            modal(
+                LayerKind::Settings,
+                false,
+                Some(KeyContext::Settings),
+                false,
+            ),
+            modal(LayerKind::Popup, true, Some(KeyContext::Popup), true),
+            modal(LayerKind::Dock, true, Some(KeyContext::Dock), true),
             base(),
         ];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Popup));
@@ -149,8 +187,13 @@ mod tests {
     #[test]
     fn falls_through_unfocused_layers_to_base() {
         let layers = [
-            layer(LayerKind::FloatingModal, false, KeyContext::Normal),
-            layer(LayerKind::Dock, false, KeyContext::Dock),
+            modal(
+                LayerKind::FloatingModal,
+                false,
+                Some(KeyContext::Normal),
+                true,
+            ),
+            modal(LayerKind::Dock, false, Some(KeyContext::Dock), false),
             base(),
         ];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
@@ -160,5 +203,46 @@ mod tests {
     fn base_layer_terminates_the_walk() {
         let layers = [base()];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
+        assert!(!any_layer_blocks_terminal_input(&layers));
+    }
+
+    /// Calibration / keybinding-editor own the keyboard via custom
+    /// dispatch — they have no `KeyContext`. `resolve_focus_context`
+    /// must walk past them and return the base context, matching the
+    /// historical behavior when `get_key_context` was queried while one
+    /// of those modals happened to be up.
+    #[test]
+    fn keycontext_walk_is_transparent_to_custom_dispatch_modals() {
+        let layers = [
+            modal(LayerKind::CalibrationWizard, true, None, true),
+            base(),
+        ];
+        assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
+        // …but the custom-dispatch modal still blocks terminal routing:
+        assert!(any_layer_blocks_terminal_input(&layers));
+    }
+
+    /// A merely-visible (unfocused) popup blocks PTY routing — the
+    /// popup is painted over the active buffer. A blurred dock does
+    /// not block; a focused dock does.
+    #[test]
+    fn terminal_blocking_differs_from_keyboard_ownership() {
+        let popup_visible_not_capturing = [
+            modal(LayerKind::Popup, false, Some(KeyContext::Popup), true),
+            base(),
+        ];
+        assert_eq!(
+            resolve_focus_context(&popup_visible_not_capturing),
+            Some(KeyContext::Normal),
+        );
+        assert!(any_layer_blocks_terminal_input(
+            &popup_visible_not_capturing
+        ));
+
+        let blurred_dock = [
+            modal(LayerKind::Dock, false, Some(KeyContext::Dock), false),
+            base(),
+        ];
+        assert!(!any_layer_blocks_terminal_input(&blurred_dock));
     }
 }

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -1,71 +1,33 @@
-//! Unified overlay **layer** model (P2 — staged migration).
+//! Unified overlay **layer** model (P2).
 //!
-//! The editor paints a stack of overlays on top of the editor content:
-//! full-screen modals (settings, the keybinding editor, the calibration
-//! wizard, …), the menu, the prompt, popups, the centered widget modal,
-//! and the left dock. Historically each was an independent field with its
-//! own focus-precedence, paint-order and mouse-routing logic scattered
-//! across `render.rs`, `input.rs`, `input_dispatch.rs` and
-//! `mouse_input.rs`. The eventual destination
-//! (see `docs/internal/orchestrator-dock-gaps.md`, "Design: dock + modal
-//! coexistence", option P2) is to make this stack a first-class *ordered
-//! list of layers* so precedence, z-order and hit-testing are *properties
-//! of layers* rather than duplicated conditionals.
+//! The editor presents a stack of overlays on top of the editor content:
+//! the event-debug dialog, full-screen modals (settings, keybinding editor,
+//! calibration wizard, workspace-trust prompt), the menu, the prompt,
+//! popups, the centered widget modal, and the left dock. Each one used to
+//! have its own focus-precedence, terminal-blocking and mouse-capture
+//! logic scattered across `input.rs`, `input_dispatch.rs`, `mouse_input.rs`
+//! and `render.rs` — and the conditional ladders went out of sync (the
+//! mouse handler's modal precedence didn't match the keyboard handler's,
+//! `dispatch_terminal_input`'s `in_modal` predicate over-listed the same
+//! fields, the unfocused-popup guard re-listed Settings/Menu/Prompt).
 //!
-//! Status of the staged migration:
-//! - Step 1: `get_key_context` resolved through the stack.
-//! - Step 2: the duplicate "higher-priority modal owns the keyboard" guard
-//!   in `resolve_unfocused_popup_action` is a stack query.
-//! - Step 3 (this revision): the stack includes the full-screen modal zoo
-//!   (calibration / keybinding editor) and tracks `blocks_terminal_input`
-//!   per layer, letting `dispatch_terminal_input`'s `in_modal` predicate
-//!   become a single stack query.
-//! - Later: render paint-order and mouse hit-testing.
+//! This module makes the stack a first-class ordered list. Every callsite
+//! that asks "which overlay is in charge?" — keyboard focus
+//! (`get_key_context`), the unfocused-popup modal guard
+//! (`resolve_unfocused_popup_action`), the terminal-input gate
+//! (`dispatch_terminal_input`) and the mouse early-capture ladder
+//! (`handle_mouse`) — reads from the *same* `Editor::overlay_layers()`
+//! list, so the precedence rules live in one place.
 
 use crate::input::keybindings::KeyContext;
 
-/// Where a layer is anchored on screen. Determines its hit-testing region
-/// and, for modal layers, what is dimmed underneath. Step 1–3 only resolve
-/// focus and terminal-blocking; it is carried on every layer so the
-/// render/mouse migrations can switch onto it without reshaping the model.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LayerRegion {
-    /// Covers the whole frame — really the *chrome area* beside the dock,
-    /// which is the full frame when no dock is present. Full-screen modals
-    /// (settings, calibration wizard, keybinding editor) and the menu/prompt
-    /// live here.
-    FullScreen,
-    /// A centered modal box sized by a percentage of the frame (the
-    /// orchestrator picker / new-session form / plugin modals).
-    Centered,
-    /// A full-height column pinned to the left of the chrome (the dock).
-    LeftDock,
-    /// Anchored near the cursor or a focused widget (popups, completions).
-    Anchored,
-    /// The editor content / window splits — the bottom-most layer.
-    EditorContent,
-}
-
-/// How a layer participates in keyboard focus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FocusPolicy {
-    /// Owns the keyboard whenever the layer is present, blocking every
-    /// layer below it (settings, calibration wizard, keybinding editor,
-    /// menu, prompt, a focused centered modal).
-    Modal,
-    /// Focusable, but only owns the keyboard while *focused*; when blurred
-    /// it coexists with the editor underneath (the dock; an unfocused
-    /// popup that is merely visible).
-    NonModal,
-    /// Never the keyboard target — the bottom editor-content layer, which
-    /// is the terminal's default key sink.
-    Base,
-}
-
-/// Identifies a concrete overlay. The ordering of `overlay_layers` — not
-/// this enum's declaration order — defines precedence.
+/// Identifies a concrete overlay. The ordering of `overlay_layers`
+/// (top-first), not this enum's declaration order, defines precedence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LayerKind {
+    /// The event-debug dialog (`active_window().event_debug`) — a
+    /// full-screen modal with its own input dispatcher.
+    EventDebug,
     Settings,
     /// The keybinding editor (`keybinding_editor`) — a full-screen modal
     /// with its own input dispatcher; transparent to `KeyContext`-driven
@@ -73,6 +35,11 @@ pub(crate) enum LayerKind {
     KeybindingEditor,
     /// The calibration wizard (`calibration_wizard`) — same as above.
     CalibrationWizard,
+    /// The workspace-trust prompt: a global popup whose top resolver is
+    /// `PopupResolver::WorkspaceTrust`, painted in the modal z-band and
+    /// dispatched by a bespoke mouse/key handler. Distinct from `Popup`
+    /// so its dedicated dispatchers can be located top-down by kind.
+    WorkspaceTrust,
     Menu,
     Prompt,
     Popup,
@@ -80,47 +47,39 @@ pub(crate) enum LayerKind {
     FloatingModal,
     /// The editor-global left dock (`dock`).
     Dock,
-    /// The editor content / window splits.
+    /// The editor content / window splits — the bottom layer.
     Editor,
 }
 
 /// One entry in the overlay stack: a present overlay (or the always-present
-/// editor base), with the data the dispatchers need to make precedence,
-/// focus, terminal-blocking and (later) paint/hit-test decisions.
+/// editor base), with the per-layer flags the dispatchers need.
 #[derive(Debug, Clone)]
 pub(crate) struct Layer {
     pub kind: LayerKind,
-    // `region` / `policy` describe the layer for the paint-order and
-    // mouse-hit-test migrations (later steps of P2). Reading is via
-    // `kind` / `owns_keyboard` / `key_context` / `blocks_terminal_input`.
-    #[allow(dead_code)]
-    pub region: LayerRegion,
-    #[allow(dead_code)]
-    pub policy: FocusPolicy,
-    /// Whether this layer currently owns the keyboard. For `Modal` layers
-    /// this is always true while present; for `NonModal` it tracks the
-    /// layer's focused/capturing state; the `Base` layer sets it true so a
-    /// top-down walk always terminates.
+    /// Whether this layer currently owns the keyboard. Modal layers set
+    /// this whenever present; focusable layers (dock, popup) only while
+    /// focused/capturing; the editor base always sets it so a top-down
+    /// walk always terminates.
     pub owns_keyboard: bool,
     /// The keybinding context to resolve against when this layer is the
     /// keyboard owner. `None` for layers whose keys are intercepted by a
-    /// custom dispatcher (calibration wizard, keybinding editor) and never
-    /// reach `KeyContext`-driven resolution — they are *transparent* to
-    /// `resolve_focus_context`, which keeps walking below them.
+    /// custom dispatcher (event-debug, calibration wizard, keybinding
+    /// editor) and never reach `KeyContext`-driven resolution — they are
+    /// transparent to `resolve_focus_context`, which keeps walking below
+    /// them.
     pub key_context: Option<KeyContext>,
     /// Whether this layer, while present, blocks routing of keys to the
-    /// PTY child of a terminal buffer underneath. A blurred dock leaves the
-    /// terminal usable; a merely-visible popup does not (it covers the
-    /// active buffer and the user's keystrokes belong to the popup).
+    /// PTY child of a terminal buffer underneath. A blurred dock leaves
+    /// the terminal usable; a merely-visible popup does not (it covers
+    /// the active buffer and the user's keystrokes belong to the popup).
     pub blocks_terminal_input: bool,
 }
 
 /// Resolve the keyboard-owning `KeyContext` from an ordered (top-first)
-/// layer list: the first owning layer that *has* a `KeyContext` wins.
+/// layer list: the first owning layer that has a `KeyContext` wins.
 /// Layers without a `KeyContext` (custom-dispatch modals) are skipped —
-/// not because they don't own the keyboard but because they don't
-/// participate in `KeyContext`-driven keybinding resolution; their input
-/// dispatcher has already intercepted the keys upstream.
+/// their input dispatcher has already intercepted keys upstream, so they
+/// are transparent to `KeyContext`-driven resolution.
 ///
 /// The editor base layer always owns and has a `KeyContext`, so this
 /// never returns `None` for a well-formed stack.
@@ -132,8 +91,7 @@ pub(crate) fn resolve_focus_context(layers: &[Layer]) -> Option<KeyContext> {
 }
 
 /// True iff any layer in the stack currently blocks routing to the PTY
-/// child of a terminal buffer underneath. Used by `dispatch_terminal_input`
-/// to decide whether to drop into PTY-passthrough mode.
+/// child of a terminal buffer underneath.
 pub(crate) fn any_layer_blocks_terminal_input(layers: &[Layer]) -> bool {
     layers.iter().any(|l| l.blocks_terminal_input)
 }
@@ -142,15 +100,9 @@ pub(crate) fn any_layer_blocks_terminal_input(layers: &[Layer]) -> bool {
 mod tests {
     use super::*;
 
-    fn modal(kind: LayerKind, owns: bool, ctx: Option<KeyContext>, blocks: bool) -> Layer {
+    fn layer(kind: LayerKind, owns: bool, ctx: Option<KeyContext>, blocks: bool) -> Layer {
         Layer {
             kind,
-            region: LayerRegion::FullScreen,
-            policy: if owns {
-                FocusPolicy::Modal
-            } else {
-                FocusPolicy::NonModal
-            },
             owns_keyboard: owns,
             key_context: ctx,
             blocks_terminal_input: blocks,
@@ -158,27 +110,20 @@ mod tests {
     }
 
     fn base() -> Layer {
-        Layer {
-            kind: LayerKind::Editor,
-            region: LayerRegion::EditorContent,
-            policy: FocusPolicy::Base,
-            owns_keyboard: true,
-            key_context: Some(KeyContext::Normal),
-            blocks_terminal_input: false,
-        }
+        layer(LayerKind::Editor, true, Some(KeyContext::Normal), false)
     }
 
     #[test]
     fn topmost_owning_layer_wins() {
         let layers = [
-            modal(
+            layer(
                 LayerKind::Settings,
                 false,
                 Some(KeyContext::Settings),
                 false,
             ),
-            modal(LayerKind::Popup, true, Some(KeyContext::Popup), true),
-            modal(LayerKind::Dock, true, Some(KeyContext::Dock), true),
+            layer(LayerKind::Popup, true, Some(KeyContext::Popup), true),
+            layer(LayerKind::Dock, true, Some(KeyContext::Dock), true),
             base(),
         ];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Popup));
@@ -187,13 +132,13 @@ mod tests {
     #[test]
     fn falls_through_unfocused_layers_to_base() {
         let layers = [
-            modal(
+            layer(
                 LayerKind::FloatingModal,
                 false,
                 Some(KeyContext::Normal),
                 true,
             ),
-            modal(LayerKind::Dock, false, Some(KeyContext::Dock), false),
+            layer(LayerKind::Dock, false, Some(KeyContext::Dock), false),
             base(),
         ];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
@@ -206,29 +151,28 @@ mod tests {
         assert!(!any_layer_blocks_terminal_input(&layers));
     }
 
-    /// Calibration / keybinding-editor own the keyboard via custom
-    /// dispatch — they have no `KeyContext`. `resolve_focus_context`
-    /// must walk past them and return the base context, matching the
-    /// historical behavior when `get_key_context` was queried while one
-    /// of those modals happened to be up.
+    /// Custom-dispatch modals own the keyboard but expose no
+    /// `KeyContext`. `resolve_focus_context` must walk past them and
+    /// return the base context — matching the historical behavior when
+    /// `get_key_context` happened to be queried while one of those
+    /// modals was up.
     #[test]
     fn keycontext_walk_is_transparent_to_custom_dispatch_modals() {
         let layers = [
-            modal(LayerKind::CalibrationWizard, true, None, true),
+            layer(LayerKind::CalibrationWizard, true, None, true),
             base(),
         ];
         assert_eq!(resolve_focus_context(&layers), Some(KeyContext::Normal));
-        // …but the custom-dispatch modal still blocks terminal routing:
         assert!(any_layer_blocks_terminal_input(&layers));
     }
 
-    /// A merely-visible (unfocused) popup blocks PTY routing — the
-    /// popup is painted over the active buffer. A blurred dock does
-    /// not block; a focused dock does.
+    /// A merely-visible (unfocused) popup blocks PTY routing — it
+    /// covers the active buffer. A blurred dock does not block; a
+    /// focused dock does.
     #[test]
     fn terminal_blocking_differs_from_keyboard_ownership() {
         let popup_visible_not_capturing = [
-            modal(LayerKind::Popup, false, Some(KeyContext::Popup), true),
+            layer(LayerKind::Popup, false, Some(KeyContext::Popup), true),
             base(),
         ];
         assert_eq!(
@@ -240,7 +184,7 @@ mod tests {
         ));
 
         let blurred_dock = [
-            modal(LayerKind::Dock, false, Some(KeyContext::Dock), false),
+            layer(LayerKind::Dock, false, Some(KeyContext::Dock), false),
             base(),
         ];
         assert!(!any_layer_blocks_terminal_input(&blurred_dock));

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -30,10 +30,19 @@ use super::{Editor, FloatingWidgetState};
 /// plugin needs them encoded the same way. On Windows that means resolving
 /// 8.3 short names (`RUNNER~1` → `runneradmin`) and stripping the `\\?\`
 /// verbatim prefix `canonicalize` adds. No-op on non-Windows.
+///
+/// `canonicalize` only works on paths that exist on disk. Worktree session
+/// roots created by the orchestrator often point at directories that haven't
+/// been materialized yet (`<repo>/wt-<name>`), so a naïve canonicalize would
+/// leave them in their original 8.3 short-name form while the launch session
+/// — whose root exists — gets the long-name form, and lex compare inverts
+/// on case (`R` 0x52 < `r` 0x72). Walk up to the deepest existing ancestor,
+/// canonicalize that, then re-attach the missing tail so siblings share the
+/// same prefix encoding regardless of which exist.
 fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
     #[cfg(windows)]
     {
-        let canonical = path.canonicalize().unwrap_or(path);
+        let canonical = canonicalize_deepest_existing(&path);
         let s = canonical.to_string_lossy();
         if let Some(stripped) = s.strip_prefix(r"\\?\") {
             return std::path::PathBuf::from(stripped);
@@ -42,6 +51,34 @@ fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
     }
     #[cfg(not(windows))]
     path
+}
+
+#[cfg(windows)]
+fn canonicalize_deepest_existing(path: &std::path::Path) -> std::path::PathBuf {
+    if let Ok(c) = path.canonicalize() {
+        return c;
+    }
+    // Walk up to the deepest ancestor that does canonicalize, then re-attach
+    // the components we walked past. Falls back to the raw path if no
+    // ancestor canonicalizes (drive root missing, etc).
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    let mut ancestor = path;
+    loop {
+        let Some(parent) = ancestor.parent() else {
+            return path.to_path_buf();
+        };
+        if let Some(name) = ancestor.file_name() {
+            tail.push(name);
+        }
+        if let Ok(c) = parent.canonicalize() {
+            let mut out = c;
+            for name in tail.iter().rev() {
+                out.push(name);
+            }
+            return out;
+        }
+        ancestor = parent;
+    }
 }
 
 /// Returns the byte offset of the start (want_end=false) or end (want_end=true)

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -24,15 +24,23 @@ use crate::view::split::SplitViewState;
 use super::window::Window;
 use super::{Editor, FloatingWidgetState};
 
-/// Strip Windows' `\\?\` verbatim prefix from a path. No-op on non-Windows.
-fn strip_verbatim_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
+/// Normalize a session path for the plugin API. Sessions reach `WindowInfo`
+/// from two sources — the canonicalized launch session and `create_window_at`'s
+/// raw `PathBuf` — so any byte-level path field (lex sort, equality, …) in a
+/// plugin needs them encoded the same way. On Windows that means resolving
+/// 8.3 short names (`RUNNER~1` → `runneradmin`) and stripping the `\\?\`
+/// verbatim prefix `canonicalize` adds. No-op on non-Windows.
+fn normalize_plugin_path(path: std::path::PathBuf) -> std::path::PathBuf {
     #[cfg(windows)]
     {
-        let s = path.to_string_lossy();
+        let canonical = path.canonicalize().unwrap_or(path);
+        let s = canonical.to_string_lossy();
         if let Some(stripped) = s.strip_prefix(r"\\?\") {
             return std::path::PathBuf::from(stripped);
         }
+        return canonical;
     }
+    #[cfg(not(windows))]
     path
 }
 
@@ -184,15 +192,11 @@ impl Editor {
                     .and_then(|m| m.get("shared_worktree"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                // Normalize paths at the plugin boundary: strip Windows'
-                // `\\?\` verbatim prefix so paths from different sources
-                // (canonicalized launch session vs raw `create_window_at`)
-                // compare/sort consistently in plugin land.
                 fresh_core::api::WindowInfo {
                     id: s.id,
                     label: s.label.clone(),
-                    root: strip_verbatim_prefix(s.root.clone()),
-                    project_path: strip_verbatim_prefix(project_path),
+                    root: normalize_plugin_path(s.root.clone()),
+                    project_path: normalize_plugin_path(project_path),
                     shared_worktree,
                 }
             })

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -24,6 +24,18 @@ use crate::view::split::SplitViewState;
 use super::window::Window;
 use super::{Editor, FloatingWidgetState};
 
+/// Strip Windows' `\\?\` verbatim prefix from a path. No-op on non-Windows.
+fn strip_verbatim_prefix(path: std::path::PathBuf) -> std::path::PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+            return std::path::PathBuf::from(stripped);
+        }
+    }
+    path
+}
+
 /// Returns the byte offset of the start (want_end=false) or end (want_end=true)
 /// of `line` (0-indexed) within `content`. Returns `None` when `line` is out of
 /// range. The "end" position is the byte index of the terminating `\n`; for the
@@ -172,11 +184,15 @@ impl Editor {
                     .and_then(|m| m.get("shared_worktree"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
+                // Normalize paths at the plugin boundary: strip Windows'
+                // `\\?\` verbatim prefix so paths from different sources
+                // (canonicalized launch session vs raw `create_window_at`)
+                // compare/sort consistently in plugin land.
                 fresh_core::api::WindowInfo {
                     id: s.id,
                     label: s.label.clone(),
-                    root: s.root.clone(),
-                    project_path,
+                    root: strip_verbatim_prefix(s.root.clone()),
+                    project_path: strip_verbatim_prefix(project_path),
                     shared_worktree,
                 }
             })

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -172,22 +172,6 @@ impl Editor {
                     .and_then(|m| m.get("shared_worktree"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                // TEMPORARY Windows-CI diagnostic for the
-                // `dock_initial_sort_…` / `dock_list_order_…` failure.
-                // Prints the exact Rust-side values fed into each
-                // WindowInfo so we can see whether the path strings on
-                // Windows match what the test's assertion message
-                // reports. Eprintln so `--nocapture` surfaces it;
-                // tests don't assert on this output. Remove once the
-                // root cause is pinned down.
-                eprintln!(
-                    "WIN_DIAG WindowInfo id={} label={:?} root={:?} project_path={:?} slot_present={}",
-                    s.id.0,
-                    s.label,
-                    s.root,
-                    project_path,
-                    slot.is_some(),
-                );
                 fresh_core::api::WindowInfo {
                     id: s.id,
                     label: s.label.clone(),

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -156,10 +156,18 @@ impl Editor {
             .values()
             .map(|s| {
                 let slot = s.plugin_state.get("orchestrator");
+                // Normalise project_path at the API boundary: explicit
+                // non-empty value if the orchestrator recorded one,
+                // otherwise the session's root. Filtering empty strings
+                // is the same guard the plugin used to apply via
+                // `?? root` / `|| root` — now centralised so plugins
+                // can treat `project_path` as an always-set `string`.
                 let project_path = slot
                     .and_then(|m| m.get("project_path"))
                     .and_then(|v| v.as_str())
-                    .map(std::path::PathBuf::from);
+                    .filter(|p| !p.is_empty())
+                    .map(std::path::PathBuf::from)
+                    .unwrap_or_else(|| s.root.clone());
                 let shared_worktree = slot
                     .and_then(|m| m.get("shared_worktree"))
                     .and_then(|v| v.as_bool())

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -172,6 +172,22 @@ impl Editor {
                     .and_then(|m| m.get("shared_worktree"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
+                // TEMPORARY Windows-CI diagnostic for the
+                // `dock_initial_sort_…` / `dock_list_order_…` failure.
+                // Prints the exact Rust-side values fed into each
+                // WindowInfo so we can see whether the path strings on
+                // Windows match what the test's assertion message
+                // reports. Eprintln so `--nocapture` surfaces it;
+                // tests don't assert on this output. Remove once the
+                // root cause is pinned down.
+                eprintln!(
+                    "WIN_DIAG WindowInfo id={} label={:?} root={:?} project_path={:?} slot_present={}",
+                    s.id.0,
+                    s.label,
+                    s.root,
+                    project_path,
+                    slot.is_some(),
+                );
                 fresh_core::api::WindowInfo {
                     id: s.id,
                     label: s.label.clone(),

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5821,8 +5821,47 @@ impl Editor {
                 fwp.focused = true;
             }
             "focus" => fwp.focused = true,
-            "blur" => fwp.focused = false,
+            "blur" => {
+                drop(fwp);
+                self.blur_floating_panel();
+            }
             other => tracing::warn!("FloatingPanelControl: unknown op {other:?}"),
+        }
+    }
+
+    /// Return keyboard focus to the editor while leaving a (docked)
+    /// floating panel visible. Clears the panel's `focused` flag and
+    /// fires a `blur` widget_event so the owning plugin can react
+    /// (e.g. drop its editor mode). No-op when no panel is mounted.
+    /// Shared by the Esc handler, the editor-click handler, and the
+    /// `FloatingPanelControl{op:"blur"}` command.
+    pub(super) fn blur_floating_panel(&mut self) {
+        let Some(panel_id) = self.floating_widget_panel.as_ref().map(|f| f.panel_id) else {
+            return;
+        };
+        if let Some(f) = self.floating_widget_panel.as_mut() {
+            f.focused = false;
+        }
+        let widget_key = self
+            .widget_registry
+            .get(panel_id)
+            .map(|p| p.focus_key.clone())
+            .unwrap_or_default();
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key,
+                    event_type: "blur".to_string(),
+                    payload: serde_json::json!({}),
+                },
+            );
         }
     }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -22,7 +22,7 @@ use crate::services::async_bridge::AsyncMessage;
 use crate::view::split::SplitViewState;
 
 use super::window::Window;
-use super::{Editor, FloatingWidgetState, FLOATING_PANEL_BUFFER_ID};
+use super::{Editor, FloatingWidgetState};
 
 /// Returns the byte offset of the start (want_end=false) or end (want_end=true)
 /// of `line` (0-indexed) within `content`. Returns `None` when `line` is out of
@@ -1482,8 +1482,9 @@ impl Editor {
                 spec,
                 width_pct,
                 height_pct,
+                as_dock,
             } => {
-                self.handle_mount_floating_widget(panel_id, spec, width_pct, height_pct);
+                self.handle_mount_floating_widget(panel_id, spec, width_pct, height_pct, as_dock);
             }
 
             PluginCommand::UpdateFloatingWidget { panel_id, spec } => {
@@ -3720,7 +3721,7 @@ impl Editor {
         // with 5 000 nodes that's a multi-MB deep clone per IPC, which
         // dominates the host's per-mutation cost during a streaming
         // search.
-        let (buffer_id, is_floating, panel_width, out_pieces) = {
+        let (buffer_id, _is_floating, panel_width, out_pieces) = {
             let (buffer_id, spec) = match self.widget_registry.buffer_and_spec_ref(panel_id) {
                 Some(s) => s,
                 None => return,
@@ -3735,9 +3736,10 @@ impl Editor {
                 .focus_key(panel_id)
                 .map(|s| s.to_string())
                 .unwrap_or_default();
-            let is_floating = buffer_id == FLOATING_PANEL_BUFFER_ID;
-            let panel_width = if is_floating {
-                self.floating_panel_inner_width()
+            let panel_slot = Self::slot_for_panel_buffer(buffer_id);
+            let is_floating = panel_slot.is_some();
+            let panel_width = if let Some(slot) = panel_slot {
+                self.floating_panel_inner_width(slot)
             } else {
                 self.widget_panel_width(buffer_id)
             };
@@ -3745,6 +3747,7 @@ impl Editor {
             (buffer_id, is_floating, panel_width, out)
         };
         let _ = panel_width;
+        let panel_slot = Self::slot_for_panel_buffer(buffer_id);
         let focus_cursor = out_pieces.focus_cursor;
         let entries = out_pieces.entries;
         let embeds = out_pieces.embeds;
@@ -3764,8 +3767,8 @@ impl Editor {
             tracing::warn!("rerender_widget_panel({}) lost panel mid-call", panel_id);
             return;
         }
-        if is_floating {
-            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+        if let Some(slot) = panel_slot {
+            if let Some(fwp) = self.panel_mut(slot) {
                 if fwp.panel_id == panel_id {
                     fwp.entries = entries;
                     fwp.focus_cursor = focus_cursor;
@@ -5628,19 +5631,46 @@ impl Editor {
         spec: fresh_core::api::WidgetSpec,
         width_pct: u8,
         height_pct: u8,
+        as_dock: bool,
     ) {
         let width_pct = width_pct.clamp(1, 100);
         let height_pct = height_pct.clamp(1, 100);
-        if let Some(existing) = self.floating_widget_panel.take() {
+        // The dock mounts into its own slot so it coexists with a
+        // centered modal; everything else is a centered overlay.
+        let slot = if as_dock {
+            super::PanelSlot::Dock
+        } else {
+            super::PanelSlot::Floating
+        };
+        let buffer_id = slot.buffer_id();
+        // A centered modal owns the keyboard: blur a focused dock so the
+        // two slots never both claim input. Without this, a dock key
+        // handler (e.g. its Esc→blur) would greedily consume keys the
+        // modal deferred to its own mode bindings, stranding the modal
+        // open. Fires the dock's `blur` widget_event so the owning plugin
+        // can mirror the state. Does nothing when the dock isn't focused.
+        if !as_dock && self.dock.as_ref().is_some_and(|f| f.focused) {
+            self.blur_floating_panel(super::PanelSlot::Dock);
+        }
+        let placement = if as_dock {
+            let width = self
+                .dock_width
+                .unwrap_or(32)
+                .clamp(10, self.terminal_width.max(20).saturating_sub(20).max(10));
+            super::PanelPlacement::LeftDock { width_cols: width }
+        } else {
+            super::PanelPlacement::Centered
+        };
+        if let Some(existing) = self.panel_opt_mut(slot).take() {
             if existing.panel_id != panel_id {
                 let _ = self.widget_registry.unmount(existing.panel_id);
             }
         }
-        self.floating_widget_panel = Some(FloatingWidgetState {
+        *self.panel_opt_mut(slot) = Some(FloatingWidgetState {
             panel_id,
             width_pct,
             height_pct,
-            placement: super::PanelPlacement::Centered,
+            placement,
             focused: true,
             entries: Vec::new(),
             focus_cursor: None,
@@ -5654,7 +5684,7 @@ impl Editor {
         });
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
-        let panel_width = self.floating_panel_inner_width();
+        let panel_width = self.floating_panel_inner_width(slot);
         let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
@@ -5663,14 +5693,14 @@ impl Editor {
         let scroll_regions = out.scroll_regions;
         self.widget_registry.mount(
             panel_id,
-            FLOATING_PANEL_BUFFER_ID,
+            buffer_id,
             spec,
             out.hits,
             out.instance_states,
             out.focus_key,
             out.tabbable,
         );
-        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+        if let Some(fwp) = self.panel_mut(slot) {
             fwp.entries = entries;
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
@@ -5686,16 +5716,13 @@ impl Editor {
     }
 
     fn handle_update_floating_widget(&mut self, panel_id: u64, spec: fresh_core::api::WidgetSpec) {
-        match self.floating_widget_panel.as_ref() {
-            Some(fwp) if fwp.panel_id == panel_id => {}
-            _ => {
-                tracing::debug!(
-                    "UpdateFloatingWidget for unknown / mismatched panel {} ignored",
-                    panel_id
-                );
-                return;
-            }
-        }
+        let Some(slot) = self.slot_of_panel(panel_id) else {
+            tracing::debug!(
+                "UpdateFloatingWidget for unknown / mismatched panel {} ignored",
+                panel_id
+            );
+            return;
+        };
         let prev = self
             .widget_registry
             .instance_states(panel_id)
@@ -5706,7 +5733,7 @@ impl Editor {
             .focus_key(panel_id)
             .map(|s| s.to_string())
             .unwrap_or_default();
-        let panel_width = self.floating_panel_inner_width();
+        let panel_width = self.floating_panel_inner_width(slot);
         let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
@@ -5731,7 +5758,7 @@ impl Editor {
             );
             return;
         }
-        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+        if let Some(fwp) = self.panel_mut(slot) {
             fwp.entries = entries;
             fwp.focus_cursor = focus_cursor;
             fwp.embeds = embeds;
@@ -5741,17 +5768,14 @@ impl Editor {
     }
 
     fn handle_unmount_floating_widget(&mut self, panel_id: u64) {
-        match self.floating_widget_panel.as_ref() {
-            Some(fwp) if fwp.panel_id == panel_id => {}
-            _ => {
-                tracing::debug!(
-                    "UnmountFloatingWidget for unknown / mismatched panel {} ignored",
-                    panel_id
-                );
-                return;
-            }
-        }
-        self.floating_widget_panel = None;
+        let Some(slot) = self.slot_of_panel(panel_id) else {
+            tracing::debug!(
+                "UnmountFloatingWidget for unknown / mismatched panel {} ignored",
+                panel_id
+            );
+            return;
+        };
+        *self.panel_opt_mut(slot) = None;
         let _ = self.widget_registry.unmount(panel_id);
         // Restore the active window's visible terminal PTYs to their
         // dive-view split rects. The orchestrator picker's preview
@@ -5774,18 +5798,17 @@ impl Editor {
     /// border. Mirrors the `widget_panel_width` reservation; never
     /// goes below 10 cols so flex spacers don't collapse to zero on
     /// narrow terminals.
-    pub(super) fn floating_panel_inner_width(&self) -> u32 {
+    pub(super) fn floating_panel_inner_width(&self, slot: super::PanelSlot) -> u32 {
         // A left-dock panel wraps its content to the dock's fixed
         // column width rather than a percentage of the terminal.
         if let Some(super::PanelPlacement::LeftDock { width_cols }) =
-            self.floating_widget_panel.as_ref().map(|f| f.placement)
+            self.panel(slot).map(|f| f.placement)
         {
             return (width_cols as u32).saturating_sub(2).max(10);
         }
         let term_w = self.terminal_width.max(1) as u32;
         let pct = self
-            .floating_widget_panel
-            .as_ref()
+            .panel(slot)
             .map(|f| f.width_pct.clamp(1, 100) as u32)
             .unwrap_or(80);
         let w = (term_w * pct) / 100;
@@ -5795,18 +5818,14 @@ impl Editor {
     /// Apply a `FloatingPanelControl` op. No-op if the panel id
     /// doesn't match the mounted floating panel.
     fn handle_floating_panel_control(&mut self, panel_id: u64, op: &str, arg: f64) {
-        let matches = self
-            .floating_widget_panel
-            .as_ref()
-            .is_some_and(|f| f.panel_id == panel_id);
-        if !matches {
+        let Some(slot) = self.slot_of_panel(panel_id) else {
             tracing::warn!("FloatingPanelControl for unknown/mismatched panel {panel_id} ignored");
             return;
-        }
+        };
         // `blur` fires a widget_event, so handle it before borrowing the
         // panel — it reborrows `self` via the shared helper.
         if op == "blur" {
-            self.blur_floating_panel();
+            self.blur_floating_panel(slot);
             return;
         }
         // Clamp the dock width relative to the terminal so it can never
@@ -5815,7 +5834,7 @@ impl Editor {
         // default so the resize survives toggling the dock off/on.
         let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
         let persisted = self.dock_width;
-        let Some(fwp) = self.floating_widget_panel.as_mut() else {
+        let Some(fwp) = self.panel_mut(slot) else {
             return;
         };
         match op {
@@ -5840,11 +5859,11 @@ impl Editor {
     /// (e.g. drop its editor mode). No-op when no panel is mounted.
     /// Shared by the Esc handler, the editor-click handler, and the
     /// `FloatingPanelControl{op:"blur"}` command.
-    pub(super) fn blur_floating_panel(&mut self) {
-        let Some(panel_id) = self.floating_widget_panel.as_ref().map(|f| f.panel_id) else {
+    pub(super) fn blur_floating_panel(&mut self, slot: super::PanelSlot) {
+        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
             return;
         };
-        if let Some(f) = self.floating_widget_panel.as_mut() {
+        if let Some(f) = self.panel_mut(slot) {
             f.focused = false;
         }
         let widget_key = self

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -747,6 +747,9 @@ impl Editor {
             PluginCommand::SetActiveWindow { id } => {
                 self.set_active_window(id);
             }
+            PluginCommand::SetActiveWindowAnimated { id, from_edge } => {
+                self.set_active_window_animated(id, &from_edge);
+            }
             PluginCommand::CloseWindow { id } => {
                 let _ = self.close_window(id);
             }
@@ -1489,6 +1492,10 @@ impl Editor {
 
             PluginCommand::UnmountFloatingWidget { panel_id } => {
                 self.handle_unmount_floating_widget(panel_id);
+            }
+
+            PluginCommand::FloatingPanelControl { panel_id, op, arg } => {
+                self.handle_floating_panel_control(panel_id, &op, arg);
             }
         }
         Ok(())
@@ -5633,6 +5640,8 @@ impl Editor {
             panel_id,
             width_pct,
             height_pct,
+            placement: super::PanelPlacement::Centered,
+            focused: true,
             entries: Vec::new(),
             focus_cursor: None,
             embeds: Vec::new(),
@@ -5766,6 +5775,13 @@ impl Editor {
     /// goes below 10 cols so flex spacers don't collapse to zero on
     /// narrow terminals.
     pub(super) fn floating_panel_inner_width(&self) -> u32 {
+        // A left-dock panel wraps its content to the dock's fixed
+        // column width rather than a percentage of the terminal.
+        if let Some(super::PanelPlacement::LeftDock { width_cols }) =
+            self.floating_widget_panel.as_ref().map(|f| f.placement)
+        {
+            return (width_cols as u32).saturating_sub(2).max(10);
+        }
         let term_w = self.terminal_width.max(1) as u32;
         let pct = self
             .floating_widget_panel
@@ -5774,6 +5790,40 @@ impl Editor {
             .unwrap_or(80);
         let w = (term_w * pct) / 100;
         w.saturating_sub(2).max(10)
+    }
+
+    /// Apply a `FloatingPanelControl` op. No-op if the panel id
+    /// doesn't match the mounted floating panel.
+    fn handle_floating_panel_control(&mut self, panel_id: u64, op: &str, arg: f64) {
+        let matches = self
+            .floating_widget_panel
+            .as_ref()
+            .is_some_and(|f| f.panel_id == panel_id);
+        if !matches {
+            tracing::warn!("FloatingPanelControl for unknown/mismatched panel {panel_id} ignored");
+            return;
+        }
+        let Some(fwp) = self.floating_widget_panel.as_mut() else {
+            return;
+        };
+        match op {
+            "dock" => {
+                // Clamp the dock width to something sane relative to
+                // the terminal so it can never swallow the whole chrome.
+                let term_w = self.terminal_width.max(20);
+                let max_cols = term_w.saturating_sub(20).max(10);
+                let width_cols = (arg as u16).clamp(10, max_cols);
+                fwp.placement = super::PanelPlacement::LeftDock { width_cols };
+                fwp.focused = true;
+            }
+            "center" => {
+                fwp.placement = super::PanelPlacement::Centered;
+                fwp.focused = true;
+            }
+            "focus" => fwp.focused = true,
+            "blur" => fwp.focused = false,
+            other => tracing::warn!("FloatingPanelControl: unknown op {other:?}"),
+        }
     }
 
     fn handle_get_text_properties_at_cursor(&self, buffer_id: BufferId) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5811,13 +5811,17 @@ impl Editor {
         }
         // Clamp the dock width relative to the terminal so it can never
         // swallow the whole chrome. Read before the &mut borrow below.
+        // A user-dragged width (`dock_width`) overrides the plugin's
+        // default so the resize survives toggling the dock off/on.
         let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
+        let persisted = self.dock_width;
         let Some(fwp) = self.floating_widget_panel.as_mut() else {
             return;
         };
         match op {
             "dock" => {
-                let width_cols = (arg as u16).clamp(10, max_cols);
+                let requested = persisted.unwrap_or(arg as u16);
+                let width_cols = requested.clamp(10, max_cols);
                 fwp.placement = super::PanelPlacement::LeftDock { width_cols };
                 fwp.focused = true;
             }

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5853,6 +5853,53 @@ impl Editor {
         }
     }
 
+    /// Restore keyboard focus to a (docked) floating panel that was
+    /// previously blurred — typically a mouse click landing back inside
+    /// the dock's column after the user dived into the editor. Sets
+    /// the panel's `focused` flag and fires a `focus` widget_event so
+    /// the owning plugin can update any mirror of the focused state
+    /// (the orchestrator's `dockBlurred`, for instance). Symmetric
+    /// with [`Editor::blur_floating_panel`], which has always fired
+    /// `blur` on the inverse transition.
+    ///
+    /// Unlike [`Editor::set_panel_focus_and_notify`] this fires the
+    /// `focus` event even when the *inner* focus_key hasn't changed —
+    /// the dive only flipped overall focus, not the active widget, so
+    /// the inner key is identical on re-focus and the "key-changed"
+    /// short-circuit would silently drop the event. That short-circuit
+    /// was the original bug: the host updated `dock.focused` but the
+    /// plugin's mirror stayed stale, and the dock's debounced
+    /// dock-switch then aborted at its `dockBlurred` guard.
+    pub(super) fn refocus_floating_panel(&mut self, slot: super::PanelSlot) {
+        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
+            return;
+        };
+        if let Some(f) = self.panel_mut(slot) {
+            f.focused = true;
+        }
+        let widget_key = self
+            .widget_registry
+            .get(panel_id)
+            .map(|p| p.focus_key.clone())
+            .unwrap_or_default();
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key,
+                    event_type: "focus".to_string(),
+                    payload: serde_json::json!({ "previous": "(re-focus)" }),
+                },
+            );
+        }
+    }
+
     /// Return keyboard focus to the editor while leaving a (docked)
     /// floating panel visible. Clears the panel's `focused` flag and
     /// fires a `blur` widget_event so the owning plugin can react

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4307,8 +4307,21 @@ impl Editor {
             .map(|s| s.to_string())
             .unwrap_or_default();
         if old_key == new_key {
+            tracing::warn!(
+                target: "fresh::dock",
+                panel_id,
+                key = %new_key,
+                "set_panel_focus_and_notify: no-op (old == new)"
+            );
             return;
         }
+        tracing::warn!(
+            target: "fresh::dock",
+            panel_id,
+            old = %old_key,
+            new = %new_key,
+            "set_panel_focus_and_notify: firing `focus` widget_event"
+        );
         self.widget_registry
             .set_focus_key(panel_id, new_key.clone());
         if self
@@ -5882,6 +5895,13 @@ impl Editor {
             .get(panel_id)
             .map(|p| p.focus_key.clone())
             .unwrap_or_default();
+        tracing::warn!(
+            target: "fresh::dock",
+            panel_id,
+            ?slot,
+            widget_key = %widget_key,
+            "refocus_floating_panel: firing unconditional `focus` widget_event"
+        );
         if self
             .plugin_manager
             .read()
@@ -5913,6 +5933,12 @@ impl Editor {
         if let Some(f) = self.panel_mut(slot) {
             f.focused = false;
         }
+        tracing::warn!(
+            target: "fresh::dock",
+            panel_id,
+            ?slot,
+            "blur_floating_panel: firing `blur` widget_event"
+        );
         let widget_key = self
             .widget_registry
             .get(panel_id)

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5803,15 +5803,20 @@ impl Editor {
             tracing::warn!("FloatingPanelControl for unknown/mismatched panel {panel_id} ignored");
             return;
         }
+        // `blur` fires a widget_event, so handle it before borrowing the
+        // panel — it reborrows `self` via the shared helper.
+        if op == "blur" {
+            self.blur_floating_panel();
+            return;
+        }
+        // Clamp the dock width relative to the terminal so it can never
+        // swallow the whole chrome. Read before the &mut borrow below.
+        let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
         let Some(fwp) = self.floating_widget_panel.as_mut() else {
             return;
         };
         match op {
             "dock" => {
-                // Clamp the dock width to something sane relative to
-                // the terminal so it can never swallow the whole chrome.
-                let term_w = self.terminal_width.max(20);
-                let max_cols = term_w.saturating_sub(20).max(10);
                 let width_cols = (arg as u16).clamp(10, max_cols);
                 fwp.placement = super::PanelPlacement::LeftDock { width_cols };
                 fwp.focused = true;
@@ -5821,10 +5826,6 @@ impl Editor {
                 fwp.focused = true;
             }
             "focus" => fwp.focused = true,
-            "blur" => {
-                drop(fwp);
-                self.blur_floating_panel();
-            }
             other => tracing::warn!("FloatingPanelControl: unknown op {other:?}"),
         }
     }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1261,7 +1261,7 @@ impl Editor {
 
         // Render file browser popup or suggestions popup AFTER status bar + prompt,
         // so they overlay on top of both (fixes bottom border being overwritten by status bar)
-        self.render_prompt_popups(frame, main_chunks[prompt_line_idx], chrome_area.width);
+        self.render_prompt_popups(frame, main_chunks[prompt_line_idx], chrome_area);
 
         // Render popups from the active buffer state
         // Clone theme to avoid borrow checker issues with active_state_mut()
@@ -1903,17 +1903,19 @@ impl Editor {
         &mut self,
         frame: &mut Frame,
         prompt_area: ratatui::layout::Rect,
-        width: u16,
+        chrome: ratatui::layout::Rect,
     ) {
+        let width = chrome.width;
         let Some(prompt) = &self.active_window_mut().prompt else {
             return;
         };
 
         // Overlay prompts (Live Grep, issue #1796) get a dedicated
         // centred floating frame instead of the bottom-anchored popup.
+        // Centre it in the chrome area (right of a left dock) so it never
+        // overlaps the dock column.
         if prompt.overlay {
-            let frame_area = frame.area();
-            self.render_overlay_prompt(frame, frame_area);
+            self.render_overlay_prompt(frame, chrome);
             return;
         }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3891,8 +3891,16 @@ impl Editor {
             crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
         }
         frame.render_widget(Clear, overlay_rect);
+        // The dock draws ONLY a right border (a thin draggable divider) —
+        // no top/left/bottom — so it reclaims those rows/cols for content
+        // and reads as a panel attached to the left edge. The centered
+        // modal keeps a full box.
         let block = Block::default()
-            .borders(Borders::ALL)
+            .borders(if is_dock {
+                Borders::RIGHT
+            } else {
+                Borders::ALL
+            })
             .border_style(ratatui::style::Style::default().fg(theme.popup_border_fg))
             .style(ratatui::style::Style::default().bg(theme.suggestion_bg));
         let inner = block.inner(overlay_rect);

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -55,6 +55,28 @@ impl Editor {
         let _span = tracing::info_span!("render").entered();
         let size = frame.area();
 
+        // Drain any plugin commands enqueued BEFORE this frame began —
+        // notably `UnmountFloatingWidget` from a Toggle-Dock invocation
+        // earlier in the same input cycle. The mid-render
+        // `process_commands` block below runs *after* `compute_dock_split`,
+        // so without this early drain the dock unmount lands too late:
+        // this frame computes `dock_area` / `chrome_area` from the stale
+        // `self.dock = Some(_)`, the chrome paints into the post-dock
+        // offset column, and the freed columns render as blank
+        // whitespace until the next user input forces another render.
+        let early_commands = self.plugin_manager.write().unwrap().process_commands();
+        if !early_commands.is_empty() {
+            tracing::trace!(
+                count = early_commands.len(),
+                "process_commands at top of render (pre-layout drain)"
+            );
+            for command in early_commands {
+                if let Err(e) = self.handle_plugin_command(command) {
+                    tracing::error!("Error handling plugin command (pre-layout drain): {}", e);
+                }
+            }
+        }
+
         // Carve a full-height left column for a docked floating panel
         // (e.g. the orchestrator dock) out of the screen *before* the
         // chrome lays itself out, so the menu bar, splits, and status

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1261,7 +1261,7 @@ impl Editor {
 
         // Render file browser popup or suggestions popup AFTER status bar + prompt,
         // so they overlay on top of both (fixes bottom border being overwritten by status bar)
-        self.render_prompt_popups(frame, main_chunks[prompt_line_idx], size.width);
+        self.render_prompt_popups(frame, main_chunks[prompt_line_idx], chrome_area.width);
 
         // Render popups from the active buffer state
         // Clone theme to avoid borrow checker issues with active_state_mut()
@@ -1926,7 +1926,9 @@ impl Editor {
             drop(keybindings);
             let max_height = prompt_area.y.saturating_sub(1).min(20);
             let popup_area = ratatui::layout::Rect {
-                x: 0,
+                // Anchor to the prompt line's x (right of a left dock,
+                // if any) so the picker never overlaps the dock column.
+                x: prompt_area.x,
                 y: prompt_area.y.saturating_sub(max_height),
                 width,
                 height: max_height,
@@ -1956,7 +1958,7 @@ impl Editor {
         let height = suggestion_count as u16 + 2 + hints_height;
 
         let suggestions_area = ratatui::layout::Rect {
-            x: 0,
+            x: prompt_area.x,
             y: prompt_area.y.saturating_sub(height),
             width,
             height: height - hints_height,
@@ -3825,6 +3827,7 @@ impl Editor {
             overlays,
             scroll_regions,
             placement,
+            panel_focused,
         ) = match self.floating_widget_panel.as_ref() {
             Some(fwp) => (
                 fwp.width_pct,
@@ -3835,6 +3838,7 @@ impl Editor {
                 fwp.overlays.clone(),
                 fwp.scroll_regions.clone(),
                 fwp.placement,
+                fwp.focused,
             ),
             None => return,
         };
@@ -4027,14 +4031,14 @@ impl Editor {
             if cx < inner.x + inner.width && cy < inner.y + inner.height {
                 frame.set_cursor_position((cx, cy));
             }
-        } else {
-            // No focused text input — the underlying editor's
-            // `set_cursor_position` (called earlier in this frame)
-            // would otherwise leave a hardware caret blinking
-            // inside the dimmed buffer behind the panel. Park the
-            // cursor on the floating panel's bottom-right corner
-            // so it's hidden under the panel chrome instead of
-            // bleeding through.
+        } else if panel_focused {
+            // No focused text input, and the panel owns the keyboard —
+            // the underlying editor's `set_cursor_position` (called
+            // earlier this frame) would otherwise leave a hardware
+            // caret blinking inside the dimmed buffer behind the panel.
+            // Park it on the panel's bottom-right corner so it hides
+            // under the panel chrome. A *blurred* dock skips this: the
+            // editor beside it is focused and must keep its caret.
             let cx = inner.x + inner.width.saturating_sub(1);
             let cy = inner.y + inner.height.saturating_sub(1);
             frame.set_cursor_position((cx, cy));

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1710,22 +1710,19 @@ impl Editor {
             .animations
             .apply_all(frame.buffer_mut());
 
-        // Floating widget panel is drawn last so it sits above every
-        // other layer (prompts, popups, animations). A centered panel
-        // paints over the whole frame; a left-dock panel paints only
-        // its carved column (`dock_area`), leaving the chrome it sits
-        // beside untouched.
-        match self.floating_widget_panel.as_ref().map(|f| f.placement) {
-            Some(super::PanelPlacement::LeftDock { .. }) => {
-                if let Some(dock) = dock_area {
-                    self.render_floating_widget_panel(frame, dock);
-                }
+        // Panels are drawn last so they sit above every other layer
+        // (prompts, popups, animations). The two slots are independent:
+        // the dock paints into its carved column (`dock_area`); a
+        // centered modal paints over the whole frame (dimmed). Draw the
+        // dock first so a centered modal sits visually above it.
+        if let Some(dock) = dock_area {
+            if self.dock.is_some() {
+                self.render_floating_widget_panel(frame, dock, super::PanelSlot::Dock);
             }
-            Some(super::PanelPlacement::Centered) => {
-                let frame_area = frame.area();
-                self.render_floating_widget_panel(frame, frame_area);
-            }
-            None => {}
+        }
+        if self.floating_widget_panel.is_some() {
+            let frame_area = frame.area();
+            self.render_floating_widget_panel(frame, frame_area, super::PanelSlot::Floating);
         }
     }
 
@@ -3797,7 +3794,7 @@ impl Editor {
         &self,
         size: ratatui::layout::Rect,
     ) -> (Option<ratatui::layout::Rect>, ratatui::layout::Rect) {
-        let width = match self.floating_widget_panel.as_ref().map(|f| f.placement) {
+        let width = match self.dock.as_ref().map(|f| f.placement) {
             Some(super::PanelPlacement::LeftDock { width_cols }) => width_cols,
             _ => return (None, size),
         };
@@ -3824,6 +3821,7 @@ impl Editor {
         &mut self,
         frame: &mut Frame,
         area: ratatui::layout::Rect,
+        slot: super::PanelSlot,
     ) {
         use ratatui::widgets::{Block, Borders, Clear};
 
@@ -3837,7 +3835,7 @@ impl Editor {
             scroll_regions,
             placement,
             panel_focused,
-        ) = match self.floating_widget_panel.as_ref() {
+        ) = match self.panel(slot) {
             Some(fwp) => (
                 fwp.width_pct,
                 fwp.height_pct,
@@ -3907,7 +3905,7 @@ impl Editor {
         frame.render_widget(block, overlay_rect);
 
         if inner.width == 0 || inner.height == 0 {
-            if let Some(fwp) = self.floating_widget_panel.as_mut() {
+            if let Some(fwp) = self.panel_mut(slot) {
                 fwp.last_inner_rect = Some(inner);
             }
             return;
@@ -4061,7 +4059,7 @@ impl Editor {
             frame.set_cursor_position((cx, cy));
         }
 
-        if let Some(fwp) = self.floating_widget_panel.as_mut() {
+        if let Some(fwp) = self.panel_mut(slot) {
             fwp.last_inner_rect = Some(inner);
             fwp.scrollbar_tracks = scrollbar_tracks;
         }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -55,6 +55,14 @@ impl Editor {
         let _span = tracing::info_span!("render").entered();
         let size = frame.area();
 
+        // Carve a full-height left column for a docked floating panel
+        // (e.g. the orchestrator dock) out of the screen *before* the
+        // chrome lays itself out, so the menu bar, splits, and status
+        // bar all sit to the dock's right. `chrome_area` is the region
+        // the rest of `render` lays into; `dock_area` (if any) is
+        // painted last alongside the centered-overlay path.
+        let (dock_area, chrome_area) = self.compute_dock_split(size);
+
         // Let active animations snapshot the previous frame's buffer
         // from the runner's own cache. We can't read the live
         // `frame.buffer_mut()` — ratatui resets it before each draw —
@@ -279,7 +287,7 @@ impl Editor {
                     },
                 ), // Prompt line
             ])
-            .split(size);
+            .split(chrome_area);
 
         let menu_bar_area = main_chunks[0];
         let main_content_area = main_chunks[1];
@@ -668,7 +676,7 @@ impl Editor {
                             },
                         ),
                     ])
-                    .split(size);
+                    .split(chrome_area);
             }
         }
 
@@ -1696,10 +1704,21 @@ impl Editor {
             .apply_all(frame.buffer_mut());
 
         // Floating widget panel is drawn last so it sits above every
-        // other layer (prompts, popups, animations).
-        if self.floating_widget_panel.is_some() {
-            let frame_area = frame.area();
-            self.render_floating_widget_panel(frame, frame_area);
+        // other layer (prompts, popups, animations). A centered panel
+        // paints over the whole frame; a left-dock panel paints only
+        // its carved column (`dock_area`), leaving the chrome it sits
+        // beside untouched.
+        match self.floating_widget_panel.as_ref().map(|f| f.placement) {
+            Some(super::PanelPlacement::LeftDock { .. }) => {
+                if let Some(dock) = dock_area {
+                    self.render_floating_widget_panel(frame, dock);
+                }
+            }
+            Some(super::PanelPlacement::Centered) => {
+                let frame_area = frame.area();
+                self.render_floating_widget_panel(frame, frame_area);
+            }
+            None => {}
         }
     }
 
@@ -3759,6 +3778,37 @@ impl Editor {
     /// caret at the focused TextInput. Stores the inner rect on the
     /// `FloatingWidgetState` so the click hit-test can recover the
     /// geometry on the next mouse event.
+    /// Split `size` into an optional full-height left dock column and
+    /// the remaining chrome area. Returns `(None, size)` unless a
+    /// floating panel is currently placed as a `LeftDock`. The dock
+    /// width is clamped so it can never crowd out the chrome.
+    pub(super) fn compute_dock_split(
+        &self,
+        size: ratatui::layout::Rect,
+    ) -> (Option<ratatui::layout::Rect>, ratatui::layout::Rect) {
+        let width = match self.floating_widget_panel.as_ref().map(|f| f.placement) {
+            Some(super::PanelPlacement::LeftDock { width_cols }) => width_cols,
+            _ => return (None, size),
+        };
+        let width = width.min(size.width.saturating_sub(4)).max(1);
+        if width == 0 || size.width <= width {
+            return (None, size);
+        }
+        let dock = ratatui::layout::Rect {
+            x: size.x,
+            y: size.y,
+            width,
+            height: size.height,
+        };
+        let chrome = ratatui::layout::Rect {
+            x: size.x.saturating_add(width),
+            y: size.y,
+            width: size.width.saturating_sub(width),
+            height: size.height,
+        };
+        (Some(dock), chrome)
+    }
+
     pub(super) fn render_floating_widget_panel(
         &mut self,
         frame: &mut Frame,
@@ -3766,19 +3816,28 @@ impl Editor {
     ) {
         use ratatui::widgets::{Block, Borders, Clear};
 
-        let (width_pct, height_pct, entries, focus_cursor, embeds, overlays, scroll_regions) =
-            match self.floating_widget_panel.as_ref() {
-                Some(fwp) => (
-                    fwp.width_pct,
-                    fwp.height_pct,
-                    fwp.entries.clone(),
-                    fwp.focus_cursor,
-                    fwp.embeds.clone(),
-                    fwp.overlays.clone(),
-                    fwp.scroll_regions.clone(),
-                ),
-                None => return,
-            };
+        let (
+            width_pct,
+            height_pct,
+            entries,
+            focus_cursor,
+            embeds,
+            overlays,
+            scroll_regions,
+            placement,
+        ) = match self.floating_widget_panel.as_ref() {
+            Some(fwp) => (
+                fwp.width_pct,
+                fwp.height_pct,
+                fwp.entries.clone(),
+                fwp.focus_cursor,
+                fwp.embeds.clone(),
+                fwp.overlays.clone(),
+                fwp.scroll_regions.clone(),
+                fwp.placement,
+            ),
+            None => return,
+        };
         let theme = self.theme.read().unwrap().clone();
         // Compute the requested rect from width%/height%, then
         // shrink the height to fit the rendered content (Bug 7).
@@ -3795,7 +3854,15 @@ impl Editor {
         // contributes N blank entries plus an EmbedRect that paints
         // over them at draw time). So `entries.len() + 2` (top
         // border + content + bottom border) is the natural fit.
-        let overlay_rect = {
+        // A left-dock panel fills its carved column (`area` is already
+        // the dock rect) at full height and does NOT dim the chrome —
+        // it's a persistent, non-modal companion to the editor, not a
+        // modal overlay. The centered placement keeps the historical
+        // fit-to-content + background-dim behaviour.
+        let is_dock = matches!(placement, super::PanelPlacement::LeftDock { .. });
+        let overlay_rect = if is_dock {
+            area
+        } else {
             let requested = Self::centered_overlay_rect(area, width_pct, height_pct);
             let needed_h = (entries.len() as u16).saturating_add(2);
             let effective_h = needed_h.min(requested.height).max(3);
@@ -3807,7 +3874,9 @@ impl Editor {
             }
         };
 
-        crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
+        if !is_dock {
+            crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
+        }
         frame.render_widget(Clear, overlay_rect);
         let block = Block::default()
             .borders(Borders::ALL)

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1480,15 +1480,17 @@ impl Editor {
             .map(|s| s.visible)
             .unwrap_or(false);
         if settings_visible {
-            // Dim the editor content behind the settings modal
-            crate::view::dimming::apply_dimming(frame, size);
+            // Dim the editor content behind the settings modal. Use the
+            // chrome area (right of a left dock) so the modal sits beside
+            // the persistent dock instead of being overlapped by it.
+            crate::view::dimming::apply_dimming(frame, chrome_area);
         }
         if let Some(ref mut settings_state) = self.settings_state {
             if settings_state.visible {
                 settings_state.update_focus_states();
                 let settings_layout = crate::view::settings::render_settings(
                     frame,
-                    size,
+                    chrome_area,
                     settings_state,
                     &*self.theme.read().unwrap(),
                 );
@@ -1499,10 +1501,10 @@ impl Editor {
         // Render calibration wizard if active
         if let Some(ref wizard) = self.calibration_wizard {
             // Dim the editor content behind the wizard modal
-            crate::view::dimming::apply_dimming(frame, size);
+            crate::view::dimming::apply_dimming(frame, chrome_area);
             crate::view::calibration_wizard::render_calibration_wizard(
                 frame,
-                size,
+                chrome_area,
                 wizard,
                 &*self.theme.read().unwrap(),
             );
@@ -1510,10 +1512,10 @@ impl Editor {
 
         // Render keybinding editor if active
         if let Some(ref mut kb_editor) = self.keybinding_editor {
-            crate::view::dimming::apply_dimming(frame, size);
+            crate::view::dimming::apply_dimming(frame, chrome_area);
             crate::view::keybinding_editor::render_keybinding_editor(
                 frame,
-                size,
+                chrome_area,
                 kb_editor,
                 &*self.theme.read().unwrap(),
             );
@@ -1522,10 +1524,10 @@ impl Editor {
         // Render event debug dialog if active
         if let Some(ref debug) = self.active_window().event_debug {
             // Dim the editor content behind the dialog modal
-            crate::view::dimming::apply_dimming(frame, size);
+            crate::view::dimming::apply_dimming(frame, chrome_area);
             crate::view::event_debug::render_event_debug(
                 frame,
-                size,
+                chrome_area,
                 debug,
                 &*self.theme.read().unwrap(),
             );

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1368,7 +1368,10 @@ impl Editor {
                         } else {
                             cursor_screen_pos
                         };
-                        let popup_area = popup.calculate_area(size, Some(popup_pos));
+                        // Clamp within the chrome area (right of a left
+                        // dock) so a cursor-anchored popup near the left
+                        // edge can't extend into the dock column.
+                        let popup_area = popup.calculate_area(chrome_area, Some(popup_pos));
 
                         // Track popup area for mouse hit testing
                         // Account for description height when calculating the list item area
@@ -1465,7 +1468,9 @@ impl Editor {
             )
         });
         if !top_is_trust_modal {
-            self.render_top_global_popup(frame, size, &theme_clone, hover_target.as_ref());
+            // Global popups render within the chrome area (right of a
+            // left dock) so corner/centred popups don't overrun it.
+            self.render_top_global_popup(frame, chrome_area, &theme_clone, hover_target.as_ref());
         }
 
         // Render menu bar last so dropdown appears on top of all other content

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -355,12 +355,21 @@ impl crate::app::Editor {
         let animate = self.active_window != id
             && self.windows.contains_key(&id)
             && self.config().editor.animations;
-        let area = self.active_layout().editor_content_area;
+        // Wipe the ENTIRE window — menu bar, explorer, tabs, splits, and
+        // status bar — i.e. everything to the right of the dock. That's
+        // the chrome area from the dock split, not just the buffer's
+        // content rect. The dock column itself stays put.
+        let full = ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: self.terminal_width,
+            height: self.terminal_height,
+        };
+        let (_dock, area) = self.compute_dock_split(full);
         self.set_active_window(id);
         if !animate {
             return;
         }
-        let Some(area) = area else { return };
         if area.width == 0 || area.height == 0 {
             return;
         }

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -345,6 +345,43 @@ impl crate::app::Editor {
         }
     }
 
+    /// Switch the active window and play a directional wipe over the
+    /// editor content as the incoming window appears. The editor
+    /// content geometry is layout-driven (identical for any session),
+    /// so the outgoing window's last content rect is the right area to
+    /// animate. `capture_before_all` snapshots the previous frame (the
+    /// outgoing window) and `SlideIn` slides the new content in over it.
+    pub fn set_active_window_animated(&mut self, id: WindowId, from_edge: &str) {
+        let animate = self.active_window != id
+            && self.windows.contains_key(&id)
+            && self.config().editor.animations;
+        let area = self.active_layout().editor_content_area;
+        self.set_active_window(id);
+        if !animate {
+            return;
+        }
+        let Some(area) = area else { return };
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        use crate::view::animation::{AnimationKind, Edge};
+        let from = match from_edge {
+            "top" => Edge::Top,
+            "bottom" => Edge::Bottom,
+            "left" => Edge::Left,
+            "right" => Edge::Right,
+            _ => Edge::Bottom,
+        };
+        self.active_window_mut().animations.start(
+            area,
+            AnimationKind::SlideIn {
+                from,
+                duration: std::time::Duration::from_millis(180),
+                delay: std::time::Duration::ZERO,
+            },
+        );
+    }
+
     /// Cycle to the next open window in the workspace.
     ///
     /// Windows are ordered by their numeric `WindowId` (which is

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -233,6 +233,11 @@ pub enum KeyContext {
     Completion,
     /// File explorer has focus
     FileExplorer,
+    /// The editor-global orchestrator dock has focus. Like
+    /// `FileExplorer` it is a persistent, non-modal chrome region, but
+    /// it is owned by the `Editor` (not per-window) — it shows all
+    /// sessions and survives session switches.
+    Dock,
     /// Menu bar is active
     Menu,
     /// Terminal has focus
@@ -271,7 +276,7 @@ impl KeyContext {
     /// which a sensible plugin mode would want to suppress. See §18 of
     /// `docs/internal/search-replace-scope-replan-on-widgets.md`.
     pub fn allows_ui_fallthrough(&self) -> bool {
-        matches!(self, Self::FileExplorer | Self::Mode(_))
+        matches!(self, Self::FileExplorer | Self::Dock | Self::Mode(_))
     }
 
     /// Check if a context should allow input
@@ -291,6 +296,7 @@ impl KeyContext {
             "popup" => Self::Popup,
             "completion" => Self::Completion,
             "fileExplorer" | "file_explorer" => Self::FileExplorer,
+            "dock" => Self::Dock,
             "normal" => Self::Normal,
             "menu" => Self::Menu,
             "terminal" => Self::Terminal,
@@ -309,6 +315,7 @@ impl KeyContext {
             Self::Popup => "popup".to_string(),
             Self::Completion => "completion".to_string(),
             Self::FileExplorer => "fileExplorer".to_string(),
+            Self::Dock => "dock".to_string(),
             Self::Menu => "menu".to_string(),
             Self::Terminal => "terminal".to_string(),
             Self::Settings => "settings".to_string(),

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -143,8 +143,13 @@ pub fn render_settings(
     // Calculate modal size (90% of screen width, 90% height to fill most of available space)
     let modal_width = (area.width * 90 / 100).min(160);
     let modal_height = area.height * 90 / 100;
-    let modal_x = (area.width.saturating_sub(modal_width)) / 2;
-    let modal_y = (area.height.saturating_sub(modal_height)) / 2;
+    // Offsets must be ABSOLUTE — `area.x` / `area.y` are nonzero when
+    // `area` is the chrome region right of the dock (or a bottom-anchored
+    // split). Centring with bare `area.width / 2` placed the modal at the
+    // FRAME origin, where the dock then over-drew its left edge — hiding
+    // the title bar and clipping the rounded top-left corner.
+    let modal_x = area.x + (area.width.saturating_sub(modal_width)) / 2;
+    let modal_y = area.y + (area.height.saturating_sub(modal_height)) / 2;
 
     let modal_area = Rect::new(modal_x, modal_y, modal_width, modal_height);
 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -125,6 +125,7 @@ pub mod multibyte_characters;
 pub mod multicursor;
 pub mod on_save_actions;
 pub mod open_folder;
+pub mod orchestrator_dock;
 pub mod overlay_extend_to_line_end;
 pub mod paste;
 #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -150,7 +150,12 @@ fn dock_list_order_is_stable_across_active_window_switch() {
     .unwrap();
     let aaa_before = row_of(&h, "aaa_project");
     let zzz_before = row_of(&h, "zzz_project");
-    assert!(aaa_before < zzz_before, "expected aaa above zzz initially");
+    assert!(
+        aaa_before < zzz_before,
+        "expected aaa above zzz initially; got aaa at row {aaa_before}, \
+         zzz at row {zzz_before}. Full screen for diagnosis:\n{}",
+        h.screen_to_string(),
+    );
 
     // Arrow down to the second row, which live-switches the active window
     // to the zzz project.
@@ -176,7 +181,9 @@ fn dock_list_order_is_stable_across_active_window_switch() {
     let zzz_after = row_of(&h, "zzz_project");
     assert!(
         aaa_after < zzz_after,
-        "dock list reordered on switch: aaa now at {aaa_after}, zzz at {zzz_after}"
+        "dock list reordered on switch: aaa now at {aaa_after}, zzz at {zzz_after}.\n\
+         Full screen for diagnosis:\n{}",
+        h.screen_to_string(),
     );
 }
 
@@ -670,9 +677,14 @@ fn dock_initial_sort_is_lex_stable_not_current_first() {
     assert!(
         aaa_row < zzz_row,
         "dock initial order should be lex-stable (aaa above zzz); got \
-         aaa at {aaa_row}, zzz at {zzz_row}. This means `filterSessions` \
-         ran with pinCurrentFirst=true (dockMode was still false), \
-         which is the line-1757-before-1765 bug in `openControlRoom`."
+         aaa at {aaa_row}, zzz at {zzz_row}.\n\
+         Roots: aaa = {:?}, zzz = {:?}\n\
+         Active root at assertion time: {:?}\n\
+         Full screen for diagnosis:\n{}",
+        root_a,
+        root_b,
+        h.editor().active_window().root,
+        h.screen_to_string(),
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -273,3 +273,84 @@ fn dock_mouse_click_row_then_space_selects_that_row() {
         "Space after click should check the clicked (beta) row"
     );
 }
+
+/// 0-based column of `needle` within screen row `row`.
+fn col_in_row(h: &EditorTestHarness, row: u16, needle: &str) -> usize {
+    let line = h.screen_row_text(row);
+    line.find(needle)
+        .unwrap_or_else(|| panic!("row {row} missing '{needle}': {line:?}"))
+}
+
+#[test]
+fn dock_right_border_drag_resizes_and_persists() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR"))
+        .unwrap();
+
+    // The menu bar ("Edit") sits right of the dock on row 0; its index in
+    // the row string shifts right as the dock widens. (We can't match the
+    // box-drawing border char — the harness renders multi-byte glyphs as
+    // raw bytes — but the menu word is ASCII and its delta tracks width.)
+    // Default dock width is 32 → right border at col 31.
+    let edit_before = col_in_row(&h, 0, "Edit");
+
+    // Drag the right border (col 31) out to col 60 to widen the dock.
+    h.mouse_drag(31, 6, 60, 6).unwrap();
+    h.render().unwrap();
+    let edit_after = col_in_row(&h, 0, "Edit");
+    assert!(
+        edit_after > edit_before + 15,
+        "drag should widen the dock: Edit index {edit_before} -> {edit_after}"
+    );
+
+    // Width persists across a hide/show toggle.
+    let widened = edit_after;
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR"))
+        .unwrap();
+    open_dock(&mut h);
+    let edit_reopened = col_in_row(&h, 0, "Edit");
+    assert!(
+        (edit_reopened as i32 - widened as i32).abs() <= 3,
+        "dock width should persist across toggle: {widened} -> {edit_reopened}"
+    );
+}
+
+#[test]
+fn dock_show_empty_toggle_flips_on_click() {
+    // The "show empty/1-file" toggle defaults to off (hide trivial
+    // sessions). Clicking it flips the checkbox `[ ]` → `[v]`, proving the
+    // dock toggle is wired to the shared hide-trivial filter.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("show empty/1-file"))
+        .unwrap();
+    let trow = row_of(&h, "show empty/1-file") as u16;
+    // Off by default: unchecked.
+    assert!(
+        h.screen_row_text(trow).contains("[ ] show empty/1-file"),
+        "expected toggle off by default: {:?}",
+        h.screen_row_text(trow)
+    );
+    // Click it → checked.
+    h.mouse_click(3, trow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[v] show empty/1-file"))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -153,19 +153,21 @@ fn dock_list_order_is_stable_across_active_window_switch() {
     assert!(aaa_before < zzz_before, "expected aaa above zzz initially");
 
     // Arrow down to the second row, which live-switches the active window
-    // to the zzz project. The previous `wait_until_stable(contains("zzz_project"))`
-    // was race-tolerant, not race-free: `contains("zzz_project")` is true
-    // *from the initial render* (both projects are listed), so phase 1
-    // returns on the first tick and phase 2 only waits for ~50 ms of
-    // quiescence. Down kicks an async chain (plugin `dock_focus` event
-    // → `scheduleDockSwitch`'s 30 ms `editor.delay` → `setActiveWindow`)
-    // whose effect can land *after* the dock side-paints settle, so the
-    // stability check fires mid-transition. Wait on an unambiguous
-    // post-switch signal — the editor's active_window root flipping to
-    // the zzz project — before reading the list order.
+    // to the zzz project.
+    //
+    // Snapshot the pre-Down screen so we can wait on a *screen-observable*
+    // post-switch signal — the dock's PROJECT column tag visibly swaps
+    // when the active session changes. Before Down: aaa is current
+    // (no project tag), zzz is not (tag = "zzz_project's basename"); after
+    // the switch: zzz is current (no tag), aaa shows its tag. This lets us
+    // detect the switch without an accessor wait (CONTRIBUTING §2) AND
+    // without false matches on mid-render snapshots — the post-Down
+    // highlight-move is a style-only change that doesn't enter
+    // `screen_to_string`, so the first diff that does is the tag swap
+    // after `scheduleDockSwitch`'s 30 ms debounce lands.
+    let pre = h.screen_to_string();
     h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| h.editor().active_window().root == root_b)
-        .unwrap();
+    h.wait_until(|h| h.screen_to_string() != pre).unwrap();
     h.wait_until_stable(|_| true).unwrap();
 
     // Order must be unchanged — aaa still above zzz (the bug floated the

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -273,6 +273,18 @@ fn dock_slash_filters_and_enter_returns_to_list() {
 
 #[test]
 fn dock_space_toggles_multiselect_checkbox() {
+    // Wire up the test-process tracing subscriber so the dock/host-side
+    // `tracing::warn!` breadcrumbs added in
+    // `dispatch_floating_widget_key` (Space branch),
+    // `set_panel_focus_and_notify`, `refocus_floating_panel`,
+    // `blur_floating_panel`, and the dock mouse-click router fire to
+    // stderr when the test runs with `RUST_LOG=fresh::dock=warn` (the
+    // default `RUST_LOG=warn` also picks them up). This is the
+    // diagnostic hook for the Windows-CI timeout of this test —
+    // `Space` doesn't produce `[x]` on Windows but does on Linux/CI,
+    // and the breadcrumbs trace the dispatch path from key arrival
+    // through plugin notification.
+    crate::common::tracing::init_tracing_from_env();
     let (_tmp, root) = setup_project("alphaproj");
     let mut h =
         EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -492,6 +492,53 @@ fn picker_space_toggles_focused_checkbox_not_list() {
 }
 
 #[test]
+fn settings_dialog_does_not_overlap_dock() {
+    // Open the dock, then open the Settings modal via the command
+    // palette. The settings dialog must render fully inside
+    // `chrome_area` (right of the dock) — the dialog's top-left
+    // rounded corner glyph `╭` must be visible on the screen, NOT
+    // clipped by the dock's right border. With the bug,
+    // `render_settings` computes the modal x/y as *relative* offsets
+    // (line 146-147 of view/settings/render.rs) and uses them as
+    // *absolute* `Rect::new` coordinates — so the modal is placed
+    // ~6 columns from the FRAME left edge (inside the dock), and the
+    // dock then over-draws its left side, hiding the title bar.
+    //
+    // Observable signal: with the bug, the full "Settings" title
+    // never paints in one piece — the leading characters are clipped
+    // by the dock column. The full literal ` Settings [User] `
+    // (with both spaces and brackets) only appears on the rendered
+    // top border when the modal is positioned correctly.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(160, 40, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Open Settings").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Open Settings"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Active Keybinding Map"))
+        .unwrap();
+
+    // The full title — including the leading space and the [User]
+    // label — must appear in one contiguous run on the screen. With
+    // the bug, the leading half is hidden behind the dock column.
+    let screen = h.screen_to_string();
+    assert!(
+        screen.contains(" Settings [User] "),
+        "settings dialog title `Settings [User]` should be visible \
+         in full on the chrome side of the dock, but the screen \
+         shows clipping:\n{screen}"
+    );
+}
+
+#[test]
 fn click_un_dive_switches_to_clicked_session() {
     // The Rust mouse handler sets `dock.focused = true` when a click
     // lands inside a blurred dock — the un-dive transition. The
@@ -626,5 +673,71 @@ fn dock_initial_sort_is_lex_stable_not_current_first() {
          aaa at {aaa_row}, zzz at {zzz_row}. This means `filterSessions` \
          ran with pinCurrentFirst=true (dockMode was still false), \
          which is the line-1757-before-1765 bug in `openControlRoom`."
+    );
+}
+
+#[test]
+fn dock_close_reflows_buffer_to_full_width() {
+    // Open dock, then toggle it closed. The active window's buffer
+    // must reflow to fill the freed columns on the LEFT — line 1's
+    // gutter (`  1 │`) must move from inside the chrome (col ~32+)
+    // back to column 0 immediately, without requiring any further
+    // keypress / mouse-wheel. With the bug, the chrome stays at its
+    // pre-close x-offset and the freed columns render as blank
+    // whitespace until the user nudges the editor.
+    let (_tmp, root) = setup_project("alphaproj");
+    // A file with multiple lines so the gutter "  1 │" is observable.
+    std::fs::write(root.join("readme.txt"), "alpha\nbeta\ngamma\n").unwrap();
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut().open_file(&root.join("readme.txt")).unwrap();
+    h.render().unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("alpha"))
+        .unwrap();
+    open_dock(&mut h);
+
+    // Sanity: with the dock open, line 1's gutter "  1 │" lives in
+    // the chrome (right of the dock column), so it sits beyond col 30.
+    h.wait_until(|h| h.screen_to_string().contains("alpha"))
+        .unwrap();
+    let with_dock_col = h
+        .screen_to_string()
+        .lines()
+        .find_map(|l| l.find("  1 │").map(|c| (c, l.to_string())))
+        .expect("`  1 │` gutter on screen with dock open");
+    assert!(
+        with_dock_col.0 > 30,
+        "with dock open, line-1 gutter should be in chrome (col > 30); got col {}: {:?}",
+        with_dock_col.0,
+        with_dock_col.1,
+    );
+
+    // Toggle the dock closed via the command palette — the same
+    // path the user took in the interactive repro.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR"))
+        .unwrap();
+
+    // After the dock closes, the line-1 gutter must land at col 0
+    // (or very near it) — the chrome filled the freed space.
+    let after_close_col = h
+        .screen_to_string()
+        .lines()
+        .find_map(|l| l.find("  1 │").map(|c| (c, l.to_string())))
+        .expect("`  1 │` gutter still on screen after dock close");
+    assert!(
+        after_close_col.0 < 5,
+        "after dock close, line-1 gutter should be at the left edge \
+         (col < 5); got col {} — chrome did not reflow to fill the \
+         freed dock columns. Row: {:?}",
+        after_close_col.0,
+        after_close_col.1,
     );
 }

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -175,6 +175,41 @@ fn mouse_click_on_dock_new_button_opens_form() {
     h.wait_until(|h| h.screen_to_string().contains("New Session"))
         .unwrap();
     h.assert_screen_contains("New Session");
+    // The dock and the centered form occupy disjoint slots, so opening
+    // the form must NOT tear down the dock — its header stays painted in
+    // the left column beside the modal.
+    h.assert_screen_contains("ORCHESTRATOR");
+
+    // Esc cancels the form; the dock regains focus and stays visible.
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.assert_screen_contains("ORCHESTRATOR");
+}
+
+#[test]
+fn dock_alt_n_opens_form_keyboard_and_dock_stays() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Alt+N from the focused dock opens the new-session form (host fires a
+    // `dock_new` widget_event since the dock has no editor mode). The dock
+    // lives in its own slot, so the centered form coexists with it.
+    h.send_key(KeyCode::Char('n'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.assert_screen_contains("New Session");
+    h.assert_screen_contains("ORCHESTRATOR");
+
+    // Esc returns to the dock, which is still mounted and re-focused.
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.assert_screen_contains("ORCHESTRATOR");
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -16,6 +16,7 @@
 //!   new-session form).
 
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
 use std::fs;
 use std::path::PathBuf;
@@ -547,6 +548,7 @@ fn settings_dialog_does_not_overlap_dock() {
 
 #[test]
 fn click_un_dive_switches_to_clicked_session() {
+    init_tracing_from_env();
     // The Rust mouse handler sets `dock.focused = true` when a click
     // lands inside a blurred dock — the un-dive transition. The
     // existing `set_panel_focus_and_notify` it then calls only fires a

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -110,20 +110,19 @@ fn dock_list_order_is_stable_across_active_window_switch() {
     // Two sessions in *different* projects: switching the active window
     // changes the "current project", which the picker would float to the
     // top. The persistent dock must keep a stable order regardless.
+    // Both projects are siblings under one parent so their project-key
+    // (path) sort is deterministic (`aaa_project` < `zzz_project`),
+    // making "stable order" testable without random-tempdir flakiness.
     let (_tmp_a, root_a) = setup_project("aaa_project");
-    let (_tmp_b, root_b) = {
-        let temp_dir = tempfile::TempDir::new().unwrap();
-        let root = temp_dir.path().join("zzz_project");
-        fs::create_dir(&root).unwrap();
-        let ok = std::process::Command::new("git")
-            .args(["init", "-q"])
-            .current_dir(&root)
-            .status()
-            .unwrap()
-            .success();
-        assert!(ok);
-        (temp_dir, root)
-    };
+    let parent = root_a.parent().unwrap().to_path_buf();
+    let root_b = parent.join("zzz_project");
+    fs::create_dir(&root_b).unwrap();
+    assert!(std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&root_b)
+        .status()
+        .unwrap()
+        .success());
 
     let mut h =
         EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root_a.clone())
@@ -176,4 +175,101 @@ fn mouse_click_on_dock_new_button_opens_form() {
     h.wait_until(|h| h.screen_to_string().contains("New Session"))
         .unwrap();
     h.assert_screen_contains("New Session");
+}
+
+#[test]
+fn dock_slash_filters_and_enter_returns_to_list() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    // Two extra sessions with distinct labels.
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.editor_mut()
+        .create_window_at(root.join("wt-gamma"), "gamma".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("beta") && s.contains("gamma")
+    })
+    .unwrap();
+
+    // "/" focuses the filter; typing narrows the list live (host-level
+    // dock key, independent of editor modes).
+    h.send_key(KeyCode::Char('/'), KeyModifiers::NONE).unwrap();
+    h.type_text("gamma").unwrap();
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("gamma") && !s.contains("] beta")
+    })
+    .unwrap();
+    h.assert_screen_not_contains("] beta");
+
+    // Enter in the filter returns to the list (does NOT dive) — the dock
+    // stays visible and focused.
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.render().unwrap();
+    h.assert_screen_contains("ORCHESTRATOR");
+    h.assert_screen_contains("gamma");
+}
+
+#[test]
+fn dock_space_toggles_multiselect_checkbox() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("beta"))
+        .unwrap();
+
+    // No row checked initially.
+    h.assert_screen_not_contains("[x]");
+    // Space toggles the highlighted row's checkbox (host fires dock_space,
+    // the plugin owns the selection set).
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[x]"))
+        .unwrap();
+    h.assert_screen_contains("[x]");
+    // Space again clears it.
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("[x]"))
+        .unwrap();
+}
+
+#[test]
+fn dock_mouse_click_row_then_space_selects_that_row() {
+    // A click on a session row must focus the dock so the keyboard works
+    // afterward (regression: clicking after a dive left the dock unable to
+    // receive keys). Click the second row, then Space; that row's checkbox
+    // must toggle — proving the click selected + re-focused it.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("beta"))
+        .unwrap();
+
+    let beta_row = row_of(&h, "beta") as u16;
+    h.mouse_click(3, beta_row).unwrap();
+    h.render().unwrap();
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[x]"))
+        .unwrap();
+    // The checked row is the one we clicked (beta).
+    let checked = row_of(&h, "[x]");
+    let beta = row_of(&h, "beta");
+    assert_eq!(
+        checked, beta,
+        "Space after click should check the clicked (beta) row"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -492,8 +492,10 @@ fn click_un_dive_switches_to_clicked_session() {
     // un-blur, symmetric with `blur_floating_panel` (which has always
     // fired `blur` on dive).
     //
-    // Reproduce: two sessions in the dock, dive into one, then click
-    // the other — active_window must flip to the clicked session.
+    // Reproduce by observing rendered output only (CONTRIBUTING §2):
+    // type a sentinel into the dived-into session's buffer and watch
+    // it disappear when the click switches the active window to a
+    // different session whose buffer is empty.
     let (_tmp, root) = setup_project("alphaproj");
     let mut h =
         EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
@@ -502,23 +504,48 @@ fn click_un_dive_switches_to_clicked_session() {
         .create_window_at(root.join("wt-beta"), "beta".to_string());
     h.render().unwrap();
     open_dock(&mut h);
-    h.wait_until(|h| h.screen_to_string().contains("beta"))
-        .unwrap();
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("alphaproj") && s.contains("beta")
+    })
+    .unwrap();
 
-    // Highlight beta and let the dock's debounced live-switch flip
-    // active_window. Then dive into beta with Enter — that blurs the
-    // dock so the editor terminal owns subsequent keys.
-    let beta_root = root.join("wt-beta");
+    // Highlight beta then dive. The `activate` handler in
+    // `orchestrator.ts` calls `setActiveWindow(beta)` and blurs the
+    // dock synchronously, so the test doesn't depend on the
+    // live-switch's 30 ms debounce landing first.
     h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    // Wait for the dock's debounced live-switch (30 ms `editor.delay`
+    // in `scheduleDockSwitch`) to actually flip active_window to beta.
+    // Without this wait, Enter fires before the plugin event queue
+    // processes Down's `select` event, so `openDialog.selectedIndex`
+    // is still 0 and Enter activates alphaproj instead. Following the
+    // `wait_for_prompt` (uses `is_prompting`) precedent — system-
+    // readiness in test setup, asserted invariant is screen-only.
+    let beta_root = root.join("wt-beta");
     h.wait_until(|h| h.editor().active_window().root == beta_root)
         .unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| !h.editor().is_dock_focused()).unwrap();
 
-    // The un-dive click on alphaproj's row must (a) re-focus the dock
-    // and (b) flip the active window to alphaproj.
+    // Type a two-char sentinel into the dived-into buffer. With the
+    // dock blurred and beta's `[No Name]` buffer active, the
+    // keystrokes land in the buffer — proving the dive succeeded
+    // AND giving a screen marker for "active session is beta". `ZZ`
+    // avoids false matches with the chrome (no `Z` appears in any
+    // dock label, menu, or status text by default).
+    h.send_key(KeyCode::Char('Z'), KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Char('Z'), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("ZZ"))
+        .unwrap();
+
+    // Click alphaproj's row. With the fix:
+    //   (a) `refocus_floating_panel` fires the `focus` widget_event,
+    //       so the plugin's `dockBlurred` mirror clears, and
+    //   (b) the click's `select` event then flips `active_window` to
+    //       alphaproj — whose `[No Name]` buffer is empty, so `ZZ`
+    //       leaves the chrome.
     let alpha_row = row_of(&h, "alphaproj") as u16;
     h.mouse_click(3, alpha_row).unwrap();
-    h.wait_until(|h| h.editor().active_window().root == root)
+    h.wait_until(|h| !h.screen_to_string().contains("ZZ"))
         .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -551,3 +551,68 @@ fn click_un_dive_switches_to_clicked_session() {
     h.wait_until(|h| !h.screen_to_string().contains("ZZ"))
         .unwrap();
 }
+
+#[test]
+fn dock_initial_sort_is_lex_stable_not_current_first() {
+    // Smoking-gun reproducer for the dock-reorder hypothesis behind the
+    // Windows-only failure of `dock_list_order_is_stable_across_active_window_switch`.
+    //
+    // `openControlRoom` in `orchestrator.ts` runs the *first*
+    // `filterSessions("")` at line 1757, BEFORE the `dockMode = true`
+    // assignment at line 1765. So the dock's initial render uses
+    // `pinCurrentFirst = !dockMode = true` — current-first ordering —
+    // while every `refreshOpenDialog` afterward (active_window_changed,
+    // window_created, …) uses `pinCurrentFirst = false` — the lex
+    // ordering the dock comment explicitly mandates ("the dock is
+    // persistent and switches the active session constantly, so it
+    // must NOT reorder as the active project changes").
+    //
+    // Trigger: make the active window NOT the lex-first session, then
+    // open the dock. The initial render puts the active session on top;
+    // the stable order (which any subsequent active-change refresh
+    // would have produced) is the lex order with aaa first.
+    //
+    // This bug is invisible to the existing
+    // `dock_list_order_is_stable_across_active_window_switch` because
+    // its launch session (aaa_project) is BOTH active and lex-first —
+    // current-first and lex-first agree on the initial render. The
+    // user-reported Windows failure of that test is consistent with
+    // this bug surfacing through some environmental difference.
+    let (_tmp_a, root_a) = setup_project("aaa_project");
+    let parent = root_a.parent().unwrap().to_path_buf();
+    let root_b = parent.join("zzz_project");
+    fs::create_dir(&root_b).unwrap();
+    assert!(std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&root_b)
+        .status()
+        .unwrap()
+        .success());
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root_a.clone())
+            .unwrap();
+    let zzz_id = h
+        .editor_mut()
+        .create_window_at(root_b.clone(), "zzz_project".to_string());
+    // Make zzz active BEFORE opening the dock — that's the trigger.
+    h.editor_mut().set_active_window(zzz_id);
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("aaa_project") && s.contains("zzz_project")
+    })
+    .unwrap();
+
+    let aaa_row = row_of(&h, "aaa_project");
+    let zzz_row = row_of(&h, "zzz_project");
+    assert!(
+        aaa_row < zzz_row,
+        "dock initial order should be lex-stable (aaa above zzz); got \
+         aaa at {aaa_row}, zzz at {zzz_row}. This means `filterSessions` \
+         ran with pinCurrentFirst=true (dockMode was still false), \
+         which is the line-1757-before-1765 bug in `openControlRoom`."
+    );
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -40,7 +40,16 @@ fn setup_project(name: &str) -> (tempfile::TempDir, PathBuf) {
     (temp_dir, root)
 }
 
-/// Toggle the dock open via the command palette and wait for it to render.
+/// Toggle the dock open via the command palette and wait for it to render
+/// *and* take keyboard focus.
+///
+/// `Toggle Dock` sets focus asynchronously through the plugin→host
+/// bridge (the plugin issues `setFocusKey("sessions")` after the dock
+/// mounts), so a key event dispatched after just `wait_until("ORCHESTRATOR")`
+/// can land *before* `dock.focused = true` — falling through to the
+/// editor base and leaving any follow-up `wait_until` to block forever
+/// on a dock response that never comes. Polling `is_dock_focused()`
+/// closes that race deterministically.
 fn open_dock(h: &mut EditorTestHarness) {
     h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
         .unwrap();
@@ -49,7 +58,7 @@ fn open_dock(h: &mut EditorTestHarness) {
     h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
         .unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
-    h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR"))
+    h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR") && h.editor().is_dock_focused())
         .unwrap();
 }
 
@@ -144,10 +153,20 @@ fn dock_list_order_is_stable_across_active_window_switch() {
     assert!(aaa_before < zzz_before, "expected aaa above zzz initially");
 
     // Arrow down to the second row, which live-switches the active window
-    // to the zzz project. Let the switch settle.
+    // to the zzz project. The previous `wait_until_stable(contains("zzz_project"))`
+    // was race-tolerant, not race-free: `contains("zzz_project")` is true
+    // *from the initial render* (both projects are listed), so phase 1
+    // returns on the first tick and phase 2 only waits for ~50 ms of
+    // quiescence. Down kicks an async chain (plugin `dock_focus` event
+    // → `scheduleDockSwitch`'s 30 ms `editor.delay` → `setActiveWindow`)
+    // whose effect can land *after* the dock side-paints settle, so the
+    // stability check fires mid-transition. Wait on an unambiguous
+    // post-switch signal — the editor's active_window root flipping to
+    // the zzz project — before reading the list order.
     h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
-    h.wait_until_stable(|h| h.screen_to_string().contains("zzz_project"))
+    h.wait_until(|h| h.editor().active_window().root == root_b)
         .unwrap();
+    h.wait_until_stable(|_| true).unwrap();
 
     // Order must be unchanged — aaa still above zzz (the bug floated the
     // now-current zzz project to the top).

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -408,3 +408,117 @@ fn dock_show_empty_toggle_flips_on_click() {
     h.wait_until(|h| h.screen_to_string().contains("[v] show empty/1-file"))
         .unwrap();
 }
+
+#[test]
+fn picker_space_toggles_focused_checkbox_not_list() {
+    // OPEN_MODE binds Space to `orchestrator_toggle_select`
+    // unconditionally — it has to, to keep Space out of the filter
+    // text input (the host's `dispatch_floating_widget_key` defers any
+    // explicitly-bound mode key, including bare chars, before the text-
+    // input path). Without context-sensitivity, Space toggles the
+    // sessions-list multi-select even while focus is on the
+    // "Show all worktrees" / "Show empty/1-file" filter checkbox above
+    // the list.
+    //
+    // With the fix, `toggleSelectCurrent` branches on the focused
+    // widget (mirrored from the existing `focus` widget_event): Space
+    // on `worktree-show` toggles that checkbox, not the list.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(140, 40, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+
+    // Open the centered picker via the command palette.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Open").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: Open"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    // Wait until the picker is fully mounted: the header is painted,
+    // the worktree filter row is visible, and the list shows alphaproj.
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("ORCHESTRATOR :: Sessions")
+            && s.contains("Show all worktrees")
+            && s.contains("[ ] alphaproj")
+    })
+    .unwrap();
+
+    // Sanity: focus opens on the sessions list, so Space toggles the
+    // list multi-select. This guards against the test landing focus
+    // elsewhere by accident on a future picker re-layout.
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[x] alphaproj"))
+        .unwrap();
+    // Reset before the focus walk.
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[ ] alphaproj"))
+        .unwrap();
+
+    // Tab cycle is spec-order: new-session → scope-toggle →
+    // worktree-show → hide-trivial → filter → sessions. Three
+    // Shift+Tabs from `sessions` land on `worktree-show`.
+    h.send_key(KeyCode::BackTab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::BackTab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::BackTab, KeyModifiers::NONE).unwrap();
+
+    // Space here must toggle `worktree-show`, NOT the list.
+    h.send_key(KeyCode::Char(' '), KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[v] Show all worktrees"))
+        .unwrap();
+    assert!(
+        h.screen_to_string().contains("[ ] alphaproj"),
+        "Space while focus is on the worktree-show checkbox must not \
+         toggle the list. Screen:\n{}",
+        h.screen_to_string()
+    );
+}
+
+#[test]
+fn click_un_dive_switches_to_clicked_session() {
+    // The Rust mouse handler sets `dock.focused = true` when a click
+    // lands inside a blurred dock — the un-dive transition. The
+    // existing `set_panel_focus_and_notify` it then calls only fires a
+    // `focus` widget_event when the inner focus_key changes, which it
+    // doesn't here (a dive leaves the inner widget alone, only toggles
+    // overall dock focus). So the plugin's `dockBlurred` mirror stays
+    // `true`, and when the click's `select` event then schedules a
+    // dock-switch (`scheduleDockSwitch`), the +30 ms check
+    // `if (... || dockBlurred) return` swallows the active-window
+    // change. The fix is host-side: fire a `focus` widget_event on
+    // un-blur, symmetric with `blur_floating_panel` (which has always
+    // fired `blur` on dive).
+    //
+    // Reproduce: two sessions in the dock, dive into one, then click
+    // the other — active_window must flip to the clicked session.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.editor_mut()
+        .create_window_at(root.join("wt-beta"), "beta".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+    h.wait_until(|h| h.screen_to_string().contains("beta"))
+        .unwrap();
+
+    // Highlight beta and let the dock's debounced live-switch flip
+    // active_window. Then dive into beta with Enter — that blurs the
+    // dock so the editor terminal owns subsequent keys.
+    let beta_root = root.join("wt-beta");
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.editor().active_window().root == beta_root)
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.editor().is_dock_focused()).unwrap();
+
+    // The un-dive click on alphaproj's row must (a) re-focus the dock
+    // and (b) flip the active window to alphaproj.
+    let alpha_row = row_of(&h, "alphaproj") as u16;
+    h.mouse_click(3, alpha_row).unwrap();
+    h.wait_until(|h| h.editor().active_window().root == root)
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1,0 +1,179 @@
+//! E2E coverage for the global Orchestrator dock (the persistent,
+//! non-modal left column toggled by "Orchestrator: Toggle Dock").
+//!
+//! Per CONTRIBUTING.md §2 these drive only keyboard/mouse and assert on
+//! rendered output. Each guards a behaviour that regressed during dock
+//! bring-up:
+//!
+//! * the dock renders as a left column beside the editor chrome;
+//! * it is non-modal — Ctrl+P while the dock is focused opens the
+//!   command palette (the key falls through to the editor) instead of
+//!   being swallowed, and the dock stays visible;
+//! * the session list order is stable as the active window changes
+//!   (the picker's current-project-first sort must not reorder the
+//!   persistent dock);
+//! * mouse clicks land on dock widgets (the "+ New" button opens the
+//!   new-session form).
+
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+use std::path::PathBuf;
+
+/// A git project with the orchestrator plugin (+ shared lib) installed.
+fn setup_project(name: &str) -> (tempfile::TempDir, PathBuf) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let root = temp_dir.path().join(name);
+    fs::create_dir(&root).unwrap();
+    let plugins_dir = root.join("plugins");
+    fs::create_dir(&plugins_dir).unwrap();
+    copy_plugin_lib(&plugins_dir);
+    copy_plugin(&plugins_dir, "orchestrator");
+    fs::write(root.join("readme.txt"), "hello\n").unwrap();
+    let ok = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(&root)
+        .status()
+        .unwrap()
+        .success();
+    assert!(ok);
+    (temp_dir, root)
+}
+
+/// Toggle the dock open via the command palette and wait for it to render.
+fn open_dock(h: &mut EditorTestHarness) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Toggle Dock").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR"))
+        .unwrap();
+}
+
+/// 0-based screen row containing `needle`, or panic with the screen.
+fn row_of(h: &EditorTestHarness, needle: &str) -> usize {
+    let screen = h.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
+}
+
+#[test]
+fn dock_renders_as_left_column_beside_chrome() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The dock and its controls render...
+    h.assert_screen_contains("ORCHESTRATOR");
+    h.assert_screen_contains("+ New");
+    // ...and the editor chrome (menu bar) is still present to its right,
+    // i.e. the dock is a column beside the window, not a replacement.
+    h.assert_screen_contains("File");
+    // The launch session is listed by its project basename.
+    h.assert_screen_contains("alphaproj");
+}
+
+#[test]
+fn ctrl_p_opens_palette_while_dock_focused_and_dock_stays() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The dock is focused on mount. Ctrl+P must NOT be swallowed: it
+    // blurs the dock and falls through to the editor's global binding,
+    // opening the command palette. Prove the palette is live by typing a
+    // query and seeing a built-in command surface — and the dock must
+    // stay visible (non-modal) throughout.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Open File").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Open File"))
+        .unwrap();
+    h.assert_screen_contains("Open File");
+    h.assert_screen_contains("ORCHESTRATOR");
+}
+
+#[test]
+fn dock_list_order_is_stable_across_active_window_switch() {
+    // Two sessions in *different* projects: switching the active window
+    // changes the "current project", which the picker would float to the
+    // top. The persistent dock must keep a stable order regardless.
+    let (_tmp_a, root_a) = setup_project("aaa_project");
+    let (_tmp_b, root_b) = {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let root = temp_dir.path().join("zzz_project");
+        fs::create_dir(&root).unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(&root)
+            .status()
+            .unwrap()
+            .success();
+        assert!(ok);
+        (temp_dir, root)
+    };
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root_a.clone())
+            .unwrap();
+    // Second session in the other project (launch session is aaa_project).
+    h.editor_mut()
+        .create_window_at(root_b.clone(), "zzz_project".to_string());
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Both sessions show; aaa sorts above zzz.
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("aaa_project") && s.contains("zzz_project")
+    })
+    .unwrap();
+    let aaa_before = row_of(&h, "aaa_project");
+    let zzz_before = row_of(&h, "zzz_project");
+    assert!(aaa_before < zzz_before, "expected aaa above zzz initially");
+
+    // Arrow down to the second row, which live-switches the active window
+    // to the zzz project. Let the switch settle.
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until_stable(|h| h.screen_to_string().contains("zzz_project"))
+        .unwrap();
+
+    // Order must be unchanged — aaa still above zzz (the bug floated the
+    // now-current zzz project to the top).
+    let aaa_after = row_of(&h, "aaa_project");
+    let zzz_after = row_of(&h, "zzz_project");
+    assert!(
+        aaa_after < zzz_after,
+        "dock list reordered on switch: aaa now at {aaa_after}, zzz at {zzz_after}"
+    );
+}
+
+#[test]
+fn mouse_click_on_dock_new_button_opens_form() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Click the "+ New" button inside the dock column. A click landing on
+    // a dock widget proves mouse hit-testing routes into the panel.
+    let new_row = row_of(&h, "+ New") as u16;
+    h.mouse_click(4, new_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.assert_screen_contains("New Session");
+}

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -4379,6 +4379,19 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Switch the active window with a directional wipe on the
+    /// incoming content. `from_edge`: "top" | "bottom" | "left" |
+    /// "right". See `PluginCommand::SetActiveWindowAnimated`.
+    #[qjs(rename = "setActiveWindowAnimated")]
+    pub fn set_active_window_animated(&self, id: u64, from_edge: String) -> bool {
+        self.command_sender
+            .send(PluginCommand::SetActiveWindowAnimated {
+                id: fresh_core::WindowId(id),
+                from_edge,
+            })
+            .is_ok()
+    }
+
     /// Close session `id`. Refuses to close the active session or
     /// the base session (id 1). Logs and no-ops on failure.
     pub fn close_window(&self, id: u64) -> bool {
@@ -5554,6 +5567,20 @@ impl JsEditorApi {
         self.command_sender
             .send(PluginCommand::UnmountFloatingWidget {
                 panel_id: panel_id as u64,
+            })
+            .is_ok()
+    }
+
+    /// Control a mounted floating panel's placement / focus without
+    /// re-sending its spec. `op`: "dock" (`arg` = width in columns),
+    /// "center", "focus", "blur". See `PluginCommand::FloatingPanelControl`.
+    #[qjs(rename = "floatingPanelControl")]
+    pub fn floating_panel_control(&self, panel_id: f64, op: String, arg: f64) -> bool {
+        self.command_sender
+            .send(PluginCommand::FloatingPanelControl {
+                panel_id: panel_id as u64,
+                op,
+                arg,
             })
             .is_ok()
     }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5514,6 +5514,7 @@ impl JsEditorApi {
         spec_obj: rquickjs::Value<'js>,
         width_pct: f64,
         height_pct: f64,
+        as_dock: rquickjs::function::Opt<bool>,
     ) -> rquickjs::Result<bool> {
         let json = js_to_json(&ctx, spec_obj);
         let spec: fresh_core::api::WidgetSpec = match serde_json::from_value(json) {
@@ -5532,6 +5533,7 @@ impl JsEditorApi {
                 spec,
                 width_pct,
                 height_pct,
+                as_dock: as_dock.0.unwrap_or(false),
             })
             .is_ok())
     }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -9638,14 +9638,14 @@ mod tests {
                     id: fresh_core::WindowId(1),
                     label: "main".into(),
                     root: std::path::PathBuf::from("/repo"),
-                    project_path: None,
+                    project_path: std::path::PathBuf::from("/repo"),
                     shared_worktree: false,
                 },
                 fresh_core::api::WindowInfo {
                     id: fresh_core::WindowId(2),
                     label: "feat-auth".into(),
                     root: std::path::PathBuf::from("/wt/feat-auth"),
-                    project_path: None,
+                    project_path: std::path::PathBuf::from("/wt/feat-auth"),
                     shared_worktree: false,
                 },
             ];

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1353,6 +1353,8 @@ mod tests {
             "mountFloatingWidget",
             "updateFloatingWidget",
             "unmountFloatingWidget",
+            "floatingPanelControl",
+            "setActiveWindowAnimated",
         ];
 
         let mut missing = Vec::new();

--- a/docs/internal/dock-ux-test-plan.md
+++ b/docs/internal/dock-ux-test-plan.md
@@ -85,6 +85,15 @@
 31d. Open Settings while the dock is **hidden** (baseline): renders
      full-width as normal.
 
+### F.2 Live Grep & other overlays (with the dock open)
+31e. Live Grep (`Alt+/`) opens its floating overlay beside the dock
+     (right of the column), not overlapping it; results + preview show.
+31f. Live Grep is keyboard-operable (type query, ↑↓ results, Enter opens
+     a match in the editor), and the dock doesn't steal keys.
+31g. Resume Live Grep (`Alt+Shift+/`) restores prior query/results.
+31h. Quickfix export to the Utility (bottom) dock works; the left dock
+     and bottom dock coexist.
+
 ## G. File explorer with the dock open
 32. `Ctrl+E` focuses the file explorer; the dock stays put.
 33. Open a file from the explorer → it opens in the dived window's buffer.
@@ -145,6 +154,19 @@ across toggles (lingering editor mode, stale focus, cursor, key capture).
   tmux harness. Covered instead by the e2e `mouse_click_on_dock_new_
   button_opens_form` (hit-test) + mode-independent keys (click re-focuses
   → keyboard works). Needs a real terminal for full manual confirmation.
+
+### Live Grep / Settings / menu run 2026-05-27 (with dock open)
+- 29 (menu dropdown)  : PASS — File menu opens right of the dock (the
+                        chrome layout already offsets it); no overlap.
+- 31a–d (Settings)    : PASS — renders beside the dock (chrome area),
+                        keyboard-operable, Esc clean, hidden-dock baseline OK.
+- 31e (Live Grep)     : PASS — `Alt+/` overlay opens beside the dock
+                        (chrome-centred), not overlapping it.
+- 31f (LG operable)   : PASS — has focus; dock doesn't steal keys; Esc
+                        closes cleanly, dock + editor intact. (Result
+                        population is a git-grep/env matter, not the dock.)
+- Note: opening LG/Settings from a *terminal* session needs `Ctrl+]`
+  first (the dock's Alt+/ blur falls through to the PTY otherwise).
 
 ### Round-trip run 2026-05-27 (flows 39–45, after rebase onto master)
 - 39 toggle ON         : PASS — dock shows, sessions listed.

--- a/docs/internal/dock-ux-test-plan.md
+++ b/docs/internal/dock-ux-test-plan.md
@@ -80,6 +80,23 @@
 38. No stray rendering artifacts in the dock column when scrolling the
     window.
 
+## I. Round-trip (toggle on → use → toggle off → edit → toggle on)
+A single end-to-end scenario, not isolated flows — catches state leaking
+across toggles (lingering editor mode, stale focus, cursor, key capture).
+39. Toggle the dock **on** (Ctrl+P → Toggle Dock).
+40. `↑`/`↓` between sessions; confirm the window re-roots each time.
+41. `Enter` to **dive** into a session; type/edit in its buffer; confirm
+    the edit lands and the dock stays visible.
+42. Toggle the dock **off**; confirm the chrome reclaims the full width
+    and the editor is fully usable (type, move cursor, `Ctrl+P` palette,
+    `Ctrl+E` explorer) with **no** residual dock key-capture.
+43. Do a normal editor workflow with the dock off (open a file, edit,
+    save) — behaves exactly as if the dock never existed.
+44. Toggle the dock **on** again; confirm it reopens focused, the session
+    list is intact/correct, and `↑↓`/dive work again (no stale state).
+45. Repeat 39–44 a couple of times — no drift, no leaked mode, cursor
+    always correct.
+
 ## Results log
 
 ### Run 2026-05-27 (after host-level dock-key rework)
@@ -109,6 +126,24 @@
   tmux harness. Covered instead by the e2e `mouse_click_on_dock_new_
   button_opens_form` (hit-test) + mode-independent keys (click re-focuses
   → keyboard works). Needs a real terminal for full manual confirmation.
+
+### Round-trip run 2026-05-27 (flows 39–45, after rebase onto master)
+- 39 toggle ON         : PASS — dock shows, sessions listed.
+- 40 ↑↓ switch          : PASS — window re-roots.
+- 41 Enter dive         : PASS — dock stays visible (blurred).
+- 42 toggle OFF         : PASS — chrome reclaims the full left edge.
+- 43 editor w/ dock off : PASS — Ctrl+P palette opens, no residual dock
+                          key-capture; editor fully usable.
+- 44 toggle ON again    : PASS — reopens focused, list intact, ↑↓ work.
+- 45 repeat             : PASS — no drift / leaked mode across cycles.
+
+### New interaction from the rebase (gap)
+Master added a **"Show empty/1-file sessions"** filter to the modal
+picker (hidden by default), and the dock shares `filterSessions`, so the
+dock now hides empty/1-file sessions (e.g. a freshly-launched session
+with no edits). But `buildDockSpec` has no toggle to reveal them — so the
+dock can't show empty sessions at all. Add the toggle (or a dock
+equivalent) to `buildDockSpec`. Tracked in `orchestrator-dock-gaps.md`.
 
 ### Key root-cause note
 Dock keys are handled at the floating-panel layer (host

--- a/docs/internal/dock-ux-test-plan.md
+++ b/docs/internal/dock-ux-test-plan.md
@@ -1,0 +1,84 @@
+# Orchestrator Dock — Interactive UX Test Plan
+
+> Manual tmux test checklist for the global orchestrator dock and its
+> interaction with the rest of the editor. Run each flow interactively
+> (`tmux` + `send-keys` + `capture-pane`) and record PASS/FAIL. This is
+> the script behind the bug sweep in `orchestrator-dock-gaps.md`.
+>
+> **Harness**: `tmux new-session -d -s v -x 160 -y 42`, launch
+> `./target/release/fresh --log-file /tmp/v.log .`. The dock toggle is
+> reachable from an editor session via `Ctrl+P → "Orchestrator: Toggle
+> Dock"`. From a terminal session, exit terminal-input first (`Ctrl+]`).
+
+## A. Dock lifecycle
+1. Toggle **show**: dock appears as a full-height left column; the menu
+   bar / explorer / splits / status bar all sit to its right.
+2. Toggle **hide**: dock disappears; chrome reclaims the left edge.
+3. Re-show after hide: dock returns, focused.
+4. Open with 1 session, 2 sessions, many (list fills height; hint pinned
+   at the bottom).
+
+## B. Session switching (the core)
+5. `↑`/`↓` moves the selection and **live-switches** the active window
+   (the pane to the right re-roots) with a directional wipe.
+6. List **order is stable** as the active window changes.
+7. `Enter` on a session **dives**: focus moves to that window, dock stays
+   visible (blurred).
+8. `Esc` **leaves** the dock: focus to editor, dock stays visible.
+9. **Mouse click** on a session row selects + switches + focuses the dock
+   (keyboard `↑↓` work afterward).
+10. Mouse **wheel** over the dock scrolls the list and does NOT scroll the
+    window underneath.
+
+## C. Editing while the dock is open
+11. Dive into an editor session → **type** → text inserts in the buffer;
+    dock stays open.
+12. After diving, the **cursor is visible** and moves as you type/arrow.
+13. While the dock is **focused**, typing does NOT leak into the buffer.
+14. Switch session → dive → edit a *different* session's buffer.
+15. Save (`Ctrl+S`) in a dived session works.
+
+## D. Filter / search
+16. `/` focuses the filter input.
+17. Typing filters the session list live.
+18. `↑`/`↓` navigate the **filtered** results (and live-switch).
+19. `Enter` in the filter returns to the list (does NOT dive/blur); a
+    second `Enter` then dives.
+20. `Esc` in the filter returns to the list; `Esc` again leaves the dock.
+
+## E. Multi-select / actions
+21. `Space` toggles the highlighted row's checkbox (`[x]`).
+22. Action buttons (Stop / Archive / Delete) reachable (Tab or mouse) and
+    fire; disabled states correct (launch session, last window).
+23. `Delete` shows an in-place confirm; Cancel/Confirm work.
+24. `+ New` (button or `Alt+N`) opens the new-session form.
+25. Scope toggle (`Alt+P` / button) flips current-project ↔ all.
+26. Worktrees toggle (`Alt+T`) shows/hides discovered on-disk worktrees.
+
+## F. Command palette / menu / popups with the dock open
+27. `Ctrl+P` while the dock is focused: **blurs** the dock and opens the
+    palette (key falls through); dock stays visible.
+28. Command palette expand is **constrained to the window** (does not
+    overlap the dock column).
+29. Menu bar (`F10` / `Alt+F`) opens; dropdowns align to the chrome (not
+    offset by the dock) — *known gap if not.*
+30. LSP / hover / completion popups position within the window.
+31. Full-screen modals (Settings, keybinding editor) — *known gap: may
+    overlap the dock.*
+
+## G. File explorer with the dock open
+32. `Ctrl+E` focuses the file explorer; the dock stays put.
+33. Open a file from the explorer → it opens in the dived window's buffer.
+34. Explorer filter (`/` inside explorer) works independently of the dock.
+
+## H. Cross-cutting
+35. Terminal session: dock visible while a terminal is the active window;
+    `Ctrl+]` then `Ctrl+P` reaches the palette.
+36. Resize the terminal: dock width clamps; chrome reflows; hint stays
+    pinned.
+37. Closing the last non-dock window / session edge cases don't panic.
+38. No stray rendering artifacts in the dock column when scrolling the
+    window.
+
+## Results log
+Record `flow# : PASS/FAIL — note` per run below.

--- a/docs/internal/dock-ux-test-plan.md
+++ b/docs/internal/dock-ux-test-plan.md
@@ -63,8 +63,27 @@
 29. Menu bar (`F10` / `Alt+F`) opens; dropdowns align to the chrome (not
     offset by the dock) — *known gap if not.*
 30. LSP / hover / completion popups position within the window.
-31. Full-screen modals (Settings, keybinding editor) — *known gap: may
-    overlap the dock.*
+31. Full-screen modals (Settings, keybinding editor, wizard, event-debug)
+    now render in the **chrome area** (right of the dock), not overlapped.
+
+### F.1 Settings editor (with the dock open) — run 2026-05-27
+31a. Open Settings while the dock is visible: PASS — the dialog renders
+     beside the dock (right of the column), fully visible, no overlap.
+     (Before the fix it centered on the full screen and the dock
+     overpainted its left ~32 cols.)
+31b. Keyboard-operable: PASS — Settings has focus (the dock blurred on
+     the Ctrl+P that opened the palette); the dock doesn't steal keys.
+31c. Esc closes: PASS — Settings dismissed, dock still visible & usable.
+31d. Dock hidden baseline: PASS — Settings renders full-width centered.
+31a. Open Settings (Ctrl+P → "Settings") while the dock is visible:
+     the Settings dialog renders and is usable; note whether the dock
+     column overlaps its left edge (z-order) or dims correctly.
+31b. Settings is keyboard-operable (navigate categories, Tab focus,
+     search, Esc) — the dock must not steal its keys.
+31c. Close Settings (Esc): the editor + dock return to a clean state
+     (no residual dim, dock still visible & usable, cursor correct).
+31d. Open Settings while the dock is **hidden** (baseline): renders
+     full-width as normal.
 
 ## G. File explorer with the dock open
 32. `Ctrl+E` focuses the file explorer; the dock stays put.

--- a/docs/internal/dock-ux-test-plan.md
+++ b/docs/internal/dock-ux-test-plan.md
@@ -81,4 +81,38 @@
     window.
 
 ## Results log
-Record `flow# : PASS/FAIL — note` per run below.
+
+### Run 2026-05-27 (after host-level dock-key rework)
+- 1 (show)           : PASS — full-height left column, chrome to its right.
+- 4 (fills/pins)     : PASS — list fills, hint pinned.
+- 5 (↑↓ live-switch) : PASS — right pane re-roots to each session.
+- 6 (order stable)   : PASS.
+- 7 (Enter dive)     : PASS — focus to editor, dock stays; Down no longer
+                       moves the dock.
+- 8 (Esc leave)      : PASS.
+- C12 (cursor)       : PASS — with the buffer focused + dock blurred the
+                       caret renders in the buffer (x=76); earlier "parked"
+                       reading was the explorer-focus confound.
+- C11/13 (edit)      : PASS — typing reaches the buffer after dive; while
+                       focused, typing does NOT leak to the buffer.
+- 16/17 (`/`, filter): PASS — `/` focuses filter, typing filters live.
+- 18 (filtered ↑↓)   : PASS — navigate filtered results.
+- 19 (Enter in filt) : PASS — returns to list (no dive); ↑↓ keep working.
+- 21 (Space select)  : PASS — toggles `[x]` on the highlighted row.
+- 27 (Ctrl+P)        : PASS — blurs dock, opens palette, dock stays.
+- 28 (palette width) : PASS — palette renders right of the dock; dock
+                       column intact.
+- A2 (toggle hide)   : PASS.
+
+### Not verifiable via tmux (terminal-mouse limitation here)
+- 9 (mouse click row): SGR mouse events don't reach the app under this
+  tmux harness. Covered instead by the e2e `mouse_click_on_dock_new_
+  button_opens_form` (hit-test) + mode-independent keys (click re-focuses
+  → keyboard works). Needs a real terminal for full manual confirmation.
+
+### Key root-cause note
+Dock keys are handled at the floating-panel layer (host
+`dispatch_floating_widget_key`), NOT via `editor.defineMode` — mode
+bindings resolve against the *active buffer's* mode, which the dock floats
+over, so a session whose buffer has a local mode (terminal, markdown, …)
+would shadow them. This is why earlier mode-based Space/`/` never worked.

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -16,10 +16,12 @@
   render against `chrome_area`, so they sit beside the dock instead of
   being overpainted by it. The workspace-trust dialog still uses `size`
   — it's a startup gate that can't be concurrent with the dock.
-- **Centered/anchored popups use full-screen coords.** Command-palette
-  suggestions and global popups (`render_prompt_popups`,
-  `render_top_global_popup`) are positioned/clamped against `size`, so
-  with the dock up they can be offset or overrun the dock column.
+- **Some global popups still use full-screen coords.** Fixed for the
+  command-palette suggestions, the Live Grep overlay, and menu dropdowns
+  (all now use `chrome_area` / the chrome layout). Still TODO:
+  `render_top_global_popup` (corner/centered global popups) and
+  LSP hover/completion popups are positioned against `size`, so with the
+  dock up they can be offset or overrun the dock column.
 - **`last_frame_width/height` store full `size`,** not `chrome_area`, so
   macro-replay / `recompute_layout` lays the chrome at the wrong width
   while the dock is up.

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -29,18 +29,17 @@
   while the dock is up.
 
 ### Dock chrome (core)
-- **Right-edge-only border + drag-resize.** The dock currently draws a
-  full box (all four borders). It should draw only a **right** border
-  (no top/left/bottom — reclaim those rows/cols for content), and that
-  right border should be **draggable** to resize the dock width (persist
-  the chosen width). Today the width is a fixed constant.
+- ~~Right-edge-only border + drag-resize.~~ **Fixed**: the dock draws
+  only a right border (no top/left/bottom — content reclaims those
+  rows/cols); the right border is draggable to resize the width, and the
+  chosen width persists across hide/show within the session (`Editor.
+  dock_width`). Cross-session persistence (config) is still TODO.
 
 ### Dock UX (plugin)
-- **No "show empty/1-file sessions" toggle in the dock.** Master added
-  this filter to the modal picker (default off); the dock shares
-  `filterSessions` so it hides empty/1-file sessions too, but
-  `buildDockSpec` has no control to reveal them — a freshly-launched
-  session with no edits never appears in the dock. Add the toggle.
+- ~~No "show empty/1-file sessions" toggle in the dock.~~ **Fixed**: the
+  dock now renders a "show empty/1-file" toggle (default off — hides
+  trivial sessions), wired to the same `hide-trivial` filter as the
+  modal.
 - **Diving into a *switched* session focuses the file explorer, not the
   buffer.** When you arrow to a different session and press Enter, the
   window activates with its file-explorer pane focused, so the first

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -33,6 +33,11 @@
   the chosen width). Today the width is a fixed constant.
 
 ### Dock UX (plugin)
+- **No "show empty/1-file sessions" toggle in the dock.** Master added
+  this filter to the modal picker (default off); the dock shares
+  `filterSessions` so it hides empty/1-file sessions too, but
+  `buildDockSpec` has no control to reveal them — a freshly-launched
+  session with no edits never appears in the dock. Add the toggle.
 - **Diving into a *switched* session focuses the file explorer, not the
   buffer.** When you arrow to a different session and press Enter, the
   window activates with its file-explorer pane focused, so the first

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -33,6 +33,14 @@
   the chosen width). Today the width is a fixed constant.
 
 ### Dock UX (plugin)
+- **Diving into a *switched* session focuses the file explorer, not the
+  buffer.** When you arrow to a different session and press Enter, the
+  window activates with its file-explorer pane focused, so the first
+  keystrokes filter the tree instead of editing — you must Ctrl+E / click
+  into the buffer first. (Editing the *current* session works seamlessly:
+  open a file → dock → dive → type all flows into the buffer.) Likely in
+  the window-activation focus-restore layer rather than the dock; verify
+  whether `set_active_window` should land focus on the last editor pane.
 - **Attention glyph (⚑).** No reliable per-session "agent waiting /
   exited" signal exists in the session model yet, so the wireframe's
   attention indicator is not implemented. Needs a real state source

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -1,0 +1,53 @@
+# Orchestrator Global Dock — Remaining Gaps
+
+> **Status**: Tracking doc for the global dock (branch
+> `claude/elegant-fermat-vKK5G`). The dock ships as a non-modal,
+> full-height left column: toggle via "Orchestrator: Toggle Dock";
+> ↑↓ live-switch the active window (30ms debounce) with a directional
+> whole-window wipe; Enter/Esc/editor-click blur to the editor with the
+> dock pinned; mouse click selects+activates a row; wheel over the dock
+> is consumed.
+
+## Open gaps
+
+### Rendering / z-order (core)
+- **Full-screen modals overlap the dock.** Settings, calibration
+  wizard, keybinding editor, and the workspace-trust dialog still
+  render against the whole screen and dim it (`render.rs` ~1482–1574
+  use `size`, not `chrome_area`). With the dock visible the dock column
+  draws over their left edge (dock is painted last). Either confine
+  these to `chrome_area` or suppress the dock while one is open.
+- **Centered/anchored popups use full-screen coords.** Command-palette
+  suggestions and global popups (`render_prompt_popups`,
+  `render_top_global_popup`) are positioned/clamped against `size`, so
+  with the dock up they can be offset or overrun the dock column.
+- **`last_frame_width/height` store full `size`,** not `chrome_area`, so
+  macro-replay / `recompute_layout` lays the chrome at the wrong width
+  while the dock is up.
+
+### Dock UX (plugin)
+- **Attention glyph (⚑).** No reliable per-session "agent waiting /
+  exited" signal exists in the session model yet, so the wireframe's
+  attention indicator is not implemented. Needs a real state source
+  (e.g. track `terminal_exit` / idle) before adding the glyph.
+- **Project grouping.** The dock shows a flat list with a per-row
+  project tag (like the modal), not collapsible project group headers
+  (the `list` widget is flat; grouping needs interleaved header rows +
+  selection-index remapping).
+- **New-session from the dock closes it** (`openForm` →
+  `closeOpenDialog`); arguably the dock should persist / reopen after.
+- **Detail strip is one line** (branch only). The richer
+  age / pgid / last-terminal-line detail (`buildPreviewEntries`) is not
+  surfaced in the dock to keep the list-fill height maths exact.
+
+### Misc
+- **Toggle keybinding unbound** (intentional — "decide later"). Only
+  reachable via the command palette today.
+- **No automated tests** for `FloatingPanelControl`,
+  `SetActiveWindowAnimated`, or the dock behaviours.
+
+## Done
+Non-modal dock placement + layout carve; focus/blur key + mouse routing;
+list fills height with pinned hint; live-switch + whole-window
+directional wipe; worktree toggle, scope, filter, inline
+Stop/Archive/Delete + in-place Delete confirm; wheel consumption.

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -56,8 +56,17 @@
   project tag (like the modal), not collapsible project group headers
   (the `list` widget is flat; grouping needs interleaved header rows +
   selection-index remapping).
-- **New-session from the dock closes it** (`openForm` →
-  `closeOpenDialog`); arguably the dock should persist / reopen after.
+- **New-session from the dock closes it** — `+ New` (`openForm`) calls
+  `closeOpenDialog`, so the centered form replaces the dock. Root cause:
+  the host (`Editor.floating_widget_panel`) holds **one** floating panel
+  at a time. The left dock and a centered modal occupy disjoint regions
+  and *should* coexist (the dock stays visible while the form is open).
+  **Proper fix (deferred to a future branch):** give the host two panel
+  slots — one `LeftDock`, one centered — and route input/mouse to the
+  focused one; render both each frame. TODO markers in
+  `app/mod.rs` (`floating_widget_panel`) and `plugins/orchestrator.ts`
+  (`orchestrator_open_new_from_picker`). Not doing the reopen-after-close
+  workaround, since the real answer is simultaneous panels.
 - **Detail strip is one line** (branch only). The richer
   age / pgid / last-terminal-line detail (`buildPreviewEntries`) is not
   surfaced in the dock to keep the list-fill height maths exact.

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -56,16 +56,15 @@
   project tag (like the modal), not collapsible project group headers
   (the `list` widget is flat; grouping needs interleaved header rows +
   selection-index remapping).
-- **New-session from the dock closes it** — `+ New` (`openForm`) calls
-  `closeOpenDialog`, so the centered form replaces the dock. Root cause:
-  the host (`Editor.floating_widget_panel`) holds **one** floating panel
-  at a time, and the dock currently lives in that slot. The left dock and
-  a centered modal occupy disjoint regions and *should* coexist (the dock
-  stays visible while the form is open). We are **not** doing the
-  reopen-after-close workaround. The principled solutions are written up
-  in [Design: dock + modal coexistence](#design-dock--modal-coexistence)
-  below. TODO markers in `app/mod.rs` (`floating_widget_panel`) and
-  `plugins/orchestrator.ts` (`orchestrator_open_new_from_picker`).
+- **New-session from the dock closes it** — *Fixed (P1).* The host now
+  holds two independent widget-panel slots (`PanelSlot::Dock` +
+  `PanelSlot::Floating`, see `app/mod.rs`); the dock mounts into the Dock
+  slot (`mountFloatingWidget(..., asDock=true)`) and a centered modal
+  (the New-Session form) into the Floating slot, so `+ New` / `Alt+N`
+  leaves the dock visible beside the form. Input/mouse/wheel route to the
+  focused slot, with the centered modal taking precedence over the dock.
+  The dock has its own `KeyContext::Dock`. See
+  [Design: dock + modal coexistence](#design-dock--modal-coexistence).
 - **Detail strip is one line** (branch only). The richer
   age / pgid / last-terminal-line detail (`buildPreviewEntries`) is not
   surfaced in the dock to keep the list-fill height maths exact.

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -40,6 +40,27 @@
   dock now renders a "show empty/1-file" toggle (default off — hides
   trivial sessions), wired to the same `hide-trivial` filter as the
   modal.
+- ~~Space toggles the list multi-select regardless of which widget owns
+  focus.~~ **Fixed**: the picker's `OPEN_MODE` binds Space to
+  `orchestrator_toggle_select` unconditionally — it has to, to keep
+  Space out of the filter text-input. `toggleSelectCurrent` now branches
+  on the focused widget key (mirrored from the existing `focus`
+  widget_event) and dispatches to the focused control's toggle
+  (`scope-toggle` → `toggleScope`, `worktree-show` →
+  `toggleShowWorktrees`, `hide-trivial` → `toggleHideTrivial`) or falls
+  through to the list when focus is on `sessions`. Buttons / filter
+  input no-op (Space has no toggle semantic on them).
+- ~~Clicking a dock row while the editor terminal is keyboard-diving
+  silently drops the row-switch.~~ **Fixed**: the host's mouse handler
+  set `dock.focused = true` on the un-dive click but didn't notify the
+  plugin (`set_panel_focus_and_notify` no-ops when the inner focus_key
+  is unchanged, which is the common case — the dive only touched
+  overall focus, not the inner widget). The plugin's `dockBlurred`
+  mirror stayed `true`, so `scheduleDockSwitch` short-circuited at the
+  +30 ms check and the click — *and* every subsequent arrow — was
+  swallowed. The host now fires a `focus` widget_event when the click
+  un-blurs the dock, symmetric with `blur_floating_panel` (which has
+  always fired `blur` on the inverse transition).
 - **Diving into a *switched* session focuses the file explorer, not the
   buffer.** When you arrow to a different session and press Enter, the
   window activates with its file-explorer pane focused, so the first

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -59,14 +59,13 @@
 - **New-session from the dock closes it** — `+ New` (`openForm`) calls
   `closeOpenDialog`, so the centered form replaces the dock. Root cause:
   the host (`Editor.floating_widget_panel`) holds **one** floating panel
-  at a time. The left dock and a centered modal occupy disjoint regions
-  and *should* coexist (the dock stays visible while the form is open).
-  **Proper fix (deferred to a future branch):** give the host two panel
-  slots — one `LeftDock`, one centered — and route input/mouse to the
-  focused one; render both each frame. TODO markers in
-  `app/mod.rs` (`floating_widget_panel`) and `plugins/orchestrator.ts`
-  (`orchestrator_open_new_from_picker`). Not doing the reopen-after-close
-  workaround, since the real answer is simultaneous panels.
+  at a time, and the dock currently lives in that slot. The left dock and
+  a centered modal occupy disjoint regions and *should* coexist (the dock
+  stays visible while the form is open). We are **not** doing the
+  reopen-after-close workaround. The principled solutions are written up
+  in [Design: dock + modal coexistence](#design-dock--modal-coexistence)
+  below. TODO markers in `app/mod.rs` (`floating_widget_panel`) and
+  `plugins/orchestrator.ts` (`orchestrator_open_new_from_picker`).
 - **Detail strip is one line** (branch only). The richer
   age / pgid / last-terminal-line detail (`buildPreviewEntries`) is not
   surfaced in the dock to keep the list-fill height maths exact.
@@ -74,8 +73,103 @@
 ### Misc
 - **Toggle keybinding unbound** (intentional — "decide later"). Only
   reachable via the command palette today.
-- **No automated tests** for `FloatingPanelControl`,
-  `SetActiveWindowAnimated`, or the dock behaviours.
+
+## Design: dock + modal coexistence
+
+We only want *principled, final* solutions here — no slot-juggling or
+reopen-after-close workarounds. All correct options start from the same
+ontology: **the dock is persistent, non-modal, owns a fixed layout
+region → it is chrome, not an overlay.** Today's bug exists only because
+it was built as a modal-ish floating panel sharing one host slot with the
+orchestrator's centered form/picker. (Settings, the keybinding editor,
+popups, and menus live in *separate* state and already coexist with the
+dock — the conflict is isolated to the orchestrator's own panels.)
+
+### Invariant that must be preserved (this is what we have today)
+The two-tier chrome must keep working exactly as it does now:
+
+- **Editor-global carve, once per frame** (`compute_dock_split` →
+  `dock_area` + `chrome_area`), independent of `active_window`.
+- The dock is **editor-global** (owned by `Editor`, shows *all*
+  sessions, persists across switches) — *not* per-window like the file
+  explorer. It renders into `dock_area`.
+- The active window (menu / tabs / explorer / splits / status) renders
+  **independently** into `chrome_area`; switching sessions only swaps
+  what's in `chrome_area`.
+- The **whole-window wipe** on switch runs on the *newly-active window's*
+  animation manager, **scoped to `chrome_area`**. Because `dock_area` and
+  `chrome_area` are disjoint, the dock stays static while the window
+  slides; the animation's "before" snapshot is bounded to the animated
+  rect, so the dock is never captured/moved.
+- **Hard rule:** the dock region must never be inside any window's
+  animation rect. Falls out naturally as long as the dock stays
+  editor-level and the carve runs first.
+
+Any solution below must preserve all of the above — they change only
+*how the dock is hosted/focused* and *how a centered modal coexists*,
+never the carve or the animation scoping.
+
+### Option P1 — dock as first-class editor-global chrome (recommended)
+Make the dock an editor-level chrome region with its own
+`KeyContext::Dock` (modeled on `KeyContext::FileExplorer`, but
+editor-global, not per-window), hosting a declarative widget spec.
+Centered modals stay as the single overlay layer *above* chrome.
+
+- **Why correct:** the dock genuinely *is* chrome; the explorer proves
+  the "persistent, non-modal, focusable region that coexists with every
+  modal/popup" pattern. Coexistence becomes automatic and uniform.
+- **Focus model:** reuses the established `KeyContext` precedence
+  (Settings > Menu > Prompt > Popup > … > Dock/FileExplorer/Normal). No
+  new focus subsystem, no per-call-site `focused` flags; dock blur/dive
+  is just a context transition back to the editor split.
+- **Preserves today:** same carve, same `chrome_area`-scoped animation;
+  only dock hosting + focus change. A centered modal then renders over
+  `chrome_area` while the dock keeps rendering in `dock_area`.
+- **Bonus:** also resolves two other open gaps — "dive focuses explorer
+  not buffer" (becomes a normal context transition) and the
+  `last_frame_width` macro-replay bug (dock width is computed once,
+  authoritatively, as part of the layout).
+- **Cost:** needs a layout-region abstraction that hosts a widget spec
+  (the explorer is bespoke; splits host buffers); re-plumb the dock's
+  render/mouse/scrollbars off the floating path. Medium-large, but it
+  *removes* the "dock as floating panel" code rather than adding slots.
+
+### Option P2 — unified layer compositor
+Replace the ad-hoc overlay/focus zoo (`floating_widget_panel`,
+`settings_state`, `keybinding_editor`, the global/buffer popup stacks,
+`menu_state`, the prompt) with one ordered **layer stack**. Each layer
+declares a *region* (full-screen-centred, left-dock column,
+cursor-anchored, …), a *focus policy* (modal / non-modal / passive), and
+*paint order*; a single `focused_layer` pointer is the keyboard target,
+and input + mouse dispatch walk layers top-down by region.
+
+- **Why correct:** the genuinely general model — focus precedence,
+  z-order, and hit-testing become *properties of layers* instead of
+  conditionals scattered across `render.rs` / `input.rs` /
+  `mouse_input.rs`. Dock + modal + popup coexistence is intrinsic, and it
+  also fixes the existing per-slot inconsistencies (each current overlay
+  reinvents dim / focus / mouse).
+- **Preserves today:** the editor content is the bottom layer, the dock a
+  non-modal `LeftDock`-region layer, modals modal layers, popups passive
+  anchored layers. The window-switch wipe is still scoped to the window's
+  region (the dock layer's region is disjoint), so persistent dock +
+  independent animated window is intrinsic to the model.
+- **Cost / risk:** the largest change; touches the whole overlay + input
+  subsystem; high migration risk; must define the focus policy
+  rigorously (the original design avoided a stack for exactly this
+  reason). It also introduces a focus model that must *subsume* — not sit
+  beside — the established `KeyContext` precedence, or it's less
+  principled than P1.
+
+### Recommendation
+**P1** is the correct minimal-principled answer (dock = chrome, reuse
+`KeyContext`, delete the floating-panel dock code, coexistence by
+construction, today's carve+animation preserved). **P2** is the eventual
+destination only if a future need demands arbitrary layered panels and we
+choose to consolidate the overlay zoo; if so, P1's dock-as-chrome should
+be a layer within it. A hybrid (P1 for the dock now + a later
+`OverlayManager` unifying just the modal/popup zoo) is a reasonable
+staged path to P2.
 
 ## Done
 Non-modal dock placement + layout carve; focus/blur key + mouse routing;

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -11,12 +11,11 @@
 ## Open gaps
 
 ### Rendering / z-order (core)
-- **Full-screen modals overlap the dock.** Settings, calibration
-  wizard, keybinding editor, and the workspace-trust dialog still
-  render against the whole screen and dim it (`render.rs` ~1482–1574
-  use `size`, not `chrome_area`). With the dock visible the dock column
-  draws over their left edge (dock is painted last). Either confine
-  these to `chrome_area` or suppress the dock while one is open.
+- ~~Full-screen modals overlap the dock.~~ **Fixed**: Settings,
+  calibration wizard, keybinding editor, and event-debug now dim +
+  render against `chrome_area`, so they sit beside the dock instead of
+  being overpainted by it. The workspace-trust dialog still uses `size`
+  — it's a startup gate that can't be concurrent with the dock.
 - **Centered/anchored popups use full-screen coords.** Command-palette
   suggestions and global popups (`render_prompt_popups`,
   `render_top_global_popup`) are positioned/clamped against `size`, so

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -25,6 +25,13 @@
   macro-replay / `recompute_layout` lays the chrome at the wrong width
   while the dock is up.
 
+### Dock chrome (core)
+- **Right-edge-only border + drag-resize.** The dock currently draws a
+  full box (all four borders). It should draw only a **right** border
+  (no top/left/bottom — reclaim those rows/cols for content), and that
+  right border should be **draggable** to resize the dock width (persist
+  the chosen width). Today the width is a fixed constant.
+
 ### Dock UX (plugin)
 - **Attention glyph (⚑).** No reliable per-session "agent waiting /
   exited" signal exists in the session model yet, so the wireframe's

--- a/docs/internal/orchestrator-dock-gaps.md
+++ b/docs/internal/orchestrator-dock-gaps.md
@@ -16,12 +16,14 @@
   render against `chrome_area`, so they sit beside the dock instead of
   being overpainted by it. The workspace-trust dialog still uses `size`
   — it's a startup gate that can't be concurrent with the dock.
-- **Some global popups still use full-screen coords.** Fixed for the
-  command-palette suggestions, the Live Grep overlay, and menu dropdowns
-  (all now use `chrome_area` / the chrome layout). Still TODO:
-  `render_top_global_popup` (corner/centered global popups) and
-  LSP hover/completion popups are positioned against `size`, so with the
-  dock up they can be offset or overrun the dock column.
+- ~~Some global popups still use full-screen coords.~~ **Fixed**: the
+  command-palette suggestions, Live Grep overlay, and menu dropdowns
+  (chrome layout), plus `render_top_global_popup` (global popups) and the
+  per-buffer LSP hover/completion popups now clamp to `chrome_area`, so
+  they can't overrun the dock column. (The popup fixes mirror the
+  verified overlay fixes; the LSP/global popups couldn't be triggered
+  interactively here — no LSP server in the sandbox — but the change is
+  the same `chrome_area` clamp and renders without regression.)
 - **`last_frame_width/height` store full `size`,** not `chrome_area`, so
   macro-replay / `recompute_layout` lays the chrome at the wrong width
   while the dock is up.


### PR DESCRIPTION
Introduce two generic host primitives and wire the orchestrator plugin to
use them as a persistent, full-height left dock:

- FloatingPanelControl (dock/center/focus/blur): lets any widget panel be
  placed as a non-modal left column carved out of the chrome before the
  menu/splits/status layout. Key routing is gated on a `focused` flag so
  the editor underneath stays usable while the dock is visible.
- SetActiveWindowAnimated: switches the active window with a directional
  SlideIn wipe on the incoming content (reuses the existing animation).

Orchestrator plugin: "Orchestrator: Toggle Dock" command mounts the open
panel as a compact single-column dock; arrowing the list live-switches the
active window (30ms debounce, wipes up/down by nav direction); Enter/Esc
blur to the editor while the dock stays pinned.