### PR TITLE
SSH sessions: optional user/extra args, awaitable+cancelable attach, and New-Session dialog/dock/input fixes (#2234)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3676,6 +3676,12 @@ pub enum PluginCommand {
         request_id: u64,
     },
 
+    /// Cancel every in-flight `attachRemoteAgent` connect. The New-Session
+    /// dialog's Cancel: the awaiting promise is rejected immediately and the
+    /// (uninterruptible) background connect's eventual result is discarded so
+    /// no window is ever built. A no-op when nothing is in flight.
+    CancelRemoteAttach,
+
     /// Activate an environment: set the live env provider's recipe (an
     /// activation shell `snippet` run in `dir`). Re-evaluated on demand on the
     /// active backend and applied to every spawn — no authority rebuild. Only

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3670,6 +3670,10 @@ pub enum PluginCommand {
     AttachRemoteAgent {
         #[ts(type = "unknown")]
         payload: JsonValue,
+        /// JS callback id of the returned promise. The editor settles it once
+        /// the session is fully constructed (resolve) or the connect/window
+        /// creation fails (reject), so the plugin can await the real outcome.
+        request_id: u64,
     },
 
     /// Activate an environment: set the live env provider's recipe (an

--- a/crates/fresh-editor/plugins/k8s-workspace.ts
+++ b/crates/fresh-editor/plugins/k8s-workspace.ts
@@ -477,8 +477,13 @@ async function connectWorkspace(): Promise<void> {
   editor.setGlobalState(SESSION_KEY, session as unknown);
 
   editor.setStatus(`K8s: attaching to ${coords.namespace}/${coords.pod}…`);
-  // Fire-and-forget: core connects asynchronously and restarts on success.
-  editor.attachRemoteAgent(spec);
+  // Core connects asynchronously and restarts on success; this provider runs
+  // in restart (not window) mode, so there is no dialog to keep open. We don't
+  // await — but we must catch the rejection so a failed connect surfaces as a
+  // status message rather than an unhandled promise rejection.
+  editor.attachRemoteAgent(spec).catch((e: unknown) => {
+    editor.setStatus(`K8s: attach failed: ${e instanceof Error ? e.message : String(e)}`);
+  });
 }
 
 async function disconnectWorkspace(): Promise<void> {

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3033,6 +3033,13 @@ interface EditorAPI {
 	*/
 	attachRemoteAgent(payload: RemoteAgentSpec): Promise<void>;
 	/**
+	* Cancel any in-flight `attachRemoteAgent` connect — the New-Session
+	* dialog's Cancel. The pending promise rejects with "cancelled" and the
+	* background connect's late result is discarded, so no window is built.
+	* A no-op when nothing is connecting.
+	*/
+	cancelRemoteAgent(): void;
+	/**
 	* Activate an environment: set the live env recipe (`snippet` run in
 	* `dir`). Applied to every spawn, re-evaluated on demand — no restart.
 	* Honored only when the workspace is Trusted.

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1551,12 +1551,17 @@ type RemoteAgentTransport = {
 	workspace?: string | null;
 } | {
 	kind: "ssh";
-	user: string;
+	/** Login user. Optional — omit for `host` / `ssh://host`, letting ssh pick
+	* the user from its own config or the current local user. */
+	user?: string | null;
 	host: string;
 	port?: number | null;
 	identity_file?: string | null;
 	/** Remote directory to root the session at. */
 	remote_path?: string | null;
+	/** Extra `ssh` arguments (e.g. `-J jump`, `-o ProxyCommand=…`) applied to
+	* every ssh invocation for this session. */
+	extra_args?: string[];
 };
 type RemoteAgentSpec = {
 	transport: RemoteAgentTransport;

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3010,18 +3010,23 @@ interface EditorAPI {
 	*/
 	clearAuthority(): void;
 	/**
-	* Attach to a remote agent that needs a live connection (today a
-	* `kubectl exec` agent in a Kubernetes pod). The connect is asynchronous:
-	* this returns immediately, the editor connects in the background,
-	* and only on success installs the authority and restarts (on
-	* failure it surfaces the error and stays put). Fire-and-forget,
-	* like `setAuthority` — any post-attach work belongs in the
-	* plugin's post-restart init.
-	* 
+	* Attach to a remote agent that needs a live connection (an SSH host or a
+	* `kubectl exec` agent in a Kubernetes pod). The connect is asynchronous —
+	* the editor spawns the carrier, bootstraps the agent and builds the
+	* session in the background — and this returns a promise that settles on
+	* the real outcome:
+	*
+	* * resolves once the session (authority + window) is fully
+	* constructed, so a caller can keep its dialog open until there is a
+	* real session to show;
+	* * rejects with the failure reason (e.g. ssh "Could not resolve
+	* hostname") if the connect or window creation fails — in which case
+	* no window is created and the editor stays on its current authority.
+	*
 	* The payload schema (`RemoteAgentSpec`) lives in `fresh-editor`;
 	* plugins hand-build an object matching it.
 	*/
-	attachRemoteAgent(payload: RemoteAgentSpec): boolean;
+	attachRemoteAgent(payload: RemoteAgentSpec): Promise<void>;
 	/**
 	* Activate an environment: set the live env recipe (`snippet` run in
 	* `dir`). Applied to every spawn, re-evaluated on demand — no restart.

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3015,14 +3015,14 @@ interface EditorAPI {
 	* the editor spawns the carrier, bootstraps the agent and builds the
 	* session in the background — and this returns a promise that settles on
 	* the real outcome:
-	*
+	* 
 	* * resolves once the session (authority + window) is fully
 	* constructed, so a caller can keep its dialog open until there is a
 	* real session to show;
 	* * rejects with the failure reason (e.g. ssh "Could not resolve
 	* hostname") if the connect or window creation fails — in which case
 	* no window is created and the editor stays on its current authority.
-	*
+	* 
 	* The payload schema (`RemoteAgentSpec`) lives in `fresh-editor`;
 	* plugins hand-build an object matching it.
 	*/

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -958,7 +958,14 @@ function filterSessions(needle: string): number[] {
     const activeId = editor.activeWindow();
     allIds = allIds.filter((id) => {
       const s = orchestratorSessions.get(id)!;
-      if (s.discovered || id === activeId) return true;
+      // Keep: the active session (you must see where you are), discovered
+      // worktree rows (their own toggle governs them), and any remote
+      // (SSH / k8s) session. A remote session is a live connection, never an
+      // "empty restored shell" — and its persisted workspace records no local
+      // terminal, so it looked trivial and got dropped the instant it stopped
+      // being the active card. In the dock (a live switcher) that made the
+      // first card vanish on the first ↓ and desynced the selection.
+      if (s.discovered || id === activeId || s.remote) return true;
       const c = sessionContentByRoot.get(normRoot(s.root));
       return !c || !c.trivial;
     });
@@ -1046,7 +1053,7 @@ function dockProjectOptions(): string[] {
   const keys = new Set<string>();
   for (const [id, s] of orchestratorSessions) {
     if (!showWorktrees && s.discovered) continue;
-    if (hideTrivial && !s.discovered && id !== activeId) {
+    if (hideTrivial && !s.discovered && id !== activeId && !s.remote) {
       const c = sessionContentByRoot.get(normRoot(s.root));
       if (c && c.trivial) continue;
     }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4545,8 +4545,87 @@ function backendBodyFields(): WidgetSpec[] {
   }
 }
 
+// While a submit is in flight the dialog is *disabled*: the editable fields and
+// the backend tabs are replaced with a read-only summary and only Cancel stays
+// actionable (Create is shown disabled). It holds until the attach resolves —
+// success closes the dialog, failure flips `submitting` back off and re-renders
+// the editable form with the error. Applies to every backend (a fresh `openForm`
+// always starts with `submitting = false`, so the next open is reset).
+function buildConnectingView(): WidgetSpec {
+  if (!form) return col();
+  const roRow = (label: string, value: string): WidgetSpec => ({
+    kind: "raw",
+    entries: [
+      styledRow([
+        { text: `${label}: `, style: { fg: "ui.menu_disabled_fg", bold: true } },
+        { text: value || "—", style: { fg: "ui.menu_disabled_fg" } },
+      ]),
+    ],
+  });
+  const rows: WidgetSpec[] = [];
+  if (form.backend === "ssh") {
+    rows.push(roRow("Run in", "SSH"));
+    rows.push(roRow("Host", form.sshHost.value.trim()));
+    if (form.sshPath.value.trim()) rows.push(roRow("Remote path", form.sshPath.value.trim()));
+  } else if (form.backend === "kubernetes") {
+    rows.push(roRow("Run in", "Kubernetes"));
+    const ns = form.k8sNamespace.value.trim();
+    const pod = form.k8sPod.value.trim();
+    rows.push(roRow("Pod", form.k8sTarget.value.trim() || `${ns}/${pod}`));
+  } else {
+    rows.push(roRow("Run in", form.backend === "devcontainer" ? "Devcontainer" : "Local"));
+    rows.push(roRow("Project", form.projectPath.value.trim() || form.defaultProjectPath));
+  }
+  const name = form.name.value.trim();
+  if (name) rows.push(roRow("Session", name));
+
+  const remote = form.backend === "ssh" || form.backend === "kubernetes";
+  return col(
+    row(
+      flexSpacer(),
+      {
+        kind: "raw",
+        entries: [
+          styledRow([
+            { text: "ORCHESTRATOR", style: HEADER_KEYWORD_STYLE },
+            { text: " :: ", style: HEADER_SEP_STYLE },
+            { text: "New Session", style: HEADER_LABEL_STYLE },
+          ]),
+        ],
+      },
+      flexSpacer(),
+    ),
+    spacer(0),
+    ...rows,
+    spacer(0),
+    {
+      kind: "raw",
+      entries: [
+        styledRow([
+          {
+            text: remote ? "Connecting… " : "Creating session… ",
+            style: { fg: "ui.menu_disabled_fg", bold: true, italic: true },
+          },
+          {
+            text: "press Cancel to abort.",
+            style: { fg: "ui.menu_disabled_fg", italic: true },
+          },
+        ]),
+      ],
+    },
+    spacer(0),
+    wrappingRow(
+      button("Cancel", { intent: "danger", key: "cancel" }),
+      spacer(2),
+      button("Create Session", { intent: "primary", key: "create", disabled: true }),
+    ),
+  );
+}
+
 function buildFormSpec(): WidgetSpec {
   if (!form) return col();
+  // Disabled/connecting state: read-only summary + Cancel-only (item 3).
+  if (form.submitting) return buildConnectingView();
 
   const children: WidgetSpec[] = [
     // === Header: centered title (no stale `Review Synthesized`). =
@@ -4609,26 +4688,9 @@ function buildFormSpec(): WidgetSpec {
     children.push(localBranchSection());
   }
   // Remote backends connect asynchronously and the dialog stays open until the
-  // session is real (see `runRemoteAttach`) — show a live "connecting" line so
-  // the wait is legible rather than a frozen dialog.
-  if (form.submitting && form.backend !== "local") {
-    children.push(spacer(0));
-    children.push({
-      kind: "raw",
-      entries: [
-        styledRow([
-          {
-            text: "Connecting… ",
-            style: { fg: "ui.menu_disabled_fg", bold: true, italic: true },
-          },
-          {
-            text: "building the remote session (this can take a few seconds).",
-            style: { fg: "ui.menu_disabled_fg", italic: true },
-          },
-        ]),
-      ],
-    });
-  }
+  // session is real (see `runRemoteAttach`). The in-flight "connecting" state
+  // is rendered by `buildConnectingView` (the early return above), so nothing
+  // is needed here for it.
   if (form.lastError) {
     children.push(spacer(0));
     children.push({
@@ -5172,6 +5234,9 @@ async function runRemoteAttach(
   // session row with this facet; cleared on failure since no window appears.
   pendingRemoteFacet = facet;
   renderForm();
+  // The disabled/connecting view exposes only Cancel — land focus there so
+  // Enter/Esc act on it.
+  formPanel?.setFocusKey("cancel");
   try {
     await editor.attachRemoteAgent(spec);
     // Authority + window are live and the hook has adopted the facet — only
@@ -5319,6 +5384,8 @@ async function submitForm(): Promise<void> {
   form.submitting = true;
   form.lastError = null;
   renderForm();
+  // Disabled/connecting view exposes only Cancel — focus it.
+  formPanel?.setFocusKey("cancel");
 
   // The Agent Command field is prefilled with the last-used command as actual
   // text (see `openForm`), so its value is authoritative: a cleared field means

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5177,18 +5177,7 @@ async function runRemoteAttach(
     // Authority + window are live and the hook has adopted the facet — only
     // now is it safe to dismiss the dialog. (Guard against the user having
     // cancelled / reopened the form while the connect was in flight.)
-    if (form && form.submitting) {
-      closeForm();
-      // When the form was opened over the dock, the born-attached remote
-      // window is the new active session — hand keyboard focus to it by
-      // blurring the dock (which stays visible). Without this, focus fell
-      // back to the still-focused dock and the new session's buffer/terminal
-      // silently swallowed the user's keystrokes (mirrors the local path).
-      if (openPanel && dockMode) {
-        dockBlurred = true;
-        editor.floatingPanelControl(openPanel.id(), "blur", 0);
-      }
-    }
+    if (form && form.submitting) closeForm();
   } catch (e) {
     pendingRemoteFacet = null;
     if (!form) return;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -241,11 +241,13 @@ interface NewSessionForm {
   // which field set `buildFormSpec` renders and which submit path runs.
   backend: SessionBackend;
   // --- SSH backend fields (rendered only when backend === "ssh") ---
-  // Host as `user@host[:port]` (also accepts a pasted `ssh://…`); remote path
-  // to root the session at; optional identity file.
+  // Host as `host`, `user@host[:port]`, or a pasted `ssh://…` (user optional);
+  // remote path to root the session at; optional identity file; and free-form
+  // extra ssh arguments (e.g. `-J jump`, `-o ProxyCommand=…`).
   sshHost: { value: string; cursor: number };
   sshPath: { value: string; cursor: number };
   sshIdentity: { value: string; cursor: number };
+  sshOptions: { value: string; cursor: number };
   // --- Kubernetes backend fields (rendered only when backend ===
   // "kubernetes") ---. `k8sTarget` names a target from `.fresh/k8s.json`;
   // when empty, the explicit context/namespace/pod/workspace fields are used
@@ -306,14 +308,6 @@ interface NewSessionForm {
   // placeholder as `HEAD  (no origin configured)` so the user
   // knows why.
   defaultBranchIsHeadFallback: boolean;
-  // Previously-submitted Agent Command (persisted across editor
-  // sessions via `orchestrator.last_cmd`). Rendered as the cmd
-  // field's *placeholder*, and used as the actual command when
-  // the user leaves the field blank — submitting "" with a
-  // visible placeholder of "python3" was confusing because the
-  // host ignored the hint and spawned a bare shell. Now the
-  // placeholder is the command if the value is empty.
-  lastCmd: string;
   // True when this form was opened from the picker (Alt+N or
   // the "+ New Session" button). On cancel (Esc / Cancel
   // button) we re-open the picker so the user lands back where
@@ -3770,7 +3764,7 @@ function rebuildFormFocusCycle(): void {
   } else if (form.backend === "devcontainer") {
     cycle.push("project_path", "name", "cmd");
   } else if (form.backend === "ssh") {
-    cycle.push("ssh_host", "ssh_path", "ssh_identity", "name", "cmd");
+    cycle.push("ssh_host", "ssh_path", "ssh_identity", "ssh_options", "name", "cmd");
   } else if (form.backend === "kubernetes") {
     cycle.push("k8s_target");
     if (form.k8sTarget.value.trim().length === 0) {
@@ -4407,16 +4401,17 @@ function devcontainerBodyFields(): WidgetSpec[] {
   ];
 }
 
-// SSH backend: host (`user@host[:port]`), remote path, optional identity file.
+// SSH backend: host (`[user@]host[:port]`), remote path, optional identity
+// file, and free-form extra ssh arguments.
 function sshBodyFields(): WidgetSpec[] {
   if (!form) return [];
   return [
     labeledSection({
-      label: "Host  (user@host[:port])",
+      label: "Host  ([user@]host[:port])",
       child: text({
         value: form.sshHost.value,
         cursorByte: form.sshHost.cursor,
-        placeholder: "deploy@build-01  ·  or paste ssh://host/path",
+        placeholder: "build-01  ·  deploy@build-01:22  ·  or paste ssh://host/path",
         fullWidth: true,
         key: "ssh_host",
       }),
@@ -4439,6 +4434,16 @@ function sshBodyFields(): WidgetSpec[] {
         placeholder: "~/.ssh/id_ed25519",
         fullWidth: true,
         key: "ssh_identity",
+      }),
+    }),
+    labeledSection({
+      label: "SSH options (optional)",
+      child: text({
+        value: form.sshOptions.value,
+        cursorByte: form.sshOptions.cursor,
+        placeholder: "-J jump-host  ·  -o ProxyCommand=…  (passed to every ssh call)",
+        fullWidth: true,
+        key: "ssh_options",
       }),
     }),
   ];
@@ -4581,14 +4586,12 @@ function buildFormSpec(): WidgetSpec {
       child: text({
         value: form.cmd.value,
         cursorByte: form.cmd.cursor,
-        // Empty submission spawns a bare terminal — the host
-        // picks the shell with the same logic it uses for any
-        // other embedded terminal, so the plugin doesn't have
-        // to second-guess `$SHELL` resolution. If the user
-        // submitted a non-empty cmd in the previous run we
-        // surface it here as a hint (placeholder only — see
-        // `NewSessionForm.lastCmd`).
-        placeholder: form.lastCmd || "terminal",
+        // Clearing the field falls back to the backend default: a bare local
+        // terminal (the host resolves `$SHELL`), or — for SSH — letting ssh
+        // spawn the remote login shell. The placeholder names that default.
+        placeholder: form.backend === "ssh"
+          ? "remote login shell  (clear to reset)"
+          : "terminal",
         fullWidth: true,
         key: "cmd",
       }),
@@ -4696,6 +4699,7 @@ function openForm(options?: { fromPicker?: boolean }): void {
     sshHost: { value: "", cursor: 0 },
     sshPath: { value: "", cursor: 0 },
     sshIdentity: { value: "", cursor: 0 },
+    sshOptions: { value: "", cursor: 0 },
     k8sTarget: { value: "", cursor: 0 },
     k8sContext: { value: "", cursor: 0 },
     k8sNamespace: { value: "", cursor: 0 },
@@ -4703,12 +4707,12 @@ function openForm(options?: { fromPicker?: boolean }): void {
     k8sWorkspace: { value: "", cursor: 0 },
     projectPath: { value: "", cursor: 0 },
     name: { value: "", cursor: 0 },
-    // Empty value — `lastCmd` shows as the placeholder. If the
-    // user submits an empty cmd, the placeholder is used as the
-    // actual command (see `submitForm`). This makes the
-    // placeholder a genuine "press Enter to re-use this" hint
-    // rather than a visual lie.
-    cmd: { value: "", cursor: 0 },
+    // Prefill the last-used command as *actual* editable text (not a
+    // placeholder), so the field value is the single source of truth: keep it,
+    // edit it, or clear it to fall back to the backend default (a bare local
+    // terminal, or — for SSH — the remote login shell). No hidden
+    // "empty means reuse lastCmd" fallback at submit time.
+    cmd: { value: lastCmd, cursor: lastCmd.length },
     branch: { value: "", cursor: 0 },
     // Default checkbox state is `true` (the historical behaviour
     // of "always create a worktree"); the renderer demotes this
@@ -4723,7 +4727,6 @@ function openForm(options?: { fromPicker?: boolean }): void {
     defaultSessionName: "",
     defaultBranch: "",
     defaultBranchIsHeadFallback: false,
-    lastCmd,
     fromPicker: !!options?.fromPicker,
     probeToken: 0,
     historyCursor: { project_path: -1, name: -1, cmd: -1, branch: -1 },
@@ -5194,7 +5197,9 @@ async function submitRemoteForm(backend: SessionBackend): Promise<void> {
     renderForm();
   };
   const sessionName = form.name.value.trim();
-  const cmd = form.cmd.value.trim() || form.lastCmd.trim();
+  // The field value is authoritative: empty means "use the backend default"
+  // (a bare remote/login shell), not "silently reuse the last command".
+  const cmd = form.cmd.value.trim();
 
   if (backend === "kubernetes") {
     const target = form.k8sTarget.value.trim();
@@ -5237,54 +5242,51 @@ async function submitRemoteForm(backend: SessionBackend): Promise<void> {
   }
 
   if (backend === "ssh") {
-    // Parse `user@host[:port]` (also tolerates a pasted `ssh://…`). The full
-    // remote-agent stack attaches over SSH — remote filesystem + LSP + an
-    // in-host terminal — as a born-attached window, not just a local `ssh`
-    // terminal.
-    let raw = form.sshHost.value.trim();
-    if (raw.startsWith("ssh://")) raw = raw.slice("ssh://".length);
-    if (!raw) {
-      fail("SSH: Host (user@host) is required.");
-      return;
-    }
-    let port: number | null = null;
+    // Parse `[user@]host[:port]` (also tolerates a pasted `ssh://…`). The user
+    // is optional — a bare `host` lets ssh resolve the user from its own
+    // config / the current user. The full remote-agent stack attaches over SSH
+    // (remote filesystem + LSP + an in-host terminal) as a born-attached
+    // window, not just a local `ssh` terminal.
+    const raw = form.sshHost.value.trim().replace(/^ssh:\/\//, "");
+    // Split an optional `:port` suffix, then an optional `user@` prefix —
+    // computed up front so there are no half-parsed intermediate values.
     const portMatch = raw.match(/^(.+):(\d+)$/);
-    if (portMatch) {
-      raw = portMatch[1];
-      port = parseInt(portMatch[2], 10);
-    }
-    let user = "";
-    let host = raw;
-    const at = raw.indexOf("@");
-    if (at >= 0) {
-      user = raw.slice(0, at);
-      host = raw.slice(at + 1);
-    }
-    if (!user) {
-      fail("SSH: a user is required — use user@host.");
+    const port = portMatch ? parseInt(portMatch[2], 10) : null;
+    const hostPart = portMatch ? portMatch[1] : raw;
+    const at = hostPart.indexOf("@");
+    const user = at > 0 ? hostPart.slice(0, at) : undefined;
+    const host = at >= 0 ? hostPart.slice(at + 1) : hostPart;
+    if (!host) {
+      fail("SSH: a host is required (host, user@host, or ssh://host).");
       return;
     }
     const identity = form.sshIdentity.value.trim();
     const remotePath = form.sshPath.value.trim();
+    // Free-form extra ssh args, whitespace-split (e.g. `-J jump -o Foo=bar`).
+    const extraArgs = form.sshOptions.value.trim()
+      ? form.sshOptions.value.trim().split(/\s+/)
+      : [];
     const agentArgv = splitAgentCmd(cmd);
+    const target = user ? `${user}@${host}` : host;
     const spec: RemoteAgentSpec = {
       transport: {
         kind: "ssh",
-        user,
+        ...(user ? { user } : {}),
         host,
         port,
         identity_file: identity || null,
         remote_path: remotePath || null,
+        ...(extraArgs.length > 0 ? { extra_args: extraArgs } : {}),
       },
       base_env: [],
       window: true,
-      label: sessionName || `ssh:${user}@${host}`,
+      label: sessionName || `ssh:${target}`,
       command: agentArgv.length > 0 ? agentArgv : undefined,
     };
     if (cmd) editor.setGlobalState("orchestrator.last_cmd", cmd);
     await runRemoteAttach(spec, {
       kind: "ssh",
-      detail: `${user}@${host}`,
+      detail: target,
       state: "running",
     });
     return;
@@ -5311,12 +5313,10 @@ async function submitForm(): Promise<void> {
   form.lastError = null;
   renderForm();
 
-  // Honour the placeholder: when the user leaves Agent Command
-  // blank, fall back to `lastCmd` (the placeholder text). The
-  // placeholder is rendered as a hint — if the user accepts it by
-  // pressing Enter on an empty field, the dialog should actually
-  // run that command rather than silently spawning a bare shell.
-  const cmd = form.cmd.value.trim() || form.lastCmd.trim();
+  // The Agent Command field is prefilled with the last-used command as actual
+  // text (see `openForm`), so its value is authoritative: a cleared field means
+  // "spawn a bare terminal", not "silently reuse the last command".
+  const cmd = form.cmd.value.trim();
   const branchInput = form.branch.value.trim();
 
   // Project Path: typed value wins; otherwise the resolved
@@ -5838,6 +5838,8 @@ editor.on("widget_event", (e) => {
         ? form.sshPath
         : field === "ssh_identity"
         ? form.sshIdentity
+        : field === "ssh_options"
+        ? form.sshOptions
         : field === "k8s_target"
         ? form.k8sTarget
         : field === "k8s_context"

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5200,6 +5200,14 @@ function restoreDockAfterForm(): boolean {
 // just hand focus back to it instead.
 function cancelForm(): void {
   const wasFromPicker = !!form?.fromPicker;
+  // Cancelling while a remote connect is in flight: tell the host to abort it.
+  // The pending `attachRemoteAgent` promise rejects with "cancelled" (its catch
+  // is a no-op once `form` is null below) and the connect's late result is
+  // discarded host-side, so no window is ever built.
+  if (form?.submitting) {
+    pendingRemoteFacet = null;
+    editor.cancelRemoteAgent();
+  }
   closeForm();
   if (restoreDockAfterForm()) return;
   if (wasFromPicker) {
@@ -6027,6 +6035,12 @@ editor.on("widget_event", (e) => {
       // mirror our own state and (if reached from the picker)
       // bounce back to the picker so Esc is "back", not "out".
       const wasFromPicker = !!form?.fromPicker;
+      // Esc while connecting aborts the in-flight remote attach, same as the
+      // Cancel button: reject the promise and discard the late result host-side.
+      if (form?.submitting) {
+        pendingRemoteFacet = null;
+        editor.cancelRemoteAgent();
+      }
       form = null;
       formPanel = null;
       editor.setEditorMode(null);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4598,6 +4598,27 @@ function buildFormSpec(): WidgetSpec {
   if (form.backend === "local") {
     children.push(localBranchSection());
   }
+  // Remote backends connect asynchronously and the dialog stays open until the
+  // session is real (see `runRemoteAttach`) — show a live "connecting" line so
+  // the wait is legible rather than a frozen dialog.
+  if (form.submitting && form.backend !== "local") {
+    children.push(spacer(0));
+    children.push({
+      kind: "raw",
+      entries: [
+        styledRow([
+          {
+            text: "Connecting… ",
+            style: { fg: "ui.menu_disabled_fg", bold: true, italic: true },
+          },
+          {
+            text: "building the remote session (this can take a few seconds).",
+            style: { fg: "ui.menu_disabled_fg", italic: true },
+          },
+        ]),
+      ],
+    });
+  }
   if (form.lastError) {
     children.push(spacer(0));
     children.push({
@@ -5123,6 +5144,46 @@ function cancelForm(): void {
 // Warm per-window remote sessions that sit *beside* local ones (rather than
 // retargeting the whole editor) are the follow-up — see Gap B in
 // docs/internal/NEW_SESSION_DIALOG_WIREFRAMES.md.
+// Submit a remote (SSH / Kubernetes) attach and keep the New-Session dialog
+// open until the session is actually real. `attachRemoteAgent` now resolves
+// only once the editor has built the authority AND the born-attached window,
+// and rejects (with the reason — e.g. ssh "Could not resolve hostname") if the
+// connect or window creation fails, creating no window. So we drive the dialog
+// off that promise: show the failure inline and stay open to retry, instead of
+// closing optimistically and leaving the user with a half-built/empty window.
+async function runRemoteAttach(
+  spec: RemoteAgentSpec,
+  facet: AgentSession["remote"],
+): Promise<void> {
+  if (!form) return;
+  form.submitting = true;
+  form.lastError = null;
+  // The `window_created` hook (fired mid-attach on success) tags the new
+  // session row with this facet; cleared on failure since no window appears.
+  pendingRemoteFacet = facet;
+  renderForm();
+  try {
+    await editor.attachRemoteAgent(spec);
+    // Authority + window are live and the hook has adopted the facet — only
+    // now is it safe to dismiss the dialog. (Guard against the user having
+    // cancelled / reopened the form while the connect was in flight.)
+    if (form && form.submitting) closeForm();
+  } catch (e) {
+    pendingRemoteFacet = null;
+    if (!form) return;
+    form.submitting = false;
+    form.lastError = remoteAttachErrorText(e);
+    renderForm();
+  }
+}
+
+// `attachRemoteAgent` rejects with an Error whose message is the host's
+// reason (ssh diagnostic, a window-creation failure, a bad spec, …).
+function remoteAttachErrorText(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e ?? "");
+  return msg.trim() || "connection failed";
+}
+
 async function submitRemoteForm(backend: SessionBackend): Promise<void> {
   if (!form) return;
   const fail = (msg: string): void => {
@@ -5167,12 +5228,11 @@ async function submitRemoteForm(backend: SessionBackend): Promise<void> {
       label: sessionName || `k8s:${namespace}/${pod}`,
       command: agentArgv.length > 0 ? agentArgv : undefined,
     };
-    closeForm();
-    editor.setStatus(`Orchestrator: attaching pod ${namespace}/${pod}…`);
-    // Remember the pending facet so the `window_created` hook can tag the new
-    // session row as a Kubernetes workspace.
-    pendingRemoteFacet = { kind: "kubernetes", detail: `${namespace}/${pod}`, state: "running" };
-    editor.attachRemoteAgent(spec);
+    await runRemoteAttach(spec, {
+      kind: "kubernetes",
+      detail: `${namespace}/${pod}`,
+      state: "running",
+    });
     return;
   }
 
@@ -5222,10 +5282,11 @@ async function submitRemoteForm(backend: SessionBackend): Promise<void> {
       command: agentArgv.length > 0 ? agentArgv : undefined,
     };
     if (cmd) editor.setGlobalState("orchestrator.last_cmd", cmd);
-    closeForm();
-    editor.setStatus(`Orchestrator: connecting SSH ${user}@${host}…`);
-    pendingRemoteFacet = { kind: "ssh", detail: `${user}@${host}`, state: "running" };
-    editor.attachRemoteAgent(spec);
+    await runRemoteAttach(spec, {
+      kind: "ssh",
+      detail: `${user}@${host}`,
+      state: "running",
+    });
     return;
   }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5556,6 +5556,17 @@ async function attachToWorktree(opts: {
       createdAt: Date.now(),
       branch: opts.branch,
     });
+    // The new window is now the active session. When this was triggered from
+    // the dock (Enter on a discovered worktree), the dock is still focused, so
+    // its keys would be swallowed and the new session's terminal couldn't
+    // receive input — mirror the dock's live-session Enter path and blur it so
+    // the new window gets the keyboard. (No-op for the modal picker, which has
+    // already closed openPanel before calling this.)
+    if (dockMode && openPanel) {
+      dockBlurred = true;
+      editor.floatingPanelControl(openPanel.id(), "blur", 0);
+      editor.setEditorMode(null);
+    }
   } catch (e) {
     editor.setStatus(
       `Orchestrator: failed to attach session — ${

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5177,7 +5177,18 @@ async function runRemoteAttach(
     // Authority + window are live and the hook has adopted the facet — only
     // now is it safe to dismiss the dialog. (Guard against the user having
     // cancelled / reopened the form while the connect was in flight.)
-    if (form && form.submitting) closeForm();
+    if (form && form.submitting) {
+      closeForm();
+      // When the form was opened over the dock, the born-attached remote
+      // window is the new active session — hand keyboard focus to it by
+      // blurring the dock (which stays visible). Without this, focus fell
+      // back to the still-focused dock and the new session's buffer/terminal
+      // silently swallowed the user's keystrokes (mirrors the local path).
+      if (openPanel && dockMode) {
+        dockBlurred = true;
+        editor.floatingPanelControl(openPanel.id(), "blur", 0);
+      }
+    }
   } catch (e) {
     pendingRemoteFacet = null;
     if (!form) return;

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -326,8 +326,8 @@ impl Editor {
                     tracing::info!("Git status changed: {}", status);
                     // TODO: Handle git status changes
                 }
-                AsyncMessage::FileExplorerInitialized(view) => {
-                    self.handle_file_explorer_initialized(view);
+                AsyncMessage::FileExplorerInitialized { window, view } => {
+                    self.handle_file_explorer_initialized(window, view);
                 }
                 AsyncMessage::FileExplorerToggleNode(node_id) => {
                     self.handle_file_explorer_toggle_node(node_id);
@@ -335,8 +335,8 @@ impl Editor {
                 AsyncMessage::FileExplorerRefreshNode(node_id) => {
                     self.handle_file_explorer_refresh_node(node_id);
                 }
-                AsyncMessage::FileExplorerExpandedToPath(view) => {
-                    self.handle_file_explorer_expanded_to_path(view);
+                AsyncMessage::FileExplorerExpandedToPath { window, view } => {
+                    self.handle_file_explorer_expanded_to_path(window, view);
                 }
                 AsyncMessage::Plugin(plugin_msg) => {
                     use fresh_core::api::{JsCallbackId, PluginAsyncMessage};

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -38,6 +38,29 @@ impl Editor {
             .reject_callback(fresh_core::api::JsCallbackId::from(request_id), error);
     }
 
+    /// Mark every in-flight `attachRemoteAgent` connect as cancelled and reject
+    /// its awaiting promise now. The background connect can't be interrupted
+    /// mid-handshake, so its eventual `RemoteAttachReady`/`RemoteAttachFailed`
+    /// is dropped on arrival (see `remote_attach_was_cancelled`) — the carrier
+    /// is torn down then and no window is built. This is the host side of the
+    /// New-Session dialog's Cancel.
+    pub(crate) fn cancel_remote_attaches(&mut self) {
+        let inflight: Vec<u64> = self.remote_attach_inflight.drain().collect();
+        for id in inflight {
+            self.remote_attach_cancelled.insert(id);
+            self.reject_remote_attach(id, "cancelled".to_string());
+        }
+    }
+
+    /// Consume the in-flight/cancelled tracking for `request_id` as a late
+    /// result arrives. Returns `true` if the connect was cancelled (the result
+    /// should be discarded), `false` for a normal completion (which still
+    /// clears the in-flight entry).
+    pub(crate) fn remote_attach_was_cancelled(&mut self, request_id: u64) -> bool {
+        self.remote_attach_inflight.remove(&request_id);
+        self.remote_attach_cancelled.remove(&request_id)
+    }
+
     /// Process pending async messages from the async bridge
     ///
     /// This should be called each frame in the main loop to handle:
@@ -686,6 +709,21 @@ impl Editor {
                         mode,
                         request_id,
                     } = ready;
+                    // If the plugin cancelled this connect while it was
+                    // in flight (the New-Session dialog's Cancel), the result
+                    // arrives too late to matter: drop the authority and its
+                    // keepalive here so the carrier is torn down and no window
+                    // is ever built. The reject was already delivered at cancel
+                    // time, so there's nothing left to resolve.
+                    if self.remote_attach_was_cancelled(request_id) {
+                        tracing::info!(
+                            "Remote attach for request {} arrived after cancellation; discarding",
+                            request_id
+                        );
+                        drop(keepalive);
+                        drop(authority);
+                        continue;
+                    }
                     // Re-root at the pod's workspace (or its home if the plugin
                     // didn't supply one) — never the stale local path. The
                     // filesystem call is safe here: `process_async_messages`
@@ -729,6 +767,15 @@ impl Editor {
                     }
                 }
                 AsyncMessage::RemoteAttachFailed { error, request_id } => {
+                    // A cancelled connect was already rejected at cancel time;
+                    // swallow the late failure rather than rejecting twice.
+                    if self.remote_attach_was_cancelled(request_id) {
+                        tracing::info!(
+                            "Remote attach for request {} failed after cancellation; discarding",
+                            request_id
+                        );
+                        continue;
+                    }
                     tracing::warn!("Remote attach failed: {}", error);
                     self.reject_remote_attach(request_id, error);
                 }

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -13,6 +13,31 @@ use crate::view::prompt::PromptType;
 use super::Editor;
 
 impl Editor {
+    /// Resolve the `attachRemoteAgent` promise behind `request_id` — the
+    /// session (authority + window) is fully constructed. Resolves with `null`;
+    /// the plugin only needs the success signal to close its dialog. Lives here
+    /// (not in the plugins-gated `plugin_dispatch`) because the non-plugin
+    /// `RemoteAttach*` async handlers call it; the plugin manager is a no-op
+    /// without the `plugins` feature, so this safely does nothing then.
+    pub(crate) fn resolve_remote_attach(&self, request_id: u64) {
+        self.plugin_manager.read().unwrap().resolve_callback(
+            fresh_core::api::JsCallbackId::from(request_id),
+            "null".to_string(),
+        );
+    }
+
+    /// Reject the `attachRemoteAgent` promise behind `request_id` with `error`
+    /// — the connect failed, the spec was bad / the runtime unavailable, or
+    /// window creation failed. The plugin surfaces the reason and creates no
+    /// window.
+    pub(crate) fn reject_remote_attach(&self, request_id: u64, error: String) {
+        tracing::warn!("attachRemoteAgent rejected: {error}");
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .reject_callback(fresh_core::api::JsCallbackId::from(request_id), error);
+    }
+
     /// Process pending async messages from the async bridge
     ///
     /// This should be called each frame in the main loop to handle:

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -659,6 +659,7 @@ impl Editor {
                         keepalive,
                         working_dir,
                         mode,
+                        request_id,
                     } = ready;
                     // Re-root at the pod's workspace (or its home if the plugin
                     // didn't supply one) — never the stale local path. The
@@ -674,6 +675,10 @@ impl Editor {
                                 authority.display_label,
                                 root.display()
                             );
+                            // Resolve before the restart tears the plugin
+                            // runtime down, so the awaiting caller observes
+                            // success rather than a vanished promise.
+                            self.resolve_remote_attach(request_id);
                             self.install_authority_with_keepalive(authority, keepalive, root);
                         }
                         crate::services::async_bridge::RemoteAttachMode::Window {
@@ -685,17 +690,22 @@ impl Editor {
                                 authority.display_label,
                                 root.display()
                             );
-                            if let Err(e) = self.create_remote_session_window(
+                            // The session is only "ready" once the window
+                            // exists. Resolve on success; on a window-creation
+                            // failure reject so the plugin keeps its dialog
+                            // open with the reason and no half-built window.
+                            match self.create_remote_session_window(
                                 authority, keepalive, root, label, command,
                             ) {
-                                self.set_status_message(format!("Attach window failed: {e}"));
+                                Ok(_) => self.resolve_remote_attach(request_id),
+                                Err(e) => self.reject_remote_attach(request_id, e),
                             }
                         }
                     }
                 }
-                AsyncMessage::RemoteAttachFailed { error } => {
+                AsyncMessage::RemoteAttachFailed { error, request_id } => {
                     tracing::warn!("Remote attach failed: {}", error);
-                    self.set_status_message(format!("Attach failed: {error}"));
+                    self.reject_remote_attach(request_id, error);
                 }
                 AsyncMessage::PluginProcessOutput {
                     process_id,

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -38,17 +38,33 @@ impl Editor {
             .reject_callback(fresh_core::api::JsCallbackId::from(request_id), error);
     }
 
-    /// Mark every in-flight `attachRemoteAgent` connect as cancelled and reject
-    /// its awaiting promise now. The background connect can't be interrupted
-    /// mid-handshake, so its eventual `RemoteAttachReady`/`RemoteAttachFailed`
-    /// is dropped on arrival (see `remote_attach_was_cancelled`) — the carrier
-    /// is torn down then and no window is built. This is the host side of the
-    /// New-Session dialog's Cancel.
+    /// Mark every in-flight `attachRemoteAgent` connect as cancelled, signal the
+    /// background connect thread to tear down its in-flight carrier (killing the
+    /// ssh/kubectl child), and reject the awaiting promise now. If a connect
+    /// races past cancellation its eventual `RemoteAttachReady`/`Failed` is
+    /// dropped on arrival (see `remote_attach_was_cancelled`) — so no window is
+    /// ever built. This is the host side of the New-Session dialog's Cancel.
     pub(crate) fn cancel_remote_attaches(&mut self) {
         let inflight: Vec<u64> = self.remote_attach_inflight.drain().collect();
+        let any = !inflight.is_empty();
         for id in inflight {
             self.remote_attach_cancelled.insert(id);
+            // Signal the background connect thread to abort. Its `select!` drops
+            // the in-flight connect future, which drops the ssh child (spawned
+            // kill-on-drop), so even a host that never completes the handshake
+            // leaves no orphaned process. A connect that already finished (its
+            // result still queued) ignores the signal; the late result is
+            // discarded by `remote_attach_was_cancelled`.
+            if let Some(cancel) = self.remote_attach_cancels.remove(&id) {
+                #[allow(clippy::let_underscore_must_use)]
+                let _ = cancel.send(());
+            }
             self.reject_remote_attach(id, "cancelled".to_string());
+        }
+        // Clear the lingering "Connecting to …" status the connect set, so the
+        // status line doesn't keep claiming a connection is in progress.
+        if any {
+            self.set_status_message("Connection cancelled".to_string());
         }
     }
 
@@ -58,6 +74,7 @@ impl Editor {
     /// clears the in-flight entry).
     pub(crate) fn remote_attach_was_cancelled(&mut self, request_id: u64) -> bool {
         self.remote_attach_inflight.remove(&request_id);
+        self.remote_attach_cancels.remove(&request_id);
         self.remote_attach_cancelled.remove(&request_id)
     }
 

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1410,54 +1410,28 @@ impl Editor {
 
 impl Editor {
     /// Handle file explorer initialized
-    pub(super) fn handle_file_explorer_initialized(&mut self, mut view: FileTreeView) {
-        tracing::info!("File explorer initialized");
-
-        // Load root .gitignore
-        let root_id = view.tree().root_id();
-        let root_path = view.tree().get_node(root_id).map(|n| n.entry.path.clone());
-
-        if let Some(root_path) = root_path {
-            crate::app::file_operations::load_gitignore_via_fs(
-                self.authority.filesystem.as_ref(),
-                &mut view,
-                &root_path,
-            );
-            tracing::debug!("Loaded root .gitignore from {:?}", root_path);
-        }
-
-        // Apply show_hidden / show_gitignored settings.
-        // Use pending session-restore values if present, otherwise fall back
-        // to the persisted config so the setting survives across sessions.
-        let show_hidden = self
-            .active_window_mut()
-            .pending_file_explorer_show_hidden
-            .take()
-            .unwrap_or(self.config.file_explorer.show_hidden);
-        view.ignore_patterns_mut().set_show_hidden(show_hidden);
-        tracing::debug!("Applied show_hidden={} on init", show_hidden);
-
-        let show_gitignored = self
-            .active_window_mut()
-            .pending_file_explorer_show_gitignored
-            .take()
-            .unwrap_or(self.config.file_explorer.show_gitignored);
-        view.ignore_patterns_mut()
-            .set_show_gitignored(show_gitignored);
-        tracing::debug!("Applied show_gitignored={} on init", show_gitignored);
-
-        view.set_compact_directories(self.config.file_explorer.compact_directories);
-
-        self.active_window_mut().file_explorer = Some(view);
-        self.set_status_message(t!("status.file_explorer_ready").to_string());
-
-        // If the user opened the explorer while a file from a nested
-        // directory was active, the sync triggered by toggle_file_explorer
-        // ran before this initialization completed (file_explorer was still
-        // None) and did nothing. Run it again now so the tree auto-expands
-        // to reveal the current file on first open (issue #1569).
-        if self.file_explorer_visible() {
-            self.active_window_mut().sync_file_explorer_to_active_file();
+    pub(super) fn handle_file_explorer_initialized(
+        &mut self,
+        window: fresh_core::WindowId,
+        view: FileTreeView,
+    ) {
+        tracing::info!("File explorer initialized for window {window}");
+        let defaults = crate::app::file_explorer::FileExplorerViewDefaults {
+            show_hidden: self.config.file_explorer.show_hidden,
+            show_gitignored: self.config.file_explorer.show_gitignored,
+            compact_directories: self.config.file_explorer.compact_directories,
+        };
+        let is_active = window == self.active_window_id();
+        // Route the result back to the window that asked for it. If that window
+        // is gone (closed before its tree finished building), drop it. The
+        // window applies the view to itself, so a background-built tree can
+        // never clobber a different (active) window's explorer.
+        let Some(win) = self.windows.get_mut(&window) else {
+            return;
+        };
+        win.install_initialized_file_explorer(view, defaults);
+        if is_active {
+            self.set_status_message(t!("status.file_explorer_ready").to_string());
         }
     }
 
@@ -1473,13 +1447,18 @@ impl Editor {
     }
 
     /// Handle file explorer expanded to path
-    pub(super) fn handle_file_explorer_expanded_to_path(&mut self, mut view: FileTreeView) {
+    pub(super) fn handle_file_explorer_expanded_to_path(
+        &mut self,
+        window: fresh_core::WindowId,
+        view: FileTreeView,
+    ) {
         tracing::trace!(
-            "handle_file_explorer_expanded_to_path: restoring file_explorer after async expand"
+            "handle_file_explorer_expanded_to_path: restoring file_explorer for window {window}"
         );
-        view.update_scroll_for_selection();
-        self.active_window_mut().file_explorer = Some(view);
-        self.active_window_mut().file_explorer_sync_in_progress = false;
+        // Route to the requesting window (see `handle_file_explorer_initialized`).
+        if let Some(win) = self.windows.get_mut(&window) {
+            win.install_expanded_file_explorer(view);
+        }
     }
 }
 

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -213,6 +213,8 @@ impl Editor {
             menu_state: crate::view::ui::MenuState::new(parts.dir_context.themes_dir()),
             windows: parts.windows,
             session_keepalives: HashMap::new(),
+            remote_attach_inflight: std::collections::HashSet::new(),
+            remote_attach_cancelled: std::collections::HashSet::new(),
             active_window: parts.active_window,
             next_window_id: parts.next_window_id,
             command_registry: parts.command_registry,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -133,7 +133,6 @@ pub(super) struct EditorParts {
     // Async / IO
     pub(super) tokio_runtime: Option<Arc<tokio::runtime::Runtime>>,
     pub(super) async_bridge: AsyncBridge,
-    pub(super) fs_manager: Arc<FsManager>,
     pub(super) authority: crate::services::authority::Authority,
     pub(super) local_filesystem: Arc<dyn FileSystem + Send + Sync>,
 
@@ -209,7 +208,6 @@ impl Editor {
             paste_pending: std::collections::HashMap::new(),
             paste_slow_path_just_armed: false,
             paste_render_suppress_until: None,
-            fs_manager: parts.fs_manager,
             authority: parts.authority,
             local_filesystem: parts.local_filesystem,
             menu_state: crate::view::ui::MenuState::new(parts.dir_context.themes_dir()),
@@ -1245,7 +1243,6 @@ impl Editor {
             color_capability,
             tokio_runtime,
             async_bridge,
-            fs_manager,
             authority,
             local_filesystem: Arc::clone(&local_filesystem),
             windows,

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -215,6 +215,7 @@ impl Editor {
             session_keepalives: HashMap::new(),
             remote_attach_inflight: std::collections::HashSet::new(),
             remote_attach_cancelled: std::collections::HashSet::new(),
+            remote_attach_cancels: std::collections::HashMap::new(),
             active_window: parts.active_window,
             next_window_id: parts.next_window_id,
             command_registry: parts.command_registry,

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -11,6 +11,16 @@ pub struct FileExplorerClipboard {
     pub is_cut: bool,
 }
 
+/// Config-derived defaults handed to `Window::install_initialized_file_explorer`
+/// so the apply logic lives on `Window` without it borrowing the editor's
+/// `Config` (which would clash with the `&mut Window` borrow).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FileExplorerViewDefaults {
+    pub show_hidden: bool,
+    pub show_gitignored: bool,
+    pub compact_directories: bool,
+}
+
 /// Outcome of a single filesystem-level paste op (`paste_one_fs_op`).
 /// The `SourceRemovalFailed` variant is a partial success: the destination
 /// exists but the original source could not be removed, so the file is
@@ -1601,6 +1611,9 @@ impl crate::app::window::Window {
         };
         let fs_manager = Arc::clone(&self.resources.fs_manager);
         let sender = self.bridge.sender();
+        // Tag the result with *this* window so it lands here even if another
+        // window is active by the time the async build finishes.
+        let window_id = self.id;
         runtime.spawn(async move {
             match FileTree::new(root_path, fs_manager).await {
                 Ok(mut tree) => {
@@ -1611,7 +1624,10 @@ impl crate::app::window::Window {
                     let view = FileTreeView::new(tree);
                     // Receiver may have been dropped during shutdown.
                     #[allow(clippy::let_underscore_must_use)]
-                    let _ = sender.send(AsyncMessage::FileExplorerInitialized(view));
+                    let _ = sender.send(AsyncMessage::FileExplorerInitialized {
+                        window: window_id,
+                        view,
+                    });
                 }
                 Err(e) => {
                     tracing::error!("Failed to initialize file explorer: {}", e);
@@ -1619,6 +1635,54 @@ impl crate::app::window::Window {
             }
         });
         self.set_status_message(t!("explorer.initializing").to_string());
+    }
+
+    /// Install a freshly-built file tree (from `init_file_explorer`) onto
+    /// *this* window. The editor's async dispatch routes the result back to the
+    /// requesting window and calls this — so a tree built for a backgrounded
+    /// (e.g. previewed) window can never land on whatever window happens to be
+    /// active, which previously clobbered the active window's explorer.
+    pub(crate) fn install_initialized_file_explorer(
+        &mut self,
+        mut view: FileTreeView,
+        defaults: FileExplorerViewDefaults,
+    ) {
+        let root_id = view.tree().root_id();
+        if let Some(root_path) = view.tree().get_node(root_id).map(|n| n.entry.path.clone()) {
+            crate::app::file_operations::load_gitignore_via_fs(
+                self.resources.authority.filesystem.as_ref(),
+                &mut view,
+                &root_path,
+            );
+        }
+        // Pending session-restore values win; otherwise fall back to config so
+        // the setting survives across sessions (fixes #569).
+        let show_hidden = self
+            .pending_file_explorer_show_hidden
+            .take()
+            .unwrap_or(defaults.show_hidden);
+        view.ignore_patterns_mut().set_show_hidden(show_hidden);
+        let show_gitignored = self
+            .pending_file_explorer_show_gitignored
+            .take()
+            .unwrap_or(defaults.show_gitignored);
+        view.ignore_patterns_mut()
+            .set_show_gitignored(show_gitignored);
+        view.set_compact_directories(defaults.compact_directories);
+        self.file_explorer = Some(view);
+        // Auto-expand to reveal the active file on first open (issue #1569),
+        // but only when this window is actually showing the explorer.
+        if self.file_explorer_visible {
+            self.sync_file_explorer_to_active_file();
+        }
+    }
+
+    /// Install an async expand-to-path result onto *this* window (routed
+    /// per-window for the same reason as `install_initialized_file_explorer`).
+    pub(crate) fn install_expanded_file_explorer(&mut self, mut view: FileTreeView) {
+        view.update_scroll_for_selection();
+        self.file_explorer = Some(view);
+        self.file_explorer_sync_in_progress = false;
     }
 
     /// Shift focus back to the editor pane (away from the file explorer)
@@ -1824,6 +1888,7 @@ impl crate::app::window::Window {
             .as_ref()
             .map(|r| r.handle().clone());
         let sender = self.resources.async_bridge.as_ref().map(|b| b.sender());
+        let window_id = self.id;
         if let (Some(runtime), Some(sender)) = (runtime_handle, sender) {
             // Mark sync as in progress so render knows to keep the layout
             self.file_explorer_sync_in_progress = true;
@@ -1833,7 +1898,10 @@ impl crate::app::window::Window {
                 // Receiver may have been dropped during shutdown.
                 #[allow(clippy::let_underscore_must_use)]
                 let _ = sender.send(
-                    crate::services::async_bridge::AsyncMessage::FileExplorerExpandedToPath(view),
+                    crate::services::async_bridge::AsyncMessage::FileExplorerExpandedToPath {
+                        window: window_id,
+                        view,
+                    },
                 );
             });
         } else {

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2461,7 +2461,7 @@ impl Editor {
         let panel_id = match self.panel(slot) {
             Some(fwp) => fwp.panel_id,
             None => {
-                tracing::warn!(
+                tracing::debug!(
                     target: "fresh::dock",
                     ?slot,
                     ?code,
@@ -2470,7 +2470,7 @@ impl Editor {
                 return false;
             }
         };
-        tracing::warn!(
+        tracing::debug!(
             target: "fresh::dock",
             panel_id,
             ?slot,
@@ -2604,7 +2604,7 @@ impl Editor {
                         .read()
                         .unwrap()
                         .has_hook_handlers("widget_event");
-                    tracing::warn!(
+                    tracing::debug!(
                         target: "fresh::dock",
                         panel_id,
                         has_handler,

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -427,6 +427,24 @@ impl Editor {
         // Create key event for dispatch methods
         let key_event = crossterm::event::KeyEvent::new(code, modifiers);
 
+        // Diagnostic for the "dock visible, buffer won't accept keys" wedge
+        // (#2234, item 4): while the dock is mounted, record its host-side focus
+        // plus the active window's key context for *every* key, before any
+        // routing. If a repro shows `dock_focused=true` for keys the user aimed
+        // at the buffer, the dock is swallowing them (line ~492) — a
+        // host-focus / plugin-`dockBlurred` desync; if `dock_focused=false`,
+        // the keys reached the window and the issue is in key-context routing.
+        if let Some(focused) = self.dock.as_ref().map(|d| d.focused) {
+            tracing::debug!(
+                target: "fresh::dock",
+                ?code,
+                dock_focused = focused,
+                key_context = ?self.active_window().key_context,
+                active_window = ?self.active_window_id(),
+                "handle_key: dock mounted (routing diagnostic)"
+            );
+        }
+
         // Event debug dialog intercepts ALL key events before any other processing.
         // This must be checked here (not just in main.rs/gui) so it works in
         // client/server mode where handle_key is called directly.

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -666,6 +666,16 @@ pub struct Editor {
     /// process-level keepalive the restart-based attach parks.
     pub(crate) session_keepalives: HashMap<fresh_core::WindowId, Box<dyn std::any::Any + Send>>,
 
+    /// Request ids of `attachRemoteAgent` connects currently in flight (added
+    /// when the connect is spawned, removed when it settles). Lets a plugin
+    /// cancel a pending connect (the New-Session dialog's Cancel).
+    pub(crate) remote_attach_inflight: std::collections::HashSet<u64>,
+    /// Request ids of in-flight attaches the plugin asked to cancel. When the
+    /// connect later resolves, the result (authority + carrier keepalive) is
+    /// dropped instead of installed — so no window is created and the carrier
+    /// is torn down — and a failure is ignored.
+    pub(crate) remote_attach_cancelled: std::collections::HashSet<u64>,
+
     /// Id of the currently active session. Always `WindowId(1)` for
     /// now; multi-session support arrives in a follow-up commit.
     pub(crate) active_window: fresh_core::WindowId,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -580,9 +580,10 @@ pub struct Editor {
     // Each window has its own preview slot.
 
     // suppress_position_history_once moved onto `Window` (Step 0f).
-    /// Filesystem manager for file explorer
-    fs_manager: Arc<FsManager>,
-
+    // The file explorer and Open File browser ride per-window fs_managers
+    // (`WindowResources::fs_manager`, derived from each window's authority), so
+    // the editor no longer holds a global one that could go stale against the
+    // active authority.
     /// Single backend slot for "where does the editor act?".
     ///
     /// Bundles filesystem, process spawner, terminal wrapper, and

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -675,6 +675,14 @@ pub struct Editor {
     /// dropped instead of installed — so no window is created and the carrier
     /// is torn down — and a failure is ignored.
     pub(crate) remote_attach_cancelled: std::collections::HashSet<u64>,
+    /// Cancellation senders for the background connect threads, keyed by
+    /// request id. The connect runs on a detached thread (so the carrier's
+    /// runtime outlives it); signalling here makes that thread's `select!` drop
+    /// the in-flight connect future, which drops the ssh child (spawned
+    /// kill-on-drop) — so even a hung handshake leaves no orphaned process. The
+    /// thread then finishes and its result is discarded. Cleared on settle.
+    pub(crate) remote_attach_cancels:
+        std::collections::HashMap<u64, tokio::sync::oneshot::Sender<()>>,
 
     /// Id of the currently active session. Always `WindowId(1)` for
     /// now; multi-session support arrives in a follow-up commit.

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3909,7 +3909,14 @@ impl Editor {
                     hit.widget_key.clone(),
                     hit.widget_kind,
                 ),
-                None => return,
+                None => {
+                    tracing::debug!(
+                        target: "fresh::dock",
+                        ?slot, col, row, brow, bcol,
+                        "handle_floating_widget_click: hit_test found no widget"
+                    );
+                    return;
+                }
             };
         if !hit_key.is_empty() {
             let tabbable = self
@@ -3917,10 +3924,25 @@ impl Editor {
                 .get(panel_id)
                 .map(|p| p.tabbable.iter().any(|k| k == &hit_key))
                 .unwrap_or(false);
+            tracing::debug!(
+                target: "fresh::dock",
+                hit_key = %hit_key,
+                hit_kind,
+                hit_event = %hit_event,
+                tabbable,
+                "handle_floating_widget_click: hit"
+            );
             if tabbable {
                 self.set_panel_focus_and_notify(panel_id, hit_key.clone());
             }
             self.rerender_widget_panel(panel_id);
+        } else {
+            tracing::debug!(
+                target: "fresh::dock",
+                hit_kind,
+                hit_event = %hit_event,
+                "handle_floating_widget_click: hit with empty key (not focusable)"
+            );
         }
         let handled_specially = if hit_kind == "tree" && hit_event == "expand" {
             if let Some(item_key) = hit_payload.get("key").and_then(|v| v.as_str()) {

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1602,7 +1602,7 @@ impl Editor {
             self.dock.as_ref().map(|f| (f.placement, f.focused))
         {
             if col < width_cols {
-                tracing::warn!(
+                tracing::debug!(
                     target: "fresh::dock",
                     col,
                     row,
@@ -1625,7 +1625,7 @@ impl Editor {
                 return Ok(());
             }
             if focused {
-                tracing::warn!(
+                tracing::debug!(
                     target: "fresh::dock",
                     col,
                     row,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3477,17 +3477,21 @@ impl Editor {
                 port,
                 identity_file,
                 remote_path,
+                extra_args,
             } => {
                 let _ = base_env; // SSH probes its own env on the remote host.
                 let params = crate::services::remote::ConnectionParams {
-                    user: user.clone(),
+                    user: user.clone().filter(|u| !u.is_empty()),
                     host: host.clone(),
                     port,
                     identity_file: identity_file.map(std::path::PathBuf::from),
+                    extra_args,
                 };
+                // Label: `user@host` when a user was given, else bare `host`.
+                let target = params.ssh_target();
                 let label = match port {
-                    Some(p) => format!("ssh:{user}@{host}:{p}"),
-                    None => format!("ssh:{user}@{host}"),
+                    Some(p) => format!("ssh:{target}:{p}"),
+                    None => format!("ssh:{target}"),
                 };
                 let workspace = remote_path.clone().map(std::path::PathBuf::from);
                 let mode = mode_for(&label);

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -974,8 +974,11 @@ impl Editor {
                 self.handle_set_authority(payload);
             }
 
-            PluginCommand::AttachRemoteAgent { payload } => {
-                self.handle_attach_remote_agent(payload);
+            PluginCommand::AttachRemoteAgent {
+                payload,
+                request_id,
+            } => {
+                self.handle_attach_remote_agent(payload, request_id);
             }
 
             PluginCommand::ClearAuthority => {
@@ -3386,7 +3389,7 @@ impl Editor {
         }
     }
 
-    fn handle_attach_remote_agent(&mut self, payload: serde_json::Value) {
+    fn handle_attach_remote_agent(&mut self, payload: serde_json::Value, request_id: u64) {
         // Opaque at the fresh-core boundary; the concrete schema lives in
         // services::authority so core stays backend-agnostic.
         let spec =
@@ -3394,7 +3397,7 @@ impl Editor {
                 Ok(spec) => spec,
                 Err(e) => {
                     tracing::warn!("attachRemoteAgent: invalid payload: {}", e);
-                    self.set_status_message(format!("attachRemoteAgent rejected: {e}"));
+                    self.reject_remote_attach(request_id, format!("invalid attach spec: {e}"));
                     return;
                 }
             };
@@ -3404,7 +3407,7 @@ impl Editor {
         let runtime = self.tokio_runtime.clone();
         let sender = self.async_bridge.as_ref().map(|b| b.sender());
         let (Some(runtime), Some(sender)) = (runtime, sender) else {
-            self.set_status_message("attachRemoteAgent: async runtime not available".to_string());
+            self.reject_remote_attach(request_id, "async runtime not available".to_string());
             return;
         };
 
@@ -3456,10 +3459,12 @@ impl Editor {
                                 keepalive: Box::new(keepalive),
                                 working_dir: workspace,
                                 mode,
+                                request_id,
                             },
                         ),
                         Err(e) => AsyncMessage::RemoteAttachFailed {
                             error: e.to_string(),
+                            request_id,
                         },
                     };
                     #[allow(clippy::let_underscore_must_use)]
@@ -3502,10 +3507,12 @@ impl Editor {
                                 keepalive: Box::new(keepalive),
                                 working_dir: workspace,
                                 mode,
+                                request_id,
                             },
                         ),
                         Err(e) => AsyncMessage::RemoteAttachFailed {
                             error: e.to_string(),
+                            request_id,
                         },
                     };
                     #[allow(clippy::let_underscore_must_use)]
@@ -3513,6 +3520,28 @@ impl Editor {
                 });
             }
         }
+    }
+
+    /// Resolve the `attachRemoteAgent` promise behind `request_id` — the
+    /// session (authority + window) is fully constructed. Resolves with
+    /// `null`; the plugin only needs the success signal to close its dialog.
+    pub(crate) fn resolve_remote_attach(&self, request_id: u64) {
+        self.plugin_manager.read().unwrap().resolve_callback(
+            fresh_core::api::JsCallbackId::from(request_id),
+            "null".to_string(),
+        );
+    }
+
+    /// Reject the `attachRemoteAgent` promise behind `request_id` with `error`
+    /// — the connect failed, or the spec was bad / the runtime unavailable, or
+    /// window creation failed. The plugin surfaces the reason and creates no
+    /// window.
+    pub(crate) fn reject_remote_attach(&self, request_id: u64, error: String) {
+        tracing::warn!("attachRemoteAgent rejected: {error}");
+        self.plugin_manager
+            .read()
+            .unwrap()
+            .reject_callback(fresh_core::api::JsCallbackId::from(request_id), error);
     }
 
     fn handle_set_remote_indicator_state(&mut self, state: serde_json::Value) {

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -981,6 +981,10 @@ impl Editor {
                 self.handle_attach_remote_agent(payload, request_id);
             }
 
+            PluginCommand::CancelRemoteAttach => {
+                self.cancel_remote_attaches();
+            }
+
             PluginCommand::ClearAuthority => {
                 tracing::info!("Plugin cleared authority; restoring local");
                 self.clear_authority();
@@ -3410,6 +3414,10 @@ impl Editor {
             self.reject_remote_attach(request_id, "async runtime not available".to_string());
             return;
         };
+
+        // Track this connect as in-flight so a plugin can cancel it (the
+        // New-Session dialog's Cancel) before it resolves.
+        self.remote_attach_inflight.insert(request_id);
 
         // Window-mode opts captured before `spec` is consumed — when `window`
         // is set the main loop spawns a born-attached new window instead of

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3526,28 +3526,6 @@ impl Editor {
         }
     }
 
-    /// Resolve the `attachRemoteAgent` promise behind `request_id` — the
-    /// session (authority + window) is fully constructed. Resolves with
-    /// `null`; the plugin only needs the success signal to close its dialog.
-    pub(crate) fn resolve_remote_attach(&self, request_id: u64) {
-        self.plugin_manager.read().unwrap().resolve_callback(
-            fresh_core::api::JsCallbackId::from(request_id),
-            "null".to_string(),
-        );
-    }
-
-    /// Reject the `attachRemoteAgent` promise behind `request_id` with `error`
-    /// — the connect failed, or the spec was bad / the runtime unavailable, or
-    /// window creation failed. The plugin surfaces the reason and creates no
-    /// window.
-    pub(crate) fn reject_remote_attach(&self, request_id: u64, error: String) {
-        tracing::warn!("attachRemoteAgent rejected: {error}");
-        self.plugin_manager
-            .read()
-            .unwrap()
-            .reject_callback(fresh_core::api::JsCallbackId::from(request_id), error);
-    }
-
     fn handle_set_remote_indicator_state(&mut self, state: serde_json::Value) {
         // Opaque JSON at the fresh-core boundary; the concrete schema
         // (RemoteIndicatorOverride) lives in the view crate.

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3416,8 +3416,12 @@ impl Editor {
         };
 
         // Track this connect as in-flight so a plugin can cancel it (the
-        // New-Session dialog's Cancel) before it resolves.
+        // New-Session dialog's Cancel) before it resolves. The cancel sender is
+        // handed to the connect via its `select!`; signalling it tears down the
+        // in-flight carrier child.
         self.remote_attach_inflight.insert(request_id);
+        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+        self.remote_attach_cancels.insert(request_id, cancel_tx);
 
         // Window-mode opts captured before `spec` is consumed — when `window`
         // is set the main loop spawns a born-attached new window instead of
@@ -3457,7 +3461,11 @@ impl Editor {
                 self.set_status_message(format!("Connecting to {label}…"));
                 runtime.spawn(async move {
                     let outcome = crate::services::authority::connect_kube_authority(
-                        target, base_env, trust, env,
+                        target,
+                        base_env,
+                        trust,
+                        env,
+                        Some(cancel_rx),
                     )
                     .await;
                     let msg = match outcome {
@@ -3510,6 +3518,7 @@ impl Editor {
                         remote_path,
                         trust,
                         env,
+                        Some(cancel_rx),
                     )
                     .await;
                     let msg = match outcome {

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -488,9 +488,11 @@ impl Editor {
             state.update_shortcuts();
         }
 
-        // Use tokio runtime to load directory
+        // Use tokio runtime to load directory. Use the *active window's*
+        // fs_manager (which rides that window's authority) so the Open File
+        // browser lists the remote host for a remote window, not the local box.
         if let Some(ref runtime) = self.tokio_runtime {
-            let fs_manager = self.fs_manager.clone();
+            let fs_manager = self.active_window().resources.fs_manager.clone();
             let sender = self.async_bridge.as_ref().map(|b| b.sender());
 
             runtime.spawn(async move {

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -544,7 +544,7 @@ impl Editor {
             .map(|s| s.to_string())
             .unwrap_or_default();
         if old_key == new_key {
-            tracing::warn!(
+            tracing::debug!(
                 target: "fresh::dock",
                 panel_id,
                 key = %new_key,
@@ -552,7 +552,7 @@ impl Editor {
             );
             return;
         }
-        tracing::warn!(
+        tracing::debug!(
             target: "fresh::dock",
             panel_id,
             old = %old_key,
@@ -1940,7 +1940,7 @@ impl Editor {
             .get(panel_id)
             .map(|p| p.focus_key.clone())
             .unwrap_or_default();
-        tracing::warn!(
+        tracing::debug!(
             target: "fresh::dock",
             panel_id,
             ?slot,
@@ -1978,7 +1978,7 @@ impl Editor {
         if let Some(f) = self.panel_mut(slot) {
             f.focused = false;
         }
-        tracing::warn!(
+        tracing::debug!(
             target: "fresh::dock",
             panel_id,
             ?slot,

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -31,7 +31,15 @@ impl crate::app::Editor {
             theme_cache: std::sync::Arc::clone(&self.theme_cache),
             keybindings: std::sync::Arc::clone(&self.keybindings),
             command_registry: std::sync::Arc::clone(&self.command_registry),
-            fs_manager: std::sync::Arc::clone(&self.fs_manager),
+            // Derive the window's fs_manager from the *same* authority we hand
+            // it below, so directory listings (the file explorer) ride the
+            // window's filesystem — local or remote — instead of a stale,
+            // boot-time local one. A born-attached SSH/k8s window otherwise
+            // showed the local machine in the explorer while its terminal ran
+            // remote, because the cached fs_manager never tracked the authority.
+            fs_manager: std::sync::Arc::new(crate::services::fs::FsManager::new(
+                std::sync::Arc::clone(&self.authority.filesystem),
+            )),
             local_filesystem: std::sync::Arc::clone(&self.local_filesystem),
             buffer_id_alloc: self.buffer_id_alloc.clone(),
             authority: self.authority.clone(),

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -1360,10 +1360,11 @@ fn connect_remote(
         .context("Failed to create Tokio runtime for remote connection")?;
 
     let connection_params = remote::ConnectionParams {
-        user: remote.user.clone(),
+        user: Some(remote.user.clone()),
         host: remote.host.clone(),
         port: remote.port,
         identity_file: None,
+        extra_args: Vec::new(),
     };
 
     match remote.port {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4168,12 +4168,57 @@ fn run_event_loop(
         terminal_modes,
         |timeout| {
             if event_poll(timeout)? {
-                Ok(Some(event_read()?))
+                Ok(safe_event_read()?)
             } else {
                 Ok(None)
             }
         },
     )
+}
+
+/// Read one terminal event, guarding against a panic inside crossterm's input
+/// parser.
+///
+/// A malformed or zero-coordinate SGR mouse sequence can trip an
+/// `attempt to subtract with overflow` inside crossterm's parse path. That
+/// panic would otherwise unwind straight through the event loop and abort the
+/// whole editor over a single bad byte sequence. We catch it and report "no
+/// event" so the loop carries on.
+///
+/// crossterm only clears its internal byte buffer when a parse returns `Err`,
+/// not when it *panics*, so the offending bytes can remain and panic again on
+/// the next read. To avoid spinning forever on a wedged parser we count
+/// consecutive recovered panics and, past a small threshold, surface an error
+/// so the caller shuts the loop down cleanly instead of busy-looping. Any
+/// successful read resets the counter.
+fn safe_event_read() -> std::io::Result<Option<CrosstermEvent>> {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    const MAX_CONSECUTIVE_PARSE_PANICS: u32 = 8;
+    static CONSECUTIVE_PANICS: AtomicU32 = AtomicU32::new(0);
+
+    match catch_unwind(AssertUnwindSafe(event_read)) {
+        Ok(res) => {
+            CONSECUTIVE_PANICS.store(0, Ordering::Relaxed);
+            res.map(Some)
+        }
+        Err(_) => {
+            let n = CONSECUTIVE_PANICS.fetch_add(1, Ordering::Relaxed) + 1;
+            tracing::warn!(
+                "crossterm event parser panicked on malformed input \
+                 (consecutive: {n}); dropping the event"
+            );
+            if n >= MAX_CONSECUTIVE_PARSE_PANICS {
+                CONSECUTIVE_PANICS.store(0, Ordering::Relaxed);
+                Err(std::io::Error::other(
+                    "crossterm input parser repeatedly panicked; aborting read loop",
+                ))
+            } else {
+                Ok(None)
+            }
+        }
+    }
 }
 
 fn run_event_loop_common<F>(
@@ -4372,7 +4417,7 @@ fn poll_with_gpm(
     // If no GPM client, just use crossterm polling
     let Some(gpm) = gpm_client else {
         return if event_poll(timeout)? {
-            Ok(Some(event_read()?))
+            Ok(safe_event_read()?)
         } else {
             Ok(None)
         };
@@ -4442,7 +4487,9 @@ fn poll_with_gpm(
     if stdin_revents.is_some_and(|r| r.contains(PollFlags::POLLIN)) {
         // Use crossterm's read since it handles escape sequence parsing
         if event_poll(Duration::ZERO)? {
-            return Ok(Some(event_read()?));
+            if let Some(ev) = safe_event_read()? {
+                return Ok(Some(ev));
+            }
         }
     }
 
@@ -4463,7 +4510,9 @@ fn coalesce_mouse_moves(
 
     let mut latest = event;
     while event_poll(Duration::ZERO)? {
-        let next = event_read()?;
+        let Some(next) = safe_event_read()? else {
+            continue;
+        };
         if matches!(&next, CrosstermEvent::Mouse(m) if m.kind == MouseEventKind::Moved) {
             latest = next; // Newer move, skip the old one
         } else {

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -250,8 +250,14 @@ pub enum AsyncMessage {
     /// Git status updated (future: git integration)
     GitStatusChanged { status: String },
 
-    /// File explorer initialized with tree view
-    FileExplorerInitialized(FileTreeView),
+    /// File explorer initialized with tree view. Carries the id of the window
+    /// that requested it: a background preview/materialize can init a
+    /// *non-active* window's explorer, so the view must land on that window —
+    /// applying it to whatever is active would clobber an unrelated explorer.
+    FileExplorerInitialized {
+        window: fresh_core::WindowId,
+        view: FileTreeView,
+    },
 
     /// File explorer node toggle completed
     FileExplorerToggleNode(NodeId),
@@ -259,9 +265,13 @@ pub enum AsyncMessage {
     /// File explorer node refresh completed
     FileExplorerRefreshNode(NodeId),
 
-    /// File explorer expand to path completed
-    /// Contains the updated FileTreeView with the path expanded and selected
-    FileExplorerExpandedToPath(FileTreeView),
+    /// File explorer expand to path completed. Carries the requesting window id
+    /// (see `FileExplorerInitialized`) so the expanded view returns to its own
+    /// window rather than the active one.
+    FileExplorerExpandedToPath {
+        window: fresh_core::WindowId,
+        view: FileTreeView,
+    },
 
     /// Plugin-related async messages
     Plugin(fresh_core::api::PluginAsyncMessage),

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -58,6 +58,11 @@ pub struct RemoteAttachReady {
     pub working_dir: Option<std::path::PathBuf>,
     /// Restart (global) vs. born-attached new window.
     pub mode: RemoteAttachMode,
+    /// JS callback id of the `attachRemoteAgent` promise to settle once the
+    /// session (authority + window) is fully constructed. The main loop
+    /// resolves it on success and rejects it if window creation fails, so the
+    /// plugin's dialog only closes when there is a real session to show.
+    pub request_id: u64,
 }
 
 impl std::fmt::Debug for RemoteAttachReady {
@@ -75,9 +80,10 @@ pub enum AsyncMessage {
     /// authority + keepalive and restart.
     RemoteAttachReady(RemoteAttachReady),
 
-    /// An async `attachRemoteAgent` connect failed — surface the error;
-    /// the editor stays on its current authority.
-    RemoteAttachFailed { error: String },
+    /// An async `attachRemoteAgent` connect failed — reject the plugin's
+    /// promise with `error` (the plugin shows it and creates no window); the
+    /// editor stays on its current authority.
+    RemoteAttachFailed { error: String, request_id: u64 },
 
     /// LSP diagnostics received for a file
     LspDiagnostics {

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -579,7 +579,10 @@ pub enum RemoteTransportSpec {
     /// `fresh user@host:path` flow, exposed at runtime so the Orchestrator can
     /// open an SSH session as a born-attached window.
     Ssh {
-        user: String,
+        /// Login user. Optional — omit for `host` / `ssh://host`, letting ssh
+        /// resolve the user from its own config or the current local user.
+        #[serde(default)]
+        user: Option<String>,
         host: String,
         #[serde(default)]
         port: Option<u16>,
@@ -588,6 +591,10 @@ pub enum RemoteTransportSpec {
         /// Remote directory to root the session at (terminal `cd` target).
         #[serde(default)]
         remote_path: Option<String>,
+        /// Extra `ssh` arguments (e.g. `-J jump`, `-o ProxyCommand=…`) applied
+        /// to every ssh invocation for this session.
+        #[serde(default)]
+        extra_args: Vec<String>,
     },
 }
 

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -675,6 +675,7 @@ pub async fn connect_kube_authority(
     base_env: Vec<(String, String)>,
     trust: Arc<WorkspaceTrust>,
     env: Arc<crate::services::env_provider::EnvProvider>,
+    cancel: Option<tokio::sync::oneshot::Receiver<()>>,
 ) -> Result<(Authority, KubeKeepalive), TransportError> {
     type Built = Result<
         (
@@ -702,7 +703,21 @@ pub async fn connect_kube_authority(
                 // running after `block_on` returns and after this helper thread
                 // exits — until the `runtime` (moved into the keepalive) drops.
                 let (connection, reconnect) = runtime.block_on(async {
-                    let connection = KubeConnection::connect(bootstrap_target.clone()).await?;
+                    // Race the connect against the cancel signal so a slow/hung
+                    // kubectl bootstrap can be aborted; dropping the connect
+                    // future drops the in-flight child. No signal → await it.
+                    let connection = match cancel {
+                        Some(cancel) => tokio::select! {
+                            biased;
+                            _ = cancel => {
+                                return Err(TransportError::AgentStartFailed(
+                                    "cancelled".to_string(),
+                                ));
+                            }
+                            res = KubeConnection::connect(bootstrap_target.clone()) => res?,
+                        },
+                        None => KubeConnection::connect(bootstrap_target.clone()).await?,
+                    };
                     let reconnect =
                         spawn_kube_reconnect_task(&connection.channel(), bootstrap_target.clone());
                     Ok::<_, TransportError>((connection, reconnect))
@@ -760,6 +775,7 @@ pub async fn connect_ssh_authority(
     remote_dir: Option<String>,
     trust: Arc<WorkspaceTrust>,
     env: Arc<crate::services::env_provider::EnvProvider>,
+    cancel: Option<tokio::sync::oneshot::Receiver<()>>,
 ) -> Result<(Authority, SshKeepalive), SshError> {
     type Built = Result<
         (
@@ -786,7 +802,20 @@ pub async fn connect_ssh_authority(
                 // workers, surviving after this helper thread exits — until the
                 // `runtime` (moved into the keepalive) drops.
                 let (connection, reconnect) = runtime.block_on(async {
-                    let connection = SshConnection::connect(bootstrap_params.clone()).await?;
+                    // Race the connect against the cancel signal. On cancel the
+                    // connect future is dropped, which drops the in-flight ssh
+                    // child (spawned kill-on-drop) so a hung handshake leaves no
+                    // orphaned process. No cancel signal → just await connect.
+                    let connection = match cancel {
+                        Some(cancel) => tokio::select! {
+                            biased;
+                            _ = cancel => {
+                                return Err(SshError::AgentStartFailed("cancelled".to_string()));
+                            }
+                            res = SshConnection::connect(bootstrap_params.clone()) => res?,
+                        },
+                        None => SshConnection::connect(bootstrap_params.clone()).await?,
+                    };
                     let reconnect =
                         spawn_reconnect_task(connection.channel(), connection.params().clone());
                     Ok::<_, SshError>((connection, reconnect))

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -174,9 +174,15 @@ impl SshConnection {
             .ok_or_else(|| SshError::AgentStartFailed("failed to get stdout".to_string()))?;
         let stderr = child.stderr.take();
 
-        // Send the agent code (exact byte count)
-        stdin.write_all(AGENT_SOURCE.as_bytes()).await?;
-        stdin.flush().await?;
+        // Send the agent code (exact byte count). If the carrier already died
+        // (a failed connect — e.g. the host was unreachable), this write/flush
+        // races the child's exit and can fail with a broken pipe. That pipe
+        // error isn't the actionable reason; the carrier's own stderr is. Fall
+        // through to the same EOF path so we surface "ssh: …" rather than a bare
+        // `SpawnFailed`, regardless of which side loses the race.
+        if stdin.write_all(AGENT_SOURCE.as_bytes()).await.is_err() || stdin.flush().await.is_err() {
+            return Err(ssh_eof_error(&mut child, &params, stderr).await);
+        }
 
         // Create buffered reader for stdout
         let mut reader = BufReader::new(stdout);

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -33,15 +33,24 @@ pub enum SshError {
 /// SSH connection parameters
 #[derive(Debug, Clone)]
 pub struct ConnectionParams {
-    pub user: String,
+    /// SSH login user. `None` lets ssh pick the user (its config / the current
+    /// local user), so `host` and `ssh://host` work without a `user@`.
+    pub user: Option<String>,
     pub host: String,
     pub port: Option<u16>,
     pub identity_file: Option<PathBuf>,
+    /// Extra `ssh` arguments inserted verbatim before the target on every ssh
+    /// invocation (agent connect, reconnect, interactive terminal, LSP/probe
+    /// spawns), so options like `-J jump` or `-o ProxyCommand=…` apply end to
+    /// end rather than only to the initial connect.
+    pub extra_args: Vec<String>,
 }
 
 impl ConnectionParams {
-    /// Parse a connection string like "user@host" or "user@host:port"
+    /// Parse a connection string like `host`, `user@host`, or `user@host:port`
+    /// (a leading `ssh://` is tolerated). The user is optional.
     pub fn parse(s: &str) -> Option<Self> {
+        let s = s.strip_prefix("ssh://").unwrap_or(s);
         let (user_host, port) = if let Some((uh, p)) = s.rsplit_once(':') {
             if let Ok(port) = p.parse::<u16>() {
                 (uh, Some(port))
@@ -52,26 +61,38 @@ impl ConnectionParams {
             (s, None)
         };
 
-        let (user, host) = user_host.split_once('@')?;
-        if user.is_empty() || host.is_empty() {
+        let (user, host) = match user_host.split_once('@') {
+            Some((u, h)) => (Some(u.to_string()), h),
+            None => (None, user_host),
+        };
+        if host.is_empty() || user.as_deref() == Some("") {
             return None;
         }
 
         Some(Self {
-            user: user.to_string(),
+            user,
             host: host.to_string(),
             port,
             identity_file: None,
+            extra_args: Vec::new(),
         })
+    }
+
+    /// The ssh target argument: `user@host` when a user is set, else bare
+    /// `host` (ssh then resolves the user itself).
+    pub fn ssh_target(&self) -> String {
+        match &self.user {
+            Some(user) if !user.is_empty() => format!("{user}@{}", self.host),
+            _ => self.host.clone(),
+        }
     }
 }
 
 impl std::fmt::Display for ConnectionParams {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(port) = self.port {
-            write!(f, "{}@{}:{}", self.user, self.host, port)
-        } else {
-            write!(f, "{}@{}", self.user, self.host)
+        match self.port {
+            Some(port) => write!(f, "{}:{}", self.ssh_target(), port),
+            None => write!(f, "{}", self.ssh_target()),
         }
     }
 }
@@ -102,7 +123,8 @@ impl SshConnection {
             cmd.arg("-i").arg(identity);
         }
 
-        cmd.arg(format!("{}@{}", params.user, params.host));
+        cmd.args(&params.extra_args);
+        cmd.arg(params.ssh_target());
 
         // Bootstrap the agent using Python itself to read the exact byte count.
         // This avoids requiring bash or other shell utilities on the remote.
@@ -503,7 +525,8 @@ async fn establish_ssh_transport(
         cmd.arg("-i").arg(identity);
     }
 
-    cmd.arg(format!("{}@{}", params.user, params.host));
+    cmd.args(&params.extra_args);
+    cmd.arg(params.ssh_target());
 
     let agent_len = AGENT_SOURCE.len();
     let bootstrap = format!(
@@ -726,16 +749,27 @@ mod tests {
     #[test]
     fn test_parse_connection_params() {
         let params = ConnectionParams::parse("user@host").unwrap();
-        assert_eq!(params.user, "user");
+        assert_eq!(params.user.as_deref(), Some("user"));
         assert_eq!(params.host, "host");
         assert_eq!(params.port, None);
 
         let params = ConnectionParams::parse("user@host:22").unwrap();
-        assert_eq!(params.user, "user");
+        assert_eq!(params.user.as_deref(), Some("user"));
         assert_eq!(params.host, "host");
         assert_eq!(params.port, Some(22));
 
-        assert!(ConnectionParams::parse("hostonly").is_none());
+        // User is optional: bare host and ssh:// both parse, user = None.
+        let params = ConnectionParams::parse("hostonly").unwrap();
+        assert_eq!(params.user, None);
+        assert_eq!(params.host, "hostonly");
+        assert_eq!(params.ssh_target(), "hostonly");
+
+        let params = ConnectionParams::parse("ssh://example.com:2222").unwrap();
+        assert_eq!(params.user, None);
+        assert_eq!(params.host, "example.com");
+        assert_eq!(params.port, Some(2222));
+
+        // Empty user / empty host are still rejected.
         assert!(ConnectionParams::parse("@host").is_none());
         assert!(ConnectionParams::parse("user@").is_none());
     }
@@ -769,19 +803,32 @@ mod tests {
     #[test]
     fn test_connection_string() {
         let params = ConnectionParams {
-            user: "alice".to_string(),
+            user: Some("alice".to_string()),
             host: "example.com".to_string(),
             port: None,
             identity_file: None,
+            extra_args: Vec::new(),
         };
         assert_eq!(params.to_string(), "alice@example.com");
 
         let params = ConnectionParams {
-            user: "bob".to_string(),
+            user: Some("bob".to_string()),
             host: "server.local".to_string(),
             port: Some(2222),
             identity_file: None,
+            extra_args: Vec::new(),
         };
         assert_eq!(params.to_string(), "bob@server.local:2222");
+
+        // No user: the target (and display) is the bare host.
+        let params = ConnectionParams {
+            user: None,
+            host: "server.local".to_string(),
+            port: Some(2222),
+            identity_file: None,
+            extra_args: Vec::new(),
+        };
+        assert_eq!(params.to_string(), "server.local:2222");
+        assert_eq!(params.ssh_target(), "server.local");
     }
 }

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -193,6 +193,9 @@ impl SshConnection {
         if let Some(mut stderr) = stderr {
             tokio::spawn(async move {
                 let mut sink = tokio::io::sink();
+                // Best-effort drain; the byte count / EOF error is irrelevant
+                // since we're discarding ssh's stderr for the session.
+                #[allow(clippy::let_underscore_must_use)]
                 let _ = tokio::io::copy(&mut stderr, &mut sink).await;
             });
         }

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -152,6 +152,13 @@ impl SshConnection {
         // fold its message into the connection error instead (see
         // `ssh_eof_error`), so a failed connect becomes a clean status line.
         cmd.stderr(Stdio::piped());
+        // Kill the ssh process if this connect future is dropped before it
+        // finishes (e.g. the New-Session dialog's Cancel aborts the connect
+        // task while the handshake is still hanging). Without this a hung
+        // connect would orphan the ssh child until it timed out on its own.
+        // For an established carrier `SshConnection`'s Drop also kills it; this
+        // covers the window before the connection object exists.
+        cmd.kill_on_drop(true);
         cmd.hide_window();
 
         let mut child = cmd.spawn()?;

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -8,8 +8,8 @@ use crate::services::remote::protocol::AgentResponse;
 use crate::services::remote::AGENT_SOURCE;
 use std::path::PathBuf;
 use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::{Child, Command};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStderr, Command};
 
 /// Error type for SSH connection
 #[derive(Debug, thiserror::Error)]
@@ -93,8 +93,6 @@ impl SshConnection {
 
         // Don't check host key strictly for ease of use
         cmd.arg("-o").arg("StrictHostKeyChecking=accept-new");
-        // Allow password prompts - SSH will use the terminal for this
-        // Note: We inherit stderr so SSH can prompt for password if needed
 
         if let Some(port) = params.port {
             cmd.arg("-p").arg(port.to_string());
@@ -123,8 +121,15 @@ impl SshConnection {
 
         cmd.stdin(Stdio::piped());
         cmd.stdout(Stdio::piped());
-        // Inherit stderr so SSH can prompt for password on the terminal
-        cmd.stderr(Stdio::inherit());
+        // Capture ssh's stderr instead of inheriting it. The editor runs a
+        // full-screen ratatui UI on the alternate screen; an inherited stderr
+        // lets ssh scribble its diagnostics ("Could not resolve hostname …")
+        // straight over the rendered UI. ratatui has no idea those cells
+        // changed, so the garbage persists until the next full repaint — the
+        // "corrupted window" users see after a bad host. We pipe stderr and
+        // fold its message into the connection error instead (see
+        // `ssh_eof_error`), so a failed connect becomes a clean status line.
+        cmd.stderr(Stdio::piped());
         cmd.hide_window();
 
         let mut child = cmd.spawn()?;
@@ -138,7 +143,7 @@ impl SshConnection {
             .stdout
             .take()
             .ok_or_else(|| SshError::AgentStartFailed("failed to get stdout".to_string()))?;
-        // Note: stderr is inherited so SSH can prompt for password on the terminal
+        let stderr = child.stderr.take();
 
         // Send the agent code (exact byte count)
         stdin.write_all(AGENT_SOURCE.as_bytes()).await?;
@@ -153,10 +158,21 @@ impl SshConnection {
         let mut ready_line = String::new();
         match reader.read_line(&mut ready_line).await {
             Ok(0) => {
-                return Err(ssh_eof_error(&mut child, &params).await);
+                return Err(ssh_eof_error(&mut child, &params, stderr).await);
             }
             Ok(_) => {}
             Err(e) => return Err(SshError::AgentStartFailed(format!("read error: {}", e))),
+        }
+
+        // Connected. Drain ssh's stderr for the life of the connection so the
+        // occasional later diagnostic (host-key warnings, etc.) is discarded
+        // rather than filling the pipe or — if we'd inherited it — landing on
+        // the editor's screen.
+        if let Some(mut stderr) = stderr {
+            tokio::spawn(async move {
+                let mut sink = tokio::io::sink();
+                let _ = tokio::io::copy(&mut stderr, &mut sink).await;
+            });
         }
 
         let ready: AgentResponse = serde_json::from_str(&ready_line).map_err(|e| {
@@ -381,7 +397,11 @@ pub fn spawn_heartbeat_task(
 /// sending a ready message. We wait for the SSH process to exit and inspect its
 /// exit code to give the user a more actionable message than a generic
 /// "connection closed".
-async fn ssh_eof_error(child: &mut Child, params: &ConnectionParams) -> SshError {
+async fn ssh_eof_error(
+    child: &mut Child,
+    params: &ConnectionParams,
+    stderr: Option<ChildStderr>,
+) -> SshError {
     // Give SSH a moment to finish so we can read its exit code.
     let status = tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await;
 
@@ -425,7 +445,35 @@ async fn ssh_eof_error(child: &mut Child, params: &ConnectionParams) -> SshError
         }
     };
 
-    SshError::AgentStartFailed(hint)
+    // ssh writes the actionable reason ("Could not resolve hostname",
+    // "Permission denied", "Connection refused", …) to stderr. We piped it
+    // (rather than letting it corrupt the editor's screen), so fold the most
+    // specific line into the error for the status bar.
+    match read_ssh_stderr(stderr).await {
+        Some(detail) => SshError::AgentStartFailed(format!("{hint}: {detail}")),
+        None => SshError::AgentStartFailed(hint),
+    }
+}
+
+/// Read whatever a failed ssh process wrote to stderr and return its most
+/// specific (last non-empty) line. ssh has closed stdout by the time we call
+/// this and is exiting, so the read is bounded; we still cap the wait so a
+/// wedged pipe can't hang the error path.
+async fn read_ssh_stderr(stderr: Option<ChildStderr>) -> Option<String> {
+    let mut stderr = stderr?;
+    let mut buf = String::new();
+    #[allow(clippy::let_underscore_must_use)]
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(2),
+        stderr.read_to_string(&mut buf),
+    )
+    .await;
+    buf.trim()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .next_back()
+        .map(str::to_string)
 }
 
 /// This is the lower-level function used by both `SshConnection::connect` and
@@ -490,7 +538,9 @@ async fn establish_ssh_transport(
     let mut ready_line = String::new();
     match reader.read_line(&mut ready_line).await {
         Ok(0) => {
-            return Err(ssh_eof_error(&mut child, params).await);
+            // Reconnect spawns with `stderr(Stdio::null())`, so there is no
+            // captured stderr to attach here.
+            return Err(ssh_eof_error(&mut child, params, None).await);
         }
         Ok(_) => {}
         Err(e) => return Err(SshError::AgentStartFailed(format!("read error: {}", e))),

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -858,7 +858,8 @@ fn build_ssh_args(
         a.push("-i".to_string());
         a.push(identity.to_string_lossy().into_owned());
     }
-    a.push(format!("{}@{}", params.user, params.host));
+    a.extend(params.extra_args.iter().cloned());
+    a.push(params.ssh_target());
     a.push(remote_cmd.to_string());
     a
 }
@@ -894,7 +895,8 @@ pub fn build_ssh_terminal_args(
         a.push("-i".to_string());
         a.push(identity.to_string_lossy().into_owned());
     }
-    a.push(format!("{}@{}", params.user, params.host));
+    a.extend(params.extra_args.iter().cloned());
+    a.push(params.ssh_target());
 
     // Land in the workspace (when known), then hand control to the user's
     // login shell. `remote_dir` is whatever path the URL pointed at, which
@@ -1266,10 +1268,11 @@ mod tests {
     #[test]
     fn build_ssh_args_full() {
         let params = crate::services::remote::ConnectionParams {
-            user: "u".into(),
+            user: Some("u".into()),
             host: "h".into(),
             port: Some(2222),
             identity_file: Some(std::path::PathBuf::from("/k")),
+            extra_args: Vec::new(),
         };
         let a = build_ssh_args(&params, "echo hi");
         let expected: Vec<String> = [
@@ -1291,12 +1294,40 @@ mod tests {
     }
 
     #[test]
+    fn build_ssh_args_omits_user_and_threads_extra_args() {
+        // No user → bare host target; extra args land verbatim before it.
+        let params = crate::services::remote::ConnectionParams {
+            user: None,
+            host: "h".into(),
+            port: None,
+            identity_file: None,
+            extra_args: vec!["-J".into(), "jump".into()],
+        };
+        let a = build_ssh_args(&params, "echo hi");
+        let expected: Vec<String> = [
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            "-o",
+            "BatchMode=yes",
+            "-J",
+            "jump",
+            "h",
+            "echo hi",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+        assert_eq!(a, expected);
+    }
+
+    #[test]
     fn build_ssh_terminal_args_forces_tty_and_login_shell() {
         let params = crate::services::remote::ConnectionParams {
-            user: "u".into(),
+            user: Some("u".into()),
             host: "h".into(),
             port: Some(2222),
             identity_file: Some(std::path::PathBuf::from("/k")),
+            extra_args: Vec::new(),
         };
         let a = build_ssh_terminal_args(&params, Some("/proj dir"));
         let expected: Vec<String> = [
@@ -1321,10 +1352,11 @@ mod tests {
     #[test]
     fn build_ssh_terminal_args_without_dir_skips_cd() {
         let params = crate::services::remote::ConnectionParams {
-            user: "u".into(),
+            user: Some("u".into()),
             host: "h".into(),
             port: None,
             identity_file: None,
+            extra_args: Vec::new(),
         };
         let a = build_ssh_terminal_args(&params, None);
         assert_eq!(

--- a/crates/fresh-editor/src/services/remote/tests.rs
+++ b/crates/fresh-editor/src/services/remote/tests.rs
@@ -188,18 +188,22 @@ fn test_remote_metadata_parsing() {
 fn test_connection_params_parse() {
     // Basic user@host
     let params = ConnectionParams::parse("alice@server.com").unwrap();
-    assert_eq!(params.user, "alice");
+    assert_eq!(params.user.as_deref(), Some("alice"));
     assert_eq!(params.host, "server.com");
     assert_eq!(params.port, None);
 
     // With port
     let params = ConnectionParams::parse("bob@example.org:2222").unwrap();
-    assert_eq!(params.user, "bob");
+    assert_eq!(params.user.as_deref(), Some("bob"));
     assert_eq!(params.host, "example.org");
     assert_eq!(params.port, Some(2222));
 
-    // Invalid cases
-    assert!(ConnectionParams::parse("noatsign").is_none());
+    // User optional: a bare host parses with user = None.
+    let params = ConnectionParams::parse("noatsign").unwrap();
+    assert_eq!(params.user, None);
+    assert_eq!(params.host, "noatsign");
+
+    // Invalid cases (empty user / empty host / empty string).
     assert!(ConnectionParams::parse("@nouser").is_none());
     assert!(ConnectionParams::parse("nohost@").is_none());
     assert!(ConnectionParams::parse("").is_none());
@@ -208,18 +212,20 @@ fn test_connection_params_parse() {
 #[test]
 fn test_connection_params_to_string() {
     let params = ConnectionParams {
-        user: "alice".to_string(),
+        user: Some("alice".to_string()),
         host: "server.com".to_string(),
         port: None,
         identity_file: None,
+        extra_args: Vec::new(),
     };
     assert_eq!(params.to_string(), "alice@server.com");
 
     let params = ConnectionParams {
-        user: "bob".to_string(),
+        user: Some("bob".to_string()),
         host: "example.org".to_string(),
         port: Some(2222),
         identity_file: None,
+        extra_args: Vec::new(),
     };
     assert_eq!(params.to_string(), "bob@example.org:2222");
 }

--- a/crates/fresh-editor/src/services/remote/transport.rs
+++ b/crates/fresh-editor/src/services/remote/transport.rs
@@ -265,7 +265,12 @@ impl KubeConnection {
     /// Bootstrap the agent inside the pod named by `target`.
     pub async fn connect(target: KubeTarget) -> Result<Self, TransportError> {
         let transport = KubectlExecTransport::new(target);
-        let (reader, writer, child) = bootstrap_agent(&transport, StderrMode::Inherit).await?;
+        // Capture (discard) the carrier's stderr rather than inheriting it: the
+        // editor renders a full-screen ratatui UI on the alternate screen, so
+        // an inherited stderr lets kubectl scribble diagnostics straight over
+        // the rendered UI and corrupt it (the same failure mode as the SSH
+        // path). The EOF error below already explains the likely causes.
+        let (reader, writer, child) = bootstrap_agent(&transport, StderrMode::Null).await?;
         let channel = Arc::new(AgentChannel::new(reader, writer));
         let heartbeat = crate::services::remote::spawn_heartbeat_task(
             &channel,

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1686,7 +1686,20 @@ fn render_widget_text(
                 byte_in_row: byte_in_row as u32,
             });
         }
-        for mut e in rendered.entries {
+        for (row_idx, mut e) in rendered.entries.into_iter().enumerate() {
+            // Clicking any rendered row of the text area focuses the field
+            // (see the single-line branch / #2234 item 1).
+            if let Some(k) = key.filter(|k| !k.is_empty()) {
+                out.hits.push(HitArea {
+                    widget_key: k.to_string(),
+                    widget_kind: "text",
+                    buffer_row: row_idx as u32,
+                    byte_start: 0,
+                    byte_end: e.text.len(),
+                    payload: json!({}),
+                    event_type: "focus",
+                });
+            }
             ensure_trailing_newline(&mut e);
             out.entries.push(e);
         }
@@ -1710,6 +1723,22 @@ fn render_widget_text(
             });
         }
         let mut entry = rendered.entry;
+        // A click anywhere on the input line focuses the field so a mouse user
+        // can type. Text widgets previously emitted no hit area, so clicks fell
+        // through and the field stayed unfocused (#2234 item 1). Focusing is
+        // driven by the tabbable path in `handle_floating_widget_click`; the
+        // `focus` event keeps the plugin's focus mirror in step.
+        if let Some(k) = key.filter(|k| !k.is_empty()) {
+            out.hits.push(HitArea {
+                widget_key: k.to_string(),
+                widget_kind: "text",
+                buffer_row: 0,
+                byte_start: 0,
+                byte_end: entry.text.len(),
+                payload: json!({}),
+                event_type: "focus",
+            });
+        }
         ensure_trailing_newline(&mut entry);
         out.entries.push(entry);
     }

--- a/crates/fresh-editor/tests/fixtures/fake-ssh/ssh
+++ b/crates/fresh-editor/tests/fixtures/fake-ssh/ssh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Fake `ssh` for tests: models a connect that fails immediately (like a real
+# ssh that can't resolve / reach the host). It writes a recognizable line to
+# stderr and exits 255 — the conventional ssh "connection error" code.
+#
+# `SshConnection::connect` streams the agent source into our stdin before
+# reading stdout, so we drain stdin in the background to keep that write from
+# blocking; the drainer's stdio is pointed at /dev/null so the stdout/stderr
+# pipes the parent captures still EOF promptly once we exit.
+cat >/dev/null 2>&1 &
+echo "ssh: simulated connect failure (fake ssh)" 1>&2
+exit 255

--- a/crates/fresh-editor/tests/kube_fake_kubectl.rs
+++ b/crates/fresh-editor/tests/kube_fake_kubectl.rs
@@ -132,6 +132,7 @@ fn agent_channel_survives_dropping_the_attach_runtime() {
             vec![],
             Arc::new(WorkspaceTrust::permissive()),
             Arc::new(EnvProvider::inactive()),
+            None,
         ))
         .expect("connect over fake kubectl");
 
@@ -200,6 +201,7 @@ fn attach_spec_payload_parses_and_connects_through_fake_kubectl() {
             base_env,
             Arc::new(WorkspaceTrust::permissive()),
             Arc::new(EnvProvider::inactive()),
+            None,
         ))
         .expect("connect from parsed attach spec");
 
@@ -235,6 +237,7 @@ fn kube_authority_spawns_one_shot_and_lsp_through_fake_kubectl() {
             vec![("E2E_BASE".to_string(), "base".to_string())],
             std::sync::Arc::clone(&trust),
             std::sync::Arc::clone(&env),
+            None,
         ))
         .expect("connect_kube_authority over fake kubectl");
 

--- a/crates/fresh-editor/tests/remote_ssh_terminal.rs
+++ b/crates/fresh-editor/tests/remote_ssh_terminal.rs
@@ -192,10 +192,11 @@ fn ssh_terminal_wrapper_runs_shell_on_remote_host() {
 
     // --- The code under test: build the SSH authority's terminal wrapper. ---
     let params = ConnectionParams {
-        user: user.clone(),
+        user: Some(user.clone()),
         host: "127.0.0.1".to_string(),
         port: Some(port),
         identity_file: Some(id.clone()),
+        extra_args: Vec::new(),
     };
     let work_str = work.to_string_lossy().into_owned();
     let wrapper = TerminalWrapper::ssh(&params, Some(&work_str));

--- a/crates/fresh-editor/tests/ssh_attach_error.rs
+++ b/crates/fresh-editor/tests/ssh_attach_error.rs
@@ -1,0 +1,72 @@
+//! A *failed* SSH connect must surface the carrier's own stderr as the error
+//! text, not dump it onto the terminal.
+//!
+//! `SshConnection::connect` used to spawn `ssh` with an **inherited** stderr so
+//! that, when the host was unreachable, ssh wrote "Could not resolve hostname …"
+//! straight onto the editor's full-screen ratatui UI — corrupting the display
+//! (ratatui never learns those cells changed). The fix pipes stderr and folds
+//! the carrier's last diagnostic line into the connection error instead.
+//!
+//! This drives the real `connect` against a fake `ssh` shim that fails like an
+//! unreachable host, so it is deterministic and needs no network. RED before
+//! the fix (the error carried only the exit-code hint, never the carrier's
+//! stderr); GREEN after.
+
+use std::path::PathBuf;
+use std::sync::Once;
+
+use fresh::services::remote::{ConnectionParams, SshConnection, SshError};
+
+static PATH_INIT: Once = Once::new();
+
+/// Prepend the fake-ssh fixtures dir to PATH once, so `Command::new("ssh")`
+/// resolves to the shim. `Once` keeps the process-global env mutation from
+/// racing across parallel tests in this binary.
+fn ensure_fake_ssh_on_path() {
+    PATH_INIT.call_once(|| {
+        let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/fake-ssh");
+        assert!(
+            dir.join("ssh").exists(),
+            "fake ssh shim missing at {}",
+            dir.display()
+        );
+        let old = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{old}", dir.display()));
+    });
+}
+
+#[test]
+fn failed_ssh_connect_surfaces_carrier_stderr_in_the_error() {
+    ensure_fake_ssh_on_path();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    let params = ConnectionParams {
+        user: Some("u".to_string()),
+        host: "fake-host".to_string(),
+        port: None,
+        identity_file: None,
+        extra_args: Vec::new(),
+    };
+
+    let err = rt
+        .block_on(SshConnection::connect(params))
+        .expect_err("fake ssh exits 255, so the connect must fail");
+
+    let msg = err.to_string();
+    assert!(
+        matches!(err, SshError::AgentStartFailed(_)),
+        "expected an AgentStartFailed error, got: {msg}"
+    );
+    // The whole point of the fix: the carrier's own stderr is captured and
+    // folded into the error (so it reaches the dialog/status), rather than
+    // being inherited onto the screen.
+    assert!(
+        msg.contains("simulated connect failure"),
+        "the failed connect must surface the carrier's stderr in the error; got: {msg}"
+    );
+}

--- a/crates/fresh-editor/tests/ssh_attach_error.rs
+++ b/crates/fresh-editor/tests/ssh_attach_error.rs
@@ -67,9 +67,15 @@ fn failed_ssh_connect_surfaces_carrier_stderr_in_the_error() {
     );
     // The whole point of the fix: the carrier's own stderr is captured and
     // folded into the error (so it reaches the dialog/status), rather than
-    // being inherited onto the screen.
+    // being inherited onto the screen. We match on the carrier's "ssh: "
+    // diagnostic prefix rather than a literal phrase: on Unix the fake shim
+    // emits "ssh: simulated connect failure", but on Windows the `#!/bin/sh`
+    // shim isn't an executable so the real `ssh.exe` runs and emits
+    // "ssh: Could not resolve hostname fake-host". Either way the lowercase
+    // "ssh: " prefix comes only from the captured stderr — the generic
+    // exit-code hint never contains it.
     assert!(
-        msg.contains("simulated connect failure"),
+        msg.contains("ssh: "),
         "the failed connect must surface the carrier's stderr in the error; got: {msg}"
     );
 }

--- a/crates/fresh-editor/tests/ssh_attach_error.rs
+++ b/crates/fresh-editor/tests/ssh_attach_error.rs
@@ -53,9 +53,12 @@ fn failed_ssh_connect_surfaces_carrier_stderr_in_the_error() {
         extra_args: Vec::new(),
     };
 
-    let err = rt
-        .block_on(SshConnection::connect(params))
-        .expect_err("fake ssh exits 255, so the connect must fail");
+    // Not `.expect_err(...)`: that needs `SshConnection: Debug` (the Ok arm)
+    // for its panic message, and the connection type doesn't implement it.
+    let err = match rt.block_on(SshConnection::connect(params)) {
+        Ok(_) => panic!("fake ssh exits 255, so the connect must fail"),
+        Err(e) => e,
+    };
 
     let msg = err.to_string();
     assert!(

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5801,6 +5801,15 @@ impl JsEditorApi {
         id
     }
 
+    /// Cancel any in-flight `attachRemoteAgent` connect — the New-Session
+    /// dialog's Cancel. The pending promise rejects with "cancelled" and the
+    /// background connect's late result is discarded, so no window is built.
+    /// A no-op when nothing is connecting.
+    #[plugin_api(js_name = "cancelRemoteAgent")]
+    pub fn cancel_remote_agent(&self) {
+        let _ = self.command_sender.send(PluginCommand::CancelRemoteAttach);
+    }
+
     /// Activate an environment: set the live env recipe (`snippet` run in
     /// `dir`). Applied to every spawn, re-evaluated on demand — no restart.
     /// Honored only when the workspace is Trusted.

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5770,27 +5770,35 @@ impl JsEditorApi {
         let _ = self.command_sender.send(PluginCommand::ClearAuthority);
     }
 
-    /// Attach to a remote agent that needs a live connection (today a
-    /// `kubectl exec` agent in a Kubernetes pod). The connect is asynchronous:
-    /// this returns immediately, the editor connects in the background,
-    /// and only on success installs the authority and restarts (on
-    /// failure it surfaces the error and stays put). Fire-and-forget,
-    /// like `setAuthority` — any post-attach work belongs in the
-    /// plugin's post-restart init.
+    /// Attach to a remote agent that needs a live connection (an SSH host or a
+    /// `kubectl exec` agent in a Kubernetes pod). The connect is asynchronous —
+    /// the editor spawns the carrier, bootstraps the agent and builds the
+    /// session in the background — and this returns a promise that settles on
+    /// the real outcome:
+    ///
+    ///   * resolves once the session (authority + window) is fully
+    ///     constructed, so a caller can keep its dialog open until there is a
+    ///     real session to show;
+    ///   * rejects with the failure reason (e.g. ssh "Could not resolve
+    ///     hostname") if the connect or window creation fails — in which case
+    ///     no window is created and the editor stays on its current authority.
     ///
     /// The payload schema (`RemoteAgentSpec`) lives in `fresh-editor`;
     /// plugins hand-build an object matching it.
-    #[plugin_api(js_name = "attachRemoteAgent")]
+    #[plugin_api(async_promise, js_name = "attachRemoteAgent", ts_return = "void")]
+    #[qjs(rename = "_attachRemoteAgentStart")]
     pub fn attach_remote_agent(
         &self,
         ctx: rquickjs::Ctx<'_>,
         #[plugin_api(ts_type = "RemoteAgentSpec")] payload: rquickjs::Value<'_>,
-    ) -> bool {
+    ) -> u64 {
         let json = js_to_json(&ctx, payload);
-        let _ = self
-            .command_sender
-            .send(PluginCommand::AttachRemoteAgent { payload: json });
-        true
+        let id = self.alloc_request_id();
+        let _ = self.command_sender.send(PluginCommand::AttachRemoteAgent {
+            payload: json,
+            request_id: id,
+        });
+        id
     }
 
     /// Activate an environment: set the live env recipe (`snippet` run in
@@ -7006,6 +7014,7 @@ impl QuickJsBackend {
                 editor.openFileStreaming = _wrapAsync("_openFileStreamingStart", "openFileStreaming");
                 editor.refreshBufferFromDisk = _wrapAsync("_refreshBufferFromDiskStart", "refreshBufferFromDisk");
                 editor.setBufferGroupPanelBuffer = _wrapAsync("_setBufferGroupPanelBufferStart", "setBufferGroupPanelBuffer");
+                editor.attachRemoteAgent = _wrapAsync("_attachRemoteAgentStart", "attachRemoteAgent");
 
                 // Pull-based streaming search. Producers (host searcher tasks)
                 // write into shared state at full speed; the consumer drains

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -243,12 +243,17 @@ const REMOTE_AGENT_SPEC_DECL: &str = r#"type RemoteAgentTransport = {
   workspace?: string | null;
 } | {
   kind: "ssh";
-  user: string;
+  /** Login user. Optional — omit for `host` / `ssh://host`, letting ssh pick
+  * the user from its own config or the current local user. */
+  user?: string | null;
   host: string;
   port?: number | null;
   identity_file?: string | null;
   /** Remote directory to root the session at. */
   remote_path?: string | null;
+  /** Extra `ssh` arguments (e.g. `-J jump`, `-o ProxyCommand=…`) applied to
+  * every ssh invocation for this session. */
+  extra_args?: string[];
 };
 
 type RemoteAgentSpec = {

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -226,8 +226,11 @@ type PathTranslationSpec = {
 };"#;
 
 /// Hand-written declaration for `RemoteAgentSpec` (the
-/// `editor.attachRemoteAgent(...)` payload). Keep in sync with
-/// `crates/fresh-editor/src/services/authority/mod.rs::RemoteAgentSpec`.
+/// `editor.attachRemoteAgent(...)` payload), covering both transports
+/// (`kubectl-exec` and `ssh`) and the window-mode fields. Keep in sync with
+/// `crates/fresh-editor/src/services/authority/mod.rs`'s `RemoteAgentSpec` /
+/// `RemoteTransportSpec` — this crate must not depend on `fresh-editor`, so the
+/// shape is mirrored by hand.
 const REMOTE_AGENT_SPEC_DECL: &str = r#"type RemoteAgentTransport = {
   kind: "kubectl-exec";
   /** kubeconfig context to select (`--context`); omit for the current one. */
@@ -238,6 +241,14 @@ const REMOTE_AGENT_SPEC_DECL: &str = r#"type RemoteAgentTransport = {
   container?: string | null;
   /** Pod-side workspace root the terminal opens in. */
   workspace?: string | null;
+} | {
+  kind: "ssh";
+  user: string;
+  host: string;
+  port?: number | null;
+  identity_file?: string | null;
+  /** Remote directory to root the session at. */
+  remote_path?: string | null;
 };
 
 type RemoteAgentSpec = {
@@ -247,6 +258,17 @@ type RemoteAgentSpec = {
   * binary-presence probes. Omit when no probe was run.
   */
   base_env?: [string, string][];
+  /**
+  * When true, attach as a NEW window (born-attached, coexisting with the
+  * existing windows) instead of the default global restart that replaces the
+  * whole editor's authority. The Orchestrator sets this so a cloud session is
+  * a real session row beside local ones.
+  */
+  window?: boolean;
+  /** Window label (window mode only). Omit to use the transport's display. */
+  label?: string;
+  /** Optional agent argv for the new window's seed terminal (window mode). */
+  command?: string[];
 };"#;
 
 /// Hand-written declaration for `RemoteIndicatorStatePayload`. Keep in


### PR DESCRIPTION
## Summary

Started as SSH session-attach enhancements in the Orchestrator and grew to cover the New-Session dialog, dock, and terminal-input robustness issues tracked in #2234.

### SSH attach enhancements
1. **Optional SSH user** — connect with just a hostname (`host`, `ssh://host`, `host:port`); ssh resolves the user from its own config / the local user. `user@host` is no longer required.
2. **Extra SSH arguments** — free-form per-session ssh args (e.g. `-J jump-host`, `-o ProxyCommand=…`) applied to every ssh invocation, enabling jump hosts and proxies.
3. **Awaitable attach with live feedback** — `attachRemoteAgent` is promise-based: it resolves only once the authority **and** window are fully built, and rejects with the real failure reason. The dialog stays open during connect and shows the reason inline instead of closing optimistically onto a half-built window.
4. **No UI corruption on failure** — the carrier's stderr is piped (not inherited onto the ratatui alternate screen) and its last diagnostic line is folded into the error.

### New-Session dialog UX — #2234
- **Item 1 — click-to-focus fields:** text inputs now emit a `focus` HitArea, so clicking a field (Host, Identity, Project Path, …) focuses it and typing lands there.
- **Item 3 — disabled "connecting" state (all backends):** on submit the dialog switches to a read-only summary with only **Cancel** active; closes on success, resets on next open. Backend-agnostic.
- **Item 2 — cancel a pending connection cleanly:** new `editor.cancelRemoteAgent()` / `PluginCommand::CancelRemoteAttach`. Cancel rejects the awaiting promise and discards any late result so **no window is ever built**. Because the connect runs on a detached thread with its own runtime (the carrier's runtime must outlive it), a cancel signal is raced against the bootstrap with `tokio::select!`; dropping the connect future drops the in-flight ssh child (spawned `kill_on_drop(true)`). Verified against an unroutable host: Cancel kills the ssh client within ~1s, creates no window, and returns the editor to a clean "Connection cancelled" state.

### Per-window authority rooting
- File explorer, File-Open browser, and quick-open are rooted on the **active window's** authority (remote vs local), and async file-tree results route back to their requesting window — so previewing/diving into one session no longer drags another window's explorer around.

### Dock fixes
- A remote (SSH/k8s) session is never hidden as "trivial" (fixes the first card disappearing + selection desync).
- The dock blurs after diving into a discovered worktree so the new session receives keys.
- Per-keystroke `fresh::dock` focus diagnostics demoted from WARN to DEBUG.

### Input hardening — #2234 item 5
- All terminal reads go through `safe_event_read()`, which wraps crossterm's parser in `catch_unwind`: a malformed/zero-coordinate SGR mouse sequence that would trip an `attempt to subtract with overflow` panic now drops the event instead of aborting the editor, with a consecutive-panic guard to avoid busy-looping.

## Notable implementation details
- `ConnectionParams::user` is `Option<String>`; `ssh_target()` yields `user@host` or bare `host`; `parse()` handles `host`, `user@host`, `host:port`, `user@host:port`, and `ssh://…`.
- On a failed connect the agent-source `write_all` can lose the race against the carrier's exit (notably on Windows CI, where the non-executable shim falls through to a real `ssh.exe`). The write/flush-error path now falls through to the same EOF handler so the carrier's `ssh: …` stderr is surfaced as `AgentStartFailed` regardless of which side loses the race.
- `cmd` field uses its actual text value as the single source of truth, with backend defaults shown as placeholder and "clear to reset" behavior.
- `fresh.d.ts` regenerated from source for the new `cancelRemoteAgent` API and the optional-user / extra-args SSH transport spec.

## Tests & fixtures
- `ssh_attach_error.rs` integration test (plus a `tests/fixtures/fake-ssh/ssh` shim) verifying a failed connect surfaces the carrier's stderr rather than dumping it on the terminal.
- Kube connect call sites updated for the new cancel parameter.
- Connection-parameter tests updated for optional user.

## Status on #2234
Items 1, 2, 3, and 5 are implemented and verified. Item 4 (the genuinely *stuck* dock keyboard-focus state) remains open pending a concrete reproduction — in every state I could construct (Enter-dive, click-in-editor, Esc) focus reliably returns to the buffer; the earlier reproducible variant is fixed, and focus diagnostics are in place to catch the stuck case if it recurs.

https://claude.ai/code/session_013wMcJS73eipDubJeo4DFcL