### PR TITLE
Plugin-scoped widget panel identity + theme-inspect coverage for editor chrome

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3806,13 +3806,13 @@ pub enum PluginCommand {
 
     /// Mount a declarative widget panel inside an existing virtual
     /// buffer. The host renders the `WidgetSpec` and writes the
-    /// resulting text-property entries into the buffer. The
-    /// `panel_id` is plugin-allocated (any unique u64 for that
-    /// plugin) and is used to address the panel for later
-    /// `UpdateWidgetPanel` / `UnmountWidgetPanel` calls.
+    /// resulting text-property entries into the buffer. `panel_id`
+    /// is plugin-local; the host keys the panel by (plugin, id), so
+    /// every widget command carries the calling plugin's name.
     ///
     /// See `docs/internal/plugin-widget-library-design.md`.
     MountWidgetPanel {
+        plugin: String,
         panel_id: u64,
         buffer_id: BufferId,
         spec: WidgetSpec,
@@ -3822,11 +3822,15 @@ pub enum PluginCommand {
     /// The reconciler diffs against the previous spec and applies
     /// the minimum mutation; widget instance state is preserved on
     /// nodes whose `key` matches.
-    UpdateWidgetPanel { panel_id: u64, spec: WidgetSpec },
+    UpdateWidgetPanel {
+        plugin: String,
+        panel_id: u64,
+        spec: WidgetSpec,
+    },
 
     /// Tear down a widget panel. Subsequent `UpdateWidgetPanel`
     /// calls for the same `panel_id` are no-ops.
-    UnmountWidgetPanel { panel_id: u64 },
+    UnmountWidgetPanel { plugin: String, panel_id: u64 },
 
     /// Route a keystroke / nav action to the panel's currently
     /// focused widget. The plugin's `defineMode` bindings dispatch
@@ -3834,13 +3838,18 @@ pub enum PluginCommand {
     /// (Tab cycle, Enter to activate, Up/Down to navigate a List,
     /// Backspace / arrows / printable input to edit a TextInput).
     /// See `WidgetAction` for the action shapes.
-    WidgetCommand { panel_id: u64, action: WidgetAction },
+    WidgetCommand {
+        plugin: String,
+        panel_id: u64,
+        action: WidgetAction,
+    },
 
     /// Apply a targeted mutation to a mounted widget panel
     /// without re-transmitting the full spec. The IPC fast path
     /// for hot-path updates (typing, selection moves, partial
     /// list refreshes). See `WidgetMutation` for the shapes.
     WidgetMutate {
+        plugin: String,
         panel_id: u64,
         mutation: WidgetMutation,
     },
@@ -3852,6 +3861,7 @@ pub enum PluginCommand {
     /// mounted at a time; a second `MountFloatingWidget` replaces
     /// any existing one.
     MountFloatingWidget {
+        plugin: String,
         panel_id: u64,
         spec: WidgetSpec,
         width_pct: u8,
@@ -3865,11 +3875,15 @@ pub enum PluginCommand {
     /// Replace the spec of the currently-mounted floating widget
     /// panel. No-op when no floating panel is mounted, or when the
     /// `panel_id` doesn't match the mounted one.
-    UpdateFloatingWidget { panel_id: u64, spec: WidgetSpec },
+    UpdateFloatingWidget {
+        plugin: String,
+        panel_id: u64,
+        spec: WidgetSpec,
+    },
 
     /// Tear down the floating widget panel. No-op when no floating
     /// panel is mounted, or when the `panel_id` doesn't match.
-    UnmountFloatingWidget { panel_id: u64 },
+    UnmountFloatingWidget { plugin: String, panel_id: u64 },
 
     /// Control a mounted floating widget panel's placement / focus
     /// without re-sending its spec. `op` is one of:
@@ -3883,7 +3897,12 @@ pub enum PluginCommand {
     /// - "fullscreen" — a centered panel renders over the *entire* frame
     ///   (covering the dimmed dock) when `arg != 0`, instead of laying
     ///   into the chrome area beside the dock. No-op when no dock is up.
-    FloatingPanelControl { panel_id: u64, op: String, arg: f64 },
+    FloatingPanelControl {
+        plugin: String,
+        panel_id: u64,
+        op: String,
+        arg: f64,
+    },
 }
 
 impl PluginCommand {

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -3629,6 +3629,9 @@ interface HookEventMap {
 	* click to a `Toggle` / `Button` widget node within a mounted
 	* widget panel. See `docs/internal/plugin-widget-library-design.md`.
 	*
+	* Panel ids are plugin-local: the host keys panels by
+	* (plugin, id) and delivers each event only to the plugin that
+	* owns the panel, so ids never need to be globally unique.
 	* Routing is by `panel_id` (matches the id the plugin allocated
 	* at mount time) plus `widget_key` (the stable `key` set on the
 	* widget spec node, or empty when the spec did not assign one).

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -937,9 +937,38 @@ export function key(name: string): WidgetAction {
 // =============================================================================
 
 let nextPanelId = 1;
+// Per-plugin high bits, derived once from the plugin's name. Plugins run in
+// isolated JS contexts that each allocate `nextPanelId` from 1, so a shared
+// base made every plugin's first panel id identical — and the host registry,
+// keyed by panel id, would have a second plugin's `mountWidgetPanel`
+// *overwrite* the first's entry (e.g. opening the theme editor evicted the
+// orchestrator dock, killing its click hit-map). Panel ids are also how a
+// plugin matches its own `widget_event`s (`e.panel_id === panel.id()`), so
+// they must be globally unique, not just unique within one plugin.
+let pluginPanelSalt: number | null = null;
+function panelSalt(): number {
+  if (pluginPanelSalt !== null) return pluginPanelSalt;
+  let name = "";
+  try {
+    name = editor.pluginName() || "";
+  } catch {
+    name = "";
+  }
+  // FNV-1a 32-bit over the plugin name → a near-unique per-plugin bucket.
+  let h = 0x811c_9dc5;
+  for (let i = 0; i < name.length; i++) {
+    h ^= name.charCodeAt(i);
+    h = Math.imul(h, 0x0100_0193);
+  }
+  pluginPanelSalt = h >>> 0;
+  return pluginPanelSalt;
+}
 function allocatePanelId(): number {
-  // Bias high so plugin-allocated ids don't collide with the
-  // editor's internal panel-id space if it ever uses small ints.
-  const id = nextPanelId++;
-  return 0x1000_0000 + id;
+  // Layout: 0x1_0000_0000 base (bias high, clear of the editor's small
+  // internal ids) + [32-bit plugin salt] * 2^20 + [20-bit local counter].
+  // Max ≈ 2^52, within JS's 2^53 exact-integer range. Distinct plugin names
+  // collide only on a full 32-bit hash clash — negligible for a handful of
+  // plugins — so each plugin owns a disjoint id range.
+  const id = nextPanelId++ & 0xf_ffff;
+  return 0x1_0000_0000 + panelSalt() * 0x10_0000 + id;
 }

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -932,43 +932,13 @@ export function key(name: string): WidgetAction {
 }
 
 // =============================================================================
-// Panel-id allocation. Plugin-side counter; need only be unique per
-// plugin instance (the host doesn't interpret the value).
+// Panel-id allocation.
 // =============================================================================
 
+// Panel ids are plugin-local: the host keys panels by (plugin, id) and
+// delivers widget_events only to the owning plugin, so a plain per-context
+// counter is all the uniqueness a panel id ever needs.
 let nextPanelId = 1;
-// Per-plugin high bits, derived once from the plugin's name. Plugins run in
-// isolated JS contexts that each allocate `nextPanelId` from 1, so a shared
-// base made every plugin's first panel id identical — and the host registry,
-// keyed by panel id, would have a second plugin's `mountWidgetPanel`
-// *overwrite* the first's entry (e.g. opening the theme editor evicted the
-// orchestrator dock, killing its click hit-map). Panel ids are also how a
-// plugin matches its own `widget_event`s (`e.panel_id === panel.id()`), so
-// they must be globally unique, not just unique within one plugin.
-let pluginPanelSalt: number | null = null;
-function panelSalt(): number {
-  if (pluginPanelSalt !== null) return pluginPanelSalt;
-  let name = "";
-  try {
-    name = editor.pluginName() || "";
-  } catch {
-    name = "";
-  }
-  // FNV-1a 32-bit over the plugin name → a near-unique per-plugin bucket.
-  let h = 0x811c_9dc5;
-  for (let i = 0; i < name.length; i++) {
-    h ^= name.charCodeAt(i);
-    h = Math.imul(h, 0x0100_0193);
-  }
-  pluginPanelSalt = h >>> 0;
-  return pluginPanelSalt;
-}
 function allocatePanelId(): number {
-  // Layout: 0x1_0000_0000 base (bias high, clear of the editor's small
-  // internal ids) + [32-bit plugin salt] * 2^20 + [20-bit local counter].
-  // Max ≈ 2^52, within JS's 2^53 exact-integer range. Distinct plugin names
-  // collide only on a full 32-bit hash clash — negligible for a handful of
-  // plugins — so each plugin owns a disjoint id range.
-  const id = nextPanelId++ & 0xf_ffff;
-  return 0x1_0000_0000 + panelSalt() * 0x10_0000 + id;
+  return nextPanelId++;
 }

--- a/crates/fresh-editor/src/app/click_handlers.rs
+++ b/crates/fresh-editor/src/app/click_handlers.rs
@@ -221,7 +221,7 @@ impl Editor {
         // driven, it stops listening to `mouse_click` for its panel
         // and the duplicate dispatch becomes a no-op.
         if let (Some(brow), Some(bcol)) = (mc_buffer_row, mc_buffer_col) {
-            if let Some((panel_id, hit)) = self.widget_registry.hit_test(buffer_id, brow, bcol) {
+            if let Some((panel_key, hit)) = self.widget_registry.hit_test(buffer_id, brow, bcol) {
                 // Click-to-focus: if the clicked widget has a stable
                 // key that's tabbable, move focus there before
                 // firing the event. The next render shows the focus
@@ -230,15 +230,15 @@ impl Editor {
                 if !hit.widget_key.is_empty() {
                     let is_tabbable = self
                         .widget_registry
-                        .get(panel_id)
+                        .get(&panel_key)
                         .map(|p| p.tabbable.iter().any(|k| k == &hit.widget_key))
                         .unwrap_or(false);
                     if is_tabbable {
-                        self.set_panel_focus_and_notify(panel_id, hit.widget_key.clone());
+                        self.set_panel_focus_and_notify(&panel_key, hit.widget_key.clone());
                     }
                     // Re-render so the focus styling updates without
                     // waiting for the plugin to re-emit the spec.
-                    self.rerender_widget_panel(panel_id);
+                    self.rerender_widget_panel(&panel_key);
                 }
                 // Tree disclosure click: the host owns expansion
                 // state, so toggle it before firing the plugin
@@ -252,7 +252,11 @@ impl Editor {
                 let mut handled_specially = false;
                 if hit.widget_kind == "tree" && hit.event_type == "expand" {
                     if let Some(item_key) = hit.payload.get("key").and_then(|v| v.as_str()) {
-                        self.handle_widget_tree_expand_toggle(panel_id, &hit.widget_key, item_key);
+                        self.handle_widget_tree_expand_toggle(
+                            &panel_key,
+                            &hit.widget_key,
+                            item_key,
+                        );
                         handled_specially = true;
                     }
                 }
@@ -275,25 +279,16 @@ impl Editor {
                     if let Some(list_key) = hit.payload.get("list_key").and_then(|v| v.as_str()) {
                         event_widget_key = list_key.to_string();
                         if let Some(idx) = hit.payload.get("index").and_then(|v| v.as_i64()) {
-                            self.set_widget_list_selected_index(panel_id, list_key, idx as i32);
+                            self.set_widget_list_selected_index(&panel_key, list_key, idx as i32);
                         }
                     }
                 }
-                if !handled_specially
-                    && self
-                        .plugin_manager
-                        .read()
-                        .unwrap()
-                        .has_hook_handlers("widget_event")
-                {
-                    self.plugin_manager.read().unwrap().run_hook(
-                        "widget_event",
-                        HookArgs::WidgetEvent {
-                            panel_id,
-                            widget_key: event_widget_key,
-                            event_type: hit.event_type.to_string(),
-                            payload: hit.payload.clone(),
-                        },
+                if !handled_specially {
+                    self.fire_widget_event(
+                        &panel_key,
+                        event_widget_key,
+                        hit.event_type.to_string(),
+                        hit.payload.clone(),
                     );
                 }
             }

--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -1163,15 +1163,15 @@ impl Editor {
         } else {
             return false;
         };
-        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
+        let Some(panel_id) = self.panel(slot).map(|f| f.panel_key.clone()) else {
             return false;
         };
-        if self.panel_focused_widget_is_text(panel_id) {
+        if self.panel_focused_widget_is_text(&panel_id) {
             // Single-line `TextEdit` strips embedded newlines; multi-line
             // stores plain `\n`. Normalise CRLF / CR → LF first, matching
             // the `Action::Paste` widget-routing path.
             let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-            self.handle_widget_insert_str(panel_id, &normalized);
+            self.handle_widget_insert_str(&panel_id, &normalized);
             self.set_status_message(t!("clipboard.pasted").to_string());
         }
         true

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -934,16 +934,23 @@ impl Editor {
         }
     }
 
-    /// Which slot currently holds the panel with this id, if any.
+    /// Which slot currently holds the panel with this identity, if any.
     #[cfg(feature = "plugins")]
-    pub(crate) fn slot_of_panel(&self, panel_id: u64) -> Option<crate::app::PanelSlot> {
+    pub(crate) fn slot_of_panel(
+        &self,
+        panel_key: &crate::widgets::PanelKey,
+    ) -> Option<crate::app::PanelSlot> {
         if self
             .floating_widget_panel
             .as_ref()
-            .is_some_and(|f| f.panel_id == panel_id)
+            .is_some_and(|f| &f.panel_key == panel_key)
         {
             Some(crate::app::PanelSlot::Floating)
-        } else if self.dock.as_ref().is_some_and(|f| f.panel_id == panel_id) {
+        } else if self
+            .dock
+            .as_ref()
+            .is_some_and(|f| &f.panel_key == panel_key)
+        {
             Some(crate::app::PanelSlot::Dock)
         } else {
             None

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -745,29 +745,30 @@ impl Editor {
                             let ctrl = modifiers.contains(KeyModifiers::CONTROL);
                             let handled = match code {
                                 KeyCode::Left if ctrl => self
-                                    .with_focused_text_editor(panel_id, |e| {
+                                    .with_focused_text_editor(&panel_id, |e| {
                                         e.move_word_left_selecting()
                                     }),
                                 KeyCode::Right if ctrl => self
-                                    .with_focused_text_editor(panel_id, |e| {
+                                    .with_focused_text_editor(&panel_id, |e| {
                                         e.move_word_right_selecting()
                                     }),
-                                KeyCode::Left => self.with_focused_text_editor(panel_id, |e| {
+                                KeyCode::Left => self.with_focused_text_editor(&panel_id, |e| {
                                     e.move_left_selecting()
                                 }),
-                                KeyCode::Right => self.with_focused_text_editor(panel_id, |e| {
+                                KeyCode::Right => self.with_focused_text_editor(&panel_id, |e| {
                                     e.move_right_selecting()
                                 }),
                                 KeyCode::Up => self
-                                    .with_focused_text_editor(panel_id, |e| e.move_up_selecting()),
-                                KeyCode::Down => self.with_focused_text_editor(panel_id, |e| {
+                                    .with_focused_text_editor(&panel_id, |e| e.move_up_selecting()),
+                                KeyCode::Down => self.with_focused_text_editor(&panel_id, |e| {
                                     e.move_down_selecting()
                                 }),
-                                KeyCode::Home => self.with_focused_text_editor(panel_id, |e| {
+                                KeyCode::Home => self.with_focused_text_editor(&panel_id, |e| {
                                     e.move_home_selecting()
                                 }),
-                                KeyCode::End => self
-                                    .with_focused_text_editor(panel_id, |e| e.move_end_selecting()),
+                                KeyCode::End => self.with_focused_text_editor(&panel_id, |e| {
+                                    e.move_end_selecting()
+                                }),
                                 _ => false,
                             };
                             // We always consume Shift+nav on a
@@ -1128,7 +1129,7 @@ impl Editor {
                 // buffer's read-only-ness.
                 let buffer_id = self.active_buffer();
                 if let Some(panel_id) = self.focused_text_widget_panel_for_buffer(buffer_id) {
-                    if self.handle_widget_copy(panel_id) {
+                    if self.handle_widget_copy(&panel_id) {
                         self.set_status_message(t!("clipboard.copied").to_string());
                         return Ok(());
                     }
@@ -1156,7 +1157,7 @@ impl Editor {
                 // are independent of the underlying virtual buffer.
                 let buffer_id = self.active_buffer();
                 if let Some(panel_id) = self.focused_text_widget_panel_for_buffer(buffer_id) {
-                    if self.handle_widget_cut(panel_id) {
+                    if self.handle_widget_cut(&panel_id) {
                         return Ok(());
                     }
                 }
@@ -1182,7 +1183,7 @@ impl Editor {
                 if let Some(panel_id) = self.focused_text_widget_panel_for_buffer(buffer_id) {
                     if let Some(text) = self.clipboard.paste() {
                         let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-                        self.handle_widget_insert_str(panel_id, &normalized);
+                        self.handle_widget_insert_str(&panel_id, &normalized);
                         self.set_status_message(t!("clipboard.pasted").to_string());
                     }
                     return Ok(());
@@ -1200,7 +1201,7 @@ impl Editor {
                 // catch-all path below.
                 let buffer_id = self.active_buffer();
                 if let Some(panel_id) = self.focused_text_widget_panel_for_buffer(buffer_id) {
-                    self.handle_widget_select_all(panel_id);
+                    self.handle_widget_select_all(&panel_id);
                     return Ok(());
                 }
                 self.apply_action_as_events(Action::SelectAll)?;
@@ -2480,23 +2481,13 @@ impl Editor {
     /// `sessions` widget. Used for dock-only gestures (Enter-activate,
     /// the Alt+T/Alt+I/Alt+P filter toggles) that the dialog handles via
     /// an editor mode the dock can't use — see `dispatch_floating_widget_key`.
-    fn fire_dock_widget_event(&self, panel_id: u64, event_type: &str) {
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: "sessions".to_string(),
-                    event_type: event_type.to_string(),
-                    payload: serde_json::json!({}),
-                },
-            );
-        }
+    fn fire_dock_widget_event(&self, panel_key: &crate::widgets::PanelKey, event_type: &str) {
+        self.fire_widget_event(
+            panel_key,
+            "sessions".to_string(),
+            event_type.to_string(),
+            serde_json::json!({}),
+        );
     }
 
     /// Route a keystroke to the floating widget panel when one is
@@ -2516,8 +2507,8 @@ impl Editor {
         modifiers: crossterm::event::KeyModifiers,
     ) -> bool {
         use crossterm::event::{KeyCode, KeyModifiers};
-        let panel_id = match self.panel(slot) {
-            Some(fwp) => fwp.panel_id,
+        let panel_key = match self.panel(slot) {
+            Some(fwp) => fwp.panel_key.clone(),
             None => {
                 tracing::debug!(
                     target: "fresh::dock",
@@ -2530,7 +2521,7 @@ impl Editor {
         };
         tracing::debug!(
             target: "fresh::dock",
-            panel_id,
+            panel = %panel_key,
             ?slot,
             ?code,
             modifiers = ?modifiers,
@@ -2551,7 +2542,7 @@ impl Editor {
         ) {
             let on_filter = self
                 .widget_registry
-                .focus_key(panel_id)
+                .focus_key(&panel_key)
                 .map(|k| k == "filter")
                 .unwrap_or(false);
             // The project dropdown owns the keyboard while panel focus
@@ -2564,40 +2555,40 @@ impl Editor {
             // so the dropdown was visible but un-navigable by keyboard.
             let on_project_menu = self
                 .widget_registry
-                .focus_key(panel_id)
+                .focus_key(&panel_key)
                 .map(|k| k.starts_with("project-pick:"))
                 .unwrap_or(false);
             if on_project_menu {
                 match code {
                     KeyCode::Up => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_prev");
                         return true;
                     }
                     KeyCode::Down => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_next");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_next");
                         return true;
                     }
                     // Tab/Shift+Tab navigate the menu too, so they can't
                     // tab focus *out* of the open dropdown into the dock
                     // toolbar behind it.
                     KeyCode::Tab if modifiers.contains(KeyModifiers::SHIFT) => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_prev");
                         return true;
                     }
                     KeyCode::BackTab => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_prev");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_prev");
                         return true;
                     }
                     KeyCode::Tab => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_next");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_next");
                         return true;
                     }
                     KeyCode::Enter | KeyCode::Char(' ') => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_accept");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_accept");
                         return true;
                     }
                     KeyCode::Esc => {
-                        self.fire_dock_widget_event(panel_id, "dock_menu_cancel");
+                        self.fire_dock_widget_event(&panel_key, "dock_menu_cancel");
                         return true;
                     }
                     _ => {}
@@ -2607,7 +2598,7 @@ impl Editor {
                 KeyCode::Esc => {
                     if on_filter {
                         // Return from the filter to the session list.
-                        self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
+                        self.set_panel_focus_and_notify(&panel_key, "sessions".to_string());
                     } else {
                         // Leave the dock — focus the editor; dock stays visible.
                         self.blur_floating_panel(slot);
@@ -2617,10 +2608,10 @@ impl Editor {
                 KeyCode::Enter => {
                     if on_filter {
                         // Return from the filter to the session list.
-                        self.set_panel_focus_and_notify(panel_id, "sessions".to_string());
+                        self.set_panel_focus_and_notify(&panel_key, "sessions".to_string());
                     } else if self
                         .widget_registry
-                        .focus_key(panel_id)
+                        .focus_key(&panel_key)
                         .map(|k| k == "sessions" || k.is_empty())
                         .unwrap_or(true)
                     {
@@ -2633,7 +2624,7 @@ impl Editor {
                         // dialog's identical `activate` logic, not split across
                         // the host (was: always blur, which silently dropped
                         // the on-disk attach in the dock).
-                        self.fire_dock_widget_event(panel_id, "dock_activate");
+                        self.fire_dock_widget_event(&panel_key, "dock_activate");
                     } else {
                         // A button or toggle is keyboard-focused (Tab-cycled
                         // onto "+ New", "Manage", "view", the project menu, or
@@ -2645,7 +2636,7 @@ impl Editor {
                         // and merely re-focused the session list, so buttons
                         // worked with the mouse but not the keyboard.
                         self.handle_widget_command(
-                            panel_id,
+                            &panel_key,
                             fresh_core::api::WidgetAction::Key {
                                 key: "Enter".to_string(),
                             },
@@ -2654,7 +2645,7 @@ impl Editor {
                     return true;
                 }
                 KeyCode::Char('/') if modifiers.is_empty() => {
-                    self.set_panel_focus_and_notify(panel_id, "filter".to_string());
+                    self.set_panel_focus_and_notify(&panel_key, "filter".to_string());
                     return true;
                 }
                 KeyCode::Char('t' | 'T') if modifiers.contains(KeyModifiers::ALT) => {
@@ -2664,19 +2655,19 @@ impl Editor {
                     // dock widget_event the plugin maps to the same toggle —
                     // otherwise it falls through to the generic chord path and
                     // merely blurs the dock.
-                    self.fire_dock_widget_event(panel_id, "dock_toggle_worktrees");
+                    self.fire_dock_widget_event(&panel_key, "dock_toggle_worktrees");
                     return true;
                 }
                 KeyCode::Char('i' | 'I') if modifiers.contains(KeyModifiers::ALT) => {
                     // Alt+I toggles "show empty/1-file sessions" — same dock
                     // routing rationale as Alt+T above.
-                    self.fire_dock_widget_event(panel_id, "dock_toggle_trivial");
+                    self.fire_dock_widget_event(&panel_key, "dock_toggle_trivial");
                     return true;
                 }
                 KeyCode::Char('p' | 'P') if modifiers.contains(KeyModifiers::ALT) => {
                     // Alt+P flips the project scope (current ↔ all) — same dock
                     // routing rationale as Alt+T above.
-                    self.fire_dock_widget_event(panel_id, "dock_toggle_scope");
+                    self.fire_dock_widget_event(&panel_key, "dock_toggle_scope");
                     return true;
                 }
                 KeyCode::Char('n' | 'N') if modifiers.contains(KeyModifiers::ALT) => {
@@ -2685,50 +2676,29 @@ impl Editor {
                     // active buffer's mode; fire a `dock_new` widget_event
                     // the plugin turns into "+ New" — and which now leaves
                     // the dock mounted (the form is a separate slot).
-                    if self
-                        .plugin_manager
-                        .read()
-                        .unwrap()
-                        .has_hook_handlers("widget_event")
-                    {
-                        self.plugin_manager.read().unwrap().run_hook(
-                            "widget_event",
-                            crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                                panel_id,
-                                widget_key: "sessions".to_string(),
-                                event_type: "dock_new".to_string(),
-                                payload: serde_json::json!({}),
-                            },
-                        );
-                    }
+                    self.fire_widget_event(
+                        &panel_key,
+                        "sessions".to_string(),
+                        "dock_new".to_string(),
+                        serde_json::json!({}),
+                    );
                     return true;
                 }
                 KeyCode::Char(' ') => {
                     // Toggle the highlighted row's multi-select checkbox
                     // (plugin owns the selection set).
-                    let has_handler = self
-                        .plugin_manager
-                        .read()
-                        .unwrap()
-                        .has_hook_handlers("widget_event");
                     tracing::debug!(
                         target: "fresh::dock",
-                        panel_id,
-                        has_handler,
-                        focus_key = ?self.widget_registry.focus_key(panel_id),
+                        panel = %panel_key,
+                        focus_key = ?self.widget_registry.focus_key(&panel_key),
                         "dispatch_floating_widget_key: Space on LeftDock — firing dock_space widget_event"
                     );
-                    if has_handler {
-                        self.plugin_manager.read().unwrap().run_hook(
-                            "widget_event",
-                            crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                                panel_id,
-                                widget_key: "sessions".to_string(),
-                                event_type: "dock_space".to_string(),
-                                payload: serde_json::json!({}),
-                            },
-                        );
-                    }
+                    self.fire_widget_event(
+                        &panel_key,
+                        "sessions".to_string(),
+                        "dock_space".to_string(),
+                        serde_json::json!({}),
+                    );
                     return true;
                 }
                 _ => {}
@@ -2761,27 +2731,17 @@ impl Editor {
                 }
                 let widget_key = self
                     .widget_registry
-                    .get(panel_id)
+                    .get(&panel_key)
                     .map(|p| p.focus_key.clone())
                     .unwrap_or_default();
-                if self
-                    .plugin_manager
-                    .read()
-                    .unwrap()
-                    .has_hook_handlers("widget_event")
-                {
-                    self.plugin_manager.read().unwrap().run_hook(
-                        "widget_event",
-                        crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                            panel_id,
-                            widget_key,
-                            event_type: "cancel".to_string(),
-                            payload: serde_json::json!({}),
-                        },
-                    );
-                }
+                self.fire_widget_event(
+                    &panel_key,
+                    widget_key,
+                    "cancel".to_string(),
+                    serde_json::json!({}),
+                );
                 *self.panel_opt_mut(slot) = None;
-                let _ = self.widget_registry.unmount(panel_id);
+                let _ = self.widget_registry.unmount(&panel_key);
                 return true;
             }
             KeyCode::Tab => Some(if modifiers.contains(KeyModifiers::SHIFT) {
@@ -2838,7 +2798,7 @@ impl Editor {
                 return false;
             }
             self.handle_widget_command(
-                panel_id,
+                &panel_key,
                 fresh_core::api::WidgetAction::Key {
                     key: name.to_string(),
                 },
@@ -2906,7 +2866,7 @@ impl Editor {
             // working.
             if ch == ' ' {
                 self.handle_widget_command(
-                    panel_id,
+                    &panel_key,
                     fresh_core::api::WidgetAction::Key {
                         key: "Space".to_string(),
                     },
@@ -2914,7 +2874,7 @@ impl Editor {
                 return true;
             }
             self.handle_widget_command(
-                panel_id,
+                &panel_key,
                 fresh_core::api::WidgetAction::TextInputChar {
                     text: ch.to_string(),
                 },

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -765,6 +765,8 @@ impl Editor {
         };
         #[cfg(feature = "plugins")]
         {
+            // The overlay toolbar isn't a registry panel — it has no
+            // owner to target, so this broadcasts with panel_id 0.
             let pm = self.plugin_manager.read().unwrap();
             if pm.has_hook_handlers("widget_event") {
                 pm.run_hook(

--- a/crates/fresh-editor/src/app/lifecycle.rs
+++ b/crates/fresh-editor/src/app/lifecycle.rs
@@ -440,14 +440,16 @@ impl Editor {
         // embed rects all reflect the new chrome (Bug 13). The hook above
         // lets plugins update their spec; this rerender picks up either the
         // updated spec or the existing spec at the new width.
-        for panel_id in [
-            self.dock.as_ref().map(|f| f.panel_id),
-            self.floating_widget_panel.as_ref().map(|f| f.panel_id),
+        for panel_key in [
+            self.dock.as_ref().map(|f| f.panel_key.clone()),
+            self.floating_widget_panel
+                .as_ref()
+                .map(|f| f.panel_key.clone()),
         ]
         .into_iter()
         .flatten()
         {
-            self.rerender_widget_panel(panel_id);
+            self.rerender_widget_panel(&panel_key);
         }
     }
 }

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1114,7 +1114,8 @@ pub(crate) enum PanelPlacement {
 
 #[derive(Debug, Clone)]
 pub(crate) struct FloatingWidgetState {
-    pub panel_id: crate::widgets::PanelId,
+    /// Composite (plugin, id) identity of the mounted panel.
+    pub panel_key: crate::widgets::PanelKey,
     pub width_pct: u8,
     pub height_pct: u8,
     /// On-screen anchor. Defaults to `Centered` on mount; a plugin
@@ -1679,7 +1680,7 @@ mod tests {
 
     fn test_panel(placement: PanelPlacement, focused: bool) -> FloatingWidgetState {
         FloatingWidgetState {
-            panel_id: 1,
+            panel_key: crate::widgets::PanelKey::new("test-plugin", 1),
             width_pct: 50,
             height_pct: 50,
             placement,
@@ -1775,7 +1776,10 @@ mod tests {
         let _ = editor.take_full_redraw_request();
 
         editor
-            .handle_plugin_command(PluginCommand::UnmountFloatingWidget { panel_id: 1 })
+            .handle_plugin_command(PluginCommand::UnmountFloatingWidget {
+                plugin: "test-plugin".to_string(),
+                panel_id: 1,
+            })
             .unwrap();
 
         assert!(editor.dock.is_none(), "dock should be unmounted");
@@ -1799,7 +1803,10 @@ mod tests {
         let _ = editor.take_full_redraw_request();
 
         editor
-            .handle_plugin_command(PluginCommand::UnmountFloatingWidget { panel_id: 1 })
+            .handle_plugin_command(PluginCommand::UnmountFloatingWidget {
+                plugin: "test-plugin".to_string(),
+                panel_id: 1,
+            })
             .unwrap();
 
         assert!(

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3973,8 +3973,8 @@ impl Editor {
     /// column). Reuses the canonical `ScrollbarMouse`/`ScrollbarState`.
     fn try_widget_scrollbar_press(&mut self, slot: super::PanelSlot, col: u16, row: u16) -> bool {
         use crate::view::ui::scrollbar::ScrollbarState;
-        let (panel_id, tracks) = match self.panel(slot) {
-            Some(fwp) => (fwp.panel_id, fwp.scrollbar_tracks.clone()),
+        let (panel_key, tracks) = match self.panel(slot) {
+            Some(fwp) => (fwp.panel_key.clone(), fwp.scrollbar_tracks.clone()),
             None => return false,
         };
         for t in &tracks {
@@ -3986,7 +3986,7 @@ impl Editor {
                 if let Some(fwp) = self.panel_mut(slot) {
                     fwp.scrollbar_drag_key = Some(t.list_key.clone());
                 }
-                self.apply_widget_scroll(panel_id, &t.list_key, new_offset, t.visible);
+                self.apply_widget_scroll(&panel_key, &t.list_key, new_offset, t.visible);
                 return true;
             }
         }
@@ -3997,9 +3997,9 @@ impl Editor {
     /// true if a drag is active (the press captured a `list_key`).
     fn try_widget_scrollbar_drag(&mut self, slot: super::PanelSlot, row: u16) -> bool {
         use crate::view::ui::scrollbar::ScrollbarState;
-        let (panel_id, key) = match self.panel(slot) {
+        let (panel_key, key) = match self.panel(slot) {
             Some(fwp) => match &fwp.scrollbar_drag_key {
-                Some(k) => (fwp.panel_id, k.clone()),
+                Some(k) => (fwp.panel_key.clone(), k.clone()),
                 None => return false,
             },
             None => return false,
@@ -4020,7 +4020,7 @@ impl Editor {
             .panel_mut(slot)
             .and_then(|fwp| fwp.scrollbar_mouse.drag(state, t.rect, row));
         if let Some(off) = new_offset {
-            self.apply_widget_scroll(panel_id, &key, off, t.visible);
+            self.apply_widget_scroll(&panel_key, &key, off, t.visible);
         }
         true
     }
@@ -4043,35 +4043,25 @@ impl Editor {
     /// preview stay in sync with the thumb.
     fn apply_widget_scroll(
         &mut self,
-        panel_id: u64,
+        panel_key: &crate::widgets::PanelKey,
         list_key: &str,
         new_offset: usize,
         visible: usize,
     ) {
         let moved_sel = self.widget_registry.set_list_scroll(
-            panel_id,
+            panel_key,
             list_key,
             new_offset as u32,
             visible as u32,
         );
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
         if let Some(sel) = moved_sel {
-            if self
-                .plugin_manager
-                .read()
-                .unwrap()
-                .has_hook_handlers("widget_event")
-            {
-                self.plugin_manager.read().unwrap().run_hook(
-                    "widget_event",
-                    crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                        panel_id,
-                        widget_key: list_key.to_string(),
-                        event_type: "select".to_string(),
-                        payload: serde_json::json!({ "index": sel as i64 }),
-                    },
-                );
-            }
+            self.fire_widget_event(
+                panel_key,
+                list_key.to_string(),
+                "select".to_string(),
+                serde_json::json!({ "index": sel as i64 }),
+            );
         }
     }
 
@@ -4089,9 +4079,9 @@ impl Editor {
         col: u16,
         row: u16,
     ) -> bool {
-        let (panel_id, inner) = match self.panel(slot) {
+        let (panel_key, inner) = match self.panel(slot) {
             Some(fwp) => match fwp.last_inner_rect {
-                Some(rect) => (fwp.panel_id, rect),
+                Some(rect) => (fwp.panel_key.clone(), rect),
                 None => return false,
             },
             None => return false,
@@ -4138,15 +4128,7 @@ impl Editor {
         {
             return false;
         }
-        self.plugin_manager.read().unwrap().run_hook(
-            "widget_event",
-            crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                panel_id,
-                widget_key: key,
-                event_type: "context".to_string(),
-                payload,
-            },
-        );
+        self.fire_widget_event(&panel_key, key, "context".to_string(), payload);
         true
     }
 
@@ -4176,33 +4158,23 @@ impl Editor {
     /// owning plugin clears its state — the click-outside analogue of the
     /// Esc dismissal in `dispatch_floating_widget_key`.
     fn dismiss_floating_panel_with_cancel(&mut self, slot: super::PanelSlot) {
-        let panel_id = match self.panel(slot) {
-            Some(f) => f.panel_id,
+        let panel_key = match self.panel(slot) {
+            Some(f) => f.panel_key.clone(),
             None => return,
         };
         let widget_key = self
             .widget_registry
-            .get(panel_id)
+            .get(&panel_key)
             .map(|p| p.focus_key.clone())
             .unwrap_or_default();
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key,
-                    event_type: "cancel".to_string(),
-                    payload: serde_json::json!({}),
-                },
-            );
-        }
+        self.fire_widget_event(
+            &panel_key,
+            widget_key,
+            "cancel".to_string(),
+            serde_json::json!({}),
+        );
         *self.panel_opt_mut(slot) = None;
-        let _ = self.widget_registry.unmount(panel_id);
+        let _ = self.widget_registry.unmount(&panel_key);
     }
 
     /// `handle_editor_click` uses; clicks outside the rect are
@@ -4213,9 +4185,9 @@ impl Editor {
         if self.try_widget_scrollbar_press(slot, col, row) {
             return;
         }
-        let (panel_id, inner) = match self.panel(slot) {
+        let (panel_key, inner) = match self.panel(slot) {
             Some(fwp) => match fwp.last_inner_rect {
-                Some(rect) => (fwp.panel_id, rect),
+                Some(rect) => (fwp.panel_key.clone(), rect),
                 None => return,
             },
             None => return,
@@ -4259,7 +4231,7 @@ impl Editor {
         if !hit_key.is_empty() {
             let tabbable = self
                 .widget_registry
-                .get(panel_id)
+                .get(&panel_key)
                 .map(|p| p.tabbable.iter().any(|k| k == &hit_key))
                 .unwrap_or(false);
             tracing::debug!(
@@ -4271,9 +4243,9 @@ impl Editor {
                 "handle_floating_widget_click: hit"
             );
             if tabbable {
-                self.set_panel_focus_and_notify(panel_id, hit_key.clone());
+                self.set_panel_focus_and_notify(&panel_key, hit_key.clone());
             }
-            self.rerender_widget_panel(panel_id);
+            self.rerender_widget_panel(&panel_key);
         } else {
             tracing::debug!(
                 target: "fresh::dock",
@@ -4284,7 +4256,7 @@ impl Editor {
         }
         let handled_specially = if hit_kind == "tree" && hit_event == "expand" {
             if let Some(item_key) = hit_payload.get("key").and_then(|v| v.as_str()) {
-                self.handle_widget_tree_expand_toggle(panel_id, &hit_key, item_key);
+                self.handle_widget_tree_expand_toggle(&panel_key, &hit_key, item_key);
                 true
             } else {
                 false
@@ -4292,13 +4264,7 @@ impl Editor {
         } else {
             false
         };
-        if !handled_specially
-            && self
-                .plugin_manager
-                .read()
-                .unwrap()
-                .has_hook_handlers("widget_event")
-        {
+        if !handled_specially {
             // Tag the event as mouse-originated. Keyboard nav (arrows)
             // fires `select` through `handle_widget_command` *without* this
             // marker, so a plugin can tell a click apart from an arrow-move
@@ -4308,15 +4274,7 @@ impl Editor {
             if let Some(obj) = hit_payload.as_object_mut() {
                 obj.insert("via".to_string(), serde_json::json!("click"));
             }
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: hit_key,
-                    event_type: hit_event,
-                    payload: hit_payload,
-                },
-            );
+            self.fire_widget_event(&panel_key, hit_key, hit_event, hit_payload);
         }
     }
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4248,22 +4248,9 @@ impl Editor {
                     hit.widget_kind,
                 ),
                 None => {
-                    // Diagnostic for the dead-click desync: dump the rendered
-                    // entry at this row alongside the registry's hit rows so we
-                    // can tell whether the list is shorter than it looks, the
-                    // click byte is past the row text, or a hit-range mismatch.
-                    let entry_text = entries
-                        .get(brow as usize)
-                        .map(|e| e.text.clone())
-                        .unwrap_or_default();
-                    let hit_rows = self.widget_registry.hit_rows_debug(slot.buffer_id());
                     tracing::debug!(
                         target: "fresh::dock",
                         ?slot, col, row, brow, bcol,
-                        entries_len = entries.len(),
-                        entry_len = entry_text.len(),
-                        entry_text = %entry_text,
-                        ?hit_rows,
                         "handle_floating_widget_click: hit_test found no widget"
                     );
                     return;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -4248,9 +4248,22 @@ impl Editor {
                     hit.widget_kind,
                 ),
                 None => {
+                    // Diagnostic for the dead-click desync: dump the rendered
+                    // entry at this row alongside the registry's hit rows so we
+                    // can tell whether the list is shorter than it looks, the
+                    // click byte is past the row text, or a hit-range mismatch.
+                    let entry_text = entries
+                        .get(brow as usize)
+                        .map(|e| e.text.clone())
+                        .unwrap_or_default();
+                    let hit_rows = self.widget_registry.hit_rows_debug(slot.buffer_id());
                     tracing::debug!(
                         target: "fresh::dock",
                         ?slot, col, row, brow, bcol,
+                        entries_len = entries.len(),
+                        entry_len = entry_text.len(),
+                        entry_text = %entry_text,
+                        ?hit_rows,
                         "handle_floating_widget_click: hit_test found no widget"
                     );
                     return;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1394,49 +1394,81 @@ impl Editor {
             }
 
             PluginCommand::MountWidgetPanel {
+                plugin,
                 panel_id,
                 buffer_id,
                 spec,
             } => {
-                self.handle_mount_widget_panel(panel_id, buffer_id, spec);
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_mount_widget_panel(key, buffer_id, spec);
             }
 
-            PluginCommand::UpdateWidgetPanel { panel_id, spec } => {
-                self.handle_update_widget_panel(panel_id, spec);
+            PluginCommand::UpdateWidgetPanel {
+                plugin,
+                panel_id,
+                spec,
+            } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_update_widget_panel(&key, spec);
             }
 
-            PluginCommand::UnmountWidgetPanel { panel_id } => {
-                self.handle_unmount_widget_panel(panel_id);
+            PluginCommand::UnmountWidgetPanel { plugin, panel_id } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_unmount_widget_panel(&key);
             }
 
-            PluginCommand::WidgetCommand { panel_id, action } => {
-                self.handle_widget_command(panel_id, action);
+            PluginCommand::WidgetCommand {
+                plugin,
+                panel_id,
+                action,
+            } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_widget_command(&key, action);
             }
 
-            PluginCommand::WidgetMutate { panel_id, mutation } => {
-                self.handle_widget_mutate(panel_id, mutation);
+            PluginCommand::WidgetMutate {
+                plugin,
+                panel_id,
+                mutation,
+            } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_widget_mutate(&key, mutation);
             }
 
             PluginCommand::MountFloatingWidget {
+                plugin,
                 panel_id,
                 spec,
                 width_pct,
                 height_pct,
                 as_dock,
             } => {
-                self.handle_mount_floating_widget(panel_id, spec, width_pct, height_pct, as_dock);
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_mount_floating_widget(key, spec, width_pct, height_pct, as_dock);
             }
 
-            PluginCommand::UpdateFloatingWidget { panel_id, spec } => {
-                self.handle_update_floating_widget(panel_id, spec);
+            PluginCommand::UpdateFloatingWidget {
+                plugin,
+                panel_id,
+                spec,
+            } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_update_floating_widget(&key, spec);
             }
 
-            PluginCommand::UnmountFloatingWidget { panel_id } => {
-                self.handle_unmount_floating_widget(panel_id);
+            PluginCommand::UnmountFloatingWidget { plugin, panel_id } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_unmount_floating_widget(&key);
             }
 
-            PluginCommand::FloatingPanelControl { panel_id, op, arg } => {
-                self.handle_floating_panel_control(panel_id, &op, arg);
+            PluginCommand::FloatingPanelControl {
+                plugin,
+                panel_id,
+                op,
+                arg,
+            } => {
+                let key = crate::widgets::PanelKey::new(plugin, panel_id);
+                self.handle_floating_panel_control(&key, &op, arg);
             }
         }
         Ok(())
@@ -3884,7 +3916,7 @@ impl Editor {
 
     fn handle_mount_widget_panel(
         &mut self,
-        panel_id: u64,
+        panel_key: crate::widgets::PanelKey,
         buffer_id: BufferId,
         spec: fresh_core::api::WidgetSpec,
     ) {
@@ -3898,7 +3930,7 @@ impl Editor {
         let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         self.widget_registry.mount(
-            panel_id,
+            panel_key.clone(),
             buffer_id,
             spec,
             out.hits,
@@ -3910,39 +3942,43 @@ impl Editor {
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
             tracing::error!(
                 "Failed to render mounted widget panel {} into {:?}: {}",
-                panel_id,
+                panel_key,
                 buffer_id,
                 e
             );
         } else {
             tracing::debug!(
                 "Mounted widget panel {} into buffer {:?}",
-                panel_id,
+                panel_key,
                 buffer_id
             );
         }
         self.apply_widget_focus_cursor(buffer_id, &entries, focus_cursor);
     }
 
-    fn handle_update_widget_panel(&mut self, panel_id: u64, spec: fresh_core::api::WidgetSpec) {
-        let prev = match self.widget_registry.instance_states(panel_id) {
+    fn handle_update_widget_panel(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        spec: fresh_core::api::WidgetSpec,
+    ) {
+        let prev = match self.widget_registry.instance_states(panel_key) {
             Some(s) => s.clone(),
             None => {
                 tracing::debug!(
                     "UpdateWidgetPanel for unknown panel {} ignored (not mounted)",
-                    panel_id
+                    panel_key
                 );
                 return;
             }
         };
         let prev_focus = self
             .widget_registry
-            .focus_key(panel_id)
+            .focus_key(panel_key)
             .map(|s| s.to_string())
             .unwrap_or_default();
         let buffer_id_for_width = self
             .widget_registry
-            .buffer_and_spec(panel_id)
+            .buffer_and_spec(panel_key)
             .map(|(b, _)| b)
             .unwrap_or(BufferId(0));
         let panel_width = self.widget_panel_width(buffer_id_for_width);
@@ -3950,7 +3986,7 @@ impl Editor {
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         match self.widget_registry.update(
-            panel_id,
+            panel_key,
             spec,
             out.hits,
             out.instance_states,
@@ -3959,14 +3995,14 @@ impl Editor {
         ) {
             Ok(buffer_id) => {
                 if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
-                    tracing::error!("Failed to render updated widget panel {}: {}", panel_id, e);
+                    tracing::error!("Failed to render updated widget panel {}: {}", panel_key, e);
                 }
                 self.apply_widget_focus_cursor(buffer_id, &entries, focus_cursor);
             }
             Err(()) => {
                 tracing::debug!(
                     "UpdateWidgetPanel for unknown panel {} ignored (not mounted)",
-                    panel_id
+                    panel_key
                 );
             }
         }
@@ -3977,14 +4013,18 @@ impl Editor {
     /// the full spec; it sends one targeted change. The host
     /// mutates the registry's spec / instance state and re-renders
     /// against the just-mutated state.
-    fn handle_widget_mutate(&mut self, panel_id: u64, mutation: fresh_core::api::WidgetMutation) {
+    fn handle_widget_mutate(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        mutation: fresh_core::api::WidgetMutation,
+    ) {
         use fresh_core::api::WidgetMutation;
 
         // Look up the panel; bail if unknown.
-        if self.widget_registry.get(panel_id).is_none() {
+        if self.widget_registry.get(panel_key).is_none() {
             tracing::debug!(
                 "WidgetMutate for unknown panel {} ignored (not mounted)",
-                panel_id
+                panel_key
             );
             return;
         }
@@ -4001,7 +4041,7 @@ impl Editor {
                 // multi-line viewport offsets don't snap on a
                 // plugin-driven update; the renderer re-clamps next
                 // render anyway.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     // Preserve `scroll` + `multiline` so plugin-
                     // driven SetValue doesn't snap the viewport,
                     // and preserve `completions` /
@@ -4055,7 +4095,7 @@ impl Editor {
                 // Toggle checked lives in the spec (not instance
                 // state). Walk the spec, find the Toggle by key,
                 // mutate.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     crate::widgets::set_toggle_checked_in_spec(
                         &mut panel.spec,
                         &widget_key,
@@ -4065,7 +4105,7 @@ impl Editor {
             }
             WidgetMutation::SetSelectedIndex { widget_key, index } => {
                 // List selected_index lives in instance state.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     let (prev_scroll, prev_index, prev_item_height, prev_user_scrolled) =
                         match panel.instance_states.get(&widget_key) {
                             Some(crate::widgets::WidgetInstanceState::List {
@@ -4107,7 +4147,7 @@ impl Editor {
                 // any render is dropped on the floor — Text
                 // instance state is seeded on first render of
                 // the spec).
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     if let Some(crate::widgets::WidgetInstanceState::Text {
                         completions,
                         completion_selected_index,
@@ -4127,7 +4167,7 @@ impl Editor {
                 item_keys,
             } => {
                 // List items live in the spec.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     crate::widgets::set_list_items_in_spec(
                         &mut panel.spec,
                         &widget_key,
@@ -4138,7 +4178,7 @@ impl Editor {
             }
             WidgetMutation::SetExpandedKeys { widget_key, keys } => {
                 // Tree expanded_keys lives in instance state.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     let (prev_scroll, prev_sel) = match panel.instance_states.get(&widget_key) {
                         Some(crate::widgets::WidgetInstanceState::Tree {
                             scroll_offset,
@@ -4170,7 +4210,7 @@ impl Editor {
                 // matching nodes so the next render reflects it
                 // immediately, without round-tripping through the
                 // plugin.
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     crate::widgets::set_tree_checked_keys_in_spec(
                         &mut panel.spec,
                         &widget_key,
@@ -4184,7 +4224,7 @@ impl Editor {
                 new_nodes,
                 new_item_keys,
             } => {
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     crate::widgets::append_tree_nodes_in_spec(
                         &mut panel.spec,
                         &widget_key,
@@ -4197,7 +4237,7 @@ impl Editor {
                 widget_key,
                 entries,
             } => {
-                if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+                if let Some(panel) = self.widget_registry.get_mut(panel_key) {
                     crate::widgets::set_raw_entries_in_spec(&mut panel.spec, &widget_key, entries);
                 }
             }
@@ -4206,22 +4246,22 @@ impl Editor {
                 // spec. The renderer reads it on the next paint and
                 // re-clamps to the first tabbable if the key isn't a
                 // current tabbable, so an unknown key is a safe no-op.
-                self.widget_registry.set_focus_key(panel_id, widget_key);
+                self.widget_registry.set_focus_key(panel_key, widget_key);
             }
         }
 
         // Re-render with the mutated state. `rerender_widget_panel`
         // reads the registry's current spec + instance state and
         // pushes the result through the buffer.
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
     }
 
-    fn handle_unmount_widget_panel(&mut self, panel_id: u64) {
-        match self.widget_registry.unmount(panel_id) {
+    fn handle_unmount_widget_panel(&mut self, panel_key: &crate::widgets::PanelKey) {
+        match self.widget_registry.unmount(panel_key) {
             Some(buffer_id) => {
                 tracing::debug!(
                     "Unmounted widget panel {} (was rendering into {:?})",
-                    panel_id,
+                    panel_key,
                     buffer_id
                 );
                 // Buffer lifetime is owned by the plugin (it created the
@@ -4230,14 +4270,14 @@ impl Editor {
                 // panel state.
             }
             None => {
-                tracing::debug!("UnmountWidgetPanel for unknown panel {} ignored", panel_id);
+                tracing::debug!("UnmountWidgetPanel for unknown panel {} ignored", panel_key);
             }
         }
     }
 
     fn handle_mount_floating_widget(
         &mut self,
-        panel_id: u64,
+        panel_key: crate::widgets::PanelKey,
         spec: fresh_core::api::WidgetSpec,
         width_pct: u8,
         height_pct: u8,
@@ -4272,12 +4312,12 @@ impl Editor {
             super::PanelPlacement::Centered
         };
         if let Some(existing) = self.panel_opt_mut(slot).take() {
-            if existing.panel_id != panel_id {
-                let _ = self.widget_registry.unmount(existing.panel_id);
+            if existing.panel_key != panel_key {
+                let _ = self.widget_registry.unmount(&existing.panel_key);
             }
         }
         *self.panel_opt_mut(slot) = Some(FloatingWidgetState {
-            panel_id,
+            panel_key: panel_key.clone(),
             width_pct,
             height_pct,
             placement,
@@ -4305,7 +4345,7 @@ impl Editor {
         let overlays = out.overlays;
         let scroll_regions = out.scroll_regions;
         self.widget_registry.mount(
-            panel_id,
+            panel_key.clone(),
             buffer_id,
             spec,
             out.hits,
@@ -4322,7 +4362,7 @@ impl Editor {
         }
         tracing::debug!(
             "Mounted floating widget panel {} ({}%x{}%)",
-            panel_id,
+            panel_key,
             width_pct,
             height_pct
         );
@@ -4336,22 +4376,26 @@ impl Editor {
         }
     }
 
-    fn handle_update_floating_widget(&mut self, panel_id: u64, spec: fresh_core::api::WidgetSpec) {
-        let Some(slot) = self.slot_of_panel(panel_id) else {
+    fn handle_update_floating_widget(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        spec: fresh_core::api::WidgetSpec,
+    ) {
+        let Some(slot) = self.slot_of_panel(panel_key) else {
             tracing::debug!(
                 "UpdateFloatingWidget for unknown / mismatched panel {} ignored",
-                panel_id
+                panel_key
             );
             return;
         };
         let prev = self
             .widget_registry
-            .instance_states(panel_id)
+            .instance_states(panel_key)
             .cloned()
             .unwrap_or_default();
         let prev_focus = self
             .widget_registry
-            .focus_key(panel_id)
+            .focus_key(panel_key)
             .map(|s| s.to_string())
             .unwrap_or_default();
         let panel_width = self.floating_panel_inner_width(slot);
@@ -4364,7 +4408,7 @@ impl Editor {
         if self
             .widget_registry
             .update(
-                panel_id,
+                panel_key,
                 spec,
                 out.hits,
                 out.instance_states,
@@ -4375,7 +4419,7 @@ impl Editor {
         {
             tracing::debug!(
                 "UpdateFloatingWidget for unknown panel {} ignored (not in registry)",
-                panel_id
+                panel_key
             );
             return;
         }
@@ -4388,16 +4432,16 @@ impl Editor {
         }
     }
 
-    fn handle_unmount_floating_widget(&mut self, panel_id: u64) {
-        let Some(slot) = self.slot_of_panel(panel_id) else {
+    fn handle_unmount_floating_widget(&mut self, panel_key: &crate::widgets::PanelKey) {
+        let Some(slot) = self.slot_of_panel(panel_key) else {
             tracing::debug!(
                 "UnmountFloatingWidget for unknown / mismatched panel {} ignored",
-                panel_id
+                panel_key
             );
             return;
         };
         *self.panel_opt_mut(slot) = None;
-        let _ = self.widget_registry.unmount(panel_id);
+        let _ = self.widget_registry.unmount(panel_key);
         // Hiding the left dock frees its full-height column. The next
         // frame's `compute_dock_split` already lays the chrome back out
         // full-width (and the early command drain in `render` makes that
@@ -4427,14 +4471,19 @@ impl Editor {
         // funnel: it re-derives `dock_cols` (now 0 for a dock unmount) and
         // reflows every window's terminals + viewports to the reclaimed width.
         self.relayout();
-        tracing::debug!("Unmounted floating widget panel {}", panel_id);
+        tracing::debug!("Unmounted floating widget panel {}", panel_key);
     }
 
     /// Apply a `FloatingPanelControl` op. No-op if the panel id
     /// doesn't match the mounted floating panel.
-    fn handle_floating_panel_control(&mut self, panel_id: u64, op: &str, arg: f64) {
-        let Some(slot) = self.slot_of_panel(panel_id) else {
-            tracing::warn!("FloatingPanelControl for unknown/mismatched panel {panel_id} ignored");
+    fn handle_floating_panel_control(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        op: &str,
+        arg: f64,
+    ) {
+        let Some(slot) = self.slot_of_panel(panel_key) else {
+            tracing::warn!("FloatingPanelControl for unknown/mismatched panel {panel_key} ignored");
             return;
         };
         // `blur` fires a widget_event, so handle it before borrowing the

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1529,9 +1529,6 @@ impl Editor {
         // Record non-editor region theme keys for the theme inspector
         self.record_non_editor_theme_regions();
 
-        // Render theme info popup (Ctrl+Right-Click)
-        self.render_theme_info_popup(frame);
-
         // Render tab drag drop zone overlay if dragging a tab
         let drag_state_clone = self.active_window().mouse_state.dragging_tab.clone();
         if let Some(ref drag_state) = drag_state_clone {
@@ -1620,6 +1617,13 @@ impl Editor {
                 self.render_floating_widget_panel(frame, dock, super::PanelSlot::Dock);
             }
         }
+
+        // The theme-info popup (Ctrl+Right-Click) anchors to an absolute
+        // screen cell that may sit over the dock column, so draw it after
+        // the dock — otherwise the dock paints over it and its "Open in
+        // Theme Editor" button is hidden and unclickable.
+        self.render_theme_info_popup(frame);
+
         if self.floating_widget_panel.is_some() {
             // A `fullscreen` modal paints over the whole frame, covering the
             // dock; otherwise it lays into `chrome_area` beside the dock.

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1032,6 +1032,9 @@ impl Editor {
             // Single window borrow, split into buffers + cursors so the
             // status-bar context can hold both.
             let __active_id = self.active_window;
+            // Theme-key runs the status bar records as it paints; applied to
+            // the chrome's cell map after the window borrow is released.
+            let mut status_bar_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
             let __win = self
                 .windows
                 .get_mut(&__active_id)
@@ -1071,14 +1074,18 @@ impl Editor {
                         dynamic_status_bar_elements: dynamic_status_bar_elements.clone(),
                         workspace_trust_level,
                     };
+                    let mut sb_rec =
+                        crate::app::types::CellThemeRecorder::new(&mut status_bar_runs);
                     StatusBarRenderer::render_status_bar(
                         frame,
                         main_chunks[status_bar_idx],
                         &mut status_ctx,
                         &self.config.editor.status_bar,
+                        Some(&mut sb_rec),
                     )
                 })
                 .expect("active buffer must be present");
+            self.active_chrome_mut().apply_theme_runs(&status_bar_runs);
 
             // Store status bar layout for click detection
             let status_bar_area = main_chunks[status_bar_idx];

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -260,6 +260,9 @@ impl Editor {
                 Some(HoverTarget::FileExplorerCloseButton)
             );
             let slot_resolver = self.file_explorer_slot_resolver();
+            // Theme-key runs the explorer records as it paints; applied to the
+            // chrome cell map after the window borrow is released.
+            let mut fe_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
             // Take one &mut on the active window; the explorer + buffers
             // come from disjoint sub-fields so they can coexist.
             let __win = self
@@ -305,10 +308,12 @@ impl Editor {
                     cut_paths,
                     &self.config.file_explorer.tree_indicator_collapsed,
                     &self.config.file_explorer.tree_indicator_expanded,
+                    Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
                 );
             }
             // Note: if file_explorer is None but sync_in_progress is true,
             // we just leave the area blank (or could render a placeholder)
+            self.active_chrome_mut().apply_theme_runs(&fe_runs);
         } else {
             // No file explorer: use entire main content area for editor
             self.active_layout_mut().file_explorer_area = None;

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1505,6 +1505,7 @@ impl Editor {
             let menu_bar_mnemonics = self.config.editor.menu_bar_mnemonics;
             let expanded = self.expanded_menus_cache.get().expect("just updated");
             let keybindings = self.keybindings.read().unwrap();
+            let mut menu_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
             let new_menu_layout = crate::view::ui::MenuRenderer::render(
                 frame,
                 menu_bar_area,
@@ -1514,9 +1515,13 @@ impl Editor {
                 &*self.theme.read().unwrap(),
                 hover_target.as_ref(),
                 menu_bar_mnemonics,
+                Some(&mut crate::app::types::CellThemeRecorder::new(
+                    &mut menu_runs,
+                )),
             );
             drop(keybindings);
             self.active_chrome_mut().menu_layout = Some(new_menu_layout);
+            self.active_chrome_mut().apply_theme_runs(&menu_runs);
         } else {
             self.active_chrome_mut().menu_layout = None;
         }
@@ -1538,8 +1543,8 @@ impl Editor {
             self.render_new_tab_menu(frame, &menu);
         }
 
-        // Record non-editor region theme keys for the theme inspector
-        self.record_non_editor_theme_regions();
+        // Chrome theme-key provenance (status bar, menu, tabs, file explorer,
+        // scrollbars) is now recorded during each region's own paint.
 
         // Render tab drag drop zone overlay if dragging a tab
         let drag_state_clone = self.active_window().mouse_state.dragging_tab.clone();

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -3094,7 +3094,7 @@ impl Editor {
                 if y >= inner.y + inner.height {
                     break;
                 }
-                paint_text_property_entry(frame, entry, inner.x, y, inner.width, &theme);
+                paint_text_property_entry(frame, entry, inner.x, y, inner.width, &theme, None);
             }
             for hit in &out.hits {
                 if hit.widget_key.is_empty() {
@@ -4172,8 +4172,16 @@ impl Editor {
             return;
         }
 
+        let dock_sw = self.active_chrome().last_frame_width;
         let max_rows = inner.height as usize;
         for (i, entry) in entries.iter().take(max_rows).enumerate() {
+            let recorder = is_dock.then(|| {
+                (
+                    &mut self.active_chrome_mut().cell_theme_map,
+                    dock_sw,
+                    "Orchestrator Dock",
+                )
+            });
             paint_text_property_entry(
                 frame,
                 entry,
@@ -4181,6 +4189,7 @@ impl Editor {
                 inner.y + i as u16,
                 inner.width,
                 &theme,
+                recorder,
             );
         }
 
@@ -4339,6 +4348,7 @@ impl Editor {
         // borders).
         let panel_bg = theme.popup_bg;
         let panel_bg_style = ratatui::style::Style::default().bg(panel_bg);
+        let overlay_sw = self.active_chrome().last_frame_width;
         for o in &overlays {
             let row_y = inner.y.saturating_add(o.buffer_row as u16);
             if row_y >= inner.y.saturating_add(inner.height) {
@@ -4352,7 +4362,22 @@ impl Editor {
             };
             frame.render_widget(Clear, row_rect);
             frame.render_widget(Block::default().style(panel_bg_style), row_rect);
-            paint_text_property_entry(frame, &o.entry, inner.x, row_y, inner.width, &theme);
+            let recorder = is_dock.then(|| {
+                (
+                    &mut self.active_chrome_mut().cell_theme_map,
+                    overlay_sw,
+                    "Orchestrator Dock",
+                )
+            });
+            paint_text_property_entry(
+                frame,
+                &o.entry,
+                inner.x,
+                row_y,
+                inner.width,
+                &theme,
+                recorder,
+            );
         }
 
         if let Some(fc) = focus_cursor {
@@ -4550,16 +4575,54 @@ fn paint_text_property_entry(
     y: u16,
     width: u16,
     theme: &crate::view::theme::Theme,
+    // When `Some`, record per-cell theme-key provenance into the
+    // `cell_theme_map` (indexed by `screen_width`) under `region`, as each
+    // span is laid out. Used by the orchestrator dock so Ctrl+Right-Click
+    // resolves the actual key the plugin's text properties carry instead of
+    // an empty cell. `None` for the completion / prompt-toolbar callers,
+    // whose surfaces aren't theme-inspectable.
+    mut recorder: Option<(
+        &mut Vec<crate::app::types::CellThemeInfo>,
+        u16,
+        &'static str,
+    )>,
 ) {
+    use fresh_core::api::OverlayColorSpec;
     use ratatui::style::Style;
     use ratatui::text::{Line, Span};
     use ratatui::widgets::Paragraph;
+    use std::borrow::Cow;
 
     let mut normalized = entry.clone();
     normalized.normalize_widths();
     let mut text = normalized.text.clone();
     while text.ends_with('\n') {
         text.pop();
+    }
+
+    // A ThemeKey overlay carries the key string we want to record; an Rgb
+    // overlay is an explicit colour with no key. Named colours (no `.`) are
+    // also keyless so "Open in Theme Editor" never targets a non-key.
+    let key_of = |spec: &OverlayColorSpec| -> Option<Cow<'static, str>> {
+        match spec {
+            OverlayColorSpec::ThemeKey(k) if k.contains('.') => Some(Cow::Owned(k.clone())),
+            _ => None,
+        }
+    };
+    // Row-level base keys: the panel surface keys unless the row's own
+    // style overrides fg/bg. Mirrors the `base_style` colour resolution
+    // below, but tracks the key instead of the resolved colour.
+    let (mut base_fg_key, mut base_bg_key) = (
+        Some(Cow::Borrowed("ui.suggestion_fg")),
+        Some(Cow::Borrowed("ui.suggestion_bg")),
+    );
+    if let Some(opts) = normalized.style.as_ref() {
+        if let Some(fg) = opts.fg.as_ref() {
+            base_fg_key = key_of(fg);
+        }
+        if let Some(bg) = opts.bg.as_ref() {
+            base_bg_key = key_of(bg);
+        }
     }
 
     let base_bg = theme.suggestion_bg;
@@ -4620,6 +4683,10 @@ fn paint_text_property_entry(
     let bounds: Vec<usize> = boundaries.into_iter().collect();
 
     let mut spans: Vec<Span<'_>> = Vec::new();
+    // Screen column of the next span's first cell, advanced by each span's
+    // display width so per-cell recording lands on the right columns
+    // (wide glyphs included).
+    let mut col_cursor = x;
     for win in bounds.windows(2) {
         let (a, b) = (win[0], win[1]);
         if a >= b {
@@ -4636,6 +4703,10 @@ fn paint_text_property_entry(
         // placeholder's italic-dim styling, making placeholder
         // text indistinguishable from a typed value under focus.
         let mut style = base_style;
+        // Track this span's effective theme keys alongside the colour,
+        // applying the same overlay precedence (last writer wins).
+        let mut fg_key = base_fg_key.clone();
+        let mut bg_key = base_bg_key.clone();
         for o in &normalized.inline_overlays {
             let os = o.start.min(text.len());
             let oe = o.end.min(text.len());
@@ -4646,6 +4717,12 @@ fn paint_text_property_entry(
                 }
                 if let Some(bg) = resolved.bg {
                     style = style.bg(bg);
+                }
+                if let Some(fg) = o.style.fg.as_ref() {
+                    fg_key = key_of(fg);
+                }
+                if let Some(bg) = o.style.bg.as_ref() {
+                    bg_key = key_of(bg);
                 }
                 // Ratatui `Style` carries add/sub modifier sets;
                 // OR the additions in so subsequent overlays can
@@ -4661,7 +4738,36 @@ fn paint_text_property_entry(
         if style.bg.is_none() {
             style = style.bg(base_bg);
         }
+        // Record this span's cells as they're laid out (same column walk
+        // the Paragraph will use), before moving the slice into the Span.
+        let span_w = crate::primitives::display_width::str_width(&slice) as u16;
+        if let Some((map, sw, region)) = recorder.as_mut() {
+            record_entry_span_cells(
+                map, *sw, *region, y, col_cursor, span_w, x, width, &fg_key, &bg_key,
+            );
+        }
+        col_cursor = col_cursor.saturating_add(span_w);
         spans.push(Span::styled(slice, style));
+    }
+    // Pad the row's trailing cells with the surface keys so right-clicking
+    // the blank tail of a dock row still resolves the panel surface rather
+    // than an empty cell.
+    if let Some((map, sw, region)) = recorder.as_mut() {
+        let row_end = x.saturating_add(width);
+        if col_cursor < row_end {
+            record_entry_span_cells(
+                map,
+                *sw,
+                *region,
+                y,
+                col_cursor,
+                row_end - col_cursor,
+                x,
+                width,
+                &base_fg_key,
+                &base_bg_key,
+            );
+        }
     }
 
     let line = Line::from(spans);
@@ -4672,6 +4778,43 @@ fn paint_text_property_entry(
         height: 1,
     };
     frame.render_widget(Paragraph::new(line).style(base_style), rect);
+}
+
+/// Record `[start_col, start_col+span_w)` of screen row `row` into the
+/// per-cell theme map under `region`, clipped to the entry's
+/// `[clip_x, clip_x+clip_width)` band. Called as each span of a widget
+/// entry is laid out so the theme inspector resolves the same keys that
+/// were painted.
+#[allow(clippy::too_many_arguments)]
+fn record_entry_span_cells(
+    map: &mut [crate::app::types::CellThemeInfo],
+    sw: u16,
+    region: &'static str,
+    row: u16,
+    start_col: u16,
+    span_w: u16,
+    clip_x: u16,
+    clip_width: u16,
+    fg_key: &Option<std::borrow::Cow<'static, str>>,
+    bg_key: &Option<std::borrow::Cow<'static, str>>,
+) {
+    if sw == 0 || span_w == 0 {
+        return;
+    }
+    let row_end = clip_x.saturating_add(clip_width);
+    let end_col = start_col.saturating_add(span_w).min(row_end);
+    let sw_us = sw as usize;
+    for col in start_col..end_col {
+        let idx = row as usize * sw_us + col as usize;
+        if let Some(cell) = map.get_mut(idx) {
+            *cell = crate::app::types::CellThemeInfo {
+                fg_key: fg_key.clone(),
+                bg_key: bg_key.clone(),
+                region: std::borrow::Cow::Borrowed(region),
+                syntax_category: None,
+            };
+        }
+    }
 }
 
 /// Translate a UTF-8 byte offset within a rendered line into a

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -158,21 +158,7 @@ impl Editor {
 
         let sw = self.active_chrome().last_frame_width as usize;
 
-        // Status bar
-        if let Some((row, x, width)) = self.active_chrome().status_bar_area {
-            let info = CellThemeInfo {
-                fg_key: Some("ui.status_bar_fg".into()),
-                bg_key: Some("ui.status_bar_bg".into()),
-                region: "Status Bar".into(),
-                syntax_category: None,
-            };
-            for col in x..x + width {
-                let idx = row as usize * sw + col as usize;
-                if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
-                    *cell = info.clone();
-                }
-            }
-        }
+        // Status bar is recorded during paint (see status_bar.rs).
 
         // Menu bar
         if let Some(bar_area) = self

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -201,37 +201,7 @@ impl Editor {
             }
         }
 
-        // Scrollbars
-        let split_areas = self.active_layout().split_areas.clone();
-        for (_, _, _, scrollbar_rect, thumb_start, thumb_end) in &split_areas {
-            for row in scrollbar_rect.y..scrollbar_rect.y + scrollbar_rect.height {
-                let rel_row = (row - scrollbar_rect.y) as usize;
-                let is_thumb = rel_row >= *thumb_start && rel_row < *thumb_end;
-                let info = CellThemeInfo {
-                    fg_key: Some(
-                        if is_thumb {
-                            "ui.scrollbar_thumb_fg"
-                        } else {
-                            "ui.scrollbar_track_fg"
-                        }
-                        .into(),
-                    ),
-                    bg_key: Some("editor.bg".into()),
-                    region: if is_thumb {
-                        "Scrollbar Thumb".into()
-                    } else {
-                        "Scrollbar Track".into()
-                    },
-                    syntax_category: None,
-                };
-                for col in scrollbar_rect.x..scrollbar_rect.x + scrollbar_rect.width {
-                    let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
-                        *cell = info.clone();
-                    }
-                }
-            }
-        }
+        // Scrollbars are recorded during paint (see orchestration/mod.rs).
 
         // Tab bars are recorded during paint (see tabs.rs).
     }

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -183,23 +183,7 @@ impl Editor {
             }
         }
 
-        // File explorer
-        if let Some(area) = self.active_layout().file_explorer_area {
-            let info = CellThemeInfo {
-                fg_key: Some("editor.fg".into()),
-                bg_key: Some("editor.bg".into()),
-                region: "File Explorer".into(),
-                syntax_category: None,
-            };
-            for row in area.y..area.y + area.height {
-                for col in area.x..area.x + area.width {
-                    let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
-                        *cell = info.clone();
-                    }
-                }
-            }
-        }
+        // File explorer is recorded during paint (see file_explorer.rs).
 
         // Scrollbars are recorded during paint (see orchestration/mod.rs).
 

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -233,27 +233,7 @@ impl Editor {
             }
         }
 
-        // Tab bars — record from tab layouts
-        let tab_layouts = self.active_layout().tab_layouts.clone();
-        for tab_layout in tab_layouts.values() {
-            {
-                let area = tab_layout.bar_area;
-                let info = CellThemeInfo {
-                    fg_key: Some("ui.tab_inactive_fg".into()),
-                    bg_key: Some("ui.tab_separator_bg".into()),
-                    region: "Tab Bar".into(),
-                    syntax_category: None,
-                };
-                for row in area.y..area.y + area.height {
-                    for col in area.x..area.x + area.width {
-                        let idx = row as usize * sw + col as usize;
-                        if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
-                            *cell = info.clone();
-                        }
-                    }
-                }
-            }
-        }
+        // Tab bars are recorded during paint (see tabs.rs).
     }
 
     /// Render the theme info popup.

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -279,6 +279,14 @@ impl Editor {
         let theme = &*self.theme.read().unwrap();
         let info = &popup.info;
 
+        // Key names render in the popup's own text colour (always legible on
+        // popup_bg) with bold to set them apart from the "Foreground:" label.
+        // `menu_highlight_fg` was wrong here: it's the fg for `menu_highlight_bg`
+        // and on some themes (e.g. dracula) equals popup_bg, so the key vanished.
+        let key_style = Style::default()
+            .fg(theme.popup_text_fg)
+            .add_modifier(ratatui::style::Modifier::BOLD);
+
         let mut lines = vec![];
         lines.push(Line::from(format!(" Region: {}", info.region)));
         lines.push(Line::from(""));
@@ -286,7 +294,7 @@ impl Editor {
         if let Some(ref fg_key) = info.fg_key {
             lines.push(Line::from(vec![
                 Span::styled(" Foreground: ", Style::default().fg(theme.popup_text_fg)),
-                Span::styled(fg_key.clone(), Style::default().fg(theme.menu_highlight_fg)),
+                Span::styled(fg_key.clone(), key_style),
             ]));
             if let Some(color) = info.fg_color {
                 let rgb_str = format_color_rgb(color);
@@ -305,7 +313,7 @@ impl Editor {
         if let Some(ref bg_key) = info.bg_key {
             lines.push(Line::from(vec![
                 Span::styled(" Background: ", Style::default().fg(theme.popup_text_fg)),
-                Span::styled(bg_key.clone(), Style::default().fg(theme.menu_highlight_fg)),
+                Span::styled(bg_key.clone(), key_style),
             ]));
             if let Some(color) = info.bg_color {
                 let rgb_str = format_color_rgb(color);

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -151,45 +151,6 @@ impl Editor {
         })
     }
 
-    /// Record theme key info for non-editor UI regions (status bar, tabs, menu, file explorer, scrollbar).
-    /// Called after all rendering is complete, using cached layout areas.
-    pub(super) fn record_non_editor_theme_regions(&mut self) {
-        use super::types::CellThemeInfo;
-
-        let sw = self.active_chrome().last_frame_width as usize;
-
-        // Status bar is recorded during paint (see status_bar.rs).
-
-        // Menu bar
-        if let Some(bar_area) = self
-            .active_chrome()
-            .menu_layout
-            .as_ref()
-            .map(|m| m.bar_area)
-        {
-            let info = CellThemeInfo {
-                fg_key: Some("ui.menu_fg".into()),
-                bg_key: Some("ui.menu_bg".into()),
-                region: "Menu Bar".into(),
-                syntax_category: None,
-            };
-            for row in bar_area.y..bar_area.y + bar_area.height {
-                for col in bar_area.x..bar_area.x + bar_area.width {
-                    let idx = row as usize * sw + col as usize;
-                    if let Some(cell) = self.active_chrome_mut().cell_theme_map.get_mut(idx) {
-                        *cell = info.clone();
-                    }
-                }
-            }
-        }
-
-        // File explorer is recorded during paint (see file_explorer.rs).
-
-        // Scrollbars are recorded during paint (see orchestration/mod.rs).
-
-        // Tab bars are recorded during paint (see tabs.rs).
-    }
-
     /// Render the theme info popup.
     pub(super) fn render_theme_info_popup(&self, frame: &mut Frame) {
         let popup = match &self.active_window().theme_info_popup {

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -125,23 +125,29 @@ impl Editor {
         let theme = &*self.theme.read().unwrap();
 
         // Resolve actual colors from theme keys
-        let fg_color = cell.fg_key.and_then(|k| theme.resolve_theme_key(k));
-        let bg_color = cell.bg_key.and_then(|k| theme.resolve_theme_key(k));
+        let fg_color = cell
+            .fg_key
+            .as_ref()
+            .and_then(|k| theme.resolve_theme_key(k));
+        let bg_color = cell
+            .bg_key
+            .as_ref()
+            .and_then(|k| theme.resolve_theme_key(k));
 
         // Build region string, incorporating syntax category if present
-        let region = if let Some(cat) = cell.syntax_category {
+        let region = if let Some(cat) = cell.syntax_category.as_ref() {
             format!("Syntax: {}", cat)
         } else {
             cell.region.to_string()
         };
 
         Some(ThemeKeyInfo {
-            fg_key: cell.fg_key.map(String::from),
-            bg_key: cell.bg_key.map(String::from),
+            fg_key: cell.fg_key.as_ref().map(|k| k.to_string()),
+            bg_key: cell.bg_key.as_ref().map(|k| k.to_string()),
             region,
             fg_color,
             bg_color,
-            syntax_category: cell.syntax_category.map(String::from),
+            syntax_category: cell.syntax_category.as_ref().map(|c| c.to_string()),
         })
     }
 
@@ -155,9 +161,9 @@ impl Editor {
         // Status bar
         if let Some((row, x, width)) = self.active_chrome().status_bar_area {
             let info = CellThemeInfo {
-                fg_key: Some("ui.status_bar_fg"),
-                bg_key: Some("ui.status_bar_bg"),
-                region: "Status Bar",
+                fg_key: Some("ui.status_bar_fg".into()),
+                bg_key: Some("ui.status_bar_bg".into()),
+                region: "Status Bar".into(),
                 syntax_category: None,
             };
             for col in x..x + width {
@@ -176,9 +182,9 @@ impl Editor {
             .map(|m| m.bar_area)
         {
             let info = CellThemeInfo {
-                fg_key: Some("ui.menu_fg"),
-                bg_key: Some("ui.menu_bg"),
-                region: "Menu Bar",
+                fg_key: Some("ui.menu_fg".into()),
+                bg_key: Some("ui.menu_bg".into()),
+                region: "Menu Bar".into(),
                 syntax_category: None,
             };
             for row in bar_area.y..bar_area.y + bar_area.height {
@@ -194,9 +200,9 @@ impl Editor {
         // File explorer
         if let Some(area) = self.active_layout().file_explorer_area {
             let info = CellThemeInfo {
-                fg_key: Some("editor.fg"),
-                bg_key: Some("editor.bg"),
-                region: "File Explorer",
+                fg_key: Some("editor.fg".into()),
+                bg_key: Some("editor.bg".into()),
+                region: "File Explorer".into(),
                 syntax_category: None,
             };
             for row in area.y..area.y + area.height {
@@ -216,16 +222,19 @@ impl Editor {
                 let rel_row = (row - scrollbar_rect.y) as usize;
                 let is_thumb = rel_row >= *thumb_start && rel_row < *thumb_end;
                 let info = CellThemeInfo {
-                    fg_key: Some(if is_thumb {
-                        "ui.scrollbar_thumb_fg"
-                    } else {
-                        "ui.scrollbar_track_fg"
-                    }),
-                    bg_key: Some("editor.bg"),
+                    fg_key: Some(
+                        if is_thumb {
+                            "ui.scrollbar_thumb_fg"
+                        } else {
+                            "ui.scrollbar_track_fg"
+                        }
+                        .into(),
+                    ),
+                    bg_key: Some("editor.bg".into()),
                     region: if is_thumb {
-                        "Scrollbar Thumb"
+                        "Scrollbar Thumb".into()
                     } else {
-                        "Scrollbar Track"
+                        "Scrollbar Track".into()
                     },
                     syntax_category: None,
                 };
@@ -244,9 +253,9 @@ impl Editor {
             {
                 let area = tab_layout.bar_area;
                 let info = CellThemeInfo {
-                    fg_key: Some("ui.tab_inactive_fg"),
-                    bg_key: Some("ui.tab_separator_bg"),
-                    region: "Tab Bar",
+                    fg_key: Some("ui.tab_inactive_fg".into()),
+                    bg_key: Some("ui.tab_separator_bg".into()),
+                    region: "Tab Bar".into(),
                     syntax_category: None,
                 };
                 for row in area.y..area.y + area.height {

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -177,6 +177,32 @@ impl ChromeLayout {
         let idx = row as usize * self.last_frame_width as usize + col as usize;
         self.cell_theme_map.get(idx)
     }
+
+    /// Write theme-key runs a chrome renderer captured during paint into the
+    /// per-cell map. The runs carry screen coordinates; cells outside the
+    /// frame are skipped.
+    pub fn apply_theme_runs(&mut self, runs: &[super::theme::ThemeRun]) {
+        use std::borrow::Cow;
+        let width = self.last_frame_width;
+        if width == 0 {
+            return;
+        }
+        let stride = width as usize;
+        for r in runs {
+            for col in r.x..r.x.saturating_add(r.w) {
+                if col >= width {
+                    break;
+                }
+                let idx = r.y as usize * stride + col as usize;
+                if let Some(cell) = self.cell_theme_map.get_mut(idx) {
+                    cell.fg_key = r.fg_key.map(Cow::Borrowed);
+                    cell.bg_key = r.bg_key.map(Cow::Borrowed);
+                    cell.region = Cow::Borrowed(r.region);
+                    cell.syntax_category = None;
+                }
+            }
+        }
+    }
 }
 
 /// Per-window layout cache: hit-test rects for content scoped to a

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -182,26 +182,8 @@ impl ChromeLayout {
     /// per-cell map. The runs carry screen coordinates; cells outside the
     /// frame are skipped.
     pub fn apply_theme_runs(&mut self, runs: &[super::theme::ThemeRun]) {
-        use std::borrow::Cow;
         let width = self.last_frame_width;
-        if width == 0 {
-            return;
-        }
-        let stride = width as usize;
-        for r in runs {
-            for col in r.x..r.x.saturating_add(r.w) {
-                if col >= width {
-                    break;
-                }
-                let idx = r.y as usize * stride + col as usize;
-                if let Some(cell) = self.cell_theme_map.get_mut(idx) {
-                    cell.fg_key = r.fg_key.map(Cow::Borrowed);
-                    cell.bg_key = r.bg_key.map(Cow::Borrowed);
-                    cell.region = Cow::Borrowed(r.region);
-                    cell.syntax_category = None;
-                }
-            }
-        }
+        super::theme::apply_theme_runs(&mut self.cell_theme_map, width, runs);
     }
 }
 

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -51,4 +51,4 @@ pub(super) use search_state::EventLineInfo;
 pub(crate) use search_state::{InteractiveReplaceState, SearchState};
 
 // theme re-exports
-pub use theme::{CellThemeInfo, ThemeInfoPopup, ThemeKeyInfo};
+pub use theme::{CellThemeInfo, CellThemeRecorder, ThemeInfoPopup, ThemeKeyInfo, ThemeRun};

--- a/crates/fresh-editor/src/app/types/mod.rs
+++ b/crates/fresh-editor/src/app/types/mod.rs
@@ -51,4 +51,6 @@ pub(super) use search_state::EventLineInfo;
 pub(crate) use search_state::{InteractiveReplaceState, SearchState};
 
 // theme re-exports
-pub use theme::{CellThemeInfo, CellThemeRecorder, ThemeInfoPopup, ThemeKeyInfo, ThemeRun};
+pub use theme::{
+    apply_theme_runs, CellThemeInfo, CellThemeRecorder, ThemeInfoPopup, ThemeKeyInfo, ThemeRun,
+};

--- a/crates/fresh-editor/src/app/types/theme.rs
+++ b/crates/fresh-editor/src/app/types/theme.rs
@@ -18,6 +18,57 @@ pub struct CellThemeInfo {
     pub syntax_category: Option<std::borrow::Cow<'static, str>>,
 }
 
+/// One horizontal run of cells a chrome renderer painted with a known set of
+/// theme keys, captured *as it paints*. Renderers collect these into a fresh
+/// `Vec` (sidestepping any borrow of the per-cell map / the window) and the
+/// caller applies them via [`ChromeLayout::apply_theme_runs`] once its own
+/// borrows are released. Keys are `&'static str` (all chrome keys are literals).
+#[derive(Debug, Clone, Copy)]
+pub struct ThemeRun {
+    pub x: u16,
+    pub y: u16,
+    pub w: u16,
+    pub fg_key: Option<&'static str>,
+    pub bg_key: Option<&'static str>,
+    pub region: &'static str,
+}
+
+/// Collects [`ThemeRun`]s during a chrome region's paint. Threaded as
+/// `Option<&mut CellThemeRecorder>` so recording is opt-in (the inspector
+/// wants it; offscreen/test renders pass `None`).
+pub struct CellThemeRecorder<'a> {
+    runs: &'a mut Vec<ThemeRun>,
+}
+
+impl<'a> CellThemeRecorder<'a> {
+    pub fn new(runs: &'a mut Vec<ThemeRun>) -> Self {
+        Self { runs }
+    }
+
+    /// Record a horizontal run of `w` cells starting at screen `(x, y)`.
+    pub fn run(
+        &mut self,
+        x: u16,
+        y: u16,
+        w: u16,
+        fg_key: Option<&'static str>,
+        bg_key: Option<&'static str>,
+        region: &'static str,
+    ) {
+        if w == 0 {
+            return;
+        }
+        self.runs.push(ThemeRun {
+            x,
+            y,
+            w,
+            fg_key,
+            bg_key,
+            region,
+        });
+    }
+}
+
 /// Information about which theme key(s) style a specific screen position.
 /// Used by the Ctrl+Right-Click theme inspector popup.
 #[derive(Debug, Clone)]

--- a/crates/fresh-editor/src/app/types/theme.rs
+++ b/crates/fresh-editor/src/app/types/theme.rs
@@ -33,6 +33,32 @@ pub struct ThemeRun {
     pub region: &'static str,
 }
 
+/// Write theme-key runs into a flat per-cell map of the given `width` (rows
+/// indexed `row * width + col`). Cells outside the frame are skipped. Used by
+/// both [`super::layout::ChromeLayout::apply_theme_runs`] and the split
+/// rendering pipeline, which holds the map directly.
+pub fn apply_theme_runs(map: &mut [CellThemeInfo], width: u16, runs: &[ThemeRun]) {
+    use std::borrow::Cow;
+    if width == 0 {
+        return;
+    }
+    let stride = width as usize;
+    for r in runs {
+        for col in r.x..r.x.saturating_add(r.w) {
+            if col >= width {
+                break;
+            }
+            let idx = r.y as usize * stride + col as usize;
+            if let Some(cell) = map.get_mut(idx) {
+                cell.fg_key = r.fg_key.map(Cow::Borrowed);
+                cell.bg_key = r.bg_key.map(Cow::Borrowed);
+                cell.region = Cow::Borrowed(r.region);
+                cell.syntax_category = None;
+            }
+        }
+    }
+}
+
 /// Collects [`ThemeRun`]s during a chrome region's paint. Threaded as
 /// `Option<&mut CellThemeRecorder>` so recording is opt-in (the inspector
 /// wants it; offscreen/test renders pass `None`).

--- a/crates/fresh-editor/src/app/types/theme.rs
+++ b/crates/fresh-editor/src/app/types/theme.rs
@@ -1,16 +1,21 @@
 /// Lightweight per-cell theme key provenance recorded during rendering.
 /// Stored in `ChromeLayout::cell_theme_map` so the theme inspector popup
 /// can look up the exact keys used for any screen position.
+///
+/// Keys are `Cow<'static, str>` so the hot editor/chrome paths store cheap
+/// borrowed `&'static str` literals while plugin-driven surfaces (the
+/// orchestrator dock) can record the runtime key strings their text
+/// properties carry.
 #[derive(Debug, Clone, Default)]
 pub struct CellThemeInfo {
     /// Foreground theme key (e.g. "syntax.keyword", "editor.fg")
-    pub fg_key: Option<&'static str>,
+    pub fg_key: Option<std::borrow::Cow<'static, str>>,
     /// Background theme key (e.g. "editor.bg", "diagnostic.warning_bg")
-    pub bg_key: Option<&'static str>,
+    pub bg_key: Option<std::borrow::Cow<'static, str>>,
     /// Short region label (e.g. "Line Numbers", "Editor Content")
-    pub region: &'static str,
+    pub region: std::borrow::Cow<'static, str>,
     /// Dynamic region suffix (e.g. syntax category display name appended to "Syntax: ")
-    pub syntax_category: Option<&'static str>,
+    pub syntax_category: Option<std::borrow::Cow<'static, str>>,
 }
 
 /// Information about which theme key(s) style a specific screen position.

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -84,6 +84,31 @@ pub(super) fn translate_plugin_animation_kind(
 }
 
 impl Editor {
+    /// Deliver a `widget_event` hook for the panel identified by
+    /// `panel_key`. Panel ids are plugin-local, so the event carries the
+    /// bare id and is routed by the panel's owning plugin.
+    pub(crate) fn fire_widget_event(
+        &self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: String,
+        event_type: String,
+        payload: serde_json::Value,
+    ) {
+        let pm = self.plugin_manager.read().unwrap();
+        if !pm.has_hook_handlers("widget_event") {
+            return;
+        }
+        pm.run_hook(
+            "widget_event",
+            fresh_core::hooks::HookArgs::WidgetEvent {
+                panel_id: panel_key.id,
+                widget_key,
+                event_type,
+                payload,
+            },
+        );
+    }
+
     /// Apply a `RenderOutput`'s focus-cursor position to the panel
     /// buffer + every split rendering it. When a `TextInput` is
     /// focused, the dispatcher flips `show_cursors=true` and moves
@@ -176,7 +201,7 @@ impl Editor {
     /// re-emitting the spec. Reads the panel's current spec from
     /// the registry, runs `render_spec` against the (possibly
     /// updated) prev state / focus key, writes the result back.
-    pub(super) fn rerender_widget_panel(&mut self, panel_id: u64) {
+    pub(super) fn rerender_widget_panel(&mut self, panel_key: &crate::widgets::PanelKey) {
         // The spec already lives in the registry — mutations (e.g.
         // `append_tree_nodes_in_spec`) edit it in place. Borrow it for
         // render, then write back only the side-effects (hits, instance
@@ -186,18 +211,18 @@ impl Editor {
         // dominates the host's per-mutation cost during a streaming
         // search.
         let (buffer_id, _is_floating, panel_width, out_pieces) = {
-            let (buffer_id, spec) = match self.widget_registry.buffer_and_spec_ref(panel_id) {
+            let (buffer_id, spec) = match self.widget_registry.buffer_and_spec_ref(panel_key) {
                 Some(s) => s,
                 None => return,
             };
             let prev = self
                 .widget_registry
-                .instance_states(panel_id)
+                .instance_states(panel_key)
                 .cloned()
                 .unwrap_or_default();
             let prev_focus = self
                 .widget_registry
-                .focus_key(panel_id)
+                .focus_key(panel_key)
                 .map(|s| s.to_string())
                 .unwrap_or_default();
             let panel_slot = Self::slot_for_panel_buffer(buffer_id);
@@ -220,7 +245,7 @@ impl Editor {
         if self
             .widget_registry
             .update_side_effects(
-                panel_id,
+                panel_key,
                 out_pieces.hits,
                 out_pieces.instance_states,
                 out_pieces.focus_key,
@@ -228,12 +253,12 @@ impl Editor {
             )
             .is_err()
         {
-            tracing::warn!("rerender_widget_panel({}) lost panel mid-call", panel_id);
+            tracing::warn!("rerender_widget_panel({}) lost panel mid-call", panel_key);
             return;
         }
         if let Some(slot) = panel_slot {
             if let Some(fwp) = self.panel_mut(slot) {
-                if fwp.panel_id == panel_id {
+                if &fwp.panel_key == panel_key {
                     fwp.entries = entries;
                     fwp.focus_cursor = focus_cursor;
                     fwp.embeds = embeds;
@@ -244,44 +269,44 @@ impl Editor {
             return;
         }
         if let Err(e) = self.set_virtual_buffer_content(buffer_id, entries.clone()) {
-            tracing::error!("rerender_widget_panel({}) failed: {}", panel_id, e);
+            tracing::error!("rerender_widget_panel({}) failed: {}", panel_key, e);
         }
         self.apply_widget_focus_cursor(buffer_id, &entries, focus_cursor);
     }
 
     pub(super) fn handle_widget_command(
         &mut self,
-        panel_id: u64,
+        panel_key: &crate::widgets::PanelKey,
         action: fresh_core::api::WidgetAction,
     ) {
         use fresh_core::api::WidgetAction;
         match action {
             WidgetAction::FocusAdvance { delta } => {
-                self.handle_widget_focus_advance(panel_id, delta);
+                self.handle_widget_focus_advance(panel_key, delta);
             }
             WidgetAction::Activate => {
-                self.handle_widget_activate(panel_id);
+                self.handle_widget_activate(panel_key);
             }
             WidgetAction::SelectMove { delta } => {
-                self.handle_widget_select_move(panel_id, delta);
+                self.handle_widget_select_move(panel_key, delta);
             }
             WidgetAction::TextInputKey { key } => {
-                self.handle_widget_text_key(panel_id, &key);
+                self.handle_widget_text_key(panel_key, &key);
             }
             WidgetAction::TextInputChar { text } => {
-                self.handle_widget_text_char(panel_id, &text);
+                self.handle_widget_text_char(panel_key, &text);
             }
             WidgetAction::Key { key } => {
-                self.handle_widget_key(panel_id, &key);
+                self.handle_widget_key(panel_key, &key);
             }
         }
     }
 
-    fn handle_widget_key(&mut self, panel_id: u64, key: &str) {
+    fn handle_widget_key(&mut self, panel_key: &crate::widgets::PanelKey, key: &str) {
         // Smart key dispatch — route to the right specialized
         // handler based on focused widget kind. See WidgetAction::Key
         // doc for the dispatch table.
-        let panel = match self.widget_registry.get(panel_id) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -301,11 +326,11 @@ impl Editor {
         // the text editor, which lets the user keep typing to
         // refine the candidate list.
         let completions_open = matches!(key, "Tab" | "Up" | "Down" | "Enter" | "Escape")
-            && self.focused_text_completions_open(panel_id);
+            && self.focused_text_completions_open(panel_key);
         if completions_open {
             match key {
                 "Tab" => {
-                    self.fire_completion_accept(panel_id);
+                    self.fire_completion_accept(panel_key);
                     // The plugin's accept handler typically calls
                     // setValue + (maybe) setCompletions — those
                     // mutations re-render on their own, so we
@@ -313,38 +338,38 @@ impl Editor {
                     return;
                 }
                 "Up" => {
-                    self.move_focused_text_completion_index(panel_id, -1);
+                    self.move_focused_text_completion_index(panel_key, -1);
                     // Selection moved host-side; force a repaint
                     // so the highlight + scroll-into-view shift
                     // is visible without waiting for the next
                     // unrelated mutation.
-                    self.rerender_widget_panel(panel_id);
+                    self.rerender_widget_panel(panel_key);
                     return;
                 }
                 "Down" => {
-                    self.move_focused_text_completion_index(panel_id, 1);
-                    self.rerender_widget_panel(panel_id);
+                    self.move_focused_text_completion_index(panel_key, 1);
+                    self.rerender_widget_panel(panel_key);
                     return;
                 }
                 "Enter" | "Escape" => {
-                    self.dismiss_focused_text_completions(panel_id);
-                    self.rerender_widget_panel(panel_id);
+                    self.dismiss_focused_text_completions(panel_key);
+                    self.rerender_widget_panel(panel_key);
                     return;
                 }
                 _ => {}
             }
         }
         match key {
-            "Tab" => self.handle_widget_focus_advance(panel_id, 1),
-            "Shift+Tab" => self.handle_widget_focus_advance(panel_id, -1),
+            "Tab" => self.handle_widget_focus_advance(panel_key, 1),
+            "Shift+Tab" => self.handle_widget_focus_advance(panel_key, -1),
             "Up" | "Down" => {
                 let delta = if key == "Up" { -1 } else { 1 };
                 match widget {
                     Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                        self.handle_widget_select_move(panel_id, delta);
+                        self.handle_widget_select_move(panel_key, delta);
                     }
                     Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                        self.handle_widget_tree_select_move(panel_id, delta);
+                        self.handle_widget_tree_select_move(panel_key, delta);
                     }
                     Some(fresh_core::api::WidgetSpec::Text { rows, .. }) if *rows > 1 => {
                         // Multi-line Text: line nav. Single-line
@@ -352,7 +377,7 @@ impl Editor {
                         // move_down would no-op on the single
                         // line, but skipping the dispatch keeps
                         // the change-event quiet.
-                        self.handle_widget_text_key(panel_id, key);
+                        self.handle_widget_text_key(panel_key, key);
                     }
                     _ => {
                         // Picker-style nav: when the focused widget
@@ -364,23 +389,23 @@ impl Editor {
                         // navigate the adjacent list.
                         let scrollable = self
                             .widget_registry
-                            .get(panel_id)
+                            .get(panel_key)
                             .and_then(|p| find_scrollable_widget_key(&p.spec));
                         if let Some(target_key) = scrollable {
-                            let target_kind = self.widget_registry.get(panel_id).and_then(|p| {
+                            let target_kind = self.widget_registry.get(panel_key).and_then(|p| {
                                 crate::widgets::find_widget_by_key(&p.spec, &target_key).cloned()
                             });
                             match target_kind {
                                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
                                     self.handle_widget_select_move_for_key(
-                                        panel_id,
+                                        panel_key,
                                         &target_key,
                                         delta,
                                     );
                                 }
                                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                                     self.handle_widget_tree_select_move_for_key(
-                                        panel_id,
+                                        panel_key,
                                         &target_key,
                                         delta,
                                     );
@@ -408,39 +433,39 @@ impl Editor {
                 let delta = if key == "PageUp" { -page } else { page };
                 match widget {
                     Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                        self.handle_widget_select_move(panel_id, delta);
+                        self.handle_widget_select_move(panel_key, delta);
                     }
                     Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                        self.handle_widget_tree_select_move(panel_id, delta);
+                        self.handle_widget_tree_select_move(panel_key, delta);
                     }
                     _ => {}
                 }
             }
             "Left" | "Right" => match widget {
                 Some(fresh_core::api::WidgetSpec::Text { .. }) => {
-                    self.handle_widget_text_key(panel_id, key);
+                    self.handle_widget_text_key(panel_key, key);
                 }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                    self.handle_widget_tree_lateral(panel_id, key == "Right");
+                    self.handle_widget_tree_lateral(panel_key, key == "Right");
                 }
                 _ => {}
             },
             "Backspace" | "Delete" | "Home" | "End" => match widget {
                 Some(fresh_core::api::WidgetSpec::Text { .. }) => {
-                    self.handle_widget_text_key(panel_id, key);
+                    self.handle_widget_text_key(panel_key, key);
                 }
                 _ => {}
             },
             "Enter" => match widget {
                 Some(fresh_core::api::WidgetSpec::Button { .. })
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {
-                    self.handle_widget_activate(panel_id);
+                    self.handle_widget_activate(panel_key);
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                    self.fire_list_activate(panel_id, &focus_key);
+                    self.fire_list_activate(panel_key, &focus_key);
                 }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                    self.fire_tree_activate(panel_id, &focus_key);
+                    self.fire_tree_activate(panel_key, &focus_key);
                 }
                 Some(fresh_core::api::WidgetSpec::Text { rows, .. }) => {
                     if *rows > 1 {
@@ -449,10 +474,10 @@ impl Editor {
                         // can intercept it in their mode binding
                         // before dispatching through the smart-key
                         // router.
-                        self.handle_widget_text_key(panel_id, "Enter");
+                        self.handle_widget_text_key(panel_key, "Enter");
                     } else if let Some(target_key) = self
                         .widget_registry
-                        .get(panel_id)
+                        .get(panel_key)
                         .and_then(|p| find_scrollable_widget_key(&p.spec))
                     {
                         // Picker-style activate: a single-line filter
@@ -460,22 +485,22 @@ impl Editor {
                         // scrollable's activate event on Enter, so the
                         // user can type-then-Enter without tabbing
                         // focus to the list.
-                        let kind = self.widget_registry.get(panel_id).and_then(|p| {
+                        let kind = self.widget_registry.get(panel_key).and_then(|p| {
                             crate::widgets::find_widget_by_key(&p.spec, &target_key).cloned()
                         });
                         match kind {
                             Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                                self.fire_list_activate(panel_id, &target_key);
+                                self.fire_list_activate(panel_key, &target_key);
                             }
                             Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
-                                self.fire_tree_activate(panel_id, &target_key);
+                                self.fire_tree_activate(panel_key, &target_key);
                             }
                             _ => {}
                         }
                     } else {
                         // Form-like UX: Enter commits the field and
                         // moves to the next tabbable widget.
-                        self.handle_widget_focus_advance(panel_id, 1);
+                        self.handle_widget_focus_advance(panel_key, 1);
                     }
                 }
                 _ => {}
@@ -483,13 +508,13 @@ impl Editor {
             "Space" => match widget {
                 Some(fresh_core::api::WidgetSpec::Button { .. })
                 | Some(fresh_core::api::WidgetSpec::Toggle { .. }) => {
-                    self.handle_widget_activate(panel_id);
+                    self.handle_widget_activate(panel_key);
                 }
                 Some(fresh_core::api::WidgetSpec::Text { .. }) => {
-                    self.handle_widget_text_char(panel_id, " ");
+                    self.handle_widget_text_char(panel_key, " ");
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                    self.fire_list_activate(panel_id, &focus_key);
+                    self.fire_list_activate(panel_key, &focus_key);
                 }
                 Some(fresh_core::api::WidgetSpec::Tree { .. }) => {
                     // On a checkable Tree, Space is the conventional
@@ -498,8 +523,8 @@ impl Editor {
                     // would do). Falls back to `activate` for trees
                     // that aren't checkable, or rows that don't have
                     // a checkbox glyph (`checked: None`).
-                    if !self.fire_tree_toggle_if_checkable(panel_id, &focus_key) {
-                        self.fire_tree_activate(panel_id, &focus_key);
+                    if !self.fire_tree_toggle_if_checkable(panel_key, &focus_key) {
+                        self.fire_tree_activate(panel_key, &focus_key);
                     }
                 }
                 _ => {}
@@ -508,8 +533,8 @@ impl Editor {
         }
     }
 
-    fn handle_widget_focus_advance(&mut self, panel_id: u64, delta: i32) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn handle_widget_focus_advance(&mut self, panel_key: &crate::widgets::PanelKey, delta: i32) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -524,8 +549,8 @@ impl Editor {
         let n = panel.tabbable.len() as i32;
         let new_idx = ((cur_idx + delta) % n + n) % n;
         let new_key = panel.tabbable[new_idx as usize].clone();
-        self.set_panel_focus_and_notify(panel_id, new_key);
-        self.rerender_widget_panel(panel_id);
+        self.set_panel_focus_and_notify(panel_key, new_key);
+        self.rerender_widget_panel(panel_key);
     }
 
     /// Update the panel's focused widget AND fire a
@@ -537,16 +562,20 @@ impl Editor {
     ///
     /// No-op when the key isn't actually changing (avoids
     /// spurious events on every render that touches focus).
-    pub(crate) fn set_panel_focus_and_notify(&mut self, panel_id: u64, new_key: String) {
+    pub(crate) fn set_panel_focus_and_notify(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        new_key: String,
+    ) {
         let old_key = self
             .widget_registry
-            .focus_key(panel_id)
+            .focus_key(panel_key)
             .map(|s| s.to_string())
             .unwrap_or_default();
         if old_key == new_key {
             tracing::debug!(
                 target: "fresh::dock",
-                panel_id,
+                panel = %panel_key,
                 key = %new_key,
                 "set_panel_focus_and_notify: no-op (old == new)"
             );
@@ -554,36 +583,26 @@ impl Editor {
         }
         tracing::debug!(
             target: "fresh::dock",
-            panel_id,
+            panel = %panel_key,
             old = %old_key,
             new = %new_key,
             "set_panel_focus_and_notify: firing `focus` widget_event"
         );
         self.widget_registry
-            .set_focus_key(panel_id, new_key.clone());
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: new_key,
-                    event_type: "focus".to_string(),
-                    payload: serde_json::json!({ "previous": old_key }),
-                },
-            );
-        }
+            .set_focus_key(panel_key, new_key.clone());
+        self.fire_widget_event(
+            panel_key,
+            new_key,
+            "focus".to_string(),
+            serde_json::json!({ "previous": old_key }),
+        );
     }
 
-    fn handle_widget_activate(&mut self, panel_id: u64) {
+    fn handle_widget_activate(&mut self, panel_key: &crate::widgets::PanelKey) {
         // Fire `widget_event` based on the focused widget's kind.
         // Button → "activate"; Toggle → "toggle" (with the
         // computed-new payload); other kinds: no-op.
-        let panel = match self.widget_registry.get(panel_id) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -606,22 +625,7 @@ impl Editor {
             }
             _ => return,
         };
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key,
-                    event_type: event_type.to_string(),
-                    payload,
-                },
-            );
-        }
+        self.fire_widget_event(panel_key, focus_key, event_type.to_string(), payload);
     }
 
     /// Fire a `widget_event { event_type: "activate", payload: {
@@ -629,14 +633,14 @@ impl Editor {
     /// selection (or spec selection on first render). The plugin's
     /// activate handler does the actual user-visible thing — open
     /// the matched file, expand/collapse a tree node, etc.
-    /// True when the focused widget on `panel_id` is a Text input
+    /// True when the focused widget on `panel_key` is a Text input
     /// whose host-managed completion popup is currently open
     /// (instance state has at least one candidate). Lets the
     /// smart-key dispatcher route Tab/Enter/Up/Down/Esc to the
     /// popup-specific paths before falling through to the
     /// widget's default key behaviour.
-    fn focused_text_completions_open(&self, panel_id: u64) -> bool {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn focused_text_completions_open(&self, panel_key: &crate::widgets::PanelKey) -> bool {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return false,
         };
@@ -660,14 +664,18 @@ impl Editor {
     /// items they expect to be in monotonic positions. No-op
     /// when the focused widget isn't a Text-with-open-
     /// completions.
-    fn move_focused_text_completion_index(&mut self, panel_id: u64, delta: i32) {
+    fn move_focused_text_completion_index(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        delta: i32,
+    ) {
         // First read the spec's visible-rows cap so we can pull
         // scroll back into view if the new selection lands above
         // the current scroll offset. (The renderer only does
         // forward-pull — it would otherwise fight the mouse-
         // wheel handler which deliberately diverges scroll from
         // selection.)
-        let panel = match self.widget_registry.get(panel_id) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -687,7 +695,7 @@ impl Editor {
         } else {
             spec_visible_rows
         };
-        let panel = match self.widget_registry.get_mut(panel_id) {
+        let panel = match self.widget_registry.get_mut(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -724,9 +732,9 @@ impl Editor {
     /// token, so a late-arriving result doesn't re-open the
     /// popup the user just closed). Used by Enter and Escape on
     /// a Text-with-open-completions.
-    fn dismiss_focused_text_completions(&mut self, panel_id: u64) {
+    fn dismiss_focused_text_completions(&mut self, panel_key: &crate::widgets::PanelKey) {
         let focus_key = {
-            let panel = match self.widget_registry.get_mut(panel_id) {
+            let panel = match self.widget_registry.get_mut(panel_key) {
                 Some(p) => p,
                 None => return,
             };
@@ -750,22 +758,12 @@ impl Editor {
             }
             focus_key
         };
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key,
-                    event_type: "completion_dismiss".into(),
-                    payload: serde_json::json!({}),
-                },
-            );
-        }
+        self.fire_widget_event(
+            panel_key,
+            focus_key,
+            "completion_dismiss".into(),
+            serde_json::json!({}),
+        );
     }
 
     /// Fire `completion_accept` on the focused Text widget's
@@ -779,9 +777,9 @@ impl Editor {
     /// stay alive so the user can keep Tab-ing. Plugins that
     /// want a one-shot accept close the popup themselves with
     /// `setCompletions(key, [])`.
-    fn fire_completion_accept(&mut self, panel_id: u64) {
+    fn fire_completion_accept(&mut self, panel_key: &crate::widgets::PanelKey) {
         let (focus_key, value) = {
-            let panel = match self.widget_registry.get(panel_id) {
+            let panel = match self.widget_registry.get(panel_key) {
                 Some(p) => p,
                 None => return,
             };
@@ -801,26 +799,16 @@ impl Editor {
                 _ => return,
             }
         };
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key,
-                    event_type: "completion_accept".into(),
-                    payload: serde_json::json!({ "value": value }),
-                },
-            );
-        }
+        self.fire_widget_event(
+            panel_key,
+            focus_key,
+            "completion_accept".into(),
+            serde_json::json!({ "value": value }),
+        );
     }
 
-    fn fire_list_activate(&mut self, panel_id: u64, focus_key: &str) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn fire_list_activate(&mut self, panel_key: &crate::widgets::PanelKey, focus_key: &str) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -843,36 +831,23 @@ impl Editor {
             return;
         }
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key.to_string(),
-                    event_type: "activate".into(),
-                    payload: serde_json::json!({
-                        "index": sel,
-                        "key": item_key,
-                    }),
-                },
-            );
-        }
+        self.fire_widget_event(
+            panel_key,
+            focus_key.to_string(),
+            "activate".into(),
+            serde_json::json!({ "index": sel, "key": item_key, }),
+        );
     }
 
-    fn handle_widget_select_move(&mut self, panel_id: u64, delta: i32) {
-        let focus_key = match self.widget_registry.get(panel_id) {
+    fn handle_widget_select_move(&mut self, panel_key: &crate::widgets::PanelKey, delta: i32) {
+        let focus_key = match self.widget_registry.get(panel_key) {
             Some(p) => p.focus_key.clone(),
             None => return,
         };
         if focus_key.is_empty() {
             return;
         }
-        self.handle_widget_select_move_for_key(panel_id, &focus_key, delta);
+        self.handle_widget_select_move_for_key(panel_key, &focus_key, delta);
     }
 
     /// Set a `List` widget's selected index to an absolute item index,
@@ -884,11 +859,11 @@ impl Editor {
     /// from the stale index.
     pub(super) fn set_widget_list_selected_index(
         &mut self,
-        panel_id: u64,
+        panel_key: &crate::widgets::PanelKey,
         widget_key: &str,
         index: i32,
     ) {
-        if let Some(panel) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel) = self.widget_registry.get_mut(panel_key) {
             let (prev_scroll, prev_item_height) = match panel.instance_states.get(widget_key) {
                 Some(crate::widgets::WidgetInstanceState::List {
                     scroll_offset,
@@ -908,7 +883,7 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
     }
 
     /// Same as [`handle_widget_select_move`] but targets an explicit
@@ -916,8 +891,13 @@ impl Editor {
     /// by the picker-style smart-key dispatch — `Up`/`Down` on a
     /// focused filter input route to the first scrollable widget in
     /// the panel without changing focus.
-    fn handle_widget_select_move_for_key(&mut self, panel_id: u64, widget_key: &str, delta: i32) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn handle_widget_select_move_for_key(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: &str,
+        delta: i32,
+    ) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -953,7 +933,7 @@ impl Editor {
         let raw = if cur_sel < 0 { 0 } else { cur_sel + delta };
         let new_sel = raw.clamp(0, total - 1);
         let new_key = item_keys.get(new_sel as usize).cloned().unwrap_or_default();
-        if let Some(panel_mut) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             let (cur_scroll, cur_item_height) = match panel_mut.instance_states.get(widget_key) {
                 Some(crate::widgets::WidgetInstanceState::List {
                     scroll_offset,
@@ -974,7 +954,7 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
         // A clamped move at the list's top/bottom edge leaves the
         // selection where it was. Still re-render above (re-arming
         // `user_scrolled = false` snaps a scrolled-away view back to the
@@ -984,21 +964,12 @@ impl Editor {
         // plugin's preview / live-switch work (in the Orchestrator dock
         // it schedules a redundant `scheduleDockSwitch`). Mirrors the
         // Tree handler's "No change → bail (don't fire spurious select)".
-        if new_sel != cur_sel
-            && self
-                .plugin_manager
-                .read()
-                .unwrap()
-                .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: widget_key.to_string(),
-                    event_type: "select".into(),
-                    payload: serde_json::json!({ "index": new_sel, "key": new_key }),
-                },
+        if new_sel != cur_sel {
+            self.fire_widget_event(
+                panel_key,
+                widget_key.to_string(),
+                "select".into(),
+                serde_json::json!({ "index": new_sel, "key": new_key }),
             );
         }
     }
@@ -1007,25 +978,25 @@ impl Editor {
     /// descendants of collapsed nodes. Selection is the *absolute*
     /// `nodes` index; we walk the visible-flat order to find the
     /// neighbour. Mirrors the List handler shape but tree-aware.
-    fn handle_widget_tree_select_move(&mut self, panel_id: u64, delta: i32) {
-        let focus_key = match self.widget_registry.get(panel_id) {
+    fn handle_widget_tree_select_move(&mut self, panel_key: &crate::widgets::PanelKey, delta: i32) {
+        let focus_key = match self.widget_registry.get(panel_key) {
             Some(p) => p.focus_key.clone(),
             None => return,
         };
         if focus_key.is_empty() {
             return;
         }
-        self.handle_widget_tree_select_move_for_key(panel_id, &focus_key, delta);
+        self.handle_widget_tree_select_move_for_key(panel_key, &focus_key, delta);
     }
 
     /// Tree counterpart of [`handle_widget_select_move_for_key`].
     fn handle_widget_tree_select_move_for_key(
         &mut self,
-        panel_id: u64,
+        panel_key: &crate::widgets::PanelKey,
         widget_key: &str,
         delta: i32,
     ) {
-        let panel = match self.widget_registry.get(panel_id) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -1070,7 +1041,7 @@ impl Editor {
         let new_pos = (cur_pos + delta).clamp(0, (visible_indices.len() as i32) - 1);
         let new_abs = visible_indices[new_pos as usize];
         let new_key = item_keys.get(new_abs).cloned().unwrap_or_default();
-        if let Some(panel_mut) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             panel_mut.instance_states.insert(
                 widget_key.to_string(),
                 crate::widgets::WidgetInstanceState::Tree {
@@ -1080,23 +1051,13 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: widget_key.to_string(),
-                    event_type: "select".into(),
-                    payload: serde_json::json!({ "index": new_abs as i64, "key": new_key }),
-                },
-            );
-        }
+        self.rerender_widget_panel(panel_key);
+        self.fire_widget_event(
+            panel_key,
+            widget_key.to_string(),
+            "select".into(),
+            serde_json::json!({ "index": new_abs as i64, "key": new_key }),
+        );
     }
 
     /// Mouse-wheel scroll over a widget panel buffer. Finds the
@@ -1115,14 +1076,14 @@ impl Editor {
     ) -> bool {
         let panels = self.widget_registry.panels_for_buffer(buffer_id);
         let mut consumed = false;
-        for panel_id in panels {
+        for panel_key in panels {
             // First chance: a focused Text widget with an open
             // completion popup absorbs the wheel — scrolling the
             // candidate list when the popup is what the user is
             // pointing at takes priority over scrolling a
             // sibling List/Tree elsewhere on the panel.
-            if self.focused_text_completions_open(panel_id) {
-                self.scroll_focused_text_completions(panel_id, delta);
+            if self.focused_text_completions_open(&panel_key) {
+                self.scroll_focused_text_completions(&panel_key, delta);
                 // The renderer reads `completion_scroll_offset`
                 // out of the Text widget's instance state on
                 // each paint, so flushing a rerender here is
@@ -1131,11 +1092,11 @@ impl Editor {
                 // the floating panel stay pinned to the old
                 // offset until the user's next keystroke
                 // happens to re-render for some other reason.
-                self.rerender_widget_panel(panel_id);
+                self.rerender_widget_panel(&panel_key);
                 consumed = true;
                 continue;
             }
-            let spec = match self.widget_registry.get(panel_id) {
+            let spec = match self.widget_registry.get(&panel_key) {
                 Some(p) => p.spec.clone(),
                 None => continue,
             };
@@ -1152,10 +1113,10 @@ impl Editor {
                     // nothing to scroll here; swallowing the event would
                     // leave the wheel dead. Falling through lets the
                     // underlying buffer scroll handle it.
-                    consumed |= self.handle_widget_tree_wheel(panel_id, &widget_key, delta);
+                    consumed |= self.handle_widget_tree_wheel(&panel_key, &widget_key, delta);
                 }
                 Some(fresh_core::api::WidgetSpec::List { .. }) => {
-                    consumed |= self.handle_widget_list_wheel(panel_id, &widget_key, delta);
+                    consumed |= self.handle_widget_list_wheel(&panel_key, &widget_key, delta);
                 }
                 _ => {}
             }
@@ -1169,8 +1130,12 @@ impl Editor {
     /// "5 if zero / unset" to mirror the renderer's default —
     /// the cap matters for clamping the max scroll so the
     /// thumb doesn't drift past the end.
-    fn scroll_focused_text_completions(&mut self, panel_id: u64, delta: i32) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn scroll_focused_text_completions(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        delta: i32,
+    ) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -1190,7 +1155,7 @@ impl Editor {
         } else {
             spec_visible_rows
         };
-        let panel = match self.widget_registry.get_mut(panel_id) {
+        let panel = match self.widget_registry.get_mut(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -1214,8 +1179,13 @@ impl Editor {
     /// selection would fall outside the new viewport, drag it to
     /// the edge so the renderer's keep-selection-visible logic
     /// doesn't snap the offset back.
-    fn handle_widget_tree_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) -> bool {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn handle_widget_tree_wheel(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: &str,
+        delta: i32,
+    ) -> bool {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return false,
         };
@@ -1267,7 +1237,7 @@ impl Editor {
             }
             _ => cur_sel,
         };
-        if let Some(panel_mut) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             panel_mut.instance_states.insert(
                 widget_key.to_string(),
                 crate::widgets::WidgetInstanceState::Tree {
@@ -1277,14 +1247,19 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
         true
     }
 
     /// List counterpart of `handle_widget_tree_wheel`. Returns true if the
     /// list's scroll offset actually changed (the wheel was consumed).
-    fn handle_widget_list_wheel(&mut self, panel_id: u64, widget_key: &str, delta: i32) -> bool {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn handle_widget_list_wheel(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        widget_key: &str,
+        delta: i32,
+    ) -> bool {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return false,
         };
@@ -1332,7 +1307,7 @@ impl Editor {
         // Wheel scrolls the *view* only — the selection stays put (and
         // may leave the visible window); `user_scrolled` tells the
         // renderer not to snap the offset back to it.
-        if let Some(panel_mut) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             panel_mut.instance_states.insert(
                 widget_key.to_string(),
                 crate::widgets::WidgetInstanceState::List {
@@ -1343,7 +1318,7 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
+        self.rerender_widget_panel(panel_key);
         true
     }
 
@@ -1356,8 +1331,8 @@ impl Editor {
     ///
     /// Both update host instance state, re-render, and (when a
     /// change happened) fire `widget_event { event_type: "expand" }`.
-    fn handle_widget_tree_lateral(&mut self, panel_id: u64, is_right: bool) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn handle_widget_tree_lateral(&mut self, panel_key: &crate::widgets::PanelKey, is_right: bool) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -1415,7 +1390,7 @@ impl Editor {
             return;
         }
         let final_key = item_keys.get(new_sel as usize).cloned().unwrap_or_default();
-        if let Some(panel_mut) = self.widget_registry.get_mut(panel_id) {
+        if let Some(panel_mut) = self.widget_registry.get_mut(panel_key) {
             panel_mut.instance_states.insert(
                 focus_key.clone(),
                 crate::widgets::WidgetInstanceState::Tree {
@@ -1425,41 +1400,28 @@ impl Editor {
                 },
             );
         }
-        self.rerender_widget_panel(panel_id);
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            if let Some(now_expanded) = expansion_changed {
-                self.plugin_manager.read().unwrap().run_hook(
-                    "widget_event",
-                    fresh_core::hooks::HookArgs::WidgetEvent {
-                        panel_id,
-                        widget_key: focus_key.clone(),
-                        event_type: "expand".into(),
-                        payload: serde_json::json!({
-                            "index": cur_sel as i64,
-                            "key": key,
-                            "expanded": now_expanded,
-                        }),
-                    },
-                );
-            } else if new_sel != cur_sel {
-                self.plugin_manager.read().unwrap().run_hook(
-                    "widget_event",
-                    fresh_core::hooks::HookArgs::WidgetEvent {
-                        panel_id,
-                        widget_key: focus_key,
-                        event_type: "select".into(),
-                        payload: serde_json::json!({
-                            "index": new_sel as i64,
-                            "key": final_key,
-                        }),
-                    },
-                );
-            }
+        self.rerender_widget_panel(panel_key);
+        if let Some(now_expanded) = expansion_changed {
+            self.fire_widget_event(
+                panel_key,
+                focus_key.clone(),
+                "expand".into(),
+                serde_json::json!({
+                    "index": cur_sel as i64,
+                    "key": key,
+                    "expanded": now_expanded,
+                }),
+            );
+        } else if new_sel != cur_sel {
+            self.fire_widget_event(
+                panel_key,
+                focus_key,
+                "select".into(),
+                serde_json::json!({
+                    "index": new_sel as i64,
+                    "key": final_key,
+                }),
+            );
         }
     }
 
@@ -1468,7 +1430,7 @@ impl Editor {
     /// handler when the user clicks the disclosure column.
     pub(crate) fn handle_widget_tree_expand_toggle(
         &mut self,
-        panel_id: u64,
+        panel_key: &crate::widgets::PanelKey,
         widget_key: &str,
         item_key: &str,
     ) {
@@ -1476,7 +1438,7 @@ impl Editor {
             return;
         }
         let now_expanded = {
-            let panel = match self.widget_registry.get_mut(panel_id) {
+            let panel = match self.widget_registry.get_mut(panel_key) {
                 Some(p) => p,
                 None => return,
             };
@@ -1505,26 +1467,13 @@ impl Editor {
             );
             next
         };
-        self.rerender_widget_panel(panel_id);
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: widget_key.to_string(),
-                    event_type: "expand".into(),
-                    payload: serde_json::json!({
-                        "key": item_key,
-                        "expanded": now_expanded,
-                    }),
-                },
-            );
-        }
+        self.rerender_widget_panel(panel_key);
+        self.fire_widget_event(
+            panel_key,
+            widget_key.to_string(),
+            "expand".into(),
+            serde_json::json!({ "key": item_key, "expanded": now_expanded, }),
+        );
     }
 
     /// Fire `widget_event { event_type: "activate" }` for the focused
@@ -1540,8 +1489,12 @@ impl Editor {
     /// Mirrors what a click on the row's `[v]`/`[ ]` glyph would
     /// do — Space is the conventional checkbox key, so on a
     /// checkable tree Space toggles instead of activating.
-    fn fire_tree_toggle_if_checkable(&mut self, panel_id: u64, focus_key: &str) -> bool {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn fire_tree_toggle_if_checkable(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        focus_key: &str,
+    ) -> bool {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return false,
         };
@@ -1574,31 +1527,17 @@ impl Editor {
         };
         let new_checked = !cur_checked;
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key.to_string(),
-                    event_type: "toggle".into(),
-                    payload: serde_json::json!({
-                        "index": sel,
-                        "key": item_key,
-                        "checked": new_checked,
-                    }),
-                },
-            );
-        }
+        self.fire_widget_event(
+            panel_key,
+            focus_key.to_string(),
+            "toggle".into(),
+            serde_json::json!({ "index": sel, "key": item_key, "checked": new_checked, }),
+        );
         true
     }
 
-    fn fire_tree_activate(&mut self, panel_id: u64, focus_key: &str) {
-        let panel = match self.widget_registry.get(panel_id) {
+    fn fire_tree_activate(&mut self, panel_key: &crate::widgets::PanelKey, focus_key: &str) {
+        let panel = match self.widget_registry.get(panel_key) {
             Some(p) => p,
             None => return,
         };
@@ -1621,25 +1560,12 @@ impl Editor {
             return;
         }
         let item_key = item_keys.get(sel as usize).cloned().unwrap_or_default();
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key.to_string(),
-                    event_type: "activate".into(),
-                    payload: serde_json::json!({
-                        "index": sel,
-                        "key": item_key,
-                    }),
-                },
-            );
-        }
+        self.fire_widget_event(
+            panel_key,
+            focus_key.to_string(),
+            "activate".into(),
+            serde_json::json!({ "index": sel, "key": item_key, }),
+        );
     }
 
     /// Walk every panel rendering into `buffer_id` and return the
@@ -1657,24 +1583,27 @@ impl Editor {
     pub(super) fn focused_text_widget_panel_for_buffer(
         &self,
         buffer_id: crate::model::event::BufferId,
-    ) -> Option<u64> {
-        for panel_id in self.widget_registry.panels_for_buffer(buffer_id) {
-            if self.panel_focused_widget_is_text(panel_id) {
-                return Some(panel_id);
+    ) -> Option<crate::widgets::PanelKey> {
+        for panel_key in self.widget_registry.panels_for_buffer(buffer_id) {
+            if self.panel_focused_widget_is_text(&panel_key) {
+                return Some(panel_key);
             }
         }
         None
     }
 
-    /// True when `panel_id`'s currently-focused widget is a `Text`
+    /// True when `panel_key`'s currently-focused widget is a `Text`
     /// field (so it can accept clipboard insertion). `false` when the
     /// panel is gone, has no focus, or focus rests on a non-text
     /// widget (`Button` / `List` / `Toggle` / …). This is the shared
     /// predicate behind both the buffer-mounted paste routing
     /// (`focused_text_widget_panel_for_buffer`) and the floating-panel
     /// bracketed-paste routing (`paste_bracketed_into_focused_panel`).
-    pub(super) fn panel_focused_widget_is_text(&self, panel_id: u64) -> bool {
-        let Some(panel) = self.widget_registry.get(panel_id) else {
+    pub(super) fn panel_focused_widget_is_text(
+        &self,
+        panel_key: &crate::widgets::PanelKey,
+    ) -> bool {
+        let Some(panel) = self.widget_registry.get(panel_key) else {
             return false;
         };
         if panel.focus_key.is_empty() {
@@ -1690,8 +1619,11 @@ impl Editor {
     /// widget on the given panel, or `None` when nothing is
     /// selected (no anchor, or anchor == cursor). Used by the
     /// host-side Copy / Cut routing path.
-    pub(super) fn focused_widget_selected_text(&self, panel_id: u64) -> Option<String> {
-        let panel = self.widget_registry.get(panel_id)?;
+    pub(super) fn focused_widget_selected_text(
+        &self,
+        panel_key: &crate::widgets::PanelKey,
+    ) -> Option<String> {
+        let panel = self.widget_registry.get(panel_key)?;
         if panel.focus_key.is_empty() {
             return None;
         }
@@ -1707,22 +1639,25 @@ impl Editor {
     /// applied (focus was a Text widget). The op fires a `change`
     /// event only if the selection range actually changed; an
     /// already-fully-selected widget is a no-op.
-    pub(super) fn handle_widget_select_all(&mut self, panel_id: u64) -> bool {
+    pub(super) fn handle_widget_select_all(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+    ) -> bool {
         // SelectAll moves the cursor to end-of-value and sets anchor
         // at start — `with_focused_text_editor` will skip re-render
         // when nothing changed, which is fine.
-        self.with_focused_text_editor(panel_id, |editor| editor.select_all())
+        self.with_focused_text_editor(panel_key, |editor| editor.select_all())
     }
 
     /// Copy the focused widget Text's current selection to the
     /// internal clipboard. Returns true when copy ran (even when
     /// the selection was empty — the action is consumed either way
     /// so it doesn't fall through to the buffer's copy path).
-    pub(super) fn handle_widget_copy(&mut self, panel_id: u64) -> bool {
-        if self.widget_registry.get(panel_id).is_none() {
+    pub(super) fn handle_widget_copy(&mut self, panel_key: &crate::widgets::PanelKey) -> bool {
+        if self.widget_registry.get(panel_key).is_none() {
             return false;
         }
-        if let Some(text) = self.focused_widget_selected_text(panel_id) {
+        if let Some(text) = self.focused_widget_selected_text(panel_key) {
             self.clipboard.copy(text);
         }
         true
@@ -1730,13 +1665,13 @@ impl Editor {
 
     /// Cut the focused widget Text's current selection — copy then
     /// delete. With no selection, this is a no-op consume.
-    pub(super) fn handle_widget_cut(&mut self, panel_id: u64) -> bool {
-        if self.widget_registry.get(panel_id).is_none() {
+    pub(super) fn handle_widget_cut(&mut self, panel_key: &crate::widgets::PanelKey) -> bool {
+        if self.widget_registry.get(panel_key).is_none() {
             return false;
         }
-        if let Some(text) = self.focused_widget_selected_text(panel_id) {
+        if let Some(text) = self.focused_widget_selected_text(panel_key) {
             self.clipboard.copy(text);
-            self.with_focused_text_editor(panel_id, |editor| {
+            self.with_focused_text_editor(panel_key, |editor| {
                 editor.delete_selection();
             });
         }
@@ -1748,12 +1683,16 @@ impl Editor {
     /// path; `text` is already line-ending-normalised by the
     /// caller (CRLF / CR → LF). `TextEdit::insert_str` strips
     /// embedded newlines when the editor is single-line.
-    pub(super) fn handle_widget_insert_str(&mut self, panel_id: u64, text: &str) -> bool {
-        if self.widget_registry.get(panel_id).is_none() {
+    pub(super) fn handle_widget_insert_str(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        text: &str,
+    ) -> bool {
+        if self.widget_registry.get(panel_key).is_none() {
             return false;
         }
         let owned = text.to_string();
-        self.with_focused_text_editor(panel_id, move |editor| {
+        self.with_focused_text_editor(panel_key, move |editor| {
             editor.insert_str(&owned);
         });
         true
@@ -1765,8 +1704,12 @@ impl Editor {
     /// spec's `value` / `cursor_byte` / `rows`. Returns true on
     /// success (focus is a Text widget that's now in instance state),
     /// false otherwise.
-    fn ensure_focused_text_seeded(&mut self, panel_id: u64, focus_key: &str) -> bool {
-        let panel = match self.widget_registry.get_mut(panel_id) {
+    fn ensure_focused_text_seeded(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        focus_key: &str,
+    ) -> bool {
+        let panel = match self.widget_registry.get_mut(panel_key) {
             Some(p) => p,
             None => return false,
         };
@@ -1816,19 +1759,23 @@ impl Editor {
     /// firing the `widget_event` "change" hook with the post-state.
     ///
     /// Returns true when the op ran *and* produced a visible change.
-    pub(super) fn with_focused_text_editor<F>(&mut self, panel_id: u64, op: F) -> bool
+    pub(super) fn with_focused_text_editor<F>(
+        &mut self,
+        panel_key: &crate::widgets::PanelKey,
+        op: F,
+    ) -> bool
     where
         F: FnOnce(&mut crate::primitives::text_edit::TextEdit),
     {
-        let focus_key = match self.widget_registry.get(panel_id) {
+        let focus_key = match self.widget_registry.get(panel_key) {
             Some(p) if !p.focus_key.is_empty() => p.focus_key.clone(),
             _ => return false,
         };
-        if !self.ensure_focused_text_seeded(panel_id, &focus_key) {
+        if !self.ensure_focused_text_seeded(panel_key, &focus_key) {
             return false;
         }
         let (before_value, before_cursor) = {
-            let panel = self.widget_registry.get(panel_id).unwrap();
+            let panel = self.widget_registry.get(panel_key).unwrap();
             match panel.instance_states.get(&focus_key) {
                 Some(crate::widgets::WidgetInstanceState::Text { editor, .. }) => {
                     (editor.value(), editor.flat_cursor_byte())
@@ -1837,14 +1784,14 @@ impl Editor {
             }
         };
         {
-            let panel = self.widget_registry.get_mut(panel_id).unwrap();
+            let panel = self.widget_registry.get_mut(panel_key).unwrap();
             match panel.instance_states.get_mut(&focus_key) {
                 Some(crate::widgets::WidgetInstanceState::Text { editor, .. }) => op(editor),
                 _ => return false,
             }
         }
         let (after_value, after_cursor) = {
-            let panel = self.widget_registry.get(panel_id).unwrap();
+            let panel = self.widget_registry.get(panel_key).unwrap();
             match panel.instance_states.get(&focus_key) {
                 Some(crate::widgets::WidgetInstanceState::Text { editor, .. }) => {
                     (editor.value(), editor.flat_cursor_byte())
@@ -1855,26 +1802,13 @@ impl Editor {
         if after_value == before_value && after_cursor == before_cursor {
             return false;
         }
-        self.rerender_widget_panel(panel_id);
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                fresh_core::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key: focus_key.clone(),
-                    event_type: "change".into(),
-                    payload: serde_json::json!({
-                        "value": after_value,
-                        "cursorByte": after_cursor as i64,
-                    }),
-                },
-            );
-        }
+        self.rerender_widget_panel(panel_key);
+        self.fire_widget_event(
+            panel_key,
+            focus_key.clone(),
+            "change".into(),
+            serde_json::json!({ "value": after_value, "cursorByte": after_cursor as i64, }),
+        );
         true
     }
 
@@ -1883,8 +1817,8 @@ impl Editor {
     /// single/multi-line discriminator is carried by `TextEdit`'s
     /// `multiline` field, so the same set of methods serves both
     /// kinds — single-line just no-ops on Up/Down/Enter.
-    fn handle_widget_text_key(&mut self, panel_id: u64, key: &str) {
-        self.with_focused_text_editor(panel_id, |editor| match key {
+    fn handle_widget_text_key(&mut self, panel_key: &crate::widgets::PanelKey, key: &str) {
+        self.with_focused_text_editor(panel_key, |editor| match key {
             "Backspace" => editor.backspace(),
             "Delete" => editor.delete(),
             "Left" => editor.move_left(),
@@ -1904,12 +1838,12 @@ impl Editor {
     /// editor was constructed single-line. `text` may be a single
     /// codepoint, a grapheme cluster, or a multi-codepoint IME
     /// commit; `insert_str` handles each identically.
-    fn handle_widget_text_char(&mut self, panel_id: u64, text: &str) {
+    fn handle_widget_text_char(&mut self, panel_key: &crate::widgets::PanelKey, text: &str) {
         if text.is_empty() {
             return;
         }
         let text = text.to_string();
-        self.with_focused_text_editor(panel_id, move |editor| {
+        self.with_focused_text_editor(panel_key, move |editor| {
             editor.insert_str(&text);
         });
     }
@@ -1954,7 +1888,7 @@ impl Editor {
     /// plugin's mirror stayed stale, and the dock's debounced
     /// dock-switch then aborted at its `dockBlurred` guard.
     pub(super) fn refocus_floating_panel(&mut self, slot: super::PanelSlot) {
-        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
+        let Some(panel_key) = self.panel(slot).map(|f| f.panel_key.clone()) else {
             return;
         };
         if let Some(f) = self.panel_mut(slot) {
@@ -1962,32 +1896,22 @@ impl Editor {
         }
         let widget_key = self
             .widget_registry
-            .get(panel_id)
+            .get(&panel_key)
             .map(|p| p.focus_key.clone())
             .unwrap_or_default();
         tracing::debug!(
             target: "fresh::dock",
-            panel_id,
+            panel = %panel_key,
             ?slot,
             widget_key = %widget_key,
             "refocus_floating_panel: firing unconditional `focus` widget_event"
         );
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key,
-                    event_type: "focus".to_string(),
-                    payload: serde_json::json!({ "previous": "(re-focus)" }),
-                },
-            );
-        }
+        self.fire_widget_event(
+            &panel_key,
+            widget_key,
+            "focus".to_string(),
+            serde_json::json!({ "previous": "(re-focus)" }),
+        );
     }
 
     /// Return keyboard focus to the editor while leaving a (docked)
@@ -1997,7 +1921,7 @@ impl Editor {
     /// Shared by the Esc handler, the editor-click handler, and the
     /// `FloatingPanelControl{op:"blur"}` command.
     pub(super) fn blur_floating_panel(&mut self, slot: super::PanelSlot) {
-        let Some(panel_id) = self.panel(slot).map(|f| f.panel_id) else {
+        let Some(panel_key) = self.panel(slot).map(|f| f.panel_key.clone()) else {
             return;
         };
         if let Some(f) = self.panel_mut(slot) {
@@ -2005,31 +1929,21 @@ impl Editor {
         }
         tracing::debug!(
             target: "fresh::dock",
-            panel_id,
+            panel = %panel_key,
             ?slot,
             "blur_floating_panel: firing `blur` widget_event"
         );
         let widget_key = self
             .widget_registry
-            .get(panel_id)
+            .get(&panel_key)
             .map(|p| p.focus_key.clone())
             .unwrap_or_default();
-        if self
-            .plugin_manager
-            .read()
-            .unwrap()
-            .has_hook_handlers("widget_event")
-        {
-            self.plugin_manager.read().unwrap().run_hook(
-                "widget_event",
-                crate::services::plugins::hooks::HookArgs::WidgetEvent {
-                    panel_id,
-                    widget_key,
-                    event_type: "blur".to_string(),
-                    payload: serde_json::json!({}),
-                },
-            );
-        }
+        self.fire_widget_event(
+            &panel_key,
+            widget_key,
+            "blur".to_string(),
+            serde_json::json!({}),
+        );
     }
 
     /// Handle CloseSplit command

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -84,9 +84,9 @@ pub(super) fn translate_plugin_animation_kind(
 }
 
 impl Editor {
-    /// Deliver a `widget_event` hook for the panel identified by
-    /// `panel_key`. Panel ids are plugin-local, so the event carries the
-    /// bare id and is routed by the panel's owning plugin.
+    /// Deliver a `widget_event` hook to the plugin owning `panel_key` —
+    /// and to that plugin only. Panel ids are plugin-local, so the event
+    /// carries the bare id; no other plugin ever sees it.
     pub(crate) fn fire_widget_event(
         &self,
         panel_key: &crate::widgets::PanelKey,
@@ -98,7 +98,8 @@ impl Editor {
         if !pm.has_hook_handlers("widget_event") {
             return;
         }
-        pm.run_hook(
+        pm.run_hook_for_plugin(
+            &panel_key.plugin,
             "widget_event",
             fresh_core::hooks::HookArgs::WidgetEvent {
                 panel_id: panel_key.id,

--- a/crates/fresh-editor/src/services/plugins/manager.rs
+++ b/crates/fresh-editor/src/services/plugins/manager.rs
@@ -255,6 +255,21 @@ impl PluginManager {
         }
     }
 
+    /// Run a hook in one plugin's context only (fire-and-forget).
+    /// Handlers registered by other plugins are skipped.
+    pub fn run_hook_for_plugin(&self, plugin: &str, hook_name: &str, args: super::hooks::HookArgs) {
+        #[cfg(feature = "plugins")]
+        {
+            if let Some(ref manager) = self.inner {
+                manager.run_hook_for_plugin(plugin, hook_name, args);
+            }
+        }
+        #[cfg(not(feature = "plugins"))]
+        {
+            let _ = (plugin, hook_name, args);
+        }
+    }
+
     /// Deliver a response to a pending async plugin operation.
     pub fn deliver_response(&self, response: super::api::PluginResponse) {
         #[cfg(feature = "plugins")]

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -1,3 +1,4 @@
+use crate::app::types::CellThemeRecorder;
 use crate::input::fuzzy::FuzzyMatch;
 use crate::primitives::display_width::str_width;
 use crate::view::file_tree::{
@@ -51,8 +52,24 @@ impl FileExplorerRenderer {
         cut_paths: &[PathBuf],
         tree_indicator_collapsed: &str,
         tree_indicator_expanded: &str,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) {
         let search_active = view.is_search_active();
+
+        // Seed the whole explorer rect with its surface keys so border/content
+        // rows resolve to the explorer; the selected row is refined below.
+        if let Some(r) = rec.as_deref_mut() {
+            for row in area.y..area.y + area.height {
+                r.run(
+                    area.x,
+                    row,
+                    area.width,
+                    Some("editor.fg"),
+                    Some("editor.bg"),
+                    "File Explorer",
+                );
+            }
+        }
 
         // Update viewport height for scrolling calculations
         // Account for borders (top + bottom = 2)
@@ -193,6 +210,31 @@ impl FileExplorerRenderer {
         }
 
         frame.render_stateful_widget(list, area, &mut list_state);
+
+        // Refine the selected row with its highlight keys (focused → selection
+        // background, blurred → current-line background).
+        if let Some(r) = rec.as_deref_mut() {
+            if let Some(selected) = selected_index {
+                if selected >= scroll_offset && selected < scroll_offset + viewport_height {
+                    let row = area.y + 1 + (selected - scroll_offset) as u16;
+                    let inner_x = area.x + 1;
+                    let inner_w = area.width.saturating_sub(2);
+                    let bg_key = if is_focused {
+                        "editor.selection_bg"
+                    } else {
+                        "editor.current_line_bg"
+                    };
+                    r.run(
+                        inner_x,
+                        row,
+                        inner_w,
+                        Some("editor.fg"),
+                        Some(bg_key),
+                        "File Explorer",
+                    );
+                }
+            }
+        }
 
         // Render close button "×" at the right side of the title bar
         let close_button_x = area.x + area.width.saturating_sub(3);

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -213,7 +213,7 @@ impl FileExplorerRenderer {
 
         // Refine the selected row with its highlight keys (focused → selection
         // background, blurred → current-line background).
-        if let Some(r) = rec.as_deref_mut() {
+        if let Some(r) = rec {
             if let Some(selected) = selected_index {
                 if selected >= scroll_offset && selected < scroll_offset + viewport_height {
                     let row = area.y + 1 + (selected - scroll_offset) as u16;

--- a/crates/fresh-editor/src/view/ui/menu.rs
+++ b/crates/fresh-editor/src/view/ui/menu.rs
@@ -1,5 +1,6 @@
 //! Menu bar rendering
 
+use crate::app::types::CellThemeRecorder;
 use crate::config::{generate_dynamic_items, Menu, MenuConfig, MenuExt, MenuItem, MenuItemExt};
 use crate::primitives::display_width::str_width;
 use crate::view::theme::Theme;
@@ -501,8 +502,21 @@ impl MenuRenderer {
         theme: &Theme,
         hover_target: Option<&crate::app::HoverTarget>,
         mnemonics_enabled: bool,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) -> MenuLayout {
         let mut layout = MenuLayout::new(area);
+        // Seed the menu bar with its base keys; each label overwrites its own
+        // cells (active menu → menu_active) below.
+        if let Some(r) = rec.as_deref_mut() {
+            r.run(
+                area.x,
+                area.y,
+                area.width,
+                Some("ui.menu_fg"),
+                Some("ui.menu_bg"),
+                "Menu Bar",
+            );
+        }
         // Combine config menus with plugin menus, expanding any DynamicSubmenus
         let all_menus: Vec<Menu> = menu_config
             .menus
@@ -559,6 +573,24 @@ impl MenuRenderer {
                 .menu_areas
                 .push((idx, Rect::new(current_x, area.y, label_width, 1)));
 
+            // Record this label's keys (active menu wears menu_active; hover is
+            // transient and not recorded).
+            if let Some(r) = rec.as_deref_mut() {
+                let (fg, bg) = if is_active {
+                    ("ui.menu_active_fg", "ui.menu_active_bg")
+                } else {
+                    ("ui.menu_fg", "ui.menu_bg")
+                };
+                r.run(
+                    current_x,
+                    area.y,
+                    label_width,
+                    Some(fg),
+                    Some(bg),
+                    "Menu Bar",
+                );
+            }
+
             // Check for mnemonic character (Alt+letter keybinding)
             let mnemonic = if mnemonics_enabled {
                 keybindings.find_menu_mnemonic(&menu.label)
@@ -614,6 +646,7 @@ impl MenuRenderer {
                     theme,
                     hover_target,
                     &mut layout,
+                    rec,
                 );
             }
         }
@@ -634,6 +667,7 @@ impl MenuRenderer {
         theme: &Theme,
         hover_target: Option<&crate::app::HoverTarget>,
         layout: &mut MenuLayout,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) {
         // Calculate the x position of the top-level dropdown based on menu index
         // Skip hidden menus (those with `when` conditions that evaluate to false)
@@ -687,6 +721,7 @@ impl MenuRenderer {
                 hover_target,
                 &menu_state.context,
                 layout,
+                rec.as_deref_mut(),
             );
 
             // If not at the deepest level, navigate into the submenu for next iteration
@@ -763,6 +798,7 @@ impl MenuRenderer {
         hover_target: Option<&crate::app::HoverTarget>,
         context: &MenuContext,
         layout: &mut MenuLayout,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) -> Rect {
         let max_width = Self::calculate_dropdown_width(items);
         let dropdown_height = items.len() + 2; // +2 for borders
@@ -800,6 +836,21 @@ impl MenuRenderer {
             height,
         };
 
+        // Seed the dropdown box (border + fill) with its surface keys; each
+        // item row overwrites its own cells below.
+        if let Some(r) = rec.as_deref_mut() {
+            for row in dropdown_area.y..dropdown_area.y + dropdown_area.height {
+                r.run(
+                    dropdown_area.x,
+                    row,
+                    dropdown_area.width,
+                    Some("ui.menu_border_fg"),
+                    Some("ui.menu_dropdown_bg"),
+                    "Menu Dropdown",
+                );
+            }
+        }
+
         // Build dropdown content
         let mut lines = Vec::new();
         let max_items = (height.saturating_sub(2)) as usize;
@@ -832,6 +883,27 @@ impl MenuRenderer {
                 layout.item_areas.push((idx, item_area));
             } else {
                 layout.submenu_areas.push((depth, idx, item_area));
+            }
+
+            // Record this item's keys, mirroring the per-kind style below.
+            if let Some(r) = rec.as_deref_mut() {
+                let (fg, bg) = match item {
+                    MenuItem::Separator { .. } => ("ui.menu_separator_fg", "ui.menu_dropdown_bg"),
+                    MenuItem::Label { .. } => ("ui.menu_disabled_fg", "ui.menu_dropdown_bg"),
+                    _ if !enabled => ("ui.menu_disabled_fg", "ui.menu_disabled_bg"),
+                    _ if is_highlighted || has_open_submenu => {
+                        ("ui.menu_highlight_fg", "ui.menu_highlight_bg")
+                    }
+                    _ => ("ui.menu_dropdown_fg", "ui.menu_dropdown_bg"),
+                };
+                r.run(
+                    item_area.x,
+                    item_area.y,
+                    item_area.width,
+                    Some(fg),
+                    Some(bg),
+                    "Menu Dropdown",
+                );
             }
 
             let line = match item {

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -804,6 +804,35 @@ pub(crate) fn render_content(
         }
     }
 
+    // Record vertical-scrollbar theme keys for the inspector, from the
+    // thumb/track geometry just computed for each split. Done here (in the
+    // render pass that painted them) rather than a post-hoc pass.
+    {
+        let mut sb_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+        for (_, _, _, scrollbar_rect, thumb_start, thumb_end) in &split_areas {
+            for row in 0..scrollbar_rect.height {
+                let is_thumb = (row as usize) >= *thumb_start && (row as usize) < *thumb_end;
+                sb_runs.push(crate::app::types::ThemeRun {
+                    x: scrollbar_rect.x,
+                    y: scrollbar_rect.y + row,
+                    w: scrollbar_rect.width,
+                    fg_key: Some(if is_thumb {
+                        "ui.scrollbar_thumb_fg"
+                    } else {
+                        "ui.scrollbar_track_fg"
+                    }),
+                    bg_key: Some("editor.bg"),
+                    region: if is_thumb {
+                        "Scrollbar Thumb"
+                    } else {
+                        "Scrollbar Track"
+                    },
+                });
+            }
+        }
+        crate::app::types::apply_theme_runs(cell_theme_map, screen_width, &sb_runs);
+    }
+
     (
         split_areas,
         tab_layouts,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -326,21 +326,29 @@ pub(crate) fn render_content(
                     }
                 })
                 .collect();
-            // Render tabs for this split and collect hit areas
-            let tab_layout = TabsRenderer::render_for_split(
-                frame,
-                layout.tabs_rect,
-                &split_buffers,
-                buffers,
-                buffer_metadata,
-                composite_buffers,
-                active_target,
-                theme,
-                is_active,
-                tab_scroll_offset,
-                tab_hover_for_split,
-                &group_names,
-            );
+            // Render tabs for this split and collect hit areas. The tab bar
+            // records its theme-key runs into a local vec as it paints; apply
+            // them to the per-cell map afterward (the map isn't borrowed here).
+            let mut tab_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+            let tab_layout = {
+                let mut rec = crate::app::types::CellThemeRecorder::new(&mut tab_runs);
+                TabsRenderer::render_for_split(
+                    frame,
+                    layout.tabs_rect,
+                    &split_buffers,
+                    buffers,
+                    buffer_metadata,
+                    composite_buffers,
+                    active_target,
+                    theme,
+                    is_active,
+                    tab_scroll_offset,
+                    tab_hover_for_split,
+                    &group_names,
+                    Some(&mut rec),
+                )
+            };
+            crate::app::types::apply_theme_runs(cell_theme_map, screen_width, &tab_runs);
 
             // Store the tab layout for this split
             tab_layouts.insert(split_id, tab_layout);

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -427,10 +427,10 @@ impl CellPass<'_, '_> {
         let idx = screen_row as usize * self.input.screen_width as usize + screen_col as usize;
         if let Some(cell) = self.cell_theme_map.get_mut(idx) {
             *cell = CellThemeInfo {
-                fg_key: resolved.fg_theme_key,
-                bg_key: resolved.bg_theme_key,
-                region: resolved.region,
-                syntax_category: resolved.syntax_category,
+                fg_key: resolved.fg_theme_key.map(std::borrow::Cow::Borrowed),
+                bg_key: resolved.bg_theme_key.map(std::borrow::Cow::Borrowed),
+                region: std::borrow::Cow::Borrowed(resolved.region),
+                syntax_category: resolved.syntax_category.map(std::borrow::Cow::Borrowed),
             };
         }
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -593,15 +593,15 @@ fn prefill_cell_theme_map(
         return;
     }
     let gutter_info = crate::app::types::CellThemeInfo {
-        fg_key: Some("editor.line_number_fg"),
-        bg_key: Some("editor.line_number_bg"),
-        region: "Line Numbers",
+        fg_key: Some("editor.line_number_fg".into()),
+        bg_key: Some("editor.line_number_bg".into()),
+        region: "Line Numbers".into(),
         syntax_category: None,
     };
     let content_info = crate::app::types::CellThemeInfo {
-        fg_key: Some("editor.fg"),
-        bg_key: Some("editor.bg"),
-        region: "Editor Content",
+        fg_key: Some("editor.fg".into()),
+        bg_key: Some("editor.bg".into()),
+        region: "Editor Content".into(),
         syntax_category: None,
     };
     let sw = screen_width as usize;

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
+use crate::app::types::CellThemeRecorder;
 use crate::app::WarningLevel;
 use crate::config::{StatusBarConfig, StatusBarElement};
 use crate::primitives::display_width::{char_width, str_width};
@@ -678,8 +679,9 @@ impl StatusBarRenderer {
         area: Rect,
         ctx: &mut StatusBarContext<'_>,
         config: &StatusBarConfig,
+        rec: Option<&mut CellThemeRecorder>,
     ) -> StatusBarLayout {
-        Self::render_status(frame, area, ctx, config)
+        Self::render_status(frame, area, ctx, config, rec)
     }
 
     /// Render the prompt/minibuffer
@@ -1350,6 +1352,54 @@ impl StatusBarRenderer {
         }
     }
 
+    /// The (fg, bg) theme-key strings an element paints with — its non-hover
+    /// provenance for the theme inspector, mirroring `element_style`. Hover is
+    /// transient so the recorded key is always the element's semantic key.
+    fn element_keys(
+        kind: ElementKind,
+        lsp_state: LspIndicatorState,
+    ) -> (&'static str, &'static str) {
+        match kind {
+            ElementKind::Normal
+            | ElementKind::Messages
+            | ElementKind::Clock
+            | ElementKind::Custom
+            | ElementKind::LineEnding
+            | ElementKind::Encoding
+            | ElementKind::Language => ("ui.status_bar_fg", "ui.status_bar_bg"),
+            ElementKind::RemoteDisconnected => (
+                "ui.status_error_indicator_fg",
+                "ui.status_error_indicator_bg",
+            ),
+            ElementKind::Lsp => match lsp_state {
+                LspIndicatorState::Error => ("diagnostic.error_fg", "diagnostic.error_bg"),
+                LspIndicatorState::Off => {
+                    ("ui.status_lsp_actionable_fg", "ui.status_lsp_actionable_bg")
+                }
+                LspIndicatorState::On => ("ui.status_lsp_on_fg", "ui.status_lsp_on_bg"),
+                LspIndicatorState::OffDismissed | LspIndicatorState::None => {
+                    ("ui.status_bar_fg", "ui.status_bar_bg")
+                }
+            },
+            ElementKind::WarningBadge => (
+                "ui.status_warning_indicator_fg",
+                "ui.status_warning_indicator_bg",
+            ),
+            ElementKind::Update => ("ui.menu_highlight_fg", "ui.menu_dropdown_bg"),
+            ElementKind::Palette => ("ui.status_palette_fg", "ui.status_palette_bg"),
+            ElementKind::RemoteIndicator(state) => match state {
+                RemoteIndicatorState::Connecting | RemoteIndicatorState::Connected => {
+                    ("ui.help_indicator_fg", "ui.help_indicator_bg")
+                }
+                RemoteIndicatorState::FailedAttach | RemoteIndicatorState::Disconnected => (
+                    "ui.status_error_indicator_fg",
+                    "ui.status_error_indicator_bg",
+                ),
+                RemoteIndicatorState::Local => ("ui.status_bar_fg", "ui.status_bar_bg"),
+            },
+        }
+    }
+
     /// Map a rendered element to the layout field(s) it should populate.
     /// Built-in indicators get their dedicated `Option<(row, start_col,
     /// end_col)>` slot. Plugin tokens (`ElementKind::Custom` carrying a
@@ -1494,6 +1544,7 @@ impl StatusBarRenderer {
         area: Rect,
         ctx: &mut StatusBarContext<'_>,
         config: &StatusBarConfig,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) -> StatusBarLayout {
         let mut layout = StatusBarLayout::default();
         let base_style = Style::default()
@@ -1503,6 +1554,21 @@ impl StatusBarRenderer {
 
         if available_width == 0 || area.height == 0 {
             return layout;
+        }
+
+        // Lay down the bar's base keys across the whole row so padding / gaps
+        // resolve to the status bar; each element below overwrites its own
+        // cells with their specific keys as it's emitted.
+        let lsp_state = ctx.lsp_indicator_state;
+        if let Some(r) = rec.as_deref_mut() {
+            r.run(
+                area.x,
+                area.y,
+                area.width,
+                Some("ui.status_bar_fg"),
+                Some("ui.status_bar_bg"),
+                "Status Bar",
+            );
         }
 
         // Tell the per-element renderer whether the dedicated
@@ -1581,6 +1647,16 @@ impl StatusBarRenderer {
                 break;
             }
             if sep_width > 0 {
+                if let Some(r) = rec.as_deref_mut() {
+                    r.run(
+                        area.x + used_left as u16,
+                        area.y,
+                        sep_width as u16,
+                        Some("ui.status_separator_fg"),
+                        Some("ui.status_separator_bg"),
+                        "Status Bar",
+                    );
+                }
                 spans.push(Span::styled(separator.to_string(), separator_style));
                 used_left += sep_width;
             }
@@ -1591,6 +1667,18 @@ impl StatusBarRenderer {
             if width <= remaining {
                 spans.extend(item_spans);
                 used_left += width;
+
+                if let Some(r) = rec.as_deref_mut() {
+                    let (fg, bg) = Self::element_keys(kind, lsp_state);
+                    r.run(
+                        area.x + start_col as u16,
+                        area.y,
+                        width as u16,
+                        Some(fg),
+                        Some(bg),
+                        "Status Bar",
+                    );
+                }
 
                 Self::update_layout_for_element(
                     &mut layout,
@@ -1615,6 +1703,18 @@ impl StatusBarRenderer {
                     ctx.lsp_indicator_state,
                 );
                 spans.push(Span::styled(truncated, overflow_style));
+
+                if let Some(r) = rec.as_deref_mut() {
+                    let (fg, bg) = Self::element_keys(kind, lsp_state);
+                    r.run(
+                        area.x + start_col as u16,
+                        area.y,
+                        truncated_width as u16,
+                        Some(fg),
+                        Some(bg),
+                        "Status Bar",
+                    );
+                }
                 used_left += truncated_width;
 
                 Self::update_layout_for_element(
@@ -1653,8 +1753,29 @@ impl StatusBarRenderer {
         let mut current_col = area.x + col_offset as u16;
         for (idx, (item_spans, width, kind, token_key)) in right_items.into_iter().enumerate() {
             if idx > 0 && separator_width > 0 {
+                if let Some(r) = rec.as_deref_mut() {
+                    r.run(
+                        current_col,
+                        area.y,
+                        separator_width as u16,
+                        Some("ui.status_separator_fg"),
+                        Some("ui.status_separator_bg"),
+                        "Status Bar",
+                    );
+                }
                 spans.push(Span::styled(separator.to_string(), separator_style));
                 current_col += separator_width as u16;
+            }
+            if let Some(r) = rec.as_deref_mut() {
+                let (fg, bg) = Self::element_keys(kind, lsp_state);
+                r.run(
+                    current_col,
+                    area.y,
+                    width as u16,
+                    Some(fg),
+                    Some(bg),
+                    "Status Bar",
+                );
             }
             Self::update_layout_for_element(
                 &mut layout,

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1397,6 +1397,16 @@ impl StatusBarRenderer {
                 ),
                 RemoteIndicatorState::Local => ("ui.status_bar_fg", "ui.status_bar_bg"),
             },
+            ElementKind::WorkspaceTrust(level) => {
+                use crate::services::workspace_trust::TrustLevel;
+                match level {
+                    TrustLevel::Restricted | TrustLevel::Blocked => (
+                        "ui.status_warning_indicator_fg",
+                        "ui.status_warning_indicator_bg",
+                    ),
+                    TrustLevel::Trusted => ("ui.status_bar_fg", "ui.status_bar_bg"),
+                }
+            }
         }
     }
 

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -904,9 +904,7 @@ impl TabsRenderer {
         }
 
         // Pinned "+" cells (drawn on top at the right edge when tabs overflow).
-        if let (Some(plus_rect), Some(r)) =
-            (layout.new_tab_area.filter(|_| pin_plus), rec.as_deref_mut())
-        {
+        if let (Some(plus_rect), Some(r)) = (layout.new_tab_area.filter(|_| pin_plus), rec) {
             r.run(
                 plus_rect.x,
                 area.y,

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -1,5 +1,6 @@
 //! Tab bar rendering for multiple buffers
 
+use crate::app::types::CellThemeRecorder;
 use crate::app::BufferMetadata;
 use crate::model::event::{BufferId, LeafId};
 use crate::primitives::display_width::str_width;
@@ -436,8 +437,21 @@ impl TabsRenderer {
         tab_scroll_offset: usize,
         hovered_tab: Option<(TabTarget, bool)>, // (target, is_close_button)
         group_names: &HashMap<LeafId, String>,
+        mut rec: Option<&mut CellThemeRecorder>,
     ) -> TabLayout {
         let mut layout = TabLayout::new(area);
+        // Seed the whole bar with the separator surface (the block bg); each
+        // visible tab / "+" overwrites its own cells below.
+        if let Some(r) = rec.as_deref_mut() {
+            r.run(
+                area.x,
+                area.y,
+                area.width,
+                None,
+                Some("ui.tab_separator_bg"),
+                "Tab Bar",
+            );
+        }
         const SCROLL_INDICATOR_LEFT: &str = "<";
         const SCROLL_INDICATOR_RIGHT: &str = ">";
         const SCROLL_INDICATOR_WIDTH: usize = 1; // Width of "<" or ">"
@@ -824,6 +838,26 @@ impl TabsRenderer {
             let tab_width = screen_end.saturating_sub(screen_start);
             let close_width = screen_end.saturating_sub(screen_close_start);
 
+            // Record this tab's visible cells with its actual keys: the active
+            // tab of the active split wears the active palette, every other tab
+            // the inactive one (hover bg / close-hover fg are transient and not
+            // recorded). Overwrites the bar's separator surface seeded above.
+            if let Some(r) = rec.as_deref_mut() {
+                let (fg, bg) = if *target == active_target && is_active_split {
+                    ("ui.tab_active_fg", "ui.tab_active_bg")
+                } else {
+                    ("ui.tab_inactive_fg", "ui.tab_inactive_bg")
+                };
+                r.run(
+                    screen_start,
+                    area.y,
+                    tab_width,
+                    Some(fg),
+                    Some(bg),
+                    "Tab Bar",
+                );
+            }
+
             layout.tabs.push(TabHitArea {
                 target: *target,
                 tab_area: Rect::new(screen_start, area.y, tab_width, 1),
@@ -855,8 +889,32 @@ impl TabsRenderer {
                 let width = screen_end.saturating_sub(screen_start);
                 if width > 0 {
                     layout.new_tab_area = Some(Rect::new(screen_start, area.y, width, 1));
+                    if let Some(r) = rec.as_deref_mut() {
+                        r.run(
+                            screen_start,
+                            area.y,
+                            width,
+                            Some("ui.tab_inactive_fg"),
+                            Some("ui.tab_inactive_bg"),
+                            "Tab Bar",
+                        );
+                    }
                 }
             }
+        }
+
+        // Pinned "+" cells (drawn on top at the right edge when tabs overflow).
+        if let (Some(plus_rect), Some(r)) =
+            (layout.new_tab_area.filter(|_| pin_plus), rec.as_deref_mut())
+        {
+            r.run(
+                plus_rect.x,
+                area.y,
+                plus_rect.width,
+                Some("ui.tab_inactive_fg"),
+                Some("ui.tab_inactive_bg"),
+                "Tab Bar",
+            );
         }
 
         layout
@@ -893,6 +951,7 @@ impl TabsRenderer {
             0,    // Default tab_scroll_offset for legacy render
             None, // No hover state for legacy render
             &group_names,
+            None, // No theme recording for legacy render
         );
     }
 }

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -23,7 +23,9 @@ pub use actions::{
     set_toggle_checked_in_spec, set_tree_checked_keys_in_spec, set_tree_nodes_in_spec,
     tree_parent_index,
 };
-pub use registry::{HitArea, PanelId, WidgetInstanceState, WidgetPanelState, WidgetRegistry};
+pub use registry::{
+    HitArea, PanelId, PanelKey, WidgetInstanceState, WidgetPanelState, WidgetRegistry,
+};
 pub use render::{
     render_spec, render_spec_no_autofocus, EmbedRect, FocusCursor, OverlayRow, RenderOutput,
     ScrollRegion,

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -1,5 +1,6 @@
-//! Panel registry — maps plugin-allocated `panel_id` to mounted spec
-//! and hit-area data for click routing.
+//! Panel registry — maps a panel's composite identity (owning plugin,
+//! plugin-local `panel_id`) to mounted spec and hit-area data for click
+//! routing.
 //!
 //! The registry is the source of truth for "which panels exist, what
 //! spec are they currently rendering, and which buffer rows belong
@@ -15,6 +16,33 @@ use std::collections::{HashMap, HashSet};
 /// Plugin-allocated panel identifier. Unique within a plugin; the
 /// editor does not interpret the value.
 pub type PanelId = u64;
+
+/// Composite panel identity: panel ids are plugin-local, so the
+/// registry key is (owning plugin, id). The owner is recorded host-side
+/// at mount time from the calling plugin's identity — never trusted
+/// from the JS side.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PanelKey {
+    /// Name of the plugin that mounted the panel.
+    pub plugin: String,
+    /// The plugin-local panel id.
+    pub id: PanelId,
+}
+
+impl PanelKey {
+    pub fn new(plugin: impl Into<String>, id: PanelId) -> Self {
+        Self {
+            plugin: plugin.into(),
+            id,
+        }
+    }
+}
+
+impl std::fmt::Display for PanelKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.plugin, self.id)
+    }
+}
 
 /// One clickable rectangle within a rendered widget panel.
 ///
@@ -174,10 +202,12 @@ pub struct WidgetPanelState {
     pub tabbable: Vec<String>,
 }
 
-/// Global registry of mounted widget panels.
+/// Global registry of mounted widget panels, keyed by composite
+/// (plugin, panel id) identity — two plugins reusing the same local id
+/// coexist without evicting each other.
 #[derive(Debug, Default)]
 pub struct WidgetRegistry {
-    panels: HashMap<PanelId, WidgetPanelState>,
+    panels: HashMap<PanelKey, WidgetPanelState>,
 }
 
 impl WidgetRegistry {
@@ -197,7 +227,7 @@ impl WidgetRegistry {
     #[allow(clippy::too_many_arguments)]
     pub fn mount(
         &mut self,
-        panel_id: PanelId,
+        panel_key: PanelKey,
         buffer_id: BufferId,
         spec: WidgetSpec,
         hits: Vec<HitArea>,
@@ -206,7 +236,7 @@ impl WidgetRegistry {
         tabbable: Vec<String>,
     ) -> Option<WidgetPanelState> {
         self.panels.insert(
-            panel_id,
+            panel_key,
             WidgetPanelState {
                 buffer_id,
                 spec,
@@ -228,14 +258,14 @@ impl WidgetRegistry {
     #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
-        panel_id: PanelId,
+        panel_key: &PanelKey,
         spec: WidgetSpec,
         hits: Vec<HitArea>,
         instance_states: HashMap<String, WidgetInstanceState>,
         focus_key: String,
         tabbable: Vec<String>,
     ) -> Result<BufferId, ()> {
-        match self.panels.get_mut(&panel_id) {
+        match self.panels.get_mut(panel_key) {
             Some(state) => {
                 state.spec = spec;
                 state.hits = hits;
@@ -253,21 +283,21 @@ impl WidgetRegistry {
     /// positions into the next render so they persist.
     pub fn instance_states(
         &self,
-        panel_id: PanelId,
+        panel_key: &PanelKey,
     ) -> Option<&HashMap<String, WidgetInstanceState>> {
-        self.panels.get(&panel_id).map(|s| &s.instance_states)
+        self.panels.get(panel_key).map(|s| &s.instance_states)
     }
 
     /// Read-only access to the previous render's focus key.
-    pub fn focus_key(&self, panel_id: PanelId) -> Option<&str> {
-        self.panels.get(&panel_id).map(|s| s.focus_key.as_str())
+    pub fn focus_key(&self, panel_key: &PanelKey) -> Option<&str> {
+        self.panels.get(panel_key).map(|s| s.focus_key.as_str())
     }
 
     /// Set the focus key directly (used by `widget_focus_advance`
     /// and click-driven focus moves). Updates the in-place state;
     /// the next render reads it via `focus_key()`.
-    pub fn set_focus_key(&mut self, panel_id: PanelId, key: String) {
-        if let Some(state) = self.panels.get_mut(&panel_id) {
+    pub fn set_focus_key(&mut self, panel_key: &PanelKey, key: String) {
+        if let Some(state) = self.panels.get_mut(panel_key) {
             state.focus_key = key;
         }
     }
@@ -283,13 +313,13 @@ impl WidgetRegistry {
     /// keep its own selection mirror + preview in sync), else `None`.
     pub fn set_list_scroll(
         &mut self,
-        panel_id: PanelId,
+        panel_key: &PanelKey,
         list_key: &str,
         scroll_offset: u32,
         visible: u32,
     ) -> Option<i32> {
         let _ = visible;
-        let state = self.panels.get_mut(&panel_id)?;
+        let state = self.panels.get_mut(panel_key)?;
         let WidgetInstanceState::List {
             scroll_offset: so,
             user_scrolled,
@@ -315,13 +345,13 @@ impl WidgetRegistry {
     /// same value would waste a 5 000-node deep clone for every IPC.
     pub fn update_side_effects(
         &mut self,
-        panel_id: PanelId,
+        panel_key: &PanelKey,
         hits: Vec<HitArea>,
         instance_states: HashMap<String, WidgetInstanceState>,
         focus_key: String,
         tabbable: Vec<String>,
     ) -> Result<BufferId, ()> {
-        match self.panels.get_mut(&panel_id) {
+        match self.panels.get_mut(panel_key) {
             Some(state) => {
                 state.hits = hits;
                 state.instance_states = instance_states;
@@ -337,52 +367,52 @@ impl WidgetRegistry {
     /// `update_side_effects` — render with the borrow and then write
     /// back only the side-effects, avoiding the deep clone of the spec
     /// that `buffer_and_spec()` does.
-    pub fn buffer_and_spec_ref(&self, panel_id: PanelId) -> Option<(BufferId, &WidgetSpec)> {
-        self.panels.get(&panel_id).map(|s| (s.buffer_id, &s.spec))
+    pub fn buffer_and_spec_ref(&self, panel_key: &PanelKey) -> Option<(BufferId, &WidgetSpec)> {
+        self.panels.get(panel_key).map(|s| (s.buffer_id, &s.spec))
     }
 
     /// Find the buffer and current spec for a panel — used by the
     /// dispatcher to re-render after a focus advance / activate
     /// command without the plugin needing to send an UpdateWidgetPanel.
-    pub fn buffer_and_spec(&self, panel_id: PanelId) -> Option<(BufferId, WidgetSpec)> {
+    pub fn buffer_and_spec(&self, panel_key: &PanelKey) -> Option<(BufferId, WidgetSpec)> {
         self.panels
-            .get(&panel_id)
+            .get(panel_key)
             .map(|s| (s.buffer_id, s.spec.clone()))
     }
 
     /// Tear down a panel. Returns the buffer_id the panel was
     /// rendering into, so the caller can clear the buffer if it
     /// owns it.
-    pub fn unmount(&mut self, panel_id: PanelId) -> Option<BufferId> {
-        self.panels.remove(&panel_id).map(|s| s.buffer_id)
+    pub fn unmount(&mut self, panel_key: &PanelKey) -> Option<BufferId> {
+        self.panels.remove(panel_key).map(|s| s.buffer_id)
     }
 
     /// Read-only access to a panel's current state.
-    pub fn get(&self, panel_id: PanelId) -> Option<&WidgetPanelState> {
-        self.panels.get(&panel_id)
+    pub fn get(&self, panel_key: &PanelKey) -> Option<&WidgetPanelState> {
+        self.panels.get(panel_key)
     }
 
     /// Mutable access — used by `WidgetCommand` handlers that
     /// update widget instance state (e.g. TextInput value/cursor)
     /// directly without round-tripping through the plugin.
-    pub fn get_mut(&mut self, panel_id: PanelId) -> Option<&mut WidgetPanelState> {
-        self.panels.get_mut(&panel_id)
+    pub fn get_mut(&mut self, panel_key: &PanelKey) -> Option<&mut WidgetPanelState> {
+        self.panels.get_mut(panel_key)
     }
 
-    /// All currently-mounted panel ids — useful for theme-change
+    /// All currently-mounted panel keys — useful for theme-change
     /// re-render passes (every panel re-renders against the new
     /// theme without plugin involvement).
-    pub fn panel_ids(&self) -> Vec<PanelId> {
-        self.panels.keys().copied().collect()
+    pub fn panel_keys(&self) -> Vec<PanelKey> {
+        self.panels.keys().cloned().collect()
     }
 
     /// Panels rendering into `buffer_id`. Used by mouse-wheel
     /// routing to find which widget panel sits under the pointer.
-    pub fn panels_for_buffer(&self, buffer_id: BufferId) -> Vec<PanelId> {
+    pub fn panels_for_buffer(&self, buffer_id: BufferId) -> Vec<PanelKey> {
         self.panels
             .iter()
             .filter(|(_, s)| s.buffer_id == buffer_id)
-            .map(|(pid, _)| *pid)
+            .map(|(key, _)| key.clone())
             .collect()
     }
 
@@ -399,8 +429,8 @@ impl WidgetRegistry {
         buffer_id: BufferId,
         row: u32,
         col_byte: u32,
-    ) -> Option<(PanelId, HitArea)> {
-        for (pid, state) in &self.panels {
+    ) -> Option<(PanelKey, HitArea)> {
+        for (key, state) in &self.panels {
             if state.buffer_id != buffer_id {
                 continue;
             }
@@ -409,7 +439,7 @@ impl WidgetRegistry {
                     && (col_byte as usize) >= hit.byte_start
                     && (col_byte as usize) < hit.byte_end
                 {
-                    return Some((*pid, hit.clone()));
+                    return Some((key.clone(), hit.clone()));
                 }
             }
         }
@@ -421,6 +451,10 @@ impl WidgetRegistry {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn pk(id: PanelId) -> PanelKey {
+        PanelKey::new("test-plugin", id)
+    }
 
     fn empty_spec() -> WidgetSpec {
         WidgetSpec::Col {
@@ -445,7 +479,7 @@ mod tests {
     fn hit_test_finds_widget_inside_range() {
         let mut reg = WidgetRegistry::new();
         reg.mount(
-            42,
+            pk(42),
             BufferId(7),
             empty_spec(),
             vec![make_hit(0, 0, 5, "a"), make_hit(0, 7, 12, "b")],
@@ -454,7 +488,7 @@ mod tests {
             Vec::new(),
         );
         let hit = reg.hit_test(BufferId(7), 0, 8).expect("inside b");
-        assert_eq!(hit.0, 42);
+        assert_eq!(hit.0, pk(42));
         assert_eq!(hit.1.widget_key, "b");
     }
 
@@ -462,7 +496,7 @@ mod tests {
     fn hit_test_returns_none_when_outside_range() {
         let mut reg = WidgetRegistry::new();
         reg.mount(
-            1,
+            pk(1),
             BufferId(0),
             empty_spec(),
             vec![make_hit(0, 0, 5, "a")],
@@ -491,7 +525,7 @@ mod tests {
             },
         );
         reg.mount(
-            7,
+            pk(7),
             BufferId(0),
             empty_spec(),
             Vec::new(),
@@ -502,7 +536,7 @@ mod tests {
     }
 
     fn list_state(reg: &WidgetRegistry) -> (u32, i32) {
-        match reg.instance_states(7).unwrap().get("lst").unwrap() {
+        match reg.instance_states(&pk(7)).unwrap().get("lst").unwrap() {
             WidgetInstanceState::List {
                 scroll_offset,
                 selected_index,
@@ -520,7 +554,7 @@ mod tests {
         // fires; the selection is allowed to leave the visible range.
         let mut reg = WidgetRegistry::new();
         mount_with_list(&mut reg, 0, 2);
-        let moved = reg.set_list_scroll(7, "lst", 10, 8);
+        let moved = reg.set_list_scroll(&pk(7), "lst", 10, 8);
         assert_eq!(moved, None);
         assert_eq!(list_state(&reg), (10, 2));
     }
@@ -531,7 +565,7 @@ mod tests {
         // selection stays, and no move is reported.
         let mut reg = WidgetRegistry::new();
         mount_with_list(&mut reg, 0, 12);
-        let moved = reg.set_list_scroll(7, "lst", 10, 8); // window [10,18)
+        let moved = reg.set_list_scroll(&pk(7), "lst", 10, 8); // window [10,18)
         assert_eq!(moved, None);
         assert_eq!(list_state(&reg), (10, 12));
     }
@@ -542,16 +576,55 @@ mod tests {
         // selection clamp, no reported move.
         let mut reg = WidgetRegistry::new();
         mount_with_list(&mut reg, 0, -1);
-        let moved = reg.set_list_scroll(7, "lst", 5, 8);
+        let moved = reg.set_list_scroll(&pk(7), "lst", 5, 8);
         assert_eq!(moved, None);
         assert_eq!(list_state(&reg), (5, -1));
+    }
+
+    #[test]
+    fn same_local_id_from_two_plugins_coexists() {
+        // Panel ids are plugin-local: a second plugin mounting the same
+        // local id must NOT evict the first plugin's panel, and the
+        // hit-test must resolve each buffer's hit to its owning plugin.
+        let mut reg = WidgetRegistry::new();
+        reg.mount(
+            PanelKey::new("alpha", 1),
+            BufferId(10),
+            empty_spec(),
+            vec![make_hit(0, 0, 5, "a-btn")],
+            HashMap::new(),
+            String::new(),
+            Vec::new(),
+        );
+        let evicted = reg.mount(
+            PanelKey::new("beta", 1),
+            BufferId(20),
+            empty_spec(),
+            vec![make_hit(0, 0, 5, "b-btn")],
+            HashMap::new(),
+            String::new(),
+            Vec::new(),
+        );
+        assert!(evicted.is_none(), "beta:1 must not evict alpha:1");
+
+        let (key_a, hit_a) = reg.hit_test(BufferId(10), 0, 2).expect("alpha hit");
+        assert_eq!(key_a, PanelKey::new("alpha", 1));
+        assert_eq!(hit_a.widget_key, "a-btn");
+        let (key_b, hit_b) = reg.hit_test(BufferId(20), 0, 2).expect("beta hit");
+        assert_eq!(key_b, PanelKey::new("beta", 1));
+        assert_eq!(hit_b.widget_key, "b-btn");
+
+        // Unmounting one plugin's panel leaves the other untouched.
+        reg.unmount(&PanelKey::new("beta", 1));
+        assert!(reg.hit_test(BufferId(20), 0, 2).is_none());
+        assert!(reg.hit_test(BufferId(10), 0, 2).is_some());
     }
 
     #[test]
     fn unmount_clears_hits() {
         let mut reg = WidgetRegistry::new();
         reg.mount(
-            5,
+            pk(5),
             BufferId(2),
             empty_spec(),
             vec![make_hit(0, 0, 3, "x")],
@@ -560,7 +633,7 @@ mod tests {
             Vec::new(),
         );
         assert!(reg.hit_test(BufferId(2), 0, 1).is_some());
-        reg.unmount(5);
+        reg.unmount(&pk(5));
         assert!(reg.hit_test(BufferId(2), 0, 1).is_none());
     }
 
@@ -568,7 +641,7 @@ mod tests {
     fn update_replaces_hits() {
         let mut reg = WidgetRegistry::new();
         reg.mount(
-            5,
+            pk(5),
             BufferId(2),
             empty_spec(),
             vec![make_hit(0, 0, 3, "old")],
@@ -577,7 +650,7 @@ mod tests {
             Vec::new(),
         );
         reg.update(
-            5,
+            &pk(5),
             empty_spec(),
             vec![make_hit(1, 4, 9, "new")],
             HashMap::new(),

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -376,27 +376,6 @@ impl WidgetRegistry {
         self.panels.keys().copied().collect()
     }
 
-    /// Diagnostic: `(buffer_row, byte_start, byte_end, event)` for every hit
-    /// area registered against `buffer_id`. Used to debug click-vs-render
-    /// desyncs (see the dock dead-click investigation).
-    pub fn hit_rows_debug(&self, buffer_id: BufferId) -> Vec<(u32, usize, usize, String)> {
-        let mut out = Vec::new();
-        for state in self.panels.values() {
-            if state.buffer_id != buffer_id {
-                continue;
-            }
-            for h in &state.hits {
-                out.push((
-                    h.buffer_row,
-                    h.byte_start,
-                    h.byte_end,
-                    h.event_type.to_string(),
-                ));
-            }
-        }
-        out
-    }
-
     /// Panels rendering into `buffer_id`. Used by mouse-wheel
     /// routing to find which widget panel sits under the pointer.
     pub fn panels_for_buffer(&self, buffer_id: BufferId) -> Vec<PanelId> {

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -376,6 +376,27 @@ impl WidgetRegistry {
         self.panels.keys().copied().collect()
     }
 
+    /// Diagnostic: `(buffer_row, byte_start, byte_end, event)` for every hit
+    /// area registered against `buffer_id`. Used to debug click-vs-render
+    /// desyncs (see the dock dead-click investigation).
+    pub fn hit_rows_debug(&self, buffer_id: BufferId) -> Vec<(u32, usize, usize, String)> {
+        let mut out = Vec::new();
+        for state in self.panels.values() {
+            if state.buffer_id != buffer_id {
+                continue;
+            }
+            for h in &state.hits {
+                out.push((
+                    h.buffer_row,
+                    h.byte_start,
+                    h.byte_end,
+                    h.event_type.to_string(),
+                ));
+            }
+        }
+        out
+    }
+
     /// Panels rendering into `buffer_id`. Used by mouse-wheel
     /// routing to find which widget panel sits under the pointer.
     pub fn panels_for_buffer(&self, buffer_id: BufferId) -> Vec<PanelId> {

--- a/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
+++ b/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
@@ -107,6 +107,7 @@ fn born_attached_session_does_not_wedge_source_window_typing() {
     harness
         .editor_mut()
         .handle_plugin_command(PluginCommand::MountFloatingWidget {
+            plugin: "test-plugin".to_string(),
             panel_id: 1,
             spec: minimal_panel_spec(),
             width_pct: 60,
@@ -150,7 +151,10 @@ fn born_attached_session_does_not_wedge_source_window_typing() {
     //    clear lands on the now-active born-attached window (B), not on A.
     harness
         .editor_mut()
-        .handle_plugin_command(PluginCommand::UnmountFloatingWidget { panel_id: 1 })
+        .handle_plugin_command(PluginCommand::UnmountFloatingWidget {
+            plugin: "test-plugin".to_string(),
+            panel_id: 1,
+        })
         .unwrap();
     harness
         .editor_mut()

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -239,4 +239,6 @@ pub mod vi_mode_bugs;
 pub mod visual_regression;
 pub mod warning_indicators;
 #[cfg(feature = "plugins")]
+pub mod widget_panel_ownership;
+#[cfg(feature = "plugins")]
 pub mod workspace;

--- a/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
+++ b/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
@@ -63,6 +63,7 @@ fn panel_mode_does_not_leak_onto_window_switched_away_from() {
     harness
         .editor_mut()
         .handle_plugin_command(PluginCommand::MountFloatingWidget {
+            plugin: "test-plugin".to_string(),
             panel_id: 1,
             spec: minimal_panel_spec(),
             width_pct: 50,

--- a/crates/fresh-editor/tests/e2e/widget_panel_ownership.rs
+++ b/crates/fresh-editor/tests/e2e/widget_panel_ownership.rs
@@ -1,0 +1,117 @@
+//! Panel identity is plugin-scoped: two plugins that allocate the SAME
+//! plugin-local panel id must coexist, and each must receive only its
+//! own `widget_event`s.
+//!
+//! This is the regression surface for two related bugs:
+//!
+//! * the host registry used to key panels by the bare id, so the second
+//!   plugin's mount evicted the first's entry (the theme editor's first
+//!   panel killed the orchestrator dock's click hit-map);
+//! * `widget_event` used to be broadcast to every plugin for client-side
+//!   `e.panel_id === panel.id()` filtering — with plugin-local ids the
+//!   filter can't tell two plugins' panels apart, so a broadcast would
+//!   tick BOTH counters below.
+//!
+//! `test_panel_owner_alpha.ts` mounts a dock panel with local id 1 and
+//! renders `ALPHA=<n>` (its `activate` counter); `test_panel_owner_beta.ts`
+//! mounts a centered modal, also with local id 1, rendering `BETA=<n>`.
+//! We mount both, click each plugin's button, and assert only the owning
+//! plugin's counter moves (CONTRIBUTING §2: drive keys/mouse, assert on
+//! rendered output).
+
+use crate::common::harness::{copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+fn install_plugins(project_root: &std::path::Path) {
+    let plugins_dir = project_root.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin_lib(&plugins_dir);
+
+    const ALPHA: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/plugins/test_panel_owner_alpha.ts"
+    ));
+    const BETA: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/plugins/test_panel_owner_beta.ts"
+    ));
+    fs::write(plugins_dir.join("test_panel_owner_alpha.ts"), ALPHA).unwrap();
+    fs::write(plugins_dir.join("test_panel_owner_beta.ts"), BETA).unwrap();
+}
+
+fn run_palette_command(h: &mut EditorTestHarness, command: &str) {
+    h.send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    h.wait_for_prompt().unwrap();
+    h.type_text(command).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains(command))
+        .unwrap();
+    h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
+}
+
+/// 0-based screen position of `needle`, or panic with the screen.
+fn find_on_screen(h: &EditorTestHarness, needle: &str) -> (u16, u16) {
+    let screen = h.screen_to_string();
+    for (row, line) in screen.lines().enumerate() {
+        if let Some(byte) = line.find(needle) {
+            let col = line[..byte].chars().count();
+            return (col as u16, row as u16);
+        }
+    }
+    panic!("screen missing '{needle}':\n{screen}");
+}
+
+#[test]
+fn same_local_panel_id_two_plugins_coexist_and_events_route_to_owner() {
+    init_tracing_from_env();
+
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let project_root = temp_dir.path().join("project_root");
+    fs::create_dir(&project_root).unwrap();
+    install_plugins(&project_root);
+
+    let mut h =
+        EditorTestHarness::with_config_and_working_dir(120, 36, Default::default(), project_root)
+            .unwrap();
+    h.render().unwrap();
+
+    // Mount alpha's dock panel (local id 1), then beta's centered modal
+    // (also local id 1). Both must render — beta's mount must NOT evict
+    // alpha's registry entry.
+    run_palette_command(&mut h, "OwnerAlpha: Mount");
+    h.wait_until(|h| h.screen_to_string().contains("ALPHA=0"))
+        .unwrap();
+    run_palette_command(&mut h, "OwnerBeta: Mount");
+    h.wait_until(|h| {
+        let s = h.screen_to_string();
+        s.contains("BETA=0") && s.contains("ALPHA=0")
+    })
+    .unwrap();
+
+    // Click beta's button (the modal is on top). Only beta's counter
+    // may tick: alpha filters on the same `e.panel_id === 1`, so a
+    // broadcast would tick ALPHA too.
+    let (bcol, brow) = find_on_screen(&h, "BetaGo");
+    h.mouse_click(bcol + 1, brow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("BETA=1"))
+        .unwrap();
+    h.wait_until_stable(|_| true).unwrap();
+    let screen = h.screen_to_string();
+    assert!(
+        screen.contains("ALPHA=0"),
+        "beta's activate must not reach alpha (same local id, different \
+         owner).\nScreen:\n{screen}"
+    );
+
+    // Close the modal, then click alpha's dock button: alpha ticks,
+    // beta (unmounted, but its plugin still listens) stays at 1.
+    h.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    h.wait_until(|h| !h.screen_to_string().contains("BetaGo"))
+        .unwrap();
+    let (acol, arow) = find_on_screen(&h, "AlphaGo");
+    h.mouse_click(acol + 1, arow).unwrap();
+    h.wait_until(|h| h.screen_to_string().contains("ALPHA=1"))
+        .unwrap();
+}

--- a/crates/fresh-editor/tests/plugins/test_panel_owner_alpha.ts
+++ b/crates/fresh-editor/tests/plugins/test_panel_owner_alpha.ts
@@ -1,0 +1,62 @@
+/// <reference path="../../plugins/lib/fresh.d.ts" />
+const editor = getEditor();
+
+/**
+ * One half of the panel-ownership e2e pair (see
+ * `test_panel_owner_beta.ts` and `widget_panel_ownership.rs`).
+ *
+ * Both plugins deliberately mount a panel with the SAME plugin-local
+ * id (1). The host keys panels by (plugin, id), so the two panels must
+ * coexist, and each plugin must receive ONLY its own `widget_event`s —
+ * the `e.panel_id === 1` check here cannot tell the two panels apart,
+ * so any cross-plugin broadcast would tick both counters.
+ *
+ * Alpha mounts into the left DOCK slot and renders an `ALPHA=<n>`
+ * counter that ticks once per received `activate` event.
+ */
+
+const PANEL_ID = 1; // plugin-local; beta uses the same value on purpose
+let activates = 0;
+let mounted = false;
+
+// deno-lint-ignore no-explicit-any
+function spec(): any {
+  return {
+    kind: "col",
+    children: [
+      {
+        kind: "raw",
+        entries: [{ text: `ALPHA=${activates}\n`, properties: {} }],
+      },
+      {
+        kind: "button",
+        label: "AlphaGo",
+        focused: false,
+        intent: "normal",
+        key: "alpha-go",
+        disabled: false,
+      },
+    ],
+  };
+}
+
+function owner_alpha_mount(): void {
+  mounted = true;
+  activates = 0;
+  editor.mountFloatingWidget(PANEL_ID, spec(), 40, 40, true);
+}
+registerHandler("owner_alpha_mount", owner_alpha_mount);
+
+editor.on("widget_event", (e) => {
+  if (!mounted || e.panel_id !== PANEL_ID) return;
+  if (e.event_type !== "activate") return;
+  activates += 1;
+  editor.updateFloatingWidget(PANEL_ID, spec());
+});
+
+editor.registerCommand(
+  "OwnerAlpha: Mount",
+  "Mount alpha's dock panel (local id 1)",
+  "owner_alpha_mount",
+  null,
+);

--- a/crates/fresh-editor/tests/plugins/test_panel_owner_beta.ts
+++ b/crates/fresh-editor/tests/plugins/test_panel_owner_beta.ts
@@ -1,0 +1,57 @@
+/// <reference path="../../plugins/lib/fresh.d.ts" />
+const editor = getEditor();
+
+/**
+ * The other half of the panel-ownership e2e pair (see
+ * `test_panel_owner_alpha.ts` and `widget_panel_ownership.rs`).
+ *
+ * Beta mounts a CENTERED modal with the same plugin-local panel id (1)
+ * alpha's dock uses, and renders a `BETA=<n>` counter that ticks once
+ * per received `activate` event.
+ */
+
+const PANEL_ID = 1; // plugin-local; alpha uses the same value on purpose
+let activates = 0;
+let mounted = false;
+
+// deno-lint-ignore no-explicit-any
+function spec(): any {
+  return {
+    kind: "col",
+    children: [
+      {
+        kind: "raw",
+        entries: [{ text: `BETA=${activates}\n`, properties: {} }],
+      },
+      {
+        kind: "button",
+        label: "BetaGo",
+        focused: false,
+        intent: "normal",
+        key: "beta-go",
+        disabled: false,
+      },
+    ],
+  };
+}
+
+function owner_beta_mount(): void {
+  mounted = true;
+  activates = 0;
+  editor.mountFloatingWidget(PANEL_ID, spec(), 50, 40);
+}
+registerHandler("owner_beta_mount", owner_beta_mount);
+
+editor.on("widget_event", (e) => {
+  if (!mounted || e.panel_id !== PANEL_ID) return;
+  if (e.event_type !== "activate") return;
+  activates += 1;
+  editor.updateFloatingWidget(PANEL_ID, spec());
+});
+
+editor.registerCommand(
+  "OwnerBeta: Mount",
+  "Mount beta's centered panel (local id 1)",
+  "owner_beta_mount",
+  null,
+);

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5525,6 +5525,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::MountWidgetPanel {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 buffer_id: BufferId(buffer_id as usize),
                 spec,
@@ -5552,6 +5553,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::UpdateWidgetPanel {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 spec,
             })
@@ -5564,6 +5566,7 @@ impl JsEditorApi {
     pub fn unmount_widget_panel(&self, panel_id: f64) -> bool {
         self.command_sender
             .send(PluginCommand::UnmountWidgetPanel {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
             })
             .is_ok()
@@ -5595,6 +5598,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::WidgetCommand {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 action,
             })
@@ -5624,6 +5628,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::WidgetMutate {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 mutation,
             })
@@ -5655,6 +5660,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::MountFloatingWidget {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 spec,
                 width_pct,
@@ -5683,6 +5689,7 @@ impl JsEditorApi {
         Ok(self
             .command_sender
             .send(PluginCommand::UpdateFloatingWidget {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 spec,
             })
@@ -5694,6 +5701,7 @@ impl JsEditorApi {
     pub fn unmount_floating_widget(&self, panel_id: f64) -> bool {
         self.command_sender
             .send(PluginCommand::UnmountFloatingWidget {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
             })
             .is_ok()
@@ -5708,6 +5716,7 @@ impl JsEditorApi {
     pub fn floating_panel_control(&self, panel_id: f64, op: String, arg: f64) -> bool {
         self.command_sender
             .send(PluginCommand::FloatingPanelControl {
+                plugin: self.plugin_name.clone(),
                 panel_id: panel_id as u64,
                 op,
                 arg,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -203,7 +203,12 @@ fn json_to_js_value<'js>(
         serde_json::Value::Bool(b) => Ok(Value::new_bool(ctx.clone(), *b)),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Ok(Value::new_int(ctx.clone(), i as i32))
+                // Integers beyond i32 must go through f64 (exact below
+                // 2^53) — `i as i32` would silently truncate them.
+                match i32::try_from(i) {
+                    Ok(small) => Ok(Value::new_int(ctx.clone(), small)),
+                    Err(_) => Ok(Value::new_float(ctx.clone(), i as f64)),
+                }
             } else if let Some(f) = n.as_f64() {
                 Ok(Value::new_float(ctx.clone(), f))
             } else {
@@ -8360,6 +8365,46 @@ mod tests {
         match cmd {
             PluginCommand::SetStatus { message } => {
                 assert!(message.contains("/test.txt"));
+            }
+            _ => panic!("Expected SetStatus from event handler, got {:?}", cmd),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_emit_event_preserves_integers_beyond_i32() {
+        // Hook payloads carry u64s (timestamps, byte offsets, ids). The
+        // JSON→JS bridge used to do `i as i32`, silently truncating
+        // anything beyond i32 — this must round-trip unchanged.
+        let (mut backend, rx) = create_test_backend();
+
+        backend
+            .execute_js(
+                r#"
+            const editor = getEditor();
+            globalThis.onBigHandler = function(data) {
+                editor.setStatus("big: " + data.big + " neg: " + data.neg + " small: " + data.small);
+            };
+            editor.on("bigEvent", "onBigHandler");
+        "#,
+                "test.js",
+            )
+            .unwrap();
+        while rx.try_recv().is_ok() {}
+
+        let event_data: serde_json::Value = serde_json::json!({
+            "big": 4_503_599_627_370_001_i64, // beyond i32, below 2^53
+            "neg": -4_503_599_627_370_001_i64,
+            "small": 42,
+        });
+        backend.emit("bigEvent", &event_data).await.unwrap();
+
+        let cmd = rx.try_recv().unwrap();
+        match cmd {
+            PluginCommand::SetStatus { message } => {
+                assert_eq!(
+                    message,
+                    "big: 4503599627370001 neg: -4503599627370001 small: 42"
+                );
             }
             _ => panic!("Expected SetStatus from event handler, got {:?}", cmd),
         }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -7514,6 +7514,18 @@ impl QuickJsBackend {
 
     /// Emit an event to all registered handlers
     pub async fn emit(&mut self, event_name: &str, event_data: &serde_json::Value) -> Result<bool> {
+        self.emit_to(event_name, event_data, None).await
+    }
+
+    /// Emit an event to registered handlers. When `target` is set, only
+    /// handlers registered by that plugin run — events owned by a single
+    /// plugin (a panel's `widget_event`) are never broadcast to others.
+    pub async fn emit_to(
+        &mut self,
+        event_name: &str,
+        event_data: &serde_json::Value,
+        target: Option<&str>,
+    ) -> Result<bool> {
         tracing::trace!("emit: event '{}' with data: {:?}", event_name, event_data);
 
         self.services
@@ -7528,6 +7540,9 @@ impl QuickJsBackend {
         if let Some(handler_pairs) = handlers {
             let plugin_contexts = self.plugin_contexts.borrow();
             for handler in &handler_pairs {
+                if target.is_some_and(|t| t != handler.plugin_name) {
+                    continue;
+                }
                 let Some(context) = plugin_contexts.get(&handler.plugin_name) else {
                     continue;
                 };
@@ -8377,6 +8392,58 @@ mod tests {
             }
             _ => panic!("Expected SetStatus from event handler, got {:?}", cmd),
         }
+    }
+
+    #[tokio::test]
+    async fn test_emit_to_targets_single_plugin() {
+        // Two plugins register handlers for the same event. A targeted
+        // emit must run only the named plugin's handler; an untargeted
+        // emit reaches both.
+        let (mut backend, rx) = create_test_backend();
+        for name in ["alpha", "beta"] {
+            backend
+                .execute_js(
+                    &format!(
+                        r#"
+                const editor = getEditor();
+                globalThis.onWidget = function(data) {{
+                    editor.setStatus("{name} got " + data.panel_id);
+                }};
+                editor.on("widget_event", "onWidget");
+            "#
+                    ),
+                    &format!("{name}.js"),
+                )
+                .unwrap();
+        }
+        while rx.try_recv().is_ok() {}
+
+        let event_data: serde_json::Value = serde_json::json!({ "panel_id": 7 });
+        backend
+            .emit_to("widget_event", &event_data, Some("beta"))
+            .await
+            .unwrap();
+        match rx.try_recv().unwrap() {
+            PluginCommand::SetStatus { message } => assert_eq!(message, "beta got 7"),
+            cmd => panic!("Expected SetStatus, got {:?}", cmd),
+        }
+        assert!(
+            rx.try_recv().is_err(),
+            "targeted emit must not reach the other plugin"
+        );
+
+        backend
+            .emit_to("widget_event", &event_data, None)
+            .await
+            .unwrap();
+        let mut got: Vec<String> = Vec::new();
+        while let Ok(cmd) = rx.try_recv() {
+            if let PluginCommand::SetStatus { message } = cmd {
+                got.push(message);
+            }
+        }
+        got.sort();
+        assert_eq!(got, vec!["alpha got 7", "beta got 7"]);
     }
 
     #[tokio::test]

--- a/crates/fresh-plugin-runtime/src/thread.rs
+++ b/crates/fresh-plugin-runtime/src/thread.rs
@@ -102,8 +102,14 @@ pub enum PluginRequest {
         response: oneshot::Sender<Result<()>>,
     },
 
-    /// Run a hook (fire-and-forget, no response needed)
-    RunHook { hook_name: String, args: HookArgs },
+    /// Run a hook (fire-and-forget, no response needed). When `target`
+    /// is set, only that plugin's handlers run — used for events that
+    /// belong to one plugin, like a panel's `widget_event`.
+    RunHook {
+        hook_name: String,
+        args: HookArgs,
+        target: Option<String>,
+    },
 
     /// Check if any handlers are registered for a hook
     HasHookHandlers {
@@ -675,6 +681,20 @@ impl PluginThreadHandle {
             fire_and_forget(sender.send(PluginRequest::RunHook {
                 hook_name: hook_name.to_string(),
                 args,
+                target: None,
+            }));
+        }
+    }
+
+    /// Run a hook in a single plugin's context only (non-blocking,
+    /// fire-and-forget). Handlers registered by other plugins are
+    /// skipped.
+    pub fn run_hook_for_plugin(&self, plugin: &str, hook_name: &str, args: HookArgs) {
+        if let Some(sender) = self.request_sender.as_ref() {
+            fire_and_forget(sender.send(PluginRequest::RunHook {
+                hook_name: hook_name.to_string(),
+                args,
+                target: Some(plugin.to_string()),
             }));
         }
     }
@@ -1076,6 +1096,7 @@ async fn run_hook_internal_rc(
     runtime: Rc<RefCell<QuickJsBackend>>,
     hook_name: &str,
     args: &HookArgs,
+    target: Option<&str>,
 ) -> Result<()> {
     // Convert HookArgs to serde_json::Value using hook_args_to_json which produces flat JSON
     // (not enum-tagged JSON from serde's default Serialize)
@@ -1089,7 +1110,10 @@ async fn run_hook_internal_rc(
 
     // Emit to TypeScript handlers
     let emit_start = std::time::Instant::now();
-    runtime.borrow_mut().emit(hook_name, &json_data).await?;
+    runtime
+        .borrow_mut()
+        .emit_to(hook_name, &json_data, target)
+        .await?;
     tracing::trace!(
         hook = hook_name,
         emit_ms = emit_start.elapsed().as_millis(),
@@ -1173,7 +1197,11 @@ async fn handle_request(
             ))));
         }
 
-        PluginRequest::RunHook { hook_name, args } => {
+        PluginRequest::RunHook {
+            hook_name,
+            args,
+            target,
+        } => {
             // Fire-and-forget hook execution
             let hook_start = std::time::Instant::now();
             // Use info level for prompt hooks to aid debugging
@@ -1182,7 +1210,10 @@ async fn handle_request(
             } else {
                 tracing::trace!(hook = %hook_name, "RunHook request received");
             }
-            if let Err(e) = run_hook_internal_rc(Rc::clone(&runtime), &hook_name, &args).await {
+            if let Err(e) =
+                run_hook_internal_rc(Rc::clone(&runtime), &hook_name, &args, target.as_deref())
+                    .await
+            {
                 let error_msg = format!("Plugin error in '{}': {}", hook_name, e);
                 tracing::error!("{}", error_msg);
                 // Surface the error to the UI

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -682,6 +682,9 @@ interface HookEventMap {
    * click to a `Toggle` / `Button` widget node within a mounted
    * widget panel. See `docs/internal/plugin-widget-library-design.md`.
    *
+   * Panel ids are plugin-local: the host keys panels by
+   * (plugin, id) and delivers each event only to the plugin that
+   * owns the panel, so ids never need to be globally unique.
    * Routing is by `panel_id` (matches the id the plugin allocated
    * at mount time) plus `widget_key` (the stable `key` set on the
    * widget spec node, or empty when the spec did not assign one).


### PR DESCRIPTION
Closes #2321.

Two strands, rebased on master (the wave-animation / auto-read-only / undo-fix commits previously on this branch already landed in master and are no longer part of this PR).

## 1. Widget panel identity is plugin-scoped, owned by the host

**Problem** (#2321): plugins mint panel ids from a local counter inside isolated JS contexts, so ids are only unique *per plugin* — but the host's widget registry was keyed by the bare id, and `widget_event` was broadcast to every plugin for client-side `e.panel_id === panel.id()` filtering. Consequences:

- One plugin's mount evicted another's registry entry (opening the theme editor killed the orchestrator dock's click hit-map).
- The interim fix (FNV-salting ids per plugin, kept in this branch's history as `40ece47`) produced ~4.5e15 ids, which exposed a latent bridge bug: `json_to_js_value` converted every integer through `i as i32`, silently truncating — so `widget_event` payloads arrived with corrupted `panel_id` and **all widget interaction went dead** (~63 e2e timeouts).

**Final design** (supersedes the salt):

- **Bridge fix** (`9b87915`): integers that fit i32 stay JS ints; anything larger goes through `new_float(i as f64)`, exact below 2^53. Real latent bug for timestamps/byte offsets independent of panel ids. Regression test round-trips i64s beyond i32.
- **Composite registry keys** (`c1677f2`): `WidgetRegistry` keys panels by `PanelKey { plugin, id }`; the owner is recorded at mount from the calling plugin's identity (every widget `PluginCommand` now carries the plugin name, set host-side — never trusted from JS). All host lookups — mount/update/unmount/mutate/rerender, mouse hit-testing, scrollbar routing, `panels_for_buffer`, focus/instance state, the floating/dock slots, clipboard/key routing — resolve through the composite key.
- **Owner-targeted events** (`6c09f8c`): the host resolves a panel's owner and delivers `widget_event` to that plugin's context only (`QuickJsBackend::emit_to` + `run_hook_for_plugin`). No broadcast-then-filter. The prompt-overlay toolbar event (`panel_id: 0`) keeps broadcasting — it isn't a registry panel.
- **Salt revert** (`8065e37`): `allocatePanelId()` is a plain local counter again; `lib/widgets.ts` / `lib/fresh.d.ts` document that panel ids are plugin-local.

**Tests**:
- Registry unit test: two plugins reusing the same local id coexist and hit-test to their own panels.
- Backend unit tests: >i32 integers round-trip to JS unchanged; targeted emit reaches only the named plugin.
- New e2e (`widget_panel_ownership.rs` + two test plugins): both plugins mount panels with the *same* local id (dock + centered modal); both render, and clicking each plugin's button ticks only that plugin's counter — pinning both the eviction and the cross-delivery regressions.
- Previously failing suites verified green: `orchestrator_dock` (40), `plugins::orchestrator_attach_worktree` / `orchestrator_new_dialog` / `orchestrator_open_cross_project`, `search_replace` (62 combined), plus full `fresh-editor` (2758) and `fresh-plugin-runtime` (112) lib tests.

## 2. Theme-inspect records chrome theme keys during paint

The theme inspector used to backfill chrome regions in a post-hoc pass that covered each region with one uniform key. Each chrome surface now records its actual theme keys as it paints — status bar (per-segment), tab bar, scrollbar, file explorer (incl. selected-row highlight), menu bar + dropdowns (highlight / disabled / separator / submenu), and the orchestrator dock's cells — and the post-hoc pass is removed. Also: the theme-info popup draws above the dock, and the inspected key name renders in a legible colour. `CellThemeInfo` moves to `Cow<'static, str>` so plugin-supplied keys can be recorded.

https://claude.ai/code/session_017QpgPFSDwocY4s9q2arq6m