### PR TITLE
feat(lsp): add global lsp_enabled master switch

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -207,6 +207,11 @@
       "default": null,
       "x-enum-from": "/languages"
     },
+    "lsp_enabled": {
+      "description": "Master switch for LSP support. When false, no language server is\nstarted automatically for any language (per-language and universal\nservers alike), without having to disable each server individually.\nServers can still be started manually, e.g. via the command palette's\n\"Start/Restart LSP Server\".",
+      "type": "boolean",
+      "default": true
+    },
     "lsp": {
       "description": "LSP server configurations by language.\nEach language maps to one or more server configs (multi-LSP support).\nAccepts both single-object and array forms for backwards compatibility.",
       "type": "object",

--- a/crates/fresh-editor/src/app/lsp_status.rs
+++ b/crates/fresh-editor/src/app/lsp_status.rs
@@ -73,6 +73,7 @@ pub(crate) fn compose_lsp_status(
     lsp_server_statuses: &HashMap<(String, String), LspServerStatus>,
     lsp_config: &HashMap<String, LspLanguageConfig>,
     user_dismissed_languages: &HashSet<String>,
+    lsp_globally_enabled: bool,
 ) -> (String, LspIndicatorState) {
     // 0. Per-buffer LSP skip — only flag it when it's a *mismatch* with
     //    language state: LSP is running for this language, but not for
@@ -162,10 +163,15 @@ pub(crate) fn compose_lsp_status(
         // server is the persistent flavour of the same idea, so render
         // it the same way: pill stays visible but dimmed, so the user
         // has a discoverable surface to re-enable.
+        // The global `lsp_enabled=false` master switch is the same flavour
+        // of deliberate opt-out, so it renders dimmed too.
         let any_enabled = lsp_config
             .get(current_language)
             .is_some_and(|cfg| cfg.as_slice().iter().any(|c| c.enabled));
-        let state = if !any_enabled || user_dismissed_languages.contains(current_language) {
+        let state = if !lsp_globally_enabled
+            || !any_enabled
+            || user_dismissed_languages.contains(current_language)
+        {
             LspIndicatorState::OffDismissed
         } else {
             LspIndicatorState::Off
@@ -227,6 +233,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         assert_eq!(text, "");
         assert_eq!(state, LspIndicatorState::None);
@@ -241,6 +248,7 @@ mod tests {
             &HashMap::new(),
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         assert!(text.contains("LSP (off)"));
         assert_eq!(state, LspIndicatorState::Off);
@@ -257,6 +265,7 @@ mod tests {
             &HashMap::new(),
             &configured_for("rust", "rust-analyzer"),
             &dismissed,
+            true,
         );
         assert!(text.contains("LSP (off)"));
         assert_eq!(state, LspIndicatorState::OffDismissed);
@@ -283,6 +292,7 @@ mod tests {
             &HashMap::new(),
             &config,
             &HashSet::new(),
+            true,
         );
         assert!(
             text.contains("LSP (off)"),
@@ -298,6 +308,25 @@ mod tests {
         );
     }
 
+    /// With the global `lsp_enabled=false` master switch, configured
+    /// servers still surface the pill (so the user has a discoverable
+    /// surface to start manually or re-enable), but dimmed — the same
+    /// deliberate-opt-out flavour as all-servers-disabled.
+    #[test]
+    fn off_dismissed_when_lsp_globally_disabled() {
+        let (text, state) = compose_lsp_status(
+            "rust",
+            None,
+            &HashMap::new(),
+            &HashMap::new(),
+            &configured_for("rust", "rust-analyzer"),
+            &HashSet::new(),
+            false,
+        );
+        assert!(text.contains("LSP (off)"));
+        assert_eq!(state, LspIndicatorState::OffDismissed);
+    }
+
     #[test]
     fn running_wins_over_off() {
         let statuses = status("rust", "rust-analyzer", LspServerStatus::Running);
@@ -308,6 +337,7 @@ mod tests {
             &statuses,
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         assert!(text.contains("LSP (on)"));
         assert_eq!(state, LspIndicatorState::On);
@@ -327,6 +357,7 @@ mod tests {
             &statuses,
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         assert!(text.contains("LSP (error)"));
         assert_eq!(state, LspIndicatorState::Error);
@@ -344,6 +375,7 @@ mod tests {
             &statuses,
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         assert!(text.contains("LSP"));
         assert_eq!(state, LspIndicatorState::On);
@@ -359,6 +391,7 @@ mod tests {
             &statuses,
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         assert!(text.contains("LSP (off)"));
         assert_eq!(state, LspIndicatorState::Off);
@@ -374,6 +407,7 @@ mod tests {
             &statuses,
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         assert_eq!(text, "");
         assert_eq!(state, LspIndicatorState::None);
@@ -390,6 +424,7 @@ mod tests {
             &HashMap::new(),
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         let (err, _) = compose_lsp_status(
             "rust",
@@ -398,6 +433,7 @@ mod tests {
             &status("rust", "rust-analyzer", LspServerStatus::Error),
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         let (na, _) = compose_lsp_status(
             "rust",
@@ -406,6 +442,7 @@ mod tests {
             &status("rust", "rust-analyzer", LspServerStatus::Running),
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         let off_w = unicode_width::UnicodeWidthStr::width(off.as_str());
         let err_w = unicode_width::UnicodeWidthStr::width(err.as_str());
@@ -430,6 +467,7 @@ mod tests {
             &statuses,
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         assert!(
             text.contains("LSP (n/a)"),
@@ -452,6 +490,7 @@ mod tests {
             &HashMap::new(),
             &HashMap::new(),
             &HashSet::new(),
+            true,
         );
         assert_eq!(text, "");
         assert_eq!(state, LspIndicatorState::None);
@@ -472,6 +511,7 @@ mod tests {
             &HashMap::new(),
             &configured_for("rust", "rust-analyzer"),
             &HashSet::new(),
+            true,
         );
         assert!(
             text.contains("LSP (off)"),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -940,6 +940,7 @@ impl Editor {
             &self.active_window().lsp_server_statuses,
             &self.config.lsp,
             &self.active_window().user_dismissed_lsp_languages,
+            self.config.lsp_enabled,
         );
         let theme = self.theme.read().unwrap().clone();
         let keybindings_cloned = self.keybindings.read().unwrap().clone(); // Clone the keybindings

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -151,6 +151,7 @@ impl Editor {
         // Update LSP configs
         let __active_id = self.active_window;
         if let Some(lsp) = self.windows.get_mut(&__active_id).map(|w| &mut w.lsp) {
+            lsp.set_globally_enabled(self.config.lsp_enabled);
             for (language, lsp_configs) in &self.config.lsp {
                 lsp.set_language_configs(language.clone(), lsp_configs.as_slice().to_vec());
             }

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -387,6 +387,7 @@ impl Editor {
         // Update LSP configs
         let __active_id = self.active_window;
         if let Some(lsp) = self.windows.get_mut(&__active_id).map(|w| &mut w.lsp) {
+            lsp.set_globally_enabled(self.config.lsp_enabled);
             for (language, lsp_configs) in &self.config.lsp {
                 lsp.set_language_configs(language.clone(), lsp_configs.as_slice().to_vec());
             }

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -818,6 +818,9 @@ pub(crate) fn configure_lsp_servers(
 ) {
     use crate::types::{LspServerConfig, ProcessLimits};
 
+    // Global master switch — gates auto-start of every server below.
+    lsp.set_globally_enabled(config.lsp_enabled);
+
     // Per-language servers from config.
     for (language, lsp_configs) in &config.lsp {
         lsp.set_language_configs(language.clone(), lsp_configs.as_slice().to_vec());

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -388,6 +388,14 @@ pub struct Config {
     #[schemars(extend("x-enum-from" = "/languages"))]
     pub default_language: Option<String>,
 
+    /// Master switch for LSP support. When false, no language server is
+    /// started automatically for any language (per-language and universal
+    /// servers alike), without having to disable each server individually.
+    /// Servers can still be started manually, e.g. via the command palette's
+    /// "Start/Restart LSP Server".
+    #[serde(default = "default_true")]
+    pub lsp_enabled: bool,
+
     /// LSP server configurations by language.
     /// Each language maps to one or more server configs (multi-LSP support).
     /// Accepts both single-object and array forms for backwards compatibility.
@@ -2609,6 +2617,7 @@ impl Default for Config {
             active_keybinding_map: default_keybinding_map_name(),
             languages: Self::default_languages(),
             default_language: None,
+            lsp_enabled: true,
             lsp: Self::default_lsp_config(),
             universal_lsp: Self::default_universal_lsp_config(),
             warnings: WarningsConfig::default(),

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -87,6 +87,7 @@ pub struct PartialConfig {
     pub active_keybinding_map: Option<KeybindingMapName>,
     pub languages: Option<HashMap<String, PartialLanguageConfig>>,
     pub default_language: Option<String>,
+    pub lsp_enabled: Option<bool>,
     pub lsp: Option<HashMap<String, LspLanguageConfig>>,
     pub universal_lsp: Option<HashMap<String, LspLanguageConfig>>,
     pub warnings: Option<PartialWarningsConfig>,
@@ -117,6 +118,7 @@ impl Merge for PartialConfig {
         merge_hashmap(&mut self.keybinding_maps, &other.keybinding_maps);
         merge_hashmap_recursive(&mut self.languages, &other.languages);
         self.default_language.merge_from(&other.default_language);
+        self.lsp_enabled.merge_from(&other.lsp_enabled);
         merge_hashmap(&mut self.lsp, &other.lsp);
         merge_hashmap(&mut self.universal_lsp, &other.universal_lsp);
         merge_hashmap_recursive(&mut self.plugins, &other.plugins);
@@ -1073,6 +1075,7 @@ impl From<&crate::config::Config> for PartialConfig {
                     .collect(),
             ),
             default_language: cfg.default_language.clone(),
+            lsp_enabled: Some(cfg.lsp_enabled),
             lsp: Some(
                 cfg.lsp
                     .iter()
@@ -1282,6 +1285,7 @@ impl PartialConfig {
             default_language: self
                 .default_language
                 .or_else(|| defaults.default_language.clone()),
+            lsp_enabled: self.lsp_enabled.unwrap_or(defaults.lsp_enabled),
             lsp,
             universal_lsp,
             warnings: self

--- a/crates/fresh-editor/src/services/lsp/manager.rs
+++ b/crates/fresh-editor/src/services/lsp/manager.rs
@@ -457,6 +457,13 @@ pub struct LspManager {
     /// Languages that have been explicitly disabled/stopped by the user
     /// These will not auto-restart until user manually restarts them
     disabled_languages: HashSet<String>,
+
+    /// Master switch mirroring the top-level `lsp_enabled` config field.
+    /// When false, `try_spawn` refuses to auto-start any server (per-language
+    /// and universal alike). Manual starts (`allow_language` + `force_spawn`)
+    /// still work — an explicit user action overrides the global opt-out,
+    /// matching how manual start already overrides per-server `enabled=false`.
+    globally_enabled: bool,
 }
 
 impl LspManager {
@@ -484,7 +491,14 @@ impl LspManager {
             pending_restarts: HashMap::new(),
             allowed_languages: HashSet::new(),
             disabled_languages: HashSet::new(),
+            globally_enabled: true,
         }
+    }
+
+    /// Mirror the top-level `lsp_enabled` config field. When false, no
+    /// server auto-starts for any language (see `try_spawn`).
+    pub fn set_globally_enabled(&mut self, enabled: bool) {
+        self.globally_enabled = enabled;
     }
 
     /// Wire the long-running spawner from the active `Authority`.
@@ -708,6 +722,18 @@ impl LspManager {
         {
             self.ensure_universal_servers_running(file_path);
             return LspSpawnResult::Spawned;
+        }
+
+        // Global master switch (top-level `lsp_enabled` config field): a
+        // deliberate user opt-out for every language, including universal
+        // servers. Checked before anything can spawn; manual starts go
+        // through `force_spawn` directly and are intentionally unaffected.
+        if !self.globally_enabled {
+            tracing::debug!(
+                "LSP for '{}' not auto-started: LSP is globally disabled (lsp_enabled=false)",
+                language
+            );
+            return LspSpawnResult::Disabled;
         }
 
         // Check if we have runtime and bridge
@@ -1331,6 +1357,12 @@ impl LspManager {
     /// across all languages. Only servers with `enabled=true` and
     /// `auto_start=true` are started automatically.
     fn ensure_universal_servers_running(&mut self, file_path: Option<&Path>) {
+        // Global master switch also covers universal servers — without this,
+        // a manually started language server would drag the universal
+        // servers up via the handles-exist fast path in `try_spawn`.
+        if !self.globally_enabled {
+            return;
+        }
         if self
             .handles
             .iter()
@@ -2232,6 +2264,45 @@ mod tests {
         );
 
         assert_eq!(manager.try_spawn("rust", None), LspSpawnResult::Disabled);
+    }
+
+    // The global master switch (top-level `lsp_enabled=false` config field)
+    // must block auto-start even for a server that is individually
+    // enabled+auto_start. It's a deliberate user opt-out, so the result is
+    // `Disabled` (callers stay silent), not `Failed`.
+    #[test]
+    fn test_lsp_manager_try_spawn_returns_disabled_when_globally_disabled() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let mut manager = LspManager::new(fresh_core::WindowId(1), None);
+        let async_bridge = AsyncBridge::new();
+        manager.set_runtime(rt.handle().clone(), async_bridge);
+
+        manager.set_language_config(
+            "rust".to_string(),
+            LspServerConfig {
+                enabled: true,
+                command: "rust-analyzer".to_string(),
+                args: vec![],
+                process_limits: crate::services::process_limits::ProcessLimits::unlimited(),
+                auto_start: true,
+                initialization_options: None,
+                env: Default::default(),
+                language_id_overrides: Default::default(),
+                name: None,
+                only_features: None,
+                except_features: None,
+                root_markers: Default::default(),
+            },
+        );
+
+        manager.set_globally_enabled(false);
+        assert_eq!(manager.try_spawn("rust", None), LspSpawnResult::Disabled);
+
+        // Flipping the switch back restores normal auto-start behaviour
+        // (the spawn itself may fail in this barebones test setup, but it
+        // must no longer short-circuit to Disabled).
+        manager.set_globally_enabled(true);
+        assert_ne!(manager.try_spawn("rust", None), LspSpawnResult::Disabled);
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_global_disable.rs
@@ -1,0 +1,290 @@
+//! E2E tests for the global LSP master switch (GitHub issue #1770).
+//!
+//! Users asked for "a general configuration to disable the LSP feature for
+//! all languages" — previously LSP could only be disabled per language
+//! (per-server `enabled` / `auto_start` flags). The top-level
+//! `lsp_enabled: false` config field must:
+//!
+//! - block auto-start of every configured server on buffer load —
+//!   per-language and universal servers alike,
+//! - keep the status-bar pill visible ("LSP (off)", dimmed) so the user
+//!   still has a discoverable surface for LSP,
+//! - NOT block manual starts: "Start/Restart LSP Server" from the command
+//!   palette is an explicit user action and overrides the global opt-out,
+//!   exactly like it already overrides per-server `enabled=false`.
+//!
+//! Verification strategy (mirrors `lsp_autostart_selective`): each fake
+//! server's first action is creating its log file, so file non-existence
+//! proves the process was never spawned. Spawned servers publish one
+//! diagnostic on didOpen, which renders as a count ("E:1") on the status
+//! bar, so positive assertions observe rendered output only.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Create a fake LSP server script whose first action is creating its log
+/// file, and which publishes one error diagnostic on `didOpen`.
+fn create_diagnostic_server_script(dir: &std::path::Path, filename: &str) -> std::path::PathBuf {
+    let script = r##"#!/bin/bash
+LOG_FILE="$1"
+SEVERITY="${2:-1}"
+> "$LOG_FILE"
+echo "ACTION: spawned severity=$SEVERITY" >> "$LOG_FILE"
+
+read_message() {
+    local content_length=0
+    while IFS=: read -r key value; do
+        key=$(echo "$key" | tr -d '\r\n')
+        value=$(echo "$value" | tr -d '\r\n ')
+        if [ "$key" = "Content-Length" ]; then
+            content_length=$value
+        fi
+        if [ -z "$key" ]; then
+            break
+        fi
+    done
+    if [ $content_length -gt 0 ]; then
+        dd bs=1 count=$content_length 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: $length\r\n\r\n%s" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then break; fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+    echo "RECV: method=$method id=$msg_id" >> "$LOG_FILE"
+
+    case "$method" in
+        "initialize")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":{"capabilities":{"positionEncoding":"utf-16","textDocumentSync":{"openClose":true,"change":2,"save":{}}}}}'
+            ;;
+        "initialized")
+            ;;
+        "textDocument/didOpen")
+            uri=$(echo "$msg" | grep -o '"uri":"[^"]*"' | head -1 | cut -d'"' -f4)
+            send_message '{"jsonrpc":"2.0","method":"textDocument/publishDiagnostics","params":{"uri":"'"$uri"'","diagnostics":[{"range":{"start":{"line":0,"character":0},"end":{"line":0,"character":1}},"severity":'"$SEVERITY"',"source":"fake","message":"sev'"$SEVERITY"'"}],"version":1}}'
+            echo "ACTION: didOpen published severity=$SEVERITY" >> "$LOG_FILE"
+            ;;
+        "shutdown")
+            send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            break
+            ;;
+        *)
+            if [ -n "$method" ] && [ -n "$msg_id" ]; then
+                send_message '{"jsonrpc":"2.0","id":'"$msg_id"',"result":null}'
+            fi
+            ;;
+    esac
+done
+"##;
+
+    let script_path = dir.join(filename);
+    std::fs::write(&script_path, script).expect("Failed to write server script");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script_path)
+            .expect("Failed to get script metadata")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script_path, perms).expect("Failed to set script permissions");
+    }
+
+    script_path
+}
+
+fn build_server_config(
+    name: &str,
+    script: &std::path::Path,
+    log_path: &std::path::Path,
+    severity: u8,
+) -> fresh::services::lsp::LspServerConfig {
+    fresh::services::lsp::LspServerConfig {
+        command: script.to_string_lossy().to_string(),
+        args: vec![log_path.to_string_lossy().to_string(), severity.to_string()],
+        enabled: true,
+        auto_start: true,
+        process_limits: fresh::services::process_limits::ProcessLimits::default(),
+        initialization_options: None,
+        env: Default::default(),
+        language_id_overrides: Default::default(),
+        root_markers: Default::default(),
+        name: Some(name.to_string()),
+        only_features: None,
+        except_features: None,
+    }
+}
+
+/// `lsp_enabled: false` must block auto-start of every configured server —
+/// the per-language server AND the universal server, both individually
+/// enabled+auto_start. The status bar still shows the "LSP (off)" pill
+/// (the language has configured servers), and no diagnostic count appears
+/// because no server ever spawned.
+///
+/// Without the fix, both servers spawn on buffer load: their log files
+/// appear and the published diagnostics render as "E:1"/"W:1", so the
+/// wait below never sees "LSP (off)" without "E:" alongside it.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
+fn test_lsp_enabled_false_blocks_all_autostart() -> anyhow::Result<()> {
+    crate::common::tracing::init_tracing_from_env();
+
+    let temp_dir = tempfile::tempdir()?;
+    let script = create_diagnostic_server_script(temp_dir.path(), "fake_lsp_global_disable.sh");
+
+    let log_rust = temp_dir.path().join("rust_auto.log");
+    let log_universal = temp_dir.path().join("universal_auto.log");
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "fn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp_enabled = false;
+
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![build_server_config(
+            "rust-auto",
+            &script,
+            &log_rust,
+            1, // error
+        )]),
+    );
+    config.universal_lsp.insert(
+        "universal-auto".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![build_server_config(
+            "universal-auto",
+            &script,
+            &log_universal,
+            2, // warning
+        )]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        200,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // The pill must surface the dormant state: servers are configured for
+    // rust, but globally disabled. If the master switch were ignored, the
+    // server would be Starting/Running by now (try_spawn registers the
+    // handle synchronously on buffer open) and the pill would render
+    // "LSP (on)" or a spinner instead — this wait would never satisfy.
+    harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
+
+    // No diagnostics can have been published by unspawned servers.
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("E:1") && !screen.contains("W:1"),
+        "No diagnostics should render when LSP is globally disabled — no \
+         server should have spawned. Screen:\n{}",
+        screen
+    );
+
+    // Belt-and-braces: each script creates its log file as its very first
+    // action, so file non-existence proves the process was never spawned.
+    assert!(
+        !log_rust.exists(),
+        "Per-language server must NOT spawn when lsp_enabled=false. \
+         Log file unexpectedly exists: {:?}",
+        log_rust
+    );
+    assert!(
+        !log_universal.exists(),
+        "Universal server must NOT spawn when lsp_enabled=false. \
+         Log file unexpectedly exists: {:?}",
+        log_universal
+    );
+
+    Ok(())
+}
+
+/// Manual start must still work while LSP is globally disabled: an
+/// explicit "Start/Restart LSP Server" action overrides the global
+/// opt-out, exactly like it already overrides per-server `enabled=false`.
+/// The spawned server publishes an error diagnostic, which must reach the
+/// status bar — proving the full spawn + didOpen flow works under the
+/// global switch.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses Bash-based fake LSP server
+fn test_lsp_enabled_false_still_allows_manual_start() -> anyhow::Result<()> {
+    crate::common::tracing::init_tracing_from_env();
+
+    let temp_dir = tempfile::tempdir()?;
+    let script = create_diagnostic_server_script(temp_dir.path(), "fake_lsp_manual_start.sh");
+    let log_rust = temp_dir.path().join("rust_manual.log");
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "fn main() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp_enabled = false;
+
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![build_server_config(
+            "rust-manual",
+            &script,
+            &log_rust,
+            1, // error
+        )]),
+    );
+
+    // Bind Alt+R to the manual start/restart action (single-server config
+    // restarts immediately, no prompt).
+    config.keybindings.push(fresh::config::Keybinding {
+        key: "r".to_string(),
+        modifiers: vec!["alt".to_string()],
+        keys: vec![],
+        action: "lsp_restart".to_string(),
+        args: std::collections::HashMap::new(),
+        when: None,
+    });
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        200,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Auto-start is suppressed by the global switch.
+    harness.wait_until(|h| h.get_status_bar().contains("LSP (off)"))?;
+    assert!(
+        !log_rust.exists(),
+        "Server must not auto-start while lsp_enabled=false"
+    );
+
+    // Manual start: explicit user action overrides the global opt-out.
+    harness.send_key(KeyCode::Char('r'), KeyModifiers::ALT)?;
+    harness.render()?;
+
+    // The manually started server receives didOpen and publishes an error
+    // diagnostic that must render on the status bar.
+    harness.wait_until(|h| h.screen_to_string().contains("E:1"))?;
+
+    let log = std::fs::read_to_string(&log_rust)?;
+    assert!(
+        log.contains("ACTION: didOpen"),
+        "Manually started server should have received didOpen. Log:\n{}",
+        log
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -102,6 +102,7 @@ pub mod lsp_crash_loop;
 pub mod lsp_cross_language_diagnostic_pull;
 pub mod lsp_diagnostic_flow;
 pub mod lsp_env;
+pub mod lsp_global_disable;
 pub mod lsp_goto_definition_readonly;
 #[cfg(feature = "plugins")]
 pub mod lsp_indicator_click_bugs;

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -97,6 +97,16 @@ The `lsp` map uses **deep merging with field-level override**:
 // Result: rust-analyzer command preserved from defaults, just disabled
 ```
 
+**Example:** To disable LSP for *all* languages at once, use the top-level
+`lsp_enabled` master switch instead of disabling each server:
+```json
+{
+  "lsp_enabled": false
+}
+// Result: no language server auto-starts for any language (universal servers
+// included). Manual starts via the command palette still work.
+```
+
 **Example:** To add initialization options without repeating the command:
 ```json
 {

--- a/docs/features/lsp.md
+++ b/docs/features/lsp.md
@@ -42,6 +42,20 @@ You can configure multiple LSP servers for the same language (e.g., pylsp + pyri
 
 Each server can opt into or out of specific features using `only_features` / `except_features` — for example, route completions to one server and diagnostics to another. Fresh merges completions from every eligible server and tracks diagnostics per-server. Servers configured for all languages are spawned once per project rather than once per language.
 
+## Disabling LSP
+
+To disable a single server, set `"enabled": false` on its entry in the `lsp` map (Settings UI: **LSP** section), or mute the language from the status-bar popup.
+
+To disable LSP for **all** languages at once, set the top-level `lsp_enabled` master switch to `false` (Settings UI: **General** section):
+
+```json
+{
+  "lsp_enabled": false
+}
+```
+
+No language server will auto-start for any language (universal servers included), and the status bar shows a dimmed `LSP (off)` pill when servers are configured for the current language. You can still start a server explicitly with **Start/Restart LSP Server** from the command palette — a manual start overrides the global switch for that language.
+
 ## C/C++ Header Routing
 
 When you open a `.h` file, Fresh routes to the C++ LSP if there's a clear signal in the project (a sibling `.cpp`, `.hpp`, or `.hxx`), and to the C LSP otherwise.


### PR DESCRIPTION
Closes #1770

Users who don't want LSP at all had to disable every server individually ("Currently you can only disable it per language"), and the built-in server configs mean popups can appear on launch as more languages gain defaults. This adds a top-level `lsp_enabled` config field (default: `true`) — a single master switch:

```json
{
  "lsp_enabled": false
}
```

## Behavior

- **No auto-start anywhere**: `LspManager::try_spawn` returns `Disabled` (the existing "deliberate user opt-out, callers stay silent" result) when the switch is off. This covers per-language **and** universal servers — `ensure_universal_servers_running` is gated too, so a manually started language server can't drag universal servers up via the handles-exist fast path.
- **Manual start still works**: "Start/Restart LSP Server" from the command palette goes through `allow_language` + `force_spawn` and overrides the global opt-out — exactly the same semantics manual start already has over per-server `enabled: false`.
- **Status bar stays discoverable**: the pill renders a dimmed `LSP (off)` (`OffDismissed`, the same flavour as all-servers-disabled), so users keep a surface to start or re-enable LSP.
- The field flows through `PartialConfig` (layered config merge), appears in the schema-driven Settings UI under **General**, and the config schema is regenerated per CONTRIBUTING.

## Testing

- **Unit**: `try_spawn` returns `Disabled` for an enabled+auto_start server when globally disabled, and resumes normal behavior when re-enabled; `compose_lsp_status` renders the dimmed pill. Verified both fail with the gate reverted.
- **E2E** (rendered-output only, fake bash LSP servers): `lsp_enabled: false` blocks auto-start of per-language + universal servers (pill shows `LSP (off)`, no diagnostics render, server log files never created — each script's first action creates its log, so non-existence proves no spawn); manual start while globally disabled spawns the server and its diagnostic reaches the status bar. Verified the blocking test hangs without the fix (external timeout), per the reproduce-before-claiming rule.
- **Manual validation** (tmux, debug build, fake LSP server): default config → `E:1` + `LSP (on)`; `lsp_enabled: false` → `LSP (off)`, no diagnostic, no server process; command palette "Start/Restart LSP Server" while disabled → server spawns, `LSP (rust) ready`, `E:1` + `LSP (on)`.
- Regression: full LSP unit suite (146 tests), config/partial_config/settings suites, and the LSP e2e subset (autostart-selective, toggle-desync, lifecycle-visibility, universal-lsp, lsp_config) all pass. `cargo check --all-targets`, `cargo fmt`, `cargo clippy` clean (no new warnings).

https://claude.ai/code/session_01Tg3GKgSL6FTxeQX2kqaYbJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tg3GKgSL6FTxeQX2kqaYbJ)_