### PR TITLE
feat(server): forward nested `fresh` launches to the parent editor

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -2829,9 +2829,7 @@ fn run_open_files_command(
     wait: bool,
 ) -> AnyhowResult<()> {
     use fresh::server::daemon::is_process_running;
-    use fresh::server::protocol::{
-        ClientControl, ClientHello, ServerControl, TermSize, PROTOCOL_VERSION,
-    };
+    use fresh::server::protocol::{ClientControl, ServerControl};
     use fresh::server::spawn_server_detached;
 
     if files.is_empty() {
@@ -2892,38 +2890,9 @@ fn run_open_files_command(
     // Connect to server
     let conn = fresh::server::ipc::ClientConnection::connect(&socket_paths)?;
 
-    // Perform handshake
-    let hello = ClientHello::new(TermSize::new(80, 24)); // Size doesn't matter, we're not rendering
-    let hello_json = serde_json::to_string(&ClientControl::Hello(hello))?;
-    conn.write_control(&hello_json)?;
-
-    // Read server response
-    let response = conn
-        .read_control()?
-        .ok_or_else(|| anyhow::anyhow!("Server closed connection during handshake"))?;
-
-    let server_msg: ServerControl = serde_json::from_str(&response)?;
-
-    match server_msg {
-        ServerControl::Hello(server_hello) => {
-            if server_hello.protocol_version != PROTOCOL_VERSION {
-                eprintln!(
-                    "Version mismatch: server is v{}",
-                    server_hello.server_version
-                );
-                return Ok(());
-            }
-        }
-        ServerControl::VersionMismatch(mismatch) => {
-            eprintln!("Version mismatch: server is v{}", mismatch.server_version);
-            return Ok(());
-        }
-        ServerControl::Error { message } => {
-            return Err(anyhow::anyhow!("Server error: {}", message));
-        }
-        _ => {
-            return Err(anyhow::anyhow!("Unexpected server response"));
-        }
+    // Perform handshake; a version mismatch aborts quietly.
+    if !client_handshake(&conn)? {
+        return Ok(());
     }
 
     // Send OpenFiles command
@@ -2971,6 +2940,162 @@ fn run_open_files_command(
         eprintln!("Opened {} file(s) in session.", file_requests.len());
     }
     Ok(())
+}
+
+/// Perform the client side of the handshake on an established connection.
+///
+/// Sends `Hello` and reads the server's reply. Returns `Ok(true)` when the
+/// server accepted the handshake, `Ok(false)` on a version mismatch (the
+/// caller should abort quietly — a message has already been printed), and
+/// `Err` on a protocol-level error.
+fn client_handshake(conn: &fresh::server::ipc::ClientConnection) -> AnyhowResult<bool> {
+    use fresh::server::protocol::{
+        ClientControl, ClientHello, ServerControl, TermSize, PROTOCOL_VERSION,
+    };
+
+    // Size doesn't matter — these clients never render.
+    let hello = ClientHello::new(TermSize::new(80, 24));
+    conn.write_control(&serde_json::to_string(&ClientControl::Hello(hello))?)?;
+
+    let response = conn
+        .read_control()?
+        .ok_or_else(|| anyhow::anyhow!("Server closed connection during handshake"))?;
+
+    match serde_json::from_str::<ServerControl>(&response)? {
+        ServerControl::Hello(server_hello) => {
+            if server_hello.protocol_version != PROTOCOL_VERSION {
+                eprintln!(
+                    "Version mismatch: server is v{}",
+                    server_hello.server_version
+                );
+                return Ok(false);
+            }
+            Ok(true)
+        }
+        ServerControl::VersionMismatch(mismatch) => {
+            eprintln!("Version mismatch: server is v{}", mismatch.server_version);
+            Ok(false)
+        }
+        ServerControl::Error { message } => Err(anyhow::anyhow!("Server error: {}", message)),
+        _ => Err(anyhow::anyhow!("Unexpected server response")),
+    }
+}
+
+/// When launched from inside Fresh's own embedded terminal, forward the
+/// file/dir arguments to the parent editor (identified by `FRESH_SESSION`)
+/// instead of starting a second editor in the terminal.
+///
+/// Returns:
+/// - `Some(Ok(()))` — forwarded; the caller should exit.
+/// - `None` — not a nested launch, nothing to forward, or the parent
+///   socket is unreachable; the caller should launch inline as usual.
+fn try_forward_nested(args: &Args) -> Option<AnyhowResult<()>> {
+    // Only plain interactive file/dir opens are forwarded. Subcommands,
+    // --server and --attach are already handled before we get here;
+    // --stdin pipes content into a real editor and can't be forwarded.
+    if args.server || args.attach || args.stdin || args.files.is_empty() {
+        return None;
+    }
+
+    let session = std::env::var("FRESH_SESSION").ok()?;
+    if session.trim().is_empty() {
+        return None;
+    }
+
+    match forward_to_session(&session, &args.files) {
+        Ok(true) => Some(Ok(())),
+        Ok(false) => None, // unreachable parent → fall back to inline
+        Err(e) => {
+            // Never fail the launch over a forwarding hiccup: fall back to
+            // opening inline, which is exactly the pre-feature behavior.
+            tracing::warn!("Nested forward failed ({}); opening inline", e);
+            None
+        }
+    }
+}
+
+/// Forward `files` (a mix of files and directories) to the parent session.
+///
+/// Files open in the parent's current window and the call blocks until the
+/// (last) buffer is closed, so `git commit`/`$EDITOR` semantics hold.
+/// Directories pop a new orchestrator window each and don't block.
+///
+/// Returns `Ok(true)` once a connection to the parent was established and
+/// the requests were sent; `Ok(false)` if the parent isn't reachable (the
+/// caller should open inline instead).
+fn forward_to_session(session: &str, files: &[String]) -> AnyhowResult<bool> {
+    use fresh::server::protocol::{ClientControl, ServerControl};
+
+    let socket_paths = resolve_session(Some(session))?;
+    socket_paths.cleanup_if_stale();
+    if !socket_paths.is_server_alive() {
+        return Ok(false);
+    }
+
+    // Partition arguments into directories (→ new windows) and files (→
+    // buffers in the current window). `build_file_requests` already drops
+    // directories, so it yields exactly the file set.
+    let working_dir = std::env::current_dir()?;
+    let mut dir_paths: Vec<PathBuf> = Vec::new();
+    for f in files {
+        let loc = parse_file_location(f);
+        let abs = if loc.path.is_relative() {
+            working_dir.join(&loc.path)
+        } else {
+            loc.path.clone()
+        };
+        let canonical = abs.canonicalize().unwrap_or(abs);
+        if canonical.is_dir() {
+            dir_paths.push(canonical);
+        }
+    }
+    let file_requests = build_file_requests(files, &working_dir);
+
+    // Establishing the connection is the commit point: once we're talking
+    // to the parent we own the request and never fall back (which would
+    // double-open). A failure to connect means "no reachable parent".
+    let conn = match fresh::server::ipc::ClientConnection::connect(&socket_paths) {
+        Ok(c) => c,
+        Err(_) => return Ok(false),
+    };
+    if !client_handshake(&conn)? {
+        // Version mismatch already reported; don't open inline on top of it.
+        return Ok(true);
+    }
+
+    // Directories first: each becomes a new focused window.
+    for dir in dir_paths {
+        let msg = ClientControl::OpenWindow {
+            path: dir.to_string_lossy().into_owned(),
+        };
+        conn.write_control(&serde_json::to_string(&msg)?)?;
+    }
+
+    // Files: open them and block until the (last) buffer is closed.
+    if !file_requests.is_empty() {
+        let msg = ClientControl::OpenFiles {
+            files: file_requests,
+            wait: true,
+        };
+        conn.write_control(&serde_json::to_string(&msg)?)?;
+
+        loop {
+            match conn.read_control() {
+                Ok(Some(line)) => {
+                    if let Ok(msg) = serde_json::from_str::<ServerControl>(&line) {
+                        match msg {
+                            ServerControl::WaitComplete | ServerControl::Quit { .. } => break,
+                            _ => {}
+                        }
+                    }
+                }
+                Ok(None) => break, // parent closed the connection
+                Err(_) => break,
+            }
+        }
+    }
+
+    Ok(true)
 }
 
 /// Attach to an existing session, starting a server if needed
@@ -3561,6 +3686,15 @@ fn real_main() -> AnyhowResult<()> {
         return result;
     }
 
+    // If launched from inside Fresh's own embedded terminal (FRESH_SESSION
+    // is set), forward file/dir opens to that parent editor instead of
+    // starting a second editor in the terminal. Returns Some(..) when the
+    // request was forwarded (we're done); None to fall through and launch
+    // inline (no reachable parent, or nothing to forward).
+    if let Some(result) = try_forward_nested(&args) {
+        return result;
+    }
+
     // Save the original console mode BEFORE anything modifies it (raw mode,
     // enable_vt_input, etc.). Restored at the very end after all cleanup.
     #[cfg(windows)]
@@ -3620,6 +3754,14 @@ fn real_main() -> AnyhowResult<()> {
     let mut warning_log_slot: Option<(std::sync::mpsc::Receiver<()>, PathBuf)> = tracing_handles
         .take()
         .map(|h| (h.warning.receiver, h.warning.path));
+
+    // Bind this process's local control socket so a `fresh` launched from
+    // inside an embedded terminal forwards opens back here (see
+    // `try_forward_nested` / `server::local_control`). Best-effort: if it
+    // fails, the editor runs normally and nested launches just open inline.
+    if let Err(e) = fresh::server::local_control::start() {
+        tracing::warn!("Local control socket unavailable: {}", e);
+    }
 
     // Main editor loop - supports restarting with a new working directory
     // Returns (loop_result, last_update_result) tuple
@@ -4024,6 +4166,13 @@ where
     let mut pending_event: Option<CrosstermEvent> = None;
 
     loop {
+        // Apply any nested-forward requests (file/dir opens from a `fresh`
+        // run inside an embedded terminal) before housekeeping, so the
+        // queued opens are drained by `editor_tick` on this same iteration.
+        if fresh::server::local_control::pump(editor) {
+            needs_render = true;
+        }
+
         // Run shared per-tick housekeeping (async messages, timers, auto-save, etc.)
         {
             let _span = tracing::info_span!("editor_tick").entered();

--- a/crates/fresh-editor/src/server/editor_server.rs
+++ b/crates/fresh-editor/src/server/editor_server.rs
@@ -997,8 +997,9 @@ impl EditorServer {
                 continue;
             }
 
-            // Always process OpenFiles - it's a one-shot command from clients that disconnect immediately
-            if let ClientControl::OpenFiles { .. } = msg {
+            // Always process OpenFiles / OpenWindow - they're one-shot
+            // commands from clients that disconnect immediately
+            if let ClientControl::OpenFiles { .. } | ClientControl::OpenWindow { .. } = msg {
                 // Fall through to process it
             } else if disconnected.contains(&idx) {
                 // Skip other messages from disconnected clients
@@ -1076,6 +1077,25 @@ impl EditorServer {
                         }
 
                         resize_occurred = true; // Force re-render
+                    }
+                }
+                ClientControl::OpenWindow { path } => {
+                    if let Some(ref mut editor) = self.editor {
+                        let path = std::path::PathBuf::from(path);
+                        if path.is_absolute() {
+                            let label = path
+                                .file_name()
+                                .map(|s| s.to_string_lossy().into_owned())
+                                .unwrap_or_else(|| path.to_string_lossy().into_owned());
+                            let id = editor.create_window_at(path, label);
+                            editor.set_active_window(id);
+                            resize_occurred = true; // Force re-render
+                        } else {
+                            tracing::warn!(
+                                "OpenWindow rejected: path must be absolute: {:?}",
+                                path
+                            );
+                        }
                     }
                 }
                 ClientControl::Quit => unreachable!(), // Handled above

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -205,6 +205,10 @@ pub fn pump(editor: &mut Editor) -> bool {
                         .unwrap_or_else(|| path.to_string_lossy().into_owned());
                     let id = editor.create_window_at(path, label);
                     editor.set_active_window(id);
+                    // Match a normal `fresh <dir>` launch, which opens the
+                    // file explorer for a directory argument (see `main.rs`),
+                    // rather than leaving the new window on an empty buffer.
+                    editor.show_file_explorer();
                     changed = true;
                 } else {
                     tracing::warn!("OpenWindow ignored: path must be absolute: {:?}", path);
@@ -278,9 +282,6 @@ fn handle_connection(
     // whole connection: the client sends several commands back-to-back
     // (one OpenWindow per directory, then a final OpenFiles), and a fresh
     // reader per message would drop lines already buffered from the socket.
-    #[cfg(not(windows))]
-    #[allow(clippy::let_underscore_must_use)]
-    let _ = conn.control.set_nonblocking(false);
     let mut reader = std::io::BufReader::new(&conn.control);
 
     if let Err(e) = handshake(&conn, &mut reader) {
@@ -289,6 +290,16 @@ fn handle_connection(
     }
 
     loop {
+        // Re-assert blocking mode before every read. `accept()` leaves the
+        // socket non-blocking, and `ServerConnection::write_control` (shared
+        // with the poll-driven session server) flips it back to non-blocking
+        // after each reply — so without this a blocking `read_line` would
+        // return `WouldBlock` immediately, drop the connection, and leave the
+        // nested client to fall back to inline. We read blocking here.
+        #[cfg(not(windows))]
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = conn.control.set_nonblocking(false);
+
         let msg = match read_msg(&mut reader) {
             Ok(Some(m)) => m,
             Ok(None) => return, // client disconnected
@@ -353,6 +364,12 @@ fn handshake(
     conn: &ServerConnection,
     reader: &mut std::io::BufReader<&StreamWrapper>,
 ) -> std::io::Result<()> {
+    // `accept()` hands us a non-blocking control socket; the Hello read must
+    // block until the client sends it (see the command loop for the same
+    // reason `write_control` requires re-asserting this).
+    #[cfg(not(windows))]
+    conn.control.set_nonblocking(false)?;
+
     let hello_json = read_msg(reader)?
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "no hello"))?;
 
@@ -606,6 +623,50 @@ mod tests {
                 assert!(wait_id.is_none());
             }
             other => panic!("expected OpenFiles, got {}", req_kind(&other)),
+        }
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// Regression test for the blocking-mode bug: a real nested `fresh` sends
+    /// its command some time *after* the handshake completes (process startup
+    /// + socket round-trip), so the server's post-handshake read runs against
+    /// an empty socket. `accept()` leaves the socket non-blocking and
+    /// `write_control` flips it back to non-blocking after the `ServerHello`,
+    /// so without re-asserting blocking mode the handler's `read_line` would
+    /// return `WouldBlock`, drop the connection, and the command would never
+    /// be forwarded (the client would then fall back to opening inline).
+    ///
+    /// The earlier tests sent their command immediately, so the bytes were
+    /// usually already buffered when the read ran — masking the bug. The
+    /// explicit delay here makes the empty-socket read deterministic.
+    #[test]
+    fn command_sent_after_a_delay_is_still_received() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("delayed-cmd-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        // Long enough that the server has finished the handshake and is
+        // parked in the command-loop read before the command arrives.
+        std::thread::sleep(Duration::from_millis(150));
+        let msg = ClientControl::OpenWindow {
+            path: "/abs/delayed".to_string(),
+        };
+        conn.write_control(&serde_json::to_string(&msg).unwrap())
+            .unwrap();
+
+        // Bounded so a regressed (connection-dropping) build fails fast
+        // instead of hanging forever on a request that never arrives.
+        match bound
+            .req_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("delayed request must still be forwarded")
+        {
+            LocalControlRequest::OpenWindow { path } => {
+                assert_eq!(path, PathBuf::from("/abs/delayed"));
+            }
+            other => panic!("expected OpenWindow, got {}", req_kind(&other)),
         }
 
         bound.shutdown.store(true, Ordering::SeqCst);

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -1,0 +1,620 @@
+//! In-process control listener for "direct" (non-server) mode.
+//!
+//! When Fresh runs as a plain in-process editor (no detached session
+//! server), it still binds a *control* socket so that a `fresh`
+//! invoked from inside its own embedded terminal can forward
+//! file/directory open requests back to this process instead of
+//! launching a second editor in the terminal.
+//!
+//! How it fits together:
+//!
+//! - On startup [`start`] binds a unique per-process control socket and
+//!   spawns an accept thread, and records the session id so the embedded
+//!   terminal can advertise it to children via `FRESH_SESSION`.
+//! - A `fresh` launched with `FRESH_SESSION` set connects as a thin
+//!   client (see `try_forward_nested` in `main.rs`) and sends
+//!   [`ClientControl::OpenFiles`] / [`ClientControl::OpenWindow`].
+//! - Each accepted connection is handled on its own thread, which hands
+//!   the decoded request to the editor's main loop via a channel and —
+//!   for `--wait`-style file opens — parks until the buffer is closed.
+//! - [`pump`] runs once per frame on the editor thread, applying queued
+//!   requests through the editor's existing `queue_file_open` /
+//!   `create_window_at` machinery and waking parked connections when a
+//!   wait completes.
+//!
+//! This deliberately reuses the same IPC primitives ([`ServerListener`],
+//! [`ServerConnection`]) and wire protocol ([`ClientControl`] /
+//! [`ServerControl`]) as the full session server, but does *not* render:
+//! the direct-mode crossterm render/input path is untouched.
+
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::app::Editor;
+use crate::server::ipc::{ServerConnection, ServerListener, SocketPaths, StreamWrapper};
+use crate::server::protocol::{
+    ClientControl, FileRequest, ServerControl, ServerHello, VersionMismatch, PROTOCOL_VERSION,
+};
+
+/// Time the accept thread sleeps between non-blocking accept polls. Only
+/// affects how quickly a freshly-launched nested `fresh` is picked up;
+/// nested launches are human-interactive (e.g. `git commit`), so this is
+/// imperceptible.
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// A request decoded from a nested client and handed to the editor thread.
+enum LocalControlRequest {
+    /// Open files in the current window. `wait_id` is `Some` when the
+    /// nested client is blocking until the (last) buffer is closed.
+    OpenFiles {
+        files: Vec<FileRequest>,
+        wait_id: Option<u64>,
+    },
+    /// Open a directory as a new, focused orchestrator window.
+    OpenWindow { path: PathBuf },
+}
+
+/// Shared state between the connection-handler threads and the editor
+/// thread's [`pump`].
+struct Shared {
+    /// Requests decoded by handler threads, drained each frame by `pump`.
+    req_rx: Mutex<Receiver<LocalControlRequest>>,
+    /// `wait_id` -> notifier that wakes the parked handler thread once the
+    /// editor reports the matching buffer closed.
+    waiters: Arc<Mutex<HashMap<u64, Sender<()>>>>,
+}
+
+/// Process-global handle. `None` until [`start`] succeeds; the control
+/// socket is inherently process-wide (one per editor process).
+static GLOBAL: OnceLock<Shared> = OnceLock::new();
+
+/// The session id encoded into the control socket filename and advertised
+/// to embedded terminals via `FRESH_SESSION`.
+static SESSION_ID: OnceLock<String> = OnceLock::new();
+
+/// The session id of this process's local control socket, if active.
+///
+/// The embedded-terminal spawner reads this to set `FRESH_SESSION` on
+/// local child shells so a nested `fresh` forwards back here.
+pub fn local_session_id() -> Option<&'static str> {
+    SESSION_ID.get().map(String::as_str)
+}
+
+/// Bind the local control socket and start accepting nested-forward
+/// connections. Best-effort: on failure the editor simply runs without
+/// nested forwarding (a nested `fresh` falls back to running inline).
+///
+/// Returns the session id on success.
+pub fn start() -> std::io::Result<&'static str> {
+    if let Some(id) = SESSION_ID.get() {
+        // Already started (e.g. a defensive double-call). Reuse it.
+        return Ok(id.as_str());
+    }
+
+    let session_id = generate_session_id();
+    let paths = SocketPaths::for_session_name(&session_id)?;
+    let bound = bind_and_spawn(paths)?;
+
+    // Records are set last so `local_session_id()` only ever reports a
+    // socket that is actually bound and accepting.
+    let _ = GLOBAL.set(Shared {
+        req_rx: Mutex::new(bound.req_rx),
+        waiters: bound.waiters,
+    });
+    let id = SESSION_ID.get_or_init(|| session_id);
+    tracing::info!("Local control socket listening as session {}", id);
+    Ok(id.as_str())
+}
+
+/// The movable pieces produced by [`bind_and_spawn`]: everything the
+/// editor thread (or a test) needs to drive an already-listening control
+/// socket.
+struct BoundControl {
+    req_rx: Receiver<LocalControlRequest>,
+    waiters: Arc<Mutex<HashMap<u64, Sender<()>>>>,
+    /// Set to stop the accept thread. Held by the caller so the socket and
+    /// its thread live exactly as long as needed.
+    shutdown: Arc<AtomicBool>,
+}
+
+/// Bind the control socket at `paths`, write the pid file, and spawn the
+/// accept thread. Shared by [`start`] (real socket) and the tests
+/// (isolated temp-dir socket), so neither path special-cases the other.
+fn bind_and_spawn(paths: SocketPaths) -> std::io::Result<BoundControl> {
+    // Clear any stale leftovers from a crashed predecessor that happened
+    // to reuse this name (astronomically unlikely given the pid+nanos id,
+    // but cleanup_if_stale is cheap and keeps bind() from failing).
+    paths.cleanup_if_stale();
+
+    let listener = ServerListener::bind(paths.clone())?;
+    paths.write_pid(std::process::id())?;
+
+    let (req_tx, req_rx) = mpsc::channel::<LocalControlRequest>();
+    let waiters: Arc<Mutex<HashMap<u64, Sender<()>>>> = Arc::new(Mutex::new(HashMap::new()));
+    let shutdown = Arc::new(AtomicBool::new(false));
+
+    let accept_waiters = waiters.clone();
+    let accept_shutdown = shutdown.clone();
+    std::thread::Builder::new()
+        .name("fresh-local-control".to_string())
+        .spawn(move || {
+            accept_loop(listener, req_tx, accept_waiters, accept_shutdown);
+        })?;
+
+    Ok(BoundControl {
+        req_rx,
+        waiters,
+        shutdown,
+    })
+}
+
+/// Apply any pending nested-forward requests to `editor` and wake parked
+/// connections whose wait completed. Runs once per frame on the editor
+/// thread. Cheap no-op when local control isn't active.
+///
+/// Returns true if anything changed and a re-render is warranted.
+pub fn pump(editor: &mut Editor) -> bool {
+    let Some(shared) = GLOBAL.get() else {
+        return false;
+    };
+
+    let mut changed = false;
+
+    // Drain decoded requests. The lock is only contended for the brief
+    // moment a handler thread sends; try_recv never blocks.
+    loop {
+        let req = {
+            let rx = shared.req_rx.lock().unwrap();
+            rx.try_recv()
+        };
+        match req {
+            Ok(LocalControlRequest::OpenFiles { files, wait_id }) => {
+                let last = files.len().saturating_sub(1);
+                for (i, fr) in files.into_iter().enumerate() {
+                    // Only the last file carries the wait id (it's the one
+                    // left active), mirroring the session server.
+                    let file_wait_id = if i == last { wait_id } else { None };
+                    editor.queue_file_open(
+                        PathBuf::from(fr.path),
+                        fr.line,
+                        fr.column,
+                        fr.end_line,
+                        fr.end_column,
+                        fr.message,
+                        file_wait_id,
+                    );
+                }
+                // Open them in the window that is active *now*, before any
+                // later OpenWindow request in this same batch switches the
+                // active window. ("Open a file → current session"; only
+                // directories spawn a new one.) This also installs the
+                // wait_tracking that `take_completed_waits` reports below.
+                editor.process_pending_file_opens();
+                changed = true;
+            }
+            Ok(LocalControlRequest::OpenWindow { path }) => {
+                if path.is_absolute() {
+                    let label = path
+                        .file_name()
+                        .map(|s| s.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| path.to_string_lossy().into_owned());
+                    let id = editor.create_window_at(path, label);
+                    editor.set_active_window(id);
+                    changed = true;
+                } else {
+                    tracing::warn!("OpenWindow ignored: path must be absolute: {:?}", path);
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Route completed waits back to the parked handler threads so they can
+    // send WaitComplete and let the blocked nested `fresh` (e.g. the editor
+    // git launched) exit.
+    let completed = editor.take_completed_waits();
+    if !completed.is_empty() {
+        let mut waiters = shared.waiters.lock().unwrap();
+        for wait_id in completed {
+            if let Some(notifier) = waiters.remove(&wait_id) {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = notifier.send(());
+            }
+        }
+    }
+
+    changed
+}
+
+/// Accept thread: poll for new connections and spawn a handler per
+/// connection so a parked (`--wait`) connection never blocks accepting
+/// the next one.
+fn accept_loop(
+    mut listener: ServerListener,
+    req_tx: Sender<LocalControlRequest>,
+    waiters: Arc<Mutex<HashMap<u64, Sender<()>>>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    let next_wait_id = Arc::new(AtomicU64::new(1));
+
+    while !shutdown.load(Ordering::SeqCst) {
+        match listener.accept() {
+            Ok(Some(conn)) => {
+                let req_tx = req_tx.clone();
+                let waiters = waiters.clone();
+                let next_wait_id = next_wait_id.clone();
+                // Best-effort: a failed handler spawn just drops the
+                // connection; the nested client falls back to inline.
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = std::thread::Builder::new()
+                    .name("fresh-local-control-conn".to_string())
+                    .spawn(move || {
+                        handle_connection(conn, req_tx, waiters, next_wait_id);
+                    });
+            }
+            Ok(None) => std::thread::sleep(ACCEPT_POLL_INTERVAL),
+            Err(e) => {
+                tracing::warn!("Local control accept error: {}", e);
+                std::thread::sleep(ACCEPT_POLL_INTERVAL);
+            }
+        }
+    }
+}
+
+/// Per-connection handler: handshake, decode one command, forward it to
+/// the editor thread, and (for waited opens) park until the buffer closes.
+fn handle_connection(
+    conn: ServerConnection,
+    req_tx: Sender<LocalControlRequest>,
+    waiters: Arc<Mutex<HashMap<u64, Sender<()>>>>,
+    next_wait_id: Arc<AtomicU64>,
+) {
+    // A dedicated blocking thread, so block on reads. One BufReader for the
+    // whole connection: the client sends several commands back-to-back
+    // (one OpenWindow per directory, then a final OpenFiles), and a fresh
+    // reader per message would drop lines already buffered from the socket.
+    #[cfg(not(windows))]
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = conn.control.set_nonblocking(false);
+    let mut reader = std::io::BufReader::new(&conn.control);
+
+    if let Err(e) = handshake(&conn, &mut reader) {
+        tracing::debug!("Local control handshake failed: {}", e);
+        return;
+    }
+
+    loop {
+        let msg = match read_msg(&mut reader) {
+            Ok(Some(m)) => m,
+            Ok(None) => return, // client disconnected
+            Err(e) => {
+                tracing::debug!("Local control read error: {}", e);
+                return;
+            }
+        };
+
+        match msg {
+            ClientControl::OpenWindow { path } => {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = req_tx.send(LocalControlRequest::OpenWindow {
+                    path: PathBuf::from(path),
+                });
+            }
+            ClientControl::OpenFiles { files, wait } => {
+                // Register a waiter *before* handing the request to the
+                // editor so the completion notification can't race ahead.
+                let wait_slot = if wait {
+                    let id = next_wait_id.fetch_add(1, Ordering::SeqCst);
+                    let (tx, rx) = mpsc::channel::<()>();
+                    waiters.lock().unwrap().insert(id, tx);
+                    Some((id, rx))
+                } else {
+                    None
+                };
+
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = req_tx.send(LocalControlRequest::OpenFiles {
+                    files,
+                    wait_id: wait_slot.as_ref().map(|(id, _)| *id),
+                });
+
+                if let Some((id, rx)) = wait_slot {
+                    // Block until `pump` reports the buffer closed. A recv
+                    // error means the editor exited first — treat that as
+                    // completion so the nested process is never wedged.
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = rx.recv();
+                    let done =
+                        serde_json::to_string(&ServerControl::WaitComplete).unwrap_or_default();
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = conn.write_control(&done);
+                    waiters.lock().unwrap().remove(&id);
+                }
+            }
+            other => {
+                tracing::debug!("Local control ignoring unexpected message: {:?}", other);
+            }
+        }
+    }
+}
+
+/// Read the `Hello`, version-check, and reply with `ServerHello` — the
+/// same shape as the session server's handshake, minus the data-channel
+/// terminal setup (nested clients never render).
+///
+/// Shares the connection's [`BufReader`] with the post-handshake command
+/// loop so no buffered bytes are lost between the two.
+fn handshake(
+    conn: &ServerConnection,
+    reader: &mut std::io::BufReader<&StreamWrapper>,
+) -> std::io::Result<()> {
+    let hello_json = read_msg(reader)?
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "no hello"))?;
+
+    let hello = match hello_json {
+        ClientControl::Hello(h) => h,
+        _ => return Err(std::io::Error::other("expected Hello")),
+    };
+
+    if hello.protocol_version != PROTOCOL_VERSION {
+        let mismatch = VersionMismatch {
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+            client_version: hello.client_version.clone(),
+            action: if hello.protocol_version > PROTOCOL_VERSION {
+                "upgrade_server".to_string()
+            } else {
+                "restart_server".to_string()
+            },
+            message: format!(
+                "Protocol version mismatch: server={}, client={}",
+                PROTOCOL_VERSION, hello.protocol_version
+            ),
+        };
+        let response = serde_json::to_string(&ServerControl::VersionMismatch(mismatch))
+            .map_err(std::io::Error::other)?;
+        conn.write_control(&response)?;
+        return Err(std::io::Error::other("version mismatch"));
+    }
+
+    let session_id = local_session_id().unwrap_or("local").to_string();
+    let response = serde_json::to_string(&ServerControl::Hello(ServerHello::new(session_id)))
+        .map_err(std::io::Error::other)?;
+    conn.write_control(&response)
+}
+
+/// Read one newline-delimited control message from a shared connection
+/// reader, parsed as a [`ClientControl`]. `Ok(None)` signals EOF (client
+/// disconnected).
+fn read_msg(
+    reader: &mut std::io::BufReader<&StreamWrapper>,
+) -> std::io::Result<Option<ClientControl>> {
+    let mut line = String::new();
+    match reader.read_line(&mut line) {
+        Ok(0) => Ok(None),
+        Ok(_) => {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return Ok(None);
+            }
+            let msg = serde_json::from_str::<ClientControl>(trimmed)
+                .map_err(|e| std::io::Error::other(format!("invalid control message: {}", e)))?;
+            Ok(Some(msg))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// A unique-per-process session id: `local-<pid>-<nanos>`. The nanosecond
+/// component guards against pid reuse across quick successive runs.
+fn generate_session_id() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("local-{}-{}", std::process::id(), nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ipc::ClientConnection;
+    use crate::server::protocol::{ClientHello, TermSize};
+    use tempfile::TempDir;
+
+    /// Connect a thin client and complete the handshake, returning the
+    /// live connection ready to send a command.
+    fn connect_client(paths: &SocketPaths) -> ClientConnection {
+        let conn = ClientConnection::connect(paths).expect("client connect");
+        let hello = ClientHello::new(TermSize::new(80, 24));
+        conn.write_control(&serde_json::to_string(&ClientControl::Hello(hello)).unwrap())
+            .expect("write hello");
+        let resp = conn
+            .read_control()
+            .expect("read server hello")
+            .expect("server hello present");
+        match serde_json::from_str::<ServerControl>(&resp).expect("parse server hello") {
+            ServerControl::Hello(_) => {}
+            other => panic!("expected ServerControl::Hello, got {:?}", other),
+        }
+        conn
+    }
+
+    fn file_req(path: &str) -> FileRequest {
+        FileRequest {
+            path: path.to_string(),
+            line: None,
+            column: None,
+            end_line: None,
+            end_column: None,
+            message: None,
+        }
+    }
+
+    /// A directory argument is forwarded as an `OpenWindow` request that
+    /// the editor thread can drain. Without the local-control listener
+    /// there is no socket to forward to.
+    #[test]
+    fn open_window_request_is_received() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("open-window-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        let msg = ClientControl::OpenWindow {
+            path: "/abs/project".to_string(),
+        };
+        conn.write_control(&serde_json::to_string(&msg).unwrap())
+            .unwrap();
+
+        // recv() blocks until the handler thread forwards the decoded
+        // request — no fixed timeout (the external runner bounds the test).
+        match bound.req_rx.recv().expect("request forwarded") {
+            LocalControlRequest::OpenWindow { path } => {
+                assert_eq!(path, PathBuf::from("/abs/project"));
+            }
+            other => panic!("expected OpenWindow, got {:?}", req_kind(&other)),
+        }
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// A waited file open forwards an `OpenFiles` request carrying a
+    /// `wait_id`, and the client stays blocked until the editor thread
+    /// reports the wait complete — at which point it receives
+    /// `WaitComplete`. This is the `git commit` / `$EDITOR` path.
+    #[test]
+    fn waited_open_files_completes_after_signal() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("wait-open-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        let msg = ClientControl::OpenFiles {
+            files: vec![file_req("/abs/COMMIT_EDITMSG")],
+            wait: true,
+        };
+        conn.write_control(&serde_json::to_string(&msg).unwrap())
+            .unwrap();
+
+        let wait_id = match bound.req_rx.recv().expect("request forwarded") {
+            LocalControlRequest::OpenFiles { files, wait_id } => {
+                assert_eq!(files.len(), 1);
+                assert_eq!(files[0].path, "/abs/COMMIT_EDITMSG");
+                wait_id.expect("wait id assigned for waited open")
+            }
+            other => panic!("expected OpenFiles, got {:?}", req_kind(&other)),
+        };
+
+        // Simulate what `pump` does when the buffer is closed: wake the
+        // parked handler via its registered waiter.
+        let notifier = bound
+            .waiters
+            .lock()
+            .unwrap()
+            .remove(&wait_id)
+            .expect("waiter registered before request was forwarded");
+        notifier.send(()).unwrap();
+
+        // The client must now observe WaitComplete and unblock.
+        let line = conn
+            .read_control()
+            .expect("read wait complete")
+            .expect("wait complete present");
+        match serde_json::from_str::<ServerControl>(&line).expect("parse") {
+            ServerControl::WaitComplete => {}
+            other => panic!("expected WaitComplete, got {:?}", other),
+        }
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// A non-waited open forwards the request and does not register a
+    /// waiter (the client returns immediately).
+    #[test]
+    fn unwaited_open_files_has_no_wait_id() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("nowait-open-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        let msg = ClientControl::OpenFiles {
+            files: vec![file_req("/abs/file.txt")],
+            wait: false,
+        };
+        conn.write_control(&serde_json::to_string(&msg).unwrap())
+            .unwrap();
+
+        match bound.req_rx.recv().expect("request forwarded") {
+            LocalControlRequest::OpenFiles { wait_id, .. } => {
+                assert!(wait_id.is_none());
+            }
+            other => panic!("expected OpenFiles, got {:?}", req_kind(&other)),
+        }
+        assert!(bound.waiters.lock().unwrap().is_empty());
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    /// `fresh dirA dirB file.txt` sends several commands back-to-back on a
+    /// single connection. All must be forwarded — a handler that reads only
+    /// one message (or a fresh reader per message that drops buffered
+    /// lines) would lose every command after the first.
+    #[test]
+    fn multiple_commands_on_one_connection_all_received() {
+        let dir = TempDir::new().unwrap();
+        let paths = SocketPaths::for_session_name_in_dir("multi-cmd-test", dir.path());
+        let bound = bind_and_spawn(paths.clone()).expect("bind");
+
+        let conn = connect_client(&paths);
+        let msgs = [
+            ClientControl::OpenWindow {
+                path: "/abs/a".to_string(),
+            },
+            ClientControl::OpenWindow {
+                path: "/abs/b".to_string(),
+            },
+            ClientControl::OpenFiles {
+                files: vec![file_req("/abs/file.txt")],
+                wait: false,
+            },
+        ];
+        for m in &msgs {
+            conn.write_control(&serde_json::to_string(m).unwrap())
+                .unwrap();
+        }
+
+        let r1 = bound.req_rx.recv().expect("first request");
+        let r2 = bound.req_rx.recv().expect("second request");
+        let r3 = bound.req_rx.recv().expect("third request");
+
+        match r1 {
+            LocalControlRequest::OpenWindow { path } => assert_eq!(path, PathBuf::from("/abs/a")),
+            other => panic!("expected OpenWindow a, got {}", req_kind(&other)),
+        }
+        match r2 {
+            LocalControlRequest::OpenWindow { path } => assert_eq!(path, PathBuf::from("/abs/b")),
+            other => panic!("expected OpenWindow b, got {}", req_kind(&other)),
+        }
+        match r3 {
+            LocalControlRequest::OpenFiles { files, wait_id } => {
+                assert_eq!(files[0].path, "/abs/file.txt");
+                assert!(wait_id.is_none());
+            }
+            other => panic!("expected OpenFiles, got {}", req_kind(&other)),
+        }
+
+        bound.shutdown.store(true, Ordering::SeqCst);
+    }
+
+    fn req_kind(req: &LocalControlRequest) -> &'static str {
+        match req {
+            LocalControlRequest::OpenFiles { .. } => "OpenFiles",
+            LocalControlRequest::OpenWindow { .. } => "OpenWindow",
+        }
+    }
+}

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -102,6 +102,7 @@ pub fn start() -> std::io::Result<&'static str> {
 
     // Records are set last so `local_session_id()` only ever reports a
     // socket that is actually bound and accepting.
+    #[allow(clippy::let_underscore_must_use)]
     let _ = GLOBAL.set(Shared {
         req_rx: Mutex::new(bound.req_rx),
         waiters: bound.waiters,

--- a/crates/fresh-editor/src/server/mod.rs
+++ b/crates/fresh-editor/src/server/mod.rs
@@ -16,6 +16,7 @@ pub mod daemon;
 pub mod editor_server;
 pub mod input_parser;
 pub mod ipc;
+pub mod local_control;
 pub mod protocol;
 
 #[cfg(test)]

--- a/crates/fresh-editor/src/server/protocol.rs
+++ b/crates/fresh-editor/src/server/protocol.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Protocol version - must match between client and server
-pub const PROTOCOL_VERSION: u32 = 1;
+///
+/// v2: added `ClientControl::OpenWindow` (open a directory as a new
+/// orchestrator window), used by the nested-terminal forwarding path.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Terminal size in columns and rows
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -121,6 +124,14 @@ pub enum ClientControl {
         #[serde(default)]
         wait: bool,
     },
+    /// Request to open a directory as a new orchestrator window/session.
+    ///
+    /// Unlike `OpenFiles` (which opens buffers in the current window),
+    /// this pops a brand-new window rooted at `path` and focuses it.
+    /// Used when a `fresh <dir>` is invoked from inside Fresh's own
+    /// embedded terminal: the directory becomes a new session instead
+    /// of launching a second editor in the terminal.
+    OpenWindow { path: String },
 }
 
 /// A file to open with optional line/column position, range, and hover message
@@ -217,6 +228,20 @@ mod tests {
         let parsed: ClientHello = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.term_size.cols, 120);
         assert_eq!(parsed.term_size.rows, 40);
+    }
+
+    #[test]
+    fn test_open_window_roundtrip() {
+        let msg = ClientControl::OpenWindow {
+            path: "/home/user/project".to_string(),
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        // serde(rename_all = "snake_case") should tag it "open_window"
+        assert!(json.contains("\"type\":\"open_window\""));
+        match serde_json::from_str::<ClientControl>(&json).unwrap() {
+            ClientControl::OpenWindow { path } => assert_eq!(path, "/home/user/project"),
+            other => panic!("expected OpenWindow, got {:?}", other),
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/src/server/runner.rs
+++ b/crates/fresh-editor/src/server/runner.rs
@@ -378,6 +378,13 @@ impl Server {
                     client.id
                 );
             }
+            ClientControl::OpenWindow { .. } => {
+                // This runner doesn't have an editor, so we can't open windows
+                tracing::warn!(
+                    "Client {} sent OpenWindow but no editor is running",
+                    client.id
+                );
+            }
         }
         Ok(())
     }

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -290,6 +290,21 @@ impl TerminalManager {
             // The built-in emulator is alacritty-based so xterm-256color is appropriate.
             cmd.env("TERM", "xterm-256color");
 
+            // Advertise this editor's local control socket to local child
+            // shells via FRESH_SESSION, so a `fresh` launched from inside
+            // this embedded terminal forwards file/dir opens back to us
+            // instead of starting a second editor. Only for the local host
+            // shell: `manages_cwd` (== `skip_cwd`) marks docker/ssh-style
+            // wrappers, whose inner `fresh` runs on another host where this
+            // unix socket isn't reachable. (A nested `fresh` that can't reach
+            // the socket falls back to running inline, so this gate is an
+            // optimization, not a correctness requirement.)
+            if !skip_cwd {
+                if let Some(session_id) = crate::server::local_control::local_session_id() {
+                    cmd.env("FRESH_SESSION", session_id);
+                }
+            }
+
             // On Windows, set additional environment variables that help with ConPTY
             #[cfg(windows)]
             {


### PR DESCRIPTION
Running `fresh` from inside Fresh's own embedded terminal used to start a
second, fully independent editor inside that terminal. This is almost never
what you want — the dominant case is `$EDITOR`/`git commit`, where the inner
editor should hand its file to the editor you're already in.

Direct (non-server) mode now binds a per-process *control* socket and
advertises it to local embedded-terminal shells via `FRESH_SESSION`. A
`fresh` launched with `FRESH_SESSION` set acts as a thin client and forwards
its arguments to the parent instead of rendering:

  - a file opens in the parent's current window and the nested process
    blocks until that buffer is closed, so `git commit`/`$EDITOR` behave
    correctly;
  - a directory pops a new, focused orchestrator window;
  - if the socket is unreachable (parent gone, or a docker/ssh terminal on
    another host), it falls back to running inline — the pre-feature
    behavior, so nothing regresses.

The direct-mode crossterm render/input path is completely untouched: this
only adds a control-channel front-end. It reuses the session server's IPC
primitives, wire protocol, and `queue_file_open`/wait machinery; a new
`ClientControl::OpenWindow` message carries the directory case (the session
server handles it too, so a remote client opening a dir gets the same
behavior). Protocol bumped to v2.

https://claude.ai/code/session_01CUhhafDhAQn6kLFepTs7wK