### PR TITLE
Remove stray XML tags from session persistence documentation

### DIFF
--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -215,5 +215,3 @@ Check for forgotten daemons with `fresh --cmd daemon list`.
 | Linux | `$XDG_RUNTIME_DIR/fresh/` or `/tmp/fresh-$UID/` |
 | macOS | `/tmp/fresh-$UID/` |
 | Windows | `%LOCALAPPDATA%\fresh\sockets\` |
-</content>
-</invoke>


### PR DESCRIPTION
## Summary
Removed erroneous XML closing tags that were inadvertently left in the session persistence documentation file.

## Changes
- Removed `</content>` and `</invoke>` XML tags from the end of `docs/features/session-persistence.md`

## Details
These tags appear to be remnants from a templating or generation process and do not belong in the markdown documentation. The file now ends cleanly after the socket directory table for different operating systems.

https://claude.ai/code/session_01QMCuksFiv8ASyXnchcvPHo