### PR TITLE
fix(popup): drive completion popup colors from the active theme

### DIFF
--- a/crates/fresh-editor/src/app/lsp_requests.rs
+++ b/crates/fresh-editor/src/app/lsp_requests.rs
@@ -209,6 +209,10 @@ impl Editor {
             crate::app::popup_actions::build_completion_popup_from_items(all_popup_items, 0);
         let accept_hint = self.completion_accept_key_hint();
         let focus_hint = self.popup_focus_key_hint();
+        let (popup_bg, popup_border_fg) = {
+            let theme = self.theme();
+            (theme.popup_bg, theme.popup_border_fg)
+        };
 
         {
             let buffer_id = self.active_buffer();
@@ -220,7 +224,8 @@ impl Editor {
                 .get_mut(&buffer_id)
                 .unwrap();
             // Convert PopupData to Popup and use show_or_replace to avoid stacking
-            let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+            let mut popup_obj =
+                crate::state::convert_popup_data_to_popup(&popup_data, popup_bg, popup_border_fg);
             popup_obj.accept_key_hint = accept_hint;
             popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
             popup_obj.focus_key_hint = focus_hint;
@@ -683,6 +688,10 @@ impl Editor {
         let popup_data = crate::app::popup_actions::build_completion_popup_from_items(items, 0);
         let accept_hint = self.completion_accept_key_hint();
         let focus_hint = self.popup_focus_key_hint();
+        let (popup_bg, popup_border_fg) = {
+            let theme = self.theme();
+            (theme.popup_bg, theme.popup_border_fg)
+        };
 
         let buffer_id = self.active_buffer();
         let state = self
@@ -692,7 +701,8 @@ impl Editor {
             .expect("active window present")
             .get_mut(&buffer_id)
             .unwrap();
-        let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+        let mut popup_obj =
+            crate::state::convert_popup_data_to_popup(&popup_data, popup_bg, popup_border_fg);
         popup_obj.accept_key_hint = accept_hint;
         popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
         popup_obj.focus_key_hint = focus_hint;

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3124,22 +3124,15 @@ impl Editor {
         // The resolver carries the popup_id so confirm/cancel fires
         // `action_popup_result` for exactly THIS popup, even when
         // multiple plugin popups are stacked concurrently.
-        let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+        let (popup_bg, popup_border_fg) = {
+            let theme = self.theme();
+            (theme.popup_bg, theme.popup_border_fg)
+        };
+        let mut popup_obj =
+            crate::state::convert_popup_data_to_popup(&popup_data, popup_bg, popup_border_fg);
         popup_obj.resolver = crate::view::popup::PopupResolver::PluginAction {
             popup_id: popup_id.clone(),
         };
-
-        // `convert_popup_data_to_popup` hardcodes a default dark
-        // background because it has no theme handle (it's called from
-        // `EditorState::apply` too). Restamp the active theme's
-        // `popup_bg` / `popup_border_fg` here so plugin popups don't
-        // render as a near-black rectangle on top of a light theme —
-        // #1941 issue 2.
-        {
-            let theme = self.theme();
-            popup_obj.background_style = ratatui::style::Style::default().bg(theme.popup_bg);
-            popup_obj.border_style = ratatui::style::Style::default().fg(theme.popup_border_fg);
-        }
 
         // Dismiss any built-in LSP-status popup that the editor put
         // on `active_state().popups` in response to the same click —

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -567,6 +567,10 @@ impl Editor {
 
         let popup_data = build_completion_popup_from_items(all_popup_items, selected);
         let accept_hint = self.completion_accept_key_hint();
+        let (popup_bg, popup_border_fg) = {
+            let theme = self.theme();
+            (theme.popup_bg, theme.popup_border_fg)
+        };
 
         // Close old popup and show new one
         self.hide_popup();
@@ -578,7 +582,8 @@ impl Editor {
             .expect("active window present")
             .get_mut(&buffer_id)
             .unwrap();
-        let mut popup_obj = crate::state::convert_popup_data_to_popup(&popup_data);
+        let mut popup_obj =
+            crate::state::convert_popup_data_to_popup(&popup_data, popup_bg, popup_border_fg);
         popup_obj.accept_key_hint = accept_hint;
         popup_obj.resolver = crate::view::popup::PopupResolver::Completion;
         state.popups.show_or_replace(popup_obj);

--- a/crates/fresh-editor/src/app/popup_overlay_actions.rs
+++ b/crates/fresh-editor/src/app/popup_overlay_actions.rs
@@ -85,13 +85,12 @@ impl Editor {
         // doesn't carry this — it's a view-layer concern set after the
         // converter pushes the Popup onto the active buffer's stack.
         //
-        // Same logic for the popup's background / border styles: the
-        // `convert_popup_data_to_popup` shim (state.rs:1040) has no
-        // theme handle, so it pushes a popup with a default-dark
-        // background. Override it here with the active theme's
-        // `popup_bg` / `popup_border_fg` so e.g. a plugin's
-        // `showActionPopup` doesn't render as a near-black rectangle
-        // inside a light theme.
+        // Background / border: the `convert_popup_data_to_popup` shim is
+        // called from `EditorState::apply` without a theme handle, so its
+        // replay path uses theme *defaults*. Re-stamp here with the
+        // *live* theme's `popup_bg` / `popup_border_fg` so the popup
+        // tracks the user's active theme (e.g. an ANSI-16 dark theme
+        // overrides the default `Rgb(30, 30, 30)` here).
         let hint = self.popup_focus_key_hint();
         let (popup_bg, popup_border_fg) = {
             let theme = self.theme();

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -687,7 +687,19 @@ impl EditorState {
             }
 
             Event::ShowPopup { popup } => {
-                let popup_obj = convert_popup_data_to_popup(popup);
+                // The replay path has no theme handle, so we synthesize the
+                // popup with theme *defaults*. Editor-level callers
+                // (`Editor::apply_event_to_active_buffer`) intercept
+                // `Event::ShowPopup` *before* it reaches `state.apply` and
+                // build the popup with the live theme — see `event_apply.rs`.
+                // This arm is reached only when tests drive `state.apply`
+                // directly (no surrounding `Editor`).
+                use crate::view::theme::{default_popup_bg, default_popup_border_fg};
+                let popup_obj = convert_popup_data_to_popup(
+                    popup,
+                    default_popup_bg().into(),
+                    default_popup_border_fg().into(),
+                );
                 self.popups.show_or_replace(popup_obj);
             }
 
@@ -1045,8 +1057,17 @@ fn convert_event_face_to_overlay_face(event_face: &EventOverlayFace) -> OverlayF
     }
 }
 
-/// Convert popup data to the actual popup object
-pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
+/// Convert popup data to the actual popup object.
+///
+/// `popup_bg` and `popup_border_fg` come from the active theme (the
+/// caller resolves them from `Theme::popup_bg` / `Theme::popup_border_fg`,
+/// which are already `ratatui::style::Color`). The replay path inside
+/// `EditorState::apply` has no theme handle and falls back to theme defaults.
+pub(crate) fn convert_popup_data_to_popup(
+    data: &PopupData,
+    popup_bg: Color,
+    popup_border_fg: Color,
+) -> Popup {
     let content = match &data.content {
         crate::model::event::PopupContentData::Text(lines) => PopupContent::Text(lines.clone()),
         crate::model::event::PopupContentData::List { items, selected } => PopupContent::List {
@@ -1132,8 +1153,8 @@ pub(crate) fn convert_popup_data_to_popup(data: &PopupData) -> Popup {
         width: data.width,
         max_height: data.max_height,
         bordered: data.bordered,
-        border_style: Style::default().fg(Color::Gray),
-        background_style: Style::default().bg(Color::Rgb(30, 30, 30)),
+        border_style: Style::default().fg(popup_border_fg),
+        background_style: Style::default().bg(popup_bg),
         scroll_offset: 0,
         text_selection: None,
         accept_key_hint: None,

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -1388,15 +1388,26 @@ impl Popup {
                             }
                         }
 
-                        // Row style (background only, no underline)
+                        // Row style: stamp the popup's text fg/bg on the
+                        // whole row so item text reads against the popup
+                        // surface rather than inheriting the terminal's
+                        // default fg (which has no relationship to the
+                        // themed popup_bg / popup_selection_bg). Selected
+                        // rows use popup_selection_fg/bg, hovered rows
+                        // use menu_hover_*, otherwise popup_text_fg on
+                        // popup_bg.
                         let row_style = if is_selected {
-                            Style::default().bg(theme.popup_selection_bg)
+                            Style::default()
+                                .fg(theme.popup_selection_fg)
+                                .bg(theme.popup_selection_bg)
                         } else if is_hovered {
                             Style::default()
                                 .bg(theme.menu_hover_bg)
                                 .fg(theme.menu_hover_fg)
                         } else {
                             Style::default()
+                                .fg(theme.popup_text_fg)
+                                .bg(theme.popup_bg)
                         };
 
                         ListItem::new(Line::from(spans)).style(row_style)

--- a/crates/fresh-editor/src/view/theme/types.rs
+++ b/crates/fresh-editor/src/view/theme/types.rs
@@ -998,10 +998,10 @@ fn default_prompt_selection_bg() -> ColorDef {
 }
 
 // Default popup colors
-fn default_popup_border_fg() -> ColorDef {
+pub(crate) fn default_popup_border_fg() -> ColorDef {
     ColorDef::Named("Gray".to_string())
 }
-fn default_popup_bg() -> ColorDef {
+pub(crate) fn default_popup_bg() -> ColorDef {
     ColorDef::Rgb(30, 30, 30)
 }
 fn default_popup_selection_bg() -> ColorDef {

--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -120,6 +120,11 @@ const KEY_COMPLETION_DIM_FG: &str = "ui.menu_disabled_fg";
 // re-skin one re-skin the other.
 const KEY_COMPLETION_SEL_FG: &str = "ui.popup_selection_fg";
 const KEY_COMPLETION_SEL_BG: &str = "ui.popup_selection_bg";
+// Foreground for *unselected* completion rows. Without this, the
+// row text inherits the terminal's default foreground, which has
+// no relationship to the popup's themed `popup_bg` and reads
+// poorly on coloured backgrounds.
+const KEY_COMPLETION_FG: &str = "ui.popup_text_fg";
 // Border chrome the popup paints around its own rows (the
 // `│ ... │` sides extending below the input + the `╰─...─╯`
 // closing border). Distinct theme key from the wrapping
@@ -2651,7 +2656,16 @@ fn render_completion_item(
             ..Default::default()
         })
     } else {
-        None
+        // Stamp the popup's text fg on the whole row so the
+        // candidate text reads against `popup_bg` rather than
+        // inheriting the terminal's default foreground (which
+        // has no relationship to the themed popup surface).
+        Some(OverlayOptions {
+            fg: Some(OverlayColorSpec::theme_key(KEY_COMPLETION_FG)),
+            extend_to_line_end: true,
+            fg_on_collision_only: false,
+            ..Default::default()
+        })
     };
     let mut inline_overlays: Vec<InlineOverlay> = Vec::new();
     // History rows: paint the `↶` marker in the popup-border

--- a/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
@@ -11,11 +11,13 @@
 //!      two popups on the buffer's popup stack.
 //!
 //!   2. **Plugin popup ignores the theme.** Every popup that flows
-//!      through `Event::ShowPopup` → `convert_popup_data_to_popup`
-//!      ends up with `background_style.bg = Color::Rgb(30, 30, 30)`,
+//!      through `Event::ShowPopup` → `convert_popup_data_to_popup` used
+//!      to end up with `background_style.bg = Color::Rgb(30, 30, 30)`,
 //!      hardcoded at `state.rs:convert_popup_data_to_popup`. In a
-//!      light theme that's a near-black rectangle in the middle of a
-//!      near-white UI.
+//!      light theme that was a near-black rectangle in the middle of
+//!      a near-white UI. Fixed: the converter now takes `popup_bg` /
+//!      `popup_border_fg` parameters; `Editor::show_popup` re-stamps
+//!      with the live theme after the event-replay path.
 //!
 //!   3. **Popup keeps showing "ready / indexing" after the server
 //!      died externally** (SIGKILL by the OOM killer, `process_limits`,
@@ -42,8 +44,9 @@
 //!      stops (e.g. server died, see #3), the spinner appears frozen
 //!      and only twitches forward by one glyph on user input.
 //!
-//! Each test is written so that **it fails today** (i.e. the bug is
-//! observable) and would pass once the bug is fixed.
+//! Each test is written so that **it fails when the bug is observable**
+//! and passes once the bug is fixed (issue 2 is fixed and the test now
+//! serves as a regression guard).
 
 use std::time::Duration;
 
@@ -311,16 +314,18 @@ fn issue_1_click_stacks_plugin_popup_and_lsp_servers_popup() -> anyhow::Result<(
 }
 
 // ---------------------------------------------------------------------------
-// Issue 2 — popups created via the `PopupData` event use a hardcoded
-//           dark background that ignores the theme.
+// Issue 2 — popups created via the `PopupData` event must follow the
+//           active theme (regression guard).
 // ---------------------------------------------------------------------------
 //
-// `state.rs::convert_popup_data_to_popup` sets
+// `state.rs::convert_popup_data_to_popup` used to set
 //     background_style: Style::default().bg(Color::Rgb(30, 30, 30))
 // regardless of theme. Every plugin popup (rust-lsp's "Not Found",
 // the Rust LSP mode chooser, every `editor.showActionPopup` call, …)
-// flows through that conversion and ends up with the same near-black
-// rectangle. In a light theme this is unmistakable on screen.
+// flowed through that conversion and ended up with the same near-black
+// rectangle. The converter now takes `popup_bg` / `popup_border_fg`
+// parameters and `Editor::show_popup` re-stamps with the live theme
+// after the event-replay path. This test guards against regression.
 
 #[test]
 fn issue_2_show_popup_ignores_theme_popup_bg() -> anyhow::Result<()> {
@@ -335,8 +340,8 @@ fn issue_2_show_popup_ignores_theme_popup_bg() -> anyhow::Result<()> {
 
     // Sanity: the theme has a `popup_bg` defined. If this ever became
     // `Color::Reset` we'd want a separate check; for now any
-    // non-`Reset` value is fine — the bug is that the rendered popup
-    // uses a *different* color (the hardcoded 30,30,30 dark grey).
+    // non-`Reset` value is fine — the regression we're guarding is
+    // the popup using a *different* color (e.g. hardcoded dark grey).
     assert_ne!(
         theme_popup_bg,
         Color::Reset,
@@ -378,10 +383,10 @@ fn issue_2_show_popup_ignores_theme_popup_bg() -> anyhow::Result<()> {
     assert_eq!(
         bg,
         Some(theme_popup_bg),
-        "BUG: a popup created via `Event::ShowPopup` has background \
-         {:?}, but the active theme's `popup_bg` is {:?}. \
-         `convert_popup_data_to_popup` hardcodes \
-         `Color::Rgb(30, 30, 30)` instead of reading the theme.",
+        "regression: a popup created via `Event::ShowPopup` has background \
+         {:?}, but the active theme's `popup_bg` is {:?}. The converter \
+         should be called with the live theme's `popup_bg`, or \
+         `Editor::show_popup` should re-stamp it.",
         bg,
         theme_popup_bg
     );


### PR DESCRIPTION
Popups (LSP completion, plugin actions, anything pushed via
Event::ShowPopup) ignored the theme's popup_* keys: the background
was hardcoded to Color::Rgb(30, 30, 30), and PopupContent::List
rows never stamped popup_selection_fg / popup_text_fg, so item
text inherited the terminal's default foreground.

- Thread popup_bg / popup_border_fg through convert_popup_data_to_popup.
  Editor-level callers pass the live theme; the replay path falls
  back to default_popup_bg / default_popup_border_fg.
- PopupContent::List row rendering now stamps popup_selection_fg/bg on
  selected rows and popup_text_fg/popup_bg on unselected rows.
- Stamp ui.popup_text_fg on unselected rows in the prompt-toolbar
  completion dropdown (widgets/render.rs).

Existing issue_2_show_popup_ignores_theme_popup_bg test is reframed
from a known-fail bug doc into a passing regression guard.

Before:
<img width="620" height="205" alt="image" src="https://github.com/user-attachments/assets/1866a70a-61ec-4103-a452-405f2b291cdc" />

After:
<img width="633" height="186" alt="image" src="https://github.com/user-attachments/assets/046b9efa-c1f8-4da7-b5e9-9bab9005cce7" />


Closes #2378
