### PR TITLE
fix(indent): apply per-language [languages.&lt;id&gt;.indent] config rules

### DIFF
--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -590,12 +590,30 @@ fn byte_is_code(state: &EditorState, pos: usize) -> bool {
     )
 }
 
+/// Resolve the per-language regex indentation rules for a buffer that has no
+/// tree-sitter grammar.
+///
+/// A user-supplied `[languages.<id>.indent]` override is registered under the
+/// buffer's *config* language id (`state.language`), which the syntax-name
+/// lookup can never resolve for a config-only language with no grammar (e.g. a
+/// user-defined filetype). So those explicit overrides are consulted first, by
+/// config id. Everything else defers to the existing syntect-syntax-name path,
+/// which keeps built-in languages on their established tiering (notably letting
+/// curly-brace languages fall through to the C-style bracket scanner). Returns
+/// `None` when no rules exist either way so the caller can fall back.
+fn buffer_indent_rules(
+    state: &EditorState,
+) -> Option<std::sync::Arc<crate::primitives::indent_rules::IndentRules>> {
+    crate::primitives::indent_rules::user_rule_for_id(&state.language).or_else(|| {
+        crate::primitives::indent_rules::rules_for_syntax_name(state.highlighter.syntax_name()?)
+    })
+}
+
 /// Try the per-language regex indentation rules for a buffer that has no
-/// tree-sitter grammar, keyed by the syntect syntax name. Returns `None` when
-/// no rules exist for the language so the caller can fall back.
+/// tree-sitter grammar. Returns `None` when no rules exist for the language so
+/// the caller can fall back.
 fn rules_indent(state: &EditorState, position: usize, tab_size: usize) -> Option<usize> {
-    let rules =
-        crate::primitives::indent_rules::rules_for_syntax_name(state.highlighter.syntax_name()?)?;
+    let rules = buffer_indent_rules(state)?;
     Some(
         rules.calculate_indent(&state.buffer, position, tab_size, |b| {
             byte_is_code(state, b)
@@ -605,8 +623,7 @@ fn rules_indent(state: &EditorState, position: usize, tab_size: usize) -> Option
 
 /// Closing-delimiter variant of [`rules_indent`].
 fn rules_dedent(state: &EditorState, position: usize, ch: char, tab_size: usize) -> Option<usize> {
-    let rules =
-        crate::primitives::indent_rules::rules_for_syntax_name(state.highlighter.syntax_name()?)?;
+    let rules = buffer_indent_rules(state)?;
     rules.calculate_dedent_for_delimiter(&state.buffer, position, ch, tab_size, |b| {
         byte_is_code(state, b)
     })

--- a/crates/fresh-editor/src/primitives/indent_rules.rs
+++ b/crates/fresh-editor/src/primitives/indent_rules.rs
@@ -260,11 +260,25 @@ fn matches(re: &Option<Regex>, text: &str) -> bool {
 /// family. Returns `None` when neither exists, so the caller falls back to the
 /// generic bracket heuristic.
 pub fn rules_for_id(id: &str) -> Option<Arc<IndentRules>> {
-    if let Some(rules) = USER_RULES.read().unwrap().get(id) {
-        return Some(rules.clone());
+    if let Some(rules) = user_rule_for_id(id) {
+        return Some(rules);
     }
     let family = family_for_id(id)?;
     FAMILY_RULES.get(&family).cloned()
+}
+
+/// Look up *only* a user override registered via [`set_user_rule`] for `id`,
+/// ignoring the built-in family fallback.
+///
+/// This is what connects a `[languages.<id>.indent]` block to the editor: a
+/// config-only language (no syntect grammar / no tree-sitter) is keyed by its
+/// config id, which the syntax-name-based lookup can never resolve. Callers that
+/// want *only* the user's explicit rules — and must otherwise defer to the
+/// existing tiering (e.g. the C-style bracket scanner for curly-brace
+/// languages) — use this rather than [`rules_for_id`], whose family fallback
+/// would shadow that tiering.
+pub fn user_rule_for_id(id: &str) -> Option<Arc<IndentRules>> {
+    USER_RULES.read().unwrap().get(id).cloned()
 }
 
 /// Look up rules from a syntect display name (e.g. `"C++"`, `"C#"`,

--- a/crates/fresh-editor/tests/e2e/auto_indent.rs
+++ b/crates/fresh-editor/tests/e2e/auto_indent.rs
@@ -1,6 +1,6 @@
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use crossterm::event::{KeyCode, KeyModifiers};
-use fresh::config::Config;
+use fresh::config::{Config, LanguageConfig};
 use tempfile::TempDir;
 
 /// Helper to create a harness with auto-indent enabled
@@ -2129,5 +2129,94 @@ fn test_dart_auto_dedent_closing_brace_top_level() {
         leading_spaces, 0,
         "Dart top-level closing brace should dedent to column 0, got {}. Content:\n{}",
         leading_spaces, content
+    );
+}
+
+/// Build a harness with auto-indent enabled and the given `[languages.<id>]`
+/// entries registered from JSON. Mirrors production config loading: the
+/// languages flow through `reload_indent_overrides`, so any `indent` block is
+/// registered under its config id — exactly the path #2314 exercises.
+fn harness_with_languages(languages: &[(&str, &str)]) -> EditorTestHarness {
+    let mut config = Config::default();
+    config.editor.auto_indent = true;
+    for (id, json) in languages {
+        let lang: LanguageConfig = serde_json::from_str(json).expect("valid LanguageConfig JSON");
+        config.languages.insert((*id).to_string(), lang);
+    }
+    EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap()
+}
+
+/// Regression for #2314: a user-defined language's `increase_indent_pattern`
+/// must indent the following line. The rule is registered under the config id
+/// (`incend`), but before the fix the auto-indent lookup keyed only off the
+/// syntect syntax name — which a config-only language with no grammar never has
+/// — so the pattern was ignored and the new line merely copied the previous
+/// line's indent (here: column 0).
+#[test]
+fn test_config_increase_indent_pattern_applies() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.t1");
+    // `OPEN` is a non-bracket, non-colon token so it can only match the custom
+    // rule, never Fresh's built-in bracket/colon heuristics.
+    std::fs::write(&file_path, "foo OPEN").unwrap();
+
+    let mut harness = harness_with_languages(&[(
+        "incend",
+        r#"{"extensions":["t1"],"tab_size":4,"use_tabs":false,"indent":{"increase_indent_pattern":"OPEN\\s*$"}}"#,
+    )]);
+    harness.open_file(&file_path).unwrap();
+
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_buffer_content("foo OPEN");
+
+    // Enter then type — the new line should be one level (4 spaces) deeper.
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("child").unwrap();
+    harness.render().unwrap();
+
+    let content = harness.get_buffer_content().unwrap();
+    assert_eq!(
+        content, "foo OPEN\n    child",
+        "increase_indent_pattern should indent the new line one level; got: {:?}",
+        content
+    );
+}
+
+/// Regression for #2314: a user-defined language's `indent_next_line_pattern`
+/// (a one-shot indent) must also take effect through the config-id lookup.
+#[test]
+fn test_config_indent_next_line_pattern_applies() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.t4");
+    std::fs::write(&file_path, "HDR thing").unwrap();
+
+    let mut harness = harness_with_languages(&[(
+        "indnext",
+        r#"{"extensions":["t4"],"tab_size":4,"use_tabs":false,"indent":{"indent_next_line_pattern":"^\\s*HDR\\b"}}"#,
+    )]);
+    harness.open_file(&file_path).unwrap();
+
+    harness
+        .send_key(KeyCode::End, KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_buffer_content("HDR thing");
+
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("body").unwrap();
+    harness.render().unwrap();
+
+    let content = harness.get_buffer_content().unwrap();
+    assert_eq!(
+        content, "HDR thing\n    body",
+        "indent_next_line_pattern should indent the immediately following line; got: {:?}",
+        content
     );
 }


### PR DESCRIPTION
## Summary

Fixes #2314. The 0.4.0 headline feature *"Configurable indentation rules per language via `[languages.<id>.indent]`"* had no effect — none of the five `indent` patterns took effect for a custom language, and auto-indentation fell back to the built-in heuristics.

## Root cause

A user's `indent` block is registered into the indentation engine under the **config language id** (e.g. `incend`) by `reload_indent_overrides` → `set_user_rule`. But the auto-indent code (`rules_indent` / `rules_dedent` in `input/actions.rs`) looked rules up **only** via `rules_for_syntax_name(highlighter.syntax_name())`.

A config-only language has no syntect grammar, so its syntax name never resolves to that config id — the registered override was simply never found. The buffer *does* know its config id (`state.language`, shown in the status bar as `incend`); it just wasn't used for the indent lookup.

## Fix

Resolve a user's explicit override by the buffer's config language id **first**, then defer to the existing syntax-name lookup:

- New `indent_rules::user_rule_for_id` — looks up *only* a user-registered rule (no built-in family fallback).
- `buffer_indent_rules` in `actions.rs` consults `user_rule_for_id(state.language)`, then falls back to `rules_for_syntax_name(...)`.

This is deliberately scoped to **explicit user rules**, so built-in languages keep their established tiering. In particular, curly-brace languages (e.g. Dart, C++) still fall through to the C-style **bracket scanner** for closing-delimiter dedents — which handles nesting correctly — rather than the weaker single-line family regex. (An earlier, broader version that resolved *any* rule by config id regressed `test_dart_auto_dedent_closing_brace`; the user-rule-only scoping avoids that.)

## Testing

- **New e2e regression tests** (`tests/e2e/auto_indent.rs`) for a config-defined language:
  - `test_config_increase_indent_pattern_applies` — `increase_indent_pattern` indents the next line.
  - `test_config_indent_next_line_pattern_applies` — one-shot `indent_next_line_pattern`.
  - Both **fail before** the change (new line not indented) and **pass after**.
- Full `auto_indent` + `indent_dedent` e2e suites pass (81 tests), all `indent` unit tests pass (84 tests) — no regressions, including the Dart dedent cases.
- `cargo fmt --check` clean; `cargo clippy` introduces no new warnings on the changed files.
- **Manual validation** in tmux against the debug `fresh` binary, using the issue's exact reproduction (`.fresh/config.json` with `incend` + `increase_indent_pattern`): typing `foo OPEN`, Enter, `child` now produces `    child` (4-space indent); status bar confirms filetype `incend`.

https://claude.ai/code/session_019fsgTYxPyw4SsLe46MyteP

---
_Generated by [Claude Code](https://claude.ai/code/session_019fsgTYxPyw4SsLe46MyteP)_