### PR TITLE
fix(clipboard): restore internal-clipboard paste fallback; add Termux clipboard

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -674,14 +674,23 @@ impl Editor {
         let (inline_tx, inline_rx) = std::sync::mpsc::sync_channel::<Option<String>>(1);
         let bridge_sender = sender.clone();
         let thread_request_id = request_id;
+        // The system-clipboard reader (overridable in tests) and the
+        // internal-clipboard snapshot captured *now*. The thread returns
+        // `system.or(internal)`: on a host where the OS clipboard is
+        // unreadable (Termux, where arboard has no Android backend; a
+        // headless TTY; an opt-out) the system read yields `None` and the
+        // paste falls back to Fresh's own internal clipboard — restoring
+        // the in-editor copy/paste round-trip that the pre-async
+        // synchronous path provided (regression from #2155).
+        let reader = self
+            .system_clipboard_reader
+            .unwrap_or(crate::services::clipboard::read_system_clipboard);
+        let internal_fallback = self.clipboard.paste_internal();
         std::thread::Builder::new()
             .name("clipboard-paste".into())
             .spawn(move || {
                 let arboard_start = Instant::now();
-                let text = arboard::Clipboard::new()
-                    .and_then(|mut cb| cb.get_text())
-                    .ok()
-                    .filter(|s| !s.is_empty());
+                let text = reader().or(internal_fallback);
                 let arboard_ms = arboard_start.elapsed().as_millis();
                 let len = text.as_ref().map(|s| s.len()).unwrap_or(0);
                 // Try the inline channel first. If the main thread
@@ -1314,6 +1323,19 @@ impl Editor {
     pub fn set_clipboard_for_test(&mut self, text: String) {
         self.clipboard.set_internal(text);
         self.clipboard.set_internal_only(true);
+    }
+
+    /// Override the async paste path's system-clipboard reader for tests.
+    ///
+    /// Lets a test deterministically simulate a host whose OS clipboard is
+    /// unreadable (e.g. Termux, where arboard has no backend) by passing
+    /// `|| None`, while leaving the system clipboard nominally *enabled* —
+    /// the exact configuration that exposed the lost internal-clipboard
+    /// fallback (#2343). Without this seam a test would read the real host
+    /// clipboard, which is neither deterministic nor isolated.
+    #[doc(hidden)]
+    pub fn set_system_clipboard_reader_for_test(&mut self, reader: fn() -> Option<String>) {
+        self.system_clipboard_reader = Some(reader);
     }
 
     /// Paste from internal clipboard only (for testing)

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -207,6 +207,7 @@ impl Editor {
             paste_pending: std::collections::HashMap::new(),
             paste_slow_path_just_armed: false,
             paste_render_suppress_until: None,
+            system_clipboard_reader: None,
             local_filesystem: parts.local_filesystem,
             menu_state: crate::view::ui::MenuState::new(parts.dir_context.themes_dir()),
             windows: parts.windows,

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -567,6 +567,15 @@ pub struct Editor {
     /// a single render with the final text.
     pub(super) paste_render_suppress_until: Option<std::time::Instant>,
 
+    /// Test-only override for the system-clipboard reader used by the
+    /// async paste path. `None` in production (the real
+    /// `services::clipboard::read_system_clipboard` is used). Tests set
+    /// this to a deterministic stub — e.g. `|| None` to simulate a
+    /// host with no usable system clipboard (Termux, headless TTY) —
+    /// so the internal-clipboard fallback can be exercised in isolation
+    /// without touching the real host clipboard.
+    pub(super) system_clipboard_reader: Option<fn() -> Option<String>>,
+
     // split_manager and split_view_states moved onto `Window`. Access
     // via `Editor::split_manager()` / `split_manager_mut()` and
     // `Editor::split_view_states()` / `split_view_states_mut()`.

--- a/crates/fresh-editor/src/services/clipboard.rs
+++ b/crates/fresh-editor/src/services/clipboard.rs
@@ -13,6 +13,96 @@ use crossterm::execute;
 use std::io::{stdout, Write};
 use std::sync::Mutex;
 
+/// True when running inside Termux on Android.
+///
+/// Termux exports `TERMUX_VERSION` and sets `$PREFIX` to a path under
+/// `com.termux`. We use this to gate the `termux-clipboard-*` helpers so we
+/// never spawn those processes on a normal Linux/macOS/Windows host.
+fn is_termux() -> bool {
+    if std::env::var_os("TERMUX_VERSION").is_some() {
+        return true;
+    }
+    std::env::var_os("PREFIX")
+        .map(|p| p.to_string_lossy().contains("com.termux"))
+        .unwrap_or(false)
+}
+
+/// Read the Android clipboard via the `termux-clipboard-get` helper.
+///
+/// Returns `None` when not on Termux, when the `termux-api` package isn't
+/// installed (helper missing / non-zero exit), or when the clipboard is empty.
+/// `arboard` has no Android backend, so this is the only way to read the
+/// system clipboard inside Termux.
+///
+/// Deliberately uses `std::process::Command` rather than the editor's
+/// `ProcessSpawner`: the clipboard is a property of the *local* Android
+/// device, so it must never be routed to a remote SSH/container host, and
+/// this runs on the detached background paste thread which has no spawner.
+fn termux_clipboard_get() -> Option<String> {
+    if !is_termux() {
+        return None;
+    }
+    let output = std::process::Command::new("termux-clipboard-get")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout).into_owned();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+/// Write the Android clipboard via the `termux-clipboard-set` helper.
+///
+/// No-op (returns `false`) when not on Termux or the helper is unavailable.
+fn termux_clipboard_set(text: &str) -> bool {
+    if !is_termux() {
+        return false;
+    }
+    use std::process::{Command, Stdio};
+    let mut child = match Command::new("termux-clipboard-set")
+        .stdin(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(e) => {
+            tracing::debug!("termux-clipboard-set spawn failed: {}", e);
+            return false;
+        }
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(text.as_bytes()) {
+            tracing::debug!("termux-clipboard-set write failed: {}", e);
+        }
+    }
+    child.wait().map(|s| s.success()).unwrap_or(false)
+}
+
+/// Read text from the system clipboard, trying platform backends in order.
+///
+/// On Linux/macOS/Windows this is `arboard` (X11/Wayland/native). On Termux,
+/// where `arboard` has no backend and always errors, it falls back to the
+/// `termux-clipboard-get` helper from the `termux-api` package. Returns `None`
+/// when no backend yields non-empty text.
+///
+/// A fresh `arboard::Clipboard` is created per call (rather than reusing the
+/// persistent `SYSTEM_CLIPBOARD` handle) so this is safe to call from the
+/// background paste thread without contending on the copy-side mutex.
+pub fn read_system_clipboard() -> Option<String> {
+    if let Some(text) = arboard::Clipboard::new()
+        .and_then(|mut cb| cb.get_text())
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        return Some(text);
+    }
+    termux_clipboard_get()
+}
+
 /// Global clipboard holder to maintain X11/Wayland clipboard ownership.
 ///
 /// On X11, the clipboard owner must stay alive to respond to paste requests.
@@ -41,6 +131,10 @@ pub fn copy_to_system_clipboard(text: &str, use_osc52: bool, use_system_clipboar
 
     if use_system_clipboard {
         set_system_clipboard_text(text);
+        // On Termux arboard is a no-op (no Android backend), so also push to
+        // the Android clipboard via the termux-api helper. The call is gated
+        // on `is_termux()` inside, so it costs nothing on other platforms.
+        termux_clipboard_set(text);
     }
 }
 
@@ -228,24 +322,12 @@ impl Clipboard {
             return self.paste_internal();
         }
 
-        // Try arboard crate via the static clipboard (reads from system clipboard)
+        // Read from the system clipboard (arboard on desktop, the
+        // termux-clipboard-get helper on Termux where arboard has no backend).
         if self.use_system_clipboard {
-            if let Ok(mut guard) = SYSTEM_CLIPBOARD.lock() {
-                // Create clipboard if it doesn't exist yet
-                if guard.is_none() {
-                    if let Ok(cb) = arboard::Clipboard::new() {
-                        *guard = Some(cb);
-                    }
-                }
-
-                if let Some(clipboard) = guard.as_mut() {
-                    if let Ok(text) = clipboard.get_text() {
-                        if !text.is_empty() {
-                            self.internal = text.clone();
-                            return Some(text);
-                        }
-                    }
-                }
+            if let Some(text) = read_system_clipboard() {
+                self.internal = text.clone();
+                return Some(text);
             }
         }
 
@@ -283,21 +365,9 @@ impl Clipboard {
             return false;
         }
 
-        // Check system clipboard via the static clipboard
-        if self.use_system_clipboard {
-            if let Ok(mut guard) = SYSTEM_CLIPBOARD.lock() {
-                if guard.is_none() {
-                    if let Ok(cb) = arboard::Clipboard::new() {
-                        *guard = Some(cb);
-                    }
-                }
-
-                if let Some(clipboard) = guard.as_mut() {
-                    if let Ok(text) = clipboard.get_text() {
-                        return text.is_empty();
-                    }
-                }
-            }
+        // Check the system clipboard (arboard / termux-clipboard-get).
+        if self.use_system_clipboard && read_system_clipboard().is_some() {
+            return false;
         }
 
         true

--- a/crates/fresh-editor/tests/e2e/paste.rs
+++ b/crates/fresh-editor/tests/e2e/paste.rs
@@ -327,6 +327,61 @@ fn test_paste_in_middle() {
 }
 
 // ============================================================================
+// System-clipboard fallback (issue #2343)
+// ============================================================================
+
+/// Regression test for issue #2343 ("paste hasn't worked since 3.10").
+///
+/// On hosts where the OS clipboard can't be read — Termux (arboard has no
+/// Android backend) or a headless TTY — `Ctrl+V` must still paste text that
+/// was copied *inside* Fresh. The async paste rework (#2155, shipped in
+/// 0.3.12) dropped the internal-clipboard fallback the old synchronous path
+/// had, so in-editor copy/paste silently did nothing on Termux: the
+/// background read returned `None` and `paste()` returned without consulting
+/// the internal clipboard.
+///
+/// We simulate the unreadable system clipboard with a reader stub returning
+/// `None`, while leaving the system clipboard nominally *enabled* (the exact
+/// configuration that triggered the bug — internal-only test mode bypasses
+/// the async path entirely and would hide it). The internal clipboard is
+/// populated by a real `Ctrl+C` copy, so this also exercises the full
+/// in-editor copy → paste round-trip.
+///
+/// Without the fix the buffer stays "hello" and this wait never completes
+/// (nextest times it out); with the fix it becomes "hellohello".
+#[test]
+fn test_ctrl_v_falls_back_to_internal_clipboard_when_system_unreadable() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Simulate Termux/headless: the OS clipboard read always yields nothing,
+    // but the system clipboard stays enabled (not internal-only mode).
+    harness
+        .editor_mut()
+        .set_system_clipboard_reader_for_test(|| None);
+
+    // Copy "hello" from inside Fresh (Ctrl+C populates the internal clipboard).
+    harness.type_text("hello").unwrap();
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap(); // select all
+    harness
+        .send_key(KeyCode::Char('c'), KeyModifiers::CONTROL)
+        .unwrap(); // copy
+
+    // Collapse the selection to the end so the paste appends rather than
+    // replacing the just-copied text.
+    harness.send_key(KeyCode::End, KeyModifiers::NONE).unwrap();
+
+    // Paste via Ctrl+V — drives the real async system-clipboard path.
+    harness
+        .send_key(KeyCode::Char('v'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // The internal "hello" must be pasted, producing "hellohello".
+    harness.wait_for_buffer_content("hellohello").unwrap();
+}
+
+// ============================================================================
 // Prompt paste tests
 // ============================================================================
 


### PR DESCRIPTION
Paste via Ctrl+V and the command palette stopped working on Termux (and any
host without a readable OS clipboard) starting in 0.3.12 — issue #2343.

Root cause: the async clipboard-paste rework (#2155) dropped the
internal-clipboard fallback that the old synchronous `Clipboard::paste()`
had. The background read does `arboard::Clipboard::new().get_text()`, which
on Termux always fails (arboard has no Android backend). The inline handler
received `Ok(None)` and returned without inserting anything and without
consulting Fresh's own internal clipboard, so an in-editor copy → paste
round-trip silently did nothing. Pre-0.3.12 the synchronous path fell back
to the internal buffer, so it worked regardless of display server.

Fix:
- The paste thread now returns `system_read.or(internal_snapshot)`, captured
  at dispatch — restoring the in-editor round-trip on Termux, headless TTYs,
  and any environment where the OS clipboard is unreadable. `None` now means
  "nothing anywhere", so the inline, slow-path, and deadline-cancel branches
  stay correct with no further changes.
- Add real Termux clipboard support via the `termux-clipboard-get`/`-set`
  helpers (termux-api), wired through a shared `read_system_clipboard()` and
  the copy path, so text copied in/out of other Android apps works too. The
  helpers are gated on `is_termux()` and are inert on every other platform.

The async path gains a test-only system-clipboard reader seam so the
regression can be reproduced deterministically (stub returning `None` while
the system clipboard stays enabled) without touching the real host
clipboard. The new e2e test copies inside Fresh, pastes with Ctrl+V, and
asserts the internal text lands; it times out without the fallback and
passes with it.

https://claude.ai/code/session_01MrQuX7R9wcsYL4pUDehHay