### PR TITLE
Resolve npm .cmd/.bat shims on Windows before local spawn (#2324)

### DIFF
--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -42,10 +42,46 @@ async fn local_captured_env(provider: &EnvProvider) -> Vec<(String, String)> {
         })
         .await
 }
+use std::borrow::Cow;
 use std::path::Path;
 use std::process::ExitStatus;
 use std::sync::Arc;
 use tokio::process::{ChildStderr, ChildStdin, ChildStdout};
+
+/// Resolve a program name to a spawnable form for a *local* child.
+///
+/// On **Windows** this is the fix for the class of "installed but `program
+/// not found`" failures (e.g. issue #2324, `typescript-language-server`).
+/// Node-based CLIs install under `npm -g` as `.cmd`/`.bat` shims, but the
+/// `CreateProcess` path that `std`/`tokio` use only auto-appends `.exe`
+/// when handed a bare name — it does not walk `PATHEXT`. So spawning
+/// `typescript-language-server` fails even though our existence check
+/// ([`crate::services::lsp::command_exists`]) finds the `.cmd` (it goes
+/// through `which`, which *does* honor `PATHEXT`). The two paths disagreed:
+/// the editor reported the server present, then the spawn failed.
+///
+/// Resolving the full path here — also via `which`, so the check and the
+/// spawn agree — hands `Command` a path ending in `.cmd`/`.bat`, which
+/// `std` (≥ 1.77.2) then runs through `cmd.exe` with the
+/// CVE-2024-24576-safe argument escaping. An unresolvable name falls back
+/// to the original string so the spawn still surfaces a meaningful error
+/// rather than masking a genuine typo.
+///
+/// On other platforms it is a pass-through: a plain `PATH` lookup already
+/// does the right thing and pre-resolving would differ only cosmetically.
+#[cfg(windows)]
+fn resolve_program(command: &str) -> Cow<'_, str> {
+    match which::which(command) {
+        Ok(path) => Cow::Owned(path.to_string_lossy().into_owned()),
+        Err(_) => Cow::Borrowed(command),
+    }
+}
+
+/// Non-Windows pass-through — see the Windows variant for rationale.
+#[cfg(not(windows))]
+fn resolve_program(command: &str) -> Cow<'_, str> {
+    Cow::Borrowed(command)
+}
 
 /// Result of spawning a process
 #[derive(Debug, Clone)]
@@ -168,7 +204,7 @@ impl ProcessSpawner for LocalProcessSpawner {
         cwd: Option<String>,
     ) -> Result<SpawnResult, SpawnError> {
         gate(&self.trust, &command, cwd.as_deref())?;
-        let mut cmd = tokio::process::Command::new(&command);
+        let mut cmd = tokio::process::Command::new(resolve_program(&command).as_ref());
         cmd.args(&args);
         self.apply_env(&mut cmd).await;
         cmd.hide_window();
@@ -204,7 +240,7 @@ impl ProcessSpawner for LocalProcessSpawner {
         use tokio::io::AsyncReadExt;
 
         gate(&self.trust, &command, cwd.as_deref())?;
-        let mut cmd = tokio::process::Command::new(&command);
+        let mut cmd = tokio::process::Command::new(resolve_program(&command).as_ref());
         cmd.args(&args);
         self.apply_env(&mut cmd).await;
         cmd.hide_window();
@@ -324,7 +360,7 @@ impl ProcessSpawner for LocalProcessSpawner {
         use tokio::io::AsyncWriteExt;
 
         gate(&self.trust, &command, cwd.as_deref())?;
-        let mut cmd = tokio::process::Command::new(&command);
+        let mut cmd = tokio::process::Command::new(resolve_program(&command).as_ref());
         cmd.args(&args);
         self.apply_env(&mut cmd).await;
         cmd.hide_window();
@@ -722,7 +758,7 @@ impl LongRunningSpawner for LocalLongRunningSpawner {
             cwd.map(|p| p.to_string_lossy()).as_deref(),
         )?;
         let captured = local_captured_env(&self.env).await;
-        let mut cmd = tokio::process::Command::new(command);
+        let mut cmd = tokio::process::Command::new(resolve_program(command).as_ref());
         cmd.args(args)
             // Provider env first, then the per-call env so the caller wins.
             .envs(captured.iter().map(|(k, v)| (k.as_str(), v.as_str())))
@@ -1054,6 +1090,38 @@ impl LongRunningSpawner for RemoteLongRunningSpawner {
 mod tests {
     use super::*;
     use tokio::io::AsyncReadExt;
+
+    // On non-Windows, `resolve_program` is a pure pass-through: PATH lookup
+    // at spawn time already does the right thing, so the command string must
+    // be returned untouched (no surprise absolute-path rewrites).
+    #[cfg(not(windows))]
+    #[test]
+    fn resolve_program_is_passthrough_on_unix() {
+        assert_eq!(
+            resolve_program("typescript-language-server"),
+            "typescript-language-server"
+        );
+        assert_eq!(resolve_program("sh"), "sh");
+        assert_eq!(resolve_program(""), "");
+    }
+
+    // On Windows, an unresolvable name must fall back to itself so the spawn
+    // still surfaces a meaningful "not found" error rather than a panic, while
+    // a real binary resolves to a full, spawnable path.
+    #[cfg(windows)]
+    #[test]
+    fn resolve_program_falls_back_and_resolves_on_windows() {
+        assert_eq!(
+            resolve_program("fresh-unlikely-binary-name-ygzu9"),
+            "fresh-unlikely-binary-name-ygzu9"
+        );
+        // `cmd` is always present on Windows and resolves to an absolute path.
+        let resolved = resolve_program("cmd");
+        assert!(
+            std::path::Path::new(resolved.as_ref()).is_absolute(),
+            "expected an absolute path, got {resolved:?}"
+        );
+    }
 
     #[tokio::test]
     async fn test_local_spawner() {


### PR DESCRIPTION
## ⚠️ Work in progress — Draft

This is a **candidate fix** for #2324 that I could not validate on the target platform. The bug is **Windows-only** and this change was developed and tested on **Linux**, where the affected code path is an intentional no-op. The fix is well-reasoned and the cross-platform build/tests are green, but it **still needs validation on a real Windows host** before it should be merged. Marking as Draft for that reason.

## The bug (#2324)

`typescript-language-server: Process error: program not found` on Windows 11, even though the server is installed.

## Root cause

Fresh checks whether an LSP server exists and then spawns it through **two different code paths that disagreed on Windows**:

- **Existence check** — `services::lsp::command_exists` → `which::which(...)`, which **honors `PATHEXT`**. Node-based CLIs installed via `npm -g` (`typescript-language-server`, `prettier`, `eslint`, `vscode-*-language-server`, …) land as `.cmd`/`.bat` shims, so `which` finds them and Fresh reports the server **present**.
- **Spawn** — `LocalLongRunningSpawner::spawn_stdio` (and the one-shot `LocalProcessSpawner` methods) handed the **bare command name** to `tokio`/`std` `Command::new`. On Windows `CreateProcess` only auto-appends `.exe`; it does **not** walk `PATHEXT`. So spawning `typescript-language-server` fails with "program not found" even though the `.cmd` shim is right there on `PATH`.

Net effect: the editor says the server is installed, then the spawn fails with a misleading "not found".

## The fix

Resolve the program through `which` **before** spawning local children, so the existence check and the spawn agree:

- On **Windows**: `which::which(command)` returns the full path (e.g. `…\typescript-language-server.cmd`). Handing `Command::new` a path ending in `.cmd`/`.bat` makes `std` (≥ 1.77.2, repo is on 1.95) run it through `cmd.exe` with the **CVE-2024-24576-safe** argument escaping — no hand-rolled `cmd /c` wrapping or quoting needed. Unresolvable names fall back to the original string so a genuine typo still surfaces a meaningful error.
- On **non-Windows**: explicit pass-through. Plain `PATH` lookup at spawn time already does the right thing; pre-resolving would only differ cosmetically. Behavior is unchanged.

Applied at all four local spawn sites (`spawn`, `spawn_cancellable`, `spawn_to_file`, `spawn_stdio`) via one shared, documented helper — so the same Windows footgun is fixed for npm-based formatters/linters (on-save, `spawnProcess`) too, not just LSP. The trust gate continues to key on the original (unresolved) command name.

## Tests / validation done (on Linux)

- `cargo fmt`, `cargo check -p fresh-editor`, `cargo clippy -p fresh-editor --lib` — clean (only pre-existing unrelated warnings).
- `cargo test -p fresh-editor --lib services::remote::spawner` — 18/18 pass, including the new `resolve_program_is_passthrough_on_unix` (asserts Unix behavior is untouched) and the existing `local_long_running_spawn_stdio_pipes_output` (the real LSP spawn path).
- A Windows-gated test (`resolve_program_falls_back_and_resolves_on_windows`) is included; it asserts fallback-on-miss and full-path resolution for `cmd`, but **only runs on Windows CI** — not exercised here.

## Validation still needed (why this is a Draft)

- [ ] On Windows 11, with `typescript-language-server` installed via `npm -g`, open a `.ts` file and confirm the server actually starts (no "program not found").
- [ ] Confirm arguments survive the implicit `cmd.exe` wrapping for a server that takes args (e.g. `--stdio`).
- [ ] Sanity-check an npm-based on-save formatter (e.g. `prettier`) on Windows.

Closes #2324 once Windows validation passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYeBePjFTcKTtTmS6QEHs2)_