### PR TITLE
Fix dock keyboard navigation and modal rendering issues

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3825,6 +3825,9 @@ pub enum PluginCommand {
     /// - "focus"  — route keys to the panel (modal-ish capture).
     /// - "blur"   — stop routing keys to the panel; it stays rendered
     ///   so focus returns to the editor while the dock remains visible.
+    /// - "fullscreen" — a centered panel renders over the *entire* frame
+    ///   (covering the dimmed dock) when `arg != 0`, instead of laying
+    ///   into the chrome area beside the dock. No-op when no dock is up.
     FloatingPanelControl { panel_id: u64, op: String, arg: f64 },
 }
 

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2970,7 +2970,9 @@ interface EditorAPI {
 	/**
 	* Control a mounted floating panel's placement / focus without
 	* re-sending its spec. `op`: "dock" (`arg` = width in columns),
-	* "center", "focus", "blur". See `PluginCommand::FloatingPanelControl`.
+	* "center", "focus", "blur", "fullscreen" (`arg != 0` makes a
+	* centered panel cover the whole frame over the dock). See
+	* `PluginCommand::FloatingPanelControl`.
 	*/
 	floatingPanelControl(panelId: number, op: string, arg: number): boolean;
 	/**

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -28,6 +28,7 @@ import {
   list,
   raw,
   row,
+  wrappingRow,
   overlay,
   spacer,
   styledRow,
@@ -1638,10 +1639,14 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
   const stopDisabled = s.discovered || !s.terminalId;
   const archiveDisabled = false;
   const deleteDisabled = false;
-  const buttonRow = row(
+  // wrappingRow so the preview-pane actions reflow onto extra lines on a
+  // narrow pane instead of the right-most ones (Stop / Archive / Delete)
+  // being clipped off-screen. The wrap path ignores flex spacers, so a
+  // fixed `spacer(4)` separates the primary "Visit" from the rest while
+  // still wrapping cleanly.
+  const buttonRow = wrappingRow(
     button("Visit", { intent: "primary", key: "visit" }),
-    spacer(2),
-    flexSpacer(),
+    spacer(4),
     button(detailsToggleLabel, { key: "toggle-details" }),
     spacer(2),
     button("Stop", { key: "stop", disabled: stopDisabled }),
@@ -1784,8 +1789,11 @@ function buildConfirmPane(
     child: col(
       { kind: "raw", entries },
       spacer(0),
-      row(
-        flexSpacer(),
+      // wrappingRow so the Cancel / Confirm pair reflows instead of the
+      // Confirm button being clipped on a narrow confirmation pane. The
+      // leading flex spacer is dropped (the wrap path ignores flex and
+      // trims a blank that would lead a line), so the pair left-packs.
+      wrappingRow(
         button("Cancel", { key: "confirm-cancel" }),
         spacer(2),
         button(`Confirm ${cap}`, { intent: "danger", key: `confirm-${action}` }),
@@ -1824,7 +1832,13 @@ function buildBulkPane(): WidgetSpec {
         },
         flexSpacer(),
       )
-    : row(
+    : // wrappingRow (not row): on a narrow pane the action buttons
+      // reflow onto extra lines instead of the right-most ones being
+      // clipped off-screen. The wrap path ignores flex spacers, so a
+      // fixed `spacer(4)` (rather than `flexSpacer()`) keeps a visible
+      // gap between the destructive actions and the non-destructive
+      // "Clear" while still wrapping cleanly.
+      wrappingRow(
         button(`Stop (${stopN})`, { key: "bulk-stop", disabled: stopN === 0 }),
         spacer(2),
         button(`Archive (${archiveN})`, {
@@ -1837,7 +1851,7 @@ function buildBulkPane(): WidgetSpec {
           key: "bulk-delete",
           disabled: deleteN === 0,
         }),
-        flexSpacer(),
+        spacer(4),
         button("Clear", { key: "bulk-clear" }),
       );
 
@@ -2531,6 +2545,11 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     // a real session list + preview pane, unlike the new-session
     // form which stays compact.
     openPanel.mount(buildOpenSpec(), { widthPct: 90, heightPct: 90 });
+    // The control room is a global orchestrator feature: render it over
+    // the full screen (covering its own dimmed dock) rather than cramped
+    // into the chrome area beside the dock. A no-op when no dock is up
+    // (the chrome area already is the whole frame then).
+    editor.floatingPanelControl(openPanel.id(), "fullscreen", 1);
   }
   if (openDialog.filteredIds.length > 0) {
     openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
@@ -4596,9 +4615,12 @@ function buildFormSpec(): WidgetSpec {
   }
   children.push(
     spacer(0),
-    // === Button row: bottom-right aligned. =======================
-    row(
-      flexSpacer(),
+    // === Button row. =============================================
+    // wrappingRow so Cancel / Create Session reflow onto a second line
+    // on a narrow form instead of "Create Session" being clipped off the
+    // right edge. The wrap path ignores the leading flex spacer (and
+    // trims a blank that would lead a line), so the pair left-packs.
+    wrappingRow(
       button("Cancel", { intent: "danger", key: "cancel" }),
       spacer(2),
       button("Create Session", { intent: "primary", key: "create" }),
@@ -4696,6 +4718,10 @@ function openForm(options?: { fromPicker?: boolean }): void {
   // it left the dialog 12 rows tall, clipping the Branch input,
   // the Cancel / Create Session buttons, and the hint bar.
   formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 90 });
+  // The New-Session form is a global orchestrator feature too: center it
+  // over the full screen (covering its own dimmed dock) rather than in the
+  // chrome area beside the dock. A no-op when no dock is up.
+  editor.floatingPanelControl(formPanel.id(), "fullscreen", 1);
   editor.setEditorMode(NEW_SESSION_MODE);
   // Mirror the host's focus cycle so Up/Down can route to the right field's
   // history. The "Run in:" type tabs sit *first* in the spec, so without an

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2511,16 +2511,38 @@ impl Editor {
                     if on_filter {
                         // Return from the filter to the session list.
                         self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
-                    } else {
-                        // Activate the highlighted row. The plugin attaches a
-                        // discovered (on-disk) worktree as a new session, or —
-                        // for a row already backed by a live window — blurs to
-                        // the editor (the dock stays visible). Handled
-                        // plugin-side so the discovered-vs-live decision lives
-                        // next to the dialog's identical `activate` logic, not
-                        // split across the host (was: always blur, which
-                        // silently dropped the on-disk attach in the dock).
+                    } else if self
+                        .widget_registry
+                        .focus_key(panel_id)
+                        .map(|k| k == "sessions" || k.is_empty())
+                        .unwrap_or(true)
+                    {
+                        // Enter on the session list activates the highlighted
+                        // row. The plugin attaches a discovered (on-disk)
+                        // worktree as a new session, or — for a row already
+                        // backed by a live window — blurs to the editor (the
+                        // dock stays visible). Handled plugin-side so the
+                        // discovered-vs-live decision lives next to the
+                        // dialog's identical `activate` logic, not split across
+                        // the host (was: always blur, which silently dropped
+                        // the on-disk attach in the dock).
                         self.fire_dock_widget_event(panel_id, "dock_activate");
+                    } else {
+                        // A button or toggle is keyboard-focused (Tab-cycled
+                        // onto "+ New", "Manage", "view", the project menu, or
+                        // a checkbox). Run THAT control's action via the
+                        // generic smart-key dispatcher — which fires `activate`
+                        // for a Button and `toggle` for a Toggle — instead of
+                        // the list's dock_activate. Without this, Enter on a
+                        // focused button silently fell through to dock_activate
+                        // and merely re-focused the session list, so buttons
+                        // worked with the mouse but not the keyboard.
+                        self.handle_widget_command(
+                            panel_id,
+                            fresh_core::api::WidgetAction::Key {
+                                key: "Enter".to_string(),
+                            },
+                        );
                     }
                     return true;
                 }

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1130,6 +1130,14 @@ pub(crate) struct FloatingWidgetState {
     /// Inner rect (frame interior) of the last draw — used by the
     /// click hit-test to map terminal coords back to buffer coords.
     pub last_inner_rect: Option<ratatui::layout::Rect>,
+    /// When true, a `Centered` panel renders over the *entire* frame
+    /// (covering the dimmed left dock) instead of being confined to the
+    /// chrome area beside the dock. Set via `FloatingPanelControl{op:
+    /// "fullscreen"}`. Lets the orchestrator's global modals (the control
+    /// room, the New-Session form) take the full screen over their own
+    /// dock, while other plugins' floating panels keep the default
+    /// coexist-beside-the-dock layout. Ignored for `LeftDock`.
+    pub fullscreen: bool,
 }
 
 /// A list scrollbar's screen rect + scroll state, captured at draw
@@ -1645,6 +1653,7 @@ mod tests {
             scrollbar_mouse: Default::default(),
             scrollbar_drag_key: None,
             last_inner_rect: None,
+            fullscreen: false,
         }
     }
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -46,7 +46,8 @@ impl Editor {
             LayerKind::Settings
             | LayerKind::KeybindingEditor
             | LayerKind::CalibrationWizard
-            | LayerKind::WorkspaceTrust => Some(l.kind),
+            | LayerKind::WorkspaceTrust
+            | LayerKind::FloatingModal => Some(l.kind),
             _ => None,
         })?;
         Some(match capturing_kind {
@@ -57,8 +58,56 @@ impl Editor {
             // here matches the previous explicit `return Ok(false)`.
             LayerKind::CalibrationWizard => Ok(false),
             LayerKind::WorkspaceTrust => self.handle_workspace_trust_mouse(mouse_event),
+            // The centered widget modal (orchestrator control room /
+            // New-Session form) captures the whole mouse channel here —
+            // before the terminal-forward and the editor's buffer paths —
+            // so a click/double-click/scroll over the dialog never leaks to
+            // an alternate-screen terminal or the buffer it covers. Clicks
+            // route to the panel's own hit-test (focusing the clicked
+            // widget); everything else is swallowed.
+            LayerKind::FloatingModal => self.handle_floating_modal_mouse(mouse_event),
             _ => unreachable!("find_map only returns capturing kinds"),
         })
+    }
+
+    /// Mouse handler for the centered widget modal (`floating_widget_panel`).
+    /// The dialog is fully modal: presses hit-test the panel (focusing the
+    /// clicked widget / placing the text cursor), wheel scrolls it, and a
+    /// drag drives only its scrollbar. Every other event — and every press
+    /// that lands outside the panel box — is swallowed, so nothing reaches
+    /// the buffer, terminal, or dock beneath. Always returns
+    /// `Ok(true)` (a render is cheap and the modal just consumed an event).
+    fn handle_floating_modal_mouse(
+        &mut self,
+        mouse_event: crossterm::event::MouseEvent,
+    ) -> AnyhowResult<bool> {
+        use crossterm::event::{MouseButton, MouseEventKind};
+        let (col, row) = (mouse_event.column, mouse_event.row);
+        match mouse_event.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                // Single / double / triple clicks all map to one panel
+                // hit-test — never the buffer's word/line select beneath.
+                self.handle_floating_widget_click(super::PanelSlot::Floating, col, row);
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                // Only a scrollbar drag is meaningful; other drags are
+                // swallowed rather than starting a buffer text-selection.
+                self.try_widget_scrollbar_drag(super::PanelSlot::Floating, row);
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                self.release_widget_scrollbar();
+            }
+            MouseEventKind::ScrollUp => {
+                self.handle_floating_widget_panel_wheel(super::PanelSlot::Floating, col, row, -3);
+            }
+            MouseEventKind::ScrollDown => {
+                self.handle_floating_widget_panel_wheel(super::PanelSlot::Floating, col, row, 3);
+            }
+            // Right-click, horizontal scroll, motion, other-button releases:
+            // swallowed — the modal eats them all.
+            _ => {}
+        }
+        Ok(true)
     }
 
     /// Handle a mouse event.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4058,6 +4058,7 @@ impl Editor {
             scrollbar_mouse: Default::default(),
             scrollbar_drag_key: None,
             last_inner_rect: None,
+            fullscreen: false,
         });
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
@@ -4248,6 +4249,15 @@ impl Editor {
             }
             "focus" => {
                 fwp.focused = true;
+                false
+            }
+            // Render a centered panel over the whole frame (covering the
+            // dimmed dock) instead of beside the dock in `chrome_area`.
+            // `arg != 0` enables it. No chrome-geometry change (the dock
+            // and editor layout are untouched — only where the modal
+            // paints), so no relayout; the next frame reads the flag.
+            "fullscreen" => {
+                fwp.fullscreen = arg != 0.0;
                 false
             }
             other => {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1766,17 +1766,31 @@ impl Editor {
             }
         }
         if self.floating_widget_panel.is_some() {
+            // A `fullscreen` modal paints over the whole frame, covering the
+            // dock; otherwise it lays into `chrome_area` beside the dock.
+            // The orchestrator's global modals (control room, New-Session
+            // form) opt into fullscreen so they're not cramped into the
+            // narrow region right of their own dock.
+            let fullscreen = self
+                .floating_widget_panel
+                .as_ref()
+                .map(|f| f.fullscreen)
+                .unwrap_or(false);
             // A centered modal makes the *whole* UI a passive, dimmed
             // background — the dock included. The dock was drawn above at
-            // full brightness, and the modal render below only dims
-            // `chrome_area`, so dim the dock column here too. The dock is
-            // also blurred + input-inaccessible while a modal is up (the
-            // host blurs it on mount and the modal swallows keys/clicks/
-            // wheel), so dimming it makes that passivity visible rather
-            // than leaving it looking live beside the dialog.
-            if let Some(dock) = dock_area {
-                if self.dock.is_some() {
-                    crate::view::dimming::apply_dimming(frame, dock);
+            // full brightness. A beside-dock modal only dims `chrome_area`,
+            // so dim the dock column explicitly here; a fullscreen modal
+            // dims the whole frame itself (its own `apply_dimming_excluding`
+            // runs over the full area below), so skip the redundant pass.
+            // Either way the dock is blurred + input-inaccessible while a
+            // modal is up (the host blurs it on mount and the modal swallows
+            // keys/clicks/wheel), so dimming it makes that passivity visible
+            // rather than leaving it looking live beside the dialog.
+            if !fullscreen {
+                if let Some(dock) = dock_area {
+                    if self.dock.is_some() {
+                        crate::view::dimming::apply_dimming(frame, dock);
+                    }
                 }
             }
             // Render the centered modal within `chrome_area` (the region to
@@ -1784,11 +1798,12 @@ impl Editor {
             // sits beside the dock and dims only the chrome instead of
             // painting over the dock column. When no dock is up
             // `chrome_area` is the whole frame, so this is unchanged for the
-            // common case. This is what lets the orchestrator's Open picker
-            // (and New-Session form) coexist with the dock — mirroring the
-            // settings / keybinding-editor modals, which already lay into
-            // `chrome_area`.
-            self.render_floating_widget_panel(frame, chrome_area, super::PanelSlot::Floating);
+            // common case. This is what lets a plugin's Open picker coexist
+            // with the dock — mirroring the settings / keybinding-editor
+            // modals, which already lay into `chrome_area`. A `fullscreen`
+            // panel instead gets the whole frame (`size`).
+            let modal_area = if fullscreen { size } else { chrome_area };
+            self.render_floating_widget_panel(frame, modal_area, super::PanelSlot::Floating);
         }
     }
 
@@ -2063,7 +2078,13 @@ impl Editor {
 
         if is_quick_open {
             let hints_area = ratatui::layout::Rect {
-                x: 0,
+                // Align with the prompt / suggestions box, which sit in the
+                // chrome area to the right of a left dock (`prompt_area.x`).
+                // Hardcoding `x: 0` here drew the hints starting at the very
+                // left edge — under the dock column — so the bar was
+                // partially obscured by the dock and visibly misaligned with
+                // the suggestions box stacked directly above it.
+                x: prompt_area.x,
                 y: prompt_area.y.saturating_sub(hints_height),
                 width,
                 height: hints_height,

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -574,30 +574,27 @@ fn dock_alt_t_toggles_worktrees_without_blurring() {
 }
 
 /// Invoking `Orchestrator: Open` while the dock is visible opens the full
-/// modal picker *beside* the dock — not as a refusal nag, and not by
-/// tearing the dock down. The dock stays mounted in its own host slot
-/// (PanelSlot::Dock) and the picker floats in the Floating slot, clamped
-/// to `chrome_area`; the dock becomes a dimmed, passive background and
-/// Esc hands control back to it.
+/// modal control room *fullscreen over* the dock — not as a refusal nag,
+/// and not by tearing the dock down. The control room is a global
+/// orchestrator feature, so it opts into fullscreen placement (covering
+/// its own dimmed dock) rather than being cramped beside it. The dock
+/// stays mounted in its own host slot (PanelSlot::Dock); Esc drops the
+/// modal and hands control back to it.
 #[test]
-fn open_picker_coexists_with_dock_dimmed_and_esc_restores_it() {
-    // Wide terminal so the dock column + the picker beside it both have
-    // room (the picker lays into `chrome_area`, right of the dock).
+fn open_picker_covers_dock_fullscreen_and_esc_restores_it() {
+    // Wide terminal so the 90%-width fullscreen modal clearly covers the
+    // dock's "Manage" button (which sits in the dock's right half).
     let (_tmp, root) = setup_project("alphaproj");
     let mut h =
         EditorTestHarness::with_config_and_working_dir(200, 40, Default::default(), root.clone())
             .unwrap();
     h.render().unwrap();
     open_dock(&mut h);
-    // Sanity: the dock (not the modal picker) is what's up.
+    // Sanity: the dock (not the modal picker) is what's up, and the dock's
+    // "Manage" button — which only the dock renders, never the picker — is
+    // on screen.
     h.assert_screen_not_contains("ORCHESTRATOR :: Sessions");
-
-    // Sample a cell in the lit dock title ("Orchestrator") so we can prove
-    // it dims once the modal owns the UI.
-    let title_row = row_of(&h, "Orchestrator") as u16;
-    let title_col = h.screen_row_text(title_row).find("Orchestrator").unwrap() as u16 + 3;
-    let dock_title_fg = |h: &EditorTestHarness| h.get_cell_style(title_col, title_row).unwrap().fg;
-    let dock_fg_lit = dock_title_fg(&h);
+    h.assert_screen_contains("Manage");
 
     // Ctrl+P falls through (blurs the dock) and opens the palette; run
     // "Orchestrator: Open" from it.
@@ -609,34 +606,235 @@ fn open_picker_coexists_with_dock_dimmed_and_esc_restores_it() {
         .unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
 
-    // The picker surfaces beside the dock (no nag) ...
+    // The control room surfaces (no nag) ...
     h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR :: Sessions"))
         .unwrap();
     h.assert_screen_not_contains("the dock already lists sessions");
-    // ... and the dock is NOT torn down: its "Manage" button — which only
-    // the dock renders, never the picker — is still on screen alongside
-    // the picker title.
+    // ... fullscreen *over* the dock: the modal's title renders well within
+    // the dock's left column (its left border lands at ~col 10 of the full
+    // frame, not past the ~40-col dock). A beside-dock modal would lay into
+    // `chrome_area`, pushing the title past the dock's right edge. Count
+    // chars (not bytes) up to the title — the modal's `│` border before it
+    // is multi-byte, so a byte offset would overstate the column.
     let screen = h.screen_to_string();
+    let title_line = screen
+        .lines()
+        .find(|l| l.contains("ORCHESTRATOR :: Sessions"))
+        .unwrap();
+    let byte_idx = title_line.find("ORCHESTRATOR :: Sessions").unwrap();
+    let title_col = title_line[..byte_idx].chars().count();
     assert!(
-        screen.contains("Manage"),
-        "the dock must stay mounted beside the picker.\nScreen:\n{screen}"
-    );
-    // ... and the dock is a passive, *dimmed* part of the background: its
-    // title colour darkens now that the modal owns the UI. (The host also
-    // blurs the dock and the modal swallows keys/clicks/wheel, so it is
-    // fully inaccessible while the dialog is up.)
-    assert_ne!(
-        dock_fg_lit,
-        dock_title_fg(&h),
-        "the dock must dim while the Open picker is up"
+        title_col < 38,
+        "the control room must render fullscreen *over* the dock — its title \
+         is at col {title_col}, expected within the dock's left region (the \
+         modal would start past col ~40 if confined beside the dock).\n\
+         Screen:\n{}",
+        h.screen_to_string()
     );
 
-    // Esc drops the picker and hands keyboard control back to the live
-    // dock — it could not regain focus if it had been unmounted.
+    // Esc drops the modal and hands keyboard control back to the live
+    // dock — it could not regain focus if it had been unmounted — and the
+    // dock's "Manage" button is still there.
     h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
     h.wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR :: Sessions"))
         .unwrap();
     h.wait_until(|h| h.editor().is_dock_focused()).unwrap();
+    h.assert_screen_contains("Manage");
+}
+
+/// The Quick Open hint bar (`file | >command | :line | #buffer`) must align
+/// with the suggestions popup above it — both sit in the chrome area to the
+/// right of the dock. The hint row used to hardcode `x: 0`, drawing the bar
+/// starting at the very left edge (under the dock column), so it was
+/// partially obscured by the dock and visibly offset from the suggestions
+/// box. The fix anchors the hint at the prompt's `x` (= the box's left
+/// column), so "file" lands exactly `left_margin` (2) cols past the box's
+/// left border.
+#[test]
+fn quick_open_hint_aligns_with_suggestions_not_under_dock() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(140, 36, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Ctrl+P blurs the dock and opens the command palette; the dock stays
+    // visible in its left column beside the prompt + suggestions.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    // Wait for both the Quick Open hint and the suggestions box to paint.
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains(">command") && s.contains('┌')
+    })
+    .unwrap();
+
+    // Char-column (not byte offset — the box borders are multi-byte) of the
+    // hint's first word and of the suggestions popup's top-left corner.
+    let screen = h.screen_to_string();
+    let hint_line = screen.lines().find(|l| l.contains(">command")).unwrap();
+    let hint_byte = hint_line.find("file").unwrap();
+    let hint_col = hint_line[..hint_byte].chars().count();
+    let box_line = screen.lines().find(|l| l.contains('┌')).unwrap();
+    let box_byte = box_line.find('┌').unwrap();
+    let box_col = box_line[..box_byte].chars().count();
+
+    // The box left border sits at the prompt's `x` (right of the dock); the
+    // hint text begins `left_margin` (2) cols into that same region. If the
+    // hint were still drawn at `x: 0`, "file" would land at col 2 — far left
+    // of the dock-offset box — and this would fail.
+    assert_eq!(
+        hint_col,
+        box_col + 2,
+        "Quick Open hint must align with the suggestions box (left_margin=2 \
+         past its left border at col {box_col}), not be drawn under the dock.\n\
+         Screen:\n{screen}"
+    );
+}
+
+/// On a narrow preview pane the control room's action buttons must wrap onto
+/// additional lines rather than the right-most ones being clipped off the
+/// edge. With a plain (non-wrapping) row the merged button line is truncated
+/// to the pane width, so "Delete" (the last button) vanishes; `wrappingRow`
+/// reflows it onto a later line, keeping every action reachable.
+#[test]
+fn control_room_preview_buttons_wrap_on_narrow_pane() {
+    // Narrow terminal so the preview pane (≈half the modal) can't fit all
+    // five action buttons on one line.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(80, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+
+    // Open the control room (no dock needed). A session is selected on
+    // mount, so its preview pane — with the action buttons — renders.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: Open").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: Open"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("ORCHESTRATOR :: Sessions"))
+        .unwrap();
+
+    // Every action stays on screen — the right-most "Delete" would be
+    // clipped off a non-wrapping row at this width.
+    h.wait_until(|h| h.screen_to_string().contains("Delete"))
+        .unwrap();
+    h.assert_screen_contains("Archive");
+
+    // And they actually wrapped: "Visit" (first button) and "Delete" (last)
+    // land on different rows.
+    let visit_row = row_of(&h, "Visit");
+    let delete_row = row_of(&h, "Delete");
+    assert_ne!(
+        visit_row,
+        delete_row,
+        "preview action buttons must wrap onto separate rows on a narrow \
+         pane (Visit at row {visit_row}, Delete at {delete_row}).\nScreen:\n{}",
+        h.screen_to_string()
+    );
+}
+
+/// The New-Session form's Cancel / Create Session buttons must wrap onto
+/// separate lines on a narrow form rather than "Create Session" being
+/// clipped off the right edge (a plain row truncates the merged button line
+/// to the form width). `wrappingRow` reflows the pair instead.
+#[test]
+fn new_session_form_buttons_wrap_on_narrow_form() {
+    // Narrow terminal so the 60%-width form can't fit both buttons on one
+    // line.
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(50, 30, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+
+    // Open the New-Session form via the palette.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: New Session").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: New Session"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+
+    // Both buttons stay on screen — "Create Session" would be clipped off a
+    // non-wrapping row at this width — and they land on different rows.
+    h.wait_until(|h| h.screen_to_string().contains("Create Session"))
+        .unwrap();
+    let cancel_row = row_of(&h, "Cancel");
+    let create_row = row_of(&h, "Create Session");
+    assert_ne!(
+        cancel_row,
+        create_row,
+        "New-Session form buttons must wrap onto separate rows on a narrow \
+         form (Cancel at row {cancel_row}, Create Session at {create_row}).\n\
+         Screen:\n{}",
+        h.screen_to_string()
+    );
+}
+
+/// The New-Session form is a fully modal dialog: it must swallow every
+/// mouse event, even a double-click landing over the editor buffer it sits
+/// in front of. Single clicks were already routed to the panel, but
+/// double/triple-clicks (and the alternate-screen terminal forward) ran
+/// *before* that guard, so a double-click leaked to the buffer underneath
+/// and selected a word there. Observed via typing after the dialog closes:
+/// a leaked word-select would be replaced by the typed text.
+#[test]
+fn new_session_form_swallows_doubleclick_no_buffer_leak() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(80, 30, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    // Selectable text in the editor buffer underneath, cursor left at end.
+    h.type_text("hello world").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("hello world"))
+        .unwrap();
+
+    // Open the New-Session form (a fully modal centered dialog).
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text("Orchestrator: New Session").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Orchestrator: New Session"))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+
+    // "hello world" stays visible above the vertically-centered form. Find
+    // "world" there and double-click it (two clicks at one spot; the test
+    // clock doesn't advance, so they register as a double-click). This point
+    // is over the editor, outside the modal box — the dialog must eat it.
+    let screen = h.screen_to_string();
+    let (wrow, wline) = screen
+        .lines()
+        .enumerate()
+        .find(|(_, l)| l.contains("hello world"))
+        .unwrap();
+    let wcol = wline.find("world").unwrap(); // ASCII row: byte == column
+    h.mouse_click(wcol as u16, wrow as u16).unwrap();
+    h.mouse_click(wcol as u16, wrow as u16).unwrap();
+
+    // Close the dialog and type. If the double-click had leaked it would
+    // have selected "world", and the keystroke would replace it ("hello Z").
+    // Full modal capture leaves the buffer untouched, so the insert lands at
+    // the cursor (end): "hello worldZ".
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.type_text("Z").unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("hello worldZ"))
+        .unwrap();
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -296,6 +296,49 @@ fn dock_alt_n_opens_form_keyboard_and_dock_stays() {
     h.assert_screen_contains("Orchestrator");
 }
 
+/// Enter on a Tab-focused dock button runs THAT button's action, not the
+/// session list's dive. The dock's `dispatch_floating_widget_key` Enter
+/// branch used to fire `dock_activate` unconditionally — so once the user
+/// Tab-cycled focus onto a button (or checkbox), Enter ignored the focused
+/// control and merely re-focused the list. Buttons worked with the mouse
+/// but not the keyboard. Enter now routes through the smart-key dispatcher
+/// when focus is off the list, activating the focused Button/Toggle.
+#[test]
+fn dock_enter_on_focused_button_runs_button_action() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // Focus opens on the sessions list. One Tab lands on the "+ New"
+    // button (spec-order first tabbable). Enter must open the new-session
+    // form — the same thing a click on "+ New" does — not dive the list.
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.assert_screen_contains("New Session");
+
+    // Esc the form; the dock is still mounted and re-focused on the list.
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("New Session"))
+        .unwrap();
+
+    // Walk focus to the "view:" toggle button (sessions → new-session →
+    // manage → view-toggle) and Enter it. The label flips card↔compact,
+    // proving Enter activated the focused button rather than diving.
+    h.assert_screen_contains("view: card");
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("view: compact"))
+        .unwrap();
+    h.assert_screen_contains("view: compact");
+}
+
 #[test]
 fn dock_slash_filters_and_enter_returns_to_list() {
     let (_tmp, root) = setup_project("alphaproj");

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5624,7 +5624,9 @@ impl JsEditorApi {
 
     /// Control a mounted floating panel's placement / focus without
     /// re-sending its spec. `op`: "dock" (`arg` = width in columns),
-    /// "center", "focus", "blur". See `PluginCommand::FloatingPanelControl`.
+    /// "center", "focus", "blur", "fullscreen" (`arg != 0` makes a
+    /// centered panel cover the whole frame over the dock). See
+    /// `PluginCommand::FloatingPanelControl`.
     #[qjs(rename = "floatingPanelControl")]
     pub fn floating_panel_control(&self, panel_id: f64, op: String, arg: f64) -> bool {
         self.command_sender


### PR DESCRIPTION
## Summary
This PR fixes several keyboard navigation and modal rendering issues in the orchestrator dock and floating panels, including proper Enter key handling on focused buttons, fullscreen modal rendering, Quick Open hint alignment, and button wrapping on narrow panes.

## Key Changes

### Keyboard Navigation Fixes
- **Enter key on focused buttons**: Fixed `dispatch_floating_widget_key` to route Enter through the smart-key dispatcher when focus is off the session list, allowing buttons and toggles to activate via keyboard (Tab+Enter) instead of only via mouse
- Added logic to distinguish between Enter on the list (dock_activate) vs. Enter on a focused control (widget action dispatch)

### Modal Rendering & Placement
- **Fullscreen modal support**: Added `fullscreen` flag to `FloatingWidgetState` to allow modals (control room, New-Session form) to render over the entire frame instead of being confined to the chrome area beside the dock
- Updated render logic to skip redundant dock dimming when a fullscreen modal is active
- Added `floatingPanelControl("fullscreen", 1)` calls in orchestrator plugin to enable fullscreen rendering for global modals

### Mouse Event Handling
- **Modal event capture**: Implemented `handle_floating_modal_mouse` to fully capture mouse events (clicks, drags, scrolls) for centered modals, preventing double-clicks from leaking to the buffer underneath
- Added `LayerKind::FloatingModal` to the mouse input capturing layer list

### UI Layout Fixes
- **Quick Open hint alignment**: Fixed hardcoded `x: 0` to use `prompt_area.x`, aligning the hint bar with the suggestions box instead of rendering under the dock
- **Button wrapping**: Replaced `row()` with `wrappingRow()` in preview pane, confirmation pane, bulk pane, and form button rows to allow buttons to wrap onto multiple lines on narrow panes instead of being clipped

### API Updates
- Added "fullscreen" operation to `FloatingPanelControl` command in the plugin API
- Updated TypeScript definitions and Rust backend documentation

## Notable Implementation Details
- The fullscreen modal logic preserves the dock's mounted state while dimming it, allowing Esc to restore focus to the dock
- `wrappingRow` ignores flex spacers and leading blanks, allowing fixed spacers to maintain visual separation while still wrapping cleanly
- Mouse event handling for modals returns `Ok(true)` to trigger a cheap re-render while consuming all events

https://claude.ai/code/session_012n31RBKzwRmgJhwr9us8oc