### PR TITLE
Add '+' new-tab button to tab bar with New Terminal / New File popup

### DIFF
--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_A_01_state_a.svg
@@ -210,9 +210,10 @@
   <text x="352" y="32" fill="#000000" class="terminal" style="font-weight:bold;">×</text>
   <rect x="360" y="18" width="9" height="18" fill="#ffff00"/>
   <rect x="369" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="378" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="387" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="396" y="18" width="9" height="18" fill="#1e1e23"/>
+  <rect x="378" y="18" width="9" height="18" fill="#000000"/>
+  <rect x="387" y="18" width="9" height="18" fill="#000000"/>
+  <text x="388" y="32" fill="#ffffff" class="terminal" style="">+</text>
+  <rect x="396" y="18" width="9" height="18" fill="#000000"/>
   <rect x="405" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="414" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="423" y="18" width="9" height="18" fill="#1e1e23"/>

--- a/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
+++ b/crates/fresh-editor/docs/visual-regression/screenshots/Comprehensive_UI_B_01_state_b.svg
@@ -176,9 +176,10 @@
   <text x="91" y="32" fill="#ffffff" class="terminal" style="font-weight:bold;">×</text>
   <rect x="99" y="18" width="9" height="18" fill="#000000"/>
   <rect x="108" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="117" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="126" y="18" width="9" height="18" fill="#1e1e23"/>
-  <rect x="135" y="18" width="9" height="18" fill="#1e1e23"/>
+  <rect x="117" y="18" width="9" height="18" fill="#000000"/>
+  <rect x="126" y="18" width="9" height="18" fill="#000000"/>
+  <text x="127" y="32" fill="#ffffff" class="terminal" style="">+</text>
+  <rect x="135" y="18" width="9" height="18" fill="#000000"/>
   <rect x="144" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="153" y="18" width="9" height="18" fill="#1e1e23"/>
   <rect x="162" y="18" width="9" height="18" fill="#1e1e23"/>
@@ -522,12 +523,12 @@
   <rect x="108" y="54" width="9" height="18" fill="#000000"/>
   <text x="109" y="68" fill="#ffff00" class="terminal" style="">n</text>
   <rect x="117" y="54" width="9" height="18" fill="#000000"/>
-  <text x="118" y="68" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="118" y="68" fill="#8be9fd" class="terminal" style="">(</text>
   <rect x="126" y="54" width="9" height="18" fill="#000000"/>
-  <text x="127" y="68" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="127" y="68" fill="#8be9fd" class="terminal" style="">)</text>
   <rect x="135" y="54" width="9" height="18" fill="#000000"/>
   <rect x="144" y="54" width="9" height="18" fill="#000000"/>
-  <text x="145" y="68" fill="#d4d4d4" class="terminal" style="">{</text>
+  <text x="145" y="68" fill="#8be9fd" class="terminal" style="">{</text>
   <rect x="153" y="54" width="9" height="18" fill="#000000"/>
   <rect x="162" y="54" width="9" height="18" fill="#000000"/>
   <rect x="171" y="54" width="9" height="18" fill="#000000"/>
@@ -878,13 +879,13 @@
   <rect x="153" y="90" width="9" height="18" fill="#000000"/>
   <text x="154" y="104" fill="#ffff00" class="terminal" style="">!</text>
   <rect x="162" y="90" width="9" height="18" fill="#000000"/>
-  <text x="163" y="104" fill="#d4d4d4" class="terminal" style="">(</text>
+  <text x="163" y="104" fill="#50fa7b" class="terminal" style="">(</text>
   <rect x="171" y="90" width="9" height="18" fill="#000000"/>
   <text x="172" y="104" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="180" y="90" width="9" height="18" fill="#000000"/>
-  <text x="181" y="104" fill="#00cd00" class="terminal" style="">{</text>
+  <text x="181" y="104" fill="#f1fa8c" class="terminal" style="">{</text>
   <rect x="189" y="90" width="9" height="18" fill="#000000"/>
-  <text x="190" y="104" fill="#00cd00" class="terminal" style="">}</text>
+  <text x="190" y="104" fill="#f1fa8c" class="terminal" style="">}</text>
   <rect x="198" y="90" width="9" height="18" fill="#000000"/>
   <text x="199" y="104" fill="#00cd00" class="terminal" style="">&quot;</text>
   <rect x="207" y="90" width="9" height="18" fill="#000000"/>
@@ -1001,7 +1002,7 @@
   <rect x="711" y="90" width="9" height="18" fill="#000000"/>
   <text x="712" y="104" fill="#ffffff" class="terminal" style="">w</text>
   <rect x="720" y="90" width="9" height="18" fill="#000000"/>
-  <text x="721" y="104" fill="#d4d4d4" class="terminal" style="">)</text>
+  <text x="721" y="104" fill="#50fa7b" class="terminal" style="">)</text>
   <rect x="729" y="90" width="9" height="18" fill="#000000"/>
   <text x="730" y="104" fill="#d4d4d4" class="terminal" style="">;</text>
   <rect x="738" y="90" width="9" height="18" fill="#000000"/>
@@ -1051,7 +1052,7 @@
   <text x="37" y="122" fill="#8c8c8c" class="terminal" style="">│</text>
   <rect x="45" y="108" width="9" height="18" fill="#000000"/>
   <rect x="54" y="108" width="9" height="18" fill="#000000"/>
-  <text x="55" y="122" fill="#d4d4d4" class="terminal" style="">}</text>
+  <text x="55" y="122" fill="#8be9fd" class="terminal" style="">}</text>
   <rect x="63" y="108" width="9" height="18" fill="#000000"/>
   <rect x="72" y="108" width="9" height="18" fill="#000000"/>
   <rect x="81" y="108" width="9" height="18" fill="#000000"/>

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Zavřít vpravo",
   "tab.copy_full_path": "Kopírovat úplnou cestu",
   "tab.copy_relative_path": "Kopírovat relativní cestu",
+  "tab.new_file": "Nový soubor",
+  "tab.new_terminal": "Nový terminál",
   "terminal.closed": "Terminál %{id} zavřen",
   "terminal.exited": "Terminál %{id} ukončen",
   "terminal.failed_to_open": "Otevření terminálu selhalo: %{error}",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Rechts schließen",
   "tab.copy_full_path": "Vollständigen Pfad kopieren",
   "tab.copy_relative_path": "Relativen Pfad kopieren",
+  "tab.new_file": "Neue Datei",
+  "tab.new_terminal": "Neues Terminal",
   "terminal.closed": "Terminal %{id} geschlossen",
   "terminal.exited": "Terminal %{id} beendet",
   "terminal.failed_to_open": "Terminal konnte nicht geöffnet werden: %{error}",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1412,6 +1412,8 @@
   "tab.close_to_right": "Close to the Right",
   "tab.copy_full_path": "Copy Full Path",
   "tab.copy_relative_path": "Copy Relative Path",
+  "tab.new_file": "New File",
+  "tab.new_terminal": "New Terminal",
   "terminal.closed": "Terminal %{id} closed",
   "terminal.exited": "Terminal %{id} exited",
   "terminal.failed_to_open": "Failed to open terminal: %{error}",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Cerrar a la derecha",
   "tab.copy_full_path": "Copiar ruta completa",
   "tab.copy_relative_path": "Copiar ruta relativa",
+  "tab.new_file": "Nuevo archivo",
+  "tab.new_terminal": "Nuevo terminal",
   "terminal.closed": "Terminal %{id} cerrado",
   "terminal.exited": "Terminal %{id} finalizado",
   "terminal.failed_to_open": "Error al abrir terminal: %{error}",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Fermer à droite",
   "tab.copy_full_path": "Copier le chemin complet",
   "tab.copy_relative_path": "Copier le chemin relatif",
+  "tab.new_file": "Nouveau fichier",
+  "tab.new_terminal": "Nouveau terminal",
   "terminal.closed": "Terminal %{id} fermé",
   "terminal.exited": "Terminal %{id} terminé",
   "terminal.failed_to_open": "Échec de l'ouverture du terminal : %{error}",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Chiudi a Destra",
   "tab.copy_full_path": "Copia Percorso Completo",
   "tab.copy_relative_path": "Copia Percorso Relativo",
+  "tab.new_file": "Nuovo File",
+  "tab.new_terminal": "Nuovo terminale",
   "terminal.closed": "Terminale %{id} chiuso",
   "terminal.exited": "Terminale %{id} uscito",
   "terminal.failed_to_open": "Apertura terminale fallita: %{error}",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "右側を閉じる",
   "tab.copy_full_path": "フルパスをコピー",
   "tab.copy_relative_path": "相対パスをコピー",
+  "tab.new_file": "新規ファイル",
+  "tab.new_terminal": "新規ターミナル",
   "terminal.closed": "ターミナル %{id} を閉じました",
   "terminal.exited": "ターミナル %{id} が終了しました",
   "terminal.failed_to_open": "ターミナルを開けませんでした: %{error}",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "오른쪽 탭 닫기",
   "tab.copy_full_path": "전체 경로 복사",
   "tab.copy_relative_path": "상대 경로 복사",
+  "tab.new_file": "새 파일",
+  "tab.new_terminal": "새 터미널",
   "terminal.closed": "터미널 %{id} 닫힘",
   "terminal.exited": "터미널 %{id} 종료됨",
   "terminal.failed_to_open": "터미널 열기 실패: %{error}",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Fechar à direita",
   "tab.copy_full_path": "Copiar caminho completo",
   "tab.copy_relative_path": "Copiar caminho relativo",
+  "tab.new_file": "Novo arquivo",
+  "tab.new_terminal": "Novo terminal",
   "terminal.closed": "Terminal %{id} fechado",
   "terminal.exited": "Terminal %{id} encerrado",
   "terminal.failed_to_open": "Falha ao abrir terminal: %{error}",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Закрыть справа",
   "tab.copy_full_path": "Копировать полный путь",
   "tab.copy_relative_path": "Копировать относительный путь",
+  "tab.new_file": "Новый файл",
+  "tab.new_terminal": "Новый терминал",
   "terminal.closed": "Терминал %{id} закрыт",
   "terminal.exited": "Терминал %{id} завершён",
   "terminal.failed_to_open": "Не удалось открыть терминал: %{error}",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "ปิดด้านขวา",
   "tab.copy_full_path": "คัดลอกพาธแบบเต็ม",
   "tab.copy_relative_path": "คัดลอกพาธแบบสัมพัทธ์",
+  "tab.new_file": "ไฟล์ใหม่",
+  "tab.new_terminal": "เทอร์มินัลใหม่",
   "terminal.closed": "ปิดเทอร์มินัล %{id} แล้ว",
   "terminal.exited": "เทอร์มินัล %{id} ออกแล้ว",
   "terminal.failed_to_open": "เปิดเทอร์มินัลไม่สำเร็จ: %{error}",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Закрити праворуч",
   "tab.copy_full_path": "Копіювати повний шлях",
   "tab.copy_relative_path": "Копіювати відносний шлях",
+  "tab.new_file": "Новий файл",
+  "tab.new_terminal": "Новий термінал",
   "terminal.closed": "Термінал %{id} закрито",
   "terminal.exited": "Термінал %{id} завершено",
   "terminal.failed_to_open": "Не вдалося відкрити термінал: %{error}",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "Đóng bên phải",
   "tab.copy_full_path": "Sao chép đường dẫn đầy đủ",
   "tab.copy_relative_path": "Sao chép đường dẫn tương đối",
+  "tab.new_file": "Tệp mới",
+  "tab.new_terminal": "Terminal mới",
   "terminal.closed": "Đã đóng terminal %{id}",
   "terminal.exited": "Terminal %{id} đã thoát",
   "terminal.failed_to_open": "Mở terminal thất bại: %{error}",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1393,6 +1393,8 @@
   "tab.close_to_right": "关闭右侧",
   "tab.copy_full_path": "复制完整路径",
   "tab.copy_relative_path": "复制相对路径",
+  "tab.new_file": "新建文件",
+  "tab.new_terminal": "新建终端",
   "terminal.closed": "终端 %{id} 已关闭",
   "terminal.exited": "终端 %{id} 已退出",
   "terminal.failed_to_open": "打开终端失败：%{error}",

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -673,6 +673,16 @@ impl Editor {
             }
         }
 
+        // Handle "+" new-tab popup menu hover - update highlighted item
+        if let Some(HoverTarget::NewTabMenuItem(item_idx)) = new_target.clone() {
+            if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
+                if menu.highlighted != item_idx {
+                    menu.highlighted = item_idx;
+                    return true;
+                }
+            }
+        }
+
         // Handle file explorer status indicator hover - show tooltip
         // Always dismiss existing tooltip first when target changes
         if old_target != new_target
@@ -711,6 +721,7 @@ impl Editor {
         // tooltips overlapping other popups.
         if self.active_window_mut().theme_info_popup.is_some()
             || self.active_window_mut().tab_context_menu.is_some()
+            || self.active_window_mut().new_tab_menu.is_some()
             || self
                 .active_window_mut()
                 .file_explorer_context_menu
@@ -969,6 +980,26 @@ impl Editor {
             }
         }
 
+        // Check the "+" new-tab popup menu (rendered on top)
+        if let Some(ref menu) = self.active_window().new_tab_menu {
+            let menu_x = menu.position.0;
+            let menu_y = menu.position.1;
+            let menu_width = super::types::NEW_TAB_MENU_WIDTH;
+            let items = super::types::NewTabMenuItem::all();
+            let menu_height = items.len() as u16 + 2;
+
+            if col >= menu_x
+                && col < menu_x + menu_width
+                && row > menu_y
+                && row < menu_y + menu_height - 1
+            {
+                let item_idx = (row - menu_y - 1) as usize;
+                if item_idx < items.len() {
+                    return Some(HoverTarget::NewTabMenuItem(item_idx));
+                }
+            }
+        }
+
         // Check tab context menu first (it's rendered on top)
         if let Some(ref menu) = self.active_window().tab_context_menu {
             let menu_x = menu.position.0;
@@ -1143,6 +1174,7 @@ impl Editor {
                 Some(TabHit::ScrollLeft)
                 | Some(TabHit::ScrollRight)
                 | Some(TabHit::BarBackground)
+                | Some(TabHit::NewTabButton)
                 | None => {}
             }
         }
@@ -1762,6 +1794,11 @@ impl Editor {
         }
         if self.active_window_mut().tab_context_menu.is_some() {
             if let Some(result) = self.handle_tab_context_menu_click(col, row) {
+                return Some(result);
+            }
+        }
+        if self.active_window_mut().new_tab_menu.is_some() {
+            if let Some(result) = self.handle_new_tab_menu_click(col, row) {
                 return Some(result);
             }
         }
@@ -2593,6 +2630,14 @@ impl Editor {
                 }
                 Some(Ok(()))
             }
+            TabHit::NewTabButton => {
+                // Open the "+" popup just below the button. Close any tab
+                // context menu first so only one popup is visible.
+                self.active_window_mut().tab_context_menu = None;
+                self.active_window_mut().new_tab_menu =
+                    Some(super::types::NewTabMenu::new(split_id, col, row + 1));
+                Some(Ok(()))
+            }
             TabHit::BarBackground => None,
         }
     }
@@ -3136,6 +3181,10 @@ impl Editor {
 
     /// Handle right-click event
     pub(super) fn handle_right_click(&mut self, col: u16, row: u16) -> AnyhowResult<()> {
+        // A right-click anywhere dismisses the "+" new-tab popup (it's a
+        // left-click-only menu).
+        self.active_window_mut().new_tab_menu = None;
+
         // Right-click inside the orchestrator dock column → let the plugin
         // raise a per-session context menu. Mirrors the left-click path:
         // re-focus the dock first (so the menu acts against a focused dock)
@@ -3295,6 +3344,73 @@ impl Editor {
 
         // Execute the action
         Some(self.execute_tab_context_menu_action(item, buffer_id, split_id))
+    }
+
+    /// Handle left-click on the "+" new-tab popup menu.
+    pub(super) fn handle_new_tab_menu_click(
+        &mut self,
+        col: u16,
+        row: u16,
+    ) -> Option<AnyhowResult<()>> {
+        let menu = self.active_window_mut().new_tab_menu.as_ref()?;
+        let (menu_x, menu_y) = menu.position;
+        let items = super::types::NewTabMenuItem::all();
+        let menu_width = super::types::NEW_TAB_MENU_WIDTH;
+        let menu_height = items.len() as u16 + 2; // items + borders
+
+        // Click outside the menu closes it.
+        if col < menu_x || col >= menu_x + menu_width || row < menu_y || row >= menu_y + menu_height
+        {
+            self.active_window_mut().new_tab_menu = None;
+            return Some(Ok(()));
+        }
+
+        // Border rows (first/last) are inert.
+        if row == menu_y || row == menu_y + menu_height - 1 {
+            return Some(Ok(()));
+        }
+
+        let item_idx = (row - menu_y - 1) as usize;
+        if item_idx >= items.len() {
+            return Some(Ok(()));
+        }
+
+        let split_id = menu.split_id;
+        let item = items[item_idx];
+
+        // Close the menu before running the action.
+        self.active_window_mut().new_tab_menu = None;
+
+        Some(self.execute_new_tab_menu_action(item, split_id))
+    }
+
+    /// Execute a "+" new-tab popup menu action.
+    fn execute_new_tab_menu_action(
+        &mut self,
+        item: super::types::NewTabMenuItem,
+        split_id: LeafId,
+    ) -> AnyhowResult<()> {
+        use super::types::NewTabMenuItem;
+        // Ensure the new buffer/terminal lands in the split whose "+" was
+        // clicked: `open_terminal`/`new_buffer` act on the active split, so
+        // focus that split first (via the buffer it currently shows).
+        if let Some(buffer_id) = self
+            .windows
+            .get(&self.active_window)
+            .and_then(|w| w.buffers.splits())
+            .and_then(|(mgr, _)| mgr.buffer_for_split(split_id))
+        {
+            self.focus_split(split_id, buffer_id);
+        }
+        match item {
+            NewTabMenuItem::NewTerminal => {
+                self.open_terminal();
+            }
+            NewTabMenuItem::NewFile => {
+                self.new_buffer();
+            }
+        }
+        Ok(())
     }
 
     /// Execute a tab context menu action

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1548,6 +1548,12 @@ impl Editor {
             self.render_file_explorer_context_menu(frame, &menu);
         }
 
+        // Render the "+" new-tab popup menu if open
+        let new_tab_menu = self.active_window().new_tab_menu.clone();
+        if let Some(menu) = new_tab_menu {
+            self.render_new_tab_menu(frame, &menu);
+        }
+
         // Record non-editor region theme keys for the theme inspector
         self.record_non_editor_theme_regions();
 
@@ -3511,6 +3517,64 @@ impl Editor {
             // Pad the label to fill the menu width
             let label = item.label();
             let content_width = (menu_width as usize).saturating_sub(2); // -2 for borders
+            let padded_label = format!(" {:<width$}", label, width = content_width - 1);
+
+            lines.push(Line::from(vec![Span::styled(padded_label, style)]));
+        }
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(self.theme.read().unwrap().menu_border_fg))
+            .style(Style::default().bg(self.theme.read().unwrap().menu_dropdown_bg));
+
+        let paragraph = Paragraph::new(lines).block(block);
+        frame.render_widget(paragraph, area);
+    }
+
+    /// Render the "+" new-tab popup menu (New Terminal / New File).
+    fn render_new_tab_menu(&self, frame: &mut Frame, menu: &super::types::NewTabMenu) {
+        use ratatui::style::Style;
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+
+        let items = super::types::NewTabMenuItem::all();
+        let menu_width = super::types::NEW_TAB_MENU_WIDTH;
+        let menu_height = items.len() as u16 + 2; // items + borders
+
+        let screen_width = frame.area().width;
+        let screen_height = frame.area().height;
+
+        let menu_x = if menu.position.0 + menu_width > screen_width {
+            screen_width.saturating_sub(menu_width)
+        } else {
+            menu.position.0
+        };
+        let menu_y = if menu.position.1 + menu_height > screen_height {
+            screen_height.saturating_sub(menu_height)
+        } else {
+            menu.position.1
+        };
+
+        let area = ratatui::layout::Rect::new(menu_x, menu_y, menu_width, menu_height);
+
+        frame.render_widget(Clear, area);
+
+        let mut lines = Vec::new();
+        for (idx, item) in items.iter().enumerate() {
+            let is_highlighted = idx == menu.highlighted;
+
+            let style = if is_highlighted {
+                Style::default()
+                    .fg(self.theme.read().unwrap().menu_highlight_fg)
+                    .bg(self.theme.read().unwrap().menu_highlight_bg)
+            } else {
+                Style::default()
+                    .fg(self.theme.read().unwrap().menu_dropdown_fg)
+                    .bg(self.theme.read().unwrap().menu_dropdown_bg)
+            };
+
+            let label = item.label();
+            let content_width = (menu_width as usize).saturating_sub(2);
             let padded_label = format!(" {:<width$}", label, width = content_width - 1);
 
             lines.push(Line::from(vec![Span::styled(padded_label, style)]));

--- a/crates/fresh-editor/src/app/scroll_sync.rs
+++ b/crates/fresh-editor/src/app/scroll_sync.rs
@@ -55,7 +55,12 @@ impl crate::app::window::Window {
             );
 
             let total_tabs_width: usize = tab_widths.iter().sum();
-            let max_visible_width = available_width as usize;
+            // Reserve the pinned "+" button's column when the tabs overflow, so
+            // the active tab stays fully visible and never slips under it.
+            let max_visible_width = crate::view::ui::tabs::tabs_render_width(
+                total_tabs_width,
+                available_width as usize,
+            );
 
             let active_target = view_state.active_target();
             let active_target = if matches!(active_target, crate::view::split::TabTarget::Buffer(_))

--- a/crates/fresh-editor/src/app/types/context_menu.rs
+++ b/crates/fresh-editor/src/app/types/context_menu.rs
@@ -3,6 +3,9 @@ use rust_i18n::t;
 
 pub const FILE_EXPLORER_CONTEXT_MENU_WIDTH: u16 = 24;
 
+/// Width of the "+" new-tab popup menu (fits "New Terminal" + padding).
+pub const NEW_TAB_MENU_WIDTH: u16 = 18;
+
 /// Tab context menu items
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabContextMenuItem {
@@ -88,6 +91,70 @@ impl TabContextMenu {
     /// Move highlight up
     pub fn prev_item(&mut self) {
         let items = TabContextMenuItem::all();
+        self.highlighted = if self.highlighted == 0 {
+            items.len() - 1
+        } else {
+            self.highlighted - 1
+        };
+    }
+}
+
+/// Items in the "+" new-tab popup menu (shown when clicking the `+`
+/// button at the end of the tab bar).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NewTabMenuItem {
+    /// Open a new terminal in the split
+    NewTerminal,
+    /// Create a new empty file buffer
+    NewFile,
+}
+
+impl NewTabMenuItem {
+    /// Get all menu items in order.
+    pub fn all() -> &'static [Self] {
+        &[Self::NewTerminal, Self::NewFile]
+    }
+
+    /// Get the display label for this menu item.
+    pub fn label(&self) -> String {
+        match self {
+            Self::NewTerminal => t!("tab.new_terminal").to_string(),
+            Self::NewFile => t!("tab.new_file").to_string(),
+        }
+    }
+}
+
+/// State for the "+" new-tab popup menu (left-click on the tab bar's
+/// trailing `+` button).
+#[derive(Debug, Clone)]
+pub struct NewTabMenu {
+    /// The split whose tab bar's `+` button was clicked.
+    pub split_id: LeafId,
+    /// Screen position where the menu should appear (x, y).
+    pub position: (u16, u16),
+    /// Currently highlighted menu item index.
+    pub highlighted: usize,
+}
+
+impl NewTabMenu {
+    /// Create a new "+" popup menu anchored at the given screen position.
+    pub fn new(split_id: LeafId, x: u16, y: u16) -> Self {
+        Self {
+            split_id,
+            position: (x, y),
+            highlighted: 0,
+        }
+    }
+
+    /// Move highlight down.
+    pub fn next_item(&mut self) {
+        let items = NewTabMenuItem::all();
+        self.highlighted = (self.highlighted + 1) % items.len();
+    }
+
+    /// Move highlight up.
+    pub fn prev_item(&mut self) {
+        let items = NewTabMenuItem::all();
         self.highlighted = if self.highlighted == 0 {
             items.len() - 1
         } else {

--- a/crates/fresh-editor/src/app/types/hover.rs
+++ b/crates/fresh-editor/src/app/types/hover.rs
@@ -70,4 +70,6 @@ pub enum HoverTarget {
     TabContextMenuItem(usize),
     /// Hovering over a file explorer context menu item (item_index)
     FileExplorerContextMenuItem(usize),
+    /// Hovering over a "+" new-tab popup menu item (item_index)
+    NewTabMenuItem(usize),
 }

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -20,8 +20,10 @@ pub use buffer_meta::{BufferKind, BufferMetadata};
 
 // context_menu re-exports
 pub use context_menu::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
+pub use context_menu::NEW_TAB_MENU_WIDTH;
 pub use context_menu::{
-    FileExplorerContextMenu, FileExplorerContextMenuItem, TabContextMenu, TabContextMenuItem,
+    FileExplorerContextMenu, FileExplorerContextMenuItem, NewTabMenu, NewTabMenuItem,
+    TabContextMenu, TabContextMenuItem,
 };
 
 // drag re-exports

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -673,6 +673,10 @@ pub struct Window {
     /// Tab context menu state (right-click on a tab in this window).
     pub tab_context_menu: Option<crate::app::types::TabContextMenu>,
 
+    /// "+" new-tab popup menu state (left-click on the tab bar's trailing
+    /// `+` button). Offers "New Terminal" / "New File".
+    pub new_tab_menu: Option<crate::app::types::NewTabMenu>,
+
     /// File-explorer context menu state (right-click in the explorer).
     pub file_explorer_context_menu: Option<crate::app::types::FileExplorerContextMenu>,
 
@@ -1791,6 +1795,7 @@ impl Window {
             last_persistent_auto_save: now,
             warning_domains: crate::app::warning_domains::WarningDomainRegistry::default(),
             tab_context_menu: None,
+            new_tab_menu: None,
             file_explorer_context_menu: None,
             theme_info_popup: None,
             event_debug: None,

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -159,6 +159,30 @@ impl TabLayout {
 /// Renders the tab bar showing open buffers
 pub struct TabsRenderer;
 
+/// The trailing "+" new-tab button cell text.
+const NEW_TAB_BUTTON_TEXT: &str = " + ";
+/// Display width (columns) of [`NEW_TAB_BUTTON_TEXT`].
+pub const NEW_TAB_BUTTON_WIDTH: usize = 3;
+
+/// Width available for laying out / scrolling the real tabs, given the total
+/// width of all tabs (including inter-tab separators) and the full tab-bar
+/// width.
+///
+/// When the tabs plus an inline "+" button fit, the "+" is rendered inline
+/// right after the last tab and the full bar width is available. When they
+/// overflow, the "+" is pinned to the right edge of the bar and its column is
+/// reserved here, so the tabs scroll within the remaining width and never slip
+/// underneath the pinned button.
+pub fn tabs_render_width(tabs_total: usize, bar_width: usize) -> usize {
+    let sep_before_plus = if tabs_total > 0 { 1 } else { 0 };
+    let inline_total = tabs_total + sep_before_plus + NEW_TAB_BUTTON_WIDTH;
+    if inline_total > bar_width && bar_width > NEW_TAB_BUTTON_WIDTH {
+        bar_width - NEW_TAB_BUTTON_WIDTH
+    } else {
+        bar_width
+    }
+}
+
 /// Compute scroll offset to bring the active tab into view.
 /// Always scrolls to put the active tab at a comfortable position.
 /// `tab_widths` includes separators between tabs.
@@ -575,13 +599,18 @@ impl TabsRenderer {
                 separator_offset += 1;
             }
         }
-        // Append a trailing "+" new-tab button as a separate tab. It sits
-        // right after the last real tab (preceded by a separator) and
-        // participates in the same scroll/truncation flow below, so no
-        // special-casing is needed when rendering the visible window.
-        let plus_logical_start: usize = {
-            let tabs_total: usize = final_spans.iter().map(|(_, w)| w).sum();
-            if !rendered_targets.is_empty() {
+        // Decide where the trailing "+" new-tab button goes. When the tabs
+        // plus an inline "+" fit, the "+" is appended into the scroll flow and
+        // sits right after the last tab. When they overflow, the "+" is pinned
+        // to the right edge of the bar (`tabs_render_width` reserves its
+        // column) and drawn on top after the main paragraph render below.
+        let tabs_total: usize = final_spans.iter().map(|(_, w)| w).sum();
+        let max_width = tabs_render_width(tabs_total, area.width as usize);
+        let pin_plus = max_width < area.width as usize;
+
+        let mut inline_plus_range: Option<(usize, usize)> = None;
+        if !pin_plus {
+            let plus_start = if !rendered_targets.is_empty() {
                 // Separator between the last real tab and the "+" button
                 final_spans.push((
                     Span::styled(" ", Style::default().bg(theme.tab_separator_bg)),
@@ -590,26 +619,23 @@ impl TabsRenderer {
                 tabs_total + 1
             } else {
                 tabs_total
-            }
-        };
-        const NEW_TAB_BUTTON_TEXT: &str = " + ";
-        let new_tab_width = str_width(NEW_TAB_BUTTON_TEXT);
-        final_spans.push((
-            Span::styled(
-                NEW_TAB_BUTTON_TEXT.to_string(),
-                Style::default()
-                    .fg(theme.tab_inactive_fg)
-                    .bg(theme.tab_inactive_bg),
-            ),
-            new_tab_width,
-        ));
-        let plus_logical_end = plus_logical_start + new_tab_width;
+            };
+            final_spans.push((
+                Span::styled(
+                    NEW_TAB_BUTTON_TEXT.to_string(),
+                    Style::default()
+                        .fg(theme.tab_inactive_fg)
+                        .bg(theme.tab_inactive_bg),
+                ),
+                NEW_TAB_BUTTON_WIDTH,
+            ));
+            inline_plus_range = Some((plus_start, plus_start + NEW_TAB_BUTTON_WIDTH));
+        }
 
         #[allow(clippy::let_and_return)]
         let all_tab_spans = final_spans;
 
         let mut current_spans: Vec<Span> = Vec::new();
-        let max_width = area.width as usize;
 
         let total_width: usize = all_tab_spans.iter().map(|(_, w)| w).sum();
         // Use rendered_targets (not tab_targets) to find active index,
@@ -718,6 +744,24 @@ impl TabsRenderer {
         let paragraph = Paragraph::new(line).block(block);
         frame.render_widget(paragraph, area);
 
+        // Pinned "+" button: when the tabs overflow, draw the button on top of
+        // the bar at the right edge. The main paragraph above filled the
+        // reserved columns with the separator background; overwrite them with
+        // the button cell here so it stays visible regardless of scroll.
+        if pin_plus {
+            let plus_w = NEW_TAB_BUTTON_WIDTH as u16;
+            let plus_x = area.x + area.width.saturating_sub(plus_w);
+            let plus_rect = Rect::new(plus_x, area.y, plus_w, 1);
+            let plus_para = Paragraph::new(Line::from(vec![Span::styled(
+                NEW_TAB_BUTTON_TEXT.to_string(),
+                Style::default()
+                    .fg(theme.tab_inactive_fg)
+                    .bg(theme.tab_inactive_bg),
+            )]));
+            frame.render_widget(plus_para, plus_rect);
+            layout.new_tab_area = Some(plus_rect);
+        }
+
         // Compute and return hit areas for mouse interaction
         // We need to map the logical tab positions to screen positions accounting for:
         // 1. The scroll offset
@@ -787,9 +831,10 @@ impl TabsRenderer {
             });
         }
 
-        // Map the trailing "+" button's logical range to a screen rect using
-        // the same visibility/clamping logic as the per-tab mapping above.
-        {
+        // Map the inline "+" button's logical range to a screen rect using the
+        // same visibility/clamping logic as the per-tab mapping above. (The
+        // pinned variant set `new_tab_area` directly after the render.)
+        if let Some((plus_logical_start, plus_logical_end)) = inline_plus_range {
             let visible_start = offset;
             let visible_end = offset + available;
             if plus_logical_end > visible_start && plus_logical_start < visible_end {
@@ -856,6 +901,26 @@ impl TabsRenderer {
 mod tests {
     use super::*;
     use crate::model::event::BufferId;
+
+    #[test]
+    fn tabs_render_width_inline_when_fits() {
+        // Tabs + inline "+" fit: full width available, no reservation.
+        assert_eq!(tabs_render_width(10, 40), 40);
+        // Exactly fits inline: tabs(33) + sep(1) + plus(3) = 37 <= 40.
+        assert_eq!(tabs_render_width(33, 40), 40);
+        // No tabs: just the "+" — still inline.
+        assert_eq!(tabs_render_width(0, 40), 40);
+    }
+
+    #[test]
+    fn tabs_render_width_pins_when_overflow() {
+        // tabs(37) + sep(1) + plus(3) = 41 > 40 → reserve 3.
+        assert_eq!(tabs_render_width(37, 40), 37);
+        // Heavy overflow still just reserves the button column.
+        assert_eq!(tabs_render_width(200, 40), 37);
+        // Degenerate: bar narrower than the button — fall back to full width.
+        assert_eq!(tabs_render_width(100, 2), 2);
+    }
 
     #[test]
     fn scroll_to_show_active_first_tab() {

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -68,6 +68,8 @@ pub struct TabLayout {
     pub left_scroll_area: Option<Rect>,
     /// Hit area for the right scroll button (if shown)
     pub right_scroll_area: Option<Rect>,
+    /// Hit area for the trailing "+" new-tab button (if visible)
+    pub new_tab_area: Option<Rect>,
 }
 
 /// Hit test result for tab interactions
@@ -83,6 +85,8 @@ pub enum TabHit {
     ScrollLeft,
     /// Hit the right scroll button
     ScrollRight,
+    /// Hit the trailing "+" new-tab button
+    NewTabButton,
 }
 
 impl TabLayout {
@@ -93,6 +97,7 @@ impl TabLayout {
             bar_area,
             left_scroll_area: None,
             right_scroll_area: None,
+            new_tab_area: None,
         }
     }
 
@@ -132,6 +137,13 @@ impl TabLayout {
             // Check tab area
             if point_in_rect(tab.tab_area, x, y) {
                 return Some(TabHit::TabName(tab.target));
+            }
+        }
+
+        // Check the trailing "+" new-tab button
+        if let Some(new_tab_area) = self.new_tab_area {
+            if point_in_rect(new_tab_area, x, y) {
+                return Some(TabHit::NewTabButton);
             }
         }
 
@@ -563,6 +575,36 @@ impl TabsRenderer {
                 separator_offset += 1;
             }
         }
+        // Append a trailing "+" new-tab button as a separate tab. It sits
+        // right after the last real tab (preceded by a separator) and
+        // participates in the same scroll/truncation flow below, so no
+        // special-casing is needed when rendering the visible window.
+        let plus_logical_start: usize = {
+            let tabs_total: usize = final_spans.iter().map(|(_, w)| w).sum();
+            if !rendered_targets.is_empty() {
+                // Separator between the last real tab and the "+" button
+                final_spans.push((
+                    Span::styled(" ", Style::default().bg(theme.tab_separator_bg)),
+                    1,
+                ));
+                tabs_total + 1
+            } else {
+                tabs_total
+            }
+        };
+        const NEW_TAB_BUTTON_TEXT: &str = " + ";
+        let new_tab_width = str_width(NEW_TAB_BUTTON_TEXT);
+        final_spans.push((
+            Span::styled(
+                NEW_TAB_BUTTON_TEXT.to_string(),
+                Style::default()
+                    .fg(theme.tab_inactive_fg)
+                    .bg(theme.tab_inactive_bg),
+            ),
+            new_tab_width,
+        ));
+        let plus_logical_end = plus_logical_start + new_tab_width;
+
         #[allow(clippy::let_and_return)]
         let all_tab_spans = final_spans;
 
@@ -743,6 +785,33 @@ impl TabsRenderer {
                 tab_area: Rect::new(screen_start, area.y, tab_width, 1),
                 close_area: Rect::new(screen_close_start, area.y, close_width, 1),
             });
+        }
+
+        // Map the trailing "+" button's logical range to a screen rect using
+        // the same visibility/clamping logic as the per-tab mapping above.
+        {
+            let visible_start = offset;
+            let visible_end = offset + available;
+            if plus_logical_end > visible_start && plus_logical_start < visible_end {
+                let screen_start = if plus_logical_start >= visible_start {
+                    area.x
+                        + left_indicator_offset as u16
+                        + (plus_logical_start - visible_start) as u16
+                } else {
+                    area.x + left_indicator_offset as u16
+                };
+                let screen_end = if plus_logical_end <= visible_end {
+                    area.x
+                        + left_indicator_offset as u16
+                        + (plus_logical_end - visible_start) as u16
+                } else {
+                    area.x + left_indicator_offset as u16 + available as u16
+                };
+                let width = screen_end.saturating_sub(screen_start);
+                if width > 0 {
+                    layout.new_tab_area = Some(Rect::new(screen_start, area.y, width, 1));
+                }
+            }
         }
 
         layout

--- a/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
+++ b/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI A__state_a.snap
@@ -4,7 +4,7 @@ assertion_line: 69
 expression: "&screen_text"
 ---
  File   Edit   View   Selection   Go   LSP   Help                                                   
-┌ File Explorer (Ctrl+E) ──×─┐ main.rs ×                                                            
+┌ File Explorer (Ctrl+E) ──×─┐ main.rs ×   +                                                        
 │▼ project_root              │  1 │ // Main entry point                                             
 │  ▼ src                     │▾ 2 │ fn main() {                                                     
 │      main.rs               │  3 │     let hello = "world";                                        

--- a/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
+++ b/crates/fresh-editor/tests/common/snapshots/e2e_tests__common__visual_testing__Comprehensive UI B__state_b.snap
@@ -4,7 +4,7 @@ assertion_line: 69
 expression: "&screen_text"
 ---
  File   Edit   View   Selection   Go   LSP   Help                                                                       
- file1.rs ×                                                                                                         □ × 
+ file1.rs ×   +                                                                                                     □ × 
   1 │ // File 1 - Contains a very long line that will require horizontal scrolling to see the end of it completely when 
 ▾ 2 │ fn main() {                                                                                                       
   3 │     let very_long_variable_name_that_extends_beyond_normal_view = "This is a string with a lot of content that go 

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -207,6 +207,7 @@ pub mod syntax_language_case;
 pub mod syntax_variable_builtin;
 pub mod tab_config;
 pub mod tab_drag;
+pub mod tab_new_button;
 pub mod terminal;
 pub mod terminal_close;
 pub mod terminal_resize;

--- a/crates/fresh-editor/tests/e2e/tab_new_button.rs
+++ b/crates/fresh-editor/tests/e2e/tab_new_button.rs
@@ -58,6 +58,35 @@ fn plus_button_opens_menu_and_new_file_creates_buffer() {
 }
 
 #[test]
+fn plus_button_pins_to_right_edge_on_overflow() {
+    // A narrow bar with many tabs forces the buffer tabs to overflow.
+    let width: u16 = 50;
+    let mut harness = EditorTestHarness::new(width, 24).unwrap();
+    for _ in 0..8 {
+        harness.new_buffer().unwrap();
+    }
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let plus_col = col_of_char_on_row(&screen, 1, '+').unwrap_or_else(|| {
+        panic!("expected a pinned '+' button on the tab row. Screen:\n{screen}")
+    });
+
+    // Pinned: the "+" cell occupies the rightmost columns of the bar
+    // (" + " => '+' sits one column in from the right edge).
+    assert!(
+        plus_col >= width - 3,
+        "expected '+' pinned near the right edge (col >= {}), got {plus_col}. Screen:\n{screen}",
+        width - 3
+    );
+
+    // It is still interactive: clicking the pinned button opens the popup.
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+    harness.assert_screen_contains("New File");
+}
+
+#[test]
 fn plus_button_menu_dismisses_on_outside_click() {
     let mut harness = EditorTestHarness::new(120, 30).unwrap();
     harness.render().unwrap();

--- a/crates/fresh-editor/tests/e2e/tab_new_button.rs
+++ b/crates/fresh-editor/tests/e2e/tab_new_button.rs
@@ -1,0 +1,85 @@
+//! E2E test for the tab bar's trailing "+" new-tab button.
+//!
+//! Clicking the "+" tab at the end of the tab bar opens a small popup
+//! menu offering "New Terminal" and "New File". Selecting "New File"
+//! creates a new empty buffer (a second tab appears).
+
+use crate::common::harness::EditorTestHarness;
+
+/// Locate the 0-based cell column of `needle` on the given (0-based) screen row.
+fn col_of_char_on_row(screen: &str, row: usize, needle: char) -> Option<u16> {
+    let line = screen.lines().nth(row)?;
+    line.chars().position(|c| c == needle).map(|p| p as u16)
+}
+
+/// Locate the (col, row) of the first cell of `needle` substring anywhere on screen.
+fn pos_of_substr(screen: &str, needle: &str) -> Option<(u16, u16)> {
+    for (row, line) in screen.lines().enumerate() {
+        if let Some(byte_idx) = line.find(needle) {
+            // Convert byte index to a cell/column index (count chars before it).
+            let col = line[..byte_idx].chars().count() as u16;
+            return Some((col, row as u16));
+        }
+    }
+    None
+}
+
+#[test]
+fn plus_button_opens_menu_and_new_file_creates_buffer() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.render().unwrap();
+
+    // The "+" button is rendered as a trailing tab on the tab row (row 1:
+    // row 0 = menu bar, row 1 = tab bar).
+    let screen = harness.screen_to_string();
+    let plus_col = col_of_char_on_row(&screen, 1, '+').unwrap_or_else(|| {
+        panic!("expected a '+' new-tab button on the tab row. Screen:\n{screen}")
+    });
+
+    // Click the "+" button — the popup should appear.
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+    harness.assert_screen_contains("New File");
+
+    // Click the "New File" item in the popup.
+    let screen = harness.screen_to_string();
+    let (nf_col, nf_row) = pos_of_substr(&screen, "New File")
+        .unwrap_or_else(|| panic!("expected 'New File' item in popup. Screen:\n{screen}"));
+    harness.mouse_click(nf_col + 1, nf_row).unwrap();
+
+    // The popup closes and a second buffer exists: with two unnamed
+    // buffers the tabs are disambiguated as "[No Name] 1" / "[No Name] 2".
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("New Terminal"),
+        "popup should be dismissed after selecting an item. Screen:\n{screen}"
+    );
+    harness.assert_screen_contains("[No Name] 2");
+}
+
+#[test]
+fn plus_button_menu_dismisses_on_outside_click() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let plus_col = col_of_char_on_row(&screen, 1, '+').unwrap_or_else(|| {
+        panic!("expected a '+' new-tab button on the tab row. Screen:\n{screen}")
+    });
+
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+
+    // Click far away in the editor content area — the popup should close
+    // without creating a new buffer.
+    harness.mouse_click(2, 10).unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("New Terminal"),
+        "popup should be dismissed by an outside click. Screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("[No Name] 2"),
+        "outside click should not create a new buffer. Screen:\n{screen}"
+    );
+}


### PR DESCRIPTION
Render a trailing '+' tab after the open buffers in each split's tab bar.
Clicking it opens a small popup menu offering 'New Terminal' and 'New File',
which open a terminal or create a new empty buffer in that split.

- tabs.rs: render the '+' as a separate tab in the scroll flow and expose
  its hit area via TabLayout::new_tab_area / TabHit::NewTabButton.
- NewTabMenu popup state, rendering, hover highlighting, and left-click
  handling mirror the existing tab/file-explorer context menus.
- Added e2e coverage for opening the popup, creating a file, and
  dismissing on outside click.