### PR TITLE
fix(vi-mode): make % jump to matching bracket

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -456,7 +456,7 @@ function vi_page_up() : void {
 registerHandler("vi_page_up", vi_page_up);
 
 function vi_matching_bracket() : void {
-  editor.executeAction("go_to_matching_bracket");
+  editor.executeAction("goto_matching_bracket");
 }
 registerHandler("vi_matching_bracket", vi_matching_bracket);
 
@@ -1657,8 +1657,13 @@ function vi_op_doc_end(): void {
 }
 registerHandler("vi_op_doc_end", vi_op_doc_end);
 
+// NOTE: operator + `%` (d%/c%/y%) is currently a no-op. `applyOperatorWithMotion`
+// resolves a motion via `atomicOperatorActions` or `motionToSelection`, and
+// `goto_matching_bracket` is in neither map, so it bails without deleting. Making
+// this work needs a selection-extending action (e.g. `select_to_matching_bracket`)
+// plus a `motionToSelection` entry. See test_vi_bug_d_percent_ignored.
 function vi_op_matching_bracket(): void {
-  handleMotionWithOperator("go_to_matching_bracket");
+  handleMotionWithOperator("goto_matching_bracket");
 }
 registerHandler("vi_op_matching_bracket", vi_op_matching_bracket);
 

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -1153,3 +1153,43 @@ fn test_vi_colon_split() {
         })
         .unwrap();
 }
+
+// =============================================================================
+// Matching Bracket Tests
+// =============================================================================
+
+/// Test '%' jumps between matching brackets (both directions).
+#[test]
+fn test_vi_percent_matching_bracket() {
+    let (mut harness, _temp_dir) = vi_mode_harness(80, 24);
+
+    // foo(bar)\n  ->  '(' at byte 3, ')' at byte 7
+    let fixture = TestFixture::new("test.txt", "foo(bar)\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    // Move cursor onto the '(' at byte 3.
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Char('l'), KeyModifiers::NONE)
+            .unwrap();
+        harness.render().unwrap();
+    }
+    harness.wait_until(|h| h.cursor_position() == 3).unwrap();
+
+    // '%' jumps forward to the matching ')'.
+    harness
+        .send_key(KeyCode::Char('%'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.wait_until(|h| h.cursor_position() == 7).unwrap();
+
+    // '%' from the ')' jumps back to the '('.
+    harness
+        .send_key(KeyCode::Char('%'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.wait_until(|h| h.cursor_position() == 3).unwrap();
+}

--- a/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode_bugs.rs
@@ -899,3 +899,40 @@ fn test_vi_2dd_delete_two_lines() {
 
     harness.wait_for_buffer_content("line3\nline4\n").unwrap();
 }
+
+// =============================================================================
+// Bug: d% / c% / y% (operator + matching-bracket motion) does nothing
+// =============================================================================
+
+/// `d%` should delete from the cursor through the matching bracket (inclusive),
+/// e.g. on the `(` of "foo(bar)baz" it should leave "foobaz".
+///
+/// Root cause: `applyOperatorWithMotion` resolves a motion to either an atomic
+/// operator action (`atomicOperatorActions`) or a selection-extending action
+/// (`motionToSelection`). The `goto_matching_bracket` motion is in neither map,
+/// so the operator bails out of the "no selection equivalent" branch without
+/// deleting anything. (The normal-mode `%` motion itself works.)
+///
+/// To fix: add a selection-extending action (e.g. `select_to_matching_bracket`)
+/// in the core editor and a `motionToSelection["goto_matching_bracket"]` entry in
+/// the vi_mode plugin, then remove the `#[ignore]`.
+#[test]
+#[ignore]
+fn test_vi_bug_d_percent_ignored() {
+    let (mut harness, _td) = vi_mode_harness(80, 24);
+    let fixture = TestFixture::new("test.txt", "foo(bar)baz\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+    enable_vi_mode(&mut harness);
+
+    // Move cursor onto the '(' at byte 3.
+    send_key(&mut harness, 'l');
+    send_key(&mut harness, 'l');
+    send_key(&mut harness, 'l');
+    harness.wait_until(|h| h.cursor_position() == 3).unwrap();
+
+    // d% should delete "(bar)" inclusive, leaving "foobaz\n".
+    send_operator_motion(&mut harness, 'd', '%');
+
+    harness.wait_for_buffer_content("foobaz\n").unwrap();
+}


### PR DESCRIPTION
## TLDR: The bug is a single underscore typo.

The vi plugin called executeAction("go_to_matching_bracket"), but the action is registered as "goto_matching_bracket". Action::from_str returned None, so % (and the operator-pending %) was a silent no-op.

Corrects the action string at both call sites. Adds a passing e2e test for the % motion, and an #[ignore]'d reproducer documenting that the operator form (d%/c%/y%) is still unimplemented (goto_matching_bracket has no motionToSelection entry).