### PR TITLE
fix(quick-open): list virtual buffers in the # buffer switcher (#2373)

### DIFF
--- a/crates/fresh-editor/src/app/prompt_lifecycle.rs
+++ b/crates/fresh-editor/src/app/prompt_lifecycle.rs
@@ -156,21 +156,46 @@ impl Editor {
 
     /// Build a QuickOpenContext from current editor state
     pub(super) fn build_quick_open_context(&self) -> QuickOpenContext {
+        let metadata = &self.active_window().buffer_metadata;
         let open_buffers = self
             .buffers()
             .iter()
             .filter_map(|(buffer_id, state)| {
-                let path = state.buffer.file_path()?;
-                let name = path
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_else(|| format!("Buffer {}", buffer_id.0));
-                Some(BufferInfo {
-                    id: buffer_id.0,
-                    path: path.display().to_string(),
-                    name,
-                    modified: state.buffer.is_modified(),
-                })
+                let meta = metadata.get(buffer_id);
+                // Mirror the tab bar: skip buffers that aren't shown as tabs
+                // (composite source buffers, the synthetic blank placeholder).
+                if meta.is_some_and(|m| m.hidden_from_tabs || m.synthetic_placeholder) {
+                    return None;
+                }
+                match state.buffer.file_path() {
+                    Some(path) => {
+                        let name = path
+                            .file_name()
+                            .map(|n| n.to_string_lossy().to_string())
+                            .unwrap_or_else(|| format!("Buffer {}", buffer_id.0));
+                        Some(BufferInfo {
+                            id: buffer_id.0,
+                            path: path.display().to_string(),
+                            name,
+                            modified: state.buffer.is_modified(),
+                            is_virtual: false,
+                        })
+                    }
+                    // No file path: only virtual buffers (plugin panels like
+                    // *blame:…*, *Git Log*) are surfaced — by their tab name —
+                    // so they're reachable without clicking the tab (#2373).
+                    // Unnamed scratch buffers stay out, as before.
+                    None => {
+                        let meta = meta.filter(|m| m.is_virtual())?;
+                        Some(BufferInfo {
+                            id: buffer_id.0,
+                            path: String::new(),
+                            name: meta.display_name.clone(),
+                            modified: state.buffer.is_modified(),
+                            is_virtual: true,
+                        })
+                    }
+                }
             })
             .collect();
 

--- a/crates/fresh-editor/src/input/quick_open/mod.rs
+++ b/crates/fresh-editor/src/input/quick_open/mod.rs
@@ -119,6 +119,10 @@ pub struct BufferInfo {
     pub path: String,
     pub name: String,
     pub modified: bool,
+    /// Whether this is a virtual buffer (a plugin panel like `*blame:…*` or
+    /// `*Git Log*`) with no backing file path. Virtual buffers are listed in
+    /// the `#` switcher even though `path` is empty.
+    pub is_virtual: bool,
 }
 
 /// Parse a `path:line:col` string into its components.

--- a/crates/fresh-editor/src/input/quick_open/providers.rs
+++ b/crates/fresh-editor/src/input/quick_open/providers.rs
@@ -136,7 +136,9 @@ impl QuickOpenProvider for BufferProvider {
         let mut scored: Vec<(Suggestion, i32, usize)> = context
             .open_buffers
             .iter()
-            .filter(|buf| !buf.path.is_empty())
+            // Virtual buffers (plugin panels) have no path but should still be
+            // listed; file buffers without a path are unnamed scratch buffers.
+            .filter(|buf| buf.is_virtual || !buf.path.is_empty())
             .filter_map(|buf| {
                 let m = matcher.match_target(&buf.name);
                 if !m.matched {
@@ -1018,12 +1020,14 @@ mod tests {
                     path: "/tmp/main.rs".to_string(),
                     name: "main.rs".to_string(),
                     modified: false,
+                    is_virtual: false,
                 },
                 BufferInfo {
                     id: 2,
                     path: "/tmp/lib.rs".to_string(),
                     name: "lib.rs".to_string(),
                     modified: true,
+                    is_virtual: false,
                 },
             ],
             active_buffer_id: 1,
@@ -1061,6 +1065,47 @@ mod tests {
         let suggestions = provider.suggestions("main", &context);
         assert_eq!(suggestions.len(), 1);
         assert!(suggestions[0].text.contains("main.rs"));
+    }
+
+    /// Issue #2373: virtual buffers (empty `path`, `is_virtual = true`) must be
+    /// listed by the `#` switcher, while pathless non-virtual buffers stay out.
+    #[test]
+    fn test_buffer_provider_includes_virtual_buffers() {
+        let provider = BufferProvider::new();
+        let mut context = make_test_context("/tmp");
+        context.open_buffers.push(BufferInfo {
+            id: 3,
+            path: String::new(),
+            name: "*blame:lib.rs*".to_string(),
+            modified: false,
+            is_virtual: true,
+        });
+        // A pathless, non-virtual buffer (e.g. unnamed scratch) must NOT appear.
+        context.open_buffers.push(BufferInfo {
+            id: 4,
+            path: String::new(),
+            name: "scratch".to_string(),
+            modified: false,
+            is_virtual: false,
+        });
+
+        // Empty query lists everything that is eligible.
+        let all = provider.suggestions("", &context);
+        assert!(
+            all.iter().any(|s| s.text.contains("*blame:lib.rs*")),
+            "virtual buffer should be listed: {:?}",
+            all.iter().map(|s| &s.text).collect::<Vec<_>>()
+        );
+        assert!(
+            !all.iter().any(|s| s.text.contains("scratch")),
+            "pathless non-virtual buffer should be excluded"
+        );
+
+        // The virtual buffer is reachable by a fuzzy query, carrying its id.
+        let filtered = provider.suggestions("blame", &context);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered[0].text.contains("*blame:lib.rs*"));
+        assert_eq!(filtered[0].value.as_deref(), Some("3"));
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/issue_2373_buffer_switcher_virtual.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2373_buffer_switcher_virtual.rs
@@ -1,0 +1,115 @@
+//! Regression test for issue #2373: the `#` buffer quick switcher
+//! (Ctrl+P → `#`) omitted virtual buffers.
+//!
+//! Virtual buffers — plugin panels like `*blame:lib.rs*` or `*Git Log: …*`
+//! — are shown as tabs but have no backing file path. The switcher built
+//! its candidate list only from file-backed buffers, so these panels could
+//! be reached only by clicking their tab, never by name.
+//!
+//! These tests drive the keyboard and assert on rendered output. Because a
+//! virtual buffer's name is *always* present in the tab bar, "listed in the
+//! switcher" is observed as the name appearing a second time — once in the
+//! tab bar and once in the suggestion dropdown.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Count non-overlapping occurrences of `needle` across the rendered screen.
+fn occurrences(screen: &str, needle: &str) -> usize {
+    screen.matches(needle).count()
+}
+
+/// Open the Quick Open prompt and switch it into `#` (buffer) mode.
+///
+/// Ctrl+P opens Quick Open pre-seeded with the `>` command prefix; deleting
+/// it and typing `#` is exactly the "Ctrl+P → #" flow from the issue.
+fn open_buffer_switcher(harness: &mut EditorTestHarness) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    // Remove the default ">" command prefix, then enter "#" buffer mode.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("#").unwrap();
+    harness.render().unwrap();
+}
+
+#[test]
+fn buffer_switcher_lists_virtual_buffers() {
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+
+    // A plugin panel: a virtual buffer shown as a tab, with no file path.
+    let panel = harness
+        .editor_mut()
+        .active_window_mut()
+        .create_virtual_buffer("*Git Log: main*".to_string(), "git-log".to_string(), true);
+    harness
+        .editor_mut()
+        .set_virtual_buffer_content(
+            panel,
+            vec![fresh::primitives::text_property::TextPropertyEntry::text(
+                "commit abc123\n  initial commit\n",
+            )],
+        )
+        .unwrap();
+    harness.render().unwrap();
+
+    // Sanity: before opening the switcher, the name is present exactly once
+    // (the tab bar).
+    let before = harness.screen_to_string();
+    assert_eq!(
+        occurrences(&before, "Git Log: main"),
+        1,
+        "virtual buffer should appear once (its tab) before opening the switcher. Screen:\n{}",
+        before
+    );
+
+    open_buffer_switcher(&mut harness);
+
+    // After opening the `#` switcher the panel must ALSO be in the suggestion
+    // dropdown — i.e. the name now appears twice (tab + suggestion).
+    let after = harness.screen_to_string();
+    assert!(
+        occurrences(&after, "Git Log: main") >= 2,
+        "buffer switcher should list the virtual buffer by name. Screen:\n{}",
+        after
+    );
+}
+
+#[test]
+fn buffer_switcher_filters_virtual_buffer_by_name() {
+    let mut harness = EditorTestHarness::new(100, 30).unwrap();
+
+    // Two virtual panels with distinct names.
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .create_virtual_buffer("*blame:lib.rs*".to_string(), "blame".to_string(), true);
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .create_virtual_buffer("*Diagnostics*".to_string(), "diagnostics".to_string(), true);
+    harness.render().unwrap();
+
+    // Switch into `#` mode and type a query matching only the blame panel.
+    open_buffer_switcher(&mut harness);
+    harness.type_text("blame").unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    // blame:lib.rs appears in the tab bar AND, with the query matching it, in
+    // the suggestion dropdown → at least twice.
+    assert!(
+        occurrences(&screen, "blame:lib.rs") >= 2,
+        "fuzzy query 'blame' should surface the blame virtual buffer. Screen:\n{}",
+        screen
+    );
+    // Diagnostics does not match the query, so it stays tab-only (once).
+    assert_eq!(
+        occurrences(&screen, "Diagnostics"),
+        1,
+        "query 'blame' should not list the unrelated Diagnostics panel. Screen:\n{}",
+        screen
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -75,6 +75,7 @@ pub mod issue_2119_wheel_scroll;
 pub mod issue_2124_quickfix_enter;
 pub mod issue_2345_language_settings;
 pub mod issue_2362_replace_toolbar_theme;
+pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod suspend_process;


### PR DESCRIPTION
## Summary

Fixes #2373. The `#` buffer quick switcher (Ctrl+P → `#`) only listed file-backed buffers, so virtual buffers — plugin panels shown as tabs like `*blame:lib.rs*` or `*Git Log: …*` — could be reached only by clicking their tab, never by name.

## Root cause

Two filters dropped virtual buffers:

1. `build_quick_open_context` (`app/prompt_lifecycle.rs`) used `let path = state.buffer.file_path()?;`, so any buffer without a backing file path (every virtual buffer) was silently filtered out before reaching the provider.
2. `BufferProvider::suggestions` (`input/quick_open/providers.rs`) had a secondary `!buf.path.is_empty()` guard that would have excluded them as well.

The separate "Switch to tab" prompt already listed virtual buffers correctly, which is why only the `#` switcher was affected.

## Fix

- `build_quick_open_context` now includes virtual buffers that are shown as tabs (skipping `hidden_from_tabs` composite sources and the synthetic blank placeholder), surfacing them by their tab display name. Unnamed scratch buffers stay out, preserving prior behavior.
- `BufferInfo` gains an `is_virtual` flag so the provider keeps virtual entries even though their `path` is empty.

## Testing

- **E2E regression** (`tests/e2e/issue_2373_buffer_switcher_virtual.rs`): drives `Ctrl+P → #` over a virtual buffer and asserts (on rendered output) that it appears in the suggestion dropdown and is fuzzy-filterable; the unrelated panel is not listed for a non-matching query. Fails without the fix, passes with it.
- **Unit test** (`BufferProvider`): a virtual buffer (empty path, `is_virtual = true`) is listed and reachable by query, while a pathless non-virtual buffer is excluded.
- **Manual validation** in a real `fresh` session (tmux): opened a file, ran Git Blame to create `*blame:main.rs*`, then `Ctrl+P → #` — the virtual buffer is listed alongside the file, filters on `blame`, and selecting it switches to the buffer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3MySj4tBBGPqdqo6a2tui

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3MySj4tBBGPqdqo6a2tui)_