### PR TITLE
Support reconnect for live remote-agent sessions with dead carriers

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -596,6 +596,24 @@ impl Editor {
                     let terminal_id = terminal.terminal;
                     let exited_window_id = terminal.window;
                     tracing::info!("Terminal {} exited", terminal);
+                    // A remote-agent window whose carrier just dropped: its
+                    // embedded PTY (a separate `ssh -t` from the agent channel)
+                    // died with the link, not because the user exited the shell.
+                    // Keep the buffer↔terminal binding (and the backing/command
+                    // maps, which this handler already leaves intact) so a later
+                    // reconnect can respawn it in place over the new authority
+                    // (`respawn_terminals_through_authority`). Removing it here
+                    // would strand the buffer as a dead read-only tab with no way
+                    // back. A normal exit (remote still connected, or any local
+                    // terminal) falls through to the usual permanent teardown.
+                    let preserve_for_reconnect = matches!(
+                        self.active_window().authority_spec,
+                        crate::services::authority::SessionAuthoritySpec::RemoteAgent(_)
+                    ) && !self
+                        .active_window()
+                        .authority()
+                        .filesystem
+                        .is_remote_connected();
                     // Find the buffer associated with this terminal
                     if let Some((&buffer_id, _)) = self
                         .active_window()
@@ -683,8 +701,12 @@ impl Editor {
                             state.buffer.set_modified(false);
                         }
 
-                        // Remove from terminal_buffers so it's no longer treated as a terminal
-                        self.active_window_mut().terminal_buffers.remove(&buffer_id);
+                        // Remove from terminal_buffers so it's no longer treated
+                        // as a terminal — unless we're holding it for a remote
+                        // reconnect to respawn in place (see above).
+                        if !preserve_for_reconnect {
+                            self.active_window_mut().terminal_buffers.remove(&buffer_id);
+                        }
 
                         self.set_status_message(
                             t!("terminal.exited", id = terminal_id.0).to_string(),
@@ -823,6 +845,16 @@ impl Editor {
                                 }
                                 self.set_session_authority(window_id, authority);
                                 self.session_keepalives.insert(window_id, keepalive);
+                                // The window's embedded terminal(s) ran over the
+                                // old `ssh -t` carrier, which died with the link
+                                // — the agent-channel reconnect doesn't revive
+                                // them. Respawn each dead PTY through the
+                                // freshly-installed authority so it runs on the
+                                // remote backend again, reusing its backing file
+                                // so scrollback continues.
+                                if let Some(w) = self.windows.get_mut(&window_id) {
+                                    w.respawn_terminals_through_authority();
+                                }
                                 self.set_status_message(format!(
                                     "Reconnected: {}",
                                     self.windows

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -3671,11 +3671,34 @@ impl Editor {
     /// the devcontainer plugin can run `devcontainer up`), left to a follow-up.
     /// Idempotent: a reconnect already in flight for this window is a no-op.
     pub(crate) fn reconnect_dormant_session_if_needed(&mut self, window_id: fresh_core::WindowId) {
-        // A live session already holds its connection (keepalive); a local
-        // session has nothing to reconnect.
+        // The *activate* path (diving into a session). A live session already
+        // holds its connection (keepalive), so leave it alone here — switching
+        // to an already-connected window must not tear down and rebuild it. A
+        // local session has nothing to reconnect.
         if self.session_keepalives.contains_key(&window_id) {
             return;
         }
+        self.start_remote_reconnect(window_id);
+    }
+
+    /// Reconnect a session's remote backend on *explicit user request* — the
+    /// remote status indicator's Reconnect / Retry action.
+    ///
+    /// Unlike [`Self::reconnect_dormant_session_if_needed`] (the activate path,
+    /// which no-ops while a keepalive is parked) this forces the connect even
+    /// for a *live* remote `Window` that lost its carrier: such a window keeps
+    /// its now-stale keepalive and `Window`, so the activate-path guard would
+    /// wrongly skip it. On success the `RemoteAttachReady::Reconnect` handler
+    /// re-points the window's authority, replaces the stale keepalive, and
+    /// respawns its dead embedded terminals (see `async_dispatch.rs`).
+    pub(crate) fn force_reconnect_remote_session(&mut self, window_id: fresh_core::WindowId) {
+        self.start_remote_reconnect(window_id);
+    }
+
+    /// Shared body of the two reconnect entry points: read the window's backend
+    /// spec and, for a remote-agent session, kick off the async connect tagged
+    /// with this window so its result re-points *this* window.
+    fn start_remote_reconnect(&mut self, window_id: fresh_core::WindowId) {
         let Some(spec) = self
             .windows
             .get(&window_id)
@@ -3704,9 +3727,7 @@ impl Editor {
                 // Container: only the owning plugin can rebuild the backend
                 // (`devcontainer up`). TODO(per-session): fire a
                 // `session_reattach_requested` hook so it can.
-                tracing::debug!(
-                    "dormant container session {window_id}: reattach is plugin-driven (TODO)"
-                );
+                tracing::debug!("remote session {window_id}: reattach is plugin-driven (TODO)");
             }
         }
     }

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -842,6 +842,22 @@ impl Editor {
                 // Disconnected — warn and offer fallbacks.
                 (Some(_), true) => {
                     title = "Remote: Disconnected".to_string();
+                    // Offer Reconnect for a live remote-agent (SSH/kube) window:
+                    // its backend can be rebuilt from the stored
+                    // `RemoteAgentSpec`, re-pointing this window's authority and
+                    // respawning its dead terminal over the new link. Container
+                    // (`Plugin`) windows reconnect through their owning plugin
+                    // (`devcontainer up`), not here, so they don't get this row.
+                    let is_remote_agent = matches!(
+                        self.active_window().authority_spec,
+                        crate::services::authority::SessionAuthoritySpec::RemoteAgent(_)
+                    );
+                    if is_remote_agent {
+                        items.push(
+                            PopupListItem::new("    Reconnect".to_string())
+                                .with_data("reconnect".to_string()),
+                        );
+                    }
                     items.push(
                         PopupListItem::new("    Go Local".to_string())
                             .with_data("detach".to_string()),
@@ -980,15 +996,18 @@ impl Editor {
             self.remote_indicator_override = None;
             return;
         }
-        if action_key == "retry_reconnect" {
-            // Re-run the core reconnect for the active dormant remote workspace.
-            // `reconnect_dormant_session_if_needed` clears the recorded error up
-            // front (so the indicator flips to "Connecting") and is a no-op for
-            // a non-remote / already-connected workspace. The reconnect path is
-            // plugins-gated (dormant remote sessions are created through the
-            // orchestrator plugin), so this is a no-op in a plugins-less build.
+        if action_key == "reconnect" || action_key == "retry_reconnect" {
+            // Reconnect the active window's remote backend on explicit request:
+            // the Disconnected popup's "Reconnect" row and the FailedAttach
+            // "Retry" row both land here. `force_reconnect_remote_session`
+            // clears any recorded error up front (so the indicator flips to
+            // "Connecting"), forces the connect even for a *live* window whose
+            // stale keepalive is still parked, and is a no-op for a non-remote
+            // workspace. The reconnect path is plugins-gated (remote sessions
+            // are created through the orchestrator plugin), so this is a no-op
+            // in a plugins-less build.
             #[cfg(feature = "plugins")]
-            self.reconnect_dormant_session_if_needed(self.active_window);
+            self.force_reconnect_remote_session(self.active_window);
             return;
         }
         if action_key == "clear_reconnect_error" {

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -786,7 +786,7 @@ impl Window {
     /// so every terminal-id-keyed entry (buffer→terminal binding, backing/log
     /// files, launch/resume commands, ephemeral marker) is remapped to the new
     /// id and the dead handle is torn down.
-    pub(crate) fn respawn_terminals_through_authority(&mut self) {
+    pub fn respawn_terminals_through_authority(&mut self) {
         // Snapshot the (buffer, old terminal id) pairs up front — the loop
         // mutates `terminal_buffers` as it remaps ids.
         let bindings: Vec<(BufferId, TerminalId)> = self

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -767,6 +767,124 @@ impl Window {
         }
         self.terminal_buffers.values().copied().max_by_key(|t| t.0)
     }
+
+    /// Respawn this window's dead embedded terminals through its *current*
+    /// authority, reusing each terminal's backing/log files so scrollback
+    /// continues across the gap.
+    ///
+    /// Called after a live remote reconnect re-points the window's authority
+    /// (`Editor::set_session_authority`): the embedded `ssh -t` PTYs died with
+    /// the carrier (a separate channel from the agent connection, which has its
+    /// own auto-reconnect), so without this they'd sit dead until manually
+    /// reopened. Each respawn re-runs the terminal's stored launch/resume argv
+    /// through `Authority::terminal_command`, so the new PTY runs on the remote
+    /// backend by construction — never the local host.
+    ///
+    /// Only terminals whose handle is missing or no longer alive are respawned;
+    /// a still-live terminal is left untouched (respawning it would orphan its
+    /// PTY). Terminal ids change on respawn — the manager allocates fresh ones —
+    /// so every terminal-id-keyed entry (buffer→terminal binding, backing/log
+    /// files, launch/resume commands, ephemeral marker) is remapped to the new
+    /// id and the dead handle is torn down.
+    pub(crate) fn respawn_terminals_through_authority(&mut self) {
+        // Snapshot the (buffer, old terminal id) pairs up front — the loop
+        // mutates `terminal_buffers` as it remaps ids.
+        let bindings: Vec<(BufferId, TerminalId)> = self
+            .terminal_buffers
+            .iter()
+            .map(|(b, t)| (*b, *t))
+            .collect();
+
+        for (buffer_id, old_id) in bindings {
+            // Leave a still-live terminal alone; only revive the dead ones.
+            let handle = self.terminal_manager.get(old_id);
+            if handle.is_some_and(|h| h.is_alive()) {
+                continue;
+            }
+
+            // Size + cwd carry over from the dead handle (so the reborn PTY
+            // matches the split), falling back to the window's dimensions.
+            let (cols, rows) = handle
+                .map(|h| h.size())
+                .unwrap_or_else(|| self.get_terminal_dimensions());
+            let cwd = handle.and_then(|h| h.cwd());
+
+            // Reuse the same backing/log files so the new PTY appends to the
+            // existing scrollback rather than starting blank.
+            let backing_path = self.terminal_backing_files.get(&old_id).cloned();
+            let log_path = self.terminal_log_files.get(&old_id).cloned();
+
+            // Same argv precedence as workspace restore: an agent-resume argv
+            // first (rejoin the conversation), then the launch command, else
+            // the plain interactive shell.
+            let resume_argv = self
+                .terminal_resume_commands
+                .get(&old_id)
+                .filter(|argv| !argv.is_empty() && self.resources.config.terminal.resume_agents)
+                .cloned();
+            let launch_argv = self
+                .terminal_commands
+                .get(&old_id)
+                .filter(|argv| !argv.is_empty())
+                .cloned();
+            let spawn_argv = resume_argv.or(launch_argv);
+            let wrapper = match spawn_argv.as_deref() {
+                Some(argv) => self.authority().terminal_command(argv),
+                None => self.resolved_terminal_wrapper(),
+            };
+            let wrapper = self.apply_remote_terminal_env(wrapper);
+            let env_delta = self.terminal_env_delta(&wrapper);
+
+            let new_id = match self.terminal_manager.spawn(
+                cols,
+                rows,
+                cwd,
+                log_path,
+                backing_path,
+                wrapper,
+                env_delta,
+            ) {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::warn!("reconnect: failed to respawn terminal {:?}: {}", old_id, e);
+                    continue;
+                }
+            };
+
+            // The dead PTY's handle is now superseded — tear it down.
+            self.terminal_manager.close(old_id);
+
+            // Remap every terminal-id-keyed entry from old_id → new_id.
+            if new_id != old_id {
+                self.terminal_buffers.insert(buffer_id, new_id);
+                if let Some(p) = self.terminal_backing_files.remove(&old_id) {
+                    self.terminal_backing_files.insert(new_id, p);
+                }
+                if let Some(p) = self.terminal_log_files.remove(&old_id) {
+                    self.terminal_log_files.insert(new_id, p);
+                }
+                if let Some(c) = self.terminal_commands.remove(&old_id) {
+                    self.terminal_commands.insert(new_id, c);
+                }
+                if let Some(c) = self.terminal_resume_commands.remove(&old_id) {
+                    self.terminal_resume_commands.insert(new_id, c);
+                }
+                if self.ephemeral_terminals.remove(&old_id) {
+                    self.ephemeral_terminals.insert(new_id);
+                }
+            }
+
+            // Register the reborn leader pid so window-level signal operations
+            // (Stop / Archive / Delete) reach the new process group.
+            if let Some(pid) = self.terminal_manager.get(new_id).and_then(|h| h.pid()) {
+                self.process_groups
+                    .register(pid, format!("terminal #{}", new_id.0));
+            }
+        }
+
+        // Size the freshly-spawned PTYs to their splits' content areas.
+        self.resize_visible_terminals();
+    }
 }
 
 impl Editor {

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -166,6 +166,7 @@ pub mod prompt_editing;
 pub mod recovery;
 pub mod remote_fs_test;
 pub mod remote_indicator_popup;
+pub mod remote_reconnect_terminal;
 pub mod rendering;
 pub mod restored_agent_terminal;
 pub mod restored_terminal_focus;

--- a/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
+++ b/crates/fresh-editor/tests/e2e/remote_indicator_popup.rs
@@ -14,11 +14,158 @@
 //! plumbing the `setRemoteIndicatorState` plugin op drives.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::model::filesystem::{
+    DirEntry, FileMetadata, FilePermissions, FileReader, FileSearchCursor, FileSearchOptions,
+    FileSystem, FileWriter, SearchMatch, StdFileSystem,
+};
 use fresh::services::authority::{
-    Authority, AuthorityPayload, FilesystemSpec, SpawnerSpec, TerminalWrapperSpec,
+    Authority, AuthorityPayload, FilesystemSpec, RemoteAgentSpec, RemoteTransportSpec,
+    SessionAuthoritySpec, SpawnerSpec, TerminalWrapperSpec,
 };
 use fresh::view::ui::status_bar::RemoteIndicatorOverride;
 use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// A filesystem that reports as a *remote* backend whose link is down — it
+/// delegates real I/O to `StdFileSystem` but advertises a connection string and
+/// answers `is_remote_connected() == false`, so `connection_display_string()`
+/// renders the "(Disconnected)" suffix the Remote Indicator's Disconnected
+/// branch keys off. Lets the popup test drive that state with no network.
+struct DisconnectedRemoteFs {
+    inner: StdFileSystem,
+}
+
+impl DisconnectedRemoteFs {
+    fn new() -> Self {
+        Self {
+            inner: StdFileSystem,
+        }
+    }
+}
+
+impl FileSystem for DisconnectedRemoteFs {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        self.inner.read_file(path)
+    }
+    fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+        self.inner.read_range(path, offset, len)
+    }
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        self.inner.write_file(path, data)
+    }
+    fn create_file(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.create_file(path)
+    }
+    fn open_file(&self, path: &Path) -> io::Result<Box<dyn FileReader>> {
+        self.inner.open_file(path)
+    }
+    fn open_file_for_write(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_write(path)
+    }
+    fn open_file_for_append(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_append(path)
+    }
+    fn set_file_length(&self, path: &Path, len: u64) -> io::Result<()> {
+        self.inner.set_file_length(path, len)
+    }
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.inner.rename(from, to)
+    }
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<u64> {
+        self.inner.copy(from, to)
+    }
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_file(path)
+    }
+    fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_dir(path)
+    }
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.metadata(path)
+    }
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.symlink_metadata(path)
+    }
+    fn is_dir(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_dir(path)
+    }
+    fn is_file(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_file(path)
+    }
+    fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()> {
+        self.inner.set_permissions(path, permissions)
+    }
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<DirEntry>> {
+        self.inner.read_dir(path)
+    }
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir(path)
+    }
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir_all(path)
+    }
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.inner.canonicalize(path)
+    }
+    fn current_uid(&self) -> u32 {
+        self.inner.current_uid()
+    }
+    fn search_file(
+        &self,
+        path: &Path,
+        pattern: &str,
+        opts: &FileSearchOptions,
+        cursor: &mut FileSearchCursor,
+    ) -> io::Result<Vec<SearchMatch>> {
+        self.inner.search_file(path, pattern, opts, cursor)
+    }
+    fn sudo_write(
+        &self,
+        path: &Path,
+        data: &[u8],
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> io::Result<()> {
+        self.inner.sudo_write(path, data, mode, uid, gid)
+    }
+    fn walk_files(
+        &self,
+        root: &Path,
+        skip_dirs: &[&str],
+        cancel: &std::sync::atomic::AtomicBool,
+        on_file: &mut dyn FnMut(&Path, &str) -> bool,
+    ) -> io::Result<()> {
+        self.inner.walk_files(root, skip_dirs, cancel, on_file)
+    }
+    fn remote_connection_info(&self) -> Option<&str> {
+        Some("root@127.0.0.1")
+    }
+    fn is_remote_connected(&self) -> bool {
+        false
+    }
+}
+
+/// A remote-agent (SSH) backend spec, the kind a live SSH window persists so a
+/// reconnect can rebuild it.
+fn ssh_agent_spec() -> SessionAuthoritySpec {
+    SessionAuthoritySpec::RemoteAgent(RemoteAgentSpec {
+        transport: RemoteTransportSpec::Ssh {
+            user: Some("root".into()),
+            host: "127.0.0.1".into(),
+            port: Some(2222),
+            identity_file: None,
+            remote_path: None,
+            extra_args: Vec::new(),
+        },
+        base_env: Vec::new(),
+        window: true,
+        label: None,
+        command: None,
+    })
+}
 
 fn popup_item_texts(harness: &EditorTestHarness) -> Vec<String> {
     harness
@@ -217,6 +364,85 @@ fn test_remote_indicator_popup_failed_attach_offers_retry() -> anyhow::Result<()
     assert!(
         !logs.2,
         "Show Build Logs must not be disabled. Row: {logs:?}"
+    );
+    Ok(())
+}
+
+/// A *live* remote-agent (SSH/kube) window whose backend dropped its carrier
+/// must offer a working **Reconnect** in the Remote Indicator popup — the
+/// status-bar surface for rebuilding the link (re-point authority, respawn the
+/// dead terminal). The row dispatches the core reconnect (`reconnect`), distinct
+/// from "Go Local" (`detach`).
+#[test]
+fn test_remote_indicator_popup_disconnected_remote_agent_offers_reconnect() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    // A filesystem that presents as a disconnected remote: the popup's
+    // `connection_display_string()` gets a "(Disconnected)" suffix, driving the
+    // Disconnected branch with no real SSH.
+    let fs = Arc::new(DisconnectedRemoteFs::new());
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_filesystem(fs)
+            .with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    // Mark the active window as a remote-agent session — its backend can be
+    // rebuilt from the stored spec, which is what gates the Reconnect row.
+    let active = harness.editor().active_window_id();
+    harness
+        .editor_mut()
+        .set_session_authority_spec(active, ssh_agent_spec());
+
+    harness.editor_mut().show_remote_indicator_popup();
+    harness.render()?;
+
+    let rows = popup_item_rows(&harness);
+    let reconnect = rows
+        .iter()
+        .find(|(t, _, _)| t.contains("Reconnect"))
+        .unwrap_or_else(|| {
+            panic!("Disconnected remote-agent popup lacks a Reconnect row. Rows: {rows:#?}")
+        });
+    assert_eq!(
+        reconnect.1.as_deref(),
+        Some("reconnect"),
+        "Reconnect must dispatch the core reconnect action. Row: {reconnect:?}"
+    );
+    assert!(
+        !reconnect.2,
+        "Reconnect must not be disabled. Row: {reconnect:?}"
+    );
+
+    // "Go Local" is still offered as the escape hatch.
+    assert!(
+        rows.iter()
+            .any(|(t, d, _)| t.contains("Go Local") && d.as_deref() == Some("detach")),
+        "Disconnected popup must still offer 'Go Local'. Rows: {rows:#?}"
+    );
+    Ok(())
+}
+
+/// A local session's Remote Indicator popup must NOT offer Reconnect — there is
+/// no remote backend to rebuild. Guards against the Reconnect row leaking into
+/// non-remote (or container) windows.
+#[test]
+fn test_remote_indicator_popup_local_does_not_offer_reconnect() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new().with_working_dir(temp.path().to_path_buf()),
+    )?;
+
+    harness.editor_mut().show_remote_indicator_popup();
+    harness.render()?;
+
+    let rows = popup_item_rows(&harness);
+    assert!(
+        !rows.iter().any(|(t, _, _)| t.contains("Reconnect")),
+        "Local popup must not offer a Reconnect row. Rows: {rows:#?}"
     );
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/remote_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_reconnect_terminal.rs
@@ -1,0 +1,149 @@
+//! Component test for the reconnect terminal-respawn mechanic.
+//!
+//! When a live remote window's carrier drops, its embedded PTY dies (a separate
+//! `ssh -t` channel from the agent connection). A reconnect re-points the
+//! window's authority and then calls
+//! [`Window::respawn_terminals_through_authority`] to revive the dead
+//! terminal(s) *in place*: a fresh PTY bound to the same buffer, spawned through
+//! the (now-reconnected) authority, reusing the backing file so scrollback
+//! continues.
+//!
+//! Whether the reborn PTY actually runs on the remote host is not observable
+//! hermetically (localhost SSH shares the host; only `$SSH_CONNECTION`
+//! discriminates — see the manual verification in the PR). What *is* a
+//! component invariant — and the part that regressed in the first cut, where the
+//! reconnect re-pointed the authority but left the terminal dead — is the
+//! respawn bookkeeping: the buffer must end up bound to a *new, live* terminal,
+//! every terminal-id-keyed map remapped off the stale id, and the backing file
+//! preserved. This drives that directly. Requires a working PTY (`/dev/ptmx`);
+//! skips when unavailable, like the other terminal e2e tests.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use portable_pty::{native_pty_system, PtySize};
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Unix PTY shell
+fn reconnect_respawns_a_dead_embedded_terminal_in_place() {
+    if !pty_available() {
+        eprintln!("Skipping reconnect terminal-respawn test: PTY not available");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new().with_working_dir(temp.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let window = harness.editor_mut().active_window_mut();
+
+    // A live embedded terminal, bound to its buffer with a backing file — the
+    // pre-disconnect state.
+    let (old_id, buffer_id) = window
+        .open_terminal_in_window()
+        .expect("terminal should spawn");
+    let backing_before = window
+        .terminal_backing_files
+        .get(&old_id)
+        .cloned()
+        .expect("a live terminal records its backing file");
+
+    // Carrier drop: the PTY died and its handle was torn down — exactly what the
+    // `TerminalExited` handler does (`terminal_manager.close`) — but the
+    // buffer↔terminal binding is *kept* (the remote-disconnect preserve path) so
+    // the reconnect has something to revive.
+    window.terminal_manager.close(old_id);
+    assert!(
+        window.terminal_manager.get(old_id).is_none(),
+        "dead terminal's handle is torn down"
+    );
+    assert_eq!(
+        window.terminal_buffers.get(&buffer_id),
+        Some(&old_id),
+        "binding is preserved across the drop, awaiting respawn"
+    );
+
+    // Reconnect's in-place respawn.
+    window.respawn_terminals_through_authority();
+
+    // The buffer is bound to a *new, live* terminal.
+    let new_id = *window
+        .terminal_buffers
+        .get(&buffer_id)
+        .expect("buffer is still bound to a terminal after respawn");
+    assert_ne!(
+        new_id, old_id,
+        "respawn allocates a fresh terminal id, not the dead one"
+    );
+    assert!(
+        window
+            .terminal_manager
+            .get(new_id)
+            .is_some_and(|h| h.is_alive()),
+        "respawned terminal is live"
+    );
+
+    // Scrollback continuity: the backing file is reused, remapped onto the new
+    // id, and the stale id is fully unmapped (no leak).
+    assert_eq!(
+        window.terminal_backing_files.get(&new_id),
+        Some(&backing_before),
+        "the new terminal reuses the old backing file"
+    );
+    assert!(
+        !window.terminal_backing_files.contains_key(&old_id),
+        "the stale terminal id is unmapped from terminal_backing_files"
+    );
+}
+
+/// A *still-live* terminal must be left untouched by a respawn pass — reviving a
+/// healthy PTY would orphan the running one. Guards the `is_alive` skip.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Unix PTY shell
+fn respawn_leaves_a_live_terminal_untouched() {
+    if !pty_available() {
+        eprintln!("Skipping live-terminal respawn test: PTY not available");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new().with_working_dir(temp.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let window = harness.editor_mut().active_window_mut();
+    let (id, buffer_id) = window
+        .open_terminal_in_window()
+        .expect("terminal should spawn");
+    assert!(
+        window
+            .terminal_manager
+            .get(id)
+            .is_some_and(|h| h.is_alive()),
+        "terminal is live before respawn"
+    );
+
+    window.respawn_terminals_through_authority();
+
+    assert_eq!(
+        window.terminal_buffers.get(&buffer_id),
+        Some(&id),
+        "a live terminal keeps its id (not respawned)"
+    );
+}


### PR DESCRIPTION
## Summary

This PR adds support for reconnecting live remote-agent (SSH/kube) sessions whose network carrier has dropped. When a remote window's embedded PTY dies due to a disconnected link, users can now reconnect through the Remote Indicator popup, which re-points the window's authority and respawns dead terminals in place, preserving scrollback and workspace state.

## Key Changes

- **Terminal respawn on reconnect**: Added `Window::respawn_terminals_through_authority()` to revive dead embedded terminals after a remote reconnect. Each dead PTY is respawned through the freshly-connected authority, reusing backing/log files for scrollback continuity. Live terminals are left untouched.

- **Dormant remote sessions**: Persisted remote sessions discovered at boot are now kept as authority-less `dormant_remote` descriptors rather than placeholder-authority windows. They are promoted to real `Window`s only after a successful connect (on first dive), ensuring terminals never run on the local host by accident.

- **Reconnect UI in Remote Indicator**: The Remote Indicator popup now offers a **Reconnect** action for disconnected remote-agent windows (distinct from "Go Local"). This dispatches the core `reconnect` action to rebuild the SSH/kube link and respawn terminals.

- **Failed reconnect visibility**: When a dive-triggered reconnect fails, the error is recorded on the window's `remote_reconnect_error` field and surfaced in the status bar as a `FailedAttach` indicator with the diagnostic message, offering Retry and Reopen Locally options.

- **Persistence fixes**: 
  - Remote sessions' workspace files are no longer garbage-collected at boot based on local filesystem checks (their `root` is a remote path). They survive discovery and can be reconnected on restore.
  - `SessionAuthoritySpec` is now read before the GC check so remote sessions degrade safely.

- **Terminal state preservation**: When a remote carrier drops, the buffer↔terminal binding and terminal metadata (backing files, launch commands) are preserved across the PTY death, awaiting respawn. Only normal exits (or local terminals) trigger permanent teardown.

- **Async reconnect handling**: Extended `RemoteAttachFailed` to track `reconnect_window` for dive-triggered reconnects, allowing the core to record per-window errors independently of plugin overrides.

## Implementation Details

- The respawn logic mirrors workspace restore's terminal-spawning precedence: resume argv (agent rejoin) → launch command → interactive shell.
- Terminal IDs change on respawn; all terminal-id-keyed maps (`terminal_buffers`, `terminal_backing_files`, `terminal_log_files`, `terminal_commands`, `terminal_resume_commands`) are remapped to the new ID.
- Dormant remote sessions appear in the Orchestrator dock (plugin snapshot) but have no live `Window` until promoted, preventing accidental local execution of restored terminals.
- Tests verify respawn bookkeeping (buffer binding, ID remapping, backing file reuse), local sessions don't offer Reconnect, and failed reconnects show in the status bar.

https://claude.ai/code/session_014oyhX27fJsXzcEhQJMVPJ7