### PR TITLE
fix(devcontainer): probe the CLI directly instead of shelling out to `which`

### DIFF
--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -1704,10 +1704,34 @@ async function runInitializeCommand(): Promise<boolean> {
   return true;
 }
 
+/// Resolve a spawnable devcontainer CLI command name, or null when
+/// none is found. Probes by running `<candidate> --version` through
+/// the same spawn machinery the actual `devcontainer up` uses, instead
+/// of shelling out to `which`: native Windows ships no `which` utility
+/// at all, so that probe reported "CLI Not Found" there regardless of
+/// installation method (#2201) — and even on Unix it answers the wrong
+/// question ("can `which` find the name?" rather than "can we spawn
+/// it?").
+///
+/// `devcontainer.cmd` covers npm's Windows shim: process spawning
+/// resolves `.exe` from PATH (e.g. Bun's shim) but never `.cmd`, which
+/// needs to be named explicitly. Probing it on platforms where it
+/// doesn't exist is a fast spawn failure — same fire-all-candidates
+/// pattern as dashboard's `openUrl`.
+async function resolveDevcontainerBin(): Promise<string | null> {
+  for (const bin of ["devcontainer", "devcontainer.cmd"]) {
+    const probe = await editor.spawnHostProcess(bin, ["--version"]);
+    if (probe.exit_code === 0) {
+      return bin;
+    }
+  }
+  return null;
+}
+
 async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
   const cwd = editor.getCwd();
-  const which = await editor.spawnHostProcess("which", ["devcontainer"]);
-  if (which.exit_code !== 0) {
+  const devcontainerBin = await resolveDevcontainerBin();
+  if (devcontainerBin === null) {
     showCliNotFoundPopup();
     return;
   }
@@ -1769,16 +1793,19 @@ async function runDevcontainerUp(extraArgs: string[]): Promise<void> {
   // continues either way.
   openBuildLogInSplit(logPath);
 
-  // `sh -c 'exec devcontainer "$@" 2> "$LOG"' sh <log> <args...>` —
-  // positional-arg form so the log path and cwd never get
-  // string-interpolated into the script body. $1 is the log path;
-  // `shift` drops it; `$@` is the devcontainer invocation.
-  const shellScript = 'LOG="$1"; shift; exec devcontainer "$@" 2> "$LOG"';
+  // `sh -c 'exec "$BIN" "$@" 2> "$LOG"' sh <log> <bin> <args...>` —
+  // positional-arg form so the log path, resolved CLI, and cwd never
+  // get string-interpolated into the script body. $1 is the log path,
+  // $2 the CLI resolved by the probe above (kept consistent so the
+  // binary we checked is the binary we run); `shift 2` drops both and
+  // `$@` is the devcontainer invocation.
+  const shellScript = 'LOG="$1"; BIN="$2"; shift 2; exec "$BIN" "$@" 2> "$LOG"';
   const args = [
     "-c",
     shellScript,
     "sh",
     logPath,
+    devcontainerBin,
     "up",
     "--workspace-folder",
     cwd,

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_attach_e2e.rs
@@ -754,3 +754,66 @@ fn attach_missing_container_id_surfaces_failed_attach_popup() {
     drop(harness);
     drop_workspace_temp(&workspace);
 }
+
+/// Regression test for issue #2201 (Devcontainer CLI not found on
+/// Windows when installed via Bun): the CLI-presence probe must not
+/// depend on an external `which` utility vouching for `devcontainer`.
+/// Native Windows ships no `which` at all, so a probe that shells out
+/// to it reports "CLI Not Found" even when `devcontainer` itself is
+/// perfectly spawnable from PATH. The probe must ask the question we
+/// actually care about — "can the CLI be spawned?" — by running it
+/// directly.
+///
+/// Modeled here (the suite is unix-only) by shadowing `which` with a
+/// shim that denies knowledge of `devcontainer` while the fake CLI
+/// stays on PATH: attach must still succeed.
+#[test]
+fn attach_succeeds_when_which_cannot_locate_cli() {
+    let (_workspace_temp, workspace) = set_up_workspace();
+
+    let mut harness = EditorTestHarness::create(
+        160,
+        40,
+        HarnessOptions::new()
+            .with_working_dir(workspace.clone())
+            .with_fake_devcontainer(),
+    )
+    .unwrap();
+
+    // Shadow `which` AFTER the harness exists so the fake-devcontainer
+    // mutex already serializes us with sibling tests (same reasoning
+    // as the FAKE_DC_* env knobs above). The shim fails only for
+    // `devcontainer` and delegates everything else, so the rest of the
+    // attach flow (sh, mkdir, docker) is unaffected.
+    let shim_temp = tempfile::tempdir().unwrap();
+    let shim = shim_temp.path().join("which");
+    fs::write(
+        &shim,
+        "#!/bin/sh\n\
+         for a in \"$@\"; do [ \"$a\" = devcontainer ] && exit 1; done\n\
+         [ -x /usr/bin/which ] && exec /usr/bin/which \"$@\"\n\
+         exit 127\n",
+    )
+    .unwrap();
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let saved_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var(
+        "PATH",
+        format!("{}:{}", shim_temp.path().display(), saved_path),
+    );
+    harness.tick_and_render().unwrap();
+
+    accept_attach(&mut harness);
+    let label = wait_for_container_authority(&mut harness);
+    assert!(
+        label.starts_with("Container:"),
+        "attach must succeed without `which` vouching for the CLI; label = {label:?}"
+    );
+
+    std::env::set_var("PATH", saved_path);
+    drop(harness);
+    drop_workspace_temp(&workspace);
+}

--- a/docs/internal/FAKE_DEVCONTAINER_CLI.md
+++ b/docs/internal/FAKE_DEVCONTAINER_CLI.md
@@ -40,8 +40,8 @@ Captured by reading every `editor.spawnHostProcess(...)` site in
 
 | Caller (file:line) | Invocation | What Fresh expects back |
 |---|---|---|
-| `devcontainer.ts:1378` | `which devcontainer` | exit 0 with path on stdout |
-| `devcontainer.ts:1440` | `sh -c 'exec devcontainer "$@" 2> "$LOG"' sh <log> up --workspace-folder <cwd> [extra]` | stdout: a line that is a JSON object `{ outcome, containerId, remoteUser, remoteWorkspaceFolder }` somewhere near the end; stderr → log file (any human progress text) |
+| `devcontainer.ts` (`resolveDevcontainerBin`) | `devcontainer --version` | exit 0 with version on stdout (probed directly — no `which`, which doesn't exist on native Windows; see #2201) |
+| `devcontainer.ts` (`runDevcontainerUp`) | `sh -c 'exec "$BIN" "$@" 2> "$LOG"' sh <log> <bin> up --workspace-folder <cwd> [extra]` | stdout: a line that is a JSON object `{ outcome, containerId, remoteUser, remoteWorkspaceFolder }` somewhere near the end; stderr → log file (any human progress text) |
 | `devcontainer.ts:1694` | `which docker` | exit 0 with path on stdout |
 | `devcontainer.ts:1701` | `docker logs --tail 1000 <id>` | stdout/stderr of the "container" |
 | `devcontainer.ts:791,880` | `docker port <id>` | lines like `8080/tcp -> 0.0.0.0:32769` |
@@ -217,8 +217,9 @@ exits 64.
 
 ### Integration with the editor
 
-The plugin doesn't know it's talking to a fake — `which devcontainer`
-just resolves earlier in `$PATH`. That means the test recipe is just:
+The plugin doesn't know it's talking to a fake — its
+`devcontainer --version` probe just resolves the fake earlier in
+`$PATH`. That means the test recipe is just:
 
 ```bash
 source scripts/fake-devcontainer/activate.sh

--- a/scripts/fake-devcontainer/bin/devcontainer
+++ b/scripts/fake-devcontainer/bin/devcontainer
@@ -316,6 +316,9 @@ main() {
     up)                 cmd_up "$@" ;;
     read-configuration) cmd_read_configuration "$@" ;;
     reset)              cmd_reset "$@" ;;
+    # Fresh probes CLI presence by running `devcontainer --version`
+    # (the real CLI prints its version and exits 0).
+    --version)          printf '0.0.0-fake\n'; exit 0 ;;
     --help|-h|help)     usage; exit 0 ;;
     *)
       echo "fake-devcontainer: unsupported subcommand: $sub" >&2


### PR DESCRIPTION
Fixes #2201

## Problem

The attach flow decided "Devcontainer CLI not found" by spawning the external `which` utility (`devcontainer.ts`, `runDevcontainerUp`). `spawnHostProcess` spawns directly with no shell, and native Windows ships no `which` executable — so the probe always failed there with a spawn error and surfaced the "Dev Container CLI Not Found" popup, even when the CLI was perfectly resolvable from PATH (e.g. Bun's `devcontainer.exe` shim, as reported in the issue). Even on Unix the probe answered the wrong question: whether `which` can find the name, not whether the editor can spawn it.

## Fix

- `resolveDevcontainerBin()` probes candidates by running `<bin> --version` through the same spawn machinery that runs the real `devcontainer up`. Exit 0 → found.
- `devcontainer.cmd` is probed as a second candidate to cover npm's Windows shim, which PATH-based `.exe` resolution never finds. On other platforms it's a fast spawn failure (same fire-all-candidates pattern as dashboard's `openUrl`).
- The resolved command is threaded through the `sh` wrapper (`exec "$BIN" "$@"`) so the binary we checked is the binary we run.
- The in-tree fake CLI learns `--version`, and the wire-surface doc (`FAKE_DEVCONTAINER_CLI.md`) is updated.

## Testing

- **New regression e2e test** `attach_succeeds_when_which_cannot_locate_cli`: shadows `which` with a shim that denies knowledge of `devcontainer` while the fake CLI stays on PATH (modeling Windows, which has no `which` at all). **Fails without the fix** (CLI-not-found popup, container authority never lands, ~13.5s timeout) and **passes with it** (0.45s).
- All 47 devcontainer e2e tests pass (`cargo test --test e2e_tests devcontainer`).
- `cargo fmt --check` and `cargo clippy --test e2e_tests` clean; plugin passes `tsc --strict`.
- **Manual validation (tmux + fake CLI)**:
  - With `which devcontainer` failing but the CLI on PATH: "Reopen in Container" attaches end-to-end, status bar shows `Container:<id>`, no popup.
  - With the CLI genuinely absent: the "Dev Container CLI Not Found" popup still appears (negative path intact).

Note: this fixes the false negative in CLI *resolution*; full Windows end-to-end attach still has other Unix-isms in the flow (`sh` wrapper, `mkdir -p`) that are out of scope here, but the resolved-bin threading is a step toward that.

https://claude.ai/code/session_01MtPkBxbdJJ8dEKkyHU5KiT

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtPkBxbdJJ8dEKkyHU5KiT)_