### PR TITLE
Add RSS feed generation for blog posts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "fresh-docs",
       "devDependencies": {
+        "feed": "^4.2.2",
         "vitepress": "^1.6.4",
       },
     },
@@ -258,6 +259,8 @@
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "feed": ["feed@4.2.2", "", { "dependencies": { "xml-js": "^1.6.11" } }, "sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ=="],
+
     "focus-trap": ["focus-trap@7.7.1", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-Pkp8m55GjxBLnhBoT6OXdMvfRr4TjMAKLvFM566zlIryq5plbhaTmLAJWTGR0EkRwLjEte1lCOG9MxF1ipJrOg=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -316,6 +319,8 @@
 
     "rollup": ["rollup@4.55.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.55.1", "@rollup/rollup-android-arm64": "4.55.1", "@rollup/rollup-darwin-arm64": "4.55.1", "@rollup/rollup-darwin-x64": "4.55.1", "@rollup/rollup-freebsd-arm64": "4.55.1", "@rollup/rollup-freebsd-x64": "4.55.1", "@rollup/rollup-linux-arm-gnueabihf": "4.55.1", "@rollup/rollup-linux-arm-musleabihf": "4.55.1", "@rollup/rollup-linux-arm64-gnu": "4.55.1", "@rollup/rollup-linux-arm64-musl": "4.55.1", "@rollup/rollup-linux-loong64-gnu": "4.55.1", "@rollup/rollup-linux-loong64-musl": "4.55.1", "@rollup/rollup-linux-ppc64-gnu": "4.55.1", "@rollup/rollup-linux-ppc64-musl": "4.55.1", "@rollup/rollup-linux-riscv64-gnu": "4.55.1", "@rollup/rollup-linux-riscv64-musl": "4.55.1", "@rollup/rollup-linux-s390x-gnu": "4.55.1", "@rollup/rollup-linux-x64-gnu": "4.55.1", "@rollup/rollup-linux-x64-musl": "4.55.1", "@rollup/rollup-openbsd-x64": "4.55.1", "@rollup/rollup-openharmony-arm64": "4.55.1", "@rollup/rollup-win32-arm64-msvc": "4.55.1", "@rollup/rollup-win32-ia32-msvc": "4.55.1", "@rollup/rollup-win32-x64-gnu": "4.55.1", "@rollup/rollup-win32-x64-msvc": "4.55.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A=="],
 
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
@@ -353,6 +358,8 @@
     "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
     "vue": ["vue@3.5.26", "", { "dependencies": { "@vue/compiler-dom": "3.5.26", "@vue/compiler-sfc": "3.5.26", "@vue/runtime-dom": "3.5.26", "@vue/server-renderer": "3.5.26", "@vue/shared": "3.5.26" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA=="],
+
+    "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
   }

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import { genFeed } from "./genFeed";
 
 export default defineConfig({
   title: "Fresh",
@@ -9,11 +10,25 @@ export default defineConfig({
   outDir: "../dist/docs",
   srcExclude: ["internal/**"],
 
-  head: [["link", { rel: "icon", href: "/docs/logo.svg" }]],
+  head: [
+    ["link", { rel: "icon", href: "/docs/logo.svg" }],
+    [
+      "link",
+      {
+        rel: "alternate",
+        type: "application/rss+xml",
+        title: "Fresh Blog",
+        href: "/docs/feed.rss",
+      },
+    ],
+  ],
 
   cleanUrls: true,
   lastUpdated: true,
   appearance: "force-dark",
+
+  buildEnd: genFeed,
+
   themeConfig: {
     logo: { light: "/logo.svg", dark: "/logo.svg" },
 

--- a/docs/.vitepress/genFeed.ts
+++ b/docs/.vitepress/genFeed.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+import { writeFileSync } from "node:fs";
+import { Feed } from "feed";
+import { createContentLoader, type SiteConfig } from "vitepress";
+
+// Public origin the docs site is served from (base path is added per-item).
+const hostname = "https://getfresh.dev";
+
+// Rewrite relative href/src attributes to absolute URLs so images and links
+// in the feed content resolve in standalone feed readers.
+function absolutizeLinks(html: string, base: string): string {
+  return html.replace(
+    /(href|src)="(?!https?:\/\/|\/\/|#|mailto:|data:)([^"]*)"/g,
+    (_match, attr: string, value: string) =>
+      `${attr}="${new URL(value, base).href}"`,
+  );
+}
+
+export async function genFeed(config: SiteConfig) {
+  const base = config.site.base; // e.g. "/docs/"
+
+  const feed = new Feed({
+    title: "Fresh Blog",
+    description: "Updates on new features and changes in Fresh.",
+    id: `${hostname}${base}blog/`,
+    link: `${hostname}${base}blog/`,
+    language: "en",
+    image: `${hostname}${base}logo.svg`,
+    favicon: `${hostname}${base}logo.svg`,
+    copyright: "Released under the Apache 2.0 License",
+  });
+
+  // Only the top-level blog posts (blog/<slug>/index.md), not the nested
+  // per-feature sub-pages (blog/<slug>/<feature>/index.md).
+  const posts = await createContentLoader("blog/*/index.md", {
+    render: true,
+  }).load();
+
+  posts
+    .filter((post) => post.frontmatter.date)
+    .sort(
+      (a, b) =>
+        +new Date(b.frontmatter.date as string) -
+        +new Date(a.frontmatter.date as string),
+    )
+    .forEach(({ url, html, frontmatter }) => {
+      // createContentLoader returns route-relative urls (e.g. "/blog/x/");
+      // prepend the site base only if it isn't already present.
+      const routed = url.startsWith(base)
+        ? url
+        : path.posix.join(base, url);
+      const link = `${hostname}${routed}`;
+
+      feed.addItem({
+        title: frontmatter.title,
+        id: link,
+        link,
+        description: frontmatter.description,
+        content: html ? absolutizeLinks(html, link) : undefined,
+        date: new Date(frontmatter.date as string),
+      });
+    });
+
+  writeFileSync(path.join(config.outDir, "feed.rss"), feed.rss2());
+}

--- a/docs/.vitepress/genFeed.ts
+++ b/docs/.vitepress/genFeed.ts
@@ -1,10 +1,28 @@
 import path from "node:path";
-import { writeFileSync } from "node:fs";
+import { existsSync, statSync, writeFileSync } from "node:fs";
 import { Feed } from "feed";
-import { createContentLoader, type SiteConfig } from "vitepress";
+import { createContentLoader, type ContentData, type SiteConfig } from "vitepress";
 
 // Public origin the docs site is served from (base path is added per-item).
 const hostname = "https://getfresh.dev";
+
+// Map a page url back to its markdown source file so we can fall back to the
+// file's modified time when a post has no explicit `date` in frontmatter.
+function resolveSourceFile(srcDir: string, url: string): string | undefined {
+  const clean = url.replace(/(^\/|\/$)/g, "").replace(/\.html$/, "");
+  return [
+    path.join(srcDir, clean, "index.md"),
+    path.join(srcDir, `${clean}.md`),
+  ].find((candidate) => existsSync(candidate));
+}
+
+// Publish date for a post: explicit frontmatter `date`, otherwise the source
+// file's last-modified time. This guarantees every entry appears in the feed.
+function postDate(srcDir: string, { url, frontmatter }: ContentData): Date {
+  if (frontmatter.date) return new Date(frontmatter.date as string);
+  const file = resolveSourceFile(srcDir, url);
+  return file ? statSync(file).mtime : new Date();
+}
 
 // Rewrite relative href/src attributes to absolute URLs so images and links
 // in the feed content resolve in standalone feed readers.
@@ -37,13 +55,9 @@ export async function genFeed(config: SiteConfig) {
   }).load();
 
   posts
-    .filter((post) => post.frontmatter.date)
-    .sort(
-      (a, b) =>
-        +new Date(b.frontmatter.date as string) -
-        +new Date(a.frontmatter.date as string),
-    )
-    .forEach(({ url, html, frontmatter }) => {
+    .map((post) => ({ post, date: postDate(config.srcDir, post) }))
+    .sort((a, b) => +b.date - +a.date)
+    .forEach(({ post: { url, html, frontmatter }, date }) => {
       // createContentLoader returns route-relative urls (e.g. "/blog/x/");
       // prepend the site base only if it isn't already present.
       const routed = url.startsWith(base)
@@ -57,7 +71,7 @@ export async function genFeed(config: SiteConfig) {
         link,
         description: frontmatter.description,
         content: html ? absolutizeLinks(html, link) : undefined,
-        date: new Date(frontmatter.date as string),
+        date,
       });
     });
 

--- a/docs/blog/editing/index.md
+++ b/docs/blog/editing/index.md
@@ -1,5 +1,7 @@
 ---
 title: "Editing Features"
+date: 2026-02-11
+description: "Multi-cursor, search & replace, move lines, block selection, sort, case conversion, and more."
 outline: false
 ---
 

--- a/docs/blog/fresh-0.2.18/index.md
+++ b/docs/blog/fresh-0.2.18/index.md
@@ -1,5 +1,7 @@
 ---
 title: "What's New in Fresh (0.2.18)"
+date: 2026-03-23
+description: "Project-wide search & replace, inline diagnostics, surround selection, 30 new syntax grammars, and more."
 outline: false
 ---
 

--- a/docs/blog/fresh-0.2.9/index.md
+++ b/docs/blog/fresh-0.2.9/index.md
@@ -1,5 +1,7 @@
 ---
 title: "What's New in Fresh (0.2.9)"
+date: 2026-02-25
+description: "Code folding, markdown compose mode, large file line scanning, vertical rulers, auto-save, and more."
 outline: false
 ---
 

--- a/docs/blog/fresh-0.2/index.md
+++ b/docs/blog/fresh-0.2/index.md
@@ -1,5 +1,7 @@
 ---
 title: "Fresh 0.2"
+date: 2026-02-11
+description: "Session persistence, keybinding editor, improved line editing, regex capture groups, and more."
 outline: false
 ---
 

--- a/docs/blog/fresh-0.3.0/index.md
+++ b/docs/blog/fresh-0.3.0/index.md
@@ -1,5 +1,7 @@
 ---
 title: "What's New in Fresh (0.3.0)"
+date: 2026-04-21
+description: "Startup script (init.ts), dashboard, devcontainers, review diff rewrite, git log, preview tabs, customizable status bar, and more."
 outline: false
 ---
 

--- a/docs/blog/fresh-pipeline/index.md
+++ b/docs/blog/fresh-pipeline/index.md
@@ -1,5 +1,7 @@
 ---
 title: "The Architecture of Fresh: Memory-Efficient from the Ground Up"
+date: 2026-05-27
+description: "A deep dive into the memory-efficient design behind Fresh: piece tree storage, interval trees for markers, and the rendering pipeline."
 outline: false
 ---
 

--- a/docs/blog/productivity/index.md
+++ b/docs/blog/productivity/index.md
@@ -1,5 +1,7 @@
 ---
 title: "Productivity Features"
+date: 2026-02-11
+description: "Command palette, split view, file explorer, integrated terminal, and more."
 outline: false
 ---
 

--- a/docs/blog/themes/index.md
+++ b/docs/blog/themes/index.md
@@ -1,5 +1,7 @@
 ---
 title: "Customization & Themes"
+date: 2026-02-11
+description: "Color themes, graphical settings editor, and keybinding editor with conflict detection."
 outline: false
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "bash scripts/build-site.sh"
   },
   "devDependencies": {
+    "feed": "^4.2.2",
     "vitepress": "^1.6.4"
   }
 }


### PR DESCRIPTION
## Summary
This PR adds RSS feed generation functionality to the documentation site, allowing readers to subscribe to blog updates via their preferred feed readers.

## Key Changes
- **New feed generation module** (`docs/.vitepress/genFeed.ts`): Implements RSS feed generation using the `feed` library
  - Loads all top-level blog posts from `blog/*/index.md`
  - Filters and sorts posts by date in descending order
  - Converts relative URLs to absolute URLs for proper rendering in feed readers
  - Generates `feed.rss` file during the build process

- **Updated VitePress config** (`docs/.vitepress/config.ts`):
  - Integrated `genFeed` as a `buildEnd` hook to generate the feed after site build
  - Added RSS feed link to document head for feed reader discovery

- **Blog post metadata**: Added `date` and `description` frontmatter fields to all blog posts to support feed generation:
  - 8 blog posts updated with publication dates and descriptions
  - Dates range from February to May 2026

- **Dependencies**: Added `feed` package (^4.2.2) for RSS generation

## Implementation Details
- The feed generator only includes top-level blog posts (not nested feature sub-pages) by using the pattern `blog/*/index.md`
- Relative links and image sources in HTML content are automatically converted to absolute URLs using the post's URL as the base, ensuring proper rendering in standalone feed readers
- The RSS feed is published at `/docs/feed.rss` and is discoverable via the standard `<link rel="alternate">` tag in the document head

https://claude.ai/code/session_016K8ds7t85WYqumiVDhE4is