### PR TITLE
test(folding): cover LSP collapsedText placeholder rendering (#1579)

### DIFF
--- a/crates/fresh-editor/tests/e2e/folding.rs
+++ b/crates/fresh-editor/tests/e2e/folding.rs
@@ -6,6 +6,18 @@ use crossterm::event::{KeyCode, KeyModifiers};
 use lsp_types::FoldingRange;
 
 fn set_fold_range(harness: &mut EditorTestHarness, start_line: usize, end_line: usize) {
+    set_fold_range_with_text(harness, start_line, end_line, None);
+}
+
+/// Like [`set_fold_range`] but lets the caller attach `collapsed_text`, the
+/// placeholder label some LSP servers return alongside a folding range
+/// (issue #1579).
+fn set_fold_range_with_text(
+    harness: &mut EditorTestHarness,
+    start_line: usize,
+    end_line: usize,
+    collapsed_text: Option<String>,
+) {
     let state = harness.editor_mut().active_state_mut();
     let ranges = vec![FoldingRange {
         start_line: start_line as u32,
@@ -13,7 +25,7 @@ fn set_fold_range(harness: &mut EditorTestHarness, start_line: usize, end_line: 
         start_character: None,
         end_character: None,
         kind: None,
-        collapsed_text: None,
+        collapsed_text,
     }];
     state
         .folding_ranges
@@ -94,6 +106,50 @@ fn test_fold_gutter_double_click_toggles_like_single() {
     assert!(
         row_text.contains("line 3"),
         "Expected folded lines to be visible after double click. Row text: '{row_text}'"
+    );
+}
+
+/// Issue #1579: an LSP folding range may carry a `collapsedText` label that
+/// the server wants shown when the range is collapsed (e.g. `{ … }` for a
+/// brace block). Collapsing such a fold must render that server-provided text
+/// as the placeholder on the header row, instead of the generic `...` default.
+#[test]
+fn test_lsp_collapsed_text_renders_as_placeholder() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    let content: String = (0..30).map(|i| format!("line {i}\n")).collect();
+    let fixture = TestFixture::new("fold_collapsed_text.py", &content).unwrap();
+    harness.open_file(&fixture.path).unwrap();
+
+    // LSP fold over lines 3..6 (header = line 2) with a custom collapsed label.
+    let header_line = 2usize;
+    let end_line = 6usize;
+    let collapsed_label = "<4 folded lines>";
+    set_fold_range_with_text(
+        &mut harness,
+        header_line,
+        end_line,
+        Some(collapsed_label.to_string()),
+    );
+    harness.render().unwrap();
+
+    // Collapse the fold via a gutter click on the header row.
+    let header_row = (layout::CONTENT_START_ROW + header_line) as u16;
+    harness.mouse_click(0, header_row).unwrap();
+    harness.render().unwrap();
+
+    // The fold collapsed: body lines are hidden, header stays visible.
+    harness.assert_screen_not_contains("line 4");
+    harness.assert_screen_not_contains("line 5");
+    harness.assert_screen_contains("line 7");
+
+    // The server-provided collapsed_text must appear on the header row.
+    let header_row_text = harness.get_row_text(header_row);
+    assert!(
+        header_row_text.contains(collapsed_label),
+        "Expected server collapsed_text '{collapsed_label}' on the fold header row, \
+         not the default placeholder.\nHeader row: '{header_row_text}'\nScreen:\n{}",
+        harness.screen_to_string()
     );
 }
 


### PR DESCRIPTION
## Summary

Issue #1579 asks Fresh to support the `collapsedText` label that some LSP servers return on a `textDocument/foldingRange` response (the text shown in place of a collapsed range, e.g. `{ … }`).

While triaging, I found this is **already implemented** end-to-end:

- `async_handler.rs` advertises `collapsed_text: Some(true)` in the client folding capabilities, so servers will send it.
- `LspFoldRanges::set_from_lsp` / `resolved` (in `view/folding.rs`) carry `collapsed_text` through buffer edits.
- `toggle_fold_at_byte` (in `app/lsp_actions.rs`) uses it as the fold placeholder when present.
- `apply_folding` (in `view/ui/split_rendering/folding.rs`) renders that placeholder on the header row, falling back to the generic `...` when it's absent/blank.

The gap was **test coverage**: every existing folding test constructed ranges with `collapsed_text: None`, so the server-provided-label path had no regression protection.

## Change

This is a **test-only** change. It adds one e2e test, `test_lsp_collapsed_text_renders_as_placeholder`, which:

1. Installs an LSP fold range carrying a `collapsedText` label.
2. Collapses it via a gutter click (the real click → byte → fold path).
3. Asserts the server label renders on the fold header row, and the body lines are hidden.

To keep the existing `collapsed_text: None` call sites untouched, `set_fold_range` now delegates to a new `set_fold_range_with_text` helper that accepts the label.

## Validation

Run inside the repo on the pinned toolchain (1.95):

- `cargo test -p fresh-editor --test e2e_tests folding::` → **19 passed, 0 failed** (including the new test).
- `cargo fmt --check` clean; `cargo clippy -p fresh-editor --tests` exits 0 (only pre-existing warnings in unrelated test files).

Since the requested behavior already works and is now covered by a regression test, this PR can close the issue — but happy to adjust if you'd rather keep it open for a broader scope.

Closes #1579

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cfx28nTGCQzzjdwu2FfxHs)_