### PR TITLE
fix(tabs): re-anchor tab scroll after batch closes so the kept tab stays visible (#2229)

### DIFF
--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -674,6 +674,7 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .set_split_buffer(split_id, keep_buffer_id);
 
+        self.reseat_tab_scroll_for_split(split_id);
         self.set_batch_close_status_message(closed, skipped_modified);
     }
 
@@ -708,6 +709,7 @@ impl Editor {
             }
         }
 
+        self.reseat_tab_scroll_for_split(split_id);
         self.set_batch_close_status_message(closed, skipped_modified);
     }
 
@@ -742,6 +744,7 @@ impl Editor {
             }
         }
 
+        self.reseat_tab_scroll_for_split(split_id);
         self.set_batch_close_status_message(closed, skipped_modified);
     }
 
@@ -770,7 +773,35 @@ impl Editor {
             }
         }
 
+        // If any modified tabs were skipped, the split survives with a reduced
+        // tab list. Re-anchor its scroll offset so the surviving tabs stay in
+        // view. (When the split was torn down entirely there's no state left to
+        // adjust; the no-op is silent.)
+        self.reseat_tab_scroll_for_split(split_id);
         self.set_batch_close_status_message(closed, skipped_modified);
+    }
+
+    /// Re-pin a split's tab-scroll offset around its currently-active buffer.
+    ///
+    /// Batch closes (Close Others / Close to Right / Close to Left / Close All)
+    /// shrink the tab strip without going through `set_active_buffer`, so the
+    /// scroll offset from the pre-close state can leave the surviving active
+    /// tab off-screen — the user sees an empty tab bar after Close Others
+    /// (sinelaw/fresh#2229). Calling this after a batch close re-runs the
+    /// "make the active tab visible" math against the new tab list using the
+    /// editor's effective tabs width. Silently no-ops if the split is gone.
+    fn reseat_tab_scroll_for_split(&mut self, split_id: LeafId) {
+        let Some(active_buffer) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .and_then(|(mgr, _)| mgr.buffer_for_split(split_id))
+        else {
+            return;
+        };
+        let tabs_width = self.active_window().effective_tabs_width();
+        self.active_window_mut()
+            .ensure_active_tab_visible(split_id, active_buffer, tabs_width);
     }
 
     /// Set status message for batch close operations

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -3613,4 +3613,94 @@ mod tests {
             .sum();
         assert!(view_state.tab_scroll_offset <= total_width);
     }
+
+    /// Regression for sinelaw/fresh#2229.
+    ///
+    /// When the tab strip is scrolled (many tabs open) and the user invokes
+    /// "Close Others" / "Close to Left" / "Close to Right" / "Close All",
+    /// the surviving active tab must stay on-screen. Before the fix the
+    /// scroll offset was carried over from the pre-close state, so the only
+    /// remaining tab sat to the left of the viewport and the tab bar
+    /// looked empty.
+    #[test]
+    fn close_others_re_anchors_tab_scroll_to_surviving_tab() {
+        let config = Config::default();
+        let (dir_context, _temp) = test_dir_context();
+        let mut editor = Editor::new(
+            config,
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap();
+        let split_id = editor.split_manager().active_split();
+
+        // Open enough long-named buffers that the strip would scroll on a
+        // realistic terminal width.
+        use crate::view::split::TabTarget;
+        let mut buffers = Vec::new();
+        for i in 0..6 {
+            let id = editor.new_buffer();
+            editor
+                .buffers_mut()
+                .get_mut(&id)
+                .unwrap()
+                .buffer
+                .rename_file_path(std::path::PathBuf::from(format!(
+                    "long_filename_for_tab_{:02}.txt",
+                    i
+                )));
+            buffers.push(id);
+        }
+
+        // Make the last buffer the active one and seed a scrolled offset
+        // — what the renderer would have computed mid-session — then mark
+        // it as the surviving "keep" tab.
+        let keep = buffers[5];
+        editor
+            .active_window_mut()
+            .split_manager_mut()
+            .unwrap()
+            .set_split_buffer(split_id, keep);
+        {
+            let view_state = editor.split_view_states_mut().get_mut(&split_id).unwrap();
+            view_state.open_buffers = buffers
+                .iter()
+                .map(|b| TabTarget::Buffer(*b))
+                .collect::<Vec<_>>();
+            view_state.tab_scroll_offset = 80;
+        }
+
+        editor.close_other_tabs_in_split(keep, split_id);
+
+        // Only the kept tab remains. Its visual range is [0, tab_width)
+        // and it must be inside the viewport — i.e. the offset must fit
+        // within the total tab strip width.
+        let view_state = editor.split_view_states().get(&split_id).unwrap();
+        let remaining_targets = view_state.buffer_tab_ids_vec();
+        assert_eq!(
+            remaining_targets,
+            vec![keep],
+            "Close Others should leave only the kept buffer"
+        );
+        let name_len = editor
+            .buffers()
+            .get(&keep)
+            .unwrap()
+            .buffer
+            .file_path()
+            .and_then(|p| p.file_name())
+            .and_then(|n| n.to_str())
+            .map(|s| s.chars().count())
+            .unwrap_or(0);
+        let kept_tab_width = 2 + name_len;
+        assert!(
+            view_state.tab_scroll_offset < kept_tab_width,
+            "scroll offset {} must keep the {}-wide kept tab in view (without the fix it stays at 80)",
+            view_state.tab_scroll_offset,
+            kept_tab_width,
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #2229: after "Close Others" on a scrolled tab strip, the remaining tab disappeared from view — only the `<` scroll indicator was visible.

**Root cause:** `Editor::close_other_tabs_in_split` (and the matching `close_tabs_to_right_in_split`, `close_tabs_to_left_in_split`, `close_all_tabs_in_split` paths) shrink the tab strip but don't go through `set_active_buffer`, which is the only place that re-runs `ensure_active_tab_visible`. The mid-session `tab_scroll_offset` is therefore preserved, and the surviving tab (now sitting at column 0 of a much shorter strip) is left to the left of the viewport.

**Fix:** add a small `reseat_tab_scroll_for_split` helper that re-runs the same "make the active tab visible" math used elsewhere (`active_focus.rs`, `lifecycle.rs`), and call it at the end of each batch-close path. The helper silently no-ops when the split was torn down entirely (Close All with no survivors), so it's safe everywhere.

## Reproduction

1. Open enough files that the tab bar overflows (`<`/`>` indicators visible).
2. Click on a tab somewhere to the right.
3. Right-click → Close Others (or run the Close Other Tabs command).

**Before:** the tab bar shows only `<`; the active buffer's tab is offscreen.
**After:** the kept tab is anchored at the start of the bar.

Manually validated in `tmux` (release build, 12 files, "Close Other Tabs" via command palette) — also verified "Close Tabs to Left" benefits from the same fix.

## Test plan

- [x] Added regression test `close_others_re_anchors_tab_scroll_to_surviving_tab` — fails without the fix (offset stays at 80), passes with it (offset clamps inside the kept tab's width).
- [x] Existing `test_ensure_active_tab_visible_static_offset` still passes.
- [x] `cargo fmt --check`, `cargo clippy -p fresh-editor` clean on the touched code.
- [x] Manual reproduction in tmux confirmed bug ↔ fix.

https://claude.ai/code/session_014SbxrYr7vusVvWvtrXr4oF

---
_Generated by [Claude Code](https://claude.ai/code/session_014SbxrYr7vusVvWvtrXr4oF)_