### PR TITLE
Move delete buttons from keybinding list to entry dialog

### DIFF
--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -101,7 +101,7 @@ fn set_json_pointer(root: &mut Value, pointer: &str, value: Value) {
 }
 
 /// Remove a value at a JSON pointer path.
-fn remove_json_pointer(root: &mut Value, pointer: &str) {
+pub(crate) fn remove_json_pointer(root: &mut Value, pointer: &str) {
     if pointer.is_empty() || pointer == "/" {
         return;
     }

--- a/crates/fresh-editor/src/view/controls/keybinding_list/input.rs
+++ b/crates/fresh-editor/src/view/controls/keybinding_list/input.rs
@@ -39,10 +39,6 @@ impl KeybindingListState {
         if let MouseEventKind::Down(MouseButton::Left) = event.kind {
             if let Some(hit) = layout.hit_test(event.column, event.row) {
                 match hit {
-                    KeybindingListHit::DeleteButton(index) => {
-                        self.remove_binding(index);
-                        return Some(KeybindingListEvent::BindingRemoved(index));
-                    }
                     KeybindingListHit::Entry(index) => {
                         self.focus_entry(index);
                         return Some(KeybindingListEvent::FocusChanged(Some(index)));
@@ -104,7 +100,6 @@ mod tests {
     fn make_layout() -> KeybindingListLayout {
         KeybindingListLayout {
             entry_rects: vec![(0, Rect::new(2, 1, 40, 1)), (1, Rect::new(2, 2, 40, 1))],
-            delete_rects: vec![Rect::new(38, 1, 3, 1), Rect::new(38, 2, 3, 1)],
             add_rect: Some(Rect::new(2, 3, 40, 1)),
         }
     }
@@ -116,17 +111,6 @@ mod tests {
             row: y,
             modifiers: KeyModifiers::empty(),
         }
-    }
-
-    #[test]
-    fn test_click_delete_button() {
-        let mut state = KeybindingListState::new("Test");
-        state.add_binding(serde_json::json!({"key": "a", "action": "test"}));
-        let layout = make_layout();
-
-        let result = state.handle_mouse(mouse_down(38, 1), &layout);
-        assert_eq!(result, Some(KeybindingListEvent::BindingRemoved(0)));
-        assert!(state.bindings.is_empty());
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/controls/keybinding_list/mod.rs
+++ b/crates/fresh-editor/src/view/controls/keybinding_list/mod.rs
@@ -201,7 +201,6 @@ pub struct KeybindingListColors {
     pub focused_bg: Color,
     /// Foreground color for focused entries (text on focused background)
     pub focused_fg: Color,
-    pub delete_fg: Color,
     pub add_fg: Color,
 }
 
@@ -214,7 +213,6 @@ impl Default for KeybindingListColors {
             row_bg: Color::Reset,
             focused_bg: Color::DarkGray,
             focused_fg: Color::White,
-            delete_fg: Color::Red,
             add_fg: Color::Green,
         }
     }
@@ -225,20 +223,12 @@ impl Default for KeybindingListColors {
 pub struct KeybindingListLayout {
     /// (data_index, screen_area) for each visible entry
     pub entry_rects: Vec<(usize, Rect)>,
-    pub delete_rects: Vec<Rect>,
     pub add_rect: Option<Rect>,
 }
 
 impl KeybindingListLayout {
     /// Find what was clicked at the given coordinates
     pub fn hit_test(&self, x: u16, y: u16) -> Option<KeybindingListHit> {
-        // Check delete buttons first (they overlap entry areas)
-        for (idx, rect) in self.delete_rects.iter().enumerate() {
-            if y == rect.y && x >= rect.x && x < rect.x + rect.width {
-                return Some(KeybindingListHit::DeleteButton(idx));
-            }
-        }
-
         // Check entry areas
         for &(data_idx, rect) in self.entry_rects.iter() {
             if y == rect.y && x >= rect.x && x < rect.x + rect.width {
@@ -262,8 +252,6 @@ impl KeybindingListLayout {
 pub enum KeybindingListHit {
     /// Clicked on an entry
     Entry(usize),
-    /// Clicked on delete button for entry
-    DeleteButton(usize),
     /// Clicked on add row
     AddRow,
 }
@@ -328,14 +316,9 @@ mod tests {
     fn test_keybinding_list_hit_test() {
         let layout = KeybindingListLayout {
             entry_rects: vec![(0, Rect::new(2, 1, 40, 1)), (1, Rect::new(2, 2, 40, 1))],
-            delete_rects: vec![Rect::new(38, 1, 3, 1), Rect::new(38, 2, 3, 1)],
             add_rect: Some(Rect::new(2, 3, 40, 1)),
         };
 
-        assert_eq!(
-            layout.hit_test(38, 1),
-            Some(KeybindingListHit::DeleteButton(0))
-        );
         assert_eq!(layout.hit_test(10, 1), Some(KeybindingListHit::Entry(0)));
         assert_eq!(layout.hit_test(10, 2), Some(KeybindingListHit::Entry(1)));
         assert_eq!(layout.hit_test(10, 3), Some(KeybindingListHit::AddRow));

--- a/crates/fresh-editor/src/view/controls/keybinding_list/render.rs
+++ b/crates/fresh-editor/src/view/controls/keybinding_list/render.rs
@@ -18,7 +18,6 @@ pub fn render_keybinding_list(
 ) -> KeybindingListLayout {
     let mut layout = KeybindingListLayout {
         entry_rects: Vec::new(),
-        delete_rects: Vec::new(),
         add_rect: None,
     };
 
@@ -62,9 +61,8 @@ pub fn render_keybinding_list(
 
         let indicator = if is_entry_focused { "> " } else { "  " };
         // Use focused_fg for all text when entry is focused for good contrast
-        let (indicator_fg, key_fg, arrow_fg, action_fg, delete_fg) = if is_entry_focused {
+        let (indicator_fg, key_fg, arrow_fg, action_fg) = if is_entry_focused {
             (
-                colors.focused_fg,
                 colors.focused_fg,
                 colors.focused_fg,
                 colors.focused_fg,
@@ -76,7 +74,6 @@ pub fn render_keybinding_list(
                 colors.key_fg,
                 colors.label_fg,
                 colors.action_fg,
-                colors.delete_fg,
             )
         };
         let line = Line::from(vec![
@@ -87,13 +84,8 @@ pub fn render_keybinding_list(
             ),
             Span::styled(" → ", Style::default().fg(arrow_fg).bg(bg)),
             Span::styled(action, Style::default().fg(action_fg).bg(bg)),
-            Span::styled(" [x]", Style::default().fg(delete_fg).bg(bg)),
         ]);
         frame.render_widget(Paragraph::new(line), entry_area);
-
-        // Track delete button area
-        let delete_x = entry_area.x + entry_area.width.saturating_sub(4);
-        layout.delete_rects.push(Rect::new(delete_x, y, 3, 1));
     }
 
     // Render add-new row

--- a/crates/fresh-editor/src/view/settings/entry_dialog.rs
+++ b/crates/fresh-editor/src/view/settings/entry_dialog.rs
@@ -54,6 +54,11 @@ pub struct EntryDialogState {
     /// When true, the dialog wraps a single non-Object value (e.g., an ObjectArray).
     /// `to_value()` returns the raw control value instead of wrapping in an Object.
     pub is_single_value: bool,
+    /// True when the dialog edits an item in an array (constructed via
+    /// `for_array_item`); false for map entries (`from_schema`). Drives
+    /// the Delete button's label/confirmation copy so the prompt doesn't
+    /// show a numeric index as if it were a meaningful name.
+    pub is_array_item: bool,
     /// Set to true on the first user-driven mutation (typed char,
     /// toggled bool, list add/remove, etc.). Drives the dirty
     /// indicator + the Esc discard prompt without relying on a
@@ -160,6 +165,7 @@ impl EntryDialogState {
             first_editable_index,
             no_delete,
             is_single_value,
+            is_array_item: false,
             user_edited: false,
         };
         // Pre-focus the first item in any ObjectArray controls so pressing
@@ -237,6 +243,7 @@ impl EntryDialogState {
             first_editable_index,
             no_delete: false, // Arrays typically allow deletion
             is_single_value: false,
+            is_array_item: true,
             user_edited: false,
         }
     }

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -6,6 +6,7 @@ use rust_i18n::t;
 
 use crate::primitives::display_width::str_width;
 
+use super::entry_dialog::EntryDialogState;
 use super::items::SettingControl;
 use super::layout::{SettingsHit, SettingsLayout};
 use super::search::{DeepMatch, SearchResult};
@@ -1352,7 +1353,6 @@ fn render_control(
                 // Use settings colors for focused items in settings UI
                 focused_bg: theme.settings_selected_bg,
                 focused_fg: theme.settings_selected_fg,
-                delete_fg: theme.diagnostic_error_fg,
                 add_fg: theme.syntax_string,
             };
             let kb_layout = render_keybinding_list_partial(frame, area, state, &colors, skip_rows);
@@ -2042,7 +2042,6 @@ fn render_keybinding_list_partial(
 
     let empty_layout = crate::view::controls::KeybindingListLayout {
         entry_rects: Vec::new(),
-        delete_rects: Vec::new(),
         add_rect: None,
     };
 
@@ -2053,7 +2052,6 @@ fn render_keybinding_list_partial(
     let indent = 2u16;
     let is_focused = state.focus == FocusState::Focused;
     let mut entry_rects = Vec::new();
-    let mut delete_rects = Vec::new();
     let mut content_row = 0u16;
     let mut y = area.y;
 
@@ -2102,9 +2100,8 @@ fn render_keybinding_list_partial(
 
             let indicator = if is_entry_focused { "> " } else { "  " };
             // Use focused_fg for all text when entry is focused for good contrast
-            let (indicator_fg, key_fg, arrow_fg, action_fg, delete_fg) = if is_entry_focused {
+            let (indicator_fg, key_fg, arrow_fg, action_fg) = if is_entry_focused {
                 (
-                    colors.focused_fg,
                     colors.focused_fg,
                     colors.focused_fg,
                     colors.focused_fg,
@@ -2116,21 +2113,16 @@ fn render_keybinding_list_partial(
                     colors.key_fg,
                     colors.label_fg,
                     colors.action_fg,
-                    colors.delete_fg,
                 )
             };
             // The KeybindingList widget is reused for non-keybinding
             // ObjectArrays (e.g. LSP servers under a language), where the
-            // `key_combo` column is always empty — a single LSP entry then
-            // rendered as `                           → clangd [x]`, with
-            // the empty Name column padding and an unexplained arrow. When
-            // there's nothing to put left of the arrow, collapse to just
-            // `action [x]` so the row reads like the form field it is.
+            // `key_combo` column is always empty. Collapse to just the
+            // action so the row reads as a single value.
             let line = if key_combo.trim().is_empty() {
                 Line::from(vec![
                     Span::styled(indicator, Style::default().fg(indicator_fg).bg(bg)),
                     Span::styled(action, Style::default().fg(action_fg).bg(bg)),
-                    Span::styled(" [x]", Style::default().fg(delete_fg).bg(bg)),
                 ])
             } else {
                 Line::from(vec![
@@ -2141,14 +2133,9 @@ fn render_keybinding_list_partial(
                     ),
                     Span::styled(" → ", Style::default().fg(arrow_fg).bg(bg)),
                     Span::styled(action, Style::default().fg(action_fg).bg(bg)),
-                    Span::styled(" [x]", Style::default().fg(delete_fg).bg(bg)),
                 ])
             };
             frame.render_widget(Paragraph::new(line), entry_area);
-
-            // Track delete button area
-            let delete_x = entry_area.x + entry_area.width.saturating_sub(4);
-            delete_rects.push(Rect::new(delete_x, y, 3, 1));
 
             y += 1;
         }
@@ -2184,7 +2171,6 @@ fn render_keybinding_list_partial(
 
     crate::view::controls::KeybindingListLayout {
         entry_rects,
-        delete_rects,
         add_rect,
     }
 }
@@ -3360,6 +3346,30 @@ fn render_entry_discard_confirm(
     );
 }
 
+/// Compute the footer Delete-button label for an entry dialog.
+///
+/// Schema-driven: shows the map key for map entries (e.g.
+/// `[ Delete "rust" ]`), a generic "item" for array items (the
+/// numeric index isn't meaningful to the user), or a bare fallback
+/// when neither is available. The key is truncated so a very long
+/// identifier can't blow out the dialog footer.
+fn entry_delete_button_label(dialog: &EntryDialogState) -> String {
+    const MAX_KEY_IN_LABEL: usize = 24;
+    if dialog.is_array_item {
+        "[ Delete item ]".to_string()
+    } else if dialog.entry_key.is_empty() {
+        "[ Delete entry ]".to_string()
+    } else {
+        let key = if dialog.entry_key.chars().count() > MAX_KEY_IN_LABEL {
+            let truncated: String = dialog.entry_key.chars().take(MAX_KEY_IN_LABEL - 1).collect();
+            format!("{}…", truncated)
+        } else {
+            dialog.entry_key.clone()
+        };
+        format!("[ Delete \"{}\" ]", key)
+    }
+}
+
 /// Render the "Delete <name>?" prompt that appears when the user
 /// activates the Delete button on an entry dialog.
 fn render_entry_delete_confirm(
@@ -3376,10 +3386,12 @@ fn render_entry_delete_confirm(
 
     frame.render_widget(Clear, dialog_area);
 
-    let title = if state.entry_delete_target_name.is_empty() {
-        " Delete entry? ".to_string()
-    } else {
+    let title = if !state.entry_delete_target_name.is_empty() {
         format!(" Delete \"{}\"? ", state.entry_delete_target_name)
+    } else if state.entry_delete_target_is_array_item {
+        " Delete item? ".to_string()
+    } else {
+        " Delete entry? ".to_string()
     };
 
     let block = Block::default()
@@ -3397,13 +3409,15 @@ fn render_entry_delete_confirm(
         dialog_area.height.saturating_sub(2),
     );
 
-    let body = if state.entry_delete_target_name.is_empty() {
-        "This will permanently remove the entry.".to_string()
-    } else {
+    let body = if !state.entry_delete_target_name.is_empty() {
         format!(
             "This will permanently remove \"{}\".",
             state.entry_delete_target_name
         )
+    } else if state.entry_delete_target_is_array_item {
+        "This will permanently remove this item.".to_string()
+    } else {
+        "This will permanently remove the entry.".to_string()
     };
     let prompt_style = Style::default().fg(theme.popup_text_fg);
     frame.render_widget(
@@ -3775,12 +3789,19 @@ fn render_entry_dialog_inner(
     // destructive action is impossible to hit by accidentally
     // tabbing one too many times. Delete keeps its red Danger
     // styling whether focused or not.
+    //
+    // The Delete label is scoped to the entry it acts on so the user
+    // can tell what gets removed without committing first. For map
+    // entries the entry_key (the map key) is shown; for array items
+    // the numeric index is useless to the user, so a generic "item"
+    // label is shown instead.
     let button_y = dialog_area.y + dialog_area.height - 2;
     let has_delete = !dialog.is_new && !dialog.no_delete;
-    let buttons: Vec<&str> = if has_delete {
-        vec!["[ Save ]", "[ Cancel ]", "[ Delete ]"]
+    let delete_label = entry_delete_button_label(dialog);
+    let buttons: Vec<String> = if has_delete {
+        vec!["[ Save ]".to_string(), "[ Cancel ]".to_string(), delete_label]
     } else {
-        vec!["[ Save ]", "[ Cancel ]"]
+        vec!["[ Save ]".to_string(), "[ Cancel ]".to_string()]
     };
     // Index of Delete (last entry, when present). Used for the
     // visual gap between safe buttons and Delete.
@@ -3861,7 +3882,7 @@ fn render_entry_dialog_inner(
             Style::default().fg(theme.editor_fg)
         };
         frame.render_widget(
-            Paragraph::new(*label).style(style),
+            Paragraph::new(label.as_str()).style(style),
             Rect::new(x, button_y, label.len() as u16, 1),
         );
         x += label.len() as u16;

--- a/crates/fresh-editor/src/view/settings/render.rs
+++ b/crates/fresh-editor/src/view/settings/render.rs
@@ -3361,7 +3361,11 @@ fn entry_delete_button_label(dialog: &EntryDialogState) -> String {
         "[ Delete entry ]".to_string()
     } else {
         let key = if dialog.entry_key.chars().count() > MAX_KEY_IN_LABEL {
-            let truncated: String = dialog.entry_key.chars().take(MAX_KEY_IN_LABEL - 1).collect();
+            let truncated: String = dialog
+                .entry_key
+                .chars()
+                .take(MAX_KEY_IN_LABEL - 1)
+                .collect();
             format!("{}…", truncated)
         } else {
             dialog.entry_key.clone()
@@ -3799,7 +3803,11 @@ fn render_entry_dialog_inner(
     let has_delete = !dialog.is_new && !dialog.no_delete;
     let delete_label = entry_delete_button_label(dialog);
     let buttons: Vec<String> = if has_delete {
-        vec!["[ Save ]".to_string(), "[ Cancel ]".to_string(), delete_label]
+        vec![
+            "[ Save ]".to_string(),
+            "[ Cancel ]".to_string(),
+            delete_label,
+        ]
     } else {
         vec!["[ Save ]".to_string(), "[ Cancel ]".to_string()]
     };

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -137,6 +137,11 @@ pub struct SettingsState {
     pub entry_delete_confirm_selection: usize,
     /// Key being deleted, displayed in the confirm prompt.
     pub entry_delete_target_name: String,
+    /// True when the entry-delete prompt is targeting an array item.
+    /// The confirm uses a generic "item" phrasing in this case since a
+    /// numeric index in `entry_delete_target_name` would mean nothing
+    /// to the user.
+    pub entry_delete_target_is_array_item: bool,
     /// Whether the help overlay is showing
     pub showing_help: bool,
     /// Scrollable panel for settings items
@@ -303,6 +308,7 @@ impl SettingsState {
             showing_entry_delete_confirm: false,
             entry_delete_confirm_selection: 0,
             entry_delete_target_name: String::new(),
+            entry_delete_target_is_array_item: false,
             showing_help: false,
             scroll_panel: ScrollablePanel::new(),
             sub_focus: None,
@@ -966,6 +972,19 @@ impl SettingsState {
     /// Apply pending changes to a config
     pub fn apply_changes(&self, config: &Config) -> Result<Config, serde_json::Error> {
         let mut config_value = serde_json::to_value(config)?;
+
+        // Process deletions first so a `pending_changes` write on the
+        // same path (rare but possible) still wins.
+        //
+        // Writing `null` at a map-entry path would fail to round-trip
+        // through the Config schema whenever the map's value type is
+        // non-nullable (e.g. `HashMap<String, LspLanguageConfig>`) —
+        // hence the dedicated removal path here, mirroring the
+        // remove-then-write order used by `save_changes_to_layer` when
+        // writing to disk.
+        for path in &self.pending_deletions {
+            crate::config_io::remove_json_pointer(&mut config_value, path);
+        }
 
         for (path, value) in &self.pending_changes {
             // `pointer_mut` only succeeds when the path already exists,
@@ -1928,11 +1947,15 @@ impl SettingsState {
     /// Cancel (selection 0) is the safe default, so a misplaced
     /// Tab+Enter on the Delete button no longer destroys data.
     pub fn request_entry_delete_confirm(&mut self) {
-        let name = self
+        let (name, is_array_item) = self
             .entry_dialog()
-            .map(|d| d.entry_key.clone())
+            .map(|d| (d.entry_key.clone(), d.is_array_item))
             .unwrap_or_default();
-        self.entry_delete_target_name = name;
+        // For array items the entry_key is a numeric index — meaningless
+        // to the user. Drop it and let the confirm render fall back to
+        // the generic "item" phrasing.
+        self.entry_delete_target_name = if is_array_item { String::new() } else { name };
+        self.entry_delete_target_is_array_item = is_array_item;
         self.entry_delete_confirm_selection = 0;
         self.showing_entry_delete_confirm = true;
     }
@@ -1983,8 +2006,15 @@ impl SettingsState {
             }
         }
 
-        // Record the pending change (null value signals deletion)
-        self.set_pending_change(&path, serde_json::Value::Null);
+        // Record the deletion. Earlier this wrote `null` via
+        // `set_pending_change`, but that round-trips through the Config
+        // schema as `<map>/<key> = null` — invalid whenever the map's
+        // value type is non-nullable. Routing through `pending_deletions`
+        // both removes the key cleanly from the in-memory Config (via
+        // `apply_changes`) and writes the removal to disk (via
+        // `save_changes_to_layer`'s `remove_json_pointer` step).
+        self.pending_changes.remove(&path);
+        self.pending_deletions.insert(path);
     }
 
     /// Get the maximum scroll offset for the current page (in rows)

--- a/crates/fresh-editor/tests/e2e/settings.rs
+++ b/crates/fresh-editor/tests/e2e/settings.rs
@@ -3781,7 +3781,7 @@ fn test_usability_entry_dialog_button_focus_indicator() {
         let screen = harness.screen_to_string();
         // The ">" indicator is rendered with a gap before the button bracket
         if screen.contains("> [ Save ]")
-            || screen.contains("> [ Delete ]")
+            || screen.contains("> [ Delete")
             || screen.contains("> [ Cancel ]")
         {
             has_focused_button = true;

--- a/crates/fresh-editor/tests/e2e/settings_ui_usability.rs
+++ b/crates/fresh-editor/tests/e2e/settings_ui_usability.rs
@@ -109,14 +109,19 @@ fn focused_field(screen: &str) -> Option<String> {
 /// Helper: find which button has focus by looking for the ">" indicator
 /// rendered before button text. The ">" is at a separate cell position,
 /// so we search for it in the vicinity of button labels.
+///
+/// The Delete button's label is scope-aware — `[ Delete ]`, `[ Delete item ]`,
+/// or `[ Delete "<key>" ]` depending on whether the entry dialog is over
+/// a map entry or an array item — so the match is on the `[ <name>` prefix
+/// rather than the full bracketed string.
 fn focused_button(harness: &EditorTestHarness) -> Option<String> {
     let screen = harness.screen_to_string();
     let buttons = ["Save", "Delete", "Cancel"];
 
     for (row_idx, line) in screen.lines().enumerate() {
         for button in &buttons {
-            let label = format!("[ {} ]", button);
-            if let Some(col) = line.find(&label) {
+            let label_prefix = format!("[ {}", button);
+            if let Some(col) = line.find(&label_prefix) {
                 // Check for ">" indicator in the 1-3 cells before the button
                 let col = col as u16;
                 let row = row_idx as u16;


### PR DESCRIPTION
## Summary
Refactors the deletion UI for keybinding and array entries by removing inline delete buttons from the keybinding list widget and consolidating deletion into the entry dialog. This improves UX by making the delete action more discoverable and providing better confirmation messaging.

## Key Changes

- **Removed inline delete buttons from keybinding list**: Deleted the `[x]` delete button rendering and hit-testing logic from both the settings keybinding list and the standalone keybinding list widget. This includes removing `delete_rects` tracking and `DeleteButton` hit type.

- **Consolidated deletion into entry dialog**: Delete functionality now exclusively lives in the entry dialog footer, accessed via a dedicated Delete button that only appears for non-new entries.

- **Enhanced delete confirmation messaging**: 
  - Added `entry_delete_target_is_array_item` field to distinguish between map entries and array items
  - Implemented `entry_delete_button_label()` function that generates context-aware labels (e.g., `[ Delete "rust" ]` for maps, `[ Delete item ]` for arrays)
  - Updated confirmation prompts to use appropriate phrasing based on entry type

- **Fixed deletion handling in state management**:
  - Changed from writing `null` values (which fail schema validation for non-nullable map types) to using a dedicated `pending_deletions` set
  - Process deletions before writes in `apply_changes()` to ensure proper ordering
  - Made `remove_json_pointer()` public for use in config application

- **Updated entry dialog state**: Added `is_array_item` field to `EntryDialogState` to track whether the dialog is editing an array item or map entry, set appropriately in `from_schema()` and `for_array_item()` constructors.

## Implementation Details

The delete button label is intelligently scoped to the entry being deleted, showing the map key for map entries (truncated to 24 chars if needed) or a generic "item" label for array items. This prevents confusing users with numeric indices that have no semantic meaning.

The deletion path now properly handles non-nullable map value types by removing the key entirely rather than attempting to set it to null, which aligns with the disk-write behavior in `save_changes_to_layer()`.

https://claude.ai/code/session_017eq3BaFfawfbTVGZXfCvNx