### PR TITLE
Fix focus handling when opening files from file explorer

### DIFF
--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -192,6 +192,14 @@
       "when": "normal"
     },
     {
+      "comment": "Ctrl+O - Open file (also available when the file explorer is focused)",
+      "key": "o",
+      "modifiers": ["ctrl"],
+      "action": "open",
+      "args": {},
+      "when": "fileExplorer"
+    },
+    {
       "comment": "Normal context - Editing",
       "key": "z",
       "modifiers": ["ctrl"],

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -1723,6 +1723,15 @@ impl Editor {
                 if let Some(line) = line {
                     self.goto_line_col(line, column);
                 }
+                // When this path is reached from the FileExplorer key context
+                // (Quick Open or LiveGrep started while the explorer was
+                // focused), the freshly opened buffer would otherwise stay
+                // unfocused — typing would feed the explorer's search filter
+                // instead of the editor. The native file browser path
+                // (`file_open_open_file_at_location`) already does this reset
+                // for the same reason.
+                self.active_window_mut().key_context =
+                    crate::input::keybindings::KeyContext::Normal;
                 self.set_status_message(
                     t!("buffer.opened", name = full_path.display().to_string()).to_string(),
                 );

--- a/crates/fresh-editor/tests/e2e/file_explorer_open_focus.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer_open_focus.rs
@@ -1,0 +1,91 @@
+//! Tests for opening files while the file explorer is focused.
+//!
+//! Two related behaviours, both exercised from the FileExplorer key context:
+//!  1. Ctrl+O must open the "Open file:" prompt, even though the binding's
+//!     default is registered only for the Normal context.
+//!  2. Opening a file via Quick Open (Ctrl+P, Backspace, type filename, Enter)
+//!     must transfer focus to the new buffer — typing afterwards goes into the
+//!     editor, not into the file explorer's search filter.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+/// Ctrl+O should open the "Open file:" prompt when the file explorer is focused.
+#[test]
+fn test_ctrl_o_opens_prompt_when_file_explorer_focused() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    fs::write(project_root.join("a.txt"), "hello").unwrap();
+
+    // Open and focus the file explorer.
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("a.txt").unwrap();
+
+    // Confirm the explorer is focused by checking the rendered status line.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File explorer"))
+        .unwrap();
+
+    // Send Ctrl+O. With the explorer focused, this should still trigger the
+    // Open File prompt — the binding currently exists only for the Normal
+    // context, which is the bug under test.
+    harness
+        .send_key(KeyCode::Char('o'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // The "Open file:" prompt text should appear on screen.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Open file:"))
+        .expect("Ctrl+O should open the file-open prompt when explorer is focused");
+}
+
+/// After opening a file via Quick Open (file mode) while the explorer is
+/// focused, typing should go into the opened buffer — not into the file
+/// explorer's search filter.
+#[test]
+fn test_quick_open_focuses_editor_when_file_explorer_focused() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+    fs::write(project_root.join("target.txt"), "world").unwrap();
+
+    // Focus the file explorer.
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("target.txt").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File explorer"))
+        .unwrap();
+
+    // Open Quick Open (command mode by default), then backspace to switch to
+    // file mode — this matches the exact user flow from the bug report.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("target.txt").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Wait for the buffer to open (its content appears on screen).
+    harness
+        .wait_until(|h| h.screen_to_string().contains("world"))
+        .unwrap();
+
+    // Type into what should now be the focused editor. If focus is still on
+    // the file explorer, the keys would feed its search filter instead.
+    harness.type_text("X").unwrap();
+
+    // The opened buffer should now contain the inserted character. Asserting
+    // on the rendered screen (per CONTRIBUTING.md) — we expect "Xworld" to
+    // appear in the editor pane, not the original "world".
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Xworld"))
+        .expect(
+            "Typing after Quick Open should land in the opened buffer, not the explorer filter",
+        );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -32,6 +32,7 @@ pub mod external_file_save_as_tab;
 pub mod file_browser;
 pub mod file_explorer;
 pub mod file_explorer_compact_chain;
+pub mod file_explorer_open_focus;
 pub mod file_permissions;
 pub mod flash;
 pub mod folding;


### PR DESCRIPTION
## Summary
This PR fixes two related issues when opening files while the file explorer is focused:
1. Ctrl+O now opens the "Open file:" prompt even when the file explorer has focus
2. Files opened via Quick Open (Ctrl+P) now properly transfer focus to the editor instead of keeping focus on the explorer

## Key Changes
- **Keymap update**: Added Ctrl+O binding to the `fileExplorer` context in `default.json`, allowing the open file action to be triggered from the file explorer
- **Focus reset**: Modified `prompt_actions.rs` to reset the key context to `Normal` after opening a file from Quick Open or LiveGrep, ensuring subsequent typing goes into the editor rather than the explorer's search filter
- **Test coverage**: Added comprehensive e2e tests (`file_explorer_open_focus.rs`) covering both scenarios:
  - `test_ctrl_o_opens_prompt_when_file_explorer_focused`: Verifies Ctrl+O works with explorer focused
  - `test_quick_open_focuses_editor_when_file_explorer_focused`: Verifies focus transfers to editor after Quick Open selection

## Implementation Details
The focus reset in `prompt_actions.rs` mirrors the existing behavior in the native file browser path (`file_open_open_file_at_location`), ensuring consistent focus handling across different file opening mechanisms. The key context is reset to `Normal` immediately after the buffer is opened, before any status message is displayed.

https://claude.ai/code/session_01EmhowH1eDs24PtqhLdJJf6