### PR TITLE
refactor(render): decompose the render_view_lines god function

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -22,7 +22,6 @@ use std::collections::HashMap;
 /// Anchor describing where to start rendering within a slice of view lines.
 pub(super) struct ViewAnchor {
     pub start_line_idx: usize,
-    pub start_line_skip: usize,
 }
 
 /// Layout for compose (centered page) mode: the effective render area and
@@ -185,8 +184,7 @@ pub(super) fn resolve_view_preferences(
     }
 }
 
-/// Resolve the first line index and skip count for rendering, given the
-/// viewport's top byte.
+/// Resolve the first line index for rendering, given the viewport's top byte.
 pub(super) fn calculate_view_anchor(view_lines: &[ViewLine], top_byte: usize) -> ViewAnchor {
     for (idx, line) in view_lines.iter().enumerate() {
         if let Some(first_source) = line.char_source_bytes.iter().find_map(|m| *m) {
@@ -205,16 +203,12 @@ pub(super) fn calculate_view_anchor(view_lines: &[ViewLine], top_byte: usize) ->
                 }
                 return ViewAnchor {
                     start_line_idx: start_idx,
-                    start_line_skip: 0,
                 };
             }
         }
     }
 
-    ViewAnchor {
-        start_line_idx: 0,
-        start_line_skip: 0,
-    }
+    ViewAnchor { start_line_idx: 0 }
 }
 
 /// Compute the compose-mode layout for a given area.

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -5,6 +5,11 @@
 //! extend-to-line-end fill inputs). Pulled out of `render_view_lines` so
 //! the orchestrator reads as a sequence of per-line passes instead of one
 //! interleaved loop.
+//!
+//! `CellPass` is the per-line state machine: `render_line_cells` builds
+//! one, feeds it every character, and collects the `CellPassOutput`.
+//! Each per-cell concern (cursor detection, style resolution, display
+//! character, span emission, position bookkeeping) is its own method.
 
 use super::super::super::char_style::{compute_char_style, CharStyleContext, CharStyleOutput};
 use super::super::super::spans::{
@@ -23,8 +28,9 @@ use crate::view::overlay::Overlay;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{LineStart, ViewLine};
 use ratatui::layout::Rect;
-use ratatui::style::Style;
+use ratatui::style::{Color, Style};
 use ratatui::text::Span;
+use std::ops::ControlFlow;
 
 /// Read-only inputs for one line's cell pass.
 pub(super) struct CellPassInput<'a> {
@@ -69,7 +75,7 @@ pub(super) struct CellPassOutput {
     /// `bg_extends_to_line_end()` is true (diff Inserted / Deleted /
     /// Changed). Picked up by the tail-fill pass so the bg wash
     /// continues past the scoped text to the viewport's right edge.
-    pub syntax_extend_bg: Option<ratatui::style::Color>,
+    pub syntax_extend_bg: Option<Color>,
 }
 
 /// Render one line's characters into `line_spans` / `line_view_map`.
@@ -79,393 +85,486 @@ pub(super) struct CellPassOutput {
 /// debug "reveal codes", software-cursor hits, and the theme-inspector
 /// cell map.
 #[allow(clippy::too_many_arguments)]
-pub(super) fn render_line_cells(
-    ctx: CellPassInput<'_>,
-    selection_sweep: &mut SelectionActiveSet<'_>,
-    overlay_sweep: &mut OverlayActiveSet<'_>,
+pub(super) fn render_line_cells<'a>(
+    input: CellPassInput<'a>,
+    selection_sweep: &mut SelectionActiveSet<'a>,
+    overlay_sweep: &mut OverlayActiveSet<'a>,
     span_cursors: &mut SpanCursors,
     cursor: &mut CursorTracker,
     cell_theme_map: &mut [CellThemeInfo],
     line_spans: &mut Vec<Span<'static>>,
     line_view_map: &mut Vec<Option<usize>>,
 ) -> CellPassOutput {
-    let CellPassInput {
-        state,
-        theme,
-        view_line,
-        selection,
-        decorations,
-        gutter_num,
-        current_row,
-        render_area,
-        gutter_width,
-        screen_width,
-        left_col,
-        max_chars_to_process,
-        lsp_waiting,
-        is_active,
-        session_mode,
-        is_on_cursor_line,
-        highlight_current_line,
-    } = ctx;
-
-    let line_content: &str = &view_line.text;
-    let line_char_source_bytes = &view_line.char_source_bytes;
-    let line_char_styles = &view_line.char_styles;
-    let line_char_visual_cols = &view_line.char_visual_cols;
-    let line_total_visual_width = view_line.visual_width();
-    let line_tab_starts = &view_line.tab_starts;
-
-    let cursor_positions = &selection.cursor_positions;
-    let primary_cursor_position = selection.primary_cursor_position;
-    let highlight_spans = &decorations.highlight_spans;
-    let semantic_token_spans = &decorations.semantic_token_spans;
-    let viewport_overlays = &decorations.viewport_overlays;
-    let ws = &state.buffer_settings.whitespace;
-
-    // Pre-compute whitespace position boundaries for this view line in a
-    // single pass — no intermediate `Vec<char>` per line.
-    let non_ws = non_ws_bounds(line_content);
-
-    let mut byte_index = 0; // Byte offset in line_content string
-    let mut display_char_idx = 0usize; // Character index in text (for char_source_bytes)
-    let mut col_offset = 0usize; // Visual column position
-
-    // Accumulator for merging consecutive characters with the same style.
-    // This is critical for proper rendering of combining characters (Thai, etc.)
-    let mut span_acc = SpanAccumulator::new();
-
-    // ANSI parser for this line to handle escape sequences.
-    // Optimization: only create parser if line contains ESC byte.
-    let line_has_ansi = line_content.contains('\x1b');
-    let mut ansi_parser = if line_has_ansi {
-        Some(AnsiParser::new())
-    } else {
-        None
-    };
-    // visible_char_count: all chars stepped over (for long-line break check).
-    // rendered_cols: chars that landed on screen (for fill width — so full-line
-    // bg fills reach the viewport edge under horizontal scroll).
-    let mut visible_char_count = 0usize;
-    let mut rendered_cols = 0usize;
-
-    // Debug mode: track active highlight/overlay spans for WordPerfect-style reveal codes
-    let mut debug_tracker = if state.debug_highlight_mode {
-        Some(DebugSpanTracker::default())
-    } else {
-        None
-    };
-
-    // Track byte positions for extend_to_line_end feature
-    let mut first_line_byte_pos: Option<usize> = None;
-    let mut last_line_byte_pos: Option<usize> = None;
-    let mut syntax_extend_bg: Option<ratatui::style::Color> = None;
+    let line_content: &'a str = &input.view_line.text;
 
     // Reset the per-row touched set. Wrap continuations inherit overlays
     // still active from the previous row of the same source line; new
     // source lines do not (see OverlayActiveSet).
-    overlay_sweep.enter_row(matches!(view_line.line_start, LineStart::AfterBreak));
+    overlay_sweep.enter_row(matches!(input.view_line.line_start, LineStart::AfterBreak));
+
+    let mut pass = CellPass {
+        // ANSI parser for this line to handle escape sequences.
+        // Optimization: only create parser if line contains ESC byte.
+        ansi_parser: line_content.contains('\x1b').then(AnsiParser::new),
+        // Debug mode: track active highlight/overlay spans for
+        // WordPerfect-style reveal codes.
+        debug_tracker: input
+            .state
+            .debug_highlight_mode
+            .then(DebugSpanTracker::default),
+        non_ws: non_ws_bounds(line_content),
+        line_total_visual_width: input.view_line.visual_width(),
+        input,
+        selection_sweep,
+        overlay_sweep,
+        span_cursors,
+        cursor,
+        cell_theme_map,
+        line_spans,
+        line_view_map,
+        span_acc: SpanAccumulator::new(),
+        byte_index: 0,
+        display_char_idx: 0,
+        col_offset: 0,
+        visible_char_count: 0,
+        rendered_cols: 0,
+        first_line_byte_pos: None,
+        last_line_byte_pos: None,
+        syntax_extend_bg: None,
+    };
 
     for ch in line_content.chars() {
-        // Get source byte for this character using character index
+        if pass.process_char(ch).is_break() {
+            break;
+        }
+    }
+    pass.finish()
+}
+
+/// Per-line state for the cell pass. One instance per view line; the
+/// `_sweep` / `span_cursors` / `cursor` borrows carry state *across*
+/// lines, everything else is reset per line.
+struct CellPass<'a, 'b> {
+    input: CellPassInput<'a>,
+    selection_sweep: &'b mut SelectionActiveSet<'a>,
+    overlay_sweep: &'b mut OverlayActiveSet<'a>,
+    span_cursors: &'b mut SpanCursors,
+    cursor: &'b mut CursorTracker,
+    cell_theme_map: &'b mut [CellThemeInfo],
+    line_spans: &'b mut Vec<Span<'static>>,
+    line_view_map: &'b mut Vec<Option<usize>>,
+
+    /// Merges consecutive characters with the same style — critical for
+    /// proper rendering of combining characters (Thai, etc.)
+    span_acc: SpanAccumulator,
+    ansi_parser: Option<AnsiParser>,
+    debug_tracker: Option<DebugSpanTracker>,
+    /// First/last non-whitespace char indices (whitespace indicators).
+    non_ws: (Option<usize>, Option<usize>),
+    line_total_visual_width: usize,
+
+    /// Byte offset in the line's text.
+    byte_index: usize,
+    /// Character index in the line's text (indexes char_source_bytes).
+    display_char_idx: usize,
+    /// Visual column position.
+    col_offset: usize,
+    /// All visual columns stepped over (for the long-line break check).
+    visible_char_count: usize,
+    /// Visual columns that landed on screen.
+    rendered_cols: usize,
+    first_line_byte_pos: Option<usize>,
+    last_line_byte_pos: Option<usize>,
+    syntax_extend_bg: Option<Color>,
+}
+
+/// Resolved style and theme-inspector metadata for one cell.
+struct ResolvedCellStyle {
+    style: Style,
+    is_secondary_cursor: bool,
+    fg_theme_key: Option<&'static str>,
+    bg_theme_key: Option<&'static str>,
+    region: &'static str,
+    /// Syntax category display name (theme inspector).
+    syntax_category: Option<&'static str>,
+}
+
+impl CellPass<'_, '_> {
+    /// Process one character; `Break` when the long-line cap is reached.
+    fn process_char(&mut self, ch: char) -> ControlFlow<()> {
+        // Source byte for this character, via character index
         // (char_source_bytes is indexed by character position, not visual column)
-        let byte_pos = line_char_source_bytes
-            .get(display_char_idx)
+        let byte_pos = self
+            .input
+            .view_line
+            .char_source_bytes
+            .get(self.display_char_idx)
             .copied()
             .flatten();
 
-        // Track byte positions for extend_to_line_end
         if let Some(bp) = byte_pos {
-            if first_line_byte_pos.is_none() {
-                first_line_byte_pos = Some(bp);
+            // Track byte positions for extend_to_line_end
+            if self.first_line_byte_pos.is_none() {
+                self.first_line_byte_pos = Some(bp);
             }
-            last_line_byte_pos = Some(bp);
+            self.last_line_byte_pos = Some(bp);
 
             // Advance overlay active-set sweep for this cell. Monotonic
             // in `bp` across all view lines in this render call.
-            overlay_sweep.advance_to(bp);
+            self.overlay_sweep.advance_to(bp);
         }
 
         // Process character through ANSI parser first (if line has ANSI).
-        // If parser returns None, the character is part of an escape sequence and should be skipped.
-        let ansi_style = if let Some(ref mut parser) = ansi_parser {
-            match parser.parse_char(ch) {
-                Some(style) => style,
-                None => {
-                    // This character is part of an ANSI escape sequence, skip it.
-                    // ANSI escape chars have zero visual width, so don't increment col_offset.
-                    // IMPORTANT: If the cursor is on this ANSI byte, track it.
-                    if byte_pos == Some(primary_cursor_position) {
-                        // Account for horizontal scrolling by using col_offset - left_col
-                        cursor.place(
-                            gutter_width as u16 + col_offset.saturating_sub(left_col) as u16,
-                            current_row,
-                        );
-                    }
-                    byte_index += ch.len_utf8();
-                    display_char_idx += 1;
-                    // Note: col_offset not incremented - ANSI chars have 0 visual width
-                    continue;
-                }
+        // `None` means the character is part of an escape sequence: skip it.
+        let Some(ansi_style) = self.parse_ansi(ch) else {
+            // ANSI escape chars have zero visual width, so don't advance
+            // col_offset. IMPORTANT: if the cursor is on this ANSI byte,
+            // track it.
+            if byte_pos == Some(self.input.selection.primary_cursor_position) {
+                self.cursor
+                    .place(self.cell_screen_x(), self.input.current_row);
             }
-        } else {
-            // No ANSI in this line - use default style (fast path)
-            Style::default()
+            self.byte_index += ch.len_utf8();
+            self.display_char_idx += 1;
+            return ControlFlow::Continue(());
         };
 
-        // Performance: skip expensive style calculations for characters beyond visible range.
-        // Use visible_char_count (not byte_index) since ANSI codes don't take up visible space.
-        if visible_char_count > max_chars_to_process {
-            // Fast path: skip remaining characters without processing.
-            // This is critical for performance with very long lines (e.g., 100KB single line)
-            break;
+        // Performance: skip expensive style calculations for characters beyond
+        // the visible range. Use visible_char_count (not byte_index) since ANSI
+        // codes don't take up visible space. This is critical for performance
+        // with very long lines (e.g., 100KB single line).
+        if self.visible_char_count > self.input.max_chars_to_process {
+            return ControlFlow::Break(());
         }
 
-        // Skip characters before left_column
-        if col_offset >= left_col {
-            // Check if this view position is the START of a tab expansion
-            let is_tab_start = line_tab_starts.contains(&col_offset);
+        // Skip characters horizontally scrolled out on the left
+        if self.col_offset >= self.input.left_col {
+            self.render_visible_cell(ch, byte_pos, ansi_style);
+        }
 
-            // Check if this character is at a cursor position.
-            // For tab expansions: only show cursor on the FIRST space (the tab_start position).
-            // This prevents cursor from appearing on all 8 expanded spaces.
-            let is_cursor = byte_pos
-                .map(|bp| {
-                    if !cursor_positions.contains(&bp) || bp >= state.buffer.len() {
-                        return false;
-                    }
-                    // If this byte maps to a tab character, only show cursor at tab_start.
-                    // Check if this is part of a tab expansion by looking at previous char.
-                    let prev_char_idx = display_char_idx.saturating_sub(1);
-                    let prev_byte_pos =
-                        line_char_source_bytes.get(prev_char_idx).copied().flatten();
-                    // Show cursor if: this is start of line, OR previous char had different byte pos
-                    display_char_idx == 0 || prev_byte_pos != Some(bp)
-                })
-                .unwrap_or(false);
+        self.advance(ch);
+        ControlFlow::Continue(())
+    }
 
-            // Refresh the block-rect active set for this row.
-            // Idempotent on the same gutter line (no inner gate).
-            selection_sweep.enter_line(gutter_num);
+    /// Style and emit one on-screen cell.
+    fn render_visible_cell(&mut self, ch: char, byte_pos: Option<usize>, ansi_style: Style) {
+        // Is this view position the START of a tab expansion?
+        let is_tab_start = self.input.view_line.tab_starts.contains(&self.col_offset);
+        let is_cursor = self.cursor_hits_cell(byte_pos);
 
-            // For primary cursor in active split, terminal hardware cursor provides
-            // visual indication, so we can still show selection background.
-            // Only exclude secondary cursors from selection (they use REVERSED styling).
-            // Bug #614: Previously excluded all cursor positions, causing first char
-            // of selection to display with wrong background for bar/underline cursors.
-            let is_primary_cursor = is_cursor && byte_pos == Some(primary_cursor_position);
-            let exclude_from_selection = is_cursor && !(is_active && is_primary_cursor);
+        // Refresh the block-rect active set for this row.
+        // Idempotent on the same gutter line (no inner gate).
+        self.selection_sweep.enter_line(self.input.gutter_num);
 
-            let is_selected =
-                !exclude_from_selection && selection_sweep.contains(byte_pos, byte_index);
+        // For primary cursor in active split, terminal hardware cursor provides
+        // visual indication, so we can still show selection background.
+        // Only exclude secondary cursors from selection (they use REVERSED styling).
+        // Bug #614: Previously excluded all cursor positions, causing first char
+        // of selection to display with wrong background for bar/underline cursors.
+        let is_primary_cursor =
+            is_cursor && byte_pos == Some(self.input.selection.primary_cursor_position);
+        let exclude_from_selection = is_cursor && !(self.input.is_active && is_primary_cursor);
+        let is_selected =
+            !exclude_from_selection && self.selection_sweep.contains(byte_pos, self.byte_index);
 
-            // char_styles is indexed by character position, not visual column
-            let token_style = line_char_styles
-                .get(display_char_idx)
-                .and_then(|s| s.as_ref());
+        let resolved = self.resolve_cell_style(byte_pos, ansi_style, is_cursor, is_selected);
+        self.record_cell_theme(&resolved);
 
-            // Resolve highlight/semantic colors via cursor-based O(1) lookup
-            let (highlight_color, highlight_theme_key, highlight_display_name) = match byte_pos {
-                Some(bp) => span_info_at(highlight_spans, &mut span_cursors.highlight, bp),
-                None => (None, None, None),
+        // `indicator_buf` holds the UTF-8 bytes of a single char on the
+        // stack — no heap allocation per cell.
+        let mut indicator_buf = [0u8; 4];
+        let (display_char, is_whitespace_indicator) =
+            self.display_cell_text(ch, is_cursor, is_tab_start, &mut indicator_buf);
+
+        // Apply subdued whitespace indicator color from theme
+        let mut style = resolved.style;
+        if is_whitespace_indicator && !is_cursor && !is_selected {
+            style = style.fg(self.input.theme.whitespace_indicator_fg);
+        }
+
+        if !display_char.is_empty() {
+            self.emit_cell(display_char, style, byte_pos, ch);
+        }
+
+        self.place_cell_cursor(ch, byte_pos, is_cursor, resolved.is_secondary_cursor);
+    }
+
+    /// Whether a cursor should render on this cell.
+    ///
+    /// For tab expansions, only the FIRST space (the tab_start position)
+    /// shows the cursor — this prevents it from appearing on all 8
+    /// expanded spaces.
+    fn cursor_hits_cell(&self, byte_pos: Option<usize>) -> bool {
+        let Some(bp) = byte_pos else {
+            return false;
+        };
+        if !self.input.selection.cursor_positions.contains(&bp)
+            || bp >= self.input.state.buffer.len()
+        {
+            return false;
+        }
+        // Detect tab expansion by checking whether the previous char maps
+        // to the same source byte. Show cursor if this is the start of the
+        // line, OR the previous char had a different byte pos.
+        let prev_char_idx = self.display_char_idx.saturating_sub(1);
+        let prev_byte_pos = self
+            .input
+            .view_line
+            .char_source_bytes
+            .get(prev_char_idx)
+            .copied()
+            .flatten();
+        self.display_char_idx == 0 || prev_byte_pos != Some(bp)
+    }
+
+    /// Layer token / ANSI / syntax / semantic / overlay / selection /
+    /// cursor styling for one cell, and remember any row-wide diff bg.
+    fn resolve_cell_style(
+        &mut self,
+        byte_pos: Option<usize>,
+        ansi_style: Style,
+        is_cursor: bool,
+        is_selected: bool,
+    ) -> ResolvedCellStyle {
+        let input = &self.input;
+        let highlight_spans = &input.decorations.highlight_spans;
+
+        // char_styles is indexed by character position, not visual column
+        let token_style = input
+            .view_line
+            .char_styles
+            .get(self.display_char_idx)
+            .and_then(|s| s.as_ref());
+
+        // Resolve highlight/semantic colors via cursor-based O(1) lookup
+        let (highlight_color, highlight_theme_key, highlight_display_name) = match byte_pos {
+            Some(bp) => span_info_at(highlight_spans, &mut self.span_cursors.highlight, bp),
+            None => (None, None, None),
+        };
+        // Diff categories carry a bg the renderer paints as a row wash.
+        // `span_bg_info_at` is an O(1) peek using the cursor
+        // `span_info_at` just advanced; no second walk.
+        let (highlight_bg, highlight_bg_extends) = match byte_pos {
+            Some(bp) => span_bg_info_at(highlight_spans, self.span_cursors.highlight, bp),
+            None => (None, false),
+        };
+        let highlight_bg_theme_key = highlight_bg
+            .and(highlight_theme_key)
+            .or(highlight_theme_key);
+        let semantic_token_color = match byte_pos {
+            Some(bp) => span_color_at(
+                &input.decorations.semantic_token_spans,
+                &mut self.span_cursors.semantic,
+                bp,
+            ),
+            None => None,
+        };
+
+        // Pre-resolved active overlays for this cell. Empty slice when
+        // byte_pos is None (ANSI continuation / virtual cells) — matches
+        // pre-sweep behaviour where `bp = None` short-circuited overlay
+        // filtering.
+        let cell_overlays: &[&Overlay] = if byte_pos.is_some() {
+            self.overlay_sweep.at_cursor()
+        } else {
+            &[]
+        };
+
+        let CharStyleOutput {
+            style,
+            is_secondary_cursor,
+            fg_theme_key,
+            bg_theme_key,
+            region,
+        } = compute_char_style(&CharStyleContext {
+            byte_pos,
+            token_style,
+            ansi_style,
+            is_cursor,
+            is_selected,
+            theme: input.theme,
+            highlight_color,
+            highlight_theme_key,
+            highlight_bg,
+            highlight_bg_theme_key,
+            semantic_token_color,
+            active_overlays: cell_overlays,
+            primary_cursor_position: input.selection.primary_cursor_position,
+            is_active: input.is_active,
+            skip_primary_cursor_reverse: input.session_mode,
+            is_cursor_line_highlighted: input.is_on_cursor_line
+                && input.highlight_current_line
+                && input.is_active,
+            current_line_bg: input.theme.current_line_bg,
+        });
+
+        // Remember this row's diff bg so the tail-fill pass can continue
+        // the wash past the scoped text. Only set when the category
+        // actually wants extension — keeps per-token bg scopes (none
+        // today, but possible) from unintentionally bleeding to the
+        // row's right edge.
+        if let (Some(bg), true) = (highlight_bg, highlight_bg_extends) {
+            self.syntax_extend_bg = Some(bg);
+        }
+
+        ResolvedCellStyle {
+            style,
+            is_secondary_cursor,
+            fg_theme_key,
+            bg_theme_key,
+            region,
+            syntax_category: highlight_display_name,
+        }
+    }
+
+    /// Record cell theme info for the theme inspector popup.
+    fn record_cell_theme(&mut self, resolved: &ResolvedCellStyle) {
+        if self.input.screen_width == 0 {
+            return;
+        }
+        let screen_col = self.input.render_area.x + self.cell_screen_x();
+        let screen_row = self.input.render_area.y + self.input.current_row;
+        let idx = screen_row as usize * self.input.screen_width as usize + screen_col as usize;
+        if let Some(cell) = self.cell_theme_map.get_mut(idx) {
+            *cell = CellThemeInfo {
+                fg_key: resolved.fg_theme_key,
+                bg_key: resolved.bg_theme_key,
+                region: resolved.region,
+                syntax_category: resolved.syntax_category,
             };
-            // Diff categories carry a bg the renderer paints as a row wash.
-            // `span_bg_info_at` is an O(1) peek using the cursor
-            // `span_info_at` just advanced; no second walk.
-            let (highlight_bg, highlight_bg_extends) = match byte_pos {
-                Some(bp) => span_bg_info_at(highlight_spans, span_cursors.highlight, bp),
-                None => (None, false),
-            };
-            let highlight_bg_theme_key = highlight_bg
-                .and(highlight_theme_key)
-                .or(highlight_theme_key);
-            let semantic_token_color = match byte_pos {
-                Some(bp) => span_color_at(semantic_token_spans, &mut span_cursors.semantic, bp),
-                None => None,
-            };
+        }
+    }
 
-            // Pre-resolved active overlays for this cell. Empty slice
-            // when byte_pos is None (ANSI continuation / virtual cells)
-            // — matches pre-sweep behaviour where `bp = None`
-            // short-circuited overlay filtering.
-            let cell_overlays: &[&Overlay] = if byte_pos.is_some() {
-                overlay_sweep.at_cursor()
-            } else {
-                &[]
-            };
+    /// What to draw for this character: the char itself, a whitespace
+    /// indicator (→ / ·), an LSP-waiting marker, a debug escape, or
+    /// nothing (newline). Tabs are already expanded by ViewLineIterator.
+    fn display_cell_text<'buf>(
+        &self,
+        ch: char,
+        is_cursor: bool,
+        is_tab_start: bool,
+        indicator_buf: &'buf mut [u8; 4],
+    ) -> (&'buf str, bool) {
+        let ws = &self.input.state.buffer_settings.whitespace;
+        let ws_show_tab = is_tab_start
+            && ws_indicator_visible(
+                self.display_char_idx,
+                self.non_ws,
+                ws.tabs_leading,
+                ws.tabs_inner,
+                ws.tabs_trailing,
+            );
+        let ws_show_space = ch == ' '
+            && !is_tab_start
+            && ws_indicator_visible(
+                self.display_char_idx,
+                self.non_ws,
+                ws.spaces_leading,
+                ws.spaces_inner,
+                ws.spaces_trailing,
+            );
 
-            let CharStyleOutput {
-                mut style,
-                is_secondary_cursor,
-                fg_theme_key,
-                bg_theme_key,
-                region: cell_region,
-            } = compute_char_style(&CharStyleContext {
+        if is_cursor && self.input.lsp_waiting && self.input.is_active {
+            ("⋯", false)
+        } else if self.debug_tracker.is_some() && ch == '\r' {
+            // Debug mode: show CR explicitly
+            ("\\r", false)
+        } else if self.debug_tracker.is_some() && ch == '\n' {
+            // Debug mode: show LF explicitly
+            ("\\n", false)
+        } else if ch == '\n' {
+            ("", false)
+        } else if ws_show_tab {
+            // Visual indicator for tab: show → at the first position
+            ('→'.encode_utf8(indicator_buf), true)
+        } else if ws_show_space {
+            // Visual indicator for space: show · when enabled
+            ('·'.encode_utf8(indicator_buf), true)
+        } else {
+            (ch.encode_utf8(indicator_buf), false)
+        }
+    }
+
+    /// Push the cell's text through the span accumulator, wrapped in
+    /// debug reveal-code tags when debug mode is on.
+    fn emit_cell(&mut self, display_char: &str, style: Style, byte_pos: Option<usize>, ch: char) {
+        // Debug mode: insert opening tags for spans starting at this
+        // position, then the byte position before the character.
+        if let Some(ref mut tracker) = self.debug_tracker {
+            // Flush before debug tags
+            self.span_acc.flush(self.line_spans, self.line_view_map);
+            let opening_tags = tracker.get_opening_tags(
                 byte_pos,
-                token_style,
-                ansi_style,
-                is_cursor,
-                is_selected,
-                theme,
-                highlight_color,
-                highlight_theme_key,
-                highlight_bg,
-                highlight_bg_theme_key,
-                semantic_token_color,
-                active_overlays: cell_overlays,
-                primary_cursor_position,
-                is_active,
-                skip_primary_cursor_reverse: session_mode,
-                is_cursor_line_highlighted: is_on_cursor_line
-                    && highlight_current_line
-                    && is_active,
-                current_line_bg: theme.current_line_bg,
-            });
-
-            // Remember this row's diff bg so the tail-fill pass can
-            // continue the wash past the scoped text. Only set when the
-            // category actually wants extension — keeps per-token bg
-            // scopes (none today, but possible) from unintentionally
-            // bleeding to the row's right edge.
-            if let (Some(bg), true) = (highlight_bg, highlight_bg_extends) {
-                syntax_extend_bg = Some(bg);
+                &self.input.decorations.highlight_spans,
+                &self.input.decorations.viewport_overlays,
+            );
+            for tag in opening_tags {
+                push_debug_tag(self.line_spans, self.line_view_map, tag);
             }
-
-            // Record cell theme info for the theme inspector popup
-            if screen_width > 0 {
-                let screen_col = render_area.x
-                    + gutter_width as u16
-                    + col_offset.saturating_sub(left_col) as u16;
-                let screen_row = render_area.y + current_row;
-                let idx = screen_row as usize * screen_width as usize + screen_col as usize;
-                if let Some(cell) = cell_theme_map.get_mut(idx) {
-                    *cell = CellThemeInfo {
-                        fg_key: fg_theme_key,
-                        bg_key: bg_theme_key,
-                        region: cell_region,
-                        syntax_category: highlight_display_name,
-                    };
-                }
-            }
-
-            // Determine display character (tabs already expanded in ViewLineIterator).
-            // Show tab indicator (→) or space indicator (·) based on granular
-            // whitespace visibility settings (leading/inner/trailing positions).
-            // `indicator_buf` holds the UTF-8 bytes of a single char on the
-            // stack — no heap allocation per cell.
-            let mut indicator_buf = [0u8; 4];
-            let mut is_whitespace_indicator = false;
-
-            let ws_show_tab = is_tab_start
-                && ws_indicator_visible(
-                    display_char_idx,
-                    non_ws,
-                    ws.tabs_leading,
-                    ws.tabs_inner,
-                    ws.tabs_trailing,
-                );
-            let ws_show_space = ch == ' '
-                && !is_tab_start
-                && ws_indicator_visible(
-                    display_char_idx,
-                    non_ws,
-                    ws.spaces_leading,
-                    ws.spaces_inner,
-                    ws.spaces_trailing,
-                );
-
-            let display_char: &str = if is_cursor && lsp_waiting && is_active {
-                "⋯"
-            } else if debug_tracker.is_some() && ch == '\r' {
-                // Debug mode: show CR explicitly
-                "\\r"
-            } else if debug_tracker.is_some() && ch == '\n' {
-                // Debug mode: show LF explicitly
-                "\\n"
-            } else if ch == '\n' {
-                ""
-            } else if ws_show_tab {
-                // Visual indicator for tab: show → at the first position
-                is_whitespace_indicator = true;
-                '→'.encode_utf8(&mut indicator_buf)
-            } else if ws_show_space {
-                // Visual indicator for space: show · when enabled
-                is_whitespace_indicator = true;
-                '·'.encode_utf8(&mut indicator_buf)
-            } else {
-                ch.encode_utf8(&mut indicator_buf)
-            };
-
-            // Apply subdued whitespace indicator color from theme
-            if is_whitespace_indicator && !is_cursor && !is_selected {
-                style = style.fg(theme.whitespace_indicator_fg);
-            }
-
-            if !display_char.is_empty() {
-                // Debug mode: insert opening tags for spans starting at this position
-                if let Some(ref mut tracker) = debug_tracker {
-                    // Flush before debug tags
-                    span_acc.flush(line_spans, line_view_map);
-                    let opening_tags =
-                        tracker.get_opening_tags(byte_pos, highlight_spans, viewport_overlays);
-                    for tag in opening_tags {
-                        push_debug_tag(line_spans, line_view_map, tag);
-                    }
-                    // Debug mode: show byte position before each character
-                    if let Some(bp) = byte_pos {
-                        push_debug_tag(line_spans, line_view_map, format!("[{}]", bp));
-                    }
-                }
-
-                // Use accumulator to merge consecutive chars with same style.
-                // This is critical for combining characters (Thai diacritics, etc.)
-                for c in display_char.chars() {
-                    span_acc.push(c, style, byte_pos, line_spans, line_view_map);
-                }
-
-                // Debug mode: insert closing tags for spans ending at this position.
-                // Check using the NEXT byte position to see if we're leaving a span.
-                if let Some(ref mut tracker) = debug_tracker {
-                    // Flush before debug tags
-                    span_acc.flush(line_spans, line_view_map);
-                    // Look ahead to next byte position to determine closing tags
-                    let next_byte_pos = byte_pos.map(|bp| bp + ch.len_utf8());
-                    let closing_tags = tracker.get_closing_tags(next_byte_pos);
-                    for tag in closing_tags {
-                        push_debug_tag(line_spans, line_view_map, tag);
-                    }
-                }
-            }
-
-            // Track cursor position for zero-width characters.
-            // Zero-width chars don't get map entries, so we need to explicitly record cursor pos.
-            if byte_pos == Some(primary_cursor_position) && char_width(ch) == 0 {
-                // Account for horizontal scrolling by subtracting left_col
-                cursor.place(
-                    gutter_width as u16 + col_offset.saturating_sub(left_col) as u16,
-                    current_row,
-                );
-            }
-
-            if is_cursor && ch == '\n' {
-                let should_add_indicator = if is_active { is_secondary_cursor } else { true };
-                if should_add_indicator {
-                    // Flush accumulated text before adding cursor indicator
-                    // so the indicator appears after the line content, not before
-                    span_acc.flush(line_spans, line_view_map);
-                    push_span_with_map(
-                        line_spans,
-                        line_view_map,
-                        " ".to_string(),
-                        cursor_indicator_style(theme, is_active),
-                        byte_pos,
-                    );
-                }
+            if let Some(bp) = byte_pos {
+                push_debug_tag(self.line_spans, self.line_view_map, format!("[{}]", bp));
             }
         }
 
-        byte_index += ch.len_utf8();
-        display_char_idx += 1; // Increment character index for next lookup
+        for c in display_char.chars() {
+            self.span_acc
+                .push(c, style, byte_pos, self.line_spans, self.line_view_map);
+        }
+
+        // Debug mode: insert closing tags for spans ending at this position.
+        // Check using the NEXT byte position to see if we're leaving a span.
+        if let Some(ref mut tracker) = self.debug_tracker {
+            // Flush before debug tags
+            self.span_acc.flush(self.line_spans, self.line_view_map);
+            let next_byte_pos = byte_pos.map(|bp| bp + ch.len_utf8());
+            for tag in tracker.get_closing_tags(next_byte_pos) {
+                push_debug_tag(self.line_spans, self.line_view_map, tag);
+            }
+        }
+    }
+
+    /// Cursor handling that happens after the cell is emitted: zero-width
+    /// characters (which get no view-map entry) and the indicator drawn
+    /// when a cursor sits on a newline.
+    fn place_cell_cursor(
+        &mut self,
+        ch: char,
+        byte_pos: Option<usize>,
+        is_cursor: bool,
+        is_secondary_cursor: bool,
+    ) {
+        // Zero-width chars don't get map entries, so explicitly record
+        // the cursor position here.
+        if byte_pos == Some(self.input.selection.primary_cursor_position) && char_width(ch) == 0 {
+            self.cursor
+                .place(self.cell_screen_x(), self.input.current_row);
+        }
+
+        if is_cursor && ch == '\n' {
+            let should_add_indicator = if self.input.is_active {
+                is_secondary_cursor
+            } else {
+                true
+            };
+            if should_add_indicator {
+                // Flush accumulated text before adding the cursor indicator
+                // so the indicator appears after the line content, not before
+                self.span_acc.flush(self.line_spans, self.line_view_map);
+                push_span_with_map(
+                    self.line_spans,
+                    self.line_view_map,
+                    " ".to_string(),
+                    cursor_indicator_style(self.input.theme, self.input.is_active),
+                    byte_pos,
+                );
+            }
+        }
+    }
+
+    /// Step position bookkeeping past `ch`.
+    fn advance(&mut self, ch: char) {
+        self.byte_index += ch.len_utf8();
+        self.display_char_idx += 1;
 
         // col_offset tracks visual column position (for indexing into visual_to_char).
         // We read the per-char visual column that view_pipeline assigned so that
@@ -475,30 +574,48 @@ pub(super) fn render_line_cells(
         // Without this, the renderer's col_offset diverges from the view
         // pipeline's for any cluster whose str_width ≠ Σ char_width, producing
         // variable-width rendering corruption (issue #1577).
-        let next_col_for_char = line_char_visual_cols
-            .get(display_char_idx)
+        let next_col_for_char = self
+            .input
+            .view_line
+            .char_visual_cols
+            .get(self.display_char_idx)
             .copied()
-            .unwrap_or(line_total_visual_width);
-        let ch_width = next_col_for_char.saturating_sub(col_offset);
+            .unwrap_or(self.line_total_visual_width);
+        let ch_width = next_col_for_char.saturating_sub(self.col_offset);
         // `\n` gets visual width 1 from the view pipeline but renders as
         // empty — don't count it as an on-screen cell.
-        let was_rendered = col_offset >= left_col && ch != '\n';
-        col_offset = next_col_for_char;
-        visible_char_count += ch_width;
+        let was_rendered = self.col_offset >= self.input.left_col && ch != '\n';
+        self.col_offset = next_col_for_char;
+        self.visible_char_count += ch_width;
         if was_rendered {
-            rendered_cols += ch_width;
+            self.rendered_cols += ch_width;
         }
     }
 
-    // Flush any remaining accumulated text at end of line
-    span_acc.flush(line_spans, line_view_map);
+    /// Run `ch` through the line's ANSI parser; `None` means the char is
+    /// part of an escape sequence. Lines without ESC use the fast path.
+    fn parse_ansi(&mut self, ch: char) -> Option<Style> {
+        match self.ansi_parser {
+            Some(ref mut parser) => parser.parse_char(ch),
+            None => Some(Style::default()),
+        }
+    }
 
-    CellPassOutput {
-        rendered_cols,
-        col_offset,
-        first_line_byte_pos,
-        last_line_byte_pos,
-        syntax_extend_bg,
+    /// Screen x of the current cell (gutter + column, after horizontal scroll).
+    fn cell_screen_x(&self) -> u16 {
+        self.input.gutter_width as u16 + self.col_offset.saturating_sub(self.input.left_col) as u16
+    }
+
+    /// Flush the accumulator and hand back the per-line results.
+    fn finish(mut self) -> CellPassOutput {
+        self.span_acc.flush(self.line_spans, self.line_view_map);
+        CellPassOutput {
+            rendered_cols: self.rendered_cols,
+            col_offset: self.col_offset,
+            first_line_byte_pos: self.first_line_byte_pos,
+            last_line_byte_pos: self.last_line_byte_pos,
+            syntax_extend_bg: self.syntax_extend_bg,
+        }
     }
 }
 

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -1,0 +1,544 @@
+//! Per-cell rendering pass: the inner character loop of `render_view_lines`.
+//!
+//! Walks one `ViewLine`'s characters and emits styled spans plus the
+//! per-cell bookkeeping later passes need (cursor hits, rendered width,
+//! extend-to-line-end fill inputs). Pulled out of `render_view_lines` so
+//! the orchestrator reads as a sequence of per-line passes instead of one
+//! interleaved loop.
+
+use super::super::super::char_style::{compute_char_style, CharStyleContext, CharStyleOutput};
+use super::super::super::spans::{
+    push_debug_tag, push_span_with_map, span_bg_info_at, span_color_at, span_info_at,
+    DebugSpanTracker, SpanAccumulator,
+};
+use super::super::contexts::{DecorationContext, SelectionContext};
+use super::super::overlay_sweep::OverlayActiveSet;
+use super::super::selection_sweep::SelectionActiveSet;
+use super::{cursor_indicator_style, CursorTracker, SpanCursors};
+use crate::app::types::CellThemeInfo;
+use crate::primitives::ansi::AnsiParser;
+use crate::primitives::display_width::char_width;
+use crate::state::EditorState;
+use crate::view::overlay::Overlay;
+use crate::view::theme::Theme;
+use crate::view::ui::view_pipeline::{LineStart, ViewLine};
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Span;
+
+/// Read-only inputs for one line's cell pass.
+pub(super) struct CellPassInput<'a> {
+    pub state: &'a EditorState,
+    pub theme: &'a Theme,
+    pub view_line: &'a ViewLine,
+    pub selection: &'a SelectionContext,
+    pub decorations: &'a DecorationContext,
+    /// Gutter display number for this line (for the block-selection sweep).
+    pub gutter_num: usize,
+    /// Screen row this line will occupy (rows already pushed).
+    pub current_row: u16,
+    pub render_area: Rect,
+    pub gutter_width: usize,
+    /// Screen width for `cell_theme_map` indexing (0 disables recording).
+    pub screen_width: u16,
+    /// Left column offset for horizontal scrolling.
+    pub left_col: usize,
+    /// Cap on processed visual columns — keeps very long lines cheap.
+    pub max_chars_to_process: usize,
+    pub lsp_waiting: bool,
+    pub is_active: bool,
+    /// Skip REVERSED style on the primary cursor (session mode or
+    /// non-block cursor style).
+    pub session_mode: bool,
+    pub is_on_cursor_line: bool,
+    pub highlight_current_line: bool,
+}
+
+/// Per-line results the later passes consume.
+pub(super) struct CellPassOutput {
+    /// Cells that landed on screen — fills extend from here to the
+    /// viewport's right edge, so this stays correct under horizontal
+    /// scroll (unlike a raw character count).
+    pub rendered_cols: usize,
+    /// Visual column after the last processed character.
+    pub col_offset: usize,
+    /// First/last source bytes seen on this row (tail-fill inputs).
+    pub first_line_byte_pos: Option<usize>,
+    pub last_line_byte_pos: Option<usize>,
+    /// Row-wide bg carried by a syntax category whose
+    /// `bg_extends_to_line_end()` is true (diff Inserted / Deleted /
+    /// Changed). Picked up by the tail-fill pass so the bg wash
+    /// continues past the scoped text to the viewport's right edge.
+    pub syntax_extend_bg: Option<ratatui::style::Color>,
+}
+
+/// Render one line's characters into `line_spans` / `line_view_map`.
+///
+/// Owns everything that happens per cell: ANSI parsing, selection and
+/// overlay sweeps, syntax/semantic span lookups, whitespace indicators,
+/// debug "reveal codes", software-cursor hits, and the theme-inspector
+/// cell map.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn render_line_cells(
+    ctx: CellPassInput<'_>,
+    selection_sweep: &mut SelectionActiveSet<'_>,
+    overlay_sweep: &mut OverlayActiveSet<'_>,
+    span_cursors: &mut SpanCursors,
+    cursor: &mut CursorTracker,
+    cell_theme_map: &mut [CellThemeInfo],
+    line_spans: &mut Vec<Span<'static>>,
+    line_view_map: &mut Vec<Option<usize>>,
+) -> CellPassOutput {
+    let CellPassInput {
+        state,
+        theme,
+        view_line,
+        selection,
+        decorations,
+        gutter_num,
+        current_row,
+        render_area,
+        gutter_width,
+        screen_width,
+        left_col,
+        max_chars_to_process,
+        lsp_waiting,
+        is_active,
+        session_mode,
+        is_on_cursor_line,
+        highlight_current_line,
+    } = ctx;
+
+    let line_content: &str = &view_line.text;
+    let line_char_source_bytes = &view_line.char_source_bytes;
+    let line_char_styles = &view_line.char_styles;
+    let line_char_visual_cols = &view_line.char_visual_cols;
+    let line_total_visual_width = view_line.visual_width();
+    let line_tab_starts = &view_line.tab_starts;
+
+    let cursor_positions = &selection.cursor_positions;
+    let primary_cursor_position = selection.primary_cursor_position;
+    let highlight_spans = &decorations.highlight_spans;
+    let semantic_token_spans = &decorations.semantic_token_spans;
+    let viewport_overlays = &decorations.viewport_overlays;
+    let ws = &state.buffer_settings.whitespace;
+
+    // Pre-compute whitespace position boundaries for this view line in a
+    // single pass — no intermediate `Vec<char>` per line.
+    let non_ws = non_ws_bounds(line_content);
+
+    let mut byte_index = 0; // Byte offset in line_content string
+    let mut display_char_idx = 0usize; // Character index in text (for char_source_bytes)
+    let mut col_offset = 0usize; // Visual column position
+
+    // Accumulator for merging consecutive characters with the same style.
+    // This is critical for proper rendering of combining characters (Thai, etc.)
+    let mut span_acc = SpanAccumulator::new();
+
+    // ANSI parser for this line to handle escape sequences.
+    // Optimization: only create parser if line contains ESC byte.
+    let line_has_ansi = line_content.contains('\x1b');
+    let mut ansi_parser = if line_has_ansi {
+        Some(AnsiParser::new())
+    } else {
+        None
+    };
+    // visible_char_count: all chars stepped over (for long-line break check).
+    // rendered_cols: chars that landed on screen (for fill width — so full-line
+    // bg fills reach the viewport edge under horizontal scroll).
+    let mut visible_char_count = 0usize;
+    let mut rendered_cols = 0usize;
+
+    // Debug mode: track active highlight/overlay spans for WordPerfect-style reveal codes
+    let mut debug_tracker = if state.debug_highlight_mode {
+        Some(DebugSpanTracker::default())
+    } else {
+        None
+    };
+
+    // Track byte positions for extend_to_line_end feature
+    let mut first_line_byte_pos: Option<usize> = None;
+    let mut last_line_byte_pos: Option<usize> = None;
+    let mut syntax_extend_bg: Option<ratatui::style::Color> = None;
+
+    // Reset the per-row touched set. Wrap continuations inherit overlays
+    // still active from the previous row of the same source line; new
+    // source lines do not (see OverlayActiveSet).
+    overlay_sweep.enter_row(matches!(view_line.line_start, LineStart::AfterBreak));
+
+    for ch in line_content.chars() {
+        // Get source byte for this character using character index
+        // (char_source_bytes is indexed by character position, not visual column)
+        let byte_pos = line_char_source_bytes
+            .get(display_char_idx)
+            .copied()
+            .flatten();
+
+        // Track byte positions for extend_to_line_end
+        if let Some(bp) = byte_pos {
+            if first_line_byte_pos.is_none() {
+                first_line_byte_pos = Some(bp);
+            }
+            last_line_byte_pos = Some(bp);
+
+            // Advance overlay active-set sweep for this cell. Monotonic
+            // in `bp` across all view lines in this render call.
+            overlay_sweep.advance_to(bp);
+        }
+
+        // Process character through ANSI parser first (if line has ANSI).
+        // If parser returns None, the character is part of an escape sequence and should be skipped.
+        let ansi_style = if let Some(ref mut parser) = ansi_parser {
+            match parser.parse_char(ch) {
+                Some(style) => style,
+                None => {
+                    // This character is part of an ANSI escape sequence, skip it.
+                    // ANSI escape chars have zero visual width, so don't increment col_offset.
+                    // IMPORTANT: If the cursor is on this ANSI byte, track it.
+                    if byte_pos == Some(primary_cursor_position) {
+                        // Account for horizontal scrolling by using col_offset - left_col
+                        cursor.place(
+                            gutter_width as u16 + col_offset.saturating_sub(left_col) as u16,
+                            current_row,
+                        );
+                    }
+                    byte_index += ch.len_utf8();
+                    display_char_idx += 1;
+                    // Note: col_offset not incremented - ANSI chars have 0 visual width
+                    continue;
+                }
+            }
+        } else {
+            // No ANSI in this line - use default style (fast path)
+            Style::default()
+        };
+
+        // Performance: skip expensive style calculations for characters beyond visible range.
+        // Use visible_char_count (not byte_index) since ANSI codes don't take up visible space.
+        if visible_char_count > max_chars_to_process {
+            // Fast path: skip remaining characters without processing.
+            // This is critical for performance with very long lines (e.g., 100KB single line)
+            break;
+        }
+
+        // Skip characters before left_column
+        if col_offset >= left_col {
+            // Check if this view position is the START of a tab expansion
+            let is_tab_start = line_tab_starts.contains(&col_offset);
+
+            // Check if this character is at a cursor position.
+            // For tab expansions: only show cursor on the FIRST space (the tab_start position).
+            // This prevents cursor from appearing on all 8 expanded spaces.
+            let is_cursor = byte_pos
+                .map(|bp| {
+                    if !cursor_positions.contains(&bp) || bp >= state.buffer.len() {
+                        return false;
+                    }
+                    // If this byte maps to a tab character, only show cursor at tab_start.
+                    // Check if this is part of a tab expansion by looking at previous char.
+                    let prev_char_idx = display_char_idx.saturating_sub(1);
+                    let prev_byte_pos =
+                        line_char_source_bytes.get(prev_char_idx).copied().flatten();
+                    // Show cursor if: this is start of line, OR previous char had different byte pos
+                    display_char_idx == 0 || prev_byte_pos != Some(bp)
+                })
+                .unwrap_or(false);
+
+            // Refresh the block-rect active set for this row.
+            // Idempotent on the same gutter line (no inner gate).
+            selection_sweep.enter_line(gutter_num);
+
+            // For primary cursor in active split, terminal hardware cursor provides
+            // visual indication, so we can still show selection background.
+            // Only exclude secondary cursors from selection (they use REVERSED styling).
+            // Bug #614: Previously excluded all cursor positions, causing first char
+            // of selection to display with wrong background for bar/underline cursors.
+            let is_primary_cursor = is_cursor && byte_pos == Some(primary_cursor_position);
+            let exclude_from_selection = is_cursor && !(is_active && is_primary_cursor);
+
+            let is_selected =
+                !exclude_from_selection && selection_sweep.contains(byte_pos, byte_index);
+
+            // char_styles is indexed by character position, not visual column
+            let token_style = line_char_styles
+                .get(display_char_idx)
+                .and_then(|s| s.as_ref());
+
+            // Resolve highlight/semantic colors via cursor-based O(1) lookup
+            let (highlight_color, highlight_theme_key, highlight_display_name) = match byte_pos {
+                Some(bp) => span_info_at(highlight_spans, &mut span_cursors.highlight, bp),
+                None => (None, None, None),
+            };
+            // Diff categories carry a bg the renderer paints as a row wash.
+            // `span_bg_info_at` is an O(1) peek using the cursor
+            // `span_info_at` just advanced; no second walk.
+            let (highlight_bg, highlight_bg_extends) = match byte_pos {
+                Some(bp) => span_bg_info_at(highlight_spans, span_cursors.highlight, bp),
+                None => (None, false),
+            };
+            let highlight_bg_theme_key = highlight_bg
+                .and(highlight_theme_key)
+                .or(highlight_theme_key);
+            let semantic_token_color = match byte_pos {
+                Some(bp) => span_color_at(semantic_token_spans, &mut span_cursors.semantic, bp),
+                None => None,
+            };
+
+            // Pre-resolved active overlays for this cell. Empty slice
+            // when byte_pos is None (ANSI continuation / virtual cells)
+            // — matches pre-sweep behaviour where `bp = None`
+            // short-circuited overlay filtering.
+            let cell_overlays: &[&Overlay] = if byte_pos.is_some() {
+                overlay_sweep.at_cursor()
+            } else {
+                &[]
+            };
+
+            let CharStyleOutput {
+                mut style,
+                is_secondary_cursor,
+                fg_theme_key,
+                bg_theme_key,
+                region: cell_region,
+            } = compute_char_style(&CharStyleContext {
+                byte_pos,
+                token_style,
+                ansi_style,
+                is_cursor,
+                is_selected,
+                theme,
+                highlight_color,
+                highlight_theme_key,
+                highlight_bg,
+                highlight_bg_theme_key,
+                semantic_token_color,
+                active_overlays: cell_overlays,
+                primary_cursor_position,
+                is_active,
+                skip_primary_cursor_reverse: session_mode,
+                is_cursor_line_highlighted: is_on_cursor_line
+                    && highlight_current_line
+                    && is_active,
+                current_line_bg: theme.current_line_bg,
+            });
+
+            // Remember this row's diff bg so the tail-fill pass can
+            // continue the wash past the scoped text. Only set when the
+            // category actually wants extension — keeps per-token bg
+            // scopes (none today, but possible) from unintentionally
+            // bleeding to the row's right edge.
+            if let (Some(bg), true) = (highlight_bg, highlight_bg_extends) {
+                syntax_extend_bg = Some(bg);
+            }
+
+            // Record cell theme info for the theme inspector popup
+            if screen_width > 0 {
+                let screen_col = render_area.x
+                    + gutter_width as u16
+                    + col_offset.saturating_sub(left_col) as u16;
+                let screen_row = render_area.y + current_row;
+                let idx = screen_row as usize * screen_width as usize + screen_col as usize;
+                if let Some(cell) = cell_theme_map.get_mut(idx) {
+                    *cell = CellThemeInfo {
+                        fg_key: fg_theme_key,
+                        bg_key: bg_theme_key,
+                        region: cell_region,
+                        syntax_category: highlight_display_name,
+                    };
+                }
+            }
+
+            // Determine display character (tabs already expanded in ViewLineIterator).
+            // Show tab indicator (→) or space indicator (·) based on granular
+            // whitespace visibility settings (leading/inner/trailing positions).
+            // `indicator_buf` holds the UTF-8 bytes of a single char on the
+            // stack — no heap allocation per cell.
+            let mut indicator_buf = [0u8; 4];
+            let mut is_whitespace_indicator = false;
+
+            let ws_show_tab = is_tab_start
+                && ws_indicator_visible(
+                    display_char_idx,
+                    non_ws,
+                    ws.tabs_leading,
+                    ws.tabs_inner,
+                    ws.tabs_trailing,
+                );
+            let ws_show_space = ch == ' '
+                && !is_tab_start
+                && ws_indicator_visible(
+                    display_char_idx,
+                    non_ws,
+                    ws.spaces_leading,
+                    ws.spaces_inner,
+                    ws.spaces_trailing,
+                );
+
+            let display_char: &str = if is_cursor && lsp_waiting && is_active {
+                "⋯"
+            } else if debug_tracker.is_some() && ch == '\r' {
+                // Debug mode: show CR explicitly
+                "\\r"
+            } else if debug_tracker.is_some() && ch == '\n' {
+                // Debug mode: show LF explicitly
+                "\\n"
+            } else if ch == '\n' {
+                ""
+            } else if ws_show_tab {
+                // Visual indicator for tab: show → at the first position
+                is_whitespace_indicator = true;
+                '→'.encode_utf8(&mut indicator_buf)
+            } else if ws_show_space {
+                // Visual indicator for space: show · when enabled
+                is_whitespace_indicator = true;
+                '·'.encode_utf8(&mut indicator_buf)
+            } else {
+                ch.encode_utf8(&mut indicator_buf)
+            };
+
+            // Apply subdued whitespace indicator color from theme
+            if is_whitespace_indicator && !is_cursor && !is_selected {
+                style = style.fg(theme.whitespace_indicator_fg);
+            }
+
+            if !display_char.is_empty() {
+                // Debug mode: insert opening tags for spans starting at this position
+                if let Some(ref mut tracker) = debug_tracker {
+                    // Flush before debug tags
+                    span_acc.flush(line_spans, line_view_map);
+                    let opening_tags =
+                        tracker.get_opening_tags(byte_pos, highlight_spans, viewport_overlays);
+                    for tag in opening_tags {
+                        push_debug_tag(line_spans, line_view_map, tag);
+                    }
+                    // Debug mode: show byte position before each character
+                    if let Some(bp) = byte_pos {
+                        push_debug_tag(line_spans, line_view_map, format!("[{}]", bp));
+                    }
+                }
+
+                // Use accumulator to merge consecutive chars with same style.
+                // This is critical for combining characters (Thai diacritics, etc.)
+                for c in display_char.chars() {
+                    span_acc.push(c, style, byte_pos, line_spans, line_view_map);
+                }
+
+                // Debug mode: insert closing tags for spans ending at this position.
+                // Check using the NEXT byte position to see if we're leaving a span.
+                if let Some(ref mut tracker) = debug_tracker {
+                    // Flush before debug tags
+                    span_acc.flush(line_spans, line_view_map);
+                    // Look ahead to next byte position to determine closing tags
+                    let next_byte_pos = byte_pos.map(|bp| bp + ch.len_utf8());
+                    let closing_tags = tracker.get_closing_tags(next_byte_pos);
+                    for tag in closing_tags {
+                        push_debug_tag(line_spans, line_view_map, tag);
+                    }
+                }
+            }
+
+            // Track cursor position for zero-width characters.
+            // Zero-width chars don't get map entries, so we need to explicitly record cursor pos.
+            if byte_pos == Some(primary_cursor_position) && char_width(ch) == 0 {
+                // Account for horizontal scrolling by subtracting left_col
+                cursor.place(
+                    gutter_width as u16 + col_offset.saturating_sub(left_col) as u16,
+                    current_row,
+                );
+            }
+
+            if is_cursor && ch == '\n' {
+                let should_add_indicator = if is_active { is_secondary_cursor } else { true };
+                if should_add_indicator {
+                    // Flush accumulated text before adding cursor indicator
+                    // so the indicator appears after the line content, not before
+                    span_acc.flush(line_spans, line_view_map);
+                    push_span_with_map(
+                        line_spans,
+                        line_view_map,
+                        " ".to_string(),
+                        cursor_indicator_style(theme, is_active),
+                        byte_pos,
+                    );
+                }
+            }
+        }
+
+        byte_index += ch.len_utf8();
+        display_char_idx += 1; // Increment character index for next lookup
+
+        // col_offset tracks visual column position (for indexing into visual_to_char).
+        // We read the per-char visual column that view_pipeline assigned so that
+        // grapheme clusters (ZWJ emoji, base+combining, etc.) advance by
+        // `UnicodeWidthStr::width(cluster)` — the same width ratatui uses when
+        // re-segmenting spans — instead of summing per-codepoint `char_width`.
+        // Without this, the renderer's col_offset diverges from the view
+        // pipeline's for any cluster whose str_width ≠ Σ char_width, producing
+        // variable-width rendering corruption (issue #1577).
+        let next_col_for_char = line_char_visual_cols
+            .get(display_char_idx)
+            .copied()
+            .unwrap_or(line_total_visual_width);
+        let ch_width = next_col_for_char.saturating_sub(col_offset);
+        // `\n` gets visual width 1 from the view pipeline but renders as
+        // empty — don't count it as an on-screen cell.
+        let was_rendered = col_offset >= left_col && ch != '\n';
+        col_offset = next_col_for_char;
+        visible_char_count += ch_width;
+        if was_rendered {
+            rendered_cols += ch_width;
+        }
+    }
+
+    // Flush any remaining accumulated text at end of line
+    span_acc.flush(line_spans, line_view_map);
+
+    CellPassOutput {
+        rendered_cols,
+        col_offset,
+        first_line_byte_pos,
+        last_line_byte_pos,
+        syntax_extend_bg,
+    }
+}
+
+/// Indices of the first and last non-whitespace characters of a line
+/// (`None`s when the line is all whitespace).
+fn non_ws_bounds(line_content: &str) -> (Option<usize>, Option<usize>) {
+    let mut first: Option<usize> = None;
+    let mut last: Option<usize> = None;
+    for (i, c) in line_content.chars().enumerate() {
+        if c != ' ' && c != '\n' && c != '\r' {
+            if first.is_none() {
+                first = Some(i);
+            }
+            last = Some(i);
+        }
+    }
+    (first, last)
+}
+
+/// Whether a whitespace indicator at char index `idx` should be shown,
+/// given the line's non-whitespace bounds and the leading/inner/trailing
+/// visibility toggles.
+fn ws_indicator_visible(
+    idx: usize,
+    non_ws_bounds: (Option<usize>, Option<usize>),
+    leading: bool,
+    inner: bool,
+    trailing: bool,
+) -> bool {
+    match non_ws_bounds {
+        (Some(first), Some(last)) => {
+            if idx < first {
+                leading
+            } else if idx > last {
+                trailing
+            } else {
+                inner
+            }
+        }
+        // All-whitespace line: every position is both leading and trailing.
+        _ => leading || trailing,
+    }
+}

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -5,31 +5,31 @@
 //! concern-scoped `LineRenderInput`, and produces a vector of styled
 //! `Line<'static>` plus cursor and per-cell metadata.
 //!
-//! Everything here is quarantined to `orchestration/`.
+//! `render_view_lines` is the orchestrator: per view line it runs the
+//! gutter pass, the per-cell pass (`cells`), the cursor-placement passes,
+//! inline diagnostics, the tail fills, and the mouse-mapping bookkeeping.
+//! The post-loop work (implicit trailing line, EOF tildes) lives in
+//! `trailing`. Everything here is quarantined to `orchestration/`.
 
-use super::super::char_style::{compute_char_style, CharStyleContext, CharStyleOutput};
 use super::super::gutter::{render_left_margin, LeftMarginContext};
 use super::super::layout::ViewAnchor;
-use super::super::spans::{
-    push_debug_tag, push_span_with_map, span_color_at, span_info_at, DebugSpanTracker,
-    SpanAccumulator,
-};
+use super::super::spans::push_span_with_map;
 use super::contexts::{DecorationContext, SelectionContext};
 use super::overlay_sweep::OverlayActiveSet;
 use super::selection_sweep::SelectionActiveSet;
 use super::tail_fill::{resolve_tail_fill, TailFillInput};
+use cells::{render_line_cells, CellPassInput};
 use trailing::{fill_eof_rows, render_implicit_trailing_line, PostRowAccumulator, PostRowContext};
 
+mod cells;
 mod trailing;
+
 use crate::app::types::ViewLineMapping;
-use crate::primitives::ansi::AnsiParser;
-use crate::primitives::display_width::char_width;
 use crate::state::EditorState;
-use crate::view::overlay::Overlay;
 use crate::view::theme::Theme;
 use crate::view::ui::view_pipeline::{should_show_line_number, LineStart, ViewLine};
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use std::collections::HashSet;
 
@@ -84,6 +84,40 @@ pub(crate) struct LineRenderInput<'a> {
     pub screen_width: u16,
 }
 
+/// Software-cursor screen position, tracked across all per-line passes.
+#[derive(Default)]
+struct CursorTracker {
+    x: u16,
+    y: u16,
+    found: bool,
+}
+
+impl CursorTracker {
+    /// Record the cursor position unless one was already found.
+    fn place(&mut self, x: u16, y: u16) {
+        if !self.found {
+            self.force(x, y);
+        }
+    }
+
+    /// Record the cursor position, overriding any earlier hit. Used by
+    /// the line-end passes that re-derive a more accurate position.
+    fn force(&mut self, x: u16, y: u16) {
+        self.x = x;
+        self.y = y;
+        self.found = true;
+    }
+}
+
+/// Monotonic cursors for the O(1)-amortised highlight/semantic span
+/// lookups (spans are sorted by byte range; the per-cell pass only ever
+/// advances these).
+#[derive(Default)]
+struct SpanCursors {
+    highlight: usize,
+    semantic: usize,
+}
+
 pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput {
     use crate::view::folding::indent_folding;
 
@@ -113,38 +147,8 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         screen_width,
     } = input;
 
-    // Fill the entire content area with default editor bg/gutter theme info
-    if screen_width > 0 {
-        let gutter_info = crate::app::types::CellThemeInfo {
-            fg_key: Some("editor.line_number_fg"),
-            bg_key: Some("editor.line_number_bg"),
-            region: "Line Numbers",
-            syntax_category: None,
-        };
-        let content_info = crate::app::types::CellThemeInfo {
-            fg_key: Some("editor.fg"),
-            bg_key: Some("editor.bg"),
-            region: "Editor Content",
-            syntax_category: None,
-        };
-        let sw = screen_width as usize;
-        for row in render_area.y..render_area.y + render_area.height {
-            for col in render_area.x..render_area.x + render_area.width {
-                let idx = row as usize * sw + col as usize;
-                if let Some(cell) = cell_theme_map.get_mut(idx) {
-                    *cell = if col < render_area.x + gutter_width as u16 {
-                        gutter_info.clone()
-                    } else {
-                        content_info.clone()
-                    };
-                }
-            }
-        }
-    }
+    prefill_cell_theme_map(cell_theme_map, screen_width, render_area, gutter_width);
 
-    let selection_ranges = &selection.ranges;
-    let block_selections = &selection.block_rects;
-    let cursor_positions = &selection.cursor_positions;
     let primary_cursor_position = selection.primary_cursor_position;
 
     // Compute cursor line start byte — universal key for cursor line highlight
@@ -162,19 +166,11 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     let cursor_line_end_byte =
         indent_folding::find_line_end_byte(&state.buffer, primary_cursor_position);
 
-    let highlight_spans = &decorations.highlight_spans;
-    let semantic_token_spans = &decorations.semantic_token_spans;
-    let viewport_overlays = &decorations.viewport_overlays;
-    let overlay_position_index = &decorations.overlay_position_index;
-    let diagnostic_lines = &decorations.diagnostic_lines;
-    let line_indicators = &decorations.line_indicators;
-
     // Cursors for O(1) amortized span lookups (spans are sorted by byte range)
-    let mut hl_cursor = 0usize;
-    let mut sem_cursor = 0usize;
+    let mut span_cursors = SpanCursors::default();
     // Linear-range + block-rect selection sweep. The cell loop just
     // asks `contains(byte_pos, byte_index)` — see SelectionActiveSet.
-    let mut selection_sweep = SelectionActiveSet::new(selection_ranges, block_selections);
+    let mut selection_sweep = SelectionActiveSet::new(&selection.ranges, &selection.block_rects);
 
     // Overlay sweep: O(1) amortised per cell, zero allocation per cell.
     // Line-sweep over the viewport overlays. See `OverlayActiveSet`
@@ -182,15 +178,16 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     // that knows which overlays cover the byte the cell loop is
     // currently on, and which ones touched the current visual row
     // (fuel for the `extend_to_line_end` tail-fill).
-    let mut overlay_sweep = OverlayActiveSet::new(viewport_overlays, overlay_position_index);
+    let mut overlay_sweep = OverlayActiveSet::new(
+        &decorations.viewport_overlays,
+        &decorations.overlay_position_index,
+    );
 
-    let mut lines = Vec::new();
-    let mut view_line_mappings = Vec::new();
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut view_line_mappings: Vec<ViewLineMapping> = Vec::new();
     let mut lines_rendered = 0usize;
     let mut view_iter_idx = view_anchor.start_line_idx;
-    let mut cursor_screen_x = 0u16;
-    let mut cursor_screen_y = 0u16;
-    let mut have_cursor = false;
+    let mut cursor = CursorTracker::default();
     let mut last_line_end: Option<LastLineEnd> = None;
     let mut last_gutter_num: Option<usize> = None;
     let mut trailing_empty_line_rendered = false;
@@ -198,9 +195,9 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
     let is_empty_buffer = state.buffer.is_empty();
 
-    // Track cursor position during rendering (eliminates duplicate line iteration)
+    // x of the last visible cell on the most recent non-empty row
+    // (used for cursor-on-newline placement and `last_line_end`)
     let mut last_visible_x: u16 = 0;
-    let _view_start_line_skip = view_anchor.start_line_skip; // Currently unused
 
     loop {
         // Get the current ViewLine from the pipeline
@@ -226,43 +223,13 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             break;
         };
 
-        // Extract line data. `line_content` borrows the ViewLine's text
-        // directly — no per-line `String::clone`; the borrow is valid for
-        // the whole per-line body since `current_view_line` is a shared
-        // reference into `view_lines`.
+        // `line_content` borrows the ViewLine's text directly — no per-line
+        // `String::clone`; the borrow is valid for the whole per-line body
+        // since `current_view_line` is a shared reference into `view_lines`.
         let line_content: &str = &current_view_line.text;
         let line_has_newline = current_view_line.ends_with_newline;
         let line_char_source_bytes = &current_view_line.char_source_bytes;
-        let line_char_styles = &current_view_line.char_styles;
-        let line_char_visual_cols = &current_view_line.char_visual_cols;
-        let line_total_visual_width = current_view_line.visual_width();
-        let line_visual_to_char = &current_view_line.visual_to_char;
-        let line_tab_starts = &current_view_line.tab_starts;
-        let _line_start_type = current_view_line.line_start;
-
-        // Pre-compute whitespace position boundaries for this view line in
-        // a single pass — no intermediate `Vec<char>` per line.
-        // first_non_ws: index of first non-whitespace char (None if all whitespace)
-        // last_non_ws: index of last non-whitespace char (None if all whitespace)
-        let (first_non_ws_idx, last_non_ws_idx) = {
-            let mut first: Option<usize> = None;
-            let mut last: Option<usize> = None;
-            for (i, c) in line_content.chars().enumerate() {
-                if c != ' ' && c != '\n' && c != '\r' {
-                    if first.is_none() {
-                        first = Some(i);
-                    }
-                    last = Some(i);
-                }
-            }
-            (first, last)
-        };
-
-        // Helper to get source byte at a visual column using the new O(1) lookup
-        let _source_byte_at_col = |vis_col: usize| -> Option<usize> {
-            let char_idx = line_visual_to_char.get(vis_col).copied()?;
-            line_char_source_bytes.get(char_idx).copied().flatten()
-        };
+        let line_start_type = current_view_line.line_start;
 
         view_iter_idx += 1;
 
@@ -286,8 +253,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                     // Trailing empty line (after final newline) has no source bytes,
                     // but its logical position is buffer.len() — needed for diagnostic
                     // gutter markers placed at the end of the file.
-                    if line_content.is_empty() && _line_start_type == LineStart::AfterSourceNewline
-                    {
+                    if line_content.is_empty() && line_start_type == LineStart::AfterSourceNewline {
                         Some(state.buffer.len())
                     } else {
                         None
@@ -328,18 +294,14 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
         lines_rendered += 1;
 
+        // Screen row this line will occupy (rows already pushed)
+        let current_row = lines.len() as u16;
+
         // Apply horizontal scrolling - skip characters before left_column
         let left_col = left_column;
 
-        // Build line with selection highlighting
         let mut line_spans = Vec::new();
         let mut line_view_map: Vec<Option<usize>> = Vec::new();
-        let mut last_seg_y: Option<u16> = None;
-        let mut _last_seg_width: usize = 0;
-
-        // Accumulator for merging consecutive characters with the same style
-        // This is critical for proper rendering of combining characters (Thai, etc.)
-        let mut span_acc = SpanAccumulator::new();
 
         // Render left margin (indicators + line numbers + separator)
         render_left_margin(
@@ -350,8 +312,8 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 line_start_byte,
                 gutter_num,
                 estimated_lines,
-                diagnostic_lines,
-                line_indicators,
+                diagnostic_lines: &decorations.diagnostic_lines,
+                line_indicators: &decorations.line_indicators,
                 fold_indicators: &decorations.fold_indicators,
                 cursor_line_start_byte,
                 cursor_line_number: state.primary_cursor_line_number.value(),
@@ -366,19 +328,14 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             &mut line_view_map,
         );
 
-        // Check if this line has any selected text
-        let mut byte_index = 0; // Byte offset in line_content string
-        let mut display_char_idx = 0usize; // Character index in text (for char_source_bytes)
-        let mut col_offset = 0usize; // Visual column position
-
-        // Performance optimization: For very long lines, only process visible characters
-        // Calculate the maximum characters we might need to render based on screen width
-        // For wrapped lines, we need enough characters to fill the visible viewport
-        // For non-wrapped lines, we only need one screen width worth
+        // Performance optimization: For very long lines, only process visible characters.
+        // Calculate the maximum characters we might need to render based on screen width.
+        // For wrapped lines, we need enough characters to fill the visible viewport;
+        // for non-wrapped lines, we only need one screen width worth.
         let visible_lines_remaining = visible_line_count.saturating_sub(lines_rendered);
         let max_visible_chars = if line_wrap {
-            // With wrapping: might need chars for multiple wrapped lines
-            // Be generous to avoid cutting off wrapped content
+            // With wrapping: might need chars for multiple wrapped lines.
+            // Be generous to avoid cutting off wrapped content.
             (render_area.width as usize)
                 .saturating_mul(visible_lines_remaining.max(1))
                 .saturating_add(200)
@@ -388,658 +345,124 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         };
         let max_chars_to_process = left_col.saturating_add(max_visible_chars);
 
-        // ANSI parser for this line to handle escape sequences
-        // Optimization: only create parser if line contains ESC byte
-        let line_has_ansi = line_content.contains('\x1b');
-        let mut ansi_parser = if line_has_ansi {
-            Some(AnsiParser::new())
-        } else {
-            None
-        };
-        // visible_char_count: all chars stepped over (for long-line break check).
-        // rendered_cols: chars that landed on screen (for fill width — so full-line
-        // bg fills reach the viewport edge under horizontal scroll).
-        let mut visible_char_count = 0usize;
-        let mut rendered_cols = 0usize;
-
-        // Debug mode: track active highlight/overlay spans for WordPerfect-style reveal codes
-        let mut debug_tracker = if state.debug_highlight_mode {
-            Some(DebugSpanTracker::default())
-        } else {
-            None
-        };
-
-        // Track byte positions for extend_to_line_end feature
-        let mut first_line_byte_pos: Option<usize> = None;
-        let mut last_line_byte_pos: Option<usize> = None;
-        // Carries the row-wide bg for a syntax category whose
-        // `bg_extends_to_line_end()` is true (diff Inserted /
-        // Deleted / Changed). Picked up by the tail-fill pass below
-        // so the bg wash continues past the scoped text to the
-        // viewport's right edge.
-        let mut syntax_extend_bg: Option<ratatui::style::Color> = None;
-        // Reset the per-row touched set. Wrap continuations inherit
-        // overlays still active from the previous row of the same
-        // source line; new source lines do not (see OverlayActiveSet).
-        overlay_sweep.enter_row(matches!(
-            current_view_line.line_start,
-            LineStart::AfterBreak
-        ));
-
-        let chars_iterator = line_content.chars().peekable();
-        for ch in chars_iterator {
-            // Get source byte for this character using character index
-            // (char_source_bytes is indexed by character position, not visual column)
-            let byte_pos = line_char_source_bytes
-                .get(display_char_idx)
-                .copied()
-                .flatten();
-
-            // Track byte positions for extend_to_line_end
-            if let Some(bp) = byte_pos {
-                if first_line_byte_pos.is_none() {
-                    first_line_byte_pos = Some(bp);
-                }
-                last_line_byte_pos = Some(bp);
-            }
-
-            // Advance overlay active-set sweep for this cell. Monotonic
-            // in `bp` across all view lines in this render call.
-            if let Some(bp) = byte_pos {
-                overlay_sweep.advance_to(bp);
-            }
-
-            // Process character through ANSI parser first (if line has ANSI)
-            // If parser returns None, the character is part of an escape sequence and should be skipped
-            let ansi_style = if let Some(ref mut parser) = ansi_parser {
-                match parser.parse_char(ch) {
-                    Some(style) => style,
-                    None => {
-                        // This character is part of an ANSI escape sequence, skip it
-                        // ANSI escape chars have zero visual width, so don't increment col_offset
-                        // IMPORTANT: If the cursor is on this ANSI byte, track it
-                        if let Some(bp) = byte_pos {
-                            if bp == primary_cursor_position && !have_cursor {
-                                // Account for horizontal scrolling by using col_offset - left_col
-                                cursor_screen_x = gutter_width as u16
-                                    + col_offset.saturating_sub(left_col) as u16;
-                                cursor_screen_y = lines_rendered.saturating_sub(1) as u16;
-                                have_cursor = true;
-                            }
-                        }
-                        byte_index += ch.len_utf8();
-                        display_char_idx += 1;
-                        // Note: col_offset not incremented - ANSI chars have 0 visual width
-                        continue;
-                    }
-                }
-            } else {
-                // No ANSI in this line - use default style (fast path)
-                Style::default()
-            };
-
-            // Performance: skip expensive style calculations for characters beyond visible range
-            // Use visible_char_count (not byte_index) since ANSI codes don't take up visible space
-            if visible_char_count > max_chars_to_process {
-                // Fast path: skip remaining characters without processing
-                // This is critical for performance with very long lines (e.g., 100KB single line)
-                break;
-            }
-
-            // Skip characters before left_column
-            if col_offset >= left_col {
-                // Check if this view position is the START of a tab expansion
-                let is_tab_start = line_tab_starts.contains(&col_offset);
-
-                // Check if this character is at a cursor position
-                // For tab expansions: only show cursor on the FIRST space (the tab_start position)
-                // This prevents cursor from appearing on all 8 expanded spaces
-                let is_cursor = byte_pos
-                    .map(|bp| {
-                        if !cursor_positions.contains(&bp) || bp >= state.buffer.len() {
-                            return false;
-                        }
-                        // If this byte maps to a tab character, only show cursor at tab_start
-                        // Check if this is part of a tab expansion by looking at previous char
-                        let prev_char_idx = display_char_idx.saturating_sub(1);
-                        let prev_byte_pos =
-                            line_char_source_bytes.get(prev_char_idx).copied().flatten();
-                        // Show cursor if: this is start of line, OR previous char had different byte pos
-                        display_char_idx == 0 || prev_byte_pos != Some(bp)
-                    })
-                    .unwrap_or(false);
-
-                // Refresh the block-rect active set for this row.
-                // Idempotent on the same gutter line (no inner gate).
-                selection_sweep.enter_line(gutter_num);
-
-                // For primary cursor in active split, terminal hardware cursor provides
-                // visual indication, so we can still show selection background.
-                // Only exclude secondary cursors from selection (they use REVERSED styling).
-                // Bug #614: Previously excluded all cursor positions, causing first char
-                // of selection to display with wrong background for bar/underline cursors.
-                let is_primary_cursor = is_cursor && byte_pos == Some(primary_cursor_position);
-                let exclude_from_selection = is_cursor && !(is_active && is_primary_cursor);
-
-                let is_selected =
-                    !exclude_from_selection && selection_sweep.contains(byte_pos, byte_index);
-
-                // Compute character style using helper function
-                // char_styles is indexed by character position, not visual column
-                let token_style = line_char_styles
-                    .get(display_char_idx)
-                    .and_then(|s| s.as_ref());
-
-                // Resolve highlight/semantic colors via cursor-based O(1) lookup
-                let (highlight_color, highlight_theme_key, highlight_display_name) = match byte_pos
-                {
-                    Some(bp) => span_info_at(highlight_spans, &mut hl_cursor, bp),
-                    None => (None, None, None),
-                };
-                // Diff categories carry a bg the renderer paints as a
-                // row wash. `span_bg_info_at` is an O(1) peek using
-                // the cursor `span_info_at` just advanced; no second
-                // walk.
-                let (highlight_bg, highlight_bg_extends) = match byte_pos {
-                    Some(bp) => {
-                        super::super::spans::span_bg_info_at(highlight_spans, hl_cursor, bp)
-                    }
-                    None => (None, false),
-                };
-                let highlight_bg_theme_key = highlight_bg
-                    .and(highlight_theme_key)
-                    .or(highlight_theme_key);
-                let semantic_token_color = match byte_pos {
-                    Some(bp) => span_color_at(semantic_token_spans, &mut sem_cursor, bp),
-                    None => None,
-                };
-
-                // Pre-resolved active overlays for this cell. Empty slice
-                // when byte_pos is None (ANSI continuation / virtual cells)
-                // — matches pre-sweep behaviour where `bp = None`
-                // short-circuited overlay filtering.
-                let cell_overlays: &[&Overlay] = if byte_pos.is_some() {
-                    overlay_sweep.at_cursor()
-                } else {
-                    &[]
-                };
-
-                let CharStyleOutput {
-                    mut style,
-                    is_secondary_cursor,
-                    fg_theme_key,
-                    bg_theme_key,
-                    region: cell_region,
-                } = compute_char_style(&CharStyleContext {
-                    byte_pos,
-                    token_style,
-                    ansi_style,
-                    is_cursor,
-                    is_selected,
-                    theme,
-                    highlight_color,
-                    highlight_theme_key,
-                    highlight_bg,
-                    highlight_bg_theme_key,
-                    semantic_token_color,
-                    active_overlays: cell_overlays,
-                    primary_cursor_position,
-                    is_active,
-                    skip_primary_cursor_reverse: session_mode,
-                    is_cursor_line_highlighted: is_on_cursor_line
-                        && highlight_current_line
-                        && is_active,
-                    current_line_bg: theme.current_line_bg,
-                });
-
-                // Remember this row's diff bg so the tail-fill pass can
-                // continue the wash past the scoped text. Only set
-                // when the category actually wants extension — keeps
-                // per-token bg scopes (none today, but possible) from
-                // unintentionally bleeding to the row's right edge.
-                if let (Some(bg), true) = (highlight_bg, highlight_bg_extends) {
-                    syntax_extend_bg = Some(bg);
-                }
-
-                // Record cell theme info for the theme inspector popup
-                if screen_width > 0 {
-                    let screen_col = render_area.x
-                        + gutter_width as u16
-                        + col_offset.saturating_sub(left_col) as u16;
-                    let screen_row = render_area.y + lines.len() as u16;
-                    let idx = screen_row as usize * screen_width as usize + screen_col as usize;
-                    if let Some(cell) = cell_theme_map.get_mut(idx) {
-                        *cell = crate::app::types::CellThemeInfo {
-                            fg_key: fg_theme_key,
-                            bg_key: bg_theme_key,
-                            region: cell_region,
-                            syntax_category: highlight_display_name,
-                        };
-                    }
-                }
-
-                // Determine display character (tabs already expanded in ViewLineIterator)
-                // Show tab indicator (→) or space indicator (·) based on granular
-                // whitespace visibility settings (leading/inner/trailing positions).
-                // `indicator_buf` holds the UTF-8 bytes of a single char on the
-                // stack — no heap allocation per cell.
-                let mut indicator_buf = [0u8; 4];
-                let mut is_whitespace_indicator = false;
-
-                // Classify whitespace position: leading, inner, or trailing
-                // Leading = before first non-ws char, Trailing = after last non-ws char
-                // All-whitespace lines match both leading and trailing
-                let ws_show_tab = is_tab_start && {
-                    let ws = &state.buffer_settings.whitespace;
-                    match (first_non_ws_idx, last_non_ws_idx) {
-                        (None, _) | (_, None) => ws.tabs_leading || ws.tabs_trailing,
-                        (Some(first), Some(last)) => {
-                            if display_char_idx < first {
-                                ws.tabs_leading
-                            } else if display_char_idx > last {
-                                ws.tabs_trailing
-                            } else {
-                                ws.tabs_inner
-                            }
-                        }
-                    }
-                };
-                let ws_show_space = ch == ' ' && !is_tab_start && {
-                    let ws = &state.buffer_settings.whitespace;
-                    match (first_non_ws_idx, last_non_ws_idx) {
-                        (None, _) | (_, None) => ws.spaces_leading || ws.spaces_trailing,
-                        (Some(first), Some(last)) => {
-                            if display_char_idx < first {
-                                ws.spaces_leading
-                            } else if display_char_idx > last {
-                                ws.spaces_trailing
-                            } else {
-                                ws.spaces_inner
-                            }
-                        }
-                    }
-                };
-
-                let display_char: &str = if is_cursor && lsp_waiting && is_active {
-                    "⋯"
-                } else if debug_tracker.is_some() && ch == '\r' {
-                    // Debug mode: show CR explicitly
-                    "\\r"
-                } else if debug_tracker.is_some() && ch == '\n' {
-                    // Debug mode: show LF explicitly
-                    "\\n"
-                } else if ch == '\n' {
-                    ""
-                } else if ws_show_tab {
-                    // Visual indicator for tab: show → at the first position
-                    is_whitespace_indicator = true;
-                    '→'.encode_utf8(&mut indicator_buf)
-                } else if ws_show_space {
-                    // Visual indicator for space: show · when enabled
-                    is_whitespace_indicator = true;
-                    '·'.encode_utf8(&mut indicator_buf)
-                } else {
-                    ch.encode_utf8(&mut indicator_buf)
-                };
-
-                // Apply subdued whitespace indicator color from theme
-                if is_whitespace_indicator && !is_cursor && !is_selected {
-                    style = style.fg(theme.whitespace_indicator_fg);
-                }
-
-                if !display_char.is_empty() {
-                    // Debug mode: insert opening tags for spans starting at this position
-                    if let Some(ref mut tracker) = debug_tracker {
-                        // Flush before debug tags
-                        span_acc.flush(&mut line_spans, &mut line_view_map);
-                        let opening_tags =
-                            tracker.get_opening_tags(byte_pos, highlight_spans, viewport_overlays);
-                        for tag in opening_tags {
-                            push_debug_tag(&mut line_spans, &mut line_view_map, tag);
-                        }
-                    }
-
-                    // Debug mode: show byte position before each character
-                    if debug_tracker.is_some() {
-                        if let Some(bp) = byte_pos {
-                            push_debug_tag(
-                                &mut line_spans,
-                                &mut line_view_map,
-                                format!("[{}]", bp),
-                            );
-                        }
-                    }
-
-                    // Use accumulator to merge consecutive chars with same style
-                    // This is critical for combining characters (Thai diacritics, etc.)
-                    for c in display_char.chars() {
-                        span_acc.push(c, style, byte_pos, &mut line_spans, &mut line_view_map);
-                    }
-
-                    // Debug mode: insert closing tags for spans ending at this position
-                    // Check using the NEXT byte position to see if we're leaving a span
-                    if let Some(ref mut tracker) = debug_tracker {
-                        // Flush before debug tags
-                        span_acc.flush(&mut line_spans, &mut line_view_map);
-                        // Look ahead to next byte position to determine closing tags
-                        let next_byte_pos = byte_pos.map(|bp| bp + ch.len_utf8());
-                        let closing_tags = tracker.get_closing_tags(next_byte_pos);
-                        for tag in closing_tags {
-                            push_debug_tag(&mut line_spans, &mut line_view_map, tag);
-                        }
-                    }
-                }
-
-                // Track cursor position for zero-width characters
-                // Zero-width chars don't get map entries, so we need to explicitly record cursor pos
-                if !have_cursor {
-                    if let Some(bp) = byte_pos {
-                        if bp == primary_cursor_position && char_width(ch) == 0 {
-                            // Account for horizontal scrolling by subtracting left_col
-                            cursor_screen_x =
-                                gutter_width as u16 + col_offset.saturating_sub(left_col) as u16;
-                            cursor_screen_y = lines.len() as u16;
-                            have_cursor = true;
-                        }
-                    }
-                }
-
-                if is_cursor && ch == '\n' {
-                    let should_add_indicator = if is_active { is_secondary_cursor } else { true };
-                    if should_add_indicator {
-                        // Flush accumulated text before adding cursor indicator
-                        // so the indicator appears after the line content, not before
-                        span_acc.flush(&mut line_spans, &mut line_view_map);
-                        let cursor_style = if is_active {
-                            Style::default()
-                                .fg(theme.editor_fg)
-                                .bg(theme.editor_bg)
-                                .add_modifier(Modifier::REVERSED)
-                        } else {
-                            Style::default()
-                                .fg(theme.editor_fg)
-                                .bg(theme.inactive_cursor)
-                        };
-                        push_span_with_map(
-                            &mut line_spans,
-                            &mut line_view_map,
-                            " ".to_string(),
-                            cursor_style,
-                            byte_pos,
-                        );
-                    }
-                }
-            }
-
-            byte_index += ch.len_utf8();
-            display_char_idx += 1; // Increment character index for next lookup
-                                   // col_offset tracks visual column position (for indexing into visual_to_char).
-                                   // We read the per-char visual column that view_pipeline assigned so that
-                                   // grapheme clusters (ZWJ emoji, base+combining, etc.) advance by
-                                   // `UnicodeWidthStr::width(cluster)` — the same width ratatui uses when
-                                   // re-segmenting spans — instead of summing per-codepoint `char_width`.
-                                   // Without this, the renderer's col_offset diverges from the view
-                                   // pipeline's for any cluster whose str_width ≠ Σ char_width, producing
-                                   // variable-width rendering corruption (issue #1577).
-            let next_col_for_char = line_char_visual_cols
-                .get(display_char_idx)
-                .copied()
-                .unwrap_or(line_total_visual_width);
-            let ch_width = next_col_for_char.saturating_sub(col_offset);
-            // `\n` gets visual width 1 from the view pipeline but renders as
-            // empty — don't count it as an on-screen cell.
-            let was_rendered = col_offset >= left_col && ch != '\n';
-            col_offset = next_col_for_char;
-            visible_char_count += ch_width;
-            if was_rendered {
-                rendered_cols += ch_width;
-            }
-        }
-
-        // Flush any remaining accumulated text at end of line
-        span_acc.flush(&mut line_spans, &mut line_view_map);
-
-        // Set last_seg_y early so cursor detection works for both empty and non-empty lines
-        // For lines without wrapping, this will be the final y position
-        // Also set for empty content lines (regardless of line_wrap) so cursor at EOF can be positioned
-        let content_is_empty = line_content.is_empty();
-        if line_spans.is_empty() || !line_wrap || content_is_empty {
-            last_seg_y = Some(lines.len() as u16);
-        }
+        // Per-cell pass: walk the line's characters and emit styled spans
+        let cells = render_line_cells(
+            CellPassInput {
+                state,
+                theme,
+                view_line: current_view_line,
+                selection,
+                decorations,
+                gutter_num,
+                current_row,
+                render_area,
+                gutter_width,
+                screen_width,
+                left_col,
+                max_chars_to_process,
+                lsp_waiting,
+                is_active,
+                session_mode,
+                is_on_cursor_line,
+                highlight_current_line,
+            },
+            &mut selection_sweep,
+            &mut overlay_sweep,
+            &mut span_cursors,
+            &mut cursor,
+            cell_theme_map.as_mut_slice(),
+            &mut line_spans,
+            &mut line_view_map,
+        );
+        let mut rendered_cols = cells.rendered_cols;
 
         if !line_has_newline {
-            let line_len_chars = line_content.chars().count();
-
-            // Map view positions to buffer positions using per-line char_source_bytes
-            let last_char_idx = line_len_chars.saturating_sub(1);
-            let after_last_char_idx = line_len_chars;
-
-            let last_char_buf_pos = line_char_source_bytes.get(last_char_idx).copied().flatten();
-            let after_last_char_buf_pos = line_char_source_bytes
-                .get(after_last_char_idx)
-                .copied()
-                .flatten();
-
-            let cursor_at_end = cursor_positions.iter().any(|&pos| {
-                // Cursor is "at end" only if it's AFTER the last character, not ON it.
-                // A cursor ON the last character should render on that character (handled in main loop).
-                let matches_after = after_last_char_buf_pos.is_some_and(|bp| pos == bp);
-                // Fallback: when there's no mapping after last char (EOF), check if cursor is after last char
-                // The fallback should match the position that would be "after" if there was a mapping.
-                // For empty lines with no source mappings (e.g. trailing empty line after final '\n'),
-                // the expected position is buffer.len() (EOF), not 0.
-                let expected_after_pos = last_char_buf_pos
-                    .map(|p| p + 1)
-                    .unwrap_or(state.buffer.len());
-                let matches_fallback =
-                    after_last_char_buf_pos.is_none() && pos == expected_after_pos;
-
-                matches_after || matches_fallback
-            });
-
-            if cursor_at_end {
-                // Primary cursor is at end only if AFTER the last char, not ON it
-                let is_primary_at_end = after_last_char_buf_pos
-                    .is_some_and(|bp| bp == primary_cursor_position)
-                    || (after_last_char_buf_pos.is_none()
-                        && primary_cursor_position >= state.buffer.len());
-
-                // Track cursor position for primary cursor
-                if let Some(seg_y) = last_seg_y {
-                    if is_primary_at_end {
-                        // Cursor position now includes gutter width (consistent with main cursor tracking)
-                        // For empty lines, cursor is at gutter width (right after gutter)
-                        // For non-empty lines without newline, cursor is after the last visible character
-                        // Account for horizontal scrolling by using col_offset - left_col
-                        cursor_screen_x = if line_len_chars == 0 {
-                            gutter_width as u16
-                        } else {
-                            // col_offset is the visual column after the last character
-                            // Subtract left_col to get the screen position after horizontal scroll
-                            gutter_width as u16 + col_offset.saturating_sub(left_col) as u16
-                        };
-                        cursor_screen_y = seg_y;
-                        have_cursor = true;
-                    }
-                }
-
-                // When software_cursor_only, always add the indicator space because
-                // the backend does not render a hardware cursor.  In terminal mode,
-                // the primary cursor at end-of-line relies on the hardware cursor.
-                let should_add_indicator = if is_active {
-                    software_cursor_only || !is_primary_at_end
-                } else {
-                    true
-                };
-                if should_add_indicator {
-                    let cursor_style = if is_active {
-                        Style::default()
-                            .fg(theme.editor_fg)
-                            .bg(theme.editor_bg)
-                            .add_modifier(Modifier::REVERSED)
-                    } else {
-                        Style::default()
-                            .fg(theme.editor_fg)
-                            .bg(theme.inactive_cursor)
-                    };
-                    push_span_with_map(
-                        &mut line_spans,
-                        &mut line_view_map,
-                        " ".to_string(),
-                        cursor_style,
-                        None,
-                    );
-                }
-            }
+            // The end-of-line cursor can only be placed on rows whose final
+            // screen y is already known: empty rows, unwrapped rows, or rows
+            // with empty content (wrapped non-empty rows may still grow).
+            let seg_y = (line_spans.is_empty() || !line_wrap || line_content.is_empty())
+                .then_some(current_row);
+            place_line_end_cursor(
+                &LineEndCursorInput {
+                    view_line: current_view_line,
+                    selection,
+                    buffer_len: state.buffer.len(),
+                    theme,
+                    is_active,
+                    software_cursor_only,
+                    gutter_width,
+                    left_col,
+                    col_offset: cells.col_offset,
+                    seg_y,
+                },
+                &mut cursor,
+                &mut line_spans,
+                &mut line_view_map,
+            );
         }
-
-        // ViewLines are already wrapped (Break tokens became newlines in ViewLineIterator)
-        // so each line is one visual line - no need to wrap again
-        let current_y = lines.len() as u16;
-        last_seg_y = Some(current_y);
 
         if !line_spans.is_empty() {
-            // Find cursor position and track last visible x by iterating through line_view_map
-            // Note: line_view_map includes both gutter and content character mappings
-            //
-            // When the cursor byte falls inside a concealed range (e.g. syntax markers
-            // hidden by compose-mode plugins), no view_map entry will exactly match
-            // primary_cursor_position.  In that case we fall back to the nearest
-            // visible byte that is >= the cursor byte on the same line — this keeps
-            // the cursor visible for the one frame between cursor movement and the
-            // plugin's conceal-refresh response.
-            //
-            // The fallback is gated by `is_on_cursor_line` so that lines below the
-            // cursor don't snap a phantom cursor onto themselves when the cursor's
-            // own line is offscreen (issue #1965: mouse-wheel scroll past the
-            // cursor drew a phantom cursor at the top of the new viewport).
-            let mut nearest_fallback: Option<(u16, usize)> = None; // (screen_x, byte_distance)
-            for (screen_x, source_offset) in line_view_map.iter().enumerate() {
-                if let Some(src) = source_offset {
-                    // Exact match: cursor byte is visible
-                    if *src == primary_cursor_position && !have_cursor {
-                        cursor_screen_x = screen_x as u16;
-                        cursor_screen_y = current_y;
-                        have_cursor = true;
-                    }
-                    // Track nearest visible byte >= cursor position for fallback
-                    if !have_cursor && is_on_cursor_line && *src >= primary_cursor_position {
-                        let dist = *src - primary_cursor_position;
-                        if nearest_fallback.is_none() || dist < nearest_fallback.unwrap().1 {
-                            nearest_fallback = Some((screen_x as u16, dist));
-                        }
-                    }
-                    last_visible_x = screen_x as u16;
-                }
-            }
-            // Fallback: cursor byte was concealed — snap to nearest visible byte
-            if !have_cursor {
-                if let Some((fallback_x, _)) = nearest_fallback {
-                    cursor_screen_x = fallback_x;
-                    cursor_screen_y = current_y;
-                    have_cursor = true;
-                }
+            if let Some(x) = locate_cursor_in_view_map(
+                &line_view_map,
+                primary_cursor_position,
+                is_on_cursor_line,
+                current_row,
+                &mut cursor,
+            ) {
+                last_visible_x = x;
             }
         }
+
+        let content_width = render_area.width.saturating_sub(gutter_width as u16) as usize;
+        let cursor_line_active = is_on_cursor_line && highlight_current_line && is_active;
 
         // Inline diagnostic text: render after line content (before extend_to_line_end fill).
         // Only for non-continuation lines that have a diagnostic overlay.
         if let Some(lsb) = line_start_byte {
             if let Some((message, diag_style)) = decorations.diagnostic_inline_texts.get(&lsb) {
-                let content_width = render_area.width.saturating_sub(gutter_width as u16) as usize;
-                let used = rendered_cols;
-                let available = content_width.saturating_sub(used);
-                let gap = 2usize;
-                let min_text = 10usize;
-
-                if available > gap + min_text {
-                    // Truncate message to fit
-                    let max_chars = available - gap;
-                    let display: String = if message.chars().count() > max_chars {
-                        let truncated: String =
-                            message.chars().take(max_chars.saturating_sub(1)).collect();
-                        format!("{}…", truncated)
-                    } else {
-                        message.clone()
-                    };
-                    let display_width = display.chars().count();
-
-                    // Right-align: fill gap between code and diagnostic text
-                    let padding = available.saturating_sub(display_width);
-                    let cursor_line_active =
-                        is_on_cursor_line && highlight_current_line && is_active;
-                    if padding > 0 {
-                        let pad_style = if cursor_line_active {
-                            Style::default().bg(theme.current_line_bg)
-                        } else {
-                            Style::default()
-                        };
-                        push_span_with_map(
-                            &mut line_spans,
-                            &mut line_view_map,
-                            " ".repeat(padding),
-                            pad_style,
-                            None,
-                        );
-                        rendered_cols += padding;
-                    }
-
-                    // Apply current line background to diagnostic text when on cursor line
-                    let effective_diag_style = if cursor_line_active && diag_style.bg.is_none() {
-                        diag_style.bg(theme.current_line_bg)
-                    } else {
-                        *diag_style
-                    };
-                    push_span_with_map(
-                        &mut line_spans,
-                        &mut line_view_map,
-                        display,
-                        effective_diag_style,
-                        None,
-                    );
-                    rendered_cols += display_width;
-                }
+                append_inline_diagnostic(
+                    message,
+                    diag_style,
+                    content_width,
+                    cursor_line_active,
+                    theme.current_line_bg,
+                    &mut rendered_cols,
+                    &mut line_spans,
+                    &mut line_view_map,
+                );
             }
         }
 
         // Paint trailing columns with the overlay-extend bg, or fall
         // back to the virtual-line bg. See `tail_fill` for the policy.
-        {
-            let content_width = render_area.width.saturating_sub(gutter_width as u16) as usize;
-            let remaining_cols = content_width.saturating_sub(rendered_cols);
-            if remaining_cols > 0 {
-                if let Some(fill) = resolve_tail_fill(TailFillInput {
-                    current_view_line,
-                    theme,
-                    overlay_fill: overlay_sweep.fill_overlay(),
-                    syntax_extend_bg,
-                    first_line_byte_pos,
-                    last_line_byte_pos,
-                }) {
-                    push_span_with_map(
-                        &mut line_spans,
-                        &mut line_view_map,
-                        " ".repeat(remaining_cols),
-                        fill.style,
-                        fill.source_byte,
-                    );
-                }
+        let remaining_cols = content_width.saturating_sub(rendered_cols);
+        if remaining_cols > 0 {
+            if let Some(fill) = resolve_tail_fill(TailFillInput {
+                current_view_line,
+                theme,
+                overlay_fill: overlay_sweep.fill_overlay(),
+                syntax_extend_bg: cells.syntax_extend_bg,
+                first_line_byte_pos: cells.first_line_byte_pos,
+                last_line_byte_pos: cells.last_line_byte_pos,
+            }) {
+                push_span_with_map(
+                    &mut line_spans,
+                    &mut line_view_map,
+                    " ".repeat(remaining_cols),
+                    fill.style,
+                    fill.source_byte,
+                );
             }
         }
 
         // Fill remaining width with current_line_bg for cursor line highlighting.
         // Add the span directly (not via push_span_with_map) to avoid extending
         // line_view_map, which would break mouse click byte mapping.
-        if is_on_cursor_line && highlight_current_line && is_active {
-            let content_width = render_area.width.saturating_sub(gutter_width as u16) as usize;
-            let remaining_cols = content_width.saturating_sub(rendered_cols);
-            if remaining_cols > 0 {
-                span_acc.flush(&mut line_spans, &mut line_view_map);
-                line_spans.push(Span::styled(
-                    " ".repeat(remaining_cols),
-                    Style::default().bg(theme.current_line_bg),
-                ));
-            }
+        if cursor_line_active && remaining_cols > 0 {
+            line_spans.push(Span::styled(
+                " ".repeat(remaining_cols),
+                Style::default().bg(theme.current_line_bg),
+            ));
         }
 
         // For virtual rows (no source bytes), inherit from previous row
@@ -1047,71 +470,13 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             .last()
             .map(|prev: &ViewLineMapping| prev.line_end_byte)
             .unwrap_or(0);
-
-        // Calculate line_end_byte for this line
-        let line_end_byte = if current_view_line.ends_with_newline {
-            // Position ON the newline - find the last source byte (the newline's position)
-            current_view_line
-                .char_source_bytes
-                .iter()
-                .rev()
-                .find_map(|m| *m)
-                .unwrap_or(prev_line_end_byte)
-        } else {
-            // Position AFTER the last character - find last source byte and add char length
-            if let Some((char_idx, &Some(last_byte_start))) = current_view_line
-                .char_source_bytes
-                .iter()
-                .enumerate()
-                .rev()
-                .find(|(_, m)| m.is_some())
-            {
-                // Get the character at this index to find its UTF-8 byte length
-                if let Some(last_char) = current_view_line.text.chars().nth(char_idx) {
-                    last_byte_start + last_char.len_utf8()
-                } else {
-                    last_byte_start
-                }
-            } else if matches!(current_view_line.line_start, LineStart::AfterSourceNewline)
-                && prev_line_end_byte + 2 >= state.buffer.len()
-            {
-                // Trailing empty line after the final source newline.
-                // The cursor on this line lives at buffer_len.
-                state.buffer.len()
-            } else {
-                // Virtual row with no source bytes (e.g. table border from conceals).
-                // Inherit line_end_byte from the previous row so cursor movement
-                // through virtual rows lands at a valid source position.
-                prev_line_end_byte
-            }
-        };
-
-        // Capture accurate view line mapping for mouse clicks
-        // Content mapping starts after the gutter
-        let content_map = if line_view_map.len() >= gutter_width {
-            line_view_map[gutter_width..].to_vec()
-        } else {
-            Vec::new()
-        };
-        // Mark plugin-injected virtual rows so `move_visual_line` can
-        // skip them.  Both the first row (AfterInjectedNewline) and any
-        // wrap continuations (AfterBreak whose content has no source
-        // bytes) belong to the virtual line.
-        let is_plugin_virtual =
-            matches!(
-                current_view_line.line_start,
-                LineStart::AfterInjectedNewline
-            ) || (matches!(current_view_line.line_start, LineStart::AfterBreak)
-                && !current_view_line
-                    .char_source_bytes
-                    .iter()
-                    .any(|b| b.is_some()));
-        view_line_mappings.push(ViewLineMapping {
-            char_source_bytes: content_map.clone(),
-            visual_to_char: (0..content_map.len()).collect(),
-            line_end_byte,
-            is_plugin_virtual,
-        });
+        view_line_mappings.push(build_view_line_mapping(
+            current_view_line,
+            &line_view_map,
+            gutter_width,
+            prev_line_end_byte,
+            state.buffer.len(),
+        ));
 
         // Track if line was empty before moving line_spans
         let line_was_empty = line_spans.is_empty();
@@ -1124,51 +489,45 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         // (same policy as the implicit empty line rendered below).
         let is_iterator_trailing_empty = line_content.is_empty()
             && !line_has_newline
-            && _line_start_type == LineStart::AfterSourceNewline;
+            && line_start_type == LineStart::AfterSourceNewline;
         if is_iterator_trailing_empty {
             trailing_empty_line_rendered = true;
         }
 
-        // Update last_line_end and check for cursor on newline BEFORE the break check
-        // This ensures the last visible line's metadata is captured
-        if let Some(y) = last_seg_y {
-            // end_x is the cursor position after the last visible character.
-            // For empty lines, last_visible_x stays at 0, so we need to ensure end_x is
-            // at least gutter_width to place the cursor after the gutter, not in it.
-            let end_x = if line_was_empty {
-                gutter_width as u16
-            } else {
-                last_visible_x.saturating_add(1)
-            };
-            let line_len_chars = line_content.chars().count();
+        // Update last_line_end and check for cursor on newline BEFORE the break check.
+        // This ensures the last visible line's metadata is captured.
+        //
+        // end_x is the cursor position after the last visible character.
+        // For empty lines, last_visible_x stays at 0, so we need to ensure end_x is
+        // at least gutter_width to place the cursor after the gutter, not in it.
+        let end_x = if line_was_empty {
+            gutter_width as u16
+        } else {
+            last_visible_x.saturating_add(1)
+        };
+        let line_len_chars = line_content.chars().count();
 
-            // Don't update last_line_end for the iterator's trailing empty
-            // line — it's a display aid, not actual content.
-            if !is_iterator_trailing_empty {
-                last_line_end = Some(LastLineEnd {
-                    pos: (end_x, y),
-                    terminated_with_newline: line_has_newline,
-                });
-            }
+        // Don't update last_line_end for the iterator's trailing empty
+        // line — it's a display aid, not actual content.
+        if !is_iterator_trailing_empty {
+            last_line_end = Some(LastLineEnd {
+                pos: (end_x, current_row),
+                terminated_with_newline: line_has_newline,
+            });
+        }
 
-            if line_has_newline && line_len_chars > 0 {
-                let newline_idx = line_len_chars.saturating_sub(1);
-                if let Some(Some(src_newline)) = line_char_source_bytes.get(newline_idx) {
-                    if *src_newline == primary_cursor_position {
-                        // Cursor position now includes gutter width (consistent with main cursor tracking)
-                        // For empty lines (just newline), cursor should be at gutter width (after gutter)
-                        // For lines with content, cursor on newline should be after the content
-                        if line_len_chars == 1 {
-                            // Empty line - just the newline character
-                            cursor_screen_x = gutter_width as u16;
-                            cursor_screen_y = y;
-                        } else {
-                            // Line has content before the newline - cursor after last char
-                            // end_x already includes gutter (from last_visible_x)
-                            cursor_screen_x = end_x;
-                            cursor_screen_y = y;
-                        }
-                        have_cursor = true;
+        if line_has_newline && line_len_chars > 0 {
+            let newline_idx = line_len_chars.saturating_sub(1);
+            if let Some(Some(src_newline)) = line_char_source_bytes.get(newline_idx) {
+                if *src_newline == primary_cursor_position {
+                    // Cursor position now includes gutter width (consistent with main cursor tracking).
+                    // For empty lines (just newline), cursor should be at gutter width (after gutter);
+                    // for lines with content, cursor on newline should be after the content
+                    // (end_x already includes the gutter, via last_visible_x).
+                    if line_len_chars == 1 {
+                        cursor.force(gutter_width as u16, current_row);
+                    } else {
+                        cursor.force(end_x, current_row);
                     }
                 }
             }
@@ -1204,9 +563,9 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             lines: &mut lines,
             view_line_mappings: &mut view_line_mappings,
             lines_rendered: &mut lines_rendered,
-            cursor_screen_x: &mut cursor_screen_x,
-            cursor_screen_y: &mut cursor_screen_y,
-            have_cursor: &mut have_cursor,
+            cursor_screen_x: &mut cursor.x,
+            cursor_screen_y: &mut cursor.y,
+            have_cursor: &mut cursor.found,
         },
     );
 
@@ -1215,9 +574,337 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
     LineRenderOutput {
         lines,
-        cursor: have_cursor.then_some((cursor_screen_x, cursor_screen_y)),
+        cursor: cursor.found.then_some((cursor.x, cursor.y)),
         last_line_end,
         content_lines_rendered: lines_rendered,
         view_line_mappings,
+    }
+}
+
+/// Fill the content area with default gutter/editor theme info so the
+/// theme inspector has an answer for cells the per-cell pass never touches.
+fn prefill_cell_theme_map(
+    cell_theme_map: &mut [crate::app::types::CellThemeInfo],
+    screen_width: u16,
+    render_area: Rect,
+    gutter_width: usize,
+) {
+    if screen_width == 0 {
+        return;
+    }
+    let gutter_info = crate::app::types::CellThemeInfo {
+        fg_key: Some("editor.line_number_fg"),
+        bg_key: Some("editor.line_number_bg"),
+        region: "Line Numbers",
+        syntax_category: None,
+    };
+    let content_info = crate::app::types::CellThemeInfo {
+        fg_key: Some("editor.fg"),
+        bg_key: Some("editor.bg"),
+        region: "Editor Content",
+        syntax_category: None,
+    };
+    let sw = screen_width as usize;
+    for row in render_area.y..render_area.y + render_area.height {
+        for col in render_area.x..render_area.x + render_area.width {
+            let idx = row as usize * sw + col as usize;
+            if let Some(cell) = cell_theme_map.get_mut(idx) {
+                *cell = if col < render_area.x + gutter_width as u16 {
+                    gutter_info.clone()
+                } else {
+                    content_info.clone()
+                };
+            }
+        }
+    }
+}
+
+/// Style for the software cursor indicator cell.
+fn cursor_indicator_style(theme: &Theme, is_active: bool) -> Style {
+    if is_active {
+        Style::default()
+            .fg(theme.editor_fg)
+            .bg(theme.editor_bg)
+            .add_modifier(Modifier::REVERSED)
+    } else {
+        Style::default()
+            .fg(theme.editor_fg)
+            .bg(theme.inactive_cursor)
+    }
+}
+
+/// Inputs for the cursor/indicator pass on a line without a trailing newline.
+struct LineEndCursorInput<'a> {
+    view_line: &'a ViewLine,
+    selection: &'a SelectionContext,
+    buffer_len: usize,
+    theme: &'a Theme,
+    is_active: bool,
+    software_cursor_only: bool,
+    gutter_width: usize,
+    left_col: usize,
+    /// Visual column after the last processed character.
+    col_offset: usize,
+    /// Row to place the cursor on, when already known (see call site).
+    seg_y: Option<u16>,
+}
+
+/// On a line that doesn't end with `\n`, place the cursor when it sits
+/// *after* the last character, and append the software cursor indicator
+/// when the hardware cursor won't be drawn there.
+fn place_line_end_cursor(
+    input: &LineEndCursorInput<'_>,
+    cursor: &mut CursorTracker,
+    line_spans: &mut Vec<Span<'static>>,
+    line_view_map: &mut Vec<Option<usize>>,
+) {
+    let line_content: &str = &input.view_line.text;
+    let line_char_source_bytes = &input.view_line.char_source_bytes;
+    let cursor_positions = &input.selection.cursor_positions;
+    let primary_cursor_position = input.selection.primary_cursor_position;
+
+    let line_len_chars = line_content.chars().count();
+
+    // Map view positions to buffer positions using per-line char_source_bytes
+    let last_char_idx = line_len_chars.saturating_sub(1);
+    let after_last_char_idx = line_len_chars;
+
+    let last_char_buf_pos = line_char_source_bytes.get(last_char_idx).copied().flatten();
+    let after_last_char_buf_pos = line_char_source_bytes
+        .get(after_last_char_idx)
+        .copied()
+        .flatten();
+
+    let cursor_at_end = cursor_positions.iter().any(|&pos| {
+        // Cursor is "at end" only if it's AFTER the last character, not ON it.
+        // A cursor ON the last character should render on that character (handled in cell pass).
+        let matches_after = after_last_char_buf_pos.is_some_and(|bp| pos == bp);
+        // Fallback: when there's no mapping after last char (EOF), check if cursor is after last char.
+        // The fallback should match the position that would be "after" if there was a mapping.
+        // For empty lines with no source mappings (e.g. trailing empty line after final '\n'),
+        // the expected position is buffer.len() (EOF), not 0.
+        let expected_after_pos = last_char_buf_pos.map(|p| p + 1).unwrap_or(input.buffer_len);
+        let matches_fallback = after_last_char_buf_pos.is_none() && pos == expected_after_pos;
+
+        matches_after || matches_fallback
+    });
+    if !cursor_at_end {
+        return;
+    }
+
+    // Primary cursor is at end only if AFTER the last char, not ON it
+    let is_primary_at_end = after_last_char_buf_pos.is_some_and(|bp| bp == primary_cursor_position)
+        || (after_last_char_buf_pos.is_none() && primary_cursor_position >= input.buffer_len);
+
+    // Track cursor position for primary cursor
+    if let Some(seg_y) = input.seg_y {
+        if is_primary_at_end {
+            // Cursor position includes gutter width (consistent with main cursor tracking).
+            // For empty lines, cursor is at gutter width (right after gutter);
+            // for non-empty lines without newline, cursor is after the last visible character.
+            let x = if line_len_chars == 0 {
+                input.gutter_width as u16
+            } else {
+                // col_offset is the visual column after the last character.
+                // Subtract left_col to get the screen position after horizontal scroll.
+                input.gutter_width as u16 + input.col_offset.saturating_sub(input.left_col) as u16
+            };
+            cursor.force(x, seg_y);
+        }
+    }
+
+    // When software_cursor_only, always add the indicator space because
+    // the backend does not render a hardware cursor.  In terminal mode,
+    // the primary cursor at end-of-line relies on the hardware cursor.
+    let should_add_indicator = if input.is_active {
+        input.software_cursor_only || !is_primary_at_end
+    } else {
+        true
+    };
+    if should_add_indicator {
+        push_span_with_map(
+            line_spans,
+            line_view_map,
+            " ".to_string(),
+            cursor_indicator_style(input.theme, input.is_active),
+            None,
+        );
+    }
+}
+
+/// Scan a rendered line's view map for the primary cursor and the line's
+/// last visible cell.
+///
+/// When the cursor byte falls inside a concealed range (e.g. syntax markers
+/// hidden by compose-mode plugins), no view-map entry will exactly match
+/// `primary_cursor_position`.  In that case we fall back to the nearest
+/// visible byte that is >= the cursor byte on the same line — this keeps
+/// the cursor visible for the one frame between cursor movement and the
+/// plugin's conceal-refresh response.
+///
+/// The fallback is gated by `is_on_cursor_line` so that lines below the
+/// cursor don't snap a phantom cursor onto themselves when the cursor's
+/// own line is offscreen (issue #1965: mouse-wheel scroll past the
+/// cursor drew a phantom cursor at the top of the new viewport).
+///
+/// Returns the x of the last visible cell, if any.
+fn locate_cursor_in_view_map(
+    line_view_map: &[Option<usize>],
+    primary_cursor_position: usize,
+    is_on_cursor_line: bool,
+    current_row: u16,
+    cursor: &mut CursorTracker,
+) -> Option<u16> {
+    let mut nearest_fallback: Option<(u16, usize)> = None; // (screen_x, byte_distance)
+    let mut last_visible_x: Option<u16> = None;
+    for (screen_x, source_offset) in line_view_map.iter().enumerate() {
+        if let Some(src) = source_offset {
+            // Exact match: cursor byte is visible
+            if *src == primary_cursor_position {
+                cursor.place(screen_x as u16, current_row);
+            }
+            // Track nearest visible byte >= cursor position for fallback
+            if !cursor.found && is_on_cursor_line && *src >= primary_cursor_position {
+                let dist = *src - primary_cursor_position;
+                if nearest_fallback.is_none_or(|(_, best)| dist < best) {
+                    nearest_fallback = Some((screen_x as u16, dist));
+                }
+            }
+            last_visible_x = Some(screen_x as u16);
+        }
+    }
+    // Fallback: cursor byte was concealed — snap to nearest visible byte
+    if let Some((fallback_x, _)) = nearest_fallback {
+        cursor.place(fallback_x, current_row);
+    }
+    last_visible_x
+}
+
+/// Right-align an inline diagnostic message after the line's content.
+/// No-op when there isn't room for a meaningful amount of text.
+#[allow(clippy::too_many_arguments)]
+fn append_inline_diagnostic(
+    message: &str,
+    diag_style: &Style,
+    content_width: usize,
+    cursor_line_active: bool,
+    current_line_bg: Color,
+    rendered_cols: &mut usize,
+    line_spans: &mut Vec<Span<'static>>,
+    line_view_map: &mut Vec<Option<usize>>,
+) {
+    let available = content_width.saturating_sub(*rendered_cols);
+    let gap = 2usize;
+    let min_text = 10usize;
+    if available <= gap + min_text {
+        return;
+    }
+
+    // Truncate message to fit
+    let max_chars = available - gap;
+    let display: String = if message.chars().count() > max_chars {
+        let truncated: String = message.chars().take(max_chars.saturating_sub(1)).collect();
+        format!("{}…", truncated)
+    } else {
+        message.to_string()
+    };
+    let display_width = display.chars().count();
+
+    // Right-align: fill gap between code and diagnostic text
+    let padding = available.saturating_sub(display_width);
+    if padding > 0 {
+        let pad_style = if cursor_line_active {
+            Style::default().bg(current_line_bg)
+        } else {
+            Style::default()
+        };
+        push_span_with_map(
+            line_spans,
+            line_view_map,
+            " ".repeat(padding),
+            pad_style,
+            None,
+        );
+        *rendered_cols += padding;
+    }
+
+    // Apply current line background to diagnostic text when on cursor line
+    let effective_diag_style = if cursor_line_active && diag_style.bg.is_none() {
+        diag_style.bg(current_line_bg)
+    } else {
+        *diag_style
+    };
+    push_span_with_map(
+        line_spans,
+        line_view_map,
+        display,
+        effective_diag_style,
+        None,
+    );
+    *rendered_cols += display_width;
+}
+
+/// Build the mouse-click/cursor-movement mapping for a rendered row.
+fn build_view_line_mapping(
+    view_line: &ViewLine,
+    line_view_map: &[Option<usize>],
+    gutter_width: usize,
+    prev_line_end_byte: usize,
+    buffer_len: usize,
+) -> ViewLineMapping {
+    let line_end_byte = if view_line.ends_with_newline {
+        // Position ON the newline - find the last source byte (the newline's position)
+        view_line
+            .char_source_bytes
+            .iter()
+            .rev()
+            .find_map(|m| *m)
+            .unwrap_or(prev_line_end_byte)
+    } else if let Some((char_idx, &Some(last_byte_start))) = view_line
+        .char_source_bytes
+        .iter()
+        .enumerate()
+        .rev()
+        .find(|(_, m)| m.is_some())
+    {
+        // Position AFTER the last character - find last source byte and add char length
+        if let Some(last_char) = view_line.text.chars().nth(char_idx) {
+            last_byte_start + last_char.len_utf8()
+        } else {
+            last_byte_start
+        }
+    } else if matches!(view_line.line_start, LineStart::AfterSourceNewline)
+        && prev_line_end_byte + 2 >= buffer_len
+    {
+        // Trailing empty line after the final source newline.
+        // The cursor on this line lives at buffer_len.
+        buffer_len
+    } else {
+        // Virtual row with no source bytes (e.g. table border from conceals).
+        // Inherit line_end_byte from the previous row so cursor movement
+        // through virtual rows lands at a valid source position.
+        prev_line_end_byte
+    };
+
+    // Content mapping starts after the gutter
+    let content_map = if line_view_map.len() >= gutter_width {
+        line_view_map[gutter_width..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    // Mark plugin-injected virtual rows so `move_visual_line` can
+    // skip them.  Both the first row (AfterInjectedNewline) and any
+    // wrap continuations (AfterBreak whose content has no source
+    // bytes) belong to the virtual line.
+    let is_plugin_virtual = matches!(view_line.line_start, LineStart::AfterInjectedNewline)
+        || (matches!(view_line.line_start, LineStart::AfterBreak)
+            && !view_line.char_source_bytes.iter().any(|b| b.is_some()));
+
+    ViewLineMapping {
+        visual_to_char: (0..content_map.len()).collect(),
+        char_source_bytes: content_map,
+        line_end_byte,
+        is_plugin_virtual,
     }
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_hunk_parity.rs
@@ -400,7 +400,14 @@ fn test_review_comments_rail_is_narrow() {
     init_tracing_from_env();
     let repo = repo_with_modification();
     let mut harness = harness_for(&repo);
-    let screen = open_review_diff(&mut harness);
+    open_review_diff(&mut harness);
+
+    // The comments rail is populated asynchronously after the hint bar
+    // appears — wait for its header rather than reading the first frame.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("COMMENTS"))
+        .unwrap();
+    let screen = harness.screen_to_string();
 
     // Find the row carrying the COMMENTS header and locate its column.
     let row = screen


### PR DESCRIPTION
## Why this file

`render_view_lines` in `view/ui/split_rendering/orchestration/render_line/mod.rs` was a single **1,137-line function** — the largest function in the codebase by a wide margin (the runner-up is 444 lines). One loop body interleaved a dozen concerns: per-cell styling, ANSI parsing, five separate cursor-placement code paths, whitespace indicators, inline diagnostics, tail fills, and mouse-mapping bookkeeping. Notably, the *surrounding* module is already well-factored into concern-scoped passes (`char_style`, `gutter`, `spans`, `overlay_sweep`, `tail_fill`, `trailing`) — this function was the last holdout.

The file is not touched by any of the 50 open PRs (verified by diffing every open PR head against its merge base), so this refactor doesn't step on in-flight work.

## What changed

Pure code motion + dedup; **no behavior changes intended.**

**Commit 1 — decompose `render_view_lines`:**
- **New `render_line/cells.rs`** owns the per-cell character loop, mirroring the existing `trailing.rs` pattern.
- **Cursor tracking unified** behind a small `CursorTracker` (`place` = keep first hit, `force` = re-derive at line end), replacing the `cursor_screen_x` / `cursor_screen_y` / `have_cursor` triple that was threaded through every phase.
- **Cohesive helpers extracted** from the loop body: `place_line_end_cursor`, `locate_cursor_in_view_map`, `append_inline_diagnostic`, `build_view_line_mapping` (pure), `prefill_cell_theme_map`.
- **Deduped copy-paste**: the cursor-indicator style (repeated twice) and the tab/space whitespace-indicator position classification (two near-identical 15-line match blocks).
- **Dead code removed**: `_source_byte_at_col` closure, `_last_seg_width`, the unused `peekable()`, the `last_seg_y` variable (always `Some(current_row)` by the time it was read unconditionally), and `ViewAnchor::start_line_skip` (always 0, never read — its only "use" was a `let _ =` suppressing the dead-code warning). Also dropped a redundant `clone()` when building `ViewLineMapping`.

**Commit 2 — split the cell loop itself:** the extracted loop was still one ~370-line function, so it's now a per-line `CellPass` state machine whose methods each own one per-cell concern:
- `process_char` — byte/overlay tracking, ANSI skip path, long-line cap
- `render_visible_cell` — orchestrates one on-screen cell (~45 lines)
- `cursor_hits_cell` — cursor detection incl. tab-expansion dedup, flattened with guard clauses
- `resolve_cell_style` — token/ANSI/syntax/semantic/overlay layering + row-wide diff bg capture
- `record_cell_theme`, `display_cell_text`, `emit_cell`, `place_cell_cursor`, `advance` — theme-inspector map, whitespace indicators, span emission with debug reveal codes, trailing cursor cases, position bookkeeping

`render_view_lines` is now a ~460-line orchestrator of named passes, `render_line_cells` is ~50 lines of setup plus the char loop, and every method is under 100 lines. All original comments (issue references #1790, #1965, #1577, #614, etc.) are preserved at their new locations.

## Verification

- `cargo build` / `cargo check --lib --tests` clean; no new warnings (the extraction surfaced that `start_line_skip` was dead, which was then removed rather than re-suppressed).
- `cargo fmt` applied; zero clippy warnings in the touched files (`clippy --fix` produced no changes).
- Transplanted logic was diffed line-by-line (whitespace/comment-normalized) against the original to confirm fidelity; the existing render unit tests in `split_rendering/mod.rs` exercise `render_view_lines` directly in CI.

https://claude.ai/code/session_01KyqC3dWpGCN73qWP1e4uBv