### PR TITLE
fix(explorer): apply configured custom_ignore_patterns to the file tree

### DIFF
--- a/crates/fresh-editor/src/app/async_messages.rs
+++ b/crates/fresh-editor/src/app/async_messages.rs
@@ -1420,6 +1420,7 @@ impl Editor {
             show_hidden: self.config.file_explorer.show_hidden,
             show_gitignored: self.config.file_explorer.show_gitignored,
             compact_directories: self.config.file_explorer.compact_directories,
+            custom_ignore_patterns: self.config.file_explorer.custom_ignore_patterns.clone(),
         };
         let is_active = window == self.active_window_id();
         // Route the result back to the window that asked for it. If that window

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -15,11 +15,12 @@ pub struct FileExplorerClipboard {
 /// Config-derived defaults handed to `Window::install_initialized_file_explorer`
 /// so the apply logic lives on `Window` without it borrowing the editor's
 /// `Config` (which would clash with the `&mut Window` borrow).
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct FileExplorerViewDefaults {
     pub show_hidden: bool,
     pub show_gitignored: bool,
     pub compact_directories: bool,
+    pub custom_ignore_patterns: Vec<String>,
 }
 
 /// Outcome of a single filesystem-level paste op (`paste_one_fs_op`).
@@ -1682,6 +1683,15 @@ impl crate::app::window::Window {
             .unwrap_or(defaults.show_gitignored);
         view.ignore_patterns_mut()
             .set_show_gitignored(show_gitignored);
+        {
+            // Wire the configured custom ignore patterns into the matcher (previously the
+            // `custom_ignore_patterns` config field was parsed but never applied).
+            let ip = view.ignore_patterns_mut();
+            ip.clear_custom_patterns();
+            for pattern in &defaults.custom_ignore_patterns {
+                ip.add_custom_pattern(pattern.clone());
+            }
+        }
         view.set_compact_directories(defaults.compact_directories);
         self.file_explorer = Some(view);
         // Auto-expand to reveal the active file on first open (issue #1569),

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -200,6 +200,12 @@ impl Editor {
             let patterns = explorer.ignore_patterns_mut();
             patterns.set_show_hidden(self.config.file_explorer.show_hidden);
             patterns.set_show_gitignored(self.config.file_explorer.show_gitignored);
+            // Apply configured custom ignore patterns (this wiring was missing, so the
+            // `custom_ignore_patterns` config field had no effect).
+            patterns.clear_custom_patterns();
+            for pattern in &self.config.file_explorer.custom_ignore_patterns {
+                patterns.add_custom_pattern(pattern.clone());
+            }
             explorer.set_compact_directories(self.config.file_explorer.compact_directories);
         }
 

--- a/crates/fresh-editor/tests/e2e/file_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer.rs
@@ -4037,3 +4037,45 @@ fn test_toggle_file_explorer_side_moves_panel() {
         "Second toggle should return the explorer to its original left position"
     );
 }
+
+/// A configured custom ignore pattern hides matching entries from the tree.
+///
+/// Regression: `file_explorer.custom_ignore_patterns` was parsed from config but
+/// never wired into the ignore matcher, so a file matching a configured pattern
+/// still appeared in the explorer. Without that wiring this test fails — `debug.log`
+/// shows up alongside `keep.rs`.
+#[test]
+fn test_file_explorer_applies_custom_ignore_patterns() {
+    let mut config = Config::default();
+    config.file_explorer.custom_ignore_patterns = vec!["*.log".to_string()];
+
+    let mut harness =
+        EditorTestHarness::with_temp_project_and_config_no_plugins(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    // A normal file (should appear) and one matching the configured pattern (should not).
+    fs::write(project_root.join("keep.rs"), "fn main() {}").unwrap();
+    fs::write(project_root.join("debug.log"), "noise").unwrap();
+
+    // Open the file explorer.
+    harness
+        .send_key(KeyCode::Char('e'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // Wait until the directory listing has populated and settled (the non-ignored
+    // file is on screen). `keep.rs` and `debug.log` are siblings loaded in the same
+    // refresh, so once the tree is stable the filtering decision is final.
+    harness
+        .wait_until_stable(|h| h.screen_to_string().contains("keep.rs"))
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("keep.rs"),
+        "non-ignored file should be listed:\n{screen}"
+    );
+    assert!(
+        !screen.contains("debug.log"),
+        "file matching custom_ignore_patterns (*.log) should be hidden:\n{screen}"
+    );
+}


### PR DESCRIPTION

  ## Why
  
  Working in a Unity project, every asset has a sibling `.meta` file — so the
  file explorer shows two entries for everything (`Player.cs` + `Player.cs.meta`,
  `Scene.unity` + `Scene.unity.meta`, …), which roughly doubles the tree and
  buries the files you actually edit.

  Fresh already has a `custom_ignore_patterns` config field meant for exactly
  this. Setting it to `["*.meta"]` *looked* like it should hide them — but it had
  no effect.
  
  ## What Claude found
  
  The feature was only half-built upstream. The config field
  (`custom_ignore_patterns`) and the matcher in `view/file_tree/ignore.rs`
  (`add_custom_pattern` / `clear_custom_patterns` / `matches_custom_pattern`)
  both already exist — but nothing ever fed the config into the matcher. The
  field was parsed and then dropped on the floor.
  
  ## Approach

Claude hooked up the one that's already there.
  The config-to-matcher wiring is added at the two points where the explorer's
  ignore state is set:
  
  - explorer install — `FileExplorerViewDefaults` (initial open)
  - live settings re-apply — `settings_actions.rs` (config change without restart)

  Both clear and repopulate the matcher's custom patterns from
  `config.file_explorer.custom_ignore_patterns`. No behaviour change for anyone
  who leaves the field empty.
  
  ## Testing
  
  Adds an e2e test: sets `custom_ignore_patterns = ["*.log"]`, creates `keep.rs`
  and `debug.log` in a temp project, opens the tree, and asserts on rendered
  output — `keep.rs` is listed, `debug.log` is not. Fails without the wiring
  (`debug.log` shows up).