### PR TITLE
fix(config): treat 0 as "not set" for wrap_column, page_width, and tab_size

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -332,7 +332,7 @@
           "x-section": "Display"
         },
         "wrap_column": {
-          "description": "Column at which to wrap lines when line wrapping is enabled.\nIf not specified (`null`), lines wrap at the viewport edge (default behavior).\nExample: `80` wraps at column 80. The actual wrap column is clamped to the\nviewport width (lines can't wrap beyond the visible area).",
+          "description": "Column at which to wrap lines when line wrapping is enabled.\nIf not specified (`null`), lines wrap at the viewport edge (default behavior).\nA value of `0` is treated the same as `null` (no fixed wrap column).\nExample: `80` wraps at column 80. The actual wrap column is clamped to the\nviewport width (lines can't wrap beyond the visible area).",
           "type": [
             "integer",
             "null"
@@ -343,7 +343,7 @@
           "x-section": "Display"
         },
         "page_width": {
-          "description": "Width of the page in page view mode (in columns).\nControls the content width when page view is active, with centering margins.\nDefaults to 80. Set to `null` to use the full viewport width.",
+          "description": "Width of the page in page view mode (in columns).\nControls the content width when page view is active, with centering margins.\nDefaults to 80. Set to `null` (or `0`) to use the full viewport width.",
           "type": [
             "integer",
             "null"
@@ -515,7 +515,7 @@
           "x-section": "Editing"
         },
         "tab_size": {
-          "description": "Number of spaces per tab character",
+          "description": "Number of spaces per tab character\nA value of `0` is treated as unset and falls back to the default (4).",
           "type": "integer",
           "format": "uint",
           "minimum": 0,
@@ -1261,7 +1261,7 @@
           "default": null
         },
         "wrap_column": {
-          "description": "Column at which to wrap lines for this language.\nIf not specified (`null`), falls back to the global `editor.wrap_column` setting.",
+          "description": "Column at which to wrap lines for this language.\nIf not specified (`null`), falls back to the global `editor.wrap_column` setting.\nA value of `0` is treated as not set at this language level (inherits the global).",
           "type": [
             "integer",
             "null"
@@ -1279,7 +1279,7 @@
           "default": null
         },
         "page_width": {
-          "description": "Width of the page in page view mode (in columns).\nControls the content width when page view is active, with centering margins.\nIf not specified (`null`), falls back to the global `editor.page_width` setting.",
+          "description": "Width of the page in page view mode (in columns).\nControls the content width when page view is active, with centering margins.\nIf not specified (`null`), falls back to the global `editor.page_width` setting.\nA value of `0` is treated as not set at this language level (inherits the global).",
           "type": [
             "integer",
             "null"
@@ -1297,7 +1297,7 @@
           "default": null
         },
         "tab_size": {
-          "description": "Tab size (number of spaces per tab) for this language.\nIf not specified, falls back to the global editor.tab_size setting.",
+          "description": "Tab size (number of spaces per tab) for this language.\nIf not specified, falls back to the global editor.tab_size setting.\nA value of `0` is treated as not set at this language level (inherits the global).",
           "type": [
             "integer",
             "null"

--- a/crates/fresh-editor/src/app/buffer_config_resolve.rs
+++ b/crates/fresh-editor/src/app/buffer_config_resolve.rs
@@ -23,14 +23,16 @@ pub(crate) fn line_wrap(language: &str, config: &Config) -> bool {
 /// Effective `wrap_column` for a buffer with the given language.
 ///
 /// Returns the language-specific `wrap_column` if explicitly set, otherwise
-/// the global `editor.wrap_column`.
+/// the global `editor.wrap_column`. A resolved value of `0` (global or
+/// language-level) is treated as unset (`None`), i.e. wrap at the viewport
+/// edge rather than at a fixed column.
 pub(crate) fn wrap_column(language: &str, config: &Config) -> Option<usize> {
-    if let Some(lang_config) = config.languages.get(language) {
-        if lang_config.wrap_column.is_some() {
-            return lang_config.wrap_column;
-        }
-    }
-    config.editor.wrap_column
+    let resolved = config
+        .languages
+        .get(language)
+        .and_then(|lang_config| lang_config.wrap_column)
+        .or(config.editor.wrap_column);
+    resolved.filter(|&col| col != 0)
 }
 
 /// Effective `page_view` width for a buffer with the given language.
@@ -99,6 +101,24 @@ mod tests {
         let mut config = Config::default();
         config.editor.wrap_column = Some(80);
         assert_eq!(wrap_column("unknown", &config), Some(80));
+    }
+
+    #[test]
+    fn wrap_column_global_zero_is_treated_as_unset() {
+        let mut config = Config::default();
+        config.editor.wrap_column = Some(0);
+        assert_eq!(wrap_column("unknown", &config), None);
+    }
+
+    #[test]
+    fn wrap_column_language_zero_is_treated_as_unset() {
+        let mut lang = LanguageConfig::default();
+        lang.wrap_column = Some(0);
+        let mut config = config_with("rust", lang);
+        // Language override of 0 wins over the global, then normalizes to None —
+        // it does NOT fall through to the global value.
+        config.editor.wrap_column = Some(80);
+        assert_eq!(wrap_column("rust", &config), None);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/buffer_config_resolve.rs
+++ b/crates/fresh-editor/src/app/buffer_config_resolve.rs
@@ -23,16 +23,17 @@ pub(crate) fn line_wrap(language: &str, config: &Config) -> bool {
 /// Effective `wrap_column` for a buffer with the given language.
 ///
 /// Returns the language-specific `wrap_column` if explicitly set, otherwise
-/// the global `editor.wrap_column`. A resolved value of `0` (global or
-/// language-level) is treated as unset (`None`), i.e. wrap at the viewport
-/// edge rather than at a fixed column.
+/// the global `editor.wrap_column`. Zero-as-unset normalization happens at
+/// config resolution (`Config::normalize_zero_sentinels`), so a language-level
+/// `0` has already been cleared to `None` (inherits global) and a global `0`
+/// to `None` (wrap at the viewport edge) by the time we get here.
 pub(crate) fn wrap_column(language: &str, config: &Config) -> Option<usize> {
-    let resolved = config
-        .languages
-        .get(language)
-        .and_then(|lang_config| lang_config.wrap_column)
-        .or(config.editor.wrap_column);
-    resolved.filter(|&col| col != 0)
+    if let Some(lang_config) = config.languages.get(language) {
+        if lang_config.wrap_column.is_some() {
+            return lang_config.wrap_column;
+        }
+    }
+    config.editor.wrap_column
 }
 
 /// Effective `page_view` width for a buffer with the given language.
@@ -101,24 +102,6 @@ mod tests {
         let mut config = Config::default();
         config.editor.wrap_column = Some(80);
         assert_eq!(wrap_column("unknown", &config), Some(80));
-    }
-
-    #[test]
-    fn wrap_column_global_zero_is_treated_as_unset() {
-        let mut config = Config::default();
-        config.editor.wrap_column = Some(0);
-        assert_eq!(wrap_column("unknown", &config), None);
-    }
-
-    #[test]
-    fn wrap_column_language_zero_is_treated_as_unset() {
-        let mut lang = LanguageConfig::default();
-        lang.wrap_column = Some(0);
-        let mut config = config_with("rust", lang);
-        // Language override of 0 wins over the global, then normalizes to None —
-        // it does NOT fall through to the global value.
-        config.editor.wrap_column = Some(80);
-        assert_eq!(wrap_column("rust", &config), None);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -41,7 +41,9 @@ impl crate::app::window::Window {
     pub(crate) fn resolve_wrap_column_for_buffer(&self, buffer_id: BufferId) -> Option<usize> {
         match self.buffers.get(&buffer_id) {
             Some(state) => buffer_config_resolve::wrap_column(&state.language, self.config()),
-            None => self.config().editor.wrap_column,
+            // `0` means "no fixed wrap column" (wrap at the viewport edge), same
+            // as the resolver above.
+            None => self.config().editor.wrap_column.filter(|&col| col != 0),
         }
     }
 

--- a/crates/fresh-editor/src/app/buffer_management.rs
+++ b/crates/fresh-editor/src/app/buffer_management.rs
@@ -41,9 +41,7 @@ impl crate::app::window::Window {
     pub(crate) fn resolve_wrap_column_for_buffer(&self, buffer_id: BufferId) -> Option<usize> {
         match self.buffers.get(&buffer_id) {
             Some(state) => buffer_config_resolve::wrap_column(&state.language, self.config()),
-            // `0` means "no fixed wrap column" (wrap at the viewport edge), same
-            // as the resolver above.
-            None => self.config().editor.wrap_column.filter(|&col| col != 0),
+            None => self.config().editor.wrap_column,
         }
     }
 

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -801,6 +801,7 @@ pub struct EditorConfig {
 
     /// Column at which to wrap lines when line wrapping is enabled.
     /// If not specified (`null`), lines wrap at the viewport edge (default behavior).
+    /// A value of `0` is treated the same as `null` (no fixed wrap column).
     /// Example: `80` wraps at column 80. The actual wrap column is clamped to the
     /// viewport width (lines can't wrap beyond the visible area).
     #[serde(default)]
@@ -2149,6 +2150,7 @@ pub struct LanguageConfig {
 
     /// Column at which to wrap lines for this language.
     /// If not specified (`null`), falls back to the global `editor.wrap_column` setting.
+    /// A value of `0` means no fixed wrap column (wrap at the viewport edge).
     #[serde(default)]
     pub wrap_column: Option<usize>,
 
@@ -2355,6 +2357,12 @@ impl BufferConfig {
             if let Some(ref wc) = lang_config.word_characters {
                 config.word_characters = wc.clone();
             }
+        }
+
+        // A wrap column of `0` (global or language-level) means "no fixed wrap
+        // column" — wrap at the viewport edge, same as `null`.
+        if config.wrap_column == Some(0) {
+            config.wrap_column = None;
         }
 
         config
@@ -7271,6 +7279,34 @@ mod tests {
         // No language should use global wrap_column
         let no_lang_config = BufferConfig::resolve(&config, None);
         assert_eq!(no_lang_config.wrap_column, Some(120));
+    }
+
+    #[test]
+    fn test_buffer_config_wrap_column_zero_is_unset() {
+        let mut config = Config::default();
+        config.editor.wrap_column = Some(0);
+
+        // Language that explicitly sets 0 — should normalize to None, not wrap at 0.
+        config.languages.insert(
+            "markdown".to_string(),
+            LanguageConfig {
+                extensions: vec!["md".to_string()],
+                wrap_column: Some(0),
+                ..Default::default()
+            },
+        );
+
+        // Global 0 -> None
+        assert_eq!(
+            BufferConfig::resolve(&config, Some("rust")).wrap_column,
+            None
+        );
+        assert_eq!(BufferConfig::resolve(&config, None).wrap_column, None);
+        // Language-level 0 -> None
+        assert_eq!(
+            BufferConfig::resolve(&config, Some("markdown")).wrap_column,
+            None
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -810,7 +810,7 @@ pub struct EditorConfig {
 
     /// Width of the page in page view mode (in columns).
     /// Controls the content width when page view is active, with centering margins.
-    /// Defaults to 80. Set to `null` to use the full viewport width.
+    /// Defaults to 80. Set to `null` (or `0`) to use the full viewport width.
     #[serde(default = "default_page_width")]
     #[schemars(extend("x-section" = "Display"))]
     pub page_width: Option<usize>,
@@ -993,6 +993,7 @@ pub struct EditorConfig {
     pub use_tabs: bool,
 
     /// Number of spaces per tab character
+    /// A value of `0` is treated as unset and falls back to the default (4).
     #[serde(default = "default_tab_size")]
     #[schemars(extend("x-section" = "Editing"))]
     pub tab_size: usize,
@@ -2150,7 +2151,7 @@ pub struct LanguageConfig {
 
     /// Column at which to wrap lines for this language.
     /// If not specified (`null`), falls back to the global `editor.wrap_column` setting.
-    /// A value of `0` means no fixed wrap column (wrap at the viewport edge).
+    /// A value of `0` is treated as not set at this language level (inherits the global).
     #[serde(default)]
     pub wrap_column: Option<usize>,
 
@@ -2164,6 +2165,7 @@ pub struct LanguageConfig {
     /// Width of the page in page view mode (in columns).
     /// Controls the content width when page view is active, with centering margins.
     /// If not specified (`null`), falls back to the global `editor.page_width` setting.
+    /// A value of `0` is treated as not set at this language level (inherits the global).
     #[serde(default)]
     pub page_width: Option<usize>,
 
@@ -2175,6 +2177,7 @@ pub struct LanguageConfig {
 
     /// Tab size (number of spaces per tab) for this language.
     /// If not specified, falls back to the global editor.tab_size setting.
+    /// A value of `0` is treated as not set at this language level (inherits the global).
     #[serde(default)]
     pub tab_size: Option<usize>,
 
@@ -2357,12 +2360,6 @@ impl BufferConfig {
             if let Some(ref wc) = lang_config.word_characters {
                 config.word_characters = wc.clone();
             }
-        }
-
-        // A wrap column of `0` (global or language-level) means "no fixed wrap
-        // column" — wrap at the viewport edge, same as `null`.
-        if config.wrap_column == Some(0) {
-            config.wrap_column = None;
         }
 
         config
@@ -3309,6 +3306,42 @@ impl MenuConfig {
 impl Config {
     /// The config filename used throughout the application
     pub(crate) const FILENAME: &'static str = "config.json";
+
+    /// Normalize "0 means not set" sentinels left over from user config.
+    ///
+    /// For these numeric settings a `0` is treated as "not set" rather than a
+    /// literal zero (which would otherwise produce nonsense — e.g. a wrap
+    /// column of 0 wraps every character, a tab size of 0 divides by zero):
+    /// - At the **global** (`editor`) level, `0` falls back to the built-in
+    ///   default behavior: `wrap_column`/`page_width` become `None` (viewport
+    ///   edge / full viewport width) and `tab_size` becomes the default (4).
+    /// - At the **language** level, `0` clears the override to `None` so it
+    ///   inherits the global value, exactly as if the key were omitted.
+    ///
+    /// Called once when the layered config is resolved, so every downstream
+    /// `lang.or(global)` / `lang.unwrap_or(global)` resolver sees clean values.
+    pub(crate) fn normalize_zero_sentinels(&mut self) {
+        if self.editor.wrap_column == Some(0) {
+            self.editor.wrap_column = None;
+        }
+        if self.editor.page_width == Some(0) {
+            self.editor.page_width = None;
+        }
+        if self.editor.tab_size == 0 {
+            self.editor.tab_size = default_tab_size();
+        }
+        for lang in self.languages.values_mut() {
+            if lang.wrap_column == Some(0) {
+                lang.wrap_column = None;
+            }
+            if lang.page_width == Some(0) {
+                lang.page_width = None;
+            }
+            if lang.tab_size == Some(0) {
+                lang.tab_size = None;
+            }
+        }
+    }
 
     /// Push config values into process-wide flags that need to be readable
     /// from contexts which don't carry a `Config` handle (e.g. the
@@ -7282,31 +7315,51 @@ mod tests {
     }
 
     #[test]
-    fn test_buffer_config_wrap_column_zero_is_unset() {
+    fn test_normalize_zero_sentinels_global() {
         let mut config = Config::default();
         config.editor.wrap_column = Some(0);
+        config.editor.page_width = Some(0);
+        config.editor.tab_size = 0;
 
-        // Language that explicitly sets 0 — should normalize to None, not wrap at 0.
+        config.normalize_zero_sentinels();
+
+        // Global 0 -> default behavior.
+        assert_eq!(config.editor.wrap_column, None);
+        assert_eq!(config.editor.page_width, None);
+        assert_eq!(config.editor.tab_size, default_tab_size());
+    }
+
+    #[test]
+    fn test_normalize_zero_sentinels_language_inherits_global() {
+        let mut config = Config::default();
+        config.editor.wrap_column = Some(120);
+        config.editor.page_width = Some(80);
+        config.editor.tab_size = 8;
+
+        // A language that sets everything to 0 — should clear to None so it
+        // inherits the (non-zero) global values, NOT become the default.
         config.languages.insert(
             "markdown".to_string(),
             LanguageConfig {
                 extensions: vec!["md".to_string()],
                 wrap_column: Some(0),
+                page_width: Some(0),
+                tab_size: Some(0),
                 ..Default::default()
             },
         );
 
-        // Global 0 -> None
-        assert_eq!(
-            BufferConfig::resolve(&config, Some("rust")).wrap_column,
-            None
-        );
-        assert_eq!(BufferConfig::resolve(&config, None).wrap_column, None);
-        // Language-level 0 -> None
-        assert_eq!(
-            BufferConfig::resolve(&config, Some("markdown")).wrap_column,
-            None
-        );
+        config.normalize_zero_sentinels();
+
+        let lang = &config.languages["markdown"];
+        assert_eq!(lang.wrap_column, None);
+        assert_eq!(lang.page_width, None);
+        assert_eq!(lang.tab_size, None);
+
+        // Resolved buffer config inherits the global values.
+        let md = BufferConfig::resolve(&config, Some("markdown"));
+        assert_eq!(md.wrap_column, Some(120));
+        assert_eq!(md.tab_size, 8);
     }
 
     #[test]

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -1231,7 +1231,7 @@ impl PartialConfig {
             result
         };
 
-        crate::config::Config {
+        let mut config = crate::config::Config {
             version: self.version.unwrap_or(defaults.version),
             theme: self.theme.unwrap_or_else(|| defaults.theme.clone()),
             locale: crate::config::LocaleName::from(
@@ -1280,7 +1280,11 @@ impl PartialConfig {
                 .packages
                 .map(|e| e.resolve(&defaults.packages))
                 .unwrap_or_else(|| defaults.packages.clone()),
-        }
+        };
+        // Treat `0` as "not set" for numeric settings where a literal zero is
+        // meaningless (wrap_column, page_width, tab_size).
+        config.normalize_zero_sentinels();
+        config
     }
 }
 


### PR DESCRIPTION
## Problem

Closes #2177 — "Live-diff view has weird single-letter wrapping in all diffs of a file."

A `wrap_column` of `0` resolved to an effective wrap width of `1` (`0.min(w)` → `0`, then `0.saturating_sub(1).max(1)` → `1`), wrapping every single character — the garbage layout in #2177. The same "literal zero is meaningless" problem exists for two sibling settings:

- `page_width = 0` → a zero-width page in page view.
- `tab_size = 0` → divide-by-zero in the tab-stop math (`self.tab_size - (col % self.tab_size)`).

## Fix

Treat `0` as **"not set"** for these three numeric settings, centralized in `Config::normalize_zero_sentinels()` and applied once when the layered config is resolved (`PartialConfig::resolve_with_defaults`):

- **Global (`editor`) `0` → default behavior:** `wrap_column` and `page_width` become `None` (viewport edge / full viewport width); `tab_size` becomes the default (`4`).
- **Language-level `0` → cleared to `None`,** so it inherits the global value, exactly as if the key were omitted.

Doing it at resolution time means every downstream `lang.or(global)` / `lang.unwrap_or(global)` resolver sees clean values with no per-call special-casing.

## Tests

- `test_normalize_zero_sentinels_global` — global `0` for all three falls back to default behavior.
- `test_normalize_zero_sentinels_language_inherits_global` — language-level `0` clears to `None` and inherits the (non-zero) global, rather than becoming the default.

## Other

- Regenerated `plugins/config-schema.json` and updated the doc comments for all four fields (global + per-language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)