### PR TITLE
Fix bracketed paste routing to Settings dialog text fields

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1133,6 +1133,18 @@ impl Editor {
     /// hidden buffer). Returns `false` when no panel owns the keyboard,
     /// so the caller falls back to the normal `paste_text` path.
     pub(crate) fn paste_bracketed_into_focused_panel(&mut self, text: &str) -> bool {
+        // The Settings dialog is a capture-all modal overlay that owns the
+        // keyboard above any panel. A bracketed paste must reach its focused
+        // text input (or be swallowed when no field is focused) rather than
+        // leaking into the buffer obscured behind it — the same class of bug
+        // the floating-panel routing below fixes (issue #2268).
+        if let Some(settings) = self.settings_state.as_mut() {
+            if settings.paste_into_focused_text(text) {
+                self.set_status_message(t!("clipboard.pasted").to_string());
+            }
+            return true;
+        }
+
         // Mirror the keyboard-dispatch precedence in `handle_key`: a
         // focused centered modal wins over a focused dock.
         let slot = if self

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -366,9 +366,7 @@ impl Editor {
                 if let Some(text) = self.clipboard.paste() {
                     if !text.is_empty() {
                         if let Some(settings) = &mut self.settings_state {
-                            if let Some(dialog) = settings.entry_dialog_mut() {
-                                dialog.insert_str(&text);
-                            }
+                            settings.paste_into_focused_text(&text);
                         }
                     }
                 }

--- a/crates/fresh-editor/src/view/settings/state.rs
+++ b/crates/fresh-editor/src/view/settings/state.rs
@@ -2160,6 +2160,47 @@ impl SettingsState {
         }
     }
 
+    /// Insert a whole string into the current editable control. Mirrors
+    /// [`Self::text_insert`] but inserts in one pass so single-line text
+    /// fields can flatten embedded newlines (used by the paste path).
+    pub fn text_insert_str(&mut self, s: &str) {
+        if let Some(item) = self.current_item_mut() {
+            match &mut item.control {
+                SettingControl::TextList(state) => state.insert_str(s),
+                SettingControl::Text(state) => state.insert_str(s),
+                SettingControl::Map(state) => {
+                    for c in s.chars() {
+                        state.new_key_text.insert(state.cursor, c);
+                        state.cursor += c.len_utf8();
+                    }
+                }
+                SettingControl::Json(state) => state.insert_str(s),
+                _ => {}
+            }
+        }
+    }
+
+    /// Route a paste to whichever Settings text input currently has focus
+    /// — the entry-dialog field when an entry dialog is open, otherwise the
+    /// main-panel control being edited. Returns `true` when a text field
+    /// accepted the paste. The bracketed-paste router relies on this so a
+    /// paste lands in the focused field instead of the buffer behind the
+    /// dialog (issue #2268).
+    pub fn paste_into_focused_text(&mut self, text: &str) -> bool {
+        if let Some(dialog) = self.entry_dialog_mut() {
+            if dialog.editing_text {
+                dialog.insert_str(text);
+                return true;
+            }
+            return false;
+        }
+        if self.editing_text {
+            self.text_insert_str(text);
+            return true;
+        }
+        false
+    }
+
     /// Backspace in the current editable control
     pub fn text_backspace(&mut self) {
         if let Some(item) = self.current_item_mut() {


### PR DESCRIPTION
## Summary
This PR fixes a bug where bracketed pastes would leak into the buffer behind a Settings dialog instead of being routed to the focused text input field within the dialog (issue #2268).

## Key Changes
- **Added `text_insert_str()` method** to `SettingsState`: A new method that mirrors `text_insert()` but inserts an entire string in one pass, allowing single-line text fields to flatten embedded newlines (important for the paste path).

- **Added `paste_into_focused_text()` method** to `SettingsState`: Routes paste operations to the appropriate text input—either the entry dialog field (when a dialog is open) or the main panel control being edited. Returns `true` when a text field accepted the paste, enabling proper focus routing.

- **Updated `paste_bracketed_into_focused_panel()`** in `clipboard.rs`: Added logic to check if a Settings dialog is open and route bracketed pastes through the new `paste_into_focused_text()` method. This ensures pastes are swallowed by the modal dialog rather than leaking to the buffer behind it, matching the keyboard dispatch precedence.

- **Simplified paste handling** in `input_dispatch.rs`: Replaced the previous ad-hoc entry dialog paste logic with a call to the new `paste_into_focused_text()` method for consistency.

## Implementation Details
The fix treats the Settings dialog as a capture-all modal overlay that owns the keyboard above any panel, similar to how floating-panel routing works. This ensures bracketed pastes reach the focused text input within the dialog or are properly swallowed when no field is focused, preventing them from accidentally modifying the buffer behind the dialog.

https://claude.ai/code/session_01MB7LJoKdYXtFkaSqfb6a6B