### PR TITLE
live-diff: word-level highlight on low-similarity removed+added pairs

### DIFF
--- a/crates/fresh-editor/plugins/live_diff.ts
+++ b/crates/fresh-editor/plugins/live_diff.ts
@@ -124,15 +124,15 @@ interface Hunk {
   /** Old-side text, line by line, no trailing newline. */
   oldLines: string[];
   /** Word-level diff results, one entry per new-side line in this
-   * hunk. Set only on `modified` hunks above the similarity threshold
-   * — where we suppress the virtual deletion line and instead bold +
-   * underline the actually-changed words on the new line. `undefined`
-   * for unrefined hunks and for `added`/`removed` hunks. */
+   * hunk. Set by `refineHunks` on 1:1-paired hunks — `modified` hunks
+   * above the similarity threshold and `added` hunks from
+   * low-similarity splits — to bold + underline the actually-changed
+   * words on the new line. `undefined` for unrefined hunks. */
   wordRanges?: WordRange[][];
   /** Old-side word ranges, one entry per `oldLines` line. Set on
-   * `removed` hunks emitted by `refineHunks` for high-similarity
-   * pairs where words were dropped/changed; passed to addVirtualLine
-   * as `textOverlays` so the deletion virtual line bolds + underlines
+   * `removed` hunks emitted by `refineHunks` for 1:1 pairs where
+   * words were dropped/changed; passed to addVirtualLine as
+   * `textOverlays` so the deletion virtual line bolds + underlines
    * the actually-removed words. */
   oldWordRanges?: WordRange[][];
 }
@@ -694,7 +694,10 @@ function collapseRanges(tokens: Token[]): WordRange[] {
  * pair also has *removed* (or otherwise unmatched) old-side words,
  * we additionally emit a `removed` hunk carrying the old line plus
  * `oldWordRanges` so the deletion virtual line shows the user which
- * words went away — not just that *something* did.
+ * words went away — not just that *something* did. Low-similarity
+ * splits get the same word-level treatment on both halves of the
+ * pair, so even a rewrite-style change calls out the words it shares
+ * (and doesn't) with the old line.
  *
  * Hunks that don't have a 1:1 mapping (e.g. 3 old lines becoming 2
  * new lines) keep their original shape — the pairing is ambiguous,
@@ -736,17 +739,27 @@ function refineHunks(hunks: Hunk[], newLines: string[]): Hunk[] {
           wordRanges: [wd.newRanges],
         });
       } else {
+        // Low-similarity rewrite: the pair splits into a deletion
+        // virtual line + a bg-highlighted added line. The word-level
+        // diff still runs so the pair calls out *which* words were
+        // removed/added — tokens common to both lines stay unmarked
+        // (issue #1949).
+        const wd = computeWordDiff(oldLine, newLine);
         out.push({
           kind: "removed",
           newStart: h.newStart + i,
           newCount: 0,
           oldLines: [oldLine],
+          ...(wd.oldRanges.length > 0
+            ? { oldWordRanges: [wd.oldRanges] }
+            : {}),
         });
         out.push({
           kind: "added",
           newStart: h.newStart + i,
           newCount: 1,
           oldLines: [],
+          ...(wd.newRanges.length > 0 ? { wordRanges: [wd.newRanges] } : {}),
         });
       }
     }
@@ -875,7 +888,8 @@ function renderHunks(state: BufferDiffState, newLines: string[]): void {
       }
 
       // Word-level diff: bold + underline the changed words on the
-      // new-side line of a refined high-similarity modified hunk.
+      // new-side line of a refined 1:1 pair (a high-similarity
+      // `modified` hunk or the `added` half of a low-similarity split).
       // `wordRanges` is set only by `refineHunks` and uses byte
       // offsets relative to each new-side line's start, so we add the
       // line's own start byte before passing to `addOverlay`.
@@ -921,9 +935,9 @@ function renderHunks(state: BufferDiffState, newLines: string[]): void {
       // No "- " prefix in the line text — the indicator goes in the
       // gutter via `gutterGlyph` so it sits next to the deletion
       // line itself, not on the source line that follows it.
-      // When `oldWordRanges` is set (from a high-similarity refined
-      // pair), bold + underline the actually-removed words so the
-      // user can see *what* changed, not just that something did.
+      // When `oldWordRanges` is set (from a refined 1:1 pair), bold +
+      // underline the actually-removed words so the user can see
+      // *what* changed, not just that something did.
       const wordRanges = h.oldWordRanges?.[i];
       const textOverlays = wordRanges
         ? wordRanges.map((r) => ({

--- a/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
@@ -913,3 +913,121 @@ fn test_live_diff_removed_line_not_split_per_char_at_tiny_width() {
          row (#2177). Screen:\n{screen}"
     );
 }
+
+/// Find the row containing `needle` and return `(y, x_of_needle_start)`.
+/// Assumes single-width ASCII content (each cell is one char).
+fn find_text_cell(buf: &ratatui::buffer::Buffer, needle: &str) -> Option<(u16, u16)> {
+    for y in 0..buf.area.height {
+        let mut row = String::new();
+        for x in 0..buf.area.width {
+            row.push_str(buf[(x, y)].symbol());
+        }
+        if let Some(idx) = row.find(needle) {
+            return Some((y, idx as u16));
+        }
+    }
+    None
+}
+
+/// True when the cell at `(x, y)` carries both the bold and underline
+/// modifiers — the word-level diff emphasis used by live-diff.
+fn is_word_diff_emphasized(buf: &ratatui::buffer::Buffer, x: u16, y: u16) -> bool {
+    use ratatui::style::Modifier;
+    let m = buf[(x, y)].style().add_modifier;
+    m.contains(Modifier::BOLD) && m.contains(Modifier::UNDERLINED)
+}
+
+/// Issue #1949: a low-similarity rewrite splits into a deletion virtual
+/// line + an added line. The deletion line must bold + underline the
+/// words that were *removed*, and the added line the words that were
+/// *added* — while tokens common to both lines stay unemphasized, so
+/// the user can spot what actually changed inside the pair.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn test_live_diff_word_highlight_on_low_similarity_removed_added_pair() {
+    let repo = GitTestRepo::new();
+    repo.setup_live_diff_plugin();
+
+    // Plain text file: no syntax highlighting, so the only bold +
+    // underline cells on screen come from the word-diff overlays.
+    // The first and last tokens are shared between HEAD and the
+    // working tree; the middle word is fully rewritten with enough
+    // unique characters to push Sørensen–Dice similarity below the
+    // 0.95 split threshold. No `-` characters anywhere so the only
+    // `-` on screen is the deletion gutter glyph.
+    repo.create_file(
+        "note.txt",
+        "SHARED_HEAD_TOKEN OLD_REMOVED_WORD_PAYLOAD_ZZZZ SHARED_TAIL_TOKEN\n",
+    );
+    repo.git_add(&["note.txt"]);
+    repo.git_commit("baseline");
+
+    let original_dir = repo.change_to_repo_dir();
+    let _guard = DirGuard::new(original_dir);
+
+    repo.modify_file(
+        "note.txt",
+        "SHARED_HEAD_TOKEN NEW_ADDED_REPLACEMENT_QQQQ SHARED_TAIL_TOKEN\n",
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Config::default(),
+        repo.path.clone(),
+    )
+    .unwrap();
+
+    enable_live_diff_globally(&mut harness);
+    open_file(&mut harness, &repo.path, "note.txt");
+
+    // Deletion virtual line (old content) + added line (new content)
+    // both on screen.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            has_glyph(&s, '-')
+                && has_text(&s, "OLD_REMOVED_WORD_PAYLOAD_ZZZZ")
+                && has_text(&s, "NEW_ADDED_REPLACEMENT_QQQQ")
+        })
+        .unwrap();
+
+    let buf = harness.buffer();
+
+    // Removed side: the rewritten word is emphasized...
+    let (old_y, old_x) = find_text_cell(buf, "OLD_REMOVED_WORD_PAYLOAD_ZZZZ")
+        .expect("deletion virtual line not found on screen");
+    assert!(
+        is_word_diff_emphasized(buf, old_x, old_y),
+        "removed word on the deletion virtual line (row {old_y}, col {old_x}) \
+         should be bold + underlined",
+    );
+    // ...while the token shared with the new line is not.
+    let (head_y, head_x) =
+        find_text_cell(buf, "SHARED_HEAD_TOKEN").expect("shared head token not found on screen");
+    assert_eq!(
+        head_y, old_y,
+        "expected the first SHARED_HEAD_TOKEN occurrence on the deletion \
+         virtual line (it renders above the added line)",
+    );
+    assert!(
+        !is_word_diff_emphasized(buf, head_x, head_y),
+        "shared token on the deletion virtual line (row {head_y}, col \
+         {head_x}) should NOT be bold + underlined",
+    );
+
+    // Added side: the replacement word is emphasized, its shared
+    // neighbor is not.
+    let (new_y, new_x) =
+        find_text_cell(buf, "NEW_ADDED_REPLACEMENT_QQQQ").expect("added line not found on screen");
+    assert!(
+        is_word_diff_emphasized(buf, new_x, new_y),
+        "added word on the new line (row {new_y}, col {new_x}) should be \
+         bold + underlined",
+    );
+    assert!(
+        !is_word_diff_emphasized(buf, head_x, new_y),
+        "shared token on the added line (row {new_y}, col {head_x}) should \
+         NOT be bold + underlined",
+    );
+}


### PR DESCRIPTION
Closes #1949

## Problem

v0.3.6 added word-level bold+underline emphasis to Live Diff, but only for high-similarity 1:1 pairs (in-place `modified` hunks). As noted in the issue, when a rewrite pushes a pair below the similarity threshold and it splits into a deletion virtual line + an added line, neither half calls out *which* words changed — the deleted words in particular are never marked.

## Fix

`refineHunks` now runs the existing token-LCS word diff (`computeWordDiff`) on the low-similarity split too, attaching `oldWordRanges` to the `removed` hunk and `wordRanges` to the `added` hunk. The renderer already supported both paths (deletion virtual lines via `textOverlays`, new-side lines via `addOverlay`), so no rendering changes were needed. Words removed and added are now emphasized while tokens shared by both lines stay unmarked.

## Testing

- New e2e test `test_live_diff_word_highlight_on_low_similarity_removed_added_pair` asserts on rendered cells: the removed word on the deletion virtual line and the added word on the new line are bold+underlined, while a token shared by both lines is not. Verified it **fails without** the plugin change and **passes with** it.
- Full `e2e::plugins::live_diff` suite passes (11/11).
- Plugin type check (`tsc --strict`) passes; `cargo fmt` and `cargo clippy` clean.
- Manually validated in tmux against a scratch repo — captured ANSI output shows `1;4m` (bold+underline) exactly around the rewritten words on both the red deletion line and the green added line:

```
- │ SHARED_HEAD_TOKEN [1;4mOLD_REMOVED_WORD_PAYLOAD_ZZZZ[0m SHARED_TAIL_TOKEN   ← red bg
1 │ SHARED_HEAD_TOKEN [1;4mNEW_ADDED_REPLACEMENT_QQQQ[0m SHARED_TAIL_TOKEN      ← green bg
```

https://claude.ai/code/session_017btjS6yciSQDugwPeSRiUj

---
_Generated by [Claude Code](https://claude.ai/code/session_017btjS6yciSQDugwPeSRiUj)_