### PR TITLE
orchestrator: fix dock worktree-activate, Alt+T/I/P, Open-while-dock, and the archive/delete lifecycle

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1078,8 +1078,9 @@ function bulkEligible(action: BulkAction, id: number): boolean {
   // Delete forgets any session. When it owns a worktree the worktree is
   // removed too; otherwise (launch/in-place) it's just dropped.
   if (action === "delete") return id > 0 || !!s.discovered;
-  // Archive moves the worktree to the graveyard, so it needs one.
-  return ownsWorktree(s);
+  // Archive applies to any session: a worktree session moves to the
+  // graveyard; a launch/in-place session is recorded at its own root.
+  return id > 0 || !!s.discovered;
 }
 
 function eligibleSelected(action: BulkAction): number[] {
@@ -1300,16 +1301,15 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   //
   //  * Stop: only a live session with an agent terminal can be
   //    stopped (the launch session has none).
-  //  * Archive: needs an owned worktree to move to the graveyard.
+  //  * Archive: every session can be archived — a worktree session moves
+  //    to the graveyard; a launch/in-place session is recorded at its own
+  //    root. Closing the last live window opens a replacement first.
   //  * Delete: forgets the session, removing the worktree only when one
-  //    is owned (otherwise the directory is left untouched).
-  //  * Archive/Delete are both refused on the last live window — the
-  //    editor must always host at least one.
-  const hasWorktree = ownsWorktree(s);
-  const isLastWindow = s.id > 0 && liveWindowCount() <= 1;
+  //    is owned (otherwise the directory is left untouched); the last
+  //    live window likewise gets a replacement before it closes.
   const stopDisabled = s.discovered || !s.terminalId;
-  const archiveDisabled = !hasWorktree || isLastWindow;
-  const deleteDisabled = isLastWindow;
+  const archiveDisabled = false;
+  const deleteDisabled = false;
   const buttonRow = row(
     button("Visit", { intent: "primary", key: "visit" }),
     spacer(2),
@@ -2388,13 +2388,55 @@ function pickNextActiveSession(excludeId: number): number {
 
 // Number of real editor windows. Discovered on-disk rows have negative
 // ids and are not windows. The editor must always host at least one
-// window, so deleting/archiving the last live window is refused.
+// window; archiving/deleting the last live window therefore opens a
+// replacement first (see `ensureReplacementWindow`).
 function liveWindowCount(): number {
   let n = 0;
   for (const s of orchestratorSessions.values()) {
     if (s.id > 0) n += 1;
   }
   return n;
+}
+
+// Closing the last live window would leave the editor with nothing to
+// show, so before archiving/deleting the sole remaining session we open
+// a fresh terminal session in `projectRoot` — the project that session
+// belonged to, i.e. "the last project" — and dive into it. The new
+// window becomes active, so the caller can then close the old one
+// normally. No-op when another live window already exists (the caller
+// just switches to it instead). Returns true when a replacement opened.
+async function ensureReplacementWindow(projectRoot: string): Promise<boolean> {
+  if (liveWindowCount() > 1) return false;
+  const label = editor.pathBasename(projectRoot) || "session";
+  try {
+    const result = await editor.createWindowWithTerminal({
+      root: projectRoot,
+      label,
+      cwd: projectRoot,
+    });
+    // `createWindowWithTerminal` fires `window_created`, which reconciles
+    // the new window into the model; set it eagerly too so the immediate
+    // close-and-switch below sees a second live window.
+    orchestratorSessions.set(result.windowId, {
+      id: result.windowId,
+      label,
+      root: projectRoot,
+      projectPath: projectRoot,
+      sharedWorktree: false,
+      terminalId: result.terminalId,
+      state: "idle",
+      lastOutputAt: null,
+      createdAt: Date.now(),
+    });
+    return true;
+  } catch (e) {
+    editor.setStatus(
+      `Orchestrator: could not open a replacement session — ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    );
+    return false;
+  }
 }
 
 // Resolve the *main* repo root a session's worktree belongs to, so
@@ -2433,76 +2475,86 @@ interface LifecycleResult {
 async function archiveOne(id: number): Promise<LifecycleResult> {
   const s = orchestratorSessions.get(id);
   if (!s) return { ok: false, err: "session gone" };
-  // Archive moves the worktree to the graveyard — only sessions that
-  // own one can be archived. A launch/in-place session has no separate
-  // worktree, so there's nothing to move; use Delete to forget it.
-  if (!ownsWorktree(s)) {
-    return { ok: false, err: "no worktree to archive — use Delete to forget this session" };
-  }
-  // The editor must keep at least one window; closing the last one
-  // would orphan the move. Refuse before touching the worktree.
-  if (s.id > 0 && liveWindowCount() <= 1) {
-    return { ok: false, err: "cannot archive the last window — open another session first" };
-  }
-  const repoRoot = await worktreeRepoRoot(s);
-  if (!repoRoot) return { ok: false, err: "not a git repository" };
+  const removable = ownsWorktree(s);
 
-  // Live session: close_window refuses to close the active window, so
-  // switch away first, then SIGKILL the process group (so pty
-  // children release worktree locks) and close the editor session.
+  // Live session: the editor must always host a window. If this is the
+  // only one, open a replacement in its project first; then switch away
+  // (close_window refuses the active window), SIGKILL the process group
+  // so pty children release any worktree locks, and close the session.
   if (!s.discovered && id > 0) {
+    await ensureReplacementWindow(s.projectPath ?? s.root);
     if (id === editor.activeWindow()) {
       editor.setActiveWindow(pickNextActiveSession(id));
     }
     if (s.terminalId) editor.signalWindow(id, "SIGKILL");
     editor.closeWindow(id);
-    // Brief settle so the filesystem reflects the pty's exit before
-    // we move the worktree out from under it.
-    await editor.delay(250);
+    // Brief settle so the filesystem reflects the pty's exit before we
+    // move the worktree out from under it.
+    if (removable) await editor.delay(250);
   }
 
-  const archivedRoot = editor.pathJoin(
-    editor.getDataDir(),
-    "orchestrator",
-    slugify(repoRoot),
-    ".archived",
-    s.label,
-  );
-  const parent = editor.pathDirname(archivedRoot);
-  if (!editor.createDir(parent)) {
-    return { ok: false, err: `could not create ${parent}`, repoRoot };
-  }
-  // git worktree move keeps git's internal bookkeeping consistent
-  // (the new path stays registered as a worktree).
-  const moveRes = await spawnCollect(
-    "git",
-    ["-C", repoRoot, "worktree", "move", s.root, archivedRoot],
-    repoRoot,
-  );
-  if (moveRes.exit_code !== 0) {
-    return {
-      ok: false,
-      err: lastNonEmptyLine(moveRes.stderr) || "worktree move failed",
+  if (removable) {
+    // Owns a worktree: move it to the `.archived/` graveyard so git's
+    // bookkeeping stays consistent and Unarchive can move it back.
+    const repoRoot = await worktreeRepoRoot(s);
+    if (!repoRoot) return { ok: false, err: "not a git repository" };
+    const archivedRoot = editor.pathJoin(
+      editor.getDataDir(),
+      "orchestrator",
+      slugify(repoRoot),
+      ".archived",
+      s.label,
+    );
+    const parent = editor.pathDirname(archivedRoot);
+    if (!editor.createDir(parent)) {
+      return { ok: false, err: `could not create ${parent}`, repoRoot };
+    }
+    const moveRes = await spawnCollect(
+      "git",
+      ["-C", repoRoot, "worktree", "move", s.root, archivedRoot],
       repoRoot,
-    };
+    );
+    if (moveRes.exit_code !== 0) {
+      return {
+        ok: false,
+        err: lastNonEmptyLine(moveRes.stderr) || "worktree move failed",
+        repoRoot,
+      };
+    }
+    const manifest = loadArchiveManifest(repoRoot);
+    manifest.sessions.push({
+      label: s.label,
+      root: archivedRoot,
+      original_root: s.root,
+      branch: s.branch || s.label,
+      archived_at: new Date().toISOString(),
+    });
+    saveArchiveManifest(repoRoot, manifest);
+    // A discovered row has no window_closed hook to drop it — remove it
+    // from the model directly.
+    if (s.discovered) {
+      orchestratorSessions.delete(id);
+      discoveredIdByPath.delete(s.root);
+    }
+    return { ok: true, repoRoot };
   }
 
+  // In-place / launch session: there's no separate worktree to move, so
+  // archiving just records the session at its own root (original_root ===
+  // root, no graveyard move) — listing it as archived and letting a
+  // future Unarchive reopen a window there — then drops the live record.
+  // The window was already closed above.
+  const repoRoot = (await resolveCanonicalRepoRoot(s.root)) ?? s.root;
   const manifest = loadArchiveManifest(repoRoot);
   manifest.sessions.push({
     label: s.label,
-    root: archivedRoot,
+    root: s.root,
     original_root: s.root,
     branch: s.branch || s.label,
     archived_at: new Date().toISOString(),
   });
   saveArchiveManifest(repoRoot, manifest);
-
-  // A discovered row has no window_closed hook to drop it — remove it
-  // from the model directly.
-  if (s.discovered) {
-    orchestratorSessions.delete(id);
-    discoveredIdByPath.delete(s.root);
-  }
+  orchestratorSessions.delete(id);
   return { ok: true, repoRoot };
 }
 
@@ -2717,19 +2769,16 @@ async function buildSyncSnapshot(repoRoot: string): Promise<unknown> {
 async function deleteOne(id: number): Promise<LifecycleResult> {
   const s = orchestratorSessions.get(id);
   if (!s) return { ok: false, err: "session gone" };
-  // The editor must keep at least one window. Refuse before any
-  // close/worktree-removal so a removable session can't `git worktree
-  // remove` the tree the live editor is still sitting in.
-  if (s.id > 0 && liveWindowCount() <= 1) {
-    return { ok: false, err: "cannot delete the last window — open another session first" };
-  }
   const removable = ownsWorktree(s);
 
   if (!s.discovered && id > 0) {
-    // close_window refuses to close the active (and the last) window,
-    // so swap away first. SIGKILL only when there's an agent terminal —
-    // a launch/in-place session has none, and signalling it must never
-    // touch the editor itself.
+    // The editor must keep at least one window. If this is the only live
+    // one, open a replacement in its project first (so a removable
+    // session can't `git worktree remove` the tree the editor is still
+    // sitting in, and the editor never goes empty). Then swap away
+    // (close_window refuses the active window), SIGKILL only when there's
+    // an agent terminal — a launch/in-place session has none — and close.
+    await ensureReplacementWindow(s.projectPath ?? s.root);
     if (id === editor.activeWindow()) {
       editor.setActiveWindow(pickNextActiveSession(id));
     }
@@ -2771,6 +2820,12 @@ async function deleteOne(id: number): Promise<LifecycleResult> {
   if (s.discovered) {
     orchestratorSessions.delete(id);
     discoveredIdByPath.delete(s.root);
+  } else if (id > 0) {
+    // Drop the live record explicitly. `close_window` fires
+    // `window_closed` → reconcile, which also prunes it, but an in-place
+    // / launch session left the directory untouched, so without this it
+    // could linger in the model and "come back" when the dialog reopens.
+    orchestratorSessions.delete(id);
   }
   return { ok: true, repoRoot };
 }
@@ -4653,33 +4708,12 @@ function enterConfirm(action: "stop" | "archive" | "delete"): void {
   if (!openDialog || !openPanel) return;
   const id = openDialog.filteredIds[openDialog.selectedIndex];
   if (typeof id !== "number" || id <= 0) return;
-  // Archive moves the worktree to the graveyard, so it only applies to
-  // a session that owns one. A launch/in-place session runs inside a
-  // real checkout with no `git worktree` entry — Archive would have
-  // nothing to move (and must never rm-rf the user's actual project).
-  // Delete forgets the session and removes the worktree only when one
-  // is owned. Both refuse the last live window (the editor must keep at
-  // least one) — surface that before the confirm step.
-  if (action === "archive" || action === "delete") {
-    const session = orchestratorSessions.get(id);
-    if (session && session.id > 0 && liveWindowCount() <= 1) {
-      setDialogError(
-        `cannot ${action} session [${id}] ${session.label} — it's the last window; open another session first`,
-      );
-      refreshOpenDialog();
-      return;
-    }
-  }
-  if (action === "archive") {
-    const session = orchestratorSessions.get(id);
-    if (session && !ownsWorktree(session)) {
-      setDialogError(
-        `cannot archive session [${id}] ${session.label} — it has no dedicated worktree; use Delete to forget it`,
-      );
-      refreshOpenDialog();
-      return;
-    }
-  }
+  // Every live session can be stopped/archived/deleted now: Archive
+  // records a launch/in-place session at its own root (no worktree to
+  // move) and worktree sessions move to the graveyard; closing the last
+  // live window opens a replacement first (see `ensureReplacementWindow`
+  // in `archiveOne` / `deleteOne`). So no eligibility refusal here — just
+  // confirm and run.
   openDialog.pendingConfirm = { action, ids: [id] };
   openPanel.update(buildOpenSpec());
   openPanel.setFocusKey("confirm-cancel");

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1877,8 +1877,24 @@ function refreshOpenDialog(): void {
 }
 
 function openControlRoom(opts: { dock?: boolean } = {}): void {
-  if (openPanel) return;
   const asDock = opts?.dock === true;
+  if (openPanel) {
+    // A panel already occupies the shared dock/dialog slot. If the dock
+    // is showing and the user asked for the modal picker (Orchestrator:
+    // Open), the dock already *is* the live session list — refocus it
+    // and say so, rather than silently doing nothing. The modal and the
+    // dock share one panel + state today, so they can't both render at
+    // once; full coexistence is the deferred P1 redesign (see
+    // docs/internal/orchestrator-dock-gaps.md). An `asDock` re-entry
+    // (Toggle Dock) never reaches here — `toggleDock` handles it first.
+    if (!asDock && dockMode) {
+      restoreDockAfterForm();
+      editor.setStatus(
+        "Orchestrator: the dock already lists sessions — hide it (Toggle Dock) to open the full picker",
+      );
+    }
+    return;
+  }
   reconcileSessions();
   // Summarise on-disk session content up front so the trivial filter
   // has data on the first render.

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4842,6 +4842,45 @@ editor.on("widget_event", (e) => {
       }
       return;
     }
+    if (e.event_type === "dock_activate") {
+      // Host Enter on the dock's session list. Mirrors the dialog's
+      // `activate` branch: a discovered (on-disk) worktree has no live
+      // window to switch to, so attach a fresh session at it; any other
+      // row is already active via the arrow live-switch, so Enter just
+      // hands keyboard focus to the editor (the dock stays visible).
+      if (!dockMode || !openPanel || !openDialog) return;
+      const id = openDialog.filteredIds[openDialog.selectedIndex];
+      const sel = typeof id === "number" ? orchestratorSessions.get(id) : undefined;
+      if (sel && sel.discovered) {
+        void attachToWorktree({
+          root: sel.root,
+          projectPath: sel.projectPath ?? sel.root,
+          label: sel.label,
+          branch: sel.branch,
+          discoveredId: sel.id,
+        });
+        return;
+      }
+      dockBlurred = true;
+      editor.floatingPanelControl(openPanel.id(), "blur", 0);
+      editor.setEditorMode(null);
+      return;
+    }
+    if (e.event_type === "dock_toggle_worktrees") {
+      // Host Alt+T on the dock — the dialog's OPEN_MODE chord has no
+      // equivalent in the dock (no editor mode), so the host routes it
+      // here. Share the same flip the click/Alt+T-in-dialog use.
+      if (dockMode) toggleShowWorktrees();
+      return;
+    }
+    if (e.event_type === "dock_toggle_trivial") {
+      if (dockMode) toggleHideTrivial();
+      return;
+    }
+    if (e.event_type === "dock_toggle_scope") {
+      if (dockMode) toggleScope();
+      return;
+    }
     if (e.event_type === "change" && e.widget_key === "filter") {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const value = payload.value;

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2640,6 +2640,29 @@ impl Editor {
         Ok(())
     }
 
+    /// Fire a `widget_event` at the plugin owning the dock, keyed to the
+    /// `sessions` widget. Used for dock-only gestures (Enter-activate,
+    /// the Alt+T/Alt+I/Alt+P filter toggles) that the dialog handles via
+    /// an editor mode the dock can't use — see `dispatch_floating_widget_key`.
+    fn fire_dock_widget_event(&self, panel_id: u64, event_type: &str) {
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key: "sessions".to_string(),
+                    event_type: event_type.to_string(),
+                    payload: serde_json::json!({}),
+                },
+            );
+        }
+    }
+
     /// Route a keystroke to the floating widget panel when one is
     /// mounted. Returns `true` if the key was consumed.
     ///
@@ -2696,19 +2719,57 @@ impl Editor {
                 .map(|k| k == "filter")
                 .unwrap_or(false);
             match code {
-                KeyCode::Enter | KeyCode::Esc => {
+                KeyCode::Esc => {
                     if on_filter {
                         // Return from the filter to the session list.
                         self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
                     } else {
-                        // Dive into / leave the dock — focus the editor;
-                        // the dock stays visible.
+                        // Leave the dock — focus the editor; dock stays visible.
                         self.blur_floating_panel(slot);
+                    }
+                    return true;
+                }
+                KeyCode::Enter => {
+                    if on_filter {
+                        // Return from the filter to the session list.
+                        self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
+                    } else {
+                        // Activate the highlighted row. The plugin attaches a
+                        // discovered (on-disk) worktree as a new session, or —
+                        // for a row already backed by a live window — blurs to
+                        // the editor (the dock stays visible). Handled
+                        // plugin-side so the discovered-vs-live decision lives
+                        // next to the dialog's identical `activate` logic, not
+                        // split across the host (was: always blur, which
+                        // silently dropped the on-disk attach in the dock).
+                        self.fire_dock_widget_event(panel_id, "dock_activate");
                     }
                     return true;
                 }
                 KeyCode::Char('/') if modifiers.is_empty() => {
                     self.set_panel_focus_and_notify(panel_id, "filter".to_string());
+                    return true;
+                }
+                KeyCode::Char('t' | 'T') if modifiers.contains(KeyModifiers::ALT) => {
+                    // Alt+T toggles "show all worktrees". In the dialog this is
+                    // an OPEN_MODE chord, but the dock has no editor mode (it
+                    // floats over the active buffer's mode), so route it as a
+                    // dock widget_event the plugin maps to the same toggle —
+                    // otherwise it falls through to the generic chord path and
+                    // merely blurs the dock.
+                    self.fire_dock_widget_event(panel_id, "dock_toggle_worktrees");
+                    return true;
+                }
+                KeyCode::Char('i' | 'I') if modifiers.contains(KeyModifiers::ALT) => {
+                    // Alt+I toggles "show empty/1-file sessions" — same dock
+                    // routing rationale as Alt+T above.
+                    self.fire_dock_widget_event(panel_id, "dock_toggle_trivial");
+                    return true;
+                }
+                KeyCode::Char('p' | 'P') if modifiers.contains(KeyModifiers::ALT) => {
+                    // Alt+P flips the project scope (current ↔ all) — same dock
+                    // routing rationale as Alt+T above.
+                    self.fire_dock_widget_event(panel_id, "dock_toggle_scope");
                     return true;
                 }
                 KeyCode::Char('n' | 'N') if modifiers.contains(KeyModifiers::ALT) => {

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -546,6 +546,58 @@ fn dock_alt_t_toggles_worktrees_without_blurring() {
     );
 }
 
+/// Invoking `Orchestrator: Open` while the dock is visible must not be a
+/// silent no-op. The dock and the modal picker share one panel + state
+/// today, so the modal can't render on top; the command refocuses the
+/// dock and surfaces a hint instead. Before the fix `openControlRoom`
+/// bailed at `if (openPanel) return` and nothing happened at all.
+#[test]
+fn open_command_gives_feedback_when_dock_is_visible() {
+    // Wide terminal so the dock (left column) still leaves the status bar
+    // room to show the full hint text.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(200, 40, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Ctrl+P falls through (blurs the dock) and opens the palette; run
+    // "Orchestrator: Open" from it.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Open").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: Open"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+
+    // With the fix the command refocuses the dock (Ctrl+P had blurred it)
+    // and surfaces a status hint. Without the fix `openControlRoom` bails
+    // at `if (openPanel) return` — nothing happens and the dock stays
+    // blurred, so this wait times out.
+    h.wait_until(|h| h.editor().is_dock_focused()).unwrap();
+
+    let screen = h.screen_to_string();
+    // The status bar carries the hint (feedback, not silence)...
+    assert!(
+        screen.contains("the dock already lists sessions"),
+        "Open should surface a hint when the dock is visible.\nScreen:\n{screen}"
+    );
+    // ...the dock is still there...
+    assert!(
+        screen.contains("ORCHESTRATOR"),
+        "the dock must stay visible.\nScreen:\n{screen}"
+    );
+    // ...and the centered modal picker did NOT open on top of it (the
+    // dock header is "ORCHESTRATOR"; the modal title is the longer
+    // "ORCHESTRATOR :: Sessions").
+    assert!(
+        !screen.contains("ORCHESTRATOR :: Sessions"),
+        "the modal picker must not open over the dock.\nScreen:\n{screen}"
+    );
+}
+
 #[test]
 fn settings_dialog_does_not_overlap_dock() {
     // Open the dock, then open the Settings modal via the command

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -507,6 +507,45 @@ fn picker_space_toggles_focused_checkbox_not_list() {
     );
 }
 
+/// Alt+T in the dock toggles "all worktrees" rather than blurring the
+/// dock. The Open dialog handles Alt+T via its OPEN_MODE chord, but the
+/// dock has no editor mode (it floats over the active buffer's mode), so
+/// before the fix the host treated Alt+T as an unhandled Ctrl/Alt chord
+/// and blurred the dock — the checkbox never flipped. The host now routes
+/// it as a `dock_toggle_worktrees` widget_event the plugin maps to the
+/// same toggle.
+#[test]
+fn dock_alt_t_toggles_worktrees_without_blurring() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The dock's worktree filter starts off.
+    h.wait_until(|h| h.screen_to_string().contains("[ ] all worktrees"))
+        .unwrap();
+
+    // Alt+T flips it on. Without the fix the chord blurs the dock and the
+    // checkbox stays unchecked, so this wait would time out.
+    h.send_key(KeyCode::Char('t'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[v] all worktrees"))
+        .unwrap();
+
+    // Alt+T again flips it back off (proves it stays wired, not one-shot).
+    h.send_key(KeyCode::Char('t'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("[ ] all worktrees"))
+        .unwrap();
+
+    // And the dock kept keyboard focus throughout — it never blurred.
+    assert!(
+        h.editor().is_dock_focused(),
+        "Alt+T must leave the dock focused, not blur it.\nScreen:\n{}",
+        h.screen_to_string()
+    );
+}
+
 #[test]
 fn settings_dialog_does_not_overlap_dock() {
     // Open the dock, then open the Settings modal via the command

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -824,3 +824,81 @@ fn dock_enter_attaches_discovered_worktree() {
             )
         });
 }
+
+/// Archiving the *last* session — which is also the launch / in-place
+/// session (no dedicated worktree) — must not be refused. Every session
+/// is archivable now: the launch session is recorded at its own root and,
+/// because it's the only live window, a replacement terminal session is
+/// opened in its project first so the editor is never left empty.
+///
+/// Before the fix this was doubly blocked: `enterConfirm` refused both
+/// "no worktree to archive" and "last window", so the confirm step never
+/// even appeared.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // replacement spawns a Unix shell terminal.
+fn archive_last_in_place_session_opens_replacement() {
+    if !pty_available() {
+        eprintln!("skipping: no PTY available in this environment");
+        return;
+    }
+    // Only the launch session exists (the on-disk worktree is never
+    // attached here) — an in-place session with no dedicated worktree.
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Open");
+
+    open_orchestrator_dialog(&mut harness);
+    // The launch session is a trivial (empty) session, hidden by default;
+    // Alt+I reveals it so it can be selected.
+    harness
+        .send_key(KeyCode::Char('i'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("launch session"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "the launch session should be listed after Alt+I.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Focus opens on Visit; Tab to the Archive button (Stop is disabled
+    // for the terminal-less launch session, so the cycle skips it:
+    // visit -> toggle-details -> archive). Activate it to open the
+    // confirm. Without the fix Archive is disabled (dropped from the Tab
+    // cycle) and the action is refused, so the confirm never shows.
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Confirm Archive"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "archiving the launch session should reach the confirm step.\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Confirm (Cancel is focused first; Tab -> Confirm Archive).
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // The launch session is archived; because it was the only window, a
+    // replacement terminal session was opened in its project — so the
+    // editor still hosts a live session, now a *Terminal*.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Terminal"))
+        .unwrap_or_else(|_| {
+            panic!(
+                "archiving the last session should open a replacement terminal \
+                 session.\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -732,3 +732,95 @@ fn worktrees_hidden_by_default_until_show_toggled() {
             )
         });
 }
+
+/// Toggle the global dock open via the command palette and wait for it
+/// to render *and* take keyboard focus (focus is set asynchronously
+/// through the plugin→host bridge, so poll `is_dock_focused`).
+fn open_dock(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Orchestrator: Toggle Dock").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Toggle Dock"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            h.screen_to_string().contains("ORCHESTRATOR") && h.editor().is_dock_focused()
+        })
+        .unwrap();
+}
+
+/// 0-based screen row containing `needle`, or panic with the screen.
+fn dock_row_of(harness: &EditorTestHarness, needle: &str) -> usize {
+    let screen = harness.screen_to_string();
+    screen
+        .lines()
+        .position(|l| l.contains(needle))
+        .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
+}
+
+/// Pressing Enter on a discovered (on-disk) worktree row in the *dock*
+/// attaches a managed session at that worktree — the same outcome the
+/// Open dialog produces. Before the fix the dock's Enter always blurred
+/// to the editor, so the on-disk attach was silently dropped: diving a
+/// worktree worked from the dialog but did nothing from the dock.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
+fn dock_enter_attaches_discovered_worktree() {
+    if !pty_available() {
+        eprintln!("skipping: no PTY available in this environment");
+        return;
+    }
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Toggle Dock");
+
+    open_dock(&mut harness);
+
+    // Alt+T reveals the discovered on-disk worktree in the dock.
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("· on-disk")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "dock should reveal the on-disk `feature-x` worktree after Alt+T.\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Click the discovered row to select it, then Enter to activate.
+    let row = dock_row_of(&harness, "· on-disk") as u16;
+    harness.mouse_click(3, row).unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Attach is async (`createWindowWithTerminal`). It opens a live
+    // session rooted at the worktree, so the dock's discovered row turns
+    // into a live `feature-x` row (no longer `· on-disk`).
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && !s.contains("· on-disk")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Enter on the dock's discovered worktree row should attach a live \
+                 session (row loses `· on-disk`).\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}


### PR DESCRIPTION
Fixes four orchestrator dock / lifecycle bugs found by interactive (tmux) testing and filed as #2183, #2184, #2185, #2186. Each fix has an e2e test that drives keyboard/mouse and asserts on rendered output, and that fails (times out) without the fix.

## #2183 + #2185 — dock keys never reached the plugin
The dock floats over the active buffer's editor mode, so the dialog's `OPEN_MODE` chords and the dialog's Enter "activate" never reached the dock — the host treated them as unhandled keys and merely blurred the dock. Two user-visible bugs, both of which already worked from the identical Open-dialog flow:

- **#2183** — Enter on a discovered (on-disk) worktree row did nothing (it blurred to the editor) instead of attaching a managed session at the worktree.
- **#2185** — Alt+T (and Alt+I / Alt+P) blurred the dock instead of toggling "show all worktrees" / "show empty/1-file" / the project scope.

The host's dock key dispatch now fires dedicated `dock_activate` and `dock_toggle_worktrees` / `dock_toggle_trivial` / `dock_toggle_scope` widget events. The plugin attaches a discovered worktree on `dock_activate` (mirroring the dialog's `activate` branch) or blurs for a row already backed by a live window, and maps the toggle events to the same shared flips the dialog's chords use.

*e2e:* `dock_enter_attaches_discovered_worktree`, `dock_alt_t_toggles_worktrees_without_blurring`.

## #2186 — "Orchestrator: Open" silently did nothing while the dock was visible
The dock and the modal Open picker share one floating-panel slot and one set of state, so `openControlRoom` bailed at `if (openPanel) return` whenever the dock was mounted — invoking "Open" from a visible dock did nothing, with no feedback. It now refocuses the dock (Ctrl+P had blurred it to open the palette) and surfaces a status hint instead of a silent no-op.

This is a pragmatic fix for the reported symptom; rendering the modal *beside* the dock requires decoupling the shared dock/modal state, tracked as the larger "P1" redesign in `docs/internal/orchestrator-dock-gaps.md`.

*e2e:* `open_command_gives_feedback_when_dock_is_visible`.

## #2184 — launch / last session couldn't be archived or deleted
Archive/Delete special-cased two kinds of session into being stuck:

- the launch / in-place session (no dedicated worktree) could never be archived — the button, `enterConfirm`, and `archiveOne` all refused it ("no worktree to archive");
- the last live window could be neither archived nor deleted, and a launch-session Delete reported success while leaving the model record behind, so it "came back".

Now every live session is archivable and deletable:

- Archive moves a worktree session to the `.archived/` graveyard as before, and records a launch/in-place session at its own root (no worktree move) so it still lists as archived.
- Before closing the **last** live window, `ensureReplacementWindow` opens a fresh terminal session in that session's project ("the last project") and dives into it, so the editor is never left empty.
- Deleting a non-discovered session now drops its model record explicitly, fixing the launch-session "delete succeeds but it stays".
- The Archive/Delete button-enable logic, `bulkEligible`, and the `enterConfirm` guards are updated to match — no more disabled Archive or last-window refusals.

*e2e:* `archive_last_in_place_session_opens_replacement`.

## Testing
- 4 new e2e tests, each verified to fail (time out) without its fix and pass with it.
- Full orchestrator e2e suite (41 tests) green — no regressions.
- `cargo fmt`, `cargo clippy --all-targets` (changed files clean), `cargo check` all pass.
- No plugin-API or schema changes (only existing APIs + widget events), so no generated `.d.ts`/schema updates were needed.

https://claude.ai/code/session_01Gx33Pb25BdZKpaGpVYxzj5