### PR TITLE
feat(orchestrator): make New Session dialog focus observable and keyboard-linear

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -1503,6 +1503,15 @@ pub enum WidgetSpec {
         /// row doesn't reshuffle when the disabled flag flips.
         #[serde(default)]
         disabled: bool,
+        /// When false, the button is dropped from the Tab cycle (but
+        /// still renders and stays clickable). Used for radio-style
+        /// groups — a row of buttons where only the *active* option
+        /// should be a Tab stop and ←/→ moves the selection within
+        /// the group, so Tab advances one stop per group rather than
+        /// one stop per option. Defaults to true (ordinary buttons
+        /// are tabbable).
+        #[serde(default = "default_true")]
+        focusable: bool,
     },
     /// Horizontal whitespace eater. In a `Row`, produces `cols`
     /// spaces (or fills remaining width if `flex: true`); in a
@@ -3870,6 +3879,13 @@ pub enum PluginCommand {
         /// (persists alongside a centered modal) rather than as a
         /// centered overlay.
         as_dock: bool,
+        /// When true, the panel reserves a two-column leading gutter on
+        /// every focusable control for the `▸ ` focus marker, so the
+        /// focused control is legible from a plain terminal capture and
+        /// the layout never shifts as focus moves. Opt-in (default
+        /// false) so existing panels render unchanged.
+        #[serde(default)]
+        focus_marker: bool,
     },
 
     /// Replace the spec of the currently-mounted floating widget

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -1044,6 +1044,16 @@ type WidgetSpec = {
 	* row doesn't reshuffle when the disabled flag flips.
 	*/
 	disabled: boolean;
+	/**
+	* When false, the button is dropped from the Tab cycle (but
+	* still renders and stays clickable). Used for radio-style
+	* groups — a row of buttons where only the *active* option
+	* should be a Tab stop and ←/→ moves the selection within
+	* the group, so Tab advances one stop per group rather than
+	* one stop per option. Defaults to true (ordinary buttons
+	* are tabbable).
+	*/
+	focusable: boolean;
 } | {
 	"kind": "spacer";
 	cols: number;
@@ -3075,7 +3085,7 @@ interface EditorAPI {
 	* Mount a declarative widget panel as a centered floating
 	* overlay (not bound to any virtual buffer).
 	*/
-	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number, asDock?: boolean): boolean;
+	mountFloatingWidget(panelId: number, specObj: unknown, widthPct: number, heightPct: number, asDock?: boolean, focusMarker?: boolean): boolean;
 	/**
 	* Replace the spec of the currently-mounted floating widget panel.
 	*/

--- a/crates/fresh-editor/plugins/lib/widgets.ts
+++ b/crates/fresh-editor/plugins/lib/widgets.ts
@@ -164,6 +164,11 @@ export function button(
     intent?: ButtonKind;
     key?: string;
     disabled?: boolean;
+    /** When false, the button renders and stays clickable but is
+     * dropped from the Tab cycle. Use for radio-style groups so Tab
+     * advances one stop per group (the active option) and ←/→ moves
+     * the selection within the group. Defaults to true. */
+    focusable?: boolean;
   },
 ): WidgetSpec {
   return {
@@ -173,6 +178,7 @@ export function button(
     intent: options?.intent ?? "normal",
     key: options?.key,
     disabled: options?.disabled ?? false,
+    focusable: options?.focusable ?? true,
   };
 }
 
@@ -783,7 +789,16 @@ export class FloatingWidgetPanel {
    * existing panel. */
   mount(
     spec: WidgetSpec,
-    options: { widthPct?: number; heightPct?: number; asDock?: boolean } = {},
+    options: {
+      widthPct?: number;
+      heightPct?: number;
+      asDock?: boolean;
+      /** When true, the host reserves a two-column gutter on every
+       * focusable control for the `▸ ` focus marker, so the focused
+       * control is legible from a plain terminal capture and the
+       * layout stays constant as focus moves. Default false. */
+      focusMarker?: boolean;
+    } = {},
   ): boolean {
     // deno-lint-ignore no-explicit-any
     const editor = (globalThis as any).editor;
@@ -796,6 +811,7 @@ export class FloatingWidgetPanel {
       wp,
       hp,
       options.asDock ?? false,
+      options.focusMarker ?? false,
     );
   }
 

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -5318,7 +5318,7 @@ function buildFormSpec(): WidgetSpec {
     row(
       flexSpacer(),
       hintBar([
-        { keys: "Tab", label: "next field" },
+        { keys: "Tab", label: "next / accept" },
         { keys: "S-Tab", label: "prev" },
         { keys: "←→", label: "change option" },
         { keys: "↑↓", label: "suggest / history" },
@@ -6341,12 +6341,18 @@ function dispatchFormKey(name: string): void {
 // host emits — `completion_accept` and `completion_dismiss`,
 // handled in the `widget_event` dispatch below.
 registerHandler("orchestrator_form_key_tab", () => {
-  // Tab always advances to the next field — it never accepts a
-  // completion. When a popup is open the host closes it and advances
-  // (firing `completion_dismiss`, which clears our mirror). The
-  // optimistic mirror advance here is re-synced from the host's
-  // authoritative `focus` event either way.
-  advanceFormFocus(1);
+  // Tab applies the highlighted candidate when the user has stepped
+  // into an open dropdown (↑/↓/wheel); otherwise it advances to the
+  // next field. The host owns that decision (it tracks which row, if
+  // any, is highlighted), so when a popup is open we must NOT
+  // optimistically advance our mirror — doing so would desync it in
+  // the accept case, where the host keeps focus on the field and
+  // fires `completion_accept` (no `focus` event to snap back from).
+  // With no popup, the host always advances and fires an authoritative
+  // `focus` event, so the optimistic advance just avoids a frame lag.
+  if (!completionVisibleForFocused()) {
+    advanceFormFocus(1);
+  }
   dispatchFormKey("Tab");
 });
 // Ctrl+Enter: submit from anywhere, no matter which field is focused

--- a/crates/fresh-editor/plugins/orchestrator.ts
+++ b/crates/fresh-editor/plugins/orchestrator.ts
@@ -4113,9 +4113,13 @@ function rebuildFormFocusCycle(): void {
     formFocusIndex = 0;
     return;
   }
-  // Tab cycle starts with the "Run in:" type tabs, then the active backend's
-  // fields, then the shared Session Name / Agent Command, then the buttons.
-  const cycle: string[] = SESSION_BACKENDS.map((b) => b.key);
+  // Tab cycle (mirrors the host's tabbable, which now skips non-active
+  // radio options): the *active* "Run in:" tab, then the active
+  // backend's fields, then the shared Session Name / Agent Command,
+  // then the buttons. ←/→ moves within the radio groups, never Tab —
+  // so each group is a single Tab stop.
+  const activeBackend = SESSION_BACKENDS.find((b) => b.id === form.backend);
+  const cycle: string[] = activeBackend ? [activeBackend.key] : [];
   if (form.backend === "local") {
     const worktreeEnabled = form.projectPathIsGit !== false;
     const branchInert = !(worktreeEnabled && form.createWorktree);
@@ -4134,12 +4138,13 @@ function rebuildFormFocusCycle(): void {
     }
     cycle.push("name", "cmd");
   }
-  // Make the agent presets keyboard-reachable: drop them just before the
-  // Agent Command field so Tab lands on the dropdown before the free-text
-  // input (mirrors how the "Run in:" tabs precede their fields).
+  // Make the agent presets keyboard-reachable: the *active* preset is a
+  // single Tab stop just before the Agent Command field (←/→ chooses
+  // within the group), mirroring how the "Run in:" tab precedes its
+  // fields.
   const cmdIdx = cycle.indexOf("cmd");
   if (cmdIdx >= 0) {
-    cycle.splice(cmdIdx, 0, ...agentPresets().map((p) => p.key));
+    cycle.splice(cmdIdx, 0, activeAgentPresetKey());
   }
   cycle.push("cancel", "create");
   formFocusCycle = cycle;
@@ -4822,7 +4827,14 @@ function backendTabsRow(): WidgetSpec {
   ];
   for (const b of SESSION_BACKENDS) {
     parts.push(spacer(1));
-    parts.push(button(b.label, { key: b.key, intent: b.id === sel ? "primary" : undefined }));
+    // Only the active tab is a Tab stop; ←/→ moves within the group.
+    // So Tab advances one stop per group, not one per option (and the
+    // `▸` focus marker only ever lands on the active tab).
+    parts.push(button(b.label, {
+      key: b.key,
+      intent: b.id === sel ? "primary" : undefined,
+      focusable: b.id === sel,
+    }));
   }
   parts.push(flexSpacer());
   parts.push({
@@ -4850,7 +4862,13 @@ function agentPresetRow(): WidgetSpec {
   for (const p of agentPresets()) {
     parts.push(spacer(1));
     const label = p.resumes && showsResume ? `${p.label} ↻` : p.label;
-    parts.push(button(label, { key: p.key, intent: p.key === activeKey ? "primary" : undefined }));
+    // Only the active preset is a Tab stop; ←/→ chooses within the
+    // group (matches the "Run in:" tabs).
+    parts.push(button(label, {
+      key: p.key,
+      intent: p.key === activeKey ? "primary" : undefined,
+      focusable: p.key === activeKey,
+    }));
   }
   parts.push(flexSpacer());
   const hint = showsResume ? "←/→ choose · ↻ resumes on restart" : "←/→ choose";
@@ -4872,7 +4890,13 @@ function localBodyFields(): WidgetSpec[] {
       child: text({
         value: form.projectPath.value,
         cursorByte: form.projectPath.cursor,
-        placeholder: form.defaultProjectPath || "detecting project root…",
+        // Label the placeholder explicitly as the default-if-blank so
+        // it can't be mistaken for a real prefilled value (it's also
+        // rendered dim-italic, but that's invisible in a plain
+        // capture). Submitting with the field empty uses this path.
+        placeholder: form.defaultProjectPath
+          ? `default (leave blank to use): ${form.defaultProjectPath}`
+          : "detecting project root…",
         fullWidth: true,
         key: "project_path",
       }),
@@ -4957,7 +4981,9 @@ function devcontainerBodyFields(): WidgetSpec[] {
       child: text({
         value: form.projectPath.value,
         cursorByte: form.projectPath.cursor,
-        placeholder: form.defaultProjectPath || "path containing .devcontainer/…",
+        placeholder: form.defaultProjectPath
+          ? `default (leave blank to use): ${form.defaultProjectPath}`
+          : "path containing .devcontainer/…",
         fullWidth: true,
         key: "project_path",
       }),
@@ -5292,12 +5318,14 @@ function buildFormSpec(): WidgetSpec {
     row(
       flexSpacer(),
       hintBar([
-        { keys: "Tab", label: "next / accept" },
+        { keys: "Tab", label: "next field" },
         { keys: "S-Tab", label: "prev" },
+        { keys: "←→", label: "change option" },
         { keys: "↑↓", label: "suggest / history" },
         { keys: "Space", label: "toggle" },
         { keys: "Enter", label: "advance / act" },
-        { keys: "Esc", label: "cancel" },
+        { keys: "^Enter", label: "create" },
+        { keys: "Esc", label: "close / cancel" },
       ]),
       flexSpacer(),
     ),
@@ -5379,7 +5407,14 @@ function openForm(options?: { fromPicker?: boolean }): void {
   // 50% cap was a fixed canvas in disguise — on a 24-row terminal
   // it left the dialog 12 rows tall, clipping the Branch input,
   // the Cancel / Create Session buttons, and the hint bar.
-  formPanel.mount(buildFormSpec(), { widthPct: 60, heightPct: 90 });
+  formPanel.mount(buildFormSpec(), {
+    widthPct: 60,
+    heightPct: 90,
+    // Reserve the `▸ ` focus-marker gutter: focus is then legible from
+    // a plain terminal capture (driveable by automation) and the
+    // layout stays constant as Tab moves focus between controls.
+    focusMarker: true,
+  });
   // The New-Session form is a global orchestrator feature too: center it
   // over the full screen (covering its own dimmed dock) rather than in the
   // chrome area beside the dock. A no-op when no dock is up.
@@ -6275,6 +6310,9 @@ const FORM_MODE_BINDINGS: [string, string][] = [
   ["Tab", "orchestrator_form_key_tab"],
   ["S-Tab", "orchestrator_form_key_shift_tab"],
   ["Enter", "orchestrator_form_key_enter"],
+  // Ctrl+Enter submits from anywhere in the form, regardless of which
+  // field is focused or whether a completion popup is open.
+  ["C-Enter", "orchestrator_form_submit"],
   ["Escape", "orchestrator_form_key_escape"],
   ["Backspace", "orchestrator_form_key_backspace"],
   ["Delete", "orchestrator_form_key_delete"],
@@ -6303,14 +6341,19 @@ function dispatchFormKey(name: string): void {
 // host emits — `completion_accept` and `completion_dismiss`,
 // handled in the `widget_event` dispatch below.
 registerHandler("orchestrator_form_key_tab", () => {
-  if (completionVisibleForFocused()) {
-    // Host fires completion_accept; plugin's widget_event
-    // handler applies the value. No focus advance.
-    dispatchFormKey("Tab");
-    return;
-  }
+  // Tab always advances to the next field — it never accepts a
+  // completion. When a popup is open the host closes it and advances
+  // (firing `completion_dismiss`, which clears our mirror). The
+  // optimistic mirror advance here is re-synced from the host's
+  // authoritative `focus` event either way.
   advanceFormFocus(1);
   dispatchFormKey("Tab");
+});
+// Ctrl+Enter: submit from anywhere, no matter which field is focused
+// or whether a completion popup is open.
+registerHandler("orchestrator_form_submit", () => {
+  if (!form) return;
+  void submitForm();
 });
 registerHandler("orchestrator_form_key_enter", () => {
   // When the popup is open, the host's smart-key fires

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -1188,6 +1188,13 @@ pub(crate) struct FloatingWidgetState {
     /// dock, while other plugins' floating panels keep the default
     /// coexist-beside-the-dock layout. Ignored for `LeftDock`.
     pub fullscreen: bool,
+    /// When true, this panel renders through `render_spec_with_marker`:
+    /// every focusable control reserves a two-column gutter for the
+    /// `▸ ` focus marker so focus is legible from a plain capture and
+    /// the layout stays constant as focus moves. Opt-in at mount
+    /// (`MountFloatingWidget.focus_marker`); the Orchestrator New
+    /// Session form uses it.
+    pub focus_marker: bool,
 }
 
 /// A list scrollbar's screen rect + scroll state, captured at draw
@@ -1706,6 +1713,7 @@ mod tests {
             scrollbar_hover_zones: Vec::new(),
             scrollbar_zone_hovered: false,
             fullscreen: false,
+            focus_marker: false,
         }
     }
 

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -24,6 +24,25 @@ use crate::view::split::SplitViewState;
 use super::window::Window;
 use super::{Editor, FloatingWidgetState};
 
+/// Render a floating panel's spec, choosing the marker-gutter
+/// renderer when the panel opted into the `▸ ` focus marker (the
+/// Orchestrator New Session form) and the plain renderer otherwise.
+/// Centralised so the mount / update / rerender paths can't drift on
+/// which renderer a given panel uses.
+pub(super) fn render_floating_spec(
+    focus_marker: bool,
+    spec: &fresh_core::api::WidgetSpec,
+    prev: &std::collections::HashMap<String, crate::widgets::WidgetInstanceState>,
+    prev_focus_key: &str,
+    panel_width: u32,
+) -> crate::widgets::RenderOutput {
+    if focus_marker {
+        crate::widgets::render_spec_with_marker(spec, prev, prev_focus_key, panel_width)
+    } else {
+        crate::widgets::render_spec(spec, prev, prev_focus_key, panel_width)
+    }
+}
+
 /// Normalize a session path for the plugin API. Sessions reach `WindowInfo`
 /// from two sources — the canonicalized launch session and `create_window_at`'s
 /// raw `PathBuf` — so any byte-level path field (lex sort, equality, …) in a
@@ -1442,9 +1461,17 @@ impl Editor {
                 width_pct,
                 height_pct,
                 as_dock,
+                focus_marker,
             } => {
                 let key = crate::widgets::PanelKey::new(plugin, panel_id);
-                self.handle_mount_floating_widget(key, spec, width_pct, height_pct, as_dock);
+                self.handle_mount_floating_widget(
+                    key,
+                    spec,
+                    width_pct,
+                    height_pct,
+                    as_dock,
+                    focus_marker,
+                );
             }
 
             PluginCommand::UpdateFloatingWidget {
@@ -4049,7 +4076,7 @@ impl Editor {
                     // (if open) doesn't disappear on a value
                     // mutation that happens to land while the
                     // user is mid-keystroke.
-                    let (scroll, multiline, completions, sel_idx, scroll_off) =
+                    let (scroll, multiline, completions, sel_idx, scroll_off, navigated) =
                         match panel.instance_states.get(&widget_key) {
                             Some(crate::widgets::WidgetInstanceState::Text {
                                 editor,
@@ -4057,14 +4084,16 @@ impl Editor {
                                 completions,
                                 completion_selected_index,
                                 completion_scroll_offset,
+                                completion_navigated,
                             }) => (
                                 *scroll,
                                 editor.multiline,
                                 completions.clone(),
                                 *completion_selected_index,
                                 *completion_scroll_offset,
+                                *completion_navigated,
                             ),
-                            _ => (0u32, true, Vec::new(), 0usize, 0u32),
+                            _ => (0u32, true, Vec::new(), 0usize, 0u32, false),
                         };
                     let mut editor = if multiline {
                         crate::primitives::text_edit::TextEdit::with_text(&value)
@@ -4084,6 +4113,7 @@ impl Editor {
                             completions,
                             completion_selected_index: sel_idx,
                             completion_scroll_offset: scroll_off,
+                            completion_navigated: navigated,
                         },
                     );
                 }
@@ -4152,12 +4182,18 @@ impl Editor {
                         completions,
                         completion_selected_index,
                         completion_scroll_offset,
+                        completion_navigated,
                         ..
                     }) = panel.instance_states.get_mut(&widget_key)
                     {
                         *completions = items;
                         *completion_selected_index = 0;
                         *completion_scroll_offset = 0;
+                        // A (re)opened popup is not yet "entered": Tab /
+                        // Enter act on the form until the user steps in
+                        // with ↑/↓. (Closing — empty `items` — also
+                        // resets it, harmlessly.)
+                        *completion_navigated = false;
                     }
                 }
             }
@@ -4282,6 +4318,7 @@ impl Editor {
         width_pct: u8,
         height_pct: u8,
         as_dock: bool,
+        focus_marker: bool,
     ) {
         let width_pct = width_pct.clamp(1, 100);
         let height_pct = height_pct.clamp(1, 100);
@@ -4334,11 +4371,12 @@ impl Editor {
             scrollbar_hover_zones: Vec::new(),
             scrollbar_zone_hovered: false,
             fullscreen: false,
+            focus_marker,
         });
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
         let panel_width = self.floating_panel_inner_width(slot);
-        let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
+        let out = render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;
@@ -4399,7 +4437,8 @@ impl Editor {
             .map(|s| s.to_string())
             .unwrap_or_default();
         let panel_width = self.floating_panel_inner_width(slot);
-        let out = crate::widgets::render_spec(&spec, &prev, &prev_focus, panel_width);
+        let focus_marker = self.panel(slot).map(|f| f.focus_marker).unwrap_or(false);
+        let out = render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -24,25 +24,6 @@ use crate::view::split::SplitViewState;
 use super::window::Window;
 use super::{Editor, FloatingWidgetState};
 
-/// Render a floating panel's spec, choosing the marker-gutter
-/// renderer when the panel opted into the `▸ ` focus marker (the
-/// Orchestrator New Session form) and the plain renderer otherwise.
-/// Centralised so the mount / update / rerender paths can't drift on
-/// which renderer a given panel uses.
-pub(super) fn render_floating_spec(
-    focus_marker: bool,
-    spec: &fresh_core::api::WidgetSpec,
-    prev: &std::collections::HashMap<String, crate::widgets::WidgetInstanceState>,
-    prev_focus_key: &str,
-    panel_width: u32,
-) -> crate::widgets::RenderOutput {
-    if focus_marker {
-        crate::widgets::render_spec_with_marker(spec, prev, prev_focus_key, panel_width)
-    } else {
-        crate::widgets::render_spec(spec, prev, prev_focus_key, panel_width)
-    }
-}
-
 /// Normalize a session path for the plugin API. Sessions reach `WindowInfo`
 /// from two sources — the canonicalized launch session and `create_window_at`'s
 /// raw `PathBuf` — so any byte-level path field (lex sort, equality, …) in a
@@ -4376,7 +4357,7 @@ impl Editor {
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
         let panel_width = self.floating_panel_inner_width(slot);
-        let out = render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
+        let out = super::widget_runtime::render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;
@@ -4438,7 +4419,7 @@ impl Editor {
             .unwrap_or_default();
         let panel_width = self.floating_panel_inner_width(slot);
         let focus_marker = self.panel(slot).map(|f| f.focus_marker).unwrap_or(false);
-        let out = render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
+        let out = super::widget_runtime::render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -4357,7 +4357,13 @@ impl Editor {
         let prev = std::collections::HashMap::new();
         let prev_focus = String::new();
         let panel_width = self.floating_panel_inner_width(slot);
-        let out = super::widget_runtime::render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
+        let out = super::widget_runtime::render_floating_spec(
+            focus_marker,
+            &spec,
+            &prev,
+            &prev_focus,
+            panel_width,
+        );
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;
@@ -4419,7 +4425,13 @@ impl Editor {
             .unwrap_or_default();
         let panel_width = self.floating_panel_inner_width(slot);
         let focus_marker = self.panel(slot).map(|f| f.focus_marker).unwrap_or(false);
-        let out = super::widget_runtime::render_floating_spec(focus_marker, &spec, &prev, &prev_focus, panel_width);
+        let out = super::widget_runtime::render_floating_spec(
+            focus_marker,
+            &spec,
+            &prev,
+            &prev_focus,
+            panel_width,
+        );
         let focus_cursor = out.focus_cursor;
         let entries = out.entries;
         let embeds = out.embeds;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -389,9 +389,19 @@ impl Editor {
                     self.dismiss_focused_text_completions(panel_key);
                 }
                 "Tab" => {
-                    // Tab never accepts a completion — it always moves
-                    // focus. Close the popup, then fall through to the
-                    // focus-advance dispatch below.
+                    if self.focused_text_completion_navigated(panel_key) {
+                        // The user stepped into the dropdown (↑/↓/wheel)
+                        // so a row is highlighted — Tab applies it and
+                        // closes the popup, just like Enter. Focus stays
+                        // on the field so the accepted value is visible
+                        // and editable (a second Tab then advances).
+                        self.fire_completion_accept(panel_key);
+                        return;
+                    }
+                    // Nothing highlighted (a freshly surfaced popup): Tab
+                    // commits the typed text and moves focus. Close the
+                    // popup, then fall through to the focus-advance
+                    // dispatch below.
                     self.dismiss_focused_text_completions(panel_key);
                 }
                 _ => {}

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -13,6 +13,27 @@ use crate::model::event::{BufferId, LeafId, SplitId};
 
 use super::Editor;
 
+/// Render a floating panel's spec, choosing the marker-gutter
+/// renderer when the panel opted into the `▸ ` focus marker (the
+/// Orchestrator New Session form) and the plain renderer otherwise.
+/// Centralised so the mount / update / rerender paths can't drift on
+/// which renderer a given panel uses. Lives here (not in the
+/// `plugins`-gated `plugin_dispatch`) so the non-plugin rerender path
+/// can call it in plugin-less builds.
+pub(super) fn render_floating_spec(
+    focus_marker: bool,
+    spec: &fresh_core::api::WidgetSpec,
+    prev: &std::collections::HashMap<String, crate::widgets::WidgetInstanceState>,
+    prev_focus_key: &str,
+    panel_width: u32,
+) -> crate::widgets::RenderOutput {
+    if focus_marker {
+        crate::widgets::render_spec_with_marker(spec, prev, prev_focus_key, panel_width)
+    } else {
+        crate::widgets::render_spec(spec, prev, prev_focus_key, panel_width)
+    }
+}
+
 /// Walk a `Tree`'s flat `nodes` and return the absolute indices of
 /// nodes that are currently visible — i.e. every ancestor is in
 /// `expanded`. Mirrors the renderer's filter so dispatcher and
@@ -242,7 +263,7 @@ impl Editor {
                 .and_then(|slot| self.panel(slot))
                 .map(|f| f.focus_marker)
                 .unwrap_or(false);
-            let out = super::plugin_dispatch::render_floating_spec(
+            let out = render_floating_spec(
                 focus_marker,
                 spec,
                 &prev,

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -263,13 +263,7 @@ impl Editor {
                 .and_then(|slot| self.panel(slot))
                 .map(|f| f.focus_marker)
                 .unwrap_or(false);
-            let out = render_floating_spec(
-                focus_marker,
-                spec,
-                &prev,
-                &prev_focus,
-                panel_width,
-            );
+            let out = render_floating_spec(focus_marker, spec, &prev, &prev_focus, panel_width);
             (buffer_id, is_floating, panel_width, out)
         };
         let _ = panel_width;

--- a/crates/fresh-editor/src/app/widget_runtime.rs
+++ b/crates/fresh-editor/src/app/widget_runtime.rs
@@ -233,7 +233,22 @@ impl Editor {
             } else {
                 self.widget_panel_width(buffer_id)
             };
-            let out = crate::widgets::render_spec(spec, &prev, &prev_focus, panel_width);
+            // Floating panels that opted into the focus-marker gutter
+            // (the Orchestrator New Session form) must re-render
+            // through the same marker renderer on every host-driven
+            // refresh — otherwise a Tab / focus advance would repaint
+            // the panel without the gutter and the layout would jump.
+            let focus_marker = panel_slot
+                .and_then(|slot| self.panel(slot))
+                .map(|f| f.focus_marker)
+                .unwrap_or(false);
+            let out = super::plugin_dispatch::render_floating_spec(
+                focus_marker,
+                spec,
+                &prev,
+                &prev_focus,
+                panel_width,
+            );
             (buffer_id, is_floating, panel_width, out)
         };
         let _ = panel_width;
@@ -312,11 +327,6 @@ impl Editor {
             None => return,
         };
         let focus_key = panel.focus_key.clone();
-        let widget = if focus_key.is_empty() {
-            None
-        } else {
-            crate::widgets::find_widget_by_key(&panel.spec, &focus_key)
-        };
         // Completion-popup short-circuit: when the focused Text
         // widget has an open completion popup, intercept Tab /
         // Up / Down / Enter / Esc so they drive the popup instead
@@ -330,14 +340,6 @@ impl Editor {
             && self.focused_text_completions_open(panel_key);
         if completions_open {
             match key {
-                "Tab" => {
-                    self.fire_completion_accept(panel_key);
-                    // The plugin's accept handler typically calls
-                    // setValue + (maybe) setCompletions — those
-                    // mutations re-render on their own, so we
-                    // don't force a render here.
-                    return;
-                }
                 "Up" => {
                     self.move_focused_text_completion_index(panel_key, -1);
                     // Selection moved host-side; force a repaint
@@ -352,14 +354,47 @@ impl Editor {
                     self.rerender_widget_panel(panel_key);
                     return;
                 }
-                "Enter" | "Escape" => {
+                "Escape" => {
+                    // First Esc only closes the popup — the form stays
+                    // open. (A second Esc, with no popup, cancels.)
                     self.dismiss_focused_text_completions(panel_key);
                     self.rerender_widget_panel(panel_key);
                     return;
                 }
+                "Enter" => {
+                    if self.focused_text_completion_navigated(panel_key) {
+                        // The user stepped into the dropdown and Enter
+                        // accepts the highlighted candidate.
+                        self.fire_completion_accept(panel_key);
+                        return;
+                    }
+                    // Not navigated: the dropdown must not swallow the
+                    // submit. Close it, then fall through so Enter acts
+                    // on the form (advance / submit) below.
+                    self.dismiss_focused_text_completions(panel_key);
+                }
+                "Tab" => {
+                    // Tab never accepts a completion — it always moves
+                    // focus. Close the popup, then fall through to the
+                    // focus-advance dispatch below.
+                    self.dismiss_focused_text_completions(panel_key);
+                }
                 _ => {}
             }
         }
+        // Re-fetch the focused widget for the main dispatch: the
+        // completion block above may have run `&mut self` (dismissing a
+        // popup), so we can't hold a borrow from before it. The spec is
+        // unchanged by a dismiss, so this resolves to the same widget.
+        let panel = match self.widget_registry.get(panel_key) {
+            Some(p) => p,
+            None => return,
+        };
+        let widget = if focus_key.is_empty() {
+            None
+        } else {
+            crate::widgets::find_widget_by_key(&panel.spec, &focus_key)
+        };
         match key {
             "Tab" => self.handle_widget_focus_advance(panel_key, 1),
             "Shift+Tab" => self.handle_widget_focus_advance(panel_key, -1),
@@ -655,6 +690,28 @@ impl Editor {
         )
     }
 
+    /// Has the user explicitly stepped into the focused Text widget's
+    /// open completion popup (via ↑/↓ / wheel)? Drives the Tab/Enter
+    /// dispatch: only a *navigated* popup accepts on Enter — a freshly
+    /// surfaced one lets Enter act on the form instead.
+    fn focused_text_completion_navigated(&self, panel_key: &crate::widgets::PanelKey) -> bool {
+        let panel = match self.widget_registry.get(panel_key) {
+            Some(p) => p,
+            None => return false,
+        };
+        if panel.focus_key.is_empty() {
+            return false;
+        }
+        matches!(
+            panel.instance_states.get(&panel.focus_key),
+            Some(crate::widgets::WidgetInstanceState::Text {
+                completions,
+                completion_navigated,
+                ..
+            }) if !completions.is_empty() && *completion_navigated
+        )
+    }
+
     /// Move the selected-index cursor of the focused Text widget's
     /// completion popup by `delta` (Up = -1, Down = +1). Clamps
     /// at the ends rather than wrapping — Down past the last
@@ -704,10 +761,19 @@ impl Editor {
             completions,
             completion_selected_index,
             completion_scroll_offset,
+            completion_navigated,
             ..
         }) = panel.instance_states.get_mut(&focus_key)
         {
             if completions.is_empty() {
+                return;
+            }
+            // The first ↑/↓ *enters* the dropdown: flip `navigated`
+            // and select the current (top) row without moving, so the
+            // user lands on a sensible candidate instead of skipping
+            // the first one. Subsequent presses move the selection.
+            if !*completion_navigated {
+                *completion_navigated = true;
                 return;
             }
             let max = (completions.len() - 1) as i32;
@@ -1163,12 +1229,16 @@ impl Editor {
         if let Some(crate::widgets::WidgetInstanceState::Text {
             completions,
             completion_scroll_offset,
+            completion_navigated,
             ..
         }) = panel.instance_states.get_mut(&focus_key)
         {
             if completions.is_empty() {
                 return;
             }
+            // Scrolling the popup with the wheel counts as stepping
+            // into it — Enter should then accept the highlighted row.
+            *completion_navigated = true;
             let total = completions.len() as u32;
             let max_scroll = total.saturating_sub(visible.min(total));
             let next = (*completion_scroll_offset as i32 + delta).clamp(0, max_scroll as i32);
@@ -1749,6 +1819,7 @@ impl Editor {
                 completions: Vec::new(),
                 completion_selected_index: 0,
                 completion_scroll_offset: 0,
+                completion_navigated: false,
             },
         );
         true

--- a/crates/fresh-editor/src/widgets/mod.rs
+++ b/crates/fresh-editor/src/widgets/mod.rs
@@ -27,6 +27,6 @@ pub use registry::{
     HitArea, PanelId, PanelKey, WidgetInstanceState, WidgetPanelState, WidgetRegistry,
 };
 pub use render::{
-    render_spec, render_spec_no_autofocus, EmbedRect, FocusCursor, OverlayRow, RenderOutput,
-    ScrollRegion,
+    render_spec, render_spec_no_autofocus, render_spec_with_marker, EmbedRect, FocusCursor,
+    OverlayRow, RenderOutput, ScrollRegion,
 };

--- a/crates/fresh-editor/src/widgets/registry.rs
+++ b/crates/fresh-editor/src/widgets/registry.rs
@@ -157,6 +157,15 @@ pub enum WidgetInstanceState {
         /// scrolls to keep selection in view); the mouse wheel
         /// scrolls it directly without moving the selection.
         completion_scroll_offset: u32,
+        /// Whether the user has *explicitly* moved into the open
+        /// completion popup (via ↑/↓ or the mouse wheel). Reset to
+        /// `false` every time the popup (re)opens from typing, so a
+        /// freshly-surfaced dropdown isn't "entered": Tab and Enter
+        /// then act on the *form* (advance / submit) instead of
+        /// accepting a candidate, and the popup paints no highlighted
+        /// row. The first ↓ flips it true — the dropdown is now
+        /// navigable, the selected row highlights, and Enter accepts.
+        completion_navigated: bool,
     },
     /// `Tree` instance state: host-owned scroll offset, selected
     /// index, and the set of expanded item keys. All three become

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -54,6 +54,37 @@ const KEY_TOGGLE_ON_FG: &str = "ui.help_key_fg";
 // so the cue reads consistently across selection UIs.
 const KEY_FOCUSED_FG: &str = "ui.popup_selection_fg";
 const KEY_FOCUSED_BG: &str = "ui.popup_selection_bg";
+// Leading marker prepended to the *focused* control (button /
+// toggle / text input) so "which control is focused" is legible
+// from a plain terminal capture — not just from the (theme-
+// dependent, capture-invisible) `popup_selection` background or
+// the hardware cursor. One glyph + a trailing space = two display
+// columns. Only ever applied to the single focused widget, so at
+// most one `▸` is on screen at a time; combined with the
+// `popup_selection` fg/bg flip it makes focus unmistakable, and
+// distinct from a `Primary` button's standing bold accent (which
+// carries no marker). See `render_button` / `render_toggle` /
+// `render_widget_text`.
+const FOCUS_MARKER: &str = "▸ ";
+// The unfocused counterpart to `FOCUS_MARKER`: two spaces, the same
+// two display columns the marker occupies, so reserving the gutter
+// keeps control widths identical whether or not they're focused.
+const FOCUS_GUTTER_BLANK: &str = "  ";
+
+/// The two-column gutter prefix a focusable control leads with when
+/// the current render reserves the focus-marker gutter
+/// ([`MARKER_GUTTER`]): `▸ ` for the focused control, two spaces for
+/// every other control. Returns `""` when the panel didn't opt into
+/// the gutter, so non-marker panels render byte-for-byte as before.
+fn focus_gutter_prefix(focused: bool) -> &'static str {
+    if !marker_gutter_enabled() {
+        ""
+    } else if focused {
+        FOCUS_MARKER
+    } else {
+        FOCUS_GUTTER_BLANK
+    }
+}
 // `ui.status_error_indicator_fg` defaults to white (designed as
 // the text-on-red status badge), so using it as a standalone fg
 // renders invisible against the panel bg. The diagnostic.error_fg
@@ -230,6 +261,61 @@ pub fn render_spec(
     prev_focus_key: &str,
     panel_width: u32,
 ) -> RenderOutput {
+    let _guard = MarkerGutterGuard::set(false);
+    render_spec_inner(spec, prev, prev_focus_key, panel_width, true)
+}
+
+// Whether the *current* render reserves a leading two-column gutter
+// on every focusable control for the `▸ ` focus marker. Opt-in per
+// panel (see `render_spec_with_marker`): when on, the focused
+// control leads with `▸ ` and every other focusable control leads
+// with two spaces, so focus is legible from a plain capture AND the
+// layout never shifts as focus moves (the gutter is always present,
+// only its glyph changes). When off — the default for every existing
+// panel — controls render exactly as before (no gutter, no marker),
+// so other dialogs are byte-for-byte unchanged. A thread-local keeps
+// the flag out of the ~dozen recursive `collect_*` signatures; it's
+// read only by the three leaf renderers (`render_button`,
+// `render_toggle`, `render_widget_text`). Rendering is synchronous
+// and non-re-entrant, so a thread-local with a restore guard is
+// sufficient.
+thread_local! {
+    static MARKER_GUTTER: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+fn marker_gutter_enabled() -> bool {
+    MARKER_GUTTER.with(|c| c.get())
+}
+
+/// RAII guard that sets the marker-gutter thread-local for the
+/// duration of one render and restores the previous value on drop —
+/// so a direct `render_button` call after a marker render doesn't
+/// observe a stale `true`.
+struct MarkerGutterGuard(bool);
+impl MarkerGutterGuard {
+    fn set(enabled: bool) -> Self {
+        let prev = MARKER_GUTTER.with(|c| c.replace(enabled));
+        MarkerGutterGuard(prev)
+    }
+}
+impl Drop for MarkerGutterGuard {
+    fn drop(&mut self) {
+        MARKER_GUTTER.with(|c| c.set(self.0));
+    }
+}
+
+/// Like [`render_spec`], but reserves the `▸ ` focus-marker gutter on
+/// every focusable control (see [`MARKER_GUTTER`]). Panels that want
+/// capture-legible, layout-stable focus (the Orchestrator New Session
+/// form) render through this entry point; everything else uses
+/// [`render_spec`] and is unaffected.
+pub fn render_spec_with_marker(
+    spec: &WidgetSpec,
+    prev: &HashMap<String, WidgetInstanceState>,
+    prev_focus_key: &str,
+    panel_width: u32,
+) -> RenderOutput {
+    let _guard = MarkerGutterGuard::set(true);
     render_spec_inner(spec, prev, prev_focus_key, panel_width, true)
 }
 
@@ -244,6 +330,7 @@ pub fn render_spec_no_autofocus(
     focus_key: &str,
     panel_width: u32,
 ) -> RenderOutput {
+    let _guard = MarkerGutterGuard::set(false);
     render_spec_inner(spec, prev, focus_key, panel_width, false)
 }
 
@@ -396,8 +483,9 @@ fn collect_tabbable(spec: &WidgetSpec, out: &mut Vec<String>) {
         WidgetSpec::Button {
             key: Some(k),
             disabled,
+            focusable,
             ..
-        } if !k.is_empty() && !*disabled => {
+        } if !k.is_empty() && !*disabled && *focusable => {
             out.push(k.clone());
         }
         WidgetSpec::Toggle { key: Some(k), .. }
@@ -459,6 +547,7 @@ fn render_collected(
             intent,
             key,
             disabled,
+            ..
         } => collect_button(
             label,
             *focused,
@@ -1612,6 +1701,7 @@ fn render_widget_text(
     let mut prev_completions: Vec<fresh_core::api::CompletionItem> = Vec::new();
     let mut prev_completion_idx: usize = 0;
     let mut prev_completion_scroll: u32 = 0;
+    let mut prev_completion_navigated = false;
     match key.filter(|k| !k.is_empty()).and_then(|k| prev.get(k)) {
         Some(WidgetInstanceState::Text {
             editor,
@@ -1619,12 +1709,14 @@ fn render_widget_text(
             completions,
             completion_selected_index,
             completion_scroll_offset,
+            completion_navigated,
         }) => {
             effective_editor = editor.clone();
             prev_scroll = *scroll;
             prev_completions = completions.clone();
             prev_completion_idx = *completion_selected_index;
             prev_completion_scroll = *completion_scroll_offset;
+            prev_completion_navigated = *completion_navigated;
         }
         _ => {
             effective_editor = if multiline {
@@ -1675,9 +1767,17 @@ fn render_widget_text(
         } else {
             label.chars().count() as u32 + 1
         };
+        // Reserve the two columns the focus-marker gutter occupies
+        // (when the panel opted in), so the bracketed region shrinks
+        // by the gutter width instead of overflowing the enclosing
+        // section's right border. Reserved unconditionally — focused
+        // and unfocused alike — so the closing bracket sits at the
+        // same column regardless of focus and the box never reflows.
+        let marker_reserve = if marker_gutter_enabled() { 2 } else { 0 };
         panel_width
             .saturating_sub(label_overhead)
             .saturating_sub(3)
+            .saturating_sub(marker_reserve)
             .max(1)
     } else {
         field_width
@@ -1743,13 +1843,35 @@ fn render_widget_text(
             full_width,
         );
         new_scroll = 0;
-        if let Some(byte_in_row) = rendered.cursor_byte_in_entry {
+        let mut entry = rendered.entry;
+        // Lead the single-line input with the focus-marker gutter
+        // (`▸ ` when focused, two spaces otherwise) so focus is
+        // legible from a plain capture — the hardware cursor lands
+        // inside the field too, but a cursor doesn't show up in
+        // `tmux capture-pane`. Shift the cursor offset and every
+        // inline overlay right by the gutter's byte length so the
+        // bracket bg / placeholder / selection spans still line up.
+        // The field width was already reduced by the gutter's two
+        // columns above, so the box doesn't overflow, and the gutter
+        // is present whether or not the field is focused so the
+        // layout never shifts.
+        let gutter = focus_gutter_prefix(is_focused);
+        let marker_bytes = gutter.len();
+        let mut cursor_in_row = rendered.cursor_byte_in_entry;
+        if marker_bytes > 0 {
+            entry.text.insert_str(0, gutter);
+            for ov in entry.inline_overlays.iter_mut() {
+                ov.start += marker_bytes;
+                ov.end += marker_bytes;
+            }
+            cursor_in_row = cursor_in_row.map(|c| c + marker_bytes);
+        }
+        if let Some(byte_in_row) = cursor_in_row {
             out.focus_cursor = Some(FocusCursor {
                 buffer_row: 0,
                 byte_in_row: byte_in_row as u32,
             });
         }
-        let mut entry = rendered.entry;
         // A click anywhere on the input line focuses the field so a mouse user
         // can type. Text widgets previously emitted no hit area, so clicks fell
         // through and the field stayed unfocused (#2234 item 1). Focusing is
@@ -1854,7 +1976,11 @@ fn render_widget_text(
                 entry: render_completion_item_overlay(
                     &item.value,
                     item.kind.as_deref(),
-                    i == prev_completion_idx,
+                    // Only paint a selected-row highlight once the user
+                    // has stepped into the dropdown (↓/↑). A freshly
+                    // surfaced popup shows plain suggestions so it's
+                    // clear Enter acts on the form, not the list.
+                    prev_completion_navigated && i == prev_completion_idx,
                     popup_total,
                     thumb,
                 ),
@@ -1877,6 +2003,7 @@ fn render_widget_text(
                 completions: prev_completions,
                 completion_selected_index: prev_completion_idx,
                 completion_scroll_offset: prev_completion_scroll,
+                completion_navigated: prev_completion_navigated,
             },
         );
     }
@@ -2750,7 +2877,15 @@ pub fn render_hint_bar(entries: &[HintEntry]) -> TextPropertyEntry {
 /// matching the prompt / palette's selected-row affordance.
 pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyEntry {
     let glyph = if checked { "[v]" } else { "[ ]" };
-    let mut text = String::with_capacity(glyph.len() + 1 + label.len());
+    // When the panel reserves the focus-marker gutter, every toggle
+    // leads with a two-column gutter — `▸ ` when focused, two spaces
+    // otherwise — so focus is capture-legible and the width never
+    // changes as focus moves. Panels without the gutter render
+    // exactly as before (no prefix).
+    let marker = focus_gutter_prefix(focused);
+    let mut text = String::with_capacity(marker.len() + glyph.len() + 1 + label.len());
+    text.push_str(marker);
+    let glyph_start = text.len();
     text.push_str(glyph);
     text.push(' ');
     text.push_str(label);
@@ -2761,8 +2896,8 @@ pub fn render_toggle(checked: bool, label: &str, focused: bool) -> TextPropertyE
     // when unchecked, which is what plugins do today).
     if checked {
         overlays.push(InlineOverlay {
-            start: 0,
-            end: glyph.len(),
+            start: glyph_start,
+            end: glyph_start + glyph.len(),
             style: OverlayOptions {
                 fg: Some(OverlayColorSpec::theme_key(KEY_TOGGLE_ON_FG)),
                 bold: true,
@@ -2816,7 +2951,17 @@ pub fn render_button(
     kind: ButtonKind,
     disabled: bool,
 ) -> TextPropertyEntry {
-    let text = format!("[ {} ]", label);
+    // In a marker-gutter panel, focused buttons lead with `▸ ` and
+    // every other button with two spaces. This is the cue that
+    // distinguishes "focused" from "Primary": a Primary button keeps
+    // its standing bold accent whether or not it's focused, so
+    // without the marker (and the focused bg flip) `[ Create Session ]`
+    // looked permanently selected. The marker rides only on the one
+    // focused control, so exactly one button reads as focused — and
+    // because the gutter is always reserved, the row never reflows as
+    // focus moves between buttons.
+    let marker = focus_gutter_prefix(focused && !disabled);
+    let text = format!("{}[ {} ]", marker, label);
     let mut overlays = Vec::new();
 
     // Disabled overrides intent: a "Delete" button that isn't
@@ -4168,6 +4313,7 @@ mod tests {
                     intent: ButtonKind::Normal,
                     key: None,
                     disabled: false,
+                    focusable: true,
                 },
             ],
             key: None,
@@ -4238,6 +4384,7 @@ mod tests {
                     intent: ButtonKind::Normal,
                     key: None,
                     disabled: false,
+                    focusable: true,
                 },
             ],
             key: None,
@@ -4310,6 +4457,7 @@ mod tests {
             intent: ButtonKind::Primary,
             key: Some("replace".into()),
             disabled: false,
+            focusable: true,
         };
         let (_entries, hits, _state) = render_no_focus(&spec, &HashMap::new());
         assert_eq!(hits.len(), 1);
@@ -4332,6 +4480,7 @@ mod tests {
                     intent: ButtonKind::Normal,
                     key: Some("archive".into()),
                     disabled: true,
+                    focusable: true,
                 },
                 WidgetSpec::Button {
                     label: "Cancel".into(),
@@ -4339,6 +4488,7 @@ mod tests {
                     intent: ButtonKind::Normal,
                     key: Some("cancel".into()),
                     disabled: false,
+                    focusable: true,
                 },
             ],
             key: None,
@@ -4475,6 +4625,7 @@ mod tests {
                             intent: ButtonKind::Normal,
                             key: Some("b".into()),
                             disabled: false,
+                            focusable: true,
                         },
                     ],
                     key: None,
@@ -6038,6 +6189,7 @@ mod tests {
                 completions: Vec::new(),
                 completion_selected_index: 0,
                 completion_scroll_offset: 0,
+                completion_navigated: false,
             },
         );
         let out = render_spec(&spec, &prev, "ta", 80);

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -2578,10 +2578,18 @@ fn render_completion_item(
     // candidate text is, so we hand-pad rather than relying on
     // entry-level `pad_to_chars`.
     //
-    // Budget = total_cols - (2 leading chars) - (1 scrollbar col).
+    // When the panel reserves the focus-marker gutter, the input's
+    // bracketed value is itself shifted right by the two-column gutter
+    // (`▸ ` / two spaces, inserted before its `[`). Lead the candidate
+    // rows by the same two columns so the candidate text stays directly
+    // under the typed value instead of sitting two columns to its left.
+    // Zero when the panel didn't opt into the gutter (every other
+    // popup), so those render exactly as before.
+    let lead = if marker_gutter_enabled() { 2 } else { 0 };
+    // Budget = total_cols - (2 leading chars) - (gutter lead) - (1 scrollbar col).
     // The two leading chars align the item with the bracketed
     // input value (see the function docstring).
-    let text_budget = total_cols.saturating_sub(2).saturating_sub(1);
+    let text_budget = total_cols.saturating_sub(2 + lead).saturating_sub(1);
     let item_chars: Vec<char> = item.chars().collect();
     let (visible_item, truncated): (String, bool) = if item_chars.len() <= text_budget {
         (item.to_string(), false)
@@ -2605,6 +2613,13 @@ fn render_completion_item(
     // item text starts in the same column on both kinds.
     let history_marker: char = '↶';
     let mut text = String::with_capacity(total_cols * 4 + 2);
+    // Gutter lead (see `lead` above): keeps the candidate aligned under
+    // the gutter-shifted input value. The history `↶` marker and the
+    // selection highlight are positioned by byte offsets captured *after*
+    // these spaces, so they ride along correctly.
+    for _ in 0..lead {
+        text.push(' ');
+    }
     text.push(' ');
     let marker_start_byte = text.len();
     if is_history {
@@ -2619,7 +2634,7 @@ fn render_completion_item(
     // Pad with spaces between the candidate text and the
     // scrollbar column so all rows have the scrollbar glyph in
     // the same column regardless of candidate length.
-    let used_cols = 2 + visible_item.chars().count();
+    let used_cols = 2 + lead + visible_item.chars().count();
     let pad_cols = total_cols.saturating_sub(used_cols).saturating_sub(1);
     for _ in 0..pad_cols {
         text.push(' ');

--- a/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
+++ b/crates/fresh-editor/tests/e2e/dock_focus_stuck_born_attached.rs
@@ -113,6 +113,7 @@ fn born_attached_session_does_not_wedge_source_window_typing() {
             width_pct: 60,
             height_pct: 90,
             as_dock: false,
+            focus_marker: false,
         })
         .unwrap();
     harness

--- a/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
+++ b/crates/fresh-editor/tests/e2e/orchestrator_dock.rs
@@ -1527,18 +1527,24 @@ fn dock_new_session_in_uncommitted_repo_surfaces_real_git_error() {
     h.wait_until(|h| h.screen_to_string().contains("New Session"))
         .unwrap();
 
-    // The form opens focused on the first field (Project Path). It now leads
-    // with a "Run in:" type-tab row (Local / SSH / Kubernetes / Devcontainer),
-    // so the four tab buttons sit *before* the fields in the focus order.
-    // Stepping back past the four tabs reaches the first focusable, and one
-    // more Shift+Tab wraps to the last one — the "Create Session" button —
-    // regardless of how many fields lie between. Five Shift+Tabs therefore
-    // land on Create (and close any path-completion popup along the way).
-    // Enter submits.
-    for _ in 0..5 {
-        h.send_key(KeyCode::BackTab, KeyModifiers::NONE).unwrap();
+    // Tab forward until the "Create Session" button is the focused
+    // control — its line carries the `▸` focus marker right before it
+    // (the form reserves the marker gutter). Walking to the button by
+    // its marker keeps this robust to the focus-cycle length: each radio
+    // group ("Run in:", "Agent:") is a single Tab stop, so the number of
+    // stops depends on the active backend's field count. Tab also closes
+    // any open path-completion popup along the way. Enter then submits.
+    let mut guard = 0;
+    while !h.screen_to_string().contains("▸ [ Create Session ]") {
+        h.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        h.render().unwrap();
+        guard += 1;
+        assert!(
+            guard < 30,
+            "Tab never focused the Create Session button.\n{}",
+            h.screen_to_string(),
+        );
     }
-    h.render().unwrap();
     h.send_key(KeyCode::Enter, KeyModifiers::NONE).unwrap();
 
     // git's actual error is surfaced (a `fatal:` line from the failed

--- a/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
+++ b/crates/fresh-editor/tests/e2e/panel_mode_window_switch_leak.rs
@@ -69,6 +69,7 @@ fn panel_mode_does_not_leak_onto_window_switched_away_from() {
             width_pct: 50,
             height_pct: 50,
             as_dock: false,
+            focus_marker: false,
         })
         .unwrap();
     harness

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -182,11 +182,13 @@ fn completion_popup_renders_with_dim_separator() {
     );
 }
 
-/// Tab does NOT accept the highlighted completion — it moves focus to
-/// the next field (closing the popup) and leaves the typed text
-/// intact. (Accepting a completion is `↓`-then-Enter, or a click.)
-/// Before the focus-model fix, Tab fired the completion's accept, so
-/// the number of Tabs to reach a button was unpredictable.
+/// Tab on an *un-engaged* popup (one the user hasn't stepped into with
+/// ↑/↓, so no row is highlighted) does NOT accept — it moves focus to
+/// the next field, closing the popup and leaving the typed text intact.
+/// (Accepting is `↓`-then-Tab/Enter, or a click — see
+/// `down_then_tab_accepts_completion`.) Before the focus-model fix, Tab
+/// always fired the completion's accept, so the number of Tabs to reach
+/// a button was unpredictable.
 #[test]
 fn tab_advances_focus_without_accepting_completion() {
     let (_temp, workspace) = set_up_workspace();
@@ -199,7 +201,8 @@ fn tab_advances_focus_without_accepting_completion() {
 
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
     // Popup closes (Tab moved focus); the typed text is untouched —
-    // Tab never accepts `alpha_dir/`.
+    // Tab doesn't accept `alpha_dir/` because the user never stepped
+    // into the dropdown.
     harness
         .wait_until(|h| !h.screen_to_string().contains("alpha_two/"))
         .unwrap();
@@ -230,10 +233,50 @@ fn tab_advances_focus_without_accepting_completion() {
     );
 }
 
+/// `↓` steps into the open dropdown (highlighting a row) and then Tab
+/// applies that highlighted candidate into the field — the "accept if
+/// engaged" half of Tab's behaviour. Focus stays on the field (the
+/// accepted value is left visible/editable), unlike an un-engaged Tab
+/// which advances. Mirrors `down_then_enter_accepts_completion`.
+#[test]
+fn down_then_tab_accepts_completion() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    // Step into the dropdown (↓ highlights the top row), then Tab
+    // applies it.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+
+    let expected = format!("{}/alpha_dir/", workspace.display());
+    harness
+        .wait_until(|h| project_path_field_value(&h.screen_to_string()) == expected)
+        .unwrap();
+
+    // Tab-accept keeps focus on the Project Path field (it didn't
+    // advance): the `▸` marker is still on the path line.
+    let screen = harness.screen_to_string();
+    let path_line = screen
+        .lines()
+        .find(|l| l.contains("alpha_dir/"))
+        .expect("project path line present");
+    assert!(
+        path_line.contains('▸'),
+        "Tab-accept should leave focus on the Project Path field. Line: {:?}\nScreen:\n{}",
+        path_line,
+        screen,
+    );
+}
+
 /// `↓` steps into the open dropdown (highlighting a row) and then
-/// Enter accepts the highlighted candidate into the field. This is the
-/// *only* keyboard accept path now that Tab and a bare Enter act on
-/// the form instead.
+/// Enter accepts the highlighted candidate into the field. Together
+/// with `down_then_tab_accepts_completion`, the keyboard accept paths
+/// are `↓`-then-Enter and `↓`-then-Tab (plus a click).
 #[test]
 fn down_then_enter_accepts_completion() {
     let (_temp, workspace) = set_up_workspace();

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -182,12 +182,13 @@ fn completion_popup_renders_with_dim_separator() {
     );
 }
 
-/// Tab accepts the highlighted completion: the Project Path field
-/// must contain the first suggestion (`<workspace>/alpha_dir/`)
-/// after Tab is pressed with the dropdown open. Pins the
-/// already-working behaviour as a regression guard.
+/// Tab does NOT accept the highlighted completion — it moves focus to
+/// the next field (closing the popup) and leaves the typed text
+/// intact. (Accepting a completion is `↓`-then-Enter, or a click.)
+/// Before the focus-model fix, Tab fired the completion's accept, so
+/// the number of Tabs to reach a button was unpredictable.
 #[test]
-fn tab_accepts_highlighted_completion() {
+fn tab_advances_focus_without_accepting_completion() {
     let (_temp, workspace) = set_up_workspace();
     let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
     harness.tick_and_render().unwrap();
@@ -196,14 +197,60 @@ fn tab_accepts_highlighted_completion() {
     open_new_session_form(&mut harness);
     let typed = type_alpha_prefix_and_wait(&mut harness, &workspace);
 
-    // Precondition: typed text intact before Tab.
-    assert_eq!(project_path_field_value(&harness.screen_to_string()), typed,);
-
-    // First item (`alpha_dir/`, sorted before `alpha_two/`) is
-    // highlighted by default — setCompletionItems resets
-    // selectedIndex to 0.
-    let expected = format!("{}/alpha_dir/", workspace.display());
     harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+    // Popup closes (Tab moved focus); the typed text is untouched —
+    // Tab never accepts `alpha_dir/`.
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("alpha_two/"))
+        .unwrap();
+    assert_eq!(
+        project_path_field_value(&harness.screen_to_string()),
+        typed,
+        "Tab must leave the typed text intact (it advances focus, it does not accept). \
+         Screen:\n{}",
+        harness.screen_to_string(),
+    );
+    // Focus left the Project Path field: exactly one `▸` marker is on
+    // screen, and it's no longer on the path line.
+    let screen = harness.screen_to_string();
+    assert_eq!(
+        screen.matches('▸').count(),
+        1,
+        "exactly one control is focused at a time. Screen:\n{}",
+        screen,
+    );
+    let path_line = screen
+        .lines()
+        .find(|l| l.contains(&typed))
+        .expect("project path line present");
+    assert!(
+        !path_line.contains('▸'),
+        "Tab moved focus off Project Path, so its `▸` marker is gone. Line: {:?}",
+        path_line,
+    );
+}
+
+/// `↓` steps into the open dropdown (highlighting a row) and then
+/// Enter accepts the highlighted candidate into the field. This is the
+/// *only* keyboard accept path now that Tab and a bare Enter act on
+/// the form instead.
+#[test]
+fn down_then_enter_accepts_completion() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+
+    open_new_session_form(&mut harness);
+    type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    // Step into the dropdown, then accept.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    let expected = format!("{}/alpha_dir/", workspace.display());
     harness
         .wait_until(|h| project_path_field_value(&h.screen_to_string()) == expected)
         .unwrap();
@@ -744,4 +791,215 @@ fn bracketed_paste_ignored_when_non_text_widget_focused() {
         "an ignored paste must not leak into the buffer behind the dialog. Screen:\n{}",
         harness.screen_to_string(),
     );
+}
+
+// ===========================================================================
+// Focus model: visible `▸` marker, linear Tab, ←/→ within selectors,
+// scoped Esc, and the Ctrl+Enter submit shortcut.
+// ===========================================================================
+
+/// The single screen line carrying the `▸` focus marker (the focused
+/// control). Panics if zero or more than one marker is present — the
+/// invariant the focus model guarantees is "exactly one control
+/// focused at a time".
+fn focused_line(screen: &str) -> String {
+    let lines: Vec<&str> = screen.lines().filter(|l| l.contains('▸')).collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "exactly one `▸` focus marker must be on screen, found {}. Screen:\n{}",
+        lines.len(),
+        screen,
+    );
+    lines[0].to_string()
+}
+
+/// Open the form on a non-git workspace (so the worktree toggle and
+/// Branch field are absent — a predictable, minimal field set).
+fn open_form_on(workspace: &PathBuf) -> EditorTestHarness {
+    let mut harness = EditorTestHarness::with_working_dir(160, 50, workspace.clone()).unwrap();
+    harness.tick_and_render().unwrap();
+    wait_for_new_session_command(&mut harness);
+    open_new_session_form(&mut harness);
+    harness
+}
+
+/// Tab moves linearly between *fields* — one stop per radio group, not
+/// one per option. Walking a full cycle lands the marker on the active
+/// "Run in:" tab exactly once and the active "Agent:" preset exactly
+/// once (never on an inactive option), and reaches `[ Create Session ]`.
+#[test]
+fn tab_is_linear_one_stop_per_radio_group() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+
+    let mut run_in_stops = 0;
+    let mut agent_stops = 0;
+    let mut saw_create = false;
+    let mut saw_inactive_option = false;
+
+    // A generous cap on the cycle length; the form has well under 12
+    // tab stops on a non-git workspace.
+    for _ in 0..12 {
+        let line = focused_line(&harness.screen_to_string());
+        if line.contains("Run in:") {
+            run_in_stops += 1;
+            // The marker must precede the *active* backend (Local), not
+            // an inactive option.
+            if line.contains("▸ [ SSH ]")
+                || line.contains("▸ [ Kubernetes ]")
+                || line.contains("▸ [ Devcontainer ]")
+            {
+                saw_inactive_option = true;
+            }
+        }
+        if line.contains("Agent:") {
+            agent_stops += 1;
+            if line.contains("▸ [ claude")
+                || line.contains("▸ [ aider")
+                || line.contains("▸ [ custom")
+            {
+                saw_inactive_option = true;
+            }
+        }
+        if line.contains("Create Session") {
+            saw_create = true;
+        }
+        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        harness.tick_and_render().unwrap();
+    }
+
+    assert!(
+        !saw_inactive_option,
+        "Tab must never land on an inactive radio option (←/→ changes the option). \
+         Screen:\n{}",
+        harness.screen_to_string(),
+    );
+    assert_eq!(
+        run_in_stops, 1,
+        "the 'Run in:' group is a single Tab stop per cycle (got {run_in_stops})",
+    );
+    assert_eq!(
+        agent_stops, 1,
+        "the 'Agent:' group is a single Tab stop per cycle (got {agent_stops})",
+    );
+    assert!(saw_create, "Tab must reach the [ Create Session ] button");
+}
+
+/// ←/→ changes the option *within* the "Run in:" selector (and swaps
+/// the body), while Tab leaves the option alone. This is the split the
+/// help line documents: Tab between fields, ←/→ within a group.
+#[test]
+fn arrows_switch_run_in_selector_option() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+
+    // Shift+Tab from the initial Project Path focus wraps to the active
+    // "Run in:" tab (the first stop in the cycle).
+    harness
+        .send_key(KeyCode::BackTab, KeyModifiers::NONE)
+        .unwrap();
+    harness.tick_and_render().unwrap();
+    assert!(
+        focused_line(&harness.screen_to_string()).contains("Run in:"),
+        "Shift+Tab should land focus on the Run in selector. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+
+    // → moves to the next option (SSH) and the body swaps to SSH fields.
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Host  ("))
+        .unwrap();
+    assert!(
+        focused_line(&harness.screen_to_string()).contains("▸ [ SSH ]"),
+        "→ should move the focus marker onto the SSH option. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+
+    // ← moves back to Local and restores the local body (Project Path).
+    harness.send_key(KeyCode::Left, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Project Path"))
+        .unwrap();
+    assert!(
+        focused_line(&harness.screen_to_string()).contains("▸ [ Local ]"),
+        "← should move the focus marker back onto the Local option. Screen:\n{}",
+        harness.screen_to_string(),
+    );
+}
+
+/// Esc is scoped: the first Esc closes an open completion dropdown
+/// (the form stays open with its input intact), and a second Esc
+/// cancels the dialog.
+#[test]
+fn esc_closes_dropdown_first_then_cancels_dialog() {
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+    let typed = type_alpha_prefix_and_wait(&mut harness, &workspace);
+
+    // First Esc: dropdown closes, form stays open, input preserved.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("alpha_two/"))
+        .unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("ORCHESTRATOR :: New Session"),
+        "first Esc must NOT cancel the dialog. Screen:\n{}",
+        screen,
+    );
+    assert_eq!(
+        project_path_field_value(&screen),
+        typed,
+        "first Esc must preserve the typed input. Screen:\n{}",
+        screen,
+    );
+
+    // Second Esc: dialog cancels.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("ORCHESTRATOR :: New Session"))
+        .unwrap();
+}
+
+/// Ctrl+Enter submits the form from anywhere — here from a text field,
+/// where a bare Enter would only advance focus. The form leaves its
+/// editable state (the "Run in:" selector row disappears as the dialog
+/// switches to the connecting/creating view or closes outright).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)]
+fn ctrl_enter_submits_from_a_text_field() {
+    use portable_pty::{native_pty_system, PtySize};
+    let pty_ok = native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok();
+    if !pty_ok {
+        eprintln!("Skipping ctrl_enter_submits test: PTY not available");
+        return;
+    }
+
+    let (_temp, workspace) = set_up_workspace();
+    let mut harness = open_form_on(&workspace);
+
+    // Focus is on the Project Path text field. A bare Enter here would
+    // advance focus (and keep the editable "Run in:" row). Ctrl+Enter
+    // must instead submit — the editable selector row goes away.
+    assert!(
+        harness.screen_to_string().contains("←/→ switch type"),
+        "precondition: the editable Run-in selector is showing",
+    );
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains("←/→ switch type"))
+        .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_dialog.rs
@@ -370,10 +370,13 @@ fn completion_popup_scrolls_with_down_arrow() {
         "precondition: `alpha_09/` must be off-screen before scrolling",
     );
 
-    // Press Down enough times to walk selection to the last
-    // candidate. Auto-scroll should snap the window so
-    // `alpha_09/` is visible at the bottom.
-    for _ in 0..9 {
+    // Press Down enough times to walk selection to the last candidate.
+    // The first `↓` only *steps into* the dropdown (highlighting the top
+    // row without moving), so reaching the 10th candidate (index 9) from
+    // the top takes one enter-press plus nine moves = ten presses.
+    // Auto-scroll should snap the window so `alpha_09/` is visible at the
+    // bottom.
+    for _ in 0..10 {
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     }
     harness
@@ -433,9 +436,17 @@ fn selection_highlight_does_not_overlap_right_border() {
     open_new_session_form(&mut harness);
     type_many_alphas_prefix_and_wait(&mut harness, &workspace);
 
-    // `alpha_00/` is the first candidate, selected by default
-    // (the host resets `selectedIndex` to 0 whenever the
-    // candidate list updates).
+    // A freshly surfaced popup paints no highlighted row — Enter still
+    // acts on the form. The first `↓` steps into the dropdown and
+    // highlights the top row (`alpha_00/`, index 0) without moving the
+    // selection off it, so we get a selected row to check the border
+    // against.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness.tick_and_render().unwrap();
+
+    // `alpha_00/` is the first candidate, now selected after the `↓`
+    // stepped into the dropdown (the host keeps `selectedIndex` at 0
+    // when first entering the list).
     let (_text_col, row) = harness
         .find_text_on_screen("alpha_00/")
         .expect("`alpha_00/` should be visible as the first candidate row");
@@ -557,12 +568,20 @@ fn completion_candidates_left_aligned_with_input_value() {
         .position(|l| l.contains("alpha_dir/") && l.contains(&workspace_str))
         .expect("popup row with `alpha_dir/` should be on screen");
 
-    let input_col = lines[input_row]
-        .find(&workspace_str)
-        .expect("input row should contain the workspace path");
-    let popup_col = lines[popup_row]
-        .find(&workspace_str)
-        .expect("popup row should contain the workspace path");
+    // Compare *display* columns, not byte offsets: the focus-marker
+    // gutter puts a multibyte `▸` (3 bytes, 1 column) ahead of the input
+    // value, so a raw `find()` byte offset would diverge from the popup
+    // row's even when the two are visually aligned. Counting chars up to
+    // the match gives the column (every glyph in the leading chrome —
+    // `│`, `▸`, spaces, `[` — is one display column wide).
+    let display_col = |line: &str| -> usize {
+        let b = line
+            .find(&workspace_str)
+            .expect("row should contain the workspace path");
+        line[..b].chars().count()
+    };
+    let input_col = display_col(lines[input_row]);
+    let popup_col = display_col(lines[popup_row]);
 
     assert_eq!(
         input_col, popup_col,
@@ -833,15 +852,48 @@ fn tab_is_linear_one_stop_per_radio_group() {
     let (_temp, workspace) = set_up_workspace();
     let mut harness = open_form_on(&workspace);
 
+    // Advance to the single "Run in:" stop — the anchor for one cycle.
+    // (The form opens focused on Project Path, so the "Run in:" tab is a
+    // few stops away.)
+    let mut guard = 0;
+    while !focused_line(&harness.screen_to_string()).contains("Run in:") {
+        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        harness.tick_and_render().unwrap();
+        guard += 1;
+        assert!(
+            guard < 20,
+            "Tab never reached the 'Run in:' stop. Screen:\n{}",
+            harness.screen_to_string(),
+        );
+    }
+
+    // Walk exactly one full cycle: collect the focused line at each stop
+    // starting from the "Run in:" anchor, tabbing until the marker lands
+    // back on a "Run in:" line. Counting over a fixed number of presses
+    // would over-count once the press count exceeds the cycle length;
+    // bounding on "back to the anchor" makes the assertions independent
+    // of how many fields the active backend has.
+    let mut cycle_lines = vec![focused_line(&harness.screen_to_string())];
+    loop {
+        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
+        harness.tick_and_render().unwrap();
+        let line = focused_line(&harness.screen_to_string());
+        if line.contains("Run in:") {
+            break; // back to the anchor — one full cycle walked
+        }
+        cycle_lines.push(line);
+        assert!(
+            cycle_lines.len() < 20,
+            "focus cycle never returned to the 'Run in:' anchor. Screen:\n{}",
+            harness.screen_to_string(),
+        );
+    }
+
     let mut run_in_stops = 0;
     let mut agent_stops = 0;
     let mut saw_create = false;
     let mut saw_inactive_option = false;
-
-    // A generous cap on the cycle length; the form has well under 12
-    // tab stops on a non-git workspace.
-    for _ in 0..12 {
-        let line = focused_line(&harness.screen_to_string());
+    for line in &cycle_lines {
         if line.contains("Run in:") {
             run_in_stops += 1;
             // The marker must precede the *active* backend (Local), not
@@ -865,8 +917,6 @@ fn tab_is_linear_one_stop_per_radio_group() {
         if line.contains("Create Session") {
             saw_create = true;
         }
-        harness.send_key(KeyCode::Tab, KeyModifiers::NONE).unwrap();
-        harness.tick_and_render().unwrap();
     }
 
     assert!(

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5646,6 +5646,7 @@ impl JsEditorApi {
         width_pct: f64,
         height_pct: f64,
         as_dock: rquickjs::function::Opt<bool>,
+        focus_marker: rquickjs::function::Opt<bool>,
     ) -> rquickjs::Result<bool> {
         let json = js_to_json(&ctx, spec_obj);
         let spec: fresh_core::api::WidgetSpec = match serde_json::from_value(json) {
@@ -5666,6 +5667,7 @@ impl JsEditorApi {
                 width_pct,
                 height_pct,
                 as_dock: as_dock.0.unwrap_or(false),
+                focus_marker: focus_marker.0.unwrap_or(false),
             })
             .is_ok())
     }


### PR DESCRIPTION
Reworks the orchestrator New Session form so its focus state is legible
from a plain terminal capture and the keyboard model is predictable.

Host (widget runtime/renderer):
- Add an opt-in focus-marker gutter (render_spec_with_marker): focused
  controls lead with `▸ `, others with a reserved two-space gutter, so
  exactly one control reads as focused and the layout never shifts as
  focus moves. Plumbed via MountFloatingWidget.focus_marker; only the
  New Session form opts in, so other panels render unchanged.
- Distinguish "focused" from "Primary": a Primary button keeps its bold
  accent but only the focused control gets the marker + selection bg.
- Add `focusable` to Button so radio-style groups expose a single Tab
  stop (the active option); ←/→ moves within the group, Tab never lands
  on an inactive option.
- Completion popup key model: Tab never accepts (it advances focus);
  Enter accepts only once the user steps into the dropdown (↑/↓/wheel),
  otherwise it acts on the form; first Esc closes the popup. Tracked via
  a new completion_navigated flag; an un-entered popup paints no
  highlighted row.

Orchestrator plugin:
- Mount the form with focusMarker; mark inactive Run-in/Agent options
  non-focusable and mirror the one-stop-per-group Tab cycle.
- Add Ctrl+Enter = Create Session from anywhere; simplify Tab handling.
- Label the Project Path placeholder as the default-if-left-blank.
- Update the help line to document the model.

Tests: focus-marker linearity, ←/→ within selectors, scoped Esc, the
dropdown not swallowing submit, Down-then-Enter accept, and Ctrl+Enter.

https://claude.ai/code/session_01TEwrhpdpR8nfaLEseSFQ55