### PR TITLE
fix(split): set_pane_buffer registers buffer as a tab

### DIFF
--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -3292,6 +3292,7 @@ impl Window {
         mgr.set_split_buffer(leaf, buffer_id);
         if let Some(view_state) = vs_map.get_mut(&leaf) {
             view_state.switch_buffer(buffer_id);
+            view_state.add_buffer(buffer_id);
         }
     }
 }


### PR DESCRIPTION
The dock fast-path mounted a virtual buffer via set_pane_buffer, which marked it active in the leaf but never inserted it into the view state's open_buffers list. Result: the panel rendered on top of the dock with no tab and no way to switch back to siblings like Terminal 1.

set_pane_buffer is the documented chokepoint for "buffer X shown in pane Y" (active_focus.rs), so the missing tab registration goes there — every caller benefits and the two-step dance is gone.