### PR TITLE
Add wave-animation screensaver after configurable idle

### DIFF
--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -44,6 +44,8 @@
         "page_width": 80,
         "syntax_highlighting": true,
         "show_menu_bar": true,
+        "screensaver_enabled": false,
+        "screensaver_idle_minutes": 5,
         "menu_bar_mnemonics": true,
         "show_tab_bar": true,
         "show_status_bar": true,
@@ -385,6 +387,20 @@
           "description": "Whether the menu bar is visible by default.\nThe menu bar provides access to menus (File, Edit, View, etc.) at the top of the screen.\nCan be toggled at runtime via command palette or keybinding.\nDefault: true",
           "type": "boolean",
           "default": true,
+          "x-section": "Display"
+        },
+        "screensaver_enabled": {
+          "description": "Enable the wave-animation screensaver. When the editor has been\nidle (no key or mouse input) for `screensaver_idle_minutes`, a\ndecorative wave washes over the screen until you press a key or\nmove the mouse.\nDefault: false",
+          "type": "boolean",
+          "default": false,
+          "x-section": "Display"
+        },
+        "screensaver_idle_minutes": {
+          "description": "Minutes of inactivity before the wave-animation screensaver starts\n(only when `screensaver_enabled`). A value of `0` disables it.\nDefault: 5",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 5,
           "x-section": "Display"
         },
         "menu_bar_mnemonics": {

--- a/crates/fresh-editor/src/app/toggle_actions.rs
+++ b/crates/fresh-editor/src/app/toggle_actions.rs
@@ -88,6 +88,37 @@ impl Editor {
         }
     }
 
+    /// The configured screensaver idle threshold, or `None` when the
+    /// screensaver is disabled (turned off, or a zero-minute timeout).
+    pub fn screensaver_idle_timeout(&self) -> Option<std::time::Duration> {
+        let editor = &self.config.editor;
+        if editor.screensaver_enabled && editor.screensaver_idle_minutes > 0 {
+            Some(std::time::Duration::from_secs(
+                editor.screensaver_idle_minutes as u64 * 60,
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Start the wave animation as a screensaver if the editor has been
+    /// idle (no key/mouse input) for at least the configured threshold.
+    /// No-op — returns `false` — when the screensaver is disabled, the
+    /// idle time is below the threshold, or a wave is already running.
+    /// Returns `true` iff it started the screensaver on this call. The
+    /// main loop calls this each time it polls and finds no input event;
+    /// any real input both dismisses the wave and resets the idle clock.
+    pub fn maybe_start_screensaver(&mut self, idle: std::time::Duration) -> bool {
+        let Some(timeout) = self.screensaver_idle_timeout() else {
+            return false;
+        };
+        if idle < timeout || self.wave_animation_active() {
+            return false;
+        }
+        self.trigger_wave_animation();
+        true
+    }
+
     /// Toggle menu bar visibility.
     ///
     /// `editor.show_menu_bar` is a global preference, so the toggle updates the

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -876,6 +876,22 @@ pub struct EditorConfig {
     #[schemars(extend("x-section" = "Display"))]
     pub show_menu_bar: bool,
 
+    /// Enable the wave-animation screensaver. When the editor has been
+    /// idle (no key or mouse input) for `screensaver_idle_minutes`, a
+    /// decorative wave washes over the screen until you press a key or
+    /// move the mouse.
+    /// Default: false
+    #[serde(default = "default_false")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub screensaver_enabled: bool,
+
+    /// Minutes of inactivity before the wave-animation screensaver starts
+    /// (only when `screensaver_enabled`). A value of `0` disables it.
+    /// Default: 5
+    #[serde(default = "default_screensaver_idle_minutes")]
+    #[schemars(extend("x-section" = "Display"))]
+    pub screensaver_idle_minutes: u32,
+
     /// Whether menu bar mnemonics (Alt+letter shortcuts) are enabled.
     /// When enabled, pressing Alt+F opens the File menu, Alt+E opens Edit, etc.
     /// Disabling this frees up Alt+letter keybindings for other actions.
@@ -1422,6 +1438,10 @@ fn default_true() -> bool {
     true
 }
 
+fn default_screensaver_idle_minutes() -> u32 {
+    5
+}
+
 fn default_false() -> bool {
     false
 }
@@ -1539,6 +1559,8 @@ impl Default for EditorConfig {
             quick_suggestions_delay_ms: default_quick_suggestions_delay(),
             suggest_on_trigger_characters: true,
             show_menu_bar: true,
+            screensaver_enabled: false,
+            screensaver_idle_minutes: default_screensaver_idle_minutes(),
             menu_bar_mnemonics: true,
             show_tab_bar: true,
             show_status_bar: true,

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4313,6 +4313,9 @@ where
     let mut last_render = Instant::now();
     let mut needs_render = true;
     let mut pending_event: Option<CrosstermEvent> = None;
+    // Wall-clock of the last real input event, used to start the
+    // wave-animation screensaver after the configured idle period.
+    let mut last_input_time = Instant::now();
 
     loop {
         // Apply any nested-forward requests (file/dir opens from a `fresh`
@@ -4436,7 +4439,18 @@ where
             poll_event(timeout)?
         };
 
-        let Some(event) = event else { continue };
+        let Some(event) = event else {
+            // No input this cycle. If the editor has been idle long enough,
+            // start the wave-animation screensaver (it renders on the next
+            // iteration via the animation-active check above).
+            if editor.maybe_start_screensaver(last_input_time.elapsed()) {
+                needs_render = true;
+            }
+            continue;
+        };
+
+        // A real input event arrived — reset the screensaver idle clock.
+        last_input_time = Instant::now();
 
         let (event, next) = coalesce_mouse_moves(event)?;
         pending_event = next;

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -4313,9 +4313,10 @@ where
     let mut last_render = Instant::now();
     let mut needs_render = true;
     let mut pending_event: Option<CrosstermEvent> = None;
-    // Wall-clock of the last real input event, used to start the
-    // wave-animation screensaver after the configured idle period.
-    let mut last_input_time = Instant::now();
+    // Time of the last real input event, used to start the wave-animation
+    // screensaver after the configured idle period. Read from the editor's
+    // injected time source so tests can drive idle time deterministically.
+    let mut last_input_time = editor.time_source().now();
 
     loop {
         // Apply any nested-forward requests (file/dir opens from a `fresh`
@@ -4443,14 +4444,15 @@ where
             // No input this cycle. If the editor has been idle long enough,
             // start the wave-animation screensaver (it renders on the next
             // iteration via the animation-active check above).
-            if editor.maybe_start_screensaver(last_input_time.elapsed()) {
+            let idle = editor.time_source().elapsed_since(last_input_time);
+            if editor.maybe_start_screensaver(idle) {
                 needs_render = true;
             }
             continue;
         };
 
         // A real input event arrived — reset the screensaver idle clock.
-        last_input_time = Instant::now();
+        last_input_time = editor.time_source().now();
 
         let (event, next) = coalesce_mouse_moves(event)?;
         pending_event = next;

--- a/crates/fresh-editor/src/partial_config.rs
+++ b/crates/fresh-editor/src/partial_config.rs
@@ -199,6 +199,8 @@ pub struct PartialEditorConfig {
     pub quick_suggestions_delay_ms: Option<u64>,
     pub suggest_on_trigger_characters: Option<bool>,
     pub show_menu_bar: Option<bool>,
+    pub screensaver_enabled: Option<bool>,
+    pub screensaver_idle_minutes: Option<u32>,
     pub menu_bar_mnemonics: Option<bool>,
     pub show_tab_bar: Option<bool>,
     pub show_status_bar: Option<bool>,
@@ -307,6 +309,10 @@ impl Merge for PartialEditorConfig {
         self.suggest_on_trigger_characters
             .merge_from(&other.suggest_on_trigger_characters);
         self.show_menu_bar.merge_from(&other.show_menu_bar);
+        self.screensaver_enabled
+            .merge_from(&other.screensaver_enabled);
+        self.screensaver_idle_minutes
+            .merge_from(&other.screensaver_idle_minutes);
         self.menu_bar_mnemonics
             .merge_from(&other.menu_bar_mnemonics);
         self.show_tab_bar.merge_from(&other.show_tab_bar);
@@ -625,6 +631,8 @@ impl From<&crate::config::EditorConfig> for PartialEditorConfig {
             quick_suggestions_delay_ms: Some(cfg.quick_suggestions_delay_ms),
             suggest_on_trigger_characters: Some(cfg.suggest_on_trigger_characters),
             show_menu_bar: Some(cfg.show_menu_bar),
+            screensaver_enabled: Some(cfg.screensaver_enabled),
+            screensaver_idle_minutes: Some(cfg.screensaver_idle_minutes),
             menu_bar_mnemonics: Some(cfg.menu_bar_mnemonics),
             show_tab_bar: Some(cfg.show_tab_bar),
             show_status_bar: Some(cfg.show_status_bar),
@@ -780,6 +788,12 @@ impl PartialEditorConfig {
                 .suggest_on_trigger_characters
                 .unwrap_or(defaults.suggest_on_trigger_characters),
             show_menu_bar: self.show_menu_bar.unwrap_or(defaults.show_menu_bar),
+            screensaver_enabled: self
+                .screensaver_enabled
+                .unwrap_or(defaults.screensaver_enabled),
+            screensaver_idle_minutes: self
+                .screensaver_idle_minutes
+                .unwrap_or(defaults.screensaver_idle_minutes),
             menu_bar_mnemonics: self
                 .menu_bar_mnemonics
                 .unwrap_or(defaults.menu_bar_mnemonics),

--- a/crates/fresh-editor/tests/screensaver_test.rs
+++ b/crates/fresh-editor/tests/screensaver_test.rs
@@ -1,0 +1,71 @@
+// Tests for the idle wave-animation screensaver.
+//
+// The screensaver is time-driven (start after N idle minutes), so the
+// decision is exposed as `Editor::maybe_start_screensaver(idle)` which
+// takes the elapsed idle duration explicitly. These tests drive that
+// method with explicit durations — no sleeping, no wall-clock timing — and
+// assert on the resulting state.
+mod common;
+
+use common::harness::EditorTestHarness;
+use std::time::Duration;
+
+/// With the screensaver enabled and a 5-minute threshold, being idle past
+/// the threshold starts the wave; below it does nothing; and it does not
+/// restart while already running.
+#[test]
+fn screensaver_starts_wave_after_configured_idle() {
+    let mut config = fresh::config::Config::default();
+    config.editor.screensaver_enabled = true;
+    config.editor.screensaver_idle_minutes = 5;
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    // Render once so the editor knows its terminal size (the wave needs a
+    // non-empty area to start).
+    harness.render().unwrap();
+
+    // Below the threshold: nothing happens.
+    assert!(!harness
+        .editor_mut()
+        .maybe_start_screensaver(Duration::from_secs(4 * 60)));
+    assert!(!harness.editor().wave_animation_active());
+
+    // At/over the threshold: the wave kicks in.
+    assert!(harness
+        .editor_mut()
+        .maybe_start_screensaver(Duration::from_secs(5 * 60)));
+    assert!(harness.editor().wave_animation_active());
+
+    // Already running: a further idle tick must not start a second wave.
+    assert!(!harness
+        .editor_mut()
+        .maybe_start_screensaver(Duration::from_secs(20 * 60)));
+}
+
+/// The screensaver is opt-in: with the default config it never starts, no
+/// matter how long the editor has been idle.
+#[test]
+fn screensaver_disabled_by_default() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+    harness.render().unwrap();
+    assert!(harness.editor().screensaver_idle_timeout().is_none());
+    assert!(!harness
+        .editor_mut()
+        .maybe_start_screensaver(Duration::from_secs(60 * 60)));
+    assert!(!harness.editor().wave_animation_active());
+}
+
+/// A zero-minute threshold disables the screensaver even when the enable
+/// flag is set, so it can't fire on every idle poll.
+#[test]
+fn screensaver_zero_minutes_is_disabled() {
+    let mut config = fresh::config::Config::default();
+    config.editor.screensaver_enabled = true;
+    config.editor.screensaver_idle_minutes = 0;
+    let mut harness = EditorTestHarness::with_config(80, 24, config).unwrap();
+    harness.render().unwrap();
+    assert!(harness.editor().screensaver_idle_timeout().is_none());
+    assert!(!harness
+        .editor_mut()
+        .maybe_start_screensaver(Duration::from_secs(60 * 60)));
+    assert!(!harness.editor().wave_animation_active());
+}


### PR DESCRIPTION
## Summary

Lets the wave animation double as a **screensaver**: when the editor sees no key or mouse input for a configurable number of minutes, the wave washes over the screen until the next input dismisses it.

Follow-up to the wave animation feature (#2306).

## Config

Two new `editor` config fields (opt-in, off by default so it never surprises anyone):

| Field | Type | Default | Meaning |
|-------|------|---------|---------|
| `screensaver_enabled` | bool | `false` | Enable the idle wave screensaver |
| `screensaver_idle_minutes` | u32 | `5` | Minutes of inactivity before it starts (`0` also disables) |

```jsonc
{ "editor": { "screensaver_enabled": true, "screensaver_idle_minutes": 5 } }
```

Mirrored through `PartialEditorConfig` (merge / from / resolve) and the regenerated `config-schema.json`.

## How it works

- `Editor::screensaver_idle_timeout()` / `maybe_start_screensaver(idle)` encapsulate the decision (enabled, past threshold, not already running) so the logic is unit-testable without wall-clock timing.
- The main event loop tracks the last real input event; when a poll returns **no** event it offers the elapsed idle time to `maybe_start_screensaver`. Real input both resets the idle clock and — via the existing dismiss-on-input wave path — stops a running screensaver (that keypress is consumed, only waking the screen).

## Testing

- `crates/fresh-editor/tests/screensaver_test.rs` — drives `maybe_start_screensaver` with explicit `Duration`s (no sleeping / no timers, per CONTRIBUTING):
  - starts the wave only once idle ≥ threshold, and not twice while running;
  - opt-in: disabled by default never starts;
  - `0` minutes disables it.
  - Verified the positive test **fails** when the trigger is stubbed out, and passes with the change.
- Manually validated end to end through the real event loop (config `idle_minutes: 1`): the idle clock climbs to 60s, the screensaver fires, the wave renders, and a keypress dismisses it.
- `cargo fmt`, `cargo clippy` (0 warnings), `cargo check --all-targets`, and the config schema diff are all clean/up-to-date.

https://claude.ai/code/session_01QwUSVrmnmUs6ksa1AmAUKn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwUSVrmnmUs6ksa1AmAUKn)_