### PR TITLE
Namespaced conceal range-clear (ConcealManager::remove_in_range_for_namespace)

### DIFF
--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -2627,6 +2627,17 @@ pub enum PluginCommand {
         end: usize,
     },
 
+    /// Remove conceal ranges overlapping a byte range, restricted to a single
+    /// namespace. Lets one plugin rebuild its conceals for a line without
+    /// destroying another plugin's ranges there (cf.
+    /// `ClearOverlaysInRangeForNamespace`, issue #2146).
+    ClearConcealsInRangeForNamespace {
+        buffer_id: BufferId,
+        namespace: OverlayNamespace,
+        start: usize,
+        end: usize,
+    },
+
     /// Add a collapsed fold range. Hides the byte range
     /// `[start, end)` from rendering — the line containing `start - 1`
     /// (the fold's "header") stays visible while the lines covered by

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -2559,6 +2559,11 @@ interface EditorAPI {
 	*/
 	stringWidth(text: string): number;
 	/**
+	* Clear conceal ranges overlapping a byte range, restricted to one
+	* namespace — other plugins' conceals in the range are untouched.
+	*/
+	clearConcealsInRangeForNamespace(bufferId: number, namespace: string, start: number, end: number): boolean;
+	/**
 	* Add a collapsed fold range. Hides bytes [start, end) from
 	* rendering — the line containing `start - 1` (the fold "header")
 	* stays visible, while subsequent lines covered by the range are

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -542,6 +542,30 @@ impl Editor {
         }
     }
 
+    /// Handle ClearConcealsInRangeForNamespace command — remove only this
+    /// namespace's conceal ranges overlapping `[start, end)`, leaving other
+    /// plugins' conceals in that range intact.
+    pub(super) fn handle_clear_conceals_in_range_for_namespace(
+        &mut self,
+        buffer_id: BufferId,
+        namespace: OverlayNamespace,
+        start: usize,
+        end: usize,
+    ) {
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .expect("active window present")
+            .buffer_state_mut(buffer_id)
+        {
+            state.conceals.remove_in_range_for_namespace(
+                &namespace,
+                &(start..end),
+                &mut state.marker_list,
+            );
+        }
+    }
+
     // ==================== Fold Commands ====================
 
     /// Handle AddFold command — register a collapsed fold range for the

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -439,6 +439,14 @@ impl Editor {
             } => {
                 self.handle_clear_conceals_in_range(buffer_id, start, end);
             }
+            PluginCommand::ClearConcealsInRangeForNamespace {
+                buffer_id,
+                namespace,
+                start,
+                end,
+            } => {
+                self.handle_clear_conceals_in_range_for_namespace(buffer_id, namespace, start, end);
+            }
 
             PluginCommand::AddFold {
                 buffer_id,

--- a/crates/fresh-editor/src/view/conceal.rs
+++ b/crates/fresh-editor/src/view/conceal.rs
@@ -170,6 +170,52 @@ impl ConcealManager {
         self.version = self.version.wrapping_add(1);
     }
 
+    /// Like [`remove_in_range`], but only removes ranges belonging to
+    /// `namespace`. Lets one plugin rebuild its conceals for a line without
+    /// destroying another plugin's ranges there (same motivation as
+    /// `clear_overlays_in_range_for_namespace`, issue #2146).
+    pub fn remove_in_range_for_namespace(
+        &mut self,
+        namespace: &OverlayNamespace,
+        range: &Range<usize>,
+        marker_list: &mut MarkerList,
+    ) {
+        if range.start >= range.end {
+            return;
+        }
+        let hits = marker_list.query_range(range.start, range.end);
+        if hits.is_empty() {
+            return;
+        }
+        let mut candidates: Vec<usize> = hits
+            .iter()
+            .filter_map(|(mid, _, _)| self.marker_to_idx.get(mid).copied())
+            .collect();
+        candidates.sort_unstable();
+        candidates.dedup();
+
+        let mut to_remove: Vec<usize> = candidates
+            .into_iter()
+            .filter(|&idx| {
+                let r = &self.ranges[idx];
+                if &r.namespace != namespace {
+                    return false;
+                }
+                let start = marker_list.get_position(r.start_marker).unwrap_or(0);
+                let end = marker_list.get_position(r.end_marker).unwrap_or(0);
+                start < range.end && range.start < end
+            })
+            .collect();
+        if to_remove.is_empty() {
+            return;
+        }
+        to_remove.sort_unstable_by(|a, b| b.cmp(a));
+        for idx in to_remove {
+            self.swap_remove_at(idx, marker_list);
+        }
+        self.version = self.version.wrapping_add(1);
+    }
+
     /// Clear all conceal ranges and their markers
     pub fn clear(&mut self, marker_list: &mut MarkerList) {
         let had_any = !self.ranges.is_empty();
@@ -365,6 +411,59 @@ mod tests {
         assert!(!manager.is_empty());
         manager.remove_in_range(&(19..21), &mut marker_list);
         assert!(manager.is_empty());
+    }
+
+    fn ns_named(name: &str) -> OverlayNamespace {
+        OverlayNamespace::from_string(name.to_string())
+    }
+
+    #[test]
+    fn test_remove_in_range_for_namespace_only_touches_that_namespace() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(200);
+        let mut manager = ConcealManager::new();
+
+        // Two plugins conceal overlapping bytes in the same range, plus an
+        // out-of-range entry in the target namespace that must survive.
+        manager.add(&mut marker_list, ns_named("md"), 10..20, None);
+        manager.add(&mut marker_list, ns_named("other"), 12..18, None);
+        manager.add(&mut marker_list, ns_named("md"), 100..110, None);
+
+        manager.remove_in_range_for_namespace(&ns_named("md"), &(0..50), &mut marker_list);
+
+        // Only "md"'s in-range range is gone; "other" and the out-of-range
+        // "md" entry remain.
+        let kept: Vec<_> = manager
+            .query_viewport(0, 1000, &marker_list)
+            .into_iter()
+            .map(|(r, _)| r)
+            .collect();
+        assert_eq!(kept, vec![12..18, 100..110]);
+    }
+
+    #[test]
+    fn test_remove_in_range_for_namespace_version_and_endpoints() {
+        let mut marker_list = MarkerList::new();
+        marker_list.set_buffer_size(100);
+        let mut manager = ConcealManager::new();
+
+        manager.add(&mut marker_list, ns_named("md"), 10..20, None);
+        let v0 = manager.version();
+
+        // No overlap with this namespace's range → no-op, version unchanged.
+        manager.remove_in_range_for_namespace(&ns_named("md"), &(20..30), &mut marker_list);
+        assert_eq!(manager.version(), v0);
+        assert!(!manager.is_empty());
+
+        // Wrong namespace over an overlapping range → no-op.
+        manager.remove_in_range_for_namespace(&ns_named("other"), &(0..50), &mut marker_list);
+        assert_eq!(manager.version(), v0);
+        assert!(!manager.is_empty());
+
+        // Right namespace, overlapping range → removed, version bumped.
+        manager.remove_in_range_for_namespace(&ns_named("md"), &(15..25), &mut marker_list);
+        assert!(manager.is_empty());
+        assert_ne!(manager.version(), v0);
     }
 
     /// Mirrors the production cycle in `markdown_compose.ts`: for each line

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -138,8 +138,9 @@ impl VirtualText {
     }
 }
 
-/// Unique identifier for a virtual text entry
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Unique identifier for a virtual text entry. Ids come from a monotonic
+/// counter, so ordering by id is ordering by insertion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct VirtualTextId(pub u64);
 
 /// Manages virtual text entries for a buffer
@@ -623,23 +624,32 @@ impl VirtualTextManager {
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, &VirtualText)> = self
+        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
             .texts
-            .values()
-            .filter_map(|vtext| {
+            .iter()
+            .filter_map(|(id, vtext)| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, vtext))
+                    Some((pos, *id, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by position, then by priority
-        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
+        // Sort by position, then priority, then insertion order — the map's
+        // iteration order is arbitrary, so equal (position, priority) entries
+        // need the id tiebreak to render deterministically.
+        results.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.2.priority.cmp(&b.2.priority))
+                .then_with(|| a.1.cmp(&b.1))
+        });
 
         results
+            .into_iter()
+            .map(|(pos, _, vtext)| (pos, vtext))
+            .collect()
     }
 
     /// Build a lookup map for efficient per-character access during rendering
@@ -704,31 +714,42 @@ impl VirtualTextManager {
     /// Query only virtual LINES (LineAbove/LineBelow) in a byte range
     ///
     /// Used by the render pipeline to inject header/footer lines.
-    /// Returns (byte_position, &VirtualText) pairs sorted by position then priority.
+    /// Returns (byte_position, &VirtualText) pairs sorted by position, then
+    /// priority, then insertion order. The insertion-order tiebreak matters:
+    /// entries live in a HashMap whose iteration order is arbitrary, so
+    /// without it, equal-priority lines at one anchor (e.g. several stacked
+    /// virtual continuation lines of one wrapped table row) would come back
+    /// shuffled.
     pub fn query_lines_in_range(
         &self,
         marker_list: &MarkerList,
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, &VirtualText)> = self
+        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
             .texts
-            .values()
-            .filter(|vtext| vtext.position.is_line())
-            .filter_map(|vtext| {
+            .iter()
+            .filter(|(_, vtext)| vtext.position.is_line())
+            .filter_map(|(id, vtext)| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, vtext))
+                    Some((pos, *id, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by position, then by priority
-        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
+        results.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.2.priority.cmp(&b.2.priority))
+                .then_with(|| a.1.cmp(&b.1))
+        });
 
         results
+            .into_iter()
+            .map(|(pos, _, vtext)| (pos, vtext))
+            .collect()
     }
 
     /// Query only INLINE virtual texts (BeforeChar/AfterChar) in a byte range
@@ -740,24 +761,32 @@ impl VirtualTextManager {
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, &VirtualText)> = self
+        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
             .texts
-            .values()
-            .filter(|vtext| vtext.position.is_inline())
-            .filter_map(|vtext| {
+            .iter()
+            .filter(|(_, vtext)| vtext.position.is_inline())
+            .filter_map(|(id, vtext)| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, vtext))
+                    Some((pos, *id, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by position, then by priority
-        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
+        // Sort by position, then priority, then insertion order (see
+        // `query_range` for why the id tiebreak is load-bearing).
+        results.sort_by(|a, b| {
+            a.0.cmp(&b.0)
+                .then_with(|| a.2.priority.cmp(&b.2.priority))
+                .then_with(|| a.1.cmp(&b.1))
+        });
 
         results
+            .into_iter()
+            .map(|(pos, _, vtext)| (pos, vtext))
+            .collect()
     }
 
     /// Build a lookup map for virtual LINES, keyed by the line's anchor byte position
@@ -1129,5 +1158,37 @@ mod tests {
         assert!(after.is_some());
         assert_eq!(before.unwrap().text, "/*param=*/");
         assert_eq!(after.unwrap().text, ": Type");
+    }
+
+    /// Several LineBelow entries anchored at the same byte with the same
+    /// priority must come back in insertion order. The entries live in a
+    /// HashMap (arbitrary iteration order), so this only holds because the
+    /// sort breaks ties on the monotonic VirtualTextId. Regression guard for
+    /// shuffled continuation rows (e.g. a wrapped markdown table row).
+    #[test]
+    fn test_query_lines_same_anchor_priority_keeps_insertion_order() {
+        let mut marker_list = MarkerList::new();
+        let mut manager = VirtualTextManager::new();
+        let ns = VirtualTextNamespace("test".to_string());
+
+        for i in 0..8 {
+            manager.add_line(
+                &mut marker_list,
+                10,
+                i.to_string(),
+                hint_style(),
+                VirtualTextPosition::LineBelow,
+                ns.clone(),
+                0, // identical priority — only the id tiebreak orders these
+            );
+        }
+
+        let order: Vec<&str> = manager
+            .query_lines_in_range(&marker_list, 0, 100)
+            .into_iter()
+            .map(|(_, vt)| vt.text.as_str())
+            .collect();
+
+        assert_eq!(order, ["0", "1", "2", "3", "4", "5", "6", "7"]);
     }
 }

--- a/crates/fresh-editor/src/view/virtual_text.rs
+++ b/crates/fresh-editor/src/view/virtual_text.rs
@@ -138,9 +138,8 @@ impl VirtualText {
     }
 }
 
-/// Unique identifier for a virtual text entry. Ids come from a monotonic
-/// counter, so ordering by id is ordering by insertion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Unique identifier for a virtual text entry
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VirtualTextId(pub u64);
 
 /// Manages virtual text entries for a buffer
@@ -624,32 +623,23 @@ impl VirtualTextManager {
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
+        let mut results: Vec<(usize, &VirtualText)> = self
             .texts
-            .iter()
-            .filter_map(|(id, vtext)| {
+            .values()
+            .filter_map(|vtext| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, *id, vtext))
+                    Some((pos, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by position, then priority, then insertion order — the map's
-        // iteration order is arbitrary, so equal (position, priority) entries
-        // need the id tiebreak to render deterministically.
-        results.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.2.priority.cmp(&b.2.priority))
-                .then_with(|| a.1.cmp(&b.1))
-        });
+        // Sort by position, then by priority
+        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
 
         results
-            .into_iter()
-            .map(|(pos, _, vtext)| (pos, vtext))
-            .collect()
     }
 
     /// Build a lookup map for efficient per-character access during rendering
@@ -714,42 +704,31 @@ impl VirtualTextManager {
     /// Query only virtual LINES (LineAbove/LineBelow) in a byte range
     ///
     /// Used by the render pipeline to inject header/footer lines.
-    /// Returns (byte_position, &VirtualText) pairs sorted by position, then
-    /// priority, then insertion order. The insertion-order tiebreak matters:
-    /// entries live in a HashMap whose iteration order is arbitrary, so
-    /// without it, equal-priority lines at one anchor (e.g. several stacked
-    /// virtual continuation lines of one wrapped table row) would come back
-    /// shuffled.
+    /// Returns (byte_position, &VirtualText) pairs sorted by position then priority.
     pub fn query_lines_in_range(
         &self,
         marker_list: &MarkerList,
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
+        let mut results: Vec<(usize, &VirtualText)> = self
             .texts
-            .iter()
-            .filter(|(_, vtext)| vtext.position.is_line())
-            .filter_map(|(id, vtext)| {
+            .values()
+            .filter(|vtext| vtext.position.is_line())
+            .filter_map(|vtext| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, *id, vtext))
+                    Some((pos, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        results.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.2.priority.cmp(&b.2.priority))
-                .then_with(|| a.1.cmp(&b.1))
-        });
+        // Sort by position, then by priority
+        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
 
         results
-            .into_iter()
-            .map(|(pos, _, vtext)| (pos, vtext))
-            .collect()
     }
 
     /// Query only INLINE virtual texts (BeforeChar/AfterChar) in a byte range
@@ -761,32 +740,24 @@ impl VirtualTextManager {
         start: usize,
         end: usize,
     ) -> Vec<(usize, &VirtualText)> {
-        let mut results: Vec<(usize, VirtualTextId, &VirtualText)> = self
+        let mut results: Vec<(usize, &VirtualText)> = self
             .texts
-            .iter()
-            .filter(|(_, vtext)| vtext.position.is_inline())
-            .filter_map(|(id, vtext)| {
+            .values()
+            .filter(|vtext| vtext.position.is_inline())
+            .filter_map(|vtext| {
                 let pos = marker_list.get_position(vtext.marker_id)?;
                 if pos >= start && pos < end {
-                    Some((pos, *id, vtext))
+                    Some((pos, vtext))
                 } else {
                     None
                 }
             })
             .collect();
 
-        // Sort by position, then priority, then insertion order (see
-        // `query_range` for why the id tiebreak is load-bearing).
-        results.sort_by(|a, b| {
-            a.0.cmp(&b.0)
-                .then_with(|| a.2.priority.cmp(&b.2.priority))
-                .then_with(|| a.1.cmp(&b.1))
-        });
+        // Sort by position, then by priority
+        results.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.priority.cmp(&b.1.priority)));
 
         results
-            .into_iter()
-            .map(|(pos, _, vtext)| (pos, vtext))
-            .collect()
     }
 
     /// Build a lookup map for virtual LINES, keyed by the line's anchor byte position
@@ -1158,37 +1129,5 @@ mod tests {
         assert!(after.is_some());
         assert_eq!(before.unwrap().text, "/*param=*/");
         assert_eq!(after.unwrap().text, ": Type");
-    }
-
-    /// Several LineBelow entries anchored at the same byte with the same
-    /// priority must come back in insertion order. The entries live in a
-    /// HashMap (arbitrary iteration order), so this only holds because the
-    /// sort breaks ties on the monotonic VirtualTextId. Regression guard for
-    /// shuffled continuation rows (e.g. a wrapped markdown table row).
-    #[test]
-    fn test_query_lines_same_anchor_priority_keeps_insertion_order() {
-        let mut marker_list = MarkerList::new();
-        let mut manager = VirtualTextManager::new();
-        let ns = VirtualTextNamespace("test".to_string());
-
-        for i in 0..8 {
-            manager.add_line(
-                &mut marker_list,
-                10,
-                i.to_string(),
-                hint_style(),
-                VirtualTextPosition::LineBelow,
-                ns.clone(),
-                0, // identical priority — only the id tiebreak orders these
-            );
-        }
-
-        let order: Vec<&str> = manager
-            .query_lines_in_range(&marker_list, 0, 100)
-            .into_iter()
-            .map(|(_, vt)| vt.text.as_str())
-            .collect();
-
-        assert_eq!(order, ["0", "1", "2", "3", "4", "5", "6", "7"]);
     }
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -3561,6 +3561,25 @@ impl JsEditorApi {
         fresh_core::display_width::str_width(&text) as u32
     }
 
+    /// Clear conceal ranges overlapping a byte range, restricted to one
+    /// namespace — other plugins' conceals in the range are untouched.
+    pub fn clear_conceals_in_range_for_namespace(
+        &self,
+        buffer_id: u32,
+        namespace: String,
+        start: u32,
+        end: u32,
+    ) -> bool {
+        self.command_sender
+            .send(PluginCommand::ClearConcealsInRangeForNamespace {
+                buffer_id: BufferId(buffer_id as usize),
+                namespace: OverlayNamespace::from_string(namespace),
+                start: start as usize,
+                end: end as usize,
+            })
+            .is_ok()
+    }
+
     // === Folds ===
 
     /// Add a collapsed fold range. Hides bytes [start, end) from

--- a/crates/fresh-plugin-runtime/src/ts_export.rs
+++ b/crates/fresh-plugin-runtime/src/ts_export.rs
@@ -1361,6 +1361,7 @@ mod tests {
             "clearConcealsInRange",
             "charWidth",
             "stringWidth",
+            "clearConcealsInRangeForNamespace",
             "addSoftBreak",
             "clearSoftBreakNamespace",
             "clearSoftBreaksInRange",


### PR DESCRIPTION
## What this is

One small, **additive** core primitive, carved out of #2325 so it can be reviewed and merged on its own. No graphics / kitty-protocol code is in here.

### `ConcealManager::remove_in_range_for_namespace()`
Clears only **one namespace's** conceal ranges that overlap a byte range, leaving other plugins' conceals in that range untouched. This mirrors the existing `OverlayManager::remove_in_range_for_namespace` (issue #2146) — conceals just never had the namespaced variant.

It's exposed to plugins as `editor.clearConcealsInRangeForNamespace(bufferId, namespace, start, end)` via a new `PluginCommand::ClearConcealsInRangeForNamespace`. This lets a plugin rebuild *its own* conceals for a line (the common per-line `lines_changed` rebuild pattern) without stomping conceals another plugin placed on the same line.

## Why it's split out like this

This is one of several PRs breaking up #2325, **which I'm closing in favor of these smaller PRs.**

This PR was originally scoped to also include a deterministic virtual-line ordering tiebreak in `virtual_text.rs`. Per @sinelaw's request, **that change has been removed** so the ConcealManager primitive can be merged on its own. The underlying scroll/flicker issue it addressed isn't reproducible on the maintainer's setup, so it'll be revisited separately rather than holding up this merge.

## Risk

Low. The change is purely additive — the conceal method is brand new; nothing previously called it.

## Tests
- `view::conceal::tests` — namespace isolation (only the target namespace's in-range conceals are removed; other namespaces and out-of-range entries survive) plus range/version no-op semantics.

Full local CI passes (`fmt`, `clippy`, `doc`, schema, `check --no-default-features`, and the touched test modules). The `ts_export` API-surface tests (incl. the generated `.d.ts` validation) pass with the new method.

---
Supersedes #2325 (being closed). Follow-up PRs will cover the virtual-line ordering, the markdown-compose rendering, and, separately, the graphics/kitty work for review.
