### PR TITLE
Consolidate layout logic into single relayout funnel

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1331,6 +1331,11 @@ fn default_list_visible_rows() -> u32 {
     20
 }
 
+/// Default glyph for a `Divider`: the light horizontal box-drawing rule.
+fn default_divider_char() -> String {
+    "─".to_string()
+}
+
 /// Default for `Tree::selected_index`. -1 ⇒ "no selection".
 fn default_tree_selected() -> i32 {
     -1
@@ -1498,6 +1503,25 @@ pub enum WidgetSpec {
         cols: u32,
         #[serde(default)]
         flex: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        key: Option<String>,
+    },
+    /// Full-width horizontal rule. The host draws `ch` repeated across
+    /// the panel's inner content width, so the separator always matches
+    /// the rendered width — including a user-dragged dock — without the
+    /// plugin computing the width itself. (A plugin-computed width forks
+    /// the host's authoritative width and drifts on resize/drag; this is
+    /// the declarative equivalent of `Spacer { flex: true }`, which fills
+    /// the row without the plugin knowing the gap size.)
+    Divider {
+        /// Glyph repeated across the full width. Defaults to `─`.
+        #[serde(default = "default_divider_char")]
+        ch: String,
+        /// Optional whole-rule styling (e.g. a dim `fg`). Same shape as a
+        /// styled segment's `style`.
+        #[ts(type = "Partial<OverlayOptions>")]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        style: Option<OverlayOptions>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         key: Option<String>,
     },

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -959,6 +959,18 @@ type WidgetSpec = {
 	flex: boolean;
 	key?: string | null;
 } | {
+	"kind": "divider";
+	/**
+	* Glyph repeated across the full width. Defaults to `─`.
+	*/
+	ch: string;
+	/**
+	* Optional whole-rule styling (e.g. a dim `fg`). Same shape as a
+	* styled segment's `style`.
+	*/
+	style?: Partial<OverlayOptions>;
+	key?: string | null;
+} | {
 	"kind": "list";
 	items: Array<TextPropertyEntry>;
 	itemKeys: Array<string>;

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -191,6 +191,25 @@ export function flexSpacer(key?: string): WidgetSpec {
   return { kind: "spacer", cols: 0, flex: true, key };
 }
 
+/** Full-width horizontal rule. The host draws `ch` (default `─`)
+ * across the panel's inner content width, so the separator always
+ * matches the rendered width — including a user-dragged dock —
+ * without the plugin computing the width itself. This is the
+ * declarative analogue of `flexSpacer()`: express "a rule here",
+ * let the host (which owns the width) size it. Optional `style`
+ * picks the colour (e.g. a dim `fg` for a quiet separator). */
+export function divider(
+  options?: { ch?: string; style?: Partial<OverlayOptions>; key?: string },
+): WidgetSpec {
+  // Omit unset keys rather than passing `undefined`: the plugin bridge
+  // turns a present `undefined` into JSON `null`, which fails to
+  // deserialize as the host's `Option<…>` fields (see `styledRow`).
+  const spec: WidgetSpec = { kind: "divider", ch: options?.ch ?? "─" };
+  if (options?.style !== undefined) spec.style = options.style;
+  if (options?.key !== undefined) spec.key = options.key;
+  return spec;
+}
+
 /** Vertical list of pre-rendered rows with host-managed selection
  * styling, click routing, and **virtual scrolling**. Plugin passes
  * the full dataset of items + a `visibleRows` count; the widget

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -22,6 +22,7 @@ import {
   flexSpacer,
   FloatingWidgetPanel,
   hintBar,
+  divider,
   key as widgetKey,
   labeledSection,
   list,
@@ -384,7 +385,8 @@ function dockDefaultWidth(): number {
 // Inner content width for a given dock width: the host reserves one
 // column for the right border plus an editor-side gutter, so list rows
 // get `dockWidth - 2` cells. Floored so a clamped/narrow dock still
-// renders something. Drives name/tag truncation and the `dockRule`.
+// renders something. Drives session name/tag truncation. (The header
+// divider is host-rendered via `divider()`, so it no longer needs this.)
 function dockContentCols(dockWidth: number): number {
   return Math.max(8, dockWidth - 2);
 }
@@ -1100,22 +1102,6 @@ function pruneSelection(): void {
 // the filter, the new-session button, and the list.
 function sessionsSeparator(): WidgetSpec {
   return spacer(0);
-}
-
-// A full-width horizontal rule (`────`) used in the dock to divide the
-// header chrome from the session list. Rendered in the dim disabled-menu
-// colour (a quiet grey, not the louder popup-border accent) so it reads
-// as a subtle separator rather than competing with the pills below.
-// `width` is the content width so it stops at the border.
-function dockRule(width: number): WidgetSpec {
-  return {
-    kind: "raw",
-    entries: [
-      styledRow([
-        { text: "─".repeat(Math.max(1, width)), style: { fg: "ui.menu_disabled_fg" } },
-      ]),
-    ],
-  };
 }
 
 // Smallest list height we'll show even when there are only a
@@ -2093,8 +2079,10 @@ function buildDockSpec(): WidgetSpec {
   // host (`dockDefaultWidth`, re-issued on resize), bounded by what the
   // host can actually grant: it keeps EDITOR_MIN (~20) cols for the
   // buffer, so on a narrow terminal the real dock is `screenW - 20` and
-  // below that it's hidden. Taking the min keeps name/tag truncation and
-  // the `dockRule` in step with the visible width.
+  // below that it's hidden. Taking the min keeps name/tag truncation
+  // roughly in step with the visible width. (The header divider is
+  // host-rendered at the true width via `divider()`, so it doesn't rely
+  // on this estimate.)
   const EDITOR_MIN_COLS = 20;
   const screenW = editor.getScreenSize().width;
   const grantable = screenW > 0 ? screenW - EDITOR_MIN_COLS : DOCK_WIDTH_COLS;
@@ -2209,7 +2197,10 @@ function buildDockSpec(): WidgetSpec {
       fullWidth: true,
       key: inConfirm ? undefined : "filter",
     }),
-    dockRule(contentW),
+    // Host-rendered full-width rule: it spans whatever width the dock is
+    // actually drawn at (incl. a user drag), so it can't drift from the
+    // chrome the way a plugin-computed `"─".repeat(width)` did.
+    divider({ style: { fg: "ui.menu_disabled_fg" } }),
     list({
       items,
       itemKeys,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -203,6 +203,7 @@ impl Editor {
             keybindings: parts.keybindings,
             terminal_width: parts.terminal_width,
             terminal_height: parts.terminal_height,
+            last_layout_signature: None,
             tokio_runtime: parts.tokio_runtime,
             async_bridge: Some(parts.async_bridge),
             fs_manager: parts.fs_manager,

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -111,14 +111,10 @@ impl Editor {
             self.set_status_message(t!("explorer.closed").to_string());
         }
 
-        // Notify plugins that the viewport dimensions changed (sidebar affects available width)
-        self.plugin_manager.read().unwrap().run_hook(
-            "resize",
-            fresh_core::hooks::HookArgs::Resize {
-                width: self.terminal_width,
-                height: self.terminal_height,
-            },
-        );
+        // Showing/hiding the sidebar changes the editor's available width.
+        // Route through the single layout funnel so split viewports and
+        // terminal PTYs reflow and plugins get the (deduped) resize hook.
+        self.relayout();
     }
 
     pub fn show_file_explorer(&mut self) {

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -412,5 +412,28 @@ impl crate::app::window::Window {
         }
 
         self.resize_visible_terminals();
+
+        // The editor narrowed/widened (dock toggle or drag, file explorer,
+        // window resize, split change). Re-pin each visible split's active
+        // tab into view at its NEW width — otherwise a tab that was flush
+        // against the right edge scrolls off when the pane shrinks and the
+        // tab-scroll offset is never revisited. Use each split's real area
+        // width (dock/explorer/split-aware), not the whole-window width, so
+        // a half-width vertical split scrolls correctly too.
+        let visible: Vec<(
+            crate::model::event::LeafId,
+            crate::model::event::BufferId,
+            u16,
+        )> = match self.buffers.splits() {
+            Some((mgr, _)) => mgr
+                .get_visible_buffers(self.editor_content_area())
+                .into_iter()
+                .map(|(split_id, buffer_id, area)| (split_id, buffer_id, area.width))
+                .collect(),
+            None => Vec::new(),
+        };
+        for (split_id, buffer_id, tab_width) in visible {
+            self.ensure_active_tab_visible(split_id, buffer_id, tab_width);
+        }
     }
 }

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -264,46 +264,121 @@ impl Editor {
         );
     }
 
-    /// Resize all buffers to match new terminal size. Loops over every
-    /// `Window` so each one updates its own split viewports and visible
-    /// terminal PTYs; the plugin `resize` hook fires once for the editor
-    /// as a whole.
+    /// Adopt new terminal (screen) dimensions, then re-derive the whole
+    /// layout. This is the OS-terminal-resize entry point; it only
+    /// records the new screen size and defers everything else to the
+    /// single layout funnel, [`Editor::relayout`].
     pub fn resize(&mut self, width: u16, height: u16) {
         // Editor's canonical screen dimensions (used to seed new windows).
         self.terminal_width = width;
         self.terminal_height = height;
+        self.relayout();
+    }
 
+    /// The single layout funnel. Every event that can change the on-screen
+    /// geometry — an OS terminal resize, toggling/dragging the dock,
+    /// toggling or dragging the file explorer, creating/closing/resizing a
+    /// split — mutates only the relevant source-of-truth state and then
+    /// calls this. `relayout` reads that state, derives the authoritative
+    /// geometry once, and pushes it *down* (one-directional) to every
+    /// consumer: split viewports, terminal PTYs (for all windows), the
+    /// dock / floating-panel rerender, and the plugin `resize` hook.
+    ///
+    /// It is intentionally cheap to call redundantly: terminal PTY resizes
+    /// are idempotent (the PTY layer drops no-op size changes) and the
+    /// plugin hook is signature-deduped, so callers never need to decide
+    /// "did this actually change the layout?" — they just call `relayout`.
+    pub fn relayout(&mut self) {
+        // Derive the dock width from its placement (the source of truth),
+        // exactly as the renderer's `compute_dock_split` does, so the
+        // geometry we push down matches what gets painted.
+        let dock_cols = self.dock_cols();
+        let (width, height) = (self.terminal_width, self.terminal_height);
+
+        // Push the derived geometry down to every window. The dock is
+        // editor-global, so every window — not just the active one —
+        // sizes its terminals for the post-dock chrome, ready for a
+        // dive without a stale first frame.
         for window in self.windows.values_mut() {
-            window.resize(width, height);
+            window.apply_layout(width, height, dock_cols);
         }
 
-        // Refresh the plugin-facing snapshot BEFORE firing the
-        // resize hook. Without this, the orchestrator's resize
-        // handler reads `editor.getViewport()` from a snapshot
-        // whose `viewport.height` still reflects the pre-resize
-        // size — the one-way ratchet in `buildOpenSpec` then sees
-        // `old > old` and skips the update, leaving the picker
-        // stuck small even after a terminal-grow event. (The
-        // ratchet itself is correct; the input it consumes was
-        // stale.) Updating the snapshot here lets plugins observe
-        // the new dimensions when they react to the hook.
+        self.notify_layout_changed();
+    }
+
+    /// Effective width (cols) the left dock currently claims, or `0` when
+    /// no dock is shown / the terminal is too narrow for one. Delegates to
+    /// the renderer's `compute_dock_split` so this and the paint path can
+    /// never disagree about how wide the dock is.
+    pub(crate) fn dock_cols(&self) -> u16 {
+        let size = ratatui::layout::Rect::new(0, 0, self.terminal_width, self.terminal_height);
+        self.compute_dock_split(size)
+            .0
+            .map(|dock| dock.width)
+            .unwrap_or(0)
+    }
+
+    /// Fire the plugin `resize` hook and rerender mounted panels, but only
+    /// when the content geometry plugins observe has actually changed since
+    /// the last notification. The dedupe is load-bearing: the orchestrator
+    /// reacts to `resize` by re-issuing the dock's `dock_width`, which loops
+    /// back through `relayout`; without the signature guard that would
+    /// re-fire every frame. Once the dock width settles the signature stops
+    /// changing and the cascade stops.
+    fn notify_layout_changed(&mut self) {
+        let dock_cols = self.dock_cols();
+        // File-explorer width of the active window, measured against the
+        // post-dock chrome (matches the renderer and `resize_visible_terminals`).
+        let fe_cols = {
+            let win = self.active_window();
+            if win.file_explorer_visible {
+                win.file_explorer_width
+                    .to_cols(self.terminal_width.saturating_sub(dock_cols))
+            } else {
+                0
+            }
+        };
+        let signature = (
+            self.terminal_width,
+            self.terminal_height,
+            dock_cols,
+            fe_cols,
+        );
+        if self.last_layout_signature == Some(signature) {
+            return;
+        }
+        self.last_layout_signature = Some(signature);
+
+        // Refresh the plugin-facing snapshot BEFORE firing the resize
+        // hook. Without this, the orchestrator's resize handler reads
+        // `editor.getViewport()` from a snapshot whose dimensions still
+        // reflect the pre-resize size — the one-way ratchet in
+        // `buildOpenSpec` then sees `old > old` and skips the update,
+        // leaving the picker stuck small. Updating the snapshot here lets
+        // plugins observe the new dimensions when they react to the hook.
         #[cfg(feature = "plugins")]
         self.update_plugin_state_snapshot();
 
-        // Notify plugins of the resize so they can adjust layouts.
+        // Notify plugins of the layout change so they can adjust their own
+        // layouts. The hook still reports the screen dimensions; plugins
+        // that care about their available area read `getViewport()` (which
+        // reflects the dock / file-explorer carve-out) from the snapshot
+        // refreshed just above.
         self.plugin_manager.read().unwrap().run_hook(
             "resize",
-            fresh_core::hooks::HookArgs::Resize { width, height },
+            fresh_core::hooks::HookArgs::Resize {
+                width: self.terminal_width,
+                height: self.terminal_height,
+            },
         );
 
         // If a floating widget panel is currently mounted (the
-        // Orchestrator picker, New-Session form, plugin overlays),
-        // its cached `entries` were laid out against the old screen
-        // width — re-render against the new one so column widths,
-        // side borders and embed rects all reflect the new
-        // dimensions (Bug 13). The hook above lets plugins update
-        // their spec; this rerender picks up either the updated
-        // spec or the existing spec at the new width.
+        // Orchestrator picker / dock, New-Session form, plugin overlays),
+        // its cached `entries` were laid out against the old geometry —
+        // re-render against the new one so column widths, side borders and
+        // embed rects all reflect the new chrome (Bug 13). The hook above
+        // lets plugins update their spec; this rerender picks up either the
+        // updated spec or the existing spec at the new width.
         for panel_id in [
             self.dock.as_ref().map(|f| f.panel_id),
             self.floating_widget_panel.as_ref().map(|f| f.panel_id),
@@ -317,16 +392,22 @@ impl Editor {
 }
 
 impl crate::app::window::Window {
-    /// Adopt the new terminal dimensions for this window: update the
-    /// cached `terminal_width` / `terminal_height`, resize every split
-    /// viewport, and resize any visible terminal PTYs.
-    pub fn resize(&mut self, width: u16, height: u16) {
+    /// Adopt the geometry handed down by [`Editor::relayout`]: cache the
+    /// screen dimensions and the editor-global dock width, reseed every
+    /// split viewport against the post-dock editor width, and resize the
+    /// visible terminal PTYs. Per-split viewport dimensions are refined
+    /// again at paint time by `sync_viewport_to_content`; terminals have
+    /// no such paint-time sync, which is why their PTY size must be pushed
+    /// here.
+    pub fn apply_layout(&mut self, width: u16, height: u16, dock_cols: u16) {
         self.terminal_width = width;
         self.terminal_height = height;
+        self.dock_cols = dock_cols;
 
+        let editor_width = width.saturating_sub(dock_cols);
         if let Some(view_states) = self.split_view_states_mut() {
             for view_state in view_states.values_mut() {
-                view_state.viewport.resize(width, height);
+                view_state.viewport.resize(editor_width, height);
             }
         }
 

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -501,6 +501,16 @@ pub struct Editor {
     terminal_width: u16,
     terminal_height: u16,
 
+    /// Last layout signature the plugin `resize` hook fired for, used
+    /// by `Editor::relayout` to dedupe notifications. The tuple is
+    /// `(terminal_width, terminal_height, dock_cols, file_explorer_cols)`
+    /// — the content geometry plugins observe. Deduping is what keeps
+    /// the orchestrator's resize→`dock_width`→relayout reaction from
+    /// looping: once the dock width settles, the signature stops
+    /// changing and the hook stops re-firing. `None` until the first
+    /// relayout.
+    last_layout_signature: Option<(u16, u16, u16, u16)>,
+
     // LSP manager moved onto `Window`. Access via
     // `Editor::lsp()` / `lsp_mut()` — each window has its own
     // LspManager rooted at its project root.

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -109,11 +109,26 @@ impl Editor {
 
         // Check if we should forward mouse events to the terminal
         // Forward if: in terminal mode, mouse is over terminal buffer, and terminal is in alternate screen mode
-        if let Some(result) =
-            self.active_window_mut()
-                .try_forward_mouse_to_terminal(col, row, mouse_event)
-        {
-            return result;
+        //
+        // ...unless a chrome drag is in progress (dock-border resize, split
+        // separator, or file-explorer width). That drag owns the mouse until
+        // release, so don't let an alternate-screen terminal swallow the
+        // motion once the pointer crosses over it — *growing* the dock drags
+        // the cursor rightward across a full-screen `btop`, and forwarding
+        // there both stalls the resize and eats the mouse-up that ends it,
+        // leaving the drag stuck. Shrinking happened to work only because the
+        // pointer stays left of the terminal the whole time.
+        let chrome_drag_active = self.dock_resizing || {
+            let ms = &self.active_window().mouse_state;
+            ms.dragging_separator.is_some() || ms.drag_start_explorer_width.is_some()
+        };
+        if !chrome_drag_active {
+            if let Some(result) =
+                self.active_window_mut()
+                    .try_forward_mouse_to_terminal(col, row, mouse_event)
+            {
+                return result;
+            }
         }
 
         // Dismiss theme info popup on any left-click; check if click is on the button first

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -243,9 +243,10 @@ impl Editor {
                 // Clear popup text selection drag state (selection remains in popup)
                 self.active_window_mut().mouse_state.selecting_in_popup = None;
 
-                // If we finished dragging a separator, resize visible terminals
+                // If we finished dragging a split separator, the split
+                // ratios changed: reflow through the single layout funnel.
                 if was_dragging_separator {
-                    self.active_window_mut().resize_visible_terminals();
+                    self.relayout();
                 }
 
                 needs_render = true;
@@ -2545,10 +2546,17 @@ impl Editor {
         if self.dock_resizing {
             let max_cols = self.terminal_width.max(20).saturating_sub(20).max(10);
             let new_w = col.saturating_add(1).clamp(10, max_cols);
+            let mut changed = false;
             if let Some(fwp) = self.dock.as_mut() {
                 if let super::PanelPlacement::LeftDock { width_cols } = &mut fwp.placement {
+                    changed = *width_cols != new_w;
                     *width_cols = new_w;
                 }
+            }
+            // The dock got wider/narrower: reflow the chrome (terminals,
+            // viewports, panels) to the new dock width via the funnel.
+            if changed {
+                self.relayout();
             }
             return Ok(());
         }
@@ -2980,6 +2988,9 @@ impl Editor {
                     ExplorerWidth::Columns(new_cols)
                 }
             };
+            // The sidebar width changed: reflow terminals/viewports/panels
+            // through the single layout funnel.
+            self.relayout();
         }
 
         Ok(())
@@ -3047,6 +3058,9 @@ impl Editor {
             } else {
                 self.set_grouped_split_ratio(split_id, new_ratio);
             }
+            // Reflow live as the separator moves so terminals track the
+            // split sizes during the drag, not just on release.
+            self.relayout();
         }
 
         Ok(())

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -2553,9 +2553,18 @@ impl Editor {
                     *width_cols = new_w;
                 }
             }
-            // The dock got wider/narrower: reflow the chrome (terminals,
-            // viewports, panels) to the new dock width via the funnel.
             if changed {
+                // Persist the live width *before* relaying out. `relayout`
+                // fires the `resize` hook, and the orchestrator answers it
+                // by re-issuing the dock's responsive `dock_width`, which
+                // `handle_floating_panel_control` clamps against the
+                // persisted `dock_width` override. Updating that override
+                // here (not only on mouse-up) lets the user's dragged width
+                // win the round-trip — otherwise the responsive re-issue
+                // snaps the dock straight back and the drag does nothing.
+                self.dock_width = Some(new_w);
+                // The dock got wider/narrower: reflow the chrome (terminals,
+                // viewports, panels) to the new dock width via the funnel.
                 self.relayout();
             }
             return Ok(());

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4008,6 +4008,14 @@ impl Editor {
             width_pct,
             height_pct
         );
+
+        // Mounting a panel as the left dock carves a full-height column out
+        // of the chrome. Run the single layout funnel so terminals and
+        // viewports reflow to the post-dock width right away (a centered
+        // panel leaves `dock_cols` at 0, so this is a cheap no-op there).
+        if as_dock {
+            self.relayout();
+        }
     }
 
     fn handle_update_floating_widget(&mut self, panel_id: u64, spec: fresh_core::api::WidgetSpec) {
@@ -4096,8 +4104,11 @@ impl Editor {
         // rows. Resizing here on every panel unmount restores the
         // full dive-view dimensions; for panels that didn't preview
         // anything (the new-session form, plugin overlays) this is a
-        // cheap no-op because the PTY sizes already match.
-        self.active_window_mut().resize_visible_terminals();
+        // cheap no-op because the PTY sizes already match. Unmounting the
+        // dock also frees its column, so route through the single layout
+        // funnel: it re-derives `dock_cols` (now 0 for a dock unmount) and
+        // reflows every window's terminals + viewports to the reclaimed width.
+        self.relayout();
         tracing::debug!("Unmounted floating widget panel {}", panel_id);
     }
 
@@ -4123,12 +4134,15 @@ impl Editor {
         let Some(fwp) = self.panel_mut(slot) else {
             return;
         };
-        match op {
+        // Whether this op changed the chrome geometry (dock width/placement),
+        // so we know to re-derive the layout once the `fwp` borrow ends.
+        let geometry_changed = match op {
             "dock" => {
                 let requested = persisted.unwrap_or(arg as u16);
                 let width_cols = requested.clamp(10, max_cols);
                 fwp.placement = super::PanelPlacement::LeftDock { width_cols };
                 fwp.focused = true;
+                true
             }
             // Update the dock's width WITHOUT touching focus — used by the
             // plugin to make the dock responsive (re-issued on terminal
@@ -4140,14 +4154,30 @@ impl Editor {
                     let requested = persisted.unwrap_or(arg as u16);
                     let width_cols = requested.clamp(10, max_cols);
                     fwp.placement = super::PanelPlacement::LeftDock { width_cols };
+                    true
+                } else {
+                    false
                 }
             }
             "center" => {
                 fwp.placement = super::PanelPlacement::Centered;
                 fwp.focused = true;
+                true
             }
-            "focus" => fwp.focused = true,
-            other => tracing::warn!("FloatingPanelControl: unknown op {other:?}"),
+            "focus" => {
+                fwp.focused = true;
+                false
+            }
+            other => {
+                tracing::warn!("FloatingPanelControl: unknown op {other:?}");
+                false
+            }
+        };
+        // The `fwp` mutable borrow ends above; now that the dock's
+        // placement/width is settled, run the single layout funnel so
+        // terminals, viewports and panels all reflow to the new chrome.
+        if geometry_changed {
+            self.relayout();
         }
     }
 

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -149,6 +149,12 @@ impl Editor {
                 self.set_status_message(t!("split.error", error = e.to_string()).to_string());
             }
         }
+
+        // A new split changes every sibling pane's width/height. Reflow
+        // through the single layout funnel so existing terminals shrink to
+        // their new pane immediately, instead of waiting for the next
+        // unrelated resize trigger.
+        self.relayout();
     }
 
     /// Close the active split
@@ -228,6 +234,11 @@ impl Editor {
                 );
             }
         }
+
+        // Closing a split gives its space back to the surviving panes.
+        // Reflow through the single layout funnel so their terminals grow
+        // into the reclaimed area.
+        self.relayout();
     }
 
     /// Switch to next split
@@ -276,7 +287,7 @@ impl Editor {
         }
 
         if was_maximized {
-            self.active_window_mut().resize_visible_terminals();
+            self.relayout();
         }
 
         // Ensure the active tab is visible in the newly active split
@@ -346,8 +357,8 @@ impl Editor {
 
             let percent = (delta * 100.0) as i32;
             self.set_status_message(t!("split.size_adjusted", percent = percent).to_string());
-            // Resize visible terminals to match new split dimensions
-            self.active_window_mut().resize_visible_terminals();
+            // Split ratios changed: reflow through the single layout funnel.
+            self.relayout();
         }
     }
 
@@ -366,8 +377,8 @@ impl Editor {
                 } else {
                     self.set_status_message(t!("split.restored").to_string());
                 }
-                // Resize visible terminals to match new split dimensions
-                self.active_window_mut().resize_visible_terminals();
+                // Maximize/restore changed the split sizes: reflow via funnel.
+                self.relayout();
             }
             Err(e) => self.set_status_message(e),
         }

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -966,18 +966,15 @@ impl Window {
         }
     }
 
-    /// Resize all this window's visible terminal PTYs to match their
-    /// current split dimensions. Reads the window's cached
-    /// `terminal_width` / `terminal_height` for the screen size.
-    pub fn resize_visible_terminals(&mut self) {
-        // Mirror the render layout (`render.rs::compute_dock_split` +
-        // the file-explorer split): the editor-global dock claims the
-        // leftmost `dock_cols`, then the file explorer claims a slice of
-        // the remaining chrome, and the splits (terminals included) get
-        // what's left. `dock_cols` is pushed down by `Editor::relayout`.
-        // Computing the file-explorer width against the post-dock chrome
-        // width (not the full screen) matches the renderer exactly, so
-        // the PTY size lines up with the cells it actually draws into.
+    /// The rect the editor splits lay out into, mirroring the renderer
+    /// (`render.rs::compute_dock_split` + the file-explorer split): the
+    /// editor-global dock claims the leftmost `dock_cols`, then the file
+    /// explorer claims a slice of the remaining chrome, and the splits get
+    /// what's left. `dock_cols` is pushed down by `Editor::relayout`.
+    /// Computing the file-explorer width against the post-dock chrome
+    /// width (not the full screen) matches the renderer exactly, so split
+    /// geometry derived from this lines up with the cells actually drawn.
+    pub(crate) fn editor_content_area(&self) -> ratatui::layout::Rect {
         let chrome_width = self.terminal_width.saturating_sub(self.dock_cols);
         let file_explorer_width = if self.file_explorer_visible {
             self.file_explorer_width.to_cols(chrome_width)
@@ -991,12 +988,19 @@ impl Window {
             crate::config::FileExplorerSide::Right => self.dock_cols,
         };
         let editor_width = chrome_width.saturating_sub(file_explorer_width);
-        let editor_area = ratatui::layout::Rect::new(
+        ratatui::layout::Rect::new(
             editor_x,
             1, // menu bar
             editor_width,
             self.terminal_height.saturating_sub(2), // menu bar + status bar
-        );
+        )
+    }
+
+    /// Resize all this window's visible terminal PTYs to match their
+    /// current split dimensions. Reads the window's cached
+    /// `terminal_width` / `terminal_height` for the screen size.
+    pub fn resize_visible_terminals(&mut self) {
+        let editor_area = self.editor_content_area();
 
         let Some((mgr, _)) = self.buffers.splits() else {
             return;

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -970,15 +970,29 @@ impl Window {
     /// current split dimensions. Reads the window's cached
     /// `terminal_width` / `terminal_height` for the screen size.
     pub fn resize_visible_terminals(&mut self) {
-        // Get the content area excluding file explorer
+        // Mirror the render layout (`render.rs::compute_dock_split` +
+        // the file-explorer split): the editor-global dock claims the
+        // leftmost `dock_cols`, then the file explorer claims a slice of
+        // the remaining chrome, and the splits (terminals included) get
+        // what's left. `dock_cols` is pushed down by `Editor::relayout`.
+        // Computing the file-explorer width against the post-dock chrome
+        // width (not the full screen) matches the renderer exactly, so
+        // the PTY size lines up with the cells it actually draws into.
+        let chrome_width = self.terminal_width.saturating_sub(self.dock_cols);
         let file_explorer_width = if self.file_explorer_visible {
-            self.file_explorer_width.to_cols(self.terminal_width)
+            self.file_explorer_width.to_cols(chrome_width)
         } else {
             0
         };
-        let editor_width = self.terminal_width.saturating_sub(file_explorer_width);
+        let editor_x = match self.file_explorer_side {
+            crate::config::FileExplorerSide::Left => {
+                self.dock_cols.saturating_add(file_explorer_width)
+            }
+            crate::config::FileExplorerSide::Right => self.dock_cols,
+        };
+        let editor_width = chrome_width.saturating_sub(file_explorer_width);
         let editor_area = ratatui::layout::Rect::new(
-            file_explorer_width,
+            editor_x,
             1, // menu bar
             editor_width,
             self.terminal_height.saturating_sub(2), // menu bar + status bar

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -1821,11 +1821,16 @@ impl Window {
     /// visible the tabs row only spans the editor area; otherwise it spans
     /// the full terminal width.
     pub fn effective_tabs_width(&self) -> u16 {
+        // Start from the chrome left after the editor-global dock, then
+        // subtract the file explorer — same carve-out order as the
+        // renderer and `editor_content_area`, so tab-scroll math matches
+        // the width the tabs actually paint into when the dock is shown.
+        let chrome = self.terminal_width.saturating_sub(self.dock_cols);
         if self.file_explorer_visible && self.file_explorer.is_some() {
-            let explorer = self.file_explorer_width.to_cols(self.terminal_width);
-            self.terminal_width.saturating_sub(explorer)
+            let explorer = self.file_explorer_width.to_cols(chrome);
+            chrome.saturating_sub(explorer)
         } else {
-            self.terminal_width
+            chrome
         }
     }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -314,6 +314,15 @@ pub struct Window {
     pub(crate) terminal_width: u16,
     pub(crate) terminal_height: u16,
 
+    /// Effective width (cols) of the editor-global left dock, pushed
+    /// down by `Editor::relayout` (the single layout funnel). Mirrored
+    /// here — like `terminal_width` — so per-window terminal sizing
+    /// (`resize_visible_terminals`) can subtract the dock without
+    /// reaching back to `Editor`. `0` when no dock is shown. This is a
+    /// derived cache, never a source of truth: `Editor::dock` owns the
+    /// real placement and `relayout` recomputes this from it.
+    pub(crate) dock_cols: u16,
+
     /// Editor-global resources shared by `Arc` clone (config, theme
     /// registry, keybindings, command registry, filesystem authority,
     /// the buffer-id allocator, …). See [`WindowResources`] for the
@@ -1579,6 +1588,7 @@ impl Window {
             chrome_layout: ChromeLayout::default(),
             terminal_width: 80,
             terminal_height: 24,
+            dock_cols: 0,
             preview: None,
             terminal_mode: false,
             terminal_mode_resume: std::collections::HashSet::new(),

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -219,13 +219,15 @@ impl crate::app::Editor {
             }
         }
 
-        // Resize the newly-active window's PTYs (mirrors
-        // `set_active_window`'s post-dive resize so the seeded
-        // terminal renders into the right cell rect on its first
-        // frame).
-        if let Some(win) = self.windows.get_mut(&id) {
-            win.resize_visible_terminals();
-        }
+        // Size the newly-created window's PTYs (mirrors
+        // `set_active_window`'s post-dive resize so the seeded terminal
+        // renders into the right cell rect on its first frame). Route
+        // through the funnel rather than `win.resize_visible_terminals()`
+        // directly: a brand-new window's `dock_cols` cache is still 0, and
+        // `relayout` pushes the current editor-global dock width into every
+        // window before sizing, so the seeded terminal accounts for a dock
+        // that's already showing.
+        self.relayout();
 
         // Plugin lifecycle: fire `window_created` first, then
         // `active_window_changed`. Order mirrors the
@@ -356,7 +358,7 @@ impl crate::app::Editor {
             },
         );
 
-        // Resize the newly-active window's visible terminal PTYs to
+        // Reflow the newly-active window's visible terminal PTYs to
         // match their dive-view split rects. Without this, a session
         // that was just previewed in the orchestrator picker
         // (`render_session_preview_into_rect` resizes PTYs to the
@@ -365,10 +367,10 @@ impl crate::app::Editor {
         // bottom of the dive view blank until something else triggers
         // a resize. Same applies for the inverse: dive away while a
         // session has a small split, dive back when the window is
-        // bigger — the terminal needs the new dimensions.
-        if let Some(win) = self.windows.get_mut(&id) {
-            win.resize_visible_terminals();
-        }
+        // bigger — the terminal needs the new dimensions. Route through
+        // the funnel so the dive-target window also picks up the current
+        // editor-global dock width (its `dock_cols` cache may be stale).
+        self.relayout();
     }
 
     /// Switch the active window and play a directional wipe over the

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -864,6 +864,30 @@ fn render_collected(
             ensure_trailing_newline(&mut entry);
             entries.push(entry);
         }
+        WidgetSpec::Divider { ch, style, .. } => {
+            // Draw the rule at the host's authoritative inner width, so it
+            // always spans the panel exactly — no plugin-side width guess.
+            // One column per glyph (the default `─` is a single cell); an
+            // empty `ch` falls back to a space so a stray empty divider
+            // still occupies its row instead of collapsing.
+            let glyph = if ch.is_empty() { " " } else { ch.as_str() };
+            let cols = (panel_width as usize).min(4096);
+            let mut text = String::with_capacity(cols * glyph.len() + 1);
+            for _ in 0..cols {
+                text.push_str(glyph);
+            }
+            let mut entry = TextPropertyEntry {
+                text,
+                properties: Default::default(),
+                style: style.clone(),
+                inline_overlays: Vec::new(),
+                segments: Vec::new(),
+                pad_to_chars: None,
+                truncate_to_chars: None,
+            };
+            ensure_trailing_newline(&mut entry);
+            entries.push(entry);
+        }
         WidgetSpec::List {
             items,
             item_keys,


### PR DESCRIPTION
## Summary
Refactor the layout system to route all geometry-changing operations through a single `Editor::relayout()` funnel. This ensures consistent, one-directional propagation of layout changes to all consumers (split viewports, terminal PTYs, panels, and plugin hooks) and eliminates redundant or inconsistent resize calls scattered throughout the codebase.

## Key Changes

- **New `Editor::relayout()` method**: Single authoritative layout funnel that derives geometry once and pushes it down to all consumers. Reads source-of-truth state (dock placement, file explorer visibility) and propagates to windows, terminals, and plugins.

- **Layout deduplication**: Added `last_layout_signature` to track the last notified layout state `(width, height, dock_cols, file_explorer_cols)`. The plugin `resize` hook and panel rerenders only fire when the signature changes, preventing cascading loops when plugins react to resize by updating dock width.

- **Renamed `Window::resize()` to `Window::apply_layout()`**: Now accepts `dock_cols` parameter and applies geometry handed down by the editor, rather than computing it independently. Resizes split viewports against post-dock width.

- **New `Editor::dock_cols()` helper**: Computes effective dock width by delegating to the renderer's `compute_dock_split`, ensuring the geometry pushed down matches what gets painted.

- **Refactored `Window::resize_visible_terminals()`**: Now accounts for the cached `dock_cols` and computes file-explorer width against post-dock chrome width, matching the renderer exactly.

- **Routed all geometry changes through `relayout()`**:
  - OS terminal resize (`Editor::resize`)
  - Dock mount/unmount/resize (plugin_dispatch.rs)
  - File explorer toggle (file_explorer.rs)
  - Split create/close/resize/drag (split_actions.rs, mouse_input.rs)
  - Window creation and active window switch (window_actions.rs)

## Notable Implementation Details

- The dock width is now a derived cache in `Window::dock_cols`, never a source of truth. `Editor::dock` owns the real placement.
- Terminal PTY resizes are idempotent (PTY layer drops no-ops), and the plugin hook is signature-deduped, so callers can safely call `relayout()` redundantly without performance cost.
- Split viewport dimensions are refined again at paint time by `sync_viewport_to_content`; terminals have no such paint-time sync, which is why PTY size must be pushed during layout.
- The deduplication signature prevents the orchestrator's resize→`dock_width`→relayout reaction from looping indefinitely.

https://claude.ai/code/session_01JZr8ygED8FrokxYZNhaFoc