### PR TITLE
Add ColorTransition animation for smooth theme switching

### DIFF
--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -1576,6 +1576,7 @@ impl Editor {
                 if old_theme != self.config.theme {
                     if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
                         *self.theme.write().unwrap() = theme;
+                        self.start_theme_transition_animation();
                     }
                 }
                 *self.keybindings.write().unwrap() =

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -115,6 +115,7 @@ impl Editor {
         if old_theme != self.config.theme {
             if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
                 *self.theme.write().unwrap() = theme;
+                self.start_theme_transition_animation();
                 tracing::info!("Theme changed to '{}'", self.config.theme.0);
             } else {
                 tracing::error!("Theme '{}' not found", self.config.theme.0);

--- a/crates/fresh-editor/src/app/settings_prompts.rs
+++ b/crates/fresh-editor/src/app/settings_prompts.rs
@@ -403,11 +403,36 @@ impl Editor {
         }
     }
 
+    /// Kick off a full-screen color-transition animation so the theme
+    /// switch crossfades into the new palette instead of flipping. Call
+    /// right after swapping `self.theme`: the effect snapshots the
+    /// previous frame (old colors) at the top of the next render and
+    /// blends every cell's fg/bg toward the freshly painted new colors.
+    ///
+    /// No-op when animations are disabled in config or nothing has been
+    /// rendered yet (there is no old frame to fade from).
+    pub(crate) fn start_theme_transition_animation(&mut self) {
+        if !self.config.editor.animations {
+            return;
+        }
+        let animations = &mut self.active_window_mut().animations;
+        let Some(area) = animations.last_frame_area() else {
+            return;
+        };
+        animations.start(
+            area,
+            crate::view::animation::AnimationKind::ColorTransition {
+                duration: std::time::Duration::from_millis(200),
+            },
+        );
+    }
+
     /// Apply a theme by key (or name for backward compat) and persist to config
     pub(super) fn apply_theme(&mut self, key_or_name: &str) {
         if !key_or_name.is_empty() {
             if let Some(theme) = self.theme_registry.get_cloned(key_or_name) {
                 *self.theme.write().unwrap() = theme;
+                self.start_theme_transition_animation();
 
                 // Set terminal cursor color to match theme
                 self.theme.read().unwrap().set_terminal_cursor_color();
@@ -519,6 +544,10 @@ impl Editor {
             if let Some(theme) = self.theme_registry.get_cloned(key_or_name) {
                 if theme.name != self.theme.read().unwrap().name {
                     *self.theme.write().unwrap() = theme;
+                    // Crossfade previews too — rapid navigation is fine:
+                    // a new transition replaces the in-flight one and
+                    // fades from whatever is on screen right now.
+                    self.start_theme_transition_animation();
                     self.theme.read().unwrap().set_terminal_cursor_color();
                     self.reapply_all_overlays();
                 }

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -366,6 +366,7 @@ impl Editor {
         if old_theme != self.config.theme {
             if let Some(theme) = self.theme_registry.get_cloned(&self.config.theme) {
                 *self.theme.write().unwrap() = theme;
+                self.start_theme_transition_animation();
                 tracing::info!("Theme changed to '{}'", self.config.theme.0);
             } else {
                 tracing::error!("Theme '{}' not found", self.config.theme.0);

--- a/crates/fresh-editor/src/view/animation.rs
+++ b/crates/fresh-editor/src/view/animation.rs
@@ -6,7 +6,8 @@
 //! active effects from the render clock. The layer knows nothing about
 //! virtual buffers; callers resolve areas and pass them in.
 //!
-//! Current effects: `SlideIn` only. Easing is an implementation detail.
+//! Current effects: `SlideIn`, `CursorJump`, `ColorTransition`. Easing is
+//! an implementation detail.
 
 use ratatui::buffer::{Buffer, Cell};
 use ratatui::layout::Rect;
@@ -46,6 +47,12 @@ pub enum AnimationKind {
         cursor_color: Color,
         bg_color: Color,
     },
+    /// Crossfade every cell's fg/bg color from what was on screen last
+    /// frame to the freshly painted colors. Glyphs are untouched — only
+    /// colors interpolate — so a theme switch melts into the new palette
+    /// instead of flipping. Cells whose colors can't be resolved to RGB
+    /// (`Reset` / indexed) switch instantly.
+    ColorTransition { duration: Duration },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -346,6 +353,80 @@ impl FrameEffect for CursorJump {
     }
 }
 
+/// Color-transition effect. Snapshots the previous frame (the colors the
+/// user was looking at before the switch) and, on every render while
+/// running, re-tints the freshly painted buffer: each cell's fg/bg is the
+/// blend of its old color and its new color at the eased progress. The
+/// paint pass keeps drawing pure new-theme colors underneath, so content
+/// changes mid-transition (typing, cursor) stay live; only the tint lags.
+pub struct ColorTransition {
+    duration: Duration,
+    before: Option<SlideSnapshot>,
+}
+
+impl ColorTransition {
+    pub fn new(duration: Duration) -> Self {
+        Self {
+            duration,
+            before: None,
+        }
+    }
+}
+
+impl FrameEffect for ColorTransition {
+    fn capture_before(&mut self, buf: &Buffer, area: Rect) {
+        if self.before.is_none() {
+            self.before = Some(SlideIn::snapshot_area(buf, area));
+        }
+    }
+
+    fn apply(&mut self, buf: &mut Buffer, area: Rect, elapsed: Duration) -> EffectStatus {
+        let t = if self.duration.is_zero() {
+            1.0
+        } else {
+            (elapsed.as_secs_f32() / self.duration.as_secs_f32()).clamp(0.0, 1.0)
+        };
+        // Final frame: the buffer already holds pure new-theme colors, so
+        // leave it untouched and report Done (same contract as CursorJump —
+        // no further redraw is scheduled after the runner drops us).
+        if t >= 1.0 {
+            return EffectStatus::Done;
+        }
+        // Nothing to fade from: no frame was rendered before the switch,
+        // or a resize invalidated the snapshot. Snap to the new colors.
+        let Some(before) = self.before.as_ref().filter(|b| b.area == area) else {
+            return EffectStatus::Done;
+        };
+
+        let eased = ease_out_cubic(t);
+        for dy in 0..area.height {
+            for dx in 0..area.width {
+                let idx = dy as usize * area.width as usize + dx as usize;
+                let old = &before.cells[idx];
+                let Some(cell) = buf.cell_mut((area.x + dx, area.y + dy)) else {
+                    continue;
+                };
+                if let (Some(new_rgb), Some(old_rgb)) =
+                    (color_to_rgb(cell.fg), color_to_rgb(old.fg))
+                {
+                    if new_rgb != old_rgb {
+                        cell.set_fg(blend_rgb(new_rgb, old_rgb, eased));
+                    }
+                }
+                if let (Some(new_rgb), Some(old_rgb)) =
+                    (color_to_rgb(cell.bg), color_to_rgb(old.bg))
+                {
+                    if new_rgb != old_rgb {
+                        cell.set_bg(blend_rgb(new_rgb, old_rgb, eased));
+                    }
+                }
+            }
+        }
+
+        EffectStatus::Running
+    }
+}
+
 fn blend_rgb(fg: (u8, u8, u8), bg: (u8, u8, u8), alpha: f32) -> Color {
     let a = alpha.clamp(0.0, 1.0);
     let mix = |f: u8, b: u8| -> u8 {
@@ -470,6 +551,11 @@ impl AnimationRunner {
                     Duration::ZERO,
                     duration,
                 ),
+                AnimationKind::ColorTransition { duration } => (
+                    Box::new(ColorTransition::new(duration)),
+                    Duration::ZERO,
+                    duration,
+                ),
             };
         self.total_started += 1;
         self.active.push(ActiveEffect {
@@ -550,6 +636,14 @@ impl AnimationRunner {
 
     pub fn next_deadline(&self) -> Option<Instant> {
         self.active.iter().map(|e| e.deadline).min()
+    }
+
+    /// Area of the cached last-frame buffer, i.e. the full screen as of
+    /// the previous render. `None` until the first frame has been drawn.
+    /// Full-screen effects (theme color transition) use this as their
+    /// Rect so callers don't need to thread the terminal size through.
+    pub fn last_frame_area(&self) -> Option<Rect> {
+        self.last_frame.as_ref().map(|b| b.area)
     }
 
     /// True if `(col, row)` falls inside the area of any running effect.
@@ -996,6 +1090,185 @@ mod tests {
             "cursor jump should complete after duration"
         );
         let _ = id;
+    }
+
+    fn paint_colors(buf: &mut Buffer, area: Rect, fg: Color, bg: Color) {
+        for dy in 0..area.height {
+            for dx in 0..area.width {
+                if let Some(cell) = buf.cell_mut((area.x + dx, area.y + dy)) {
+                    cell.set_symbol("x");
+                    cell.set_fg(fg);
+                    cell.set_bg(bg);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn color_transition_starts_at_old_colors() {
+        let area = Rect::new(0, 0, 3, 2);
+        let mut old = make_buf(3, 2);
+        paint_colors(
+            &mut old,
+            area,
+            Color::Rgb(200, 100, 0),
+            Color::Rgb(10, 20, 30),
+        );
+        let mut new = make_buf(3, 2);
+        paint_colors(
+            &mut new,
+            area,
+            Color::Rgb(0, 100, 200),
+            Color::Rgb(90, 80, 70),
+        );
+
+        let mut effect = ColorTransition::new(Duration::from_millis(100));
+        effect.capture_before(&old, area);
+        let status = effect.apply(&mut new, area, Duration::ZERO);
+        assert_eq!(status, EffectStatus::Running);
+        let cell = new.cell((0, 0)).unwrap();
+        assert_eq!(cell.fg, Color::Rgb(200, 100, 0), "t=0 shows old fg");
+        assert_eq!(cell.bg, Color::Rgb(10, 20, 30), "t=0 shows old bg");
+        assert_eq!(cell.symbol(), "x", "glyphs are not touched");
+    }
+
+    #[test]
+    fn color_transition_blends_mid_flight() {
+        let area = Rect::new(0, 0, 2, 2);
+        let mut old = make_buf(2, 2);
+        paint_colors(&mut old, area, Color::Rgb(255, 0, 0), Color::Rgb(0, 0, 0));
+        let mut new = make_buf(2, 2);
+        paint_colors(
+            &mut new,
+            area,
+            Color::Rgb(0, 0, 0),
+            Color::Rgb(255, 255, 255),
+        );
+
+        let mut effect = ColorTransition::new(Duration::from_millis(100));
+        effect.capture_before(&old, area);
+        let status = effect.apply(&mut new, area, Duration::from_millis(50));
+        assert_eq!(status, EffectStatus::Running);
+        let cell = new.cell((1, 1)).unwrap();
+        match cell.fg {
+            Color::Rgb(r, g, b) => {
+                assert!(r > 0 && r < 255, "fg red mid-blend, got {}", r);
+                assert_eq!((g, b), (0, 0));
+            }
+            other => panic!("expected RGB fg, got {:?}", other),
+        }
+        match cell.bg {
+            Color::Rgb(r, g, b) => {
+                assert!(r > 0 && r < 255, "bg mid-blend, got {}", r);
+                assert_eq!(r, g);
+                assert_eq!(g, b);
+            }
+            other => panic!("expected RGB bg, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn color_transition_final_frame_is_untouched() {
+        // At t>=duration the buffer must keep its pure new-theme colors —
+        // the runner drops the effect after this call and no further
+        // redraw is scheduled, so any tint painted now would stick.
+        let area = Rect::new(0, 0, 2, 2);
+        let mut old = make_buf(2, 2);
+        paint_colors(&mut old, area, Color::Rgb(255, 0, 0), Color::Rgb(0, 0, 0));
+        let mut new = make_buf(2, 2);
+        paint_colors(&mut new, area, Color::Rgb(1, 2, 3), Color::Rgb(4, 5, 6));
+
+        let mut effect = ColorTransition::new(Duration::from_millis(100));
+        effect.capture_before(&old, area);
+        let status = effect.apply(&mut new, area, Duration::from_millis(100));
+        assert_eq!(status, EffectStatus::Done);
+        let cell = new.cell((0, 1)).unwrap();
+        assert_eq!(cell.fg, Color::Rgb(1, 2, 3));
+        assert_eq!(cell.bg, Color::Rgb(4, 5, 6));
+    }
+
+    #[test]
+    fn color_transition_without_before_snapshot_is_done() {
+        let area = Rect::new(0, 0, 2, 2);
+        let mut new = make_buf(2, 2);
+        paint_colors(&mut new, area, Color::Rgb(1, 2, 3), Color::Rgb(4, 5, 6));
+
+        let mut effect = ColorTransition::new(Duration::from_millis(100));
+        let status = effect.apply(&mut new, area, Duration::ZERO);
+        assert_eq!(status, EffectStatus::Done, "no old frame — snap to new");
+        let cell = new.cell((0, 0)).unwrap();
+        assert_eq!(cell.fg, Color::Rgb(1, 2, 3));
+        assert_eq!(cell.bg, Color::Rgb(4, 5, 6));
+    }
+
+    #[test]
+    fn color_transition_leaves_unresolvable_colors_alone() {
+        // Reset has no RGB equivalent — those cells must flip instantly
+        // rather than blend through a bogus fallback color.
+        let area = Rect::new(0, 0, 1, 1);
+        let mut old = make_buf(1, 1);
+        paint_colors(&mut old, area, Color::Reset, Color::Rgb(0, 0, 0));
+        let mut new = make_buf(1, 1);
+        paint_colors(&mut new, area, Color::Rgb(10, 10, 10), Color::Reset);
+
+        let mut effect = ColorTransition::new(Duration::from_millis(100));
+        effect.capture_before(&old, area);
+        effect.apply(&mut new, area, Duration::from_millis(50));
+        let cell = new.cell((0, 0)).unwrap();
+        assert_eq!(
+            cell.fg,
+            Color::Rgb(10, 10, 10),
+            "old fg was Reset — no blend"
+        );
+        assert_eq!(cell.bg, Color::Reset, "new bg is Reset — no blend");
+    }
+
+    #[test]
+    fn color_transition_through_runner_uses_cached_frame() {
+        // Frame 1: old-theme colors, no effects — runner caches the frame.
+        let area = Rect::new(0, 0, 3, 2);
+        let mut runner = AnimationRunner::new();
+        let mut frame1 = make_buf(3, 2);
+        paint_colors(
+            &mut frame1,
+            area,
+            Color::Rgb(255, 0, 0),
+            Color::Rgb(0, 0, 255),
+        );
+        runner.apply_all(&mut frame1);
+        assert_eq!(runner.last_frame_area(), Some(area));
+
+        // Frame 2: theme switched — start the transition, capture the old
+        // frame from the cache, paint new-theme colors, apply. Right after
+        // start (t≈0) the visible colors must still be (close to) the old
+        // ones, not the new ones.
+        runner.start(
+            area,
+            AnimationKind::ColorTransition {
+                duration: Duration::from_secs(3600),
+            },
+        );
+        runner.capture_before_all();
+        let mut frame2 = make_buf(3, 2);
+        paint_colors(
+            &mut frame2,
+            area,
+            Color::Rgb(0, 255, 0),
+            Color::Rgb(255, 255, 0),
+        );
+        runner.apply_all(&mut frame2);
+        assert!(runner.is_active());
+
+        let cell = frame2.cell((1, 1)).unwrap();
+        let Color::Rgb(r, g, _) = cell.fg else {
+            panic!("expected RGB fg, got {:?}", cell.fg);
+        };
+        assert!(
+            r > 200 && g < 55,
+            "right after start the fg should still be mostly the old red, got ({}, {})",
+            r,
+            g
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/audit_mode.rs
@@ -2878,6 +2878,10 @@ fn start_server(config: Config) {
     // Start in the dark theme so we have well-known expected colors.
     let mut config = Config::default();
     config.theme = "dark".into();
+    // The theme switch below kicks off a color-transition crossfade; the
+    // assertions check settled colors, so disable animations (the harness
+    // only does this automatically when no custom config is passed).
+    config.editor.animations = false;
 
     let mut harness =
         EditorTestHarness::with_config_and_working_dir(140, 40, config, repo.path.clone()).unwrap();

--- a/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/theme_editor.rs
@@ -4047,6 +4047,10 @@ fn test_theme_editor_colors_update_on_theme_change() {
 
     let mut config = fresh::config::Config::default();
     config.theme = "dark".into();
+    // The theme switch below kicks off a color-transition crossfade; the
+    // assertions check settled colors, so disable animations (the harness
+    // only does this automatically when no custom config is passed).
+    config.editor.animations = false;
 
     let mut harness =
         EditorTestHarness::with_config_and_working_dir(140, 40, config, project_root).unwrap();

--- a/crates/fresh-editor/tests/e2e/theme.rs
+++ b/crates/fresh-editor/tests/e2e/theme.rs
@@ -758,6 +758,10 @@ fn test_diagnostic_overlay_colors_update_on_theme_change() -> anyhow::Result<()>
 
     let mut config = Config::default();
     config.theme = "dark".into();
+    // The theme switch below kicks off a color-transition crossfade; the
+    // assertions check settled colors, so disable animations (the harness
+    // only does this automatically when no custom config is passed).
+    config.editor.animations = false;
     config.lsp.insert(
         "rust".to_string(),
         fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {


### PR DESCRIPTION
## Summary
Adds a new `ColorTransition` animation effect that smoothly crossfades colors when switching themes, instead of the colors flipping instantly. The effect preserves glyphs and only interpolates foreground and background colors, allowing theme changes to "melt" into the new palette.

## Key Changes

- **New `ColorTransition` animation variant**: Added to `AnimationKind` enum with configurable duration
- **`ColorTransition` effect implementation**: 
  - Snapshots the previous frame's colors before the theme switch
  - Blends each cell's fg/bg from old to new colors using cubic easing
  - Handles unresolvable colors (Reset, indexed) by switching them instantly
  - Leaves glyphs untouched during the transition
  - Respects the final frame contract (returns `Done` at t≥duration so no further redraws occur)

- **Animation runner enhancements**:
  - Added `last_frame_area()` method to expose the cached frame's area for full-screen effects
  - Integrated `ColorTransition` into the effect spawning logic

- **Theme switching integration**:
  - New `start_theme_transition_animation()` method in Editor that kicks off the color transition
  - Called after theme application in `apply_theme()`, theme preview navigation, and config-based theme loading
  - Respects the animations config flag and gracefully handles cases where no frame has been rendered yet

- **Comprehensive test coverage**: Added 6 tests covering:
  - Initial state (old colors at t=0)
  - Mid-flight blending
  - Final frame preservation
  - Missing snapshot handling
  - Unresolvable color handling
  - Integration through the animation runner

## Implementation Details

The effect uses the existing `SlideSnapshot` infrastructure to cache cell colors from the previous frame. During application, it iterates through the affected area and blends RGB values using `ease_out_cubic` easing. The blend only occurs when both old and new colors can be resolved to RGB; otherwise, the new color is used immediately. This ensures theme switches feel smooth while maintaining correctness for terminal colors that don't have RGB equivalents.

https://claude.ai/code/session_01D7rxREzTytfcjKbGpA2Bqn