### PR TITLE
fix(vi-mode): move cursor left when leaving insert mode

### DIFF
--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -500,7 +500,17 @@ function vi_open_above() : void {
 registerHandler("vi_open_above", vi_open_above);
 
 function vi_escape() : void {
+  // When leaving insert mode, vi_mode should move the cursor one
+  // column left (clamped to the line start), since the insert-mode
+  // cursor sits one position right of normal. This aligns with the
+  // actual vi/vim behavior. Guard on the current mode so a
+  // normal-mode Escape (cancel count/operator) does not move the
+  // cursor.
+  const leavingInsert = state.mode === "insert";
   switchMode("normal");
+  if (leavingInsert) {
+    editor.executeAction("move_left_in_line");
+  }
 }
 registerHandler("vi_escape", vi_escape);
 

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -1193,3 +1193,44 @@ fn test_vi_percent_matching_bracket() {
     harness.render().unwrap();
     harness.wait_until(|h| h.cursor_position() == 3).unwrap();
 }
+
+// =============================================================================
+// Insert-mode exit cursor adjustment
+// =============================================================================
+
+/// Leaving insert mode with Escape should move the cursor one column left
+/// (vim behavior): the insert cursor sits one position right of normal, so on
+/// Escape it drops back onto the last edited character.
+#[test]
+fn test_vi_escape_from_insert_moves_cursor_left() {
+    let (mut harness, _temp_dir) = vi_mode_harness(80, 24);
+
+    let fixture = TestFixture::new("test.txt", "hello\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    // Enter insert at the start and type "AB" -> "ABhello", cursor at byte 2.
+    harness
+        .send_key(KeyCode::Char('i'), KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-insert".to_string()))
+        .unwrap();
+
+    harness.type_text("AB").unwrap();
+    harness.render().unwrap();
+    harness.wait_until(|h| h.cursor_position() == 2).unwrap();
+
+    // Escape -> normal mode, and the cursor drops one column left to byte 1.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    harness.wait_until(|h| h.cursor_position() == 1).unwrap();
+
+    harness.assert_buffer_content("ABhello\n");
+}


### PR DESCRIPTION
In vim, pressing Escape to exit insert mode drops the cursor one column left (clamped to the line start), since the insert-mode cursor sits one position right of normal. `Fresh` left the cursor in place, which deviates from the expected Vim behavior.

vi_escape now runs move_left_in_line when leaving insert, guarded on the current mode so a normal-mode Escape (cancel count/operator) is unaffected. Adds an e2e test asserting the cursor drops one column on insert exit.