### PR TITLE
Support dynamic LSP capability registration and refresh requests

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -304,6 +304,12 @@ impl Editor {
                 AsyncMessage::LspDiagnosticRefresh { language } => {
                     self.handle_lsp_diagnostic_refresh(language);
                 }
+                AsyncMessage::LspInlayHintRefresh { language } => {
+                    self.handle_lsp_inlay_hint_refresh(language);
+                }
+                AsyncMessage::LspSemanticTokensRefresh { language } => {
+                    self.handle_lsp_semantic_tokens_refresh(language);
+                }
                 AsyncMessage::LspDynamicCapabilities {
                     language,
                     server_name,

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -304,6 +304,19 @@ impl Editor {
                 AsyncMessage::LspDiagnosticRefresh { language } => {
                     self.handle_lsp_diagnostic_refresh(language);
                 }
+                AsyncMessage::LspDynamicCapabilities {
+                    language,
+                    server_name,
+                    register,
+                    registrations,
+                } => {
+                    self.handle_lsp_dynamic_capabilities(
+                        language,
+                        server_name,
+                        register,
+                        registrations,
+                    );
+                }
                 AsyncMessage::FileChanged { path } => {
                     self.handle_async_file_changed(path);
                 }

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -901,6 +901,22 @@ impl Editor {
         self.pull_diagnostics_for_language(&language);
     }
 
+    pub(super) fn handle_lsp_inlay_hint_refresh(&mut self, language: String) {
+        tracing::info!(
+            "LSP ({}) inlay-hint refresh requested, re-pulling inlay hints",
+            language
+        );
+        self.request_inlay_hints_for_language(&language);
+    }
+
+    pub(super) fn handle_lsp_semantic_tokens_refresh(&mut self, language: String) {
+        tracing::info!(
+            "LSP ({}) semantic-tokens refresh requested, re-pulling semantic tokens",
+            language
+        );
+        self.request_semantic_tokens_for_language(&language);
+    }
+
     /// Apply a dynamic capability (un)registration from the server, then — when
     /// a capability newly turned on — kick off the corresponding requests for
     /// buffers that were already open before the registration arrived (they

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -901,6 +901,48 @@ impl Editor {
         self.pull_diagnostics_for_language(&language);
     }
 
+    /// Apply a dynamic capability (un)registration from the server, then — when
+    /// a capability newly turned on — kick off the corresponding requests for
+    /// buffers that were already open before the registration arrived (they
+    /// would otherwise never be requested, mirroring `LspInitialized`).
+    pub(super) fn handle_lsp_dynamic_capabilities(
+        &mut self,
+        language: String,
+        server_name: String,
+        register: bool,
+        registrations: Vec<(String, Option<serde_json::Value>)>,
+    ) {
+        tracing::info!(
+            "LSP ({}) server '{}' {} {} capability registration(s)",
+            language,
+            server_name,
+            if register {
+                "registered"
+            } else {
+                "unregistered"
+            },
+            registrations.len()
+        );
+
+        let __active_id = self.active_window;
+        let changed = self
+            .windows
+            .get_mut(&__active_id)
+            .and_then(|w| w.lsp.as_mut())
+            .is_some_and(|lsp| {
+                lsp.apply_dynamic_capabilities(&server_name, register, &registrations)
+            });
+
+        // Only re-issue requests on a net-new capability; an unregister or a
+        // no-op registration should not trigger a fresh round of requests.
+        if changed && register {
+            self.request_semantic_tokens_for_language(&language);
+            self.request_folding_ranges_for_language(&language);
+            self.request_inlay_hints_for_language(&language);
+            self.pull_diagnostics_for_language(&language);
+        }
+    }
+
     /// Re-pull diagnostics for all open buffers associated with the given language.
     pub(super) fn pull_diagnostics_for_language(&mut self, language: &str) {
         // Use the shared language-filtered buffer enumeration so requests

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -164,6 +164,17 @@ pub enum AsyncMessage {
     /// Client should re-pull diagnostics for all open documents
     LspDiagnosticRefresh { language: String },
 
+    /// LSP server requests an inlay-hint refresh (workspace/inlayHint/refresh).
+    /// Client should re-pull inlay hints for all open documents — used when the
+    /// server learns more later (e.g. a change in file A alters inferred types
+    /// in file B, which the user never edited so was never otherwise re-pulled).
+    LspInlayHintRefresh { language: String },
+
+    /// LSP server requests a semantic-tokens refresh
+    /// (workspace/semanticTokens/refresh). Client should re-pull semantic
+    /// tokens for all open documents.
+    LspSemanticTokensRefresh { language: String },
+
     /// LSP server registered (`client/registerCapability`) or unregistered
     /// (`client/unregisterCapability`) one or more capabilities dynamically.
     /// Many servers advertise little or nothing statically in their

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -164,6 +164,20 @@ pub enum AsyncMessage {
     /// Client should re-pull diagnostics for all open documents
     LspDiagnosticRefresh { language: String },
 
+    /// LSP server registered (`client/registerCapability`) or unregistered
+    /// (`client/unregisterCapability`) one or more capabilities dynamically.
+    /// Many servers advertise little or nothing statically in their
+    /// `initialize` result and instead register providers afterwards, so these
+    /// must update the stored `ServerCapabilities` or the features stay gated
+    /// off for the whole session. `register == false` means unregister.
+    /// Each entry is `(method, register_options)`.
+    LspDynamicCapabilities {
+        language: String,
+        server_name: String,
+        register: bool,
+        registrations: Vec<(String, Option<Value>)>,
+    },
+
     /// File changed externally (future: file watching)
     FileChanged { path: String },
 

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -2140,7 +2140,11 @@ impl LspState {
     ) -> Result<(), String> {
         use lsp_types::DocumentDiagnosticParams;
 
-        // Check if server supports pull diagnostics (diagnosticProvider capability)
+        // Check if server supports pull diagnostics (diagnosticProvider capability).
+        // This raw `ServerCapabilities` snapshot is kept in sync with dynamic
+        // `client/registerCapability` updates (sinelaw/fresh#2195) by the stdout
+        // reader, so a server like pyright that registers `diagnosticProvider`
+        // dynamically rather than statically is honored here too.
         let supports_pull = self
             .capabilities
             .lock()
@@ -2808,6 +2812,7 @@ impl LspTask {
         shutting_down: Arc<AtomicBool>,
         document_versions: Arc<std::sync::Mutex<HashMap<PathBuf, i64>>>,
         config_options: Arc<std::sync::Mutex<Option<Value>>>,
+        capabilities: Arc<std::sync::Mutex<Option<ServerCapabilities>>>,
     ) {
         tokio::spawn(async move {
             tracing::info!("LSP stdout reader task started for {}", language);
@@ -2825,6 +2830,7 @@ impl LspTask {
                             &stdin_writer,
                             &document_versions,
                             &config_options,
+                            &capabilities,
                         )
                         .await
                         {
@@ -2936,6 +2942,7 @@ impl LspTask {
             shutting_down.clone(),
             self.document_versions.clone(),
             config_options.clone(),
+            state.capabilities.clone(),
         );
 
         // Sequential command dispatch loop.
@@ -3631,6 +3638,46 @@ fn unregistrations_from_params(params: Option<&Value>) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Reflect dynamic capability (un)registrations into the raw `ServerCapabilities`
+/// snapshot held by the LSP task.
+///
+/// The main-loop `ServerCapabilitySummary` is the primary gate for whether a
+/// request is sent, and it is updated from the same registrations. But a few
+/// task-side send checks read this raw snapshot instead — currently only
+/// `handle_document_diagnostic` (pull diagnostics) — so the diagnostic provider
+/// must be mirrored here or those requests are silently skipped for servers
+/// (e.g. pyright) that register `diagnosticProvider` dynamically rather than
+/// statically. Other features gate solely on the summary; extend this if a new
+/// task-side gate is added (sinelaw/fresh#2195).
+fn sync_raw_capabilities(
+    capabilities: &Arc<std::sync::Mutex<Option<ServerCapabilities>>>,
+    registrations: &[(String, Option<Value>)],
+    register: bool,
+) {
+    use lsp_types::{DiagnosticOptions, DiagnosticServerCapabilities};
+
+    if !registrations
+        .iter()
+        .any(|(method, _)| method == "textDocument/diagnostic")
+    {
+        return;
+    }
+
+    let mut guard = capabilities.lock().unwrap();
+    let caps = guard.get_or_insert_with(ServerCapabilities::default);
+    for (method, options) in registrations {
+        if method == "textDocument/diagnostic" {
+            caps.diagnostic_provider = register.then(|| {
+                let opts = options
+                    .as_ref()
+                    .and_then(|o| serde_json::from_value::<DiagnosticOptions>(o.clone()).ok())
+                    .unwrap_or_default();
+                DiagnosticServerCapabilities::Options(opts)
+            });
+        }
+    }
+}
+
 /// Build the response to a `workspace/configuration` request.
 ///
 /// LSP servers pull their settings by asking the client for named
@@ -3737,6 +3784,7 @@ async fn handle_message_dispatch(
     stdin_writer: &Arc<tokio::sync::Mutex<ChildStdin>>,
     document_versions: &Arc<std::sync::Mutex<HashMap<PathBuf, i64>>>,
     config_options: &Arc<std::sync::Mutex<Option<Value>>>,
+    capabilities: &Arc<std::sync::Mutex<Option<ServerCapabilities>>>,
 ) -> Result<(), String> {
     match message {
         JsonRpcMessage::Response(response) => {
@@ -3839,6 +3887,9 @@ async fn handle_message_dispatch(
                         registrations.iter().map(|(m, _)| m).collect::<Vec<_>>()
                     );
                     if !registrations.is_empty() {
+                        // Keep the task-side raw capability snapshot in sync for
+                        // the few send gates that read it (pull diagnostics).
+                        sync_raw_capabilities(capabilities, &registrations, true);
                         let _ = async_tx.send(AsyncMessage::LspDynamicCapabilities {
                             language: language.to_string(),
                             server_name: server_name.to_string(),
@@ -3865,11 +3916,14 @@ async fn handle_message_dispatch(
                         methods
                     );
                     if !methods.is_empty() {
+                        let registrations: Vec<(String, Option<Value>)> =
+                            methods.into_iter().map(|m| (m, None)).collect();
+                        sync_raw_capabilities(capabilities, &registrations, false);
                         let _ = async_tx.send(AsyncMessage::LspDynamicCapabilities {
                             language: language.to_string(),
                             server_name: server_name.to_string(),
                             register: false,
-                            registrations: methods.into_iter().map(|m| (m, None)).collect(),
+                            registrations,
                         });
                     }
                     JsonRpcResponse {
@@ -5237,6 +5291,66 @@ mod tests {
                 .and_then(|c| c.refresh_support),
             Some(true),
             "workspace.semanticTokens.refreshSupport must be advertised"
+        );
+    }
+
+    #[test]
+    fn sync_raw_capabilities_mirrors_dynamic_diagnostic_provider() {
+        // The task-side raw `ServerCapabilities` snapshot gates pull diagnostics
+        // (`handle_document_diagnostic`). A server like pyright registers
+        // `diagnosticProvider` dynamically, not statically, so without mirroring
+        // it here the pull is silently skipped (sinelaw/fresh#2195).
+        let caps: Arc<std::sync::Mutex<Option<ServerCapabilities>>> =
+            Arc::new(std::sync::Mutex::new(Some(ServerCapabilities::default())));
+        assert!(caps
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .diagnostic_provider
+            .is_none());
+
+        sync_raw_capabilities(
+            &caps,
+            &[("textDocument/diagnostic".to_string(), None)],
+            true,
+        );
+        assert!(
+            caps.lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .diagnostic_provider
+                .is_some(),
+            "dynamic diagnostic registration must set diagnostic_provider so pulls aren't skipped"
+        );
+
+        sync_raw_capabilities(
+            &caps,
+            &[("textDocument/diagnostic".to_string(), None)],
+            false,
+        );
+        assert!(
+            caps.lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .diagnostic_provider
+                .is_none(),
+            "unregister must clear diagnostic_provider"
+        );
+    }
+
+    #[test]
+    fn sync_raw_capabilities_ignores_non_diagnostic_methods() {
+        // Only the diagnostic provider is gated task-side; other methods must
+        // not disturb the raw snapshot (they gate on the main-loop summary).
+        let caps: Arc<std::sync::Mutex<Option<ServerCapabilities>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        sync_raw_capabilities(&caps, &[("textDocument/hover".to_string(), None)], true);
+        assert!(
+            caps.lock().unwrap().is_none(),
+            "a non-diagnostic registration must not materialize the raw snapshot"
         );
     }
 

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -268,11 +268,12 @@ fn create_client_capabilities() -> ClientCapabilities {
         DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities,
         FoldingRangeCapability, FoldingRangeClientCapabilities, FoldingRangeKind,
         FoldingRangeKindCapability, GeneralClientCapabilities, GotoCapability,
-        HoverClientCapabilities, InlayHintClientCapabilities, MarkupKind,
-        PublishDiagnosticsClientCapabilities, RenameClientCapabilities,
-        SignatureHelpClientCapabilities, TagSupport, TextDocumentClientCapabilities,
-        TextDocumentSyncClientCapabilities, WorkspaceClientCapabilities,
-        WorkspaceEditClientCapabilities, WorkspaceSymbolClientCapabilities,
+        HoverClientCapabilities, InlayHintClientCapabilities, InlayHintWorkspaceClientCapabilities,
+        MarkupKind, PublishDiagnosticsClientCapabilities, RenameClientCapabilities,
+        SemanticTokensWorkspaceClientCapabilities, SignatureHelpClientCapabilities, TagSupport,
+        TextDocumentClientCapabilities, TextDocumentSyncClientCapabilities,
+        WorkspaceClientCapabilities, WorkspaceEditClientCapabilities,
+        WorkspaceSymbolClientCapabilities,
     };
 
     ClientCapabilities {
@@ -308,6 +309,18 @@ fn create_client_capabilities() -> ClientCapabilities {
             // refresh support — e.g. rust-analyzer fires it once indexing
             // finishes, which is when the first real diagnostics exist.
             diagnostic: Some(DiagnosticWorkspaceClientCapabilities {
+                refresh_support: Some(true),
+            }),
+            // Accept server-driven inlay-hint and semantic-token refreshes.
+            // These fire when the server learns something later that changes a
+            // file the user never edited (e.g. cross-file type inference), so
+            // it isn't otherwise re-pulled. We handle them by re-pulling for
+            // all open docs of the language; servers only send them because we
+            // advertise refresh support here (sinelaw/fresh#2195 §2).
+            inlay_hint: Some(InlayHintWorkspaceClientCapabilities {
+                refresh_support: Some(true),
+            }),
+            semantic_tokens: Some(SemanticTokensWorkspaceClientCapabilities {
                 refresh_support: Some(true),
             }),
             ..Default::default()
@@ -3883,6 +3896,41 @@ async fn handle_message_dispatch(
                         error: None,
                     }
                 }
+                "workspace/inlayHint/refresh" => {
+                    // Server learned more (e.g. a cross-file type change) and
+                    // wants cached inlay hints re-pulled for all open documents.
+                    // Servers only send this because we advertise
+                    // `workspace.inlayHint.refreshSupport` (sinelaw/fresh#2195 §2).
+                    tracing::info!(
+                        "LSP ({}) requested inlay-hint refresh (workspace/inlayHint/refresh)",
+                        language
+                    );
+                    let _ = async_tx.send(AsyncMessage::LspInlayHintRefresh {
+                        language: language.to_string(),
+                    });
+                    JsonRpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: request.id,
+                        result: Some(Value::Null),
+                        error: None,
+                    }
+                }
+                "workspace/semanticTokens/refresh" => {
+                    // Same idea as inlayHint/refresh, for semantic highlighting.
+                    tracing::info!(
+                        "LSP ({}) requested semantic-tokens refresh (workspace/semanticTokens/refresh)",
+                        language
+                    );
+                    let _ = async_tx.send(AsyncMessage::LspSemanticTokensRefresh {
+                        language: language.to_string(),
+                    });
+                    JsonRpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: request.id,
+                        result: Some(Value::Null),
+                        error: None,
+                    }
+                }
                 "workspace/applyEdit" => {
                     // Server asks client to apply a workspace edit (e.g. during executeCommand)
                     tracing::info!("LSP ({}) received workspace/applyEdit request", language);
@@ -5163,6 +5211,32 @@ mod tests {
                 .and_then(|s| s.dynamic_registration),
             Some(true),
             "workspace.symbol must advertise dynamicRegistration"
+        );
+    }
+
+    #[test]
+    fn advertises_inlay_hint_and_semantic_tokens_refresh_support() {
+        // A server only sends `workspace/inlayHint/refresh` (and the semantic
+        // tokens equivalent) when the client advertised refresh support; we now
+        // handle both, so both must be advertised (sinelaw/fresh#2195 §2).
+        let caps = create_client_capabilities();
+        let workspace = caps.workspace.as_ref().expect("workspace caps must be set");
+
+        assert_eq!(
+            workspace
+                .inlay_hint
+                .as_ref()
+                .and_then(|c| c.refresh_support),
+            Some(true),
+            "workspace.inlayHint.refreshSupport must be advertised"
+        );
+        assert_eq!(
+            workspace
+                .semantic_tokens
+                .as_ref()
+                .and_then(|c| c.refresh_support),
+            Some(true),
+            "workspace.semanticTokens.refreshSupport must be advertised"
         );
     }
 

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -263,14 +263,16 @@ fn create_client_capabilities() -> ClientCapabilities {
     use lsp_types::{
         CodeActionClientCapabilities, CodeActionKindLiteralSupport, CodeActionLiteralSupport,
         CompletionClientCapabilities, DiagnosticClientCapabilities, DiagnosticTag,
-        DiagnosticWorkspaceClientCapabilities, DynamicRegistrationClientCapabilities,
+        DiagnosticWorkspaceClientCapabilities, DocumentFormattingClientCapabilities,
+        DocumentHighlightClientCapabilities, DocumentRangeFormattingClientCapabilities,
+        DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities,
         FoldingRangeCapability, FoldingRangeClientCapabilities, FoldingRangeKind,
         FoldingRangeKindCapability, GeneralClientCapabilities, GotoCapability,
         HoverClientCapabilities, InlayHintClientCapabilities, MarkupKind,
         PublishDiagnosticsClientCapabilities, RenameClientCapabilities,
         SignatureHelpClientCapabilities, TagSupport, TextDocumentClientCapabilities,
         TextDocumentSyncClientCapabilities, WorkspaceClientCapabilities,
-        WorkspaceEditClientCapabilities,
+        WorkspaceEditClientCapabilities, WorkspaceSymbolClientCapabilities,
     };
 
     ClientCapabilities {
@@ -293,6 +295,13 @@ fn create_client_capabilities() -> ClientCapabilities {
             // pulls in `resolve_workspace_configuration`, sourcing the
             // requested section from each server's `initialization_options`.
             configuration: Some(true),
+            // Accept dynamically-registered workspace-symbol providers. We
+            // apply `client/registerCapability` (see handler), so servers that
+            // register `workspace/symbol` after `initialize` get the feature.
+            symbol: Some(WorkspaceSymbolClientCapabilities {
+                dynamic_registration: Some(true),
+                ..Default::default()
+            }),
             // Accept server-driven diagnostic refreshes. We handle
             // `workspace/diagnostic/refresh` (re-pulling diagnostics for all
             // open docs), but servers only send it when the client advertises
@@ -308,22 +317,45 @@ fn create_client_capabilities() -> ClientCapabilities {
                 did_save: Some(true),
                 ..Default::default()
             }),
+            // `dynamicRegistration: true` on every capability we actually
+            // honor: many servers advertise little statically in `initialize`
+            // and register providers afterwards via `client/registerCapability`
+            // (which we now apply). Without the flag a spec-compliant server is
+            // entitled to never register the provider. See sinelaw/fresh#2195.
             completion: Some(CompletionClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
             }),
             hover: Some(HoverClientCapabilities {
+                dynamic_registration: Some(true),
                 content_format: Some(vec![MarkupKind::Markdown, MarkupKind::PlainText]),
-                ..Default::default()
             }),
             signature_help: Some(SignatureHelpClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
             }),
             definition: Some(GotoCapability {
+                dynamic_registration: Some(true),
                 link_support: Some(true),
+            }),
+            references: Some(DynamicRegistrationClientCapabilities {
+                dynamic_registration: Some(true),
+            }),
+            document_highlight: Some(DocumentHighlightClientCapabilities {
+                dynamic_registration: Some(true),
+            }),
+            document_symbol: Some(DocumentSymbolClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
             }),
-            references: Some(DynamicRegistrationClientCapabilities::default()),
+            formatting: Some(DocumentFormattingClientCapabilities {
+                dynamic_registration: Some(true),
+            }),
+            range_formatting: Some(DocumentRangeFormattingClientCapabilities {
+                dynamic_registration: Some(true),
+            }),
             code_action: Some(CodeActionClientCapabilities {
+                dynamic_registration: Some(true),
                 // Without `codeActionLiteralSupport`, rust-analyzer (and
                 // servers that follow the same spec branch) returns `null`
                 // for `textDocument/codeAction` whenever the action would be
@@ -362,9 +394,11 @@ fn create_client_capabilities() -> ClientCapabilities {
                 data_support: Some(true),
             }),
             inlay_hint: Some(InlayHintClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
             }),
             diagnostic: Some(DiagnosticClientCapabilities {
+                dynamic_registration: Some(true),
                 ..Default::default()
             }),
             folding_range: Some(FoldingRangeClientCapabilities {
@@ -3560,6 +3594,30 @@ async fn read_message_from_stdout(
     serde_json::from_str(&json).map_err(|e| format!("Failed to deserialize message: {}", e))
 }
 
+/// Parse the `registrations` out of a `client/registerCapability` request's
+/// params into `(method, register_options)` pairs. Malformed params yield an
+/// empty list (we still ack the request).
+fn registrations_from_params(params: Option<&Value>) -> Vec<(String, Option<Value>)> {
+    params
+        .and_then(|p| serde_json::from_value::<lsp_types::RegistrationParams>(p.clone()).ok())
+        .map(|rp| {
+            rp.registrations
+                .into_iter()
+                .map(|r| (r.method, r.register_options))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Parse the unregistered method names out of a `client/unregisterCapability`
+/// request's params. Malformed params yield an empty list.
+fn unregistrations_from_params(params: Option<&Value>) -> Vec<String> {
+    params
+        .and_then(|p| serde_json::from_value::<lsp_types::UnregistrationParams>(p.clone()).ok())
+        .map(|up| up.unregisterations.into_iter().map(|u| u.method).collect())
+        .unwrap_or_default()
+}
+
 /// Build the response to a `workspace/configuration` request.
 ///
 /// LSP servers pull their settings by asking the client for named
@@ -3754,11 +3812,53 @@ async fn handle_message_dispatch(
                     }
                 }
                 "client/registerCapability" => {
-                    // Server wants to register a capability dynamically - acknowledge
-                    tracing::trace!(
-                        "Acknowledging client/registerCapability (id={})",
-                        request.id
+                    // Many servers advertise little or nothing statically in
+                    // their `initialize` result and register providers
+                    // dynamically here instead. Parse the registrations and
+                    // forward them so the stored `ServerCapabilities` is updated
+                    // — otherwise the feature stays gated off for the whole
+                    // session (sinelaw/fresh#2195). Still ack with `null`.
+                    let registrations = registrations_from_params(request.params.as_ref());
+                    tracing::debug!(
+                        "client/registerCapability (id={}) registering {} method(s): {:?}",
+                        request.id,
+                        registrations.len(),
+                        registrations.iter().map(|(m, _)| m).collect::<Vec<_>>()
                     );
+                    if !registrations.is_empty() {
+                        let _ = async_tx.send(AsyncMessage::LspDynamicCapabilities {
+                            language: language.to_string(),
+                            server_name: server_name.to_string(),
+                            register: true,
+                            registrations,
+                        });
+                    }
+                    JsonRpcResponse {
+                        jsonrpc: "2.0".to_string(),
+                        id: request.id,
+                        result: Some(Value::Null),
+                        error: None,
+                    }
+                }
+                "client/unregisterCapability" => {
+                    // Mirror of registerCapability: the server is withdrawing a
+                    // dynamically-registered provider, so clear the matching
+                    // capability flag.
+                    let methods = unregistrations_from_params(request.params.as_ref());
+                    tracing::debug!(
+                        "client/unregisterCapability (id={}) unregistering {} method(s): {:?}",
+                        request.id,
+                        methods.len(),
+                        methods
+                    );
+                    if !methods.is_empty() {
+                        let _ = async_tx.send(AsyncMessage::LspDynamicCapabilities {
+                            language: language.to_string(),
+                            server_name: server_name.to_string(),
+                            register: false,
+                            registrations: methods.into_iter().map(|m| (m, None)).collect(),
+                        });
+                    }
                     JsonRpcResponse {
                         jsonrpc: "2.0".to_string(),
                         id: request.id,
@@ -5020,6 +5120,82 @@ mod tests {
                 "expected codeActionKind value_set to include {required:?}, got {kinds:?}",
             );
         }
+    }
+
+    #[test]
+    fn advertises_dynamic_registration_on_honored_capabilities() {
+        // Servers that register providers dynamically only do so when the
+        // client advertised `dynamicRegistration` for that capability
+        // (sinelaw/fresh#2195 §1). Spot-check the ones most commonly registered
+        // dynamically.
+        let caps = create_client_capabilities();
+        let td = caps
+            .text_document
+            .as_ref()
+            .expect("text_document capabilities must be set");
+
+        assert_eq!(
+            td.inlay_hint.as_ref().and_then(|c| c.dynamic_registration),
+            Some(true),
+            "inlay_hint must advertise dynamicRegistration"
+        );
+        assert_eq!(
+            td.completion.as_ref().and_then(|c| c.dynamic_registration),
+            Some(true),
+            "completion must advertise dynamicRegistration"
+        );
+        assert_eq!(
+            td.formatting.as_ref().and_then(|c| c.dynamic_registration),
+            Some(true),
+            "formatting must advertise dynamicRegistration"
+        );
+        assert_eq!(
+            td.document_symbol
+                .as_ref()
+                .and_then(|c| c.dynamic_registration),
+            Some(true),
+            "document_symbol must advertise dynamicRegistration"
+        );
+        assert_eq!(
+            caps.workspace
+                .as_ref()
+                .and_then(|w| w.symbol.as_ref())
+                .and_then(|s| s.dynamic_registration),
+            Some(true),
+            "workspace.symbol must advertise dynamicRegistration"
+        );
+    }
+
+    #[test]
+    fn parses_register_and_unregister_capability_params() {
+        let register = serde_json::json!({
+            "registrations": [
+                { "id": "1", "method": "textDocument/inlayHint" },
+                {
+                    "id": "2",
+                    "method": "textDocument/completion",
+                    "registerOptions": { "triggerCharacters": ["."] }
+                }
+            ]
+        });
+        let parsed = registrations_from_params(Some(&register));
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].0, "textDocument/inlayHint");
+        assert!(parsed[0].1.is_none());
+        assert_eq!(parsed[1].0, "textDocument/completion");
+        assert!(parsed[1].1.is_some());
+
+        let unregister = serde_json::json!({
+            "unregisterations": [
+                { "id": "1", "method": "textDocument/inlayHint" }
+            ]
+        });
+        let methods = unregistrations_from_params(Some(&unregister));
+        assert_eq!(methods, vec!["textDocument/inlayHint".to_string()]);
+
+        // Malformed params must not panic and yield empty lists.
+        assert!(registrations_from_params(Some(&serde_json::json!({ "bogus": 1 }))).is_empty());
+        assert!(unregistrations_from_params(None).is_empty());
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -218,6 +218,127 @@ pub struct ServerCapabilitySummary {
     pub diagnostics: bool,
 }
 
+impl ServerCapabilitySummary {
+    /// Apply a single dynamic capability registration
+    /// (`client/registerCapability`) or unregistration
+    /// (`client/unregisterCapability`) by toggling the matching capability
+    /// flag. `register == false` clears the flag (and any derived state such
+    /// as completion trigger characters or the semantic-tokens legend).
+    ///
+    /// Many servers advertise little or nothing in their `initialize` result
+    /// and register providers dynamically afterwards; without this the feature
+    /// stays gated off (`has_capability` → false) for the whole session.
+    ///
+    /// Returns `true` if `method` is one we recognize and gate a feature on,
+    /// so the caller knows whether to re-issue requests for already-open
+    /// buffers. Unknown methods (e.g. `workspace/didChangeWatchedFiles`, which
+    /// is handled separately) return `false`.
+    pub fn apply_dynamic_registration(
+        &mut self,
+        method: &str,
+        register_options: Option<&serde_json::Value>,
+        register: bool,
+    ) -> bool {
+        use lsp_types::SemanticTokensFullOptions;
+
+        match method {
+            "textDocument/hover" => self.hover = register,
+            "textDocument/completion" => {
+                self.completion = register;
+                if register {
+                    if let Some(opts) = register_options {
+                        if let Some(chars) =
+                            opts.get("triggerCharacters").and_then(|v| v.as_array())
+                        {
+                            self.completion_trigger_characters = chars
+                                .iter()
+                                .filter_map(|v| v.as_str().map(str::to_string))
+                                .collect();
+                        }
+                        if let Some(resolve) = opts
+                            .get("resolveProvider")
+                            .and_then(serde_json::Value::as_bool)
+                        {
+                            self.completion_resolve = resolve;
+                        }
+                    }
+                } else {
+                    self.completion_trigger_characters.clear();
+                    self.completion_resolve = false;
+                }
+            }
+            "textDocument/definition" => self.definition = register,
+            "textDocument/references" => self.references = register,
+            "textDocument/formatting" => self.document_formatting = register,
+            "textDocument/rangeFormatting" => self.document_range_formatting = register,
+            "textDocument/rename" => self.rename = register,
+            "textDocument/signatureHelp" => self.signature_help = register,
+            "textDocument/inlayHint" => self.inlay_hints = register,
+            "textDocument/foldingRange" => self.folding_ranges = register,
+            "textDocument/documentHighlight" => self.document_highlight = register,
+            "textDocument/codeAction" => {
+                self.code_action = register;
+                if register {
+                    if let Some(resolve) = register_options
+                        .and_then(|opts| opts.get("resolveProvider"))
+                        .and_then(serde_json::Value::as_bool)
+                    {
+                        self.code_action_resolve = resolve;
+                    }
+                } else {
+                    self.code_action_resolve = false;
+                }
+            }
+            "textDocument/documentSymbol" => self.document_symbols = register,
+            "workspace/symbol" => self.workspace_symbols = register,
+            "textDocument/diagnostic" => self.diagnostics = register,
+            "textDocument/semanticTokens" => {
+                if register {
+                    // Registration options carry the legend and full/range
+                    // flags. They are `SemanticTokensRegistrationOptions`, but
+                    // its extra fields (documentSelector, id) are ignored by
+                    // serde, so parsing the embedded `SemanticTokensOptions`
+                    // succeeds.
+                    match register_options.and_then(|opts| {
+                        serde_json::from_value::<lsp_types::SemanticTokensOptions>(opts.clone())
+                            .ok()
+                    }) {
+                        Some(opts) => {
+                            self.semantic_tokens_legend = Some(opts.legend);
+                            match opts.full {
+                                Some(SemanticTokensFullOptions::Bool(v)) => {
+                                    self.semantic_tokens_full = v;
+                                    self.semantic_tokens_full_delta = false;
+                                }
+                                Some(SemanticTokensFullOptions::Delta { delta }) => {
+                                    self.semantic_tokens_full = true;
+                                    self.semantic_tokens_full_delta = delta.unwrap_or(false);
+                                }
+                                None => {
+                                    self.semantic_tokens_full = false;
+                                    self.semantic_tokens_full_delta = false;
+                                }
+                            }
+                            self.semantic_tokens_range = opts.range.unwrap_or(false);
+                        }
+                        // No parseable options: assume full support so the
+                        // feature isn't silently dropped, but a legend is
+                        // required to decode tokens, so leave it as-is.
+                        None => self.semantic_tokens_full = true,
+                    }
+                } else {
+                    self.semantic_tokens_full = false;
+                    self.semantic_tokens_full_delta = false;
+                    self.semantic_tokens_range = false;
+                    self.semantic_tokens_legend = None;
+                }
+            }
+            _ => return false,
+        }
+        true
+    }
+}
+
 /// A named LSP handle with feature filter metadata and per-server capabilities.
 /// Wraps an LspHandle with the server's display name, feature routing filter,
 /// and the capabilities reported by this specific server during initialization.
@@ -476,6 +597,36 @@ impl LspManager {
         if let Some(sh) = self.handles.iter_mut().find(|sh| sh.name == server_name) {
             sh.capabilities = capabilities;
         }
+    }
+
+    /// Apply dynamic capability (un)registrations to the named server's stored
+    /// capabilities. Each entry is `(method, register_options)`. Returns `true`
+    /// if any recognized feature flag changed, so the caller can re-issue
+    /// requests for buffers that opened before the registration arrived.
+    ///
+    /// Per the LSP spec a server only sends `client/registerCapability` after
+    /// it has received our `initialized` notification — i.e. after the
+    /// `initialize` result was processed and `set_server_capabilities` ran — so
+    /// these merge on top of the static summary rather than racing it.
+    pub fn apply_dynamic_capabilities(
+        &mut self,
+        server_name: &str,
+        register: bool,
+        registrations: &[(String, Option<serde_json::Value>)],
+    ) -> bool {
+        let Some(sh) = self.handles.iter_mut().find(|sh| sh.name == server_name) else {
+            return false;
+        };
+        let mut changed = false;
+        for (method, options) in registrations {
+            if sh
+                .capabilities
+                .apply_dynamic_registration(method, options.as_ref(), register)
+            {
+                changed = true;
+            }
+        }
+        changed
     }
 
     /// Get the semantic token legend for a language from the first eligible server.
@@ -2554,5 +2705,100 @@ mod tests {
     fn test_path_to_uri_with_spaces() {
         let uri = path_to_uri(Path::new("/tmp/my project/src")).unwrap();
         assert_eq!(uri.as_str(), "file:///tmp/my%20project/src");
+    }
+
+    #[test]
+    fn dynamic_registration_enables_then_disables_inlay_hints() {
+        // A server that advertised no static inlayHintProvider but registers it
+        // dynamically must end up with the capability enabled — and unregister
+        // must turn it back off (sinelaw/fresh#2195 §1).
+        let mut caps = ServerCapabilitySummary::default();
+        assert!(!caps.inlay_hints);
+
+        let recognized = caps.apply_dynamic_registration("textDocument/inlayHint", None, true);
+        assert!(
+            recognized,
+            "inlayHint must be a recognized capability method"
+        );
+        assert!(
+            caps.inlay_hints,
+            "dynamic registration must enable inlay hints"
+        );
+
+        let recognized = caps.apply_dynamic_registration("textDocument/inlayHint", None, false);
+        assert!(recognized);
+        assert!(!caps.inlay_hints, "unregister must disable inlay hints");
+    }
+
+    #[test]
+    fn dynamic_registration_ignores_unknown_methods() {
+        // Methods we don't gate a feature on (e.g. file watching, handled
+        // elsewhere) must report "not recognized" so the caller doesn't
+        // needlessly re-issue feature requests.
+        let mut caps = ServerCapabilitySummary::default();
+        let recognized =
+            caps.apply_dynamic_registration("workspace/didChangeWatchedFiles", None, true);
+        assert!(!recognized);
+    }
+
+    #[test]
+    fn dynamic_registration_parses_completion_options() {
+        let mut caps = ServerCapabilitySummary::default();
+        let opts = serde_json::json!({
+            "triggerCharacters": [".", "::"],
+            "resolveProvider": true,
+        });
+        let recognized =
+            caps.apply_dynamic_registration("textDocument/completion", Some(&opts), true);
+        assert!(recognized);
+        assert!(caps.completion);
+        assert!(caps.completion_resolve);
+        assert_eq!(caps.completion_trigger_characters, vec![".", "::"]);
+
+        // Unregister clears the derived state too.
+        caps.apply_dynamic_registration("textDocument/completion", None, false);
+        assert!(!caps.completion);
+        assert!(!caps.completion_resolve);
+        assert!(caps.completion_trigger_characters.is_empty());
+    }
+
+    #[test]
+    fn dynamic_registration_parses_semantic_tokens_legend() {
+        let mut caps = ServerCapabilitySummary::default();
+        let opts = serde_json::json!({
+            "legend": {
+                "tokenTypes": ["namespace", "type"],
+                "tokenModifiers": ["declaration"],
+            },
+            "full": { "delta": true },
+            "range": true,
+        });
+        let recognized =
+            caps.apply_dynamic_registration("textDocument/semanticTokens", Some(&opts), true);
+        assert!(recognized);
+        assert!(caps.semantic_tokens_full);
+        assert!(caps.semantic_tokens_full_delta);
+        assert!(caps.semantic_tokens_range);
+        let legend = caps
+            .semantic_tokens_legend
+            .as_ref()
+            .expect("legend must be parsed from registration options");
+        assert_eq!(legend.token_types.len(), 2);
+
+        caps.apply_dynamic_registration("textDocument/semanticTokens", None, false);
+        assert!(!caps.semantic_tokens_full);
+        assert!(caps.semantic_tokens_legend.is_none());
+    }
+
+    #[test]
+    fn apply_dynamic_capabilities_reports_change_only_for_known_methods() {
+        // The manager-level entry point returns whether any recognized feature
+        // flag changed, which gates whether the dispatcher re-issues requests.
+        let mut caps = ServerCapabilitySummary::default();
+        let known = caps.apply_dynamic_registration("textDocument/hover", None, true);
+        let unknown = caps.apply_dynamic_registration("some/unknownMethod", None, true);
+        assert!(known);
+        assert!(!unknown);
+        assert!(caps.hover);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds support for LSP servers that dynamically register capabilities after initialization, and implements handlers for server-driven refresh requests. Many LSP servers advertise little or nothing in their static `initialize` result and instead register providers dynamically via `client/registerCapability`. Without this support, such features remain gated off for the entire session.

## Key Changes

- **Dynamic Capability Registration**: Implemented `apply_dynamic_registration()` in `ServerCapabilitySummary` to parse and apply `client/registerCapability` and `client/unregisterCapability` requests, updating feature flags and derived state (e.g., completion trigger characters, semantic tokens legend).

- **Client Capability Advertisements**: Enhanced `create_client_capabilities()` to advertise `dynamicRegistration: true` on all capabilities we honor, and added workspace-level refresh support flags for inlay hints and semantic tokens. This signals to servers that they can register these providers dynamically.

- **Refresh Request Handlers**: Added handlers for `workspace/inlayHint/refresh` and `workspace/semanticTokens/refresh` requests, which servers send when they learn something later that changes files the user never edited (e.g., cross-file type inference).

- **Manager-Level Integration**: Added `apply_dynamic_capabilities()` to `LspManager` to apply registrations to a specific server's capabilities and report whether any recognized feature flags changed, triggering re-issuance of requests for already-open buffers.

- **Async Message Routing**: Introduced three new `AsyncMessage` variants (`LspDynamicCapabilities`, `LspInlayHintRefresh`, `LspSemanticTokensRefresh`) to route server requests through the async bridge and dispatch them to appropriate handlers.

- **Comprehensive Tests**: Added tests verifying dynamic registration parsing, capability advertisement, and state transitions (enable/disable) for various LSP features.

## Implementation Details

- Dynamic registrations are parsed from request params and forwarded to the LSP manager, which updates the stored `ServerCapabilities` before the feature is used.
- Unregistration clears both the main capability flag and any derived state (e.g., `completion_trigger_characters`, `semantic_tokens_legend`).
- Refresh requests trigger re-pulling of the corresponding feature for all open documents of the language, ensuring consistency when the server's analysis changes.
- Unknown methods (e.g., `workspace/didChangeWatchedFiles`) are gracefully ignored and don't trigger unnecessary re-requests.
- Semantic tokens registration options are parsed to extract the legend and full/range/delta flags, which are required to decode tokens.

https://claude.ai/code/session_01MUsq6TeNyRQCf7GUEZwjSZ