### PR TITLE
orchestrator: track session activity by window, covering any terminal + in-place output

### DIFF
--- a/crates/fresh-core/src/hooks.rs
+++ b/crates/fresh-core/src/hooks.rs
@@ -356,6 +356,13 @@ pub enum HookArgs {
     TerminalOutput {
         /// Stable terminal session id (matches `TerminalId.0`).
         terminal_id: u64,
+        /// Editor window that owns this terminal (matches `WindowId.0`).
+        /// Lets a plugin attribute output to a *session* — Orchestrator
+        /// keys activity off the window, so output from ANY terminal in
+        /// the window (not just the one the plugin spawned) counts. Fires
+        /// on every PTY read, so in-place redraws and carriage-return
+        /// progress bars register as activity too, not just newlines.
+        window_id: u64,
         /// Snapshot of the cursor row's text content. May be empty
         /// (just-resized terminal, cleared screen). Trailing whitespace
         /// is preserved because prompt detection often depends on it
@@ -369,6 +376,8 @@ pub enum HookArgs {
     TerminalExited {
         /// Stable terminal session id (matches `TerminalId.0`).
         terminal_id: u64,
+        /// Editor window that owned this terminal (matches `WindowId.0`).
+        window_id: u64,
         /// Process exit code if known. `None` when the platform did
         /// not report a status (signal, detach, kill before wait).
         /// Plugins that can't distinguish should treat `None` as
@@ -664,10 +673,12 @@ mod tests {
     fn hook_args_to_json_terminal_output_fields_are_flat() {
         let json = hook_args_to_json(&HookArgs::TerminalOutput {
             terminal_id: 7,
+            window_id: 2,
             last_line: "Do you want me to attempt a fix? (Y/n): ".into(),
         })
         .unwrap();
         assert_eq!(json["terminal_id"], 7);
+        assert_eq!(json["window_id"], 2);
         assert_eq!(
             json["last_line"],
             "Do you want me to attempt a fix? (Y/n): "
@@ -678,14 +689,17 @@ mod tests {
     fn hook_args_to_json_terminal_exited_serializes_exit_code() {
         let json_some = hook_args_to_json(&HookArgs::TerminalExited {
             terminal_id: 3,
+            window_id: 1,
             exit_code: Some(0),
         })
         .unwrap();
         assert_eq!(json_some["terminal_id"], 3);
+        assert_eq!(json_some["window_id"], 1);
         assert_eq!(json_some["exit_code"], 0);
 
         let json_err = hook_args_to_json(&HookArgs::TerminalExited {
             terminal_id: 4,
+            window_id: 1,
             exit_code: Some(2),
         })
         .unwrap();
@@ -693,6 +707,7 @@ mod tests {
 
         let json_none = hook_args_to_json(&HookArgs::TerminalExited {
             terminal_id: 5,
+            window_id: 1,
             exit_code: None,
         })
         .unwrap();

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -464,14 +464,19 @@ type WindowInfo = {
 	*/
 	root: string;
 	/**
-	* Project this session belongs to — the canonical repo
-	* root (or arbitrary directory) the user pointed the
-	* new-session form at. `null` for legacy sessions that
-	* predate the Project Path field. The Orchestrator Open
-	* dialog filters by this so the "this project's sessions"
-	* view is one keystroke away from the all-projects view.
+	* Project this session belongs to — the canonical repo root
+	* (or arbitrary directory) the user pointed the new-session
+	* form at. For sessions without an explicit project (legacy
+	* sessions, the launch session, sessions created outside the
+	* orchestrator's new-session form) this equals `root` — the
+	* host normalises at the API boundary so plugins never have
+	* to deal with `null`/`undefined`/`""` ambiguity (`??` only
+	* falls through on `null`, but the orchestrator's
+	* `WindowInfo` round-trips a `Some(PathBuf::new())` as `""`,
+	* which then becomes a poisoned lex sort key — observed as
+	* the Windows-only dock reorder).
 	*/
-	project_path?: string | null;
+	project_path: string;
 	/**
 	* `true` when the session shares its working tree with
 	* other sessions (worktree-creation was off at session

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3350,12 +3350,18 @@ interface HookEventMap {
 		}[];
 	};
 	// ── PTY terminals (see crates/fresh-core/src/hooks.rs) ───────────────────
+	// `window_id` is the editor window owning the terminal (== session id),
+	// so a plugin can attribute output to a session: output from ANY terminal
+	// in the window counts, and it fires on every PTY read (in-place redraws
+	// and carriage-return progress bars register, not just newlines).
 	terminal_output: {
 		terminal_id: number;
+		window_id: number;
 		last_line: string;
 	};
 	terminal_exit: {
 		terminal_id: number;
+		window_id: number;
 		exit_code: number | null;
 	};
 	// ── filesystem watching (watchPath plugin API) ────────────────────────────

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5130,34 +5130,39 @@ editor.on("resize", () => {
 // IDLE_AFTER_MS at render time. We don't poll the process, so this tracks
 // *output*, not liveness — a wedged agent reads idle, same as a finished
 // one, which is the honest limit of what we can see from here.
+//
+// Keyed by `window_id`, not the one terminal id Orchestrator spawned: a
+// session is its editor window (its id == the session id), so output from
+// ANY terminal in that window counts — a second shell the user opened, an
+// agent that re-execs, etc. The host fires `terminal_output` on every PTY
+// read, so this also lights up for in-place redraws and carriage-return
+// progress bars, not just newline-terminated lines.
 // =============================================================================
 
 editor.on("terminal_output", (payload) => {
-  for (const s of orchestratorSessions.values()) {
-    if (s.terminalId === payload.terminal_id) {
-      // Stamp the moment of output. `sessionState` turns this into
-      // working/idle; the cached `state` is updated so persistence and
-      // any non-render reader see a fresh value too.
-      s.lastOutputAt = Date.now();
-      s.state = "working";
-      break;
-    }
+  const s = orchestratorSessions.get(payload.window_id);
+  if (s) {
+    // Stamp the moment of output. `sessionState` turns this into
+    // working/idle; the cached `state` is updated so persistence and
+    // any non-render reader see a fresh value too.
+    s.lastOutputAt = Date.now();
+    s.state = "working";
+    refreshOpenDialog();
   }
-  refreshOpenDialog();
 });
 
 editor.on("terminal_exit", (payload) => {
-  for (const s of orchestratorSessions.values()) {
-    if (s.terminalId === payload.terminal_id) {
-      // The agent process is gone — it can't be working. Clear the
-      // output timestamp so the row reads idle immediately rather than
-      // riding out the IDLE_AFTER_MS tail from its last line.
-      s.lastOutputAt = null;
-      s.state = "idle";
-      break;
-    }
+  const s = orchestratorSessions.get(payload.window_id);
+  if (s) {
+    // A terminal in this session ended — it can't be the source of work
+    // anymore. Drop to idle and clear the timestamp so the row reads idle
+    // immediately rather than riding out the IDLE_AFTER_MS tail. If another
+    // terminal in the same window is still printing, the next
+    // `terminal_output` re-marks it working within the debounce window.
+    s.lastOutputAt = null;
+    s.state = "idle";
+    refreshOpenDialog();
   }
-  refreshOpenDialog();
 });
 
 // =============================================================================

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -456,20 +456,24 @@ impl Editor {
                         }
                     }
 
-                    // Notify plugins. Snapshot the cursor row's text so the
-                    // listener can match prompt patterns without a separate
-                    // readback API. The grid lock is released before
+                    // Notify plugins. Resolve the owning window so a plugin
+                    // can attribute output to a *session* even when it's a
+                    // background one (terminals live in their own window's
+                    // manager, not the active window's). Snapshot the cursor
+                    // row's text from that same window so prompt detection
+                    // works off-focus too. The grid lock is released before
                     // `run_hook` runs to avoid holding it across plugin code.
-                    let last_line = self
-                        .active_window()
-                        .terminal_manager
-                        .get(terminal_id)
+                    let owner = self.window_id_of_terminal(terminal_id);
+                    let last_line = owner
+                        .and_then(|wid| self.windows.get(&wid))
+                        .and_then(|w| w.terminal_manager.get(terminal_id))
                         .and_then(|handle| handle.state.lock().ok().map(|s| s.last_visible_line()))
                         .unwrap_or_default();
                     self.plugin_manager.read().unwrap().run_hook(
                         "terminal_output",
                         crate::services::plugins::hooks::HookArgs::TerminalOutput {
                             terminal_id: terminal_id.0 as u64,
+                            window_id: owner.map(|w| w.0).unwrap_or(0),
                             last_line,
                         },
                     );
@@ -490,6 +494,9 @@ impl Editor {
                     exit_code,
                 } => {
                     tracing::info!("Terminal {:?} exited", terminal_id);
+                    // Resolve the owning window before the cleanup below
+                    // closes the terminal (which would make the lookup fail).
+                    let exited_window_id = self.window_id_of_terminal(terminal_id);
                     // Find the buffer associated with this terminal
                     if let Some((&buffer_id, _)) = self
                         .active_window()
@@ -595,6 +602,7 @@ impl Editor {
                         "terminal_exit",
                         crate::services::plugins::hooks::HookArgs::TerminalExited {
                             terminal_id: terminal_id.0 as u64,
+                            window_id: exited_window_id.map(|w| w.0).unwrap_or(0),
                             exit_code,
                         },
                     );

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -531,6 +531,21 @@ impl Editor {
         self.active_window
     }
 
+    /// Find the window that owns `terminal_id`, if any. Terminals live in
+    /// their owning window's `terminal_manager`, so a background session's
+    /// terminal is invisible from `active_window()` — this scans every
+    /// window. Used to attribute `TerminalOutput`/`TerminalExited` to the
+    /// right session even when it isn't the focused one.
+    pub fn window_id_of_terminal(
+        &self,
+        terminal_id: crate::services::terminal::TerminalId,
+    ) -> Option<fresh_core::WindowId> {
+        self.windows
+            .iter()
+            .find(|(_, w)| w.terminal_manager.get(terminal_id).is_some())
+            .map(|(id, _)| *id)
+    }
+
     /// True iff the editor-global dock is open AND currently holds
     /// keyboard focus. Test helpers use this to wait for `Toggle Dock`'s
     /// async focus-grab to settle before dispatching subsequent keys;

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -579,8 +579,12 @@ interface HookEventMap {
   keyboard_shortcuts: { bindings: { key: string; action: string }[] };
 
   // ── PTY terminals (see crates/fresh-core/src/hooks.rs) ───────────────────
-  terminal_output: { terminal_id: number; last_line: string };
-  terminal_exit: { terminal_id: number; exit_code: number | null };
+  // `window_id` is the editor window owning the terminal (== session id),
+  // so a plugin can attribute output to a session: output from ANY terminal
+  // in the window counts, and it fires on every PTY read (in-place redraws
+  // and carriage-return progress bars register, not just newlines).
+  terminal_output: { terminal_id: number; window_id: number; last_line: string };
+  terminal_exit: { terminal_id: number; window_id: number; exit_code: number | null };
 
   // ── filesystem watching (watchPath plugin API) ────────────────────────────
   path_changed: {


### PR DESCRIPTION
The working/idle dot only watched the single agent terminal Orchestrator
spawned, keyed by terminal id. Sessions with a different/extra terminal
(a second shell, an agent that re-execs) read permanently idle.

Host: add window_id to the terminal_output / terminal_exit hooks,
resolved by scanning every window's terminal_manager (terminals live in
their owning window, not the active one). The PTY reader already fires
terminal_output on every read, so carriage-return progress bars and
raw-mode in-place redraws register as activity — not just newline output.

Plugin: key activity off window_id (== session id) instead of the spawned
terminal id, so output from ANY terminal in the session marks it working.

ts_export.rs is the source of truth for the HookEventMap; fresh.d.ts
updated to match.