### PR TITLE
fix(remote): run agent terminals on the remote host in the workspace dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The cli now supports `--cmd daemon`, but still accepts the now-deprecated `--cmd
 * Fixed a crash on a stale soft-wrap position in multi-byte text (#2320).
 * Trusting a workspace with a shell or virtualenv environment (`.envrc` / `mise` / `.venv`) no longer restarts the whole editor: other windows keep their running terminals, language servers, and Orchestrator dock; only the active window refreshes to pick up the new environment.
 * A file opened while a split is maximized — for example via an embedded `fresh <file>` forwarded from a maximized terminal dock — is now revealed instead of rendering hidden behind the maximized split (which previously looked like the terminal had hung).
+* Launching an agent (e.g. `claude`) in an SSH or Kubernetes workspace now runs it **on the remote host / in the pod**, rooted at the workspace's remote path, instead of silently running it on the local machine. The agent's launch and resume commands compose with the session's backend via a `cd <dir>; exec <argv>` shell hop (the argv is shell-quoted and handed to a remote login shell so its `PATH` resolves the agent).
 
 ### Internals
 

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -39,10 +39,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::model::filesystem::{FileSystem, StdFileSystem};
 use crate::services::remote::{
-    build_kube_terminal_args, build_ssh_terminal_args, spawn_kube_reconnect_task,
-    spawn_reconnect_task, ConnectionParams, KubeConnection, KubeTarget, LocalLongRunningSpawner,
-    LocalProcessSpawner, LongRunningSpawner, ProcessSpawner, RemoteFileSystem,
-    RemoteLongRunningSpawner, RemoteProcessSpawner, SshConnection, SshError, TransportError,
+    build_kube_agent_terminal_args, build_kube_terminal_args, build_ssh_agent_terminal_args,
+    build_ssh_terminal_args, spawn_kube_reconnect_task, spawn_reconnect_task, ConnectionParams,
+    KubeConnection, KubeTarget, LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner,
+    ProcessSpawner, RemoteFileSystem, RemoteLongRunningSpawner, RemoteProcessSpawner,
+    SshConnection, SshError, TransportError,
 };
 use crate::services::workspace_trust::WorkspaceTrust;
 
@@ -311,14 +312,43 @@ pub struct Authority {
     /// `setEnv`/`clearEnv` plugin ops, never a stored snapshot. Same `Arc` the
     /// server owns; born in `main.rs` alongside trust.
     pub env_provider: Arc<crate::services::env_provider::EnvProvider>,
-    /// Argv **prefix** that runs an arbitrary *interactive* command inside
-    /// this backend, used by [`Self::terminal_command`]. Empty for a local
-    /// authority (the command is the PTY child directly); for a container it
-    /// is `docker exec -it … <id>`, so an agent argv (`claude --resume <id>`)
-    /// runs *in the container* rather than on the host. This is the seam
-    /// where the per-session backend and the agent-resume terminal command
-    /// compose — see `docs/internal/PER_SESSION_BACKENDS_DESIGN.md`.
-    pub command_prefix: Vec<String>,
+    /// How an arbitrary *interactive* argv (an agent like `claude --resume
+    /// <id>`, or a plain command) is turned into a PTY command that runs
+    /// **inside** this backend, rooted at the session's workspace dir. Used by
+    /// [`Self::terminal_command`]. This is the seam where the per-session
+    /// backend and the agent-resume terminal command compose — see
+    /// `docs/internal/PER_SESSION_BACKENDS_DESIGN.md`.
+    pub command_wrap: CommandWrap,
+}
+
+/// How [`Authority::terminal_command`] composes an interactive argv with the
+/// authority's backend. Each backend pins the argv's working directory in the
+/// way that backend supports: a `-w` flag for `docker exec`, or a `cd <dir>`
+/// shell hop for `ssh` / `kubectl` (which have no cwd flag).
+#[derive(Debug, Clone)]
+pub enum CommandWrap {
+    /// Local: the argv is the PTY child directly; the terminal sets cwd.
+    Direct,
+    /// Argv-pure exec prefix (`docker exec -it [-u][-w][-e] <id>`): the agent
+    /// argv is appended verbatim — never a shell string — and cwd is pinned by
+    /// the prefix's own `-w` flag. The prefix is non-empty (`prefix[0]` is the
+    /// program, e.g. `docker`).
+    Prefix(Vec<String>),
+    /// SSH: re-exec the argv on the remote host rooted at `remote_dir`. `ssh`
+    /// has no cwd flag, so cwd is pinned via a `cd <dir>` shell hop and the
+    /// argv is shell-quoted (not appended raw). Without this an agent argv ran
+    /// on the **local** host instead of the remote.
+    Ssh {
+        params: ConnectionParams,
+        remote_dir: Option<String>,
+    },
+    /// Kubernetes: re-exec the argv inside the pod rooted at the target's
+    /// workspace, same shell-hop contract as SSH. `base_env` is the captured
+    /// in-pod env probe, exported before the agent so its `PATH` resolves.
+    Kube {
+        target: KubeTarget,
+        base_env: Vec<(String, String)>,
+    },
 }
 
 /// A session's **execution scope**: the trust gate (*may it run?*) and env
@@ -367,35 +397,61 @@ impl Authority {
     }
 
     /// Build a [`TerminalWrapper`] that runs `argv` as an interactive PTY
-    /// child **inside this authority's backend**. Local runs it directly;
-    /// container/remote authorities prepend their exec prefix
-    /// ([`Self::command_prefix`]) so the command runs in the backend with its
-    /// argv intact (no shell-string interpolation). An empty `argv` falls
-    /// back to the authority's interactive shell wrapper.
+    /// child **inside this authority's backend**, rooted at the session's
+    /// workspace dir. Local runs it directly; container/remote authorities wrap
+    /// it per [`CommandWrap`] so it runs in the backend (a container exec, an
+    /// `ssh`/`kubectl` shell hop) rather than on the host. An empty `argv`
+    /// falls back to the authority's interactive shell wrapper.
     ///
     /// This is what the Orchestrator agent-resume path spawns through, so a
     /// `claude --resume <id>` restored in a devcontainer session runs as
-    /// `docker exec -it … <id> claude --resume <id>` rather than on the host.
+    /// `docker exec -it … <id> claude --resume <id>`, and an SSH session runs
+    /// it as `ssh -t … 'cd <dir>; exec <argv>'` on the remote host — never on
+    /// the local machine.
     pub fn terminal_command(&self, argv: &[String]) -> TerminalWrapper {
         let Some((cmd, rest)) = argv.split_first() else {
             return self.terminal_wrapper.clone();
         };
-        if self.command_prefix.is_empty() {
-            // Local: the command is the PTY child; cwd is the terminal's.
-            TerminalWrapper {
-                command: cmd.clone(),
-                args: rest.to_vec(),
-                manages_cwd: false,
+        match &self.command_wrap {
+            CommandWrap::Direct => {
+                // Local: the command is the PTY child; cwd is the terminal's.
+                TerminalWrapper {
+                    command: cmd.clone(),
+                    args: rest.to_vec(),
+                    manages_cwd: false,
+                }
             }
-        } else {
-            // Remote: `<exec-prefix> <argv>`. The prefix pins the backend
-            // (and its cwd), so cwd is managed by the wrapper's own args.
-            let mut args = self.command_prefix[1..].to_vec();
-            args.extend(argv.iter().cloned());
-            TerminalWrapper {
-                command: self.command_prefix[0].clone(),
-                args,
-                manages_cwd: true,
+            CommandWrap::Prefix(prefix) => {
+                // Container: `<exec-prefix> <argv>`, argv-pure. The prefix pins
+                // the backend (and its cwd via `-w`), so cwd is managed by the
+                // wrapper's own args.
+                let mut args = prefix[1..].to_vec();
+                args.extend(argv.iter().cloned());
+                TerminalWrapper {
+                    command: prefix[0].clone(),
+                    args,
+                    manages_cwd: true,
+                }
+            }
+            CommandWrap::Ssh { params, remote_dir } => {
+                // SSH: run the argv on the remote host rooted at `remote_dir`
+                // via a `cd <dir>; exec <argv>` shell hop. cwd is pinned by the
+                // wrapper's own args.
+                TerminalWrapper {
+                    command: "ssh".to_string(),
+                    args: build_ssh_agent_terminal_args(params, remote_dir.as_deref(), argv),
+                    manages_cwd: true,
+                }
+            }
+            CommandWrap::Kube { target, base_env } => {
+                // Kubernetes: run the argv inside the pod rooted at the target's
+                // workspace via the same shell hop. cwd is pinned by the
+                // wrapper's own args.
+                TerminalWrapper {
+                    command: "kubectl".to_string(),
+                    args: build_kube_agent_terminal_args(target, base_env, argv),
+                    manages_cwd: true,
+                }
             }
         }
     }
@@ -423,8 +479,8 @@ impl Authority {
             path_translation: None,
             workspace_trust: trust,
             env_provider: env,
-            // Local: commands run directly as the PTY child, no exec prefix.
-            command_prefix: Vec::new(),
+            // Local: commands run directly as the PTY child, no backend wrap.
+            command_wrap: CommandWrap::Direct,
         }
     }
 
@@ -461,11 +517,13 @@ impl Authority {
             path_translation: None,
             workspace_trust: trust,
             env_provider: env,
-            // TODO(per-session): build an `ssh -t … <target> --` exec prefix
-            // so a restored agent runs on the remote host. Empty for now —
-            // an agent command falls back to running on the host (today's
-            // behaviour), no regression.
-            command_prefix: Vec::new(),
+            // An agent argv (`claude --resume <id>`) runs on the *remote* host
+            // rooted at `remote_dir` via a `cd <dir>; exec <argv>` shell hop —
+            // not on the local machine. See [`CommandWrap::Ssh`].
+            command_wrap: CommandWrap::Ssh {
+                params: params.clone(),
+                remote_dir: remote_dir.map(str::to_string),
+            },
         }
     }
 
@@ -498,10 +556,13 @@ impl Authority {
             path_translation: None,
             workspace_trust: trust,
             env_provider: env,
-            // TODO(per-session): build a `kubectl exec -it … -- ` exec prefix
-            // (argv-pure via `kubectl_exec_argv`) so a restored agent runs in
-            // the pod. Empty for now — falls back to host, no regression.
-            command_prefix: Vec::new(),
+            // An agent argv runs *inside the pod* rooted at the target's
+            // workspace via a `cd <ws>; exec <argv>` shell hop — not on the
+            // local machine. See [`CommandWrap::Kube`].
+            command_wrap: CommandWrap::Kube {
+                target: target.clone(),
+                base_env: base_env.to_vec(),
+            },
         }
     }
 
@@ -567,10 +628,10 @@ impl Authority {
 
         // Both spawner traits need the docker-exec params when the
         // payload is a container, so destructure once and reuse.
-        let (process_spawner, long_running_spawner, command_prefix): (
+        let (process_spawner, long_running_spawner, command_wrap): (
             Arc<dyn ProcessSpawner>,
             Arc<dyn LongRunningSpawner>,
-            Vec<String>,
+            CommandWrap,
         ) = match payload.spawner {
             SpawnerSpec::Local => (
                 Arc::new(LocalProcessSpawner::new(
@@ -581,8 +642,8 @@ impl Authority {
                     Arc::clone(&env),
                     Arc::clone(&trust),
                 )),
-                // Host-local spawner: commands run directly, no exec prefix.
-                Vec::new(),
+                // Host-local spawner: commands run directly, no backend wrap.
+                CommandWrap::Direct,
             ),
             SpawnerSpec::DockerExec {
                 container_id,
@@ -620,7 +681,7 @@ impl Authority {
                             Arc::clone(&trust),
                         ),
                     ),
-                    command_prefix,
+                    CommandWrap::Prefix(command_prefix),
                 )
             }
         };
@@ -652,7 +713,7 @@ impl Authority {
             path_translation,
             workspace_trust: trust,
             env_provider: env,
-            command_prefix,
+            command_wrap,
         })
     }
 }
@@ -1442,6 +1503,127 @@ mod tests {
                 "--resume",
                 "u-1",
             ]
+        );
+    }
+
+    /// Build a minimal SSH authority for the terminal_command tests. The
+    /// spawners are local stubs — `terminal_command` only consults
+    /// `command_wrap` (built from `params` + `remote_dir`), never the spawners.
+    fn ssh_authority(params: &ConnectionParams, remote_dir: Option<&str>) -> Authority {
+        let trust = Arc::new(WorkspaceTrust::permissive());
+        let env = Arc::new(crate::services::env_provider::EnvProvider::inactive());
+        Authority::ssh(
+            Arc::new(StdFileSystem),
+            Arc::new(LocalProcessSpawner::new(
+                Arc::clone(&env),
+                Arc::clone(&trust),
+            )),
+            Arc::new(LocalLongRunningSpawner::new(
+                Arc::clone(&env),
+                Arc::clone(&trust),
+            )),
+            params,
+            remote_dir,
+            trust,
+            env,
+        )
+    }
+
+    #[test]
+    fn ssh_terminal_command_runs_agent_on_remote_in_workspace() {
+        // Regression: launching an agent (e.g. `claude`) in an SSH session ran
+        // it on the *local* host (command == "claude", manages_cwd == false),
+        // ignoring the session's remote path. It must run through `ssh` on the
+        // remote host, rooted at the provided remote workspace dir.
+        let params = ConnectionParams {
+            user: Some("u".into()),
+            host: "h".into(),
+            port: Some(2222),
+            identity_file: None,
+            extra_args: Vec::new(),
+        };
+        let auth = ssh_authority(&params, Some("/srv/proj"));
+
+        let w = auth.terminal_command(&["claude".into(), "--resume".into(), "u-1".into()]);
+        assert_eq!(
+            w.command, "ssh",
+            "agent must launch through ssh, not locally"
+        );
+        assert!(
+            w.manages_cwd,
+            "ssh re-parents the agent, so it manages its own cwd"
+        );
+        // Target precedes the single remote-command argument.
+        assert!(w.args.contains(&"u@h".to_string()));
+        let remote_cmd = w.args.last().expect("ssh passes a remote command");
+        assert!(
+            remote_cmd.contains("/srv/proj") && remote_cmd.contains("cd "),
+            "agent must be rooted at the remote workspace dir: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("claude"),
+            "agent argv must be present in the remote command: {remote_cmd}"
+        );
+    }
+
+    #[test]
+    fn ssh_terminal_command_empty_argv_falls_back_to_shell_wrapper() {
+        // Empty argv = "spawn a bare remote shell": still the ssh login-shell
+        // wrapper, not an empty/garbage command.
+        let params = ConnectionParams {
+            user: None,
+            host: "h".into(),
+            port: None,
+            identity_file: None,
+            extra_args: Vec::new(),
+        };
+        let auth = ssh_authority(&params, Some("/srv/proj"));
+        let w = auth.terminal_command(&[]);
+        assert_eq!(w.command, auth.terminal_wrapper.command);
+        assert_eq!(w.args, auth.terminal_wrapper.args);
+    }
+
+    #[test]
+    fn kube_terminal_command_runs_agent_in_pod_workspace() {
+        // Same regression as SSH, but for a Kubernetes-backed session: the
+        // agent must run inside the pod (`kubectl exec … -- sh -lc 'cd <ws>;
+        // exec <argv>'`), rooted at the pod-side workspace, not on the host.
+        let target = KubeTarget {
+            context: None,
+            namespace: "dev".into(),
+            pod: "pod-1".into(),
+            container: None,
+            workspace: Some("/workspace".into()),
+        };
+        let trust = Arc::new(WorkspaceTrust::permissive());
+        let env = Arc::new(crate::services::env_provider::EnvProvider::inactive());
+        let auth = Authority::kube(
+            Arc::new(StdFileSystem),
+            Arc::new(LocalProcessSpawner::new(
+                Arc::clone(&env),
+                Arc::clone(&trust),
+            )),
+            Arc::new(LocalLongRunningSpawner::new(
+                Arc::clone(&env),
+                Arc::clone(&trust),
+            )),
+            &target,
+            &[],
+            trust,
+            env,
+        );
+
+        let w = auth.terminal_command(&["claude".into(), "--resume".into(), "u-1".into()]);
+        assert_eq!(w.command, "kubectl", "agent must launch through kubectl");
+        assert!(w.manages_cwd);
+        let remote_cmd = w.args.last().expect("kubectl passes a remote command");
+        assert!(
+            remote_cmd.contains("/workspace") && remote_cmd.contains("cd "),
+            "agent must be rooted at the pod workspace dir: {remote_cmd}"
+        );
+        assert!(
+            remote_cmd.contains("claude"),
+            "agent argv must be present in the pod command: {remote_cmd}"
         );
     }
 

--- a/crates/fresh-editor/src/services/remote/mod.rs
+++ b/crates/fresh-editor/src/services/remote/mod.rs
@@ -35,10 +35,10 @@ pub use protocol::{
     write_params, AgentRequest, AgentResponse,
 };
 pub use spawner::{
-    build_kube_terminal_args, build_ssh_terminal_args, ssh_remote_env_launcher,
-    LocalLongRunningSpawner, LocalProcessSpawner, LongRunningSpawner, ProcessSpawner,
-    RemoteLongRunningSpawner, RemoteProcessSpawner, SpawnError, SpawnResult, StdioChild,
-    SSH_EXEC_LOGIN_SHELL,
+    build_kube_agent_terminal_args, build_kube_terminal_args, build_ssh_agent_terminal_args,
+    build_ssh_terminal_args, ssh_remote_env_launcher, LocalLongRunningSpawner, LocalProcessSpawner,
+    LongRunningSpawner, ProcessSpawner, RemoteLongRunningSpawner, RemoteProcessSpawner, SpawnError,
+    SpawnResult, StdioChild, SSH_EXEC_LOGIN_SHELL,
 };
 /// Shared `kubectl exec` argv builder, used by the agent transport, the
 /// terminal wrapper, and the long-running (LSP) spawner. Crate-internal.

--- a/crates/fresh-editor/src/services/remote/spawner.rs
+++ b/crates/fresh-editor/src/services/remote/spawner.rs
@@ -918,6 +918,37 @@ pub fn build_ssh_terminal_args(
     params: &crate::services::remote::ConnectionParams,
     remote_dir: Option<&str>,
 ) -> Vec<String> {
+    build_ssh_remote_args(params, remote_dir, SSH_EXEC_LOGIN_SHELL)
+}
+
+/// Build the `ssh` argv that runs an interactive *agent* `argv` on the remote
+/// host, rooted at the workspace dir — the agent analogue of
+/// [`build_ssh_terminal_args`]. `ssh` has no cwd flag, so cwd is pinned through
+/// the same `cd <dir>` shell hop the bare terminal uses; the agent argv is then
+/// handed to a remote **login** shell (`exec $SHELL -lc 'exec <argv>'`) so its
+/// profile-derived `PATH` resolves the agent binary exactly as the bare
+/// terminal would. The argv is POSIX-quoted, so paths/args with spaces survive
+/// the remote shell's re-parse intact. Without this an agent command under an
+/// SSH session ran on the **local** host instead of the remote.
+pub fn build_ssh_agent_terminal_args(
+    params: &crate::services::remote::ConnectionParams,
+    remote_dir: Option<&str>,
+    argv: &[String],
+) -> Vec<String> {
+    build_ssh_remote_args(params, remote_dir, &agent_login_exec_tail(argv))
+}
+
+/// Shared body of the SSH integrated-terminal argv: the `ssh` flags + target,
+/// then a remote command that lands in the workspace and runs `exec_tail`. The
+/// bare terminal passes [`SSH_EXEC_LOGIN_SHELL`]; the agent terminal passes
+/// [`agent_login_exec_tail`]. Kept as one function so the cwd-landing logic
+/// (and the `-t` / StrictHostKeyChecking / `-p` / `-i` / extra-args assembly)
+/// stays identical between the two.
+fn build_ssh_remote_args(
+    params: &crate::services::remote::ConnectionParams,
+    remote_dir: Option<&str>,
+    exec_tail: &str,
+) -> Vec<String> {
     let mut a = vec![
         "-t".to_string(),
         "-o".to_string(),
@@ -934,12 +965,12 @@ pub fn build_ssh_terminal_args(
     a.extend(params.extra_args.iter().cloned());
     a.push(params.ssh_target());
 
-    // Land in the workspace (when known), then hand control to the user's
-    // login shell. `remote_dir` is whatever path the URL pointed at, which
-    // may be a *file* (`fresh ssh://host/proj/main.rs`) — so fall back to
-    // its parent dir, and treat a failed `cd` as non-fatal so the shell
-    // always starts. `exec` replaces the ssh-side shell so closing the
-    // terminal tears the session down cleanly.
+    // Land in the workspace (when known), then run `exec_tail`. `remote_dir`
+    // is whatever path the URL pointed at, which may be a *file* (`fresh
+    // ssh://host/proj/main.rs`) — so fall back to its parent dir, and treat a
+    // failed `cd` as non-fatal so the command always starts. `exec` replaces
+    // the ssh-side shell so closing the terminal tears the session down
+    // cleanly.
     let mut remote_cmd = String::new();
     if let Some(dir) = remote_dir.filter(|d| !d.is_empty()) {
         let quoted = shell_quote(dir);
@@ -947,9 +978,29 @@ pub fn build_ssh_terminal_args(
             "d={quoted}; [ -d \"$d\" ] || d=$(dirname \"$d\"); cd \"$d\" 2>/dev/null; "
         ));
     }
-    remote_cmd.push_str(SSH_EXEC_LOGIN_SHELL);
+    remote_cmd.push_str(exec_tail);
     a.push(remote_cmd);
     a
+}
+
+/// The `exec ${SHELL:-/bin/sh} -lc '<exec argv…>'` tail shared by the SSH and
+/// K8s **agent** terminals: hand the agent argv to a remote **login** shell (so
+/// its profile-derived `PATH` resolves the agent binary), which `exec`s it as
+/// the session leader (so closing the terminal tears it down). Each argv token
+/// is POSIX-quoted, then the whole `exec …` string is quoted again as the
+/// single `-c` argument, so the argv survives the remote shell's re-parse with
+/// spaces/metacharacters intact. `argv` is always non-empty here (the empty
+/// case falls back to the bare-shell wrapper before reaching this).
+fn agent_login_exec_tail(argv: &[String]) -> String {
+    let joined = argv
+        .iter()
+        .map(|a| shell_quote(a))
+        .collect::<Vec<_>>()
+        .join(" ");
+    format!(
+        "exec ${{SHELL:-/bin/sh}} -lc {}",
+        shell_quote(&format!("exec {joined}"))
+    )
 }
 
 /// The tail of the SSH terminal's remote command: hand control to the user's
@@ -1032,6 +1083,34 @@ pub fn build_kube_terminal_args(
     target: &crate::services::remote::KubeTarget,
     base_env: &[(String, String)],
 ) -> Vec<String> {
+    build_kube_remote_args(target, base_env, "exec ${SHELL:-/bin/sh} -l")
+}
+
+/// Build the `kubectl` argv that runs an interactive *agent* `argv` inside the
+/// pod, rooted at the workspace dir — the agent analogue of
+/// [`build_kube_terminal_args`]. `kubectl exec` has no cwd flag, so cwd is
+/// pinned through the same `cd <ws>` shell hop the bare terminal uses, and the
+/// agent argv is handed to a pod-side **login** shell (`exec $SHELL -lc 'exec
+/// <argv>'`) so its `PATH` resolves the agent binary. Without this an agent
+/// command under a K8s session ran on the **local** host instead of the pod.
+pub fn build_kube_agent_terminal_args(
+    target: &crate::services::remote::KubeTarget,
+    base_env: &[(String, String)],
+    argv: &[String],
+) -> Vec<String> {
+    build_kube_remote_args(target, base_env, &agent_login_exec_tail(argv))
+}
+
+/// Shared body of the K8s integrated-terminal argv: export the in-pod env
+/// probe, land in the workspace, then run `exec_tail` inside a `sh -lc`
+/// wrapper. The bare terminal passes `exec ${SHELL:-/bin/sh} -l`; the agent
+/// terminal passes [`agent_login_exec_tail`]. Kept as one function so the
+/// env-export + cwd-landing logic stays identical between the two.
+fn build_kube_remote_args(
+    target: &crate::services::remote::KubeTarget,
+    base_env: &[(String, String)],
+    exec_tail: &str,
+) -> Vec<String> {
     let mut remote_cmd = String::new();
     // Apply the captured in-pod env probe to the integrated terminal so it
     // matches what LSP / spawnProcess get in the pod (issue #2355; see
@@ -1051,7 +1130,7 @@ pub fn build_kube_terminal_args(
             "d={quoted}; [ -d \"$d\" ] || d=$(dirname \"$d\"); cd \"$d\" 2>/dev/null; "
         ));
     }
-    remote_cmd.push_str("exec ${SHELL:-/bin/sh} -l");
+    remote_cmd.push_str(exec_tail);
     crate::services::remote::transport::kubectl_exec_argv(
         target,
         &["-it"],
@@ -1568,6 +1647,95 @@ mod tests {
         );
         // Empty dir is treated the same as no dir.
         assert_eq!(build_ssh_terminal_args(&params, Some("")), a);
+    }
+
+    #[test]
+    fn build_ssh_agent_terminal_args_runs_agent_in_remote_workspace() {
+        let params = crate::services::remote::ConnectionParams {
+            user: Some("u".into()),
+            host: "h".into(),
+            port: Some(2222),
+            identity_file: Some(std::path::PathBuf::from("/k")),
+            extra_args: Vec::new(),
+        };
+        let argv = vec![
+            "claude".to_string(),
+            "--resume".to_string(),
+            "u-1".to_string(),
+        ];
+        let a = build_ssh_agent_terminal_args(&params, Some("/srv/proj"), &argv);
+
+        // Same ssh head as the bare terminal: -t, StrictHostKeyChecking, port,
+        // identity, then the target.
+        assert_eq!(
+            &a[..8],
+            &[
+                "-t",
+                "-o",
+                "StrictHostKeyChecking=accept-new",
+                "-p",
+                "2222",
+                "-i",
+                "/k",
+                "u@h",
+            ]
+        );
+        let remote_cmd = a.last().unwrap();
+        // Lands in the workspace before exec'ing the agent.
+        assert!(remote_cmd.contains("cd \"$d\"") && remote_cmd.contains("'/srv/proj'"));
+        // Hands the agent to a remote *login* shell so its PATH resolves it,
+        // then execs the (quoted) agent argv.
+        assert!(remote_cmd.contains("exec ${SHELL:-/bin/sh} -lc "));
+        assert!(
+            remote_cmd.contains("claude")
+                && remote_cmd.contains("--resume")
+                && remote_cmd.contains("u-1")
+        );
+    }
+
+    #[test]
+    fn build_ssh_agent_terminal_args_quotes_args_with_spaces() {
+        // An argv token containing a space (or shell metacharacter) must be
+        // POSIX-quoted so the remote shell parses it as a single argument
+        // rather than splitting it.
+        let params = crate::services::remote::ConnectionParams {
+            user: None,
+            host: "h".into(),
+            port: None,
+            identity_file: None,
+            extra_args: Vec::new(),
+        };
+        let argv = vec!["agent".to_string(), "a b".to_string()];
+        let remote_cmd = build_ssh_agent_terminal_args(&params, None, &argv)
+            .pop()
+            .unwrap();
+        // The space-containing token appears single-quoted, never bare.
+        assert!(remote_cmd.contains("'a b'"));
+    }
+
+    #[test]
+    fn build_kube_agent_terminal_args_runs_agent_in_pod_workspace() {
+        let target = crate::services::remote::KubeTarget {
+            context: None,
+            namespace: "dev".into(),
+            pod: "pod-1".into(),
+            container: None,
+            workspace: Some("/workspace".into()),
+        };
+        let argv = vec![
+            "claude".to_string(),
+            "--resume".to_string(),
+            "u-1".to_string(),
+        ];
+        let a = build_kube_agent_terminal_args(&target, &[], &argv);
+        // `kubectl exec -it … -- sh -lc '<remote_cmd>'`.
+        assert_eq!(a[0], "exec");
+        assert!(a.contains(&"-it".to_string()));
+        assert!(a.contains(&"sh".to_string()) && a.contains(&"-lc".to_string()));
+        let remote_cmd = a.last().unwrap();
+        assert!(remote_cmd.contains("cd \"$d\"") && remote_cmd.contains("'/workspace'"));
+        assert!(remote_cmd.contains("exec ${SHELL:-/bin/sh} -lc "));
+        assert!(remote_cmd.contains("claude"));
     }
 
     #[test]

--- a/docs/internal/PER_SESSION_BACKENDS_DESIGN.md
+++ b/docs/internal/PER_SESSION_BACKENDS_DESIGN.md
@@ -78,15 +78,17 @@ agent-resume feature landed assuming a local backend:
    instead of bypassing it. (This also fixes a born-attached remote agent's
    *seed* terminal, which has the same bypass today.)
 
-   > **Status: shipped for local + containers** (`docker exec -it [-u][-w][-e
-   > env] <id> <argv>`), the argv staying intact (no shell string). SSH and
-   > Kubernetes are stubbed (TODO): the agent must run **in the workspace
-   > dir**, and `docker exec` expresses that argv-pure via `-w <dir>`, but
-   > `kubectl exec` and `ssh` have **no cwd flag** — doing it there needs a
-   > shell hop (`sh -lc 'cd <dir> && exec <argv>'`), which trades away the
-   > argv-slot purity (acceptable for a UUID, but a real decision). Until that
-   > lands, ssh/kube command terminals fall back to running on the host
-   > (today's behaviour), no regression.
+   > **Status: shipped for local, containers, SSH, and Kubernetes.** Local
+   > runs the argv directly; containers prepend `docker exec -it [-u][-w][-e
+   > env] <id>`, the argv staying intact (no shell string, cwd pinned via
+   > `-w`). `kubectl exec` and `ssh` have **no cwd flag**, so they pin cwd with
+   > a shell hop (`… 'cd <dir>; exec ${SHELL:-/bin/sh} -lc <argv>'`): the argv
+   > is POSIX-quoted and handed to a remote **login** shell so its `PATH`
+   > resolves the agent binary, exactly as the bare remote terminal does. This
+   > trades away argv-slot purity for ssh/kube (the quoting carries the argv
+   > intact instead), the deliberate decision flagged here. Before this landed,
+   > ssh/kube command terminals ran the agent on the **local** host, ignoring
+   > the session's remote path — see `CommandWrap` in `services/authority`.
 
 2. **Backend first, then agent.** A restored remote session is **Dormant**
    (local placeholder) until reconnect, so its agent must **not** re-run on


### PR DESCRIPTION
Launching an agent (e.g. `claude`) in an SSH or Kubernetes workspace
silently ran it on the *local* machine, ignoring the session's remote
path: the SSH/K8s authorities left `command_prefix` empty, so
`Authority::terminal_command` took the local branch and spawned the agent
as the PTY child directly, with the remote workspace path as a (locally
meaningless) cwd. This was the documented per-session-backends TODO, and
it affected both born-attached "New Workspace" seed terminals and restored
agent terminals on reconnect.

Replace the `command_prefix: Vec<String>` field with a `CommandWrap` enum
that captures how each backend composes an interactive argv with its
workspace dir: Direct (local), Prefix (`docker exec -w <dir>`, argv-pure),
and Ssh/Kube shell hops. `ssh` and `kubectl` have no cwd flag, so they pin
cwd via `cd <dir>; exec <argv>` and hand the (POSIX-quoted) argv to a
remote login shell so its PATH resolves the agent binary — mirroring the
bare remote terminal. The launch and resume argvs already route through
`terminal_command`, so this fixes new and restored sessions alike.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HHcNdbdxeszgBrsV3BkBTK