### PR TITLE
Fix LSP diagnostics hidden in markdown compose mode (#2146)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2399,6 +2399,17 @@ pub enum PluginCommand {
         end: usize,
     },
 
+    /// Remove overlays in a namespace that overlap with a byte range.
+    /// Like [`ClearOverlaysInRange`] but scoped to a single namespace, so a
+    /// plugin can invalidate its own decorations for a line without clobbering
+    /// editor-owned overlays (e.g. LSP diagnostics) in the same range.
+    ClearOverlaysInRangeForNamespace {
+        buffer_id: BufferId,
+        namespace: OverlayNamespace,
+        start: usize,
+        end: usize,
+    },
+
     /// Add virtual text (inline text that doesn't exist in the buffer)
     /// Used for color swatches, type hints, parameter hints, etc.
     AddVirtualText {
@@ -4798,6 +4809,24 @@ impl PluginApi {
         })
     }
 
+    /// Clear overlays in a single namespace that overlap with a byte range.
+    /// Unlike [`clear_overlays_in_range`], overlays in other namespaces
+    /// (e.g. editor-owned LSP diagnostics) are left untouched.
+    pub fn clear_overlays_in_range_for_namespace(
+        &self,
+        buffer_id: BufferId,
+        namespace: String,
+        start: usize,
+        end: usize,
+    ) -> Result<(), String> {
+        self.send_command(PluginCommand::ClearOverlaysInRangeForNamespace {
+            buffer_id,
+            namespace: OverlayNamespace::from_string(namespace),
+            start,
+            end,
+        })
+    }
+
     /// Set the status message
     pub fn set_status(&self, message: String) -> Result<(), String> {
         self.send_command(PluginCommand::SetStatus { message })
@@ -5930,6 +5959,21 @@ mod tests {
             |a: &PluginApi| a.clear_overlays_in_range(BufferId(4), 10, 20),
             PluginCommand::ClearOverlaysInRange { buffer_id, start, end }
                 if buffer_id == BufferId(4) && start == 10 && end == 20
+        );
+
+        // clear_overlays_in_range_for_namespace
+        assert_dispatches!(
+            |a: &PluginApi| a.clear_overlays_in_range_for_namespace(
+                BufferId(5),
+                "md-emphasis".into(),
+                10,
+                20
+            ),
+            PluginCommand::ClearOverlaysInRangeForNamespace { buffer_id, namespace, start, end }
+                if buffer_id == BufferId(5)
+                    && namespace.as_str() == "md-emphasis"
+                    && start == 10
+                    && end == 20
         );
 
         // open_file_at_location

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2290,6 +2290,12 @@ interface EditorAPI {
 	*/
 	clearOverlaysInRange(bufferId: number, start: number, end: number): boolean;
 	/**
+	* Clear overlays in a single namespace that overlap with a byte range.
+	* Unlike clearOverlaysInRange, overlays in other namespaces (e.g.
+	* editor-owned LSP diagnostics) are left untouched.
+	*/
+	clearOverlaysInRangeForNamespace(bufferId: number, namespace: string, start: number, end: number): boolean;
+	/**
 	* Remove an overlay by its handle
 	*/
 	removeOverlay(bufferId: number, handle: string): boolean;

--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -1046,7 +1046,9 @@ function processLineConceals(
   // the one-frame glitch where conceals are cleared but not yet rebuilt.
   editor.debug(`[mc] processLine clear+rebuild bytes=${byteStart}..${byteEnd} content="${lineContent.slice(0,40)}"`);
   editor.clearConcealsInRange(bufferId, byteStart, byteEnd);
-  editor.clearOverlaysInRange(bufferId, byteStart, byteEnd);
+  // Only clear our own emphasis overlays — clearing ALL overlays in the range
+  // would also wipe editor-owned overlays like LSP diagnostics (issue #2146).
+  editor.clearOverlaysInRangeForNamespace(bufferId, "md-emphasis", byteStart, byteEnd);
 
   const cursorOnLine = cursors.some(c => c >= byteStart && c <= byteEnd);
   // Strict version: excludes the boundary at byteEnd so that the cursor

--- a/crates/fresh-editor/src/app/click_geometry.rs
+++ b/crates/fresh-editor/src/app/click_geometry.rs
@@ -61,7 +61,21 @@ pub(crate) fn screen_to_buffer_position(
     allow_gutter_click: bool,
     compose_width: Option<u16>,
 ) -> Option<usize> {
-    let content_rect = adjust_content_rect_for_compose(content_rect, compose_width);
+    let orig_content_rect = content_rect;
+    let mut content_rect = adjust_content_rect_for_compose(content_rect, compose_width);
+
+    // Mirror the render-time gutter reclaim (issue #2146): in compose mode the
+    // indicator gutter is drawn in the reclaimed left margin, so the view-line
+    // mappings' origin sits `gutter_width` columns left of the centered paper.
+    // Apply the same shift here (only when there was margin room to reclaim,
+    // matching `calculate_compose_layout` + the reclaim in render_buffer).
+    if compose_width.is_some() && gutter_width > 0 {
+        let left_pad = content_rect.x.saturating_sub(orig_content_rect.x);
+        if left_pad >= gutter_width {
+            content_rect.x -= gutter_width;
+            content_rect.width += gutter_width;
+        }
+    }
 
     // Calculate relative position in content area
     let content_col = col.saturating_sub(content_rect.x);

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -161,6 +161,30 @@ impl Editor {
         }
     }
 
+    /// Handle ClearOverlaysInRangeForNamespace command
+    pub(super) fn handle_clear_overlays_in_range_for_namespace(
+        &mut self,
+        buffer_id: BufferId,
+        namespace: OverlayNamespace,
+        start: usize,
+        end: usize,
+    ) {
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .map(|w| &mut w.buffers)
+            .expect("active window present")
+            .get_mut(&buffer_id)
+        {
+            state.overlays.remove_in_range_for_namespace(
+                &(start..end),
+                &namespace,
+                &mut state.marker_list,
+            );
+            // Note: Overlays are ephemeral, not added to event log for undo/redo
+        }
+    }
+
     // ==================== Virtual Text Commands ====================
 
     /// Handle AddVirtualText command

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -258,6 +258,14 @@ impl Editor {
             } => {
                 self.handle_clear_overlays_in_range(buffer_id, start, end);
             }
+            PluginCommand::ClearOverlaysInRangeForNamespace {
+                buffer_id,
+                namespace,
+                start,
+                end,
+            } => {
+                self.handle_clear_overlays_in_range_for_namespace(buffer_id, namespace, start, end);
+            }
 
             // ==================== Virtual Text Commands ====================
             PluginCommand::AddVirtualText {

--- a/crates/fresh-editor/src/view/margin.rs
+++ b/crates/fresh-editor/src/view/margin.rs
@@ -653,10 +653,18 @@ impl MarginManager {
     /// line number state.
     pub fn configure_for_line_numbers(&mut self, show_line_numbers: bool) {
         if !show_line_numbers {
+            // Hide the line-number digits and the separator, but keep the gutter
+            // enabled with a zero-width number column so the 1-char indicator
+            // slot survives. This lets diagnostic / git / fold indicators still
+            // render in compose mode (issue #2146) without showing line numbers
+            // or the `│` separator. The render layer draws this slot in the
+            // compose desk margin so it doesn't shrink the text width.
             self.left_config.width = 0;
-            self.left_config.enabled = false;
+            self.left_config.enabled = true;
+            self.left_config.show_separator = false;
         } else {
             self.left_config.enabled = true;
+            self.left_config.show_separator = true;
             if self.left_config.width == 0 {
                 self.left_config.width = MIN_LINE_NUMBER_DIGITS;
             }

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -484,6 +484,55 @@ impl OverlayManager {
         self.rebuild_marker_index();
     }
 
+    /// Like [`remove_in_range`], but only removes overlays belonging to
+    /// `namespace`. Overlays in other namespaces (e.g. editor-owned LSP
+    /// diagnostics) that happen to overlap the range are left intact.
+    ///
+    /// [`remove_in_range`]: Self::remove_in_range
+    pub fn remove_in_range_for_namespace(
+        &mut self,
+        range: &Range<usize>,
+        namespace: &OverlayNamespace,
+        marker_list: &mut MarkerList,
+    ) {
+        if range.start >= range.end {
+            return;
+        }
+        let hits = marker_list.query_range(range.start, range.end);
+        if hits.is_empty() {
+            return;
+        }
+        let mut candidates: Vec<usize> = hits
+            .iter()
+            .filter_map(|(mid, _, _)| self.marker_to_idx.get(mid).copied())
+            .collect();
+        candidates.sort_unstable();
+        candidates.dedup();
+
+        let mut to_remove: Vec<usize> = candidates
+            .into_iter()
+            .filter(|&idx| {
+                let o = &self.overlays[idx];
+                if o.namespace.as_ref() != Some(namespace) {
+                    return false;
+                }
+                let start = marker_list.get_position(o.start_marker).unwrap_or(0);
+                let end = marker_list.get_position(o.end_marker).unwrap_or(0);
+                start < range.end && range.start < end
+            })
+            .collect();
+        if to_remove.is_empty() {
+            return;
+        }
+        to_remove.sort_unstable_by(|a, b| b.cmp(a));
+        for idx in to_remove {
+            self.swap_remove_at(idx, marker_list);
+        }
+        // Restore priority order broken by swap_removes.
+        self.overlays.sort_by_key(|o| o.priority);
+        self.rebuild_marker_index();
+    }
+
     /// Clear all overlays and their markers
     pub fn clear(&mut self, marker_list: &mut MarkerList) {
         for overlay in &self.overlays {

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -145,6 +145,15 @@ pub(crate) fn compute_buffer_layout(
     state
         .margins
         .update_width_for_buffer(estimated_lines, show_line_numbers);
+    // The diagnostic/indicator gutter is kept when line numbers are off only in
+    // compose mode, where the render below reclaims its width from the desk
+    // margin (issue #2146). In normal editor mode, line-numbers-off means no
+    // gutter at all — otherwise the 1-col indicator slot would eat into the
+    // text width and shift content right.
+    if !show_line_numbers && !matches!(view_mode, ViewMode::PageView) {
+        state.margins.left_config.enabled = false;
+        state.margins.left_config.width = 0;
+    }
     let mut gutter_width = state.margins.left_total_width();
 
     let mut compose_layout = calculate_compose_layout(area, &view_mode, compose_width);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -145,9 +145,26 @@ pub(crate) fn compute_buffer_layout(
     state
         .margins
         .update_width_for_buffer(estimated_lines, show_line_numbers);
-    let gutter_width = state.margins.left_total_width();
+    let mut gutter_width = state.margins.left_total_width();
 
-    let compose_layout = calculate_compose_layout(area, &view_mode, compose_width);
+    let mut compose_layout = calculate_compose_layout(area, &view_mode, compose_width);
+    // In compose mode the gutter (diagnostic / indicator slot) is drawn in the
+    // reclaimed desk margin so it does not shrink the centered text width
+    // (issue #2146). Only do this when there is enough desk margin to give up;
+    // if the paper already fills the area, drop the gutter instead of eating
+    // into the text so table/wrap layout stays intact.
+    if matches!(view_mode, ViewMode::PageView) && gutter_width > 0 {
+        let g = gutter_width as u16;
+        if compose_layout.left_pad >= g {
+            compose_layout.left_pad -= g;
+            let ra = compose_layout.render_area;
+            compose_layout.render_area = Rect::new(ra.x - g, ra.y, ra.width + g, ra.height);
+        } else {
+            state.margins.left_config.enabled = false;
+            state.margins.left_config.width = 0;
+            gutter_width = 0;
+        }
+    }
     let render_area = compose_layout.render_area;
 
     // Clone view_transform so we can reuse it if scrolling triggers a rebuild

--- a/crates/fresh-editor/tests/e2e/markdown_compose_diagnostics.rs
+++ b/crates/fresh-editor/tests/e2e/markdown_compose_diagnostics.rs
@@ -1,0 +1,257 @@
+//! Regression test for issue #2146.
+//!
+//! Markdown compose (preview) mode hides LSP diagnostic highlighting and the
+//! gutter indicators. e.g. enabling harper-ls to find spelling mistakes: the
+//! diagnostics show up in source mode but vanish the moment compose mode is
+//! toggled on, even though the diagnostic data is still present (the status
+//! bar still reports `E:1`).
+//!
+//! The test uses a fake LSP server (configured for the `markdown` language)
+//! that publishes a single error diagnostic on `didOpen`, then drives the real
+//! `markdown_compose` plugin to toggle compose mode and checks that the gutter
+//! diagnostic indicator (`●`) survives the transition.
+
+use crate::common::harness::EditorTestHarness;
+
+/// Fake LSP server (à la harper-ls) that publishes one error diagnostic on
+/// `didOpen`. The diagnostic covers the misspelled word on line 2.
+fn create_markdown_diag_server_script(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = r##"#!/bin/bash
+LOG_FILE="${1:-/tmp/fake_md_diag_log.txt}"
+> "$LOG_FILE"
+DID_OPEN_URI=""
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then
+        break
+    fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+    echo "RECV: method=$method id=$msg_id" >> "$LOG_FILE"
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"positionEncoding":"utf-16","textDocumentSync":{"openClose":true,"change":2,"save":{}}}}}'
+            ;;
+        "initialized")
+            ;;
+        "textDocument/didOpen")
+            DID_OPEN_URI=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            echo "ACTION: didOpen uri=$DID_OPEN_URI" >> "$LOG_FILE"
+            # Spelling error on "sentance" (line 2, chars 5-13).
+            send_message '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"'"$DID_OPEN_URI"'","diagnostics":[{"range":{"start":{"line":2,"character":5},"end":{"line":2,"character":13}},"severity":1,"source":"harper","message":"Did you mean \"sentence\"?"}],"version":1}}'
+            echo "SENT: publishDiagnostics" >> "$LOG_FILE"
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+        *)
+            if [ -n "$method" ] && [ -n "$msg_id" ]; then
+                send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            fi
+            ;;
+    esac
+done
+echo "SERVER: exiting" >> "$LOG_FILE"
+"##;
+
+    let script_path = dir.join("fake_md_diag_server.sh");
+    std::fs::write(&script_path, script).expect("Failed to write markdown diag server script");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("Failed to get script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("Failed to set script permissions");
+    }
+
+    script_path
+}
+
+/// Issue #2146: LSP diagnostics should remain visible after toggling compose
+/// mode. The diagnostic data is still live (the status bar shows `E:1`) but the
+/// gutter indicator (`●`) disappears because compose mode hides line numbers,
+/// which in turn disables the entire left margin (gutter).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
+fn test_compose_mode_keeps_diagnostic_gutter() -> anyhow::Result<()> {
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("fresh=debug")
+        .try_init();
+
+    // -- Set up a project with the real markdown_compose plugin ──────────
+    let temp_dir = tempfile::tempdir()?;
+    let project_root = temp_dir.path().join("project");
+    std::fs::create_dir(&project_root)?;
+
+    let plugins_dir = project_root.join("plugins");
+    std::fs::create_dir(&plugins_dir)?;
+    copy_plugin(&plugins_dir, "markdown_compose");
+    copy_plugin_lib(&plugins_dir);
+
+    let script_path = create_markdown_diag_server_script(temp_dir.path());
+    let log_file = temp_dir.path().join("md_diag_log.txt");
+
+    // Line 2 holds the misspelled word "sentance" the fake server flags.
+    let md_path = project_root.join("notes.md");
+    std::fs::write(&md_path, "# Notes\n\nThis sentance is wrong.\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "markdown".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![log_file.to_string_lossy().to_string()],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(120, 30, config, project_root)?;
+
+    // The error background color the diagnostic overlay paints on the word.
+    let error_bg = harness.editor().theme().diagnostic_error_bg;
+
+    // Scan the content area for `word` and report whether every cell that
+    // spells it carries `error_bg` as its background — i.e. the diagnostic
+    // highlight is actually painted on the word, not just stored.
+    let word_is_highlighted = |h: &EditorTestHarness, word: &str| -> bool {
+        let (first_row, last_row) = h.content_area_rows();
+        for y in first_row..=last_row {
+            let row = h.get_row_text(y as u16);
+            if let Some(byte_idx) = row.find(word) {
+                // `find` returns a byte offset; the gutter glyphs (●, │) are
+                // multi-byte, so convert to a screen column count.
+                let start_col = row[..byte_idx].chars().count();
+                return (start_col..start_col + word.chars().count()).all(|x| {
+                    h.get_cell_style(x as u16, y as u16)
+                        .and_then(|s| s.bg)
+                        .map(|bg| bg == error_bg)
+                        .unwrap_or(false)
+                });
+            }
+        }
+        false
+    };
+
+    // Open the markdown file (triggers initialize + didOpen → publishDiagnostics).
+    harness.open_file(&md_path)?;
+    harness.render()?;
+
+    // Wait for the diagnostic to round-trip into the editor.
+    harness.wait_until(|_| {
+        let log = std::fs::read_to_string(&log_file).unwrap_or_default();
+        log.contains("SENT: publishDiagnostics")
+    })?;
+    harness.wait_until(|h| h.screen_to_string().contains("E:1"))?;
+
+    // -- Source mode: the gutter diagnostic indicator must be visible ────
+    let source_screen = harness.screen_to_string();
+    assert!(
+        source_screen.contains('●'),
+        "Expected the diagnostic gutter indicator (●) in source mode.\nScreen:\n{}",
+        source_screen
+    );
+    // ...and the misspelled word itself is highlighted with the error bg.
+    assert!(
+        word_is_highlighted(&harness, "sentance"),
+        "Expected the misspelled word to be highlighted in source mode.\nScreen:\n{}",
+        source_screen
+    );
+
+    // -- Toggle compose mode via the command palette ─────────────────────
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_prompt()?;
+    harness.type_text("Toggle Compose")?;
+    harness.wait_for_screen_contains("Toggle Compose")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.wait_for_prompt_closed()?;
+
+    // Set a compose width narrower than the terminal so there's a reading
+    // margin. The diagnostic / indicator gutter is drawn in that reclaimed
+    // desk margin (so it doesn't shrink the text width).
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.wait_for_prompt()?;
+    harness.type_text("Set Compose Width")?;
+    harness.wait_for_screen_contains("Set Compose Width")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.wait_for_prompt()?;
+    harness.type_text("80")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.wait_for_prompt_closed()?;
+
+    // Wait for compose mode to settle. Compose hides the line-number gutter,
+    // so the `│` separator disappears from the content line — a reliable
+    // signal that the mode flipped (the heading text itself stays on screen).
+    harness.wait_until_stable(|h| {
+        let s = h.screen_to_string();
+        s.contains("sentance") && !s.lines().any(|l| l.contains("sentance") && l.contains('│'))
+    })?;
+
+    let compose_screen = harness.screen_to_string();
+
+    // The diagnostic data is still present — the status bar still reports it.
+    assert!(
+        compose_screen.contains("E:1"),
+        "Diagnostic data should still be live in compose mode (status bar E:1).\nScreen:\n{}",
+        compose_screen
+    );
+
+    // Issue #2146: the gutter indicator must still be shown in compose mode.
+    assert!(
+        compose_screen.contains('●'),
+        "Issue #2146: the diagnostic gutter indicator (●) disappeared in \
+         compose mode.\nScreen:\n{}",
+        compose_screen
+    );
+
+    // Issue #2146: the word-level highlight must also survive compose mode.
+    assert!(
+        word_is_highlighted(&harness, "sentance"),
+        "Issue #2146: the misspelled word lost its diagnostic highlight in \
+         compose mode.\nScreen:\n{}",
+        compose_screen
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -112,6 +112,7 @@ pub mod lsp_unified_code_actions;
 pub mod lsp_unresponsive_capability_does_not_block;
 pub mod macros;
 pub mod markdown_compose;
+pub mod markdown_compose_diagnostics;
 pub mod markdown_compose_scroll_reach;
 pub mod memory_scroll_leak;
 pub mod menu_bar;

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3413,6 +3413,24 @@ impl JsEditorApi {
             .is_ok()
     }
 
+    /// Clear overlays in a namespace that overlap with a byte range
+    pub fn clear_overlays_in_range_for_namespace(
+        &self,
+        buffer_id: u32,
+        namespace: String,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        self.command_sender
+            .send(PluginCommand::ClearOverlaysInRangeForNamespace {
+                buffer_id: BufferId(buffer_id as usize),
+                namespace: OverlayNamespace::from_string(namespace),
+                start: start as usize,
+                end: end as usize,
+            })
+            .is_ok()
+    }
+
     /// Remove an overlay by its handle
     pub fn remove_overlay(&self, buffer_id: u32, handle: String) -> bool {
         use fresh_core::overlay::OverlayHandle;

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1266,6 +1266,7 @@ mod tests {
             "clearNamespace",
             "clearAllOverlays",
             "clearOverlaysInRange",
+            "clearOverlaysInRangeForNamespace",
             "removeOverlay",
             "addConceal",
             "clearConcealNamespace",


### PR DESCRIPTION
Compose mode erased LSP diagnostics entirely: the markdown_compose
plugin's per-line refresh called clearOverlaysInRange, which removed
ALL overlays in the line range — including editor-owned diagnostic
overlays. Since the highlight, the gutter dot, and the E:N status
count all derive from overlays, every trace of the diagnostic vanished
on the compose toggle (with no LSP traffic involved).

- Add a namespace-scoped clearOverlaysInRangeForNamespace API so the
  plugin clears only its own md-emphasis overlays, leaving LSP
  diagnostics intact. Restores the word highlight and E:N in compose.
- Keep the diagnostic/indicator gutter in compose mode (line numbers
  off) and draw its 1-col slot in the reclaimed compose desk margin so
  the centered text width is preserved (no table/wrap regressions);
  fall back to hiding it when there is no margin room.
- Mirror that reclaim in click_geometry so mouse mapping stays aligned.

Adds an e2e test (fake harper-style LSP) asserting the gutter dot, the
word highlight, and E:1 all survive the compose toggle.