### PR TITLE
ci(release): add Windows ARM64 release artifacts

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -95,7 +95,8 @@ jobs:
               'darwin-arm64': { target: 'aarch64-apple-darwin', ext: 'tar.xz' },
               'linux-x64': { target: 'x86_64-unknown-linux-gnu', ext: 'tar.xz' },
               'linux-arm64': { target: 'aarch64-unknown-linux-gnu', ext: 'tar.xz' },
-              'win32-x64': { target: 'x86_64-pc-windows-msvc', ext: 'zip' }
+              'win32-x64': { target: 'x86_64-pc-windows-msvc', ext: 'zip' },
+              'win32-arm64': { target: 'aarch64-pc-windows-msvc', ext: 'zip' }
             };
 
             const key = `${platform}-${arch}`;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-2022
             archive_ext: zip
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            archive_ext: zip
     runs-on: ${{ matrix.os }}
     env:
       VERSION: ${{ needs.plan.outputs.version }}
@@ -138,7 +141,7 @@ jobs:
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
           fi
           # Static link the C runtime on Windows MSVC to avoid vcruntime DLL dependency
-          if [ "${{ matrix.target }}" = "x86_64-pc-windows-msvc" ]; then
+          if [[ "${{ matrix.target }}" == *-pc-windows-msvc ]]; then
             export RUSTFLAGS="-C target-feature=+crt-static"
           fi
           # Default features include embed-plugins; plugins (and themes via build.rs)

--- a/crates/fresh-editor/npm-package/binary.js
+++ b/crates/fresh-editor/npm-package/binary.js
@@ -10,6 +10,7 @@ function getBinaryInfo() {
     'linux-x64': { target: 'x86_64-unknown-linux-gnu', ext: 'tar.xz' },
     'linux-arm64': { target: 'aarch64-unknown-linux-gnu', ext: 'tar.xz' },
     'win32-x64': { target: 'x86_64-pc-windows-msvc', ext: 'zip' },
+    'win32-arm64': { target: 'aarch64-pc-windows-msvc', ext: 'zip' },
     'freebsd-x64': { target: 'x86_64-unknown-freebsd', ext: 'tar.xz' }
   };
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["npm", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-pc-windows-msvc", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program

--- a/scripts/winget-publish.py
+++ b/scripts/winget-publish.py
@@ -22,6 +22,10 @@ from pathlib import Path
 PACKAGE_ID = "sinelaw.fresh-editor"
 MANIFEST_BASE = "manifests/s/sinelaw/fresh-editor"
 WINGET_REPO = "microsoft/winget-pkgs"
+WINDOWS_INSTALLERS = [
+    ("x64", "x86_64-pc-windows-msvc"),
+    ("arm64", "aarch64-pc-windows-msvc"),
+]
 
 
 def run(cmd: list[str], check: bool = True, capture: bool = False) -> subprocess.CompletedProcess:
@@ -47,6 +51,23 @@ def get_sha256(url: str) -> str:
     return sha256.hexdigest()
 
 
+def release_asset_url(version: str, target: str) -> str:
+    return f"https://github.com/sinelaw/fresh/releases/download/v{version}/fresh-editor-{target}.zip"
+
+
+def render_installers(version: str, hashes: dict[str, str]) -> str:
+    lines = ["Installers:"]
+    for arch, target in WINDOWS_INSTALLERS:
+        lines.extend(
+            [
+                f"  - Architecture: {arch}",
+                f"    InstallerUrl: {release_asset_url(version, target)}",
+                f"    InstallerSha256: {hashes[arch]}",
+            ]
+        )
+    return "\n".join(lines)
+
+
 def main():
     if len(sys.argv) != 2:
         print(f"Usage: {sys.argv[0]} <version>")
@@ -54,11 +75,12 @@ def main():
         sys.exit(1)
 
     version = sys.argv[1]
-    installer_url = f"https://github.com/sinelaw/fresh/releases/download/v{version}/fresh-editor-x86_64-pc-windows-msvc.zip"
     branch_name = f"{PACKAGE_ID}-{version}"
 
     print(f"Publishing {PACKAGE_ID} version {version}")
-    print(f"Installer URL: {installer_url}")
+    print("Installer URLs:")
+    for arch, target in WINDOWS_INSTALLERS:
+        print(f"  {arch}: {release_asset_url(version, target)}")
     print()
 
     # Check gh is authenticated
@@ -69,8 +91,10 @@ def main():
 
     # Compute SHA256
     print("Computing SHA256...")
-    sha256 = get_sha256(installer_url)
-    print(f"SHA256: {sha256}")
+    hashes = {}
+    for arch, target in WINDOWS_INSTALLERS:
+        hashes[arch] = get_sha256(release_asset_url(version, target))
+        print(f"SHA256 ({arch}): {hashes[arch]}")
     print()
 
     # Use cache directory for persistent clone
@@ -140,18 +164,30 @@ def main():
     shutil.copytree(old_path, new_path)
 
     # Update manifests
-    print("Updating version, URL, and SHA256...")
+    print("Updating version, URLs, and SHA256 hashes...")
     for yaml_file in new_path.glob("*.yaml"):
         content = yaml_file.read_text()
 
         # Update PackageVersion
         content = re.sub(r"^PackageVersion:.*$", f"PackageVersion: {version}", content, flags=re.MULTILINE)
 
-        # Update InstallerUrl
-        content = re.sub(r"^(\s*)InstallerUrl:.*$", rf"\1InstallerUrl: {installer_url}", content, flags=re.MULTILINE)
-
-        # Update InstallerSha256
-        content = re.sub(r"^(\s*)InstallerSha256:.*$", rf"\1InstallerSha256: {sha256}", content, flags=re.MULTILINE)
+        # Update installer entries only in the manifest file that owns them.
+        if "Installers:" in content:
+            # Keep this in sync with the existing multi-file manifest style in
+            # winget-pkgs: installer metadata at the root, arch-specific
+            # download details under Installers.
+            if "InstallerType:" not in content:
+                content = re.sub(
+                    r"^(PackageVersion:.*)$",
+                    r"\1\nInstallerLocale: en-US\nInstallerType: zip\nScope: user\nNestedInstallerType: portable\nUpgradeBehavior: uninstallPrevious\nNestedInstallerFiles:\n  - RelativeFilePath: fresh.exe\n    PortableCommandAlias: fresh",
+                    content,
+                    flags=re.MULTILINE,
+                )
+            content = re.sub(
+                r"(?ms)^Installers:\n.*?(?=^ManifestType:)",
+                render_installers(version, hashes) + "\n",
+                content,
+            )
 
         # Update ReleaseNotesUrl
         content = re.sub(


### PR DESCRIPTION
Closes #784.

Windows ARM64 builds were requested in #784 when the old Deno/rusty_v8 dependency chain still blocked the target. Fresh now uses QuickJS, and the TUI binary builds on `aarch64-pc-windows-msvc`.

## Changes

- Add `aarch64-pc-windows-msvc` to the release build matrix, using GitHub's `windows-11-arm` runner.
- Apply the static CRT `RUSTFLAGS` branch to all `*-pc-windows-msvc` release targets so x64 and arm64 follow the same Windows build path.
- Add `aarch64-pc-windows-msvc` to `dist-workspace.toml`.
- Add npm platform detection for `win32-arm64`.
- Update the winget publish helper to emit both x64 and arm64 installer entries for the existing multi-file winget manifest layout.

## Notes

This is limited to the TUI release artifact. It does not add a Windows ARM64 GUI build; the GUI package is still experimental and has separate Windows packaging behavior.

For winget, the current package in `microsoft/winget-pkgs` uses a multi-file manifest. The installer manifest keeps shared zip/portable metadata at the root and puts only architecture-specific URL/hash entries under `Installers`.

## Validation

Local Windows ARM64 machine:

```powershell
cargo build --release --target aarch64-pc-windows-msvc --locked
target\aarch64-pc-windows-msvc\release\fresh.exe --version
```

Result:

```text
fresh 0.4.0
```

Other local checks:

```powershell
cargo fmt -- --check
cargo check --no-default-features --features runtime --all-targets --locked
```

npm route:

- packed the npm package locally
- verified `win32-arm64` resolves to `aarch64-pc-windows-msvc.zip`
- verified the binary name remains `fresh.exe`

winget route:

```powershell
winget validate --manifest <generated multi-file manifest> --disable-interactivity --nowarn
```

Result: manifest validation succeeded.

Fork release workflow validation:

- Release run: https://github.com/NihilDigit/fresh/actions/runs/27529369432
- `build (x86_64-pc-windows-msvc, windows-2022, zip)`: passed
- `build (aarch64-pc-windows-msvc, windows-11-arm, zip)`: passed
- uploaded artifacts include `artifacts-x86_64-pc-windows-msvc` and `artifacts-aarch64-pc-windows-msvc`

Fork PR CI validation so far:

- PR CI run: https://github.com/NihilDigit/fresh/actions/runs/27530303906
- `fmt`: passed
- `doc`: passed
- `schema`: passed
- `check (no plugins)`: passed
- `clippy`: passed
