### PR TITLE
fix(env): scope env activation to the active window, not a full editor restart

### DIFF
--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -896,10 +896,13 @@ impl Editor {
     /// Handle an action (for normal mode and command execution).
     /// Used by the app module internally and by the GUI module for native menu dispatch.
     /// Change the current workspace's trust level, persist it, and report it.
-    /// When the level actually changes, the editor restarts so the new policy
-    /// applies to already-running tooling (a now-trusted project's LSP starts;
-    /// a now-restricted/blocked one is torn down). Already-correct selections
-    /// (e.g. confirming the current level) only persist the decision.
+    /// The new policy applies live at the next authority-routed spawn (the
+    /// guarding spawners read the level on every spawn) — there is NO editor
+    /// restart here, deliberately: a rebuild would reset every other
+    /// orchestrator session's buffers/layout (see the body). Trust-gated work
+    /// re-triggers via the `trust_changed` hook instead (e.g. env-manager
+    /// re-activates a now-trusted env). Already-correct selections (e.g.
+    /// confirming the current level) only persist the decision.
     pub(crate) fn set_workspace_trust_level(
         &mut self,
         level: crate::services::workspace_trust::TrustLevel,

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1520,8 +1520,9 @@ impl Editor {
             self.authority()
                 .env_provider
                 .set(snippet, dir.map(std::path::PathBuf::from));
-            // Re-evaluate already-running tooling under the new env.
-            self.request_restart(self.working_dir().to_path_buf());
+            // Re-evaluate already-running tooling under the new env — scoped to
+            // THIS window only.
+            self.refresh_active_window_lsp_for_env();
         } else {
             self.active_window_mut().status_message =
                 Some("Workspace not trusted — cannot activate environment".to_string());
@@ -1532,7 +1533,48 @@ impl Editor {
         let was_active = self.authority().env_provider.is_active();
         self.authority().env_provider.clear();
         if was_active {
-            self.request_restart(self.working_dir().to_path_buf());
+            self.refresh_active_window_lsp_for_env();
+        }
+    }
+
+    /// Re-launch the *active window's* already-running language servers so they
+    /// pick up a just-changed environment (`editor.setEnv` / `clearEnv`),
+    /// WITHOUT a process-wide editor rebuild.
+    ///
+    /// The window's `EnvProvider` is updated in place (see
+    /// `services::env_provider` — "the plugin sets the recipe in place […] and
+    /// there is no authority rebuild"), so every *new* spawn — new terminals,
+    /// servers started later — already inherits the change. Only servers that
+    /// were spawned under the old env need a re-launch, and only this window's:
+    /// each `Window` owns its own LSP, terminals, and authority, so a single
+    /// workspace's env activation must not touch the others. The previous
+    /// `request_restart` here rebuilt the whole editor — tearing down every
+    /// other orchestrator session's terminals and closing the dock — which is
+    /// the "Trust restarted everything" bug. Already-open terminals keep
+    /// running and only adopt the new env when reopened (matching the env
+    /// subsystem's lazy, capture-at-spawn model).
+    fn refresh_active_window_lsp_for_env(&mut self) {
+        let active_id = self.active_window;
+        let running: Vec<String> = self
+            .windows
+            .get(&active_id)
+            .map(|w| w.lsp.running_servers())
+            .unwrap_or_default();
+        if running.is_empty() {
+            return;
+        }
+        let file_path = self
+            .active_window()
+            .buffer_metadata
+            .get(&self.active_buffer())
+            .and_then(|meta| meta.file_path().cloned());
+        for language in &running {
+            if let Some(w) = self.windows.get_mut(&active_id) {
+                let _ = w.lsp.manual_restart(language, file_path.as_deref());
+            }
+            // Re-send didOpen for this language's buffers so the fresh server
+            // (now under the new env) sees the open documents.
+            self.reopen_buffers_for_language(language);
         }
     }
 

--- a/crates/fresh-editor/tests/e2e/per_session_authority.rs
+++ b/crates/fresh-editor/tests/e2e/per_session_authority.rs
@@ -547,6 +547,7 @@ fn activating_env_in_one_session_does_not_affect_another() -> anyhow::Result<()>
 /// activation locks that out. Drives `PluginCommand::SetEnv` directly (what
 /// `editor.setEnv` dispatches) rather than poking the provider, so it covers
 /// the actual restart decision.
+#[cfg(feature = "plugins")]
 #[test]
 fn activating_env_does_not_restart_the_editor() -> anyhow::Result<()> {
     use fresh::services::workspace_trust::TrustLevel;

--- a/crates/fresh-editor/tests/e2e/per_session_authority.rs
+++ b/crates/fresh-editor/tests/e2e/per_session_authority.rs
@@ -534,3 +534,61 @@ fn activating_env_in_one_session_does_not_affect_another() -> anyhow::Result<()>
     );
     Ok(())
 }
+
+/// Regression (orchestrator "Trust restarted everything"): activating an env
+/// via `setEnv` — the path the env-manager drives on `trust_changed` for a
+/// shell/venv project — must NOT request a process-wide editor restart.
+///
+/// The `EnvProvider` is updated in place and every *new* spawn inherits it, so
+/// no rebuild is needed. The old `handle_set_env` called `request_restart`,
+/// which rebuilds the whole editor process — dropping every window's
+/// `terminal_manager` (all orchestrator sessions' PTYs) and reconstructing the
+/// orchestrator plugin (closing the dock). Asserting `!should_restart()` after
+/// activation locks that out. Drives `PluginCommand::SetEnv` directly (what
+/// `editor.setEnv` dispatches) rather than poking the provider, so it covers
+/// the actual restart decision.
+#[test]
+fn activating_env_does_not_restart_the_editor() -> anyhow::Result<()> {
+    use fresh::services::workspace_trust::TrustLevel;
+    use fresh_core::api::PluginCommand;
+
+    let temp = tempfile::tempdir()?;
+    let mut harness = EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new().with_working_dir(temp.path().to_path_buf()),
+    )?;
+    let active = harness.editor_mut().active_window_id();
+    // Env activation only applies in a Trusted workspace (`handle_set_env`).
+    harness
+        .editor()
+        .session(active)
+        .unwrap()
+        .authority()
+        .workspace_trust
+        .set_level(TrustLevel::Trusted);
+
+    harness
+        .editor_mut()
+        .handle_plugin_command(PluginCommand::SetEnv {
+            snippet: "export FRESH_TEST=1".into(),
+            dir: None,
+        })?;
+
+    assert!(
+        harness
+            .editor()
+            .session(active)
+            .unwrap()
+            .authority()
+            .env_provider
+            .is_active(),
+        "env activated in place"
+    );
+    assert!(
+        !harness.editor().should_restart(),
+        "activating an env must not request a process-wide editor restart \
+         (a rebuild tears down other sessions' terminals and closes the dock)"
+    );
+    Ok(())
+}


### PR DESCRIPTION
Trusting a workspace with a shell/venv env (mise/direnv/.venv) tore down
every *other* open orchestrator session's running terminal and closed the
dock. The trust write itself is already non-destructive, but the
env-manager reacts to the `trust_changed` hook with `editor.setEnv`, and
`handle_set_env` ended with `request_restart` — a process-wide editor
rebuild that drops every window's `terminal_manager` (all sessions' PTYs)
and reconstructs the orchestrator plugin (closing the dock).

The `EnvProvider` is updated in place and captured lazily at spawn time, so
new spawns already inherit the new env with no rebuild. Replace the global
`request_restart` in `handle_set_env`/`handle_clear_env` with a
window-scoped refresh that only re-launches the active window's
already-running language servers. Other windows — their terminals, LSP, and
the dock — are left untouched. Already-open terminals keep running and adopt
the new env when reopened, matching the env subsystem's capture-at-spawn
model.

Also corrects the stale doc comment on `set_workspace_trust_level` (it no
longer restarts) and adds a regression test asserting env activation does
not request an editor restart (fails against the old global-restart path).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GH9XnGj9YnKSwMNAdBdGPV