### PR TITLE
Add SSH terminal wrapper for remote integrated terminals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,15 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest
-      # Install Vulkan + Xvfb for headless GPU testing (Linux only)
+      # Install Vulkan + Xvfb for headless GPU testing (Linux only).
+      # openssh-server/client back the remote-mode SSH terminal integration
+      # test (tests/remote_ssh_terminal.rs), which spins up a throwaway
+      # non-root sshd on localhost; it skips itself if these are absent.
       - name: Install Vulkan and Xvfb
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y mesa-vulkan-drivers libvulkan1 xvfb libxkbcommon-x11-0
+          sudo apt-get install -y mesa-vulkan-drivers libvulkan1 xvfb libxkbcommon-x11-0 openssh-server openssh-client
       # enable this ci template to run regardless of whether the lockfile is checked in or not
       - name: cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1412,7 +1412,7 @@ fn connect_remote(
     // We need a runtime context for tokio::spawn inside spawn_reconnect_task.
     let reconnect_handle = {
         let _guard = rt.enter();
-        remote::spawn_reconnect_task(channel, reconnect_params)
+        remote::spawn_reconnect_task(channel, reconnect_params.clone())
     };
 
     // SSH authority: leave the display label empty so the status bar
@@ -1423,6 +1423,8 @@ fn connect_remote(
             filesystem,
             process_spawner,
             long_running_spawner,
+            &reconnect_params,
+            Some(remote.path.as_str()),
             trust.clone(),
             env.clone(),
         ),

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -22,8 +22,10 @@
 //! - `Authority::local(trust, env)` — host filesystem + host spawner + host
 //!   shell. Always available; the editor boots with this. Trust + env are
 //!   mandatory shared handles.
-//! - `Authority::ssh(filesystem, spawner, long_running, trust, env)` — used by
-//!   the `fresh user@host:path` startup flow.
+//! - `Authority::ssh(filesystem, spawner, long_running, params, remote_dir,
+//!   trust, env)` — used by the `fresh user@host:path` startup flow. `params`
+//!   and `remote_dir` build the `ssh -t …` terminal wrapper so the integrated
+//!   terminal opens on the remote host.
 //! - `Authority::from_plugin_payload(payload, trust, env)` — built from the
 //!   `editor.setAuthority(...)` plugin op. The payload is a tagged shape
 //!   (filesystem kind + spawner kind + terminal wrapper + label); it stays
@@ -37,7 +39,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::filesystem::{FileSystem, StdFileSystem};
 use crate::services::remote::{
-    LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner, ProcessSpawner,
+    build_ssh_terminal_args, ConnectionParams, LocalLongRunningSpawner, LocalProcessSpawner,
+    LongRunningSpawner, ProcessSpawner,
 };
 use crate::services::workspace_trust::WorkspaceTrust;
 
@@ -120,6 +123,22 @@ impl TerminalWrapper {
             command: crate::services::terminal::manager::detect_shell(),
             args: Vec::new(),
             manages_cwd: false,
+        }
+    }
+
+    /// Re-parent the integrated terminal onto the remote host over SSH:
+    /// `ssh -t … user@host 'cd <dir>; exec $SHELL -l'`. Like the
+    /// `docker exec -w …` wrapper, this pins cwd through its own args
+    /// (`cd <dir>`), so `manages_cwd` is true and the terminal manager
+    /// must not call `CommandBuilder::cwd()` with a remote path the local
+    /// PTY can't honour. Without this, SSH authorities would fall back to
+    /// the local host shell and the embedded terminal would run on the
+    /// *local* machine instead of the remote host.
+    pub fn ssh(params: &ConnectionParams, remote_dir: Option<&str>) -> Self {
+        Self {
+            command: "ssh".to_string(),
+            args: build_ssh_terminal_args(params, remote_dir),
+            manages_cwd: true,
         }
     }
 
@@ -311,10 +330,18 @@ impl Authority {
     /// ([`RemoteLongRunningSpawner`](crate::services::remote::RemoteLongRunningSpawner)),
     /// so LSP servers run on the remote host rather than the host-local
     /// fallback that earlier versions used.
+    ///
+    /// `params` / `remote_dir` build the integrated-terminal wrapper so the
+    /// embedded terminal opens a shell *on the remote host* (`ssh -t …`)
+    /// rooted at the workspace, matching where the filesystem and spawners
+    /// already act. Earlier versions hardcoded the local host shell here,
+    /// so terminals silently ran on the local machine.
     pub fn ssh(
         filesystem: Arc<dyn FileSystem + Send + Sync>,
         process_spawner: Arc<dyn ProcessSpawner>,
         long_running_spawner: Arc<dyn LongRunningSpawner>,
+        params: &ConnectionParams,
+        remote_dir: Option<&str>,
         trust: Arc<WorkspaceTrust>,
         env: Arc<crate::services::env_provider::EnvProvider>,
     ) -> Self {
@@ -322,7 +349,7 @@ impl Authority {
             filesystem,
             process_spawner,
             long_running_spawner,
-            terminal_wrapper: TerminalWrapper::host_shell(),
+            terminal_wrapper: TerminalWrapper::ssh(params, remote_dir),
             display_label: String::new(),
             path_translation: None,
             workspace_trust: trust,

--- a/crates/fresh-editor/src/services/remote/mod.rs
+++ b/crates/fresh-editor/src/services/remote/mod.rs
@@ -31,8 +31,9 @@ pub use protocol::{
     write_params, AgentRequest, AgentResponse,
 };
 pub use spawner::{
-    LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner, ProcessSpawner,
-    RemoteLongRunningSpawner, RemoteProcessSpawner, SpawnError, SpawnResult, StdioChild,
+    build_ssh_terminal_args, LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner,
+    ProcessSpawner, RemoteLongRunningSpawner, RemoteProcessSpawner, SpawnError, SpawnResult,
+    StdioChild,
 };
 
 /// The Python agent source code, embedded at compile time.

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -863,6 +863,57 @@ fn build_ssh_args(
     a
 }
 
+/// Assemble the `ssh` argv for an *interactive terminal* under a remote
+/// authority. Unlike [`build_ssh_args`] (one-shot, non-interactive LSP /
+/// probe spawns) this:
+///
+/// * forces remote PTY allocation with `-t` so the remote shell behaves
+///   interactively (job control, line editing, a real prompt);
+/// * omits `BatchMode=yes` so auth prompts (key passphrase, password,
+///   2FA) can surface *inside* the embedded terminal rather than failing;
+/// * runs an interactive login shell (`exec ${SHELL:-/bin/sh} -l`) after
+///   `cd`-ing into the workspace, so the user lands where the editor is
+///   rooted with their normal remote environment.
+///
+/// Returned as the argv *after* the leading `ssh` program name; the caller
+/// (the SSH terminal wrapper) sets `command = "ssh"` and these as `args`.
+pub fn build_ssh_terminal_args(
+    params: &crate::services::remote::ConnectionParams,
+    remote_dir: Option<&str>,
+) -> Vec<String> {
+    let mut a = vec![
+        "-t".to_string(),
+        "-o".to_string(),
+        "StrictHostKeyChecking=accept-new".to_string(),
+    ];
+    if let Some(port) = params.port {
+        a.push("-p".to_string());
+        a.push(port.to_string());
+    }
+    if let Some(ref identity) = params.identity_file {
+        a.push("-i".to_string());
+        a.push(identity.to_string_lossy().into_owned());
+    }
+    a.push(format!("{}@{}", params.user, params.host));
+
+    // Land in the workspace (when known), then hand control to the user's
+    // login shell. `remote_dir` is whatever path the URL pointed at, which
+    // may be a *file* (`fresh ssh://host/proj/main.rs`) — so fall back to
+    // its parent dir, and treat a failed `cd` as non-fatal so the shell
+    // always starts. `exec` replaces the ssh-side shell so closing the
+    // terminal tears the session down cleanly.
+    let mut remote_cmd = String::new();
+    if let Some(dir) = remote_dir.filter(|d| !d.is_empty()) {
+        let quoted = shell_quote(dir);
+        remote_cmd.push_str(&format!(
+            "d={quoted}; [ -d \"$d\" ] || d=$(dirname \"$d\"); cd \"$d\" 2>/dev/null; "
+        ));
+    }
+    remote_cmd.push_str("exec ${SHELL:-/bin/sh} -l");
+    a.push(remote_cmd);
+    a
+}
+
 /// Long-running spawner over SSH: each LSP server (or tool agent) gets its own
 /// `ssh user@host <remote-cmd>` subprocess, whose piped stdio *is* the remote
 /// process's stdio. Returning a real local [`tokio::process::Child`] (the ssh
@@ -1207,5 +1258,56 @@ mod tests {
         .map(String::from)
         .collect();
         assert_eq!(a, expected);
+    }
+
+    #[test]
+    fn build_ssh_terminal_args_forces_tty_and_login_shell() {
+        let params = crate::services::remote::ConnectionParams {
+            user: "u".into(),
+            host: "h".into(),
+            port: Some(2222),
+            identity_file: Some(std::path::PathBuf::from("/k")),
+        };
+        let a = build_ssh_terminal_args(&params, Some("/proj dir"));
+        let expected: Vec<String> = [
+            "-t",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-p",
+            "2222",
+            "-i",
+            "/k",
+            "u@h",
+            "d='/proj dir'; [ -d \"$d\" ] || d=$(dirname \"$d\"); cd \"$d\" 2>/dev/null; exec ${SHELL:-/bin/sh} -l",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        assert_eq!(a, expected);
+        // No BatchMode — interactive auth must be able to prompt in the PTY.
+        assert!(!a.iter().any(|s| s == "BatchMode=yes"));
+    }
+
+    #[test]
+    fn build_ssh_terminal_args_without_dir_skips_cd() {
+        let params = crate::services::remote::ConnectionParams {
+            user: "u".into(),
+            host: "h".into(),
+            port: None,
+            identity_file: None,
+        };
+        let a = build_ssh_terminal_args(&params, None);
+        assert_eq!(
+            a,
+            vec![
+                "-t",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "u@h",
+                "exec ${SHELL:-/bin/sh} -l",
+            ]
+        );
+        // Empty dir is treated the same as no dir.
+        assert_eq!(build_ssh_terminal_args(&params, Some("")), a);
     }
 }

--- a/crates/fresh-editor/tests/remote_ssh_terminal.rs
+++ b/crates/fresh-editor/tests/remote_ssh_terminal.rs
@@ -1,0 +1,251 @@
+//! Integration test for the remote-mode integrated terminal.
+//!
+//! Regression for: when running `fresh ssh://host/path`, opening the
+//! embedded terminal ran a shell on the *local* machine instead of on the
+//! remote host. The fix builds an `ssh -t … user@host 'cd <dir>; exec
+//! $SHELL -l'` wrapper for the SSH authority.
+//!
+//! This test spins up a throwaway, **non-root** `sshd` on `127.0.0.1` and
+//! runs the real [`TerminalWrapper::ssh`] command against it — the same
+//! command the terminal manager spawns. The shell's `$SSH_CONNECTION` is
+//! set *only* by sshd on the remote side, so observing a non-empty value
+//! proves the shell genuinely runs through SSH rather than locally. We
+//! also check `pwd` to confirm the wrapper lands in the workspace dir.
+//!
+//! Linux-only: the non-root sshd bring-up relies on OpenSSH's Linux
+//! behaviour (a non-root daemon happily serves logins for the user that
+//! launched it). The test *skips* (rather than fails) when
+//! `ssh`/`sshd`/`ssh-keygen` aren't installed, so it's a no-op on hosts
+//! without OpenSSH.
+#![cfg(target_os = "linux")]
+
+use std::io::Write;
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use fresh::services::authority::TerminalWrapper;
+use fresh::services::remote::ConnectionParams;
+
+/// True if `p` is a regular file (good enough to treat as an executable
+/// candidate here — we only ever feed these to `Command`).
+fn is_file(p: &Path) -> bool {
+    p.is_file()
+}
+
+/// Resolve a program by searching `PATH` and then a few well-known
+/// absolute fallbacks (sshd usually lives in `/usr/sbin`, which is often
+/// absent from a test process's `PATH`).
+fn resolve(name: &str, fallbacks: &[&str]) -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path) {
+            let cand = dir.join(name);
+            if is_file(&cand) {
+                return Some(cand);
+            }
+        }
+    }
+    fallbacks
+        .iter()
+        .map(PathBuf::from)
+        .find(|cand| is_file(cand))
+}
+
+/// Generate an unencrypted ed25519 keypair at `path` (+ `path.pub`).
+fn keygen(keygen_bin: &Path, path: &Path) {
+    let status = Command::new(keygen_bin)
+        .args(["-t", "ed25519", "-q", "-N", ""])
+        .arg("-f")
+        .arg(path)
+        .status()
+        .expect("run ssh-keygen");
+    assert!(status.success(), "ssh-keygen failed for {path:?}");
+}
+
+fn set_mode(path: &Path, mode: u32) {
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+}
+
+/// A free localhost TCP port. Bound briefly to discover the number, then
+/// released for `sshd` to claim — a small race window that's fine for a
+/// loopback test.
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+fn wait_for_listen(port: u16, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    false
+}
+
+/// Kill the child `sshd` when the test ends (pass or panic).
+struct KillOnDrop(Child);
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn current_user() -> Option<String> {
+    std::env::var("USER")
+        .ok()
+        .or_else(|| std::env::var("LOGNAME").ok())
+        .or_else(|| {
+            let out = Command::new("id").arg("-un").output().ok()?;
+            String::from_utf8(out.stdout)
+                .ok()
+                .map(|s| s.trim().to_string())
+        })
+        .filter(|s| !s.is_empty())
+}
+
+#[test]
+fn ssh_terminal_wrapper_runs_shell_on_remote_host() {
+    let (Some(ssh), Some(sshd), Some(ssh_keygen)) = (
+        resolve("ssh", &[]),
+        resolve(
+            "sshd",
+            &["/usr/sbin/sshd", "/sbin/sshd", "/usr/local/sbin/sshd"],
+        ),
+        resolve("ssh-keygen", &[]),
+    ) else {
+        eprintln!("skipping: ssh/sshd/ssh-keygen not installed");
+        return;
+    };
+    let _ = ssh; // resolved only to confirm the client exists; wrapper calls `ssh` by name.
+
+    let Some(user) = current_user() else {
+        eprintln!("skipping: could not determine current user");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let t = tmp.path();
+    let hostkey = t.join("hostkey");
+    let id = t.join("id");
+    let authorized = t.join("authorized_keys");
+    let config = t.join("sshd_config");
+    let work = t.join("work");
+    std::fs::create_dir(&work).unwrap();
+    // accept-new writes the host key here; pre-create so we never touch the
+    // real user's ~/.ssh.
+    let dot_ssh = t.join(".ssh");
+    std::fs::create_dir(&dot_ssh).unwrap();
+    set_mode(&dot_ssh, 0o700);
+
+    keygen(&ssh_keygen, &hostkey);
+    keygen(&ssh_keygen, &id);
+    std::fs::copy(t.join("id.pub"), &authorized).unwrap();
+    set_mode(&authorized, 0o600);
+
+    let port = free_port();
+    std::fs::write(
+        &config,
+        format!(
+            "Port {port}\n\
+             ListenAddress 127.0.0.1\n\
+             HostKey {hostkey}\n\
+             PidFile {pid}\n\
+             AuthorizedKeysFile {authorized}\n\
+             StrictModes no\n\
+             UsePAM no\n\
+             PasswordAuthentication no\n\
+             PubkeyAuthentication yes\n",
+            hostkey = hostkey.display(),
+            pid = t.join("sshd.pid").display(),
+            authorized = authorized.display(),
+        ),
+    )
+    .unwrap();
+
+    let log = t.join("sshd.log");
+    let logf = std::fs::File::create(&log).unwrap();
+    let sshd_child = Command::new(&sshd)
+        .arg("-D") // foreground
+        .arg("-e") // log to stderr
+        .arg("-f")
+        .arg(&config)
+        .stdout(Stdio::from(logf.try_clone().unwrap()))
+        .stderr(Stdio::from(logf))
+        .spawn()
+        .expect("spawn sshd");
+    let _sshd_guard = KillOnDrop(sshd_child);
+
+    assert!(
+        wait_for_listen(port, Duration::from_secs(10)),
+        "sshd never listened on {port}.\nsshd log:\n{}",
+        std::fs::read_to_string(&log).unwrap_or_default()
+    );
+
+    // --- The code under test: build the SSH authority's terminal wrapper. ---
+    let params = ConnectionParams {
+        user: user.clone(),
+        host: "127.0.0.1".to_string(),
+        port: Some(port),
+        identity_file: Some(id.clone()),
+    };
+    let work_str = work.to_string_lossy().into_owned();
+    let wrapper = TerminalWrapper::ssh(&params, Some(&work_str));
+    assert_eq!(
+        wrapper.command, "ssh",
+        "remote terminal must launch via ssh"
+    );
+    assert!(
+        wrapper.manages_cwd,
+        "ssh terminal re-parents the shell, so it manages its own cwd"
+    );
+
+    // Spawn the wrapper exactly as the terminal manager would, feeding a
+    // tiny script on stdin. HOME is redirected into the temp dir so the
+    // accept-new host key lands there rather than the real user's file.
+    let mut child = Command::new(&wrapper.command)
+        .args(&wrapper.args)
+        .env("HOME", t)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ssh terminal wrapper");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"pwd\nprintf 'CONN=%s\\n' \"$SSH_CONNECTION\"\nexit\n")
+        .unwrap();
+    let out = child.wait_with_output().expect("wait for ssh wrapper");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    // (1) The shell ran on the *remote* side. `$SSH_CONNECTION` is injected
+    //     only by sshd for a real SSH session; a locally-spawned shell would
+    //     print an empty "CONN=".
+    let conn = stdout
+        .lines()
+        .find(|l| l.starts_with("CONN="))
+        .unwrap_or_else(|| panic!("no CONN line.\nstdout:\n{stdout}\nstderr:\n{stderr}"));
+    assert!(
+        conn.len() > "CONN=".len() && conn.contains("127.0.0.1"),
+        "SSH_CONNECTION empty — the terminal shell did NOT run through SSH.\n\
+         line={conn:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    // (2) The wrapper cd'd into the workspace directory before exec'ing the
+    //     shell, so the user lands where the editor is rooted.
+    assert!(
+        stdout.contains(&work_str),
+        "shell did not start in the workspace dir {work_str:?}.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds support for running the integrated terminal on the remote host when using SSH authorities, instead of falling back to the local host shell. Previously, terminals would silently run on the local machine even when the filesystem and spawners were configured for remote execution.

## Key Changes

- **New `build_ssh_terminal_args()` function** in `spawner.rs`: Assembles SSH arguments specifically for interactive terminals, with:
  - `-t` flag to force PTY allocation for interactive behavior (job control, line editing, prompts)
  - Omission of `BatchMode=yes` to allow interactive auth prompts (passphrases, passwords, 2FA) to surface in the terminal
  - Automatic `cd` into the workspace directory with fallback to parent directory if the path is a file
  - Execution of an interactive login shell (`exec ${SHELL:-/bin/sh} -l`) to provide the user's normal remote environment

- **New `TerminalWrapper::ssh()` method** in `authority/mod.rs`: Creates a terminal wrapper that:
  - Uses the SSH command with arguments from `build_ssh_terminal_args()`
  - Sets `manages_cwd = true` to prevent the terminal manager from calling `cwd()` with remote paths the local PTY cannot honor
  - Pins the working directory through SSH's own arguments

- **Updated `Authority::ssh()` constructor**: Now accepts `params` and `remote_dir` to build the SSH terminal wrapper, replacing the hardcoded `TerminalWrapper::host_shell()` that was causing terminals to run locally

- **Export updates**: Added `build_ssh_terminal_args` to the public API in `remote/mod.rs`

- **Test coverage**: Added two comprehensive tests verifying:
  - TTY forcing, login shell execution, and absence of `BatchMode=yes`
  - Correct behavior when no directory is provided

## Implementation Details

The solution mirrors the existing `docker exec -w …` wrapper pattern, where the wrapper itself manages the working directory through its command arguments rather than relying on the terminal manager's `cwd()` calls. This ensures the integrated terminal opens on the remote host with the correct working directory, matching the behavior of the filesystem and spawner components.

https://claude.ai/code/session_019oUBEteG3KH8iBWdKdmv2m