### PR TITLE
fix(clipboard): strip ANSI escape codes from default copy

### DIFF
--- a/crates/fresh-editor/src/app/clipboard.rs
+++ b/crates/fresh-editor/src/app/clipboard.rs
@@ -17,6 +17,7 @@ use crate::input::multi_cursor::{
 use crate::model::buffer_position::byte_to_2d;
 use crate::model::cursor::Cursor;
 use crate::model::event::{BufferId, CursorId, Event};
+use crate::primitives::ansi::strip_ansi_codes;
 use crate::primitives::word_navigation::{
     find_vi_word_end, find_word_start_left, find_word_start_right,
 };
@@ -133,8 +134,11 @@ impl Editor {
             .any(|(_, cursor)| cursor.has_block_selection());
 
         if has_block_selection {
-            // Block selection: copy rectangular region
-            let text = self.copy_block_selection_text();
+            // Block selection: copy rectangular region. Strip ANSI escape
+            // codes so the plain copy matches the styled text the user sees
+            // rather than the raw escape sequences (see `copy_selection_with_theme`
+            // for the formatting-preserving variant).
+            let text = strip_ansi_codes(&self.copy_block_selection_text());
             if !text.is_empty() {
                 self.clipboard.copy(text);
                 self.active_window_mut().status_message = Some(t!("clipboard.copied").to_string());
@@ -166,6 +170,10 @@ impl Editor {
                 text.push_str(&range_text);
             }
 
+            // Strip ANSI escape codes: ANSI-aware buffers render escapes as
+            // zero-width styling, so the user sees colored text — the plain
+            // copy should carry that visible text, not the control codes.
+            let text = strip_ansi_codes(&text);
             if !text.is_empty() {
                 self.clipboard.copy(text);
                 self.active_window_mut().status_message = Some(t!("clipboard.copied").to_string());
@@ -193,6 +201,7 @@ impl Editor {
                 }
             }
 
+            let text = strip_ansi_codes(&text);
             if !text.is_empty() {
                 self.clipboard.copy(text);
                 self.active_window_mut().status_message =

--- a/crates/fresh-editor/src/app/composite_buffer_actions.rs
+++ b/crates/fresh-editor/src/app/composite_buffer_actions.rs
@@ -1209,6 +1209,9 @@ impl Editor {
             text
         };
 
+        // Strip ANSI escape codes so the plain copy carries the visible text
+        // rather than the raw control codes that ANSI-aware panes render as styling.
+        let text = crate::primitives::ansi::strip_ansi_codes(&text);
         if !text.is_empty() {
             self.clipboard.copy(text);
         }

--- a/crates/fresh-editor/tests/e2e/paste.rs
+++ b/crates/fresh-editor/tests/e2e/paste.rs
@@ -1031,6 +1031,31 @@ fn test_block_selection_copy_paste_roundtrip() {
         .assert_buffer_content("Line 4Line 1\nLine 5Line 2\nLine 6Line 3\nLine 4\nLine 5\nLine 6");
 }
 
+/// The plain copy command must not carry ANSI escape codes. ANSI-aware
+/// buffers render escape sequences as zero-width styling, so what the user
+/// sees is the colored text — the default copy should yield that visible text,
+/// not the raw control codes. (Copy-with-formatting is the styled variant.)
+#[test]
+fn test_copy_strips_ansi_escape_codes() {
+    use fresh::input::keybindings::Action;
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Insert text with SGR color escape sequences directly: typing ESC through
+    // the key path would be intercepted rather than inserted as content.
+    harness
+        .editor_mut()
+        .paste_text("\x1b[31mRed\x1b[0m and \x1b[32mGreen\x1b[0m".to_string());
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::SelectAll);
+    harness.editor_mut().copy_selection();
+
+    let copied = harness.editor().clipboard_content_for_test();
+    assert_eq!(copied, "Red and Green");
+}
+
 /// Column-mode paste must remain atomic for undo: a single Ctrl+Z reverts
 /// every per-cursor insertion.
 #[test]


### PR DESCRIPTION
ANSI-aware buffers render embedded escape sequences as zero-width styling
(ansi_aware = !is_binary), so the user sees colored text rather than the raw
control codes. The plain copy command, however, grabbed the underlying bytes
including those escapes, so pasting elsewhere dumped garbage like `^[[31m`.

Strip ANSI codes in the default copy paths (selection, whole-line, block, and
composite-buffer copy) so the clipboard carries the visible text. Copy with
Formatting remains the styled variant (HTML). The strip has a cheap fast path
that returns the input unchanged when no ESC byte is present.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LgSWAMP2MecaS8F7gqFMaD