### PR TITLE
Skip Microsoft Store pwsh App Execution Alias when opening terminal

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -161,7 +161,8 @@
       "$ref": "#/$defs/TerminalConfig",
       "default": {
         "jump_to_end_on_output": true,
-        "shell": null
+        "shell": null,
+        "skip_app_execution_alias": true
       }
     },
     "keybindings": {
@@ -1048,6 +1049,11 @@
             }
           ],
           "default": null
+        },
+        "skip_app_execution_alias": {
+          "description": "Workaround for fresh#2077: when auto-detecting a shell on Windows,\nskip Microsoft Store **App Execution Alias** stubs (zero-byte\n`APPEXECLINK` reparse points under `%LOCALAPPDATA%\\Microsoft\\WindowsApps`).\nSpawning such a stub through ConPTY has been reported to crash with\n`0xc0000142` (STATUS_DLL_INIT_FAILED) on Windows 11 23H2.\n\nDefault `true`. Set to `false` to launch whatever `pwsh.exe`\nappears first on `PATH`, including the Store alias — useful if you\nwant the old behavior, or if you've confirmed the alias works on\nyour Windows build. No effect on non-Windows platforms or when\n`terminal.shell` is set explicitly.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1866,6 +1866,20 @@ pub struct TerminalConfig {
     /// (e.g. `docker exec`) keep their own wrapper.
     #[serde(default)]
     pub shell: Option<TerminalShellConfig>,
+
+    /// Workaround for fresh#2077: when auto-detecting a shell on Windows,
+    /// skip Microsoft Store **App Execution Alias** stubs (zero-byte
+    /// `APPEXECLINK` reparse points under `%LOCALAPPDATA%\Microsoft\WindowsApps`).
+    /// Spawning such a stub through ConPTY has been reported to crash with
+    /// `0xc0000142` (STATUS_DLL_INIT_FAILED) on Windows 11 23H2.
+    ///
+    /// Default `true`. Set to `false` to launch whatever `pwsh.exe`
+    /// appears first on `PATH`, including the Store alias — useful if you
+    /// want the old behavior, or if you've confirmed the alias works on
+    /// your Windows build. No effect on non-Windows platforms or when
+    /// `terminal.shell` is set explicitly.
+    #[serde(default = "default_true")]
+    pub skip_app_execution_alias: bool,
 }
 
 impl Default for TerminalConfig {
@@ -1873,6 +1887,7 @@ impl Default for TerminalConfig {
         Self {
             jump_to_end_on_output: true,
             shell: None,
+            skip_app_execution_alias: true,
         }
     }
 }
@@ -3275,6 +3290,19 @@ impl MenuConfig {
 impl Config {
     /// The config filename used throughout the application
     pub(crate) const FILENAME: &'static str = "config.json";
+
+    /// Push config values into process-wide flags that need to be readable
+    /// from contexts which don't carry a `Config` handle (e.g. the
+    /// parameter-less `services::terminal::detect_shell`). Idempotent —
+    /// safe to call multiple times as the config is reloaded.
+    pub fn apply_runtime_flags(&self) {
+        #[cfg(windows)]
+        {
+            crate::services::terminal::set_skip_app_execution_alias(
+                self.terminal.skip_app_execution_alias,
+            );
+        }
+    }
 
     /// Get the local config path (in the working directory)
     pub(crate) fn local_config_path(working_dir: &Path) -> std::path::PathBuf {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1642,6 +1642,7 @@ fn initialize_app(args: &Args) -> AnyhowResult<SetupState> {
     };
 
     tracing::info!("Config loaded");
+    config.apply_runtime_flags();
 
     // CLI flag overrides config
     if args.no_upgrade_check {
@@ -2743,6 +2744,7 @@ fn run_server_command(args: &Args) -> AnyhowResult<()> {
         config::Config::load_with_layers(&dir_context, &config_dir)
     };
     eprintln!("[server] Editor config loaded");
+    editor_config.apply_runtime_flags();
 
     let session_keepalive: Option<Box<dyn std::any::Any + Send>> =
         remote_session.map(|rs| Box::new(rs) as Box<dyn std::any::Any + Send>);

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -412,6 +412,7 @@ impl Merge for PartialClipboardConfig {
 pub struct PartialTerminalConfig {
     pub jump_to_end_on_output: Option<bool>,
     pub shell: Option<crate::config::TerminalShellConfig>,
+    pub skip_app_execution_alias: Option<bool>,
 }
 
 impl Merge for PartialTerminalConfig {
@@ -419,6 +420,8 @@ impl Merge for PartialTerminalConfig {
         self.jump_to_end_on_output
             .merge_from(&other.jump_to_end_on_output);
         self.shell.merge_from(&other.shell);
+        self.skip_app_execution_alias
+            .merge_from(&other.skip_app_execution_alias);
     }
 }
 
@@ -886,6 +889,7 @@ impl From<&TerminalConfig> for PartialTerminalConfig {
         Self {
             jump_to_end_on_output: Some(cfg.jump_to_end_on_output),
             shell: cfg.shell.clone(),
+            skip_app_execution_alias: Some(cfg.skip_app_execution_alias),
         }
     }
 }
@@ -897,6 +901,9 @@ impl PartialTerminalConfig {
                 .jump_to_end_on_output
                 .unwrap_or(defaults.jump_to_end_on_output),
             shell: self.shell.or_else(|| defaults.shell.clone()),
+            skip_app_execution_alias: self
+                .skip_app_execution_alias
+                .unwrap_or(defaults.skip_app_execution_alias),
         }
     }
 }

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -730,81 +730,8 @@ pub fn detect_shell() -> String {
     }
     #[cfg(windows)]
     {
-        select_windows_shell()
+        super::windows_shell::select_windows_shell()
     }
-}
-
-/// Pick a Windows shell, preferring PowerShell for its ConPTY/ANSI support.
-///
-/// Candidates are resolved to a concrete on-disk path and any Microsoft
-/// Store **App Execution Alias** stub is skipped (see
-/// [`is_app_execution_alias`]). Returning the fully-resolved path — rather
-/// than a bare name — also keeps spawn-time PATH resolution from re-finding
-/// the alias.
-#[cfg(windows)]
-fn select_windows_shell() -> String {
-    // Prefer a real PowerShell 7 install over a Store alias, then bare
-    // `pwsh.exe`/`powershell.exe` from PATH, then Windows PowerShell 5.
-    let mut candidates: Vec<String> = Vec::new();
-    for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
-        if let Ok(base) = std::env::var(var) {
-            if !base.is_empty() {
-                candidates.push(format!(r"{base}\PowerShell\7\pwsh.exe"));
-            }
-        }
-    }
-    candidates.push("pwsh.exe".to_string());
-    candidates.push("powershell.exe".to_string());
-    candidates.push(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string());
-
-    for candidate in &candidates {
-        if let Some(resolved) = resolve_shell_candidate(candidate) {
-            if is_app_execution_alias(&resolved) {
-                // A zero-byte WindowsApps stub crashes under ConPTY with
-                // 0xc0000142 (STATUS_DLL_INIT_FAILED); skip it. (issue #2077)
-                continue;
-            }
-            return resolved.to_string_lossy().into_owned();
-        }
-    }
-
-    // Fall back to COMSPEC (cmd.exe)
-    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
-}
-
-/// Resolve a shell candidate to a concrete file path.
-///
-/// Candidates containing a path separator are checked directly; bare names
-/// are looked up on `PATH`. Returns `None` when no matching file exists.
-#[cfg(windows)]
-fn resolve_shell_candidate(cmd: &str) -> Option<std::path::PathBuf> {
-    if cmd.contains('\\') || cmd.contains('/') {
-        let p = std::path::PathBuf::from(cmd);
-        return p.is_file().then_some(p);
-    }
-    let path_var = std::env::var("PATH").ok()?;
-    path_var
-        .split(';')
-        .filter(|d| !d.is_empty())
-        .find_map(|dir| {
-            let full = std::path::Path::new(dir).join(cmd);
-            full.is_file().then_some(full)
-        })
-}
-
-/// Detect a Microsoft Store **App Execution Alias** stub.
-///
-/// These aliases (e.g. the Store build of `pwsh.exe` under
-/// `%LOCALAPPDATA%\Microsoft\WindowsApps`) are zero-byte `APPEXECLINK`
-/// reparse points, not real executables. Spawning one through ConPTY makes
-/// the target crash with `0xc0000142` (STATUS_DLL_INIT_FAILED), so callers
-/// must never hand one to the PTY. A genuine shell binary is always
-/// non-empty. (issue #2077)
-#[cfg(windows)]
-fn is_app_execution_alias(path: &std::path::Path) -> bool {
-    std::fs::metadata(path)
-        .map(|m| m.len() == 0)
-        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -829,40 +756,6 @@ mod tests {
         use std::path::Path;
         let p = Path::new("/home/user/project");
         assert_eq!(strip_verbatim_prefix(p).as_ref(), p);
-    }
-
-    // A Microsoft Store App Execution Alias is a zero-byte stub that crashes
-    // under ConPTY with 0xc0000142; detect_shell must skip it. (issue #2077)
-    #[cfg(windows)]
-    #[test]
-    fn app_execution_alias_is_detected_and_skipped() {
-        use std::io::Write;
-
-        let dir = tempfile::tempdir().unwrap();
-
-        // Zero-byte stub mimicking a WindowsApps App Execution Alias.
-        let alias = dir.path().join("pwsh.exe");
-        std::fs::File::create(&alias).unwrap();
-        assert!(is_app_execution_alias(&alias));
-
-        // A real (non-empty) executable must not be treated as an alias.
-        let real = dir.path().join("powershell.exe");
-        let mut f = std::fs::File::create(&real).unwrap();
-        f.write_all(b"MZ\x90\x00").unwrap();
-        drop(f);
-        assert!(!is_app_execution_alias(&real));
-
-        // resolve_shell_candidate honors explicit paths and reports the stub.
-        let resolved = resolve_shell_candidate(&alias.to_string_lossy()).unwrap();
-        assert!(is_app_execution_alias(&resolved));
-        assert!(!is_app_execution_alias(
-            &resolve_shell_candidate(&real.to_string_lossy()).unwrap()
-        ));
-
-        // A missing path resolves to nothing.
-        assert!(
-            resolve_shell_candidate(&dir.path().join("missing.exe").to_string_lossy()).is_none()
-        );
     }
 
     #[cfg(windows)]

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -730,37 +730,81 @@ pub fn detect_shell() -> String {
     }
     #[cfg(windows)]
     {
-        // On Windows, prefer PowerShell for better ConPTY and ANSI escape support
-        // Check for PowerShell Core (pwsh) first, then Windows PowerShell
-        let powershell_paths = [
-            "pwsh.exe",
-            "powershell.exe",
-            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
-        ];
-
-        for ps in &powershell_paths {
-            if std::path::Path::new(ps).exists() || which_exists(ps) {
-                return ps.to_string();
-            }
-        }
-
-        // Fall back to COMSPEC (cmd.exe)
-        std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+        select_windows_shell()
     }
 }
 
-/// Check if command exists in PATH (Windows)
+/// Pick a Windows shell, preferring PowerShell for its ConPTY/ANSI support.
+///
+/// Candidates are resolved to a concrete on-disk path and any Microsoft
+/// Store **App Execution Alias** stub is skipped (see
+/// [`is_app_execution_alias`]). Returning the fully-resolved path — rather
+/// than a bare name — also keeps spawn-time PATH resolution from re-finding
+/// the alias.
 #[cfg(windows)]
-fn which_exists(cmd: &str) -> bool {
-    if let Ok(path_var) = std::env::var("PATH") {
-        for path in path_var.split(';') {
-            let full_path = std::path::Path::new(path).join(cmd);
-            if full_path.exists() {
-                return true;
+fn select_windows_shell() -> String {
+    // Prefer a real PowerShell 7 install over a Store alias, then bare
+    // `pwsh.exe`/`powershell.exe` from PATH, then Windows PowerShell 5.
+    let mut candidates: Vec<String> = Vec::new();
+    for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
+        if let Ok(base) = std::env::var(var) {
+            if !base.is_empty() {
+                candidates.push(format!(r"{base}\PowerShell\7\pwsh.exe"));
             }
         }
     }
-    false
+    candidates.push("pwsh.exe".to_string());
+    candidates.push("powershell.exe".to_string());
+    candidates.push(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string());
+
+    for candidate in &candidates {
+        if let Some(resolved) = resolve_shell_candidate(candidate) {
+            if is_app_execution_alias(&resolved) {
+                // A zero-byte WindowsApps stub crashes under ConPTY with
+                // 0xc0000142 (STATUS_DLL_INIT_FAILED); skip it. (issue #2077)
+                continue;
+            }
+            return resolved.to_string_lossy().into_owned();
+        }
+    }
+
+    // Fall back to COMSPEC (cmd.exe)
+    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+}
+
+/// Resolve a shell candidate to a concrete file path.
+///
+/// Candidates containing a path separator are checked directly; bare names
+/// are looked up on `PATH`. Returns `None` when no matching file exists.
+#[cfg(windows)]
+fn resolve_shell_candidate(cmd: &str) -> Option<std::path::PathBuf> {
+    if cmd.contains('\\') || cmd.contains('/') {
+        let p = std::path::PathBuf::from(cmd);
+        return p.is_file().then_some(p);
+    }
+    let path_var = std::env::var("PATH").ok()?;
+    path_var
+        .split(';')
+        .filter(|d| !d.is_empty())
+        .find_map(|dir| {
+            let full = std::path::Path::new(dir).join(cmd);
+            full.is_file().then_some(full)
+        })
+}
+
+/// Detect a Microsoft Store **App Execution Alias** stub.
+///
+/// These aliases (e.g. the Store build of `pwsh.exe` under
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps`) are zero-byte `APPEXECLINK`
+/// reparse points, not real executables. Spawning one through ConPTY makes
+/// the target crash with `0xc0000142` (STATUS_DLL_INIT_FAILED), so callers
+/// must never hand one to the PTY. A genuine shell binary is always
+/// non-empty. (issue #2077)
+#[cfg(windows)]
+fn is_app_execution_alias(path: &std::path::Path) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.len() == 0)
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -785,6 +829,40 @@ mod tests {
         use std::path::Path;
         let p = Path::new("/home/user/project");
         assert_eq!(strip_verbatim_prefix(p).as_ref(), p);
+    }
+
+    // A Microsoft Store App Execution Alias is a zero-byte stub that crashes
+    // under ConPTY with 0xc0000142; detect_shell must skip it. (issue #2077)
+    #[cfg(windows)]
+    #[test]
+    fn app_execution_alias_is_detected_and_skipped() {
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+
+        // Zero-byte stub mimicking a WindowsApps App Execution Alias.
+        let alias = dir.path().join("pwsh.exe");
+        std::fs::File::create(&alias).unwrap();
+        assert!(is_app_execution_alias(&alias));
+
+        // A real (non-empty) executable must not be treated as an alias.
+        let real = dir.path().join("powershell.exe");
+        let mut f = std::fs::File::create(&real).unwrap();
+        f.write_all(b"MZ\x90\x00").unwrap();
+        drop(f);
+        assert!(!is_app_execution_alias(&real));
+
+        // resolve_shell_candidate honors explicit paths and reports the stub.
+        let resolved = resolve_shell_candidate(&alias.to_string_lossy()).unwrap();
+        assert!(is_app_execution_alias(&resolved));
+        assert!(!is_app_execution_alias(
+            &resolve_shell_candidate(&real.to_string_lossy()).unwrap()
+        ));
+
+        // A missing path resolves to nothing.
+        assert!(
+            resolve_shell_candidate(&dir.path().join("missing.exe").to_string_lossy()).is_none()
+        );
     }
 
     #[cfg(windows)]

--- a/crates/fresh-editor/src/services/terminal/mod.rs
+++ b/crates/fresh-editor/src/services/terminal/mod.rs
@@ -50,6 +50,10 @@
 pub mod manager;
 pub mod pty;
 pub mod term;
+#[cfg(windows)]
+pub mod windows_shell;
 
 pub use manager::{detect_shell, TerminalId, TerminalManager};
 pub use term::{TerminalCell, TerminalState};
+#[cfg(windows)]
+pub use windows_shell::set_skip_app_execution_alias;

--- a/crates/fresh-editor/src/services/terminal/windows_shell.rs
+++ b/crates/fresh-editor/src/services/terminal/windows_shell.rs
@@ -1,0 +1,151 @@
+//! Windows shell-detection helpers for the integrated terminal.
+//!
+//! Picks the executable handed to ConPTY when the user hasn't overridden
+//! `terminal.shell` in their config. The main wrinkle this module exists to
+//! handle is the Microsoft Store build of `pwsh.exe`, which lives on PATH
+//! as a zero-byte `APPEXECLINK` reparse-point stub (under
+//! `%LOCALAPPDATA%\Microsoft\WindowsApps`). Spawning that stub through
+//! ConPTY has been reported to crash with `0xc0000142`
+//! (STATUS_DLL_INIT_FAILED) on Windows 11 23H2; see issue #2077.
+//!
+//! The workaround is opt-out via `terminal.skip_app_execution_alias`. The
+//! flag is mirrored into a process-wide atomic so [`detect_shell`] stays a
+//! parameter-less function (its many callers don't all have a
+//! `TerminalConfig` handy); [`set_skip_app_execution_alias`] is called
+//! once at editor startup from `Config::apply_runtime_flags`.
+//!
+//! [`detect_shell`]: super::detect_shell
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static SKIP_APP_EXECUTION_ALIAS: AtomicBool = AtomicBool::new(true);
+
+/// Set the workaround flag at editor startup.
+///
+/// `true` (the default) makes [`select_windows_shell`] skip Microsoft
+/// Store App Execution Alias stubs. Set to `false` to disable the
+/// workaround — useful for users who want to debug or who only ever have
+/// a real `pwsh.exe` on PATH.
+pub fn set_skip_app_execution_alias(skip: bool) {
+    SKIP_APP_EXECUTION_ALIAS.store(skip, Ordering::Relaxed);
+}
+
+fn skip_app_execution_alias() -> bool {
+    SKIP_APP_EXECUTION_ALIAS.load(Ordering::Relaxed)
+}
+
+/// Pick a Windows shell, preferring PowerShell for its ConPTY/ANSI support.
+///
+/// Candidates are resolved to a concrete on-disk path. When the workaround
+/// is enabled (see [`set_skip_app_execution_alias`]), Microsoft Store
+/// App Execution Alias stubs are skipped — see [`is_app_execution_alias`].
+/// Returning the fully-resolved path keeps spawn-time PATH resolution from
+/// re-finding the alias.
+pub fn select_windows_shell() -> String {
+    let skip_alias = skip_app_execution_alias();
+
+    // Prefer a real PowerShell 7 install over a Store alias, then bare
+    // `pwsh.exe`/`powershell.exe` from PATH, then Windows PowerShell 5.
+    let mut candidates: Vec<String> = Vec::new();
+    for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
+        if let Ok(base) = std::env::var(var) {
+            if !base.is_empty() {
+                candidates.push(format!(r"{base}\PowerShell\7\pwsh.exe"));
+            }
+        }
+    }
+    candidates.push("pwsh.exe".to_string());
+    candidates.push("powershell.exe".to_string());
+    candidates.push(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string());
+
+    for candidate in &candidates {
+        if let Some(resolved) = resolve_shell_candidate(candidate) {
+            if skip_alias && is_app_execution_alias(&resolved) {
+                // Zero-byte WindowsApps stub: crashes under ConPTY with
+                // 0xc0000142 (STATUS_DLL_INIT_FAILED). (issue #2077)
+                continue;
+            }
+            return resolved.to_string_lossy().into_owned();
+        }
+    }
+
+    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+}
+
+/// Resolve a shell candidate to a concrete file path.
+///
+/// Candidates containing a path separator are checked directly; bare names
+/// are looked up on `PATH`. Returns `None` when no matching file exists.
+pub(crate) fn resolve_shell_candidate(cmd: &str) -> Option<PathBuf> {
+    if cmd.contains('\\') || cmd.contains('/') {
+        let p = PathBuf::from(cmd);
+        return p.is_file().then_some(p);
+    }
+    let path_var = std::env::var("PATH").ok()?;
+    path_var
+        .split(';')
+        .filter(|d| !d.is_empty())
+        .find_map(|dir| {
+            let full = Path::new(dir).join(cmd);
+            full.is_file().then_some(full)
+        })
+}
+
+/// Detect a Microsoft Store **App Execution Alias** stub.
+///
+/// Aliases such as the Store build of `pwsh.exe` under
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps` are zero-byte `APPEXECLINK`
+/// reparse points, not real executables. A genuine shell binary is always
+/// non-empty. (issue #2077)
+pub(crate) fn is_app_execution_alias(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .map(|m| m.len() == 0)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // A Microsoft Store App Execution Alias is a zero-byte stub; the
+    // workaround must detect and skip it. (issue #2077)
+    #[test]
+    fn detects_zero_byte_stub() {
+        let dir = tempfile::tempdir().unwrap();
+        let alias = dir.path().join("pwsh.exe");
+        std::fs::File::create(&alias).unwrap();
+        assert!(is_app_execution_alias(&alias));
+
+        let real = dir.path().join("powershell.exe");
+        let mut f = std::fs::File::create(&real).unwrap();
+        f.write_all(b"MZ\x90\x00").unwrap();
+        drop(f);
+        assert!(!is_app_execution_alias(&real));
+    }
+
+    #[test]
+    fn resolve_candidate_honors_explicit_path_and_misses() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("powershell.exe");
+        std::fs::write(&real, b"MZ").unwrap();
+
+        let resolved = resolve_shell_candidate(&real.to_string_lossy()).unwrap();
+        assert_eq!(resolved, real);
+        assert!(
+            resolve_shell_candidate(&dir.path().join("missing.exe").to_string_lossy()).is_none()
+        );
+    }
+
+    #[test]
+    fn workaround_flag_toggle_round_trips() {
+        // Restore whatever the test harness left in place.
+        let original = skip_app_execution_alias();
+        set_skip_app_execution_alias(false);
+        assert!(!skip_app_execution_alias());
+        set_skip_app_execution_alias(true);
+        assert!(skip_app_execution_alias());
+        set_skip_app_execution_alias(original);
+    }
+}

--- a/crates/fresh-editor/src/services/terminal/windows_shell.rs
+++ b/crates/fresh-editor/src/services/terminal/windows_shell.rs
@@ -43,10 +43,16 @@ fn skip_app_execution_alias() -> bool {
 /// Returning the fully-resolved path keeps spawn-time PATH resolution from
 /// re-finding the alias.
 pub fn select_windows_shell() -> String {
-    let skip_alias = skip_app_execution_alias();
+    pick_shell(skip_app_execution_alias(), &default_candidates(), |c| {
+        resolve_shell_candidate(c)
+    })
+    .unwrap_or_else(|| std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string()))
+}
 
-    // Prefer a real PowerShell 7 install over a Store alias, then bare
-    // `pwsh.exe`/`powershell.exe` from PATH, then Windows PowerShell 5.
+/// Default shell candidates, in preference order. Real PowerShell 7
+/// installs first (so they win over a Store alias on PATH), then bare
+/// `pwsh.exe`/`powershell.exe`, then Windows PowerShell 5.
+fn default_candidates() -> Vec<String> {
     let mut candidates: Vec<String> = Vec::new();
     for var in ["ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"] {
         if let Ok(base) = std::env::var(var) {
@@ -58,19 +64,28 @@ pub fn select_windows_shell() -> String {
     candidates.push("pwsh.exe".to_string());
     candidates.push("powershell.exe".to_string());
     candidates.push(r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string());
+    candidates
+}
 
-    for candidate in &candidates {
-        if let Some(resolved) = resolve_shell_candidate(candidate) {
+/// Pure shell-selection core: walks `candidates`, asking `resolve` to map
+/// each one to a concrete path, and skips Microsoft Store alias stubs when
+/// `skip_alias` is true. Extracted from [`select_windows_shell`] so tests
+/// can drive it without touching PATH or the real filesystem.
+fn pick_shell<F>(skip_alias: bool, candidates: &[String], mut resolve: F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<PathBuf>,
+{
+    for candidate in candidates {
+        if let Some(resolved) = resolve(candidate) {
             if skip_alias && is_app_execution_alias(&resolved) {
                 // Zero-byte WindowsApps stub: crashes under ConPTY with
                 // 0xc0000142 (STATUS_DLL_INIT_FAILED). (issue #2077)
                 continue;
             }
-            return resolved.to_string_lossy().into_owned();
+            return Some(resolved.to_string_lossy().into_owned());
         }
     }
-
-    std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string())
+    None
 }
 
 /// Resolve a shell candidate to a concrete file path.
@@ -138,14 +153,36 @@ mod tests {
         );
     }
 
+    // Reproducer for issue #2077. Same candidate list, same on-disk state,
+    // only difference is the workaround flag: without it the picker returns
+    // the zero-byte alias stub (the buggy old behavior); with it the
+    // stub is skipped and the real binary is returned.
     #[test]
-    fn workaround_flag_toggle_round_trips() {
-        // Restore whatever the test harness left in place.
-        let original = skip_app_execution_alias();
-        set_skip_app_execution_alias(false);
-        assert!(!skip_app_execution_alias());
-        set_skip_app_execution_alias(true);
-        assert!(skip_app_execution_alias());
-        set_skip_app_execution_alias(original);
+    fn pick_shell_skips_alias_stub_only_when_flag_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let alias = dir.path().join("pwsh.exe");
+        std::fs::File::create(&alias).unwrap();
+        let real = dir.path().join("powershell.exe");
+        std::fs::write(&real, b"MZ").unwrap();
+
+        let candidates = vec![
+            alias.to_string_lossy().into_owned(),
+            real.to_string_lossy().into_owned(),
+        ];
+
+        // Workaround on: zero-byte stub is skipped, real binary wins.
+        let picked = pick_shell(true, &candidates, resolve_shell_candidate).unwrap();
+        assert_eq!(PathBuf::from(picked), real);
+
+        // Workaround off: first candidate wins, even though it's the stub
+        // (this is what crashed ConPTY in the issue).
+        let picked = pick_shell(false, &candidates, resolve_shell_candidate).unwrap();
+        assert_eq!(PathBuf::from(picked), alias);
+    }
+
+    #[test]
+    fn pick_shell_returns_none_when_nothing_resolves() {
+        let candidates = vec!["nonexistent.exe".to_string()];
+        assert!(pick_shell(true, &candidates, |_| None).is_none());
     }
 }


### PR DESCRIPTION
The Store build of pwsh.exe is a zero-byte APPEXECLINK reparse stub under
WindowsApps. Spawning it through ConPTY crashes with 0xc0000142
(STATUS_DLL_INIT_FAILED), so detect_shell now resolves candidates to a
concrete path, prefers a real PowerShell 7 install, and falls back to
Windows PowerShell when only the alias stub is present.

https://claude.ai/code/session_013W1JsUysvPDVk89rnwPpTa