### PR TITLE
Fix Settings paste router swallowing buffer pastes after close; add e2e test

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1137,10 +1137,15 @@ impl Editor {
         // keyboard above any panel. A bracketed paste must reach its focused
         // text input (or be swallowed when no field is focused) rather than
         // leaking into the buffer obscured behind it — the same class of bug
-        // the floating-panel routing below fixes (issue #2268).
-        if let Some(settings) = self.settings_state.as_mut() {
-            if settings.paste_into_focused_text(text) {
-                self.set_status_message(t!("clipboard.pasted").to_string());
+        // the floating-panel routing below fixes (issue #2268). Gate on
+        // `visible`, not mere presence: `close_settings` only hides the
+        // state (it isn't dropped), and a lingering hidden dialog must not
+        // swallow pastes meant for the buffer.
+        if self.settings_state.as_ref().is_some_and(|s| s.visible) {
+            if let Some(settings) = self.settings_state.as_mut() {
+                if settings.paste_into_focused_text(text) {
+                    self.set_status_message(t!("clipboard.pasted").to_string());
+                }
             }
             return true;
         }

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -175,6 +175,7 @@ pub mod session_hot_exit;
 #[cfg(feature = "plugins")]
 pub mod sessions;
 pub mod settings;
+pub mod settings_bracketed_paste_routing;
 pub mod settings_config_issue_806;
 pub mod settings_fallback_category;
 pub mod settings_lsp_entry_dialog_bugs;

--- a/crates/fresh-editor/tests/e2e/settings_bracketed_paste_routing.rs
+++ b/crates/fresh-editor/tests/e2e/settings_bracketed_paste_routing.rs
@@ -1,0 +1,92 @@
+//! Regression test for issue #2268.
+//!
+//! A terminal-initiated bracketed paste (`Event::Paste`) while a Settings
+//! text input is focused must land in that field — not in the editor buffer
+//! obscured behind the dialog. The test also guards the inverse: once the
+//! dialog is closed, a bracketed paste must reach the buffer again. The
+//! `settings_state` is only *hidden* on close (not dropped), so the router
+//! must gate on visibility or it would keep swallowing buffer pastes.
+//!
+//! Mirrors the manual repro: paste into the buffer, open Settings, go to
+//! Terminal -> Command and paste, close Settings, then paste again.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// A label only rendered while the Terminal settings panel is shown. Used
+/// both to detect that the Terminal category is selected and to confirm the
+/// dialog has closed.
+const TERMINAL_PANEL_MARKER: &str = "Jump To End On Output";
+
+/// Arrow down through the category list until the right panel renders
+/// `marker`, i.e. the desired category is selected.
+fn select_category_showing(harness: &mut EditorTestHarness, marker: &str) {
+    for _ in 0..40 {
+        if harness.screen_to_string().contains(marker) {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    panic!(
+        "category showing {marker:?} never selected; screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+/// Arrow down through the focused settings panel until `label` is the
+/// focused row. The focus marker is ">  " (unchanged) or ">● " (changed),
+/// matching the renderer (see settings_paste.rs).
+fn focus_setting_row(harness: &mut EditorTestHarness, label: &str) {
+    let unchanged = format!(">  {label}");
+    let changed = format!(">● {label}");
+    for _ in 0..40 {
+        let screen = harness.screen_to_string();
+        if screen.contains(&unchanged) || screen.contains(&changed) {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    panic!(
+        "settings row {label:?} never focused; screen:\n{}",
+        harness.screen_to_string()
+    );
+}
+
+#[test]
+fn test_bracketed_paste_routing_with_settings_dialog() {
+    let mut harness = EditorTestHarness::new(150, 45).unwrap();
+
+    // Step 1: bracketed paste into the editor buffer.
+    harness.send_paste("BUF1").unwrap();
+    harness.assert_buffer_content("BUF1");
+
+    // Step 2: open the Settings UI.
+    harness.open_settings().unwrap();
+
+    // Step 3: select the Terminal category, move focus into the settings
+    // panel, and land on the Command text input.
+    select_category_showing(&mut harness, TERMINAL_PANEL_MARKER);
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    focus_setting_row(&mut harness, "Command");
+    // Enter edit mode on the focused Command field.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    // Step 4: bracketed paste into the focused Command field.
+    harness.send_paste("CMD2").unwrap();
+    // It landed in the field...
+    harness.assert_screen_contains("CMD2");
+    // ...and NOT in the buffer hidden behind the dialog.
+    harness.assert_buffer_content("BUF1");
+
+    // Step 5: close the Settings UI (Esc exits edit mode, Esc closes).
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.assert_screen_not_contains(TERMINAL_PANEL_MARKER);
+
+    // Step 6: with the dialog closed, a bracketed paste must reach the
+    // buffer again (cursor sits at the end of "BUF1").
+    harness.send_paste("BUF3").unwrap();
+    harness.assert_buffer_content("BUF1BUF3");
+}


### PR DESCRIPTION
## Summary

Follow-up to #2269 (already merged). That fix routed bracketed pastes to the Settings overlay when `settings_state.is_some()`, but `close_settings` only **hides** the dialog — it does not drop `settings_state`. As a result, once the Settings UI had been opened, every subsequent bracketed paste into the editor buffer was silently swallowed.

This PR gates the router on the dialog's `visible` flag (matching the render path in `app/render.rs`), so it only claims pastes while the Settings dialog is actually shown. It also adds an e2e test covering the full flow.

## The bug

```rust
// before: true even after the dialog is closed (state lingers, just hidden)
if let Some(settings) = self.settings_state.as_mut() { ... return true; }
```

`close_settings` → `state.hide()` sets `visible = false` but keeps `settings_state = Some(..)`. The `is_some()` check therefore swallowed buffer pastes for the rest of the session.

## Fix

Gate on visibility:

```rust
if self.settings_state.as_ref().is_some_and(|s| s.visible) {
    if let Some(settings) = self.settings_state.as_mut() {
        if settings.paste_into_focused_text(text) { ... }
    }
    return true;
}
```

## Test

`settings_bracketed_paste_routing.rs` exercises the exact reported flow via the harness `send_paste` (real `Event::Paste`) path:

1. Bracketed paste into the editor buffer → lands in buffer.
2. Open Settings, go to **Terminal → Command**, bracketed paste → lands in the field, buffer untouched.
3. Close Settings, bracketed paste again → lands in the buffer.

Step 3 is the regression guard. Verified manually in tmux and via `cargo test` (passes).


---
_Generated by [Claude Code](https://claude.ai/code/session_01MB7LJoKdYXtFkaSqfb6a6B)_