### PR TITLE
test(e2e): isolate clipboard copy/paste tests from the host OS clipboard

### DIFF
--- a/crates/fresh-editor/tests/e2e/settings_paste.rs
+++ b/crates/fresh-editor/tests/e2e/settings_paste.rs
@@ -13,6 +13,12 @@ fn send_text(harness: &mut EditorTestHarness, text: &str) {
 fn test_settings_paste() {
     let mut harness = EditorTestHarness::new(100, 40).unwrap();
 
+    // Isolate from the host clipboard: the Ctrl+C below writes the copied
+    // text to the internal clipboard and the later Ctrl+V reads it back from
+    // there, so the copy/paste round-trip can't be corrupted by (or corrupt)
+    // a parallel test sharing the real OS clipboard.
+    harness.editor_mut().set_clipboard_for_test(String::new());
+
     // Set clipboard content to "rust"
     send_text(&mut harness, "rust");
     harness

--- a/crates/fresh-editor/tests/e2e/split_view_expectations.rs
+++ b/crates/fresh-editor/tests/e2e/split_view_expectations.rs
@@ -630,6 +630,12 @@ fn test_split_with_minimal_height() {
 fn test_clipboard_shared_across_splits() {
     let mut harness = EditorTestHarness::new(120, 40).unwrap();
 
+    // Use the internal-only clipboard so copy/paste doesn't read or write the
+    // host's real clipboard. Besides keeping the test parallel-safe in CI, this
+    // makes paste fully synchronous (Ctrl+V otherwise races a background arboard
+    // read against a timer), which is what made this test flaky.
+    harness.editor_mut().set_clipboard_for_test(String::new());
+
     // Type and select text in first buffer
     harness.type_text("CopyThis").unwrap();
     // Select all


### PR DESCRIPTION
CONTRIBUTING (Testing rule 4) requires e2e tests to use the internal
clipboard mode so they are isolated from the host system clipboard and
stay parallel-safe in CI. `test_clipboard_shared_across_splits` was flaky
because it drove Ctrl+C/Ctrl+V against the real OS clipboard: the async
paste path races a background arboard read against a timer, and the shared
host clipboard can be clobbered by other parallel tests, so the paste
intermittently produced "CopyThis" instead of "CopyThisCopyThis".

Seed the internal clipboard via `set_clipboard_for_test`, which enables
internal-only mode. That makes the copy/paste round-trip deterministic
and synchronous while still exercising the editor's copy/paste flow (the
feature under test is clipboard sharing across splits, not OS-clipboard
integration).

`test_settings_paste` had the same un-isolated copy->paste round-trip with
a live assertion, so apply the same fix. The other Ctrl+V sites in the
suite are either menu mnemonics (Alt+V), the file-explorer's own node
clipboard, already isolated, or #[ignore]d, so they need no change.