### PR TITLE
Make dock project dropdown keyboard-navigable

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -463,6 +463,12 @@ interface OpenDialogState {
   projectFilter: string | null;
   // `true` while the dock project dropdown overlay is open.
   projectMenuOpen: boolean;
+  // Keyboard cursor (highlighted row) within the open project
+  // dropdown, indexing `projectMenuKeys()` (0 = "All projects").
+  // Distinct from `projectFilter`, which is the *applied* scope shown
+  // with a `●`; this is just where ↑/↓ currently sit before Enter
+  // commits. Only meaningful while `projectMenuOpen`.
+  projectMenuIndex: number;
 }
 let openDialog: OpenDialogState | null = null;
 let openPanel: FloatingWidgetPanel | null = null;
@@ -2227,6 +2233,21 @@ function refreshOpenDialog(): void {
   }
 }
 
+// Move the dock's highlighted row onto the active window. Used when the
+// active session changes from *outside* the dock's own ↑/↓ live-switch —
+// a new session is created, or another window is focused — so the dock,
+// which is a passive mirror while blurred, highlights the session the
+// editor actually switched to instead of stranding the highlight on the
+// previously-active row. No-op when the active window isn't in the
+// (filtered) list.
+function syncDockSelectionToActive(): void {
+  if (!openDialog || !openPanel || !dockMode) return;
+  const idx = openDialog.filteredIds.indexOf(editor.activeWindow());
+  if (idx < 0) return;
+  openDialog.selectedIndex = idx;
+  openPanel.setSelectedIndex("sessions", idx);
+}
+
 // =============================================================================
 // PR probe — opportunistic `gh` integration for the pill's second line
 //
@@ -2508,6 +2529,7 @@ function openControlRoom(opts: { dock?: boolean } = {}): void {
     bulkInFlight: null,
     projectFilter: asDock ? lastDockProjectFilter : null,
     projectMenuOpen: false,
+    projectMenuIndex: 0,
   };
   // Set `dockMode` BEFORE the initial `filterSessions("")`. The sort
   // inside `filterSessions` keys off `pinCurrentFirst = !dockMode`: the
@@ -2693,37 +2715,122 @@ function dockTitleRow(): WidgetSpec {
   };
 }
 
+// Option keys for the dock's project dropdown, in display order. Index 0
+// is always "All projects" (the empty-string key); the rest are the
+// projects with a session in the worktree/trivial-filtered set. The
+// project menu's keyboard cursor (`projectMenuIndex`) and the
+// `dock_menu_*` nav handlers index into this list, so it's the single
+// source of truth for both render and navigation.
+function projectMenuKeys(): string[] {
+  return ["", ...dockProjectOptions()];
+}
+
+// The `project-pick:<key>` widget key for a menu row — the host reads
+// this focus key to recognise that the dropdown (not the session list)
+// owns the keyboard, and to route ↑/↓/Enter/Esc to the `dock_menu_*`
+// events. Empty suffix = "All projects".
+function projectPickKey(optionKey: string): string {
+  return `project-pick:${optionKey}`;
+}
+
 // Floating menu for the dock's project dropdown: "All projects" plus
 // every project with a session in the worktree/trivial-filtered set.
 // Anchored just under the toolbar via `overlay`, so it paints over the
 // rows below without reflowing them. Each option is a button whose key
 // (`project-pick:<key>`, empty suffix = all) the widget_event handler
-// decodes.
+// decodes. The `●` marks the *applied* filter; the `primary` intent
+// marks the keyboard *cursor* (`projectMenuIndex`) — two separate
+// signals so ↑/↓ can move the cursor over options without yet applying
+// them, the way a standard dropdown behaves.
 function dockProjectMenu(): WidgetSpec {
   const cur = openDialog?.projectFilter ?? null;
-  const opts = dockProjectOptions();
-  const rows: WidgetSpec[] = [
-    row(
-      button(cur === null ? "● All projects" : "  All projects", {
-        key: "project-pick:",
-        intent: cur === null ? "primary" : "normal",
+  const keys = projectMenuKeys();
+  const cursor = clampMenuIndex(openDialog?.projectMenuIndex ?? 0, keys.length);
+  const rows: WidgetSpec[] = keys.map((key, i) => {
+    const applied = key === "" ? cur === null : key === cur;
+    const label = key === "" ? "All projects" : projectLabel(key);
+    return row(
+      button((applied ? "● " : "  ") + label, {
+        key: projectPickKey(key),
+        intent: i === cursor ? "primary" : "normal",
       }),
       flexSpacer(),
-    ),
-  ];
-  for (const key of opts) {
-    const sel = key === cur;
-    rows.push(
-      row(
-        button((sel ? "● " : "  ") + projectLabel(key), {
-          key: `project-pick:${key}`,
-          intent: sel ? "primary" : "normal",
-        }),
-        flexSpacer(),
-      ),
     );
-  }
+  });
   return overlay(labeledSection({ label: "project", child: col(...rows) }));
+}
+
+// Clamp a menu cursor into `[0, len)`, tolerating an empty list.
+function clampMenuIndex(idx: number, len: number): number {
+  if (len <= 0) return 0;
+  return Math.max(0, Math.min(idx, len - 1));
+}
+
+// Open the dock's project dropdown and hand it the keyboard. Seeds the
+// cursor on the *applied* option (so ↑/↓ start from where you are) and
+// moves panel focus onto that option's button — which is the signal the
+// host uses to route nav keys here instead of the session list.
+function openProjectMenu(): void {
+  if (!openDialog || !openPanel) return;
+  const keys = projectMenuKeys();
+  const applied = openDialog.projectFilter;
+  const idx = applied === null ? 0 : Math.max(0, keys.indexOf(applied));
+  openDialog.projectMenuOpen = true;
+  openDialog.projectMenuIndex = clampMenuIndex(idx, keys.length);
+  // Render the menu first so its buttons exist in the spec, *then* move
+  // focus onto the cursor row — otherwise the host re-clamps an unknown
+  // focus key back to the first tabbable.
+  openPanel.update(buildDockSpec());
+  openPanel.setFocusKey(projectPickKey(keys[openDialog.projectMenuIndex]));
+}
+
+// Close the dropdown and return the keyboard to the session list.
+function closeProjectMenu(): void {
+  if (!openDialog || !openPanel) return;
+  openDialog.projectMenuOpen = false;
+  openPanel.update(buildDockSpec());
+  openPanel.setFocusKey("sessions");
+}
+
+// Move the dropdown cursor by `delta` (clamped, no wrap) and keep panel
+// focus on the highlighted row so the host keeps routing nav keys here.
+function moveProjectMenu(delta: number): void {
+  if (!openDialog || !openPanel || !openDialog.projectMenuOpen) return;
+  const keys = projectMenuKeys();
+  const next = clampMenuIndex(openDialog.projectMenuIndex + delta, keys.length);
+  openDialog.projectMenuIndex = next;
+  openPanel.update(buildDockSpec());
+  openPanel.setFocusKey(projectPickKey(keys[next]));
+}
+
+// Commit the cursor's option as the active project filter and close.
+function acceptProjectMenu(): void {
+  if (!openDialog || !openDialog.projectMenuOpen) return;
+  const keys = projectMenuKeys();
+  const key = keys[clampMenuIndex(openDialog.projectMenuIndex, keys.length)] ?? "";
+  pickProject(key);
+}
+
+// Apply a project-dropdown option (empty = "All projects") as the dock's
+// project filter, re-filter the session list, close the menu, and return
+// focus to the list. Shared by mouse clicks on a row, Enter on the
+// keyboard cursor, and any programmatic pick.
+function pickProject(optionKey: string): void {
+  if (!openDialog) return;
+  openDialog.projectFilter = optionKey === "" ? null : optionKey;
+  lastDockProjectFilter = openDialog.projectFilter;
+  // Re-filter to the chosen project and keep the active session selected
+  // when it's still in view.
+  const activeId = editor.activeWindow();
+  const next = filterSessions(openDialog.filter.value);
+  openDialog.filteredIds = next;
+  const activeIdx = next.indexOf(activeId);
+  openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
+  closeProjectMenu();
+  refreshOpenDialog();
+  if (openPanel && next.length > 0) {
+    openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+  }
 }
 
 // Single-column spec for the dock. Reuses the same `sessions` list key +
@@ -2760,13 +2867,24 @@ function buildDockSpec(): WidgetSpec {
   // (req: hide them when the editor owns the keyboard). A blurred dock
   // gives the row back to the list.
   const showHints = !dockBlurred;
+  // While the project dropdown owns the keyboard, the hints describe the
+  // dropdown (choose/select/cancel), not the session list — otherwise
+  // they'd advertise the wrong keys for where focus actually is.
   const hintRow = row(
     flexSpacer(),
-    hintBar([
-      { keys: "↑↓", label: "switch" },
-      { keys: "Enter", label: "edit" },
-      { keys: "Esc", label: "editor" },
-    ]),
+    hintBar(
+      openDialog.projectMenuOpen
+        ? [
+          { keys: "↑↓", label: "choose" },
+          { keys: "Enter", label: "select" },
+          { keys: "Esc", label: "cancel" },
+        ]
+        : [
+          { keys: "↑↓", label: "switch" },
+          { keys: "Enter", label: "edit" },
+          { keys: "Esc", label: "editor" },
+        ],
+    ),
     flexSpacer(),
   );
   const bottom: WidgetSpec[] = showHints ? [hintRow] : [];
@@ -5583,8 +5701,16 @@ async function submitForm(): Promise<void> {
       branch: reportedBranch || undefined,
     };
     orchestratorSessions.set(id, tracked);
-    // Refresh the dock so the freshly-created session shows up.
-    if (openPanel && dockMode) refreshOpenDialog();
+    // Refresh the dock so the freshly-created session shows up, then move
+    // the highlight onto it: it's now the active window, so the dock
+    // (blurred to hand focus to the new terminal) should point at it
+    // rather than leave the highlight on the previously-active row. The
+    // `active_window_changed` that fired mid-`createWindowWithTerminal`
+    // ran before this session was tracked, so it couldn't select it.
+    if (openPanel && dockMode) {
+      refreshOpenDialog();
+      syncDockSelectionToActive();
+    }
   } catch (e) {
     editor.setStatus(
       `Orchestrator: failed to start session — ${
@@ -6167,10 +6293,32 @@ editor.on("widget_event", (e) => {
     if (e.event_type === "dock_toggle_scope") {
       // The dock's scope control is now the project dropdown; Alt+P
       // opens/closes it instead of flipping the old current/all scope.
+      // Opening hands the keyboard to the menu; closing returns it to
+      // the session list.
       if (dockMode) {
-        openDialog.projectMenuOpen = !openDialog.projectMenuOpen;
-        if (openPanel) openPanel.update(buildDockSpec());
+        if (openDialog.projectMenuOpen) closeProjectMenu();
+        else openProjectMenu();
       }
+      return;
+    }
+    // Dock project dropdown keyboard nav. The host fires these only
+    // while panel focus sits on a `project-pick:` row (i.e. the menu is
+    // open and owns the keyboard), so ↑/↓/Enter/Esc drive the dropdown
+    // instead of leaking to the session list underneath.
+    if (e.event_type === "dock_menu_prev") {
+      moveProjectMenu(-1);
+      return;
+    }
+    if (e.event_type === "dock_menu_next") {
+      moveProjectMenu(1);
+      return;
+    }
+    if (e.event_type === "dock_menu_accept") {
+      acceptProjectMenu();
+      return;
+    }
+    if (e.event_type === "dock_menu_cancel") {
+      closeProjectMenu();
       return;
     }
     if (e.event_type === "change" && e.widget_key === "filter") {
@@ -6306,8 +6454,8 @@ editor.on("widget_event", (e) => {
     // Dock project dropdown: the toolbar button toggles the menu open,
     // and each option button picks a project (empty suffix = all).
     if (e.event_type === "activate" && e.widget_key === "project-menu") {
-      openDialog.projectMenuOpen = !openDialog.projectMenuOpen;
-      if (openPanel) openPanel.update(buildDockSpec());
+      if (openDialog.projectMenuOpen) closeProjectMenu();
+      else openProjectMenu();
       return;
     }
     if (
@@ -6315,21 +6463,7 @@ editor.on("widget_event", (e) => {
       typeof e.widget_key === "string" &&
       e.widget_key.startsWith("project-pick:")
     ) {
-      const key = e.widget_key.slice("project-pick:".length);
-      openDialog.projectFilter = key === "" ? null : key;
-      lastDockProjectFilter = openDialog.projectFilter;
-      openDialog.projectMenuOpen = false;
-      // Re-filter to the chosen project and keep the active session
-      // selected when it's still in view.
-      const activeId = editor.activeWindow();
-      const next = filterSessions(openDialog.filter.value);
-      openDialog.filteredIds = next;
-      const activeIdx = next.indexOf(activeId);
-      openDialog.selectedIndex = activeIdx >= 0 ? activeIdx : 0;
-      refreshOpenDialog();
-      if (openPanel && next.length > 0) {
-        openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
-      }
+      pickProject(e.widget_key.slice("project-pick:".length));
       return;
     }
     if (e.event_type === "activate" && e.widget_key === "scope-toggle") {
@@ -6488,6 +6622,12 @@ editor.on("active_window_changed", () => {
   const s = orchestratorSessions.get(editor.activeWindow());
   if (s) s.activatedAt = Date.now();
   refreshOpenDialog();
+  // A passive (blurred) dock mirrors the active window, so keep its
+  // highlighted row in sync when focus moves to another window from
+  // outside the dock. While the dock holds focus the user drives ↑/↓
+  // selection (and the debounced live-switch already aligns the two), so
+  // re-selecting here would fight the scroll — hence the blurred guard.
+  if (dockBlurred) syncDockSelectionToActive();
 });
 
 // Re-flow the open-picker on terminal resize. The dialog's

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2514,6 +2514,55 @@ impl Editor {
                 .focus_key(panel_id)
                 .map(|k| k == "filter")
                 .unwrap_or(false);
+            // The project dropdown owns the keyboard while panel focus
+            // sits on one of its `project-pick:` rows (the plugin moves
+            // focus there when the menu opens). In that state ↑/↓ move
+            // the dropdown cursor, Enter commits it, and Esc cancels —
+            // all routed to the plugin as `dock_menu_*` events. Without
+            // this, those keys fell through to the generic list nav
+            // below and drove the session list *under* the open menu,
+            // so the dropdown was visible but un-navigable by keyboard.
+            let on_project_menu = self
+                .widget_registry
+                .focus_key(panel_id)
+                .map(|k| k.starts_with("project-pick:"))
+                .unwrap_or(false);
+            if on_project_menu {
+                match code {
+                    KeyCode::Up => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        return true;
+                    }
+                    KeyCode::Down => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_next");
+                        return true;
+                    }
+                    // Tab/Shift+Tab navigate the menu too, so they can't
+                    // tab focus *out* of the open dropdown into the dock
+                    // toolbar behind it.
+                    KeyCode::Tab if modifiers.contains(KeyModifiers::SHIFT) => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        return true;
+                    }
+                    KeyCode::BackTab => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        return true;
+                    }
+                    KeyCode::Tab => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_next");
+                        return true;
+                    }
+                    KeyCode::Enter | KeyCode::Char(' ') => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_accept");
+                        return true;
+                    }
+                    KeyCode::Esc => {
+                        self.fire_dock_widget_event(panel_id, "dock_menu_cancel");
+                        return true;
+                    }
+                    _ => {}
+                }
+            }
             match code {
                 KeyCode::Esc => {
                     if on_filter {

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1235,9 +1235,36 @@ fn collect_list(
         let mut style = entry.style.clone().unwrap_or_default();
         style.bold = true;
         if entry.text.starts_with('┏') || entry.text.starts_with('┗') {
+            // Top / bottom rows are pure border, so a whole-row fg tints
+            // the corner-to-corner run.
             style.fg = Some(OverlayColorSpec::theme_key("ui.popup_border_fg"));
+            entry.style = Some(style);
+        } else {
+            // Side rows hold the session text between two vertical border
+            // glyphs. A whole-row fg would repaint the name / git text
+            // (which only carries an fg overlay when the row is *active*),
+            // so tint just the leading and trailing `┃` glyphs with
+            // sub-range overlays. This frames the selected card on all
+            // four sides instead of only top + bottom.
+            entry.style = Some(style);
+            let bar = '┃';
+            let bar_len = bar.len_utf8();
+            let first = entry.text.find(bar);
+            let last = entry.text.rfind(bar);
+            for pos in [first, last].into_iter().flatten().collect::<HashSet<_>>() {
+                entry.inline_overlays.push(InlineOverlay {
+                    start: pos,
+                    end: pos + bar_len,
+                    style: OverlayOptions {
+                        fg: Some(OverlayColorSpec::theme_key("ui.popup_border_fg")),
+                        bold: true,
+                        ..Default::default()
+                    },
+                    properties: Default::default(),
+                    unit: OffsetUnit::Byte,
+                });
+            }
         }
-        entry.style = Some(style);
     };
 
     let rows_emitted: u32 = if use_specs {
@@ -4711,6 +4738,75 @@ mod tests {
         // Rounded corners survived the per-item render.
         assert!(entries[0].text.starts_with('╭'));
         assert!(entries[2].text.starts_with('╰'));
+    }
+
+    #[test]
+    fn selected_card_accent_frames_all_four_sides() {
+        // A selected multi-row card frames itself with a heavy accent
+        // border. Regression: the accent fg was applied only to the
+        // top/bottom border rows, leaving the vertical `┃` glyphs on the
+        // body rows uncoloured — so the highlight framed only two sides.
+        // The fix tints the side `┃` glyphs via sub-range overlays without
+        // repainting the body text between them.
+        let card = |body: &str| WidgetSpec::LabeledSection {
+            label: String::new(),
+            child: Box::new(WidgetSpec::Raw {
+                entries: vec![TextPropertyEntry::text(body)],
+                key: None,
+            }),
+            width_pct: None,
+            key: None,
+        };
+        let spec = WidgetSpec::List {
+            items: vec![],
+            item_specs: vec![card("aaa"), card("bbb")],
+            item_keys: vec!["a".into(), "b".into()],
+            selected_index: 1,
+            visible_rows: 12,
+            focusable: true,
+            key: Some("cards".into()),
+        };
+        let out = render_spec(&spec, &HashMap::new(), "", 40);
+        let entries = out.entries;
+        // Selected card is index 1 → rows 3 (top), 4 (body/side), 5 (bottom).
+        let accent_is = |c: &OverlayColorSpec| matches!(c, OverlayColorSpec::ThemeKey(k) if k == "ui.popup_border_fg");
+        // Top + bottom carry the accent as a whole-row fg (entire row is border).
+        for r in [3usize, 5] {
+            let fg = entries[r].style.as_ref().and_then(|s| s.fg.as_ref());
+            assert!(
+                fg.map(accent_is).unwrap_or(false),
+                "row {r} (top/bottom border) should carry the accent fg"
+            );
+        }
+        // The body row keeps heavy side borders but must NOT set a
+        // whole-row fg (that would repaint the session text). Its vertical
+        // `┃` glyphs are tinted via sub-range overlays instead.
+        let body = &entries[4];
+        assert!(
+            body.text.contains('┃'),
+            "selected card body row should have heavy side borders: {:?}",
+            body.text
+        );
+        assert!(
+            body.style.as_ref().and_then(|s| s.fg.as_ref()).is_none(),
+            "body row must not set a whole-row fg (would repaint the text)"
+        );
+        let bar_overlays: Vec<_> = body
+            .inline_overlays
+            .iter()
+            .filter(|o| o.style.fg.as_ref().map(accent_is).unwrap_or(false))
+            .collect();
+        assert_eq!(
+            bar_overlays.len(),
+            2,
+            "both the leading and trailing ┃ should be accent-tinted: {:?}",
+            body.inline_overlays
+        );
+        // Each accent overlay covers exactly one `┃` glyph.
+        for o in bar_overlays {
+            assert_eq!(o.end - o.start, '┃'.len_utf8());
+            assert_eq!(&body.text[o.start..o.end], "┃");
+        }
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1281,3 +1281,159 @@ fn dock_form_tab_accepting_directory_completion_closes_dropdown() {
     h.wait_until(|h| h.screen_to_string().contains("Session Name"))
         .unwrap();
 }
+
+/// Regression: with the dock's project dropdown open, the keyboard drives
+/// the *dropdown* — ↑/↓ move its cursor and Enter commits the highlighted
+/// option — instead of leaking to the session list beneath it. Before the
+/// fix the menu opened but was inert: focus stayed on the session list, so
+/// ↑/↓ switched sessions and Enter dived into one, and a keyboard user
+/// could never pick a project from the dropdown.
+///
+/// The toolbar's project control is the discriminator: it reads "All ▾"
+/// while unfiltered and the project's basename once a project is picked.
+/// Driving Alt+P → ↓ → Enter must flip it to "alphaproj ▾"; with the bug
+/// the filter stays on "All".
+#[test]
+fn dock_project_dropdown_is_keyboard_navigable() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The project control starts unfiltered.
+    h.assert_screen_contains("All ▾");
+
+    // Alt+P opens the dropdown; it lists "All projects" plus this project.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("All projects"))
+        .unwrap();
+
+    // ↓ moves the cursor from "All projects" onto the project row; Enter
+    // commits it. With the bug these keys drove the session list instead,
+    // leaving the filter on "All".
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+
+    // The dropdown closed and the project filter is applied: the toolbar
+    // now reads the project basename, no longer "All".
+    h.wait_until(|h| h.screen_to_string().contains("alphaproj ▾"))
+        .unwrap();
+    let screen = h.screen_to_string();
+    assert!(
+        !screen.contains("All ▾"),
+        "project filter should be applied (toolbar should not read 'All ▾'):\n{screen}"
+    );
+    // And the menu itself is gone.
+    assert!(
+        !screen.contains("All projects"),
+        "dropdown should have closed after Enter:\n{screen}"
+    );
+}
+
+/// Esc cancels the open project dropdown without applying a filter and
+/// leaves the keyboard with the dock (it must not commit the cursor's
+/// option, nor blur the dock to the editor). We prove the dock kept focus
+/// by re-opening the dropdown with Alt+P afterwards: if Esc had blurred the
+/// dock, Alt+P would reach the editor instead and the menu would not return.
+#[test]
+fn dock_project_dropdown_esc_cancels_without_filtering() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    h.send_key(KeyCode::Char('p'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("All projects"))
+        .unwrap();
+    // Move the cursor onto the project row, then cancel.
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+
+    // Menu closed and no filter applied — toolbar still reads "All ▾".
+    h.wait_until(|h| !h.screen_to_string().contains("All projects"))
+        .unwrap();
+    let screen = h.screen_to_string();
+    assert!(
+        screen.contains("All ▾"),
+        "Esc must not apply the cursor's project (toolbar should still read 'All ▾'):\n{screen}"
+    );
+
+    // The dock still owns the keyboard: Alt+P re-opens the dropdown.
+    h.send_key(KeyCode::Char('p'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("All projects"))
+        .unwrap();
+}
+
+/// Regression: creating a session while the dock is open moves the dock's
+/// highlight onto the new session. It becomes the active window, and the
+/// dock — a passive mirror once focus dives into the new terminal — must
+/// re-point at it instead of stranding the highlight on the previously
+/// active row. We read this off the *selected card border*: the highlighted
+/// card uses heavy box glyphs (a `┃` down each side), unselected cards keep
+/// the light `│`. After creation the new session's card must be the heavy
+/// one and the old session's must not.
+#[test]
+fn creating_session_moves_dock_highlight_to_new_session() {
+    let (_tmp, root) = setup_project("alphaproj");
+    // A non-git directory for the new session: the worktree toggle
+    // auto-disables there, so it spawns a plain terminal session with no
+    // git worktree to create. It sits beside the git project (the tempdir
+    // root is not itself a repo).
+    let plain = root.parent().unwrap().join("plainwork");
+    fs::create_dir(&plain).unwrap();
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+    // The launch session (alphaproj) is the only row, and it's selected.
+    h.assert_screen_contains("alphaproj");
+
+    // Open the new-session form and point it at the non-git dir.
+    h.send_key(KeyCode::Char('n'), KeyModifiers::ALT).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("New Session"))
+        .unwrap();
+    h.type_text(&plain.display().to_string()).unwrap();
+    // The typed path lands in the field (its last segment is visible).
+    h.wait_until(|h| h.screen_to_string().contains("plainwork"))
+        .unwrap();
+    // Accept the path completion with Tab so the popup closes and the
+    // Create button is no longer obscured by it.
+    h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Create Session"))
+        .unwrap();
+
+    // Submit by clicking "Create Session".
+    let screen = h.screen_to_string();
+    let (col, btn_row) = screen
+        .lines()
+        .enumerate()
+        .find_map(|(r, l)| l.find("Create Session").map(|c| (c as u16, r as u16)))
+        .expect("Create Session button should be visible");
+    h.mouse_click(col, btn_row).unwrap();
+
+    // The new session appears and becomes the highlighted (heavy-border)
+    // card; the spawn + active-window switch + dock refresh are async, so
+    // wait until the highlight has actually migrated onto it.
+    h.wait_until(|h| {
+        h.screen_to_string()
+            .lines()
+            .any(|l| l.contains("plainwork") && l.starts_with('┃'))
+    })
+    .unwrap();
+
+    let screen = h.screen_to_string();
+    let alpha_line = screen
+        .lines()
+        .find(|l| l.contains("alphaproj"))
+        .expect("the original session row should still be listed");
+    assert!(
+        !alpha_line.starts_with('┃'),
+        "the previously-active session must drop the heavy highlight border:\n{screen}"
+    );
+}


### PR DESCRIPTION
## Summary
Fixes the dock's project dropdown menu to be fully keyboard-navigable. Previously, the dropdown would open visually but keyboard input (↑/↓/Enter) would leak through to the session list beneath it, making it impossible for keyboard users to select a project filter.

## Key Changes

- **Added keyboard cursor state to dropdown**: Introduced `projectMenuIndex` field to `OpenDialogState` to track the highlighted row in the project menu separately from the applied filter (`projectFilter`).

- **Implemented dropdown navigation functions**:
  - `openProjectMenu()`: Opens the dropdown and hands keyboard focus to it, seeding the cursor on the currently-applied option
  - `closeProjectMenu()`: Closes the dropdown and returns focus to the session list
  - `moveProjectMenu(delta)`: Moves the cursor up/down with clamping and keeps panel focus on the highlighted row
  - `acceptProjectMenu()`: Commits the cursor's option as the active filter
  - `pickProject(optionKey)`: Shared handler for applying a project filter (via keyboard, mouse, or programmatic pick)

- **Added keyboard event routing**: Modified `input.rs` to detect when focus is on a `project-pick:` menu row and route ↑/↓/Tab/Enter/Esc to new `dock_menu_*` events instead of letting them fall through to the session list.

- **Separated visual states**: The dropdown now displays two distinct signals:
  - `●` marks the *applied* filter (persistent across navigation)
  - `primary` intent marks the keyboard *cursor* (moves with ↑/↓)

- **Fixed dock highlight sync**: Added `syncDockSelectionToActive()` to move the dock's highlight onto the active window when focus changes from outside the dock (e.g., when creating a new session). This ensures the dock mirrors the editor's active window while blurred.

- **Updated hint bar**: The dock's hint bar now shows context-appropriate hints depending on whether the dropdown is open ("choose/select/cancel") or the session list is active ("switch/edit/editor").

- **Fixed selected card border rendering**: Corrected the accent color application on multi-row selected cards so the heavy `┃` side borders are tinted on all four sides, not just top/bottom. Uses sub-range overlays to tint the vertical glyphs without repainting the body text.

## Notable Implementation Details

- The `projectMenuKeys()` function is the single source of truth for dropdown options, ensuring consistency between rendering and navigation.
- Menu cursor is clamped to valid range with `clampMenuIndex()` to handle edge cases gracefully.
- The dropdown only owns the keyboard when panel focus sits on a `project-pick:` row—the host uses this focus key as the signal to route nav keys to the plugin.
- Creating a new session now properly moves the dock highlight to the newly-created (and now-active) session, preventing the highlight from stranding on the previously-active row.

https://claude.ai/code/session_011E6FRm6XYxLYUHQdd7kKqo