### PR TITLE
test(live_diff): fix flaky virtual-line anchoring test via stable wait

### DIFF
--- a/crates/fresh-editor/tests/e2e/open_folder.rs
+++ b/crates/fresh-editor/tests/e2e/open_folder.rs
@@ -961,13 +961,25 @@ fn test_switch_project_double_click_parent_navigates_up() {
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
 
-    // Wait for the folder browser, including the ".." entry.
+    // Wait for the folder browser AND its async directory listing to land.
+    // There are two ".." on screen: the inline parent *shortcut* on the
+    // "Navigation:" line (built synchronously, so it appears the instant the
+    // browser opens) and the ".." *list entry* (added only when the async
+    // directory read completes). The click below targets the list entry by
+    // anchoring below the header, so a bare `screen.contains("..")` is the
+    // wrong signal — it is satisfied by the sync shortcut before the list
+    // populates, after which the row-finder below finds no ".." entry and
+    // panics. Gate on the same thing the click needs: a ".." on a row below
+    // the Navigation header.
     harness
         .wait_until(|h| {
             let screen = h.screen_to_string();
-            screen.contains("Navigation:") && screen.contains("..")
+            let Some(nav_row) = screen.lines().position(|l| l.contains("Navigation:")) else {
+                return false;
+            };
+            screen.lines().skip(nav_row + 1).any(|l| l.contains(".."))
         })
-        .expect("Folder browser should appear with parent entry");
+        .expect("Folder browser should appear with the parent ('..') list entry");
 
     // Locate the row with the ".." entry by *position*, not by dot-matching.
     // The ".." entry is the first list row, which sits below the

--- a/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/live_diff.rs
@@ -633,9 +633,17 @@ fn test_live_diff_virtual_line_anchored_to_correct_modified_line() {
     harness.type_text(APPEND_PAYLOAD).unwrap();
     harness.render().unwrap();
 
-    // Wait until BOTH OLD virtual lines are present as their own rows.
+    // Wait until BOTH OLD virtual lines are present as their own rows AND
+    // the screen has stopped changing. Presence alone is necessary but not
+    // sufficient for the anchoring assertions below: the recompute is
+    // debounced/async, so there is a transient window where both virtual
+    // lines exist but the layout hasn't converged to its final anchoring
+    // yet. Snapshotting that intermediate frame produces an off-by-one row
+    // (the source of the rare flake). `wait_until_stable` drains the
+    // debounce before we read the buffer, so the positioning assertions run
+    // against a settled frame.
     harness
-        .wait_until(|h| {
+        .wait_until_stable(|h| {
             let s = h.screen_to_string();
             virtual_row_present(&s, "UNIQUE_IF_BODY_OLD_MARKER")
                 && virtual_row_present(&s, "UNIQUE_ELSE_BODY_OLD_MARKER")


### PR DESCRIPTION
The virtual-line anchoring assertions snapshot the buffer right after a
plain `wait_until` that only checks both OLD virtual rows are *present*.
Presence is necessary but not sufficient for the asserted invariant: the
live-diff recompute is debounced/async, so there is a transient window
where both virtual lines exist but the layout has not yet converged to
its final anchoring. Snapshotting that intermediate frame yields an
off-by-one row, which is the rare CI flake.

Per CONTRIBUTING's "semantic waiting" guideline, wait for the specific
state the assertion depends on. Switch the snapshot-feeding wait to
`wait_until_stable`, which drains the debounce (waits for the screen to
stop changing) before reading the buffer, so the positioning assertions
run against a settled frame. A genuine regression still fails fast with
the existing descriptive message.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JdBmHizWu2dXWZNABV1Szu