### PR TITLE
conditionally cp plugins

### DIFF
--- a/crates/fresh-editor/packaging/aur/fresh-editor/PKGBUILD.template
+++ b/crates/fresh-editor/packaging/aur/fresh-editor/PKGBUILD.template
@@ -43,8 +43,10 @@ package() {
     # License
     install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-    # Plugins
-    cp -r crates/fresh-editor/plugins "$pkgdir/usr/share/$pkgname/"
+    # Plugins (not shipped in all releases)
+    if [ -d plugins ]; then
+      cp -r plugins "$pkgdir/usr/share/fresh-editor/"
+    fi
 
     # Keymaps
     cp -r crates/fresh-editor/keymaps "$pkgdir/usr/share/$pkgname/"


### PR DESCRIPTION
(Potential) Fix #2250 
I am just getting started with Fresh and installing on CachyOS is broken. I applied this fix locally (I am not sure why `plugins` does not exist) and it completed.

This may not be an appropriate change - maybe the folder should exist?