### PR TITLE
fix(status-bar): persistent, clickable [RO] read-only indicator (#2309)

### DIFF
--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Ukončit (%{key})",
   "statusbar.trust.trusted": "Důvěryhodné",
   "statusbar.trust.restricted": "Omezeno",
-  "statusbar.trust.blocked": "Blokováno"
+  "statusbar.trust.blocked": "Blokováno",
+  "action.show_read_only_menu": "Zobrazit nabídku jen pro čtení",
+  "read_only.menu.title": "Vyrovnávací paměť jen pro čtení",
+  "read_only.menu.enable_editing": "Povolit úpravy",
+  "read_only.menu.cancel": "Zrušit"
 }

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Beenden (%{key})",
   "statusbar.trust.trusted": "Vertraut",
   "statusbar.trust.restricted": "Eingeschränkt",
-  "statusbar.trust.blocked": "Blockiert"
+  "statusbar.trust.blocked": "Blockiert",
+  "action.show_read_only_menu": "Schreibschutz-Menü anzeigen",
+  "read_only.menu.title": "Schreibgeschützter Puffer",
+  "read_only.menu.enable_editing": "Bearbeitung aktivieren",
+  "read_only.menu.cancel": "Abbrechen"
 }

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Quit (%{key})",
   "statusbar.trust.trusted": "Trusted",
   "statusbar.trust.restricted": "Restricted",
-  "statusbar.trust.blocked": "Blocked"
+  "statusbar.trust.blocked": "Blocked",
+  "action.show_read_only_menu": "Show read-only menu",
+  "read_only.menu.title": "Read-only buffer",
+  "read_only.menu.enable_editing": "Enable editing",
+  "read_only.menu.cancel": "Cancel"
 }

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Salir (%{key})",
   "statusbar.trust.trusted": "Confiable",
   "statusbar.trust.restricted": "Restringido",
-  "statusbar.trust.blocked": "Bloqueado"
+  "statusbar.trust.blocked": "Bloqueado",
+  "action.show_read_only_menu": "Mostrar menú de solo lectura",
+  "read_only.menu.title": "Búfer de solo lectura",
+  "read_only.menu.enable_editing": "Habilitar edición",
+  "read_only.menu.cancel": "Cancelar"
 }

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Quitter (%{key})",
   "statusbar.trust.trusted": "Approuvé",
   "statusbar.trust.restricted": "Restreint",
-  "statusbar.trust.blocked": "Bloqué"
+  "statusbar.trust.blocked": "Bloqué",
+  "action.show_read_only_menu": "Afficher le menu lecture seule",
+  "read_only.menu.title": "Tampon en lecture seule",
+  "read_only.menu.enable_editing": "Activer l'édition",
+  "read_only.menu.cancel": "Annuler"
 }

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Esci (%{key})",
   "statusbar.trust.trusted": "Attendibile",
   "statusbar.trust.restricted": "Limitato",
-  "statusbar.trust.blocked": "Bloccato"
+  "statusbar.trust.blocked": "Bloccato",
+  "action.show_read_only_menu": "Mostra menu sola lettura",
+  "read_only.menu.title": "Buffer in sola lettura",
+  "read_only.menu.enable_editing": "Abilita modifica",
+  "read_only.menu.cancel": "Annulla"
 }

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "終了 (%{key})",
   "statusbar.trust.trusted": "信頼済み",
   "statusbar.trust.restricted": "制限",
-  "statusbar.trust.blocked": "ブロック"
+  "statusbar.trust.blocked": "ブロック",
+  "action.show_read_only_menu": "読み取り専用メニューを表示",
+  "read_only.menu.title": "読み取り専用バッファー",
+  "read_only.menu.enable_editing": "編集を有効化",
+  "read_only.menu.cancel": "キャンセル"
 }

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "종료 (%{key})",
   "statusbar.trust.trusted": "신뢰됨",
   "statusbar.trust.restricted": "제한됨",
-  "statusbar.trust.blocked": "차단됨"
+  "statusbar.trust.blocked": "차단됨",
+  "action.show_read_only_menu": "읽기 전용 메뉴 표시",
+  "read_only.menu.title": "읽기 전용 버퍼",
+  "read_only.menu.enable_editing": "편집 활성화",
+  "read_only.menu.cancel": "취소"
 }

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Sair (%{key})",
   "statusbar.trust.trusted": "Confiável",
   "statusbar.trust.restricted": "Restrito",
-  "statusbar.trust.blocked": "Bloqueado"
+  "statusbar.trust.blocked": "Bloqueado",
+  "action.show_read_only_menu": "Mostrar menu somente leitura",
+  "read_only.menu.title": "Buffer somente leitura",
+  "read_only.menu.enable_editing": "Ativar edição",
+  "read_only.menu.cancel": "Cancelar"
 }

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Выйти (%{key})",
   "statusbar.trust.trusted": "Доверено",
   "statusbar.trust.restricted": "Ограничено",
-  "statusbar.trust.blocked": "Заблокировано"
+  "statusbar.trust.blocked": "Заблокировано",
+  "action.show_read_only_menu": "Показать меню «только чтение»",
+  "read_only.menu.title": "Буфер только для чтения",
+  "read_only.menu.enable_editing": "Включить редактирование",
+  "read_only.menu.cancel": "Отмена"
 }

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "ออก (%{key})",
   "statusbar.trust.trusted": "เชื่อถือ",
   "statusbar.trust.restricted": "จำกัด",
-  "statusbar.trust.blocked": "ปิดกั้น"
+  "statusbar.trust.blocked": "ปิดกั้น",
+  "action.show_read_only_menu": "แสดงเมนูอ่านอย่างเดียว",
+  "read_only.menu.title": "บัฟเฟอร์อ่านอย่างเดียว",
+  "read_only.menu.enable_editing": "เปิดใช้การแก้ไข",
+  "read_only.menu.cancel": "ยกเลิก"
 }

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Вийти (%{key})",
   "statusbar.trust.trusted": "Довірено",
   "statusbar.trust.restricted": "Обмежено",
-  "statusbar.trust.blocked": "Заблоковано"
+  "statusbar.trust.blocked": "Заблоковано",
+  "action.show_read_only_menu": "Показати меню «лише читання»",
+  "read_only.menu.title": "Буфер лише для читання",
+  "read_only.menu.enable_editing": "Увімкнути редагування",
+  "read_only.menu.cancel": "Скасувати"
 }

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "Thoát (%{key})",
   "statusbar.trust.trusted": "Tin cậy",
   "statusbar.trust.restricted": "Giới hạn",
-  "statusbar.trust.blocked": "Đã chặn"
+  "statusbar.trust.blocked": "Đã chặn",
+  "action.show_read_only_menu": "Hiện menu chỉ đọc",
+  "read_only.menu.title": "Bộ đệm chỉ đọc",
+  "read_only.menu.enable_editing": "Bật chỉnh sửa",
+  "read_only.menu.cancel": "Hủy"
 }

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1553,5 +1553,9 @@
   "trust.dialog.btn_quit_key": "退出 (%{key})",
   "statusbar.trust.trusted": "已信任",
   "statusbar.trust.restricted": "受限",
-  "statusbar.trust.blocked": "已阻止"
+  "statusbar.trust.blocked": "已阻止",
+  "action.show_read_only_menu": "显示只读菜单",
+  "read_only.menu.title": "只读缓冲区",
+  "read_only.menu.enable_editing": "启用编辑",
+  "read_only.menu.cancel": "取消"
 }

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -59,6 +59,7 @@
             "{messages}"
           ],
           "right": [
+            "{read_only}",
             "{line_ending}",
             "{encoding}",
             "{language}",
@@ -506,6 +507,7 @@
               "{messages}"
             ],
             "right": [
+              "{read_only}",
               "{line_ending}",
               "{encoding}",
               "{language}",
@@ -932,12 +934,13 @@
           "x-dynamically-extendable-status-bar-elements": true
         },
         "right": {
-          "description": "Elements shown on the right side of the status bar.\nDefault: [\"{line_ending}\", \"{encoding}\", \"{language}\", \"{lsp}\", \"{warnings}\", \"{update}\", \"{palette}\"]",
+          "description": "Elements shown on the right side of the status bar.\nDefault: [\"{read_only}\", \"{line_ending}\", \"{encoding}\", \"{language}\", \"{lsp}\", \"{warnings}\", \"{update}\", \"{palette}\"]",
           "type": "array",
           "items": {
             "$ref": "#/$defs/StatusBarElement"
           },
           "default": [
+            "{read_only}",
             "{line_ending}",
             "{encoding}",
             "{language}",
@@ -964,6 +967,10 @@
         {
           "value": "{filename}",
           "name": "Filename"
+        },
+        {
+          "value": "{read_only}",
+          "name": "Read-Only"
         },
         {
           "value": "{cursor}",

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -1269,6 +1269,9 @@ impl Editor {
             Action::ShowRemoteIndicatorMenu => {
                 self.show_remote_indicator_popup();
             }
+            Action::ShowReadOnlyMenu => {
+                self.show_read_only_popup();
+            }
             Action::ClearWarnings => {
                 self.active_window_mut().clear_warnings();
             }

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1283,44 +1283,13 @@ impl Editor {
             }
         }
 
-        // Check status bar indicators
+        // Check status bar indicators — one generic hit-test over every
+        // clickable segment recorded last frame (encoding, LSP, remote, …).
         if let Some((status_row, _status_x, _status_width)) = self.active_chrome().status_bar_area {
             if row == status_row {
-                let indicators = [
-                    (
-                        self.active_chrome().status_bar_line_ending_area,
-                        HoverTarget::StatusBarLineEndingIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_encoding_area,
-                        HoverTarget::StatusBarEncodingIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_language_area,
-                        HoverTarget::StatusBarLanguageIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_lsp_area,
-                        HoverTarget::StatusBarLspIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_remote_area,
-                        HoverTarget::StatusBarRemoteIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_trust_area,
-                        HoverTarget::StatusBarTrustIndicator,
-                    ),
-                    (
-                        self.active_chrome().status_bar_warning_area,
-                        HoverTarget::StatusBarWarningBadge,
-                    ),
-                ];
-                for (area, target) in indicators {
-                    if let Some((indicator_row, start, end)) = area {
-                        if row == indicator_row && col >= start && col < end {
-                            return Some(target);
-                        }
+                for (id, indicator_row, start, end) in &self.active_chrome().status_bar_clickable {
+                    if row == *indicator_row && col >= *start && col < *end {
+                        return Some(HoverTarget::StatusBarClickable(*id));
                     }
                 }
             }
@@ -2416,73 +2385,65 @@ impl Editor {
         Some(Ok(()))
     }
 
+    /// Map a click on a status-bar segment to its editor `Action`. This is the
+    /// single id→action table for the generic click rail; adding a clickable
+    /// element means adding one arm here (plus listing it in
+    /// `StatusBarRenderer::clickable_for_kind`).
+    ///
+    /// Most segments dismiss any open menu-style popup first (the #1941
+    /// follow-up: otherwise a stale popup overlaps the new prompt). The LSP,
+    /// remote, and read-only menus are the exceptions — each owns a toggle
+    /// (a second click closes it), so dismissing first would defeat the toggle;
+    /// they clear other popups themselves after their toggle check.
+    fn dispatch_status_bar_click(
+        &mut self,
+        id: crate::view::ui::status_bar::StatusBarClickable,
+    ) -> AnyhowResult<()> {
+        use crate::view::ui::status_bar::StatusBarClickable as C;
+        match id {
+            C::LineEnding => {
+                self.dismiss_menu_popups_for_prompt();
+                self.handle_action(Action::SetLineEnding)
+            }
+            C::Encoding => {
+                self.dismiss_menu_popups_for_prompt();
+                self.handle_action(Action::SetEncoding)
+            }
+            C::Language => {
+                self.dismiss_menu_popups_for_prompt();
+                self.handle_action(Action::SetLanguage)
+            }
+            // Owns its own toggle (second click closes the popup).
+            C::Lsp => self.handle_action(Action::ShowLspStatus),
+            // Owns its own toggle; clears other popups itself after the check.
+            C::RemoteIndicator => self.handle_action(Action::ShowRemoteIndicatorMenu),
+            C::WorkspaceTrust => {
+                // Opens the (cancellable) workspace-trust prompt.
+                self.dismiss_menu_popups_for_prompt();
+                self.handle_action(Action::WorkspaceTrustPrompt)
+            }
+            C::Warnings => {
+                self.dismiss_menu_popups_for_prompt();
+                self.handle_action(Action::ShowWarnings)
+            }
+            C::Messages => self.handle_action(Action::ShowStatusLog),
+            // Owns its own toggle (second click closes the read-only menu).
+            C::ReadOnly => self.handle_action(Action::ShowReadOnlyMenu),
+        }
+    }
+
     fn handle_click_status_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
         let (status_row, _status_x, _status_width) = self.active_chrome().status_bar_area?;
         if row != status_row {
             return None;
         }
-        // Helper: dismiss any open menu-style popup (LSP-Servers, plugin
-        // action popups, etc.) before opening a new modal UI. Without
-        // this, clicking a different status-bar indicator while a
-        // popup is up leaves the popup overlapping the new prompt or
-        // picker — the user-reported #1941 follow-up.
-        //
-        // Skipped for the LSP indicator itself: it has its own toggle
-        // semantics inside `show_lsp_status_popup` (second click closes
-        // the popup), which we don't want to undermine.
-        if let Some((r, s, e)) = self.active_chrome().status_bar_line_ending_area {
+        // Generic click rail: one hit-test over every clickable segment drawn
+        // last frame. The id→Action mapping (and each element's popup-dismiss
+        // nuance) lives in `dispatch_status_bar_click`.
+        let clickables = self.active_chrome().status_bar_clickable.clone();
+        for (id, r, s, e) in clickables {
             if row == r && col >= s && col < e {
-                self.dismiss_menu_popups_for_prompt();
-                return Some(self.handle_action(Action::SetLineEnding));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_encoding_area {
-            if row == r && col >= s && col < e {
-                self.dismiss_menu_popups_for_prompt();
-                return Some(self.handle_action(Action::SetEncoding));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_language_area {
-            if row == r && col >= s && col < e {
-                self.dismiss_menu_popups_for_prompt();
-                return Some(self.handle_action(Action::SetLanguage));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_lsp_area {
-            if row == r && col >= s && col < e {
-                // Intentionally NOT calling `dismiss_menu_popups_for_prompt`
-                // here — `show_lsp_status_popup` owns the toggle.
-                return Some(self.handle_action(Action::ShowLspStatus));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_remote_area {
-            if row == r && col >= s && col < e {
-                // Intentionally NOT calling `dismiss_menu_popups_for_prompt`
-                // here — `show_remote_indicator_popup` owns the toggle (a
-                // second click closes it). Dismissing first would close the
-                // popup, then the action would find nothing open and re-open
-                // it, so it could never be toggled shut. It clears any *other*
-                // menu popup itself, after its toggle check.
-                return Some(self.handle_action(Action::ShowRemoteIndicatorMenu));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_trust_area {
-            if row == r && col >= s && col < e {
-                // Clicking the trust indicator opens the (cancellable)
-                // workspace-trust prompt so the user can change the decision.
-                self.dismiss_menu_popups_for_prompt();
-                return Some(self.handle_action(Action::WorkspaceTrustPrompt));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_warning_area {
-            if row == r && col >= s && col < e {
-                self.dismiss_menu_popups_for_prompt();
-                return Some(self.handle_action(Action::ShowWarnings));
-            }
-        }
-        if let Some((r, s, e)) = self.active_chrome().status_bar_message_area {
-            if row == r && col >= s && col < e {
-                return Some(self.handle_action(Action::ShowStatusLog));
+                return Some(self.dispatch_status_bar_click(id));
             }
         }
         // Plugin-registered tokens. Walk the per-frame map produced by

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -123,6 +123,20 @@ impl Editor {
                 PopupConfirmResult::EarlyReturn
             }
 
+            Some(PopupResolver::ReadOnly) => {
+                let action_key = self
+                    .active_state()
+                    .popups
+                    .top()
+                    .and_then(|p| p.selected_item())
+                    .and_then(|item| item.data.clone());
+                self.hide_popup();
+                if let Some(key) = action_key {
+                    self.handle_read_only_menu_action(&key);
+                }
+                PopupConfirmResult::EarlyReturn
+            }
+
             Some(PopupResolver::WorkspaceTrust) => {
                 // The trust prompt lives on the global stack; read its
                 // selection there (global-first, matching the resolver lookup).
@@ -360,6 +374,10 @@ impl Editor {
             }
 
             Some(PopupResolver::RemoteIndicator) => {
+                self.hide_popup();
+            }
+
+            Some(PopupResolver::ReadOnly) => {
                 self.hide_popup();
             }
 

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -600,7 +600,7 @@ impl Editor {
         // even in prompt-auto-hide mode.
         let position = self
             .active_chrome()
-            .status_bar_lsp_area
+            .status_bar_clickable_area(crate::view::ui::status_bar::StatusBarClickable::Lsp)
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
                     x: col_start,
@@ -921,7 +921,9 @@ impl Editor {
         // even in prompt-auto-hide mode.
         let position = self
             .active_chrome()
-            .status_bar_remote_area
+            .status_bar_clickable_area(
+                crate::view::ui::status_bar::StatusBarClickable::RemoteIndicator,
+            )
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
                     x: col_start,
@@ -971,6 +973,111 @@ impl Editor {
             .get_mut(&buffer_id)
         {
             state.popups.show(popup);
+        }
+    }
+
+    /// Show the read-only indicator menu, anchored to the status bar's
+    /// `{read_only}` segment. Offers to enable editing (which dispatches
+    /// `Action::ToggleReadOnly`). Toggles closed on a second click, mirroring
+    /// the LSP / remote menus.
+    pub fn show_read_only_popup(&mut self) {
+        use crate::view::popup::{
+            Popup, PopupContent, PopupKind, PopupListItem, PopupPosition, PopupResolver,
+        };
+        use ratatui::style::Style;
+
+        // Second click on the indicator closes the menu instead of rebuilding.
+        if self
+            .active_state()
+            .popups
+            .top()
+            .is_some_and(|p| matches!(p.resolver, PopupResolver::ReadOnly))
+        {
+            self.hide_popup();
+            return;
+        }
+        // Not a toggle-close: clear any other menu popup left open so this one
+        // never renders over a stale popup (#1941).
+        self.dismiss_menu_popups_for_prompt();
+
+        let items = vec![
+            PopupListItem::new(format!("    {}", t!("read_only.menu.enable_editing")))
+                .with_data("toggle_read_only".to_string()),
+            PopupListItem::new(format!("    {}", t!("read_only.menu.cancel")))
+                .with_data("cancel".to_string()),
+        ];
+
+        let position = self
+            .active_chrome()
+            .status_bar_clickable_area(crate::view::ui::status_bar::StatusBarClickable::ReadOnly)
+            .map(
+                |(status_row, col_start, _)| PopupPosition::AboveStatusBarAt {
+                    x: col_start,
+                    status_row,
+                },
+            )
+            .unwrap_or(PopupPosition::BottomRight);
+
+        let popup_width = (items
+            .iter()
+            .map(|i| unicode_width::UnicodeWidthStr::width(i.text.as_str()))
+            .max()
+            .unwrap_or(24)
+            + 4) as u16;
+
+        let popup = Popup {
+            kind: PopupKind::List,
+            title: Some(t!("read_only.menu.title").to_string()),
+            description: None,
+            transient: false,
+            content: PopupContent::List { items, selected: 0 },
+            position,
+            width: popup_width.clamp(28, 50),
+            max_height: 10,
+            bordered: true,
+            border_style: Style::default().fg(self.theme.read().unwrap().popup_border_fg),
+            background_style: Style::default().bg(self.theme.read().unwrap().popup_bg),
+            scroll_offset: 0,
+            text_selection: None,
+            accept_key_hint: None,
+            resolver: PopupResolver::ReadOnly,
+            // Explicitly invoked from the status-bar `{read_only}` element, so
+            // this popup wants the keyboard immediately.
+            focused: true,
+            focus_key_hint: None,
+        };
+
+        let buffer_id = self.active_buffer();
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .map(|w| &mut w.buffers)
+            .expect("active window present")
+            .get_mut(&buffer_id)
+        {
+            state.popups.show(popup);
+        }
+    }
+
+    /// Dispatch the action selected from the read-only indicator menu.
+    /// `"toggle_read_only"` flips the buffer's read-only state (enabling
+    /// editing); `"cancel"` is a no-op (the popup already closed).
+    pub fn handle_read_only_menu_action(&mut self, action_key: &str) {
+        match action_key {
+            "toggle_read_only" => {
+                if let Err(e) =
+                    self.handle_action(crate::input::keybindings::Action::ToggleReadOnly)
+                {
+                    tracing::warn!("read-only menu: toggling read-only failed: {}", e);
+                }
+            }
+            "cancel" => {}
+            other => {
+                tracing::warn!(
+                    "handle_read_only_menu_action: unknown action key '{}'",
+                    other
+                );
+            }
         }
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -990,19 +990,11 @@ impl Editor {
                     (WarningLevel::None, 0)
                 };
 
-            // Compute status bar hover state for styling
-            use crate::view::ui::status_bar::StatusBarHover;
-            let status_bar_hover = match &self.active_window_mut().mouse_state.hover_target {
-                Some(HoverTarget::StatusBarLspIndicator) => StatusBarHover::LspIndicator,
-                Some(HoverTarget::StatusBarWarningBadge) => StatusBarHover::WarningBadge,
-                Some(HoverTarget::StatusBarLineEndingIndicator) => {
-                    StatusBarHover::LineEndingIndicator
-                }
-                Some(HoverTarget::StatusBarEncodingIndicator) => StatusBarHover::EncodingIndicator,
-                Some(HoverTarget::StatusBarLanguageIndicator) => StatusBarHover::LanguageIndicator,
-                Some(HoverTarget::StatusBarRemoteIndicator) => StatusBarHover::RemoteIndicator,
-                Some(HoverTarget::StatusBarTrustIndicator) => StatusBarHover::WorkspaceTrust,
-                _ => StatusBarHover::None,
+            // Which clickable status-bar segment (if any) the mouse is over —
+            // drives hover styling generically (one variant for the whole bar).
+            let status_bar_hovered = match &self.active_window_mut().mouse_state.hover_target {
+                Some(HoverTarget::StatusBarClickable(id)) => Some(*id),
+                _ => None,
             };
 
             let remote_connection = self.connection_display_string();
@@ -1068,7 +1060,7 @@ impl Editor {
                         update_available: update_available.as_deref(),
                         warning_level,
                         general_warning_count,
-                        hover: status_bar_hover,
+                        hovered: status_bar_hovered,
                         remote_connection: remote_connection.as_deref(),
                         session_name: session_name.as_deref(),
                         read_only: is_read_only,
@@ -1101,17 +1093,7 @@ impl Editor {
             let status_bar_area = main_chunks[status_bar_idx];
             self.active_chrome_mut().status_bar_area =
                 Some((status_bar_area.y, status_bar_area.x, status_bar_area.width));
-            self.active_chrome_mut().status_bar_lsp_area = status_bar_layout.lsp_indicator;
-            self.active_chrome_mut().status_bar_warning_area = status_bar_layout.warning_badge;
-            self.active_chrome_mut().status_bar_line_ending_area =
-                status_bar_layout.line_ending_indicator;
-            self.active_chrome_mut().status_bar_encoding_area =
-                status_bar_layout.encoding_indicator;
-            self.active_chrome_mut().status_bar_language_area =
-                status_bar_layout.language_indicator;
-            self.active_chrome_mut().status_bar_message_area = status_bar_layout.message_area;
-            self.active_chrome_mut().status_bar_remote_area = status_bar_layout.remote_indicator;
-            self.active_chrome_mut().status_bar_trust_area = status_bar_layout.trust_indicator;
+            self.active_chrome_mut().status_bar_clickable = status_bar_layout.clickable;
             self.active_chrome_mut().status_bar_plugin_token_areas =
                 status_bar_layout.plugin_token_areas;
             self.active_chrome_mut().status_bar_segments = status_bar_layout.segments;

--- a/crates/fresh-editor/src/app/types/hover.rs
+++ b/crates/fresh-editor/src/app/types/hover.rs
@@ -46,20 +46,12 @@ pub enum HoverTarget {
     FileExplorerCloseButton,
     /// Hovering over a file explorer item's status indicator (path)
     FileExplorerStatusIndicator(std::path::PathBuf),
-    /// Hovering over the status bar LSP indicator
-    StatusBarLspIndicator,
-    /// Hovering over the status bar remote-authority indicator
-    StatusBarRemoteIndicator,
-    /// Hovering over the status bar workspace-trust indicator
-    StatusBarTrustIndicator,
-    /// Hovering over the status bar warning badge
-    StatusBarWarningBadge,
-    /// Hovering over the status bar line ending indicator
-    StatusBarLineEndingIndicator,
-    /// Hovering over the status bar encoding indicator
-    StatusBarEncodingIndicator,
-    /// Hovering over the status bar language indicator
-    StatusBarLanguageIndicator,
+    /// Hovering over a clickable status-bar segment (LSP / encoding / line
+    /// ending / language / warnings / messages / remote / trust / read-only).
+    /// One generic variant carrying the segment's identity — the renderer
+    /// styles it and `handle_click_status_bar` dispatches it via a single
+    /// hit-test over `ChromeLayout::status_bar_clickable`.
+    StatusBarClickable(crate::view::ui::status_bar::StatusBarClickable),
     /// Hovering over the search options "Case Sensitive" checkbox
     SearchOptionCaseSensitive,
     /// Hovering over the search options "Whole Word" checkbox

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -126,24 +126,17 @@ pub(crate) struct ChromeLayout {
     pub workspace_trust_dialog: Option<crate::view::workspace_trust_dialog::TrustDialogLayout>,
     /// Status bar area (row, x, width)
     pub status_bar_area: Option<(u16, u16, u16)>,
-    /// Status bar LSP indicator area (row, start_col, end_col)
-    pub status_bar_lsp_area: Option<(u16, u16, u16)>,
-    /// Status bar warning badge area (row, start_col, end_col)
-    pub status_bar_warning_area: Option<(u16, u16, u16)>,
-    /// Status bar line ending indicator area (row, start_col, end_col)
-    pub status_bar_line_ending_area: Option<(u16, u16, u16)>,
-    /// Status bar encoding indicator area (row, start_col, end_col)
-    pub status_bar_encoding_area: Option<(u16, u16, u16)>,
-    /// Status bar language indicator area (row, start_col, end_col)
-    pub status_bar_language_area: Option<(u16, u16, u16)>,
-    /// Status bar message area (row, start_col, end_col) - clickable to show status log
-    pub status_bar_message_area: Option<(u16, u16, u16)>,
-    /// Status bar remote-authority indicator area (row, start_col, end_col)
-    /// — clickable to open the remote-authority context menu.
-    pub status_bar_remote_area: Option<(u16, u16, u16)>,
-    /// Status bar workspace-trust indicator area (row, start_col, end_col)
-    /// — clickable to open the workspace-trust prompt.
-    pub status_bar_trust_area: Option<(u16, u16, u16)>,
+    /// Every clickable built-in status-bar segment drawn last frame, as
+    /// `(id, row, start_col, end_col)`. One generic list (mirroring
+    /// `StatusBarLayout::clickable`) walked by both the hover hit-test and
+    /// `handle_click_status_bar` — no per-indicator field. See
+    /// `StatusBarClickable`.
+    pub status_bar_clickable: Vec<(
+        crate::view::ui::status_bar::StatusBarClickable,
+        u16,
+        u16,
+        u16,
+    )>,
     /// Plugin-registered status-bar token areas, keyed by
     /// `"<plugin>:<token>"`. Populated by `render_status_bar`; consumed
     /// by `handle_click_status_bar` which fires the
@@ -169,6 +162,19 @@ pub(crate) struct ChromeLayout {
 }
 
 impl ChromeLayout {
+    /// Screen area `(row, start_col, end_col)` of a given clickable status-bar
+    /// segment from the last frame, if it was drawn. Used to anchor popups to
+    /// their indicator (e.g. the LSP / remote / read-only menus).
+    pub fn status_bar_clickable_area(
+        &self,
+        id: crate::view::ui::status_bar::StatusBarClickable,
+    ) -> Option<(u16, u16, u16)> {
+        self.status_bar_clickable
+            .iter()
+            .find(|(cid, _, _, _)| *cid == id)
+            .map(|(_, row, start, end)| (*row, *start, *end))
+    }
+
     /// Reset the cell theme map for a new frame
     pub fn reset_cell_theme_map(&mut self) {
         let total = self.last_frame_width as usize * self.last_frame_height as usize;

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -679,6 +679,7 @@ impl WhitespaceVisibility {
 ///
 /// Elements are specified as strings in the config:
 /// - `"{filename}"` — file path with session/remote prefix, modified and read-only indicators
+/// - `"{read_only}"` — persistent `[RO]` indicator, shown only while the buffer is read-only
 /// - `"{cursor}"` — cursor position as `Ln 1, Col 1`
 /// - `"{cursor:compact}"` — cursor position as `1:1`
 /// - `"{diagnostics}"` — error/warning/info counts (e.g. `E:1 W:2`)
@@ -699,6 +700,10 @@ impl WhitespaceVisibility {
 pub enum StatusBarElement {
     /// File path with session/remote prefix, modified/read-only indicators
     Filename,
+    /// Persistent `[RO]` read-only indicator. Renders only while the active
+    /// buffer is read-only, as a steady status segment independent of the
+    /// `{filename}` element (which is omitted from the default layout).
+    ReadOnly,
     /// Cursor position (default format: `Ln 1, Col 1`)
     Cursor,
     /// Cursor position (compact format: `1:1`)
@@ -751,6 +756,7 @@ impl TryFrom<String> for StatusBarElement {
             .unwrap_or(&s);
         match inner {
             "filename" => Ok(Self::Filename),
+            "read_only" => Ok(Self::ReadOnly),
             "cursor" => Ok(Self::Cursor),
             "cursor:compact" => Ok(Self::CursorCompact),
             "diagnostics" => Ok(Self::Diagnostics),
@@ -783,6 +789,7 @@ impl From<StatusBarElement> for String {
     fn from(e: StatusBarElement) -> String {
         match e {
             StatusBarElement::Filename => "{filename}".to_string(),
+            StatusBarElement::ReadOnly => "{read_only}".to_string(),
             StatusBarElement::Cursor => "{cursor}".to_string(),
             StatusBarElement::CursorCompact => "{cursor:compact}".to_string(),
             StatusBarElement::Diagnostics => "{diagnostics}".to_string(),
@@ -813,6 +820,7 @@ impl schemars::JsonSchema for StatusBarElement {
             "type": "string",
             "x-dual-list-options": [
                 {"value": "{filename}", "name": "Filename"},
+                {"value": "{read_only}", "name": "Read-Only"},
                 {"value": "{cursor}", "name": "Cursor"},
                 {"value": "{cursor:compact}", "name": "Cursor (compact)"},
                 {"value": "{diagnostics}", "name": "Diagnostics"},
@@ -856,6 +864,11 @@ fn default_status_bar_left() -> Vec<StatusBarElement> {
 
 fn default_status_bar_right() -> Vec<StatusBarElement> {
     vec![
+        // `{read_only}` leads the right cluster: it renders only while the
+        // buffer is read-only, giving the documented `[RO]` indicator a
+        // standing home even though `{filename}` (its other host) is omitted
+        // from the default layout.
+        StatusBarElement::ReadOnly,
         StatusBarElement::LineEnding,
         StatusBarElement::Encoding,
         StatusBarElement::Language,
@@ -889,7 +902,7 @@ pub struct StatusBarConfig {
     pub left: Vec<StatusBarElement>,
 
     /// Elements shown on the right side of the status bar.
-    /// Default: ["{line_ending}", "{encoding}", "{language}", "{lsp}", "{warnings}", "{update}", "{palette}"]
+    /// Default: ["{read_only}", "{line_ending}", "{encoding}", "{language}", "{lsp}", "{warnings}", "{update}", "{palette}"]
     #[serde(default = "default_status_bar_right")]
     #[schemars(extend("x-section" = "Status Bar", "x-dual-list-sibling" = "/editor/status_bar/left", "x-dynamically-extendable-status-bar-elements" = true))]
     pub right: Vec<StatusBarElement>,

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -2886,6 +2886,7 @@ pub fn action_to_events(
         | Action::ShowStatusLog
         | Action::ShowLspStatus
         | Action::ShowRemoteIndicatorMenu
+        | Action::ShowReadOnlyMenu
         | Action::ClearWarnings
         | Action::SmartHome
         | Action::ToggleComment

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -535,6 +535,7 @@ pub enum Action {
     ShowStatusLog,
     ShowLspStatus,
     ShowRemoteIndicatorMenu,
+    ShowReadOnlyMenu,
     ClearWarnings,
     CommandPalette, // Alias for QuickOpen — kept for keymap/plugin compatibility
     /// Quick Open - unified prompt with prefix-based provider routing
@@ -1058,6 +1059,7 @@ impl Action {
             "show_status_log" => ShowStatusLog,
             "show_lsp_status" => ShowLspStatus,
             "show_remote_indicator_menu" => ShowRemoteIndicatorMenu,
+            "show_read_only_menu" => ShowReadOnlyMenu,
             "clear_warnings" => ClearWarnings,
             "command_palette" => CommandPalette,
             "quick_open" => QuickOpen,
@@ -2518,6 +2520,7 @@ impl KeybindingResolver {
             Action::ShowStatusLog => t!("action.show_status_log"),
             Action::ShowLspStatus => t!("action.show_lsp_status"),
             Action::ShowRemoteIndicatorMenu => t!("action.show_remote_indicator_menu"),
+            Action::ShowReadOnlyMenu => t!("action.show_read_only_menu"),
             Action::ClearWarnings => t!("action.clear_warnings"),
             Action::CommandPalette => t!("action.command_palette"),
             Action::QuickOpen => t!("action.quick_open"),

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -119,6 +119,10 @@ pub enum PopupResolver {
     /// ("trusted" / "restricted" / "blocked") through
     /// `handle_workspace_trust_action`.
     WorkspaceTrust,
+    /// Read-only indicator menu (anchored to the status bar's `{read_only}`
+    /// segment). Confirm dispatches the selected row's `data`
+    /// ("toggle_read_only" / "cancel") through `handle_read_only_menu_action`.
+    ReadOnly,
 }
 
 /// Content of a popup window

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -23,6 +23,32 @@ use rust_i18n::t;
 const SSH_PREFIX: &str = "[SSH:";
 const SSH_PREFIX_TERMINATOR: &str = "] ";
 
+/// Stable identity of a *clickable* status-bar segment.
+///
+/// This is the generic rail that replaces per-element layout fields, hover
+/// enum variants, and bespoke mouse-detective branches. The renderer records
+/// each clickable element's screen area under its `StatusBarClickable` id in
+/// [`StatusBarLayout::clickable`]; the app layer (`mouse_input.rs`) runs a
+/// single hit-test over that list for both hover and click, mapping the id to
+/// an editor `Action` in one place (`dispatch_status_bar_click`).
+///
+/// Wiring a new clickable built-in element is therefore: give it an
+/// `ElementKind`, list it in [`StatusBarRenderer::clickable_for_kind`], and add
+/// one arm to the app-side dispatch. No new layout field / hover variant /
+/// chrome area / mouse loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusBarClickable {
+    LineEnding,
+    Encoding,
+    Language,
+    Lsp,
+    Warnings,
+    Messages,
+    RemoteIndicator,
+    WorkspaceTrust,
+    ReadOnly,
+}
+
 /// Categorization of how a rendered element should be styled and tracked for click detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ElementKind {
@@ -44,6 +70,8 @@ enum ElementKind {
     Palette,
     /// Status message area (clickable to show history)
     Messages,
+    /// Read-only `[RO]` indicator (clickable to open the read-only menu)
+    ReadOnly,
     /// Remote disconnected prefix (error colors)
     RemoteDisconnected,
     /// Clock element — colon rendered with hardware blink
@@ -226,7 +254,10 @@ pub struct StatusBarContext<'a> {
     pub update_available: Option<&'a str>,
     pub warning_level: WarningLevel,
     pub general_warning_count: usize,
-    pub hover: StatusBarHover,
+    /// The clickable status-bar segment the mouse is currently over, if any.
+    /// Drives hover styling generically — each element underlines/recolors when
+    /// its own `clickable_for_kind` id equals this.
+    pub hovered: Option<StatusBarClickable>,
     pub remote_connection: Option<&'a str>,
     pub session_name: Option<&'a str>,
     pub read_only: bool,
@@ -272,24 +303,11 @@ pub struct StatusBarContext<'a> {
 /// Layout information returned from status bar rendering for mouse click detection
 #[derive(Debug, Clone, Default)]
 pub struct StatusBarLayout {
-    /// LSP indicator area (row, start_col, end_col) - None if no LSP indicator shown
-    pub lsp_indicator: Option<(u16, u16, u16)>,
-    /// Warning badge area (row, start_col, end_col) - None if no warnings
-    pub warning_badge: Option<(u16, u16, u16)>,
-    /// Line ending indicator area (row, start_col, end_col)
-    pub line_ending_indicator: Option<(u16, u16, u16)>,
-    /// Encoding indicator area (row, start_col, end_col)
-    pub encoding_indicator: Option<(u16, u16, u16)>,
-    /// Language indicator area (row, start_col, end_col)
-    pub language_indicator: Option<(u16, u16, u16)>,
-    /// Status message area (row, start_col, end_col) - clickable to show full history
-    pub message_area: Option<(u16, u16, u16)>,
-    /// Remote authority indicator area (row, start_col, end_col) - clickable
-    /// to open the remote-authority context menu.
-    pub remote_indicator: Option<(u16, u16, u16)>,
-    /// Workspace-trust indicator area (row, start_col, end_col) - clickable
-    /// to open the workspace-trust prompt.
-    pub trust_indicator: Option<(u16, u16, u16)>,
+    /// Every clickable built-in segment drawn this frame, as
+    /// `(id, row, start_col, end_col)`, in render order. One generic list
+    /// instead of a field per indicator — both hover hit-testing and click
+    /// dispatch walk it (see `StatusBarClickable`).
+    pub clickable: Vec<(StatusBarClickable, u16, u16, u16)>,
     /// Plugin-registered status-bar token areas, keyed by the
     /// `"<plugin_name>:<token_name>"` registry key (same key the
     /// editor uses in `status_bar_token_registry`). Populated by the
@@ -342,29 +360,6 @@ fn element_kind_name(kind: ElementKind) -> &'static str {
         ElementKind::Custom => "plugin",
         _ => "text",
     }
-}
-
-/// Status bar hover state for styling clickable indicators
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum StatusBarHover {
-    #[default]
-    None,
-    /// Mouse is over the LSP indicator
-    LspIndicator,
-    /// Mouse is over the warning badge
-    WarningBadge,
-    /// Mouse is over the line ending indicator
-    LineEndingIndicator,
-    /// Mouse is over the encoding indicator
-    EncodingIndicator,
-    /// Mouse is over the language indicator
-    LanguageIndicator,
-    /// Mouse is over the status message area
-    MessageArea,
-    /// Mouse is over the remote authority indicator
-    RemoteIndicator,
-    /// Mouse is over the workspace-trust indicator
-    WorkspaceTrust,
 }
 
 /// Which search option checkbox is being hovered
@@ -988,7 +983,7 @@ impl StatusBarRenderer {
                 }
                 Some(RenderedElement {
                     text: "[RO]".to_string(),
-                    kind: ElementKind::Normal,
+                    kind: ElementKind::ReadOnly,
                     token_key: None,
                 })
             }
@@ -1260,11 +1255,13 @@ impl StatusBarRenderer {
         }
     }
 
-    /// Get the style for a rendered element based on its kind, theme, and hover state.
+    /// Get the style for a rendered element based on its kind, theme, and
+    /// whether the mouse is currently over it (`is_hovering`, computed
+    /// generically by the caller from the element's `clickable_for_kind` id).
     fn element_style(
         kind: ElementKind,
         theme: &crate::view::theme::Theme,
-        hover: StatusBarHover,
+        is_hovering: bool,
         _warning_level: WarningLevel,
         lsp_state: LspIndicatorState,
     ) -> Style {
@@ -1276,7 +1273,6 @@ impl StatusBarRenderer {
                 .fg(theme.status_error_indicator_fg)
                 .bg(theme.status_error_indicator_bg),
             ElementKind::LineEnding => {
-                let is_hovering = hover == StatusBarHover::LineEndingIndicator;
                 let (fg, bg) = if is_hovering {
                     (theme.menu_hover_fg, theme.menu_hover_bg)
                 } else {
@@ -1289,7 +1285,6 @@ impl StatusBarRenderer {
                 style
             }
             ElementKind::Encoding => {
-                let is_hovering = hover == StatusBarHover::EncodingIndicator;
                 let (fg, bg) = if is_hovering {
                     (theme.menu_hover_fg, theme.menu_hover_bg)
                 } else {
@@ -1302,7 +1297,6 @@ impl StatusBarRenderer {
                 style
             }
             ElementKind::Language => {
-                let is_hovering = hover == StatusBarHover::LanguageIndicator;
                 let (fg, bg) = if is_hovering {
                     (theme.menu_hover_fg, theme.menu_hover_bg)
                 } else {
@@ -1314,8 +1308,19 @@ impl StatusBarRenderer {
                 }
                 style
             }
+            // The read-only indicator paints with the neutral status-bar
+            // palette and only underlines on hover, signalling it's clickable
+            // (opens the read-only menu) without breaking the bar's color band.
+            ElementKind::ReadOnly => {
+                let mut style = Style::default()
+                    .fg(theme.status_bar_fg)
+                    .bg(theme.status_bar_bg);
+                if is_hovering {
+                    style = style.add_modifier(Modifier::UNDERLINED);
+                }
+                style
+            }
             ElementKind::Lsp => {
-                let is_hovering = hover == StatusBarHover::LspIndicator;
                 // Color by LSP state:
                 //   Error  → diagnostic_error_*       (red-ish; problem)
                 //   Off    → status_lsp_actionable_*  (prominent; click to act)
@@ -1349,7 +1354,6 @@ impl StatusBarRenderer {
                 style
             }
             ElementKind::WarningBadge => {
-                let is_hovering = hover == StatusBarHover::WarningBadge;
                 let (fg, bg) = if is_hovering {
                     (
                         theme.status_warning_indicator_hover_fg,
@@ -1381,7 +1385,6 @@ impl StatusBarRenderer {
                 .fg(theme.status_bar_fg)
                 .bg(theme.status_bar_bg),
             ElementKind::RemoteIndicator(state) => {
-                let is_hovering = hover == StatusBarHover::RemoteIndicator;
                 let (fg, bg) = match state {
                     // Connecting and Connected share the "help
                     // indicator" palette so the transition from one to
@@ -1409,7 +1412,6 @@ impl StatusBarRenderer {
             }
             ElementKind::WorkspaceTrust(level) => {
                 use crate::services::workspace_trust::TrustLevel;
-                let is_hovering = hover == StatusBarHover::WorkspaceTrust;
                 let (fg, bg) = match level {
                     // Gated states reuse the warning indicator palette so
                     // "execution is restricted/blocked" reads at a glance.
@@ -1443,6 +1445,7 @@ impl StatusBarRenderer {
             | ElementKind::Custom
             | ElementKind::LineEnding
             | ElementKind::Encoding
+            | ElementKind::ReadOnly
             | ElementKind::Language => ("ui.status_bar_fg", "ui.status_bar_bg"),
             ElementKind::RemoteDisconnected => (
                 "ui.status_error_indicator_fg",
@@ -1487,12 +1490,35 @@ impl StatusBarRenderer {
         }
     }
 
-    /// Map a rendered element to the layout field(s) it should populate.
-    /// Built-in indicators get their dedicated `Option<(row, start_col,
-    /// end_col)>` slot. Plugin tokens (`ElementKind::Custom` carrying a
-    /// `token_key`) get an entry in `plugin_token_areas`, keyed by the
-    /// plugin's registry key — that's what `handle_click_status_bar`
-    /// uses to dispatch clicks back to the right plugin.
+    /// The clickable identity of an element kind, or `None` for static
+    /// (non-interactive) elements. This single mapping is what makes the click
+    /// + hover rail generic: it's the *only* place that decides whether a
+    /// built-in element is clickable. Plugin tokens are handled separately
+    /// (they dispatch a hook, not a core `Action`).
+    fn clickable_for_kind(kind: ElementKind) -> Option<StatusBarClickable> {
+        match kind {
+            ElementKind::LineEnding => Some(StatusBarClickable::LineEnding),
+            ElementKind::Encoding => Some(StatusBarClickable::Encoding),
+            ElementKind::Language => Some(StatusBarClickable::Language),
+            ElementKind::Lsp => Some(StatusBarClickable::Lsp),
+            ElementKind::WarningBadge => Some(StatusBarClickable::Warnings),
+            ElementKind::Messages => Some(StatusBarClickable::Messages),
+            ElementKind::RemoteIndicator(_) => Some(StatusBarClickable::RemoteIndicator),
+            ElementKind::WorkspaceTrust(_) => Some(StatusBarClickable::WorkspaceTrust),
+            ElementKind::ReadOnly => Some(StatusBarClickable::ReadOnly),
+            ElementKind::Normal
+            | ElementKind::RemoteDisconnected
+            | ElementKind::Update
+            | ElementKind::Palette
+            | ElementKind::Clock
+            | ElementKind::Custom => None,
+        }
+    }
+
+    /// Record an element's screen area for click/hover dispatch. Clickable
+    /// built-ins land in the generic `clickable` list keyed by their
+    /// `StatusBarClickable` id; plugin tokens (`ElementKind::Custom` carrying a
+    /// `token_key`) land in `plugin_token_areas` keyed by their registry key.
     fn update_layout_for_element(
         layout: &mut StatusBarLayout,
         kind: ElementKind,
@@ -1501,29 +1527,15 @@ impl StatusBarRenderer {
         start_col: u16,
         end_col: u16,
     ) {
-        match kind {
-            ElementKind::LineEnding => {
-                layout.line_ending_indicator = Some((row, start_col, end_col))
+        if let Some(id) = Self::clickable_for_kind(kind) {
+            layout.clickable.push((id, row, start_col, end_col));
+        }
+        if kind == ElementKind::Custom {
+            if let Some(key) = token_key {
+                layout
+                    .plugin_token_areas
+                    .insert(key.to_string(), (row, start_col, end_col));
             }
-            ElementKind::Encoding => layout.encoding_indicator = Some((row, start_col, end_col)),
-            ElementKind::Language => layout.language_indicator = Some((row, start_col, end_col)),
-            ElementKind::Lsp => layout.lsp_indicator = Some((row, start_col, end_col)),
-            ElementKind::WarningBadge => layout.warning_badge = Some((row, start_col, end_col)),
-            ElementKind::Messages => layout.message_area = Some((row, start_col, end_col)),
-            ElementKind::RemoteIndicator(_) => {
-                layout.remote_indicator = Some((row, start_col, end_col))
-            }
-            ElementKind::WorkspaceTrust(_) => {
-                layout.trust_indicator = Some((row, start_col, end_col))
-            }
-            ElementKind::Custom => {
-                if let Some(key) = token_key {
-                    layout
-                        .plugin_token_areas
-                        .insert(key.to_string(), (row, start_col, end_col));
-                }
-            }
-            _ => {}
         }
     }
 
@@ -1534,10 +1546,12 @@ impl StatusBarRenderer {
     fn element_spans(
         rendered: &RenderedElement,
         theme: &crate::view::theme::Theme,
-        hover: StatusBarHover,
+        hovered: Option<StatusBarClickable>,
         warning_level: WarningLevel,
         lsp_state: LspIndicatorState,
     ) -> (Vec<Span<'static>>, usize) {
+        let is_hovering =
+            Self::clickable_for_kind(rendered.kind).is_some_and(|c| Some(c) == hovered);
         let base_style = Style::default()
             .fg(theme.status_bar_fg)
             .bg(theme.status_bar_bg);
@@ -1576,7 +1590,8 @@ impl StatusBarRenderer {
             );
         }
 
-        let style = Self::element_style(rendered.kind, theme, hover, warning_level, lsp_state);
+        let style =
+            Self::element_style(rendered.kind, theme, is_hovering, warning_level, lsp_state);
         let mut spans = vec![Span::styled(" ", style)];
         if rendered.kind == ElementKind::Clock {
             // "HH:MM" — blink the colon via terminal hardware (SGR 5)
@@ -1610,7 +1625,7 @@ impl StatusBarRenderer {
             .collect();
 
         let theme = ctx.theme;
-        let hover = ctx.hover;
+        let hovered = ctx.hovered;
         let warning_level = ctx.warning_level;
         let lsp_state = ctx.lsp_indicator_state;
         rendered
@@ -1619,7 +1634,7 @@ impl StatusBarRenderer {
                 let kind = r.kind;
                 let token_key = r.token_key.clone();
                 let (spans, width) =
-                    Self::element_spans(&r, theme, hover, warning_level, lsp_state);
+                    Self::element_spans(&r, theme, hovered, warning_level, lsp_state);
                 (spans, width, kind, token_key)
             })
             .collect()
@@ -1802,10 +1817,12 @@ impl StatusBarRenderer {
                 let group_text: String = item_spans.iter().map(|s| s.content.as_ref()).collect();
                 let truncated = truncate_to_width(&group_text, remaining);
                 let truncated_width = str_width(&truncated);
+                let overflow_is_hovering =
+                    Self::clickable_for_kind(kind).is_some_and(|c| Some(c) == ctx.hovered);
                 let overflow_style = Self::element_style(
                     kind,
                     ctx.theme,
-                    ctx.hover,
+                    overflow_is_hovering,
                     ctx.warning_level,
                     ctx.lsp_indicator_state,
                 );
@@ -2489,7 +2506,7 @@ mod tests {
         let palette_style = StatusBarRenderer::element_style(
             ElementKind::Palette,
             &theme,
-            StatusBarHover::None,
+            false,
             WarningLevel::None,
             LspIndicatorState::None,
         );
@@ -2499,7 +2516,7 @@ mod tests {
         let lsp_on_style = StatusBarRenderer::element_style(
             ElementKind::Lsp,
             &theme,
-            StatusBarHover::None,
+            false,
             WarningLevel::None,
             LspIndicatorState::On,
         );
@@ -2511,7 +2528,7 @@ mod tests {
         let lsp_off_style = StatusBarRenderer::element_style(
             ElementKind::Lsp,
             &theme,
-            StatusBarHover::None,
+            false,
             WarningLevel::None,
             LspIndicatorState::Off,
         );
@@ -2521,7 +2538,7 @@ mod tests {
         let lsp_error_style = StatusBarRenderer::element_style(
             ElementKind::Lsp,
             &theme,
-            StatusBarHover::None,
+            false,
             WarningLevel::None,
             LspIndicatorState::Error,
         );

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -976,6 +976,22 @@ impl StatusBarRenderer {
                     token_key: None,
                 })
             }
+            StatusBarElement::ReadOnly => {
+                // Persistent `[RO]` indicator. Renders only while the active
+                // buffer is read-only, as a steady status segment — the
+                // documented affordance that tells the user editing is
+                // disabled *before* they try to type. Independent of the
+                // `{filename}` element (which also carries `[RO]` but is
+                // omitted from the default layout).
+                if !ctx.read_only {
+                    return None;
+                }
+                Some(RenderedElement {
+                    text: "[RO]".to_string(),
+                    kind: ElementKind::Normal,
+                    token_key: None,
+                })
+            }
             StatusBarElement::Cursor => {
                 if !ctx.state.show_cursors {
                     return None;

--- a/crates/fresh-editor/tests/e2e/auto_read_only.rs
+++ b/crates/fresh-editor/tests/e2e/auto_read_only.rs
@@ -162,6 +162,79 @@ fn test_editable_buffer_has_no_ro_status_indicator() {
     );
 }
 
+/// Locate a substring on the rendered screen, returning `(col, row)` of its
+/// first character. Columns are counted as grapheme cells (the status bar is
+/// ASCII here, so char count == display column).
+fn find_on_screen(screen: &str, needle: &str) -> Option<(u16, u16)> {
+    for (row, line) in screen.lines().enumerate() {
+        if let Some(byte_idx) = line.find(needle) {
+            let col = line[..byte_idx].chars().count();
+            return Some((col as u16, row as u16));
+        }
+    }
+    None
+}
+
+/// Clicking the `[RO]` indicator opens the read-only menu, and choosing
+/// "Enable editing" makes the buffer editable (issue #2309 follow-up). Drives
+/// a real mouse click + keypress and asserts only on rendered output.
+#[test]
+fn test_read_only_indicator_click_opens_menu_and_enables_editing() {
+    use crossterm::event::{KeyCode, KeyModifiers};
+
+    let temp_dir = TempDir::new().unwrap();
+    let lib_dir = temp_dir.path().join("node_modules").join("somelib");
+    std::fs::create_dir_all(&lib_dir).unwrap();
+    let ro_file = lib_dir.join("index.js");
+    std::fs::write(&ro_file, "library content\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        24,
+        Config::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&ro_file).unwrap();
+    harness.render().unwrap();
+
+    // The indicator is on the status bar; find it and click it.
+    let screen = harness.screen_to_string();
+    let (ro_col, ro_row) =
+        find_on_screen(&screen, READ_ONLY_INDICATOR).expect("[RO] indicator should be visible");
+    harness.mouse_click(ro_col + 1, ro_row).unwrap();
+    harness.render().unwrap();
+
+    // The read-only menu should be open with an "Enable editing" action.
+    harness.assert_screen_contains("Enable editing");
+
+    // Confirm the (pre-selected) "Enable editing" row.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Editing is now enabled: the [RO] indicator is gone and typed text lands.
+    harness.type_text("ZZTYPEDZZ").unwrap();
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("ZZTYPEDZZ"),
+        "After enabling editing from the [RO] menu, typing should work. Screen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains(EDITING_DISABLED_MSG),
+        "Editing should no longer be disabled after the menu enabled it. Screen:\n{}",
+        screen
+    );
+    assert!(
+        !screen.contains(READ_ONLY_INDICATOR),
+        "[RO] indicator should disappear once editing is enabled. Screen:\n{}",
+        screen
+    );
+}
+
 /// A file in a library directory (node_modules) opens read-only by default.
 #[test]
 fn test_library_file_opens_read_only_by_default() {

--- a/crates/fresh-editor/tests/e2e/auto_read_only.rs
+++ b/crates/fresh-editor/tests/e2e/auto_read_only.rs
@@ -20,6 +20,9 @@ use std::os::unix::fs::PermissionsExt;
 
 const EDITING_DISABLED_MSG: &str = "Editing disabled in this buffer";
 
+/// Persistent read-only indicator rendered in the status bar (issue #2309).
+const READ_ONLY_INDICATOR: &str = "[RO]";
+
 /// A file without write permission opens read-only by default: keystrokes are
 /// dropped and the "editing disabled" status message appears.
 #[test]
@@ -98,6 +101,63 @@ fn test_auto_read_only_disabled_opens_unwritable_file_editable() {
     assert!(
         !screen.contains(EDITING_DISABLED_MSG),
         "No editing-disabled message expected when auto_read_only is off. Screen:\n{}",
+        screen
+    );
+}
+
+/// A read-only buffer shows the persistent `[RO]` status-bar indicator, while
+/// an editable buffer does not (issue #2309). The indicator is its own status
+/// segment — it must appear in the default layout, which omits `{filename}`.
+#[test]
+fn test_read_only_buffer_shows_ro_status_indicator() {
+    let temp_dir = TempDir::new().unwrap();
+
+    // Library file: opens read-only by default.
+    let lib_dir = temp_dir.path().join("node_modules").join("somelib");
+    std::fs::create_dir_all(&lib_dir).unwrap();
+    let ro_file = lib_dir.join("index.js");
+    std::fs::write(&ro_file, "library content\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        24,
+        Config::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&ro_file).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains(READ_ONLY_INDICATOR),
+        "Read-only buffer should show a persistent [RO] status indicator. Screen:\n{}",
+        screen
+    );
+}
+
+/// An editable buffer shows no `[RO]` indicator (issue #2309): the segment is
+/// only present while the buffer is actually read-only.
+#[test]
+fn test_editable_buffer_has_no_ro_status_indicator() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("editable.txt");
+    std::fs::write(&file_path, "editable content\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        160,
+        24,
+        Config::default(),
+        temp_dir.path().to_path_buf(),
+    )
+    .unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains(READ_ONLY_INDICATOR),
+        "Editable buffer should not show the [RO] status indicator. Screen:\n{}",
         screen
     );
 }


### PR DESCRIPTION
## Summary

Fixes #2309.

Read-only buffers are documented to show a `[RO]` status-bar indicator (`docs/features/editing.md`, the 0.2.18 blog post), but no such indicator was ever rendered. Read-only state was communicated only through transient one-shot messages (`Editing disabled in this buffer`), so a user opening a read-only file got **no standing cue** — they discovered the buffer was read-only only by typing and having the edit silently rejected.

This PR lands in three commits:

### 1. Add the persistent `{read_only}` indicator

The `[RO]` text was emitted **only** as part of the `{filename}` status-bar element — but the default layout **intentionally omits `{filename}`** (the file is already in the tab bar), so the indicator's only host wasn't present and `[RO]` never appeared. The underlying read-only *behavior* (auto read-only on library paths, binary files, Toggle Read-Only Mode) was correct; only the indicator was missing.

Adds a dedicated `{read_only}` status-bar element that renders a steady `[RO]` segment whenever the active buffer is read-only (independent of `{filename}`, and rendering nothing when editable — like `{warnings}`/`{update}`). It's placed at the head of the default right cluster so the documented indicator appears out of the box, and is exposed in the settings dual-list and config schema so users can move or remove it.

### 2. Generic clickable-segment rail (refactor)

Making a built-in indicator clickable previously meant touching ~12 places across six files (a dedicated `StatusBarLayout` field, a chrome area field, a `HoverTarget` variant, the mouse-move detective's indicator array, a `HoverTarget → StatusBarHover` map line, a `StatusBarHover` variant, an `element_style` hover arm, a click branch, …). Only plugin tokens had a generic rail.

This commit introduces one generic rail and migrates **all** core indicators (line ending, encoding, language, LSP, warnings, messages, remote, trust) onto it:

- `StatusBarClickable` ids each clickable segment; `StatusBarRenderer::clickable_for_kind` is the *single* place that decides whether a kind is clickable. The renderer records each one's screen area in a single `StatusBarLayout.clickable` list (chrome mirrors it).
- Hover and click are now **one hit-test each** over that list. Hover styling flows through a single `HoverTarget::StatusBarClickable(id)` + an `is_hovering: bool` into `element_style` — the per-element `StatusBarHover` enum and the eight per-indicator chrome area fields are **deleted**.
- The id → `Action` mapping lives in one match (`dispatch_status_bar_click`), preserving each segment's popup-dismiss nuance (LSP/remote own their toggle).

Adding a clickable element is now: give it an `ElementKind`, list it in `clickable_for_kind`, and add one dispatch arm.

### 3. Make `[RO]` clickable → read-only menu

Clicking `[RO]` opens a small popup anchored to the segment — **"Read-only buffer"** → **Enable editing** / **Cancel** — modeled on the existing remote/LSP menus. "Enable editing" dispatches `Action::ToggleReadOnly`. Adds `Action::ShowReadOnlyMenu`, `PopupResolver::ReadOnly`, the popup builder, and locale keys for all 14 locales.

## Testing
- New e2e tests (rendered-output only, per CONTRIBUTING): `[RO]` shown for a read-only buffer and absent for an editable one; a **real mouse click** on `[RO]` opens the menu and "Enable editing" makes the buffer editable. The indicator tests fail without the fix and pass with it (verified by temporarily removing the element from the default layout).
- Existing indicator click/hover suites (`lsp_indicator_click*`, `mouse`, `status_bar_config`, `warning_indicators`, `audit_mode`, workspace-trust) cover the migrated segments; full lib unit tests (2760) green.
- `cargo fmt` / `cargo clippy` clean; config schema regenerated and matches CI's `generate_schema`.
- **Manual validation** (tmux): a read-only library file renders `… [RO]  LF  ASCII  JavaScript …` as a steady segment; clicking `[RO]` opens the anchored "Read-only buffer" popup; choosing **Enable editing** clears the `[RO]` segment and typing then works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xptdt92shjjon5YYJQK1M7