### PR TITLE
fix(lsp): accept string JSON-RPC ids so jdtls dynamic registration works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 
 ### Bug Fixes
 
+* Java (jdtls) completion, hover, and other features registered via `client/registerCapability` now work. Fresh modelled JSON-RPC ids as integers, but Eclipse LSP4J servers (jdtls, the Groovy/Kotlin servers, lemminx) send their server-initiated requests with string ids, which Fresh misparsed as notifications — dropping every dynamic capability registration (#2340, reported by @maxandersen).
 * Occurrence highlighting now uses a theme-appropriate background in every shipped theme; the `dracula`, `nord`, and `solarized-dark` themes no longer fall back to a hard-wired dark color that clashed with their palette (#2312).
 * Windows: the TUI attaches to the parent process's stdio instead of failing in `-gui` builds (#2276, reported and fixed by @mokurin000 in #2277).
 * Right-side status bar elements render with configurable separators (#2088, reported and fixed by @PavelLoparev), and cursor column numbers are grapheme-correct (#2090, reported and fixed by @PavelLoparev).

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2239,6 +2239,19 @@ impl Window {
             .count()
     }
 
+    /// Number of LSP servers for `language` whose effective capabilities
+    /// currently advertise `textDocument/completion`. This reflects
+    /// dynamically-registered providers (`client/registerCapability`), not
+    /// only the static `initialize` result, so tests can wait for a server
+    /// like jdtls to register completion before triggering it.
+    pub fn completion_capable_lsp_server_count(&self, language: &str) -> usize {
+        self.lsp
+            .get_handles(language)
+            .iter()
+            .filter(|sh| sh.capabilities.completion)
+            .count()
+    }
+
     /// Shutdown the LSP server for `language` in this window (marks it
     /// disabled until manual restart). Returns true if a server was
     /// shutdown, false if no server was running for that language.

--- a/crates/fresh-editor/src/services/lsp/async_handler.rs
+++ b/crates/fresh-editor/src/services/lsp/async_handler.rs
@@ -132,11 +132,60 @@ pub enum JsonRpcMessage {
     Notification(JsonRpcNotification),
 }
 
+/// A JSON-RPC request/response id.
+///
+/// The LSP base protocol types ids as `integer | string`, and that distinction
+/// is not academic: servers built on Eclipse LSP4J (jdtls, the Groovy/Kotlin
+/// language servers, lemminx, …) send *string* ids for the requests they
+/// initiate, such as `client/registerCapability`. Modelling the id as a plain
+/// `i64` made those requests fail to deserialize as `Request` and — because
+/// `JsonRpcMessage` is `#[serde(untagged)]` — silently fall through to
+/// `Notification`, which ignores the stray `id`. The dynamic-capability handler
+/// therefore never ran, jdtls's dynamically-registered `textDocument/completion`
+/// (and hover, etc.) stayed gated off, and the request was never even
+/// acknowledged (sinelaw/fresh#2340).
+///
+/// `Number` is listed first so numeric ids round-trip as integers; a JSON
+/// string id only matches `Str`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    Number(i64),
+    Str(String),
+}
+
+impl JsonRpcId {
+    /// The id as an `i64`, when it is numeric. Fresh only ever issues numeric
+    /// ids for its own outgoing requests, so response correlation keys on this;
+    /// a string id can only have come from a server-initiated request.
+    fn as_i64(&self) -> Option<i64> {
+        match self {
+            JsonRpcId::Number(n) => Some(*n),
+            JsonRpcId::Str(_) => None,
+        }
+    }
+}
+
+impl From<i64> for JsonRpcId {
+    fn from(n: i64) -> Self {
+        JsonRpcId::Number(n)
+    }
+}
+
+impl std::fmt::Display for JsonRpcId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsonRpcId::Number(n) => write!(f, "{}", n),
+            JsonRpcId::Str(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 /// A JSON-RPC request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest {
     pub jsonrpc: String,
-    pub id: i64,
+    pub id: JsonRpcId,
     pub method: String,
     pub params: Option<Value>,
 }
@@ -145,7 +194,7 @@ pub struct JsonRpcRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcResponse {
     pub jsonrpc: String,
-    pub id: i64,
+    pub id: JsonRpcId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1080,7 +1129,7 @@ impl LspState {
             .map_err(|e| format!("Failed to serialize params: {}", e))?;
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
-            id,
+            id: JsonRpcId::Number(id),
             method: method.to_string(),
             params: params_value,
         };
@@ -3772,7 +3821,7 @@ fn server_command_is_rust_analyzer(server_command: &str) -> bool {
 }
 
 /// Build a null-result JSON-RPC response for `id`.
-fn null_response(id: i64) -> JsonRpcResponse {
+fn null_response(id: JsonRpcId) -> JsonRpcResponse {
     JsonRpcResponse {
         jsonrpc: "2.0".to_string(),
         id,
@@ -3913,7 +3962,12 @@ async fn handle_message_dispatch(
     match message {
         JsonRpcMessage::Response(response) => {
             tracing::trace!("Received LSP response for request id={}", response.id);
-            if let Some(tx) = pending.lock().unwrap().remove(&response.id) {
+            // Fresh only issues numeric ids, so a response that correlates to one
+            // of our pending requests must carry a numeric id. A string id here
+            // can only be a stray/echoed server id we never tracked — drop it
+            // rather than letting it look like an unknown request.
+            let pending_id = response.id.as_i64();
+            if let Some(tx) = pending_id.and_then(|id| pending.lock().unwrap().remove(&id)) {
                 let result = if let Some(error) = response.error {
                     log_response_error(error.code, &error.message, server_name, language);
                     Err(format!(
@@ -5111,7 +5165,7 @@ mod tests {
     fn test_json_rpc_request_serialization() {
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
-            id: 1,
+            id: JsonRpcId::Number(1),
             method: "initialize".to_string(),
             params: Some(serde_json::json!({"rootUri": "file:///test"})),
         };
@@ -5127,7 +5181,7 @@ mod tests {
     fn test_json_rpc_response_serialization() {
         let response = JsonRpcResponse {
             jsonrpc: "2.0".to_string(),
-            id: 1,
+            id: JsonRpcId::Number(1),
             result: Some(serde_json::json!({"success": true})),
             error: None,
         };
@@ -5344,7 +5398,7 @@ mod tests {
     fn test_json_rpc_error_response() {
         let response = JsonRpcResponse {
             jsonrpc: "2.0".to_string(),
-            id: 1,
+            id: JsonRpcId::Number(1),
             result: None,
             error: Some(JsonRpcError {
                 code: -32600,
@@ -5486,12 +5540,48 @@ mod tests {
         match message {
             JsonRpcMessage::Request(request) => {
                 assert_eq!(request.jsonrpc, "2.0");
-                assert_eq!(request.id, 1);
+                assert_eq!(request.id, JsonRpcId::Number(1));
                 assert_eq!(request.method, "initialize");
                 assert!(request.params.is_some());
             }
             _ => panic!("Expected Request"),
         }
+    }
+
+    /// Eclipse LSP4J servers (jdtls, the Groovy/Kotlin servers, lemminx, …)
+    /// send the requests they initiate — notably `client/registerCapability` —
+    /// with a **string** JSON-RPC id. Such a message must still deserialize as
+    /// a `Request` so it reaches the request handler (which records the
+    /// dynamically-registered capability and acks the request).
+    ///
+    /// Before the id type accepted strings this parsed as a `Notification`
+    /// (the untagged enum fell through and the stray `id` was dropped), so
+    /// jdtls's dynamically-registered completion never turned on
+    /// (sinelaw/fresh#2340).
+    #[test]
+    fn string_id_request_deserializes_as_request_not_notification() {
+        let json = r#"{"jsonrpc":"2.0","id":"dyn-reg-1","method":"client/registerCapability","params":{"registrations":[{"id":"completion-reg","method":"textDocument/completion"}]}}"#;
+        let message: JsonRpcMessage = serde_json::from_str(json).unwrap();
+
+        match message {
+            JsonRpcMessage::Request(request) => {
+                assert_eq!(request.id, JsonRpcId::Str("dyn-reg-1".to_string()));
+                assert_eq!(request.method, "client/registerCapability");
+            }
+            other => panic!("expected Request for a string-id message, got {other:?}"),
+        }
+    }
+
+    /// The string id must round-trip on the way back out, so the `null` ack we
+    /// send for a server-initiated request correlates on the server side.
+    #[test]
+    fn null_response_preserves_string_id() {
+        let json = serde_json::to_string(&null_response(JsonRpcId::Str("dyn-reg-1".to_string())))
+            .expect("serialize null response");
+        assert!(
+            json.contains(r#""id":"dyn-reg-1""#),
+            "string id must be echoed verbatim, got: {json}"
+        );
     }
 
     #[test]
@@ -5502,7 +5592,7 @@ mod tests {
         match message {
             JsonRpcMessage::Response(response) => {
                 assert_eq!(response.jsonrpc, "2.0");
-                assert_eq!(response.id, 1);
+                assert_eq!(response.id, JsonRpcId::Number(1));
                 assert!(response.result.is_some());
                 assert!(response.error.is_none());
             }
@@ -5534,7 +5624,7 @@ mod tests {
         match message {
             JsonRpcMessage::Response(response) => {
                 assert_eq!(response.jsonrpc, "2.0");
-                assert_eq!(response.id, 1);
+                assert_eq!(response.id, JsonRpcId::Number(1));
                 assert!(response.result.is_none());
                 assert!(response.error.is_some());
                 let error = response.error.unwrap();

--- a/crates/fresh-editor/tests/common/fake_lsp.rs
+++ b/crates/fresh-editor/tests/common/fake_lsp.rs
@@ -158,6 +158,107 @@ done
         Ok(Self { handle, stop_tx })
     }
 
+    /// Spawn a fake LSP server that registers completion *dynamically*, the
+    /// way Eclipse LSP4J servers (jdtls, the Groovy/Kotlin servers, …) do.
+    ///
+    /// Two things make this a faithful jdtls stand-in:
+    /// 1. The static `initialize` result advertises **no** `completionProvider`.
+    /// 2. After `initialized`, it sends a `client/registerCapability` request
+    ///    for `textDocument/completion` whose JSON-RPC id is a **string**
+    ///    (`"dyn-reg-1"`) — LSP4J always uses string ids for the requests it
+    ///    initiates.
+    ///
+    /// A client that types JSON-RPC ids as integers misparses that request as a
+    /// notification (the `id` is dropped), never enables completion, and never
+    /// acks the request — so completion stays dead (sinelaw/fresh#2340).
+    pub fn spawn_with_dynamic_completion(dir: &std::path::Path) -> anyhow::Result<Self> {
+        let (stop_tx, stop_rx) = mpsc::channel();
+
+        let script = r#"#!/bin/bash
+
+# Function to read a message
+read_message() {
+    local content_length=0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        if [ -z "$line" ]; then
+            break
+        fi
+        case "$line" in
+            Content-Length:*)
+                content_length="${line#Content-Length:}"
+                content_length="${content_length// /}"
+                ;;
+        esac
+    done
+
+    if [ "$content_length" -gt 0 ] 2>/dev/null; then
+        dd bs=1 count="$content_length" 2>/dev/null
+    fi
+}
+
+# Function to send a message
+send_message() {
+    local message="$1"
+    local length=${#message}
+    printf "Content-Length: %d\r\n\r\n%s" "$length" "$message"
+}
+
+# Main loop
+while true; do
+    msg=$(read_message)
+
+    if [ -z "$msg" ]; then
+        break
+    fi
+
+    method=$(echo "$msg" | grep -o '"method":"[^"]*"' | cut -d'"' -f4)
+    msg_id=$(echo "$msg" | grep -o '"id":[0-9]*' | cut -d':' -f2)
+
+    case "$method" in
+    "initialize")
+        # Deliberately NO completionProvider here — completion is registered
+        # dynamically once the client signals `initialized` (see below).
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"capabilities":{"textDocumentSync":1}}}'
+        ;;
+    "initialized")
+        # Server-to-client request with a STRING id, exactly like jdtls/LSP4J.
+        send_message '{"jsonrpc":"2.0","id":"dyn-reg-1","method":"client/registerCapability","params":{"registrations":[{"id":"completion-reg","method":"textDocument/completion","registerOptions":{"triggerCharacters":["."]}}]}}'
+        ;;
+    "textDocument/completion")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":{"isIncomplete":false,"items":[{"label":"dynamicCompletion","kind":3,"detail":"fn dynamicCompletion()","insertText":"dynamicCompletion"}]}}'
+        ;;
+    "shutdown")
+        send_message '{"jsonrpc":"2.0","id":'$msg_id',"result":null}'
+        break
+        ;;
+    esac
+done
+"#;
+
+        let script_path = Self::dynamic_completion_script_path(dir);
+        std::fs::write(&script_path, script)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script_path)?.permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script_path, perms)?;
+        }
+
+        let handle = Some(thread::spawn(move || {
+            let _ = stop_rx.recv();
+        }));
+
+        Ok(Self { handle, stop_tx })
+    }
+
+    /// Path to the dynamic-completion script.
+    pub fn dynamic_completion_script_path(dir: &std::path::Path) -> std::path::PathBuf {
+        dir.join("fake_lsp_server_dynamic_completion.sh")
+    }
+
     /// Spawn a fake LSP server that delays semantic token responses.
     pub fn spawn_with_semantic_tokens_delay(
         dir: &std::path::Path,

--- a/crates/fresh-editor/tests/e2e/lsp_completion_dynamic_registration.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_completion_dynamic_registration.rs
@@ -1,0 +1,100 @@
+//! Regression test for sinelaw/fresh#2340.
+//!
+//! Eclipse jdtls (and every other Eclipse LSP4J-based server) advertises almost
+//! nothing in its static `initialize` result and instead registers providers
+//! like `textDocument/completion` *dynamically* via a `client/registerCapability`
+//! request — a request whose JSON-RPC id LSP4J always sends as a **string**.
+//!
+//! Fresh modelled JSON-RPC ids as `i64`, so that string-id request failed to
+//! deserialize as a `Request` and — because `JsonRpcMessage` is
+//! `#[serde(untagged)]` — silently fell through to `Notification`, which ignores
+//! the stray `id`. The dynamic-capability handler therefore never ran, completion
+//! stayed gated off, and the request was never even acknowledged. The observable
+//! symptom: Java completions never appear even though diagnostics (a plain
+//! server notification) work fine.
+//!
+//! The fake server here mirrors that exact shape: no static `completionProvider`,
+//! then a string-id `client/registerCapability` for completion on `initialized`.
+//! Before the fix `completion_capable_lsp_server_count` stays 0 forever and the
+//! `wait_until` below times out; after the fix the capability turns on and the
+//! completion popup renders the fake item.
+
+use crate::common::fake_lsp::FakeLspServer;
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore = "FakeLspServer uses a Bash script")]
+fn test_completion_works_when_registered_dynamically_with_string_id() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let _server = FakeLspServer::spawn_with_dynamic_completion(temp_dir.path())?;
+    let script_path = FakeLspServer::dynamic_completion_script_path(temp_dir.path());
+
+    // "rust" is just a convenient language with a built-in entry we override
+    // with our fake server; the bug is about JSON-RPC transport, not Java.
+    let test_file = temp_dir.path().join("script.rs");
+    std::fs::write(&test_file, "fn main() {\n    \n}\n")?;
+
+    let mut config = fresh::config::Config::default();
+    // Trigger completion explicitly so the test doesn't depend on debounced
+    // quick-suggestion timing.
+    config.editor.quick_suggestions = false;
+    config.lsp.insert(
+        "rust".to_string(),
+        fresh::types::LspLanguageConfig::Multi(vec![fresh::services::lsp::LspServerConfig {
+            command: script_path.to_string_lossy().to_string(),
+            args: vec![],
+            enabled: true,
+            auto_start: true,
+            process_limits: fresh::services::process_limits::ProcessLimits::default(),
+            initialization_options: None,
+            env: Default::default(),
+            language_id_overrides: Default::default(),
+            root_markers: Default::default(),
+            name: Some("fake-jdtls".to_string()),
+            only_features: None,
+            except_features: None,
+        }]),
+    );
+
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_config(config)
+            .with_working_dir(temp_dir.path().to_path_buf()),
+    )?;
+
+    harness.open_file(&test_file)?;
+    harness.render()?;
+
+    // The server advertises no completion statically; it only becomes
+    // completion-capable once it has registered the provider dynamically with
+    // its string-id `client/registerCapability`. Waiting on this both proves
+    // the registration was parsed (the regression) and removes any race
+    // between registration and the one-shot completion trigger below.
+    harness.wait_until(|h| {
+        h.editor()
+            .active_window()
+            .completion_capable_lsp_server_count("rust")
+            >= 1
+    })?;
+
+    // Move into the function body and ask for completion.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE)?;
+    harness.send_key(KeyCode::End, KeyModifiers::NONE)?;
+    harness.render()?;
+    harness.send_key(KeyCode::Char(' '), KeyModifiers::CONTROL)?;
+    harness.render()?;
+
+    // The completion popup must render the item served by the fake LSP.
+    harness.wait_until(|h| h.editor().active_window().completion_items_count() > 0)?;
+    assert!(
+        harness.screen_to_string().contains("dynamicCompletion"),
+        "expected the dynamically-registered completion item on screen, screen was:\n{}",
+        harness.screen_to_string()
+    );
+
+    Ok(())
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -95,6 +95,7 @@ pub mod lsp_code_action_diagnostic_context;
 pub mod lsp_code_action_modal;
 pub mod lsp_code_action_resolve_and_commands;
 pub mod lsp_completion_duplicate_entries_1514;
+pub mod lsp_completion_dynamic_registration;
 pub mod lsp_completion_french_locale;
 pub mod lsp_completion_popup_behavior;
 pub mod lsp_completion_resolve_and_formatting;


### PR DESCRIPTION
Java completion never appeared because Fresh modelled JSON-RPC message ids
as `i64`. The LSP base protocol types ids as `integer | string`, and
Eclipse LSP4J servers (jdtls, the Groovy/Kotlin servers, lemminx) send
their server-initiated requests — notably `client/registerCapability` —
with string ids.

Because `JsonRpcMessage` is an untagged enum, a request whose id failed to
deserialize as `i64` fell through to the `Notification` variant (which
ignores the stray `id`). jdtls registers `textDocument/completion`, hover,
etc. dynamically rather than in its static `initialize` result, so every
one of those registrations was silently dropped and the request was never
acknowledged. Diagnostics still worked because `publishDiagnostics` is a
genuine notification — matching the "python works, java doesn't" report.

Introduce a `JsonRpcId` (`integer | string`) for the request/response id
fields. Fresh still issues numeric ids for its own outgoing requests, so
response correlation keys on the numeric value; incoming string-id requests
now parse as requests, reach the dynamic-capability handler, and are acked
with the same id echoed back.

Adds a unit test that a string-id `client/registerCapability` deserializes
as a request, and an e2e (new fake-LSP variant that registers completion
dynamically with a string id) asserting the completion popup renders.

Closes #2340

https://claude.ai/code/session_015NohMv5b4aHbaKjMfk9989