### PR TITLE
Orchestrator: open an inactive worktree on click, no extra confirm

### DIFF
--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1009,19 +1009,26 @@ function filterSessions(needle: string): number[] {
   // so an "all" view groups the current project's sessions at the top and
   // other projects' below.
   //
-  // Within a project the order is a *stable* identity key — label, then
-  // root — deliberately NOT the live/discovered state or the numeric id.
-  // A row must keep its place when its session changes state: opening a
-  // discovered on-disk worktree turns it into a live session (and swaps
-  // its synthetic negative id for a positive window id), but it should
-  // stay exactly where it was instead of jumping into a "live" group and
-  // shuffling the rows under you as you arrow-navigate. `id` is only a
-  // final tie-break for two otherwise-identical rows.
+  // Within a project the order is a *stable* identity key, deliberately
+  // NOT the live/discovered state or the numeric id — a row must keep its
+  // place when its session changes state. Opening a discovered on-disk
+  // worktree turns it into a live session (and swaps its synthetic
+  // negative id for a positive window id), but it should stay exactly
+  // where it was instead of jumping into a "live" group and shuffling the
+  // rows under you as you arrow-navigate. The key is:
+  //   1. main checkout first — the project's own checkout (root ===
+  //      projectPath) sits above its linked worktrees. This is stable:
+  //      whether a worktree is discovered or open, its root never equals
+  //      its projectPath, so it never crosses this boundary.
+  //   2. then label, then root — alphabetical within each group.
+  //   3. id only as a final tie-break for two otherwise-identical rows.
   //
   // The dock is persistent and switches the active session constantly, so
   // it must NOT reorder as the active project changes — it pins this
   // stable order. The modal picker, opened fresh each time, additionally
   // floats the current project to the top.
+  const isWorktree = (s: AgentSession): number =>
+    normRoot(s.root) === normRoot(projectKeyOf(s)) ? 0 : 1;
   const pinCurrentFirst = !dockMode;
   const byProjectThenStable = (a: number, b: number): number => {
     const sa = orchestratorSessions.get(a)!;
@@ -1032,6 +1039,9 @@ function filterSessions(needle: string): number[] {
     const ka = projectKeyOf(sa);
     const kb = projectKeyOf(sb);
     if (ka !== kb) return ka < kb ? -1 : 1;
+    const wa = isWorktree(sa);
+    const wb = isWorktree(sb);
+    if (wa !== wb) return wa - wb;
     const la = sa.label.toLowerCase();
     const lb = sb.label.toLowerCase();
     if (la !== lb) return la < lb ? -1 : 1;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1072,11 +1072,17 @@ function filterSessions(needle: string): number[] {
       matches.push({ id, score: 2, len: label.length });
     }
   }
-  // Live sessions before discovered worktrees at equal relevance, so
-  // the on-disk rows still trail the real sessions in search results.
+  // At equal relevance, a project's own checkout sorts before its
+  // worktrees (same stable `isWorktree` grouping as the browse list), so
+  // the on-disk / worktree rows still trail the project's own session in
+  // search results — and a result doesn't jump when a discovered worktree
+  // is opened (its root/projectPath, hence its group, don't change).
   matches.sort(
     (a, b) =>
-      a.score - b.score || isDisc(a.id) - isDisc(b.id) || a.len - b.len ||
+      a.score - b.score ||
+      isWorktree(orchestratorSessions.get(a.id)!) -
+        isWorktree(orchestratorSessions.get(b.id)!) ||
+      a.len - b.len ||
       a.id - b.id,
   );
   return matches.map((m) => m.id);

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -2988,12 +2988,15 @@ function dockMenuVisit(id: number): void {
   const s = orchestratorSessions.get(id);
   if (!s) return;
   if (s.discovered) {
+    // Visit "dives in" (like the live path below, which blurs to the
+    // editor), so attach with dive: true.
     void attachToWorktree({
       root: s.root,
       projectPath: s.projectPath ?? s.root,
       label: s.label,
       branch: s.branch,
       discoveredId: s.id,
+      dive: true,
     });
     return;
   }
@@ -3122,9 +3125,27 @@ function scheduleDockSwitch(fromEdge: "top" | "bottom" | null): void {
     if (token !== dockSwitchToken) return;
     if (!openDialog || !openPanel || !dockMode || dockBlurred) return;
     const id = openDialog.filteredIds[openDialog.selectedIndex];
-    if (typeof id !== "number" || id <= 0) return;
-    // A discovered worktree has no window to switch to.
-    if (orchestratorSessions.get(id)?.discovered) return;
+    if (typeof id !== "number") return;
+    const sess = orchestratorSessions.get(id);
+    // A discovered (on-disk) worktree has no window to switch to — in the
+    // dock's live-switch model the highlighted row *is* the active
+    // session, so opening it means attaching a fresh session at the
+    // worktree. Do that without diving (keep the dock focused) so it
+    // matches switching to a live row, and you can keep arrowing. The
+    // 30 ms debounce above means scrolling *past* it without pausing
+    // never spawns a session.
+    if (sess?.discovered) {
+      void attachToWorktree({
+        root: sess.root,
+        projectPath: sess.projectPath ?? sess.root,
+        label: sess.label,
+        branch: sess.branch,
+        discoveredId: sess.id,
+        dive: false,
+      });
+      return;
+    }
+    if (id <= 0) return;
     if (id === editor.activeWindow()) return;
     if (fromEdge) editor.setActiveWindowAnimated(id, fromEdge);
     else editor.setActiveWindow(id);
@@ -5878,6 +5899,17 @@ async function attachToWorktree(opts: {
   label: string;
   branch?: string;
   discoveredId?: number;
+  /**
+   * Whether to hand keyboard focus to the new window (blur the dock) once
+   * attached. `true` for the "dive in" gestures (Enter, Visit) — mirrors
+   * the dock's live-session Enter, which blurs to the editor. `false`
+   * (default) for the "activate / live-switch" gestures (arrow-nav, a
+   * row click), which open the worktree as the active session but keep
+   * the dock focused so you can keep navigating — mirrors the dock's
+   * live-session arrow/click switch, which never blurs. No-op in the
+   * modal picker (it closes `openPanel` before calling here).
+   */
+  dive?: boolean;
 }): Promise<void> {
   try {
     const result = await editor.createWindowWithTerminal({
@@ -5903,16 +5935,24 @@ async function attachToWorktree(opts: {
       createdAt: Date.now(),
       branch: opts.branch,
     });
-    // The new window is now the active session. When this was triggered from
-    // the dock (Enter on a discovered worktree), the dock is still focused, so
-    // its keys would be swallowed and the new session's terminal couldn't
-    // receive input — mirror the dock's live-session Enter path and blur it so
-    // the new window gets the keyboard. (No-op for the modal picker, which has
-    // already closed openPanel before calling this.)
-    if (dockMode && openPanel) {
+    // The new window is now the active session. For a "dive in" gesture
+    // (Enter / Visit) the dock is still focused, so its keys would be
+    // swallowed and the new session's terminal couldn't receive input —
+    // mirror the dock's live-session Enter path and blur it so the new
+    // window gets the keyboard. The "activate / live-switch" gestures
+    // (arrow-nav, row click) deliberately keep the dock focused, exactly
+    // like switching to a live session does.
+    if (opts.dive && dockMode && openPanel) {
       dockBlurred = true;
       editor.floatingPanelControl(openPanel.id(), "blur", 0);
       editor.setEditorMode(null);
+    } else if (dockMode && openPanel) {
+      // Live-switch: keep the dock focused, but rebuild the list (the
+      // `· on-disk` row's synthetic id is gone, replaced by the new live
+      // window's) and move the highlight onto the now-active session so
+      // the user stays put on the row they just opened.
+      refreshOpenDialog();
+      syncDockSelectionToActive();
     }
   } catch (e) {
     editor.setStatus(
@@ -6453,11 +6493,12 @@ editor.on("widget_event", (e) => {
       return;
     }
     if (e.event_type === "dock_activate") {
-      // Host Enter on the dock's session list. Mirrors the dialog's
-      // `activate` branch: a discovered (on-disk) worktree has no live
-      // window to switch to, so attach a fresh session at it; any other
-      // row is already active via the arrow live-switch, so Enter just
-      // hands keyboard focus to the editor (the dock stays visible).
+      // Host Enter on the dock's session list — the "dive in" gesture.
+      // Every row is already the active session via the arrow/click
+      // live-switch (a discovered worktree was opened on navigation too),
+      // so Enter just hands keyboard focus to the editor. If the row is
+      // still discovered here (Enter pressed before the debounced switch
+      // landed) attach it now, diving in to match the live path below.
       if (!dockMode || !openPanel || !openDialog) return;
       const id = openDialog.filteredIds[openDialog.selectedIndex];
       const sel = typeof id === "number" ? orchestratorSessions.get(id) : undefined;
@@ -6468,6 +6509,7 @@ editor.on("widget_event", (e) => {
           label: sel.label,
           branch: sel.branch,
           discoveredId: sel.id,
+          dive: true,
         });
         return;
       }
@@ -6572,33 +6614,14 @@ editor.on("widget_event", (e) => {
         openDialog.selectedIndex = idx;
         clearDialogError();
         if (dockMode) {
-          // The editor to the dock's right is the preview: arrowing
-          // the list switches the active window live (debounced),
-          // wiping down when moving down the list and up when moving up.
+          // The editor to the dock's right is the preview: arrowing the
+          // list (or clicking a row) switches the active window live
+          // (debounced), wiping down when moving down and up when moving
+          // up. A discovered (on-disk) worktree has no window to switch
+          // to, so `scheduleDockSwitch` opens it as the active session
+          // instead — both click and arrow land there the same way.
           openPanel.update(buildDockSpec());
           openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
-          // A mouse click (payload.via === "click") on an inactive
-          // on-disk worktree opens it directly — there's no live window
-          // to switch to, so attach a fresh session, mirroring how a
-          // click on a live row switches to it (and the dock's Enter /
-          // `dock_activate`). Arrow-nav fires `select` *without* `via`,
-          // so scrolling past a discovered row never spawns a session.
-          if (payload.via === "click") {
-            const clickedId = openDialog.filteredIds[openDialog.selectedIndex];
-            const clicked = typeof clickedId === "number"
-              ? orchestratorSessions.get(clickedId)
-              : undefined;
-            if (clicked && clicked.discovered) {
-              void attachToWorktree({
-                root: clicked.root,
-                projectPath: clicked.projectPath ?? clicked.root,
-                label: clicked.label,
-                branch: clicked.branch,
-                discoveredId: clicked.id,
-              });
-              return;
-            }
-          }
           const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
           scheduleDockSwitch(fromEdge);
           return;

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1005,20 +1005,25 @@ function filterSessions(needle: string): number[] {
     allIds = allIds.filter((id) => projectKeyOf(orchestratorSessions.get(id)!) === want);
   }
 
-  const isDisc = (id: number): number =>
-    orchestratorSessions.get(id)!.discovered ? 1 : 0;
-
-  // Sort by (current-project-first, project, live-before-discovered,
-  // then id) so an "all" view groups the current project's sessions
-  // at the top and other projects' below, and within each project the
-  // pre-existing live sessions come first with the discovered on-disk
-  // worktrees listed after them.
-  // The dock is persistent and switches the active session constantly,
-  // so it must NOT reorder as the active project changes — pin a stable
-  // order (project, then id). The modal picker, opened fresh each time,
-  // keeps the current-project-first grouping.
+  // Sort by (current-project-first, project, then a stable identity key)
+  // so an "all" view groups the current project's sessions at the top and
+  // other projects' below.
+  //
+  // Within a project the order is a *stable* identity key — label, then
+  // root — deliberately NOT the live/discovered state or the numeric id.
+  // A row must keep its place when its session changes state: opening a
+  // discovered on-disk worktree turns it into a live session (and swaps
+  // its synthetic negative id for a positive window id), but it should
+  // stay exactly where it was instead of jumping into a "live" group and
+  // shuffling the rows under you as you arrow-navigate. `id` is only a
+  // final tie-break for two otherwise-identical rows.
+  //
+  // The dock is persistent and switches the active session constantly, so
+  // it must NOT reorder as the active project changes — it pins this
+  // stable order. The modal picker, opened fresh each time, additionally
+  // floats the current project to the top.
   const pinCurrentFirst = !dockMode;
-  const byProjectThenId = (a: number, b: number): number => {
+  const byProjectThenStable = (a: number, b: number): number => {
     const sa = orchestratorSessions.get(a)!;
     const sb = orchestratorSessions.get(b)!;
     const aCur = projectKeyOf(sa) === cur ? 0 : 1;
@@ -1027,14 +1032,15 @@ function filterSessions(needle: string): number[] {
     const ka = projectKeyOf(sa);
     const kb = projectKeyOf(sb);
     if (ka !== kb) return ka < kb ? -1 : 1;
-    const da = isDisc(a);
-    const db = isDisc(b);
-    if (da !== db) return da - db;
+    const la = sa.label.toLowerCase();
+    const lb = sb.label.toLowerCase();
+    if (la !== lb) return la < lb ? -1 : 1;
+    if (sa.root !== sb.root) return sa.root < sb.root ? -1 : 1;
     return a - b;
   };
 
   if (!needle) {
-    const ids = allIds.slice().sort(byProjectThenId);
+    const ids = allIds.slice().sort(byProjectThenStable);
     if (scope === "current") {
       return ids.filter((id) => projectKeyOf(orchestratorSessions.get(id)!) === cur);
     }

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -1632,7 +1632,7 @@ function buildPreviewPane(s: AgentSession | undefined): WidgetSpec {
       styledRow([{ text: "" }]),
       styledRow([
         {
-          text: "Press Enter to open this worktree as a session.",
+          text: "Click it (or press Enter) to open this worktree as a session.",
           style: { fg: "ui.help_key_fg", italic: true },
         },
       ]),
@@ -6577,6 +6577,28 @@ editor.on("widget_event", (e) => {
           // wiping down when moving down the list and up when moving up.
           openPanel.update(buildDockSpec());
           openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+          // A mouse click (payload.via === "click") on an inactive
+          // on-disk worktree opens it directly — there's no live window
+          // to switch to, so attach a fresh session, mirroring how a
+          // click on a live row switches to it (and the dock's Enter /
+          // `dock_activate`). Arrow-nav fires `select` *without* `via`,
+          // so scrolling past a discovered row never spawns a session.
+          if (payload.via === "click") {
+            const clickedId = openDialog.filteredIds[openDialog.selectedIndex];
+            const clicked = typeof clickedId === "number"
+              ? orchestratorSessions.get(clickedId)
+              : undefined;
+            if (clicked && clicked.discovered) {
+              void attachToWorktree({
+                root: clicked.root,
+                projectPath: clicked.projectPath ?? clicked.root,
+                label: clicked.label,
+                branch: clicked.branch,
+                discoveredId: clicked.id,
+              });
+              return;
+            }
+          }
           const fromEdge = idx > prevIdx ? "bottom" : idx < prevIdx ? "top" : null;
           scheduleDockSwitch(fromEdge);
           return;
@@ -6586,6 +6608,29 @@ editor.on("widget_event", (e) => {
         // Re-pin the list selection so the spec re-emit doesn't
         // snap it back to 0.
         openPanel.setSelectedIndex("sessions", openDialog.selectedIndex);
+        // A mouse click on an inactive on-disk worktree opens it
+        // directly — no Enter/Visit "confirmation" needed. There's no
+        // live window to switch to, so attach a fresh session, mirroring
+        // the dialog's Visit (`activate`) path. Live rows keep
+        // select+preview (opened with Enter / Visit). Arrow-nav fires
+        // `select` without `via`, so it only previews.
+        if (payload.via === "click") {
+          const clickedId = openDialog.filteredIds[openDialog.selectedIndex];
+          const clicked = typeof clickedId === "number"
+            ? orchestratorSessions.get(clickedId)
+            : undefined;
+          if (clicked && clicked.discovered) {
+            closeOpenDialog();
+            void attachToWorktree({
+              root: clicked.root,
+              projectPath: clicked.projectPath ?? clicked.root,
+              label: clicked.label,
+              branch: clicked.branch,
+              discoveredId: clicked.id,
+            });
+            return;
+          }
+        }
         // Up/Down on a focused action button (Stop / Archive /
         // Delete / Details / +New Session) routes to the sessions
         // list via the host's smart-key dispatch but leaves focus

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4040,7 +4040,7 @@ impl Editor {
             Some(entry) => screen_col_to_byte(&entry.text, local_screen_col),
             None => return,
         };
-        let (hit_payload, hit_event, hit_key, hit_kind) =
+        let (mut hit_payload, hit_event, hit_key, hit_kind) =
             match self
                 .widget_registry
                 .hit_test(slot.buffer_id(), brow, bcol as u32)
@@ -4103,6 +4103,15 @@ impl Editor {
                 .unwrap()
                 .has_hook_handlers("widget_event")
         {
+            // Tag the event as mouse-originated. Keyboard nav (arrows)
+            // fires `select` through `handle_widget_command` *without* this
+            // marker, so a plugin can tell a click apart from an arrow-move
+            // that happens to emit the same event/payload — e.g. the
+            // orchestrator dock opens an inactive on-disk worktree on
+            // *click* but not when you merely arrow past it.
+            if let Some(obj) = hit_payload.as_object_mut() {
+                obj.insert("via".to_string(), serde_json::json!("click"));
+            }
             self.plugin_manager.read().unwrap().run_hook(
                 "widget_event",
                 crate::services::plugins::hooks::HookArgs::WidgetEvent {

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -390,16 +390,16 @@ fn new_session_form_hints_existing_worktree() {
         });
 }
 
-/// The session list is sorted by a *stable* lexicographic key (label),
-/// with no special-casing of live vs discovered rows — so a row keeps its
-/// place when its session changes state (see
-/// `dock_opening_worktree_keeps_its_row_position`). Here the discovered
-/// `feature-x` worktree sorts *above* the `mainrepo` base row purely
-/// because `"feature-x" < "mainrepo"`, not because of any live/on-disk
-/// grouping. The base row is identified by its `[ ]` checkbox and the
-/// absence of the `· on-disk` tag (which marks the discovered worktree).
+/// The session list sorts by a *stable* key: the project's own checkout
+/// (the `mainrepo` base) sits above its linked worktrees, then rows are
+/// alphabetical. This grouping is by `root == projectPath`, NOT by
+/// live/discovered state — so a worktree keeps its place when opened (see
+/// `dock_opening_worktree_keeps_its_row_position`) instead of jumping into
+/// a "live" group. Here the `mainrepo` base row stays above the discovered
+/// `feature-x` worktree. The base row is identified by its `[ ]` checkbox
+/// and the absence of the `· on-disk` tag (which marks the worktree).
 #[test]
-fn rows_sort_stably_by_label_not_by_live_state() {
+fn rows_sort_stably_main_checkout_above_worktrees() {
     let (_temp, repo, _wt) = set_up_repo_with_worktree();
     let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
     harness.tick_and_render().unwrap();
@@ -418,10 +418,9 @@ fn rows_sort_stably_by_label_not_by_live_state() {
         .position(|l| l.contains("[ ]") && l.contains("mainrepo") && !l.contains("· on-disk"));
     let disc_idx = lines.iter().position(|l| l.contains("· on-disk"));
     assert!(
-        base_idx.is_some() && disc_idx.is_some() && disc_idx < base_idx,
-        "rows must sort lexically by label (feature-x above mainrepo), \
-         independent of live/discovered state.\nbase_idx={:?} disc_idx={:?}\n\
-         Screen:\n{}",
+        base_idx.is_some() && disc_idx.is_some() && base_idx < disc_idx,
+        "main checkout (mainrepo) must sort above its worktrees, independent \
+         of live/discovered state.\nbase_idx={:?} disc_idx={:?}\nScreen:\n{}",
         base_idx,
         disc_idx,
         screen
@@ -882,11 +881,11 @@ fn dock_arrow_nav_opens_discovered_worktree() {
 }
 
 /// Opening a discovered worktree from the dock keeps it in the *same row*
-/// — the sort is stable. With two on-disk worktrees the lexicographic
-/// order is `feature-x`, `feature-y`, then the `mainrepo` base; opening
-/// `feature-x` turns it live but it must stay above `feature-y` rather
-/// than jumping into a "live" group (the old live-before-discovered sort
-/// shuffled rows under you as you navigated).
+/// — the sort is stable. The order is the `mainrepo` base (main checkout)
+/// first, then its worktrees alphabetically (`feature-x`, `feature-y`);
+/// opening `feature-x` turns it live but it must stay above `feature-y`
+/// rather than jumping into a "live" group (the old live-before-discovered
+/// sort shuffled rows under you as you navigated).
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
 fn dock_opening_worktree_keeps_its_row_position() {

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -390,13 +390,16 @@ fn new_session_form_hints_existing_worktree() {
         });
 }
 
-/// Discovered on-disk worktree rows sort *after* the live sessions:
-/// the base session's list row appears above the discovered worktree
-/// row. The base list row is identified by the `[ ]` checkbox + the
-/// `BASE` badge (both unique to that list row); the discovered row by
-/// its `· on-disk` tag.
+/// The session list is sorted by a *stable* lexicographic key (label),
+/// with no special-casing of live vs discovered rows — so a row keeps its
+/// place when its session changes state (see
+/// `dock_opening_worktree_keeps_its_row_position`). Here the discovered
+/// `feature-x` worktree sorts *above* the `mainrepo` base row purely
+/// because `"feature-x" < "mainrepo"`, not because of any live/on-disk
+/// grouping. The base row is identified by its `[ ]` checkbox and the
+/// absence of the `· on-disk` tag (which marks the discovered worktree).
 #[test]
-fn discovered_rows_sort_after_live_sessions() {
+fn rows_sort_stably_by_label_not_by_live_state() {
     let (_temp, repo, _wt) = set_up_repo_with_worktree();
     let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
     harness.tick_and_render().unwrap();
@@ -410,18 +413,16 @@ fn discovered_rows_sort_after_live_sessions() {
 
     let screen = harness.screen_to_string();
     let lines: Vec<&str> = screen.lines().collect();
-    // The live launch session is the `mainrepo` row with a checkbox and
-    // no `· on-disk` tag (that tag marks the discovered worktree). There
-    // is no longer a `BASE` badge — id 1 is just a normal session now.
-    let live_idx = lines
+    let base_idx = lines
         .iter()
         .position(|l| l.contains("[ ]") && l.contains("mainrepo") && !l.contains("· on-disk"));
     let disc_idx = lines.iter().position(|l| l.contains("· on-disk"));
     assert!(
-        live_idx.is_some() && disc_idx.is_some() && live_idx < disc_idx,
-        "live launch session must list above the discovered worktree.\n\
-         live_idx={:?} disc_idx={:?}\nScreen:\n{}",
-        live_idx,
+        base_idx.is_some() && disc_idx.is_some() && disc_idx < base_idx,
+        "rows must sort lexically by label (feature-x above mainrepo), \
+         independent of live/discovered state.\nbase_idx={:?} disc_idx={:?}\n\
+         Screen:\n{}",
+        base_idx,
         disc_idx,
         screen
     );
@@ -878,6 +879,73 @@ fn dock_arrow_nav_opens_discovered_worktree() {
                 harness.screen_to_string()
             )
         });
+}
+
+/// Opening a discovered worktree from the dock keeps it in the *same row*
+/// — the sort is stable. With two on-disk worktrees the lexicographic
+/// order is `feature-x`, `feature-y`, then the `mainrepo` base; opening
+/// `feature-x` turns it live but it must stay above `feature-y` rather
+/// than jumping into a "live" group (the old live-before-discovered sort
+/// shuffled rows under you as you navigated).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
+fn dock_opening_worktree_keeps_its_row_position() {
+    if !pty_available() {
+        eprintln!("skipping: no PTY available in this environment");
+        return;
+    }
+    let (_temp, repo, _wt1, _wt2) = set_up_repo_with_two_worktrees();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Toggle Dock");
+
+    open_dock(&mut harness);
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("feature-y") && s.contains("· on-disk")
+        })
+        .unwrap();
+
+    // Stable lexicographic order before opening: feature-x above feature-y.
+    let fx_before = dock_row_of(&harness, "feature-x");
+    let fy_before = dock_row_of(&harness, "feature-y");
+    assert!(
+        fx_before < fy_before,
+        "initial order should be lexicographic (feature-x above feature-y).\n\
+         Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    // Open feature-x by clicking it.
+    harness.mouse_click(3, fx_before as u16).unwrap();
+    harness
+        .wait_until(|h| {
+            // feature-x is now live (its on-disk tag is gone) while feature-y
+            // is still discovered.
+            let s = h.screen_to_string();
+            s.matches("· on-disk").count() == 1 && s.contains("feature-y")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "clicking feature-x should open it (one on-disk row left).\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Stable: feature-x kept its place above feature-y after going live.
+    let fx_after = dock_row_of(&harness, "feature-x");
+    let fy_after = dock_row_of(&harness, "feature-y");
+    assert!(
+        fx_after < fy_after,
+        "opening feature-x must not reorder it below feature-y — the sort is \
+         stable.\nfx_after={fx_after} fy_after={fy_after}\nScreen:\n{}",
+        harness.screen_to_string()
+    );
 }
 
 /// Archiving the *last* session — which is also the launch / in-place

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -826,6 +826,60 @@ fn dock_click_attaches_discovered_worktree() {
         });
 }
 
+/// Arrowing the dock's highlight onto a discovered (on-disk) worktree
+/// opens it — keyboard parity with the click path. The dock's live-switch
+/// treats the highlighted row as the active session, so for an inactive
+/// worktree "becoming active" means attaching a session there. No click
+/// and no Enter: just moving the selection onto it with the keyboard.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
+fn dock_arrow_nav_opens_discovered_worktree() {
+    if !pty_available() {
+        eprintln!("skipping: no PTY available in this environment");
+        return;
+    }
+    let (_temp, repo, _wt) = set_up_repo_with_worktree();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, repo.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_command(&mut harness, "Orchestrator: Toggle Dock");
+
+    open_dock(&mut harness);
+
+    // Alt+T reveals the discovered on-disk worktree below the base session.
+    harness
+        .send_key(KeyCode::Char('t'), KeyModifiers::ALT)
+        .unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && s.contains("· on-disk")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "dock should reveal the on-disk `feature-x` worktree after Alt+T.\n\
+                 Screen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+
+    // Move the highlight down onto the on-disk row — no click, no Enter.
+    // The debounced live-switch then opens it.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains("feature-x") && !s.contains("· on-disk")
+        })
+        .unwrap_or_else(|_| {
+            panic!(
+                "Arrowing onto the dock's discovered worktree row should open it \
+                 (row loses `· on-disk`).\nScreen:\n{}",
+                harness.screen_to_string()
+            )
+        });
+}
+
 /// Archiving the *last* session — which is also the launch / in-place
 /// session (no dedicated worktree) — must not be refused. Every session
 /// is archivable now: the launch session is recorded at its own root and,

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_attach_worktree.rs
@@ -263,7 +263,7 @@ fn open_dialog_discovers_existing_worktree() {
 }
 
 /// Selecting the discovered worktree row shows the on-disk preview
-/// panel — the "On-disk worktree" header and the "Press Enter to
+/// panel — the "On-disk worktree" header and the "click / Enter to
 /// open" affordance — rather than a live window embed.
 #[test]
 fn discovered_worktree_preview_offers_open() {
@@ -285,7 +285,7 @@ fn discovered_worktree_preview_offers_open() {
     harness
         .wait_until(|h| {
             let s = h.screen_to_string();
-            s.contains("On-disk worktree") && s.contains("Press Enter to open")
+            s.contains("On-disk worktree") && s.contains("to open this worktree as a session")
         })
         .unwrap_or_else(|_| {
             panic!(
@@ -766,14 +766,17 @@ fn dock_row_of(harness: &EditorTestHarness, needle: &str) -> usize {
         .unwrap_or_else(|| panic!("screen missing '{needle}':\n{screen}"))
 }
 
-/// Pressing Enter on a discovered (on-disk) worktree row in the *dock*
-/// attaches a managed session at that worktree — the same outcome the
-/// Open dialog produces. Before the fix the dock's Enter always blurred
-/// to the editor, so the on-disk attach was silently dropped: diving a
-/// worktree worked from the dialog but did nothing from the dock.
+/// Clicking a discovered (on-disk) worktree row in the *dock* opens it
+/// directly — it attaches a managed session at that worktree, the same
+/// outcome the Open dialog produces. There's no live window to switch
+/// to, so a click can't "live-switch" the way it does for a live row;
+/// before the fix the click was therefore a silent no-op and visiting an
+/// inactive session from the dock did nothing (you had to press Enter or
+/// the Visit button). The dock's Enter (`dock_activate`) path still works
+/// too — this just makes a click open the worktree without that step.
 #[test]
 #[cfg_attr(target_os = "windows", ignore)] // attach spawns a Unix shell terminal.
-fn dock_enter_attaches_discovered_worktree() {
+fn dock_click_attaches_discovered_worktree() {
     if !pty_available() {
         eprintln!("skipping: no PTY available in this environment");
         return;
@@ -802,13 +805,9 @@ fn dock_enter_attaches_discovered_worktree() {
             )
         });
 
-    // Click the discovered row to select it, then Enter to activate.
+    // A single click on the discovered row opens it — no Enter needed.
     let row = dock_row_of(&harness, "· on-disk") as u16;
     harness.mouse_click(3, row).unwrap();
-    harness.render().unwrap();
-    harness
-        .send_key(KeyCode::Enter, KeyModifiers::NONE)
-        .unwrap();
 
     // Attach is async (`createWindowWithTerminal`). It opens a live
     // session rooted at the worktree, so the dock's discovered row turns
@@ -820,7 +819,7 @@ fn dock_enter_attaches_discovered_worktree() {
         })
         .unwrap_or_else(|_| {
             panic!(
-                "Enter on the dock's discovered worktree row should attach a live \
+                "Clicking the dock's discovered worktree row should attach a live \
                  session (row loses `· on-disk`).\nScreen:\n{}",
                 harness.screen_to_string()
             )


### PR DESCRIPTION
Visiting an inactive (discovered on-disk) worktree from the dock did
nothing: a click on a live row live-switches to its window, but a
discovered row has no window to switch to, so the click fell through
`scheduleDockSwitch` as a no-op. Opening one required Enter
(`dock_activate`) or the Visit button — and the Open dialog likewise
only offered "Press Enter to open this worktree as a session".

Make a mouse click on a discovered row open it directly (attach a fresh
session) in both the dock and the Open dialog, mirroring how a click on
a live row switches to it. Clicks flow exclusively through
`handle_floating_widget_click`, so the host now tags click-originated
widget events with `via: "click"`; keyboard arrow-nav emits the same
`select` event without it, so scrolling past a discovered row never
spawns a session. The dock's Enter path and the Visit button still work.

- host: tag mouse-originated widget events with `via: "click"`
- orchestrator: attach on click of a discovered row (dock + dialog)
- update the preview hint to "Click it (or press Enter) to open ..."
- e2e: dock_click_attaches_discovered_worktree (was the Enter variant,
  which the click now subsumes)

https://claude.ai/code/session_01KHVuB1tpzBZLCoCkyoFjhm