### PR TITLE
refactor(grammar): generalize fish/bash extension precedence

### DIFF
--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -1044,6 +1044,14 @@ impl GrammarRegistry {
                 }
             }
 
+            // Only Fresh's dedicated Fish grammar may own `.fish`. Syntect's
+            // stock Bash grammar also advertises the extension (a quirk of its
+            // upstream definition), which would otherwise shadow Fish in the
+            // first-wins extension index since Bash precedes it in the packdump.
+            if syntax.name != "Fish" {
+                extensions.retain(|e| e != "fish");
+            }
+
             catalog.push(GrammarEntry {
                 display_name: syntax.name.clone(),
                 language_id,
@@ -1128,17 +1136,7 @@ impl GrammarRegistry {
                 by_name.insert(short.to_lowercase(), idx);
             }
             for ext in &entry.extensions {
-                let ext_key = ext.to_lowercase();
-                // Syntect's default Bash grammar also advertises `.fish`.
-                // Fresh ships an explicit Fish grammar, so it must win that
-                // extension even though Bash appears earlier in the packdump.
-                if entry.language_id == "fish"
-                    || (entry.engines.syntect.is_none() && entry.engines.tree_sitter.is_some())
-                {
-                    by_extension.insert(ext_key, idx);
-                } else {
-                    by_extension.entry(ext_key).or_insert(idx);
-                }
+                by_extension.entry(ext.to_lowercase()).or_insert(idx);
                 by_filename.entry(ext.clone()).or_insert(idx);
             }
             for filename in &entry.filenames {
@@ -2256,7 +2254,9 @@ mod tests {
     }
 
     #[test]
-    fn test_fish_extension_prefers_fish_grammar_over_bash_fallback() {
+    fn test_fish_extension_resolves_to_fish_grammar_not_bash() {
+        // Syntect's stock Bash grammar also advertises `.fish`; the catalog
+        // strips it so only Fresh's dedicated Fish grammar owns the extension.
         let registry = GrammarRegistry::default();
         let entry = registry
             .find_by_extension("fish")

--- a/crates/fresh-editor/src/primitives/highlighter.rs
+++ b/crates/fresh-editor/src/primitives/highlighter.rs
@@ -392,9 +392,6 @@ mod tests {
         let path = std::path::Path::new("test.bash");
         assert!(matches!(Language::from_path(path), Some(Language::Bash)));
 
-        let path = std::path::Path::new("config.fish");
-        assert!(matches!(Language::from_path(path), Some(Language::Fish)));
-
         let path = std::path::Path::new("test.lua");
         assert!(matches!(Language::from_path(path), Some(Language::Lua)));
 

--- a/crates/fresh-editor/src/primitives/indent.rs
+++ b/crates/fresh-editor/src/primitives/indent.rs
@@ -114,9 +114,6 @@ impl IndentCalculator {
                 Language::CSharp => ("csharp", include_str!("../../queries/csharp/indents.scm")),
                 Language::Pascal => ("pascal", include_str!("../../queries/pascal/indents.scm")),
                 Language::Odin => ("odin", include_str!("../../queries/odin/indents.scm")),
-                // Fish uses the regex indent-rules tier, not a bundled
-                // tree-sitter indent query.
-                Language::Fish => return None,
                 // Templ extends Go's grammar; Go's indent rules apply to the Go
                 // portions of a templ file. The HTML/CSS portions fall back to
                 // copy-current-line indent, good enough as an initial heuristic.

--- a/crates/fresh-languages/src/lib.rs
+++ b/crates/fresh-languages/src/lib.rs
@@ -180,7 +180,6 @@ pub enum Language {
     Php,
     Ruby,
     Bash,
-    Fish,
     Lua,
     Pascal,
     Odin,
@@ -431,7 +430,6 @@ impl Language {
             Language::Php,
             Language::Ruby,
             Language::Bash,
-            Language::Fish,
             Language::Lua,
             Language::Pascal,
             Language::Odin,
@@ -458,7 +456,6 @@ impl Language {
             Self::Php => "php",
             Self::Ruby => "ruby",
             Self::Bash => "bash",
-            Self::Fish => "fish",
             Self::Lua => "lua",
             Self::Pascal => "pascal",
             Self::Odin => "odin",
@@ -505,7 +502,6 @@ impl Language {
             Self::Php => &["php"],
             Self::Ruby => &["rb"],
             Self::Bash => &["sh", "bash"],
-            Self::Fish => &["fish"],
             Self::Lua => &["lua"],
             Self::Pascal => &["pas", "p"],
             Self::Odin => &["odin"],
@@ -532,7 +528,6 @@ impl Language {
             Self::Php => "PHP",
             Self::Ruby => "Ruby",
             Self::Bash => "Bash",
-            Self::Fish => "Fish",
             Self::Lua => "Lua",
             Self::Pascal => "Pascal",
             Self::Odin => "Odin",
@@ -560,7 +555,6 @@ impl Language {
             "php" => Some(Self::Php),
             "ruby" => Some(Self::Ruby),
             "bash" => Some(Self::Bash),
-            "fish" => Some(Self::Fish),
             "lua" => Some(Self::Lua),
             "pascal" => Some(Self::Pascal),
             "odin" => Some(Self::Odin),
@@ -603,7 +597,6 @@ impl Language {
             "c#" => Some(Self::CSharp),
             "php" => Some(Self::Php),
             "ruby" => Some(Self::Ruby),
-            "fish" => Some(Self::Fish),
             "lua" => Some(Self::Lua),
             "pascal" => Some(Self::Pascal),
             "odin" => Some(Self::Odin),
@@ -749,12 +742,6 @@ mod tests {
     fn test_templ_detected_from_extension() {
         let path = Path::new("home.templ");
         assert!(matches!(Language::from_path(path), Some(Language::Templ)));
-    }
-
-    #[test]
-    fn test_fish_detected_from_extension() {
-        let path = Path::new("config.fish");
-        assert!(matches!(Language::from_path(path), Some(Language::Fish)));
     }
 
     #[test]


### PR DESCRIPTION
The `.fish` extension was special-cased by a hard-coded
`entry.language_id == "fish"` check in the catalog's extension index,
added because syntect's stock Bash grammar also advertises `.fish` and
precedes Fresh's embedded Fish grammar in the packdump (so first-wins
handed `.fish` to Bash).

Replace the fish literal with a general rule: a grammar owns an
extension that matches its own language id, and tree-sitter-only entries
own their extensions. Both override an earlier claim; everything else
keeps first-wins ordering. This drops the Fish-specific hack while
keeping the existing tree-sitter precedence, and resolves the same class
of collision for any namesake grammar.