### PR TITLE
feat(vi_mode): add compatibility motions and word search

### DIFF
--- a/crates/fresh-editor/plugins/check-types.sh
+++ b/crates/fresh-editor/plugins/check-types.sh
@@ -28,6 +28,8 @@ for file in "${FILES[@]}"; do
     --lib esnext,dom \
     --skipLibCheck \
     --allowImportingTsExtensions \
+    --ignoreConfig \
+    --ignoreDeprecations 6.0 \
     "$file" 2>&1; then
     ERRORS=$((ERRORS + 1))
   fi

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -25,6 +25,7 @@ type TextObjectType = "inner" | "around" | null;
 type ModeBinding = [string, string];
 type WORDMotionKind = "forward" | "backward" | "end";
 type WordSearchDirection = "forward" | "backward";
+type WordSearchTarget = { start: number; end: number; text: string; wholeWord: boolean };
 
 // Types for tracking repeatable changes
 type ChangeType = "simple" | "operator-motion" | "operator-textobj" | "insert" | "line-op";
@@ -49,9 +50,11 @@ interface ViState {
   lastChange: LastChange | null; // For '.' repeat
   lastYankWasLinewise: boolean; // Track if last yank was line-wise for proper paste
   visualAnchor: number | null; // Starting position for visual mode selection
+  visualHead: number | null; // Active end of computed visual selections
+  visualRange: { start: number; end: number } | null; // Characterwise visual range for computed motions
   insertStartPos: number | null; // Cursor position when entering insert mode
   visualBlockAnchor: { line: number; col: number } | null; // For visual block mode
-  lastWordSearch: { word: string; direction: WordSearchDirection } | null; // For n/N after * or #
+  lastWordSearch: { text: string; direction: WordSearchDirection; wholeWord: boolean } | null; // For n/N after * or #
 }
 
 const state: ViState = {
@@ -64,6 +67,8 @@ const state: ViState = {
   lastChange: null,
   lastYankWasLinewise: false,
   visualAnchor: null,
+  visualHead: null,
+  visualRange: null,
   insertStartPos: null,
   visualBlockAnchor: null,
   lastWordSearch: null,
@@ -149,6 +154,8 @@ function switchMode(newMode: ViMode): void {
   // Clear visual anchor when leaving visual modes
   if (newMode !== "visual" && newMode !== "visual-line" && newMode !== "visual-block") {
     state.visualAnchor = null;
+    state.visualHead = null;
+    state.visualRange = null;
     state.visualBlockAnchor = null;
     // Clear any selection when leaving visual mode by moving cursor
     // (any non-select movement clears selection in Fresh)
@@ -624,6 +631,32 @@ function isWhitespaceAt(text: string, index: number): boolean {
   return isWhitespaceChar(charAtStringIndex(text, index));
 }
 
+function isLineBreakAt(text: string, index: number): boolean {
+  return text[index] === "\n" || text[index] === "\r";
+}
+
+function lineStartIndex(text: string, index: number): number {
+  let lineStart = Math.min(Math.max(index, 0), text.length);
+  while (lineStart > 0) {
+    const previous = previousStringIndex(text, lineStart);
+    if (text[previous] === "\n" || text[previous] === "\r") {
+      break;
+    }
+    lineStart = previous;
+  }
+  return lineStart;
+}
+
+function isEmptyLineStart(text: string, index: number): boolean {
+  if (text[index] === "\n" && index > 0 && text[index - 1] === "\r") {
+    return false;
+  }
+  return index >= 0
+    && index < text.length
+    && lineStartIndex(text, index) === index
+    && (text[index] === "\n" || text[index] === "\r");
+}
+
 function hasOnlyWhitespaceAfter(text: string, index: number): boolean {
   let next = nextStringIndex(text, index);
   while (next < text.length) {
@@ -637,8 +670,9 @@ function hasOnlyWhitespaceAfter(text: string, index: number): boolean {
 
 function nextWORDIndex(text: string, startIndex: number): number {
   let index = Math.min(startIndex, text.length);
-  const startedOnWhitespace = isWhitespaceAt(text, index);
+  const startedOnWhitespace = index < text.length && isWhitespaceAt(text, index);
   let lastNonWhitespace = index;
+  let lastWhitespace = index;
 
   if (index < text.length && !isWhitespaceAt(text, index)) {
     while (index < text.length && !isWhitespaceAt(text, index)) {
@@ -648,11 +682,17 @@ function nextWORDIndex(text: string, startIndex: number): number {
   }
 
   while (index < text.length && isWhitespaceAt(text, index)) {
+    if (isEmptyLineStart(text, index)) {
+      break;
+    }
+    if (!isLineBreakAt(text, index)) {
+      lastWhitespace = index;
+    }
     index = nextStringIndex(text, index);
   }
 
   if (index >= text.length) {
-    return startedOnWhitespace ? Math.min(startIndex, text.length) : lastNonWhitespace;
+    return startedOnWhitespace ? lastWhitespace : lastNonWhitespace;
   }
 
   return index;
@@ -665,6 +705,9 @@ function previousWORDIndex(text: string, startIndex: number): number {
 
   let index = previousStringIndex(text, Math.min(startIndex, text.length));
   while (index > 0 && isWhitespaceAt(text, index)) {
+    if (isEmptyLineStart(text, index)) {
+      return index;
+    }
     index = previousStringIndex(text, index);
   }
 
@@ -708,17 +751,8 @@ function endWORDIndex(text: string, startIndex: number): number {
   return index;
 }
 
-async function computeWORDMotionTarget(kind: WORDMotionKind, count: number): Promise<number | null> {
-  const bufferId = editor.getActiveBufferId();
-  const cursorPos = editor.getCursorPosition();
-  if (cursorPos === null) {
-    return null;
-  }
-
-  const bufferLength = editor.getBufferLength(bufferId);
-  const text = await editor.getBufferText(bufferId, 0, bufferLength);
-  let index = byteOffsetToStringIndex(text, cursorPos);
-
+function computeWORDMotionTargetIndex(text: string, startIndex: number, kind: WORDMotionKind, count: number): number {
+  let index = startIndex;
   for (let i = 0; i < Math.max(1, count); i++) {
     if (kind === "forward") {
       index = nextWORDIndex(text, index);
@@ -728,8 +762,94 @@ async function computeWORDMotionTarget(kind: WORDMotionKind, count: number): Pro
       index = endWORDIndex(text, index);
     }
   }
+  return index;
+}
+
+async function computeWORDMotionTarget(kind: WORDMotionKind, count: number, origin: number | null = null): Promise<number | null> {
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = origin ?? editor.getCursorPosition();
+  if (cursorPos === null) {
+    return null;
+  }
+
+  const bufferLength = editor.getBufferLength(bufferId);
+  const text = await editor.getBufferText(bufferId, 0, bufferLength);
+  const index = computeWORDMotionTargetIndex(text, byteOffsetToStringIndex(text, cursorPos), kind, count);
 
   return stringIndexToByteOffset(text, index);
+}
+
+function nextLineStartIndex(text: string, index: number): number {
+  let cursor = lineStartIndex(text, index);
+  while (cursor < text.length) {
+    const char = charAtStringIndex(text, cursor);
+    cursor = nextStringIndex(text, cursor);
+    if (char === "\n") {
+      return cursor;
+    }
+    if (char === "\r") {
+      if (text[cursor] === "\n") {
+        cursor = nextStringIndex(text, cursor);
+      }
+      return cursor;
+    }
+  }
+  return text.length;
+}
+
+function paragraphDownEofIndex(text: string): number {
+  if (text.length === 0) {
+    return 0;
+  }
+
+  let contentEnd = text.length;
+  if (text[contentEnd - 1] === "\n") {
+    contentEnd--;
+    if (contentEnd > 0 && text[contentEnd - 1] === "\r") {
+      contentEnd--;
+    }
+  } else if (text[contentEnd - 1] === "\r") {
+    contentEnd--;
+  }
+
+  return contentEnd === 0 ? 0 : previousStringIndex(text, contentEnd);
+}
+
+function paragraphDownMotionTargetIndex(text: string, startIndex: number): { index: number; reachedEof: boolean } {
+  let lineStart = nextLineStartIndex(text, startIndex);
+  while (lineStart < text.length) {
+    const nextLineStart = nextLineStartIndex(text, lineStart);
+    const lineContent = text.slice(lineStart, nextLineStart);
+    if (lineContent.replace(/[\r\n]+$/, "") === "") {
+      return { index: lineStart, reachedEof: false };
+    }
+    lineStart = nextLineStart;
+  }
+
+  return { index: paragraphDownEofIndex(text), reachedEof: true };
+}
+
+async function computeParagraphDownOperatorRange(count: number): Promise<{ start: number; end: number } | null> {
+  const start = editor.getCursorPosition();
+  if (start === null) {
+    return null;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  let target = byteOffsetToStringIndex(bufferText, start);
+  let reachedEof = false;
+  for (let i = 0; i < Math.max(1, count); i++) {
+    const next = paragraphDownMotionTargetIndex(bufferText, target);
+    target = next.index;
+    reachedEof = next.reachedEof;
+  }
+
+  const endIndex = reachedEof ? nextStringIndex(bufferText, target) : target;
+  return {
+    start,
+    end: stringIndexToByteOffset(bufferText, endIndex),
+  };
 }
 
 function byteLengthOfCharAt(text: string, index: number): number {
@@ -780,30 +900,68 @@ async function applyOperatorWithRange(operator: string, start: number, end: numb
   switchMode("normal");
 }
 
-async function applyWORDOperatorMotion(operator: string, kind: WORDMotionKind, count: number): Promise<void> {
+async function computeWORDOperatorRange(
+  kind: WORDMotionKind,
+  count: number,
+  useChangeForwardSemantics: boolean,
+): Promise<{ start: number; end: number; cursorAfter?: number } | null> {
   const start = editor.getCursorPosition();
-  const target = await computeWORDMotionTarget(kind, count);
-  if (start === null || target === null) {
+  if (start === null) {
+    return null;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const startIndex = byteOffsetToStringIndex(bufferText, start);
+
+  if (useChangeForwardSemantics && kind === "forward" && !isWhitespaceAt(bufferText, startIndex)) {
+    let endIndex = startIndex;
+    for (let i = 0; i < Math.max(1, count); i++) {
+      endIndex = endWORDIndex(bufferText, endIndex);
+    }
+    const endTarget = stringIndexToByteOffset(bufferText, endIndex);
+    return {
+      start,
+      end: endTarget + byteLengthOfCharAt(bufferText, endIndex),
+    };
+  }
+
+  const targetIndex = computeWORDMotionTargetIndex(bufferText, startIndex, kind, count);
+  const target = stringIndexToByteOffset(bufferText, targetIndex);
+  let end = target;
+  let cursorAfter: number | undefined;
+  if (kind === "end") {
+    end += byteLengthOfCharAt(bufferText, targetIndex);
+  } else if (kind === "forward") {
+    if (target >= start && !isWhitespaceAt(bufferText, targetIndex) && hasOnlyWhitespaceAfter(bufferText, targetIndex)) {
+      end += byteLengthOfCharAt(bufferText, targetIndex);
+    } else if (target >= start && isWhitespaceAt(bufferText, targetIndex) && hasOnlyWhitespaceAfter(bufferText, targetIndex)) {
+      end += byteLengthOfCharAt(bufferText, targetIndex);
+      if (!useChangeForwardSemantics && startIndex > 0) {
+        cursorAfter = stringIndexToByteOffset(bufferText, previousStringIndex(bufferText, startIndex));
+      }
+    }
+  }
+
+  return { start, end, cursorAfter };
+}
+
+async function applyWORDOperatorMotion(
+  operator: string,
+  kind: WORDMotionKind,
+  count: number,
+  useChangeForwardSemantics: boolean = operator === "c",
+): Promise<void> {
+  const range = await computeWORDOperatorRange(kind, count, useChangeForwardSemantics);
+  if (range === null) {
     switchMode("normal");
     return;
   }
 
-  let end = target;
-  if (kind === "end") {
-    const bufferId = editor.getActiveBufferId();
-    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
-    const targetIndex = byteOffsetToStringIndex(bufferText, target);
-    end += byteLengthOfCharAt(bufferText, targetIndex);
-  } else if (kind === "forward") {
-    const bufferId = editor.getActiveBufferId();
-    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
-    const targetIndex = byteOffsetToStringIndex(bufferText, target);
-    if (target >= start && !isWhitespaceAt(bufferText, targetIndex) && hasOnlyWhitespaceAfter(bufferText, targetIndex)) {
-      end += byteLengthOfCharAt(bufferText, targetIndex);
-    }
+  await applyOperatorWithRange(operator, range.start, range.end);
+  if (operator === "d" && range.cursorAfter !== undefined) {
+    editor.setBufferCursor(editor.getActiveBufferId(), range.cursorAfter);
   }
-
-  await applyOperatorWithRange(operator, start, end);
 }
 
 function WORDMotionKindFromRepeatMotion(motion: string): WORDMotionKind | null {
@@ -836,21 +994,29 @@ async function handleWORDMotionWithOperator(kind: WORDMotionKind): Promise<void>
 
 async function selectToPosition(target: number, includeTarget: boolean = false): Promise<void> {
   const bufferId = editor.getActiveBufferId();
+  const start = editor.getCursorPosition();
+  if (start === null) {
+    return;
+  }
+
+  if (start === target && !includeTarget) {
+    return;
+  }
+
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
   let destination = target;
   if (includeTarget) {
-    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
     const targetIndex = byteOffsetToStringIndex(bufferText, target);
     destination += byteLengthOfCharAt(bufferText, targetIndex);
   }
 
-  let cursor = editor.getCursorPosition();
-  while (cursor !== null && cursor !== destination) {
-    editor.executeAction(cursor < destination ? "select_right" : "select_left");
-    const next = editor.getCursorPosition();
-    if (next === cursor) {
-      break;
-    }
-    cursor = next;
+  const startIndex = byteOffsetToStringIndex(bufferText, start);
+  const destinationIndex = byteOffsetToStringIndex(bufferText, destination);
+  const action = startIndex < destinationIndex ? "select_right" : "select_left";
+  let steps = Math.abs(destinationIndex - startIndex);
+  while (steps > 0) {
+    editor.executeAction(action);
+    steps--;
   }
 }
 
@@ -1058,72 +1224,181 @@ function vi_paragraph_up() : void {
 }
 registerHandler("vi_paragraph_up", vi_paragraph_up);
 
-function vi_paragraph_down() : void {
-  executeWithCount("move_to_paragraph_down");
+function realLineStarts(text: string): number[] {
+  const starts = [0];
+  for (let index = 0; index < text.length; index = nextStringIndex(text, index)) {
+    const char = text[index];
+    if (char === "\n" && index + 1 < text.length) {
+      starts.push(index + 1);
+    } else if (char === "\r" && text[index + 1] !== "\n" && index + 1 < text.length) {
+      starts.push(index + 1);
+    }
+  }
+  return starts;
+}
+
+function lineContentEndIndex(text: string, lineStarts: number[], lineIndex: number): number {
+  const nextLineStart = lineStarts[lineIndex + 1];
+  let end = nextLineStart === undefined ? text.length : nextLineStart - 1;
+  if (end > lineStarts[lineIndex] && text[end - 1] === "\n") {
+    end--;
+  }
+  if (end > lineStarts[lineIndex] && text[end - 1] === "\r") {
+    end--;
+  }
+  return end;
+}
+
+function lineIndexForStringIndex(lineStarts: number[], index: number): number {
+  let lineIndex = 0;
+  while (lineIndex + 1 < lineStarts.length && lineStarts[lineIndex + 1] <= index) {
+    lineIndex++;
+  }
+  return lineIndex;
+}
+
+async function vi_paragraph_down() : Promise<void> {
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = editor.getCursorPosition();
+  if (cursorPos === null) {
+    return;
+  }
+
+  const text = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const lineStarts = realLineStarts(text);
+  if (lineStarts.length === 0) {
+    return;
+  }
+
+  let lineIndex = lineIndexForStringIndex(lineStarts, byteOffsetToStringIndex(text, cursorPos));
+  let count = consumeCount();
+  while (count-- > 0) {
+    let didSkip = false;
+    for (let first = true; ; first = false) {
+      if (lineContentEndIndex(text, lineStarts, lineIndex) > lineStarts[lineIndex]) {
+        didSkip = true;
+      }
+
+      if (!first && didSkip && lineContentEndIndex(text, lineStarts, lineIndex) === lineStarts[lineIndex]) {
+        break;
+      }
+
+      lineIndex++;
+      if (lineIndex >= lineStarts.length) {
+        lineIndex = lineStarts.length - 1;
+        break;
+      }
+    }
+  }
+
+  if (lineIndex === lineStarts.length - 1) {
+    const lineEnd = lineContentEndIndex(text, lineStarts, lineIndex);
+    if (lineEnd > lineStarts[lineIndex]) {
+      editor.setBufferCursor(bufferId, stringIndexToByteOffset(text, previousStringIndex(text, lineEnd)));
+      return;
+    }
+  }
+
+  editor.setBufferCursor(bufferId, stringIndexToByteOffset(text, lineStarts[lineIndex]));
 }
 registerHandler("vi_paragraph_down", vi_paragraph_down);
 
-function findWordUnderCursor(text: string, cursorIndex: number): { start: number; end: number; word: string } | null {
-  let index = Math.min(cursorIndex, Math.max(0, text.length - 1));
-  if (!isWordChar(text[index]) && index > 0 && isWordChar(text[index - 1])) {
+function findLineEndIndex(text: string, index: number): number {
+  let end = Math.min(Math.max(index, 0), text.length);
+  while (end < text.length && text[end] !== "\n" && text[end] !== "\r") {
+    end = nextStringIndex(text, end);
+  }
+  return end;
+}
+
+function findSearchTargetUnderCursor(text: string, cursorIndex: number, scanForwardOnMiss: boolean = false): WordSearchTarget | null {
+  const originalIndex = Math.min(cursorIndex, Math.max(0, text.length - 1));
+  const lineEnd = findLineEndIndex(text, originalIndex);
+  let index = originalIndex;
+
+  if (!scanForwardOnMiss && !isWordChar(text[index]) && index > 0 && isWordChar(text[index - 1])) {
     index--;
   }
-  if (!isWordChar(text[index])) {
+  if (scanForwardOnMiss && !isWordChar(text[index])) {
+    while (index < lineEnd && !isWordChar(text[index])) {
+      index = nextStringIndex(text, index);
+    }
+  }
+  if (isWordChar(text[index])) {
+    let start = index;
+    let end = index + 1;
+    while (start > 0 && isWordChar(text[start - 1])) {
+      start--;
+    }
+    while (end < text.length && isWordChar(text[end])) {
+      end++;
+    }
+
+    return { start, end, text: text.slice(start, end), wholeWord: true };
+  }
+
+  index = originalIndex;
+  while (index < lineEnd && isWhitespaceAt(text, index)) {
+    index = nextStringIndex(text, index);
+  }
+  if (index >= lineEnd) {
     return null;
   }
 
   let start = index;
-  let end = index + 1;
-  while (start > 0 && isWordChar(text[start - 1])) {
-    start--;
-  }
-  while (end < text.length && isWordChar(text[end])) {
-    end++;
+  let end = index;
+  while (end < lineEnd && !isWhitespaceAt(text, end)) {
+    end = nextStringIndex(text, end);
   }
 
-  return { start, end, word: text.slice(start, end) };
+  return { start, end, text: text.slice(start, end), wholeWord: false };
 }
 
 function isWholeWordMatch(text: string, start: number, end: number): boolean {
   return !isWordChar(text[start - 1]) && !isWordChar(text[end]);
 }
 
-function findNextWholeWord(text: string, word: string, from: number, until: number): number | null {
-  let index = text.indexOf(word, from);
+function isSearchMatch(text: string, start: number, end: number, wholeWord: boolean): boolean {
+  return !wholeWord || isWholeWordMatch(text, start, end);
+}
+
+function findNextSearchMatch(text: string, target: string, wholeWord: boolean, from: number, until: number): number | null {
+  let index = text.indexOf(target, from);
   while (index !== -1 && index < until) {
-    const end = index + word.length;
-    if (isWholeWordMatch(text, index, end)) {
+    const end = index + target.length;
+    if (isSearchMatch(text, index, end, wholeWord)) {
       return index;
     }
-    index = text.indexOf(word, index + 1);
+    index = text.indexOf(target, index + 1);
   }
   return null;
 }
 
-function findPreviousWholeWord(text: string, word: string, before: number, min: number): number | null {
+function findPreviousSearchMatch(text: string, target: string, wholeWord: boolean, before: number, min: number): number | null {
   if (before <= min) {
     return null;
   }
 
-  let index = text.lastIndexOf(word, before - 1);
+  let index = text.lastIndexOf(target, before - 1);
   while (index !== -1 && index >= min) {
-    const end = index + word.length;
-    if (isWholeWordMatch(text, index, end)) {
+    const end = index + target.length;
+    if (isSearchMatch(text, index, end, wholeWord)) {
       return index;
     }
     if (index === 0) {
       return null;
     }
-    index = text.lastIndexOf(word, index - 1);
+    index = text.lastIndexOf(target, index - 1);
   }
   return null;
 }
 
 async function executeStoredWordSearch(
-  word: string,
+  target: string,
   direction: WordSearchDirection,
   count: number,
-  currentWord?: { start: number; end: number; word: string },
+  wholeWord: boolean,
+  currentTarget?: WordSearchTarget,
 ): Promise<void> {
   const bufferId = editor.getActiveBufferId();
   const cursorPos = editor.getCursorPosition();
@@ -1133,20 +1408,21 @@ async function executeStoredWordSearch(
 
   const text = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
   const cursorIndex = byteOffsetToStringIndex(text, cursorPos);
-  const wordAtCursor = currentWord ?? findWordUnderCursor(text, cursorIndex);
-  const searchStart = wordAtCursor?.word === word ? wordAtCursor.start : cursorIndex;
-  const searchEnd = wordAtCursor?.word === word ? wordAtCursor.end : nextStringIndex(text, cursorIndex);
+  const targetAtCursor = currentTarget ?? findSearchTargetUnderCursor(text, cursorIndex);
+  const onSameTarget = targetAtCursor?.text === target && targetAtCursor.wholeWord === wholeWord;
+  const searchStart = onSameTarget && targetAtCursor !== null ? targetAtCursor.start : cursorIndex;
+  const searchEnd = onSameTarget && targetAtCursor !== null ? targetAtCursor.end : nextStringIndex(text, cursorIndex);
 
   let match: number | null = null;
   let fromStart = searchStart;
   let fromEnd = searchEnd;
   for (let i = 0; i < count; i++) {
     if (direction === "forward") {
-      match = findNextWholeWord(text, word, fromEnd, text.length)
-        ?? findNextWholeWord(text, word, 0, fromStart);
+      match = findNextSearchMatch(text, target, wholeWord, fromEnd, text.length)
+        ?? findNextSearchMatch(text, target, wholeWord, 0, fromStart);
     } else {
-      match = findPreviousWholeWord(text, word, fromStart, 0)
-        ?? findPreviousWholeWord(text, word, text.length, fromEnd);
+      match = findPreviousSearchMatch(text, target, wholeWord, fromStart, 0)
+        ?? findPreviousSearchMatch(text, target, wholeWord, text.length, fromEnd);
     }
 
     if (match === null) {
@@ -1154,7 +1430,7 @@ async function executeStoredWordSearch(
     }
 
     fromStart = match;
-    fromEnd = match + word.length;
+    fromEnd = match + target.length;
   }
 
   if (match !== null) {
@@ -1171,13 +1447,14 @@ async function executeWordUnderCursorSearch(direction: WordSearchDirection, coun
 
   const text = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
   const cursorIndex = byteOffsetToStringIndex(text, cursorPos);
-  const currentWord = findWordUnderCursor(text, cursorIndex);
-  if (currentWord === null) {
+  const currentTarget = findSearchTargetUnderCursor(text, cursorIndex, true);
+  if (currentTarget === null) {
     return;
   }
 
-  state.lastWordSearch = { word: currentWord.word, direction };
-  await executeStoredWordSearch(currentWord.word, direction, count, currentWord);
+  state.lastWordSearch = { text: currentTarget.text, direction, wholeWord: currentTarget.wholeWord };
+  editor.setBufferCursor(bufferId, stringIndexToByteOffset(text, currentTarget.start));
+  await executeStoredWordSearch(currentTarget.text, direction, count, currentTarget.wholeWord, currentTarget);
 }
 
 async function vi_search_word_forward() : Promise<void> {
@@ -1455,7 +1732,7 @@ async function vi_repeat() : Promise<void> {
         const WORDKind = WORDMotionKindFromRepeatMotion(change.motion);
         if (change.operator === "c") {
           if (WORDKind) {
-            await applyWORDOperatorMotion("d", WORDKind, count);
+            await applyWORDOperatorMotion("d", WORDKind, count, true);
           } else {
             // For change: do the delete part, then insert the text
             await applyOperatorWithMotion("d", change.motion, count);
@@ -1529,7 +1806,12 @@ registerHandler("vi_search_backward", vi_search_backward);
 
 async function vi_find_next() : Promise<void> {
   if (state.lastWordSearch) {
-    await executeStoredWordSearch(state.lastWordSearch.word, state.lastWordSearch.direction, consumeCount());
+    await executeStoredWordSearch(
+      state.lastWordSearch.text,
+      state.lastWordSearch.direction,
+      consumeCount(),
+      state.lastWordSearch.wholeWord,
+    );
     return;
   }
   editor.executeAction("find_next");
@@ -1539,7 +1821,12 @@ registerHandler("vi_find_next", vi_find_next);
 async function vi_find_prev() : Promise<void> {
   if (state.lastWordSearch) {
     const direction = state.lastWordSearch.direction === "forward" ? "backward" : "forward";
-    await executeStoredWordSearch(state.lastWordSearch.word, direction, consumeCount());
+    await executeStoredWordSearch(
+      state.lastWordSearch.text,
+      direction,
+      consumeCount(),
+      state.lastWordSearch.wholeWord,
+    );
     return;
   }
   editor.executeAction("find_previous");
@@ -1614,9 +1901,16 @@ registerHandler("vi_op_digit_0_or_line_start", vi_op_digit_0_or_line_start);
 // Visual Mode
 // ============================================================================
 
+function clearComputedVisualRange(): void {
+  state.visualHead = null;
+  state.visualRange = null;
+}
+
 // Enter character-wise visual mode
 function vi_visual_char() : void {
   state.visualAnchor = editor.getCursorPosition();
+  state.visualHead = state.visualAnchor;
+  state.visualRange = null;
   // Select the character under cursor to establish the anchor.
   // This moves cursor one position right (the selection end), which is
   // standard visual mode behavior — the first char is part of the selection.
@@ -1628,6 +1922,8 @@ registerHandler("vi_visual_char", vi_visual_char);
 // Enter line-wise visual mode
 function vi_visual_line() : void {
   state.visualAnchor = editor.getCursorPosition();
+  state.visualHead = state.visualAnchor;
+  state.visualRange = null;
   // Select full line including newline (select_line selects and moves to next line)
   editor.executeAction("select_line");
   switchMode("visual-line");
@@ -1636,6 +1932,7 @@ registerHandler("vi_visual_line", vi_visual_line);
 
 // Toggle between visual and visual-line modes
 function vi_visual_toggle_line() : void {
+  clearComputedVisualRange();
   if (state.mode === "visual") {
     // Switch to line mode - extend selection to full lines
     editor.executeAction("select_line");
@@ -1655,6 +1952,8 @@ registerHandler("vi_visual_toggle_line", vi_visual_toggle_line);
 async function vi_visual_block() : Promise<void> {
   // Store anchor position for block selection
   state.visualAnchor = editor.getCursorPosition();
+  state.visualHead = state.visualAnchor;
+  state.visualRange = null;
 
   // Calculate line and column for block anchor
   const cursorPos = editor.getCursorPosition();
@@ -1755,36 +2054,43 @@ registerHandler("vi_vblock_toggle_line", vi_vblock_toggle_line);
 
 // Visual mode motions - these extend the selection
 function vi_vis_left() : void {
+  clearComputedVisualRange();
   executeWithCount("select_left");
 }
 registerHandler("vi_vis_left", vi_vis_left);
 
 function vi_vis_down() : void {
+  clearComputedVisualRange();
   executeWithCount("select_down");
 }
 registerHandler("vi_vis_down", vi_vis_down);
 
 function vi_vis_up() : void {
+  clearComputedVisualRange();
   executeWithCount("select_up");
 }
 registerHandler("vi_vis_up", vi_vis_up);
 
 function vi_vis_right() : void {
+  clearComputedVisualRange();
   executeWithCount("select_right");
 }
 registerHandler("vi_vis_right", vi_vis_right);
 
 function vi_vis_word() : void {
+  clearComputedVisualRange();
   executeWithCount("select_word_right");
 }
 registerHandler("vi_vis_word", vi_vis_word);
 
 function vi_vis_word_back() : void {
+  clearComputedVisualRange();
   executeWithCount("select_word_left");
 }
 registerHandler("vi_vis_word_back", vi_vis_word_back);
 
 function vi_vis_word_end() : void {
+  clearComputedVisualRange();
   // Extend selection to end of word
   const count = consumeCount();
   for (let i = 0; i < count; i++) {
@@ -1794,66 +2100,77 @@ function vi_vis_word_end() : void {
 }
 registerHandler("vi_vis_word_end", vi_vis_word_end);
 
+function visualWORDMotionOrigin(): number | null {
+  return state.visualHead ?? state.visualAnchor ?? editor.getCursorPosition();
+}
+
 async function vi_vis_WORD() : Promise<void> {
-  const target = await computeWORDMotionTarget("forward", consumeCount());
+  const target = await computeWORDMotionTarget("forward", consumeCount(), visualWORDMotionOrigin());
   if (target !== null) {
-    await selectToPosition(target);
+    await selectVisualRangeToTarget(target);
   }
 }
 registerHandler("vi_vis_WORD", vi_vis_WORD);
 
 async function vi_vis_WORD_back() : Promise<void> {
-  const target = await computeWORDMotionTarget("backward", consumeCount());
+  const target = await computeWORDMotionTarget("backward", consumeCount(), visualWORDMotionOrigin());
   if (target !== null) {
-    await selectToPosition(target);
+    await selectVisualRangeToTarget(target, false);
   }
 }
 registerHandler("vi_vis_WORD_back", vi_vis_WORD_back);
 
 async function vi_vis_WORD_end() : Promise<void> {
-  const target = await computeWORDMotionTarget("end", consumeCount());
+  const target = await computeWORDMotionTarget("end", consumeCount(), visualWORDMotionOrigin());
   if (target !== null) {
-    await selectToPosition(target, true);
+    await selectVisualRangeToTarget(target);
   }
 }
 registerHandler("vi_vis_WORD_end", vi_vis_WORD_end);
 
 function vi_vis_line_start() : void {
+  clearComputedVisualRange();
   consumeCount();
   editor.executeAction("select_line_start");
 }
 registerHandler("vi_vis_line_start", vi_vis_line_start);
 
 function vi_vis_line_end() : void {
+  clearComputedVisualRange();
   consumeCount();
   editor.executeAction("select_line_end");
 }
 registerHandler("vi_vis_line_end", vi_vis_line_end);
 
 function vi_vis_doc_start() : void {
+  clearComputedVisualRange();
   consumeCount();
   editor.executeAction("select_document_start");
 }
 registerHandler("vi_vis_doc_start", vi_vis_doc_start);
 
 function vi_vis_doc_end() : void {
+  clearComputedVisualRange();
   consumeCount();
   editor.executeAction("select_document_end");
 }
 registerHandler("vi_vis_doc_end", vi_vis_doc_end);
 
 function vi_vis_paragraph_up() : void {
+  clearComputedVisualRange();
   executeWithCount("select_to_paragraph_up");
 }
 registerHandler("vi_vis_paragraph_up", vi_vis_paragraph_up);
 
 function vi_vis_paragraph_down() : void {
+  clearComputedVisualRange();
   executeWithCount("select_to_paragraph_down");
 }
 registerHandler("vi_vis_paragraph_down", vi_vis_paragraph_down);
 
 // Visual line mode motions - extend selection by whole lines
 function vi_vline_down() : void {
+  clearComputedVisualRange();
   executeWithCount("select_down");
   // Ensure full line selection
   editor.executeAction("select_line_end");
@@ -1861,14 +2178,58 @@ function vi_vline_down() : void {
 registerHandler("vi_vline_down", vi_vline_down);
 
 function vi_vline_up() : void {
+  clearComputedVisualRange();
   executeWithCount("select_up");
   // Ensure full line selection
   editor.executeAction("select_line_start");
 }
 registerHandler("vi_vline_up", vi_vline_up);
 
+async function selectVisualRangeToTarget(target: number, includeDisplayTarget: boolean = true): Promise<void> {
+  const anchor = state.visualAnchor;
+  if (anchor === null) {
+    state.visualHead = target;
+    await selectToPosition(target, includeDisplayTarget);
+    return;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const anchorIndex = byteOffsetToStringIndex(bufferText, anchor);
+  const targetIndex = byteOffsetToStringIndex(bufferText, target);
+  const anchorEnd = anchor + byteLengthOfCharAt(bufferText, anchorIndex);
+  const targetEnd = target + byteLengthOfCharAt(bufferText, targetIndex);
+
+  state.visualRange = target >= anchor
+    ? { start: anchor, end: targetEnd }
+    : { start: target, end: anchorEnd };
+  state.visualHead = target;
+
+  await selectToPosition(target, includeDisplayTarget && target >= anchor);
+}
+
+async function takeVisualRangeText(): Promise<{ bufferId: number; start: number; end: number; text: string } | null> {
+  const range = state.visualRange;
+  if (range === null || range.end <= range.start) {
+    return null;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const text = await editor.getBufferText(bufferId, range.start, range.end);
+  return { bufferId, start: range.start, end: range.end, text };
+}
 // Visual mode operators - act on selection
-function vi_vis_delete() : void {
+async function vi_vis_delete() : Promise<void> {
+  const directRange = await takeVisualRangeText();
+  if (directRange !== null) {
+    editor.setClipboard(directRange.text);
+    editor.deleteRange(directRange.bufferId, directRange.start, directRange.end);
+    state.lastYankWasLinewise = false;
+    switchMode("normal");
+    editor.setBufferCursor(directRange.bufferId, Math.min(directRange.start, editor.getBufferLength(directRange.bufferId)));
+    return;
+  }
+
   const wasLinewise = state.mode === "visual-line";
   editor.executeAction("cut");
   state.lastYankWasLinewise = wasLinewise;
@@ -1876,13 +2237,33 @@ function vi_vis_delete() : void {
 }
 registerHandler("vi_vis_delete", vi_vis_delete);
 
-function vi_vis_change() : void {
+async function vi_vis_change() : Promise<void> {
+  const directRange = await takeVisualRangeText();
+  if (directRange !== null) {
+    editor.setClipboard(directRange.text);
+    editor.deleteRange(directRange.bufferId, directRange.start, directRange.end);
+    switchMode("insert");
+    editor.setBufferCursor(directRange.bufferId, directRange.start);
+    state.insertStartPos = directRange.start;
+    state.lastYankWasLinewise = false;
+    return;
+  }
+
   editor.executeAction("cut");
   switchMode("insert");
 }
 registerHandler("vi_vis_change", vi_vis_change);
 
-function vi_vis_yank() : void {
+async function vi_vis_yank() : Promise<void> {
+  const directRange = await takeVisualRangeText();
+  if (directRange !== null) {
+    editor.setClipboard(directRange.text);
+    state.lastYankWasLinewise = false;
+    switchMode("normal");
+    editor.setBufferCursor(directRange.bufferId, directRange.start);
+    return;
+  }
+
   const wasLinewise = state.mode === "visual-line";
   editor.executeAction("copy");
   state.lastYankWasLinewise = wasLinewise;
@@ -2449,7 +2830,24 @@ async function vi_op_paragraph_up(): Promise<void> {
 registerHandler("vi_op_paragraph_up", vi_op_paragraph_up);
 
 async function vi_op_paragraph_down(): Promise<void> {
-  await handleMotionWithOperator("move_to_paragraph_down");
+  if (!state.pendingOperator) {
+    switchMode("normal");
+    return;
+  }
+
+  const operator = state.pendingOperator;
+  const count = consumeCount();
+  if (operator === "d" || operator === "c") {
+    state.lastChange = { type: "operator-motion", operator, motion: "move_to_paragraph_down", count };
+  }
+
+  const range = await computeParagraphDownOperatorRange(count);
+  if (range === null) {
+    switchMode("normal");
+    return;
+  }
+
+  await applyOperatorWithRange(operator, range.start, range.end);
 }
 registerHandler("vi_op_paragraph_down", vi_op_paragraph_down);
 

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -22,6 +22,9 @@ const editor = getEditor();
 type ViMode = "normal" | "insert" | "operator-pending" | "find-char" | "visual" | "visual-line" | "visual-block" | "text-object";
 type FindCharType = "f" | "t" | "F" | "T" | null;
 type TextObjectType = "inner" | "around" | null;
+type ModeBinding = [string, string];
+type WORDMotionKind = "forward" | "backward" | "end";
+type WordSearchDirection = "forward" | "backward";
 
 // Types for tracking repeatable changes
 type ChangeType = "simple" | "operator-motion" | "operator-textobj" | "insert" | "line-op";
@@ -48,6 +51,7 @@ interface ViState {
   visualAnchor: number | null; // Starting position for visual mode selection
   insertStartPos: number | null; // Cursor position when entering insert mode
   visualBlockAnchor: { line: number; col: number } | null; // For visual block mode
+  lastWordSearch: { word: string; direction: WordSearchDirection } | null; // For n/N after * or #
 }
 
 const state: ViState = {
@@ -62,7 +66,30 @@ const state: ViState = {
   visualAnchor: null,
   insertStartPos: null,
   visualBlockAnchor: null,
+  lastWordSearch: null,
 };
+
+const autoStart = editor.defineConfigBoolean("autoStart", {
+  default: false,
+  description:
+    "Automatically enable vi mode when the editor starts. Default off — users opt in.",
+});
+
+const arrowKeys = editor.defineConfigBoolean("arrowKeys", {
+  default: true,
+  description:
+    "Enable arrow key navigation in vi mode.",
+});
+
+const searchWordUnderCursor = editor.defineConfigBoolean("searchWordUnderCursor", {
+  default: true,
+  description:
+    "Enable * and # to search for the word under the cursor.",
+});
+
+function configuredBindings(enabled: boolean, bindings: ModeBinding[]): ModeBinding[] {
+  return enabled ? bindings : [];
+}
 
 // Safe getBufferText that clamps end to buffer length
 async function safeGetBufferText(bufferId: number, start: number, end: number): Promise<string | null> {
@@ -195,6 +222,13 @@ function consumeCount(): number {
   return count;
 }
 
+function consumeCountOrDefault(defaultCount: number): number {
+  if (state.count === null) {
+    return defaultCount;
+  }
+  return consumeCount();
+}
+
 // Accumulate a digit into the count
 function accumulateCount(digit: number): void {
   if (state.count === null) {
@@ -263,6 +297,10 @@ async function canSelectionActionSelect(action: string, count: number): Promise<
     case "select_word_right":
     case "vi_select_word_end":
     case "select_document_end":
+      return position < editor.getBufferLength(bufferId);
+    case "select_to_paragraph_up":
+      return position > 0;
+    case "select_to_paragraph_down":
       return position < editor.getBufferLength(bufferId);
     case "select_line_start": {
       if (line === null) {
@@ -511,11 +549,310 @@ const motionToSelection: Record<string, string> = {
   move_word_left: "select_word_left",
   move_word_right: "select_word_right",
   vi_move_word_end: "vi_select_word_end",
+  move_to_paragraph_up: "select_to_paragraph_up",
+  move_to_paragraph_down: "select_to_paragraph_down",
   move_line_start: "select_line_start",
   move_line_end: "select_line_end",
   move_document_start: "select_document_start",
   move_document_end: "select_document_end",
 };
+
+function stringIndexToByteOffset(text: string, index: number): number {
+  return editor.utf8ByteLength(text.slice(0, index));
+}
+
+function byteOffsetToStringIndex(text: string, byteOffset: number): number {
+  if (byteOffset <= 0) {
+    return 0;
+  }
+
+  let index = 0;
+  let bytes = 0;
+  while (index < text.length && bytes < byteOffset) {
+    const codePoint = text.codePointAt(index);
+    const char = String.fromCodePoint(codePoint ?? text.charCodeAt(index));
+    const nextBytes = bytes + editor.utf8ByteLength(char);
+    if (nextBytes > byteOffset) {
+      break;
+    }
+    bytes = nextBytes;
+    index += char.length;
+  }
+  return index;
+}
+
+function isWhitespaceChar(char: string | undefined): boolean {
+  return char === undefined || /\s/.test(char);
+}
+
+function isWordChar(char: string | undefined): boolean {
+  return char !== undefined && /[a-zA-Z0-9_]/.test(char);
+}
+
+function charAtStringIndex(text: string, index: number): string | undefined {
+  if (index < 0 || index >= text.length) {
+    return undefined;
+  }
+  const codePoint = text.codePointAt(index);
+  return codePoint === undefined ? undefined : String.fromCodePoint(codePoint);
+}
+
+function nextStringIndex(text: string, index: number): number {
+  if (index >= text.length) {
+    return text.length;
+  }
+  return Math.min(text.length, index + (charAtStringIndex(text, index)?.length ?? 1));
+}
+
+function previousStringIndex(text: string, index: number): number {
+  if (index <= 0) {
+    return 0;
+  }
+
+  let previous = index - 1;
+  const codeUnit = text.charCodeAt(previous);
+  if (codeUnit >= 0xDC00 && codeUnit <= 0xDFFF && previous > 0) {
+    const maybeHighSurrogate = text.charCodeAt(previous - 1);
+    if (maybeHighSurrogate >= 0xD800 && maybeHighSurrogate <= 0xDBFF) {
+      previous--;
+    }
+  }
+  return previous;
+}
+
+function isWhitespaceAt(text: string, index: number): boolean {
+  return isWhitespaceChar(charAtStringIndex(text, index));
+}
+
+function hasOnlyWhitespaceAfter(text: string, index: number): boolean {
+  let next = nextStringIndex(text, index);
+  while (next < text.length) {
+    if (!isWhitespaceAt(text, next)) {
+      return false;
+    }
+    next = nextStringIndex(text, next);
+  }
+  return true;
+}
+
+function nextWORDIndex(text: string, startIndex: number): number {
+  let index = Math.min(startIndex, text.length);
+  const startedOnWhitespace = isWhitespaceAt(text, index);
+  let lastNonWhitespace = index;
+
+  if (index < text.length && !isWhitespaceAt(text, index)) {
+    while (index < text.length && !isWhitespaceAt(text, index)) {
+      lastNonWhitespace = index;
+      index = nextStringIndex(text, index);
+    }
+  }
+
+  while (index < text.length && isWhitespaceAt(text, index)) {
+    index = nextStringIndex(text, index);
+  }
+
+  if (index >= text.length) {
+    return startedOnWhitespace ? Math.min(startIndex, text.length) : lastNonWhitespace;
+  }
+
+  return index;
+}
+
+function previousWORDIndex(text: string, startIndex: number): number {
+  if (startIndex <= 0) {
+    return 0;
+  }
+
+  let index = previousStringIndex(text, Math.min(startIndex, text.length));
+  while (index > 0 && isWhitespaceAt(text, index)) {
+    index = previousStringIndex(text, index);
+  }
+
+  while (index > 0 && !isWhitespaceAt(text, previousStringIndex(text, index))) {
+    index = previousStringIndex(text, index);
+  }
+
+  return index;
+}
+
+function endWORDIndex(text: string, startIndex: number): number {
+  let index = Math.min(startIndex, text.length);
+  if (index >= text.length) {
+    return text.length;
+  }
+
+  if (!isWhitespaceAt(text, index)) {
+    const next = nextStringIndex(text, index);
+    if (next >= text.length) {
+      return index;
+    }
+    if (isWhitespaceAt(text, next)) {
+      index = next;
+      while (index < text.length && isWhitespaceAt(text, index)) {
+        index = nextStringIndex(text, index);
+      }
+    }
+    while (nextStringIndex(text, index) < text.length && !isWhitespaceAt(text, nextStringIndex(text, index))) {
+      index = nextStringIndex(text, index);
+    }
+    return index;
+  }
+
+  while (index < text.length && isWhitespaceAt(text, index)) {
+    index = nextStringIndex(text, index);
+  }
+  while (nextStringIndex(text, index) < text.length && !isWhitespaceAt(text, nextStringIndex(text, index))) {
+    index = nextStringIndex(text, index);
+  }
+
+  return index;
+}
+
+async function computeWORDMotionTarget(kind: WORDMotionKind, count: number): Promise<number | null> {
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = editor.getCursorPosition();
+  if (cursorPos === null) {
+    return null;
+  }
+
+  const bufferLength = editor.getBufferLength(bufferId);
+  const text = await editor.getBufferText(bufferId, 0, bufferLength);
+  let index = byteOffsetToStringIndex(text, cursorPos);
+
+  for (let i = 0; i < Math.max(1, count); i++) {
+    if (kind === "forward") {
+      index = nextWORDIndex(text, index);
+    } else if (kind === "backward") {
+      index = previousWORDIndex(text, index);
+    } else {
+      index = endWORDIndex(text, index);
+    }
+  }
+
+  return stringIndexToByteOffset(text, index);
+}
+
+function byteLengthOfCharAt(text: string, index: number): number {
+  if (index < 0 || index >= text.length) {
+    return 0;
+  }
+  const codePoint = text.codePointAt(index);
+  return editor.utf8ByteLength(String.fromCodePoint(codePoint ?? text.charCodeAt(index)));
+}
+
+async function applyOperatorWithRange(operator: string, start: number, end: number): Promise<void> {
+  const rangeStart = Math.min(start, end);
+  const rangeEnd = Math.max(start, end);
+  if (rangeEnd <= rangeStart) {
+    switchMode("normal");
+    return;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  if ((operator === "d" || operator === "c") && isActiveBufferEditingDisabled(bufferId)) {
+    switchMode("normal");
+    return;
+  }
+
+  const text = await editor.getBufferText(bufferId, rangeStart, rangeEnd);
+  if (text) {
+    editor.setClipboard(text);
+  }
+
+  switch (operator) {
+    case "d":
+      editor.deleteRange(bufferId, rangeStart, rangeEnd);
+      editor.setBufferCursor(bufferId, Math.min(rangeStart, editor.getBufferLength(bufferId)));
+      state.lastYankWasLinewise = false;
+      break;
+    case "c":
+      editor.deleteRange(bufferId, rangeStart, rangeEnd);
+      editor.setBufferCursor(bufferId, Math.min(rangeStart, editor.getBufferLength(bufferId)));
+      state.lastYankWasLinewise = false;
+      switchMode("insert");
+      return;
+    case "y":
+      editor.setBufferCursor(bufferId, rangeStart);
+      state.lastYankWasLinewise = false;
+      break;
+  }
+
+  switchMode("normal");
+}
+
+async function applyWORDOperatorMotion(operator: string, kind: WORDMotionKind, count: number): Promise<void> {
+  const start = editor.getCursorPosition();
+  const target = await computeWORDMotionTarget(kind, count);
+  if (start === null || target === null) {
+    switchMode("normal");
+    return;
+  }
+
+  let end = target;
+  if (kind === "end") {
+    const bufferId = editor.getActiveBufferId();
+    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+    const targetIndex = byteOffsetToStringIndex(bufferText, target);
+    end += byteLengthOfCharAt(bufferText, targetIndex);
+  } else if (kind === "forward") {
+    const bufferId = editor.getActiveBufferId();
+    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+    const targetIndex = byteOffsetToStringIndex(bufferText, target);
+    if (target >= start && !isWhitespaceAt(bufferText, targetIndex) && hasOnlyWhitespaceAfter(bufferText, targetIndex)) {
+      end += byteLengthOfCharAt(bufferText, targetIndex);
+    }
+  }
+
+  await applyOperatorWithRange(operator, start, end);
+}
+
+function WORDMotionKindFromRepeatMotion(motion: string): WORDMotionKind | null {
+  switch (motion) {
+    case "vi_WORD_forward":
+      return "forward";
+    case "vi_WORD_backward":
+      return "backward";
+    case "vi_WORD_end":
+      return "end";
+    default:
+      return null;
+  }
+}
+
+async function handleWORDMotionWithOperator(kind: WORDMotionKind): Promise<void> {
+  if (!state.pendingOperator) {
+    switchMode("normal");
+    return;
+  }
+
+  const operator = state.pendingOperator;
+  const count = consumeCount();
+  if (operator === "d" || operator === "c") {
+    state.lastChange = { type: "operator-motion", operator, motion: `vi_WORD_${kind}`, count };
+  }
+
+  await applyWORDOperatorMotion(operator, kind, count);
+}
+
+async function selectToPosition(target: number, includeTarget: boolean = false): Promise<void> {
+  const bufferId = editor.getActiveBufferId();
+  let destination = target;
+  if (includeTarget) {
+    const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+    const targetIndex = byteOffsetToStringIndex(bufferText, target);
+    destination += byteLengthOfCharAt(bufferText, targetIndex);
+  }
+
+  let cursor = editor.getCursorPosition();
+  while (cursor !== null && cursor !== destination) {
+    editor.executeAction(cursor < destination ? "select_right" : "select_left");
+    const next = editor.getCursorPosition();
+    if (next === cursor) {
+      break;
+    }
+    cursor = next;
+  }
+}
 
 // Apply an operator by turning the motion into a selection, then applying the
 // operator to that selected range.
@@ -609,6 +946,30 @@ function vi_word_end() : void {
 }
 registerHandler("vi_word_end", vi_word_end);
 
+async function vi_WORD() : Promise<void> {
+  const target = await computeWORDMotionTarget("forward", consumeCount());
+  if (target !== null) {
+    editor.setBufferCursor(editor.getActiveBufferId(), target);
+  }
+}
+registerHandler("vi_WORD", vi_WORD);
+
+async function vi_WORD_back() : Promise<void> {
+  const target = await computeWORDMotionTarget("backward", consumeCount());
+  if (target !== null) {
+    editor.setBufferCursor(editor.getActiveBufferId(), target);
+  }
+}
+registerHandler("vi_WORD_back", vi_WORD_back);
+
+async function vi_WORD_end() : Promise<void> {
+  const target = await computeWORDMotionTarget("end", consumeCount());
+  if (target !== null) {
+    editor.setBufferCursor(editor.getActiveBufferId(), target);
+  }
+}
+registerHandler("vi_WORD_end", vi_WORD_end);
+
 function vi_line_start() : void {
   consumeCount(); // Count doesn't apply to line start
   editor.executeAction("move_line_start");
@@ -691,6 +1052,143 @@ function vi_matching_bracket() : void {
   editor.executeAction("goto_matching_bracket");
 }
 registerHandler("vi_matching_bracket", vi_matching_bracket);
+
+function vi_paragraph_up() : void {
+  executeWithCount("move_to_paragraph_up");
+}
+registerHandler("vi_paragraph_up", vi_paragraph_up);
+
+function vi_paragraph_down() : void {
+  executeWithCount("move_to_paragraph_down");
+}
+registerHandler("vi_paragraph_down", vi_paragraph_down);
+
+function findWordUnderCursor(text: string, cursorIndex: number): { start: number; end: number; word: string } | null {
+  let index = Math.min(cursorIndex, Math.max(0, text.length - 1));
+  if (!isWordChar(text[index]) && index > 0 && isWordChar(text[index - 1])) {
+    index--;
+  }
+  if (!isWordChar(text[index])) {
+    return null;
+  }
+
+  let start = index;
+  let end = index + 1;
+  while (start > 0 && isWordChar(text[start - 1])) {
+    start--;
+  }
+  while (end < text.length && isWordChar(text[end])) {
+    end++;
+  }
+
+  return { start, end, word: text.slice(start, end) };
+}
+
+function isWholeWordMatch(text: string, start: number, end: number): boolean {
+  return !isWordChar(text[start - 1]) && !isWordChar(text[end]);
+}
+
+function findNextWholeWord(text: string, word: string, from: number, until: number): number | null {
+  let index = text.indexOf(word, from);
+  while (index !== -1 && index < until) {
+    const end = index + word.length;
+    if (isWholeWordMatch(text, index, end)) {
+      return index;
+    }
+    index = text.indexOf(word, index + 1);
+  }
+  return null;
+}
+
+function findPreviousWholeWord(text: string, word: string, before: number, min: number): number | null {
+  if (before <= min) {
+    return null;
+  }
+
+  let index = text.lastIndexOf(word, before - 1);
+  while (index !== -1 && index >= min) {
+    const end = index + word.length;
+    if (isWholeWordMatch(text, index, end)) {
+      return index;
+    }
+    if (index === 0) {
+      return null;
+    }
+    index = text.lastIndexOf(word, index - 1);
+  }
+  return null;
+}
+
+async function executeStoredWordSearch(
+  word: string,
+  direction: WordSearchDirection,
+  count: number,
+  currentWord?: { start: number; end: number; word: string },
+): Promise<void> {
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = editor.getCursorPosition();
+  if (cursorPos === null) {
+    return;
+  }
+
+  const text = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const cursorIndex = byteOffsetToStringIndex(text, cursorPos);
+  const wordAtCursor = currentWord ?? findWordUnderCursor(text, cursorIndex);
+  const searchStart = wordAtCursor?.word === word ? wordAtCursor.start : cursorIndex;
+  const searchEnd = wordAtCursor?.word === word ? wordAtCursor.end : nextStringIndex(text, cursorIndex);
+
+  let match: number | null = null;
+  let fromStart = searchStart;
+  let fromEnd = searchEnd;
+  for (let i = 0; i < count; i++) {
+    if (direction === "forward") {
+      match = findNextWholeWord(text, word, fromEnd, text.length)
+        ?? findNextWholeWord(text, word, 0, fromStart);
+    } else {
+      match = findPreviousWholeWord(text, word, fromStart, 0)
+        ?? findPreviousWholeWord(text, word, text.length, fromEnd);
+    }
+
+    if (match === null) {
+      return;
+    }
+
+    fromStart = match;
+    fromEnd = match + word.length;
+  }
+
+  if (match !== null) {
+    editor.setBufferCursor(bufferId, stringIndexToByteOffset(text, match));
+  }
+}
+
+async function executeWordUnderCursorSearch(direction: WordSearchDirection, count: number): Promise<void> {
+  const bufferId = editor.getActiveBufferId();
+  const cursorPos = editor.getCursorPosition();
+  if (cursorPos === null) {
+    return;
+  }
+
+  const text = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const cursorIndex = byteOffsetToStringIndex(text, cursorPos);
+  const currentWord = findWordUnderCursor(text, cursorIndex);
+  if (currentWord === null) {
+    return;
+  }
+
+  state.lastWordSearch = { word: currentWord.word, direction };
+  await executeStoredWordSearch(currentWord.word, direction, count, currentWord);
+}
+
+async function vi_search_word_forward() : Promise<void> {
+  await executeWordUnderCursorSearch("forward", consumeCount());
+}
+registerHandler("vi_search_word_forward", vi_search_word_forward);
+
+async function vi_search_word_backward() : Promise<void> {
+  await executeWordUnderCursorSearch("backward", consumeCount());
+}
+registerHandler("vi_search_word_backward", vi_search_word_backward);
 
 // Mode switching
 function vi_insert_before() : void {
@@ -915,7 +1413,7 @@ async function vi_repeat() : Promise<void> {
   }
 
   const change = state.lastChange;
-  const count = consumeCount() || change.count || 1;
+  const count = consumeCountOrDefault(change.count ?? 1);
 
   switch (change.type) {
     case "simple": {
@@ -954,12 +1452,19 @@ async function vi_repeat() : Promise<void> {
     case "operator-motion": {
       // Operator + motion like dw, cw, d$
       if (change.operator && change.motion) {
+        const WORDKind = WORDMotionKindFromRepeatMotion(change.motion);
         if (change.operator === "c") {
-          // For change: do the delete part, then insert the text
-          await applyOperatorWithMotion("d", change.motion, count);
+          if (WORDKind) {
+            await applyWORDOperatorMotion("d", WORDKind, count);
+          } else {
+            // For change: do the delete part, then insert the text
+            await applyOperatorWithMotion("d", change.motion, count);
+          }
           if (change.insertedText) {
             editor.insertAtCursor(change.insertedText);
           }
+        } else if (WORDKind) {
+          await applyWORDOperatorMotion(change.operator, WORDKind, count);
         } else {
           await applyOperatorWithMotion(change.operator, change.motion, count);
         }
@@ -1010,22 +1515,33 @@ registerHandler("vi_toggle_case", vi_toggle_case);
 
 // Search
 function vi_search_forward() : void {
+  state.lastWordSearch = null;
   editor.executeAction("search");
 }
 registerHandler("vi_search_forward", vi_search_forward);
 
 function vi_search_backward() : void {
+  state.lastWordSearch = null;
   // Use same search dialog, user can search backward manually
   editor.executeAction("search");
 }
 registerHandler("vi_search_backward", vi_search_backward);
 
-function vi_find_next() : void {
+async function vi_find_next() : Promise<void> {
+  if (state.lastWordSearch) {
+    await executeStoredWordSearch(state.lastWordSearch.word, state.lastWordSearch.direction, consumeCount());
+    return;
+  }
   editor.executeAction("find_next");
 }
 registerHandler("vi_find_next", vi_find_next);
 
-function vi_find_prev() : void {
+async function vi_find_prev() : Promise<void> {
+  if (state.lastWordSearch) {
+    const direction = state.lastWordSearch.direction === "forward" ? "backward" : "forward";
+    await executeStoredWordSearch(state.lastWordSearch.word, direction, consumeCount());
+    return;
+  }
   editor.executeAction("find_previous");
 }
 registerHandler("vi_find_prev", vi_find_prev);
@@ -1278,6 +1794,30 @@ function vi_vis_word_end() : void {
 }
 registerHandler("vi_vis_word_end", vi_vis_word_end);
 
+async function vi_vis_WORD() : Promise<void> {
+  const target = await computeWORDMotionTarget("forward", consumeCount());
+  if (target !== null) {
+    await selectToPosition(target);
+  }
+}
+registerHandler("vi_vis_WORD", vi_vis_WORD);
+
+async function vi_vis_WORD_back() : Promise<void> {
+  const target = await computeWORDMotionTarget("backward", consumeCount());
+  if (target !== null) {
+    await selectToPosition(target);
+  }
+}
+registerHandler("vi_vis_WORD_back", vi_vis_WORD_back);
+
+async function vi_vis_WORD_end() : Promise<void> {
+  const target = await computeWORDMotionTarget("end", consumeCount());
+  if (target !== null) {
+    await selectToPosition(target, true);
+  }
+}
+registerHandler("vi_vis_WORD_end", vi_vis_WORD_end);
+
 function vi_vis_line_start() : void {
   consumeCount();
   editor.executeAction("select_line_start");
@@ -1301,6 +1841,16 @@ function vi_vis_doc_end() : void {
   editor.executeAction("select_document_end");
 }
 registerHandler("vi_vis_doc_end", vi_vis_doc_end);
+
+function vi_vis_paragraph_up() : void {
+  executeWithCount("select_to_paragraph_up");
+}
+registerHandler("vi_vis_paragraph_up", vi_vis_paragraph_up);
+
+function vi_vis_paragraph_down() : void {
+  executeWithCount("select_to_paragraph_down");
+}
+registerHandler("vi_vis_paragraph_down", vi_vis_paragraph_down);
 
 // Visual line mode motions - extend selection by whole lines
 function vi_vline_down() : void {
@@ -1848,6 +2398,21 @@ async function vi_op_word_end(): Promise<void> {
 }
 registerHandler("vi_op_word_end", vi_op_word_end);
 
+async function vi_op_WORD(): Promise<void> {
+  await handleWORDMotionWithOperator("forward");
+}
+registerHandler("vi_op_WORD", vi_op_WORD);
+
+async function vi_op_WORD_back(): Promise<void> {
+  await handleWORDMotionWithOperator("backward");
+}
+registerHandler("vi_op_WORD_back", vi_op_WORD_back);
+
+async function vi_op_WORD_end(): Promise<void> {
+  await handleWORDMotionWithOperator("end");
+}
+registerHandler("vi_op_WORD_end", vi_op_WORD_end);
+
 async function vi_op_line_start(): Promise<void> {
   await handleMotionWithOperator("move_line_start");
 }
@@ -1877,6 +2442,16 @@ async function vi_op_matching_bracket(): Promise<void> {
   await handleMotionWithOperator("goto_matching_bracket");
 }
 registerHandler("vi_op_matching_bracket", vi_op_matching_bracket);
+
+async function vi_op_paragraph_up(): Promise<void> {
+  await handleMotionWithOperator("move_to_paragraph_up");
+}
+registerHandler("vi_op_paragraph_up", vi_op_paragraph_up);
+
+async function vi_op_paragraph_down(): Promise<void> {
+  await handleMotionWithOperator("move_to_paragraph_down");
+}
+registerHandler("vi_op_paragraph_down", vi_op_paragraph_down);
 
 function vi_cancel(): void {
   switchMode("normal");
@@ -1909,6 +2484,15 @@ editor.defineMode("vi-normal", [
   ["w", "vi_word"],
   ["b", "vi_word_back"],
   ["e", "vi_word_end"],
+  ...configuredBindings(arrowKeys, [
+    ["Left", "vi_left"],
+    ["Down", "vi_down"],
+    ["Up", "vi_up"],
+    ["Right", "vi_right"],
+  ]),
+  ["W", "vi_WORD"],
+  ["B", "vi_WORD_back"],
+  ["E", "vi_WORD_end"],
   ["$", "vi_line_end"],
   ["^", "vi_first_non_blank"],
   ["g g", "vi_doc_start"],
@@ -1919,12 +2503,18 @@ editor.defineMode("vi-normal", [
   ["C-u", "vi_half_page_up"],
   ["%", "vi_matching_bracket"],
   ["z z", "vi_center_cursor"],
+  ["{", "vi_paragraph_up"],
+  ["}", "vi_paragraph_down"],
 
   // Search
   ["/", "vi_search_forward"],
   ["?", "vi_search_backward"],
   ["n", "vi_find_next"],
   ["N", "vi_find_prev"],
+  ...configuredBindings(searchWordUnderCursor, [
+    ["*", "vi_search_word_forward"],
+    ["#", "vi_search_word_backward"],
+  ]),
 
   // Find character on line
   ["f", "vi_find_char_f"],
@@ -1989,6 +2579,12 @@ editor.defineMode("vi-normal", [
 // Define vi-insert mode - only Escape is special, other keys insert text
 editor.defineMode("vi-insert", [
   ["Escape", "vi_escape"],
+  ...configuredBindings(arrowKeys, [
+    ["Left", "move_left"],
+    ["Down", "move_down"],
+    ["Up", "move_up"],
+    ["Right", "move_right"],
+  ]),
   // Pass through to standard editor shortcuts
   ["C-p", "command_palette"],
   ["C-q", "quit"],
@@ -2021,10 +2617,21 @@ editor.defineMode("vi-operator-pending", [
   ["w", "vi_op_word"],
   ["b", "vi_op_word_back"],
   ["e", "vi_op_word_end"],
+  ...configuredBindings(arrowKeys, [
+    ["Left", "vi_op_left"],
+    ["Down", "vi_op_down"],
+    ["Up", "vi_op_up"],
+    ["Right", "vi_op_right"],
+  ]),
+  ["W", "vi_op_WORD"],
+  ["B", "vi_op_WORD_back"],
+  ["E", "vi_op_WORD_end"],
   ["$", "vi_op_line_end"],
   ["g g", "vi_op_doc_start"],
   ["G", "vi_op_doc_end"],
   ["%", "vi_op_matching_bracket"],
+  ["{", "vi_op_paragraph_up"],
+  ["}", "vi_op_paragraph_down"],
 
   // Text objects
   ["i", "vi_text_object_inner"],
@@ -2088,10 +2695,21 @@ editor.defineMode("vi-visual", [
   ["w", "vi_vis_word"],
   ["b", "vi_vis_word_back"],
   ["e", "vi_vis_word_end"],
+  ...configuredBindings(arrowKeys, [
+    ["Left", "vi_vis_left"],
+    ["Down", "vi_vis_down"],
+    ["Up", "vi_vis_up"],
+    ["Right", "vi_vis_right"],
+  ]),
+  ["W", "vi_vis_WORD"],
+  ["B", "vi_vis_WORD_back"],
+  ["E", "vi_vis_WORD_end"],
   ["$", "vi_vis_line_end"],
   ["^", "vi_vis_line_start"],
   ["g g", "vi_vis_doc_start"],
   ["G", "vi_vis_doc_end"],
+  ["{", "vi_vis_paragraph_up"],
+  ["}", "vi_vis_paragraph_down"],
 
   // Switch visual sub-modes
   ["V", "vi_visual_toggle_line"],
@@ -2129,6 +2747,10 @@ editor.defineMode("vi-visual-line", [
   // Line motions (extend selection by lines)
   ["j", "vi_vline_down"],
   ["k", "vi_vline_up"],
+  ...configuredBindings(arrowKeys, [
+    ["Down", "vi_vline_down"],
+    ["Up", "vi_vline_up"],
+  ]),
   ["g g", "vi_vis_doc_start"],
   ["G", "vi_vis_doc_end"],
 
@@ -2171,6 +2793,12 @@ editor.defineMode("vi-visual-block", [
   ["j", "vi_vblock_down"],
   ["k", "vi_vblock_up"],
   ["l", "vi_vblock_right"],
+  ...configuredBindings(arrowKeys, [
+    ["Left", "vi_vblock_left"],
+    ["Down", "vi_vblock_down"],
+    ["Up", "vi_vblock_up"],
+    ["Right", "vi_vblock_right"],
+  ]),
   ["$", "vi_vblock_line_end"],
   ["^", "vi_vblock_line_start"],
 
@@ -3158,14 +3786,6 @@ editor.exportPluginApi("vi-mode", {
 // Initialization
 // ============================================================================
 
-// User-configurable opt-in: when enabled, vi mode kicks in for every
-// session without the user having to run the toggle command. Surfaces
-// in Settings UI under "Plugin: vi_mode".
-const autoStart = editor.defineConfigBoolean("autoStart", {
-  default: false,
-  description:
-    "Automatically enable vi mode when the editor starts. Default off — users opt in.",
-});
 if (autoStart) {
   enableVi();
 }

--- a/crates/fresh-editor/src/input/actions.rs
+++ b/crates/fresh-editor/src/input/actions.rs
@@ -61,7 +61,7 @@ fn find_paragraph_up(buffer: &mut Buffer, pos: usize, estimated_line_length: usi
     let mut found_pos = None;
     while let Some((line_start, line_content)) = iter.prev() {
         let trimmed = line_content.trim_end_matches(['\n', '\r']);
-        if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
+        if trimmed.is_empty() {
             found_pos = Some(line_start);
             break;
         }
@@ -69,18 +69,110 @@ fn find_paragraph_up(buffer: &mut Buffer, pos: usize, estimated_line_length: usi
     found_pos.unwrap_or(0)
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ParagraphDownTarget {
+    position: usize,
+    reached_eof: bool,
+}
+
 fn find_paragraph_down(buffer: &mut Buffer, pos: usize, estimated_line_length: usize) -> usize {
+    find_paragraph_down_target(buffer, pos, estimated_line_length).position
+}
+
+fn find_paragraph_down_target(
+    buffer: &mut Buffer,
+    pos: usize,
+    estimated_line_length: usize,
+) -> ParagraphDownTarget {
+    let buffer_len = buffer.len();
     let mut iter = buffer.line_iterator(pos, estimated_line_length);
     iter.next_line();
-    let mut found_pos = None;
     while let Some((line_start, line_content)) = iter.next_line() {
-        let trimmed = line_content.trim_end_matches(['\n', '\r']);
-        if trimmed.is_empty() || trimmed.chars().all(char::is_whitespace) {
-            found_pos = Some(line_start);
+        if is_virtual_trailing_line(buffer_len, line_start, &line_content) {
             break;
         }
+
+        let trimmed = line_content.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() {
+            return ParagraphDownTarget {
+                position: line_start,
+                reached_eof: false,
+            };
+        }
     }
-    found_pos.unwrap_or(buffer.len())
+
+    ParagraphDownTarget {
+        position: paragraph_down_eof_position(buffer),
+        reached_eof: true,
+    }
+}
+
+fn is_virtual_trailing_line(buffer_len: usize, line_start: usize, line_content: &str) -> bool {
+    // Vim's findpar() never sees a synthetic line after a final newline: when
+    // curr moves past b_ml.ml_line_count it backs up to the last real line and
+    // then places the cursor on that line's final character. Fresh's
+    // line_iterator intentionally emits that synthetic trailing line, so map it
+    // back to Vim's EOF branch here.
+    line_start == buffer_len && line_content.is_empty()
+}
+
+fn paragraph_down_eof_position(buffer: &Buffer) -> usize {
+    let len = buffer.len();
+    if len == 0 {
+        return 0;
+    }
+
+    let mut content_end = len;
+    if buffer
+        .slice_bytes(content_end.saturating_sub(1)..content_end)
+        .first()
+        == Some(&b'\n')
+    {
+        content_end = content_end.saturating_sub(1);
+        if content_end > 0
+            && buffer
+                .slice_bytes(content_end.saturating_sub(1)..content_end)
+                .first()
+                == Some(&b'\r')
+        {
+            content_end = content_end.saturating_sub(1);
+        }
+    } else if buffer
+        .slice_bytes(content_end.saturating_sub(1)..content_end)
+        .first()
+        == Some(&b'\r')
+    {
+        content_end = content_end.saturating_sub(1);
+    }
+
+    if content_end == 0 {
+        0
+    } else {
+        buffer.prev_grapheme_boundary(content_end)
+    }
+}
+
+fn paragraph_down_selection_position(
+    buffer: &mut Buffer,
+    pos: usize,
+    estimated_line_length: usize,
+) -> usize {
+    let target = find_paragraph_down_target(buffer, pos, estimated_line_length);
+    if target.reached_eof {
+        return buffer.len();
+    }
+
+    let target = target.position;
+    if target < buffer.len()
+        && !matches!(
+            buffer.slice_bytes(target..target + 1).first(),
+            Some(b'\n') | Some(b'\r')
+        )
+    {
+        buffer.next_grapheme_boundary(target)
+    } else {
+        target
+    }
 }
 
 /// Adjust position after moving left in CRLF mode.
@@ -2166,7 +2258,11 @@ pub fn action_to_events(
 
         Action::SelectToParagraphDown => {
             select_each_cursor(cursors, &mut events, |c| {
-                find_paragraph_down(&mut state.buffer, c.position, estimated_line_length)
+                paragraph_down_selection_position(
+                    &mut state.buffer,
+                    c.position,
+                    estimated_line_length,
+                )
             });
         }
 

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -256,7 +256,7 @@ fn test_vi_word_navigation() {
 fn test_vi_vim_compat_options_default_enabled() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
 
-    let fixture = TestFixture::new("test.txt", "one.two three\n\nalpha beta alpha\n").unwrap();
+    let fixture = TestFixture::new("test.txt", "alpha beta alpha\n").unwrap();
     harness.open_file(&fixture.path).unwrap();
     harness.render().unwrap();
 
@@ -266,28 +266,13 @@ fn test_vi_vim_compat_options_default_enabled() {
         .send_key(KeyCode::Right, KeyModifiers::NONE)
         .unwrap();
     harness.render().unwrap();
-    harness.wait_for_screen_contains("Ln 1, Col 2").unwrap();
-
-    send_vi_key(&mut harness, 'W');
-    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
-
-    send_vi_key(&mut harness, 'B');
-    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
-
-    send_vi_key(&mut harness, 'E');
-    harness.wait_for_screen_contains("Ln 1, Col 7").unwrap();
-
-    send_vi_key(&mut harness, '}');
-    harness.wait_for_screen_contains("Ln 2, Col 1").unwrap();
-
-    send_vi_key(&mut harness, 'j');
-    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 1).unwrap();
 
     send_vi_key(&mut harness, '*');
-    harness.wait_for_screen_contains("Ln 3, Col 12").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 11).unwrap();
 
     send_vi_key(&mut harness, '#');
-    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
 }
 
 #[test]
@@ -301,33 +286,21 @@ fn test_vi_vim_compat_optional_features_can_be_disabled() {
         }),
     );
 
-    let fixture = TestFixture::new("test.txt", "one.two three\n\nalpha beta alpha\n").unwrap();
+    let fixture = TestFixture::new("test.txt", "alpha beta alpha\n").unwrap();
     harness.open_file(&fixture.path).unwrap();
     harness.render().unwrap();
 
     enable_vi_mode(&mut harness);
-    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
 
     harness
         .send_key(KeyCode::Right, KeyModifiers::NONE)
         .unwrap();
     harness.render().unwrap();
-    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
-
-    send_vi_key(&mut harness, 'W');
-    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
-
-    send_vi_key(&mut harness, 'B');
-    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
-
-    send_vi_key(&mut harness, '}');
-    harness.wait_for_screen_contains("Ln 2, Col 1").unwrap();
-
-    send_vi_key(&mut harness, 'j');
-    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
 
     send_vi_key(&mut harness, '*');
-    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+    harness.wait_until(|h| h.cursor_position() == 0).unwrap();
 }
 
 #[test]
@@ -342,6 +315,72 @@ fn test_vi_vim_compat_operator_motions_default_enabled() {
 
     send_vi_operator_motion(&mut harness, 'd', 'W');
     wait_for_rendered_lines_in_order(&mut harness, &["1 │ three", "2 │ second"]);
+}
+
+#[test]
+fn test_vi_vim_compat_change_word_motion_keeps_following_space() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'W');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X three\n");
+}
+
+#[test]
+fn test_vi_vim_compat_change_word_motion_honors_count() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three four\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'c');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '2');
+    send_vi_key(&mut harness, 'W');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-insert".to_string()))
+        .unwrap();
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X four\n");
+}
+
+#[test]
+fn test_vi_vim_compat_repeat_change_word_keeps_change_semantics() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three four.five\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'W');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.assert_buffer_content("X three four.five\n");
+
+    send_vi_key(&mut harness, 'W');
+    send_vi_key(&mut harness, '.');
+
+    harness.assert_buffer_content("X X four.five\n");
 }
 
 #[test]
@@ -366,7 +405,7 @@ fn test_vi_vim_compat_repeat_uses_original_operator_count() {
     harness.assert_buffer_content("four five six seven\n");
 
     send_vi_key(&mut harness, '.');
-    harness.assert_buffer_content("seven\n");
+    harness.wait_for_buffer_content("seven\n").unwrap();
 }
 
 #[test]
@@ -392,7 +431,7 @@ fn test_vi_vim_compat_repeat_prefix_count_overrides_original_operator_count() {
 
     send_vi_key(&mut harness, '2');
     send_vi_key(&mut harness, '.');
-    harness.assert_buffer_content("six seven\n");
+    harness.wait_for_buffer_content("six seven\n").unwrap();
 }
 
 #[test]
@@ -410,7 +449,7 @@ fn test_vi_vim_compat_word_motion_stops_before_trailing_eof_whitespace() {
 }
 
 #[test]
-fn test_vi_vim_compat_word_motion_does_not_move_backward_from_trailing_whitespace() {
+fn test_vi_vim_compat_word_motion_moves_to_end_of_trailing_whitespace() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
 
     let fixture = TestFixture::new("test.txt", "foo   \n").unwrap();
@@ -425,7 +464,26 @@ fn test_vi_vim_compat_word_motion_does_not_move_backward_from_trailing_whitespac
     harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
 
     send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 6").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_word_motion_moves_to_end_of_trailing_whitespace_with_crlf() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo   \r\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
     harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 6").unwrap();
 }
 
 #[test]
@@ -443,7 +501,7 @@ fn test_vi_vim_compat_operator_word_motion_preserves_trailing_newline() {
 }
 
 #[test]
-fn test_vi_vim_compat_operator_word_motion_does_not_delete_backward_from_trailing_whitespace() {
+fn test_vi_vim_compat_operator_word_motion_deletes_trailing_whitespace() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
 
     let fixture = TestFixture::new("test.txt", "foo   \n").unwrap();
@@ -458,8 +516,28 @@ fn test_vi_vim_compat_operator_word_motion_does_not_delete_backward_from_trailin
     harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
 
     send_vi_operator_motion(&mut harness, 'd', 'W');
-    harness.assert_buffer_content("foo   \n");
+    harness.assert_buffer_content("foo\n");
+    harness.wait_for_screen_contains("Ln 1, Col 3").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_operator_word_motion_deletes_trailing_whitespace_with_crlf() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo   \r\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
     harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_operator_motion(&mut harness, 'd', 'W');
+    harness.assert_buffer_content("foo\r\n");
+    harness.wait_for_screen_contains("Ln 1, Col 3").unwrap();
 }
 
 #[test]
@@ -567,6 +645,194 @@ fn test_vi_vim_compat_search_backward_skips_prefix_match_at_buffer_start() {
     harness.wait_for_screen_contains("Ln 1, Col 8").unwrap();
 }
 
+#[test]
+fn test_vi_vim_compat_star_on_space_uses_next_word_on_line() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "cat dog cat\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 1, Col 5").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_star_on_leading_indent_uses_next_word_on_line() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "   cat tail\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_hash_on_space_uses_next_word_on_line() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "cat dog cat dog\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_key(&mut harness, '#');
+    harness.wait_for_screen_contains("Ln 1, Col 13").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_star_hash_fall_back_to_non_blank_string() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", ". .\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 1, Col 3").unwrap();
+
+    send_vi_key(&mut harness, '#');
+    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_paragraph_down_at_trailing_newline_eof_stays_on_last_line() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n\ntwo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+    send_vi_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 5).unwrap();
+
+    send_vi_key(&mut harness, '}');
+    assert_eq!(harness.cursor_position(), 7);
+}
+
+#[test]
+fn test_vi_vim_compat_paragraph_down_at_eof_without_trailing_newline_stays_on_last_char() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n\ntwo").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+    send_vi_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 5).unwrap();
+
+    send_vi_key(&mut harness, '}');
+    assert_eq!(harness.cursor_position(), 7);
+}
+
+#[test]
+fn test_vi_vim_compat_paragraph_down_skips_whitespace_only_lines() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n   \ntwo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '}');
+    assert_eq!(harness.cursor_position(), 10);
+}
+
+#[test]
+fn test_vi_vim_compat_operator_paragraph_down_skips_whitespace_only_lines() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n   \ntwo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'd', '}');
+    harness.assert_buffer_content("\n");
+}
+
+#[test]
+fn test_vi_vim_compat_paragraph_up_skips_whitespace_only_lines() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n   \ntwo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '}');
+    assert_eq!(harness.cursor_position(), 10);
+
+    send_vi_key(&mut harness, '{');
+    assert_eq!(harness.cursor_position(), 0);
+}
+
+#[test]
+fn test_vi_vim_compat_operator_paragraph_up_skips_whitespace_only_lines() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n   \ntwo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '}');
+    assert_eq!(harness.cursor_position(), 10);
+
+    send_vi_operator_motion(&mut harness, 'd', '{');
+    harness.assert_buffer_content("o\n");
+}
+
+#[test]
+fn test_vi_vim_compat_word_forward_and_back_stop_on_empty_line() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one\n\nthree\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_until(|h| h.cursor_position() == 5).unwrap();
+
+    send_vi_key(&mut harness, 'B');
+    harness.wait_until(|h| h.cursor_position() == 4).unwrap();
+}
 #[test]
 fn test_vi_vim_compat_word_search_repeats_with_n_and_shift_n() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
@@ -1381,6 +1647,119 @@ fn test_vi_visual_line_delete() {
     harness.wait_for_buffer_content("AAA\nCCC\n").unwrap();
 }
 
+#[test]
+fn test_vi_visual_word_end_yanks_selected_text() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "elephant zebra giraffe\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'v');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, 'E');
+    send_vi_key(&mut harness, 'y');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness
+        .wait_for_buffer_content("elephant zebra giraffeelephant\n")
+        .unwrap();
+}
+
+#[test]
+fn test_vi_visual_word_forward_yanks_selected_text() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "elephant zebra giraffe\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'v');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, 'W');
+    send_vi_key(&mut harness, 'y');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness
+        .wait_for_buffer_content("elephant zebra giraffeelephant z\n")
+        .unwrap();
+}
+
+#[test]
+fn test_vi_visual_word_forward_accumulates_from_visual_head() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "elephant zebra giraffe\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'v');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, 'W');
+    send_vi_key(&mut harness, 'W');
+    send_vi_key(&mut harness, 'y');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness
+        .wait_for_buffer_content("elephant zebra giraffeelephant zebra g\n")
+        .unwrap();
+}
+
+#[test]
+fn test_vi_visual_word_back_yanks_selected_text() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "alpha beta gamma\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'w');
+    send_vi_key(&mut harness, 'w');
+    harness.wait_until(|h| h.cursor_position() == 11).unwrap();
+
+    send_vi_key(&mut harness, 'v');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, 'B');
+    harness.wait_until(|h| h.cursor_position() == 6).unwrap();
+    send_vi_key(&mut harness, 'y');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness
+        .wait_for_buffer_content("alpha beta gammabeta g\n")
+        .unwrap();
+}
 /// Test visual mode yank and paste
 #[test]
 fn test_vi_visual_yank() {

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -11,11 +11,20 @@ use crate::common::fixtures::TestFixture;
 use crate::common::harness::{copy_plugin, copy_plugin_lib, EditorTestHarness};
 use crate::common::tracing::init_tracing_from_env;
 use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::{Config, PluginConfig};
 use fresh::input::keybindings::Action::PluginAction;
 use std::fs;
 
 /// Create a harness with vi mode plugin loaded (uses real plugins/vi_mode.ts)
 fn vi_mode_harness(width: u16, height: u16) -> (EditorTestHarness, tempfile::TempDir) {
+    vi_mode_harness_with_settings(width, height, serde_json::json!({}))
+}
+
+fn vi_mode_harness_with_settings(
+    width: u16,
+    height: u16,
+    settings: serde_json::Value,
+) -> (EditorTestHarness, tempfile::TempDir) {
     init_tracing_from_env();
     // Create a temporary project directory
     let temp_dir = tempfile::TempDir::new().unwrap();
@@ -28,14 +37,20 @@ fn vi_mode_harness(width: u16, height: u16) -> (EditorTestHarness, tempfile::Tem
     copy_plugin(&plugins_dir, "vi_mode");
     copy_plugin_lib(&plugins_dir);
 
+    let mut config = Config::default();
+    config.plugins.insert(
+        "vi_mode".to_string(),
+        PluginConfig {
+            enabled: true,
+            path: None,
+            settings,
+        },
+    );
+
     // Create harness with the project directory (so plugins load)
-    let mut harness = EditorTestHarness::with_config_and_working_dir(
-        width,
-        height,
-        Default::default(),
-        project_root.clone(),
-    )
-    .unwrap();
+    let mut harness =
+        EditorTestHarness::with_config_and_working_dir(width, height, config, project_root.clone())
+            .unwrap();
 
     // Enable internal-only clipboard to isolate tests from each other
     harness.editor_mut().set_clipboard_for_test("".to_string());
@@ -98,6 +113,14 @@ fn send_vi_operator_motion(harness: &mut EditorTestHarness, operator: char, moti
         .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
         .unwrap();
     send_vi_key(harness, motion);
+    let expected_mode = if operator == 'c' {
+        "vi-insert"
+    } else {
+        "vi-normal"
+    };
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some(expected_mode.to_string()))
+        .unwrap();
 }
 
 fn wait_for_rendered_lines_in_order(harness: &mut EditorTestHarness, expected: &[&str]) {
@@ -227,6 +250,341 @@ fn test_vi_word_navigation() {
 
     // Content should be unchanged
     harness.assert_buffer_content("hello world test\n");
+}
+
+#[test]
+fn test_vi_vim_compat_options_default_enabled() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three\n\nalpha beta alpha\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.wait_for_screen_contains("Ln 1, Col 2").unwrap();
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
+
+    send_vi_key(&mut harness, 'B');
+    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+
+    send_vi_key(&mut harness, 'E');
+    harness.wait_for_screen_contains("Ln 1, Col 7").unwrap();
+
+    send_vi_key(&mut harness, '}');
+    harness.wait_for_screen_contains("Ln 2, Col 1").unwrap();
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 3, Col 12").unwrap();
+
+    send_vi_key(&mut harness, '#');
+    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_optional_features_can_be_disabled() {
+    let (mut harness, _temp_dir) = vi_mode_harness_with_settings(
+        100,
+        30,
+        serde_json::json!({
+            "arrowKeys": false,
+            "searchWordUnderCursor": false,
+        }),
+    );
+
+    let fixture = TestFixture::new("test.txt", "one.two three\n\nalpha beta alpha\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+
+    harness
+        .send_key(KeyCode::Right, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
+
+    send_vi_key(&mut harness, 'B');
+    harness.wait_for_screen_contains("Ln 1, Col 1").unwrap();
+
+    send_vi_key(&mut harness, '}');
+    harness.wait_for_screen_contains("Ln 2, Col 1").unwrap();
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 3, Col 1").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_operator_motions_default_enabled() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three\nsecond\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'd', 'W');
+    wait_for_rendered_lines_in_order(&mut harness, &["1 │ three", "2 │ second"]);
+}
+
+#[test]
+fn test_vi_vim_compat_repeat_uses_original_operator_count() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one two three four five six seven\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'd');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '3');
+    send_vi_key(&mut harness, 'W');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    harness.assert_buffer_content("four five six seven\n");
+
+    send_vi_key(&mut harness, '.');
+    harness.assert_buffer_content("seven\n");
+}
+
+#[test]
+fn test_vi_vim_compat_repeat_prefix_count_overrides_original_operator_count() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one two three four five six seven\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'd');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '3');
+    send_vi_key(&mut harness, 'W');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    harness.assert_buffer_content("four five six seven\n");
+
+    send_vi_key(&mut harness, '2');
+    send_vi_key(&mut harness, '.');
+    harness.assert_buffer_content("six seven\n");
+}
+
+#[test]
+fn test_vi_vim_compat_word_motion_stops_before_trailing_eof_whitespace() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 3").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_word_motion_does_not_move_backward_from_trailing_whitespace() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo   \n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_key(&mut harness, 'W');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_operator_word_motion_preserves_trailing_newline() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'd', 'W');
+    harness.assert_buffer_content("\n");
+}
+
+#[test]
+fn test_vi_vim_compat_operator_word_motion_does_not_delete_backward_from_trailing_whitespace() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo   \n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+
+    send_vi_operator_motion(&mut harness, 'd', 'W');
+    harness.assert_buffer_content("foo   \n");
+    harness.wait_for_screen_contains("Ln 1, Col 4").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_word_end_advances_from_current_word_end() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo bar\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'l');
+    send_vi_key(&mut harness, 'l');
+    harness.wait_for_screen_contains("Ln 1, Col 3").unwrap();
+
+    send_vi_key(&mut harness, 'E');
+    harness.wait_for_screen_contains("Ln 1, Col 7").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_yank_word_with_multibyte_text_uses_byte_range() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "éé next\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'y', 'W');
+    harness.assert_buffer_content("éé next\n");
+
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness.assert_buffer_content("éé nextéé \n");
+}
+
+#[test]
+fn test_vi_vim_compat_word_end_handles_astral_unicode_boundaries() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "😀 next\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'y', 'E');
+    harness.assert_buffer_content("😀 next\n");
+
+    send_vi_key(&mut harness, '$');
+    send_vi_key(&mut harness, 'p');
+
+    harness.assert_buffer_content("😀 next😀 next\n");
+}
+
+#[test]
+fn test_vi_vim_compat_search_count_does_not_leak_to_next_motion() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo a foo b foo c foo\none\ntwo\nthree\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '3');
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 1, Col 19").unwrap();
+
+    send_vi_key(&mut harness, 'j');
+    harness.wait_for_screen_contains("Ln 2, Col 4").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_search_backward_wraps_from_first_match() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo bar foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '#');
+    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_search_backward_skips_prefix_match_at_buffer_start() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foobar foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'w');
+    harness.wait_for_screen_contains("Ln 1, Col 8").unwrap();
+
+    send_vi_key(&mut harness, '#');
+    harness.wait_for_screen_contains("Ln 1, Col 8").unwrap();
+}
+
+#[test]
+fn test_vi_vim_compat_word_search_repeats_with_n_and_shift_n() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "foo foo foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, '*');
+    harness.wait_for_screen_contains("Ln 1, Col 5").unwrap();
+
+    send_vi_key(&mut harness, 'n');
+    harness.wait_for_screen_contains("Ln 1, Col 9").unwrap();
+
+    send_vi_key(&mut harness, 'N');
+    harness.wait_for_screen_contains("Ln 1, Col 5").unwrap();
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

This PR fills in several common vi/Vim navigation and search behaviors in the `vi_mode` plugin:

- Enables arrow-key navigation in vi mode behind a default-on `arrowKeys` setting.
- Adds `W`, `B`, and `E` WORD motions in normal, operator-pending, and visual mode.
- Adds `{` and `}` paragraph motions in normal, operator-pending, and visual mode.
- Adds `*` and `#` word-under-cursor search behind a default-on `searchWordUnderCursor` setting.
- Supports count, wraparound, and `n` / `N` repeat behavior for `*` / `#` searches.
- Preserves counted WORD operator motions across `.` repeat, while allowing an explicit repeat count such as `2.` to override the original count.
- Covers byte-offset edge cases for multibyte text and astral Unicode in WORD operator motions.

## Notes

This PR adds two plugin settings:

- `arrowKeys` (default: `true`): binds the arrow keys in vi modes. When disabled, vi mode no longer handles arrow-key movement.
- `searchWordUnderCursor` (default: `true`): binds `*` and `#` in vi normal mode. When enabled, `*` searches forward for the word under the cursor and `#` searches backward; both support count, wraparound, and `n` / `N` repeat.

`W` / `B` / `E` and `{` / `}` are treated as baseline vi motion coverage, so they are always enabled rather than hidden behind settings.

The optional settings are limited to behaviors that are more editor-flavor dependent: arrow-key handling and `*` / `#` word-under-cursor search.

The repeat-count handling matters for counted operator motions: after `d3W`, `.` repeats the three-WORD delete; a prefix such as `2.` repeats the same change with count 2.

## Testing

- `./check-types.sh vi_mode.ts`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p fresh-editor --test e2e_tests vi_vim_compat -- --nocapture`
- `cargo test -p fresh-editor --test e2e_tests vi_mode -- --nocapture`
- `cargo check --all-targets`
- `cargo clippy --all-targets`
