### PR TITLE
fix(on-save): keep the view in place when undoing a format/trim rewrite

### DIFF
--- a/crates/fresh-editor/src/app/on_save_actions.rs
+++ b/crates/fresh-editor/src/app/on_save_actions.rs
@@ -497,8 +497,26 @@ impl Editor {
         let new_buffer_len = output.len();
         let new_cursor_pos = old_cursor_pos.min(new_buffer_len);
 
+        // Leading cursor-restore event. Applied forward this is a no-op (the
+        // cursor is already at `old_cursor_pos`), but a `Batch` is undone by
+        // applying the *inverse* of each event in reverse order, so this
+        // event's inverse runs last on undo and pins the cursor/selection back
+        // to exactly where it was before the rewrite. Without it, the last
+        // inverse applied on undo is the re-`Insert` of the original text,
+        // which leaves the cursor at the end of the buffer and scrolls the
+        // view to the bottom of the file (issue #2027).
+        let restore_cursor_event = Event::MoveCursor {
+            cursor_id,
+            old_position: old_cursor_pos,
+            new_position: old_cursor_pos,
+            old_anchor,
+            new_anchor: old_anchor,
+            old_sticky_column,
+            new_sticky_column: old_sticky_column,
+        };
+
         // Only add MoveCursor event if position actually changes
-        let mut events = vec![delete_event, insert_event];
+        let mut events = vec![restore_cursor_event, delete_event, insert_event];
         if new_cursor_pos != new_buffer_len {
             let move_cursor_event = Event::MoveCursor {
                 cursor_id,

--- a/crates/fresh-editor/tests/format_on_save_undo_view_test.rs
+++ b/crates/fresh-editor/tests/format_on_save_undo_view_test.rs
@@ -1,0 +1,56 @@
+// Regression test for issue #2027.
+//
+// Undoing an on-save buffer rewrite (format-on-save, or the
+// trim-trailing-whitespace-on-save that shares the same
+// `replace_buffer_with_output` undo path) used to leave the primary cursor at
+// the very end of the buffer, scrolling the view to the bottom of the file.
+// The fix prepends a cursor-restore event to the rewrite batch so undo pins
+// the cursor/view back to where it was before the format.
+
+mod common;
+
+use common::harness::EditorTestHarness;
+
+#[test]
+fn undo_of_on_save_rewrite_keeps_view_at_top() {
+    let mut config = fresh::config::Config::default();
+    // Trim-on-save rewrites the buffer through the exact code path
+    // (`replace_buffer_with_output`) that format-on-save uses, without needing
+    // an external formatter process — keeping the test deterministic.
+    config.editor.trim_trailing_whitespace_on_save = true;
+
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+
+    // A buffer taller than the 24-row viewport, with trailing whitespace on
+    // every line so the on-save trim actually changes the content.
+    let content: String = (1..=60).map(|i| format!("line {i:04}   \n")).collect();
+    let _fixture = harness
+        .load_buffer_from_text_named("repro.txt", &content)
+        .unwrap();
+
+    harness.render().unwrap();
+    assert_eq!(
+        harness.top_line_number(),
+        0,
+        "precondition: a freshly opened buffer starts scrolled to the top (line 0)",
+    );
+
+    // Save: triggers the on-save trim, which rewrites the whole buffer.
+    harness.editor_mut().save().unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.top_line_number(),
+        0,
+        "the on-save rewrite itself should not move the view",
+    );
+
+    // Undo the on-save rewrite.
+    harness.editor_mut().handle_undo();
+    harness.render().unwrap();
+
+    assert_eq!(
+        harness.top_line_number(),
+        0,
+        "undoing an on-save format/trim must not scroll the view to the bottom (issue #2027)",
+    );
+}


### PR DESCRIPTION
## Summary

Fixes the second part of #2027: *"don't move the view after undoing a format update — currently, undoing such a change results in the view moving to the bottom of the file."*

### Context

The first ask in #2027 (run the configured formatter on save) is **already supported** today via the per-language `formatter` + `format_on_save` config, handled in `run_on_save_actions`. This PR addresses the remaining, concrete issue: the view jumping to the bottom when you **undo** an on-save format.

### Root cause

On-save rewrites — both format-on-save and trim-trailing-whitespace-on-save — replace the whole buffer through `replace_buffer_with_output`, which logs a `Delete` + `Insert` batch. A `Batch` is undone by applying the **inverse of each event in reverse order**, so the last inverse applied on undo is the re-`Insert` of the original text. `apply_insert` moves the editing cursor to the end of the inserted text, so after undo the cursor sits at the end of the buffer and the viewport follows it to the bottom of the file.

### Fix

Prepend a cursor-restore `MoveCursor` to the rewrite batch. Applied forward it's a no-op (the cursor is already at that position), but its inverse runs **last** on undo and pins the cursor/selection back to where it was before the rewrite — so undo no longer scrolls the view to the bottom. The fix lives in the shared `replace_buffer_with_output`, so it benefits format-on-save, trim-trailing-whitespace-on-save, ensure-final-newline-on-save, and the interactive Format Buffer command alike.

### Testing

- **New e2e regression test** (`tests/format_on_save_undo_view_test.rs`): opens a buffer taller than the viewport, saves (triggering the on-save trim, which shares the exact `replace_buffer_with_output` undo path), undoes, and asserts the viewport stays scrolled to the top. Fails without the fix (view jumps to line 41), passes with it.
- All 14 existing on-save e2e tests pass.
- `cargo fmt` / `cargo clippy` clean for the change.
- **Manual validation** in a tmux session with `trim_trailing_whitespace_on_save` enabled: opened a 60-line file, Ctrl+S, Ctrl+Z — confirmed the trailing whitespace is restored and the view stays at line 1 (cursor on line 1) instead of jumping to the bottom.

Closes #2027.

https://claude.ai/code/session_014bJ1ZJarTS7pTBsywq9u1Z

---
_Generated by [Claude Code](https://claude.ai/code/session_014bJ1ZJarTS7pTBsywq9u1Z)_