### PR TITLE
fix(splits): reveal opened file hidden behind a maximized split

### DIFF
--- a/crates/fresh-editor/src/app/file_open_orchestrators.rs
+++ b/crates/fresh-editor/src/app/file_open_orchestrators.rs
@@ -176,6 +176,13 @@ impl Editor {
 
         self.set_active_buffer(buffer_id);
 
+        // Opening a file focuses a buffer in the active split. If a
+        // *different* split is maximized (most commonly the docked
+        // terminal), the renderer shows only the maximized split, so the
+        // freshly-focused buffer would be invisible. Restore the layout so
+        // the user actually sees the file they just opened.
+        self.reveal_active_split_if_hidden_by_maximize();
+
         // If the initial empty buffer was replaced in-place with file content,
         // set_active_buffer is a no-op (same buffer ID). Fire buffer_activated
         // explicitly so plugins see the newly loaded file.
@@ -217,6 +224,32 @@ impl Editor {
         }
 
         Ok(buffer_id)
+    }
+
+    /// Restore the split layout when the just-focused buffer would be
+    /// hidden behind a maximized split.
+    ///
+    /// `SplitManager::get_visible_buffers` renders *only* the maximized
+    /// split. A file open focuses its buffer in the active split, which —
+    /// after `redirect_active_split_away_from_dock_if_needed` — is a
+    /// regular editor leaf, not the maximized dock. With nothing reset, the
+    /// new buffer renders behind the maximized terminal: the user sees no
+    /// change, and an embedded `fresh <file>` that forwarded the open
+    /// blocks waiting for that invisible buffer to be closed, so the
+    /// terminal appears to hang. Un-maximize so the focused buffer shows.
+    fn reveal_active_split_if_hidden_by_maximize(&mut self) {
+        let mgr = self.split_manager();
+        let active: crate::model::event::SplitId = mgr.active_split().into();
+        let hidden = matches!(mgr.maximized_split(), Some(maximized) if maximized != active);
+        if !hidden {
+            return;
+        }
+        // `unmaximize_split` only errors when nothing is maximized, which
+        // the `hidden` guard above already excludes.
+        self.split_manager_mut()
+            .unmaximize_split()
+            .expect("a split is maximized (checked above)");
+        self.relayout();
     }
 
     /// If the active split leaf carries `SplitRole::UtilityDock`,

--- a/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
+++ b/crates/fresh-editor/tests/e2e/dock_panel_routing.rs
@@ -227,3 +227,108 @@ fn test_maximize_button_click_targets_clicked_split_not_active() {
         "After maximizing the top split, main.txt should still be on screen.\nScreen:\n{screen}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bug 3
+// ---------------------------------------------------------------------------
+
+/// Maximize the focused dock via the command palette ("Toggle Maximize
+/// Split"). The dock currently holds focus, so it becomes the maximized
+/// split and the editor content is hidden.
+fn maximize_focused_dock(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    harness.type_text("Toggle Maximize Split").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Toggle Maximize Split"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    // A maximized split shows the restore glyph "⧉" on its tab bar in
+    // place of the "□" maximize glyph. (The global status bar's "Maximized
+    // split" message is covered by the dock's own footer here, so the glyph
+    // is the reliable rendered signal.)
+    harness
+        .wait_until(|h| h.screen_to_string().contains('⧉'))
+        .unwrap();
+}
+
+/// Opening a file while a *different* split is maximized must restore the
+/// layout so the freshly-focused buffer is actually visible.
+///
+/// This is the rendered-output repro of the embedded-`fresh` hang: with the
+/// docked panel maximized, forwarding a file open from a nested process (or
+/// any Quick Open — both go through `Editor::open_file`) focuses the buffer
+/// in the editor split, but `get_visible_buffers` only draws the maximized
+/// dock. The buffer renders hidden behind the dock, so the user sees no
+/// change and a blocking `fresh <file>` forward looks like it has hung.
+///
+/// Fails on the buggy build (the opened file's content never renders) and
+/// passes once the open path un-maximizes to reveal the focused split.
+#[test]
+fn test_open_file_while_split_maximized_reveals_buffer() {
+    let (_temp_dir, project_root) = setup_dock_project();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        30,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+    harness.open_file(&project_root.join("main.txt")).unwrap();
+    harness.render().unwrap();
+
+    // Open Search/Replace in the bottom dock (it takes focus), then
+    // maximize it so only the dock is shown.
+    open_search_replace_panel(&mut harness);
+    maximize_focused_dock(&mut harness);
+
+    // Precondition: maximizing the dock hides the editor — main.txt's
+    // content is no longer on screen.
+    harness
+        .wait_until_stable(|h| !h.screen_to_string().contains("main file content"))
+        .unwrap();
+
+    // Now open another file via Quick Open. This focuses other.txt in the
+    // editor split. Under the bug the dock stays maximized and the new
+    // buffer renders behind it; the fix restores the layout.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.wait_for_prompt().unwrap();
+    // Drop the ">" command-mode prefix the palette remembers from the
+    // previous (maximize) invocation, so the filename query runs in file mode.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("other").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("other.txt"))
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.wait_for_prompt_closed().unwrap();
+
+    // The "Opened …/other.txt" status (full path) lands in the always-visible
+    // status bar in both the buggy and fixed builds, so this wait completes
+    // either way — it just marks "the open finished". The assertion below is
+    // what distinguishes them.
+    harness
+        .wait_until_stable(|h| {
+            let s = h.screen_to_string();
+            s.contains("Opened ") && s.contains("other.txt")
+        })
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("other file content"),
+        "Bug: the opened file is hidden behind the maximized dock — its content never \
+         rendered, so the user can't see the buffer that was opened.\nScreen:\n{screen}"
+    );
+}


### PR DESCRIPTION
Opening a file focuses its buffer in the active split, but the renderer
(`SplitManager::get_visible_buffers`) draws *only* the maximized split.
When the docked terminal is maximized and an embedded `fresh <file>`
forwards the open to the parent, the file routes to a regular editor
leaf — not the maximized dock — so the new buffer renders behind the
terminal. The user sees no change, and because the forwarding child
blocks until that buffer is closed, the terminal looks like it has hung
with no way to tell a buffer is waiting.

Un-maximize on the file-open path whenever the freshly-focused buffer
lands in a split other than the maximized one, so the buffer the user
just asked for is actually visible. Opens that target the maximized
split itself (the common editor-maximize case) are untouched.

Adds an e2e reproduction in dock_panel_routing.rs that maximizes the
focused dock, opens another file via Quick Open (the same `open_file`
path the embedded-fresh forward uses), and asserts the file's content
renders. It fails on the unfixed build and passes with the fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XNnHSMPCtd5JrfvpoZdAgX