### PR TITLE
Route terminal bracketed paste to the focused dialog field

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1114,6 +1114,52 @@ impl Editor {
         }
     }
 
+    /// Route a terminal-initiated bracketed paste to a focused
+    /// floating panel (Orchestrator picker / New-Session form / plugin
+    /// overlay) or focused dock when one owns the keyboard.
+    ///
+    /// Bracketed paste arrives as a single `Event::Paste` rather than
+    /// per-key events, so — unlike typed characters and `Ctrl+V` — it
+    /// never passes through `dispatch_floating_widget_key`. Without this
+    /// routing it falls straight through to `paste_text`, which targets
+    /// the buffer underneath the modal (the user-reported bug: pasting
+    /// into the New-Session dialog dumped the text into the obscured
+    /// file instead of the focused field).
+    ///
+    /// Returns `true` when a panel owns the keyboard (the paste was
+    /// either inserted into its focused `Text` widget, or deliberately
+    /// swallowed because focus isn't on a text field — a modal with no
+    /// text input focused must ignore the paste, not leak it into the
+    /// hidden buffer). Returns `false` when no panel owns the keyboard,
+    /// so the caller falls back to the normal `paste_text` path.
+    pub(crate) fn paste_bracketed_into_focused_panel(&mut self, text: &str) -> bool {
+        // Mirror the keyboard-dispatch precedence in `handle_key`: a
+        // focused centered modal wins over a focused dock.
+        let slot = if self
+            .floating_widget_panel
+            .as_ref()
+            .is_some_and(|f| f.focused)
+        {
+            super::PanelSlot::Floating
+        } else if self.dock.as_ref().is_some_and(|d| d.focused) {
+            super::PanelSlot::Dock
+        } else {
+            return false;
+        };
+        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
+            return false;
+        };
+        if self.panel_focused_widget_is_text(panel_id) {
+            // Single-line `TextEdit` strips embedded newlines; multi-line
+            // stores plain `\n`. Normalise CRLF / CR → LF first, matching
+            // the `Action::Paste` widget-routing path.
+            let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+            self.handle_widget_insert_str(panel_id, &normalized);
+            self.set_status_message(t!("clipboard.pasted").to_string());
+        }
+        true
+    }
+
     /// Paste text directly into the editor
     ///
     /// Handles:

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -307,7 +307,14 @@ impl Editor {
             Ev::Paste(text) => {
                 // Terminal-initiated bracketed paste — no async read
                 // needed, the terminal already harvested the clipboard.
-                self.paste_text(text);
+                // When a floating modal / dock owns the keyboard the
+                // paste belongs to its focused text field, not the
+                // buffer underneath; route there first (and let a modal
+                // with no text field focused swallow it) before falling
+                // back to the buffer/prompt paste path.
+                if !self.paste_bracketed_into_focused_panel(&text) {
+                    self.paste_text(text);
+                }
                 Ok(true)
             }
             Ev::FocusGained => {

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -1649,16 +1649,31 @@ impl Editor {
         buffer_id: crate::model::event::BufferId,
     ) -> Option<u64> {
         for panel_id in self.widget_registry.panels_for_buffer(buffer_id) {
-            let panel = self.widget_registry.get(panel_id)?;
-            if panel.focus_key.is_empty() {
-                continue;
-            }
-            let widget = crate::widgets::find_widget_by_key(&panel.spec, &panel.focus_key);
-            if matches!(widget, Some(fresh_core::api::WidgetSpec::Text { .. })) {
+            if self.panel_focused_widget_is_text(panel_id) {
                 return Some(panel_id);
             }
         }
         None
+    }
+
+    /// True when `panel_id`'s currently-focused widget is a `Text`
+    /// field (so it can accept clipboard insertion). `false` when the
+    /// panel is gone, has no focus, or focus rests on a non-text
+    /// widget (`Button` / `List` / `Toggle` / …). This is the shared
+    /// predicate behind both the buffer-mounted paste routing
+    /// (`focused_text_widget_panel_for_buffer`) and the floating-panel
+    /// bracketed-paste routing (`paste_bracketed_into_focused_panel`).
+    pub(super) fn panel_focused_widget_is_text(&self, panel_id: u64) -> bool {
+        let Some(panel) = self.widget_registry.get(panel_id) else {
+            return false;
+        };
+        if panel.focus_key.is_empty() {
+            return false;
+        }
+        matches!(
+            crate::widgets::find_widget_by_key(&panel.spec, &panel.focus_key),
+            Some(fresh_core::api::WidgetSpec::Text { .. })
+        )
     }
 
     /// Read the currently-selected text from the focused `Text`

--- a/crates/fresh-editor/tests/common/harness.rs
+++ b/crates/fresh-editor/tests/common/harness.rs
@@ -1385,6 +1385,20 @@ impl EditorTestHarness {
         Ok(())
     }
 
+    /// Deliver a terminal-initiated bracketed paste, exactly as the
+    /// event loop does for `crossterm::event::Event::Paste` — the
+    /// single-`Event::Paste` path the terminal uses (distinct from the
+    /// per-key `type_text` path and from `Ctrl+V`). Routes through the
+    /// editor's real `handle_input_event` so floating-panel / dock
+    /// paste routing is exercised.
+    pub fn send_paste(&mut self, text: &str) -> anyhow::Result<()> {
+        self.editor
+            .handle_input_event(crossterm::event::Event::Paste(text.to_string()))?;
+        self.drain_async_work();
+        self.render()?;
+        Ok(())
+    }
+
     /// Force a render cycle and capture output
     pub fn render(&mut self) -> anyhow::Result<()> {
         self.terminal.draw(|frame| {

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -646,3 +646,102 @@ fn completion_popup_scrolls_with_mouse_wheel() {
         screen,
     );
 }
+
+/// A terminal bracketed paste (`Event::Paste`, the single-event path
+/// a real terminal emits for clipboard paste — distinct from typed
+/// keys and from `Ctrl+V`) must land in the focused Project Path
+/// field, NOT in the buffer obscured by the modal.
+///
+/// Regression for the reported bug: with the New-Session dialog open,
+/// pasting via the terminal dumped the text into the underlying file
+/// buffer instead of the focused dialog field. Bracketed paste arrives
+/// as one `Event::Paste` that never passes through the floating-panel
+/// key dispatcher, so it fell straight through to the buffer paste
+/// path. Without the fix the Project Path field stays unchanged (the
+/// text went to the buffer) and this assertion fails.
+#[test]
+fn bracketed_paste_routes_to_focused_dialog_field() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+
+    // The Project Path text field is focused on open. Paste a marker
+    // through the real bracketed-paste event path.
+    harness.send_paste("PASTEDMARKER").unwrap();
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()).contains("PASTEDMARKER"))
+        .unwrap();
+
+    assert!(
+        project_path_field_value(&harness.screen_to_string()).contains("PASTEDMARKER"),
+        "bracketed paste should land in the focused Project Path field. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+
+    // And it must not have leaked into the buffer underneath: close
+    // the dialog (Esc cancels) and confirm the marker is nowhere on
+    // the now-revealed buffer.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR :: New Session"))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("PASTEDMARKER"),
+        "bracketed paste must not leak into the buffer behind the dialog. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// When the dialog is open but focus rests on a non-text widget (a
+/// button / backend tab), a terminal bracketed paste must be ignored
+/// — neither inserted into any field nor leaked into the obscured
+/// buffer.
+///
+/// The form's tab cycle always starts with the "Run in:" backend
+/// tabs (`[local, ssh, kubernetes, devcontainer, project_path, …]`)
+/// and opens with `project_path` focused, so a single Shift+Tab walks
+/// focus back onto the `devcontainer` backend tab — a non-text Button,
+/// regardless of git / worktree state. Pasting there must be
+/// swallowed. Without the fix the paste falls through to the buffer;
+/// revealing the buffer after Esc shows the marker and this fails.
+#[test]
+fn bracketed_paste_ignored_when_non_text_widget_focused() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+
+    // Walk focus off the Project Path text field onto a backend tab
+    // (a non-text Button) — the tabbable immediately before it.
+    harness
+        .send_key(KeyCode::BackTab, KeyModifiers::NONE)
+        .unwrap();
+
+    harness.send_paste("IGNORED_PASTE").unwrap();
+    harness.tick_and_render().unwrap();
+
+    // No field absorbed it (it would render inside the dialog).
+    assert!(
+        !harness.screen_to_string().contains("IGNORED_PASTE"),
+        "paste onto a non-text widget must not appear in any field. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+
+    // And — the load-bearing check — it must not have leaked into the
+    // buffer underneath. Without the fix the paste falls through to
+    // the hidden buffer; revealing it after Esc surfaces the marker.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR :: New Session"))
+        .unwrap();
+    assert!(
+        !harness.screen_to_string().contains("IGNORED_PASTE"),
+        "an ignored paste must not leak into the buffer behind the dialog. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}


### PR DESCRIPTION
When a floating widget modal (the Orchestrator "New Session" form /
picker) or a focused dock owns the keyboard, a terminal-initiated
bracketed paste was inserted into the buffer obscured by the modal
instead of the focused text field. Typed characters and Ctrl+V route
through `dispatch_floating_widget_key`, but bracketed paste arrives as a
single `Event::Paste` that bypassed it entirely and fell straight to the
buffer paste path.

Route `Event::Paste` through the same precedence the keyboard dispatch
uses: a focused floating panel / dock claims the paste. It lands in the
panel's focused `Text` widget, or — when focus is on a non-text widget —
is swallowed so the paste can never leak into the hidden buffer.

Adds a `send_paste` test harness helper that drives the real
`handle_input_event` bracketed-paste path, and two e2e tests: one
asserting the paste reaches the focused field (times out without the fix
since the field never receives it), one asserting a paste onto a
non-text widget is ignored and never reaches the buffer behind the
dialog.

https://claude.ai/code/session_01FtkoUcthCSyEDauLCNmGYb