### PR TITLE
docs(ssh): document persistent sessions over SSH from a single jump box

### DIFF
--- a/docs/features/ssh.md
+++ b/docs/features/ssh.md
@@ -62,3 +62,21 @@ fresh -a
 ```
 
 You can also pair SSH with `tmux` for a similar effect—run `tmux` on the remote host and launch Fresh inside it. Daemon mode has the advantage of being built into Fresh, so editor state (open files, terminals, undo history) is preserved without an external multiplexer.
+
+### Single-install "jump box" pattern
+
+You don't need Fresh on every machine you edit. Pass a remote target directly to a daemon: the remote URL becomes the daemon's startup authority, so the daemon runs on the machine you launched it from (e.g. a jump/bastion host) and edits the remote over SSH. The target still only needs Python 3; Fresh is installed solely on the box you launch from.
+
+```bash
+# On the one box where Fresh is installed:
+fresh -a webserver deploy@server.example.com:/etc/nginx/nginx.conf
+
+# Detach (Command Palette → "Detach"), then reattach later from the same box:
+fresh -a webserver
+```
+
+Notes:
+
+- The remote target is only consumed when the daemon is *started*; reattaching to an existing daemon ignores it, so `fresh -a webserver` is enough to reconnect.
+- Unsaved buffers survive detach/reattach via [Hot Exit](./session-persistence.md#hot-exit).
+- A single workspace binds to one backend: you can't mix local and remote paths, or files from more than one remote host, *within the same workspace*. To work across backends, open more than one workspace. The **Orchestrator: New Workspace** command (`Ctrl+P` → "Orchestrator: New Workspace") spawns an additional workspace with its own authority, so a local workspace and a remote workspace (or workspaces on different hosts) can run side by side in one Fresh daemon.


### PR DESCRIPTION
## What

Documents the "jump box" workflow for SSH remote editing: launching a **persistent session bound to a remote target** from a single machine that has Fresh installed — `fresh -a <name> user@host:path`. Adds a short subsection to the existing *Alternative: SSH + Session Persistence* part of `docs/features/ssh.md`.

## Why

Remote editing and session persistence are documented separately. The current "SSH + Session Persistence" section only shows running `fresh -a` **on the remote host**, which assumes Fresh is installed there. But the CLI already supports passing a remote target straight to a persistent session, so you can keep Fresh on **one** jump/bastion box (targets only need Python 3) and still get detach/reattach persistence. That's a genuinely useful workflow that wasn't written down anywhere.

## This is existing, intended behavior — not a new feature

The combination is already implemented and guarded in `crates/fresh-editor/src/main.rs`:

- `run_attach()` calls `extract_ssh_url_from_files()` and forwards the result to `spawn_server_detached(session_name, ssh_url)` — the comment notes the remote URL "becomes the daemon's startup authority," and that it's consumed only when *starting* a server (reattach ignores it).
- `extract_ssh_url_from_files()` enforces the single-backend rule with explicit errors: "Cannot open files from multiple remote hosts" and "Cannot mix local and remote files."

The doc wording mirrors those semantics (one session = one backend; reattach with bare `fresh -a <name>`; unsaved buffers preserved via hot-exit).

## Notes

- Docs-only change; no code touched.
- Happy to adjust wording/placement, or fold it into the main flow instead of the alternatives section, if you'd prefer.