### PR TITLE
Fix: trust-level change resets entire editor instead of active session

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -895,8 +895,19 @@ impl Editor {
         level: crate::services::workspace_trust::TrustLevel,
     ) {
         use crate::services::workspace_trust::TrustLevel;
+        // Trust is a per-window gate: each `Window` owns its own authority +
+        // `WorkspaceTrust` (issue #2280), and the guarding spawners read the
+        // level live at spawn time. Writing the new level here is the whole
+        // change — `set_level` itself documents "no rebuild required". The
+        // next authority-routed spawn (LSP, terminal command, task, formatter,
+        // plugin `spawnProcess`) honours the new level automatically.
+        //
+        // We deliberately do NOT `request_restart` here: that tears down and
+        // rebuilds the *entire* editor — every orchestrator session window,
+        // not just this one — which discarded other sessions' buffers and
+        // reset the layout when toggling a single session's trust (the
+        // trust-level-modal reset bug).
         let trust = &self.authority().workspace_trust;
-        let changed = trust.level() != level;
         trust.set_level(level);
         let msg = match level {
             TrustLevel::Trusted => t!("trust.now_trusted"),
@@ -905,11 +916,6 @@ impl Editor {
         }
         .to_string();
         self.active_window_mut().status_message = Some(msg);
-        // Re-evaluate all authority-routed processes (LSP, terminals, …)
-        // under the new level by rebuilding around the same authority.
-        if changed {
-            self.request_restart(self.working_dir().to_path_buf());
-        }
     }
 
     pub(crate) fn handle_action(&mut self, action: Action) -> AnyhowResult<()> {

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -1153,9 +1153,10 @@ impl Editor {
     }
 
     /// Dispatch the choice selected from the workspace-trust prompt.
-    /// `"trusted"` / `"restricted"` / `"blocked"` set the level (persisted,
-    /// and the editor restarts so the new policy applies to already-running
-    /// tooling). Anything else is logged and ignored.
+    /// `"trusted"` / `"restricted"` / `"blocked"` set the level (persisted);
+    /// the new policy applies live to the next authority-routed spawn, scoped
+    /// to this session's window — no editor restart. Anything else is logged
+    /// and ignored.
     pub fn handle_workspace_trust_action(&mut self, action_key: &str) {
         use crate::services::workspace_trust::TrustLevel;
         let level = match action_key {


### PR DESCRIPTION
Changing a session's workspace-trust level via the modal called the
global request_restart, which tears down and rebuilds the whole Editor
(every orchestrator session window), discarding other sessions' buffers
and resetting the layout.

Workspace trust is a per-window gate (issue #2280): each Window owns its
own authority + WorkspaceTrust, and the guarding spawners read the level
live at spawn time (WorkspaceTrust::set_level documents "no rebuild
required"). Writing the new level is the entire change; the next
authority-routed spawn honours it automatically. Drop the request_restart
so toggling one session's trust no longer touches any other session.

https://claude.ai/code/session_01B5XWSdX9rGQTQSwPQzFvjH