### PR TITLE
fix(win32): try to attach parent process's stdio, otherwise force GUI…

### DIFF
--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -3367,7 +3367,10 @@ fn dump_config_command(args: &Args) -> AnyhowResult<()> {
 /// Route non-interactive subcommands. Returns `Some(result)` if a subcommand
 /// was handled so the caller can propagate it; returns `None` for an
 /// interactive editor launch.
-fn run_if_subcommand(args: &Args, console_available: bool) -> Option<AnyhowResult<()>> {
+fn run_if_subcommand(
+    args: &Args,
+    #[cfg(feature = "gui")] console_available: bool,
+) -> Option<AnyhowResult<()>> {
     if args.show_paths {
         return Some(show_paths_command());
     }
@@ -3666,7 +3669,7 @@ fn real_main() -> AnyhowResult<()> {
     // Early check, otherwise terminal check would fail.
     #[cfg(all(windows, feature = "gui"))]
     let console_available = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) != 0 };
-    #[cfg(not(all(windows, feature = "gui")))]
+    #[cfg(all(not(windows), feature = "gui"))]
     let console_available = true;
 
     // Enable backtraces for error reporting if not already set.
@@ -3704,7 +3707,11 @@ fn real_main() -> AnyhowResult<()> {
         std::env::set_var("FRESH_INTERACTIVE", "1");
     }
 
-    if let Some(result) = run_if_subcommand(&args, console_available) {
+    if let Some(result) = run_if_subcommand(
+        &args,
+        #[cfg(feature = "gui")]
+        console_available,
+    ) {
         return result;
     }
 

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -2,6 +2,8 @@
 // from Explorer / a Start-Menu shortcut does not flash a console window.
 // The TUI build (no `gui` feature) keeps the default "console" subsystem.
 #![cfg_attr(all(windows, feature = "gui"), windows_subsystem = "windows")]
+#[cfg(all(windows, feature = "gui"))]
+use windows_sys::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
 
 use anyhow::{Context, Result as AnyhowResult};
 use clap::{CommandFactory, FromArgMatches, Parser};
@@ -3365,7 +3367,7 @@ fn dump_config_command(args: &Args) -> AnyhowResult<()> {
 /// Route non-interactive subcommands. Returns `Some(result)` if a subcommand
 /// was handled so the caller can propagate it; returns `None` for an
 /// interactive editor launch.
-fn run_if_subcommand(args: &Args) -> Option<AnyhowResult<()>> {
+fn run_if_subcommand(args: &Args, console_available: bool) -> Option<AnyhowResult<()>> {
     if args.show_paths {
         return Some(show_paths_command());
     }
@@ -3405,7 +3407,7 @@ fn run_if_subcommand(args: &Args) -> Option<AnyhowResult<()>> {
         return Some(run_attach_command(args));
     }
     #[cfg(feature = "gui")]
-    if args.gui {
+    if !console_available || args.gui {
         return Some(fresh::gui::run_gui(
             &args.files,
             args.no_plugins,
@@ -3661,6 +3663,12 @@ fn build_localized_cli_command() -> clap::Command {
 }
 
 fn real_main() -> AnyhowResult<()> {
+    // Early check, otherwise terminal check would fail.
+    #[cfg(all(windows, feature = "gui"))]
+    let console_available = unsafe { AttachConsole(ATTACH_PARENT_PROCESS) != 0 };
+    #[cfg(not(all(windows, feature = "gui")))]
+    let console_available = true;
+
     // Enable backtraces for error reporting if not already set.
     // Errors that crash the editor are bugs — backtraces help diagnose them.
     if std::env::var_os("RUST_BACKTRACE").is_none() {
@@ -3696,7 +3704,7 @@ fn real_main() -> AnyhowResult<()> {
         std::env::set_var("FRESH_INTERACTIVE", "1");
     }
 
-    if let Some(result) = run_if_subcommand(&args) {
+    if let Some(result) = run_if_subcommand(&args, console_available) {
         return result;
     }
 


### PR DESCRIPTION
Fix #2276

Try to attach console from parent process, if that failed, force to use GUI mode.

Otherwise, if the `--gui` argument was not passed, TUI mode in entered.

## What works now

- `--help`
- GUI mode in explorer.exe by just double-clicking
- TUI mode in terminal, with `subsystem=windows`

## TODO

- [ ] write integration test runner on Windows, with `subsystem=windows` launcher and `subsystem=console` launcher, to test startup behavior