### PR TITLE
fix(themes): theme-appropriate occurrence-highlight color in every theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* Occurrence highlighting now uses a theme-appropriate background in every shipped theme; the `dracula`, `nord`, and `solarized-dark` themes no longer fall back to a hard-wired dark color that clashed with their palette (#2312).
 * Windows: the TUI attaches to the parent process's stdio instead of failing in `-gui` builds (#2276, reported and fixed by @mokurin000 in #2277).
 * Right-side status bar elements render with configurable separators (#2088, reported and fixed by @PavelLoparev), and cursor column numbers are grapheme-correct (#2090, reported and fixed by @PavelLoparev).
 * Scroll panels compute focus offsets from the render width when a scrollbar is present (#2175, by @masmu).

--- a/crates/fresh-editor/src/view/theme/types.rs
+++ b/crates/fresh-editor/src/view/theme/types.rs
@@ -3065,4 +3065,47 @@ mod tests {
             }
         }
     }
+
+    /// Regression for #2312: occurrence highlighting must use a
+    /// theme-appropriate background in *every* shipped theme. A theme that
+    /// omits `ui.semantic_highlight_bg` silently inherits the global default
+    /// (a fixed dark color), which is invisible on dark high-contrast themes
+    /// and an inverted block on light themes. Each builtin must therefore
+    /// either define its own highlight color or opt into a modifier-only
+    /// highlight (e.g. `reversed`/`bold`), and the resulting highlight must be
+    /// visibly distinct from the editor background.
+    #[test]
+    fn test_all_builtin_themes_define_visible_occurrence_highlight() {
+        for builtin in BUILTIN_THEMES {
+            let raw: serde_json::Value = serde_json::from_str(builtin.json)
+                .unwrap_or_else(|e| panic!("Theme '{}' is not valid JSON: {}", builtin.name, e));
+            let ui = raw.get("ui").and_then(|u| u.as_object());
+            let has_bg = ui.is_some_and(|u| u.contains_key("semantic_highlight_bg"));
+            let has_modifier = ui.is_some_and(|u| u.contains_key("semantic_highlight_modifier"));
+            assert!(
+                has_bg || has_modifier,
+                "Theme '{}' must explicitly define `ui.semantic_highlight_bg` (or a \
+                 `semantic_highlight_modifier`) so occurrence highlighting is theme-appropriate \
+                 instead of falling back to the hard-wired global default (#2312)",
+                builtin.name
+            );
+
+            let theme = Theme::from_json(builtin.json)
+                .unwrap_or_else(|e| panic!("Theme '{}' failed to parse: {}", builtin.name, e));
+            // When the highlight relies purely on a color (no SGR modifier such
+            // as reversed/bold to make it stand out), that color must differ
+            // from the editor background, otherwise the highlight is invisible.
+            if theme
+                .modifier_for_bg_key("ui.semantic_highlight_bg")
+                .is_empty()
+            {
+                assert_ne!(
+                    theme.semantic_highlight_bg, theme.editor_bg,
+                    "Theme '{}': occurrence-highlight background equals the editor background \
+                     (highlight would be invisible) and no modifier compensates (#2312)",
+                    builtin.name
+                );
+            }
+        }
+    }
 }

--- a/crates/fresh-editor/themes/dracula.json
+++ b/crates/fresh-editor/themes/dracula.json
@@ -22,6 +22,7 @@
     "bracket_rainbow_6": [189, 147, 249]
   },
   "ui": {
+    "semantic_highlight_bg": [68, 71, 90],
     "tab_active_fg": [248, 248, 242],
     "tab_active_bg": [189, 147, 249],
     "tab_inactive_fg": [248, 248, 242],

--- a/crates/fresh-editor/themes/nord.json
+++ b/crates/fresh-editor/themes/nord.json
@@ -18,6 +18,7 @@
     "bracket_rainbow_6": [180, 142, 173]
   },
   "ui": {
+    "semantic_highlight_bg": [67, 76, 94],
     "tab_active_fg": [236, 239, 244],
     "tab_active_bg": [67, 76, 94],
     "tab_inactive_fg": [216, 222, 233],

--- a/crates/fresh-editor/themes/solarized-dark.json
+++ b/crates/fresh-editor/themes/solarized-dark.json
@@ -18,6 +18,7 @@
     "bracket_rainbow_6": [203, 75, 22]
   },
   "ui": {
+    "semantic_highlight_bg": [7, 54, 66],
     "tab_active_fg": [253, 246, 227],
     "tab_active_bg": [38, 139, 210],
     "tab_inactive_fg": [131, 148, 150],


### PR DESCRIPTION
Fixes #2312.

## Problem

Occurrence highlighting (the word-under-cursor highlight, #2154) paints its background from the theme key `ui.semantic_highlight_bg`. That value is wired through correctly (`overlays.rs` passes `theme.semantic_highlight_bg`), but **three shipped themes never defined the key** — `dracula`, `nord`, and `solarized-dark` — so they silently inherited the global serde default, a fixed `[60, 60, 80]` dark box.

This is the core complaint in #2312: *"the highlight color is hard-wired rather than theme-derived; it only looks correct on dark themes."* On these palettes the highlight reads as an out-of-place blue-gray block rather than a theme-native tint, and the same hard-wired fallback would be invisible (on a dark high-contrast theme) or an inverted block (on a light theme) for any future theme that forgot the key.

Note: the `dark`, `light`, and `high-contrast` themes the issue specifically tested **already** define appropriate values in the current tree, so the originally-reported breakage on those three no longer reproduces — this PR closes the remaining gap and guards against regressions.

## Fix

Give each of the three themes its own theme-native subtle surface color:

| Theme | `editor.bg` | new `semantic_highlight_bg` | source |
|-------|-------------|------------------------------|--------|
| dracula | `[40,42,54]` | `[68,71,90]` | Dracula `#44475a` (current line / selection) |
| nord | `[46,52,64]` | `[67,76,94]` | Nord `nord2` `#434c5e` (its own selection color) |
| solarized-dark | `[0,43,54]` | `[7,54,66]` | Solarized `base02` `#073642` (its highlight background) |

Each is the scheme's canonical secondary background, so the highlight is a subtle, legible tint that matches the theme — and each is visibly distinct from that theme's editor background.

## Test

Added `test_all_builtin_themes_define_visible_occurrence_highlight` (mirrors the existing `test_all_builtin_themes_have_file_status_colors`): every builtin theme must explicitly define `ui.semantic_highlight_bg` (or opt into a `semantic_highlight_modifier`), and the resulting highlight must differ from the editor background unless a modifier compensates. The test **fails without** the theme changes (panics on `dracula`) and **passes with** them.

## Manual validation

Built the binary and drove it in tmux on a Python file with a repeated word; switched themes via the command palette and captured the occurrence-highlight background with `tmux capture-pane -e`:

```
THEME nord           -> 48;2;67;76;94m   (was 60;60;80)
THEME dracula        -> 48;2;68;71;90m   (was 60;60;80)
THEME solarized-dark -> 48;2;7;54;66m    (was 60;60;80)
THEME high-contrast  -> 48;2;0;25;55m    (already correct)
THEME light          -> 48;2;220;230;240m (already correct)
```

`cargo fmt`, `cargo test -p fresh-editor --lib view::theme` (41 passed), and `cargo clippy` are clean for the change (no new warnings).

---
_Generated by [Claude Code](https://claude.ai/code/session_015jif6VJZ9QHtKTjys8vZFq)_