### PR TITLE
fix(ci): resolve arm64 .deb shlibdeps failure in release build

### DIFF
--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -507,6 +507,7 @@ jobs:
             devscripts \
             fakeroot \
             lintian \
+            rsync \
             xz-utils
 
       - uses: actions/checkout@v6

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -255,9 +255,11 @@ jobs:
 
       - name: Install .rpm package
         run: |
-          # Fedora/Rocky minimal images default to tsflags=nodocs in dnf.conf,
-          # which skips man pages. Override with an empty tsflags so docs install
-          # and the man-page verification below reflects a real install.
+          # Fedora/Rocky minimal images ship neither the `file` utility (used by
+          # the ELF check below) nor, by default, man pages — dnf.conf sets
+          # tsflags=nodocs. Install `file` and override tsflags so docs install
+          # and the verification below reflects a real install.
+          dnf install -y file
           dnf install -y --setopt=tsflags='' packages/*.rpm
 
       - name: Verify installation

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -68,6 +68,26 @@ jobs:
             libc6-dev-arm64-cross \
             binutils-aarch64-linux-gnu
 
+      - name: Install arm64 runtime libraries for shlibdeps
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          # dpkg-shlibdeps (run by dh_shlibdeps during the .deb build) resolves
+          # the cross-built binary's library deps against installed dpkg metadata.
+          # libc6-dev-arm64-cross installs into /usr/aarch64-linux-gnu with no
+          # shlibs/symbols files, so dpkg-shlibdeps can neither find the libraries
+          # nor map them to package names. Enable the arm64 architecture and pull
+          # the real runtime libraries from the Ubuntu ports mirror; this both
+          # satisfies the lookup and lets ${shlibs:Depends} resolve to correct,
+          # versioned dependencies (libc6, libgcc-s1).
+          sed -i 's|^deb http|deb [arch=amd64] http|g' /etc/apt/sources.list
+          {
+            echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main restricted universe multiverse'
+            echo 'deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal-updates main restricted universe multiverse'
+          } >> /etc/apt/sources.list
+          dpkg --add-architecture arm64
+          apt-get update
+          apt-get install -y --no-install-recommends libc6:arm64 libgcc-s1:arm64
+
       - name: Install cargo-generate-rpm
         run: |
           cargo install cargo-generate-rpm

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -177,6 +177,11 @@ jobs:
 
       - name: Install .deb package
         run: |
+          # Ubuntu's minimal docker images ship /etc/dpkg/dpkg.cfg.d/excludes
+          # which path-excludes /usr/share/man and /usr/share/doc, so man pages
+          # never land on disk even though they're in the package. Remove it so
+          # the man-page verification below reflects a real install.
+          rm -f /etc/dpkg/dpkg.cfg.d/excludes
           apt-get update
           apt-get install -y ./packages/*.deb
 
@@ -250,7 +255,10 @@ jobs:
 
       - name: Install .rpm package
         run: |
-          dnf install -y packages/*.rpm
+          # Fedora/Rocky minimal images default to tsflags=nodocs in dnf.conf,
+          # which skips man pages. Override with an empty tsflags so docs install
+          # and the man-page verification below reflects a real install.
+          dnf install -y --setopt=tsflags='' packages/*.rpm
 
       - name: Verify installation
         run: |


### PR DESCRIPTION
## Problem

The release workflow's `build-linux-packages` job failed on the **arm64** leg at `dh_shlibdeps` → `dpkg-shlibdeps`:

```
dpkg-shlibdeps: error: cannot find library libc.so.6 needed by .../fresh (ELF format: 'elf64-littleaarch64' ...)
dpkg-shlibdeps: error: cannot find library libgcc_s.so.1 ...
(libutil, libpthread, libm, ld-linux-aarch64 ...)
```

`dpkg-shlibdeps` resolves the binary's `${shlibs:Depends}` by looking up each linked library in the installed dpkg metadata. The workflow only installed `libc6-dev-arm64-cross`, which drops arm64 libs into `/usr/aarch64-linux-gnu/` with **no shlibs/symbols files** and no dpkg registration — so the libraries could neither be found nor mapped to package names.

Only the arm64 leg is affected (amd64 builds natively). The amd64 `.deb` is the one installation-tested in CI, which is why this wasn't caught earlier.

## Fix

Add an arm64-only step that enables the `arm64` foreign architecture and installs the real runtime libraries from the Ubuntu ports mirror before the `.deb` build:

- Existing `archive.ubuntu.com` entries are pinned to `[arch=amd64]` (it doesn't serve arm64), and `ports.ubuntu.com` is added for `[arch=arm64]`.
- `libc6:arm64` provides `libc/libm/libpthread/libdl/libutil.so` and `ld-linux-aarch64.so.1`; `libgcc-s1:arm64` provides `libgcc_s.so.1` — exactly the missing libraries.
- These install into `/usr/lib/aarch64-linux-gnu/` **with** proper shlibs/symbols metadata, so `${shlibs:Depends}` resolves to correct, versioned dependencies. They coexist cleanly with the amd64 toolchain and `libc6-dev-arm64-cross`.

## Notes

- CI-only change; no runtime/source effect.
- The arm64 `.deb` still isn't installation-tested in CI (all `test-deb-*` jobs pull the amd64 artifact) — a QEMU-based arm64 smoke test could be a useful follow-up, but is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)