### PR TITLE
aur(fresh-editor-bin): drop obsolete plugins copy from PKGBUILD template

### DIFF
--- a/crates/fresh-editor/packaging/aur/fresh-editor-bin/PKGBUILD.template
+++ b/crates/fresh-editor/packaging/aur/fresh-editor-bin/PKGBUILD.template
@@ -39,8 +39,8 @@ package() {
     # License
     install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 
-    # Plugins
-    cp -r plugins "$pkgdir/usr/share/fresh-editor/"
+    # Plugins and themes are compiled into the binary (embed-plugins feature),
+    # so the release tarball ships no on-disk plugins/ directory.
 
     # Desktop file
     install -Dm644 fresh.desktop "$pkgdir/usr/share/applications/fresh.desktop"


### PR DESCRIPTION
Since plugins and themes are compiled into the binary (embed-plugins feature), the release tarball no longer ships an on-disk plugins/ directory. The `cp -r plugins` step in package() therefore fails with "cp: cannot stat 'plugins': No such file or directory", breaking install.sh's manual AUR build path on Arch.

Remove the copy. aur-publish.yml regenerates the published PKGBUILD from this template, so future releases won't reintroduce the bug.

Fixes #2250