### PR TITLE
fix(help): bind 'q' to close help viewers (#2165); natural-sort the file explorer (#2073)

### DIFF
--- a/crates/fresh-editor/src/app/help_actions.rs
+++ b/crates/fresh-editor/src/app/help_actions.rs
@@ -7,9 +7,18 @@
 //! buffer storage and use window-side `create_virtual_buffer` +
 //! `set_active_buffer`.
 
+use crossterm::event::{KeyCode, KeyModifiers};
+
 use super::help;
 use crate::app::window::Window;
 use crate::app::Editor;
+use crate::input::buffer_mode::BufferMode;
+use crate::input::keybindings::{Action, KeyContext};
+
+/// Mode name carried on the help/manual virtual buffers. Referenced
+/// both when creating the buffer (so input dispatch resolves keys
+/// against this context) and when installing the close binding.
+pub(super) const HELP_PANEL_MODE: &str = "special";
 
 impl Editor {
     /// Register the built-in `"special"` buffer mode used by the help
@@ -18,19 +27,31 @@ impl Editor {
     /// `inherit_normal_bindings` keeps cursor motion / copy / search
     /// usable even though `editing_disabled` blocks edits.
     ///
-    /// Idempotent: `handle_define_mode` clears prior plugin defaults
-    /// for the mode before re-installing, so it's safe to call on
-    /// every viewer open. Re-calling after a config reload (which
-    /// wipes `KeybindingResolver`) also restores the binding without
-    /// any extra wiring.
+    /// Idempotent: clears any prior binding for this mode context
+    /// before installing, so it's safe to call on every viewer open
+    /// (also restores the binding after a config reload, which
+    /// reinitializes `KeybindingResolver`).
+    ///
+    /// Avoids calling into `handle_define_mode` because that path
+    /// lives under `#[cfg(feature = "plugins")]`; we only need the
+    /// keybinding + mode-registry slice here, which is always built.
     pub(super) fn ensure_help_panel_mode_registered(&mut self) {
-        self.handle_define_mode(
-            "special".to_string(),
-            vec![("q".to_string(), "close_tab".to_string())],
-            true,
-            false,
-            true,
-            None,
+        let mode_ctx = KeyContext::Mode(HELP_PANEL_MODE.to_string());
+        {
+            let mut kb = self.keybindings.write().unwrap();
+            kb.clear_plugin_defaults_for_mode(HELP_PANEL_MODE);
+            kb.set_mode_inherits_normal_bindings(HELP_PANEL_MODE, true);
+            kb.load_plugin_default(
+                mode_ctx,
+                KeyCode::Char('q'),
+                KeyModifiers::NONE,
+                Action::CloseTab,
+            );
+        }
+        self.mode_registry.register(
+            BufferMode::new(HELP_PANEL_MODE)
+                .with_read_only(true)
+                .with_inherit_normal_bindings(true),
         );
     }
 }
@@ -56,7 +77,7 @@ impl Window {
         // Create new help buffer with "special" mode (has 'q' to close).
         let buffer_id = self.create_virtual_buffer(
             help::HELP_MANUAL_BUFFER_NAME.to_string(),
-            "special".to_string(),
+            HELP_PANEL_MODE.to_string(),
             true,
         );
 
@@ -123,7 +144,7 @@ impl Window {
 
         let buffer_id = self.create_virtual_buffer(
             help::KEYBOARD_SHORTCUTS_BUFFER_NAME.to_string(),
-            "special".to_string(),
+            HELP_PANEL_MODE.to_string(),
             true,
         );
 

--- a/crates/fresh-editor/src/app/help_actions.rs
+++ b/crates/fresh-editor/src/app/help_actions.rs
@@ -9,6 +9,31 @@
 
 use super::help;
 use crate::app::window::Window;
+use crate::app::Editor;
+
+impl Editor {
+    /// Register the built-in `"special"` buffer mode used by the help
+    /// manual and keyboard-shortcuts viewers. Both viewers document
+    /// "Press q to close" inline, so we bind `q -> close_tab` here.
+    /// `inherit_normal_bindings` keeps cursor motion / copy / search
+    /// usable even though `editing_disabled` blocks edits.
+    ///
+    /// Idempotent: `handle_define_mode` clears prior plugin defaults
+    /// for the mode before re-installing, so it's safe to call on
+    /// every viewer open. Re-calling after a config reload (which
+    /// wipes `KeybindingResolver`) also restores the binding without
+    /// any extra wiring.
+    pub(super) fn ensure_help_panel_mode_registered(&mut self) {
+        self.handle_define_mode(
+            "special".to_string(),
+            vec![("q".to_string(), "close_tab".to_string())],
+            true,
+            false,
+            true,
+            None,
+        );
+    }
+}
 
 impl Window {
     /// Open the built-in help manual in a read-only buffer.

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1211,9 +1211,11 @@ impl Editor {
                 self.handle_redo();
             }
             Action::ShowHelp => {
+                self.ensure_help_panel_mode_registered();
                 self.active_window_mut().open_help_manual();
             }
             Action::ShowKeyboardShortcuts => {
+                self.ensure_help_panel_mode_registered();
                 self.active_window_mut().open_keyboard_shortcuts();
             }
             Action::ShowWarnings => {

--- a/crates/fresh-editor/src/view/file_tree/tree.rs
+++ b/crates/fresh-editor/src/view/file_tree/tree.rs
@@ -141,12 +141,14 @@ impl FileTree {
 
         match result {
             Ok(entries) => {
-                // Sort entries: directories first, then by name
+                // Sort entries: directories first, then by name using
+                // a natural (alphanumeric) comparison so `chapter-2`
+                // sorts before `chapter-10` (issue #2073).
                 let mut sorted_entries = entries;
                 sorted_entries.sort_by(|a, b| match (a.is_dir(), b.is_dir()) {
                     (true, false) => std::cmp::Ordering::Less,
                     (false, true) => std::cmp::Ordering::Greater,
-                    _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+                    _ => natural_cmp(&a.name, &b.name),
                 });
 
                 // Create child nodes
@@ -441,12 +443,147 @@ impl FileTree {
     }
 }
 
+/// Natural ordering of two filenames: ASCII-digit runs compare as
+/// integers, everything else as lowercase strings. This gives a
+/// "human" order like `chapter-2 < chapter-10` (issue #2073) without
+/// pulling in a sort crate.
+///
+/// Only ASCII digits are treated as a numeric run — letters, symbols,
+/// and non-ASCII characters fall back to lowercase string comparison.
+/// Leading zeros are ignored when comparing magnitudes (`v01 == v1`
+/// by value); ties resolve by raw width, with the shorter (unpadded)
+/// form first, matching GNU `sort -V` (`v1 < v01`).
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut ai = a.char_indices().peekable();
+    let mut bi = b.char_indices().peekable();
+    loop {
+        match (ai.peek().copied(), bi.peek().copied()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some((_, ca)), Some((_, cb))) => {
+                if ca.is_ascii_digit() && cb.is_ascii_digit() {
+                    // Compare numeric runs by magnitude (length of the
+                    // non-zero portion, then digit-by-digit), then by
+                    // raw width so leading-zero variants are ordered
+                    // deterministically without claiming equality.
+                    let (a_start, a_end) = take_digit_run(&mut ai);
+                    let (b_start, b_end) = take_digit_run(&mut bi);
+                    let a_digits = &a[a_start..a_end];
+                    let b_digits = &b[b_start..b_end];
+                    let a_trim = a_digits.trim_start_matches('0');
+                    let b_trim = b_digits.trim_start_matches('0');
+                    match a_trim.len().cmp(&b_trim.len()) {
+                        Ordering::Equal => match a_trim.cmp(b_trim) {
+                            Ordering::Equal => {
+                                if a_digits.len() != b_digits.len() {
+                                    return a_digits.len().cmp(&b_digits.len());
+                                }
+                            }
+                            other => return other,
+                        },
+                        other => return other,
+                    }
+                } else {
+                    let (_, ca) = ai.next().unwrap();
+                    let (_, cb) = bi.next().unwrap();
+                    let la = ca.to_ascii_lowercase();
+                    let lb = cb.to_ascii_lowercase();
+                    if la != lb {
+                        return la.cmp(&lb);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Consume a contiguous ASCII-digit run from `iter` and return its
+/// byte range in the original string. `iter` is left pointing at the
+/// first non-digit (or exhausted).
+fn take_digit_run<I>(iter: &mut std::iter::Peekable<I>) -> (usize, usize)
+where
+    I: Iterator<Item = (usize, char)>,
+{
+    let (start, _) = *iter.peek().expect("caller checked at least one digit");
+    let mut end = start;
+    while let Some(&(idx, c)) = iter.peek() {
+        if c.is_ascii_digit() {
+            end = idx + c.len_utf8();
+            iter.next();
+        } else {
+            break;
+        }
+    }
+    (start, end)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::filesystem::StdFileSystem;
     use std::fs as std_fs;
     use tempfile::TempDir;
+
+    // ── natural_cmp ──────────────────────────────────────────────────
+
+    /// Issue #2073: digit runs in filenames should compare by
+    /// magnitude so `chapter-2 < chapter-10`, not lexicographically.
+    #[test]
+    fn natural_cmp_orders_digit_runs_by_magnitude() {
+        let mut names = vec![
+            "chapter-1.md",
+            "chapter-10.md",
+            "chapter-2.md",
+            "chapter-21.md",
+            "chapter-3.md",
+        ];
+        names.sort_by(|a, b| natural_cmp(a, b));
+        assert_eq!(
+            names,
+            vec![
+                "chapter-1.md",
+                "chapter-2.md",
+                "chapter-3.md",
+                "chapter-10.md",
+                "chapter-21.md",
+            ]
+        );
+    }
+
+    /// Non-digit segments keep falling back to case-insensitive
+    /// comparison — `Foo` and `foo` compare equal, `bar` sorts before
+    /// `Foo`, mixed cases still group together rather than splitting
+    /// upper- and lowercase apart the way raw `cmp` would.
+    #[test]
+    fn natural_cmp_is_case_insensitive_for_text() {
+        use std::cmp::Ordering;
+        assert_eq!(natural_cmp("Foo.txt", "foo.txt"), Ordering::Equal);
+        assert_eq!(natural_cmp("bar.txt", "Foo.txt"), Ordering::Less);
+    }
+
+    /// Leading zeros do not change magnitude but still break ties —
+    /// the shorter (unpadded) form wins, matching GNU `sort -V` so a
+    /// sorted listing is deterministic regardless of input order.
+    #[test]
+    fn natural_cmp_leading_zeros_break_ties_after_magnitude() {
+        use std::cmp::Ordering;
+        assert_eq!(natural_cmp("v1", "v01"), Ordering::Less);
+        assert_eq!(natural_cmp("v01", "v1"), Ordering::Greater);
+        // But magnitude wins over width — `v002` still sorts before `v10`.
+        assert_eq!(natural_cmp("v002.txt", "v10.txt"), Ordering::Less);
+    }
+
+    /// Mixed digit + text runs alternate cleanly: shared prefix,
+    /// numeric run by magnitude, shared suffix.
+    #[test]
+    fn natural_cmp_handles_mixed_runs() {
+        use std::cmp::Ordering;
+        assert_eq!(natural_cmp("img2a.png", "img10a.png"), Ordering::Less);
+        assert_eq!(natural_cmp("img2b.png", "img2a.png"), Ordering::Greater);
+        assert_eq!(natural_cmp("img.png", "img2.png"), Ordering::Less);
+    }
 
     async fn create_test_tree() -> (TempDir, FileTree) {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/fresh-editor/tests/e2e/command_palette.rs
+++ b/crates/fresh-editor/tests/e2e/command_palette.rs
@@ -1721,6 +1721,92 @@ fn test_show_keyboard_shortcuts_open_close_reopen() {
     );
 }
 
+/// Regression test for issue #2165: pressing `q` in the
+/// `*Keyboard Shortcuts*` buffer must close it, matching the
+/// "Press 'q' to close this buffer." instruction the buffer itself
+/// renders. Before the fix, `q` fell through to the read-only text
+/// layer and tripped `Editing disabled in this buffer` while the
+/// buffer stayed open.
+#[test]
+fn test_keyboard_shortcuts_q_closes_buffer() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("show keyboard").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.screen_to_string().contains("Keyboard Shortcuts"),
+        "Keyboard Shortcuts buffer should be visible before 'q'. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    harness
+        .send_key(KeyCode::Char('q'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let after = harness.screen_to_string();
+    assert!(
+        !after.contains("Editing disabled"),
+        "Pressing q should close the buffer, not trip 'Editing disabled'.\nScreen:\n{}",
+        after
+    );
+    assert!(
+        !after.contains("*Keyboard Shortcuts*"),
+        "*Keyboard Shortcuts* tab should be gone after pressing q.\nScreen:\n{}",
+        after
+    );
+}
+
+/// Regression test paired with `test_keyboard_shortcuts_q_closes_buffer`:
+/// the Fresh Manual viewer shares the same `"special"` buffer mode and
+/// also documents "Press q or Esc to close this page", so `q` must
+/// close it too.
+#[test]
+fn test_fresh_manual_q_closes_buffer() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.type_text("show manual").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    assert!(
+        harness.screen_to_string().contains("*Fresh Manual*"),
+        "Fresh Manual buffer should be visible before 'q'. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    harness
+        .send_key(KeyCode::Char('q'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let after = harness.screen_to_string();
+    assert!(
+        !after.contains("Editing disabled"),
+        "Pressing q should close the buffer, not trip 'Editing disabled'.\nScreen:\n{}",
+        after
+    );
+    assert!(
+        !after.contains("*Fresh Manual*"),
+        "*Fresh Manual* tab should be gone after pressing q.\nScreen:\n{}",
+        after
+    );
+}
+
 /// Test that command palette fuzzy matches on command descriptions
 #[test]
 fn test_command_palette_description_fuzzy_matching() {

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -504,6 +504,57 @@ fn test_file_explorer_toggle_hidden_smoke() {
     // Test passes if no panic occurs
 }
 
+/// Regression test for issue #2073: file explorer should sort
+/// filenames naturally — `chapter-2.md` before `chapter-10.md`, not
+/// after.
+#[test]
+fn test_file_explorer_natural_sort_order() {
+    let mut harness = EditorTestHarness::with_temp_project(120, 40).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    for name in &[
+        "chapter-1.md",
+        "chapter-2.md",
+        "chapter-10.md",
+        "chapter-11.md",
+        "chapter-3.md",
+    ] {
+        fs::write(project_root.join(name), "x").unwrap();
+    }
+
+    harness.editor_mut().focus_file_explorer();
+    harness.wait_for_file_explorer().unwrap();
+    harness.wait_for_file_explorer_item("chapter-1.md").unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+
+    let order = [
+        "chapter-1.md",
+        "chapter-2.md",
+        "chapter-3.md",
+        "chapter-10.md",
+        "chapter-11.md",
+    ];
+    let positions: Vec<_> = order
+        .iter()
+        .map(|name| {
+            screen
+                .find(name)
+                .unwrap_or_else(|| panic!("missing {name} in explorer screen:\n{screen}"))
+        })
+        .collect();
+
+    for window in positions.windows(2) {
+        assert!(
+            window[0] < window[1],
+            "Files should appear in natural order. positions={:?}\nScreen:\n{}",
+            positions,
+            screen
+        );
+    }
+}
+
 /// Test that file_explorer_toggle_gitignored can be called (smoke test)
 #[test]
 fn test_file_explorer_toggle_gitignored_smoke() {


### PR DESCRIPTION
Two small, independent fixes on one branch.

---

## Fixes #2165 — `q` should close the help viewers

The `*Keyboard Shortcuts*` and `*Fresh Manual*` viewers both render **"Press 'q' to close this buffer."**, but `q` fell through to the read-only text layer and tripped `Editing disabled in this buffer` while the viewer stayed open. Only `Alt+W` could close it.

**Root cause:** Both viewers create their virtual buffer with mode `"special"`, but nothing actually registered that mode. The `KeyContext::Mode("special")` lookup found no bindings, so `q` got dispatched as character input.

**Fix:** Register the `"special"` mode from the `ShowHelp` / `ShowKeyboardShortcuts` action handlers, binding `q -> close_tab` with `inherit_normal_bindings: true` so cursor motion / Copy / search keep working. The registration is idempotent — safe to call on every viewer open and after a config reload (which wipes plugin defaults).

---

## Fixes #2073 — Natural-order sort in the file explorer

Sibling sort was `to_lowercase().cmp()`, which split ASCII-digit runs character-by-character — so `chapter-{1, 10, 11, 2, 3}.md` rendered in that broken order instead of `1, 2, 3, 10, 11`.

**Fix:** Replace the comparator with an inline `natural_cmp` that compares ASCII-digit runs by magnitude (`chapter-2 < chapter-10`), falls back to lowercase comparison for everything else, and breaks magnitude ties by raw width — shorter unpadded form first, matching `sort -V` (`v1 < v01`). No new dependencies.

---

## Test plan

- [x] **#2165** — new e2e regressions `test_keyboard_shortcuts_q_closes_buffer` and `test_fresh_manual_q_closes_buffer` (both fail on master, pass with the fix); existing `test_show_keyboard_shortcuts_*` and `test_diagnostics_panel_q_closes` still pass; manual tmux repro confirms `q` closes both viewers, cursor keys still navigate, `q` still inserts a literal `q` in editable buffers.
- [x] **#2073** — new unit tests pin `natural_cmp` (digit magnitude, case folding, leading-zero tie-breaking, mixed runs); new e2e `test_file_explorer_natural_sort_order` opens the explorer on five `chapter-N.md` files and asserts their visible row order; all 64 `file_explorer::*` e2e tests pass.