### PR TITLE
Add comprehensive guide for adding languages to Fresh

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -126,6 +126,7 @@ export default defineConfig({
         text: "Developer Docs",
         items: [
           { text: "Architecture", link: "/architecture" },
+          { text: "Adding a Language", link: "/development/adding-languages" },
           { text: "WASM Compatibility", link: "/wasm" },
           { text: "QuickJS Migration", link: "/quickjs" },
           {

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -277,6 +277,11 @@ line doesn't indent the next line:
 > Note: patterns are written in a JSON string, so backslashes must be escaped
 > (`\\s`, `\\{`).
 
+These patterns are the same mechanism Fresh's built-in languages use, grouped
+into **families** (curly-brace, Python, Ruby-like, …). To add a language to
+Fresh's source tree — or to understand which family yours resembles — see
+[Adding a Built-in Language](/development/adding-languages).
+
 ### Set a Default Language for Unrecognized Files
 
 When Fresh opens a file whose type it cannot detect (no matching extension, filename, or glob pattern), it shows it as "Plain Text" with no syntax highlighting. Set `default_language` to the name of any entry in the `languages` map and unrecognized files will use that language's full configuration — useful for `.conf`, `.rc`, `.rules`, and other config files that Fresh doesn't recognize.

--- a/docs/development/adding-languages.md
+++ b/docs/development/adding-languages.md
@@ -1,55 +1,66 @@
 # Adding a Built-in Language
 
-This guide explains how Fresh supports a language's **syntax highlighting** and
-**auto-indentation**, and how to add a new one.
+Fresh supports a language through two independent systems — **syntax
+highlighting** and **auto-indentation**. You can add either on its own. Both are
+connected through the grammar catalog (`GrammarRegistry`), which maps a file to a
+language; detection (extension, filename, glob, shebang, configured default)
+lives in `crates/fresh-editor/src/primitives/detected_language.rs`.
 
-## Prime directive: avoid tree-sitter
+| System | What powers it |
+|--------|----------------|
+| **Highlighting** | a syntect (TextMate/Sublime) grammar, or a language pack |
+| **Auto-indent** | the regex **indent-rules** tier (language *families*) |
 
-Fresh deliberately does **not** use tree-sitter for most languages, and new
-languages should not add it. Tree-sitter grammars cost multiple megabytes of
-parse tables each (≈18 MB was removed by dropping them), and they don't work in
-the WASM/min-size builds. Fresh keeps tree-sitter only for the handful of
-languages nothing else can serve, and treats it as legacy for everything else.
+## Adding a language
 
-Instead, the two systems each have a lightweight, tree-sitter-free path that you
-should prefer:
+Pick only the pieces you need.
 
-| System | Preferred mechanism | Tree-sitter? |
-|--------|--------------------|--------------|
-| **Highlighting** | a syntect (TextMate/Sublime) grammar, or a language pack | only when syntect genuinely can't render the language |
-| **Auto-indent** | the regex **indent-rules** tier (language *families*) | avoid — the rules tier is the primary path |
+### Highlighting
 
-Both systems are independent: you can add highlighting without indentation, or
-vice versa. They are wired together through the grammar catalog
-(`GrammarRegistry`), which maps a file to a language; detection (extension,
-filename, glob, shebang, configured default) lives in
-`crates/fresh-editor/src/primitives/detected_language.rs`.
+1. **Syntect grammar.** Add a self-contained `.sublime-syntax` file under
+   `crates/fresh-editor/src/grammars/` and register it with the catalog
+   (`primitives/grammar/loader.rs`).
+2. **Language pack.** Ship the same grammar as an installable pack — no recompile
+   and no core change. See [Language Packs](/plugins/development/language-packs).
 
-## How auto-indentation is decided
+### Auto-indentation
+
+1. **Map to a family.** If the language fits an existing family (below), that's a
+   one-line addition to the family table in `indent_rules.rs`.
+2. **Custom rules from config.** Users (and language packs) can define or tune a
+   language's indent rules in config — no recompile. Full reference:
+   [Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
+3. **New family.** If the language's block syntax matches none of the existing
+   ones, add a family to `indent_rules.rs`.
+
+### Detection and LSP
+
+- **Detection** (extensions, filenames, globs) comes from the catalog entry or a
+  `[languages.<id>]` config block.
+- **LSP** is orthogonal to both systems: a server config under `[lsp.<id>]` (or a
+  pack's `fresh.lsp`).
+
+## How auto-indentation works
 
 When you press Enter or type a closing bracket, Fresh chooses an indent through a
-tiered fallback, in this order of preference:
+tiered fallback:
 
-1. **Regex indent-rules tier** — the primary, tree-sitter-free path. Each
-   language belongs to a *family* of simple rules. Lives in
-   `crates/fresh-editor/src/primitives/indent_rules.rs`.
-2. **Tree-sitter AST** — legacy, used only for the few languages that still ship
-   a bundled grammar. Not something a new language should opt into.
-   (`primitives/indent.rs`.)
-3. **Generic bracket heuristic** — a language-agnostic last resort for unknown
-   files. (`primitives/indent_pattern.rs`.)
+1. **Regex indent-rules tier** — the primary path. Each language belongs to a
+   *family* of simple rules (`primitives/indent_rules.rs`).
+2. **Tree-sitter AST** — used for the few languages that still ship a bundled
+   grammar (`primitives/indent.rs`).
+3. **Generic bracket heuristic** — a language-agnostic fallback for unknown
+   files (`primitives/indent_pattern.rs`).
 
-The rules tier's one important guarantee is **scope masking**: before matching,
-it blanks out comment and string spans (reusing the highlighter's existing
-output), so a bracket or keyword inside a string or comment never triggers an
-indent. This is what keeps regex-based indentation from being glitchy, and it's
-why the rules tier is good enough to replace tree-sitter for indentation.
+The rules tier applies **scope masking**: before matching, it blanks out comment
+and string spans (reusing the highlighter's existing output), so a bracket or
+keyword inside a string or comment doesn't trigger an indent.
 
-## Language families
+### Language families
 
 A **family** is a shared set of indent rules describing one class of block
-syntax. Most languages just need to be pointed at the right family — no bespoke
-logic. The families (defined in `indent_rules.rs`) are:
+syntax. Most languages can be pointed at an existing family rather than needing
+bespoke logic. The families (defined in `indent_rules.rs`) are:
 
 - **CurlyBrace** — `{ } [ ] ( )` block structure (C, Rust, JS/TS, Go, JSON, CSS…).
 - **Python** — layout-defined: `:` opens a block, indentation *is* the structure.
@@ -64,40 +75,13 @@ a "self-close" rule so one-liners (`def f; end`) don't over-indent. The exact
 patterns are data in `indent_rules.rs`; the user-facing equivalents are
 documented in [Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
 
-## Adding a language
+## A note on tree-sitter
 
-Pick only the pieces you need.
-
-### Highlighting
-
-In order of preference:
-
-1. **Syntect grammar (preferred).** Add a self-contained `.sublime-syntax` file
-   under `crates/fresh-editor/src/grammars/` and register it with the catalog
-   (`primitives/grammar/loader.rs`). No parse-table weight, works everywhere.
-2. **Language pack.** Ship the same grammar as an installable pack — no recompile
-   and no core change at all. See [Language Packs](/plugins/development/language-packs).
-3. **Tree-sitter (last resort).** Only if syntect truly can't render the language
-   and the cost is justified. This is the path we're trying *not* to grow.
-
-### Auto-indentation
-
-Prefer the rules tier — never add a tree-sitter indent query for a new language.
-
-1. **Map to a family.** If the language fits an existing family, that's a
-   one-line addition to the family table in `indent_rules.rs`.
-2. **Custom rules from config.** Users (and language packs) can define or tune a
-   language's indent rules entirely in config — no recompile. Full reference:
-   [Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
-3. **New family.** Only if the language's block syntax matches none of the
-   existing ones; add a family to `indent_rules.rs`.
-
-### Detection and LSP
-
-- **Detection** (extensions, filenames, globs) comes from the catalog entry or a
-  `[languages.<id>]` config block.
-- **LSP** is orthogonal to both systems: a server config under `[lsp.<id>]` (or a
-  pack's `fresh.lsp`).
+Fresh leans toward the syntect and indent-rules paths above rather than
+tree-sitter. Each tree-sitter grammar adds a sizable parse table to the binary
+(around 18 MB was reclaimed by dropping the ones that weren't essential), so it's
+reserved for languages syntect can't render, and a new language usually doesn't
+need a tree-sitter indent query — the rules tier covers it.
 
 ## Where things live
 
@@ -105,7 +89,7 @@ Prefer the rules tier — never add a tree-sitter indent query for a new languag
 |---------|----------|
 | Indent families & rules | `crates/fresh-editor/src/primitives/indent_rules.rs` |
 | Generic bracket fallback | `crates/fresh-editor/src/primitives/indent_pattern.rs` |
-| Legacy tree-sitter indent | `crates/fresh-editor/src/primitives/indent.rs` |
+| Tree-sitter indent | `crates/fresh-editor/src/primitives/indent.rs` |
 | Syntect grammars | `crates/fresh-editor/src/grammars/` + `primitives/grammar/loader.rs` |
 | Language detection / catalog | `crates/fresh-editor/src/primitives/detected_language.rs`, `primitives/grammar/` |
 | User-facing indent config | [Configuration guide](/configuration/#customize-auto-indentation) |

--- a/docs/development/adding-languages.md
+++ b/docs/development/adding-languages.md
@@ -1,274 +1,120 @@
 # Adding a Built-in Language
 
-This is the contributor's guide to teaching Fresh about a new language *in the
-source tree* — syntax highlighting, auto-indentation, and the indent
-**families** — plus how those systems decide what to do at runtime.
+This guide explains how Fresh supports a language's **syntax highlighting** and
+**auto-indentation**, and how to add a new one.
 
-Two audiences, two paths:
+## Prime directive: avoid tree-sitter
 
-- **Adding a built-in language** (this page) — you're editing Fresh's Rust
-  source: an embedded grammar, a tree-sitter parser, or a row in the indent
-  family table. Requires a rebuild.
-- **Shipping a language pack or tweaking config** — no recompile. See
-  [Language Packs](/plugins/development/language-packs) and the
-  [Configuration guide](/configuration/#customize-auto-indentation). Most
-  niche-language needs are best met this way.
+Fresh deliberately does **not** use tree-sitter for most languages, and new
+languages should not add it. Tree-sitter grammars cost multiple megabytes of
+parse tables each (≈18 MB was removed by dropping them), and they don't work in
+the WASM/min-size builds. Fresh keeps tree-sitter only for the handful of
+languages nothing else can serve, and treats it as legacy for everything else.
 
-The deeper design rationale lives in the repo's internal docs:
-[`indentation-rules-design.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/indentation-rules-design.md)
-(why the regex indentation tier exists and the binary-size win it bought) and
-[`language-support-review.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/language-support-review.md)
-(the current per-language support matrix).
+Instead, the two systems each have a lightweight, tree-sitter-free path that you
+should prefer:
 
----
+| System | Preferred mechanism | Tree-sitter? |
+|--------|--------------------|--------------|
+| **Highlighting** | a syntect (TextMate/Sublime) grammar, or a language pack | only when syntect genuinely can't render the language |
+| **Auto-indent** | the regex **indent-rules** tier (language *families*) | avoid — the rules tier is the primary path |
 
-## Mental model: two independent systems
-
-Fresh treats *how a language looks* and *how it indents* as separate concerns,
-resolved separately. You can add one without the other.
-
-| System | What it does | Engines |
-|--------|--------------|---------|
-| **Highlighting** | colors tokens (keywords, strings, comments) | Syntect (TextMate/Sublime grammars) — primary; tree-sitter — fallback for ~18 languages |
-| **Auto-indent** | picks the indent of a new line on Enter / when typing a closer | Tree-sitter AST (bundled grammars) → per-language regex rules → generic bracket heuristic |
-
-A language can be highlighted by syntect while indented by the regex rules tier,
-with no tree-sitter grammar at all — that is the common case (Kotlin, Swift,
-Dart, …). Both systems hang off the **unified grammar catalog**
-(`GrammarRegistry`), which maps a file path / name to a `GrammarEntry` recording
-which engines can serve it. Detection order (filename → glob → extension →
-first-line/shebang → configured default) lives in
+Both systems are independent: you can add highlighting without indentation, or
+vice versa. They are wired together through the grammar catalog
+(`GrammarRegistry`), which maps a file to a language; detection (extension,
+filename, glob, shebang, configured default) lives in
 `crates/fresh-editor/src/primitives/detected_language.rs`.
 
----
+## How auto-indentation is decided
 
-## How auto-indentation works
+When you press Enter or type a closing bracket, Fresh chooses an indent through a
+tiered fallback, in this order of preference:
 
-When you press Enter (or type a closing `}` / `]` / `)`), Fresh computes the new
-line's indent through a **three-tier dispatch** in
-`crates/fresh-editor/src/input/actions.rs` (the Enter path around
-`insert_newline_with_indent`, and `calculate_closing_delimiter_indent` for typed
-closers). Tiers are tried in order; the first that produces an answer wins:
+1. **Regex indent-rules tier** — the primary, tree-sitter-free path. Each
+   language belongs to a *family* of simple rules. Lives in
+   `crates/fresh-editor/src/primitives/indent_rules.rs`.
+2. **Tree-sitter AST** — legacy, used only for the few languages that still ship
+   a bundled grammar. Not something a new language should opt into.
+   (`primitives/indent.rs`.)
+3. **Generic bracket heuristic** — a language-agnostic last resort for unknown
+   files. (`primitives/indent_pattern.rs`.)
 
-```
-1. Tree-sitter AST tier   — only for languages with a *bundled* grammar
-                            (Go, JSON/JSONC, TypeScript, JavaScript, Templ).
-                            Parses the block structure, exact on strings/comments.
-2. Regex rules tier        — every other language. Keyed by the syntect syntax
-                            name, scope-masked. This is where families live.
-3. Generic bracket heuristic — unknown syntaxes (.txt, …). C-style { } [ ] (  ) +
-                            trailing ':'. Language-agnostic last resort.
-```
-
-Which tier applies hinges on one check: `state.highlighter.language()` returns a
-tree-sitter `Language` *and* `language.ts_language().is_some()` (its grammar is
-compiled into this build). If so → tier 1; otherwise → tier 2, falling through to
-tier 3 when no rules match. Most grammars were deliberately dropped from the
-default build to save ~18 MB of parse tables, so in practice **most languages
-indent via the regex rules tier.**
-
-### The regex rules tier (tier 2)
-
-Source: `crates/fresh-editor/src/primitives/indent_rules.rs`. Pure Rust, WASM-safe
-(no tree-sitter dependency), so it works in min-size and browser builds too.
-
-Each language is described by a small set of anchored regexes
-(`IndentRulesDef`). Every field is optional (`None` = "never matches"):
-
-| Field | Tested against | Effect |
-|-------|----------------|--------|
-| `increase` | the **reference line** (line being split, or nearest non-blank above) | new line is **+1** level |
-| `decrease` | the **new line's tail** (text that moves down past the cursor) | that line is **−1** level |
-| `indent_next_line` | the reference line | **+1** for the immediately following line only (one-shot; braceless `if (x)`) |
-| `dedent_next_line` | the reference line | **−1** for the following line (one-shot; Python flow-exit `return`/`pass`/…) |
-| `self_close` | the reference line | **cancels** `increase` when the same line also closes its block (one-liner `def f; end`) |
-| `indentation_significant` (bool) | — | layout-defined languages (Python, YAML): on a blank line, keep the cursor's current column instead of re-deriving, so a manual dedent sticks |
-
-The algorithm (`IndentRules::calculate_indent`): take the reference line's visual
-indent as `base`; add a unit if it `increase`s (and isn't `self_close`d) or
-matches `indent_next_line`, else subtract a unit if it matches
-`dedent_next_line`; then subtract a unit if the new line's tail `decrease`s
-(unless the opener was on this same line — the `{│}` bracket-expansion case). The
-unit is one `tab_size`.
-
-#### Scope masking — the key anti-glitch mechanism
-
-The classic regex-indentation bug is triggering on a `{` inside a string or an
-`end` inside a comment. Fresh avoids it without lookarounds (the `regex` crate is
-RE2 — linear, no look-around/backrefs). Before matching, each line is turned into
-a **code view**: every byte the highlighter reports as `Comment` or `String` is
-replaced with a space (`byte_is_code` in `actions.rs` sources this from the
-highlighter's *already-computed* render spans — no second parse). So
-`let x = "{"` and `// end` have no trigger characters left to match. When no
-scope info is cached (line outside the viewport, plain buffer), the code view is
-the raw line, degrading to plain regex matching rather than misbehaving.
-
----
+The rules tier's one important guarantee is **scope masking**: before matching,
+it blanks out comment and string spans (reusing the highlighter's existing
+output), so a bracket or keyword inside a string or comment never triggers an
+indent. This is what keeps regex-based indentation from being glitchy, and it's
+why the rules tier is good enough to replace tree-sitter for indentation.
 
 ## Language families
 
-Most languages don't need bespoke patterns — they need *a correct family*. A
-**family** is a shared `IndentRulesDef` covering a class of block syntax. The
-enum and the per-language mapping live in `indent_rules.rs`:
+A **family** is a shared set of indent rules describing one class of block
+syntax. Most languages just need to be pointed at the right family — no bespoke
+logic. The families (defined in `indent_rules.rs`) are:
 
-```rust
-pub enum Family {
-    CurlyBrace,  // block structure is { } [ ] ( )
-    Python,      // ':' opens a block; flow-exit dedents next line
-    RubyLike,    // def…end, do…end, midblock else/when/rescue
-    LuaLike,     // function…end, if…then…end, for…do…end, repeat…until
-    BashLike,    // if…then…fi, for/while…do…done, case…esac, { }
-    PascalLike,  // begin…end, case…of…end, repeat…until
-}
-```
+- **CurlyBrace** — `{ } [ ] ( )` block structure (C, Rust, JS/TS, Go, JSON, CSS…).
+- **Python** — layout-defined: `:` opens a block, indentation *is* the structure.
+- **RubyLike** — `def…end`, `do…end`, with midblock keywords.
+- **LuaLike** — `function…end`, `if…then…end`, `for…do…end`.
+- **BashLike** — `if…then…fi`, `for…do…done`, `case…esac`.
+- **PascalLike** — `begin…end`, `case…of…end`.
 
-Each family's actual patterns (the `const CURLY_BRACE`, `const PYTHON`, … defs):
+A family captures the usual signals: what opens a deeper level, what closes one,
+one-shot indent/dedent for things like a braceless `if` or a Python `return`, and
+a "self-close" rule so one-liners (`def f; end`) don't over-indent. The exact
+patterns are data in `indent_rules.rs`; the user-facing equivalents are
+documented in [Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
 
-| Family | `increase` (opener) | `decrease` (closer) | Notable extras |
-|--------|---------------------|---------------------|----------------|
-| **CurlyBrace** | line ends with `{ [ (` | line starts with `} ] )` | `indent_next_line` for braceless `if/for/while(…)`/`else` |
-| **Python** | line ends with `:` | moved-down `elif/else/except/finally/case` | `dedent_next_line` for `return/pass/raise/break/continue`; `indentation_significant = true` |
-| **RubyLike** | `def/class/module/if/case/…` at line start, or trailing `do`/`do \|x\|` | `end` + midblock `else/elsif/when/in/rescue/ensure` | `self_close = \bend\b` (one-liners) |
-| **LuaLike** | `function/if/elseif/for/while/repeat`, or trailing `do`/`then` | `end/else/elseif/until` | `self_close = \bend\b` |
-| **BashLike** | trailing `then`/`do`, `case … in`, function-body `{` | `fi/done/esac/else/elif/}` | `(` deliberately **excluded** (subshell, not a block) |
-| **PascalLike** | `begin/case/record/try/repeat/asm`, or trailing `begin`/`of` | `end/until/except/finally` | `self_close = \bend\b` |
+## Adding a language
 
-Study the Python row when adding any **layout-defined** language (YAML, etc.): it
-has no real closing tokens, so it leans on `dedent_next_line` and the
-`indentation_significant` flag rather than `decrease`.
+Pick only the pieces you need.
 
-### The mapping is just data
+### Highlighting
 
-`family_for_id` is a single `match` from a normalized language id to a family —
-the one extension point for the common case:
+In order of preference:
 
-```rust
-fn family_for_id(id: &str) -> Option<Family> {
-    let f = match id {
-        "rust" | "c" | "cpp" | "csharp" | "java" | "go" | "javascript"
-        | "typescript" | "php" | "swift" | "kotlin" | "dart" | "scala"
-        | "json" | "css" | "scss" | "less" /* … */ => Family::CurlyBrace,
-        "python" => Family::Python,
-        "ruby"   => Family::RubyLike,
-        "lua"    => Family::LuaLike,
-        "bash" | "sh" | "shell" | "shellscript" => Family::BashLike,
-        "pascal" => Family::PascalLike,
-        _ => return None,   // → falls through to the generic bracket heuristic
-    };
-    Some(f)
-}
-```
+1. **Syntect grammar (preferred).** Add a self-contained `.sublime-syntax` file
+   under `crates/fresh-editor/src/grammars/` and register it with the catalog
+   (`primitives/grammar/loader.rs`). No parse-table weight, works everywhere.
+2. **Language pack.** Ship the same grammar as an installable pack — no recompile
+   and no core change at all. See [Language Packs](/plugins/development/language-packs).
+3. **Tree-sitter (last resort).** Only if syntect truly can't render the language
+   and the cost is justified. This is the path we're trying *not* to grow.
 
-Languages absent here fall through to tier 3 — the universal default never goes
-away. Lookup is keyed by a **string id**, not the tree-sitter `Language` enum, so
-syntect-only languages get rules and the whole tier survives with the
-`tree-sitter` feature off. `rules_for_syntax_name` maps a syntect display name
-(`"C++"`, `"Bourne Again Shell (bash)"`) to an id before calling `rules_for_id`.
+### Auto-indentation
 
----
+Prefer the rules tier — never add a tree-sitter indent query for a new language.
 
-## Recipes: how to add a language
+1. **Map to a family.** If the language fits an existing family, that's a
+   one-line addition to the family table in `indent_rules.rs`.
+2. **Custom rules from config.** Users (and language packs) can define or tune a
+   language's indent rules entirely in config — no recompile. Full reference:
+   [Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
+3. **New family.** Only if the language's block syntax matches none of the
+   existing ones; add a family to `indent_rules.rs`.
 
-Pick the dimensions you need. They are independent.
+### Detection and LSP
 
-### A. Just indentation, existing family — one line
+- **Detection** (extensions, filenames, globs) comes from the catalog entry or a
+  `[languages.<id>]` config block.
+- **LSP** is orthogonal to both systems: a server config under `[lsp.<id>]` (or a
+  pack's `fresh.lsp`).
 
-The language already highlights (syntect default or a pack) and behaves like an
-existing family. Add an arm to `family_for_id` in `indent_rules.rs`:
+## Where things live
 
-```rust
-"zig" | "odin" => Family::CurlyBrace,
-```
+| Concern | Location |
+|---------|----------|
+| Indent families & rules | `crates/fresh-editor/src/primitives/indent_rules.rs` |
+| Generic bracket fallback | `crates/fresh-editor/src/primitives/indent_pattern.rs` |
+| Legacy tree-sitter indent | `crates/fresh-editor/src/primitives/indent.rs` |
+| Syntect grammars | `crates/fresh-editor/src/grammars/` + `primitives/grammar/loader.rs` |
+| Language detection / catalog | `crates/fresh-editor/src/primitives/detected_language.rs`, `primitives/grammar/` |
+| User-facing indent config | [Configuration guide](/configuration/#customize-auto-indentation) |
+| Language packs (no recompile) | [Language Packs](/plugins/development/language-packs) |
 
-Add a golden test in the same file's `tests` module and you're done. No grammar,
-no recompile path for users (they can do the same via config — see D).
+## Background
 
-### B. Syntax highlighting via an embedded syntect grammar
-
-For a language syntect doesn't ship (Kotlin, Swift, Nix, …):
-
-1. Drop a self-contained `.sublime-syntax` file into
-   `crates/fresh-editor/src/grammars/`. (No `extends:` — Fresh supports a subset;
-   only internal `include` works. See the language-packs page's compatibility
-   notes.)
-2. Register it in `GrammarRegistry::add_embedded_grammars`
-   (`crates/fresh-editor/src/primitives/grammar/loader.rs`) with its extensions /
-   filenames. The catalog picks it up on the next rebuild.
-3. If the language should also indent, add it to a family (recipe A).
-
-### C. Syntax highlighting + structural features via tree-sitter
-
-Only when tree-sitter buys something syntect can't (e.g. TypeScript, which
-syntect has no grammar for, or precise indent where the regex rules aren't good
-enough). This is the **heavy** option — each grammar adds multi-MB parse tables —
-so it's gated behind build features and reserved for the must-keep set.
-
-1. Add a variant to `fresh_languages::Language`
-   (`crates/fresh-languages/src/lib.rs`) with its extensions, display name, and
-   highlight config; bundle the `tree-sitter-<lang>` crate behind the appropriate
-   feature.
-2. Add `crates/fresh-editor/queries/<lang>/indents.scm` for AST-driven indent.
-3. The catalog auto-creates a tree-sitter entry if no syntect grammar matches.
-
-Keep a **parity test** (the `parity` module in `indent_rules.rs`): the regex
-rules for the language must agree with the tree-sitter output, so the grammar can
-be dropped from default builds without regressing indentation.
-
-### D. Indentation or detection from config — no recompile
-
-Users (and language packs) add or tune a language entirely in config. This is the
-right answer for niche languages.
-
-```toml
-[languages.kotlin]
-extensions = ["kt", "kts"]
-comment_prefix = "//"
-
-[languages.kotlin.indent]
-increase_indent_pattern = "[\\{\\[\\(]\\s*$"
-decrease_indent_pattern = "^\\s*[\\}\\]\\)]"
-```
-
-The `[languages.<id>.indent]` block maps field-for-field onto the rule set
-(`increase_indent_pattern`, `decrease_indent_pattern`, `indent_next_line_pattern`,
-`dedent_next_line_pattern`, `self_close_pattern`). An omitted pattern **inherits
-from the language's built-in family**, so you can override just one thing; a
-language with no family starts from blank rules, which is how config adds
-indentation for an otherwise-unknown language. Full reference with examples:
-[Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
-
-A language **pack** manifest (`package.json`) only exposes an `autoIndent`
-boolean — the per-pattern `indent` block is a config feature. A pack that needs
-custom patterns documents them for the user's config, or relies on the built-in
-family.
-
-### E. LSP
-
-Orthogonal to both systems. Add a server config block (`command`, `args`,
-`autoStart`) under `[lsp.<id>]` in config or in a pack's `fresh.lsp`. See
-[Language Packs](/plugins/development/language-packs) for common servers.
-
----
-
-## Where to make each change — quick map
-
-| Goal | File / location | Effort |
-|------|-----------------|--------|
-| Map a language to an existing indent family | `family_for_id` in `primitives/indent_rules.rs` | one line |
-| New indent family | add a `Family` variant + `const <FAMILY>` def + `def_for_family`/`FAMILY_RULES` arms in `indent_rules.rs` | small |
-| Embedded syntect highlighting | `.sublime-syntax` in `src/grammars/` + register in `grammar/loader.rs` | medium |
-| Tree-sitter grammar + AST indent | `fresh_languages::Language` + `queries/<lang>/indents.scm` (feature-gated) | high |
-| Extension / filename / glob detection | `GrammarEntry` in the catalog, or `[languages.<id>]` config | low |
-| Indent without recompiling | `[languages.<id>.indent]` in config, or a language pack | low |
-| LSP | `[lsp.<id>]` config or pack `fresh.lsp` | low |
-
-## Testing
-
-- **Unit (rules tier):** table-driven golden tests in `indent_rules.rs`'s `tests`
-  module, run with the `tree-sitter` feature off so they exercise exactly the
-  rules tier. Always include the **anti-glitch corpus**: a brace in a string, a
-  keyword in a comment, a one-liner `def f; end`, a braceless `if (x)`.
-- **Parity (when adding a tree-sitter grammar):** the `parity` module asserts the
-  rules tier matches tree-sitter on a corpus, gated on the `tree-sitter` feature —
-  the safety net for dropping a grammar from the default build.
-- **Highlighting:** open a sample file and confirm tokens color.
+The design rationale and the per-language support matrix live in the repo's
+internal docs:
+[`indentation-rules-design.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/indentation-rules-design.md)
+and
+[`language-support-review.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/language-support-review.md).

--- a/docs/development/adding-languages.md
+++ b/docs/development/adding-languages.md
@@ -1,0 +1,274 @@
+# Adding a Built-in Language
+
+This is the contributor's guide to teaching Fresh about a new language *in the
+source tree* — syntax highlighting, auto-indentation, and the indent
+**families** — plus how those systems decide what to do at runtime.
+
+Two audiences, two paths:
+
+- **Adding a built-in language** (this page) — you're editing Fresh's Rust
+  source: an embedded grammar, a tree-sitter parser, or a row in the indent
+  family table. Requires a rebuild.
+- **Shipping a language pack or tweaking config** — no recompile. See
+  [Language Packs](/plugins/development/language-packs) and the
+  [Configuration guide](/configuration/#customize-auto-indentation). Most
+  niche-language needs are best met this way.
+
+The deeper design rationale lives in the repo's internal docs:
+[`indentation-rules-design.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/indentation-rules-design.md)
+(why the regex indentation tier exists and the binary-size win it bought) and
+[`language-support-review.md`](https://github.com/sinelaw/fresh/blob/master/docs/internal/language-support-review.md)
+(the current per-language support matrix).
+
+---
+
+## Mental model: two independent systems
+
+Fresh treats *how a language looks* and *how it indents* as separate concerns,
+resolved separately. You can add one without the other.
+
+| System | What it does | Engines |
+|--------|--------------|---------|
+| **Highlighting** | colors tokens (keywords, strings, comments) | Syntect (TextMate/Sublime grammars) — primary; tree-sitter — fallback for ~18 languages |
+| **Auto-indent** | picks the indent of a new line on Enter / when typing a closer | Tree-sitter AST (bundled grammars) → per-language regex rules → generic bracket heuristic |
+
+A language can be highlighted by syntect while indented by the regex rules tier,
+with no tree-sitter grammar at all — that is the common case (Kotlin, Swift,
+Dart, …). Both systems hang off the **unified grammar catalog**
+(`GrammarRegistry`), which maps a file path / name to a `GrammarEntry` recording
+which engines can serve it. Detection order (filename → glob → extension →
+first-line/shebang → configured default) lives in
+`crates/fresh-editor/src/primitives/detected_language.rs`.
+
+---
+
+## How auto-indentation works
+
+When you press Enter (or type a closing `}` / `]` / `)`), Fresh computes the new
+line's indent through a **three-tier dispatch** in
+`crates/fresh-editor/src/input/actions.rs` (the Enter path around
+`insert_newline_with_indent`, and `calculate_closing_delimiter_indent` for typed
+closers). Tiers are tried in order; the first that produces an answer wins:
+
+```
+1. Tree-sitter AST tier   — only for languages with a *bundled* grammar
+                            (Go, JSON/JSONC, TypeScript, JavaScript, Templ).
+                            Parses the block structure, exact on strings/comments.
+2. Regex rules tier        — every other language. Keyed by the syntect syntax
+                            name, scope-masked. This is where families live.
+3. Generic bracket heuristic — unknown syntaxes (.txt, …). C-style { } [ ] (  ) +
+                            trailing ':'. Language-agnostic last resort.
+```
+
+Which tier applies hinges on one check: `state.highlighter.language()` returns a
+tree-sitter `Language` *and* `language.ts_language().is_some()` (its grammar is
+compiled into this build). If so → tier 1; otherwise → tier 2, falling through to
+tier 3 when no rules match. Most grammars were deliberately dropped from the
+default build to save ~18 MB of parse tables, so in practice **most languages
+indent via the regex rules tier.**
+
+### The regex rules tier (tier 2)
+
+Source: `crates/fresh-editor/src/primitives/indent_rules.rs`. Pure Rust, WASM-safe
+(no tree-sitter dependency), so it works in min-size and browser builds too.
+
+Each language is described by a small set of anchored regexes
+(`IndentRulesDef`). Every field is optional (`None` = "never matches"):
+
+| Field | Tested against | Effect |
+|-------|----------------|--------|
+| `increase` | the **reference line** (line being split, or nearest non-blank above) | new line is **+1** level |
+| `decrease` | the **new line's tail** (text that moves down past the cursor) | that line is **−1** level |
+| `indent_next_line` | the reference line | **+1** for the immediately following line only (one-shot; braceless `if (x)`) |
+| `dedent_next_line` | the reference line | **−1** for the following line (one-shot; Python flow-exit `return`/`pass`/…) |
+| `self_close` | the reference line | **cancels** `increase` when the same line also closes its block (one-liner `def f; end`) |
+| `indentation_significant` (bool) | — | layout-defined languages (Python, YAML): on a blank line, keep the cursor's current column instead of re-deriving, so a manual dedent sticks |
+
+The algorithm (`IndentRules::calculate_indent`): take the reference line's visual
+indent as `base`; add a unit if it `increase`s (and isn't `self_close`d) or
+matches `indent_next_line`, else subtract a unit if it matches
+`dedent_next_line`; then subtract a unit if the new line's tail `decrease`s
+(unless the opener was on this same line — the `{│}` bracket-expansion case). The
+unit is one `tab_size`.
+
+#### Scope masking — the key anti-glitch mechanism
+
+The classic regex-indentation bug is triggering on a `{` inside a string or an
+`end` inside a comment. Fresh avoids it without lookarounds (the `regex` crate is
+RE2 — linear, no look-around/backrefs). Before matching, each line is turned into
+a **code view**: every byte the highlighter reports as `Comment` or `String` is
+replaced with a space (`byte_is_code` in `actions.rs` sources this from the
+highlighter's *already-computed* render spans — no second parse). So
+`let x = "{"` and `// end` have no trigger characters left to match. When no
+scope info is cached (line outside the viewport, plain buffer), the code view is
+the raw line, degrading to plain regex matching rather than misbehaving.
+
+---
+
+## Language families
+
+Most languages don't need bespoke patterns — they need *a correct family*. A
+**family** is a shared `IndentRulesDef` covering a class of block syntax. The
+enum and the per-language mapping live in `indent_rules.rs`:
+
+```rust
+pub enum Family {
+    CurlyBrace,  // block structure is { } [ ] ( )
+    Python,      // ':' opens a block; flow-exit dedents next line
+    RubyLike,    // def…end, do…end, midblock else/when/rescue
+    LuaLike,     // function…end, if…then…end, for…do…end, repeat…until
+    BashLike,    // if…then…fi, for/while…do…done, case…esac, { }
+    PascalLike,  // begin…end, case…of…end, repeat…until
+}
+```
+
+Each family's actual patterns (the `const CURLY_BRACE`, `const PYTHON`, … defs):
+
+| Family | `increase` (opener) | `decrease` (closer) | Notable extras |
+|--------|---------------------|---------------------|----------------|
+| **CurlyBrace** | line ends with `{ [ (` | line starts with `} ] )` | `indent_next_line` for braceless `if/for/while(…)`/`else` |
+| **Python** | line ends with `:` | moved-down `elif/else/except/finally/case` | `dedent_next_line` for `return/pass/raise/break/continue`; `indentation_significant = true` |
+| **RubyLike** | `def/class/module/if/case/…` at line start, or trailing `do`/`do \|x\|` | `end` + midblock `else/elsif/when/in/rescue/ensure` | `self_close = \bend\b` (one-liners) |
+| **LuaLike** | `function/if/elseif/for/while/repeat`, or trailing `do`/`then` | `end/else/elseif/until` | `self_close = \bend\b` |
+| **BashLike** | trailing `then`/`do`, `case … in`, function-body `{` | `fi/done/esac/else/elif/}` | `(` deliberately **excluded** (subshell, not a block) |
+| **PascalLike** | `begin/case/record/try/repeat/asm`, or trailing `begin`/`of` | `end/until/except/finally` | `self_close = \bend\b` |
+
+Study the Python row when adding any **layout-defined** language (YAML, etc.): it
+has no real closing tokens, so it leans on `dedent_next_line` and the
+`indentation_significant` flag rather than `decrease`.
+
+### The mapping is just data
+
+`family_for_id` is a single `match` from a normalized language id to a family —
+the one extension point for the common case:
+
+```rust
+fn family_for_id(id: &str) -> Option<Family> {
+    let f = match id {
+        "rust" | "c" | "cpp" | "csharp" | "java" | "go" | "javascript"
+        | "typescript" | "php" | "swift" | "kotlin" | "dart" | "scala"
+        | "json" | "css" | "scss" | "less" /* … */ => Family::CurlyBrace,
+        "python" => Family::Python,
+        "ruby"   => Family::RubyLike,
+        "lua"    => Family::LuaLike,
+        "bash" | "sh" | "shell" | "shellscript" => Family::BashLike,
+        "pascal" => Family::PascalLike,
+        _ => return None,   // → falls through to the generic bracket heuristic
+    };
+    Some(f)
+}
+```
+
+Languages absent here fall through to tier 3 — the universal default never goes
+away. Lookup is keyed by a **string id**, not the tree-sitter `Language` enum, so
+syntect-only languages get rules and the whole tier survives with the
+`tree-sitter` feature off. `rules_for_syntax_name` maps a syntect display name
+(`"C++"`, `"Bourne Again Shell (bash)"`) to an id before calling `rules_for_id`.
+
+---
+
+## Recipes: how to add a language
+
+Pick the dimensions you need. They are independent.
+
+### A. Just indentation, existing family — one line
+
+The language already highlights (syntect default or a pack) and behaves like an
+existing family. Add an arm to `family_for_id` in `indent_rules.rs`:
+
+```rust
+"zig" | "odin" => Family::CurlyBrace,
+```
+
+Add a golden test in the same file's `tests` module and you're done. No grammar,
+no recompile path for users (they can do the same via config — see D).
+
+### B. Syntax highlighting via an embedded syntect grammar
+
+For a language syntect doesn't ship (Kotlin, Swift, Nix, …):
+
+1. Drop a self-contained `.sublime-syntax` file into
+   `crates/fresh-editor/src/grammars/`. (No `extends:` — Fresh supports a subset;
+   only internal `include` works. See the language-packs page's compatibility
+   notes.)
+2. Register it in `GrammarRegistry::add_embedded_grammars`
+   (`crates/fresh-editor/src/primitives/grammar/loader.rs`) with its extensions /
+   filenames. The catalog picks it up on the next rebuild.
+3. If the language should also indent, add it to a family (recipe A).
+
+### C. Syntax highlighting + structural features via tree-sitter
+
+Only when tree-sitter buys something syntect can't (e.g. TypeScript, which
+syntect has no grammar for, or precise indent where the regex rules aren't good
+enough). This is the **heavy** option — each grammar adds multi-MB parse tables —
+so it's gated behind build features and reserved for the must-keep set.
+
+1. Add a variant to `fresh_languages::Language`
+   (`crates/fresh-languages/src/lib.rs`) with its extensions, display name, and
+   highlight config; bundle the `tree-sitter-<lang>` crate behind the appropriate
+   feature.
+2. Add `crates/fresh-editor/queries/<lang>/indents.scm` for AST-driven indent.
+3. The catalog auto-creates a tree-sitter entry if no syntect grammar matches.
+
+Keep a **parity test** (the `parity` module in `indent_rules.rs`): the regex
+rules for the language must agree with the tree-sitter output, so the grammar can
+be dropped from default builds without regressing indentation.
+
+### D. Indentation or detection from config — no recompile
+
+Users (and language packs) add or tune a language entirely in config. This is the
+right answer for niche languages.
+
+```toml
+[languages.kotlin]
+extensions = ["kt", "kts"]
+comment_prefix = "//"
+
+[languages.kotlin.indent]
+increase_indent_pattern = "[\\{\\[\\(]\\s*$"
+decrease_indent_pattern = "^\\s*[\\}\\]\\)]"
+```
+
+The `[languages.<id>.indent]` block maps field-for-field onto the rule set
+(`increase_indent_pattern`, `decrease_indent_pattern`, `indent_next_line_pattern`,
+`dedent_next_line_pattern`, `self_close_pattern`). An omitted pattern **inherits
+from the language's built-in family**, so you can override just one thing; a
+language with no family starts from blank rules, which is how config adds
+indentation for an otherwise-unknown language. Full reference with examples:
+[Configuration → Customize Auto-Indentation](/configuration/#customize-auto-indentation).
+
+A language **pack** manifest (`package.json`) only exposes an `autoIndent`
+boolean — the per-pattern `indent` block is a config feature. A pack that needs
+custom patterns documents them for the user's config, or relies on the built-in
+family.
+
+### E. LSP
+
+Orthogonal to both systems. Add a server config block (`command`, `args`,
+`autoStart`) under `[lsp.<id>]` in config or in a pack's `fresh.lsp`. See
+[Language Packs](/plugins/development/language-packs) for common servers.
+
+---
+
+## Where to make each change — quick map
+
+| Goal | File / location | Effort |
+|------|-----------------|--------|
+| Map a language to an existing indent family | `family_for_id` in `primitives/indent_rules.rs` | one line |
+| New indent family | add a `Family` variant + `const <FAMILY>` def + `def_for_family`/`FAMILY_RULES` arms in `indent_rules.rs` | small |
+| Embedded syntect highlighting | `.sublime-syntax` in `src/grammars/` + register in `grammar/loader.rs` | medium |
+| Tree-sitter grammar + AST indent | `fresh_languages::Language` + `queries/<lang>/indents.scm` (feature-gated) | high |
+| Extension / filename / glob detection | `GrammarEntry` in the catalog, or `[languages.<id>]` config | low |
+| Indent without recompiling | `[languages.<id>.indent]` in config, or a language pack | low |
+| LSP | `[lsp.<id>]` config or pack `fresh.lsp` | low |
+
+## Testing
+
+- **Unit (rules tier):** table-driven golden tests in `indent_rules.rs`'s `tests`
+  module, run with the `tree-sitter` feature off so they exercise exactly the
+  rules tier. Always include the **anti-glitch corpus**: a brace in a string, a
+  keyword in a comment, a one-liner `def f; end`, a braceless `if (x)`.
+- **Parity (when adding a tree-sitter grammar):** the `parity` module asserts the
+  rules tier matches tree-sitter on a corpus, gated on the `tree-sitter` feature —
+  the safety net for dropping a grammar from the default build.
+- **Highlighting:** open a sample file and confirm tokens color.

--- a/docs/internal/indentation-rules-design.md
+++ b/docs/internal/indentation-rules-design.md
@@ -1,5 +1,14 @@
 # VS Code–Style Indentation Rules — Design
 
+> **Status:** implemented (see the Rollout section). This is the *design
+> rationale*; for a how-to on adding a language and the current data model, read
+> [Adding a Built-in Language](../development/adding-languages.md). The "Data
+> model" and "Families" snippets below describe the original plan — the shipped
+> `IndentRulesDef` makes `increase`/`decrease` optional, replaces the planned
+> `unindented` field with `self_close` plus an `indentation_significant` flag, and
+> ships no `Markup` family. The authoritative shape is the source in
+> `crates/fresh-editor/src/primitives/indent_rules.rs`.
+
 ## Motivation
 
 Today Fresh has two auto-indent tiers:

--- a/docs/internal/language-support-review.md
+++ b/docs/internal/language-support-review.md
@@ -1,5 +1,12 @@
 # Language & Syntax Highlighting Support Review
 
+> **New to adding languages?** Start with
+> [Adding a Built-in Language](../development/adding-languages.md) — the
+> step-by-step contributor guide (published in the docs site) covering how
+> auto-indent works, the language families, and every way to add support. This
+> document is the per-language *support matrix* and a reference for the
+> grammar-catalog lookup API.
+
 ## How Syntax Highlighting Works in Fresh
 
 Fresh keeps every known language in a **unified grammar catalog**
@@ -32,6 +39,11 @@ one place: `HighlightEngine::from_entry`.
 
 ### Adding a language
 
+Highlighting and auto-indentation are independent systems — add either without
+the other. Full walkthrough: [Adding a Built-in Language](../development/adding-languages.md).
+
+**Highlighting:**
+
 - **New syntect grammar** — drop a `.sublime-syntax` into
   `crates/fresh-editor/src/grammars/` and register it in
   `GrammarRegistry::add_embedded_grammars`. The catalog picks it up on the
@@ -42,6 +54,20 @@ one place: `HighlightEngine::from_entry`.
 - **User config mapping** — edit `~/.config/fresh/config.toml`
   `[languages]` section. Extensions, exact filenames, and globs all merge
   through `apply_language_config` into the catalog.
+
+**Auto-indentation** (separate from highlighting — see
+[Adding a Built-in Language](../development/adding-languages.md) for the three-tier dispatch and family
+details):
+
+- **Existing family** — add the language id to `family_for_id` in
+  `primitives/indent_rules.rs` (one line). Families: `CurlyBrace`, `Python`,
+  `RubyLike`, `LuaLike`, `BashLike`, `PascalLike`. This covers most languages and
+  needs no tree-sitter grammar.
+- **Custom rules from config** — `[languages.<id>.indent]` regex patterns in
+  `config.toml`; an omitted pattern inherits from the language's family. See the
+  [configuration doc](../configuration/index.md#customize-auto-indentation).
+- **AST indent** — only for bundled tree-sitter grammars: add
+  `queries/<lang>/indents.scm` (kept in parity with the rules tier).
 
 ---
 

--- a/docs/plugins/development/language-packs.md
+++ b/docs/plugins/development/language-packs.md
@@ -2,6 +2,12 @@
 
 Language packs add syntax highlighting, language configuration, and LSP support for new languages in Fresh.
 
+> Want to add a language *inside* Fresh's source tree (a built-in family, an
+> embedded grammar, or a tree-sitter parser) rather than ship a pack? See the
+> contributor guide [Adding a Built-in Language](/development/adding-languages),
+> which explains how auto-indent and the language families work. This page covers
+> the user-facing pack path, which needs no recompile.
+
 ## Quick Start
 
 Use the CLI to scaffold a new language pack:


### PR DESCRIPTION
## Summary
This PR adds a new contributor guide documenting how to add language support to Fresh, along with updates to existing documentation to cross-reference the new guide and clarify the relationship between syntax highlighting and auto-indentation systems.

## Key Changes

- **New guide: `docs/development/adding-languages.md`** — A comprehensive step-by-step guide covering:
  - The two independent systems for language support (syntax highlighting and auto-indentation)
  - How to add highlighting via syntect grammars or language packs
  - How to add auto-indentation by mapping to existing families, using config, or creating new families
  - Explanation of the three-tier auto-indentation dispatch (regex rules → tree-sitter AST → generic fallback)
  - Documentation of the six language families (CurlyBrace, Python, RubyLike, LuaLike, BashLike, PascalLike)
  - File locations and architecture overview
  - Design rationale references

- **Updated `docs/internal/language-support-review.md`** — Added introductory note directing new contributors to the step-by-step guide, and expanded the "Adding a language" section to clarify that highlighting and auto-indentation are independent systems with separate implementation paths

- **Updated `docs/internal/indentation-rules-design.md`** — Added status note explaining this is the design rationale and directing readers to the new how-to guide for current implementation details

- **Updated `docs/plugins/development/language-packs.md`** — Added note distinguishing between built-in language additions (via the new guide) and user-facing language packs

- **Updated `docs/configuration/index.md`** — Added cross-reference explaining that indent patterns are the same mechanism used by built-in languages, grouped into families

- **Updated `docs/.vitepress/config.ts`** — Added navigation link to the new "Adding a Language" guide in the Developer Docs section

## Notable Details

The new guide establishes a clear mental model: language support in Fresh is built on two orthogonal systems (highlighting and indentation) connected through a grammar catalog. It explains why tree-sitter is used sparingly (binary size concerns) and emphasizes the regex indent-rules tier as the primary path for most languages. The guide also clarifies the scope-masking behavior that prevents indentation triggers inside strings and comments.

https://claude.ai/code/session_01U5k9fwutarBRu3cMiyXc2W