### PR TITLE
Fix Alt+W leaking into close prompt by narrowing search toggles

### DIFF
--- a/crates/fresh-editor/keymaps/default.json
+++ b/crates/fresh-editor/keymaps/default.json
@@ -1277,26 +1277,26 @@
       "when": "prompt"
     },
     {
-      "comment": "Prompt context - Search options",
+      "comment": "Search options — bound in the narrower 'searchPrompt' context (a sub-context of 'prompt' that is active only while a find/replace prompt is up). This keeps Alt+C/Alt+W/Alt+R/Alt+I from firing in unrelated prompts (e.g. the save/discard/cancel close confirmation), where Alt+W previously toggled whole-word match mode instead of being inert. searchPrompt falls through to 'prompt' for all generic editing keys.",
       "key": "c",
       "modifiers": ["alt"],
       "action": "toggle_search_case_sensitive",
       "args": {},
-      "when": "prompt"
+      "when": "searchPrompt"
     },
     {
       "key": "w",
       "modifiers": ["alt"],
       "action": "toggle_search_whole_word",
       "args": {},
-      "when": "prompt"
+      "when": "searchPrompt"
     },
     {
       "key": "r",
       "modifiers": ["alt"],
       "action": "toggle_search_regex",
       "args": {},
-      "when": "prompt"
+      "when": "searchPrompt"
     },
     {
       "comment": "Toggle confirm each in search/replace (mnemonic: I for Interactive)",
@@ -1304,7 +1304,7 @@
       "modifiers": ["alt"],
       "action": "toggle_search_confirm_each",
       "args": {},
-      "when": "prompt"
+      "when": "searchPrompt"
     },
     {
       "comment": "File browser - toggle hidden files (mnemonic: dotfiles start with '.')",

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -325,10 +325,19 @@ impl Editor {
             });
         }
         if self.is_prompting() {
+            // Find/replace prompts resolve in the narrower `SearchPrompt`
+            // context, which owns the match-mode toggles and otherwise falls
+            // through to `Prompt`. Every other prompt stays in `Prompt`, so
+            // the toggle keys (Alt+W etc.) never fire outside an actual search.
+            let key_context = if self.active_prompt_has_search_options() {
+                KeyContext::SearchPrompt
+            } else {
+                KeyContext::Prompt
+            };
             layers.push(Layer {
                 kind: LayerKind::Prompt,
                 owns_keyboard: true,
-                key_context: Some(KeyContext::Prompt),
+                key_context: Some(key_context),
                 blocks_terminal_input: true,
             });
         }
@@ -1954,6 +1963,9 @@ impl Editor {
             Action::ListBookmarks => {
                 self.active_window_mut().list_bookmarks();
             }
+            Action::ToggleSearchCaseSensitive if !self.active_prompt_has_search_options() => {}
+            Action::ToggleSearchWholeWord if !self.active_prompt_has_search_options() => {}
+            Action::ToggleSearchRegex if !self.active_prompt_has_search_options() => {}
             Action::ToggleSearchCaseSensitive => {
                 self.active_window_mut().search_case_sensitive =
                     !self.active_window().search_case_sensitive;

--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -1014,6 +1014,18 @@ impl Editor {
         self.active_window().prompt.is_some()
     }
 
+    /// Whether the active prompt is a search/replace prompt that exposes the
+    /// match-mode toggles (case sensitive / whole word / regex). Gates both
+    /// the search-options bar and the `ToggleSearch*` actions so those keys
+    /// stay inert in unrelated prompts (e.g. the save/discard/cancel close
+    /// confirmation).
+    pub fn active_prompt_has_search_options(&self) -> bool {
+        self.active_window()
+            .prompt
+            .as_ref()
+            .is_some_and(|p| p.prompt_type.has_search_options())
+    }
+
     /// Get or create a prompt history for the given key
     pub(super) fn get_or_create_prompt_history(
         &mut self,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -115,16 +115,7 @@ impl Editor {
         // rendering uses an up-to-date layout. See the
         // "Recompute layout if mid-render commands changed state"
         // block below.)
-        let mut show_search_options = self.active_window().prompt.as_ref().is_some_and(|p| {
-            matches!(
-                p.prompt_type,
-                PromptType::Search
-                    | PromptType::ReplaceSearch
-                    | PromptType::Replace { .. }
-                    | PromptType::QueryReplaceSearch
-                    | PromptType::QueryReplace { .. }
-            )
-        });
+        let mut show_search_options = self.active_prompt_has_search_options();
 
         // Hide status bar when suggestions popup or file browser
         // popup is shown — those popups float just above the prompt
@@ -540,16 +531,7 @@ impl Editor {
             // the next frame, where the layout is built consistently
             // from the start.
             if dispatched_any {
-                show_search_options = self.active_window().prompt.as_ref().is_some_and(|p| {
-                    matches!(
-                        p.prompt_type,
-                        PromptType::Search
-                            | PromptType::ReplaceSearch
-                            | PromptType::Replace { .. }
-                            | PromptType::QueryReplaceSearch
-                            | PromptType::QueryReplace { .. }
-                    )
-                });
+                show_search_options = self.active_prompt_has_search_options();
                 prompt_is_overlay = self
                     .active_window()
                     .prompt

--- a/crates/fresh-editor/src/input/keybindings.rs
+++ b/crates/fresh-editor/src/input/keybindings.rs
@@ -225,6 +225,13 @@ pub enum KeyContext {
     Normal,
     /// Prompt/minibuffer is active
     Prompt,
+    /// A find/replace search prompt is active. A narrowing of `Prompt`: it
+    /// owns the match-mode toggles (case / whole word / regex / confirm-each)
+    /// and falls through to `Prompt` for every generic editing/navigation key.
+    /// Keeping these toggles out of the broad `Prompt` scope is what stops
+    /// e.g. Alt+W from flipping whole-word match mode while an unrelated
+    /// prompt (the save/discard/cancel close confirmation) is up.
+    SearchPrompt,
     /// Popup window is visible
     Popup,
     /// Completion popup is visible (LSP or non-LSP). Takes precedence over `Popup`
@@ -281,7 +288,22 @@ impl KeyContext {
 
     /// Check if a context should allow input
     pub fn allows_text_input(&self) -> bool {
-        matches!(self, Self::Normal | Self::Prompt | Self::FileExplorer)
+        matches!(
+            self,
+            Self::Normal | Self::Prompt | Self::SearchPrompt | Self::FileExplorer
+        )
+    }
+
+    /// The context whose bindings this context inherits when it has no binding
+    /// of its own for a key. `SearchPrompt` is a narrowing of `Prompt`, so it
+    /// inherits all of `Prompt`'s editing/navigation/confirm keys and only
+    /// adds (or overrides) the few search-option toggles it owns. Checked
+    /// after this context's own bindings but before the Normal fallthrough.
+    pub fn parent_context(&self) -> Option<Self> {
+        match self {
+            Self::SearchPrompt => Some(Self::Prompt),
+            _ => None,
+        }
     }
 
     /// Parse context from a "when" string
@@ -293,6 +315,7 @@ impl KeyContext {
         Some(match trimmed {
             "global" => Self::Global,
             "prompt" => Self::Prompt,
+            "searchPrompt" | "search_prompt" => Self::SearchPrompt,
             "popup" => Self::Popup,
             "completion" => Self::Completion,
             "fileExplorer" | "file_explorer" => Self::FileExplorer,
@@ -312,6 +335,7 @@ impl KeyContext {
             Self::Global => "global".to_string(),
             Self::Normal => "normal".to_string(),
             Self::Prompt => "prompt".to_string(),
+            Self::SearchPrompt => "searchPrompt".to_string(),
             Self::Popup => "popup".to_string(),
             Self::Completion => "completion".to_string(),
             Self::FileExplorer => "fileExplorer".to_string(),
@@ -1890,6 +1914,24 @@ impl KeybindingResolver {
             }
         }
 
+        // Fall through to the parent context's bindings (e.g. SearchPrompt →
+        // Prompt) so a narrowed context inherits all of its parent's keys and
+        // only owns/overrides the few it declares. Checked after this context's
+        // own bindings but before the Normal fallthrough below, so the parent's
+        // editing/navigation keys outrank Normal.
+        if let Some(parent) = context.parent_context() {
+            if let Some(parent_bindings) = self.bindings.get(&parent) {
+                if let Some(action) = parent_bindings.get(norm) {
+                    return action.clone();
+                }
+            }
+            if let Some(parent_bindings) = self.default_bindings.get(&parent) {
+                if let Some(action) = parent_bindings.get(norm) {
+                    return action.clone();
+                }
+            }
+        }
+
         // Fall back to Normal context bindings.
         // Contexts with allows_normal_fallthrough (e.g. CompositeBuffer) get ALL
         // Normal bindings; other contexts only get application-wide actions.
@@ -3207,6 +3249,14 @@ mod tests {
             Some(KeyContext::Prompt)
         );
         assert_eq!(
+            KeyContext::from_when_clause("searchPrompt"),
+            Some(KeyContext::SearchPrompt)
+        );
+        assert_eq!(
+            KeyContext::from_when_clause("search_prompt"),
+            Some(KeyContext::SearchPrompt)
+        );
+        assert_eq!(
             KeyContext::from_when_clause("popup"),
             Some(KeyContext::Popup)
         );
@@ -3220,7 +3270,13 @@ mod tests {
     fn test_key_context_to_when_clause() {
         assert_eq!(KeyContext::Normal.to_when_clause(), "normal");
         assert_eq!(KeyContext::Prompt.to_when_clause(), "prompt");
+        assert_eq!(KeyContext::SearchPrompt.to_when_clause(), "searchPrompt");
         assert_eq!(KeyContext::Popup.to_when_clause(), "popup");
+        // Round-trips through from_when_clause.
+        assert_eq!(
+            KeyContext::from_when_clause(&KeyContext::SearchPrompt.to_when_clause()),
+            Some(KeyContext::SearchPrompt)
+        );
     }
 
     #[test]
@@ -3248,6 +3304,58 @@ mod tests {
         assert_eq!(
             resolver.resolve(&up_event, KeyContext::Normal),
             Action::MoveUp
+        );
+    }
+
+    #[test]
+    fn test_search_prompt_owns_toggles_and_inherits_prompt() {
+        let config = Config::default();
+        let resolver = KeybindingResolver::new(&config);
+
+        let alt_w = KeyEvent::new(KeyCode::Char('w'), KeyModifiers::ALT);
+
+        // Alt+W toggles whole-word ONLY in the SearchPrompt context.
+        assert_eq!(
+            resolver.resolve(&alt_w, KeyContext::SearchPrompt),
+            Action::ToggleSearchWholeWord,
+        );
+        // In the broad Prompt context (e.g. the save/discard/cancel close
+        // confirmation) Alt+W must NOT toggle whole-word — that was the bug.
+        assert_ne!(
+            resolver.resolve(&alt_w, KeyContext::Prompt),
+            Action::ToggleSearchWholeWord,
+        );
+
+        // The other match-mode toggles are likewise SearchPrompt-only.
+        let alt_c = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::ALT);
+        let alt_r = KeyEvent::new(KeyCode::Char('r'), KeyModifiers::ALT);
+        assert_eq!(
+            resolver.resolve(&alt_c, KeyContext::SearchPrompt),
+            Action::ToggleSearchCaseSensitive,
+        );
+        assert_eq!(
+            resolver.resolve(&alt_r, KeyContext::SearchPrompt),
+            Action::ToggleSearchRegex,
+        );
+
+        // SearchPrompt inherits all generic editing/navigation keys from its
+        // parent Prompt context (Enter confirms, Esc cancels, text types).
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&enter, KeyContext::SearchPrompt),
+            resolver.resolve(&enter, KeyContext::Prompt),
+        );
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::empty());
+        assert_eq!(
+            resolver.resolve(&esc, KeyContext::SearchPrompt),
+            resolver.resolve(&esc, KeyContext::Prompt),
+        );
+        assert_eq!(
+            resolver.resolve(
+                &KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()),
+                KeyContext::SearchPrompt,
+            ),
+            Action::InsertChar('x'),
         );
     }
 

--- a/crates/fresh-editor/src/view/prompt.rs
+++ b/crates/fresh-editor/src/view/prompt.rs
@@ -185,6 +185,26 @@ impl PromptType {
     pub fn click_confirms(&self) -> bool {
         !matches!(self, PromptType::ReloadWithEncoding)
     }
+
+    /// Whether this prompt is one of the search/replace prompts that exposes
+    /// the match-mode toggles (case sensitive / whole word / regex).
+    ///
+    /// This is the single source of truth for "are search options in scope":
+    /// it gates both the rendering of the search-options bar and the
+    /// `ToggleSearch*` actions, so the toggle keys are inert in unrelated
+    /// prompts like the (s)ave/(d)iscard/(C)ancel close confirmation
+    /// (otherwise Alt+W there would silently flip whole-word match mode —
+    /// see issue with Alt+W leaking into the close-buffer prompt).
+    pub fn has_search_options(&self) -> bool {
+        matches!(
+            self,
+            PromptType::Search
+                | PromptType::ReplaceSearch
+                | PromptType::Replace { .. }
+                | PromptType::QueryReplaceSearch
+                | PromptType::QueryReplace { .. }
+        )
+    }
 }
 
 /// Prompt state for the minibuffer

--- a/crates/fresh-editor/src/view/ui/status_bar.rs
+++ b/crates/fresh-editor/src/view/ui/status_bar.rs
@@ -1842,10 +1842,21 @@ impl StatusBarRenderer {
             .fg(theme.menu_hover_fg)
             .bg(theme.menu_hover_bg);
 
-        // Helper to look up keybinding for an action (Prompt context first, then Global)
+        // Helper to look up keybinding for an action. The search-option toggles
+        // live in the SearchPrompt context; fall back to Prompt then Global so a
+        // user override in either still surfaces in the hint.
         let get_shortcut = |action: &crate::input::keybindings::Action| -> Option<String> {
             keybindings
-                .get_keybinding_for_action(action, crate::input::keybindings::KeyContext::Prompt)
+                .get_keybinding_for_action(
+                    action,
+                    crate::input::keybindings::KeyContext::SearchPrompt,
+                )
+                .or_else(|| {
+                    keybindings.get_keybinding_for_action(
+                        action,
+                        crate::input::keybindings::KeyContext::Prompt,
+                    )
+                })
                 .or_else(|| {
                     keybindings.get_keybinding_for_action(
                         action,

--- a/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
+++ b/crates/fresh-editor/tests/e2e/buffer_lifecycle.rs
@@ -29,6 +29,64 @@ fn test_save_unnamed_buffer_shows_save_as_prompt() {
     harness.assert_screen_contains("Save as:");
 }
 
+/// Regression: Alt+W must not toggle "whole word" search while the
+/// save/discard/cancel close confirmation is up.
+///
+/// Alt+W is `close_tab` in the normal context. When closing a *modified*
+/// buffer it raises the (s)ave/(d)iscard/(C)ancel prompt — at which point a
+/// second Alt+W used to leak into the search-options toggle (the binding lived
+/// in the broad `prompt` context). The toggles now live in the narrower
+/// `searchPrompt` context, active only for find/replace prompts, so Alt+W is
+/// inert here and the close prompt stays put.
+#[test]
+fn test_alt_w_does_not_toggle_whole_word_in_close_prompt() {
+    let mut config = Config::default();
+    config.editor.hot_exit = false;
+    let mut harness = EditorTestHarness::with_config(100, 24, config).unwrap();
+
+    // Modify the buffer so closing it requires confirmation.
+    harness.type_text("Modified content").unwrap();
+    harness.render().unwrap();
+
+    // Alt+W = close_tab → save/discard/cancel confirmation for the dirty buffer.
+    harness
+        .send_key(KeyCode::Char('w'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("(d)iscard");
+
+    // A second Alt+W must be inert here — not flip whole-word match mode.
+    harness
+        .send_key(KeyCode::Char('w'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_not_contains("Whole word");
+    // The close confirmation is still the active prompt.
+    harness.assert_screen_contains("(d)iscard");
+}
+
+/// Counterpart to the regression above: inside an actual search prompt Alt+W
+/// still toggles whole-word match mode (its `searchPrompt`-context binding).
+#[test]
+fn test_alt_w_toggles_whole_word_in_search_prompt() {
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.render().unwrap();
+
+    // Open the find prompt; the search-options bar shows the toggles.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Whole Word");
+
+    // Alt+W flips whole-word match mode here.
+    harness
+        .send_key(KeyCode::Char('w'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Whole word search enabled");
+}
+
 /// Test that quitting with modified buffers shows confirmation and doesn't quit immediately
 #[test]
 fn test_quit_with_modified_buffers_shows_confirmation() {


### PR DESCRIPTION
## Summary

This PR fixes a bug where Alt+W (and other search option toggle keys) would inadvertently toggle whole-word match mode while the save/discard/cancel close confirmation prompt was active. The root cause was that these toggle bindings lived in the broad `Prompt` context, which applies to all prompts. The fix introduces a narrower `SearchPrompt` context that is active only during find/replace prompts, keeping the toggle keys inert in unrelated prompts.

## Key Changes

- **New `SearchPrompt` context**: Added a new `KeyContext::SearchPrompt` enum variant that represents find/replace prompts specifically. This context inherits from `Prompt` for generic editing/navigation keys but owns only the search option toggles.

- **Context inheritance system**: Implemented `parent_context()` method on `KeyContext` to support context fallthrough. `SearchPrompt` falls through to `Prompt`, allowing it to inherit all editing/navigation bindings while only declaring its own toggle bindings.

- **Keybinding resolution update**: Modified `KeybindingResolver::resolve()` to check parent context bindings after the current context but before the Normal fallthrough, enabling proper inheritance.

- **Moved toggle bindings**: Migrated Alt+C, Alt+W, Alt+R, and Alt+I keybindings from `prompt` context to `searchPrompt` context in the default keymap.

- **Helper method**: Added `active_prompt_has_search_options()` to `Editor` as a single source of truth for determining whether the active prompt is a search/replace prompt. This gates both the search-options bar rendering and the toggle action handlers.

- **Action guards**: Added early returns in the toggle action handlers to silently ignore the actions when `active_prompt_has_search_options()` returns false, providing defense-in-depth.

- **Parsing and serialization**: Updated `KeyContext::from_when_clause()` and `to_when_clause()` to handle both camelCase (`searchPrompt`) and snake_case (`search_prompt`) variants.

## Implementation Details

- The `SearchPrompt` context is only set as the active key context when `is_prompting()` is true AND the active prompt has search options (checked via `PromptType::has_search_options()`).

- `PromptType::has_search_options()` is the single source of truth for which prompts expose search toggles, matching against `Search`, `ReplaceSearch`, `Replace`, `QueryReplaceSearch`, and `QueryReplace` variants.

- Comprehensive test coverage added, including regression tests verifying Alt+W is inert in the close prompt but still works in search prompts, and unit tests for context inheritance and parsing.

https://claude.ai/code/session_01EiHh9ufrRoY8s5zYpzRXLk