### PR TITLE
Move per-read/per-resolve logging off the hot path to break log feedback loop

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3921,14 +3921,6 @@ pub enum PluginCommand {
     },
 }
 
-impl PluginCommand {
-    /// Extract the enum variant name from the Debug representation.
-    pub fn debug_variant_name(&self) -> String {
-        let dbg = format!("{:?}", self);
-        dbg.split([' ', '{', '(']).next().unwrap_or("?").to_string()
-    }
-}
-
 // =============================================================================
 // Language Pack Configuration Types
 // =============================================================================
@@ -6046,23 +6038,6 @@ mod tests {
         let tk = OverlayColorSpec::theme_key("ui.status_bar_bg");
         assert_eq!(tk.as_rgb(), None);
         assert_eq!(tk.as_theme_key(), Some("ui.status_bar_bg"));
-    }
-
-    /// `PluginCommand::debug_variant_name` returns the actual variant name
-    /// derived from the `Debug` impl, not an empty or hard-coded string.
-    #[test]
-    fn plugin_command_debug_variant_name_returns_real_variant() {
-        let c = PluginCommand::SetStatus {
-            message: "hi".into(),
-        };
-        assert_eq!(c.debug_variant_name(), "SetStatus");
-
-        let c2 = PluginCommand::InsertText {
-            buffer_id: BufferId(1),
-            position: 0,
-            text: String::new(),
-        };
-        assert_eq!(c2.debug_variant_name(), "InsertText");
     }
 
     // ── PluginApi dispatch / mutation tests ────────────────────────────────

--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1547,13 +1547,6 @@ impl Editor {
             _ => true,
         });
 
-        let cmd_names: Vec<String> = commands.iter().map(|c| c.debug_variant_name()).collect();
-        tracing::trace!(
-            count = commands.len(),
-            cmds = ?cmd_names,
-            "process_plugin_commands"
-        );
-
         for command in &commands {
             match command {
                 fresh_core::api::PluginCommand::RegisterGrammar {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -496,11 +496,6 @@ impl Editor {
             let dispatched_any = {
                 let commands = self.plugin_manager.write().unwrap().process_commands();
                 let dispatched_any = !commands.is_empty();
-                if dispatched_any {
-                    let cmd_names: Vec<String> =
-                        commands.iter().map(|c| c.debug_variant_name()).collect();
-                    tracing::trace!(count = commands.len(), cmds = ?cmd_names, "process_commands during render");
-                }
                 for command in commands {
                     if let Err(e) = self.handle_plugin_command(command) {
                         tracing::error!("Error handling plugin command: {}", e);

--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -520,7 +520,16 @@ impl TerminalManager {
                         }
                         Ok(n) => {
                             total_bytes += n;
-                            tracing::debug!(
+                            // Per-read logging is on the PTY hot path: a busy
+                            // terminal reads tens of thousands of chunks/sec, so
+                            // this must stay at `trace` (off by default). At
+                            // `debug` it not only floods the log but, if that log
+                            // is being `tail -f`'d into a terminal this manager
+                            // owns, it closes a positive-feedback loop (each read
+                            // logs a line, which tail echoes, which is read and
+                            // logged again). Lifecycle boundaries (EOF, error)
+                            // are logged above/below at higher levels instead.
+                            tracing::trace!(
                                 "Terminal {:?} received {} bytes (total: {})",
                                 terminal_id,
                                 n,

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -6907,15 +6907,14 @@ impl QuickJsBackend {
 
                 // Resolve a pending callback (called from Rust)
                 globalThis._resolveCallback = function(callbackId, result) {
-                    console.log('[JS] _resolveCallback called with callbackId=' + callbackId + ', pendingCallbacks.size=' + globalThis._pendingCallbacks.size);
+                    // No per-resolve logging here: this fires once per async op
+                    // completion (potentially at very high frequency), and
+                    // console.log is captured into the host log, so logging here
+                    // floods the log and can feed a tail-driven feedback loop.
                     const cb = globalThis._pendingCallbacks.get(callbackId);
                     if (cb) {
-                        console.log('[JS] _resolveCallback: found callback, calling resolve()');
                         globalThis._pendingCallbacks.delete(callbackId);
                         cb.resolve(result);
-                        console.log('[JS] _resolveCallback: resolve() called');
-                    } else {
-                        console.log('[JS] _resolveCallback: NO callback found for id=' + callbackId);
                     }
                 };
 

--- a/crates/fresh-plugin-runtime/src/thread.rs
+++ b/crates/fresh-plugin-runtime/src/thread.rs
@@ -1254,7 +1254,11 @@ async fn handle_request(
             callback_id,
             result_json,
         } => {
-            tracing::info!(
+            // One callback resolves per async op completion; a plugin that
+            // fires async calls in bulk (or a feedback loop) drives this at
+            // high frequency, and `result_json` can be large. Keep both at
+            // `trace` so it's off by default and not amplifying log volume.
+            tracing::trace!(
                 "ResolveCallback: resolving callback_id={} with result_json={}",
                 callback_id,
                 result_json
@@ -1263,7 +1267,7 @@ async fn handle_request(
                 .borrow_mut()
                 .resolve_callback(callback_id, &result_json);
             // resolve_callback now runs execute_pending_job() internally
-            tracing::info!(
+            tracing::trace!(
                 "ResolveCallback: done resolving callback_id={}",
                 callback_id
             );


### PR DESCRIPTION
A busy PTY reads tens of thousands of chunks/sec and a plugin can resolve
async callbacks at the same rate. Three log sites fired unconditionally on
those hot paths and were captured into the host log:

- terminal manager logged every PTY read at `debug` (with a running byte
  total),
- the plugin runtime logged every `ResolveCallback` at `info` (including
  the full `result_json`),
- the QuickJS bootstrap `console.log`'d three lines per callback resolve.

Besides flooding the log, these close a positive-feedback loop when the
log file is `tail -f`'d into a terminal the manager owns: each read logs a
line, tail echoes it into the terminal, the manager reads and logs it
again, and so on — pegging CPU and growing memory without bound.

Drop the per-resolve `console.log`s, move the per-read terminal log and
the per-resolve runtime logs to `trace` (off by default, and lazily
formatted so they cost nothing when disabled). Lifecycle boundaries (EOF,
errors) stay logged at their existing higher levels.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015199iMqbyVkN1pQBg4GcBY