### PR TITLE
fix(lsp): suppress hover popups while the LSP status popup is open

### DIFF
--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -1194,9 +1194,29 @@ impl Editor {
     /// This implements debounced hover - we wait for the configured delay before
     /// sending the request to avoid spamming the LSP server on every mouse move.
     /// Returns true if a hover request was triggered.
+    /// True when the LSP status popup (the one opened by clicking the "LSP"
+    /// indicator in the status bar) is the top popup.
+    ///
+    /// Hover popups share the active state's popup stack with it, but the LSP
+    /// status popup is non-transient, so the hover dismiss-transients pass
+    /// leaves it in place and a hover would stack on top of it. Callers use
+    /// this to suppress hover while it is open.
+    pub(crate) fn is_lsp_status_popup_open(&self) -> bool {
+        self.active_state()
+            .popups
+            .top()
+            .is_some_and(|p| matches!(p.resolver, crate::view::popup::PopupResolver::LspStatus))
+    }
+
     pub fn check_mouse_hover_timer(&mut self) -> bool {
         // Check if mouse hover is enabled
         if !self.config.editor.mouse_hover_enabled {
+            return false;
+        }
+
+        // Suppress hover while the LSP status popup is open so the hover card
+        // doesn't stack on top of it.
+        if self.is_lsp_status_popup_open() {
             return false;
         }
 

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -900,6 +900,14 @@ impl Editor {
             tracing::debug!("Ignoring stale hover response: {}", request_id);
             return;
         };
+
+        // A hover request may have been in flight when the user opened the
+        // status-bar LSP status popup. Don't show the hover card on top of it.
+        if self.is_lsp_status_popup_open() {
+            tracing::debug!("Suppressing hover response: LSP status popup is open");
+            self.active_window_mut().hover.set_symbol_range(None);
+            return;
+        }
         let hover_lsp_position = Some(position);
 
         // Gather any diagnostics whose range overlaps the hover position so

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -697,13 +697,15 @@ impl Editor {
         tracing::trace!(col, row, "update_lsp_hover_state: raw mouse position");
 
         // Suppress LSP hover when a popup is already visible (e.g. theme info popup,
-        // tab context menu) to avoid hover tooltips overlapping other popups.
+        // tab context menu, or the status-bar LSP status popup) to avoid hover
+        // tooltips overlapping other popups.
         if self.active_window_mut().theme_info_popup.is_some()
             || self.active_window_mut().tab_context_menu.is_some()
             || self
                 .active_window_mut()
                 .file_explorer_context_menu
                 .is_some()
+            || self.is_lsp_status_popup_open()
         {
             if self
                 .active_window_mut()

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -7245,6 +7245,98 @@ fn test_hover_does_not_trigger_on_empty_line() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression (#2244): while the status-bar LSP status popup is open, moving the
+/// mouse over a symbol must NOT show the LSP hover card on top of it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_hover_suppressed_while_lsp_status_popup_open() -> anyhow::Result<()> {
+    use crate::common::fake_lsp::FakeLspServer;
+    use std::time::Duration;
+
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn(temp_dir.path())?;
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "use std;\n\nfn foo() {}\n\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // `fn foo() {}` is line 3 -> display row 4 after the tab bar; `foo` sits
+    // around column 10. Sanity-check that hover works normally first, so the
+    // suppression assertion below can't pass for the wrong reason.
+    let symbol_row = 4u16;
+    let symbol_col = 10u16;
+    harness.mouse_move(symbol_col, symbol_row)?;
+    harness.render()?;
+    harness.sleep(Duration::from_millis(600));
+    harness.editor_mut().force_check_mouse_hover();
+    harness.wait_until(|h| h.screen_to_string().contains("Test hover content"))?;
+
+    // Dismiss the hover by moving away.
+    harness.mouse_move(0, 0)?;
+    harness.render()?;
+    harness.sleep(Duration::from_millis(100));
+    harness.editor_mut().force_check_mouse_hover();
+    harness.wait_until(|h| !h.screen_to_string().contains("Test hover content"))?;
+
+    // Open the LSP status popup (same entry point as clicking the indicator).
+    harness.editor_mut().show_lsp_status_popup();
+    harness.render()?;
+    harness.wait_until(|h| h.screen_to_string().contains("LSP Servers (rust)"))?;
+
+    // Now hover over the symbol again. The hover card must NOT appear.
+    harness.mouse_move(symbol_col, symbol_row)?;
+    harness.render()?;
+    harness.sleep(Duration::from_millis(600));
+    harness.editor_mut().force_check_mouse_hover();
+    for _ in 0..10 {
+        harness.process_async_and_render()?;
+        harness.sleep(Duration::from_millis(100));
+    }
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Test hover content"),
+        "Hover card must not show while the LSP status popup is open. Screen:\n{}",
+        screen
+    );
+    // The LSP status popup itself should still be on screen.
+    assert!(
+        screen.contains("LSP Servers (rust)"),
+        "LSP status popup should remain open. Screen:\n{}",
+        screen
+    );
+
+    Ok(())
+}
+
 /// Test that moving mouse within symbol during hover request does not create duplicate popups
 ///
 /// This reproduces a race condition:


### PR DESCRIPTION
## Problem

Closes #2244.

Clicking the **LSP** indicator in the status bar opens the LSP status popup. While it's open, mousing over a symbol still triggers the LSP hover card, which stacks **on top of** the status popup.

Root cause: the status popup is pushed onto the active state's popup stack and is **non-transient**. Hover cards live on that same stack, but the hover code's "dismiss existing transient popups before showing" pass only clears *transient* popups — so the hover ends up layered over the (non-transient) status popup.

## Fix

Guard every hover entry point against an open LSP status popup (new shared helper `Editor::is_lsp_status_popup_open`):

- **`update_lsp_hover_state`** (primary) — extends the existing popup-suppression check (theme info / tab / file-explorer menus) so the hover state is never armed. This also avoids the symbol-highlight overlay, not just the popup.
- **`check_mouse_hover_timer`** — bails before dispatching a hover request (covers the case where hover state was armed just before the popup opened).
- **`handle_hover_response`** — drops a response that was already in flight when the popup opened, rather than displaying it.

## Test

`test_hover_suppressed_while_lsp_status_popup_open` (e2e): connects a fake LSP, confirms hover works normally, opens the status popup, then mouses over the symbol and asserts the hover card never appears while the popup stays open. Verified it **fails without** the guards and **passes with** them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)