### PR TITLE
fix: clear panel-scoped editor mode when switching away from a window

### DIFF
--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -284,6 +284,32 @@ impl crate::app::Editor {
 
         let previous_id = self.active_window;
 
+        // A plugin-defined editor mode (`editor.setEditorMode`) tied to a
+        // mounted floating widget panel — the Orchestrator picker
+        // (`orchestrator-open`) or new-session form (`orchestrator-new-form`)
+        // — is transient UI state that belongs to the *panel*, not to the
+        // window it was opened over. `setEditorMode` writes to whatever
+        // window is active when the plugin calls it, so a plugin that
+        // switches the active window while its panel is still mounted
+        // (the orchestrator "dive": `setActiveWindow(target)` first, then
+        // `closeOpenDialog()` which runs `setEditorMode(null)`) lands the
+        // clear on the *incoming* window and leaves the *outgoing* one
+        // stuck in the panel's mode. That stuck mode stays masked while the
+        // window sits in terminal mode, then silently swallows every
+        // printable key the moment the user leaves terminal mode (e.g.
+        // opens a file via quick-open) — the buffer ignores all keyboard
+        // input until the user switches sessions back and forth (which
+        // re-dives into the window and finally clears it). Clear any
+        // panel-scoped mode on the outgoing window here so it can never
+        // outlive the switch. vi-mode and other persistent per-window modes
+        // are unaffected: they never have a floating panel mounted during a
+        // window switch.
+        if self.floating_widget_panel.is_some() {
+            if let Some(win) = self.windows.get_mut(&previous_id) {
+                win.editor_mode = None;
+            }
+        }
+
         // Lazy materialization: if this window's saved workspace hasn't
         // been restored yet, restore it now (before seeding) so the
         // dive lands on real content rather than an empty buffer.

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -129,6 +129,7 @@ pub mod on_save_actions;
 pub mod open_folder;
 pub mod orchestrator_dock;
 pub mod overlay_extend_to_line_end;
+pub mod panel_mode_window_switch_leak;
 pub mod paste;
 #[cfg(feature = "plugins")]
 pub mod plugins;

--- a/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
+++ b/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
@@ -1,0 +1,105 @@
+//! Regression test: a floating-panel-scoped editor mode must not
+//! leak onto a window the user switches *away* from.
+//!
+//! Bug: after using the Orchestrator (which mounts a floating widget
+//! panel — the session picker / new-session form — and sets a
+//! per-window `editor_mode` via `setEditorMode`), then interacting
+//! with a session's terminal and opening a file via quick-open, the
+//! newly opened buffer ignored *all* keyboard input — no cursor
+//! movement, no edits, no status-bar feedback — until the user
+//! "switched orchestrator sessions back and forth".
+//!
+//! Root cause: `setEditorMode` writes to whichever window is active
+//! when the plugin calls it. The orchestrator "dive" switches the
+//! active window (`setActiveWindow(target)`) *before* it clears the
+//! mode (`closeOpenDialog()` → `setEditorMode(null)`), so the clear
+//! lands on the destination window and the source window is left
+//! stuck in the panel's mode. That mode is masked while the window
+//! sits in terminal mode and then silently swallows every printable
+//! key once the user leaves terminal mode (opens a file).
+//!
+//! Fix: `set_active_window` clears the outgoing window's `editor_mode`
+//! whenever a floating widget panel is mounted — a panel-scoped mode
+//! belongs to the (global) panel, not the window it was opened over.
+//!
+//! This test reproduces the leak with a minimal plugin-command
+//! sequence: mount a panel + set a mode on window A, switch to B,
+//! switch back to A, and assert A's mode was cleared (it would still
+//! be `Some(...)` — and thus eat input — without the fix).
+
+use crate::common::harness::EditorTestHarness;
+use fresh_core::api::{PluginCommand, WidgetSpec};
+
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 40;
+
+/// Minimal valid panel spec — its contents don't matter, only that a
+/// floating widget panel is mounted (`floating_widget_panel.is_some()`).
+fn minimal_panel_spec() -> WidgetSpec {
+    WidgetSpec::Spacer {
+        cols: 1,
+        flex: false,
+        key: None,
+    }
+}
+
+#[test]
+fn panel_mode_does_not_leak_onto_window_switched_away_from() {
+    let mut harness = EditorTestHarness::with_temp_project(WIDTH, HEIGHT).unwrap();
+
+    // Window A is the base window (id 1), active at boot. Window B is
+    // a second project window we create but do NOT activate yet.
+    // Keep the tempdir alive for the test's duration (dropping it
+    // would delete B's root out from under the harness).
+    let win_b_dir = tempfile::tempdir().unwrap();
+    let win_b = harness
+        .editor_mut()
+        .create_window_at(win_b_dir.path().to_path_buf(), "session-b".into());
+
+    // Simulate the Orchestrator picker on window A: mount a floating
+    // widget panel and set a panel-scoped editor mode. This is exactly
+    // what `openControlRoom` does (`setEditorMode("orchestrator-open")`
+    // + a mounted picker panel).
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::MountFloatingWidget {
+            panel_id: 1,
+            spec: minimal_panel_spec(),
+            width_pct: 50,
+            height_pct: 50,
+            as_dock: false,
+        })
+        .unwrap();
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::SetEditorMode {
+            mode: Some("orchestrator-open".into()),
+        })
+        .unwrap();
+
+    assert_eq!(
+        harness.editor().editor_mode(),
+        Some("orchestrator-open".to_string()),
+        "precondition: window A should hold the panel-scoped mode"
+    );
+
+    // The "dive": switch the active window while the panel is still
+    // mounted (mirrors the orchestrator calling `setActiveWindow`
+    // before `closeOpenDialog`'s `setEditorMode(null)`).
+    harness.editor_mut().set_active_window(win_b);
+
+    // Return to window A by any non-picker route (the host
+    // Next/Prev Window cycle, a tab click, etc. — none of which clear
+    // a plugin mode). Without the fix, A is still stuck in
+    // "orchestrator-open" here.
+    harness
+        .editor_mut()
+        .set_active_window(fresh_core::WindowId(1));
+
+    assert_eq!(
+        harness.editor().editor_mode(),
+        None,
+        "panel-scoped mode leaked onto window A after switching away \
+         and back — it would silently swallow all buffer input"
+    );
+}


### PR DESCRIPTION
After interacting with an Orchestrator session's terminal and then
opening a file via quick-open, the newly opened buffer ignored all
keyboard input — no cursor movement, no edits, no status-bar feedback —
until the user "switched orchestrator sessions back and forth".

Root cause: the Orchestrator picker / new-session form sets a per-window
`editor_mode` via `setEditorMode`, which writes to whichever window is
active when the plugin calls it. The "dive" switches the active window
(`setActiveWindow(target)`) before clearing the mode (`closeOpenDialog`
→ `setEditorMode(null)`), so the clear lands on the destination window
and the source window is left stuck in the panel's mode. That mode is
masked while the window sits in terminal mode, then — once the user
leaves terminal mode by opening a file — becomes the effective mode and
silently swallows every printable key (read-only / text-input modes
route chars to a now-closed panel). Re-diving into the window via the
picker finally runs `setEditorMode(null)` while it is active, which is
why switching sessions back and forth "fixes" it.

Fix: a floating-panel-scoped editor mode belongs to the (global) panel,
not the window it was opened over. `set_active_window` now clears the
outgoing window's `editor_mode` whenever a floating widget panel is
mounted. This covers every leak path (dive, kill/archive auto-switch,
…) at a single point. vi-mode and other persistent per-window modes are
unaffected — they never have a floating panel mounted during a window
switch.

Adds an e2e regression test that mounts a panel + sets a mode on one
window, switches away and back, and asserts the mode was cleared (it
stays stuck — and eats input — without the fix).