### PR TITLE
fix: support monorepo/multi-repo workspaces with nested git sub-projects

### DIFF
--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -472,12 +472,23 @@ function reviewStoragePathFor(repoRoot: string, reviewKey: string): string | nul
 }
 
 /**
- * Resolve the git top-level for `editor.getCwd()`. Returns `''` when the
- * cwd isn't inside a repo — callers then skip persistence.
+ * Resolve the git top-level for the current context. Tries active buffer's
+ * directory first (supports monorepo sub-projects), then falls back to
+ * editor.getCwd(). Returns `''` when not inside a repo.
  */
 async function detectRepoRoot(): Promise<string> {
     try {
-        const result = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"]);
+        // Try active buffer's directory first for monorepo support
+        let cwd = editor.getCwd();
+        const bufferId = editor.getActiveBufferId();
+        if (bufferId) {
+            const bufPath = editor.getBufferPath(bufferId);
+            if (bufPath) {
+                const dir = editor.pathDirname(bufPath);
+                if (dir) cwd = dir;
+            }
+        }
+        const result = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
         if (result.exit_code === 0) {
             return result.stdout.trim();
         }
@@ -721,7 +732,8 @@ interface GitStatusResult {
 }
 
 async function getGitStatus(): Promise<GitStatusResult> {
-    const result = await editor.spawnProcess("git", ["status", "--porcelain", "-z", "-uall"]);
+    const cwd = state.repoRoot || editor.getCwd();
+    const result = await editor.spawnProcess("git", ["status", "--porcelain", "-z", "-uall"], cwd);
     if (result.exit_code !== 0) {
         return { files: [], emptyReason: 'not_git' };
     }
@@ -738,6 +750,7 @@ async function getGitStatus(): Promise<GitStatusResult> {
  */
 async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
     const allHunks: Hunk[] = [];
+    const cwd = state.repoRoot || editor.getCwd();
 
     const hasStaged = files.some(f => f.category === 'staged');
     const hasUnstaged = files.some(f => f.category === 'unstaged');
@@ -745,7 +758,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Staged diffs
     if (hasStaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--cached", "--unified=3"]);
+        const result = await editor.spawnProcess("git", ["diff", "--cached", "--unified=3"], cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'staged'));
         }
@@ -753,7 +766,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
 
     // Unstaged diffs
     if (hasUnstaged) {
-        const result = await editor.spawnProcess("git", ["diff", "--unified=3"]);
+        const result = await editor.spawnProcess("git", ["diff", "--unified=3"], cwd);
         if (result.exit_code === 0 && result.stdout.trim()) {
             allHunks.push(...parseDiffOutput(result.stdout, 'unstaged'));
         }
@@ -763,7 +776,7 @@ async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
     for (const f of untrackedFiles) {
         const result = await editor.spawnProcess("git", [
             "diff", "--no-index", "--unified=3", "/dev/null", f.path
-        ]);
+        ], cwd);
         if (result.stdout.trim()) {
             const hunks = parseDiffOutput(result.stdout, 'untracked');
             for (const h of hunks) {
@@ -2988,13 +3001,14 @@ async function applyHunkPatch(patch: string, flags: string[]): Promise<boolean> 
     const tmpDir = editor.getTempDir();
     const patchPath = editor.pathJoin(tmpDir, `fresh-review-${Date.now()}.patch`);
     editor.writeFile(patchPath, patch);
+    const cwd = state.repoRoot || editor.getCwd();
     // Validate first
-    const check = await editor.spawnProcess("git", ["apply", "--check", ...flags, patchPath]);
+    const check = await editor.spawnProcess("git", ["apply", "--check", ...flags, patchPath], cwd);
     if (check.exit_code !== 0) {
         editor.setStatus("Patch failed: " + (check.stderr || "").trim());
         return false;
     }
-    const result = await editor.spawnProcess("git", ["apply", ...flags, patchPath]);
+    const result = await editor.spawnProcess("git", ["apply", ...flags, patchPath], cwd);
     return result.exit_code === 0;
 }
 
@@ -3129,13 +3143,15 @@ registerHandler("review_unstage_file", review_unstage_file);
 
 async function stageFileEntry(f: FileEntry) {
     rememberPendingHunkAnchor(null);
-    await editor.spawnProcess("git", ["add", "--", f.path]);
+    const cwd = state.repoRoot || editor.getCwd();
+    await editor.spawnProcess("git", ["add", "--", f.path], cwd);
     await refreshMagitData();
 }
 
 async function unstageFileEntry(f: FileEntry) {
     rememberPendingHunkAnchor(null);
-    await editor.spawnProcess("git", ["reset", "HEAD", "--", f.path]);
+    const cwd = state.repoRoot || editor.getCwd();
+    await editor.spawnProcess("git", ["reset", "HEAD", "--", f.path], cwd);
     await refreshMagitData();
 }
 
@@ -3143,7 +3159,8 @@ async function stageHunk(hunk: Hunk | null) {
     if (!hunk || !hunk.file) return;
     rememberPendingHunkAnchor(hunk.id);
     if (hunk.gitStatus === 'untracked') {
-        await editor.spawnProcess("git", ["add", "--", hunk.file]);
+        const cwd = state.repoRoot || editor.getCwd();
+        await editor.spawnProcess("git", ["add", "--", hunk.file], cwd);
     } else {
         const patch = buildHunkPatch(hunk.file, hunk);
         const ok = await applyHunkPatch(patch, ["--cached"]);
@@ -3789,17 +3806,18 @@ function teardownCenterComposite(): void {
 async function fetchFileVersions(file: FileEntry): Promise<{ oldContent: string; newContent: string; absPath: string }> {
     const root = state.repoRoot || editor.getCwd() || "";
     const absPath = root ? editor.pathJoin(root, file.path) : file.path;
+    const cwd = root || editor.getCwd();
     let oldContent = "";
     let newContent = "";
     if (state.mode === 'range' && state.range) {
-        const showOld = await editor.spawnProcess("git", ["show", `${state.range.from}:${file.path}`]);
+        const showOld = await editor.spawnProcess("git", ["show", `${state.range.from}:${file.path}`], cwd);
         if (showOld.exit_code === 0) oldContent = showOld.stdout;
-        const showNew = await editor.spawnProcess("git", ["show", `${state.range.to}:${file.path}`]);
+        const showNew = await editor.spawnProcess("git", ["show", `${state.range.to}:${file.path}`], cwd);
         if (showNew.exit_code === 0) newContent = showNew.stdout;
         return { oldContent, newContent, absPath };
     }
     if (file.category !== 'untracked' && file.status !== 'A') {
-        const show = await editor.spawnProcess("git", ["show", `HEAD:${file.path}`]);
+        const show = await editor.spawnProcess("git", ["show", `HEAD:${file.path}`], cwd);
         if (show.exit_code === 0) oldContent = show.stdout;
     }
     if (file.status !== 'D') {
@@ -3991,7 +4009,8 @@ async function review_drill_down() {
     if (fileHunks.length === 0) return;
 
     // Get git root to construct absolute path
-    const gitRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"]);
+    const cwd = state.repoRoot || editor.getCwd();
+    const gitRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
     if (gitRootResult.exit_code !== 0) {
         editor.setStatus(editor.t("status.not_git_repo"));
         return;
@@ -4001,7 +4020,7 @@ async function review_drill_down() {
 
     // Get old (HEAD) and new (working) file content
     let oldContent: string;
-    const gitShow = await editor.spawnProcess("git", ["show", `HEAD:${h.file}`]);
+    const gitShow = await editor.spawnProcess("git", ["show", `HEAD:${h.file}`], cwd);
     if (gitShow.exit_code !== 0) {
         oldContent = "";
     } else {
@@ -5101,10 +5120,11 @@ editor.on("prompt_confirmed", async (args) => {
     if (response === "discard" || args.selected_index === 0) {
         const f = pendingDiscardFile;
         if (f) {
+            const cwd = state.repoRoot || editor.getCwd();
             if (f.category === 'untracked') {
-                await editor.spawnProcess("rm", ["--", f.path]);
+                await editor.spawnProcess("rm", ["--", f.path], cwd);
             } else {
-                await editor.spawnProcess("git", ["checkout", "--", f.path]);
+                await editor.spawnProcess("git", ["checkout", "--", f.path], cwd);
             }
             await refreshMagitData();
             editor.setStatus(`Discarded: ${f.path}`);
@@ -5498,7 +5518,8 @@ function parseRangeInput(input: string): ReviewRange | null {
  */
 async function fetchRangeDiff(range: ReviewRange): Promise<{ hunks: Hunk[]; files: FileEntry[] }> {
     const args = range.command || ["diff", "--unified=3", `${range.from}..${range.to}`];
-    const result = await editor.spawnProcess("git", args);
+    const cwd = state.repoRoot || editor.getCwd();
+    const result = await editor.spawnProcess("git", args, cwd);
     if (result.exit_code !== 0) {
         return { hunks: [], files: [] };
     }
@@ -5531,7 +5552,8 @@ async function buildRangeSuggestions(): Promise<PromptSuggestion[]> {
     suggestions.push({ text: "HEAD", description: "Review last commit", value: "HEAD" });
     // Current-branch-vs-main style ranges.
     const tryRange = async (base: string) => {
-        const exists = await editor.spawnProcess("git", ["rev-parse", "--verify", base]);
+        const cwd = state.repoRoot || editor.getCwd();
+        const exists = await editor.spawnProcess("git", ["rev-parse", "--verify", base], cwd);
         if (exists.exit_code === 0) {
             suggestions.push({
                 text: `${base}..HEAD`,
@@ -5544,9 +5566,10 @@ async function buildRangeSuggestions(): Promise<PromptSuggestion[]> {
     await tryRange("master");
     // Recent commits for one-off review.
     try {
+        const cwd = state.repoRoot || editor.getCwd();
         const log = await editor.spawnProcess("git", [
             "log", "-n", "5", "--pretty=format:%h %s",
-        ]);
+        ], cwd);
         if (log.exit_code === 0) {
             for (const line of log.stdout.split('\n')) {
                 const m = line.match(/^([0-9a-f]+)\s+(.*)$/);
@@ -6071,10 +6094,11 @@ const branchState: ReviewBranchState = {
  * default in an empty / unusual repo.
  */
 async function detectDefaultBranch(): Promise<string> {
+    const cwd = state.repoRoot || editor.getCwd();
     try {
         const r = await editor.spawnProcess("git", [
             "symbolic-ref", "--short", "refs/remotes/origin/HEAD",
-        ]);
+        ], cwd);
         if (r.exit_code === 0) {
             const name = r.stdout.trim();
             // Output looks like "origin/main"; strip the remote prefix.
@@ -6087,7 +6111,7 @@ async function detectDefaultBranch(): Promise<string> {
         try {
             const r = await editor.spawnProcess("git", [
                 "show-ref", "--verify", "--quiet", `refs/heads/${candidate}`,
-            ]);
+            ], cwd);
             if (r.exit_code === 0) return candidate;
         } catch { /* fall through */ }
     }
@@ -6184,7 +6208,7 @@ async function branchRefreshDetail(): Promise<void> {
             editor.t("status.loading_commit", { hash: commit.shortHash }) || `Loading ${commit.shortHash}…`,
         ),
     );
-    const output = await fetchCommitShow(editor, commit.hash);
+    const output = await fetchCommitShow(editor, commit.hash, state.repoRoot || editor.getCwd());
     if (myId !== branchState.pendingDetailId) return;
     if (branchState.groupId === null) return;
     branchState.detailCache = { hash: commit.hash, output };
@@ -6218,7 +6242,8 @@ async function start_review_branch(): Promise<void> {
     branchState.baseRef = base;
 
     editor.setStatus(editor.t("status.loading") || "Loading commits…");
-    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500 });
+    const gitCwd = state.repoRoot || editor.getCwd();
+    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: gitCwd });
     if (branchState.commits.length === 0) {
         editor.setStatus(
             editor.t("status.review_branch_empty", { base }) ||
@@ -6293,7 +6318,7 @@ registerHandler("stop_review_branch", stop_review_branch);
 async function review_branch_refresh(): Promise<void> {
     if (!branchState.isOpen) return;
     const base = branchState.baseRef;
-    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500 });
+    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: state.repoRoot || editor.getCwd() });
     branchState.detailCache = null;
     if (branchState.selectedIndex >= branchState.commits.length) {
         branchState.selectedIndex = Math.max(0, branchState.commits.length - 1);
@@ -6364,7 +6389,7 @@ async function review_branch_detail_open_file(): Promise<void> {
     const result = await editor.spawnProcess("git", [
         "show",
         `${commit.hash}:${file}`,
-    ]);
+    ], state.repoRoot || editor.getCwd());
     if (result.exit_code !== 0) {
         editor.setStatus(
             editor.t("status.file_not_found", { file, hash: commit.shortHash }),

--- a/crates/fresh-editor/plugins/audit_mode.ts
+++ b/crates/fresh-editor/plugins/audit_mode.ts
@@ -17,6 +17,7 @@ import {
   fetchCommitShow,
   fetchGitLog,
 } from "./lib/git_history.ts";
+import { type GitRepo, resolveGitRepo } from "./lib/git_repo.ts";
 const VirtualBufferFactory = createVirtualBufferFactory(editor);
 
 
@@ -120,8 +121,13 @@ interface ReviewState {
   mode: ReviewMode;
   /** Populated when `mode === 'range'`. */
   range: ReviewRange | null;
-  /** Absolute path to the git repo root — stable key for persistence. */
-  repoRoot: string;
+  /**
+   * The resolved git repository for this review, or `null` when not inside
+   * one. Resolved once at each review entry point *before* any git command
+   * runs, so `gitCwd()` reads the right root. Its `root` is the stable key
+   * for persistence.
+   */
+  repo: GitRepo | null;
   /**
    * Persistence key within the repo's review dir:
    *   `worktree`            — `mode === 'worktree'`
@@ -263,7 +269,7 @@ const state: ReviewState = {
   reviewBufferId: null,
   mode: 'worktree',
   range: null,
-  repoRoot: '',
+  repo: null,
   reviewKey: 'worktree',
   files: [],
   emptyState: null,
@@ -472,30 +478,13 @@ function reviewStoragePathFor(repoRoot: string, reviewKey: string): string | nul
 }
 
 /**
- * Resolve the git top-level for the current context. Tries active buffer's
- * directory first (supports monorepo sub-projects), then falls back to
- * editor.getCwd(). Returns `''` when not inside a repo.
+ * cwd for git commands in the current review. `state.repo` is resolved at the
+ * start of every review entry point (before any git call), so this returns the
+ * repo root once a review is open; the `getCwd()` fallback only covers stray
+ * calls made before a review is bootstrapped.
  */
-async function detectRepoRoot(): Promise<string> {
-    try {
-        // Try active buffer's directory first for monorepo support
-        let cwd = editor.getCwd();
-        const bufferId = editor.getActiveBufferId();
-        if (bufferId) {
-            const bufPath = editor.getBufferPath(bufferId);
-            if (bufPath) {
-                const dir = editor.pathDirname(bufPath);
-                if (dir) cwd = dir;
-            }
-        }
-        const result = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
-        if (result.exit_code === 0) {
-            return result.stdout.trim();
-        }
-    } catch {
-        // fall through
-    }
-    return '';
+function gitCwd(): string {
+    return state.repo ? state.repo.root : editor.getCwd();
 }
 
 /**
@@ -504,10 +493,10 @@ async function detectRepoRoot(): Promise<string> {
  * truth during the session and writes are just a cache for restore.
  */
 function persistReview(): void {
-    if (!state.repoRoot) return;
-    const path = reviewStoragePathFor(state.repoRoot, state.reviewKey);
+    if (!state.repo) return;
+    const path = reviewStoragePathFor(state.repo.root, state.reviewKey);
     if (!path) return;
-    const dir = reviewStorageDirFor(state.repoRoot);
+    const dir = reviewStorageDirFor(state.repo.root);
     if (dir) {
         try { editor.createDir(dir); } catch {}
     }
@@ -732,7 +721,7 @@ interface GitStatusResult {
 }
 
 async function getGitStatus(): Promise<GitStatusResult> {
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     const result = await editor.spawnProcess("git", ["status", "--porcelain", "-z", "-uall"], cwd);
     if (result.exit_code !== 0) {
         return { files: [], emptyReason: 'not_git' };
@@ -750,7 +739,7 @@ async function getGitStatus(): Promise<GitStatusResult> {
  */
 async function fetchDiffsForFiles(files: FileEntry[]): Promise<Hunk[]> {
     const allHunks: Hunk[] = [];
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
 
     const hasStaged = files.some(f => f.category === 'staged');
     const hasUnstaged = files.some(f => f.category === 'unstaged');
@@ -2702,7 +2691,7 @@ function review_open_working_file() {
             }
         }
     }
-    const absPath = state.repoRoot ? editor.pathJoin(state.repoRoot, file.path) : file.path;
+    const absPath = state.repo ? editor.pathJoin(state.repo.root, file.path) : file.path;
     editor.openFile(absPath, line ?? 1, 1);
 }
 registerHandler("review_open_working_file", review_open_working_file);
@@ -3001,7 +2990,7 @@ async function applyHunkPatch(patch: string, flags: string[]): Promise<boolean> 
     const tmpDir = editor.getTempDir();
     const patchPath = editor.pathJoin(tmpDir, `fresh-review-${Date.now()}.patch`);
     editor.writeFile(patchPath, patch);
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     // Validate first
     const check = await editor.spawnProcess("git", ["apply", "--check", ...flags, patchPath], cwd);
     if (check.exit_code !== 0) {
@@ -3143,14 +3132,14 @@ registerHandler("review_unstage_file", review_unstage_file);
 
 async function stageFileEntry(f: FileEntry) {
     rememberPendingHunkAnchor(null);
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     await editor.spawnProcess("git", ["add", "--", f.path], cwd);
     await refreshMagitData();
 }
 
 async function unstageFileEntry(f: FileEntry) {
     rememberPendingHunkAnchor(null);
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     await editor.spawnProcess("git", ["reset", "HEAD", "--", f.path], cwd);
     await refreshMagitData();
 }
@@ -3159,7 +3148,7 @@ async function stageHunk(hunk: Hunk | null) {
     if (!hunk || !hunk.file) return;
     rememberPendingHunkAnchor(hunk.id);
     if (hunk.gitStatus === 'untracked') {
-        const cwd = state.repoRoot || editor.getCwd();
+        const cwd = gitCwd();
         await editor.spawnProcess("git", ["add", "--", hunk.file], cwd);
     } else {
         const patch = buildHunkPatch(hunk.file, hunk);
@@ -3804,7 +3793,7 @@ function teardownCenterComposite(): void {
 }
 
 async function fetchFileVersions(file: FileEntry): Promise<{ oldContent: string; newContent: string; absPath: string }> {
-    const root = state.repoRoot || editor.getCwd() || "";
+    const root = state.repo ? state.repo.root : (editor.getCwd() || "");
     const absPath = root ? editor.pathJoin(root, file.path) : file.path;
     const cwd = root || editor.getCwd();
     let oldContent = "";
@@ -4009,7 +3998,7 @@ async function review_drill_down() {
     if (fileHunks.length === 0) return;
 
     // Get git root to construct absolute path
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     const gitRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
     if (gitRootResult.exit_code !== 0) {
         editor.setStatus(editor.t("status.not_git_repo"));
@@ -4700,7 +4689,7 @@ function centerCompositeDiffState(): CompositeDiffState | null {
         oldBufferId: cc.oldBufId,
         newBufferId: cc.newBufId,
         filePath: file.path,
-        gitRoot: state.repoRoot,
+        gitRoot: state.repo?.root ?? '',
         absPath: cc.absPath,
         isUntracked: cc.isUntracked,
         hunkLineMap: cc.hunkLineMap,
@@ -5120,7 +5109,7 @@ editor.on("prompt_confirmed", async (args) => {
     if (response === "discard" || args.selected_index === 0) {
         const f = pendingDiscardFile;
         if (f) {
-            const cwd = state.repoRoot || editor.getCwd();
+            const cwd = gitCwd();
             if (f.category === 'untracked') {
                 await editor.spawnProcess("rm", ["--", f.path], cwd);
             } else {
@@ -5418,6 +5407,10 @@ function pruneOrphanComments(comments: ReviewComment[], hunks: Hunk[]): ReviewCo
 async function start_review_diff() {
     editor.setStatus(editor.t("status.generating"));
 
+    // Resolve the repo *before* any git call: getGitStatus/fetchDiffsForFiles
+    // read gitCwd(), which derives from state.repo.
+    state.repo = await resolveGitRepo(editor);
+
     // Fetch data using the git status approach.
     const status = await getGitStatus();
     state.files = status.files;
@@ -5427,12 +5420,11 @@ async function start_review_diff() {
     // Persistence setup: worktree mode keyed by repo root.
     state.mode = 'worktree';
     state.range = null;
-    state.repoRoot = await detectRepoRoot();
     state.reviewKey = buildReviewKey(state.mode, state.range);
 
     // Restore persisted comments (if any). We drop orphans so the UI
     // doesn't display comments that no longer point at visible lines.
-    const loaded = loadPersistedReview(state.repoRoot, state.reviewKey);
+    const loaded = loadPersistedReview(state.repo?.root ?? '', state.reviewKey);
     state.comments = loaded ? pruneOrphanComments(loaded.comments, state.hunks) : [];
     state.note = loaded?.note ?? '';
 
@@ -5518,7 +5510,7 @@ function parseRangeInput(input: string): ReviewRange | null {
  */
 async function fetchRangeDiff(range: ReviewRange): Promise<{ hunks: Hunk[]; files: FileEntry[] }> {
     const args = range.command || ["diff", "--unified=3", `${range.from}..${range.to}`];
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     const result = await editor.spawnProcess("git", args, cwd);
     if (result.exit_code !== 0) {
         return { hunks: [], files: [] };
@@ -5552,7 +5544,7 @@ async function buildRangeSuggestions(): Promise<PromptSuggestion[]> {
     suggestions.push({ text: "HEAD", description: "Review last commit", value: "HEAD" });
     // Current-branch-vs-main style ranges.
     const tryRange = async (base: string) => {
-        const cwd = state.repoRoot || editor.getCwd();
+        const cwd = gitCwd();
         const exists = await editor.spawnProcess("git", ["rev-parse", "--verify", base], cwd);
         if (exists.exit_code === 0) {
             suggestions.push({
@@ -5566,7 +5558,7 @@ async function buildRangeSuggestions(): Promise<PromptSuggestion[]> {
     await tryRange("master");
     // Recent commits for one-off review.
     try {
-        const cwd = state.repoRoot || editor.getCwd();
+        const cwd = gitCwd();
         const log = await editor.spawnProcess("git", [
             "log", "-n", "5", "--pretty=format:%h %s",
         ], cwd);
@@ -5592,6 +5584,8 @@ async function start_review_range(): Promise<void> {
         stop_review_diff();
     }
 
+    // Resolve the repo before buildRangeSuggestions(), which reads gitCwd().
+    state.repo = await resolveGitRepo(editor);
     const suggestions = await buildRangeSuggestions();
     const label = editor.t("prompt.review_range") || "Review range (A..B or commit):";
     editor.startPromptWithInitial(label, "review-range", "HEAD");
@@ -5617,6 +5611,8 @@ editor.on("prompt_confirmed", (args) => {
 
 async function bootstrapRangeReview(range: ReviewRange): Promise<void> {
     editor.setStatus(editor.t("status.generating") || "Generating diff…");
+    // Resolve the repo before fetchRangeDiff, which reads gitCwd().
+    state.repo = await resolveGitRepo(editor);
     const { hunks, files } = await fetchRangeDiff(range);
     if (hunks.length === 0) {
         editor.setStatus(
@@ -5630,12 +5626,11 @@ async function bootstrapRangeReview(range: ReviewRange): Promise<void> {
     state.hunks = hunks;
     state.files = files;
     state.emptyState = null;
-    state.repoRoot = await detectRepoRoot();
     state.reviewKey = buildReviewKey(state.mode, state.range);
 
     // Load persisted comments for this exact range — the diff is static
     // so they always line up.
-    const loaded = loadPersistedReview(state.repoRoot, state.reviewKey);
+    const loaded = loadPersistedReview(state.repo?.root ?? '', state.reviewKey);
     state.comments = loaded ? loaded.comments : [];
     state.note = loaded?.note ?? '';
 
@@ -6094,7 +6089,7 @@ const branchState: ReviewBranchState = {
  * default in an empty / unusual repo.
  */
 async function detectDefaultBranch(): Promise<string> {
-    const cwd = state.repoRoot || editor.getCwd();
+    const cwd = gitCwd();
     try {
         const r = await editor.spawnProcess("git", [
             "symbolic-ref", "--short", "refs/remotes/origin/HEAD",
@@ -6208,7 +6203,7 @@ async function branchRefreshDetail(): Promise<void> {
             editor.t("status.loading_commit", { hash: commit.shortHash }) || `Loading ${commit.shortHash}…`,
         ),
     );
-    const output = await fetchCommitShow(editor, commit.hash, state.repoRoot || editor.getCwd());
+    const output = await fetchCommitShow(editor, commit.hash, gitCwd());
     if (myId !== branchState.pendingDetailId) return;
     if (branchState.groupId === null) return;
     branchState.detailCache = { hash: commit.hash, output };
@@ -6228,6 +6223,8 @@ async function start_review_branch(): Promise<void> {
     // one branched off main. The default offered is either what the user
     // picked last time in this session, or the repo's actual default
     // branch (main/master/etc.) on first use.
+    // Resolve the repo before any git call in the branch-review flow.
+    state.repo = await resolveGitRepo(editor);
     const suggested = branchState.baseRef || await detectDefaultBranch();
     const rawPromptText = editor.t("prompt.branch_base", { default: suggested });
     const promptText = (rawPromptText && !rawPromptText.startsWith("prompt."))
@@ -6242,8 +6239,7 @@ async function start_review_branch(): Promise<void> {
     branchState.baseRef = base;
 
     editor.setStatus(editor.t("status.loading") || "Loading commits…");
-    const gitCwd = state.repoRoot || editor.getCwd();
-    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: gitCwd });
+    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: gitCwd() });
     if (branchState.commits.length === 0) {
         editor.setStatus(
             editor.t("status.review_branch_empty", { base }) ||
@@ -6318,7 +6314,7 @@ registerHandler("stop_review_branch", stop_review_branch);
 async function review_branch_refresh(): Promise<void> {
     if (!branchState.isOpen) return;
     const base = branchState.baseRef;
-    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: state.repoRoot || editor.getCwd() });
+    branchState.commits = await fetchGitLog(editor, { range: `${base}..HEAD`, maxCommits: 500, cwd: gitCwd() });
     branchState.detailCache = null;
     if (branchState.selectedIndex >= branchState.commits.length) {
         branchState.selectedIndex = Math.max(0, branchState.commits.length - 1);
@@ -6389,7 +6385,7 @@ async function review_branch_detail_open_file(): Promise<void> {
     const result = await editor.spawnProcess("git", [
         "show",
         `${commit.hash}:${file}`,
-    ], state.repoRoot || editor.getCwd());
+    ], gitCwd());
     if (result.exit_code !== 0) {
         editor.setStatus(
             editor.t("status.file_not_found", { file, hash: commit.shortHash }),

--- a/crates/fresh-editor/plugins/code-tour.ts
+++ b/crates/fresh-editor/plugins/code-tour.ts
@@ -251,7 +251,7 @@ async function loadTour(manifestPath: string): Promise<void> {
         "rev-parse",
         "--short",
         "HEAD",
-      ], editor.getCwd());
+      ]);
       if (result.exit_code === 0) {
         const currentCommit = result.stdout.trim();
         if (!currentCommit.startsWith(manifest.commit_hash) &&

--- a/crates/fresh-editor/plugins/code-tour.ts
+++ b/crates/fresh-editor/plugins/code-tour.ts
@@ -251,7 +251,7 @@ async function loadTour(manifestPath: string): Promise<void> {
         "rev-parse",
         "--short",
         "HEAD",
-      ]);
+      ], editor.getCwd());
       if (result.exit_code === 0) {
         const currentCommit = result.stdout.trim();
         if (!currentCommit.startsWith(manifest.commit_hash) &&

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -250,10 +250,14 @@ function formatRelativeDate(timestamp: number): string {
  */
 async function fetchFileContent(filePath: string, commit: string | null): Promise<string> {
   if (commit) {
-    // Get historical file content — use file's directory as cwd for
-    // monorepo sub-projects where editor cwd isn't a git repo.
+    // Get historical file content. Run from the file's directory and refer to
+    // it as `<rev>:./<name>` — the `./` makes git resolve the path relative to
+    // cwd. `git show <rev>:<abs-path>` is a fatal error, which would otherwise
+    // silently fall through to the *current* working-tree content below. This
+    // also covers monorepo sub-projects where the editor cwd isn't a repo.
     const cwd = editor.pathDirname(filePath);
-    const result = await editor.spawnProcess("git", ["show", `${commit}:${filePath}`], cwd);
+    const name = editor.pathBasename(filePath);
+    const result = await editor.spawnProcess("git", ["show", `${commit}:./${name}`], cwd);
     if (result.exit_code === 0) {
       return result.stdout;
     }

--- a/crates/fresh-editor/plugins/git_blame.ts
+++ b/crates/fresh-editor/plugins/git_blame.ts
@@ -127,7 +127,10 @@ async function fetchGitBlame(filePath: string, commit: string | null): Promise<B
 
   args.push("--", filePath);
 
-  const result = await editor.spawnProcess("git", args);
+  // Use the file's directory as cwd so git blame works in monorepo
+  // sub-projects where the editor's cwd is not itself a git repo.
+  const cwd = editor.pathDirname(filePath);
+  const result = await editor.spawnProcess("git", args, cwd);
 
   if (result.exit_code !== 0) {
     editor.setStatus(editor.t("status.git_error", { error: result.stderr }));
@@ -247,8 +250,10 @@ function formatRelativeDate(timestamp: number): string {
  */
 async function fetchFileContent(filePath: string, commit: string | null): Promise<string> {
   if (commit) {
-    // Get historical file content
-    const result = await editor.spawnProcess("git", ["show", `${commit}:${filePath}`]);
+    // Get historical file content — use file's directory as cwd for
+    // monorepo sub-projects where editor cwd isn't a git repo.
+    const cwd = editor.pathDirname(filePath);
+    const result = await editor.spawnProcess("git", ["show", `${commit}:${filePath}`], cwd);
     if (result.exit_code === 0) {
       return result.stdout;
     }

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -157,7 +157,7 @@ function discoverSubRepos(dir: string, maxDepth: number = 3): string[] {
   const repos: string[] = [];
   const entries = editor.readDir(dir);
   for (const entry of entries) {
-    if (entry.name.startsWith(".") || !entry.is_dir) continue;
+    if (entry.name.startsWith(".") || entry.name === "node_modules" || !entry.is_dir) continue;
     const subDir = editor.pathJoin(dir, entry.name);
     if (editor.fileExists(editor.pathJoin(subDir, ".git"))) {
       repos.push(subDir);

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -1,4 +1,6 @@
 /// <reference path="./lib/fresh.d.ts" />
+import { discoverSubRepos } from "./lib/git_history.ts";
+
 const editor = getEditor();
 
 /**
@@ -147,26 +149,6 @@ function buildNameColorSlots(
   }));
 }
 
-/**
- * Recursively discover directories containing `.git` entries, up to maxDepth
- * levels. Stops descending into a directory once `.git` is found (git repo
- * internals like submodules are managed by git itself).
- */
-function discoverSubRepos(dir: string, maxDepth: number = 3): string[] {
-  if (maxDepth <= 0) return [];
-  const repos: string[] = [];
-  const entries = editor.readDir(dir);
-  for (const entry of entries) {
-    if (entry.name.startsWith(".") || entry.name === "node_modules" || !entry.is_dir) continue;
-    const subDir = editor.pathJoin(dir, entry.name);
-    if (editor.fileExists(editor.pathJoin(subDir, ".git"))) {
-      repos.push(subDir);
-    } else {
-      repos.push(...discoverSubRepos(subDir, maxDepth - 1));
-    }
-  }
-  return repos;
-}
 async function refreshGitExplorerDecorations() {
   if (refreshInFlight) {
     refreshPending = true;
@@ -190,7 +172,7 @@ async function refreshGitExplorerDecorations() {
       }
     } else {
       // cwd is not a git repo — discover sub-repos (monorepo/multi-repo)
-      const subRepos = discoverSubRepos(cwd);
+      const subRepos = discoverSubRepos(editor, cwd);
       for (const subDir of subRepos) {
         const subRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], subDir);
         if (subRootResult.exit_code !== 0) continue;

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -147,6 +147,26 @@ function buildNameColorSlots(
   }));
 }
 
+/**
+ * Recursively discover directories containing `.git` entries, up to maxDepth
+ * levels. Stops descending into a directory once `.git` is found (git repo
+ * internals like submodules are managed by git itself).
+ */
+function discoverSubRepos(dir: string, maxDepth: number = 3): string[] {
+  if (maxDepth <= 0) return [];
+  const repos: string[] = [];
+  const entries = editor.readDir(dir);
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || !entry.is_dir) continue;
+    const subDir = editor.pathJoin(dir, entry.name);
+    if (editor.fileExists(editor.pathJoin(subDir, ".git"))) {
+      repos.push(subDir);
+    } else {
+      repos.push(...discoverSubRepos(subDir, maxDepth - 1));
+    }
+  }
+  return repos;
+}
 async function refreshGitExplorerDecorations() {
   if (refreshInFlight) {
     refreshPending = true;
@@ -156,42 +176,48 @@ async function refreshGitExplorerDecorations() {
   try {
     const cwd = editor.getCwd();
     const rootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
-    if (rootResult.exit_code !== 0) {
-      editor.clearFileExplorerDecorations(NAMESPACE);
-      editor.clearFileExplorerSlots(NAMESPACE);
-      return;
-    }
-    const repoRoot = rootResult.stdout.trim();
-    if (!repoRoot) {
-      editor.clearFileExplorerDecorations(NAMESPACE);
-      editor.clearFileExplorerSlots(NAMESPACE);
-      return;
+
+    let allDecorations: Array<{ path: string; symbol: string; color: string; priority: number }> = [];
+    let allRepoRoots: string[] = [];
+
+    if (rootResult.exit_code === 0 && rootResult.stdout.trim()) {
+      // cwd is inside a git repo — single-repo mode
+      const repoRoot = rootResult.stdout.trim();
+      allRepoRoots = [repoRoot];
+      const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
+      if (statusResult.exit_code === 0) {
+        allDecorations = parseStatusOutput(statusResult.stdout, repoRoot);
+      }
+    } else {
+      // cwd is not a git repo — discover sub-repos (monorepo/multi-repo)
+      const subRepos = discoverSubRepos(cwd);
+      for (const subDir of subRepos) {
+        const subRootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], subDir);
+        if (subRootResult.exit_code !== 0) continue;
+        const repoRoot = subRootResult.stdout.trim();
+        if (!repoRoot) continue;
+        allRepoRoots.push(repoRoot);
+        const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
+        if (statusResult.exit_code === 0) {
+          allDecorations = allDecorations.concat(parseStatusOutput(statusResult.stdout, repoRoot));
+        }
+      }
     }
 
-    const statusResult = await editor.spawnProcess(
-      "git",
-      ["status", "--porcelain", "-z"],
-      repoRoot
-    );
-    if (statusResult.exit_code !== 0) {
-      editor.clearFileExplorerDecorations(NAMESPACE);
-      editor.clearFileExplorerSlots(NAMESPACE);
-      return;
-    }
-
-    const decorations = parseStatusOutput(statusResult.stdout, repoRoot);
-    if (decorations.length === 0) {
+    if (allDecorations.length === 0) {
       editor.clearFileExplorerDecorations(NAMESPACE);
       editor.clearFileExplorerSlots(NAMESPACE);
     } else {
-      editor.setFileExplorerDecorations(NAMESPACE, decorations);
+      editor.setFileExplorerDecorations(NAMESPACE, allDecorations);
 
       const cfg = (editor.getPluginConfig() ?? {}) as { colorNames?: boolean };
       if (cfg.colorNames) {
-        editor.setFileExplorerSlots(
-          NAMESPACE,
-          buildNameColorSlots(decorations, repoRoot)
-        );
+        let allSlots: Array<{ path: string; nameColor: string; priority: number }> = [];
+        for (const repoRoot of allRepoRoots) {
+          const repoDecorations = allDecorations.filter(d => d.path.startsWith(repoRoot));
+          allSlots = allSlots.concat(buildNameColorSlots(repoDecorations, repoRoot));
+        }
+        editor.setFileExplorerSlots(NAMESPACE, allSlots);
       } else {
         editor.clearFileExplorerSlots(NAMESPACE);
       }

--- a/crates/fresh-editor/plugins/git_explorer.ts
+++ b/crates/fresh-editor/plugins/git_explorer.ts
@@ -159,16 +159,19 @@ async function refreshGitExplorerDecorations() {
     const cwd = editor.getCwd();
     const rootResult = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
 
-    let allDecorations: Array<{ path: string; symbol: string; color: string; priority: number }> = [];
-    let allRepoRoots: string[] = [];
+    type Decoration = { path: string; symbol: string; color: string; priority: number };
+    // Keep each repo's decorations grouped with the root they came from, so
+    // slots are built per-repo without re-deriving membership by path prefix
+    // (a bare startsWith(root) mis-groups sibling repos that share a prefix,
+    // e.g. project-a vs project-a-extra).
+    const repoGroups: Array<{ root: string; decorations: Decoration[] }> = [];
 
     if (rootResult.exit_code === 0 && rootResult.stdout.trim()) {
       // cwd is inside a git repo — single-repo mode
       const repoRoot = rootResult.stdout.trim();
-      allRepoRoots = [repoRoot];
       const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
       if (statusResult.exit_code === 0) {
-        allDecorations = parseStatusOutput(statusResult.stdout, repoRoot);
+        repoGroups.push({ root: repoRoot, decorations: parseStatusOutput(statusResult.stdout, repoRoot) });
       }
     } else {
       // cwd is not a git repo — discover sub-repos (monorepo/multi-repo)
@@ -178,14 +181,14 @@ async function refreshGitExplorerDecorations() {
         if (subRootResult.exit_code !== 0) continue;
         const repoRoot = subRootResult.stdout.trim();
         if (!repoRoot) continue;
-        allRepoRoots.push(repoRoot);
         const statusResult = await editor.spawnProcess("git", ["status", "--porcelain", "-z"], repoRoot);
         if (statusResult.exit_code === 0) {
-          allDecorations = allDecorations.concat(parseStatusOutput(statusResult.stdout, repoRoot));
+          repoGroups.push({ root: repoRoot, decorations: parseStatusOutput(statusResult.stdout, repoRoot) });
         }
       }
     }
 
+    const allDecorations = repoGroups.flatMap(g => g.decorations);
     if (allDecorations.length === 0) {
       editor.clearFileExplorerDecorations(NAMESPACE);
       editor.clearFileExplorerSlots(NAMESPACE);
@@ -194,11 +197,7 @@ async function refreshGitExplorerDecorations() {
 
       const cfg = (editor.getPluginConfig() ?? {}) as { colorNames?: boolean };
       if (cfg.colorNames) {
-        let allSlots: Array<{ path: string; nameColor: string; priority: number }> = [];
-        for (const repoRoot of allRepoRoots) {
-          const repoDecorations = allDecorations.filter(d => d.path.startsWith(repoRoot));
-          allSlots = allSlots.concat(buildNameColorSlots(repoDecorations, repoRoot));
-        }
+        const allSlots = repoGroups.flatMap(g => buildNameColorSlots(g.decorations, g.root));
         editor.setFileExplorerSlots(NAMESPACE, allSlots);
       } else {
         editor.clearFileExplorerSlots(NAMESPACE);

--- a/crates/fresh-editor/plugins/git_find_file.ts
+++ b/crates/fresh-editor/plugins/git_find_file.ts
@@ -24,28 +24,35 @@ const finder = new Finder<string>(editor, {
 
 // Load git-tracked files
 async function loadGitFiles(): Promise<string[]> {
-  // Use active buffer's directory to find the right git repo in monorepo setups
-  let cwd = editor.getCwd();
-  const bufferId = editor.getActiveBufferId();
-  if (bufferId) {
-    const bufPath = editor.getBufferPath(bufferId);
-    if (bufPath) {
-      const dir = editor.pathDirname(bufPath);
-      if (dir) cwd = dir;
-    }
-  }
-  const result = await editor.spawnProcess("git", ["ls-files"], cwd);
+  const result = await editor.spawnProcess("git", [
+    "ls-files",
+    "--full-name",
+  ]);
 
-  if (result.exit_code === 0) {
-    // Split by newline and trim each line to handle \r\n on Windows
-    return result.stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line !== "");
+  if (result.exit_code !== 0) {
+    editor.debug(`Failed to load git files: ${result.stderr}`);
+    return [];
   }
 
-  editor.debug(`Failed to load git files: ${result.stderr}`);
-  return [];
+  const files = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+
+  // `ls-files --full-name` returns paths relative to the repo root.
+  // Resolve them to absolute paths so openFile works regardless of the
+  // workspace root (important in monorepo setups where the workspace
+  // root may differ from the git root).
+  const topResult = await editor.spawnProcess("git", [
+    "rev-parse",
+    "--show-toplevel",
+  ]);
+  if (topResult.exit_code === 0) {
+    const repoRoot = topResult.stdout.trim();
+    return files.map((f) => `${repoRoot}/${f}`);
+  }
+
+  return files;
 }
 
 // Global function to start file finder

--- a/crates/fresh-editor/plugins/git_find_file.ts
+++ b/crates/fresh-editor/plugins/git_find_file.ts
@@ -8,51 +8,54 @@
  */
 
 import { Finder } from "./lib/finder.ts";
+import { resolveGitRepo } from "./lib/git_repo.ts";
 
 const editor = getEditor();
 
+// One git-tracked file: `rel` (repo-relative) is what the user sees and
+// fuzzy-matches against; `abs` is what actually opens, because in a monorepo
+// the workspace root can differ from the repo root, so a relative path
+// wouldn't resolve.
+type GitFile = { rel: string; abs: string };
+
 // Create the finder instance with filter mode
-const finder = new Finder<string>(editor, {
+const finder = new Finder<GitFile>(editor, {
   id: "git-find-file",
   format: (file) => ({
-    label: file,
-    location: { file, line: 1, column: 1 },
+    label: file.rel,
+    location: { file: file.abs, line: 1, column: 1 },
   }),
   preview: false, // No preview for file finder
   maxResults: 100,
 });
 
 // Load git-tracked files
-async function loadGitFiles(): Promise<string[]> {
-  const result = await editor.spawnProcess("git", [
-    "ls-files",
-    "--full-name",
-  ]);
+async function loadGitFiles(): Promise<GitFile[]> {
+  // Resolve the repo from the active buffer's dir too, so this works from a
+  // sub-project buffer even when the workspace root isn't itself a repo.
+  const repo = await resolveGitRepo(editor);
+  if (!repo) {
+    editor.debug("git-find-file: not inside a git repository");
+    return [];
+  }
 
+  const result = await editor.spawnProcess(
+    "git",
+    ["ls-files", "--full-name"],
+    repo.root,
+  );
   if (result.exit_code !== 0) {
     editor.debug(`Failed to load git files: ${result.stderr}`);
     return [];
   }
 
-  const files = result.stdout
+  // `ls-files --full-name` yields repo-relative paths. Keep them for display
+  // and join to the repo root for opening.
+  return result.stdout
     .split("\n")
     .map((line) => line.trim())
-    .filter((line) => line !== "");
-
-  // `ls-files --full-name` returns paths relative to the repo root.
-  // Resolve them to absolute paths so openFile works regardless of the
-  // workspace root (important in monorepo setups where the workspace
-  // root may differ from the git root).
-  const topResult = await editor.spawnProcess("git", [
-    "rev-parse",
-    "--show-toplevel",
-  ]);
-  if (topResult.exit_code === 0) {
-    const repoRoot = topResult.stdout.trim();
-    return files.map((f) => `${repoRoot}/${f}`);
-  }
-
-  return files;
+    .filter((line) => line !== "")
+    .map((rel) => ({ rel, abs: editor.pathJoin(repo.root, rel) }));
 }
 
 // Global function to start file finder

--- a/crates/fresh-editor/plugins/git_find_file.ts
+++ b/crates/fresh-editor/plugins/git_find_file.ts
@@ -24,7 +24,17 @@ const finder = new Finder<string>(editor, {
 
 // Load git-tracked files
 async function loadGitFiles(): Promise<string[]> {
-  const result = await editor.spawnProcess("git", ["ls-files"]);
+  // Use active buffer's directory to find the right git repo in monorepo setups
+  let cwd = editor.getCwd();
+  const bufferId = editor.getActiveBufferId();
+  if (bufferId) {
+    const bufPath = editor.getBufferPath(bufferId);
+    if (bufPath) {
+      const dir = editor.pathDirname(bufPath);
+      if (dir) cwd = dir;
+    }
+  }
+  const result = await editor.spawnProcess("git", ["ls-files"], cwd);
 
   if (result.exit_code === 0) {
     // Split by newline and trim each line to handle \r\n on Windows

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -1126,7 +1126,7 @@ async function git_log_detail_open_file(): Promise<void> {
   const result = await editor.spawnProcess("git", [
     "show",
     `${commit.hash}:${file}`,
-  ], editor.getCwd());
+  ]);
   if (result.exit_code !== 0) {
     editor.setStatus(
       editor.t("status.file_not_found", { file, hash: commit.shortHash })

--- a/crates/fresh-editor/plugins/git_log.ts
+++ b/crates/fresh-editor/plugins/git_log.ts
@@ -1126,7 +1126,7 @@ async function git_log_detail_open_file(): Promise<void> {
   const result = await editor.spawnProcess("git", [
     "show",
     `${commit.hash}:${file}`,
-  ]);
+  ], editor.getCwd());
   if (result.exit_code !== 0) {
     editor.setStatus(
       editor.t("status.file_not_found", { file, hash: commit.shortHash })

--- a/crates/fresh-editor/plugins/git_statusbar.ts
+++ b/crates/fresh-editor/plugins/git_statusbar.ts
@@ -17,6 +17,23 @@ let watchedCwd: string | null = null;
 let watchedHeadPath: string | null = null;
 let ensureWatchInFlight: Promise<void> | null = null;
 
+/**
+ * Resolve the best cwd for git operations: use the active buffer's
+ * directory when available (supports monorepo sub-projects), falling
+ * back to editor.getCwd().
+ */
+function getGitCwd(): string {
+  const bufferId = editor.getActiveBufferId();
+  if (bufferId) {
+    const bufPath = editor.getBufferPath(bufferId);
+    if (bufPath) {
+      const dir = editor.pathDirname(bufPath);
+      if (dir) return dir;
+    }
+  }
+  return editor.getCwd();
+}
+
 async function discoverHeadPath(cwd: string): Promise<string | null> {
   const result = await editor.spawnProcess(
     "git",
@@ -32,7 +49,7 @@ async function discoverHeadPath(cwd: string): Promise<string | null> {
 }
 
 async function ensureHeadWatch(): Promise<void> {
-  const cwd = editor.getCwd();
+  const cwd = getGitCwd();
   if (watchedCwd === cwd && headWatchHandle !== null) return;
   if (ensureWatchInFlight) return ensureWatchInFlight;
 
@@ -65,7 +82,7 @@ async function getCurrentGitBranch(): Promise<string> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
     try {
-      const cwd = editor.getCwd();
+      const cwd = getGitCwd();
       const result = await editor.spawnProcess(
         "git",
         ["rev-parse", "--abbrev-ref", "HEAD"],

--- a/crates/fresh-editor/plugins/lib/git_history.ts
+++ b/crates/fresh-editor/plugins/lib/git_history.ts
@@ -11,6 +11,39 @@
  */
 
 // =============================================================================
+// Sub-repo discovery (monorepo support)
+// =============================================================================
+
+/**
+ * Recursively discover directories containing `.git` entries, up to
+ * `maxDepth` levels. Stops descending into a directory once `.git` is
+ * found (git repo internals are managed by git itself). Skips hidden
+ * directories and `node_modules`.
+ *
+ * NOTE: a parallel BFS lives on the Rust side in `file_operations.rs`
+ * (`resolve_git_indexes`). Keep the two in sync.
+ */
+export function discoverSubRepos(
+  editor: EditorAPI,
+  dir: string,
+  maxDepth: number = 3,
+): string[] {
+  if (maxDepth <= 0) return [];
+  const repos: string[] = [];
+  const entries = editor.readDir(dir);
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || entry.name === "node_modules" || !entry.is_dir) continue;
+    const subDir = editor.pathJoin(dir, entry.name);
+    if (editor.fileExists(editor.pathJoin(subDir, ".git"))) {
+      repos.push(subDir);
+    } else {
+      repos.push(...discoverSubRepos(editor, subDir, maxDepth - 1));
+    }
+  }
+  return repos;
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 

--- a/crates/fresh-editor/plugins/lib/git_history.ts
+++ b/crates/fresh-editor/plugins/lib/git_history.ts
@@ -15,13 +15,15 @@
 // =============================================================================
 
 /**
- * Recursively discover directories containing `.git` entries, up to
- * `maxDepth` levels. Stops descending into a directory once `.git` is
- * found (git repo internals are managed by git itself). Skips hidden
- * directories and `node_modules`.
+ * Recursively discover directories containing `.git` entries. Scans
+ * `maxDepth` levels below `dir` (level 1 = direct children of `dir`).
+ * Stops descending into a directory once `.git` is found (git repo
+ * internals are managed by git itself). Skips hidden directories and
+ * `node_modules`.
  *
  * NOTE: a parallel BFS lives on the Rust side in `app/git_index.rs`
- * (`resolve_git_indexes_blocking`). Keep the two in sync.
+ * (`resolve_git_indexes_blocking`). It scans the SAME levels — keep the
+ * two in sync (both scan levels 1..=maxDepth below the working dir).
  */
 export function discoverSubRepos(
   editor: EditorAPI,

--- a/crates/fresh-editor/plugins/lib/git_history.ts
+++ b/crates/fresh-editor/plugins/lib/git_history.ts
@@ -20,8 +20,8 @@
  * found (git repo internals are managed by git itself). Skips hidden
  * directories and `node_modules`.
  *
- * NOTE: a parallel BFS lives on the Rust side in `file_operations.rs`
- * (`resolve_git_indexes`). Keep the two in sync.
+ * NOTE: a parallel BFS lives on the Rust side in `app/git_index.rs`
+ * (`resolve_git_indexes_blocking`). Keep the two in sync.
  */
 export function discoverSubRepos(
   editor: EditorAPI,

--- a/crates/fresh-editor/plugins/lib/git_repo.ts
+++ b/crates/fresh-editor/plugins/lib/git_repo.ts
@@ -1,0 +1,53 @@
+/// <reference path="./fresh.d.ts" />
+
+/**
+ * A resolved git repository. The only way to obtain one is `resolveGitRepo`,
+ * which guarantees `root` is a real toplevel path. Pass this to `git()`
+ * instead of a raw cwd string so a git command can never run in an
+ * unresolved / non-repo directory (which silently fails as "not a git repo").
+ */
+export type GitRepo = { readonly root: string };
+
+/**
+ * The single place cwd-resolution logic lives: the active buffer's directory
+ * (so monorepo sub-projects resolve to their own repo), falling back to the
+ * editor cwd. Returns a candidate directory to *probe* — not a confirmed repo.
+ */
+export function gitCwdCandidate(editor: EditorAPI): string {
+  const bufferId = editor.getActiveBufferId();
+  if (bufferId) {
+    const bufPath = editor.getBufferPath(bufferId);
+    if (bufPath) {
+      const dir = editor.pathDirname(bufPath);
+      if (dir) return dir;
+    }
+  }
+  return editor.getCwd();
+}
+
+/**
+ * Resolve the git repository for the current context, or `null` when not
+ * inside one. Because this returns `GitRepo | null`, callers are forced to
+ * handle the "not a repo" case explicitly instead of falling through to a
+ * bare cwd.
+ */
+export async function resolveGitRepo(editor: EditorAPI): Promise<GitRepo | null> {
+  try {
+    const cwd = gitCwdCandidate(editor);
+    const r = await editor.spawnProcess("git", ["rev-parse", "--show-toplevel"], cwd);
+    if (r.exit_code !== 0) return null;
+    const root = r.stdout.trim();
+    return root ? { root } : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Run a git command inside a resolved repository. */
+export function git(
+  editor: EditorAPI,
+  repo: GitRepo,
+  args: string[],
+): ProcessHandle<SpawnResult> {
+  return editor.spawnProcess("git", args, repo.root);
+}

--- a/crates/fresh-editor/plugins/live_grep.ts
+++ b/crates/fresh-editor/plugins/live_grep.ts
@@ -524,7 +524,22 @@ registerProvider({
         ["rev-parse", "--is-inside-work-tree"],
         cwd
       );
-      return inRepo.exit_code === 0;
+      if (inRepo.exit_code === 0) return true;
+      // cwd may not be a repo (monorepo root); check active buffer's dir
+      const bufferId = editor.getActiveBufferId();
+      if (bufferId) {
+        const bufPath = editor.getBufferPath(bufferId);
+        if (bufPath) {
+          const bufDir = editor.pathDirname(bufPath);
+          if (bufDir) {
+            const bufInRepo = await editor.spawnProcess(
+              "git", ["rev-parse", "--is-inside-work-tree"], bufDir
+            );
+            return bufInRepo.exit_code === 0;
+          }
+        }
+      }
+      return false;
     } catch {
       return false;
     }

--- a/crates/fresh-editor/plugins/live_grep.ts
+++ b/crates/fresh-editor/plugins/live_grep.ts
@@ -1,4 +1,5 @@
 /// <reference path="./lib/fresh.d.ts" />
+import { gitCwdCandidate } from "./lib/git_repo.ts";
 
 /**
  * Live Grep Plugin
@@ -506,6 +507,25 @@ registerProvider({
   },
 });
 
+/** The cwd git-grep should run in: the caller's `preferred` cwd when it is
+ *  itself inside a repo, else the active buffer's dir (monorepo: the workspace
+ *  root isn't a repo but the open file is). Returns null when neither is a
+ *  repo. Used by both `isAvailable` and `search` so they can't disagree. */
+async function gitGrepCwd(preferred: string): Promise<string | null> {
+  const inRepo = await editor.spawnProcess(
+    "git", ["rev-parse", "--is-inside-work-tree"], preferred
+  );
+  if (inRepo.exit_code === 0) return preferred;
+  const cand = gitCwdCandidate(editor);
+  if (cand !== preferred) {
+    const r = await editor.spawnProcess(
+      "git", ["rev-parse", "--is-inside-work-tree"], cand
+    );
+    if (r.exit_code === 0) return cand;
+  }
+  return null;
+}
+
 registerProvider({
   name: "git-grep",
   // Top priority. git grep is the default *when available* — i.e.
@@ -515,36 +535,21 @@ registerProvider({
   priority: 0,
   isAvailable: async () => {
     try {
-      // git grep needs both `git` on PATH and to be inside a repo.
-      const cwd = editor.getCwd();
-      const ver = await editor.spawnProcess("git", ["--version"], cwd);
+      // git grep needs both `git` on PATH and a repo to run in. Resolve
+      // the repo cwd the *same way* search() does, so the two can never
+      // disagree (availability said yes but search runs in a non-repo).
+      const ver = await editor.spawnProcess("git", ["--version"], editor.getCwd());
       if (ver.exit_code !== 0) return false;
-      const inRepo = await editor.spawnProcess(
-        "git",
-        ["rev-parse", "--is-inside-work-tree"],
-        cwd
-      );
-      if (inRepo.exit_code === 0) return true;
-      // cwd may not be a repo (monorepo root); check active buffer's dir
-      const bufferId = editor.getActiveBufferId();
-      if (bufferId) {
-        const bufPath = editor.getBufferPath(bufferId);
-        if (bufPath) {
-          const bufDir = editor.pathDirname(bufPath);
-          if (bufDir) {
-            const bufInRepo = await editor.spawnProcess(
-              "git", ["rev-parse", "--is-inside-work-tree"], bufDir
-            );
-            return bufInRepo.exit_code === 0;
-          }
-        }
-      }
-      return false;
+      return (await gitGrepCwd(editor.getCwd())) !== null;
     } catch {
       return false;
     }
   },
   search: async (query, { cwd, maxResults, includeIgnored, wholeWord, regex }) => {
+    // Run in the same repo cwd isAvailable() confirmed. Null means the
+    // context is no longer a repo — return empty rather than throwing.
+    const gitCwd = await gitGrepCwd(cwd);
+    if (!gitCwd) return [] as GrepMatch[];
     const args = ["grep", "-n", "--column", "-I"];
     // Default git-grep is basic regex; use extended when regex is on, or
     // fixed-strings when it's off so the query is matched literally.
@@ -557,7 +562,7 @@ registerProvider({
       args.push("--untracked", "--no-exclude-standard");
     }
     args.push("-e", query);
-    const r = await editor.spawnProcess("git", args, cwd);
+    const r = await editor.spawnProcess("git", args, gitCwd);
     // git grep exits 1 when no matches — treat as empty, not error.
     if (r.exit_code === 0 || r.exit_code === 1) {
       return parseGrepOutput(r.stdout, maxResults, (msg) => editor.debug(msg)) as GrepMatch[];

--- a/crates/fresh-editor/plugins/merge_conflict.ts
+++ b/crates/fresh-editor/plugins/merge_conflict.ts
@@ -1260,7 +1260,7 @@ async function start_merge_conflict() : Promise<void> {
   }
 
   // Get file content from git's working tree (has conflict markers)
-  const catFileResult = await editor.spawnProcess("git", ["show", `:0:${info.path}`]);
+  const catFileResult = await editor.spawnProcess("git", ["show", `:0:${info.path}`], fileDir);
 
   // If :0: doesn't exist, read the working tree file directly
   let content: string;

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -784,7 +784,8 @@ impl Editor {
         path: std::path::PathBuf,
         kind: crate::services::async_bridge::PathChangeKind,
     ) {
-        self.last_path_change_for_test = Some((handle, path.clone(), kind.as_str()));
+        self.path_changes_for_test
+            .push((handle, path.clone(), kind.as_str()));
         self.plugin_manager.read().unwrap().run_hook(
             "path_changed",
             crate::services::plugins::hooks::HookArgs::PathChanged {

--- a/crates/fresh-editor/src/app/editor_accessors.rs
+++ b/crates/fresh-editor/src/app/editor_accessors.rs
@@ -884,12 +884,12 @@ impl Editor {
         self.lsp().is_some()
     }
 
-    /// Most-recent `path_changed` event the editor received.
-    /// Test-only — used by `watch_path` e2e tests to assert
-    /// kernel events surfaced to the editor.
+    /// `path_changed` events received so far. Test-only — used by
+    /// `watch_path` e2e tests to assert kernel events surfaced to
+    /// the editor.
     #[doc(hidden)]
-    pub fn last_path_change_for_test(&self) -> Option<&(u64, std::path::PathBuf, &'static str)> {
-        self.last_path_change_for_test.as_ref()
+    pub fn path_changes_for_test(&self) -> &[(u64, std::path::PathBuf, &'static str)] {
+        &self.path_changes_for_test
     }
 
     /// Most-recent `WatchPathRegistered` plugin response, paired

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -507,7 +507,7 @@ impl Editor {
             status_log_path: None,
             #[cfg(feature = "plugins")]
             file_watcher_manager: crate::services::file_watcher::FileWatcherManager::new(),
-            last_path_change_for_test: None,
+            path_changes_for_test: Vec::new(),
             last_watch_response_for_test: None,
             preview_window_id: None,
             settings_state: None,

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -958,6 +958,7 @@ impl Editor {
         // Working dir is not a git repo — recursively scan subdirectories
         // (up to 3 levels) to find a sub-repo's .git/index (monorepo support).
         let working_dir = self.working_dir().to_path_buf();
+        let fs = self.authority().filesystem.clone();
 
         use std::collections::VecDeque;
         let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
@@ -965,27 +966,22 @@ impl Editor {
         const MAX_DEPTH: u32 = 3;
 
         while let Some((dir, depth)) = queue.pop_front() {
-            let entries = match std::fs::read_dir(&dir) {
+            let entries = match fs.read_dir(&dir) {
                 Ok(e) => e,
                 Err(_) => continue,
             };
 
-            for entry in entries.filter_map(|e| e.ok()) {
-                let path = entry.path();
-                if !path.is_dir() {
+            for entry in entries {
+                if !entry.is_dir() {
                     continue;
                 }
-                if path.file_name()
-                    .and_then(|n| n.to_str())
-                    .map(|n| n.starts_with('.'))
-                    .unwrap_or(false)
-                {
+                if entry.name.starts_with('.') || entry.name == "node_modules" {
                     continue;
                 }
 
-                let dot_git = path.join(".git");
-                if dot_git.exists() {
-                    let sub_cwd = path.to_string_lossy().to_string();
+                let dot_git = entry.path.join(".git");
+                if fs.exists(&dot_git) {
+                    let sub_cwd = entry.path.to_string_lossy().to_string();
                     let sub_result = rt.block_on(spawner.spawn(
                         "git".to_string(),
                         vec!["rev-parse".to_string(), "--git-dir".to_string()],
@@ -997,13 +993,13 @@ impl Editor {
                             let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
                                 PathBuf::from(git_dir)
                             } else {
-                                path.join(git_dir)
+                                entry.path.join(git_dir)
                             };
                             return Some(git_dir_path.join("index"));
                         }
                     }
                 } else if depth < MAX_DEPTH {
-                    queue.push_back((path, depth + 1));
+                    queue.push_back((entry.path.clone(), depth + 1));
                 }
             }
         }

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -659,9 +659,9 @@ impl Editor {
         let mut dir_poll_pending = false;
         if let Some(ref rx) = self.active_window_mut().pending_dir_poll_rx {
             match rx.try_recv() {
-                Ok((dir_results, git_index_mtime)) => {
+                Ok((dir_results, git_index_mtimes)) => {
                     self.active_window_mut().pending_dir_poll_rx = None;
-                    any_refreshed = self.process_dir_poll_results(dir_results, git_index_mtime);
+                    any_refreshed = self.process_dir_poll_results(dir_results, git_index_mtimes);
                 }
                 Err(std::sync::mpsc::TryRecvError::Empty) => {
                     dir_poll_pending = true;
@@ -695,12 +695,13 @@ impl Editor {
             return any_refreshed;
         }
 
-        // Resolve the git index path once (first poll only). This uses the
-        // ProcessSpawner which may block briefly on the first call, but only
-        // happens once per session.
+        // Resolve all git index paths once (first poll only). This uses
+        // the ProcessSpawner which may block briefly on the first call,
+        // but only happens once per session. In a monorepo every sub-repo
+        // gets its own watched index so decorations refresh for all of them.
         if !self.active_window_mut().git_index_resolved {
             self.active_window_mut().git_index_resolved = true;
-            if let Some(path) = self.resolve_git_index() {
+            for path in self.resolve_git_indexes() {
                 if let Ok(meta) = self.authority().filesystem.metadata(&path) {
                     if let Some(mtime) = meta.modified {
                         self.active_window_mut().dir_mod_times.insert(path, mtime);
@@ -722,19 +723,21 @@ impl Editor {
             .map(|node| (node.id, node.entry.path.clone()))
             .collect();
 
-        // Find the git index path to include in the background metadata check
-        let git_index_path: Option<PathBuf> = self
+        // Collect all watched git index paths for the background metadata check.
+        // In a monorepo there may be several; in a single-repo just one.
+        let git_index_paths: Vec<PathBuf> = self
             .active_window()
             .dir_mod_times
             .keys()
-            .find(|p| p.ends_with(".git/index") || p.ends_with(".git\\index"))
-            .cloned();
+            .filter(|p| p.ends_with(".git/index") || p.ends_with(".git\\index"))
+            .cloned()
+            .collect();
 
-        if expanded_dirs.is_empty() && git_index_path.is_none() {
+        if expanded_dirs.is_empty() && git_index_paths.is_empty() {
             return any_refreshed;
         }
 
-        // Spawn background metadata checks (directories + git index)
+        // Spawn background metadata checks (directories + git indexes)
         let (tx, rx) = std::sync::mpsc::channel();
         let fs = self.authority().filesystem.clone();
         std::thread::Builder::new()
@@ -748,14 +751,16 @@ impl Editor {
                     })
                     .collect();
 
-                // Also check git index mtime in the same background thread
-                let git_index_mtime = git_index_path.and_then(|path| {
-                    let mtime = fs.metadata(&path).ok().and_then(|m| m.modified);
-                    Some((path, mtime?))
-                });
+                let git_index_mtimes: Vec<(PathBuf, std::time::SystemTime)> = git_index_paths
+                    .into_iter()
+                    .filter_map(|path| {
+                        let mtime = fs.metadata(&path).ok().and_then(|m| m.modified)?;
+                        Some((path, mtime))
+                    })
+                    .collect();
 
                 // Receiver may have been dropped during shutdown — that's fine.
-                if tx.send((results, git_index_mtime)).is_err() {}
+                if tx.send((results, git_index_mtimes)).is_err() {}
             })
             .ok();
         self.active_window_mut().pending_dir_poll_rx = Some(rx);
@@ -771,7 +776,7 @@ impl Editor {
             PathBuf,
             Option<std::time::SystemTime>,
         )>,
-        git_index_mtime: Option<(PathBuf, std::time::SystemTime)>,
+        git_index_mtimes: Vec<(PathBuf, std::time::SystemTime)>,
     ) -> bool {
         let mut dirs_to_refresh: Vec<(crate::view::file_tree::NodeId, PathBuf)> = Vec::new();
 
@@ -795,23 +800,19 @@ impl Editor {
             }
         }
 
-        // Check if .git/index mtime changed (detected in background thread)
-        let git_index_changed = if let Some((path, current_mtime)) = git_index_mtime {
+        // Check if any .git/index mtime changed (detected in background thread).
+        // In a monorepo multiple indexes are watched; fire the hook if any changed.
+        let mut git_index_changed = false;
+        for (path, current_mtime) in git_index_mtimes {
             if let Some(&stored_mtime) = self.active_window_mut().dir_mod_times.get(&path) {
                 if current_mtime != stored_mtime {
                     self.active_window_mut()
                         .dir_mod_times
                         .insert(path, current_mtime);
-                    true
-                } else {
-                    false
+                    git_index_changed = true;
                 }
-            } else {
-                false
             }
-        } else {
-            false
-        };
+        }
 
         if dirs_to_refresh.is_empty() && !git_index_changed {
             return false;
@@ -928,14 +929,24 @@ impl Editor {
         changed
     }
 
-    /// Resolve the path to `.git/index` via `git rev-parse --git-dir`.
+    /// Resolve the paths to every `.git/index` reachable from the working
+    /// directory. In a normal repo this returns a single entry; in a
+    /// monorepo (working dir is not itself a git repo) it BFS-scans
+    /// subdirectories up to 3 levels deep and returns one entry per
+    /// discovered sub-repo so that *all* indexes are watched.
+    ///
     /// Uses the `ProcessSpawner` so it works transparently on both local
     /// and remote (SSH) filesystems.
-    fn resolve_git_index(&self) -> Option<PathBuf> {
+    ///
+    /// NOTE: a parallel BFS lives on the TypeScript side in
+    /// `lib/git_history.ts` (`discoverSubRepos`). Keep the two in sync.
+    fn resolve_git_indexes(&self) -> Vec<PathBuf> {
         let spawner = &self.authority().process_spawner;
         let cwd = self.working_dir().to_string_lossy().to_string();
 
-        let rt = self.tokio_runtime.as_ref()?;
+        let Some(rt) = self.tokio_runtime.as_ref() else {
+            return Vec::new();
+        };
 
         let result = rt.block_on(spawner.spawn(
             "git".to_string(),
@@ -951,12 +962,12 @@ impl Editor {
                 } else {
                     self.working_dir().join(git_dir)
                 };
-                return Some(git_dir_path.join("index"));
+                return vec![git_dir_path.join("index")];
             }
         }
 
         // Working dir is not a git repo — recursively scan subdirectories
-        // (up to 3 levels) to find a sub-repo's .git/index (monorepo support).
+        // (up to 3 levels) to find all sub-repos' .git/index (monorepo).
         let working_dir = self.working_dir().to_path_buf();
         let fs = self.authority().filesystem.clone();
 
@@ -964,6 +975,7 @@ impl Editor {
         let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
         queue.push_back((working_dir, 0));
         const MAX_DEPTH: u32 = 3;
+        let mut indexes = Vec::new();
 
         while let Some((dir, depth)) = queue.pop_front() {
             let entries = match fs.read_dir(&dir) {
@@ -995,7 +1007,7 @@ impl Editor {
                             } else {
                                 entry.path.join(git_dir)
                             };
-                            return Some(git_dir_path.join("index"));
+                            indexes.push(git_dir_path.join("index"));
                         }
                     }
                 } else if depth < MAX_DEPTH {
@@ -1004,7 +1016,7 @@ impl Editor {
             }
         }
 
-        None
+        indexes
     }
 
     /// Notify LSP server about a newly opened file

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -672,6 +672,10 @@ impl Editor {
             }
         }
 
+        // Fold in any completed background git-index resolution (see
+        // `git_index.rs`), seeding the explicit `.git/index` watch set.
+        self.collect_git_index_resolution();
+
         // Check poll interval
         let poll_interval =
             std::time::Duration::from_millis(self.config.editor.file_tree_poll_interval_ms);
@@ -695,20 +699,9 @@ impl Editor {
             return any_refreshed;
         }
 
-        // Resolve all git index paths once (first poll only). This uses
-        // the ProcessSpawner which may block briefly on the first call,
-        // but only happens once per session. In a monorepo every sub-repo
-        // gets its own watched index so decorations refresh for all of them.
-        if !self.active_window_mut().git_index_resolved {
-            self.active_window_mut().git_index_resolved = true;
-            for path in self.resolve_git_indexes() {
-                if let Ok(meta) = self.authority().filesystem.metadata(&path) {
-                    if let Some(mtime) = meta.modified {
-                        self.active_window_mut().dir_mod_times.insert(path, mtime);
-                    }
-                }
-            }
-        }
+        // Kick off the one-shot git-index discovery on a background thread
+        // (see `git_index.rs`) so the first poll never blocks on `git`.
+        self.spawn_git_index_resolution();
 
         // Get file explorer reference
         let Some(explorer) = self.file_explorer() else {
@@ -723,15 +716,10 @@ impl Editor {
             .map(|node| (node.id, node.entry.path.clone()))
             .collect();
 
-        // Collect all watched git index paths for the background metadata check.
+        // The watch set is stored explicitly (populated once above), not
+        // re-derived from `dir_mod_times` by pattern-matching `.git/index`.
         // In a monorepo there may be several; in a single-repo just one.
-        let git_index_paths: Vec<PathBuf> = self
-            .active_window()
-            .dir_mod_times
-            .keys()
-            .filter(|p| p.ends_with(".git/index") || p.ends_with(".git\\index"))
-            .cloned()
-            .collect();
+        let git_index_paths: Vec<PathBuf> = self.active_window().watched_git_indexes.clone();
 
         if expanded_dirs.is_empty() && git_index_paths.is_empty() {
             return any_refreshed;
@@ -927,96 +915,6 @@ impl Editor {
             }
         }
         changed
-    }
-
-    /// Resolve the paths to every `.git/index` reachable from the working
-    /// directory. In a normal repo this returns a single entry; in a
-    /// monorepo (working dir is not itself a git repo) it BFS-scans
-    /// subdirectories up to 3 levels deep and returns one entry per
-    /// discovered sub-repo so that *all* indexes are watched.
-    ///
-    /// Uses the `ProcessSpawner` so it works transparently on both local
-    /// and remote (SSH) filesystems.
-    ///
-    /// NOTE: a parallel BFS lives on the TypeScript side in
-    /// `lib/git_history.ts` (`discoverSubRepos`). Keep the two in sync.
-    fn resolve_git_indexes(&self) -> Vec<PathBuf> {
-        let spawner = &self.authority().process_spawner;
-        let cwd = self.working_dir().to_string_lossy().to_string();
-
-        let Some(rt) = self.tokio_runtime.as_ref() else {
-            return Vec::new();
-        };
-
-        let result = rt.block_on(spawner.spawn(
-            "git".to_string(),
-            vec!["rev-parse".to_string(), "--git-dir".to_string()],
-            Some(cwd.clone()),
-        ));
-
-        if let Ok(ref output) = result {
-            if output.exit_code == 0 {
-                let git_dir = output.stdout.trim();
-                let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
-                    PathBuf::from(git_dir)
-                } else {
-                    self.working_dir().join(git_dir)
-                };
-                return vec![git_dir_path.join("index")];
-            }
-        }
-
-        // Working dir is not a git repo — recursively scan subdirectories
-        // (up to 3 levels) to find all sub-repos' .git/index (monorepo).
-        let working_dir = self.working_dir().to_path_buf();
-        let fs = self.authority().filesystem.clone();
-
-        use std::collections::VecDeque;
-        let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
-        queue.push_back((working_dir, 0));
-        const MAX_DEPTH: u32 = 3;
-        let mut indexes = Vec::new();
-
-        while let Some((dir, depth)) = queue.pop_front() {
-            let entries = match fs.read_dir(&dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            for entry in entries {
-                if !entry.is_dir() {
-                    continue;
-                }
-                if entry.name.starts_with('.') || entry.name == "node_modules" {
-                    continue;
-                }
-
-                let dot_git = entry.path.join(".git");
-                if fs.exists(&dot_git) {
-                    let sub_cwd = entry.path.to_string_lossy().to_string();
-                    let sub_result = rt.block_on(spawner.spawn(
-                        "git".to_string(),
-                        vec!["rev-parse".to_string(), "--git-dir".to_string()],
-                        Some(sub_cwd.clone()),
-                    ));
-                    if let Ok(ref output) = sub_result {
-                        if output.exit_code == 0 {
-                            let git_dir = output.stdout.trim();
-                            let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
-                                PathBuf::from(git_dir)
-                            } else {
-                                entry.path.join(git_dir)
-                            };
-                            indexes.push(git_dir_path.join("index"));
-                        }
-                    }
-                } else if depth < MAX_DEPTH {
-                    queue.push_back((entry.path.clone(), depth + 1));
-                }
-            }
-        }
-
-        indexes
     }
 
     /// Notify LSP server about a newly opened file

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -935,32 +935,80 @@ impl Editor {
         let spawner = &self.authority().process_spawner;
         let cwd = self.working_dir().to_string_lossy().to_string();
 
-        // ProcessSpawner is async — run it on the tokio runtime if available,
-        // otherwise fall back to blocking (should only happen in tests without
-        // a runtime).
-        let result = if let Some(ref rt) = self.tokio_runtime {
-            rt.block_on(spawner.spawn(
-                "git".to_string(),
-                vec!["rev-parse".to_string(), "--git-dir".to_string()],
-                Some(cwd),
-            ))
-        } else {
-            // No runtime — can't run async spawner. This shouldn't happen
-            // in production but can in minimal test setups.
-            return None;
-        };
+        let rt = self.tokio_runtime.as_ref()?;
 
-        let output = result.ok()?;
-        if output.exit_code != 0 {
-            return None;
+        let result = rt.block_on(spawner.spawn(
+            "git".to_string(),
+            vec!["rev-parse".to_string(), "--git-dir".to_string()],
+            Some(cwd.clone()),
+        ));
+
+        if let Ok(ref output) = result {
+            if output.exit_code == 0 {
+                let git_dir = output.stdout.trim();
+                let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
+                    PathBuf::from(git_dir)
+                } else {
+                    self.working_dir().join(git_dir)
+                };
+                return Some(git_dir_path.join("index"));
+            }
         }
-        let git_dir = output.stdout.trim();
-        let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
-            PathBuf::from(git_dir)
-        } else {
-            self.working_dir().join(git_dir)
-        };
-        Some(git_dir_path.join("index"))
+
+        // Working dir is not a git repo — recursively scan subdirectories
+        // (up to 3 levels) to find a sub-repo's .git/index (monorepo support).
+        let working_dir = self.working_dir().to_path_buf();
+
+        use std::collections::VecDeque;
+        let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
+        queue.push_back((working_dir, 0));
+        const MAX_DEPTH: u32 = 3;
+
+        while let Some((dir, depth)) = queue.pop_front() {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            for entry in entries.filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                if path.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with('.'))
+                    .unwrap_or(false)
+                {
+                    continue;
+                }
+
+                let dot_git = path.join(".git");
+                if dot_git.exists() {
+                    let sub_cwd = path.to_string_lossy().to_string();
+                    let sub_result = rt.block_on(spawner.spawn(
+                        "git".to_string(),
+                        vec!["rev-parse".to_string(), "--git-dir".to_string()],
+                        Some(sub_cwd.clone()),
+                    ));
+                    if let Ok(ref output) = sub_result {
+                        if output.exit_code == 0 {
+                            let git_dir = output.stdout.trim();
+                            let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
+                                PathBuf::from(git_dir)
+                            } else {
+                                path.join(git_dir)
+                            };
+                            return Some(git_dir_path.join("index"));
+                        }
+                    }
+                } else if depth < MAX_DEPTH {
+                    queue.push_back((path, depth + 1));
+                }
+            }
+        }
+
+        None
     }
 
     /// Notify LSP server about a newly opened file

--- a/crates/fresh-editor/src/app/git_index.rs
+++ b/crates/fresh-editor/src/app/git_index.rs
@@ -119,15 +119,19 @@ fn resolve_git_indexes_blocking(
         }
     }
 
-    // Working dir is not a git repo — recursively scan subdirectories
-    // (up to 3 levels) to find all sub-repos' .git/index (monorepo).
+    // Working dir is not a git repo — scan subdirectories to find all
+    // sub-repos' .git/index (monorepo). `MAX_DEPTH` levels below the working
+    // dir are scanned (level 1 = direct children). This MUST match the levels
+    // scanned by the TypeScript `discoverSubRepos` (lib/git_history.ts) — the
+    // two walks are expected to discover the same repos.
     use std::collections::VecDeque;
-    let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
-    queue.push_back((working_dir, 0));
     const MAX_DEPTH: u32 = 3;
+    // Queue entries are (dir_to_scan, level_of_that_dir's_children).
+    let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
+    queue.push_back((working_dir, 1));
     let mut indexes = Vec::new();
 
-    while let Some((dir, depth)) = queue.pop_front() {
+    while let Some((dir, level)) = queue.pop_front() {
         let entries = match fs.read_dir(&dir) {
             Ok(e) => e,
             Err(_) => continue,
@@ -160,8 +164,8 @@ fn resolve_git_indexes_blocking(
                         indexes.push(git_dir_path.join("index"));
                     }
                 }
-            } else if depth < MAX_DEPTH {
-                queue.push_back((entry.path.clone(), depth + 1));
+            } else if level < MAX_DEPTH {
+                queue.push_back((entry.path.clone(), level + 1));
             }
         }
     }

--- a/crates/fresh-editor/src/app/git_index.rs
+++ b/crates/fresh-editor/src/app/git_index.rs
@@ -1,0 +1,170 @@
+//! Git-index discovery and watching for the file-tree change poller.
+//!
+//! The file explorer refreshes its git-status decorations when a repo's
+//! `.git/index` changes. This module owns the logic that
+//!   1. discovers every index to watch — one per repo, or several in a
+//!      monorepo whose root is not itself a repo — on a background thread so
+//!      the first poll never blocks the event loop, and
+//!   2. folds the results back into the active window's explicit watch set.
+//!
+//! NOTE: a parallel BFS lives on the TypeScript side in
+//! `lib/git_history.ts` (`discoverSubRepos`). Keep the two in sync.
+
+use super::Editor;
+use crate::model::filesystem::FileSystem;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+impl Editor {
+    /// Fold in the result of a background git-index resolution if the thread
+    /// has finished. Seeds the explicit watch set (`watched_git_indexes`) and
+    /// records each index's mtime. Called at the top of the file-tree poll.
+    pub(super) fn collect_git_index_resolution(&mut self) {
+        if let Some(ref rx) = self.active_window_mut().pending_git_index_rx {
+            match rx.try_recv() {
+                Ok(seeded) => {
+                    self.active_window_mut().pending_git_index_rx = None;
+                    self.active_window_mut().git_index_resolved = true;
+                    for (path, mtime) in seeded {
+                        self.active_window_mut()
+                            .watched_git_indexes
+                            .push(path.clone());
+                        if let Some(mtime) = mtime {
+                            self.active_window_mut().dir_mod_times.insert(path, mtime);
+                        }
+                    }
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.active_window_mut().pending_git_index_rx = None;
+                    self.active_window_mut().git_index_resolved = true;
+                }
+            }
+        }
+    }
+
+    /// Kick off the one-shot git-index resolution on a background thread, if it
+    /// hasn't run yet and isn't already in flight. Resolution spawns one `git`
+    /// process per repo plus a directory scan, so it must not run inline on the
+    /// event loop. `git_index_resolved` only flips true once results land (in
+    /// `collect_git_index_resolution`), so the guard below prevents spawning a
+    /// second thread while one is pending.
+    pub(super) fn spawn_git_index_resolution(&mut self) {
+        if self.active_window().git_index_resolved
+            || self.active_window().pending_git_index_rx.is_some()
+        {
+            return;
+        }
+        let Some(rt) = self.tokio_runtime.clone() else {
+            // No tokio runtime (minimal test setups) — nothing to resolve.
+            self.active_window_mut().git_index_resolved = true;
+            return;
+        };
+        let spawner = self.authority().process_spawner.clone();
+        let fs = self.authority().filesystem.clone();
+        let working_dir = self.working_dir().to_path_buf();
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::Builder::new()
+            .name("resolve-git-indexes".to_string())
+            .spawn(move || {
+                let indexes = resolve_git_indexes_blocking(spawner, fs.clone(), working_dir, rt);
+                // Pair each index with its current mtime so the main thread
+                // just inserts without extra stat calls.
+                let seeded: Vec<(PathBuf, Option<std::time::SystemTime>)> = indexes
+                    .into_iter()
+                    .map(|path| {
+                        let mtime = fs.metadata(&path).ok().and_then(|m| m.modified);
+                        (path, mtime)
+                    })
+                    .collect();
+                // Receiver may have been dropped during shutdown.
+                if tx.send(seeded).is_err() {}
+            })
+            .ok();
+        self.active_window_mut().pending_git_index_rx = Some(rx);
+    }
+}
+
+/// Resolve the paths to every `.git/index` reachable from `working_dir`. In a
+/// normal repo this returns a single entry; in a monorepo (working dir is not
+/// itself a git repo) it BFS-scans subdirectories up to 3 levels deep and
+/// returns one entry per discovered sub-repo so that *all* indexes are watched.
+///
+/// Uses the `ProcessSpawner` so it works transparently on both local and
+/// remote (SSH) filesystems. Takes owned handles (no `&self`) so it can run on
+/// a background thread.
+fn resolve_git_indexes_blocking(
+    spawner: Arc<dyn crate::services::remote::ProcessSpawner>,
+    fs: Arc<dyn FileSystem + Send + Sync>,
+    working_dir: PathBuf,
+    rt: Arc<tokio::runtime::Runtime>,
+) -> Vec<PathBuf> {
+    let cwd = working_dir.to_string_lossy().to_string();
+
+    let result = rt.block_on(spawner.spawn(
+        "git".to_string(),
+        vec!["rev-parse".to_string(), "--git-dir".to_string()],
+        Some(cwd),
+    ));
+
+    if let Ok(ref output) = result {
+        if output.exit_code == 0 {
+            let git_dir = output.stdout.trim();
+            let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
+                PathBuf::from(git_dir)
+            } else {
+                working_dir.join(git_dir)
+            };
+            return vec![git_dir_path.join("index")];
+        }
+    }
+
+    // Working dir is not a git repo — recursively scan subdirectories
+    // (up to 3 levels) to find all sub-repos' .git/index (monorepo).
+    use std::collections::VecDeque;
+    let mut queue: VecDeque<(PathBuf, u32)> = VecDeque::new();
+    queue.push_back((working_dir, 0));
+    const MAX_DEPTH: u32 = 3;
+    let mut indexes = Vec::new();
+
+    while let Some((dir, depth)) = queue.pop_front() {
+        let entries = match fs.read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        for entry in entries {
+            if !entry.is_dir() {
+                continue;
+            }
+            if entry.name.starts_with('.') || entry.name == "node_modules" {
+                continue;
+            }
+
+            let dot_git = entry.path.join(".git");
+            if fs.exists(&dot_git) {
+                let sub_cwd = entry.path.to_string_lossy().to_string();
+                let sub_result = rt.block_on(spawner.spawn(
+                    "git".to_string(),
+                    vec!["rev-parse".to_string(), "--git-dir".to_string()],
+                    Some(sub_cwd),
+                ));
+                if let Ok(ref output) = sub_result {
+                    if output.exit_code == 0 {
+                        let git_dir = output.stdout.trim();
+                        let git_dir_path = if std::path::Path::new(git_dir).is_absolute() {
+                            PathBuf::from(git_dir)
+                        } else {
+                            entry.path.join(git_dir)
+                        };
+                        indexes.push(git_dir_path.join("index"));
+                    }
+                }
+            } else if depth < MAX_DEPTH {
+                queue.push_back((entry.path.clone(), depth + 1));
+            }
+        }
+    }
+
+    indexes
+}

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -27,6 +27,7 @@ mod file_open_input;
 mod file_open_orchestrators;
 mod file_open_queue;
 mod file_operations;
+mod git_index;
 mod help;
 mod help_actions;
 mod hover;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -946,12 +946,12 @@ pub struct Editor {
     #[cfg(feature = "plugins")]
     file_watcher_manager: crate::services::file_watcher::FileWatcherManager,
 
-    /// Test-only sink for `path_changed` plugin events. Captured
-    /// by `async_dispatch` whenever a PathChanged AsyncMessage
-    /// arrives, so e2e tests can assert filesystem events
-    /// reached the editor without standing up a JS plugin.
-    /// Production builds never read this.
-    pub(crate) last_path_change_for_test: Option<(u64, std::path::PathBuf, &'static str)>,
+    /// Test-only log of `path_changed` plugin events. Captured by
+    /// `async_dispatch` whenever a PathChanged AsyncMessage arrives,
+    /// so e2e tests can assert filesystem events reached the editor
+    /// without standing up a JS plugin. Production builds never read
+    /// this.
+    pub(crate) path_changes_for_test: Vec<(u64, std::path::PathBuf, &'static str)>,
 
     /// Test-only sink for the most-recent `WatchPathRegistered`
     /// plugin response, keyed by request_id. Used by

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -701,6 +701,8 @@ pub struct Window {
         Option<std::sync::mpsc::Receiver<Vec<(PathBuf, Option<std::time::SystemTime>)>>>,
 
     /// Receiver for background directory change poll results for this window.
+    /// The second element carries mtimes for all watched `.git/index` files
+    /// (one per repo in a monorepo, or a single entry for a normal repo).
     #[allow(clippy::type_complexity)]
     pub pending_dir_poll_rx: Option<
         std::sync::mpsc::Receiver<(
@@ -709,7 +711,7 @@ pub struct Window {
                 PathBuf,
                 Option<std::time::SystemTime>,
             )>,
-            Option<(PathBuf, std::time::SystemTime)>,
+            Vec<(PathBuf, std::time::SystemTime)>,
         )>,
     >,
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -694,6 +694,13 @@ pub struct Window {
     /// path in `dir_mod_times`.
     pub git_index_resolved: bool,
 
+    /// The explicit set of `.git/index` paths this window watches for
+    /// changes (one per repo; several in a monorepo). Stored directly
+    /// rather than re-derived from `dir_mod_times` by name so that
+    /// submodule/worktree gitdirs (`.git/modules/<x>/index`) are not
+    /// dropped by a `.git/index` suffix match.
+    pub watched_git_indexes: Vec<PathBuf>,
+
     /// Receiver for background file change poll results for this window.
     /// `Some` while a metadata poll is in flight.
     #[allow(clippy::type_complexity)]
@@ -714,6 +721,14 @@ pub struct Window {
             Vec<(PathBuf, std::time::SystemTime)>,
         )>,
     >,
+
+    /// Receiver for the one-shot background git-index resolution (discovering
+    /// every repo's `.git/index` to watch, including monorepo sub-repos).
+    /// `Some` while that resolution thread is in flight. Each entry pairs an
+    /// index path with its mtime at resolution time.
+    #[allow(clippy::type_complexity)]
+    pub pending_git_index_rx:
+        Option<std::sync::mpsc::Receiver<Vec<(PathBuf, Option<std::time::SystemTime>)>>>,
 
     /// Terminals in this window that should not persist to the
     /// workspace file. Plugin-created terminals default to ephemeral;
@@ -1928,6 +1943,8 @@ impl Window {
             last_auto_revert_poll: now,
             last_file_tree_poll: now,
             git_index_resolved: false,
+            watched_git_indexes: Vec::new(),
+            pending_git_index_rx: None,
             pending_file_poll_rx: None,
             pending_dir_poll_rx: None,
             ephemeral_terminals: std::collections::HashSet::new(),

--- a/crates/fresh-editor/tests/common/git_test_helper.rs
+++ b/crates/fresh-editor/tests/common/git_test_helper.rs
@@ -343,6 +343,7 @@ A sample project for testing.
         let plugins_dir = self.path.join("plugins");
         fs::create_dir_all(&plugins_dir).expect("Failed to create plugins directory");
         copy_plugin(&plugins_dir, "git_explorer");
+        copy_plugin_lib(&plugins_dir);
     }
 
     /// Buffer-modified indicators are now computed natively during rendering.

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -4134,3 +4134,97 @@ fn test_file_explorer_shows_placeholder_during_slow_build() {
         harness.screen_to_string()
     );
 }
+
+/// Test that git status decorations appear for sub-repos when the workspace root
+/// is NOT a git repository (monorepo / multi-repo layout).
+///
+/// Layout:
+///   /tmp/workspace/          (not a git repo)
+///     project-a/             (git repo with modified file)
+///     project-b/             (git repo with untracked file)
+///
+/// The git_explorer plugin should discover both sub-repos and show decorations.
+#[test]
+#[cfg_attr(windows, ignore)] // Git plugin tests are flaky on Windows CI
+fn test_file_explorer_git_decorations_monorepo_subrepos() {
+    use crate::common::git_test_helper::git_command;
+    use crate::common::harness::{copy_plugin, copy_plugin_lib};
+    use tempfile::TempDir;
+
+    let workspace_dir = TempDir::new().expect("Failed to create workspace dir");
+    let ws = workspace_dir.path();
+
+    // Create project-a as a git sub-repo with a modified tracked file
+    let project_a = ws.join("project-a");
+    fs::create_dir_all(&project_a).unwrap();
+    let output = git_command(&project_a).arg("init").output().unwrap();
+    assert!(output.status.success(), "git init project-a failed");
+    fs::write(project_a.join("file-a.txt"), "original").unwrap();
+    git_command(&project_a)
+        .args(["add", "."])
+        .output()
+        .unwrap();
+    git_command(&project_a)
+        .args(["commit", "-m", "init-a"])
+        .output()
+        .unwrap();
+    fs::write(project_a.join("file-a.txt"), "modified").unwrap();
+
+    // Create project-b as a git sub-repo with an untracked file
+    let project_b = ws.join("project-b");
+    fs::create_dir_all(&project_b).unwrap();
+    let output = git_command(&project_b).arg("init").output().unwrap();
+    assert!(output.status.success(), "git init project-b failed");
+    fs::write(project_b.join("file-b.txt"), "tracked").unwrap();
+    git_command(&project_b)
+        .args(["add", "."])
+        .output()
+        .unwrap();
+    git_command(&project_b)
+        .args(["commit", "-m", "init-b"])
+        .output()
+        .unwrap();
+    fs::write(project_b.join("new-file.txt"), "untracked content").unwrap();
+
+    // Install the git_explorer plugin into the workspace
+    let plugins_dir = ws.join("plugins");
+    fs::create_dir_all(&plugins_dir).unwrap();
+    copy_plugin(&plugins_dir, "git_explorer");
+    copy_plugin_lib(&plugins_dir);
+
+    let mut harness = EditorTestHarness::with_working_dir(120, 40, ws.to_path_buf()).unwrap();
+
+    harness.editor_mut().toggle_file_explorer();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+        .unwrap();
+
+    // Wait for git_explorer to discover sub-repos and apply decorations.
+    // project-a/file-a.txt should show M (modified), project-b/new-file.txt should show U (untracked).
+    harness
+        .wait_until(|h| {
+            let screen = h.screen_to_string();
+            screen
+                .lines()
+                .any(|line| line.contains("project-a") && line.contains("●"))
+                || screen
+                    .lines()
+                    .any(|line| line.contains("file-a.txt") && line.contains("M"))
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    println!("Monorepo file explorer:\n{screen}");
+
+    // Verify project-b also has a decoration (● on directory or U on new-file.txt)
+    let has_project_b_decoration = screen
+        .lines()
+        .any(|line| line.contains("project-b") && line.contains("●"))
+        || screen
+            .lines()
+            .any(|line| line.contains("new-file") && line.contains("U"));
+    assert!(
+        has_project_b_decoration,
+        "project-b should show git status decorations in monorepo layout.\nScreen:\n{screen}"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -4160,10 +4160,7 @@ fn test_file_explorer_git_decorations_monorepo_subrepos() {
     let output = git_command(&project_a).arg("init").output().unwrap();
     assert!(output.status.success(), "git init project-a failed");
     fs::write(project_a.join("file-a.txt"), "original").unwrap();
-    git_command(&project_a)
-        .args(["add", "."])
-        .output()
-        .unwrap();
+    git_command(&project_a).args(["add", "."]).output().unwrap();
     git_command(&project_a)
         .args(["commit", "-m", "init-a"])
         .output()
@@ -4176,10 +4173,7 @@ fn test_file_explorer_git_decorations_monorepo_subrepos() {
     let output = git_command(&project_b).arg("init").output().unwrap();
     assert!(output.status.success(), "git init project-b failed");
     fs::write(project_b.join("file-b.txt"), "tracked").unwrap();
-    git_command(&project_b)
-        .args(["add", "."])
-        .output()
-        .unwrap();
+    git_command(&project_b).args(["add", "."]).output().unwrap();
     git_command(&project_b)
         .args(["commit", "-m", "init-b"])
         .output()

--- a/crates/fresh-editor/tests/e2e/plugins/watch_path.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/watch_path.rs
@@ -13,7 +13,6 @@
 use crate::common::harness::EditorTestHarness;
 use crate::common::tracing::init_tracing_from_env;
 use fresh_core::api::PluginCommand;
-use std::time::Duration;
 
 #[test]
 fn watch_path_round_trip_registers_and_fires() {
@@ -42,32 +41,26 @@ fn watch_path_round_trip_registers_and_fires() {
         .expect("watchPath should succeed for a fresh tmp directory");
     assert!(handle > 0, "handle should be a positive opaque id");
 
-    // Create a file inside the watched directory. notify reports
-    // create + (often) modify; we just need at least one
-    // PathChanged to surface to the editor.
+    // Create a file inside the watched directory. notify's backend decides
+    // whether the surfaced event names the created file or the watched
+    // directory itself — Linux inotify reports the directory (kind "other") —
+    // and how many events coalesce. So the only stable contract is the one the
+    // plugin hook guarantees: *some* path_changed fires for our handle under
+    // the watched dir. Wait indefinitely (semantic wait); nextest bounds it
+    // externally. A fixed timeout here is the source of the CI flake.
     let f = watched.join("trigger.txt");
     std::fs::write(&f, "hello").unwrap();
 
-    let mut got_event = false;
-    for _ in 0..120 {
-        harness.process_async_and_render().unwrap();
-        if harness
-            .editor()
-            .last_path_change_for_test()
-            .map(|(_h, p, _k)| p.ends_with("trigger.txt"))
-            .unwrap_or(false)
-        {
-            got_event = true;
-            break;
-        }
-        harness.sleep(Duration::from_millis(25));
-    }
-    assert!(
-        got_event,
-        "creating a file under the watched dir should produce a path_changed event; \
-         last seen: {:?}",
-        harness.editor().last_path_change_for_test()
-    );
+    harness
+        .wait_until(|h| {
+            h.editor()
+                .last_path_change_for_test()
+                .map(|(evt_handle, path, _kind)| {
+                    *evt_handle == handle && path.starts_with(&watched)
+                })
+                .unwrap_or(false)
+        })
+        .unwrap();
 
     harness
         .editor_mut()

--- a/crates/fresh-editor/tests/e2e/plugins/watch_path.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/watch_path.rs
@@ -54,11 +54,11 @@ fn watch_path_round_trip_registers_and_fires() {
     harness
         .wait_until(|h| {
             h.editor()
-                .last_path_change_for_test()
-                .map(|(evt_handle, path, _kind)| {
+                .path_changes_for_test()
+                .iter()
+                .any(|(evt_handle, path, _kind)| {
                     *evt_handle == handle && path.starts_with(&watched)
                 })
-                .unwrap_or(false)
         })
         .unwrap();
 

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -2341,10 +2341,26 @@ impl JsEditorApi {
                 .filter_map(|e| e.ok())
                 .map(|entry| {
                     let file_type = entry.file_type().ok();
+                    let is_symlink = file_type
+                        .as_ref()
+                        .map(|ft| ft.is_symlink())
+                        .unwrap_or(false);
+                    let (is_file, is_dir) = if is_symlink {
+                        let meta = std::fs::metadata(entry.path());
+                        (
+                            meta.as_ref().map(|m| m.is_file()).unwrap_or(false),
+                            meta.as_ref().map(|m| m.is_dir()).unwrap_or(false),
+                        )
+                    } else {
+                        (
+                            file_type.as_ref().map(|ft| ft.is_file()).unwrap_or(false),
+                            file_type.as_ref().map(|ft| ft.is_dir()).unwrap_or(false),
+                        )
+                    };
                     DirEntry {
                         name: entry.file_name().to_string_lossy().to_string(),
-                        is_file: file_type.map(|ft| ft.is_file()).unwrap_or(false),
-                        is_dir: file_type.map(|ft| ft.is_dir()).unwrap_or(false),
+                        is_file,
+                        is_dir,
                     }
                 })
                 .collect(),


### PR DESCRIPTION
## Summary

When opening a workspace that is not itself a git repository but contains nested git sub-projects (monorepo/multi-repo layout), fresh failed to:
- Recognize sub-projects as git repositories
- Display git status decorations in the file explorer
- Show correct branch name in the status bar
- Execute git blame, git grep, git find-file, and other git commands

This PR fixes all git-related functionality to work correctly in monorepo setups.

## Root Causes

1. **Symlink handling in `readDir`**: The `editor.readDir()` backend used `std::fs::DirEntry::file_type()` which does not follow symlinks. In monorepos, `.git` is often a symlink to the actual git directory — it was incorrectly reported as `is_dir=false`, preventing plugins from detecting git repos.

2. **Missing `cwd` in git command execution**: Most plugins called `editor.spawnProcess("git", args)` without specifying a `cwd` parameter, causing git commands to execute in the workspace root (which is not a git repo in monorepo setups). This caused all git operations to fail with "not a git repository" errors.

3. **Single-level sub-repo discovery**: The file explorer and git index watcher only scanned immediate subdirectories. Multi-level structures like `workspace/group/project/` were not discovered.

## Changes

### Core (Rust)

| File | Change |
|------|--------|
| `quickjs_backend.rs` | `read_dir` now follows symlinks via `std::fs::metadata()` to correctly report `is_dir` for `.git` symlinks |
| `file_operations.rs` | `resolve_git_index` uses BFS with max depth 3 to discover nested sub-repos |

### Plugins (TypeScript)

| File | Change |
|------|--------|
| `git_explorer.ts` | Added recursive `discoverSubRepos(dir, maxDepth=3)` for multi-level repo discovery |
| `git_statusbar.ts` | Added `getGitCwd()` helper — prioritizes active buffer's directory for branch detection |
| `git_blame.ts` | Passes `editor.pathDirname(filePath)` as cwd for `git blame` and `git show` |
| `git_find_file.ts` | Uses active buffer's directory as cwd for `git ls-files` |
| `git_log.ts` | Passes explicit cwd for `git show` |
| `live_grep.ts` | Git-grep availability check falls back to active buffer's directory |
| `merge_conflict.ts` | Passes file's directory as cwd for `git show :0:path` |
| `code-tour.ts` | Passes explicit cwd for `git rev-parse` |
| `audit_mode.ts` | All ~20 git spawn calls now use `state.repoRoot \|\| editor.getCwd()` as cwd |

## Design Decisions

- **Active buffer context**: For per-file operations (blame, status bar, find-file), the file's own directory is used as cwd. Git automatically resolves the containing repository via `rev-parse --show-toplevel`.
- **Recursive discovery with depth limit**: Sub-repo scanning stops at depth 3 and prunes at `.git` boundaries (won't enter a git repo to find submodules — those are managed by git itself).
- **Hidden directory filtering**: Directories starting with `.` are skipped during discovery to avoid scanning `.git`, `.cache`, `node_modules` etc.
- **Backward compatible**: For single-repo workspaces, behavior is unchanged — the explicit cwd resolves to the same directory that was previously used implicitly.

## Test Plan

- [x] Project compiles without errors
- [ ] Open a monorepo workspace (top-level dir with multiple git sub-projects)
- [ ] Verify file explorer shows git status decorations for sub-projects
- [ ] Verify status bar shows correct branch when editing a file in a sub-project
- [ ] Verify git blame works for files in sub-projects
- [ ] Verify git find-file (ls-files) lists files from the active sub-project
- [ ] Verify git grep searches within the active sub-project
- [ ] Verify Review Diff mode works for sub-project changes
- [ ] Open a single-repo workspace and verify all features still work as before

Made with [Cursor](https://cursor.com)