### PR TITLE
Make bare URLs in LSP hover popups clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Unreleased
+
+### Improvements
+
+* **Clickable links in LSP hover popups**: bare `http`/`https` URLs embedded in
+  hover documentation (as emitted by servers like pyrefly) now render as
+  underlined links and open in the browser when clicked (#603).
+
 ## 0.4.4
 
 For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).

--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -1124,7 +1124,7 @@ impl Editor {
         use ratatui::style::Style;
         use unicode_width::UnicodeWidthStr;
 
-        let hover_lines: Vec<StyledLine> = if contents.is_empty() {
+        let mut hover_lines: Vec<StyledLine> = if contents.is_empty() {
             Vec::new()
         } else if is_markdown {
             parse_markdown(
@@ -1145,6 +1145,11 @@ impl Editor {
                 })
                 .collect()
         };
+        // Make bare URLs (http/https) embedded in hover prose clickable. Servers
+        // like pyrefly emit raw URLs that CommonMark does not autolink, so without
+        // this they render as inert text. Markdown `[text](url)` links already
+        // carry their URL and are left untouched. See issue #603.
+        crate::view::markdown::linkify_bare_urls(&mut hover_lines);
 
         let has_diagnostic = !diagnostic_lines.is_empty();
         let mut all_lines: Vec<StyledLine> = Vec::new();

--- a/crates/fresh-editor/src/view/markdown.rs
+++ b/crates/fresh-editor/src/view/markdown.rs
@@ -656,6 +656,158 @@ pub fn parse_markdown(
     lines
 }
 
+/// Scan already-parsed styled lines for bare URLs (`http://` / `https://`) and
+/// turn them into clickable link spans, in place.
+///
+/// LSP hover payloads frequently embed raw URLs in prose (pyrefly, doc links,
+/// …). CommonMark — and therefore [`parse_markdown`] — only treats `[text](url)`
+/// and `<url>` as links, so a bare `https://…` renders as inert text. This pass
+/// closes that gap for both markdown and plain-text hovers, reusing the same
+/// `link_url` span metadata that `[text](url)` links populate, so the existing
+/// popup click handling makes them clickable for free.
+///
+/// Spans that already carry a `link_url` are left untouched, so a markdown link
+/// is never double-processed. See issue #603.
+pub fn linkify_bare_urls(lines: &mut [StyledLine]) {
+    for line in lines.iter_mut() {
+        let has_candidate = line
+            .spans
+            .iter()
+            .any(|s| s.link_url.is_none() && s.text.contains("http"));
+        if !has_candidate {
+            continue;
+        }
+        let mut rebuilt = Vec::with_capacity(line.spans.len());
+        for span in std::mem::take(&mut line.spans) {
+            if span.link_url.is_some() {
+                rebuilt.push(span);
+            } else {
+                split_span_at_urls(span, &mut rebuilt);
+            }
+        }
+        line.spans = rebuilt;
+    }
+}
+
+/// Split a single span into plain + link segments at any bare URLs it contains,
+/// pushing the results onto `out`. If the span contains no URL it is pushed
+/// unchanged (preserving empty spans and styling).
+fn split_span_at_urls(span: StyledSpan, out: &mut Vec<StyledSpan>) {
+    let text = span.text.as_str();
+    let mut pos = 0;
+    let mut found = false;
+    while let Some((start, end)) = next_url(text, pos) {
+        found = true;
+        if start > pos {
+            out.push(StyledSpan {
+                text: text[pos..start].to_string(),
+                style: span.style,
+                link_url: None,
+            });
+        }
+        let url = &text[start..end];
+        out.push(StyledSpan {
+            text: url.to_string(),
+            style: span
+                .style
+                .add_modifier(Modifier::UNDERLINED)
+                .fg(Color::Cyan),
+            link_url: Some(url.to_string()),
+        });
+        pos = end;
+    }
+    if !found {
+        out.push(span);
+    } else if pos < text.len() {
+        out.push(StyledSpan {
+            text: text[pos..].to_string(),
+            style: span.style,
+            link_url: None,
+        });
+    }
+}
+
+/// Find the next bare `http`/`https` URL in `text` at or after byte offset
+/// `from`. Returns the `(start, end)` byte range, with trailing sentence
+/// punctuation excluded. Returns `None` when no URL with a host follows.
+fn next_url(text: &str, mut from: usize) -> Option<(usize, usize)> {
+    loop {
+        let rel_http = text[from..].find("http://");
+        let rel_https = text[from..].find("https://");
+        let (rel, scheme_len) = match (rel_http, rel_https) {
+            (Some(a), Some(b)) => {
+                if a <= b {
+                    (a, "http://".len())
+                } else {
+                    (b, "https://".len())
+                }
+            }
+            (Some(a), None) => (a, "http://".len()),
+            (None, Some(b)) => (b, "https://".len()),
+            (None, None) => return None,
+        };
+        let start = from + rel;
+        let host_start = start + scheme_len;
+        let mut end = host_start;
+        for (i, ch) in text[host_start..].char_indices() {
+            if is_url_char(ch) {
+                end = host_start + i + ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+        // Exclude trailing punctuation commonly adjacent to URLs in prose,
+        // e.g. "see https://x." or "(https://x)".
+        while end > host_start {
+            let last = text[host_start..end].chars().next_back().unwrap();
+            if matches!(
+                last,
+                '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '"' | '\''
+            ) {
+                end -= last.len_utf8();
+            } else {
+                break;
+            }
+        }
+        if end > host_start {
+            return Some((start, end));
+        }
+        // Bare scheme with no host (e.g. "http://" alone) — keep scanning past it.
+        from = host_start;
+    }
+}
+
+/// Whether `c` may appear inside a URL per RFC 3986 (unreserved + reserved
+/// gen/sub-delims + percent-encoding).
+fn is_url_char(c: char) -> bool {
+    c.is_ascii_alphanumeric()
+        || matches!(
+            c,
+            '-' | '.'
+                | '_'
+                | '~'
+                | ':'
+                | '/'
+                | '?'
+                | '#'
+                | '['
+                | ']'
+                | '@'
+                | '!'
+                | '$'
+                | '&'
+                | '\''
+                | '('
+                | ')'
+                | '*'
+                | '+'
+                | ','
+                | ';'
+                | '='
+                | '%'
+        )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1422,6 +1574,151 @@ mod tests {
         assert_eq!(
             cont_indent, orig_indent,
             "Continuation line should have same indent as original"
+        );
+    }
+
+    // ==================== Bare URL Linkification Tests ====================
+
+    /// Build a single styled line from one plain-text span (no link), mirroring
+    /// how a plain-text LSP hover is constructed.
+    fn plain_line(text: &str) -> StyledLine {
+        let mut line = StyledLine::new();
+        line.push(text.to_string(), Style::default());
+        line
+    }
+
+    #[test]
+    fn test_linkify_bare_url_in_prose() {
+        let mut lines = vec![plain_line("See https://docs.example.com/path for details")];
+        linkify_bare_urls(&mut lines);
+
+        // The URL becomes its own span carrying the link URL.
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("a link span");
+        assert_eq!(link.text, "https://docs.example.com/path");
+        assert_eq!(
+            link.link_url.as_deref(),
+            Some("https://docs.example.com/path")
+        );
+        assert!(
+            link.style.add_modifier.contains(Modifier::UNDERLINED),
+            "link should be underlined"
+        );
+        assert_eq!(link.style.fg, Some(Color::Cyan), "link should be cyan");
+
+        // Surrounding prose is preserved and stays unlinked.
+        assert_eq!(
+            lines[0].plain_text(),
+            "See https://docs.example.com/path for details"
+        );
+        assert_eq!(lines[0].link_at_column(0), None, "leading prose not a link");
+        let after = lines[0].plain_text().find("for").unwrap();
+        assert_eq!(
+            lines[0].link_at_column(after),
+            None,
+            "trailing prose not a link"
+        );
+    }
+
+    #[test]
+    fn test_linkify_trims_trailing_punctuation() {
+        let mut lines = vec![plain_line("docs at https://example.com/a.")];
+        linkify_bare_urls(&mut lines);
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("a link span");
+        // The sentence-ending period is not part of the URL.
+        assert_eq!(link.link_url.as_deref(), Some("https://example.com/a"));
+        // But the period is still rendered as trailing text.
+        assert!(lines[0].plain_text().ends_with("a."));
+    }
+
+    #[test]
+    fn test_linkify_parenthesized_url() {
+        let mut lines = vec![plain_line("(https://example.com)")];
+        linkify_bare_urls(&mut lines);
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("a link span");
+        assert_eq!(link.link_url.as_deref(), Some("https://example.com"));
+        assert_eq!(lines[0].plain_text(), "(https://example.com)");
+    }
+
+    #[test]
+    fn test_linkify_multiple_urls() {
+        let mut lines = vec![plain_line("a http://one.test b https://two.test c")];
+        linkify_bare_urls(&mut lines);
+        let urls: Vec<&str> = lines[0]
+            .spans
+            .iter()
+            .filter_map(|s| s.link_url.as_deref())
+            .collect();
+        assert_eq!(urls, vec!["http://one.test", "https://two.test"]);
+        assert_eq!(
+            lines[0].plain_text(),
+            "a http://one.test b https://two.test c"
+        );
+    }
+
+    #[test]
+    fn test_linkify_ignores_non_url_http() {
+        // "http" or "https" without a scheme separator is not a link.
+        let mut lines = vec![plain_line("the https protocol and http header")];
+        linkify_bare_urls(&mut lines);
+        assert!(
+            lines[0].spans.iter().all(|s| s.link_url.is_none()),
+            "no link should be produced for bare 'http'/'https' words"
+        );
+    }
+
+    #[test]
+    fn test_linkify_leaves_markdown_links_untouched() {
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+        // A markdown link already carries link_url; its visible text is "here".
+        let mut lines = parse_markdown("Click [here](https://example.com)", &theme, None);
+        linkify_bare_urls(&mut lines);
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("the markdown link span");
+        assert_eq!(link.text, "here", "markdown link text must be preserved");
+        assert_eq!(link.link_url.as_deref(), Some("https://example.com"));
+        // Exactly one link span — the bare-URL pass didn't add a duplicate.
+        assert_eq!(
+            lines[0]
+                .spans
+                .iter()
+                .filter(|s| s.link_url.is_some())
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_linkify_makes_url_clickable_in_popup() {
+        use crate::view::popup::{Popup, PopupContent};
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+
+        let mut lines = vec![plain_line("https://example.com/docs")];
+        linkify_bare_urls(&mut lines);
+
+        let mut popup = Popup::text(Vec::new(), &theme);
+        popup.content = PopupContent::Markdown(lines);
+        popup.width = 60;
+        popup.bordered = true;
+
+        // Column 0 of row 0 sits on the URL → resolves to a clickable link.
+        assert_eq!(
+            popup.link_at_position(0, 0).as_deref(),
+            Some("https://example.com/docs")
         );
     }
 }

--- a/crates/fresh-editor/src/view/markdown.rs
+++ b/crates/fresh-editor/src/view/markdown.rs
@@ -1721,4 +1721,57 @@ mod tests {
             Some("https://example.com/docs")
         );
     }
+
+    #[test]
+    fn test_linkify_multibyte_surrounding_text() {
+        // Multi-byte prose on both sides of the URL, including a multi-byte
+        // character immediately adjacent to the URL boundaries. Must not panic
+        // (no slicing on a non-char-boundary) and must preserve all content.
+        let mut lines = vec![plain_line("日本語 https://example.com/path → 続き")];
+        linkify_bare_urls(&mut lines);
+
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("a link span");
+        assert_eq!(link.link_url.as_deref(), Some("https://example.com/path"));
+        // No content lost or corrupted across the multi-byte boundaries.
+        assert_eq!(
+            lines[0].plain_text(),
+            "日本語 https://example.com/path → 続き"
+        );
+    }
+
+    #[test]
+    fn test_linkify_url_terminated_by_multibyte_char() {
+        // A non-ASCII character directly after the URL terminates it cleanly at
+        // a char boundary (the arrow is 3 bytes; the period is trimmed).
+        let mut lines = vec![plain_line("https://example.com/x→tail")];
+        linkify_bare_urls(&mut lines);
+        let link = lines[0]
+            .spans
+            .iter()
+            .find(|s| s.link_url.is_some())
+            .expect("a link span");
+        assert_eq!(link.link_url.as_deref(), Some("https://example.com/x"));
+        assert_eq!(lines[0].plain_text(), "https://example.com/x→tail");
+    }
+
+    #[test]
+    fn test_linkify_emoji_and_combining_marks_preserved() {
+        // Grapheme clusters (ZWJ emoji, combining marks) in surrounding prose
+        // are passed through untouched; only the ASCII URL is split out.
+        let mut lines = vec![plain_line("👨‍👩‍👧 café https://ex.com/a done")];
+        linkify_bare_urls(&mut lines);
+        assert_eq!(
+            lines[0]
+                .spans
+                .iter()
+                .filter_map(|s| s.link_url.as_deref())
+                .collect::<Vec<_>>(),
+            vec!["https://ex.com/a"]
+        );
+        assert_eq!(lines[0].plain_text(), "👨‍👩‍👧 café https://ex.com/a done");
+    }
 }

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -1446,6 +1446,98 @@ done
         dir.join("fake_lsp_server_no_range.sh")
     }
 
+    /// Spawn a fake LSP server whose hover content embeds a bare URL in prose.
+    ///
+    /// This mimics servers like pyrefly that put raw `https://…` links into the
+    /// hover documentation. Used to verify that bare URLs render as clickable
+    /// links in the hover popup (issue #603).
+    pub fn spawn_with_url_hover(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+while true; do
+    msg=$(read_message)
+    if [ -z "$msg" ]; then
+        break
+    fi
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    case "$method" in
+    "initialize")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"hoverProvider":true,"textDocumentSync":1}}}'
+        ;;
+    "textDocument/hover")
+        line=$(echo "$msg" | grep -o '"line":[0-9]*' | head -1 | cut -d':' -f2)
+        char=$(echo "$msg" | grep -o '"character":[0-9]*' | head -1 | cut -d':' -f2)
+        end_char=$((char + 10))
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"contents":{"kind":"markdown","value":"Docs: https://docs.example.com/path here"},"range":{"start":{"line":'$line',"character":'$char'},"end":{"line":'$line',"character":'$end_char'}}}}'
+        ;;
+    "textDocument/didOpen"|"textDocument/didChange"|"textDocument/didSave")
+        ;;
+    "textDocument/diagnostic")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"items":[]}}'
+        ;;
+    "textDocument/inlayHint")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":[]}'
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    esac
+done
+"#;
+
+        let script_path = dir.join("fake_lsp_server_url_hover.sh");
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Get the path to the URL-hover fake LSP server script.
+    pub fn url_hover_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_url_hover.sh")
+    }
+
     /// Spawn a fake LSP server that supports folding ranges.
     ///
     /// Based on the standard fake LSP script with `foldingRangeProvider` added

--- a/crates/fresh-editor/tests/e2e/lsp.rs
+++ b/crates/fresh-editor/tests/e2e/lsp.rs
@@ -10152,3 +10152,91 @@ fn lsp_spawn_failure_writes_stub_log_for_view_log_popup() -> anyhow::Result<()> 
 
     Ok(())
 }
+
+/// A bare URL embedded in LSP hover prose should render as a clickable link.
+///
+/// Servers like pyrefly put raw `https://…` URLs into hover docs. CommonMark
+/// does not autolink bare URLs, so before issue #603 they rendered as inert
+/// text. This drives a real hover whose content contains a bare URL and asserts
+/// the URL is rendered with the link style (cyan + underline) in the popup —
+/// the observable signal that it is now a link. The click→open path itself is
+/// covered by a component unit test on `Popup::link_at_position`.
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "FakeLspServer uses a Bash script which is not available on Windows"
+)]
+fn test_hover_bare_url_renders_as_clickable_link() -> anyhow::Result<()> {
+    use crate::common::fake_lsp::FakeLspServer;
+    use ratatui::style::{Color, Modifier};
+    use std::time::Duration;
+
+    let temp_dir = tempfile::tempdir()?;
+    let _fake_server = FakeLspServer::spawn_with_url_hover(temp_dir.path())?;
+
+    let test_file = temp_dir.path().join("test.rs");
+    std::fs::write(&test_file, "fn foo() {}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: FakeLspServer::url_hover_script_path(temp_dir.path())
+                .to_string_lossy()
+                .to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: None,
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        config,
+        temp_dir.path().to_path_buf(),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // Hover over "foo" to trigger the LSP hover request.
+    harness.mouse_move(10, 2)?;
+    harness.render()?;
+    harness.sleep(Duration::from_millis(600));
+    harness.editor_mut().force_check_mouse_hover();
+
+    // Wait for the hover popup carrying the bare URL to render.
+    let url = "https://docs.example.com/path";
+    harness.wait_until(|h| h.screen_to_string().contains(url))?;
+
+    // The URL must render as a link: cyan foreground + underline. Inspect the
+    // first cell of the URL on screen.
+    let (col, row) = harness
+        .find_text_on_screen(url)
+        .expect("URL text should be on screen");
+    let style = harness
+        .get_cell_style(col, row)
+        .expect("cell style at URL start");
+    assert_eq!(
+        style.fg,
+        Some(Color::Cyan),
+        "bare URL should render in the link color (cyan). Screen:\n{}",
+        harness.screen_to_string()
+    );
+    assert!(
+        style.add_modifier.contains(Modifier::UNDERLINED),
+        "bare URL should render underlined like a link. Screen:\n{}",
+        harness.screen_to_string()
+    );
+
+    Ok(())
+}

--- a/docs/internal/hover-bare-url-links-design.md
+++ b/docs/internal/hover-bare-url-links-design.md
@@ -1,0 +1,50 @@
+# Clickable bare URLs in LSP hover popups (issue #603)
+
+## Problem
+
+Some LSP servers (e.g. pyrefly) embed plain URLs in their hover documentation,
+for example `See https://docs.example.com/path for details`. Today those URLs
+render as inert text — you cannot click them to open the page.
+
+## What already works
+
+The popup link plumbing is already complete:
+
+- `view/markdown.rs` stores an optional `link_url` on each `StyledSpan` and
+  exposes `StyledLine::link_at_column`.
+- `Popup::link_at_position` (`view/popup.rs`) maps a click position to a URL.
+- The popup click handlers (`app/mouse_input.rs`, `view/popup_mouse.rs`) open
+  that URL via `open::that`.
+
+`parse_markdown` populates `link_url` for CommonMark `[text](url)` and `<url>`
+links, so those are *already* clickable in hover popups. The gap is **bare**
+URLs: CommonMark (and therefore `parse_markdown`) does not autolink a raw
+`https://…`, and plain-text (non-markdown) hovers never get any link metadata.
+
+## Design
+
+Add a single post-processing pass, `markdown::linkify_bare_urls(&mut [StyledLine])`,
+that scans each span's text for `http://` / `https://` URLs and splits the span
+into plain + link segments, tagging the link segment with `link_url` and the
+existing link style (underlined cyan). Spans that already carry a `link_url`
+(markdown links) are left untouched, so nothing is double-processed.
+
+Apply it once in `app/lsp_requests.rs` to the parsed hover content (both the
+markdown and the plain-text branch). Because it reuses the same `link_url`
+metadata, the existing click handling makes bare URLs clickable for free — no
+changes to the mouse layer.
+
+URL boundary heuristic: consume RFC-3986 URL characters, then strip trailing
+sentence punctuation (`. , ; : ! ? ) ] } " '`) so `…details.` and `(see https://x)`
+behave naturally. A scheme with no host (`http://` alone) is not linkified.
+
+## Testing
+
+- Unit tests on `linkify_bare_urls` (markdown.rs): bare URL → link span; leading
+  and trailing prose preserved; trailing punctuation trimmed; multiple URLs per
+  line; existing markdown link spans untouched; `http` without `://` ignored.
+- Component test on `Popup::link_at_position` proving a bare URL in a Markdown
+  popup resolves to a clickable URL at the right column.
+- E2E (`tests/e2e/lsp.rs`) with a fake LSP whose hover contains a bare URL:
+  hover the symbol, render, and assert the URL cells render with the link style
+  (cyan + underline) — observable rendered output, no real browser launch.


### PR DESCRIPTION
## Summary

Closes #603.

Some LSP servers (e.g. **pyrefly**) embed plain `http`/`https` URLs in their hover documentation. CommonMark — and therefore `parse_markdown` — does **not** autolink bare URLs, so they rendered as inert text and could not be clicked. (Markdown `[text](url)` and `<url>` links were *already* clickable: the popup click plumbing `Popup::link_at_position` → `open::that` has been in place.)

This PR closes that gap by detecting bare URLs in the parsed hover content and reusing the existing link infrastructure.

## What changed

- **`view/markdown.rs`** — new `linkify_bare_urls(&mut [StyledLine])` pass. It splits each span at any bare `http`/`https` URL, tagging the URL segment with the existing `link_url` metadata and the link style (underlined cyan). Spans that already carry a `link_url` (real markdown links) are left untouched, so nothing is double‑processed. URL boundaries follow RFC‑3986 chars and trailing sentence punctuation (`. , ; : ! ? ) ] } " '`) is excluded.
- **`app/lsp_requests.rs`** — apply the pass once when building the hover popup, covering both the markdown and the plain‑text branch. The existing mouse layer then makes the URLs clickable for free; no changes to the click handlers were needed.
- **`docs/internal/hover-bare-url-links-design.md`** — short design note.

## Testing

- **Unit tests** (`markdown.rs`): bare URL → link span; leading/trailing prose preserved; trailing punctuation trimmed; parenthesized URL; multiple URLs per line; `http`/`https` without `://` ignored; markdown links untouched; and a component test proving `Popup::link_at_position` resolves a bare URL to a clickable link.
- **E2E** (`tests/e2e/lsp.rs`, with a new `FakeLspServer::spawn_with_url_hover`): hover a symbol whose LSP hover contains a bare URL, render, and assert the URL renders with the link style (cyan + underline) — observable rendered output, no real browser launch.

All new tests pass; existing markdown (40) and hover e2e (25) suites remain green. Validated manually by running the new e2e test in a tmux session.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Acj4JqiCCSJQv37SZikyJm)_