### PR TITLE
fix(terminal): restore terminals to a live state on focus and session switch

### DIFF
--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -52,6 +52,22 @@ impl Editor {
         if !self.active_window_mut().set_active_buffer(buffer_id) {
             return;
         }
+        // Restored terminals load read-only (editing disabled) and the
+        // Window-side resume branch only flips the `terminal_mode` flag —
+        // it can't reach the Editor-level `enter_terminal_mode` that
+        // re-enables editing, drops the stale screen tail, and resizes the
+        // PTY. Without that completion, focusing a restored terminal tab
+        // leaves it in the read-only scrollback view (often a blank screen
+        // with no prompt) instead of a live terminal. Detect that exact
+        // state — a terminal we just resumed into terminal mode but whose
+        // buffer is still editing-disabled — and finish the transition.
+        // Live terminals (editing already enabled) are unaffected.
+        if self.active_window().terminal_mode
+            && self.active_window().is_terminal_buffer(buffer_id)
+            && self.active_window().is_editing_disabled()
+        {
+            self.enter_terminal_mode();
+        }
         // Plugin state snapshot reaches editor-wide state (clipboard,
         // windows list, config cache) so it stays on Editor. Run it
         // BEFORE the hook so the handler sees the new active buffer.

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -421,6 +421,27 @@ impl crate::app::Editor {
         // the funnel so the dive-target window also picks up the current
         // editor-global dock width (its `dock_cols` cache may be stale).
         self.relayout();
+
+        // Diving / switching into a session should land on a *live*
+        // terminal, not whatever stale state a previous visit or the
+        // lazy restore left behind. A materialized window's terminal is
+        // restored read-only (scrollback view), and a window we visited
+        // before keeps its last per-window `terminal_mode` / scroll
+        // position — so switching between restored terminal sessions
+        // intermittently shows a blank pane, stale scrollback, or a
+        // frozen screen instead of the live prompt. If the now-active
+        // window's active buffer is a terminal the user hasn't explicitly
+        // exited (restored terminals are seeded into `terminal_mode_resume`
+        // by the restore path), normalize it to a live terminal scrolled
+        // to the bottom. Mirrors the buffer-switch path in
+        // `Editor::set_active_buffer`; `enter_terminal_mode` is a no-op
+        // unless the active buffer really is a terminal.
+        let active = self.active_buffer();
+        if self.active_window().is_terminal_buffer(active)
+            && self.active_window().terminal_mode_resume.contains(&active)
+        {
+            self.enter_terminal_mode();
+        }
     }
 
     /// Switch the active window and play a directional wipe over the

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -593,6 +593,15 @@ impl crate::app::window::Window {
         for terminal in terminals {
             if let Some(buffer_id) = self.restore_terminal_from_workspace(terminal) {
                 terminal_buffer_map.insert(terminal.terminal_index, buffer_id);
+                // The terminal was live when the session was saved and the
+                // user never explicitly exited it, so focusing it should
+                // bring back a live terminal rather than the read-only
+                // scrollback view. Seed the resume set so `set_active_buffer`
+                // re-enters terminal mode when the tab is focused (the
+                // editing-disabled completion in `Editor::set_active_buffer`
+                // finishes the read-only → live transition). An explicit
+                // Ctrl+Space exit later removes it from the set as usual.
+                self.terminal_mode_resume.insert(buffer_id);
             }
         }
         terminal_buffer_map

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -156,6 +156,7 @@ pub mod recovery;
 pub mod remote_fs_test;
 pub mod remote_indicator_popup;
 pub mod rendering;
+pub mod restored_terminal_focus;
 pub mod save_as_language_detection;
 pub mod save_nonexistent_directory;
 pub mod scroll_clearing;

--- a/crates/fresh-editor/tests/e2e/restored_terminal_focus.rs
+++ b/crates/fresh-editor/tests/e2e/restored_terminal_focus.rs
@@ -16,7 +16,6 @@ use fresh::config::Config;
 use fresh::config_io::DirectoryContext;
 use portable_pty::{native_pty_system, PtySize};
 use tempfile::TempDir;
-
 fn pty_available() -> bool {
     native_pty_system()
         .openpty(PtySize {
@@ -172,4 +171,81 @@ fn test_focusing_restored_terminal_activates_terminal_mode() {
             .wait_until(|h| h.screen_to_string().contains("SECOND_SESSION_LIVE"))
             .expect("restored terminal should be live and produce output");
     }
+}
+
+/// Regression test: switching *windows* (orchestrator "dive" / session
+/// switch) into a window whose active buffer is a resumable terminal must
+/// land on a live terminal, not whatever read-only / scrollback state the
+/// previous visit left behind.
+///
+/// Before the fix, `set_active_window` relaid out the PTY but never
+/// normalized the terminal's view state, so switching between restored
+/// terminal sessions intermittently showed a blank pane or a frozen
+/// scrollback view instead of the live prompt. The buffer-switch path
+/// (`Editor::set_active_buffer`) handled this within a window; this covers
+/// the window-switch path.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses a Unix shell / PTY
+fn test_switching_window_into_resumable_terminal_enters_terminal_mode() {
+    if !pty_available() {
+        eprintln!("Skipping window-switch terminal test: PTY not available");
+        return;
+    }
+
+    let mut harness = EditorTestHarness::with_temp_project(100, 30).unwrap();
+    let project_dir = harness.project_dir().unwrap();
+
+    // Base window stays active; create a second window ("beta") to dive into.
+    let base = harness.editor().active_session_id();
+    let beta = harness
+        .editor_mut()
+        .create_window_at(project_dir.join("wt-beta"), "beta".into());
+
+    // Dive into beta and open a terminal there (active, live terminal mode).
+    harness.editor_mut().set_active_window(beta);
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "freshly opened terminal in beta should be in terminal mode"
+    );
+
+    // Leave the terminal (switch to beta's other tab) and come back, which
+    // records the terminal in beta's `terminal_mode_resume` set — the same
+    // state a restore produces. The buffer-switch fix resumes terminal mode.
+    harness.editor_mut().prev_buffer();
+    harness.render().unwrap();
+    harness.editor_mut().next_buffer();
+    harness.render().unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "returning to beta's terminal tab should resume terminal mode"
+    );
+
+    // Drop into scrollback (read-only) — the terminal stays the active
+    // buffer and stays in the resume set, but terminal mode is now OFF.
+    // This is the exact state a window left behind by a previous visit (or
+    // a fresh restore) sits in.
+    harness
+        .send_key(KeyCode::PageUp, KeyModifiers::SHIFT)
+        .unwrap();
+    harness.render().unwrap();
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "Shift+PageUp should drop beta's terminal into read-only scrollback"
+    );
+
+    // Switch away to the base window, then dive back into beta.
+    harness.editor_mut().set_active_window(base);
+    harness.render().unwrap();
+    harness.editor_mut().set_active_window(beta);
+    harness.render().unwrap();
+
+    // The fix: diving back into beta normalizes its resumable terminal to a
+    // live terminal instead of leaving it read-only/blank.
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "switching back into beta should re-activate its terminal (live), \
+         not leave it stuck in read-only scrollback"
+    );
 }

--- a/crates/fresh-editor/tests/e2e/restored_terminal_focus.rs
+++ b/crates/fresh-editor/tests/e2e/restored_terminal_focus.rs
@@ -1,0 +1,175 @@
+//! Regression test: focusing a restored terminal tab activates terminal mode.
+//!
+//! A terminal that was live when a session was saved is restored read-only
+//! (showing the last rendered scrollback). Before the fix, focusing such a
+//! terminal tab left it stuck in the read-only scrollback view — often a
+//! blank screen with no prompt — instead of bringing the live terminal back.
+//! A freshly opened terminal, by contrast, drops you straight into terminal
+//! mode. This test pins the restored-terminal behavior to match.
+//!
+//! Requires a working PTY (/dev/ptmx); skips when unavailable, like the other
+//! terminal e2e tests.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use fresh::config_io::DirectoryContext;
+use portable_pty::{native_pty_system, PtySize};
+use tempfile::TempDir;
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// Build a config with hot exit on and `jump_to_end_on_output` off.
+///
+/// Disabling `jump_to_end_on_output` is deliberate: it removes the
+/// "new terminal output re-enters terminal mode" path so the *only* way a
+/// restored terminal can end up in terminal mode after restore is the focus
+/// path under test. That isolates the behavior and keeps the test
+/// deterministic (no dependence on shell-prompt output timing).
+fn session_config() -> Config {
+    let mut config = Config::default();
+    config.editor.hot_exit = true;
+    config.terminal.jump_to_end_on_output = false;
+    config
+}
+
+/// Restore a session whose terminal tab was a *background* tab at save time,
+/// then focus it via a normal tab switch. The restored terminal must come
+/// back live (terminal mode active), not stuck in the read-only view.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses a Unix shell
+fn test_focusing_restored_terminal_activates_terminal_mode() {
+    if !pty_available() {
+        eprintln!("Skipping restored-terminal test: PTY not available in this environment");
+        return;
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    std::fs::create_dir(&project_dir).unwrap();
+
+    let file = project_dir.join("hello.txt");
+    std::fs::write(&file, "editor content").unwrap();
+
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // ---- First session: open a file + a terminal, then leave the terminal
+    // as a background tab and shut down (saving the workspace). ----
+    {
+        let mut harness = EditorTestHarness::create(
+            120,
+            30,
+            HarnessOptions::new()
+                .with_config(session_config())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+        harness.editor_mut().set_session_mode(true);
+
+        // A non-terminal tab to be the active tab at save time.
+        harness.open_file(&file).unwrap();
+        harness.render().unwrap();
+        harness.assert_screen_contains("editor content");
+
+        // Open a terminal (becomes active + terminal mode) and run a command
+        // so the backing file has recognizable content to restore.
+        harness.editor_mut().open_terminal();
+        harness.render().unwrap();
+        harness
+            .editor_mut()
+            .active_window_mut()
+            .send_terminal_input(b"echo RESTORE_MARKER_42\n");
+        harness
+            .wait_until(|h| h.screen_to_string().contains("RESTORE_MARKER_42"))
+            .expect("terminal command output should appear");
+        assert!(
+            harness.editor().is_terminal_mode(),
+            "freshly opened terminal should be in terminal mode"
+        );
+
+        // Switch focus back to the file so the terminal is a *background*
+        // tab when the workspace is saved (this also exits terminal mode).
+        harness
+            .send_key(KeyCode::PageUp, KeyModifiers::CONTROL)
+            .unwrap();
+        harness.render().unwrap();
+        assert!(
+            !harness.editor().is_terminal_mode(),
+            "terminal mode should be off after switching to the file tab"
+        );
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // ---- Second session: restore, then focus the restored terminal tab. ----
+    {
+        let mut harness = EditorTestHarness::create(
+            120,
+            30,
+            HarnessOptions::new()
+                .with_config(session_config())
+                .with_working_dir(project_dir.clone())
+                .with_shared_dir_context(dir_context.clone())
+                .without_empty_plugins_dir(),
+        )
+        .unwrap();
+
+        let restored = harness.startup(true, &[]).unwrap();
+        assert!(restored, "session should have been restored");
+        harness.render().unwrap();
+
+        // The file tab was active at save time, so the restored terminal is a
+        // background tab and we are not in terminal mode yet.
+        assert!(
+            !harness.editor().is_terminal_mode(),
+            "restored background terminal should not start in terminal mode"
+        );
+
+        // Focus the terminal tab the way a user would: cycle tabs until the
+        // active buffer is the terminal.
+        for _ in 0..8 {
+            let active = harness.editor().active_buffer_id();
+            if harness.editor().active_window().is_terminal_buffer(active) {
+                break;
+            }
+            harness
+                .send_key(KeyCode::PageDown, KeyModifiers::CONTROL)
+                .unwrap();
+            harness.render().unwrap();
+        }
+        let active = harness.editor().active_buffer_id();
+        assert!(
+            harness.editor().active_window().is_terminal_buffer(active),
+            "should have focused the restored terminal tab"
+        );
+
+        // The fix: focusing a restored terminal activates terminal mode, so
+        // the user lands on a live terminal instead of a read-only screen.
+        // Visible on screen via the status message, and in the editor state.
+        harness.assert_screen_contains("Terminal mode enabled");
+        assert!(
+            harness.editor().is_terminal_mode(),
+            "focusing a restored terminal tab should activate terminal mode"
+        );
+
+        // The terminal is genuinely live: a new command's output appears.
+        harness
+            .editor_mut()
+            .active_window_mut()
+            .send_terminal_input(b"echo SECOND_SESSION_LIVE\n");
+        harness
+            .wait_until(|h| h.screen_to_string().contains("SECOND_SESSION_LIVE"))
+            .expect("restored terminal should be live and produce output");
+    }
+}


### PR DESCRIPTION
## Problem

Restored terminals didn't come back to the proper state. Two related cases:

1. **Focusing a restored terminal tab** showed a blank / read-only screen with no prompt instead of activating terminal mode (a freshly opened terminal, by contrast, drops you straight into terminal mode).
2. **Switching between sessions** (orchestrator dive / window switch) into a window whose active buffer is a terminal left it in an inconsistent state — intermittently a blank pane, a frozen scrollback view, or a stale screen instead of the live prompt.

## Root cause

A terminal that was live when a session was saved is restored **read-only** (showing the last rendered scrollback), with the live terminal meant to come back on re-entry. But re-entry never happened on the two paths above:

- **Buffer switch** (`Editor::set_active_buffer`): restored terminals were never seeded into `terminal_mode_resume`, so the resume-on-focus branch never fired; and that branch only flipped the `terminal_mode` flag — it couldn't reach the editor-level `enter_terminal_mode` that re-enables editing, drops the stale screen tail, and resizes the PTY (restored terminals load with editing disabled).
- **Window switch** (`set_active_window`): relaid out the PTY but never normalized the terminal's view state, so a materialized window's read-only terminal — or a window visited before with a stale `terminal_mode` / scroll position — was shown as-is.

## Fix

- Seed restored terminals into `terminal_mode_resume` at restore time (they were live and never explicitly exited).
- Complete the read-only → live transition in `Editor::set_active_buffer` when the resumed buffer is a terminal whose editing is still disabled.
- Normalize the active buffer to a live terminal at the end of `set_active_window` when it's a terminal the user hasn't explicitly exited.

`enter_terminal_mode` is a no-op unless the active buffer really is a terminal, and explicitly-exited terminals (removed from the resume set) are left read-only — so non-terminal focus/dives and deliberate scrollback views are unaffected.

## Tests

Two e2e regression tests in `restored_terminal_focus.rs`, both verified to fail without the fix and pass with it:

- Restore a session with a background terminal tab → focus it → must come back live.
- Window with a terminal left in read-only scrollback → switch away → switch back → must come back live.

No regressions: terminal (83), session/dive (18), and orchestrator (55) suites all pass; `cargo fmt` clean.

## Verified manually (tmux)

- Focusing a restored terminal now shows the live prompt and accepts input immediately.
- Repeatedly switching between two restored terminal sessions now lands on a live prompt every time (no blank / frozen scrollback).

## Out of scope (separate bugs noted while testing)

- A deeper restore inconsistency (the closed [#1939](https://github.com/sinelaw/fresh/issues/1939) class — split leaf pointing at an orphaned/removed buffer) can still blank a dived window when its saved active tab was an empty `[No Name]`.
- Intermittent flakiness where a session materializes empty until stale session sockets under `/tmp/fresh-$UID/` are cleared.

https://claude.ai/code/session_01KVJKbPT4DAKmbt2iZeStCh

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVJKbPT4DAKmbt2iZeStCh)_