### PR TITLE
Support terminal window title updates via OSC escape codes

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -70,6 +70,7 @@
         "show_tilde": true,
         "use_terminal_bg": false,
         "set_window_title": true,
+        "terminal_auto_title": true,
         "cursor_style": "default",
         "rulers": [],
         "whitespace_show": true,
@@ -438,6 +439,12 @@
         },
         "set_window_title": {
           "description": "Update the terminal window title (via OSC 2) to reflect the active buffer.\nWhen enabled, Fresh sets the terminal/tab title to \"<file> — Fresh\" as\nyou switch buffers. Harmless on terminals that don't understand the\nescape sequence — they silently ignore it.\nDefault: true",
+          "type": "boolean",
+          "default": true,
+          "x-section": "Display"
+        },
+        "terminal_auto_title": {
+          "description": "Auto-name terminal tabs after the running program (tmux-style). When\nenabled, an integrated terminal's tab reflects its foreground process\n(e.g. `python3`, `vim`) combined with any title the program set via\nan OSC escape sequence, instead of the static `*Terminal N*` label.\nDisable to keep the fixed `*Terminal N*` names.\nDefault: true",
           "type": "boolean",
           "default": true,
           "x-section": "Display"

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -74,6 +74,13 @@ impl Editor {
         if let Some(terminal_id) = self.active_window_mut().terminal_buffers.remove(&id) {
             // Close the terminal process
             self.active_window_mut().terminal_manager.close(terminal_id);
+            // Drop any explicit-title marker / cached foreground name so the
+            // id can't carry stale auto-naming state if a future buffer
+            // reuses it.
+            self.active_window_mut()
+                .terminal_explicit_titles
+                .remove(&id);
+            self.active_window_mut().terminal_fg_cache.remove(&id);
 
             // Retain the rendered backing file so its scrollback stays
             // searchable after close (Universal Search "Terminals" scope).

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -341,6 +341,9 @@ impl Editor {
     /// UI is otherwise idle (the render that follows runs
     /// `Window::sync_terminal_titles`).
     pub fn terminal_title_poll_deadline(&self) -> Option<std::time::Instant> {
+        if !self.config.editor.terminal_auto_title {
+            return None;
+        }
         let mut earliest: Option<std::time::Instant> = None;
         for window in self.windows.values() {
             let has_auto = window

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -323,10 +323,49 @@ impl Editor {
         // exactly when the timeout needs to fire, so a hung clipboard
         // owner can't block the UI past `PASTE_ASYNC_DEADLINE`.
         let paste_deadline = self.next_paste_deadline();
+        // Note: the terminal-title poll deadline is intentionally NOT folded
+        // in here. This deadline path caps the loop's wait to one frame
+        // (~16ms) for smooth animation, which would turn the ~1s title poll
+        // into a 60Hz busy loop. The loop's existing 50ms idle poll is fine
+        // granularity to notice `terminal_titles_need_poll` going true.
         [lsp_progress_deadline, anim_deadline, paste_deadline]
             .into_iter()
             .flatten()
             .min()
+    }
+
+    /// Earliest time a terminal tab needs its foreground-process title
+    /// re-polled, across all windows. `None` when no window has an
+    /// auto-named (non-explicit) terminal. Drives the event loop's periodic
+    /// wakeups so a tab reflects a command that starts or exits while the
+    /// UI is otherwise idle (the render that follows runs
+    /// `Window::sync_terminal_titles`).
+    pub fn terminal_title_poll_deadline(&self) -> Option<std::time::Instant> {
+        let mut earliest: Option<std::time::Instant> = None;
+        for window in self.windows.values() {
+            let has_auto = window
+                .terminal_buffers
+                .keys()
+                .any(|b| !window.terminal_explicit_titles.contains(b));
+            if !has_auto {
+                continue;
+            }
+            let deadline = match window.terminal_fg_poll_at {
+                Some(last) => last + crate::app::terminal::FG_POLL_INTERVAL,
+                None => std::time::Instant::now(),
+            };
+            earliest = Some(earliest.map_or(deadline, |e| e.min(deadline)));
+        }
+        earliest
+    }
+
+    /// Whether a terminal tab is due for a foreground-process title poll
+    /// (its deadline has passed). The event loop ORs this into its
+    /// `needs_render` decision so the periodic wakeup actually paints a
+    /// frame, matching how animations and the LSP spinner are handled.
+    pub fn terminal_titles_need_poll(&self) -> bool {
+        self.terminal_title_poll_deadline()
+            .is_some_and(|d| d <= std::time::Instant::now())
     }
 
     /// Get stored LSP diagnostics (for testing and external access)

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -80,6 +80,13 @@ impl Editor {
             }
         }
 
+        // Refresh terminal tab titles from any OSC 0/1/2 title the running
+        // programs set since the last frame. Done for every window so
+        // background tabs stay current, not just the active one.
+        for window in self.windows.values_mut() {
+            window.sync_terminal_titles();
+        }
+
         // Carve a full-height left column for a docked floating panel
         // (e.g. the orchestrator dock) out of the screen *before* the
         // chrome lays itself out, so the menu bar, splits, and status

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -513,6 +513,49 @@ impl Window {
         format!("{} (n)", desired)
     }
 
+    /// Update terminal buffers' tab titles from the title the running
+    /// program set via OSC escape codes (OSC 0/1/2). Intended to run once
+    /// per frame. When a terminal hasn't set a title (or only ever set an
+    /// empty one), its buffer keeps whatever name it already had — the
+    /// default `*Terminal N*` or a plugin-provided title.
+    ///
+    /// Titles are sanitized (control characters stripped, length capped)
+    /// the same way as the host window title. OSC titles are applied
+    /// verbatim without the `name (k)` disambiguation used for plugin
+    /// titles: programs rewrite these frequently (e.g. to show the cwd or
+    /// the running command) and re-disambiguating on every change would
+    /// make the suffix flicker.
+    pub fn sync_terminal_titles(&mut self) {
+        // Snapshot (buffer, title) pairs first so the mutable
+        // `buffer_metadata` borrow below doesn't overlap the immutable
+        // `terminal_manager` / `terminal_buffers` borrows. Each terminal
+        // state lock is taken and released within the closure.
+        let updates: Vec<(BufferId, String)> = self
+            .terminal_buffers
+            .iter()
+            .filter_map(|(buffer_id, terminal_id)| {
+                let handle = self.terminal_manager.get(*terminal_id)?;
+                let title = handle.state.lock().ok()?.title().to_string();
+                if title.is_empty() {
+                    return None;
+                }
+                let sanitized = crate::services::terminal_title::sanitize_title(&title);
+                if sanitized.is_empty() {
+                    return None;
+                }
+                Some((*buffer_id, sanitized))
+            })
+            .collect();
+
+        for (buffer_id, title) in updates {
+            if let Some(meta) = self.buffer_metadata.get_mut(&buffer_id) {
+                if meta.display_name != title {
+                    meta.display_name = title;
+                }
+            }
+        }
+    }
+
     /// Open a new terminal in this window: spawn the PTY, create
     /// the buffer, attach to the active split, switch this window's
     /// active buffer to it, enable terminal mode, and resize the PTY

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -571,6 +571,14 @@ impl Window {
     /// the same way as the host window title, and applied without the
     /// `name (k)` disambiguation used for plugin titles.
     pub fn sync_terminal_titles(&mut self) {
+        // Gated by config: when off, tabs keep their static `*Terminal N*`
+        // (or plugin) names. Clearing the cache lets a later enable start
+        // fresh.
+        if !self.config().editor.terminal_auto_title {
+            self.terminal_fg_cache.clear();
+            return;
+        }
+
         // Refresh the foreground-name cache. A terminal is re-read when the
         // poll interval has elapsed, or eagerly while it has no cached name
         // yet (its first prompt may not have a foreground pgid the instant

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -40,6 +40,28 @@ use std::path::PathBuf;
 /// the editor's periodic-redraw deadline so the tab refreshes while idle.
 pub(crate) const FG_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1000);
 
+/// Combine the foreground process name with the program's OSC title into one
+/// tab label. The command leads (short, answers "what's running"); the OSC
+/// title follows as context, e.g. `python3 — root@host: ~/proj`.
+///
+/// Returns `None` only when both are absent, so the caller falls back to the
+/// default name. When the OSC title already names the command (e.g. vim's
+/// `file - VIM`), the command isn't prepended again to avoid `vim — … VIM`.
+fn combine_terminal_title(pty: Option<&str>, osc: Option<&str>) -> Option<String> {
+    match (pty, osc) {
+        (Some(p), Some(o)) => {
+            if o.to_lowercase().contains(&p.to_lowercase()) {
+                Some(o.to_string())
+            } else {
+                Some(format!("{p} \u{2014} {o}"))
+            }
+        }
+        (Some(p), None) => Some(p.to_string()),
+        (None, Some(o)) => Some(o.to_string()),
+        (None, None) => None,
+    }
+}
+
 impl Window {
     /// Resolve the terminal wrapper used to spawn a new integrated
     /// terminal in this window, applying the `terminal.shell` config
@@ -528,25 +550,25 @@ impl Window {
     /// group (`tcgetpgrp` + `/proc`) — is throttled to [`FG_POLL_INTERVAL`]
     /// and cached; the cached name is re-applied to the tab on every frame
     /// so the title is responsive to renders without re-running the syscall.
-    /// Precedence per terminal:
     ///
-    /// 1. **Foreground process name** — the command currently in the
-    ///    terminal's foreground process group (e.g. `python3` while a REPL
-    ///    runs, `bash` at the prompt). Mirrors tmux's
-    ///    `#{pane_current_command}` and is the primary source so a tab
-    ///    reflects what's actually running, even for programs (top,
-    ///    python3) that never emit a title.
-    /// 2. **OSC title** — what a program set via OSC 0/1/2. Used only as a
-    ///    fallback where the foreground process can't be read (currently
-    ///    every non-Linux platform).
-    /// 3. **Default** — `*Terminal N*` when nothing else is available.
+    /// The tab label **combines** two sources (see [`combine_terminal_title`]):
+    ///
+    /// - **Foreground process name** — the command currently in the
+    ///   terminal's foreground process group (e.g. `python3` while a REPL
+    ///   runs, `bash` at the prompt). Mirrors tmux's
+    ///   `#{pane_current_command}`; read on Linux, `None` elsewhere.
+    /// - **OSC title** — what a program set via OSC 0/1/2 (e.g. a shell's
+    ///   `user@host: ~/dir` prompt title, or vim's `file - VIM`).
+    ///
+    /// e.g. `python3 — root@host: ~/proj`. When only one is present that one
+    /// is used; when neither is, the default `*Terminal N*` stands.
     ///
     /// Terminals with an explicit (plugin-/command-derived) title are left
     /// untouched — like a tmux manual rename, an intentional name opts out
     /// of auto-naming.
     ///
-    /// Names are sanitized (control characters stripped, length capped) the
-    /// same way as the host window title, and applied without the
+    /// Both parts are sanitized (control characters stripped, length capped)
+    /// the same way as the host window title, and applied without the
     /// `name (k)` disambiguation used for plugin titles.
     pub fn sync_terminal_titles(&mut self) {
         // Refresh the foreground-name cache. A terminal is re-read when the
@@ -585,26 +607,21 @@ impl Window {
         }
 
         // Apply a title to every (non-explicit) terminal tab every frame,
-        // from the cached foreground name or the OSC fallback. Snapshot
-        // first so the mutable `buffer_metadata` borrow doesn't overlap the
-        // immutable reads above.
+        // combining the cached foreground name with the current OSC title.
+        // Snapshot first so the mutable `buffer_metadata` borrow doesn't
+        // overlap the immutable reads above.
         let mut updates: Vec<(BufferId, String)> = Vec::new();
         for (buffer_id, terminal_id) in self.terminal_buffers.iter() {
             if self.terminal_explicit_titles.contains(buffer_id) {
                 continue;
             }
-            let name = self
-                .terminal_fg_cache
-                .get(buffer_id)
-                .cloned()
-                .or_else(|| {
-                    // Fallback: the OSC title, where the foreground process
-                    // isn't available (non-Linux).
-                    let handle = self.terminal_manager.get(*terminal_id)?;
-                    let osc = handle.state.lock().ok()?.title().to_string();
-                    let sanitized = crate::services::terminal_title::sanitize_title(&osc);
-                    (!sanitized.is_empty()).then_some(sanitized)
-                })
+            let pty = self.terminal_fg_cache.get(buffer_id).cloned();
+            let osc = self.terminal_manager.get(*terminal_id).and_then(|handle| {
+                let osc = handle.state.lock().ok()?.title().to_string();
+                let sanitized = crate::services::terminal_title::sanitize_title(&osc);
+                (!sanitized.is_empty()).then_some(sanitized)
+            });
+            let name = combine_terminal_title(pty.as_deref(), osc.as_deref())
                 .unwrap_or_else(|| format!("*Terminal {}*", terminal_id.0));
             updates.push((*buffer_id, name));
         }
@@ -1673,4 +1690,43 @@ fn encode_x10_mouse(
     let cb = cb + 32;
 
     Some(vec![0x1b, b'[', b'M', cb, cx, cy])
+}
+
+#[cfg(test)]
+mod title_tests {
+    use super::combine_terminal_title;
+
+    #[test]
+    fn combines_command_and_osc_title() {
+        assert_eq!(
+            combine_terminal_title(Some("python3"), Some("root@host: ~/proj")).as_deref(),
+            Some("python3 \u{2014} root@host: ~/proj")
+        );
+    }
+
+    #[test]
+    fn uses_single_source_when_only_one_present() {
+        assert_eq!(
+            combine_terminal_title(Some("bash"), None).as_deref(),
+            Some("bash")
+        );
+        assert_eq!(
+            combine_terminal_title(None, Some("root@host: ~/proj")).as_deref(),
+            Some("root@host: ~/proj")
+        );
+    }
+
+    #[test]
+    fn does_not_duplicate_command_already_in_osc_title() {
+        // vim sets its own OSC title; don't prepend "vim — … VIM".
+        assert_eq!(
+            combine_terminal_title(Some("vim"), Some("README.md (~/proj) - VIM")).as_deref(),
+            Some("README.md (~/proj) - VIM")
+        );
+    }
+
+    #[test]
+    fn none_when_neither_present() {
+        assert_eq!(combine_terminal_title(None, None), None);
+    }
 }

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -33,6 +33,13 @@ use crate::view::split::SplitViewState;
 use rust_i18n::t;
 use std::path::PathBuf;
 
+/// How often [`Window::sync_terminal_titles`] polls each terminal's
+/// foreground process group for tmux-style tab auto-naming. Frequent enough
+/// to feel responsive when a command starts/exits, infrequent enough that
+/// the per-terminal `tcgetpgrp` + `/proc` read is negligible. Also drives
+/// the editor's periodic-redraw deadline so the tab refreshes while idle.
+pub(crate) const FG_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1000);
+
 impl Window {
     /// Resolve the terminal wrapper used to spawn a new integrated
     /// terminal in this window, applying the `terminal.shell` config
@@ -452,6 +459,9 @@ impl Window {
             if let Some(meta) = self.buffer_metadata.get_mut(&buffer_id) {
                 meta.display_name = final_name;
             }
+            // Mark this tab as explicitly titled so foreground-process
+            // auto-naming leaves it alone (an OSC title still overrides).
+            self.terminal_explicit_titles.insert(buffer_id);
         }
 
         // When the new terminal ended up as this window's active
@@ -513,39 +523,91 @@ impl Window {
         format!("{} (n)", desired)
     }
 
-    /// Update terminal buffers' tab titles from the title the running
-    /// program set via OSC escape codes (OSC 0/1/2). Intended to run once
-    /// per frame. When a terminal hasn't set a title (or only ever set an
-    /// empty one), its buffer keeps whatever name it already had — the
-    /// default `*Terminal N*` or a plugin-provided title.
+    /// Refresh terminal buffers' tab titles, tmux-style. Runs every frame,
+    /// but the expensive part — reading each terminal's foreground process
+    /// group (`tcgetpgrp` + `/proc`) — is throttled to [`FG_POLL_INTERVAL`]
+    /// and cached; the cached name is re-applied to the tab on every frame
+    /// so the title is responsive to renders without re-running the syscall.
+    /// Precedence per terminal:
     ///
-    /// Titles are sanitized (control characters stripped, length capped)
-    /// the same way as the host window title. OSC titles are applied
-    /// verbatim without the `name (k)` disambiguation used for plugin
-    /// titles: programs rewrite these frequently (e.g. to show the cwd or
-    /// the running command) and re-disambiguating on every change would
-    /// make the suffix flicker.
+    /// 1. **Foreground process name** — the command currently in the
+    ///    terminal's foreground process group (e.g. `python3` while a REPL
+    ///    runs, `bash` at the prompt). Mirrors tmux's
+    ///    `#{pane_current_command}` and is the primary source so a tab
+    ///    reflects what's actually running, even for programs (top,
+    ///    python3) that never emit a title.
+    /// 2. **OSC title** — what a program set via OSC 0/1/2. Used only as a
+    ///    fallback where the foreground process can't be read (currently
+    ///    every non-Linux platform).
+    /// 3. **Default** — `*Terminal N*` when nothing else is available.
+    ///
+    /// Terminals with an explicit (plugin-/command-derived) title are left
+    /// untouched — like a tmux manual rename, an intentional name opts out
+    /// of auto-naming.
+    ///
+    /// Names are sanitized (control characters stripped, length capped) the
+    /// same way as the host window title, and applied without the
+    /// `name (k)` disambiguation used for plugin titles.
     pub fn sync_terminal_titles(&mut self) {
-        // Snapshot (buffer, title) pairs first so the mutable
-        // `buffer_metadata` borrow below doesn't overlap the immutable
-        // `terminal_manager` / `terminal_buffers` borrows. Each terminal
-        // state lock is taken and released within the closure.
-        let updates: Vec<(BufferId, String)> = self
-            .terminal_buffers
-            .iter()
-            .filter_map(|(buffer_id, terminal_id)| {
-                let handle = self.terminal_manager.get(*terminal_id)?;
-                let title = handle.state.lock().ok()?.title().to_string();
-                if title.is_empty() {
-                    return None;
+        // Refresh the foreground-name cache. A terminal is re-read when the
+        // poll interval has elapsed, or eagerly while it has no cached name
+        // yet (its first prompt may not have a foreground pgid the instant
+        // it spawns, and renders are event-driven — so keep trying until it
+        // resolves rather than waiting a full interval).
+        let now = std::time::Instant::now();
+        let interval_due = self
+            .terminal_fg_poll_at
+            .is_none_or(|last| now.duration_since(last) >= FG_POLL_INTERVAL);
+        if interval_due {
+            self.terminal_fg_poll_at = Some(now);
+        }
+        for (buffer_id, terminal_id) in self.terminal_buffers.iter() {
+            if self.terminal_explicit_titles.contains(buffer_id) {
+                continue;
+            }
+            if !interval_due && self.terminal_fg_cache.contains_key(buffer_id) {
+                continue;
+            }
+            let name = self
+                .terminal_manager
+                .get(*terminal_id)
+                .and_then(|h| h.foreground_process_name())
+                .map(|n| crate::services::terminal_title::sanitize_title(&n))
+                .filter(|n| !n.is_empty());
+            match name {
+                Some(n) => {
+                    self.terminal_fg_cache.insert(*buffer_id, n);
                 }
-                let sanitized = crate::services::terminal_title::sanitize_title(&title);
-                if sanitized.is_empty() {
-                    return None;
+                None => {
+                    self.terminal_fg_cache.remove(buffer_id);
                 }
-                Some((*buffer_id, sanitized))
-            })
-            .collect();
+            }
+        }
+
+        // Apply a title to every (non-explicit) terminal tab every frame,
+        // from the cached foreground name or the OSC fallback. Snapshot
+        // first so the mutable `buffer_metadata` borrow doesn't overlap the
+        // immutable reads above.
+        let mut updates: Vec<(BufferId, String)> = Vec::new();
+        for (buffer_id, terminal_id) in self.terminal_buffers.iter() {
+            if self.terminal_explicit_titles.contains(buffer_id) {
+                continue;
+            }
+            let name = self
+                .terminal_fg_cache
+                .get(buffer_id)
+                .cloned()
+                .or_else(|| {
+                    // Fallback: the OSC title, where the foreground process
+                    // isn't available (non-Linux).
+                    let handle = self.terminal_manager.get(*terminal_id)?;
+                    let osc = handle.state.lock().ok()?.title().to_string();
+                    let sanitized = crate::services::terminal_title::sanitize_title(&osc);
+                    (!sanitized.is_empty()).then_some(sanitized)
+                })
+                .unwrap_or_else(|| format!("*Terminal {}*", terminal_id.0));
+            updates.push((*buffer_id, name));
+        }
 
         for (buffer_id, title) in updates {
             if let Some(meta) = self.buffer_metadata.get_mut(&buffer_id) {

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -286,6 +286,24 @@ pub struct Window {
     /// from the PTY, used for replay / save-history).
     pub terminal_log_files: HashMap<crate::services::terminal::TerminalId, std::path::PathBuf>,
 
+    /// Terminal buffers whose tab title was set explicitly (plugin- or
+    /// command-derived). These are excluded from foreground-process
+    /// auto-naming so a program running inside doesn't clobber the chosen
+    /// title; an OSC title emitted by the program still takes precedence.
+    pub terminal_explicit_titles: std::collections::HashSet<BufferId>,
+
+    /// Last time foreground-process names were polled for terminal tab
+    /// auto-naming. Throttles the `tcgetpgrp` + `/proc` reads to roughly
+    /// once a second rather than every frame. `None` until the first poll.
+    pub(crate) terminal_fg_poll_at: Option<std::time::Instant>,
+
+    /// Cached foreground-process name per terminal buffer, refreshed on the
+    /// [`FG_POLL_INTERVAL`] poll. Present means a name was read; absent
+    /// means none was available (so callers fall back to the OSC title or
+    /// default). Applied to the tab every frame so the title stays put
+    /// between polls without re-running the syscall.
+    pub(crate) terminal_fg_cache: HashMap<BufferId, String>,
+
     /// Plugin-managed per-window state. Outer key is plugin name,
     /// inner is the plugin-defined key. Read via
     /// `editor.getWindowState(key)` and written via
@@ -1639,6 +1657,9 @@ impl Window {
             terminal_buffers: HashMap::new(),
             terminal_backing_files: HashMap::new(),
             terminal_log_files: HashMap::new(),
+            terminal_explicit_titles: std::collections::HashSet::new(),
+            terminal_fg_poll_at: None,
+            terminal_fg_cache: HashMap::new(),
             event_logs: HashMap::new(),
             status_message: None,
             plugin_status_message: None,

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -906,6 +906,16 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub set_window_title: bool,
 
+    /// Auto-name terminal tabs after the running program (tmux-style). When
+    /// enabled, an integrated terminal's tab reflects its foreground process
+    /// (e.g. `python3`, `vim`) combined with any title the program set via
+    /// an OSC escape sequence, instead of the static `*Terminal N*` label.
+    /// Disable to keep the fixed `*Terminal N*` names.
+    /// Default: true
+    #[serde(default = "default_true")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub terminal_auto_title: bool,
+
     /// Cursor style for the terminal cursor.
     /// Options: blinking_block, steady_block, blinking_bar, steady_bar, blinking_underline, steady_underline
     /// Default: blinking_block
@@ -1475,6 +1485,7 @@ impl Default for EditorConfig {
             show_tilde: true,
             use_terminal_bg: false,
             set_window_title: true,
+            terminal_auto_title: true,
             rulers: Vec::new(),
             whitespace_show: true,
             whitespace_spaces_leading: false,

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4253,6 +4253,13 @@ where
             needs_render = true;
         }
 
+        // Terminal tabs auto-name from the foreground process (tmux-style);
+        // poll on an interval so a command that starts/exits while the UI is
+        // idle is reflected without waiting for an unrelated event.
+        if editor.terminal_titles_need_poll() {
+            needs_render = true;
+        }
+
         if needs_render
             && last_render.elapsed() >= FRAME_DURATION
             && !editor.should_suppress_render()

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -204,6 +204,7 @@ pub struct PartialEditorConfig {
     pub show_tilde: Option<bool>,
     pub use_terminal_bg: Option<bool>,
     pub set_window_title: Option<bool>,
+    pub terminal_auto_title: Option<bool>,
     pub rulers: Option<Vec<usize>>,
     pub whitespace_show: Option<bool>,
     pub whitespace_spaces_leading: Option<bool>,
@@ -315,6 +316,8 @@ impl Merge for PartialEditorConfig {
         self.show_tilde.merge_from(&other.show_tilde);
         self.use_terminal_bg.merge_from(&other.use_terminal_bg);
         self.set_window_title.merge_from(&other.set_window_title);
+        self.terminal_auto_title
+            .merge_from(&other.terminal_auto_title);
         self.rulers.merge_from(&other.rulers);
         self.whitespace_show.merge_from(&other.whitespace_show);
         self.whitespace_spaces_leading
@@ -619,6 +622,7 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             show_tilde: Some(cfg.show_tilde),
             use_terminal_bg: Some(cfg.use_terminal_bg),
             set_window_title: Some(cfg.set_window_title),
+            terminal_auto_title: Some(cfg.terminal_auto_title),
             rulers: Some(cfg.rulers.clone()),
             whitespace_show: Some(cfg.whitespace_show),
             whitespace_spaces_leading: Some(cfg.whitespace_spaces_leading),
@@ -774,6 +778,9 @@ impl PartialEditorConfig {
             show_tilde: self.show_tilde.unwrap_or(defaults.show_tilde),
             use_terminal_bg: self.use_terminal_bg.unwrap_or(defaults.use_terminal_bg),
             set_window_title: self.set_window_title.unwrap_or(defaults.set_window_title),
+            terminal_auto_title: self
+                .terminal_auto_title
+                .unwrap_or(defaults.terminal_auto_title),
             rulers: self.rulers.unwrap_or_else(|| defaults.rulers.clone()),
             whitespace_show: self.whitespace_show.unwrap_or(defaults.whitespace_show),
             whitespace_spaces_leading: self

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -63,6 +63,12 @@ pub struct TerminalHandle {
     /// shell or agent forked. `None` on Windows or when
     /// portable_pty couldn't report the pid.
     pid: Option<u32>,
+    /// PTY master file descriptor, captured at spawn. Used to read the
+    /// terminal's foreground process group via `tcgetpgrp` for tmux-style
+    /// tab auto-naming. `None` on Windows or when the platform doesn't
+    /// expose it. Only read on Linux (the only `/proc`-backed target).
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    master_fd: Option<i32>,
 }
 
 impl TerminalHandle {
@@ -105,6 +111,44 @@ impl TerminalHandle {
     /// platforms / configurations that don't expose a pid.
     pub fn pid(&self) -> Option<u32> {
         self.pid
+    }
+
+    /// Name of the command currently in the foreground of this terminal,
+    /// e.g. `"bash"` at the prompt or `"python3"` while a REPL runs.
+    ///
+    /// Derived from the PTY's foreground process *group* (`tcgetpgrp` on
+    /// the master fd) rather than the shell pid, so it tracks whatever the
+    /// user is actually interacting with — the same signal tmux uses for
+    /// `#{pane_current_command}`. This is how a tab can read `python3`
+    /// even though `python3` never emits an OSC title sequence.
+    ///
+    /// Only implemented on Linux (via `/proc/<pgid>/comm`); returns `None`
+    /// elsewhere so callers fall back to the OSC title or default name.
+    pub fn foreground_process_name(&self) -> Option<String> {
+        #[cfg(target_os = "linux")]
+        {
+            let fd = self.master_fd?;
+            // SAFETY: `fd` is the PTY master, kept open by the writer
+            // thread for the terminal's lifetime. `tcgetpgrp` only reads.
+            let pgid = unsafe { libc::tcgetpgrp(fd) };
+            if pgid <= 0 {
+                return None;
+            }
+            // Local OS introspection of a local fd. The `FileSystem` trait
+            // abstracts the *editing* filesystem (possibly remote); it does
+            // not apply to reading this host's `/proc`.
+            let comm = std::fs::read_to_string(format!("/proc/{pgid}/comm")).ok()?;
+            let name = comm.trim();
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.to_string())
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
     }
 
     /// Send `signal` to the terminal's process group. Returns
@@ -578,6 +622,21 @@ impl TerminalManager {
                 }
             });
 
+            // Capture the PTY master fd before the master moves into the
+            // writer thread below. Used later by `foreground_process_name`
+            // (tmux-style tab auto-naming). The fd stays valid for the
+            // terminal's lifetime because the writer thread owns the master.
+            let master_fd: Option<i32> = {
+                #[cfg(unix)]
+                {
+                    pty_pair.master.as_raw_fd()
+                }
+                #[cfg(not(unix))]
+                {
+                    None
+                }
+            };
+
             // Spawn writer thread
             let pty_size_ref = pty_pair.master;
             thread::spawn(move || {
@@ -626,6 +685,7 @@ impl TerminalManager {
                 cwd: cwd.clone(),
                 shell,
                 pid: child_pid,
+                master_fd,
             })
         })();
 

--- a/crates/fresh-editor/src/services/terminal/term.rs
+++ b/crates/fresh-editor/src/services/terminal/term.rs
@@ -48,24 +48,50 @@ const SCROLLBACK_LINES: usize = 200_000;
 struct PtyWriteListener {
     /// Queue of data to write back to the PTY
     write_queue: Arc<Mutex<Vec<String>>>,
+    /// Latest title requested by the program via OSC 0/1/2 (or a reset
+    /// via the OSC reset sequence). `Some` means a change is pending;
+    /// the inner string is the new title (empty string for a reset).
+    /// `process_output` drains this after parsing to update the
+    /// terminal's stored title.
+    pending_title: Arc<Mutex<Option<String>>>,
 }
 
 impl PtyWriteListener {
     fn new() -> Self {
         Self {
             write_queue: Arc::new(Mutex::new(Vec::new())),
+            pending_title: Arc::new(Mutex::new(None)),
         }
     }
 }
 
 impl EventListener for PtyWriteListener {
     fn send_event(&self, event: Event) {
-        if let Event::PtyWrite(text) = event {
-            if let Ok(mut queue) = self.write_queue.lock() {
-                queue.push(text);
+        match event {
+            Event::PtyWrite(text) => {
+                if let Ok(mut queue) = self.write_queue.lock() {
+                    queue.push(text);
+                }
             }
+            // OSC 0 (icon + window title), OSC 1 (icon title), and OSC 2
+            // (window title) all surface as `Title`. Record the latest;
+            // `process_output` propagates it to `terminal_title` so the
+            // buffer's tab auto-adjusts to whatever the running program set.
+            Event::Title(title) => {
+                if let Ok(mut pending) = self.pending_title.lock() {
+                    *pending = Some(title);
+                }
+            }
+            // Title reset (OSC with empty payload) — clear back to the
+            // buffer's default name by recording an empty title.
+            Event::ResetTitle => {
+                if let Ok(mut pending) = self.pending_title.lock() {
+                    *pending = Some(String::new());
+                }
+            }
+            // Other events (ClipboardStore, etc.) are ignored for now.
+            _ => {}
         }
-        // Other events (Title, ClipboardStore, etc.) are ignored for now
     }
 }
 
@@ -88,6 +114,9 @@ pub struct TerminalState {
     backing_file_history_end: u64,
     /// Queue of data to write back to the PTY (for DSR responses, etc.)
     pty_write_queue: Arc<Mutex<Vec<String>>>,
+    /// Pending title set by the program via OSC 0/1/2 (shared with the
+    /// event listener). Drained in `process_output` into `terminal_title`.
+    pending_title: Arc<Mutex<Option<String>>>,
 }
 
 impl TerminalState {
@@ -100,6 +129,7 @@ impl TerminalState {
         };
         let listener = PtyWriteListener::new();
         let pty_write_queue = listener.write_queue.clone();
+        let pending_title = listener.pending_title.clone();
         let term = Term::new(config, &size, listener);
 
         Self {
@@ -112,6 +142,7 @@ impl TerminalState {
             synced_history_lines: 0,
             backing_file_history_end: 0,
             pty_write_queue,
+            pending_title,
         }
     }
 
@@ -130,6 +161,14 @@ impl TerminalState {
     /// Process output from the PTY
     pub fn process_output(&mut self, data: &[u8]) {
         self.parser.advance(&mut self.term, data);
+        // The parser may have emitted OSC title events (0/1/2) into the
+        // listener's pending slot during `advance`. Apply the latest so
+        // the stored title reflects what the program requested.
+        if let Ok(mut pending) = self.pending_title.lock() {
+            if let Some(title) = pending.take() {
+                self.terminal_title = title;
+            }
+        }
         self.dirty = true;
     }
 
@@ -1019,5 +1058,38 @@ mod tests {
         let response = &responses[0];
         // Should report position as row 5, col 10
         assert_eq!(response, "\x1b[5;10R", "Response should be \\x1b[5;10R");
+    }
+
+    /// OSC 2 ("set window title") drives the stored terminal title so the
+    /// buffer's tab can auto-adjust to whatever the program requested.
+    #[test]
+    fn test_osc_set_window_title() {
+        let mut state = TerminalState::new(80, 24);
+        assert_eq!(state.title(), "");
+        // ESC ] 2 ; <title> BEL
+        state.process_output(b"\x1b]2;my-shell: ~/project\x07");
+        assert_eq!(state.title(), "my-shell: ~/project");
+    }
+
+    /// OSC 0 sets both the icon name and the window title; we treat it the
+    /// same as OSC 2 for the buffer title.
+    #[test]
+    fn test_osc_set_icon_and_window_title() {
+        let mut state = TerminalState::new(80, 24);
+        state.process_output(b"\x1b]0;vim README.md\x07");
+        assert_eq!(state.title(), "vim README.md");
+    }
+
+    /// A later OSC title overrides an earlier one, and the title can arrive
+    /// in the same chunk as other output.
+    #[test]
+    fn test_osc_title_updates_and_mixes_with_output() {
+        let mut state = TerminalState::new(80, 24);
+        state.process_output(b"\x1b]2;first\x07hello");
+        assert_eq!(state.title(), "first");
+        state.process_output(b"world\x1b]2;second\x07");
+        assert_eq!(state.title(), "second");
+        // The printable bytes still landed on the grid.
+        assert!(state.content_string().contains("helloworld"));
     }
 }

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -645,6 +645,11 @@ impl EditorTestHarness {
         // by passing a config, so the override here never gets in their
         // way.
         config.editor.show_prompt_line = true;
+        // Keep terminal tabs on their static `*Terminal N*` names in tests so
+        // assertions don't depend on the host's shell / foreground process.
+        // The tmux-style auto-naming (default on for users) is exercised by
+        // tests that opt back in via `set_config` after construction.
+        config.editor.terminal_auto_title = false;
         // Force "default" keybinding map for consistent test behavior across platforms
         // (Config::default() uses platform-specific keymaps which breaks test assumptions)
         // Skip this if the test explicitly wants to preserve its keymap (e.g., testing emacs bindings)

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -282,6 +282,12 @@ fn test_terminal_content_rendering() {
 fn test_terminal_tab_title_follows_foreground_process() {
     let mut harness = harness_or_return!(80, 24);
 
+    // Opt into tmux-style auto-naming (the harness disables it by default for
+    // deterministic `*Terminal N*` tabs elsewhere).
+    let mut cfg = harness.editor().config().clone();
+    cfg.editor.terminal_auto_title = true;
+    harness.editor_mut().set_config(cfg);
+
     harness.editor_mut().open_terminal();
     harness.render().unwrap();
 

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -269,6 +269,45 @@ fn test_terminal_content_rendering() {
     assert!(!content[0].is_empty());
 }
 
+/// A program running in the terminal can rename its own tab by emitting an
+/// OSC 2 ("set window title") escape sequence, just like in a standalone
+/// terminal emulator. The default `*Terminal 0*` tab label is replaced by
+/// the requested title on the next render, asserted purely on screen output.
+#[test]
+fn test_terminal_tab_title_follows_osc_sequence() {
+    let mut harness = harness_or_return!(80, 24);
+
+    // Open a terminal — the tab starts with the default label.
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    harness.assert_screen_contains("*Terminal 0*");
+
+    // Emulate the program emitting OSC 2 by feeding the bytes into the
+    // live terminal's emulator state (the same path PTY output takes).
+    let buffer_id = harness.editor().active_buffer_id();
+    let terminal_id = harness
+        .editor()
+        .active_window()
+        .get_terminal_id(buffer_id)
+        .expect("active buffer should be a terminal");
+    {
+        let handle = harness
+            .editor()
+            .terminal_manager()
+            .get(terminal_id)
+            .expect("terminal handle should exist");
+        let mut state = handle.state.lock().expect("terminal state lock");
+        // ESC ] 2 ; <title> BEL
+        state.process_output(b"\x1b]2;my-shell: ~/project\x07");
+    }
+
+    // After the next render the tab reflects the OSC title and the default
+    // label is gone.
+    harness.render().unwrap();
+    harness.assert_screen_contains("my-shell: ~/project");
+    harness.assert_screen_not_contains("*Terminal 0*");
+}
+
 /// Test terminal handles ANSI escape sequences for cursor positioning
 /// Uses direct terminal state processing (synchronous) instead of PTY
 #[test]

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -269,43 +269,58 @@ fn test_terminal_content_rendering() {
     assert!(!content[0].is_empty());
 }
 
-/// A program running in the terminal can rename its own tab by emitting an
-/// OSC 2 ("set window title") escape sequence, just like in a standalone
-/// terminal emulator. The default `*Terminal 0*` tab label is replaced by
-/// the requested title on the next render, asserted purely on screen output.
+/// A terminal tab auto-names from its foreground process, tmux-style: the
+/// command running in the pty (here the shell itself, right after open)
+/// replaces the default `*Terminal 0*` label. Asserted on the rendered tab
+/// bar row, so it observes real output rather than inspecting model state.
+///
+/// Linux-only: the foreground process group is read via `tcgetpgrp` +
+/// `/proc`, which other platforms don't implement (they fall back to the
+/// OSC title / default).
+#[cfg(target_os = "linux")]
 #[test]
-fn test_terminal_tab_title_follows_osc_sequence() {
+fn test_terminal_tab_title_follows_foreground_process() {
     let mut harness = harness_or_return!(80, 24);
 
-    // Open a terminal — the tab starts with the default label.
     harness.editor_mut().open_terminal();
     harness.render().unwrap();
-    harness.assert_screen_contains("*Terminal 0*");
 
-    // Emulate the program emitting OSC 2 by feeding the bytes into the
-    // live terminal's emulator state (the same path PTY output takes).
     let buffer_id = harness.editor().active_buffer_id();
     let terminal_id = harness
         .editor()
         .active_window()
         .get_terminal_id(buffer_id)
         .expect("active buffer should be a terminal");
-    {
-        let handle = harness
+
+    // Semantic wait: the shell becomes the pty's foreground process group
+    // shortly after spawn. Drive renders until auto-naming resolves; the
+    // bound only guards against a hang (cargo nextest times out externally).
+    let mut expected = None;
+    for _ in 0..2000 {
+        if let Some(name) = harness
             .editor()
             .terminal_manager()
             .get(terminal_id)
-            .expect("terminal handle should exist");
-        let mut state = handle.state.lock().expect("terminal state lock");
-        // ESC ] 2 ; <title> BEL
-        state.process_output(b"\x1b]2;my-shell: ~/project\x07");
+            .and_then(|h| h.foreground_process_name())
+        {
+            expected = Some(name);
+            harness.render().unwrap();
+            break;
+        }
+        harness.render().unwrap();
     }
+    let expected = expected.expect("foreground process name should resolve on Linux");
 
-    // After the next render the tab reflects the OSC title and the default
-    // label is gone.
-    harness.render().unwrap();
-    harness.assert_screen_contains("my-shell: ~/project");
-    harness.assert_screen_not_contains("*Terminal 0*");
+    // The tab bar (row 1) now shows the foreground command, not the default.
+    let tab_bar = harness.get_tab_bar();
+    assert!(
+        tab_bar.contains(&expected),
+        "tab bar {tab_bar:?} should contain foreground command {expected:?}"
+    );
+    assert!(
+        !tab_bar.contains("*Terminal 0*"),
+        "tab bar {tab_bar:?} should no longer show the default label"
+    );
 }
 
 /// Test terminal handles ANSI escape sequences for cursor positioning


### PR DESCRIPTION
## Summary
Add support for terminal window title updates via OSC (Operating System Command) escape codes, allowing running programs to dynamically set the buffer tab title. This enables better UX when running programs like shells, vim, tmux, etc. that update their window titles to show the current directory, command, or file being edited.

## Key Changes

- **PtyWriteListener event handling**: Extended to capture `Event::Title` and `Event::ResetTitle` events emitted by the terminal parser when programs send OSC 0/1/2 escape sequences. These are stored in a new `pending_title` field shared with `TerminalState`.

- **TerminalState title processing**: Added `pending_title` field to track pending title changes from the event listener. The `process_output` method now drains this field after parsing PTY data, updating the stored `terminal_title` to reflect what the program requested.

- **Window title synchronization**: Implemented `sync_terminal_titles()` method in `Window` to propagate terminal titles from running programs into buffer metadata display names. Titles are sanitized (control characters stripped, length capped) but applied verbatim without disambiguation suffixes, since programs rewrite these frequently.

- **Render loop integration**: Integrated `sync_terminal_titles()` into the render loop so terminal tab titles update every frame, including for background tabs.

- **Test coverage**: Added three tests validating OSC 2 (window title), OSC 0 (icon + window title), and title updates mixed with other output.

## Implementation Details

- Title updates use `Arc<Mutex<Option<String>>>` to safely share pending state between the event listener and terminal state without blocking the parser.
- Empty titles (from OSC reset sequences) clear back to the buffer's default name.
- The implementation handles titles arriving mid-chunk alongside other PTY output.

https://claude.ai/code/session_013XDKgAa943a4MdHcBuyDet