### PR TITLE
feat: add Smali syntax highlighting and auto-indentation

### DIFF
--- a/crates/fresh-editor/build.rs
+++ b/crates/fresh-editor/build.rs
@@ -368,6 +368,7 @@ fn generate_syntax_packdump() -> Result<(), Box<dyn std::error::Error>> {
         ("src/grammars/systemverilog.sublime-syntax", "SystemVerilog"),
         ("src/grammars/vhdl.sublime-syntax", "VHDL"),
         ("src/grammars/c3.sublime-syntax", "C3"),
+        ("src/grammars/smali.sublime-syntax", "Smali"),
     ];
 
     let mut loaded = 0;

--- a/crates/fresh-editor/src/grammars/smali.sublime-syntax
+++ b/crates/fresh-editor/src/grammars/smali.sublime-syntax
@@ -1,0 +1,89 @@
+%YAML 1.2
+---
+# Smali — the human-readable assembly format for Dalvik (Android) bytecode,
+# as produced by baksmali / used by smali. Files use the .smali extension.
+name: Smali
+file_extensions: [smali]
+scope: source.smali
+contexts:
+  main:
+    - include: comments
+    - include: directives
+    - include: access-modifiers
+    - include: labels
+    - include: opcodes
+    - include: types
+    - include: member-references
+    - include: registers
+    - include: strings
+    - include: numbers
+
+  comments:
+    - match: '#.*$'
+      scope: comment.line.number-sign.smali
+
+  strings:
+    - match: '"'
+      push:
+        - meta_scope: string.quoted.double.smali
+        - match: '\\(x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|.)'
+          scope: constant.character.escape.smali
+        - match: '"'
+          pop: true
+        - match: '$'
+          pop: true
+    - match: "'"
+      push:
+        - meta_scope: string.quoted.single.smali
+        - match: '\\(x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|.)'
+          scope: constant.character.escape.smali
+        - match: "'"
+          pop: true
+        - match: '$'
+          pop: true
+
+  directives:
+    # Statement-level directives, e.g. .class, .method, .end method, .line
+    - match: '\.(end\s+)?(class|super|implements|source|field|method|registers|locals|param|parameter|prologue|epilogue|line|local|restart\s+local|end\s+local|catch|catchall|annotation|subannotation|sparse-switch|packed-switch|array-data|enum)\b'
+      scope: keyword.control.directive.smali
+
+  access-modifiers:
+    - match: '\b(public|private|protected|static|final|synchronized|volatile|bridge|transient|varargs|native|interface|abstract|strict|synthetic|annotation|enum|constructor|declared-synchronized)\b'
+      scope: storage.modifier.smali
+
+  registers:
+    # Local registers (vN) and parameter registers (pN).
+    - match: '\b[vp]\d+\b'
+      scope: variable.parameter.register.smali
+
+  labels:
+    # Label definitions and references: :goto_0, :cond_1, :try_start_0, ...
+    - match: ':[A-Za-z_$][\w$]*'
+      scope: entity.name.label.smali
+
+  numbers:
+    - match: '[+-]?0[xX][0-9a-fA-F]+[lLsSt]?'
+      scope: constant.numeric.hex.smali
+    - match: '[+-]?\d+\.\d+([eE][+-]?\d+)?[fFdD]?'
+      scope: constant.numeric.float.smali
+    - match: '[+-]?\d+(\.\d+)?[lLsStfFdD]?\b'
+      scope: constant.numeric.integer.smali
+
+  types:
+    # Object type descriptors: Lpackage/Name; (with optional array prefix).
+    - match: '\[*L[\w$/]+;'
+      scope: storage.type.object.smali
+    # Primitive type descriptors and void, optionally array-prefixed.
+    - match: '\[*[VZBSCIJFD](?![\w$])'
+      scope: storage.type.primitive.smali
+
+  member-references:
+    # The -> separator used in field/method references.
+    - match: '->'
+      scope: keyword.operator.member.smali
+
+  opcodes:
+    # Dalvik instruction mnemonics. Match a base mnemonic plus any
+    # -suffix / /variant tail (e.g. invoke-virtual/range, iget-object).
+    - match: '\b(nop|move|return|const|monitor|check-cast|instance-of|array-length|new-instance|new-array|filled-new-array|fill-array-data|throw|goto|packed-switch|sparse-switch|cmpl|cmpg|cmp|if|aget|aput|iget|iput|sget|sput|invoke|neg|not|add|sub|mul|div|rem|and|or|xor|shl|shr|ushr|rsub|int-to|long-to|float-to|double-to|execute-inline|throw-verification-error|iget-quick|iput-quick|invoke-virtual-quick|invoke-super-quick)(-[a-z0-9]+)*(/[a-z0-9-]+)*\b'
+      scope: keyword.other.opcode.smali

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -247,6 +247,9 @@ pub const VHDL_GRAMMAR: &str = include_str!("../../grammars/vhdl.sublime-syntax"
 
 pub const C3_GRAMMAR: &str = include_str!("../../grammars/c3.sublime-syntax");
 
+/// Embedded Smali grammar (Dalvik bytecode assembly; syntect doesn't include one)
+pub const SMALI_GRAMMAR: &str = include_str!("../../grammars/smali.sublime-syntax");
+
 /// Registry of all available TextMate grammars.
 ///
 /// This struct holds the compiled syntax set and provides lookup methods.
@@ -682,6 +685,7 @@ impl GrammarRegistry {
             (SYSTEMVERILOG_GRAMMAR, "SystemVerilog"),
             (VHDL_GRAMMAR, "VHDL"),
             (C3_GRAMMAR, "C3"),
+            (SMALI_GRAMMAR, "Smali"),
         ];
 
         for (grammar_str, name) in additional_grammars {
@@ -1622,6 +1626,21 @@ mod tests {
             );
             let entry = registry.find_by_path(Path::new(filename), None).unwrap();
             assert_eq!(entry.display_name, "Racket", "for {}", filename);
+        }
+    }
+
+    #[test]
+    fn test_smali_grammar_loaded() {
+        let registry = GrammarRegistry::default();
+        for filename in ["MainActivity.smali", "R$id.smali"] {
+            let result = registry.find_syntax_for_file(Path::new(filename));
+            assert!(
+                result.is_some(),
+                "Smali grammar should be available for {}",
+                filename
+            );
+            let entry = registry.find_by_path(Path::new(filename), None).unwrap();
+            assert_eq!(entry.display_name, "Smali", "for {}", filename);
         }
     }
 

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -69,6 +69,10 @@ pub enum Family {
     BashLike,
     /// Pascal — `begin…end`, `case…of…end`, `repeat…until`.
     PascalLike,
+    /// Smali (Dalvik bytecode assembly) — block-opening directives
+    /// (`.method`, `.annotation`, `.array-data`, `.packed-switch`, …) are
+    /// closed by a matching `.end <name>`.
+    SmaliLike,
 }
 
 /// String form of a rule set (what a family or user config provides).
@@ -292,6 +296,7 @@ fn family_for_id(id: &str) -> Option<Family> {
         "lua" => Family::LuaLike,
         "bash" | "sh" | "shell" | "shellscript" => Family::BashLike,
         "pascal" => Family::PascalLike,
+        "smali" => Family::SmaliLike,
         _ => return None,
     };
     Some(f)
@@ -307,6 +312,7 @@ fn def_for_family(family: Family) -> &'static IndentRulesDef {
         Family::LuaLike => &LUA_LIKE,
         Family::BashLike => &BASH_LIKE,
         Family::PascalLike => &PASCAL_LIKE,
+        Family::SmaliLike => &SMALI_LIKE,
     }
 }
 
@@ -320,6 +326,7 @@ static FAMILY_RULES: Lazy<HashMap<Family, Arc<IndentRules>>> = Lazy::new(|| {
         Family::LuaLike,
         Family::BashLike,
         Family::PascalLike,
+        Family::SmaliLike,
     ] {
         m.insert(
             family,
@@ -441,6 +448,23 @@ const PASCAL_LIKE: IndentRulesDef = IndentRulesDef {
     indent_next_line: None,
     dedent_next_line: None,
     self_close: Some(r"\bend\b"),
+    indentation_significant: false,
+};
+
+const SMALI_LIKE: IndentRulesDef = IndentRulesDef {
+    // Block-opening directives. Each is always closed by a matching
+    // `.end <name>`, so — unlike `.field`, which is usually a one-liner —
+    // they reliably open an indented block. The `.end …` forms are excluded
+    // because `end` follows the dot, not the directive name.
+    increase: Some(
+        r"^\s*\.(method|annotation|subannotation|array-data|packed-switch|sparse-switch)\b",
+    ),
+    // Any `.end …` closes the current block and dedents its own line.
+    decrease: Some(r"^\s*\.end\b"),
+    indent_next_line: None,
+    dedent_next_line: None,
+    // Block directives never close on the same line, so no self-close guard.
+    self_close: None,
     indentation_significant: false,
 };
 
@@ -782,6 +806,57 @@ mod tests {
     #[test]
     fn pascal_one_liner_with_end_does_not_indent() {
         assert_eq!(indent("pascal", "begin end;\n", 4), 0);
+    }
+
+    // ---- SmaliLike --------------------------------------------------------
+
+    #[test]
+    fn smali_indents_method_body() {
+        // Pressing Enter after a `.method` header indents the body one level.
+        assert_eq!(indent("smali", ".method public foo()V\n", 4), 4);
+    }
+
+    #[test]
+    fn smali_indents_other_block_directives() {
+        assert_eq!(indent("smali", ".annotation runtime Lfoo;\n", 4), 4);
+        assert_eq!(indent("smali", "    .array-data 4\n", 4), 8);
+        assert_eq!(indent("smali", "    .packed-switch 0x0\n", 4), 8);
+    }
+
+    #[test]
+    fn smali_maintains_indent_inside_body() {
+        // A plain instruction line is not a block opener — keep its indent.
+        let content = ".method public foo()V\n    const/4 v0, 0x0\n";
+        assert_eq!(indent("smali", content, 4), 4);
+    }
+
+    #[test]
+    fn smali_end_directive_does_not_open_block() {
+        // `.end method` must not be mistaken for a `.method` opener: the line
+        // after it stays at the closer's column instead of indenting deeper.
+        assert_eq!(
+            indent("smali", ".method public foo()V\n.end method\n", 4),
+            0
+        );
+    }
+
+    #[test]
+    fn smali_dedents_typed_end_before_body() {
+        // Enter pressed with a trailing `.end method` on the new line dedents it
+        // back to the opener's column.
+        let content = ".method public foo()V\n    \n    .end method";
+        let pos = content.rfind(".end").unwrap();
+        let b = buf(content);
+        let got = rules_for_id("smali")
+            .unwrap()
+            .calculate_indent(&b, pos, 4, |_| true);
+        assert_eq!(got, 0);
+    }
+
+    #[test]
+    fn smali_resolves_from_syntect_name() {
+        // The no-tree-sitter Enter path keys off the syntect display name.
+        assert!(rules_for_syntax_name("Smali").is_some());
     }
 
     // ---- registry ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2265.

Adds full editing support for Smali — the human-readable assembly form of Dalvik/Android bytecode (`.smali` extension). Previously these files were detected as plain text (syntect ships no grammar) with no language-aware indentation.

## 1. Syntax highlighting

New embedded `smali.sublime-syntax` grammar, registered the same way as every other bundled-but-not-in-syntect language (TOML, Zig, Nim, C3, …):

- directives (`.class`, `.method`, `.end method`, `.field`, `.line`, `.local`, `.annotation`, …)
- instruction mnemonics with `-suffix`/`/variant` tails (`invoke-virtual/range`, `iget-object`, `add-int/2addr`, `const-string`, `if-eqz`, …)
- type descriptors (`Lcom/example/Foo;`, primitives `V Z B S C I J F D`, array-prefixed forms)
- registers (`v0`, `p1`), labels (`:cond_0`, `:goto_0`), access modifiers, strings, numbers, comments

Registered in both `types.rs` (`add_embedded_grammars`) and `build.rs` (the build-time packdump generator), which must stay in sync.

## 2. Auto-indentation

Smali has no tree-sitter grammar and previously had no entry in the regex indent-rules tier, so it fell through to the universal bracket heuristic — which only reacts to `{ } [ ] ( ) :`, none of which delimit Smali blocks. Pressing Enter after a `.method` header left the body at column 0.

Added a `SmaliLike` family to the regex indent-rules tier:
- **increase** after block-opening directives that always have a matching `.end …`: `.method`, `.annotation`, `.subannotation`, `.array-data`, `.packed-switch`, `.sparse-switch`
- **decrease** on any `.end …` line
- `.field` is deliberately excluded (usually a one-liner). Comment/string scope masking (already provided by the tier) prevents a directive inside a `#` comment from triggering.

## Testing

- `test_smali_grammar_loaded` — asserts `.smali` resolves to the `Smali` grammar (fails before the change, passes after).
- 6 new `indent_rules` tests covering method-body indent, other block directives, body maintenance, `.end` not opening a block, typed-`.end` dedent, and syntect-name resolution.
- `cargo test -p fresh-editor --lib primitives::grammar` → 41 passed; `… indent_rules` → 35 passed.
- `cargo fmt` / `cargo clippy` clean for touched code.
- **Manual validation (tmux):** opened `.smali` files in the editor — status bar reports the language as **Smali**, all token classes highlight correctly, and pressing Enter after `.method public foo()V` auto-indents the body to 4 spaces with subsequent body lines maintaining indent.

https://claude.ai/code/session_012ACTacoPpLGVZmUgWnTHsn