### PR TITLE
Add right-click context menu to orchestrator dock sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Improvements
 
+* **Orchestrator Dock right-click menu**: right-click a session row for a context menu with Visit / Archive / Delete. Archive and Delete open a centered, full-screen-dimmed confirmation before they run.
 * **`variable.builtin` syntax category** for `this` / `self` / `super` (#2150, by @masmu).
 * **`storage.type`** keywords highlight as keywords rather than types (#2151, by @masmu).
 * **Async clipboard paste**: paste no longer blocks the editor, and a hung X11/Wayland clipboard owner should no longer freeze it (#2155).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Improvements
 
-* **Orchestrator Dock right-click menu**: right-click a session row for a context menu with Visit / Archive / Delete. Archive and Delete open a centered, full-screen-dimmed confirmation before they run.
+* **Orchestrator Dock right-click menu**: right-click a session row for an unobtrusive popup anchored at the cursor with Visit / Archive / Delete. Archive and Delete open a centered, full-screen-dimmed confirmation before they run.
 * **`variable.builtin` syntax category** for `this` / `self` / `super` (#2150, by @masmu).
 * **`storage.type`** keywords highlight as keywords rather than types (#2151, by @masmu).
 * **Async clipboard paste**: paste no longer blocks the editor, and a hung X11/Wayland clipboard owner should no longer freeze it (#2155).

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -492,6 +492,17 @@ let dockBlurred = false;
 // Monotonic token so a rapid run of ↑/↓ only commits the *last*
 // selection after the debounce window (30ms) — see `scheduleDockSwitch`.
 let dockSwitchToken = 0;
+// Right-click context menu for a dock session row. A centered, dimmed
+// floating modal (its own host slot, so the dock stays visible behind
+// it) that offers Visit / Archive / Delete against one session. The
+// menu opens at `stage: "menu"`; choosing Archive/Delete swaps the same
+// panel to a `stage: "confirm"` pane (the destructive actions require a
+// confirmation), reusing `buildConfirmPane`. Visit acts immediately.
+type DockMenuState =
+  | { sessionId: number; stage: "menu" }
+  | { sessionId: number; stage: "confirm"; action: "archive" | "delete" };
+let dockMenuPanel: FloatingWidgetPanel | null = null;
+let dockMenuState: DockMenuState | null = null;
 // Default dock width on a "typical" terminal, and the bounds the
 // responsive width is clamped to. The dock scales with the terminal
 // (`dockDefaultWidth`) between these; a user drag still overrides it
@@ -2948,6 +2959,106 @@ function buildDockSpec(): WidgetSpec {
     }),
     ...bottom,
   );
+}
+
+// ---------------------------------------------------------------------
+// Dock session context menu (right-click).
+//
+// A centered, dimmed floating modal (its own host slot, so the dock
+// stays visible behind it) offering Visit / Archive / Delete against a
+// single right-clicked session. The destructive actions (Archive,
+// Delete) swap the same panel to a confirmation pane — reusing the
+// modal picker's `buildConfirmPane` — before they run. Visit acts
+// immediately.
+// ---------------------------------------------------------------------
+
+// Visit the session behind the context menu: switch the active window to
+// it and hand keyboard focus to the editor (the dock stays visible). A
+// discovered on-disk worktree has no live window, so attach a fresh
+// session to it instead — mirrors the dock's Enter (`dock_activate`).
+function dockMenuVisit(id: number): void {
+  const s = orchestratorSessions.get(id);
+  if (!s) return;
+  if (s.discovered) {
+    void attachToWorktree({
+      root: s.root,
+      projectPath: s.projectPath ?? s.root,
+      label: s.label,
+      branch: s.branch,
+      discoveredId: s.id,
+    });
+    return;
+  }
+  if (id > 0 && id !== editor.activeWindow()) editor.setActiveWindow(id);
+  if (openPanel && dockMode) {
+    dockBlurred = true;
+    editor.floatingPanelControl(openPanel.id(), "blur", 0);
+    editor.setEditorMode(null);
+  }
+}
+
+function buildDockMenuSpec(state: DockMenuState): WidgetSpec {
+  if (state.stage === "confirm") {
+    // Reuse the picker's confirmation pane (single-session form). Its
+    // buttons are keyed `confirm-cancel` / `confirm-<action>`, handled
+    // in the dock-menu `widget_event` block.
+    return buildConfirmPane({ action: state.action, ids: [state.sessionId] });
+  }
+  const s = orchestratorSessions.get(state.sessionId);
+  const label = s?.label ?? `[${state.sessionId}]`;
+  const canArchive = bulkEligible("archive", state.sessionId);
+  const canDelete = bulkEligible("delete", state.sessionId);
+  return labeledSection({
+    label: `Session: ${label}`,
+    child: col(
+      button("Visit…", { intent: "primary", key: "ctx-visit" }),
+      spacer(0),
+      button("Archive", { key: "ctx-archive", disabled: !canArchive }),
+      spacer(0),
+      button("Delete", { intent: "danger", key: "ctx-delete", disabled: !canDelete }),
+      spacer(0),
+      row(flexSpacer(), hintBar([{ keys: "Esc", label: "close" }]), flexSpacer()),
+    ),
+  });
+}
+
+function renderDockMenu(): void {
+  if (dockMenuPanel && dockMenuState) {
+    dockMenuPanel.update(buildDockMenuSpec(dockMenuState));
+  }
+}
+
+// Open the right-click context menu for the session at filtered-list
+// `index`. Mounts a small centered modal over the dock (the dock stays
+// mounted in its own slot behind the dimmed overlay).
+function openDockContextMenu(index: number): void {
+  if (!openDialog) return;
+  const id = openDialog.filteredIds[index];
+  if (typeof id !== "number") return;
+  // Align the dock's highlighted row with the right-clicked one so the
+  // menu and the list agree on the target.
+  openDialog.selectedIndex = index;
+  if (openPanel) openPanel.setSelectedIndex("sessions", index);
+  dockMenuState = { sessionId: id, stage: "menu" };
+  if (!dockMenuPanel) dockMenuPanel = new FloatingWidgetPanel();
+  // Sized to fit the tallest stage (the Delete confirmation pane); the
+  // menu stage simply leaves blank space below its three buttons.
+  dockMenuPanel.mount(buildDockMenuSpec(dockMenuState), {
+    widthPct: 50,
+    heightPct: 44,
+  });
+  // Center + dim over the *full* screen (covering the dock), so the menu
+  // and its confirmation read as a true modal rather than a panel cramped
+  // into the chrome area beside the dock. Mirrors the modal picker.
+  editor.floatingPanelControl(dockMenuPanel.id(), "fullscreen", 1);
+}
+
+function closeDockContextMenu(): void {
+  if (dockMenuPanel) {
+    dockMenuPanel.unmount();
+    dockMenuPanel = null;
+  }
+  dockMenuState = null;
 }
 
 // Commit the highlighted session as the active window after a short
@@ -6007,6 +6118,51 @@ function enterBulkConfirm(action: BulkAction): void {
 
 editor.on("widget_event", (e) => {
   // ---------------------------------------------------------------------
+  // Dock session context menu (right-click): Visit / Archive / Delete.
+  // ---------------------------------------------------------------------
+  if (dockMenuPanel && dockMenuState && e.panel_id === dockMenuPanel.id()) {
+    const id = dockMenuState.sessionId;
+    if (e.event_type === "cancel") {
+      // Esc dismissed the menu — the host already unmounted the panel,
+      // so just drop our handle (don't unmount it again).
+      dockMenuPanel = null;
+      dockMenuState = null;
+      return;
+    }
+    if (e.event_type === "activate") {
+      if (e.widget_key === "ctx-visit") {
+        closeDockContextMenu();
+        dockMenuVisit(id);
+        return;
+      }
+      if (e.widget_key === "ctx-archive" && bulkEligible("archive", id)) {
+        dockMenuState = { sessionId: id, stage: "confirm", action: "archive" };
+        renderDockMenu();
+        return;
+      }
+      if (e.widget_key === "ctx-delete" && bulkEligible("delete", id)) {
+        dockMenuState = { sessionId: id, stage: "confirm", action: "delete" };
+        renderDockMenu();
+        return;
+      }
+      if (e.widget_key === "confirm-cancel") {
+        // Back to the menu (not all the way out) so a mis-click on a
+        // destructive action is one click from recoverable.
+        dockMenuState = { sessionId: id, stage: "menu" };
+        renderDockMenu();
+        return;
+      }
+      if (e.widget_key === "confirm-archive" || e.widget_key === "confirm-delete") {
+        const action = e.widget_key === "confirm-archive" ? "archive" : "delete";
+        closeDockContextMenu();
+        void runConfirmedAction(action, [id]);
+        return;
+      }
+    }
+    return;
+  }
+
+  // ---------------------------------------------------------------------
   // New-session form
   // ---------------------------------------------------------------------
   if (form && formPanel && e.panel_id === formPanel.id()) {
@@ -6324,6 +6480,19 @@ editor.on("widget_event", (e) => {
       const nextIdx = prevId !== undefined ? next.indexOf(prevId) : -1;
       openDialog.selectedIndex = nextIdx >= 0 ? nextIdx : 0;
       refreshOpenDialog();
+      return;
+    }
+    // Right-click on a session row → open its context menu. Only the
+    // dock wires this up (the host fires `context` for right-clicks in
+    // the dock column); the modal picker has its own action buttons.
+    if (
+      e.event_type === "context" &&
+      dockMode &&
+      ((e.payload ?? {}) as Record<string, unknown>).list_key === "sessions"
+    ) {
+      const payload = (e.payload ?? {}) as Record<string, unknown>;
+      const idx = payload.index;
+      if (typeof idx === "number") openDockContextMenu(idx);
       return;
     }
     // List selection. Keyboard nav fires this with `widget_key`

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -3016,18 +3016,22 @@ function buildDockMenuSpec(state: DockMenuState): WidgetSpec {
   const label = s?.label ?? `[${state.sessionId}]`;
   const canArchive = bulkEligible("archive", state.sessionId);
   const canDelete = bulkEligible("delete", state.sessionId);
-  return labeledSection({
-    label: `Session: ${label}`,
-    child: col(
-      button("Visit…", { intent: "primary", key: "ctx-visit" }),
-      spacer(0),
-      button("Archive", { key: "ctx-archive", disabled: !canArchive }),
-      spacer(0),
-      button("Delete", { intent: "danger", key: "ctx-delete", disabled: !canDelete }),
-      spacer(0),
-      row(flexSpacer(), hintBar([{ keys: "Esc", label: "close" }]), flexSpacer()),
-    ),
-  });
+  // Intentionally intrinsic-width content only: NO `labeledSection`,
+  // `flexSpacer`, or `fullWidth` widgets — those expand to the panel
+  // width and would blow the anchored popup up to ~half the screen. The
+  // host frames the box (its border) and sizes it to the widest of these
+  // rows, so the popup hugs its items like a real context menu.
+  return col(
+    { kind: "raw", entries: [
+      styledRow([{ text: `${label}`, style: { bold: true } }]),
+    ] },
+    button("Visit…", { intent: "primary", key: "ctx-visit" }),
+    button("Archive", { key: "ctx-archive", disabled: !canArchive }),
+    button("Delete", { intent: "danger", key: "ctx-delete", disabled: !canDelete }),
+    { kind: "raw", entries: [
+      styledRow([{ text: "Esc to close", style: { fg: "ui.menu_disabled_fg" } }]),
+    ] },
+  );
 }
 
 function renderDockMenu(): void {

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -492,15 +492,23 @@ let dockBlurred = false;
 // Monotonic token so a rapid run of ↑/↓ only commits the *last*
 // selection after the debounce window (30ms) — see `scheduleDockSwitch`.
 let dockSwitchToken = 0;
-// Right-click context menu for a dock session row. A centered, dimmed
-// floating modal (its own host slot, so the dock stays visible behind
-// it) that offers Visit / Archive / Delete against one session. The
-// menu opens at `stage: "menu"`; choosing Archive/Delete swaps the same
-// panel to a `stage: "confirm"` pane (the destructive actions require a
+// Right-click context menu for a dock session row. At `stage: "menu"`
+// it's an unobtrusive content-sized popup anchored at the click (no
+// background dim) offering Visit / Archive / Delete against one session.
+// Choosing Archive/Delete swaps the SAME panel to a centered, dimmed
+// `stage: "confirm"` modal (the destructive actions require a
 // confirmation), reusing `buildConfirmPane`. Visit acts immediately.
+// `anchorCol`/`anchorRow` are the right-click cell, kept so a return
+// from confirm→menu (Cancel) re-anchors the popup where it opened.
 type DockMenuState =
-  | { sessionId: number; stage: "menu" }
-  | { sessionId: number; stage: "confirm"; action: "archive" | "delete" };
+  | { sessionId: number; anchorCol: number; anchorRow: number; stage: "menu" }
+  | {
+      sessionId: number;
+      anchorCol: number;
+      anchorRow: number;
+      stage: "confirm";
+      action: "archive" | "delete";
+    };
 let dockMenuPanel: FloatingWidgetPanel | null = null;
 let dockMenuState: DockMenuState | null = null;
 // Default dock width on a "typical" terminal, and the bounds the
@@ -3028,10 +3036,27 @@ function renderDockMenu(): void {
   }
 }
 
+// Pack a screen cell into the single numeric arg `floatingPanelControl`
+// takes (the host unpacks `y << 16 | x`). Both coords fit a u16.
+function packCell(col: number, row: number): number {
+  return (Math.max(0, row) * 65536) + Math.max(0, col);
+}
+
+// Anchor the menu popup at its stored right-click cell — an unobtrusive,
+// content-sized popup with no background dim.
+function anchorDockMenu(): void {
+  if (!dockMenuPanel || !dockMenuState) return;
+  editor.floatingPanelControl(
+    dockMenuPanel.id(),
+    "anchor",
+    packCell(dockMenuState.anchorCol, dockMenuState.anchorRow),
+  );
+}
+
 // Open the right-click context menu for the session at filtered-list
-// `index`. Mounts a small centered modal over the dock (the dock stays
-// mounted in its own slot behind the dimmed overlay).
-function openDockContextMenu(index: number): void {
+// `index`, anchored at the click cell `(col, row)`. The dock stays
+// mounted in its own slot behind the popup.
+function openDockContextMenu(index: number, col: number, row: number): void {
   if (!openDialog) return;
   const id = openDialog.filteredIds[index];
   if (typeof id !== "number") return;
@@ -3039,18 +3064,26 @@ function openDockContextMenu(index: number): void {
   // menu and the list agree on the target.
   openDialog.selectedIndex = index;
   if (openPanel) openPanel.setSelectedIndex("sessions", index);
-  dockMenuState = { sessionId: id, stage: "menu" };
+  dockMenuState = { sessionId: id, anchorCol: col, anchorRow: row, stage: "menu" };
   if (!dockMenuPanel) dockMenuPanel = new FloatingWidgetPanel();
-  // Sized to fit the tallest stage (the Delete confirmation pane); the
-  // menu stage simply leaves blank space below its three buttons.
+  // widthPct/heightPct seed the centered confirm stage; the anchored menu
+  // stage ignores them (it sizes to content). Mount, then anchor.
   dockMenuPanel.mount(buildDockMenuSpec(dockMenuState), {
     widthPct: 50,
     heightPct: 44,
   });
-  // Center + dim over the *full* screen (covering the dock), so the menu
-  // and its confirmation read as a true modal rather than a panel cramped
-  // into the chrome area beside the dock. Mirrors the modal picker.
+  anchorDockMenu();
+}
+
+// Switch the popup to the centered, full-screen-dimmed confirmation for a
+// destructive action. Reuses the same panel; only the placement + spec
+// change.
+function dockMenuEnterConfirm(action: "archive" | "delete"): void {
+  if (!dockMenuPanel || !dockMenuState) return;
+  dockMenuState = { ...dockMenuState, stage: "confirm", action };
+  editor.floatingPanelControl(dockMenuPanel.id(), "center", 0);
   editor.floatingPanelControl(dockMenuPanel.id(), "fullscreen", 1);
+  renderDockMenu();
 }
 
 function closeDockContextMenu(): void {
@@ -3059,6 +3092,19 @@ function closeDockContextMenu(): void {
     dockMenuPanel = null;
   }
   dockMenuState = null;
+}
+
+// Tear down the menu and hand keyboard focus back to the dock (whose
+// keys were blurred when the popup mounted). Mirrors `restoreDockAfterForm`.
+function closeDockContextMenuAndRestoreDock(): void {
+  closeDockContextMenu();
+  if (openPanel && dockMode) {
+    dockBlurred = false;
+    dockFocus = "list";
+    editor.floatingPanelControl(openPanel.id(), "focus", 0);
+    openPanel.setFocusKey("sessions");
+    refreshOpenDialog();
+  }
 }
 
 // Commit the highlighted session as the active window after a short
@@ -6123,38 +6169,46 @@ editor.on("widget_event", (e) => {
   if (dockMenuPanel && dockMenuState && e.panel_id === dockMenuPanel.id()) {
     const id = dockMenuState.sessionId;
     if (e.event_type === "cancel") {
-      // Esc dismissed the menu — the host already unmounted the panel,
-      // so just drop our handle (don't unmount it again).
+      // Esc or a click outside dismissed the popup — the host already
+      // unmounted the panel, so just drop our handle (don't unmount it
+      // again) and hand keyboard focus back to the dock.
       dockMenuPanel = null;
       dockMenuState = null;
+      if (openPanel && dockMode) {
+        dockBlurred = false;
+        dockFocus = "list";
+        editor.floatingPanelControl(openPanel.id(), "focus", 0);
+        openPanel.setFocusKey("sessions");
+        refreshOpenDialog();
+      }
       return;
     }
     if (e.event_type === "activate") {
       if (e.widget_key === "ctx-visit") {
+        // Visit dives into the editor — no dock refocus.
         closeDockContextMenu();
         dockMenuVisit(id);
         return;
       }
       if (e.widget_key === "ctx-archive" && bulkEligible("archive", id)) {
-        dockMenuState = { sessionId: id, stage: "confirm", action: "archive" };
-        renderDockMenu();
+        dockMenuEnterConfirm("archive");
         return;
       }
       if (e.widget_key === "ctx-delete" && bulkEligible("delete", id)) {
-        dockMenuState = { sessionId: id, stage: "confirm", action: "delete" };
-        renderDockMenu();
+        dockMenuEnterConfirm("delete");
         return;
       }
       if (e.widget_key === "confirm-cancel") {
-        // Back to the menu (not all the way out) so a mis-click on a
-        // destructive action is one click from recoverable.
-        dockMenuState = { sessionId: id, stage: "menu" };
+        // Back to the anchored menu (not all the way out) so a mis-click
+        // on a destructive action is one click from recoverable.
+        dockMenuState = { ...dockMenuState, stage: "menu" };
         renderDockMenu();
+        anchorDockMenu();
         return;
       }
       if (e.widget_key === "confirm-archive" || e.widget_key === "confirm-delete") {
         const action = e.widget_key === "confirm-archive" ? "archive" : "delete";
-        closeDockContextMenu();
+        closeDockContextMenuAndRestoreDock();
         void runConfirmedAction(action, [id]);
         return;
       }
@@ -6492,7 +6546,9 @@ editor.on("widget_event", (e) => {
     ) {
       const payload = (e.payload ?? {}) as Record<string, unknown>;
       const idx = payload.index;
-      if (typeof idx === "number") openDockContextMenu(idx);
+      const col = typeof payload.col === "number" ? payload.col : 0;
+      const row = typeof payload.row === "number" ? payload.row : 0;
+      if (typeof idx === "number") openDockContextMenu(idx, col, row);
       return;
     }
     // List selection. Keyboard nav fires this with `widget_key`

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1098,6 +1098,13 @@ pub(crate) enum PanelPlacement {
     /// chrome is laid out in the remaining width; no background
     /// dimming. Non-modal — see `FloatingWidgetState::focused`.
     LeftDock { width_cols: u16 },
+    /// Content-sized popup anchored near a screen cell — a right-click
+    /// context menu. Drawn at `(x, y)` (clamped to stay fully on
+    /// screen), sized to its rendered content, with **no** background
+    /// dimming, so it reads as an unobtrusive popup rather than a modal.
+    /// Still input-modal via the `FloatingModal` layer: keys route to it
+    /// and a click outside dismisses it.
+    Anchored { x: u16, y: u16 },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3126,6 +3126,23 @@ impl Editor {
 
     /// Handle right-click event
     pub(super) fn handle_right_click(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
+        // Right-click inside the orchestrator dock column → let the plugin
+        // raise a per-session context menu. Mirrors the left-click path:
+        // re-focus the dock first (so the menu acts against a focused dock)
+        // and swallow the event so it never falls through to the editor or
+        // the file-explorer menu below.
+        if let Some(super::PanelPlacement::LeftDock { width_cols }) =
+            self.dock.as_ref().map(|f| f.placement)
+        {
+            if col < width_cols {
+                if self.dock.as_ref().map(|f| !f.focused).unwrap_or(false) {
+                    self.refocus_floating_panel(super::PanelSlot::Dock);
+                }
+                self.handle_floating_widget_context_click(super::PanelSlot::Dock, col, row);
+                return Ok(());
+            }
+        }
+
         let frame_w = self.active_chrome().last_frame_width;
         let frame_h = self.active_chrome().last_frame_height;
         if let Some(ref menu) = self.active_window().file_explorer_context_menu {
@@ -3850,6 +3867,75 @@ impl Editor {
                 );
             }
         }
+    }
+
+    /// Right-click hit-test against a floating widget panel. Resolves the
+    /// cell under the cursor to a widget and — only when it lands on a
+    /// `list` row — fires a `widget_event` with `event_type: "context"`
+    /// (carrying the same `{ index, key, list_key }` payload a left-click
+    /// "select" would). Plugins use this to raise a context menu for the
+    /// right-clicked row. Returns `true` when a context event fired (so the
+    /// caller swallows the click). Clicks on non-list widgets, padding, or
+    /// outside the inner rect return `false`.
+    fn handle_floating_widget_context_click(
+        &mut self,
+        slot: super::PanelSlot,
+        col: u16,
+        row: u16,
+    ) -> bool {
+        let (panel_id, inner) = match self.panel(slot) {
+            Some(fwp) => match fwp.last_inner_rect {
+                Some(rect) => (fwp.panel_id, rect),
+                None => return false,
+            },
+            None => return false,
+        };
+        if col < inner.x || col >= inner.x + inner.width {
+            return false;
+        }
+        if row < inner.y || row >= inner.y + inner.height {
+            return false;
+        }
+        let brow = (row - inner.y) as u32;
+        let entries = self
+            .panel(slot)
+            .map(|f| f.entries.clone())
+            .unwrap_or_default();
+        let local_screen_col = (col - inner.x) as usize;
+        let bcol = match entries.get(brow as usize) {
+            Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
+            None => return false,
+        };
+        let (payload, key, kind) =
+            match self
+                .widget_registry
+                .hit_test(slot.buffer_id(), brow, bcol as u32)
+            {
+                Some((_, hit)) => (hit.payload.clone(), hit.widget_key.clone(), hit.widget_kind),
+                None => return false,
+            };
+        // A context menu only makes sense over a real list row.
+        if kind != "list" {
+            return false;
+        }
+        if !self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            return false;
+        }
+        self.plugin_manager.read().unwrap().run_hook(
+            "widget_event",
+            crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                panel_id,
+                widget_key: key,
+                event_type: "context".to_string(),
+                payload,
+            },
+        );
+        true
     }
 
     /// `handle_editor_click` uses; clicks outside the rect are

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -85,6 +85,16 @@ impl Editor {
         let (col, row) = (mouse_event.column, mouse_event.row);
         match mouse_event.kind {
             MouseEventKind::Down(MouseButton::Left) => {
+                // An anchored popup (right-click context menu) dismisses when
+                // the press lands outside its box — standard menu behaviour.
+                // The centered modal instead swallows outside-clicks (it has
+                // explicit Cancel / Esc).
+                if self.floating_panel_is_anchored()
+                    && !self.point_in_floating_panel(super::PanelSlot::Floating, col, row)
+                {
+                    self.dismiss_floating_panel_with_cancel(super::PanelSlot::Floating);
+                    return Ok(true);
+                }
                 // Single / double / triple clicks all map to one panel
                 // hit-test — never the buffer's word/line select beneath.
                 self.handle_floating_widget_click(super::PanelSlot::Floating, col, row);
@@ -3906,7 +3916,7 @@ impl Editor {
             Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
             None => return false,
         };
-        let (payload, key, kind) =
+        let (mut payload, key, kind) =
             match self
                 .widget_registry
                 .hit_test(slot.buffer_id(), brow, bcol as u32)
@@ -3917,6 +3927,12 @@ impl Editor {
         // A context menu only makes sense over a real list row.
         if kind != "list" {
             return false;
+        }
+        // Carry the screen cell so the plugin can anchor its popup at the
+        // click (the list `select` payload only has the row index).
+        if let Some(obj) = payload.as_object_mut() {
+            obj.insert("col".to_string(), serde_json::json!(col));
+            obj.insert("row".to_string(), serde_json::json!(row));
         }
         if !self
             .plugin_manager
@@ -3936,6 +3952,61 @@ impl Editor {
             },
         );
         true
+    }
+
+    /// True when the centered (`Floating`) slot currently holds an
+    /// anchored context-menu popup rather than a centered modal.
+    fn floating_panel_is_anchored(&self) -> bool {
+        matches!(
+            self.floating_widget_panel.as_ref().map(|f| f.placement),
+            Some(super::PanelPlacement::Anchored { .. })
+        )
+    }
+
+    /// True when `(col, row)` falls within the panel's drawn box — the
+    /// last-rendered inner rect grown by its 1-cell border. False when the
+    /// panel or its rect is absent.
+    fn point_in_floating_panel(&self, slot: super::PanelSlot, col: u16, row: u16) -> bool {
+        let Some(inner) = self.panel(slot).and_then(|f| f.last_inner_rect) else {
+            return false;
+        };
+        let x0 = inner.x.saturating_sub(1);
+        let y0 = inner.y.saturating_sub(1);
+        // inner.{x,y} + {width,height} already lands on the far border cell.
+        col >= x0 && col <= inner.x + inner.width && row >= y0 && row <= inner.y + inner.height
+    }
+
+    /// Unmount the floating panel and fire a `cancel` widget_event so the
+    /// owning plugin clears its state — the click-outside analogue of the
+    /// Esc dismissal in `dispatch_floating_widget_key`.
+    fn dismiss_floating_panel_with_cancel(&mut self, slot: super::PanelSlot) {
+        let panel_id = match self.panel(slot) {
+            Some(f) => f.panel_id,
+            None => return,
+        };
+        let widget_key = self
+            .widget_registry
+            .get(panel_id)
+            .map(|p| p.focus_key.clone())
+            .unwrap_or_default();
+        if self
+            .plugin_manager
+            .read()
+            .unwrap()
+            .has_hook_handlers("widget_event")
+        {
+            self.plugin_manager.read().unwrap().run_hook(
+                "widget_event",
+                crate::services::plugins::hooks::HookArgs::WidgetEvent {
+                    panel_id,
+                    widget_key,
+                    event_type: "cancel".to_string(),
+                    payload: serde_json::json!({}),
+                },
+            );
+        }
+        *self.panel_opt_mut(slot) = None;
+        let _ = self.widget_registry.unmount(panel_id);
     }
 
     /// `handle_editor_click` uses; clicks outside the rect are

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4349,6 +4349,20 @@ impl Editor {
                 fwp.focused = true;
                 true
             }
+            // Place the panel as an unobtrusive content-sized popup anchored
+            // at a screen cell (a right-click context menu). The (x, y) cell
+            // is packed into the single `f64` arg as `y << 16 | x` — both fit
+            // a u16 and the sum is exact in `f64`. No chrome-geometry change
+            // (the dock/editor layout is untouched), so no relayout.
+            "anchor" => {
+                let packed = arg.max(0.0) as u64;
+                let x = (packed & 0xFFFF) as u16;
+                let y = ((packed >> 16) & 0xFFFF) as u16;
+                fwp.placement = super::PanelPlacement::Anchored { x, y };
+                fwp.focused = true;
+                fwp.fullscreen = false;
+                false
+            }
             "focus" => {
                 fwp.focused = true;
                 false

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1653,6 +1653,14 @@ impl Editor {
                 .as_ref()
                 .map(|f| f.fullscreen)
                 .unwrap_or(false);
+            // An anchored context-menu popup is unobtrusive: it neither
+            // dims the dock nor confines itself to `chrome_area` (its
+            // anchor is an absolute screen cell that may sit over the
+            // dock). Treat it like a non-dimming, full-frame placement.
+            let is_anchored = matches!(
+                self.floating_widget_panel.as_ref().map(|f| f.placement),
+                Some(super::PanelPlacement::Anchored { .. })
+            );
             // A centered modal makes the *whole* UI a passive, dimmed
             // background — the dock included. The dock was drawn above at
             // full brightness. A beside-dock modal only dims `chrome_area`,
@@ -1663,7 +1671,7 @@ impl Editor {
             // modal is up (the host blurs it on mount and the modal swallows
             // keys/clicks/wheel), so dimming it makes that passivity visible
             // rather than leaving it looking live beside the dialog.
-            if !fullscreen {
+            if !fullscreen && !is_anchored {
                 if let Some(dock) = dock_area {
                     if self.dock.is_some() {
                         crate::view::dimming::apply_dimming(frame, dock);
@@ -1679,7 +1687,11 @@ impl Editor {
             // with the dock — mirroring the settings / keybinding-editor
             // modals, which already lay into `chrome_area`. A `fullscreen`
             // panel instead gets the whole frame (`size`).
-            let modal_area = if fullscreen { size } else { chrome_area };
+            let modal_area = if fullscreen || is_anchored {
+                size
+            } else {
+                chrome_area
+            };
             self.render_floating_widget_panel(frame, modal_area, super::PanelSlot::Floating);
         }
     }
@@ -3993,21 +4005,47 @@ impl Editor {
         // modal overlay. The centered placement keeps the historical
         // fit-to-content + background-dim behaviour.
         let is_dock = matches!(placement, super::PanelPlacement::LeftDock { .. });
-        let overlay_rect = if is_dock {
-            area
-        } else {
-            let requested = Self::centered_overlay_rect(area, width_pct, height_pct);
-            let needed_h = (entries.len() as u16).saturating_add(2);
-            let effective_h = needed_h.min(requested.height).max(3);
-            ratatui::layout::Rect {
-                x: requested.x,
-                y: area.y + (area.height.saturating_sub(effective_h)) / 2,
-                width: requested.width,
-                height: effective_h,
+        let overlay_rect = match placement {
+            super::PanelPlacement::LeftDock { .. } => area,
+            super::PanelPlacement::Anchored { x, y } => {
+                // Size to the rendered content (not a percentage): an
+                // unobtrusive popup hugs its items. Width = widest entry +
+                // borders; height = entry count + borders. Then clamp the
+                // top-left so the whole box stays on screen.
+                use crate::primitives::display_width::str_width;
+                let content_w = entries
+                    .iter()
+                    .map(|e| str_width(&e.text) as u16)
+                    .max()
+                    .unwrap_or(0);
+                let w = content_w.saturating_add(2).clamp(6, area.width);
+                let needed_h = (entries.len() as u16).saturating_add(2);
+                let h = needed_h.clamp(3, area.height);
+                let max_x = area.x + area.width.saturating_sub(w);
+                let max_y = area.y + area.height.saturating_sub(h);
+                ratatui::layout::Rect {
+                    x: x.clamp(area.x, max_x),
+                    y: y.clamp(area.y, max_y),
+                    width: w,
+                    height: h,
+                }
+            }
+            super::PanelPlacement::Centered => {
+                let requested = Self::centered_overlay_rect(area, width_pct, height_pct);
+                let needed_h = (entries.len() as u16).saturating_add(2);
+                let effective_h = needed_h.min(requested.height).max(3);
+                ratatui::layout::Rect {
+                    x: requested.x,
+                    y: area.y + (area.height.saturating_sub(effective_h)) / 2,
+                    width: requested.width,
+                    height: effective_h,
+                }
             }
         };
 
-        if !is_dock {
+        // Only the centered modal dims the background; the dock and the
+        // anchored context-menu popup paint over the editor without it.
+        if matches!(placement, super::PanelPlacement::Centered) {
             crate::view::dimming::apply_dimming_excluding(frame, area, Some(overlay_rect));
         }
         frame.render_widget(Clear, overlay_rect);

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1437,3 +1437,107 @@ fn creating_session_moves_dock_highlight_to_new_session() {
         "the previously-active session must drop the heavy highlight border:\n{screen}"
     );
 }
+
+// ── right-click session context menu ──────────────────────────────────────
+//
+// Right-clicking a session card opens a small dimmed modal with
+// Visit / Archive / Delete; the destructive actions swap it to a centered
+// confirmation pane before they run. These drive only the mouse/keyboard
+// and assert on rendered output per CONTRIBUTING §2.
+
+/// Open the dock and right-click the first session card. Returns the
+/// harness with the context menu showing.
+fn open_dock_context_menu(name: &str) -> (tempfile::TempDir, EditorTestHarness) {
+    let (tmp, root) = setup_project(name);
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    // The session card's name line bears the project basename; right-click
+    // a column well inside the dock on that row.
+    let card_row = row_of(&h, name) as u16;
+    h.mouse_right_click(4, card_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Archive"))
+        .unwrap();
+    (tmp, h)
+}
+
+/// 0-based screen position (col, row) of the first occurrence of `needle`.
+fn pos_of(h: &EditorTestHarness, needle: &str) -> (u16, u16) {
+    let screen = h.screen_to_string();
+    screen
+        .lines()
+        .enumerate()
+        .find_map(|(r, l)| l.find(needle).map(|c| (c as u16, r as u16)))
+        .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
+}
+
+#[test]
+fn dock_right_click_opens_context_menu() {
+    let (_tmp, h) = open_dock_context_menu("alphaproj");
+
+    // All three actions plus the session header are present.
+    h.assert_screen_contains("Visit");
+    h.assert_screen_contains("Archive");
+    h.assert_screen_contains("Delete");
+    h.assert_screen_contains("alphaproj");
+}
+
+#[test]
+fn dock_context_menu_esc_closes() {
+    let (_tmp, mut h) = open_dock_context_menu("alphaproj");
+
+    // Esc dismisses the menu; the dock returns (its "Manage" button shows)
+    // and the menu-only "Archive"/"Delete" actions are gone.
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Archive"))
+        .unwrap();
+    h.assert_screen_contains("Manage");
+}
+
+#[test]
+fn dock_context_menu_delete_shows_centered_confirmation() {
+    let (_tmp, mut h) = open_dock_context_menu("alphaproj");
+
+    // Click the menu's "Delete" action → the confirmation pane replaces
+    // the menu (full-screen dimmed, centered).
+    let (dcol, drow) = pos_of(&h, "Delete");
+    h.mouse_click(dcol, drow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
+        .unwrap();
+    // The destructive-action warning and the Confirm/Cancel pair render.
+    h.assert_screen_contains("Uncommitted changes will be lost");
+    h.assert_screen_contains("Cancel");
+}
+
+#[test]
+fn dock_context_menu_confirm_cancel_returns_to_menu() {
+    let (_tmp, mut h) = open_dock_context_menu("alphaproj");
+
+    let (dcol, drow) = pos_of(&h, "Delete");
+    h.mouse_click(dcol, drow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Confirm Delete"))
+        .unwrap();
+
+    // Cancel returns to the three-action menu rather than closing outright,
+    // so a mis-click on a destructive action is recoverable.
+    let (ccol, crow) = pos_of(&h, "Cancel");
+    h.mouse_click(ccol, crow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Visit"))
+        .unwrap();
+    h.assert_screen_contains("Archive");
+    h.assert_screen_contains("Delete");
+}
+
+#[test]
+fn dock_context_menu_archive_shows_confirmation() {
+    let (_tmp, mut h) = open_dock_context_menu("alphaproj");
+
+    let (acol, arow) = pos_of(&h, "Archive");
+    h.mouse_click(acol, arow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Confirm Archive"))
+        .unwrap();
+    h.assert_screen_contains("Cancel");
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1541,3 +1541,47 @@ fn dock_context_menu_archive_shows_confirmation() {
         .unwrap();
     h.assert_screen_contains("Cancel");
 }
+
+/// The menu is an unobtrusive popup anchored at the click, not a centered
+/// modal: its items render in the left columns (near the dock click), not
+/// around mid-screen, and at roughly the clicked row.
+#[test]
+fn dock_context_menu_is_anchored_near_click() {
+    let (_tmp, root) = setup_project("alphaproj");
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 32, Default::default(), root.clone())
+            .unwrap();
+    h.render().unwrap();
+    open_dock(&mut h);
+
+    let card_row = row_of(&h, "alphaproj") as u16;
+    h.mouse_right_click(3, card_row).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("Visit"))
+        .unwrap();
+
+    let (vcol, vrow) = pos_of(&h, "Visit");
+    // Anchored to the left edge where the click landed — a centered modal
+    // on a 120-wide terminal would put this near col ~50.
+    assert!(
+        vcol < 24,
+        "context menu should hug the click (left columns), got col {vcol}"
+    );
+    // And vertically near the clicked row, not screen-centered.
+    assert!(
+        vrow >= card_row && vrow <= card_row + 6,
+        "context menu should open near the clicked row {card_row}, got row {vrow}"
+    );
+}
+
+/// Clicking outside the anchored popup dismisses it (standard menu
+/// behaviour) and returns control to the dock.
+#[test]
+fn dock_context_menu_click_outside_dismisses() {
+    let (_tmp, mut h) = open_dock_context_menu("alphaproj");
+
+    // Click far away in the editor area, well outside the popup box.
+    h.mouse_click(90, 20).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("Archive"))
+        .unwrap();
+    h.assert_screen_contains("Manage");
+}

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1465,12 +1465,15 @@ fn open_dock_context_menu(name: &str) -> (tempfile::TempDir, EditorTestHarness) 
 }
 
 /// 0-based screen position (col, row) of the first occurrence of `needle`.
+/// `str::find` returns a *byte* offset, but dock rows contain multibyte
+/// box-drawing glyphs (`┗━━━│`, 3 bytes each), so convert to a character
+/// column — that's the screen column for width-1 glyphs — before returning.
 fn pos_of(h: &EditorTestHarness, needle: &str) -> (u16, u16) {
     let screen = h.screen_to_string();
     screen
         .lines()
         .enumerate()
-        .find_map(|(r, l)| l.find(needle).map(|c| (c as u16, r as u16)))
+        .find_map(|(r, l)| l.find(needle).map(|b| (l[..b].chars().count() as u16, r as u16)))
         .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
 }
 

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1473,7 +1473,10 @@ fn pos_of(h: &EditorTestHarness, needle: &str) -> (u16, u16) {
     screen
         .lines()
         .enumerate()
-        .find_map(|(r, l)| l.find(needle).map(|b| (l[..b].chars().count() as u16, r as u16)))
+        .find_map(|(r, l)| {
+            l.find(needle)
+                .map(|b| (l[..b].chars().count() as u16, r as u16))
+        })
         .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
 }
 


### PR DESCRIPTION
## Summary
Adds a right-click context menu for session rows in the orchestrator dock, allowing users to Visit, Archive, or Delete sessions directly from the dock without opening the modal picker.

## Key Changes

* **New dock context menu UI**: Right-clicking a session row opens a centered, dimmed floating modal with three actions:
  - Visit: Immediately switches to the session (or attaches to discovered worktrees)
  - Archive: Opens a confirmation pane before archiving
  - Delete: Opens a confirmation pane before deleting

* **State management**: Added `DockMenuState` type and module-level state (`dockMenuPanel`, `dockMenuState`) to track the menu's visibility and current stage (menu vs. confirmation)

* **Menu implementation** (`orchestrator.ts`):
  - `openDockContextMenu()`: Opens the menu for a right-clicked session
  - `closeDockContextMenu()`: Closes and cleans up the menu
  - `buildDockMenuSpec()`: Renders either the action menu or confirmation pane
  - `dockMenuVisit()`: Handles the Visit action
  - `renderDockMenu()`: Updates the menu when transitioning between stages

* **Event handling**: Added `widget_event` handler block to process menu interactions (Visit, Archive, Delete, Cancel) and confirmation actions

* **Right-click detection** (`mouse_input.rs`):
  - New `handle_floating_widget_context_click()` method performs hit-testing on floating widget panels
  - Fires a `widget_event` with `event_type: "context"` only when right-clicking list rows
  - Integrated into `handle_right_click()` to intercept right-clicks in the dock column

* **Confirmation flow**: Destructive actions (Archive/Delete) transition the menu to a confirmation pane (reusing `buildConfirmPane`) rather than acting immediately. Clicking Cancel returns to the menu for recoverability.

## Notable Details

- The menu is a full-screen dimmed modal (like the modal picker) so it reads as a true modal rather than a panel cramped into the chrome area
- The dock remains visible and mounted behind the dimmed overlay
- Keyboard navigation (Esc to close, Enter to confirm) is supported via the existing floating panel infrastructure
- Only the dock wires up right-click context menus; the modal picker uses its own action buttons
- Reuses existing `bulkEligible()` checks to disable Archive/Delete when not applicable

## Tests
Added 5 end-to-end tests covering:
- Opening the context menu via right-click
- Closing with Esc
- Transitioning to Delete confirmation
- Returning from confirmation to menu via Cancel
- Transitioning to Archive confirmation

https://claude.ai/code/session_01TBxDsDDPyJ65q3U8Sq6o9o