### PR TITLE
fix(lsp): populate context.diagnostics on textDocument/codeAction (#2212)

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -56,6 +56,46 @@ fn lsp_range_contains(range: &lsp_types::Range, line: u32, character: u32) -> bo
     true
 }
 
+/// Whether an LSP range overlaps the half-open range
+/// `[(b_start_line, b_start_char), (b_end_line, b_end_char))`. Zero-length
+/// ranges on either side are treated as their single anchor point — so a
+/// point cursor matches any diagnostic whose range covers that point, and a
+/// point-style diagnostic matches a selection that covers its anchor.
+fn lsp_range_overlaps(
+    a: &lsp_types::Range,
+    b_start_line: u32,
+    b_start_char: u32,
+    b_end_line: u32,
+    b_end_char: u32,
+) -> bool {
+    let b_is_point = b_start_line == b_end_line && b_start_char == b_end_char;
+    if b_is_point {
+        return lsp_range_contains(a, b_start_line, b_start_char);
+    }
+    let a_is_point = a.start.line == a.end.line && a.start.character == a.end.character;
+    if a_is_point {
+        let (p_line, p_char) = (a.start.line, a.start.character);
+        if p_line < b_start_line || (p_line == b_start_line && p_char < b_start_char) {
+            return false;
+        }
+        if p_line > b_end_line || (p_line == b_end_line && p_char >= b_end_char) {
+            return false;
+        }
+        return true;
+    }
+    // Both have extent. A entirely before B?
+    if a.end.line < b_start_line || (a.end.line == b_start_line && a.end.character <= b_start_char)
+    {
+        return false;
+    }
+    // A entirely after B?
+    if a.start.line > b_end_line || (a.start.line == b_end_line && a.start.character >= b_end_char)
+    {
+        return false;
+    }
+    true
+}
+
 const SEMANTIC_TOKENS_RANGE_DEBOUNCE_MS: u64 = 50;
 const SEMANTIC_TOKENS_RANGE_PADDING_LINES: usize = 10;
 
@@ -1596,10 +1636,31 @@ impl Editor {
             (line as u32, character as u32, line as u32, character as u32)
         };
 
-        // Get diagnostics at cursor position for context
-        // TODO: Implement diagnostic retrieval when needed
-        let diagnostics: Vec<lsp_types::Diagnostic> = Vec::new();
         let buffer_id = self.active_buffer();
+
+        // Populate `context.diagnostics` with stored diagnostics whose ranges
+        // overlap the code-action request range. Many servers (clangd,
+        // eslint, ...) gate quickfix actions on this — without it, every
+        // diagnostic-driven "fix available" produces zero actions
+        // (sinelaw/fresh#2212).
+        let diagnostics: Vec<lsp_types::Diagnostic> = {
+            let window = self.active_window();
+            window
+                .buffer_metadata
+                .get(&buffer_id)
+                .and_then(|m| m.file_uri())
+                .and_then(|uri| window.stored_diagnostics.get(uri.as_str()))
+                .map(|diags| {
+                    diags
+                        .iter()
+                        .filter(|d| {
+                            lsp_range_overlaps(&d.range, start_line, start_char, end_line, end_char)
+                        })
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
 
         // Pre-allocate request IDs for all eligible servers
         let base_request_id = self.active_window_mut().next_lsp_request_id;
@@ -3448,7 +3509,7 @@ mod tests {
     fn test_fs() -> Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> {
         Arc::new(StdFileSystem)
     }
-    use super::{lsp_range_contains, Editor};
+    use super::{lsp_range_contains, lsp_range_overlaps, Editor};
 
     fn range(sl: u32, sc: u32, el: u32, ec: u32) -> lsp_types::Range {
         lsp_types::Range {
@@ -3512,6 +3573,74 @@ mod tests {
         assert!(!lsp_range_contains(&r, 6, 4));
         assert!(!lsp_range_contains(&r, 8, 4));
     }
+
+    #[test]
+    fn test_lsp_range_overlaps_point_cursor_in_diagnostic_range() {
+        // Diagnostic at line 3, cols 10..20. A zero-width cursor anywhere
+        // inside (including at start) overlaps; just outside does not.
+        let diag = range(3, 10, 3, 20);
+        // Cursor on the start anchor.
+        assert!(lsp_range_overlaps(&diag, 3, 10, 3, 10));
+        // Cursor inside.
+        assert!(lsp_range_overlaps(&diag, 3, 15, 3, 15));
+        // Cursor at exclusive end — not contained.
+        assert!(!lsp_range_overlaps(&diag, 3, 20, 3, 20));
+        // Cursor before start.
+        assert!(!lsp_range_overlaps(&diag, 3, 9, 3, 9));
+        // Cursor on a different line.
+        assert!(!lsp_range_overlaps(&diag, 4, 15, 4, 15));
+    }
+
+    #[test]
+    fn test_lsp_range_overlaps_selection_intersects_diagnostic() {
+        // Diagnostic at line 3, cols 10..20.
+        let diag = range(3, 10, 3, 20);
+        // Selection entirely inside diag.
+        assert!(lsp_range_overlaps(&diag, 3, 12, 3, 18));
+        // Selection straddling the start of diag.
+        assert!(lsp_range_overlaps(&diag, 3, 5, 3, 15));
+        // Selection straddling the end of diag.
+        assert!(lsp_range_overlaps(&diag, 3, 15, 3, 25));
+        // Selection entirely covering diag.
+        assert!(lsp_range_overlaps(&diag, 3, 0, 3, 30));
+        // Selection adjacent before (touches at start, half-open end).
+        assert!(!lsp_range_overlaps(&diag, 3, 0, 3, 10));
+        // Selection adjacent after (starts at exclusive end of diag).
+        assert!(!lsp_range_overlaps(&diag, 3, 20, 3, 30));
+        // Selection on the wrong line.
+        assert!(!lsp_range_overlaps(&diag, 4, 0, 4, 100));
+    }
+
+    #[test]
+    fn test_lsp_range_overlaps_point_diagnostic_within_selection() {
+        // Point-style diagnostic at line 3, col 10.
+        let diag = range(3, 10, 3, 10);
+        // Selection covering the point.
+        assert!(lsp_range_overlaps(&diag, 3, 5, 3, 15));
+        // Selection starting at the point (half-open includes start).
+        assert!(lsp_range_overlaps(&diag, 3, 10, 3, 15));
+        // Selection ending at the point (half-open excludes end).
+        assert!(!lsp_range_overlaps(&diag, 3, 0, 3, 10));
+        // Zero-width cursor on the exact anchor.
+        assert!(lsp_range_overlaps(&diag, 3, 10, 3, 10));
+        // Zero-width cursor not on the anchor.
+        assert!(!lsp_range_overlaps(&diag, 3, 9, 3, 9));
+    }
+
+    #[test]
+    fn test_lsp_range_overlaps_multiline() {
+        // Diagnostic spans line 2 col 5 through line 4 col 3.
+        let diag = range(2, 5, 4, 3);
+        // Cursor on an interior line, anywhere.
+        assert!(lsp_range_overlaps(&diag, 3, 0, 3, 0));
+        // Selection crossing line boundary into the diagnostic.
+        assert!(lsp_range_overlaps(&diag, 1, 0, 2, 6));
+        // Selection that starts at the exclusive end of the diagnostic — no overlap.
+        assert!(!lsp_range_overlaps(&diag, 4, 3, 4, 10));
+        // Selection entirely after the diagnostic.
+        assert!(!lsp_range_overlaps(&diag, 5, 0, 5, 10));
+    }
+
     use crate::model::buffer::Buffer;
     use crate::state::EditorState;
     use crate::view::virtual_text::VirtualTextPosition;

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1928,6 +1928,119 @@ done
         dir.join("fake_lsp_server_code_actions_b.sh")
     }
 
+    /// Spawn a fake LSP server that mimics clangd-style diagnostic-gated
+    /// quickfixes: it publishes a diagnostic on `didOpen`, and only returns
+    /// a code action when the `textDocument/codeAction` request carries a
+    /// non-empty `context.diagnostics`. Used to regression-test
+    /// sinelaw/fresh#2212.
+    pub fn spawn_with_diagnostic_gated_code_actions(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+case "$method" in
+    "initialize")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"textDocumentSync":1,"codeActionProvider":true}}}'
+        ;;
+    "textDocument/didOpen")
+        uri=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+        # Publish a diagnostic at line 0, cols 4..5 (the "x" in "let x = ...").
+        send_message '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"'$uri'","diagnostics":[{"range":{"start":{"line":0,"character":4},"end":{"line":0,"character":5}},"severity":2,"message":"Unused variable (fix available)","source":"fake-lsp"}]}}'
+        ;;
+    "textDocument/codeAction")
+        # Gate quickfix actions on context.diagnostics being non-empty,
+        # mirroring clangd's behavior: empty context -> no fixes.
+        if echo "$msg" | grep -q '"diagnostics":\[\]'; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[]}'
+        else
+            uri=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[{"title":"Remove unused variable","kind":"quickfix","edit":{"changes":{"'$uri'":[{"range":{"start":{"line":0,"character":0},"end":{"line":1,"character":0}},"newText":""}]}}}]}'
+        fi
+        ;;
+    "textDocument/didChange"|"textDocument/didClose"|"initialized")
+        ;;
+    "textDocument/diagnostic")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[],"resultId":null}}'
+        ;;
+    "textDocument/inlayHint")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[]}'
+        ;;
+    "textDocument/foldingRange")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[]}'
+        ;;
+    "textDocument/documentSymbol")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[]}'
+        ;;
+    "$/cancelRequest")
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    *)
+        if [ -n "$msg_id" ]; then
+            send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        fi
+        ;;
+esac
+done
+"#;
+
+        let script_path = Self::diagnostic_gated_code_actions_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Get the path to the diagnostic-gated code actions fake LSP server script
+    pub fn diagnostic_gated_code_actions_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_diag_gated_code_actions.sh")
+    }
+
     /// Spawn a fake LSP server that returns completion items.
     /// Unlike the default `spawn()`, this does NOT declare semanticTokensProvider.
     pub fn spawn_with_completions_a(dir: &std::path::Path) -> anyhow::Result<Self> {

--- a/crates/fresh-editor/tests/e2e/lsp_code_action_diagnostic_context.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_code_action_diagnostic_context.rs
@@ -1,0 +1,100 @@
+//! Regression test for sinelaw/fresh#2212.
+//!
+//! When the user invokes "Code Actions" at a cursor position covered by an
+//! LSP diagnostic, the `textDocument/codeAction` request must carry the
+//! matching diagnostic in `context.diagnostics`. Many servers (clangd,
+//! eslint, ...) gate quickfix actions on this — sending an empty context
+//! produces zero actions and the user sees a misleading "No code actions
+//! available".
+//!
+//! This test wires up a fake LSP server that:
+//!   * publishes a diagnostic at line 0, cols 4..5 on `didOpen`, and
+//!   * returns a quickfix only when `context.diagnostics` is non-empty.
+//!
+//! Without the fix the popup never materializes (the server returns `[]`
+//! because Fresh sent `"diagnostics": []`). With the fix the popup shows
+//! "Remove unused variable".
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::EditorTestHarness;
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+#[test]
+#[cfg_attr(
+    target_os = "windows",
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_code_action_request_includes_overlapping_diagnostic() -> anyhow::Result<()> {
+    init_tracing_from_env();
+    fresh::services::signal_handler::install_signal_handlers();
+
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_with_diagnostic_gated_code_actions(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test.rs");
+    // "let x = 5;" — the fake LSP flags the `x` at col 4..5.
+    std::fs::write(&test_file, "let x = 5;\nfn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::diagnostic_gated_code_actions_script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        24,
+        crate::common::harness::HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Wait for the LSP handshake to complete.
+    harness.wait_until(|h| h.editor().active_window().is_lsp_server_ready("rust"))?;
+
+    // Wait for the diagnostic round-trip — the fake server publishes
+    // diagnostics on `didOpen`, but it arrives asynchronously.
+    harness.wait_until(|h| {
+        h.editor()
+            .get_stored_diagnostics()
+            .values()
+            .any(|v| !v.is_empty())
+    })?;
+
+    // Cursor starts at (0, 0). Move it to (0, 4) — on the diagnostic.
+    for _ in 0..4 {
+        harness.send_key(KeyCode::Right, KeyModifiers::NONE)?;
+    }
+    harness.render()?;
+
+    // Trigger code actions via the command palette (Alt+. is unreliable on
+    // macOS CI terminals — see sibling tests).
+    harness.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)?;
+    harness.type_text("Code Actions")?;
+    harness.send_key(KeyCode::Enter, KeyModifiers::NONE)?;
+    harness.render()?;
+
+    // With the fix, the diagnostic-gated quickfix appears.
+    harness.wait_for_screen_contains("Remove unused variable")?;
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -90,6 +90,7 @@ pub mod locale;
 pub mod lsp;
 pub mod lsp_autostart_selective;
 pub mod lsp_bulk_edit_undo_desync;
+pub mod lsp_code_action_diagnostic_context;
 pub mod lsp_code_action_modal;
 pub mod lsp_code_action_resolve_and_commands;
 pub mod lsp_completion_duplicate_entries_1514;


### PR DESCRIPTION
## Summary

Fixes #2212 — `Alt+.` shows "No code actions available" for diagnostic-based fixes even when the server (clangd, eslint, ...) reports "(fix available)".

The bug reporter pinpointed the exact cause: `request_code_actions` had been sending `context.diagnostics: []` since v0.3.6 with a `TODO: Implement diagnostic retrieval when needed` comment. Servers that gate quickfixes on the request context (as the LSP spec encourages) responded with `[]`, so no fix popup ever appeared.

## Fix

- `request_code_actions` now resolves the active buffer's URI from `buffer_metadata`, reads `stored_diagnostics` for that URI, and forwards diagnostics whose ranges overlap the code-action request range to `CodeActionContext.diagnostics`.
- New `lsp_range_overlaps` helper (sibling to the existing `lsp_range_contains`) handles both the zero-width cursor case and the multi-line selection case, including point-style diagnostics inside larger selections.

## Tests

- Unit tests for `lsp_range_overlaps` covering inclusive-start / exclusive-end semantics, multiline ranges, point cursors inside diagnostic ranges, and point diagnostics inside selections.
- New E2E test `lsp_code_action_diagnostic_context::test_code_action_request_includes_overlapping_diagnostic` driving the full editor through a fake LSP server that mirrors clangd's diagnostic-gated quickfix behavior (publishes a diagnostic on `didOpen`, returns `[]` for code actions with empty `context.diagnostics`, returns a quickfix otherwise). Without the fix the popup never materializes and the test hangs; with the fix the popup shows "Remove unused variable".
- All 6 existing code-action E2E tests (`lsp_code_action_modal`, `lsp_code_action_resolve_and_commands`) still pass — the new context is additive and the action-selection / resolve / command paths are unchanged.

## Manual validation

Reproduced the exact bug-report scenario locally with `clangd 18.1.3` on `/tmp/cpp_test/main.cpp`:

```
● 1 │ #include <string>
▾ 2 │ ┌Code Actions───────────────────────────────────────────[×]┐
  3 │ │1. remove #include directive quickfix                     │
  4 │ └──────────────────────────────────────────────────────────┘
```

Before this patch: "No code actions available". After: the expected clangd quickfix appears.

## Test plan

- [x] `cargo test -p fresh-editor --lib lsp_range` — 7 passed
- [x] `cargo test -p fresh-editor --test e2e_tests lsp_code_action` — 6 passed (incl. new test)
- [x] Manual repro with real clangd produces the expected quickfix popup

https://claude.ai/code/session_01YYYsa8JiXPsG3zow8j5jaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYYsa8JiXPsG3zow8j5jaV)_