### PR TITLE
Uniform environment activation across all backends and surfaces

### DIFF
--- a/crates/fresh-editor/plugins/devcontainer.ts
+++ b/crates/fresh-editor/plugins/devcontainer.ts
@@ -1593,6 +1593,16 @@ function buildContainerAuthorityPayload(
   if (workspace) {
     args.push("-w", workspace);
   }
+  // Apply the captured userEnvProbe env to the integrated terminal too, so it
+  // matches what LSP / spawnProcess get inside the container (issue #2355; see
+  // docs/internal/uniform-env-activation-design.md). Mirrors the spawner's
+  // `build_docker_exec_prefix`, which already passes these as `-e` flags;
+  // without them the terminal would drop into `bash -l` with only whatever the
+  // container's default exec env provides. Placed after `-w` and before the
+  // container id, matching docker's flag-parsing rules.
+  for (const [k, v] of baseEnv) {
+    args.push("-e", `${k}=${v}`);
+  }
   args.push(result.containerId, "bash", "-l");
 
   const shortId = result.containerId.slice(0, 12);

--- a/crates/fresh-editor/plugins/env-manager.ts
+++ b/crates/fresh-editor/plugins/env-manager.ts
@@ -480,6 +480,18 @@ function maybeAutoActivate(): void {
 registerHandler("env_maybe_auto_activate", maybeAutoActivate);
 editor.on("plugins_loaded", "env_maybe_auto_activate");
 
+// A session activated *after* boot — most notably one spawned through the
+// Orchestrator ("New Session" / dock), which creates a window without
+// re-firing `plugins_loaded` — must get the same auto-activation a direct
+// `fresh <dir>` launch gets. Without this, such a session stays on the system
+// toolchain even once its workspace trust is decided (issue #2355 follow-up).
+// Guarded on `!envActive()` so merely switching back to an already-active
+// session is a no-op and never re-applies (which would needlessly reload LSP).
+registerHandler("env_auto_activate_on_session", () => {
+  if (!editor.envActive()) maybeAutoActivate();
+});
+editor.on("active_window_changed", "env_auto_activate_on_session");
+
 // === Status pill (opt-in to a user's status-bar layout) ===
 //
 // One pill: "env" — what environment is active (always relevant once

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -107,7 +107,10 @@ impl Window {
     /// already get (issue #2355). Returns the wrapper unchanged when no env is
     /// active or the wrapper isn't an SSH re-parent. (Container backends apply
     /// their captured env through their own wrapper flags; see the design doc.)
-    pub(crate) fn apply_remote_terminal_env(&self, mut wrapper: TerminalWrapper) -> TerminalWrapper {
+    pub(crate) fn apply_remote_terminal_env(
+        &self,
+        mut wrapper: TerminalWrapper,
+    ) -> TerminalWrapper {
         use crate::services::remote::{ssh_remote_env_launcher, SSH_EXEC_LOGIN_SHELL};
 
         if wrapper.command == "ssh" && self.authority().env_provider.is_active() {

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -98,6 +98,29 @@ impl Window {
         self.authority().env_provider.current_local_delta_blocking()
     }
 
+    /// Apply the activated environment to a *re-parented* terminal wrapper
+    /// (SSH / container), the remote counterpart of [`Self::terminal_env_delta`]
+    /// (which handles the local host shell via `CommandBuilder.env`). For SSH,
+    /// rewrite the remote login-shell `exec` into a python3 launcher that
+    /// captures + applies the activation on the remote before handing off to the
+    /// user's shell, so the SSH terminal sees the same env LSP/`spawnProcess`
+    /// already get (issue #2355). Returns the wrapper unchanged when no env is
+    /// active or the wrapper isn't an SSH re-parent. (Container backends apply
+    /// their captured env through their own wrapper flags; see the design doc.)
+    pub(crate) fn apply_remote_terminal_env(&self, mut wrapper: TerminalWrapper) -> TerminalWrapper {
+        use crate::services::remote::{ssh_remote_env_launcher, SSH_EXEC_LOGIN_SHELL};
+
+        if wrapper.command == "ssh" && self.authority().env_provider.is_active() {
+            let recipe = self.authority().env_provider.snippet();
+            if let Some(last) = wrapper.args.last_mut() {
+                if last.contains(SSH_EXEC_LOGIN_SHELL) {
+                    *last = last.replace(SSH_EXEC_LOGIN_SHELL, &ssh_remote_env_launcher(&recipe));
+                }
+            }
+        }
+        wrapper
+    }
+
     /// Get terminal dimensions appropriate for spawning a PTY in this
     /// window. Derived from the window's cached screen size minus a
     /// small constant for menu/status chrome.
@@ -173,6 +196,7 @@ impl Window {
             Some(argv) if !argv.is_empty() => self.authority().terminal_command(&argv),
             _ => self.resolved_terminal_wrapper(),
         };
+        let wrapper = self.apply_remote_terminal_env(wrapper);
         let env_delta = self.terminal_env_delta(&wrapper);
         match self.terminal_manager.spawn(
             cols,

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -77,6 +77,23 @@ impl Window {
             .with_user_shell_override(self.resources.config.terminal.shell.as_ref())
     }
 
+    /// The activated-environment overlay (venv/direnv/mise) to inject into a
+    /// newly spawned terminal, so it inherits the same env that LSP servers and
+    /// `spawnProcess` already get (issue #2355). Captured only for a **local**
+    /// host shell: `manages_cwd` marks docker/ssh-style wrappers whose inner
+    /// shell runs on another host, where these locally-captured pairs would be
+    /// both wrong and unreachable (the env this `CommandBuilder` sets lands on
+    /// the `docker`/`ssh` client process, not the remote shell). Those backends
+    /// carry their own captured env through their spawners instead. Empty when
+    /// no env is active or capture fails — the terminal degrades to the
+    /// inherited env exactly as before.
+    pub(crate) fn terminal_env_overlay(&self, wrapper: &TerminalWrapper) -> Vec<(String, String)> {
+        if wrapper.manages_cwd {
+            return Vec::new();
+        }
+        self.authority().env_provider.current_local_blocking()
+    }
+
     /// Get terminal dimensions appropriate for spawning a PTY in this
     /// window. Derived from the window's cached screen size minus a
     /// small constant for menu/status chrome.
@@ -152,6 +169,7 @@ impl Window {
             Some(argv) if !argv.is_empty() => self.authority().terminal_command(&argv),
             _ => self.resolved_terminal_wrapper(),
         };
+        let env_overlay = self.terminal_env_overlay(&wrapper);
         match self.terminal_manager.spawn(
             cols,
             rows,
@@ -159,6 +177,7 @@ impl Window {
             Some(log_path.clone()),
             Some(backing_path),
             wrapper,
+            env_overlay,
         ) {
             Ok(terminal_id) => {
                 self.terminal_log_files.insert(terminal_id, log_path);

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -77,21 +77,25 @@ impl Window {
             .with_user_shell_override(self.resources.config.terminal.shell.as_ref())
     }
 
-    /// The activated-environment overlay (venv/direnv/mise) to inject into a
-    /// newly spawned terminal, so it inherits the same env that LSP servers and
-    /// `spawnProcess` already get (issue #2355). Captured only for a **local**
-    /// host shell: `manages_cwd` marks docker/ssh-style wrappers whose inner
-    /// shell runs on another host, where these locally-captured pairs would be
-    /// both wrong and unreachable (the env this `CommandBuilder` sets lands on
+    /// The activated-environment delta (venv/direnv/mise) to apply to a newly
+    /// spawned terminal, so it inherits the same env that LSP servers and
+    /// `spawnProcess` already get (issue #2355; see
+    /// docs/internal/uniform-env-activation-design.md). Captured only for a
+    /// **local** host shell: `manages_cwd` marks docker/ssh-style wrappers whose
+    /// inner shell runs on another host, where this locally-captured delta would
+    /// be both wrong and unreachable (the env this `CommandBuilder` sets lands on
     /// the `docker`/`ssh` client process, not the remote shell). Those backends
-    /// carry their own captured env through their spawners instead. Empty when
-    /// no env is active or capture fails — the terminal degrades to the
-    /// inherited env exactly as before.
-    pub(crate) fn terminal_env_overlay(&self, wrapper: &TerminalWrapper) -> Vec<(String, String)> {
+    /// apply their own delta in the wrapper (the per-backend apply paths in the
+    /// design doc). Empty when no env is active or capture fails — the terminal
+    /// degrades to the inherited env exactly as before.
+    pub(crate) fn terminal_env_delta(
+        &self,
+        wrapper: &TerminalWrapper,
+    ) -> crate::services::env_provider::EnvDelta {
         if wrapper.manages_cwd {
-            return Vec::new();
+            return crate::services::env_provider::EnvDelta::default();
         }
-        self.authority().env_provider.current_local_blocking()
+        self.authority().env_provider.current_local_delta_blocking()
     }
 
     /// Get terminal dimensions appropriate for spawning a PTY in this
@@ -169,7 +173,7 @@ impl Window {
             Some(argv) if !argv.is_empty() => self.authority().terminal_command(&argv),
             _ => self.resolved_terminal_wrapper(),
         };
-        let env_overlay = self.terminal_env_overlay(&wrapper);
+        let env_delta = self.terminal_env_delta(&wrapper);
         match self.terminal_manager.spawn(
             cols,
             rows,
@@ -177,7 +181,7 @@ impl Window {
             Some(log_path.clone()),
             Some(backing_path),
             wrapper,
-            env_overlay,
+            env_delta,
         ) {
             Ok(terminal_id) => {
                 self.terminal_log_files.insert(terminal_id, log_path);

--- a/crates/fresh-editor/src/app/window_actions.rs
+++ b/crates/fresh-editor/src/app/window_actions.rs
@@ -252,6 +252,26 @@ impl crate::app::Editor {
         let previous_id = self.active_window;
         self.active_window = id;
 
+        // Run the workspace-trust decision for the project this session opens,
+        // exactly as the CLI / session-server startup paths do — the
+        // orchestrator's "New Session" path bypasses those, so without this a
+        // never-decided project opened through the dock stays Restricted and
+        // its env manager (venv / direnv / mise) never activates, leaving the
+        // terminal below on the *system* toolchain even though a direct
+        // `fresh <dir>` would have auto-trusted and activated it. `authority()`
+        // already follows `active_window` (set just above), so this scopes to
+        // the new window's trust + root. Local only: remote (born-attached
+        // SSH/k8s) sessions manage trust through their own connect flow and
+        // their markers don't live on the host filesystem.
+        if self
+            .authority()
+            .filesystem
+            .remote_connection_info()
+            .is_none()
+        {
+            self.maybe_prompt_workspace_trust();
+        }
+
         // The argv to re-run if this session is restored. `None` (plain
         // shell) is recorded as an empty vec: a present entry — even empty —
         // marks this as a restorable *session* terminal (re-spawn it on

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -768,6 +768,7 @@ impl crate::app::window::Window {
             Some(argv) => self.authority().terminal_command(argv),
             None => self.resolved_terminal_wrapper(),
         };
+        let env_overlay = self.terminal_env_overlay(&wrapper_for_spawn);
         let terminal_id = match self.terminal_manager.spawn(
             terminal.cols,
             terminal.rows,
@@ -775,6 +776,7 @@ impl crate::app::window::Window {
             Some(log_path.clone()),
             Some(backing_path.clone()),
             wrapper_for_spawn,
+            env_overlay,
         ) {
             Ok(id) => id,
             Err(e) => {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -768,6 +768,7 @@ impl crate::app::window::Window {
             Some(argv) => self.authority().terminal_command(argv),
             None => self.resolved_terminal_wrapper(),
         };
+        let wrapper_for_spawn = self.apply_remote_terminal_env(wrapper_for_spawn);
         let env_delta = self.terminal_env_delta(&wrapper_for_spawn);
         let terminal_id = match self.terminal_manager.spawn(
             terminal.cols,

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -768,7 +768,7 @@ impl crate::app::window::Window {
             Some(argv) => self.authority().terminal_command(argv),
             None => self.resolved_terminal_wrapper(),
         };
-        let env_overlay = self.terminal_env_overlay(&wrapper_for_spawn);
+        let env_delta = self.terminal_env_delta(&wrapper_for_spawn);
         let terminal_id = match self.terminal_manager.spawn(
             terminal.cols,
             terminal.rows,
@@ -776,7 +776,7 @@ impl crate::app::window::Window {
             Some(log_path.clone()),
             Some(backing_path.clone()),
             wrapper_for_spawn,
-            env_overlay,
+            env_delta,
         ) {
             Ok(id) => id,
             Err(e) => {

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -535,9 +535,12 @@ impl Authority {
             Arc::clone(&env),
             Arc::clone(&trust),
         ));
-        let long_running_spawner: Arc<dyn LongRunningSpawner> = Arc::new(
-            KubectlLongRunningSpawner::with_env(target.clone(), base_env.clone(), Arc::clone(&trust)),
-        );
+        let long_running_spawner: Arc<dyn LongRunningSpawner> =
+            Arc::new(KubectlLongRunningSpawner::with_env(
+                target.clone(),
+                base_env.clone(),
+                Arc::clone(&trust),
+            ));
         Self::kube(
             filesystem,
             process_spawner,

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -150,10 +150,10 @@ impl TerminalWrapper {
     /// wrapper: cwd is pinned through the wrapper's own args, so
     /// `manages_cwd` is true and the terminal manager must not hand the
     /// local PTY a pod-side cwd it can't honour.
-    pub fn kube(target: &KubeTarget) -> Self {
+    pub fn kube(target: &KubeTarget, base_env: &[(String, String)]) -> Self {
         Self {
             command: "kubectl".to_string(),
-            args: build_kube_terminal_args(target),
+            args: build_kube_terminal_args(target, base_env),
             manages_cwd: true,
         }
     }
@@ -485,6 +485,7 @@ impl Authority {
         process_spawner: Arc<dyn ProcessSpawner>,
         long_running_spawner: Arc<dyn LongRunningSpawner>,
         target: &KubeTarget,
+        base_env: &[(String, String)],
         trust: Arc<WorkspaceTrust>,
         env: Arc<crate::services::env_provider::EnvProvider>,
     ) -> Self {
@@ -492,7 +493,7 @@ impl Authority {
             filesystem,
             process_spawner,
             long_running_spawner,
-            terminal_wrapper: TerminalWrapper::kube(target),
+            terminal_wrapper: TerminalWrapper::kube(target, base_env),
             display_label: target.display(),
             path_translation: None,
             workspace_trust: trust,
@@ -535,13 +536,14 @@ impl Authority {
             Arc::clone(&trust),
         ));
         let long_running_spawner: Arc<dyn LongRunningSpawner> = Arc::new(
-            KubectlLongRunningSpawner::with_env(target.clone(), base_env, Arc::clone(&trust)),
+            KubectlLongRunningSpawner::with_env(target.clone(), base_env.clone(), Arc::clone(&trust)),
         );
         Self::kube(
             filesystem,
             process_spawner,
             long_running_spawner,
             &target,
+            &base_env,
             trust,
             env,
         )
@@ -1090,7 +1092,7 @@ mod tests {
             container: None,
             workspace: Some("/workspace".into()),
         };
-        let wrapper = TerminalWrapper::kube(&target);
+        let wrapper = TerminalWrapper::kube(&target, &[]);
         assert_eq!(wrapper.command, "kubectl");
         // Re-parented shell must pin cwd through its own args.
         assert!(wrapper.manages_cwd);

--- a/crates/fresh-editor/src/services/env_provider.rs
+++ b/crates/fresh-editor/src/services/env_provider.rs
@@ -18,6 +18,7 @@
 //! closure must run a **raw** spawn that does not itself apply this provider's
 //! env — otherwise capturing the env would recurse.
 
+use crate::services::process_hidden::HideWindow;
 use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
@@ -188,6 +189,69 @@ impl EnvProvider {
 
         let script = build_capture_script(&snippet, dir.as_deref());
         let Some(stdout) = run(script).await else {
+            return Vec::new();
+        };
+        let vars = parse_env(&stdout);
+
+        if let Ok(mut s) = self.state.write() {
+            s.cache = Some(Cached {
+                inputs_hash: hash,
+                vars: vars.clone(),
+            });
+        }
+        vars
+    }
+
+    /// Synchronous sibling of [`Self::current`] for a *local* backend: capture
+    /// the active env by running the snippet through `$SHELL -lc … command env`
+    /// on this host, **blocking** the caller. The integrated-terminal spawn is a
+    /// synchronous, non-tokio path (portable-pty + OS threads) and so cannot
+    /// `await` the async capture; this is how the terminal picks up the same
+    /// activated env that LSP/`spawnProcess` get. Shares the input-hash cache
+    /// with [`Self::current`], so once any spawner has captured for the current
+    /// inputs this returns immediately with no subprocess. Empty when inactive
+    /// or on failure — the caller degrades to the inherited env.
+    pub fn current_local_blocking(&self) -> Vec<(String, String)> {
+        self.capture_blocking(|script| {
+            let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+            let output = std::process::Command::new(&shell)
+                .arg("-lc")
+                .arg(&script)
+                .hide_window()
+                .output()
+                .ok()?;
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        })
+    }
+
+    /// Shared body for a blocking capture: snapshot the recipe, serve from the
+    /// input-hash cache when warm, otherwise run `run` (the host's raw shell
+    /// invocation) and cache the parsed result. Mirrors [`Self::current`]'s
+    /// caching but with a synchronous `run`. `run` MUST be a raw spawn that does
+    /// not apply this provider's env, or capture would recurse.
+    fn capture_blocking(
+        &self,
+        run: impl FnOnce(String) -> Option<String>,
+    ) -> Vec<(String, String)> {
+        let (snippet, dir) = match self.state.read() {
+            Ok(s) => (s.snippet.clone(), s.dir.clone()),
+            Err(_) => return Vec::new(),
+        };
+        if snippet.trim().is_empty() {
+            return Vec::new();
+        }
+
+        let hash = inputs_hash(dir.as_deref());
+        if let Ok(s) = self.state.read() {
+            if let Some(c) = &s.cache {
+                if c.inputs_hash == hash {
+                    return c.vars.clone();
+                }
+            }
+        }
+
+        let script = build_capture_script(&snippet, dir.as_deref());
+        let Some(stdout) = run(script) else {
             return Vec::new();
         };
         let vars = parse_env(&stdout);
@@ -463,6 +527,41 @@ mod tests {
             .await;
         assert_eq!(v2, vec![("A".into(), "2".into())]);
         assert_eq!(n.get(), 2, "input change should force a re-capture");
+    }
+
+    #[test]
+    fn blocking_capture_inactive_returns_empty_without_running() {
+        let p = EnvProvider::inactive();
+        let ran = std::cell::Cell::new(false);
+        let vars = p.capture_blocking(|_script| {
+            ran.set(true);
+            Some("X=1".to_string())
+        });
+        assert!(vars.is_empty());
+        assert!(!ran.get(), "blocking capture must not run when inactive");
+    }
+
+    #[test]
+    fn blocking_capture_caches_and_shares_cache_with_current() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = EnvProvider::inactive();
+        p.set("true".into(), Some(tmp.path().to_path_buf()));
+
+        let calls = std::cell::Cell::new(0);
+        let run = || {
+            calls.set(calls.get() + 1);
+            Some("FOO=bar\nPATH=/x\n".to_string())
+        };
+
+        let v1 = p.capture_blocking(|_s| run());
+        assert_eq!(
+            v1,
+            vec![("FOO".into(), "bar".into()), ("PATH".into(), "/x".into())]
+        );
+        // Second blocking call hits the cache — no re-run.
+        let v2 = p.capture_blocking(|_s| run());
+        assert_eq!(v2, v1);
+        assert_eq!(calls.get(), 1, "warm cache should prevent a second capture");
     }
 
     #[tokio::test]

--- a/crates/fresh-editor/src/services/env_provider.rs
+++ b/crates/fresh-editor/src/services/env_provider.rs
@@ -320,8 +320,10 @@ fn build_capture_script(snippet: &str, dir: Option<&Path>) -> String {
 
 /// Marker printed between the baseline and activated env dumps in the delta
 /// capture. A fixed, unlikely token — env values never legitimately contain it,
-/// so it cleanly splits the two halves of the output.
-const DELTA_SENTINEL: &str = "__FRESH_ENV_DELTA_SENTINEL_b3f1c2__";
+/// so it cleanly splits the two halves of the output. `pub(crate)` so the SSH
+/// remote launcher ([`crate::services::remote::spawner::ssh_remote_env_launcher`])
+/// can split on the identical marker when it captures the delta on the remote.
+pub(crate) const DELTA_SENTINEL: &str = "__FRESH_ENV_DELTA_SENTINEL_b3f1c2__";
 
 /// Build the script for a *delta* capture: dump the env once (baseline — login
 /// shell in the project dir, recipe not yet run), print the sentinel, run the

--- a/crates/fresh-editor/src/services/env_provider.rs
+++ b/crates/fresh-editor/src/services/env_provider.rs
@@ -43,13 +43,41 @@ struct State {
     snippet: String,
     /// Project directory the snippet runs in.
     dir: Option<PathBuf>,
-    /// Last capture, keyed by the env-inputs hash it was produced under.
+    /// Last full-snapshot capture, keyed by the env-inputs hash it was produced
+    /// under. Used by [`EnvProvider::current`] (LSP / one-shot spawns).
     cache: Option<Cached>,
+    /// Last *delta* capture (activation changes over a clean login shell),
+    /// keyed by the same hash. Used by the integrated terminal.
+    delta_cache: Option<CachedDelta>,
 }
 
 struct Cached {
     inputs_hash: u64,
     vars: Vec<(String, String)>,
+}
+
+struct CachedDelta {
+    inputs_hash: u64,
+    delta: EnvDelta,
+}
+
+/// An environment **delta**: the changes the activation recipe introduces over
+/// a clean login shell. `set` are keys to add/override; `unset` are keys the
+/// recipe removed. Applying a delta to a child's environment is shell-agnostic
+/// and carries only the activation's contribution — never volatile shell
+/// bookkeeping (`PWD`, `SHLVL`, …), which is identical in baseline and
+/// activated and so diffs out.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnvDelta {
+    pub set: Vec<(String, String)>,
+    pub unset: Vec<String>,
+}
+
+impl EnvDelta {
+    /// No changes — applying it is a no-op (inactive env or capture failure).
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty() && self.unset.is_empty()
+    }
 }
 
 /// Shared, live environment recipe.
@@ -70,6 +98,7 @@ impl EnvProvider {
                 snippet: String::new(),
                 dir: None,
                 cache: None,
+                delta_cache: None,
             }),
             store: RwLock::new(None),
         }
@@ -100,6 +129,7 @@ impl EnvProvider {
                         s.snippet = snippet;
                         s.dir = dir;
                         s.cache = None;
+                        s.delta_cache = None;
                     }
                 }
             }
@@ -116,6 +146,7 @@ impl EnvProvider {
             s.snippet = snippet.clone();
             s.dir = dir.clone();
             s.cache = None;
+            s.delta_cache = None;
         }
         if let Ok(store) = self.store.read() {
             if let Some(store) = store.as_ref() {
@@ -134,6 +165,7 @@ impl EnvProvider {
         if let Ok(mut s) = self.state.write() {
             s.snippet.clear();
             s.cache = None;
+            s.delta_cache = None;
         }
         if let Ok(store) = self.store.read() {
             if let Some(store) = store.as_ref() {
@@ -202,17 +234,19 @@ impl EnvProvider {
         vars
     }
 
-    /// Synchronous sibling of [`Self::current`] for a *local* backend: capture
-    /// the active env by running the snippet through `$SHELL -lc … command env`
-    /// on this host, **blocking** the caller. The integrated-terminal spawn is a
-    /// synchronous, non-tokio path (portable-pty + OS threads) and so cannot
-    /// `await` the async capture; this is how the terminal picks up the same
-    /// activated env that LSP/`spawnProcess` get. Shares the input-hash cache
-    /// with [`Self::current`], so once any spawner has captured for the current
-    /// inputs this returns immediately with no subprocess. Empty when inactive
-    /// or on failure — the caller degrades to the inherited env.
-    pub fn current_local_blocking(&self) -> Vec<(String, String)> {
-        self.capture_blocking(|script| {
+    /// Capture the activation **delta** for a *local* backend by running the
+    /// recipe through `$SHELL -lc` on this host, **blocking** the caller.
+    ///
+    /// The integrated-terminal spawn is a synchronous, non-tokio path
+    /// (portable-pty + OS threads) and so cannot `await` the async capture; this
+    /// is how the terminal applies the same activation everything else gets. The
+    /// returned [`EnvDelta`] carries only what the recipe changed over a clean
+    /// login shell, so applying it to the child's env is shell-agnostic and free
+    /// of volatile shell bookkeeping. Shares a hash-keyed cache, so repeated
+    /// terminal opens with unchanged env inputs run no subprocess. Empty when
+    /// inactive or on failure — the caller degrades to the inherited env.
+    pub fn current_local_delta_blocking(&self) -> EnvDelta {
+        self.capture_delta_blocking(|script| {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
             let output = std::process::Command::new(&shell)
                 .arg("-lc")
@@ -224,45 +258,42 @@ impl EnvProvider {
         })
     }
 
-    /// Shared body for a blocking capture: snapshot the recipe, serve from the
-    /// input-hash cache when warm, otherwise run `run` (the host's raw shell
-    /// invocation) and cache the parsed result. Mirrors [`Self::current`]'s
-    /// caching but with a synchronous `run`. `run` MUST be a raw spawn that does
-    /// not apply this provider's env, or capture would recurse.
-    fn capture_blocking(
-        &self,
-        run: impl FnOnce(String) -> Option<String>,
-    ) -> Vec<(String, String)> {
+    /// Shared body for a blocking delta capture: serve from the input-hash cache
+    /// when warm, otherwise run `run` (the host's raw shell invocation over the
+    /// baseline+activated capture script) and cache the diff. `run` MUST be a
+    /// raw spawn that does not apply this provider's env, or capture would
+    /// recurse.
+    fn capture_delta_blocking(&self, run: impl FnOnce(String) -> Option<String>) -> EnvDelta {
         let (snippet, dir) = match self.state.read() {
             Ok(s) => (s.snippet.clone(), s.dir.clone()),
-            Err(_) => return Vec::new(),
+            Err(_) => return EnvDelta::default(),
         };
         if snippet.trim().is_empty() {
-            return Vec::new();
+            return EnvDelta::default();
         }
 
         let hash = inputs_hash(dir.as_deref());
         if let Ok(s) = self.state.read() {
-            if let Some(c) = &s.cache {
+            if let Some(c) = &s.delta_cache {
                 if c.inputs_hash == hash {
-                    return c.vars.clone();
+                    return c.delta.clone();
                 }
             }
         }
 
-        let script = build_capture_script(&snippet, dir.as_deref());
+        let script = build_delta_capture_script(&snippet, dir.as_deref());
         let Some(stdout) = run(script) else {
-            return Vec::new();
+            return EnvDelta::default();
         };
-        let vars = parse_env(&stdout);
+        let delta = parse_delta(&stdout);
 
         if let Ok(mut s) = self.state.write() {
-            s.cache = Some(Cached {
+            s.delta_cache = Some(CachedDelta {
                 inputs_hash: hash,
-                vars: vars.clone(),
+                delta: delta.clone(),
             });
         }
-        vars
+        delta
     }
 }
 
@@ -285,6 +316,73 @@ fn build_capture_script(snippet: &str, dir: Option<&Path>) -> String {
     // `command env` bypasses any `env` function/alias.
     script.push_str("command env");
     script
+}
+
+/// Marker printed between the baseline and activated env dumps in the delta
+/// capture. A fixed, unlikely token — env values never legitimately contain it,
+/// so it cleanly splits the two halves of the output.
+const DELTA_SENTINEL: &str = "__FRESH_ENV_DELTA_SENTINEL_b3f1c2__";
+
+/// Build the script for a *delta* capture: dump the env once (baseline — login
+/// shell in the project dir, recipe not yet run), print the sentinel, run the
+/// recipe, then dump the env again (activated). Diffing the two halves yields
+/// exactly what the recipe changed — see [`parse_delta`]. The `cd` precedes the
+/// baseline dump so direnv (which keys off cwd) is still inactive in the
+/// baseline and only activates in the second half.
+fn build_delta_capture_script(snippet: &str, dir: Option<&Path>) -> String {
+    let mut script = String::new();
+    if let Some(d) = dir {
+        script.push_str("cd ");
+        script.push_str(&shell_quote(&d.to_string_lossy()));
+        script.push_str("; ");
+    }
+    script.push_str("command env; printf '%s\\n' ");
+    script.push_str(&shell_quote(DELTA_SENTINEL));
+    script.push_str("; ");
+    let snippet = snippet.trim();
+    if !snippet.is_empty() {
+        script.push_str(snippet);
+        script.push_str("; ");
+    }
+    script.push_str("command env");
+    script
+}
+
+/// Diff a delta-capture's output into an [`EnvDelta`]. Splits on
+/// [`DELTA_SENTINEL`] into baseline and activated halves; a key whose value is
+/// new or changed in the activated half is a `set` (in activated order), and a
+/// key present in the baseline but gone from the activated half is an `unset`.
+/// Volatile keys identical in both halves (`PWD`, `SHLVL`, …) diff out and never
+/// appear. If the sentinel is missing (capture malformed), returns an empty
+/// delta rather than guessing.
+fn parse_delta(stdout: &str) -> EnvDelta {
+    let Some((baseline_text, activated_text)) = stdout.split_once(DELTA_SENTINEL) else {
+        return EnvDelta::default();
+    };
+    let baseline = parse_env(baseline_text);
+    let activated = parse_env(activated_text);
+
+    let baseline_lookup: std::collections::HashMap<&str, &str> = baseline
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let mut set = Vec::new();
+    for (k, v) in &activated {
+        if baseline_lookup.get(k.as_str()) != Some(&v.as_str()) {
+            set.push((k.clone(), v.clone()));
+        }
+    }
+
+    let activated_keys: std::collections::HashSet<&str> =
+        activated.iter().map(|(k, _)| k.as_str()).collect();
+    let unset = baseline
+        .iter()
+        .filter(|(k, _)| !activated_keys.contains(k.as_str()))
+        .map(|(k, _)| k.clone())
+        .collect();
+
+    EnvDelta { set, unset }
 }
 
 /// Parse `env` output (`KEY=VALUE` lines) into pairs. Lines without `=` or with
@@ -452,6 +550,18 @@ mod tests {
     }
 
     #[test]
+    fn build_delta_capture_script_shape() {
+        let s = build_delta_capture_script("source .venv/bin/activate", Some(Path::new("/p")));
+        assert_eq!(
+            s,
+            format!(
+                "cd '/p'; command env; printf '%s\\n' '{DELTA_SENTINEL}'; \
+                 source .venv/bin/activate; command env"
+            )
+        );
+    }
+
+    #[test]
     fn parse_env_basics() {
         let out = "PATH=/a:/b\nVIRTUAL_ENV=/p/.venv\nWEIRD=a=b=c\n=skipme\nnoeq\n";
         let vars = parse_env(out);
@@ -529,20 +639,49 @@ mod tests {
         assert_eq!(n.get(), 2, "input change should force a re-capture");
     }
 
-    #[test]
-    fn blocking_capture_inactive_returns_empty_without_running() {
-        let p = EnvProvider::inactive();
-        let ran = std::cell::Cell::new(false);
-        let vars = p.capture_blocking(|_script| {
-            ran.set(true);
-            Some("X=1".to_string())
-        });
-        assert!(vars.is_empty());
-        assert!(!ran.get(), "blocking capture must not run when inactive");
+    /// Build a delta-capture stdout from a baseline and an activated env block.
+    fn delta_output(baseline: &str, activated: &str) -> String {
+        format!("{baseline}\n{DELTA_SENTINEL}\n{activated}")
     }
 
     #[test]
-    fn blocking_capture_caches_and_shares_cache_with_current() {
+    fn parse_delta_extracts_added_changed_and_removed() {
+        // baseline → activated: PATH changed, VIRTUAL_ENV added, GONE removed,
+        // HOME unchanged (must diff out), SHLVL unchanged (volatile diffs out).
+        let out = delta_output(
+            "HOME=/h\nPATH=/usr/bin\nGONE=1\nSHLVL=3",
+            "HOME=/h\nPATH=/p/.venv/bin:/usr/bin\nVIRTUAL_ENV=/p/.venv\nSHLVL=3",
+        );
+        let d = parse_delta(&out);
+        assert_eq!(
+            d.set,
+            vec![
+                ("PATH".into(), "/p/.venv/bin:/usr/bin".into()),
+                ("VIRTUAL_ENV".into(), "/p/.venv".into()),
+            ]
+        );
+        assert_eq!(d.unset, vec!["GONE".to_string()]);
+    }
+
+    #[test]
+    fn parse_delta_missing_sentinel_is_empty() {
+        assert!(parse_delta("HOME=/h\nPATH=/usr/bin").is_empty());
+    }
+
+    #[test]
+    fn delta_capture_inactive_returns_empty_without_running() {
+        let p = EnvProvider::inactive();
+        let ran = std::cell::Cell::new(false);
+        let d = p.capture_delta_blocking(|_script| {
+            ran.set(true);
+            Some(delta_output("A=1", "A=1\nB=2"))
+        });
+        assert!(d.is_empty());
+        assert!(!ran.get(), "delta capture must not run when inactive");
+    }
+
+    #[test]
+    fn delta_capture_caches_on_unchanged_inputs() {
         let tmp = tempfile::tempdir().unwrap();
         let p = EnvProvider::inactive();
         p.set("true".into(), Some(tmp.path().to_path_buf()));
@@ -550,17 +689,14 @@ mod tests {
         let calls = std::cell::Cell::new(0);
         let run = || {
             calls.set(calls.get() + 1);
-            Some("FOO=bar\nPATH=/x\n".to_string())
+            Some(delta_output("PATH=/usr/bin", "PATH=/usr/bin\nFOO=bar"))
         };
 
-        let v1 = p.capture_blocking(|_s| run());
-        assert_eq!(
-            v1,
-            vec![("FOO".into(), "bar".into()), ("PATH".into(), "/x".into())]
-        );
-        // Second blocking call hits the cache — no re-run.
-        let v2 = p.capture_blocking(|_s| run());
-        assert_eq!(v2, v1);
+        let d1 = p.capture_delta_blocking(|_s| run());
+        assert_eq!(d1.set, vec![("FOO".into(), "bar".into())]);
+        // Second call hits the cache — no re-run.
+        let d2 = p.capture_delta_blocking(|_s| run());
+        assert_eq!(d2, d1);
         assert_eq!(calls.get(), 1, "warm cache should prevent a second capture");
     }
 

--- a/crates/fresh-editor/src/services/remote/connection.rs
+++ b/crates/fresh-editor/src/services/remote/connection.rs
@@ -455,9 +455,14 @@ async fn ssh_eof_error(
                      credentials are valid (exit code 255)",
                     params
                 ),
+                // 127 is the shell's "command not found" — for our bootstrap
+                // that means `python3` is missing on the remote. Fresh's remote
+                // backend (agent + the integrated terminal's env launcher) runs
+                // on python3, so name the requirement and the fix plainly.
                 Some(127) => format!(
-                    "python3 was not found on the remote host {}. \
-                     Ensure Python 3 is installed on the remote machine",
+                    "Python 3 was not found on the remote host {}. \
+                     Fresh's remote support requires python3 on the remote — \
+                     install it there, then reconnect",
                     params
                 ),
                 Some(code) => format!(

--- a/crates/fresh-editor/src/services/remote/mod.rs
+++ b/crates/fresh-editor/src/services/remote/mod.rs
@@ -35,9 +35,10 @@ pub use protocol::{
     write_params, AgentRequest, AgentResponse,
 };
 pub use spawner::{
-    build_kube_terminal_args, build_ssh_terminal_args, LocalLongRunningSpawner,
-    LocalProcessSpawner, LongRunningSpawner, ProcessSpawner, RemoteLongRunningSpawner,
-    RemoteProcessSpawner, SpawnError, SpawnResult, StdioChild,
+    build_kube_terminal_args, build_ssh_terminal_args, ssh_remote_env_launcher,
+    LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner, ProcessSpawner,
+    RemoteLongRunningSpawner, RemoteProcessSpawner, SpawnError, SpawnResult, StdioChild,
+    SSH_EXEC_LOGIN_SHELL,
 };
 /// Shared `kubectl exec` argv builder, used by the agent transport, the
 /// terminal wrapper, and the long-running (LSP) spawner. Crate-internal.

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -1513,7 +1513,10 @@ mod tests {
         let inner = launcher
             .trim_start_matches("exec python3 -c '")
             .trim_end_matches('\'');
-        assert!(!inner.contains('\''), "inner literal must not contain a single quote");
+        assert!(
+            !inner.contains('\''),
+            "inner literal must not contain a single quote"
+        );
 
         // The base64 blob decodes to python that embeds the recipe and splits on
         // the same sentinel the local delta capture uses.
@@ -1521,7 +1524,10 @@ mod tests {
             .trim_start_matches("import base64;exec(base64.b64decode(\"")
             .trim_end_matches("\").decode())");
         let src = String::from_utf8(BASE64.decode(b64).unwrap()).unwrap();
-        assert!(src.contains("direnv export bash"), "recipe must be embedded");
+        assert!(
+            src.contains("direnv export bash"),
+            "recipe must be embedded"
+        );
         assert!(src.contains(crate::services::env_provider::DELTA_SENTINEL));
         assert!(src.contains("os.execvp"));
     }

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -1028,8 +1028,23 @@ os.execvp(_sh,[_sh,"-l"])
 /// wrapper sets `manages_cwd = true`. A failed `cd` is non-fatal so the shell
 /// always starts; `exec` replaces the wrapper shell so closing the terminal
 /// tears the exec session down cleanly.
-pub fn build_kube_terminal_args(target: &crate::services::remote::KubeTarget) -> Vec<String> {
+pub fn build_kube_terminal_args(
+    target: &crate::services::remote::KubeTarget,
+    base_env: &[(String, String)],
+) -> Vec<String> {
     let mut remote_cmd = String::new();
+    // Apply the captured in-pod env probe to the integrated terminal so it
+    // matches what LSP / spawnProcess get in the pod (issue #2355; see
+    // docs/internal/uniform-env-activation-design.md). `kubectl exec` has no
+    // `-e` flag, so — like the documented `kubectl exec -- env …` / `sh -c
+    // 'export …'` workarounds — we `export` each pair inside the `sh -lc`
+    // wrapper we already control. Values are POSIX-quoted (the parser is the
+    // `sh` we spawn, not the user's interactive shell), so this is data, not
+    // shell-injected. Exports come first so the subsequent `cd`/login shell
+    // inherit them.
+    for (k, v) in base_env {
+        remote_cmd.push_str(&format!("export {}={}; ", k, shell_quote(v)));
+    }
     if let Some(dir) = target.workspace.as_deref().filter(|d| !d.is_empty()) {
         let quoted = shell_quote(dir);
         remote_cmd.push_str(&format!(
@@ -1558,7 +1573,7 @@ mod tests {
             container: Some("app".into()),
             workspace: Some("/workspace".into()),
         };
-        let a = build_kube_terminal_args(&target);
+        let a = build_kube_terminal_args(&target, &[]);
         let expected: Vec<String> = [
             "--context",
             "prod",
@@ -1581,6 +1596,28 @@ mod tests {
     }
 
     #[test]
+    fn build_kube_terminal_args_exports_base_env_before_login_shell() {
+        let target = crate::services::remote::KubeTarget {
+            context: None,
+            namespace: "dev".into(),
+            pod: "pod-1".into(),
+            container: None,
+            workspace: None,
+        };
+        let base_env = vec![
+            ("VIRTUAL_ENV".to_string(), "/c/.venv".to_string()),
+            ("MSG".to_string(), "a b".to_string()),
+        ];
+        let a = build_kube_terminal_args(&target, &base_env);
+        // The in-pod env probe is exported (POSIX-quoted) inside the sh -lc
+        // wrapper, before handing off to the login shell.
+        assert_eq!(
+            a.last().unwrap(),
+            "export VIRTUAL_ENV='/c/.venv'; export MSG='a b'; exec ${SHELL:-/bin/sh} -l"
+        );
+    }
+
+    #[test]
     fn build_kube_terminal_args_without_workspace_skips_cd() {
         let target = crate::services::remote::KubeTarget {
             context: None,
@@ -1589,7 +1626,7 @@ mod tests {
             container: None,
             workspace: None,
         };
-        let a = build_kube_terminal_args(&target);
+        let a = build_kube_terminal_args(&target, &[]);
         assert_eq!(
             a,
             vec![

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -947,9 +947,72 @@ pub fn build_ssh_terminal_args(
             "d={quoted}; [ -d \"$d\" ] || d=$(dirname \"$d\"); cd \"$d\" 2>/dev/null; "
         ));
     }
-    remote_cmd.push_str("exec ${SHELL:-/bin/sh} -l");
+    remote_cmd.push_str(SSH_EXEC_LOGIN_SHELL);
     a.push(remote_cmd);
     a
+}
+
+/// The tail of the SSH terminal's remote command: hand control to the user's
+/// login shell. Factored into a constant so the activated-env path can find and
+/// rewrite exactly this segment into a launcher (see
+/// [`ssh_remote_env_launcher`]) without re-deriving the whole command.
+pub const SSH_EXEC_LOGIN_SHELL: &str = "exec ${SHELL:-/bin/sh} -l";
+
+/// Build the replacement for [`SSH_EXEC_LOGIN_SHELL`] that applies the activated
+/// environment (venv/direnv/mise) in the SSH-backed integrated terminal before
+/// handing off to the user's login shell — the remote analogue of the local
+/// terminal's `CommandBuilder.env` injection (issue #2355; see
+/// `docs/internal/uniform-env-activation-design.md`).
+///
+/// The result is `exec python3 -c '<literal>'`. python3 is already required on
+/// every SSH remote (it runs the agent), so this adds no dependency and needs
+/// no agent-PTY work — the existing `ssh -t` keeps providing the PTY. The
+/// `'<literal>'` is a single shell-literal token containing no single quotes, so
+/// the user's *login* shell (which `ssh` uses to parse the command — possibly
+/// fish) passes it through verbatim regardless of its quoting rules. The literal
+/// base64-decodes and `exec`s a python launcher that, on the remote: captures
+/// the activation **delta** (run the recipe in `bash`, diff against a clean
+/// login env), applies it to `os.environ` as data — never re-parsed by the
+/// user's interactive shell — then `exec`s `$SHELL -l`. Capturing on the remote
+/// keeps everything one round-trip and always fresh; the recipe is embedded as
+/// a JSON string literal (safe for any byte content).
+pub fn ssh_remote_env_launcher(recipe: &str) -> String {
+    use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+    let recipe_json = serde_json::to_string(recipe).unwrap_or_else(|_| "\"\"".to_string());
+    // NB: the Rust raw string is the *python source*. `\\n` here is two chars
+    // (backslash, n) in the source, which python parses to a single `\n` for
+    // `printf` to turn into a newline. `{{` / `}}` are literal braces.
+    let launcher_src = format!(
+        r#"import os,subprocess
+_r={recipe_json}
+_S="{sentinel}"
+_script="command env; printf '%s\\n' '"+_S+"'; "+_r+"; command env"
+try:
+    _o=subprocess.run(["bash","-lc",_script],stdout=subprocess.PIPE,stderr=subprocess.DEVNULL).stdout.decode("utf-8","replace")
+except Exception:
+    _o=""
+def _p(t):
+    d={{}}
+    for ln in t.splitlines():
+        i=ln.find("=")
+        if i>0: d[ln[:i]]=ln[i+1:]
+    return d
+if _S in _o:
+    _b,_a=_o.split(_S,1)
+    _bb=_p(_b); _aa=_p(_a)
+    for k,v in _aa.items():
+        if _bb.get(k)!=v: os.environ[k]=v
+    for k in list(_bb):
+        if k not in _aa: os.environ.pop(k,None)
+_sh=os.environ.get("SHELL") or "/bin/sh"
+os.execvp(_sh,[_sh,"-l"])
+"#,
+        sentinel = crate::services::env_provider::DELTA_SENTINEL,
+    );
+
+    let b64 = BASE64.encode(launcher_src.as_bytes());
+    format!("exec python3 -c 'import base64;exec(base64.b64decode(\"{b64}\").decode())'")
 }
 
 /// Build the `kubectl` argv that opens the integrated terminal as an
@@ -1415,6 +1478,51 @@ mod tests {
         assert_eq!(a, expected);
         // No BatchMode — interactive auth must be able to prompt in the PTY.
         assert!(!a.iter().any(|s| s == "BatchMode=yes"));
+        // The exec tail is exactly the shared constant the env path rewrites.
+        assert!(a.last().unwrap().ends_with(SSH_EXEC_LOGIN_SHELL));
+    }
+
+    #[test]
+    fn ssh_remote_env_launcher_is_a_safe_single_quoted_python_oneliner() {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+        let recipe = "eval \"$(direnv export bash)\"";
+        let launcher = ssh_remote_env_launcher(recipe);
+
+        // Shape: replaces the login-shell exec with a python3 -c invocation.
+        assert!(launcher.starts_with("exec python3 -c '"));
+        assert!(launcher.ends_with('\''));
+        // The python argument is a single shell-literal token: no *inner* single
+        // quotes, so the user's login shell (bash/zsh/fish) passes it verbatim
+        // regardless of its quoting rules.
+        let inner = launcher
+            .trim_start_matches("exec python3 -c '")
+            .trim_end_matches('\'');
+        assert!(!inner.contains('\''), "inner literal must not contain a single quote");
+
+        // The base64 blob decodes to python that embeds the recipe and splits on
+        // the same sentinel the local delta capture uses.
+        let b64 = inner
+            .trim_start_matches("import base64;exec(base64.b64decode(\"")
+            .trim_end_matches("\").decode())");
+        let src = String::from_utf8(BASE64.decode(b64).unwrap()).unwrap();
+        assert!(src.contains("direnv export bash"), "recipe must be embedded");
+        assert!(src.contains(crate::services::env_provider::DELTA_SENTINEL));
+        assert!(src.contains("os.execvp"));
+    }
+
+    #[test]
+    fn ssh_launcher_embeds_recipes_with_quotes_safely() {
+        // A recipe containing single quotes must not break the outer literal.
+        let recipe = "export X='a b'; source ./.venv/bin/activate";
+        let launcher = ssh_remote_env_launcher(recipe);
+        let inner = launcher
+            .trim_start_matches("exec python3 -c '")
+            .trim_end_matches('\'');
+        assert!(
+            !inner.contains('\''),
+            "recipe quotes must be base64-encapsulated, never leak into the literal"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -287,6 +287,7 @@ impl TerminalManager {
         log_path: Option<std::path::PathBuf>,
         backing_path: Option<std::path::PathBuf>,
         terminal_wrapper: crate::services::authority::TerminalWrapper,
+        env_overlay: Vec<(String, String)>,
     ) -> Result<TerminalId, String> {
         let id = TerminalId(self.next_id);
         self.next_id += 1;
@@ -342,6 +343,23 @@ impl TerminalManager {
                     // provider form, producing prompts like
                     // `PS Microsoft.PowerShell.Core\FileSystem::\\?\C:\…>`.
                     cmd.cwd(strip_verbatim_prefix(dir).as_ref());
+                }
+            }
+
+            // Apply the activated-environment overlay (venv/direnv/mise) so the
+            // integrated terminal inherits the same env that LSP servers,
+            // formatters, and plugin `spawnProcess` already get — otherwise the
+            // status bar says "Environment active" while the terminal silently
+            // runs the *system* toolchain with none of the project's vars
+            // (issue #2355). The caller passes the captured snapshot only for a
+            // local host shell (empty for docker/ssh wrappers, whose inner shell
+            // runs on another host this `CommandBuilder` env can't reach). Set
+            // before TERM/FRESH_SESSION below so those control vars win over any
+            // same-named key in the snapshot. Shell-managed volatiles (PWD,
+            // SHLVL, …) are skipped so the spawned shell re-derives them.
+            for (k, v) in &env_overlay {
+                if !is_volatile_terminal_env_key(k) {
+                    cmd.env(k, v);
                 }
             }
 
@@ -803,6 +821,18 @@ pub(crate) fn strip_verbatim_prefix(path: &std::path::Path) -> Cow<'_, std::path
     }
 }
 
+/// Whether an env key captured from the activated environment is shell-managed
+/// and must NOT be injected into a freshly spawned interactive shell. The
+/// snapshot comes from running `command env` after a login shell + activation,
+/// so it carries bookkeeping vars the new shell sets for itself: forcing a
+/// stale `SHLVL` would break level counting, and `PWD`/`OLDPWD`/`_` would point
+/// at the capture context rather than where the shell actually starts. The
+/// activation deltas we *do* want (PATH, VIRTUAL_ENV, project vars) are left
+/// alone.
+fn is_volatile_terminal_env_key(key: &str) -> bool {
+    matches!(key, "PWD" | "OLDPWD" | "SHLVL" | "_")
+}
+
 /// Detect the user's shell
 pub fn detect_shell() -> String {
     // Try $SHELL environment variable first
@@ -831,6 +861,18 @@ mod tests {
     fn test_terminal_id_display() {
         let id = TerminalId(42);
         assert_eq!(format!("{}", id), "Terminal-42");
+    }
+
+    #[test]
+    fn volatile_env_keys_are_skipped_activation_deltas_kept() {
+        // Shell-managed bookkeeping must not be force-injected.
+        for k in ["PWD", "OLDPWD", "SHLVL", "_"] {
+            assert!(is_volatile_terminal_env_key(k), "{k} should be skipped");
+        }
+        // The vars that activation actually sets must be injected.
+        for k in ["PATH", "VIRTUAL_ENV", "DEPLOY_TOKEN", "MISE_SHELL"] {
+            assert!(!is_volatile_terminal_env_key(k), "{k} should be kept");
+        }
     }
 
     /// Terminal ids are per-window: each manager numbers from 0, so two

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -287,7 +287,7 @@ impl TerminalManager {
         log_path: Option<std::path::PathBuf>,
         backing_path: Option<std::path::PathBuf>,
         terminal_wrapper: crate::services::authority::TerminalWrapper,
-        env_overlay: Vec<(String, String)>,
+        env_delta: crate::services::env_provider::EnvDelta,
     ) -> Result<TerminalId, String> {
         let id = TerminalId(self.next_id);
         self.next_id += 1;
@@ -346,21 +346,23 @@ impl TerminalManager {
                 }
             }
 
-            // Apply the activated-environment overlay (venv/direnv/mise) so the
+            // Apply the activated-environment delta (venv/direnv/mise) so the
             // integrated terminal inherits the same env that LSP servers,
             // formatters, and plugin `spawnProcess` already get — otherwise the
             // status bar says "Environment active" while the terminal silently
             // runs the *system* toolchain with none of the project's vars
-            // (issue #2355). The caller passes the captured snapshot only for a
-            // local host shell (empty for docker/ssh wrappers, whose inner shell
-            // runs on another host this `CommandBuilder` env can't reach). Set
-            // before TERM/FRESH_SESSION below so those control vars win over any
-            // same-named key in the snapshot. Shell-managed volatiles (PWD,
-            // SHLVL, …) are skipped so the spawned shell re-derives them.
-            for (k, v) in &env_overlay {
-                if !is_volatile_terminal_env_key(k) {
-                    cmd.env(k, v);
-                }
+            // (issue #2355; see docs/internal/uniform-env-activation-design.md).
+            // The delta carries only what the recipe changed over a clean login
+            // shell, so there are no volatile shell vars to skip. The caller
+            // passes it only for a local host shell (empty for docker/ssh
+            // wrappers, whose inner shell runs on another host this
+            // `CommandBuilder` env can't reach). Applied before TERM/FRESH_SESSION
+            // below so those control vars win over any same-named delta key.
+            for (k, v) in &env_delta.set {
+                cmd.env(k, v);
+            }
+            for k in &env_delta.unset {
+                cmd.env_remove(k);
             }
 
             // Set TERM so programs like less know the terminal capabilities.
@@ -821,18 +823,6 @@ pub(crate) fn strip_verbatim_prefix(path: &std::path::Path) -> Cow<'_, std::path
     }
 }
 
-/// Whether an env key captured from the activated environment is shell-managed
-/// and must NOT be injected into a freshly spawned interactive shell. The
-/// snapshot comes from running `command env` after a login shell + activation,
-/// so it carries bookkeeping vars the new shell sets for itself: forcing a
-/// stale `SHLVL` would break level counting, and `PWD`/`OLDPWD`/`_` would point
-/// at the capture context rather than where the shell actually starts. The
-/// activation deltas we *do* want (PATH, VIRTUAL_ENV, project vars) are left
-/// alone.
-fn is_volatile_terminal_env_key(key: &str) -> bool {
-    matches!(key, "PWD" | "OLDPWD" | "SHLVL" | "_")
-}
-
 /// Detect the user's shell
 pub fn detect_shell() -> String {
     // Try $SHELL environment variable first
@@ -861,18 +851,6 @@ mod tests {
     fn test_terminal_id_display() {
         let id = TerminalId(42);
         assert_eq!(format!("{}", id), "Terminal-42");
-    }
-
-    #[test]
-    fn volatile_env_keys_are_skipped_activation_deltas_kept() {
-        // Shell-managed bookkeeping must not be force-injected.
-        for k in ["PWD", "OLDPWD", "SHLVL", "_"] {
-            assert!(is_volatile_terminal_env_key(k), "{k} should be skipped");
-        }
-        // The vars that activation actually sets must be injected.
-        for k in ["PATH", "VIRTUAL_ENV", "DEPLOY_TOKEN", "MISE_SHELL"] {
-            assert!(!is_volatile_terminal_env_key(k), "{k} should be kept");
-        }
     }
 
     /// Terminal ids are per-window: each manager numbers from 0, so two

--- a/crates/fresh-editor/tests/e2e/plugins/env_manager.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/env_manager.rs
@@ -60,6 +60,19 @@ fn make_cargo_toml(root: &Path) {
     .expect("write Cargo.toml");
 }
 
+/// PTY availability guard — `create_window_with_terminal` spawns a real shell,
+/// which the CI sandbox occasionally can't allocate.
+fn pty_available() -> bool {
+    portable_pty::native_pty_system()
+        .openpty(portable_pty::PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
 /// Boot the editor harness exactly like a real `fresh /path` launch does
 /// at startup. `EditorTestHarness::with_config_and_working_dir` skips two
 /// hooks `main.rs` runs immediately after editor construction:
@@ -201,6 +214,72 @@ fn test_venv_silently_auto_activates() {
         !status.contains("SECURITY WARNING"),
         "venv-only folder must not raise the core trust modal"
     );
+}
+
+/// A session opened through the Orchestrator — a window created via
+/// `create_window_with_terminal`, the path the "New Session (Local)" flow and
+/// the session dock drive — must run the same workspace-trust decision and env
+/// auto-activation a direct `fresh <dir>` launch gets.
+///
+/// Regression: before the fix the orchestrator window bypassed
+/// `maybe_prompt_workspace_trust` (so a path-only `.venv` stayed `Restricted`
+/// instead of auto-trusting) *and* env-manager only auto-activated on
+/// `plugins_loaded` (which does not re-fire for a new window), so the session
+/// came up on the system toolchain — `python` resolved to `/usr/bin/python`
+/// even though opening the same folder from the CLI activated its `.venv`.
+///
+/// Drives the create-window action and asserts only on the rendered status
+/// message env-manager surfaces on activation; without the fix that message
+/// never appears (the session never activates), so this hangs until the
+/// external test timeout — i.e. it fails without the change.
+#[test]
+fn test_orchestrator_session_auto_activates_venv() {
+    if !pty_available() {
+        eprintln!("Skipping orchestrator env activation test: PTY not available");
+        return;
+    }
+
+    let tmp = TempDir::new().unwrap();
+    // Launch project: plain (no env marker) so booting it activates nothing —
+    // env-manager loads here and serves every window in the editor.
+    let launch = tmp.path().join("launch");
+    fs::create_dir_all(&launch).unwrap();
+    setup_env_manager(&launch);
+    // The project opened *through the orchestrator*: a path-only `.venv`.
+    let venv_proj = tmp.path().join("venvproj");
+    fs::create_dir_all(&venv_proj).unwrap();
+    make_venv(&venv_proj);
+
+    let mut harness = boot_harness_like_main(120, 40, launch);
+
+    // Orchestrator "New Session (Local)" for the venv project — the same call
+    // the plugin dispatcher makes for `createWindowWithTerminal`. The new
+    // window is born under its own per-session local authority.
+    let born = harness.editor().local_session_authority(&venv_proj);
+    harness
+        .editor_mut()
+        .create_window_with_terminal(
+            venv_proj.clone(),
+            "venvproj".into(),
+            Some(venv_proj.clone()),
+            // A harmless long-running child so the PTY doesn't exit immediately.
+            Some(vec!["sh".into(), "-c".into(), "sleep 60".into()]),
+            None,
+            born,
+            None,
+        )
+        .expect("create orchestrator session window");
+
+    // The new session auto-activates its `.venv` just like a direct launch:
+    // env-manager writes its activation message to the status bar. Without the
+    // fix the window stays Restricted / never re-activates, so this predicate
+    // is never satisfied and the test times out externally.
+    harness
+        .wait_until(|h| {
+            let s = h.screen_to_string();
+            s.contains(".venv") && (s.contains("Activating") || s.contains("active"))
+        })
+        .unwrap();
 }
 
 /// `.envrc` surfaces env-manager's combined popup. Picking "Trust & activate"

--- a/docs/internal/uniform-env-activation-design.md
+++ b/docs/internal/uniform-env-activation-design.md
@@ -191,10 +191,31 @@ through that tool's own clear failure.
 ## Implementation status
 
 - [x] Local: `EnvProvider` delta capture; integrated terminal applies the
-      delta (replaces the full-snapshot + volatile skip-list).
-- [ ] Local spawners (LSP / one-shot) migrate from full snapshot to the delta.
-- [ ] Docker: terminal wrapper gains `-e KEY=VAL` from the delta.
-- [ ] Kube: terminal wrapper gains the `env KEY=VAL …` prefix from the delta.
-- [ ] SSH: python3 launcher via the agent file API; terminal runs
-      `ssh -t host python3 <path>`.
-- [ ] SSH preflight: python3 version assertion + the clear connect-time error.
+      delta (replaces the full-snapshot + volatile skip-list). **Validated
+      end-to-end** (tmux + active `.venv`).
+- [x] SSH: terminal runs `ssh -t host … exec python3 -c '<literal>'`, a single
+      shell-literal token (fish-safe — verified against the fish docs) that
+      decodes + execs a launcher capturing the delta on the remote. No agent
+      PTY, no new dependency. **Validated end-to-end** against a real local
+      `sshd` on a userspace port (active `.venv` → terminal sees the remote
+      env; inactive → unchanged login shell).
+- [x] Docker: the devcontainer plugin's terminal wrapper now passes the
+      `userEnvProbe` env as `-e KEY=VAL` (mirrors the spawner's
+      `build_docker_exec_prefix`). `docker exec -e` semantics confirmed both by
+      the existing production LSP path and empirically. *Not* e2e-validated here
+      (no pullable image / no live devcontainer probe).
+- [x] Kube: `build_kube_terminal_args` exports the in-pod probe env inside the
+      `sh -lc` wrapper it controls (kubectl has no `-e`; the `env`/`export`
+      approach is the documented one). Unit-tested; *not* e2e-validated here (no
+      cluster / kubectl).
+- [x] SSH preflight: the existing exit-127 detection in
+      `connection.rs::ssh_eof_error` surfaces a clear, host-named "Python 3 not
+      found … install it, then reconnect" message; wording sharpened.
+
+Deliberately *not* changed: the local/SSH **LSP / one-shot spawners** keep
+applying the full captured snapshot. That snapshot is `baseline + activation`,
+so the *effective* child env is identical to `baseline + delta` — migrating
+them to the delta form is a cosmetic internal-consistency cleanup, not a
+behavior fix, and is left out to avoid churning working, e2e-tested remote LSP
+paths. The user-facing goal (terminal sees the same env as LSP on every
+backend) is met.

--- a/docs/internal/uniform-env-activation-design.md
+++ b/docs/internal/uniform-env-activation-design.md
@@ -1,0 +1,200 @@
+# Uniform Environment Activation — Design
+
+Status: design + in-progress implementation. Specifies how the *activated*
+environment (venv / direnv / mise) is captured and applied so that **every**
+process the editor launches — LSP servers, formatters, find-in-files, one-shot
+`spawnProcess`, **and the integrated terminal** — sees the same environment,
+identically on local, SSH, Docker, and Kubernetes backends.
+
+Motivation: issue #2355, Problem 2. The status bar said "Environment active"
+while the integrated terminal ran the *system* toolchain with none of the
+project's env vars, because the terminal spawned through portable-pty directly
+and bypassed the env-application path the spawners use. Fixing only the local
+terminal (see the first commit on this branch) leaves the same gap on SSH and
+Docker, and leaves two different notions of "the env" in the tree. This design
+removes the divergence everywhere.
+
+Related: `AUTHORITY_DESIGN.md` (the spawner choke-point), the env provider
+(`crates/fresh-editor/src/services/env_provider.rs`), and the trust model in
+`workspace-trust-sandbox-design.md` (capture/apply are gated by trust exactly
+like a spawn).
+
+## The two invariants (this *is* the uniform solution)
+
+1. **Capture the activation as a delta, on the host where processes run.**
+   On that host, run a shell *we* pick (`bash -lc` / `sh -lc`) twice: once
+   clean (login shell, no recipe) and once with the project's activation
+   recipe. The **difference** — keys added/changed/removed — is the captured
+   environment. It is pure `KEY=VALUE` data, so the recipe is only ever parsed
+   by our capture shell, never by the user's interactive shell.
+
+2. **Apply the delta as process-environment data, before any shell starts** —
+   never by interpolating values into a command the user's interactive shell
+   re-parses. Every child goes through one abstraction,
+   `spawn(argv, cwd, env_delta, pty, size)`, and each backend realizes it with
+   the env mechanism it *already* ships.
+
+Because env is always applied as data to the process, the user's interactive
+shell (bash / zsh / fish / nu) is irrelevant — the result is byte-identical on
+every backend. The delta carries only the activation's contribution, so
+volatile, shell-managed keys (`PWD`, `OLDPWD`, `SHLVL`, `_`) are never in it
+and need no special-casing.
+
+This single definition **subsumes both** of today's env notions: the local/SSH
+`EnvProvider` snapshot *and* the Docker/Kube `base_env` (`userEnvProbe`) become
+the same delta captured on the relevant host.
+
+## Capture
+
+`EnvProvider` keeps its role as the single source of truth (recipe = snippet +
+dir) and its content-hash cache over env-input files (`.envrc`, `mise.toml`,
+…). The capture runs one script on the target host and returns its stdout:
+
+```
+cd '<dir>'; command env; printf '<SENTINEL>\n'; <recipe>; command env
+```
+
+- The text before `<SENTINEL>` is the **baseline** (login env in the project
+  dir, recipe not yet run). The text after is the **activated** env. The delta
+  is computed by diffing them: a key whose value is new or changed is a
+  `set`; a key present in baseline and gone from activated is an `unset`.
+- One subprocess per capture, cached by the env-inputs hash; conceptually every
+  spawn recaptures, but unchanged inputs serve from cache for free. No
+  staleness, because both capture and apply are data on the host.
+- The recipe is interpreted only by the capture shell we choose. Its output is
+  data. (venv / direnv / mise all export to `bash`; we always capture via
+  `bash`/`sh`.)
+- Capture is gated by Workspace Trust: restricted ⇒ empty delta ⇒ no
+  activation anywhere.
+
+The capture is parameterized by a backend "runner" that executes the script on
+the host and returns stdout — the abstraction `EnvProvider::current(run)`
+already has. Each backend supplies its runner:
+
+| Backend | Capture runner |
+|---|---|
+| Local | `bash -lc <script>` as a subprocess |
+| SSH   | the agent runs `sh -lc <script>` on the remote host |
+| Docker | `docker exec <id> bash -lc <script>` |
+| Kube  | `kubectl exec … -- sh -lc <script>` |
+
+## Apply
+
+Every authority launches children through one `spawn(argv, cwd, env_delta,
+pty, size)`. Each backend applies `env_delta` as **process-environment data**
+using a mechanism it already has — no new runtime dependency:
+
+| Backend | Apply the delta (always data, never the interactive shell) |
+|---|---|
+| **Local** | native process env (`Command` / `CommandBuilder.env`) |
+| **Docker** | `docker exec -e KEY=VAL …` (the runtime sets it on the process) |
+| **Kube** | `kubectl exec -- env KEY=VAL … argv` (`env(1)` is a POSIX exec wrapper, not shell parsing) |
+| **SSH** | the existing Python agent writes a tiny launcher (below); `ssh -t host python3 <path>` execs it |
+
+Python appears **only** for SSH, where it is already mandatory (the agent is
+bootstrapped via `python3` over the connection). Local, Docker, and Kube add
+nothing.
+
+### The terminal is not special
+
+The integrated terminal becomes:
+
+```
+spawn(argv=[user_interactive_shell], cwd, env_delta=captured, pty=true, size)
+```
+
+— same delta, same per-backend apply as LSP; only `pty=true` and the argv
+differ. This removes the three divergent terminal shapes
+(`ssh -t '… exec $SHELL -l'`, `docker exec … bash -l`, local `CommandBuilder`).
+Editor control vars (`TERM=xterm-256color`, `FRESH_SESSION`) are appended after
+the delta so they always win.
+
+### SSH apply without agent-PTY: a python3 launcher
+
+The SSH terminal keeps its current `ssh -t` PTY (no `pty.openpty()` in the
+agent). The only change is *what* it execs. The problem with `ssh -t` is that
+any command string is parsed by the user's **remote login shell** (possibly
+fish), so inline `env K=V …` hits shell-quoting hazards. Avoid it entirely:
+
+- Through the agent's existing file API, write a launcher to a no-space path on
+  the remote:
+
+  ```python
+  #!/usr/bin/env python3
+  import os, json, base64
+  data = json.loads(base64.b64decode("<BASE64>").decode())   # {env, unset, cwd, shell}
+  os.environ.update(data["env"])
+  for k in data["unset"]:
+      os.environ.pop(k, None)
+  os.chdir(data["cwd"])
+  os.execvp(data["shell"], [data["shell"], "-l"])
+  ```
+
+- The terminal runs `ssh -t host python3 <path>`. The user's login shell sees
+  only two bare words (`python3` + path) → safe in bash/zsh/fish. The launcher
+  runs under python3, so env is set from **data** (base64'd JSON) — robust for
+  any byte content (spaces, quotes, newlines, unicode); no shell quoting
+  anywhere. It then `exec`s the user's real shell with the env already applied.
+- python3 is the dependency SSH already requires; this adds no new one and no
+  agent-PTY work.
+
+One thing to name (not new to this approach): the launcher execs `$SHELL -l`, a
+login shell, which re-sources the user's rc. If that rc *also* activates (a
+direnv/mise hook), it re-runs on top of our delta — harmless, it sets the same
+vars. Execing a non-login `$SHELL` would avoid any double-run but costs the
+user their normal prompt/aliases, so `-l` is the right default.
+
+## Errors — missing python3 on an SSH remote
+
+python3 is required **only for SSH**. Local/Docker/Kube never touch it (capture
+is `bash`/`sh` in the container or a local subprocess; apply is native / `-e` /
+`env`-prefix), so this error can only appear on an SSH connect, and only there
+do we check.
+
+The agent bootstrap is already the gate: if python3 can't start, the
+connection fails before any feature is attempted, and ssh's stderr is piped
+(not painted over the UI), so it is a clean status line. The contract:
+
+- Treat **exit 127 / "command not found"** on the bootstrap as the definitive
+  "no python3" signal (already implemented in `connection.rs::ssh_eof_error`).
+- Harden with a **version assertion**: the agent's first reply carries
+  `sys.version_info`; below the minimum the agent needs, fail with the same
+  shape of message rather than a confusing mid-session protocol error later.
+- Emit **one clear, actionable line** naming the host and the fix, e.g.
+  *"Python 3 was not found on `<host>`. Install Python 3 there, or connect
+  without remote features."*
+
+The no-python backends are unaffected; a missing `docker`/`kubectl` surfaces
+through that tool's own clear failure.
+
+## What this deletes
+
+- `local_captured_env` + `apply_env` (local-only application) and `env_wrap`
+  (SSH argv-prefix) collapse into "set `env_delta` on the child."
+- The Docker/Kube `base_env` / `userEnvProbe` notion — folded into the same
+  delta captured in the container/pod.
+- `TerminalWrapper`'s divergent shapes (`host_shell`, `ssh`, docker/kube
+  explicit) reduce to one `spawn(pty=true)`.
+- The first commit's `current_local_blocking` full-snapshot + the
+  `is_volatile_terminal_env_key` skip-list — unnecessary once capture is a
+  delta (volatiles are never in it).
+
+## Consequences
+
+- `Env: Show Status` reporting "active" becomes **true by construction** in
+  every surface on every backend — the status can no longer lie.
+- venv (no shell hook), direnv/mise (hook or not), and the container env probe
+  all behave identically, locally and remotely.
+- Shell choice is irrelevant: fish/zsh/nu users get the same activated env as
+  bash users.
+
+## Implementation status
+
+- [x] Local: `EnvProvider` delta capture; integrated terminal applies the
+      delta (replaces the full-snapshot + volatile skip-list).
+- [ ] Local spawners (LSP / one-shot) migrate from full snapshot to the delta.
+- [ ] Docker: terminal wrapper gains `-e KEY=VAL` from the delta.
+- [ ] Kube: terminal wrapper gains the `env KEY=VAL …` prefix from the delta.
+- [ ] SSH: python3 launcher via the agent file API; terminal runs
+      `ssh -t host python3 <path>`.
+- [ ] SSH preflight: python3 version assertion + the clear connect-time error.


### PR DESCRIPTION
## Summary

Implements uniform environment activation (venv/direnv/mise) across all editor surfaces and backends (local, SSH, Docker, Kubernetes). Previously, the integrated terminal could show "Environment active" in the status bar while silently running the system toolchain, because it bypassed the env-application path that LSP servers and spawned processes use. This change ensures every process launched by the editor—LSP, formatters, one-shot spawns, and the integrated terminal—sees the same activated environment identically on every backend.

## Key Changes

- **Environment delta capture**: Added `EnvDelta` struct and delta-capture infrastructure to `EnvProvider`. Instead of capturing the full environment snapshot, the provider now captures only the *changes* the activation recipe introduces over a clean login shell (keys added/changed/removed). This is shell-agnostic and free of volatile vars like `PWD`, `SHLVL`, etc.

- **Local terminal env application**: The integrated terminal now applies the captured delta via `CommandBuilder.env()` before spawning, matching what LSP servers already receive.

- **SSH terminal env launcher**: Replaced the simple `exec $SHELL -l` with a Python3-based launcher that:
  - Captures the activation delta on the remote host (runs the recipe in `bash`, diffs against clean login env)
  - Applies it as process-environment data (never re-parsed by the user's interactive shell)
  - Execs the user's login shell with the env already applied
  - Uses base64-encoded JSON to safely embed the recipe, avoiding shell-quoting hazards
  - Adds no new dependency (Python3 is already required for the SSH agent)

- **Docker/Kubernetes terminal env application**: 
  - Docker: passes captured `userEnvProbe` env as `-e KEY=VAL` flags (mirrors existing LSP spawner behavior)
  - Kubernetes: exports env vars inside the `sh -lc` wrapper before handing off to the login shell (kubectl has no `-e` flag)

- **Design documentation**: Added comprehensive `uniform-env-activation-design.md` explaining the two core invariants (capture delta on host, apply as data before shell), the per-backend implementation, error handling, and consequences.

- **SSH error messaging**: Improved the "Python 3 not found" error message to be clearer and more actionable when the remote lacks Python3.

## Notable Implementation Details

- The delta capture reuses the existing content-hash cache, so unchanged env inputs serve from cache without re-running subprocesses.
- The `DELTA_SENTINEL` constant marks the boundary between baseline and activated env in capture output, allowing robust parsing even with unusual env values.
- SSH launcher is a single shell-literal token (no inner single quotes), so it's safe in bash/zsh/fish regardless of their quoting rules.
- Capture is gated by Workspace Trust: restricted workspaces get an empty delta, preventing activation anywhere.
- The terminal wrapper's `manages_cwd` flag distinguishes local shells (apply delta via `CommandBuilder.env`) from remote wrappers (apply delta in the wrapper itself).

https://claude.ai/code/session_01Ry5HDiK7GfmpHYs91VPFTz