### PR TITLE
fix(review-diff): line-level stage/unstage/discard works beyond the first file (#2317)

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -2778,15 +2778,15 @@ function selectionLineRange(): { hunk: Hunk; range: { start: number; end: number
     const sel = state.lineSelection;
     const hunk = state.hunks.find(h => h.id === sel.hunkId);
     if (!hunk) return null;
-    // Find the row of this hunk's header in the unified stream.
-    const hunkIdx = state.hunks.indexOf(hunk);
-    let visibleIdx = 0;
-    for (let i = 0; i < hunkIdx; i++) {
-        const h = state.hunks[i];
-        if (state.collapsedFiles.has(fileKeyOf(h.file, h.gitStatus || 'unstaged'))) continue;
-        visibleIdx++;
-    }
-    const headerRow = state.hunkHeaderRows[visibleIdx];
+    // Row of this hunk's header in the unified stream. `hunkRowByHunkId` is
+    // populated for exactly the hunks emitted in the current render, keyed by
+    // id — so it stays correct regardless of focus mode (which paints only the
+    // focused file's body), collapsed files, or staged/unstaged section order.
+    // The previous approach counted hunks across *all* files to index
+    // `hunkHeaderRows`, which overshot whenever the focused hunk wasn't the
+    // first one rendered (e.g. a line in the second file), yielding a null
+    // range and the spurious "no add/remove lines" error.
+    const headerRow = state.hunkRowByHunkId[hunk.id];
     if (headerRow === undefined) return null;
 
     const lo = Math.min(sel.startRow, sel.endRow);

--- a/crates/fresh-editor/tests/e2e/plugins/mod.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/mod.rs
@@ -56,6 +56,7 @@ pub mod plugin_config_registration;
 pub mod plugin_keybinding_execution;
 pub mod plugins_dir_in_working_dir;
 pub mod review_diff_hunk_parity;
+pub mod review_diff_line_staging;
 pub mod review_diff_ux_bugs;
 pub mod tab_actions;
 pub mod terminal_hooks;

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -1,0 +1,429 @@
+//! E2E tests for Review Diff line-level visual staging / unstaging / discard
+//! (issue #2317).
+//!
+//! The feature's own help bar advertises `Visual: j/k extend, s/u/d apply`,
+//! and the docs promise "a line-level visual selection on the cursor row".
+//! These tests drive that exact path: put the cursor on a real added line,
+//! press `v` to start a visual selection, then `s`/`u`/`d`, and assert the
+//! git index/worktree actually changed.
+//!
+//! All assertions observe rendered screen output and real `git` state only.
+
+use crate::common::git_test_helper::{git_command, GitTestRepo};
+use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
+use crate::common::tracing::init_tracing_from_env;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+fn setup_audit_mode_plugin(repo: &GitTestRepo) {
+    let plugins_dir = repo.path.join("plugins");
+    fs::create_dir_all(&plugins_dir).expect("create plugins dir");
+    copy_plugin(&plugins_dir, "audit_mode");
+    copy_plugin_lib(&plugins_dir);
+}
+
+/// A repo with one committed file and a single appended line in the working
+/// tree — exactly the reproduction from issue #2317.
+fn repo_with_one_added_line() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("README.md", "# Calc\nA tiny calculator.\n");
+    repo.git_add_all();
+    repo.git_commit("initial");
+    // One unstaged "+extra line" addition.
+    fs::write(
+        repo.path.join("README.md"),
+        "# Calc\nA tiny calculator.\nextra line\n",
+    )
+    .unwrap();
+    repo
+}
+
+fn harness_for(repo: &GitTestRepo) -> EditorTestHarness {
+    EditorTestHarness::with_config_and_working_dir(160, 44, Config::default(), repo.path.clone())
+        .unwrap()
+}
+
+fn open_review_diff(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Review Diff").unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            if s.contains("TypeError") || s.contains("Error:") {
+                panic!("Error loading review diff. Screen:\n{}", s);
+            }
+            s.contains("next hunk")
+        })
+        .unwrap();
+}
+
+/// Parse the `Ln N` indicator from the status bar (the diff buffer's
+/// 1-indexed cursor line).
+fn status_line_number(harness: &EditorTestHarness) -> Option<usize> {
+    let screen = harness.screen_to_string();
+    for line in screen.lines() {
+        if let Some(idx) = line.find("Ln ") {
+            let rest = &line[idx + 3..];
+            let num: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+            if let Ok(n) = num.parse::<usize>() {
+                return Some(n);
+            }
+        }
+    }
+    None
+}
+
+/// Find the diff-buffer line number whose rendered center-panel row contains
+/// `needle`. The center diff panel starts at a fixed screen row, so the
+/// buffer line is `screen_row - CENTER_FIRST_ROW + 1`.
+const CENTER_FIRST_ROW: usize = 7;
+fn diff_line_of(harness: &mut EditorTestHarness, needle: &str) -> usize {
+    harness.render().unwrap();
+    let screen = harness.screen_to_string();
+    for (row, line) in screen.lines().enumerate() {
+        if row >= CENTER_FIRST_ROW && line.contains(needle) {
+            return row - CENTER_FIRST_ROW + 1;
+        }
+    }
+    panic!(
+        "no center-panel row renders {:?}. Screen:\n{}",
+        needle, screen
+    );
+}
+
+/// Step the diff cursor down until the status bar reports `target` line.
+fn move_cursor_to_line(harness: &mut EditorTestHarness, target: usize) {
+    for _ in 0..60 {
+        harness.render().unwrap();
+        if status_line_number(harness) == Some(target) {
+            return;
+        }
+        harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    }
+    panic!(
+        "never reached diff line {} (status: {:?}). Screen:\n{}",
+        target,
+        status_line_number(harness),
+        harness.screen_to_string()
+    );
+}
+
+/// Bounded settle loop: pump the async runtime up to ~3s waiting for
+/// `cond` to hold, then return whether it did. Unlike `wait_until`, this
+/// never hangs — a failing operation simply returns `false`.
+fn settle_until<F: Fn() -> bool>(harness: &mut EditorTestHarness, cond: F) -> bool {
+    for _ in 0..60 {
+        harness.tick_and_render().unwrap();
+        if cond() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        harness.advance_time(std::time::Duration::from_millis(50));
+    }
+    cond()
+}
+
+fn cached_diff(repo: &GitTestRepo) -> String {
+    let out = git_command(&repo.path)
+        .args(["diff", "--cached"])
+        .output()
+        .expect("git diff --cached");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+/// #2317 — `v` then `s` stages exactly the selected added line.
+#[test]
+fn test_review_visual_stage_single_added_line() {
+    init_tracing_from_env();
+    let repo = repo_with_one_added_line();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    // Jump to the hunk, then walk down onto the green "+extra line" row.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    let target = diff_line_of(&mut harness, "+extra line");
+    move_cursor_to_line(&mut harness, target);
+
+    // Start a visual selection and stage it.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
+        .unwrap();
+
+    // The line-level selection must stage the line. Give the async git
+    // apply + refresh a chance to complete.
+    settle_until(&mut harness, || cached_diff(&repo).contains("+extra line"));
+
+    let staged = cached_diff(&repo);
+    assert!(
+        staged.contains("+extra line"),
+        "line-level visual stage should stage the selected added line; \
+         `git diff --cached` was:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+}
+
+/// A repo with a one-line modification in the working tree (produces a
+/// `-old`/`+new` pair in the hunk).
+fn repo_with_one_modified_line() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("README.md", "alpha\nbeta\ngamma\n");
+    repo.git_add_all();
+    repo.git_commit("initial");
+    fs::write(repo.path.join("README.md"), "alpha\nBETA\ngamma\n").unwrap();
+    repo
+}
+
+/// #2317 — `v` then `j` (extend over the `-old`/`+new` pair) then `s` stages
+/// the whole one-line modification.
+#[test]
+fn test_review_visual_stage_modified_line_pair() {
+    init_tracing_from_env();
+    let repo = repo_with_one_modified_line();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    // Land on the removed "-beta" row, then visual-extend down over "+BETA".
+    let target = diff_line_of(&mut harness, "-beta");
+    move_cursor_to_line(&mut harness, target);
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('j'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
+        .unwrap();
+
+    settle_until(&mut harness, || cached_diff(&repo).contains("+BETA"));
+
+    let staged = cached_diff(&repo);
+    assert!(
+        staged.contains("+BETA") && staged.contains("-beta"),
+        "line-level visual stage should stage the -/+ modification pair; \
+         `git diff --cached` was:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+}
+
+/// #2317 — `v` then `d` discards the selected added line from the working tree.
+#[test]
+fn test_review_visual_discard_single_added_line() {
+    init_tracing_from_env();
+    let repo = repo_with_one_added_line();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    let target = diff_line_of(&mut harness, "+extra line");
+    move_cursor_to_line(&mut harness, target);
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('d'), KeyModifiers::NONE)
+        .unwrap();
+
+    settle_until(&mut harness, || {
+        let content = fs::read_to_string(repo.path.join("README.md")).unwrap_or_default();
+        !content.contains("extra line")
+    });
+
+    let content = fs::read_to_string(repo.path.join("README.md")).unwrap();
+    assert!(
+        !content.contains("extra line"),
+        "line-level visual discard should remove the added line from the \
+         working tree; README.md is:\n{}\nScreen:\n{}",
+        content,
+        harness.screen_to_string()
+    );
+}
+
+/// A repo whose single hunk contains two *separate* added lines, so a
+/// line-level selection of one is observably different from staging the
+/// whole hunk.
+fn repo_with_two_separate_additions() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("README.md", "a\nb\nc\n");
+    repo.git_add_all();
+    repo.git_commit("initial");
+    fs::write(repo.path.join("README.md"), "a\nADD1\nb\nADD2\nc\n").unwrap();
+    repo
+}
+
+/// #2317 — the decisive test: selecting *only* the first added line and
+/// staging must stage `+ADD1` but leave `+ADD2` unstaged. If the line-level
+/// path silently fell through to whole-hunk staging, both would appear.
+#[test]
+fn test_review_visual_stage_only_selected_line_of_hunk() {
+    init_tracing_from_env();
+    let repo = repo_with_two_separate_additions();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    let target = diff_line_of(&mut harness, "+ADD1");
+    move_cursor_to_line(&mut harness, target);
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
+        .unwrap();
+
+    settle_until(&mut harness, || cached_diff(&repo).contains("+ADD1"));
+
+    let staged = cached_diff(&repo);
+    assert!(
+        staged.contains("+ADD1"),
+        "the selected line should be staged; `git diff --cached`:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+    assert!(
+        !staged.contains("+ADD2"),
+        "ONLY the selected line should be staged — `+ADD2` must remain \
+         unstaged, proving this is line-level (not whole-hunk) staging; \
+         `git diff --cached`:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+}
+
+/// Two unstaged files, each with one added line. Used to exercise the
+/// hunk-header row lookup when a *preceding* file is collapsed.
+fn repo_with_two_files_each_one_addition() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("alpha.txt", "alpha-line\n");
+    repo.create_file("bravo.txt", "bravo-line\n");
+    repo.git_add_all();
+    repo.git_commit("initial");
+    fs::write(repo.path.join("alpha.txt"), "alpha-line\nADDED_A\n").unwrap();
+    fs::write(repo.path.join("bravo.txt"), "bravo-line\nADDED_B\n").unwrap();
+    repo
+}
+
+/// #2317 — regression for the hunk-header row mapping in the default
+/// focus-mode view. Only the focused file's hunks are emitted into the diff
+/// stream, but the old `selectionLineRange` counted hunks across *all* files
+/// to index `hunkHeaderRows`. For any file that isn't the first, that index
+/// overshot, the header row came back `undefined`, and the operation failed
+/// with "Selection has no add/remove lines or crosses hunk boundary".
+#[test]
+fn test_review_visual_stage_line_in_second_file() {
+    init_tracing_from_env();
+    let repo = repo_with_two_files_each_one_addition();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    // Jump hunk-to-hunk until the second file's added line is rendered
+    // (focus mode only paints the focused file's body), then land on it.
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    let bravo_added = diff_line_of(&mut harness, "+ADDED_B");
+    move_cursor_to_line(&mut harness, bravo_added);
+
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
+        .unwrap();
+
+    settle_until(&mut harness, || cached_diff(&repo).contains("+ADDED_B"));
+
+    let staged = cached_diff(&repo);
+    assert!(
+        staged.contains("+ADDED_B"),
+        "line-staging a line in the second (focused) file should stage \
+         `+ADDED_B`; `git diff --cached`:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+}
+
+/// A repo with a single added line already staged in the index.
+fn repo_with_one_staged_added_line() -> GitTestRepo {
+    let repo = GitTestRepo::new();
+    setup_audit_mode_plugin(&repo);
+    repo.create_file("README.md", "# Calc\nA tiny calculator.\n");
+    repo.git_add_all();
+    repo.git_commit("initial");
+    fs::write(
+        repo.path.join("README.md"),
+        "# Calc\nA tiny calculator.\nextra line\n",
+    )
+    .unwrap();
+    repo.git_add_all(); // stage the addition
+    repo
+}
+
+/// #2317 — `v` then `u` unstages the selected staged line (the scenario that
+/// reported `patch does not apply`).
+#[test]
+fn test_review_visual_unstage_single_added_line() {
+    init_tracing_from_env();
+    let repo = repo_with_one_staged_added_line();
+    let mut harness = harness_for(&repo);
+    open_review_diff(&mut harness);
+
+    harness
+        .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
+        .unwrap();
+    let target = diff_line_of(&mut harness, "+extra line");
+    move_cursor_to_line(&mut harness, target);
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('u'), KeyModifiers::NONE)
+        .unwrap();
+
+    settle_until(&mut harness, || !cached_diff(&repo).contains("+extra line"));
+
+    let staged = cached_diff(&repo);
+    assert!(
+        !staged.contains("+extra line"),
+        "line-level visual unstage should unstage the selected line; \
+         `git diff --cached` still shows it:\n{}\nScreen:\n{}",
+        staged,
+        harness.screen_to_string()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2317. Review Diff's **line-level visual selection** (`v` then `s`/`u`/`d`) failed for any file that wasn't the first one rendered, reporting `Selection has no add/remove lines or crosses hunk boundary` and staging nothing.

## Root cause

`selectionLineRange` located the selected hunk's header row by counting non-collapsed hunks across **all** files and indexing into `hunkHeaderRows`:

```ts
const hunkIdx = state.hunks.indexOf(hunk);
let visibleIdx = 0;
for (let i = 0; i < hunkIdx; i++) { /* skip collapsed files */ visibleIdx++; }
const headerRow = state.hunkHeaderRows[visibleIdx];
```

But in the **default focus-mode** view (`focusOnly: true`), only the focused file's body — and therefore only its hunk headers — is emitted into the diff stream. So that running count overshot the array, `headerRow` came back `undefined`, and the selection resolved to an empty/invalid range.

This is why the bug hid on the single-file reproduction in the report (the count is conveniently `0`) but surfaced the moment the cursor was on the **second or later file**, or a preceding file was collapsed. The original issue's unstage case referenced `src/calc.py` — a second file — matching this exactly.

## Fix

Look the header row up directly via `state.hunkRowByHunkId[hunk.id]`, which is already built during the same render pass, keyed by hunk id, and is used by the rest of the plugin for the same purpose. It stays correct regardless of focus mode, collapsed files, or staged/unstaged section ordering, and removes the fragile cross-file counting entirely.

## Tests

New e2e suite `review_diff_line_staging.rs` driving the real editor + plugin + git, asserting actual index/worktree state:

- `stage` of a single added line
- `stage` of **only** the selected line in a hunk with two separate additions (proves it's line-level, not whole-hunk)
- `stage` of a `-old`/`+new` modification pair (`v` + `j`)
- `stage` of a line in the **second, focused** file — the regression that reproduced this bug (failed before, passes after)
- `unstage` of a staged line
- `discard` of an added line from the working tree

The second-file test fails on the old code and passes on the fix. The existing `review_diff_*` (54) and `audit_mode` (42) suites still pass.

## Manual validation

Built `fresh` and drove it in tmux against a two-file repo. Selecting `+ADDED_B` in the second file and pressing `v` then `s` now reports **"Lines staged"**; `git diff --cached` shows only `+ADDED_B` staged while `+ADDED_A` in the first file stays unstaged. Before the fix the same action printed "Selection has no add/remove lines or crosses hunk boundary" and staged nothing.

https://claude.ai/code/session_01GnzsGNhC8YfB6Vy5sAoMb8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GnzsGNhC8YfB6Vy5sAoMb8)_