### PR TITLE
Web UI: chrome polish + portrait/mobile touch shell

### DIFF
--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -422,6 +422,41 @@
   /* Focus as a soft ring rather than a hard 1px outline. */
   .w-toggle.focus,.w-button.focus,.kbedit .kb-search.focus,.w-text.focus{outline:none;
     box-shadow:0 0 0 2px color-mix(in srgb,var(--accent) 55%,transparent)}
+
+  /* ----------------------------------------------------------------------
+     Selection pills. The old edge-to-edge highlight blocks become inset,
+     rounded "pills" with a faint top-down sheen: each scrolling list gets a
+     small side gutter and every row a matching radius, so only the selected
+     row paints — floating clear of the panel edge. Rows keep the same box
+     whether selected or not, so the text never shifts as selection moves.
+     ---------------------------------------------------------------------- */
+  :root{--sel:linear-gradient(180deg, color-mix(in srgb,var(--menuhi) 86%, var(--fg)), var(--menuhi))}
+  .fileexplorer .fx-list{padding:4px 6px}
+  .palette .plist{padding:6px 6px}
+  .popup .popup-body{padding:4px 6px}
+  .ctxmenu{padding:5px 6px}
+  .settings-modal .set-cats{padding:6px 6px}
+  .settings-modal .set-items{padding:6px 8px}
+  .kbedit .kb-table{padding:0 6px}
+  .settings-modal .set-dual-list{padding:2px 4px}
+  .w-list{padding:0 2px}
+
+  .fileexplorer .fx-row,.palette .prow,.popup .popup-row,.ctxmenu .ctxitem,
+  .settings-modal .set-cat,.settings-modal .set-cat-sec,.kbedit .kb-row:not(.kb-head),
+  .settings-modal .set-dual-row,.w-list-row{border-radius:7px}
+  .fileexplorer .fx-row{margin:1px 0}
+  /* Settings rows: drop the per-row hairline divider in favour of spacing and a
+     rounded selection, the way modern settings panes read. */
+  .settings-modal .set-item{border-bottom:0;border-radius:9px;margin:1px 0}
+
+  /* The sheen + rounded fill for every selected/highlighted row. */
+  .fileexplorer .fx-row.sel,.palette .prow.sel,.popup .popup-row.sel,
+  .ctxmenu .ctxitem.sel,.settings-modal .set-cat.sel,.settings-modal .set-item.sel,
+  .kbedit .kb-row.sel,.settings-modal .set-dual-row.sel,.w-list-row.sel,
+  .auxmodal .am-line.sel{background:var(--sel)}
+  /* Menu dropdown highlight: gently rounded to match (items stay cell-pinned). */
+  .mitem{border-radius:7px}
+  .mitem.hi{background:var(--sel)}
 </style>
 </head>
 <body>

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -457,10 +457,90 @@
   /* Menu dropdown highlight: gently rounded to match (items stay cell-pinned). */
   .mitem{border-radius:7px}
   .mitem.hi{background:var(--sel)}
+
+  /* ======================================================================
+     Mobile / portrait touch shell. Gated entirely by body.mobile (set in JS
+     from a max-width media query), so the desktop layout is untouched. The
+     editor keeps its cell grid — JS just reports fewer rows so the pane ends
+     above the bottom stack, and a 36px header sits over the two hidden chrome
+     rows (menu+tab) so the pane lines up with no offset math. Desktop cell
+     chrome is hidden and replaced with native touch bars.
+     ====================================================================== */
+  #mobile{display:none}
+  body.mobile{font-size:14px}
+  body.mobile #mobile{display:block}
+  body.mobile .menubar,body.mobile .tabbar,body.mobile .statusbar,
+  body.mobile .scrollbar,body.mobile .thumb,body.mobile .separator,
+  body.mobile .resize-grip{display:none!important}
+
+  /* Header: logo · filename · search / run / overflow. Overlays the two hidden
+     top chrome rows (=36px), so the editor pane starts cleanly beneath it. */
+  .m-header{position:fixed;top:0;left:0;right:0;height:36px;z-index:88;display:flex;
+    align-items:center;gap:8px;padding:0 8px;background:var(--surface-2);
+    border-bottom:1px solid var(--hairline);box-shadow:0 1px 6px rgba(0,0,0,.3)}
+  .m-logo{display:flex;align-items:center;gap:5px;font-weight:700;color:var(--fg);white-space:nowrap}
+  .m-logo .m-spark{color:var(--accent)}
+  .m-file{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;
+    color:var(--muted);font-size:12.5px}
+  .m-icon{flex:0 0 auto;width:30px;height:28px;display:flex;align-items:center;justify-content:center;
+    border-radius:var(--r-sm);color:var(--fg);font-size:15px}
+  .m-icon:active{background:var(--hover)}
+
+  /* Overflow (kebab) sheet, anchored under the header on the right. */
+  .m-sheet{position:fixed;top:40px;right:6px;z-index:92;min-width:210px;background:var(--surface);
+    border:1px solid var(--hairline);border-radius:var(--r-md);box-shadow:var(--shadow);padding:5px}
+  .m-sheet .m-sheet-item{padding:9px 12px;border-radius:var(--r-sm);color:var(--fg);
+    display:flex;align-items:center;gap:10px;white-space:nowrap}
+  .m-sheet .m-sheet-item:active{background:var(--sel)}
+  .m-sheet .m-sheet-ic{width:18px;text-align:center;color:var(--muted)}
+
+  /* Bottom stack: coding-symbol accessory row · nav · status. Fixed; the editor
+     grid is shortened by its height (--m-bottom) so no code hides behind it. */
+  .m-bottom{position:fixed;left:0;right:0;bottom:0;z-index:88;background:var(--surface-2);
+    border-top:1px solid var(--hairline)}
+  .m-syms{display:flex;gap:6px;overflow-x:auto;padding:6px 8px;
+    border-bottom:1px solid var(--hairline);-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  .m-syms::-webkit-scrollbar{display:none}
+  .m-sym{flex:0 0 auto;min-width:32px;height:32px;padding:0 9px;display:flex;align-items:center;
+    justify-content:center;font:14px/1 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    color:var(--fg);background:var(--surface);border:1px solid var(--hairline);border-radius:var(--r-sm)}
+  .m-sym:active{background:var(--hover)}
+  .m-sym.m-save{margin-left:auto;color:var(--on-accent);background:var(--accent);
+    border-color:var(--accent);font-weight:700;font-family:inherit;padding:0 16px}
+
+  .m-nav{display:flex;align-items:stretch}
+  .m-nav-item{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;
+    gap:2px;padding:7px 0 6px;color:var(--muted);border-radius:var(--r-sm)}
+  .m-nav-item:active{background:var(--hover)}
+  .m-nav-item .m-nav-ic{font-size:17px;line-height:1}
+  .m-nav-item .m-nav-lb{font-size:10px;letter-spacing:.02em}
+  .m-nav-item.active{color:var(--accent)}
+
+  .m-status{display:flex;align-items:center;gap:0;height:22px;padding:0 6px;
+    border-top:1px solid var(--hairline);background:var(--surface);overflow-x:auto;
+    scrollbar-width:none;white-space:nowrap}
+  .m-status::-webkit-scrollbar{display:none}
+  .m-status .m-seg{flex:0 0 auto;padding:0 7px;font-size:11px;color:var(--muted)}
+  .m-status .m-seg.trust{color:var(--accent)}
+
+  /* Panels/overlays become full-width sheets between the header and bottom stack. */
+  body.mobile .fileexplorer{position:fixed!important;left:0!important;top:36px!important;
+    width:100vw!important;height:auto!important;bottom:var(--m-bottom,124px)!important;z-index:80;
+    border-right:none;border-bottom:1px solid var(--hairline)}
+  body.mobile .palette{left:3vw!important;width:94vw!important;top:7vh!important}
+  body.mobile .settings-modal,body.mobile .kbedit{left:2vw!important;right:2vw!important;
+    width:96vw!important;top:42px!important;bottom:calc(var(--m-bottom,124px) + 6px)!important;
+    height:auto!important;max-height:none!important;transform:none!important}
+  body.mobile .settings-modal .set-cats{width:128px}
+  body.mobile .settings-modal .set-body{font-size:12px}
+  body.mobile .kbedit .kb-context,body.mobile .kbedit .kb-source{display:none}
+  body.mobile .kbedit .kb-key{width:11ch}
+  body.mobile .kbedit .kb-action{width:18ch}
 </style>
 </head>
 <body>
 <div id="app"></div>
+<div id="mobile"></div>
 <div id="err"></div>
 
 <script>
@@ -649,6 +729,10 @@ function render(){
   }
   // Restore the scroll positions snapshotted above.
   document.querySelectorAll(SCROLL_KEEP).forEach((e,i)=>{ if(savedScroll[i]) e.scrollTop=savedScroll[i]; });
+
+  // Native touch shell on narrow/portrait viewports (desktop is untouched).
+  document.body.classList.toggle("mobile", isMobile());
+  renderMobileChrome(reg);
 }
 
 // ---- native menu bar ----------------------------------------------------
@@ -1346,6 +1430,83 @@ function borderDragHandle(bx, by, h){
   return grip;
 }
 
+// ---- native mobile / portrait touch shell -------------------------------
+// Gated by a max-width media query. The header reuses the two hidden top chrome
+// rows (36px); the bottom stack's height (M_BOTTOM) is subtracted from the grid
+// in resize() so no code hides behind it. Every control routes to the REAL
+// editor (sendKey / sendAction), exactly like the desktop chrome.
+const M_BOTTOM = 124;                  // px: symbol row + nav + status
+const mqMobile = window.matchMedia("(max-width: 640px)");
+function isMobile(){ return mqMobile.matches; }
+let mSheetOpen = false;                 // overflow (kebab) sheet visibility
+
+// Coding-symbol accessory keys (sent as real key events) + Tab; Save = Ctrl+S.
+const M_SYMS = ["Tab","{","}","[","]","(",")","<",">",";",":","=","!","&","|","/","\"","'"];
+// Bottom-nav destinations → real editor actions.
+const M_NAV = [
+  {ic:"🗀", lb:"Files",   act:"toggle_file_explorer"},
+  {ic:"⚠", lb:"Issues",  act:"jump_to_next_error"},
+  {ic:"❯_",lb:"Console", act:"terminal"},
+  {ic:"◈", lb:"LSP",     act:"show_lsp_status"},
+  {ic:"⌘", lb:"Palette", act:"command_palette"},
+];
+// Overflow-menu items → real actions.
+const M_MENU = [
+  {ic:"⌕", lb:"Go to File…",   act:"quick_open"},
+  {ic:"⇄", lb:"Find & Replace", act:"replace"},
+  {ic:"❯_",lb:"Terminal",       act:"terminal"},
+  {ic:"◈", lb:"LSP Status",     act:"show_lsp_status"},
+  {ic:"⚙", lb:"Settings",       act:"open_settings"},
+];
+
+function renderMobileChrome(reg){
+  const host=document.getElementById("mobile");
+  if(!isMobile()){ if(host.childElementCount) host.innerHTML=""; return; }
+  document.documentElement.style.setProperty("--m-bottom", M_BOTTOM+"px");
+  host.innerHTML="";
+
+  // header: ⚡ Fresh · filename · 🔍 ▶ ⋮
+  const hd=div("m-header");
+  const logo=div("m-logo"); logo.innerHTML='<span class="m-spark">⚡</span>Fresh'; hd.appendChild(logo);
+  const tabs=(reg.panes[0]&&reg.panes[0].tabs)||[]; const at=tabs.find(t=>t.active)||tabs[0];
+  const file=div("m-file"); file.textContent=at?at.label.split("/").pop():"untitled"; hd.appendChild(file);
+  const icon=(glyph,fn)=>{ const b=div("m-icon"); b.textContent=glyph;
+    b.onclick=e=>{ e.stopPropagation(); fn(); }; return b; };
+  hd.appendChild(icon("🔍",()=>{ mSheetOpen=false; sendAction("search"); }));
+  hd.appendChild(icon("▶",()=>{ mSheetOpen=false; sendAction("command_palette"); }));
+  hd.appendChild(icon("⋮",()=>{ mSheetOpen=!mSheetOpen; render(); }));
+  host.appendChild(hd);
+
+  if(mSheetOpen){
+    const sh=div("m-sheet");
+    for(const m of M_MENU){ const it=div("m-sheet-item");
+      it.innerHTML='<span class="m-sheet-ic">'+esc(m.ic)+'</span>'+esc(m.lb);
+      it.onclick=e=>{ e.stopPropagation(); mSheetOpen=false; sendAction(m.act); }; sh.appendChild(it); }
+    host.appendChild(sh);
+  }
+
+  // bottom stack: symbols · nav · status
+  const bot=div("m-bottom");
+  const syms=div("m-syms");
+  for(const s of M_SYMS){ const k=div("m-sym"); k.textContent=s==="Tab"?"⇥":s;
+    k.onclick=e=>{ e.stopPropagation(); sendKey({key:s}); }; syms.appendChild(k); }
+  const save=div("m-sym m-save"); save.textContent="Save";
+  save.onclick=e=>{ e.stopPropagation(); sendKey({key:"s",ctrl:true}); }; syms.appendChild(save);
+  bot.appendChild(syms);
+
+  const nav=div("m-nav");
+  for(const n of M_NAV){ const it=div("m-nav-item");
+    it.innerHTML='<span class="m-nav-ic">'+esc(n.ic)+'</span><span class="m-nav-lb">'+esc(n.lb)+'</span>';
+    it.onclick=e=>{ e.stopPropagation(); mSheetOpen=false; sendAction(n.act); }; nav.appendChild(it); }
+  bot.appendChild(nav);
+
+  const st=div("m-status");
+  const segs=(reg.statusbar&&reg.statusbar.segments||[]).filter(s=>s.text);
+  for(const s of segs){ const seg=div("m-seg"+(s.name==="trust"?" trust":"")); seg.textContent=s.text; st.appendChild(seg); }
+  bot.appendChild(st);
+  host.appendChild(bot);
+}
+
 // --- bridge to the real editor ---
 // Apply a scene from any endpoint, re-rendering only when it actually changed
 // so the idle poll loop doesn't churn the DOM (or restart the caret blink).
@@ -1353,8 +1514,14 @@ let sceneStr=null;
 function applyScene(s){ const str=JSON.stringify(s); if(str===sceneStr) return; sceneStr=str; scene=s; render(); }
 async function refresh(){ try{ applyScene(await (await fetch("/state")).json()); }catch(e){ showErr("load failed: "+e); } }
 async function sendKey(d){ try{ applyScene(await (await fetch("/key",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify(d)})).json()); }catch(e){ showErr("key failed: "+e); } }
-async function resize(){ const cols=Math.max(20,Math.floor(window.innerWidth/CW)), rows=Math.max(8,Math.floor(window.innerHeight/CH));
+async function resize(){ const cols=Math.max(20,Math.floor(window.innerWidth/CW));
+  // On mobile, leave room for the fixed bottom stack so no code hides behind it
+  // (the header reuses the two hidden top chrome rows, so it needs no reserve).
+  const availH=window.innerHeight - (isMobile()?M_BOTTOM:0);
+  const rows=Math.max(8,Math.floor(availH/CH));
   try{ applyScene(await (await fetch("/resize",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({cols,rows})})).json()); }catch(e){} }
+async function sendAction(name){ mSheetOpen=false;
+  try{ applyScene(await (await fetch("/action",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({action:name})})).json()); }catch(e){ showErr("action failed: "+e); } }
 function showErr(m){ const e=document.getElementById("err"); e.textContent=m; e.style.display="block"; }
 
 // Poll loop: each GET /state ticks the real editor (drains async LSP/plugin/file
@@ -1396,8 +1563,8 @@ let dragging=false, lastCell=null;
 // forwards them to the editor at the exact cell rects the pipeline reported.
 // The document-level handlers are the fallback for buffer interiors, scrollbars
 // and separators, so they ignore anything that lands on a chrome element.
-const onChrome = e => e.target.closest(".menubar,.dropdown,.tabbar,.statusbar,.palette,.popup,.fileexplorer,.trustdialog,.modal-scrim,.widget-surface,.ctxmenu,.auxmodal,.kbedit,.settings-modal");
-document.addEventListener("mousedown",e=>{ if(onChrome(e)) return; const c=cellAt(e); dragging=true; lastCell=c; sendMouse({kind:"down",button:btn(e),col:c.col,row:c.row,ctrl:e.ctrlKey,shift:e.shiftKey,alt:e.altKey}); });
+const onChrome = e => e.target.closest("#mobile,.menubar,.dropdown,.tabbar,.statusbar,.palette,.popup,.fileexplorer,.trustdialog,.modal-scrim,.widget-surface,.ctxmenu,.auxmodal,.kbedit,.settings-modal");
+document.addEventListener("mousedown",e=>{ if(onChrome(e)) return; if(mSheetOpen){ mSheetOpen=false; render(); } const c=cellAt(e); dragging=true; lastCell=c; sendMouse({kind:"down",button:btn(e),col:c.col,row:c.row,ctrl:e.ctrlKey,shift:e.shiftKey,alt:e.altKey}); });
 document.addEventListener("mousemove",e=>{ if(!dragging) return; const c=cellAt(e); if(lastCell&&c.col===lastCell.col&&c.row===lastCell.row) return; lastCell=c; sendMouse({kind:"drag",button:"left",col:c.col,row:c.row,ctrl:e.ctrlKey,shift:e.shiftKey,alt:e.altKey}); });
 document.addEventListener("mouseup",e=>{ dragging=false; if(onChrome(e)) return; const c=cellAt(e); sendMouse({kind:"up",button:btn(e),col:c.col,row:c.row}); });
 document.addEventListener("contextmenu",e=>e.preventDefault());
@@ -1409,6 +1576,8 @@ const onScrollable = e => e.target.closest(".set-items,.set-cats,.w-list,.widget
 document.addEventListener("wheel",e=>{ if(onScrollable(e)) return; const c=cellAt(e); const n=Math.min(8,Math.max(1,Math.round(Math.abs(e.deltaY)/40))); sendMouse({kind:e.deltaY>0?"scrolldown":"scrollup",col:c.col,row:c.row,n}); },{passive:true});
 
 let rt; window.addEventListener("resize",()=>{ clearTimeout(rt); rt=setTimeout(resize,150); });
+// Re-fit the grid when crossing the mobile/desktop breakpoint (e.g. rotation).
+mqMobile.addEventListener("change", resize);
 
 window.fresh = { get scene(){return scene;}, refresh, sendKey, resize };
 resize().then(poll); // size to the window, render, then start the frame poll loop

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -22,7 +22,22 @@
 <style>
   :root{--bg:#1e1e1e;--bg2:#252526;--bg3:#333;--fg:#d4d4d4;--muted:#9aa0a6;
     --accent:#0a84ff;--border:#3a3a3a;--menuhi:#0a64c8;
-    --status-bg:#0a84ff;--status-fg:#fff}
+    --status-bg:#0a84ff;--status-fg:#fff;
+    /* Readable text/fill for anything painted ON the accent colour. Recomputed
+       per theme in applyTheme() so e.g. high-contrast's white accent gets dark
+       text instead of the white-on-white it used to render. */
+    --on-accent:#fff}
+  /* Theme-derived design tokens: elevated surfaces and soft hairlines mixed from
+     the live --bg/--fg, so chrome reads as depth on ANY theme instead of piping
+     the terminal palette's hard borders (e.g. high-contrast's cyan) into the UI.
+     color-mix re-evaluates when applyTheme() updates --bg/--fg. */
+  :root{
+    --surface:color-mix(in srgb, var(--bg) 92%, var(--fg));
+    --surface-2:color-mix(in srgb, var(--bg) 84%, var(--fg));
+    --hairline:color-mix(in srgb, var(--fg) 14%, transparent);
+    --hairline-strong:color-mix(in srgb, var(--fg) 26%, transparent);
+    --hover:color-mix(in srgb, var(--fg) 9%, transparent);
+    --shadow:0 16px 50px rgba(0,0,0,.5), 0 2px 8px rgba(0,0,0,.35)}
   *{box-sizing:border-box}
   :focus{outline:none}
   html,body{height:100%;margin:0}
@@ -297,6 +312,116 @@
   svg.cells{display:block;width:100%;height:100%;
     font-family:ui-monospace,SFMono-Regular,JetBrains Mono,Menlo,Consolas,monospace}
   #err{position:fixed;left:0;bottom:0;right:0;background:#5a1d1d;color:#fff;padding:6px 12px;display:none;z-index:99}
+
+  /* ======================================================================
+     Visual polish pass — subtle craft, not a recolor. A single radius scale,
+     true hairline dividers, considered padding/gaps, and depth-from-surface
+     instead of hard outlines. Class names and geometry (cell-pinned rects)
+     are untouched; this only refines borders, corners, dividers and spacing.
+     ====================================================================== */
+  :root{--r-sm:6px;--r-md:9px;--r-lg:12px}
+
+  /* Floating surfaces: one elevation language — soft hairline edge + real
+     shadow + a consistent large radius, so menus/popups/palette/modals feel
+     like the same family of cards. */
+  .dropdown,.popup,.ctxmenu,.palette,.settings-modal .set-dd{
+    border:1px solid var(--hairline);border-radius:var(--r-md);box-shadow:var(--shadow)}
+  .settings-modal,.kbedit,.auxmodal.centered,.trustdialog,.widget-surface.w-floatingModal{
+    border:1px solid var(--hairline);border-radius:var(--r-lg);box-shadow:var(--shadow)}
+  .popup{border-radius:var(--r-md)}
+  .palette{border-radius:var(--r-lg)}
+  .set-overlay,.kb-overlay{border:1px solid var(--hairline);border-radius:var(--r-md)!important}
+
+  /* Hairline dividers everywhere a structural line is drawn — replaces the
+     assorted hard greys and the theme border (often a harsh cyan) with one
+     low-contrast 1px rule, the single most "off" detail in the old UI. */
+  .menubar,.tabbar{border-bottom:1px solid var(--hairline)}
+  .tab{border-right:1px solid var(--hairline)}
+  .fileexplorer{border-right:1px solid var(--hairline)}
+  .separator{background:var(--hairline)}
+  .msep{background:var(--hairline);margin:5px 10px}
+  .popup .popup-title,.popup .popup-desc{border-bottom:1px solid var(--hairline)}
+  .palette .pinput,.palette .ptitle,.palette .ptoolbar,.palette .pbody .plist{border-color:var(--hairline)}
+  .w-section,.w-text,.w-list-card,.w-button,.w-divider{border-color:var(--hairline)}
+  .ptoolbar{border-bottom:1px solid var(--hairline)}
+  .settings-modal .set-title,.settings-modal .set-cats,.settings-modal .set-items.focus,
+  .settings-modal .set-section,.settings-modal .set-item,.settings-modal .set-footer,
+  .settings-modal .set-item-block .set-list,.settings-modal .set-list-row,
+  .settings-modal .set-list-add,.settings-modal .set-dual-col,.settings-modal .set-dual-coltitle,
+  .settings-modal .set-field,.settings-modal .set-pill,.settings-modal .set-step,
+  .settings-modal .set-dd-row,.settings-modal .btn{border-color:var(--hairline)}
+  .kbedit .kb-title,.kbedit .kb-header,.kbedit .kb-footer,.kbedit .kb-table .kb-row.kb-head,
+  .kbedit .kb-btn,.kbedit .kb-field,.kbedit .kb-autocomplete{border-color:var(--hairline)}
+  .auxmodal .am-title,.auxmodal .am-footer{border-color:var(--hairline)}
+  .trustdialog{border-color:var(--hairline)}
+
+  /* Header / footer strips get a faintly raised surface so they read as
+     distinct bands without a heavy rule. */
+  .settings-modal .set-title,.kbedit .kb-title,.auxmodal .am-title{background:var(--surface-2)}
+  .settings-modal .set-footer{background:var(--surface-2)}
+  .kbedit .kb-table .kb-row.kb-head{background:var(--surface)}
+  .set-overlay,.kb-overlay,.trustdialog{background:var(--surface-2)!important}
+
+  /* Consistent inner radii for the small controls — pills, fields, steppers,
+     buttons, cards — all share the small radius. */
+  .settings-modal .set-pill,.settings-modal .set-field,.settings-modal .set-step,
+  .settings-modal .btn,.kbedit .kb-btn,.w-button,.td-btn,.w-toggle,.pkey,.tab .x{border-radius:var(--r-sm)}
+  .settings-modal .set-item-block .set-list,.settings-modal .set-dual-col,
+  .w-section,.w-list-card,.settings-modal .set-dd{border-radius:var(--r-md)}
+
+  /* Readable text/fills ON accent-coloured backgrounds (fixes the white-on-white
+     primary button under high-contrast). */
+  .settings-modal .btn.primary,.w-button.primary,.trustdialog .td-btn.primary{color:var(--on-accent)}
+  .settings-modal .set-switch.on::after{background:var(--on-accent)}
+  .settings-modal .set-dd-row.sel,.kbedit .kb-btn.focus{color:var(--on-accent)}
+
+  /* Quiet, uniform hover affordance. */
+  .menu:hover{background:var(--hover)}
+  .tab .x:hover{background:var(--hover)}
+  .statusbar .seg:hover{background:var(--hover)}
+  .settings-modal .set-dual-row:hover{background:var(--hover)}
+  .prow:not(.sel):hover,.popup-row:not(.sel):not(.disabled):hover,
+  .fx-row:not(.sel):hover,.ctxitem:not(.sel):hover,
+  .settings-modal .set-cat:not(.sel):hover,
+  .kbedit .kb-row:not(.sel):not(.kb-head):hover{background:var(--hover)}
+
+  /* Tabs: a quiet recessed bar with the active tab lifted and marked by a thin
+     accent rule on top — a clear indicator even when active/inactive share a bg
+     (as high-contrast does). */
+  .tabbar{background:var(--surface)}
+  .tab{background:transparent}
+  .tab.active{background:var(--surface-2);box-shadow:inset 0 2px 0 var(--accent)}
+
+  /* Breathing room: a touch more horizontal padding and even gaps in the
+     natively-flowed lists (kept near one cell tall so the editor's row window
+     still lines up). */
+  .palette .prow{padding:4px 14px}
+  .palette .plist{padding:6px 0}
+  .popup .popup-body{padding:3px 0}
+  .popup .popup-row{padding:2px 12px}
+  .ctxmenu{padding:5px 0}
+  .ctxmenu .ctxitem{padding:3px 14px}
+  .fileexplorer .fx-title{padding:6px 10px 4px}
+  .settings-modal .set-cat{padding:3px 12px}
+  .settings-modal .set-item{padding:6px 16px}
+
+  /* Keep long composite-list values (e.g. the Languages JSON) on one tidy line
+     instead of overflowing the row. */
+  .settings-modal .set-list-row{min-width:0;gap:10px}
+  .settings-modal .set-list-label{min-width:0;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+  /* Slim, rounded, low-contrast scrollbars that match the hairline language. */
+  *::-webkit-scrollbar{width:10px;height:10px}
+  *::-webkit-scrollbar-thumb{background:var(--hairline-strong);border-radius:8px;
+    border:3px solid transparent;background-clip:padding-box}
+  *::-webkit-scrollbar-thumb:hover{background:color-mix(in srgb,var(--fg) 38%,transparent);background-clip:padding-box}
+  *::-webkit-scrollbar-track{background:transparent}
+  .scrollbar .thumb{background:var(--hairline-strong);border-radius:8px}
+  .scrollbar .thumb:hover{background:color-mix(in srgb,var(--fg) 38%,transparent)}
+
+  /* Focus as a soft ring rather than a hard 1px outline. */
+  .w-toggle.focus,.w-button.focus,.kbedit .kb-search.focus,.w-text.focus{outline:none;
+    box-shadow:0 0 0 2px color-mix(in srgb,var(--accent) 55%,transparent)}
 </style>
 </head>
 <body>
@@ -390,6 +515,14 @@ function applyTheme(t){
   set("--muted",t.muted); set("--bg2",t.popupBg); set("--bg3",t.menuBg);
   set("--menuhi",t.menuHi); set("--border",t.border);
   set("--status-bg",t.statusBg); set("--status-fg",t.statusFg);
+  // Pick black/white text for fills painted in the accent / menu-highlight color
+  // by luminance, so a control filled with a light accent (e.g. high-contrast's
+  // white cursor) still shows its label instead of white-on-white.
+  const onColor=hex=>{ const m=/^#?([0-9a-fA-F]{6})$/.exec((hex||"").trim()); if(!m) return null;
+    const n=parseInt(m[1],16), lin=c=>{c/=255; return c<=.03928?c/12.92:Math.pow((c+.055)/1.055,2.4);};
+    const L=.2126*lin((n>>16)&255)+.7152*lin((n>>8)&255)+.0722*lin(n&255);
+    return L>.45?"#10131a":"#ffffff"; };
+  set("--on-accent", onColor(t.accent));
 }
 
 // Selectors for natively-scrolled chrome whose scrollTop must survive a full
@@ -642,10 +775,23 @@ function paletteEl(p){
   const el=div("palette"+(hasPreview?" with-preview":""));
   // Position the card on the outer rect, with the input bar stacked above it so
   // it reads as one palette. (Clicks use the list cell rect below.)
-  const inputH=34, w=outer?Math.max(360,px(outer.w,CW)):420;
-  const left = outer?px(outer.x,CW):(window.innerWidth-w)/2;
-  const top  = outer?Math.max(4, px(outer.y,CH)-inputH):80;
-  el.style.left=left+"px"; el.style.top=top+"px"; el.style.width=w+"px";
+  if(hasPreview){
+    // Preview overlays (quick-open / live-grep) keep the editor's geometry so the
+    // results column lines up with the framed preview cells beside it.
+    const inputH=34, w=Math.max(360,px(outer.w,CW));
+    el.style.left=px(outer.x,CW)+"px";
+    el.style.top=Math.max(4, px(outer.y,CH)-inputH)+"px";
+    el.style.width=w+"px";
+  } else {
+    // The plain command palette is a centered floating card (VSCode-style). Its
+    // pixel position is purely cosmetic — row clicks route through the editor's
+    // list cell rect and keys go through handle_key, both independent of where
+    // the card sits — so we place it where it reads best.
+    const w=Math.min(640, Math.round(window.innerWidth*0.62));
+    el.style.width=w+"px";
+    el.style.left=Math.round((window.innerWidth-w)/2)+"px";
+    el.style.top=Math.round(window.innerHeight*0.12)+"px";
+  }
 
   if(p.title){ const t=div("ptitle"); t.textContent=p.title; el.appendChild(t); }
   // plugin-built toolbar (real WidgetSpec widgets, e.g. live-grep scope toggles)

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -485,6 +485,12 @@
   .m-icon{flex:0 0 auto;width:30px;height:28px;display:flex;align-items:center;justify-content:center;
     border-radius:var(--r-sm);color:var(--fg);font-size:15px}
   .m-icon:active{background:var(--hover)}
+  .m-icon.on{color:var(--on-accent);background:var(--accent)}
+  /* Invisible capture input that raises/dismisses the native soft keyboard.
+     Kept inside the viewport (not off-screen) so focusing it doesn't scroll;
+     16px font avoids iOS zoom-on-focus. */
+  #m-kbinput{position:fixed;left:0;bottom:var(--m-bottom,124px);width:1px;height:1px;
+    opacity:0;border:0;padding:0;margin:0;font-size:16px;z-index:-1}
 
   /* Overflow (kebab) sheet, anchored under the header on the right. */
   .m-sheet{position:fixed;top:40px;right:6px;z-index:92;min-width:210px;background:var(--surface);
@@ -507,6 +513,19 @@
   .m-sym:active{background:var(--hover)}
   .m-sym.m-save{margin-left:auto;color:var(--on-accent);background:var(--accent);
     border-color:var(--accent);font-weight:700;font-family:inherit;padding:0 16px}
+
+  /* Termux-style modifier / navigation row (optional; toggled from overflow). */
+  .m-mods{display:flex;gap:6px;overflow-x:auto;padding:6px 8px;
+    border-bottom:1px solid var(--hairline);-webkit-overflow-scrolling:touch;scrollbar-width:none}
+  .m-mods::-webkit-scrollbar{display:none}
+  .m-mod{flex:0 0 auto;min-width:34px;height:32px;padding:0 11px;display:flex;align-items:center;
+    justify-content:center;font-size:12.5px;color:var(--fg);background:var(--surface);
+    border:1px solid var(--hairline);border-radius:var(--r-sm)}
+  .m-mod:active{background:var(--hover)}
+  /* armed sticky modifier (Ctrl/Alt/Shift held for the next key) */
+  .m-mod.m-modkey{font-weight:600}
+  .m-mod.on{color:var(--on-accent);background:var(--accent);border-color:var(--accent);
+    box-shadow:0 0 0 2px color-mix(in srgb,var(--accent) 45%,transparent)}
 
   .m-nav{display:flex;align-items:stretch}
   .m-nav-item{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;
@@ -1435,13 +1454,64 @@ function borderDragHandle(bx, by, h){
 // rows (36px); the bottom stack's height (M_BOTTOM) is subtracted from the grid
 // in resize() so no code hides behind it. Every control routes to the REAL
 // editor (sendKey / sendAction), exactly like the desktop chrome.
-const M_BOTTOM = 124;                  // px: symbol row + nav + status
+const M_BASE = 124;                     // px: symbol row + nav + status
+const M_MODS_H = 44;                    // px: the optional modifier-key row
 const mqMobile = window.matchMedia("(max-width: 640px)");
 function isMobile(){ return mqMobile.matches; }
 let mSheetOpen = false;                 // overflow (kebab) sheet visibility
+let mShowMods = true;                    // show the Termux-style modifier row
+// Sticky one-shot modifiers: armed by tapping Ctrl/Alt/Shift, merged into the
+// NEXT key (from the symbol row, an arrow, or the device's native keyboard),
+// then cleared — like Termux's extra-keys row.
+let mMods = { ctrl:false, alt:false, shift:false };
+function mBottom(){ return M_BASE + (isMobile() && mShowMods ? M_MODS_H : 0); }
+
+// Native soft-keyboard control. The page can't toggle the OS keyboard directly,
+// but focusing a hidden input summons it and blurring dismisses it. Keystrokes
+// still flow through the global keydown handler (which preventDefaults), so the
+// input never accumulates text — it's purely the focus target that raises the
+// keyboard. The header ⌨ button toggles focus.
+let mKbInput=null, mKbWanted=false;
+function ensureKbInput(){
+  if(mKbInput) return mKbInput;
+  const i=document.createElement("input");
+  i.id="m-kbinput"; i.type="text";
+  i.setAttribute("autocapitalize","off"); i.setAttribute("autocomplete","off");
+  i.setAttribute("autocorrect","off"); i.setAttribute("spellcheck","false");
+  i.setAttribute("aria-hidden","true");
+  i.addEventListener("input",()=>{ i.value=""; });   // never keep typed text
+  document.body.appendChild(i); mKbInput=i; return i;
+}
+function kbVisible(){ return mKbWanted; }
+// Toggle driven by an explicit intent flag (not activeElement) so a tap that
+// transiently blurs the input can't flip the toggle into re-showing it.
+function toggleKeyboard(){
+  const i=ensureKbInput();
+  mKbWanted=!mKbWanted;
+  if(mKbWanted) i.focus({preventScroll:true}); else i.blur();
+  render();   // refresh the ⌨ button's active state
+}
+
+// Send a key with the armed sticky modifiers folded in, then disarm them.
+function mobileSendKey(d){
+  const k={ key:d.key,
+    ctrl:!!d.ctrl||mMods.ctrl, alt:!!d.alt||mMods.alt,
+    shift:!!d.shift||mMods.shift, meta:!!d.meta };
+  const wasArmed = mMods.ctrl||mMods.alt||mMods.shift;
+  mMods={ ctrl:false, alt:false, shift:false };
+  sendKey(k);
+  if(wasArmed) render();                // clear the armed-key highlight at once
+}
 
 // Coding-symbol accessory keys (sent as real key events) + Tab; Save = Ctrl+S.
 const M_SYMS = ["Tab","{","}","[","]","(",")","<",">",";",":","=","!","&","|","/","\"","'"];
+// Termux-style modifier / navigation row. Ctrl/Alt/Shift are sticky toggles
+// (key:null); the rest are sent immediately (with any armed modifiers).
+const M_MODSKEYS = [
+  {lb:"Esc", key:"Escape"}, {lb:"Ctrl", mod:"ctrl"}, {lb:"Alt", mod:"alt"}, {lb:"Shift", mod:"shift"},
+  {lb:"←", key:"ArrowLeft"}, {lb:"↑", key:"ArrowUp"}, {lb:"↓", key:"ArrowDown"}, {lb:"→", key:"ArrowRight"},
+  {lb:"Home", key:"Home"}, {lb:"End", key:"End"},
+];
 // Bottom-nav destinations → real editor actions.
 const M_NAV = [
   {ic:"🗀", lb:"Files",   act:"toggle_file_explorer"},
@@ -1462,7 +1532,7 @@ const M_MENU = [
 function renderMobileChrome(reg){
   const host=document.getElementById("mobile");
   if(!isMobile()){ if(host.childElementCount) host.innerHTML=""; return; }
-  document.documentElement.style.setProperty("--m-bottom", M_BOTTOM+"px");
+  document.documentElement.style.setProperty("--m-bottom", mBottom()+"px");
   host.innerHTML="";
 
   // header: ⚡ Fresh · filename · 🔍 ▶ ⋮
@@ -1474,6 +1544,9 @@ function renderMobileChrome(reg){
     b.onclick=e=>{ e.stopPropagation(); fn(); }; return b; };
   hd.appendChild(icon("🔍",()=>{ mSheetOpen=false; sendAction("search"); }));
   hd.appendChild(icon("▶",()=>{ mSheetOpen=false; sendAction("command_palette"); }));
+  const kb=icon("⌨",()=>{ mSheetOpen=false; toggleKeyboard(); });
+  if(kbVisible()) kb.classList.add("on");
+  hd.appendChild(kb);
   hd.appendChild(icon("⋮",()=>{ mSheetOpen=!mSheetOpen; render(); }));
   host.appendChild(hd);
 
@@ -1482,16 +1555,31 @@ function renderMobileChrome(reg){
     for(const m of M_MENU){ const it=div("m-sheet-item");
       it.innerHTML='<span class="m-sheet-ic">'+esc(m.ic)+'</span>'+esc(m.lb);
       it.onclick=e=>{ e.stopPropagation(); mSheetOpen=false; sendAction(m.act); }; sh.appendChild(it); }
+    // show/hide the Termux-style modifier row (local view preference)
+    const tog=div("m-sheet-item"); tog.innerHTML='<span class="m-sheet-ic">'+(mShowMods?"☑":"☐")+'</span>Modifier keys';
+    tog.onclick=e=>{ e.stopPropagation(); mShowMods=!mShowMods; mSheetOpen=false; resize(); }; sh.appendChild(tog);
     host.appendChild(sh);
   }
 
-  // bottom stack: symbols · nav · status
+  // bottom stack: [modifier row] · symbols · nav · status
   const bot=div("m-bottom");
+  if(mShowMods){
+    const mods=div("m-mods");
+    for(const m of M_MODSKEYS){
+      const armed = m.mod && mMods[m.mod];
+      const k=div("m-mod"+(m.mod?" m-modkey":"")+(armed?" on":"")); k.textContent=m.lb;
+      k.onclick=e=>{ e.stopPropagation();
+        if(m.mod){ mMods[m.mod]=!mMods[m.mod]; render(); }   // sticky toggle
+        else mobileSendKey({key:m.key}); };                  // immediate (with armed mods)
+      mods.appendChild(k);
+    }
+    bot.appendChild(mods);
+  }
   const syms=div("m-syms");
   for(const s of M_SYMS){ const k=div("m-sym"); k.textContent=s==="Tab"?"⇥":s;
-    k.onclick=e=>{ e.stopPropagation(); sendKey({key:s}); }; syms.appendChild(k); }
+    k.onclick=e=>{ e.stopPropagation(); mobileSendKey({key:s}); }; syms.appendChild(k); }
   const save=div("m-sym m-save"); save.textContent="Save";
-  save.onclick=e=>{ e.stopPropagation(); sendKey({key:"s",ctrl:true}); }; syms.appendChild(save);
+  save.onclick=e=>{ e.stopPropagation(); mobileSendKey({key:"s",ctrl:true}); }; syms.appendChild(save);
   bot.appendChild(syms);
 
   const nav=div("m-nav");
@@ -1517,7 +1605,7 @@ async function sendKey(d){ try{ applyScene(await (await fetch("/key",{method:"PO
 async function resize(){ const cols=Math.max(20,Math.floor(window.innerWidth/CW));
   // On mobile, leave room for the fixed bottom stack so no code hides behind it
   // (the header reuses the two hidden top chrome rows, so it needs no reserve).
-  const availH=window.innerHeight - (isMobile()?M_BOTTOM:0);
+  const availH=window.innerHeight - (isMobile()?mBottom():0);
   const rows=Math.max(8,Math.floor(availH/CH));
   try{ applyScene(await (await fetch("/resize",{method:"POST",headers:{"content-type":"application/json"},body:JSON.stringify({cols,rows})})).json()); }catch(e){} }
 async function sendAction(name){ mSheetOpen=false;
@@ -1540,7 +1628,12 @@ document.addEventListener("keydown",e=>{
   // forward single characters (with or without modifiers, so Ctrl+P / Ctrl+S
   // shortcuts reach the editor) and the named navigation/edit keys.
   const single=e.key.length===1;
-  if(single||NAMED.has(e.key)){ e.preventDefault(); sendKey({key:e.key,ctrl:e.ctrlKey,meta:e.metaKey,shift:e.shiftKey,alt:e.altKey}); }
+  if(single||NAMED.has(e.key)){ e.preventDefault();
+    const d={key:e.key,ctrl:e.ctrlKey,meta:e.metaKey,shift:e.shiftKey,alt:e.altKey};
+    // On mobile, fold in any armed sticky modifiers so e.g. tap-Ctrl then a
+    // native-keyboard letter sends Ctrl+<letter>.
+    if(isMobile()) mobileSendKey(d); else sendKey(d);
+  }
 });
 // Mouse + wheel: forward to the REAL Editor::handle_mouse at cell coordinates.
 const cellAt = e => ({ col: Math.max(0, Math.floor(e.clientX/CW)), row: Math.max(0, Math.floor(e.clientY/CH)) });

--- a/web-ui/index.html
+++ b/web-ui/index.html
@@ -1471,7 +1471,7 @@ function mBottom(){ return M_BASE + (isMobile() && mShowMods ? M_MODS_H : 0); }
 // still flow through the global keydown handler (which preventDefaults), so the
 // input never accumulates text — it's purely the focus target that raises the
 // keyboard. The header ⌨ button toggles focus.
-let mKbInput=null, mKbWanted=false;
+let mKbInput=null, mKbWanted=false, kdHandledAt=0;
 function ensureKbInput(){
   if(mKbInput) return mKbInput;
   const i=document.createElement("input");
@@ -1479,6 +1479,21 @@ function ensureKbInput(){
   i.setAttribute("autocapitalize","off"); i.setAttribute("autocomplete","off");
   i.setAttribute("autocorrect","off"); i.setAttribute("spellcheck","false");
   i.setAttribute("aria-hidden","true");
+  // Android fallback: many soft keyboards report key="Unidentified" on keydown
+  // and only deliver the real text via beforeinput. iOS/desktop fire a usable
+  // keydown (which cancels its default, normally suppressing this) — so if a
+  // keydown was just handled, skip here to avoid double-inserting.
+  i.addEventListener("beforeinput",ev=>{
+    if(Date.now()-kdHandledAt < 120) return;
+    const t=ev.inputType||""; let handled=true;
+    if(t==="insertText" && ev.data){ for(const ch of ev.data) mobileSendKey({key:ch}); }
+    else if(t==="insertLineBreak" || t==="insertParagraph") mobileSendKey({key:"Enter"});
+    else if(t==="deleteContentBackward") mobileSendKey({key:"Backspace"});
+    else if(t==="deleteContentForward") mobileSendKey({key:"Delete"});
+    else handled=false;
+    if(handled) ev.preventDefault();
+    i.value="";
+  });
   i.addEventListener("input",()=>{ i.value=""; });   // never keep typed text
   document.body.appendChild(i); mKbInput=i; return i;
 }
@@ -1631,8 +1646,9 @@ document.addEventListener("keydown",e=>{
   if(single||NAMED.has(e.key)){ e.preventDefault();
     const d={key:e.key,ctrl:e.ctrlKey,meta:e.metaKey,shift:e.shiftKey,alt:e.altKey};
     // On mobile, fold in any armed sticky modifiers so e.g. tap-Ctrl then a
-    // native-keyboard letter sends Ctrl+<letter>.
-    if(isMobile()) mobileSendKey(d); else sendKey(d);
+    // native-keyboard letter sends Ctrl+<letter>. Record the time so the
+    // beforeinput fallback (Android) knows this key was already handled.
+    if(isMobile()){ kdHandledAt=Date.now(); mobileSendKey(d); } else sendKey(d);
   }
 });
 // Mouse + wheel: forward to the REAL Editor::handle_mouse at cell coordinates.


### PR DESCRIPTION
Resumes the experimental web frontend. It rendered correctly but looked rough, and it had no portrait/mobile story. This branch is a styling + responsive pass on `web-ui/index.html` only — no Rust/core changes — verified headless against the real editor bridge (Playwright, Chromium). The existing 50-assertion suite (`web-ui/test/drive.mjs`) stays green at desktop size throughout.

## Desktop chrome polish
The native chrome piped the terminal theme's colours straight into CSS, so the default `high-contrast` theme produced harsh cyan box borders, flat black-on-black tabs, and an invisible white-on-white "Save" button. Reworked into a deliberate visual language:

- **Theme-derived tokens** (`color-mix` of the live `--bg`/`--fg`): elevated `--surface` layers + soft `--hairline` dividers, so chrome reads as depth on any theme instead of hard outlines. One radius scale and one shadow/elevation language shared by menus, popups, palette and modals.
- **Hairline dividers** replace the assorted hard greys and the theme border (the cyan) everywhere a structural line is drawn.
- **Inset rounded selection "pills"** with a faint top-down sheen, replacing edge-to-edge highlight blocks (explorer, palette, popups, context menu, settings, keybinding table, …). Rows keep the same box selected or not, so text never shifts.
- **Bug fix:** luminance-derived `--on-accent` so accent-filled controls (the Save button, toggle dots, selected dropdown rows) are always legible.
- Centered floating command palette, clear active-tab indicator, quiet hover, soft focus rings, slim scrollbars, and overflow-safe list rows (the Languages JSON no longer spills).

## Portrait / mobile touch shell
Gated entirely by `body.mobile` (`max-width:640px` media query) — the desktop layout is untouched. The editor keeps its cell grid; JS just reports fewer rows so the pane ends above the bottom stack, and a 36px header overlays the two hidden top chrome rows (menu+tab) so the pane lines up with no offset math. Every control routes through the real editor (`sendKey` / `sendAction`) — no mock state.

- **Header:** ⚡ logo · live filename · search / run / ⌨ keyboard / ⋮ overflow.
- **Overflow sheet:** Go to File, Find & Replace, Terminal, LSP Status, Settings.
- **Coding-symbol accessory row** (`{ } [ ] ( ) < > ; : = ! & | / " '` + Tab) and a **Save** key — real key events.
- **Termux-style modifier row** (optional; toggle from the overflow sheet): Esc · Ctrl · Alt · Shift · arrows · Home/End. Ctrl/Alt/Shift are **sticky one-shot** toggles that fold into the next key from the symbol row, an arrow, *or the device's native keyboard*. Showing/hiding it re-fits the editor grid.
- **Bottom nav:** Files / Issues / Console / LSP / Palette → `toggle_file_explorer`, `jump_to_next_error`, `terminal`, `show_lsp_status`, `command_palette`. Status strip from the live status segments.
- **Native-keyboard toggle** (`⌨`): focuses a hidden, text-free capture input to summon the OS keyboard and blurs to dismiss it, driven by an explicit intent flag. Keystrokes still flow through the global keydown handler (which `preventDefault`s). **Android fallback:** the capture input also handles `beforeinput` (insertText / deleteContentBackward / line-breaks) for soft keyboards that report `key="Unidentified"`, with a timestamp guard so iOS/desktop don't double-insert.
- File explorer, palette, and the Settings/keybinding modals become full-width sheets between the header and bottom stack.

## Verification
Headless Playwright against the live bridge:
- Desktop `drive.mjs`: **50/50** after every commit.
- Mobile (390×844 @3×, touch): header/nav/symbols render; overflow sheet, Settings, Palette, full-width Files all reachable; symbol keys and Save edit through the real pipeline; modifier arming/clearing and the show/hide re-fit; `⌨` summon/dismiss; Android `beforeinput` reaches the editor with no double-insert. Zero JS page errors throughout.

Commits are scoped one concern each (chrome polish → pills → mobile shell → modifier keys + keyboard toggle → Android fallback). Screenshots for every surface (desktop high-contrast + dark, and the full mobile shell) were shared during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkVw18h2cpkouakSub7HuK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkVw18h2cpkouakSub7HuK)_