### PR TITLE
Fix List widget firing spurious select events at boundaries

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2837,33 +2837,16 @@ function buildDockSpec(): WidgetSpec {
 // every session in between. `fromEdge` drives the directional wipe.
 function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
   const token = ++dockSwitchToken;
-  console.warn(`[dock-switch] scheduled token=${token} fromEdge=${fromEdge}`);
   void (async () => {
     await editor.delay(30);
-    if (token !== dockSwitchToken) {
-      console.warn(`[dock-switch] token=${token} superseded by ${dockSwitchToken}`);
-      return;
-    }
-    if (!openDialog || !openPanel || !dockMode || dockBlurred) {
-      console.warn(
-        `[dock-switch] token=${token} skipped: openDialog=${!!openDialog} openPanel=${!!openPanel} dockMode=${dockMode} dockBlurred=${dockBlurred}`,
-      );
-      return;
-    }
+    // Superseded by a later keystroke — let the latest one win.
+    if (token !== dockSwitchToken) return;
+    if (!openDialog || !openPanel || !dockMode || dockBlurred) return;
     const id = openDialog.filteredIds[openDialog.selectedIndex];
-    if (typeof id !== "number" || id <= 0) {
-      console.warn(`[dock-switch] token=${token} no valid id: ${id}`);
-      return;
-    }
-    if (orchestratorSessions.get(id)?.discovered) {
-      console.warn(`[dock-switch] token=${token} id=${id} is discovered, skipping`);
-      return;
-    }
-    if (id === editor.activeWindow()) {
-      console.warn(`[dock-switch] token=${token} id=${id} already active`);
-      return;
-    }
-    console.warn(`[dock-switch] token=${token} firing setActiveWindow(${id}) fromEdge=${fromEdge}`);
+    if (typeof id !== "number" || id <= 0) return;
+    // A discovered worktree has no window to switch to.
+    if (orchestratorSessions.get(id)?.discovered) return;
+    if (id === editor.activeWindow()) return;
     if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
     else editor.setActiveWindow(id);
   })();
@@ -6207,9 +6190,6 @@ editor.on("widget_event", (e) => {
     ) {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const idx = payload.index;
-      console.warn(
-        `[dock-select] event reached plugin: idx=${idx} widget_key=${e.widget_key} dockMode=${dockMode} dockBlurred=${dockBlurred}`,
-      );
       if (typeof idx === "number") {
         const prevIdx = openDialog.selectedIndex;
         openDialog.selectedIndex = idx;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -975,11 +975,21 @@ impl Editor {
             );
         }
         self.rerender_widget_panel(panel_id);
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
+        // A clamped move at the list's top/bottom edge leaves the
+        // selection where it was. Still re-render above (re-arming
+        // `user_scrolled = false` snaps a scrolled-away view back to the
+        // selection), but don't fire a `select` event for a no-op move:
+        // holding ↑/↓ against the boundary would otherwise spam the
+        // plugin with same-index selections — each one re-runs the
+        // plugin's preview / live-switch work (in the Orchestrator dock
+        // it schedules a redundant `scheduleDockSwitch`). Mirrors the
+        // Tree handler's "No change → bail (don't fire spurious select)".
+        if new_sel != cur_sel
+            && self
+                .plugin_manager
+                .read()
+                .unwrap()
+                .has_hook_handlers("widget_event")
         {
             self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",

--- a/crates/fresh-editor/tests/e2e/list_clamp_no_spurious_select.rs
+++ b/crates/fresh-editor/tests/e2e/list_clamp_no_spurious_select.rs
@@ -1,0 +1,95 @@
+//! A List widget's keyboard navigation must NOT fire a `select`
+//! `widget_event` for a move that is clamped at the list's top/bottom
+//! edge — i.e. when the selection doesn't actually change.
+//!
+//! Regression for the host bug in
+//! `widget_runtime::handle_widget_select_move_for_key`: it fired a
+//! `select` event on every Up/Down, including no-op moves at a list
+//! boundary. Holding ↓ against the bottom (or ↑ against the top) then
+//! spammed the plugin with same-index selections; in the Orchestrator
+//! dock each spurious event scheduled a redundant live-switch (the
+//! `fromEdge=null` "heartbeat" seen in the dock-switch traces). The Tree
+//! handler already guarded this ("No change → bail"); the List handler
+//! did not.
+//!
+//! The `test_list_clamp_select.ts` plugin mounts a 3-item focusable List
+//! and a `SELECTS=<n>` counter that ticks once per received `select`
+//! event. We arrow to the bottom, keep pressing ↓ into the boundary, and
+//! assert the counter stops climbing — a screen-observable proxy for "no
+//! spurious select fired" (CONTRIBUTING §2: drive keys, assert on
+//! rendered output).
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+/// Install the clamp-select test plugin into the project's plugin dir.
+fn install_plugin(project_root: &std::path::Path) {
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin_lib(&plugins_dir);
+
+    const SRC: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/plugins/test_list_clamp_select.ts"
+    ));
+    let dst = plugins_dir.join("test_list_clamp_select.ts");
+    fs::write(&dst, SRC).unwrap_or_else(|e| panic!("Failed to write test plugin to {dst:?}: {e}"));
+}
+
+#[test]
+fn list_boundary_keyrepeat_fires_no_spurious_select() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    install_plugin(&project_root);
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(100, 32, Default::default(), project_root)
+            .unwrap();
+    h.render().unwrap();
+
+    // Mount the focusable 3-item list (selection starts at index 0).
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.render().unwrap();
+    h.type_text("TestSel: Mount").unwrap();
+    h.render().unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("SELECTS=0"))
+        .unwrap();
+
+    // Two Downs move 0→1→2 (the last item), firing one `select` each.
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("SELECTS=1"))
+        .unwrap();
+    h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("SELECTS=2"))
+        .unwrap();
+
+    // Now hammer Down against the bottom edge. Each press is a clamped,
+    // no-op move — with the fix it fires NO `select`, so the counter
+    // stays at 2. With the bug each press ticked it (SELECTS=3,4,5…).
+    for _ in 0..4 {
+        h.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        h.render().unwrap();
+    }
+    // Give the plugin event queue ample time to deliver any (buggy)
+    // spurious selects before asserting they did not arrive.
+    h.wait_until_stable(|_| true).unwrap();
+
+    let screen = h.screen_to_string();
+    assert!(
+        screen.contains("SELECTS=2"),
+        "after 2 real moves + 4 clamped Downs the counter must read \
+         SELECTS=2 (no spurious select at the boundary).\nScreen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("SELECTS=3"),
+        "a clamped Down at the list's bottom edge must not fire a \
+         `select` event — the counter climbed past 2.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -84,6 +84,7 @@ pub mod lifecycle;
 pub mod line_number_bugs;
 pub mod line_wrap_cache_consistency;
 pub mod line_wrapping;
+pub mod list_clamp_no_spurious_select;
 pub mod live_grep;
 pub mod locale;
 pub mod lsp;

--- a/crates/fresh-editor/tests/plugins/test_list_clamp_select.ts
+++ b/crates/fresh-editor/tests/plugins/test_list_clamp_select.ts
@@ -1,0 +1,85 @@
+/// <reference path="../../plugins/lib/fresh.d.ts" />
+const editor = getEditor();
+
+/**
+ * Regression surface for the List keyboard-nav "clamped move still fires
+ * a select event" bug.
+ *
+ * The host's `handle_widget_select_move_for_key` used to fire a
+ * `widget_event` "select" on EVERY Up/Down — including a move clamped at
+ * the list's top/bottom edge, where the selection doesn't actually move.
+ * Holding ↓ against the bottom (or ↑ against the top) therefore spammed
+ * the plugin with same-index selections (in the Orchestrator dock each
+ * one scheduled a redundant live-switch). The Tree handler already
+ * guarded this; the List handler did not.
+ *
+ * This plugin mounts a 3-item focusable List plus a `SELECTS=<n>` counter
+ * line that ticks once per received `select` event. The e2e test arrows
+ * to the bottom, keeps pressing ↓ into the boundary, and asserts the
+ * counter stops climbing — a screen-observable proxy for "no spurious
+ * select event fired" (CONTRIBUTING §2).
+ */
+
+const PANEL_ID = 882277; // arbitrary stable id for the float
+const LIST_KEY = "clamp-list";
+
+interface State {
+  mounted: boolean;
+  selects: number;
+  idx: number;
+}
+const state: State = { mounted: false, selects: 0, idx: 0 };
+
+// deno-lint-ignore no-explicit-any
+function spec(): any {
+  return {
+    kind: "col",
+    children: [
+      {
+        kind: "raw",
+        entries: [{ text: `SELECTS=${state.selects}\n`, properties: {} }],
+      },
+      {
+        kind: "list",
+        items: [
+          { text: "ITEM-A", properties: {} },
+          { text: "ITEM-B", properties: {} },
+          { text: "ITEM-C", properties: {} },
+        ],
+        itemSpecs: [],
+        itemKeys: ["a", "b", "c"],
+        selectedIndex: state.idx,
+        visibleRows: 5,
+        focusable: true,
+        key: LIST_KEY,
+      },
+    ],
+  };
+}
+
+function sel_mount(): void {
+  state.mounted = true;
+  state.selects = 0;
+  state.idx = 0;
+  editor.mountFloatingWidget(PANEL_ID, spec(), 60, 40);
+  editor.widgetMutate(PANEL_ID, { kind: "setFocusKey", widgetKey: LIST_KEY });
+  editor.setStatus("TestSel: MOUNTED");
+}
+registerHandler("sel_mount", sel_mount);
+
+editor.on("widget_event", (e) => {
+  if (!state.mounted || e.panel_id !== PANEL_ID) return;
+  if (e.event_type !== "select") return;
+  const payload = (e.payload ?? {}) as Record<string, unknown>;
+  const idx = payload.index;
+  if (typeof idx === "number") state.idx = idx;
+  state.selects += 1;
+  editor.updateFloatingWidget(PANEL_ID, spec());
+});
+
+editor.registerCommand(
+  "TestSel: Mount",
+  "Mount a focusable List with a select-event counter",
+  "sel_mount",
+  null,
+);


### PR DESCRIPTION
## Summary
Fix a regression where the List widget's keyboard navigation fired `select` widget events even when the selection didn't actually change due to clamping at the list's top/bottom edge. This caused the plugin to receive redundant same-index selections, leading to unnecessary work like redundant live-switches in the Orchestrator dock.

## Key Changes
- **widget_runtime.rs**: Added a guard in `handle_widget_select_move_for_key` to only fire `select` events when the selection actually changes (`new_sel != cur_sel`). This mirrors the existing behavior in the Tree handler and prevents spurious events when arrow keys are held against list boundaries.

- **orchestrator.ts**: Cleaned up debug logging in `scheduleDockSwitch` and the dock-select event handler. Removed verbose `console.warn` statements that were used to trace the spurious select event issue.

- **Test coverage**: Added comprehensive e2e regression test (`list_clamp_no_spurious_select.rs`) with a test plugin (`test_list_clamp_select.ts`) that:
  - Mounts a 3-item focusable List
  - Tracks select events with a visible counter
  - Verifies that holding Down at the list's bottom edge doesn't increment the counter
  - Ensures the fix prevents the spam of same-index selections

## Implementation Details
The fix is minimal and surgical: before firing a `widget_event` with type "select", we now check that `new_sel != cur_sel`. When a move is clamped at a boundary, the selection index remains unchanged, so the event is not fired. The re-render still happens (to reset scroll state), but the plugin is not notified of a non-existent selection change.

https://claude.ai/code/session_012t6i8REfmWjnUUG2MwHceg