### PR TITLE
fix(brackets): don't highlight brackets inside comments and strings (#2405)

### DIFF
--- a/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
+++ b/crates/fresh-editor/src/view/bracket_highlight_overlay.rs
@@ -9,6 +9,7 @@ use crate::model::marker::MarkerList;
 use crate::view::overlay::{Overlay, OverlayFace, OverlayManager, OverlayNamespace};
 use crate::view::theme::Theme;
 use ratatui::style::Color;
+use std::ops::Range;
 
 /// Default rainbow bracket colors (cycle through these based on nesting depth)
 pub const DEFAULT_BRACKET_COLORS: [Color; 6] = [
@@ -57,6 +58,27 @@ fn opening_for_closing(ch: char) -> Option<char> {
         .find_map(|(open, close)| if *close == ch { Some(*open) } else { None })
 }
 
+/// Whether `pos` falls inside any of the given byte ranges.
+///
+/// `ranges` must be sorted by `start` and non-overlapping (the syntax
+/// highlighter produces spans in this order), which lets us binary-search.
+/// These are the comment/string ranges where brackets are prose/data rather
+/// than structural punctuation, so they are excluded from bracket matching
+/// and rainbow colorization (issue #2405).
+fn pos_in_ranges(ranges: &[Range<usize>], pos: usize) -> bool {
+    ranges
+        .binary_search_by(|r| {
+            if pos < r.start {
+                std::cmp::Ordering::Greater
+            } else if pos >= r.end {
+                std::cmp::Ordering::Less
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        })
+        .is_ok()
+}
+
 /// Get the matching bracket pair for a character
 fn get_bracket_pair(ch: char) -> Option<(char, char, bool)> {
     for &(open, close) in BRACKET_PAIRS {
@@ -98,7 +120,12 @@ impl BracketHighlightOverlay {
 
     /// Update bracket highlights based on cursor position
     ///
+    /// `skip_ranges` are byte ranges (comments and strings, sorted by start)
+    /// whose brackets must be ignored — they are prose/data, not structural
+    /// punctuation (issue #2405).
+    ///
     /// Returns true if overlays were updated
+    #[allow(clippy::too_many_arguments)]
     pub fn update(
         &mut self,
         buffer: &Buffer,
@@ -108,6 +135,7 @@ impl BracketHighlightOverlay {
         cursor_position: usize,
         viewport_start: usize,
         viewport_end: usize,
+        skip_ranges: &[Range<usize>],
     ) -> bool {
         if !self.enabled && !self.rainbow_enabled {
             return false;
@@ -139,6 +167,7 @@ impl BracketHighlightOverlay {
                 marker_list,
                 viewport_start,
                 viewport_end,
+                skip_ranges,
             );
         } else {
             updated |= self.clear_colorization(overlays, marker_list);
@@ -178,16 +207,28 @@ impl BracketHighlightOverlay {
             None => return true, // Not on a bracket
         };
 
+        // A bracket inside a comment or string is not structural punctuation,
+        // so don't highlight it (issue #2405).
+        if pos_in_ranges(skip_ranges, cursor_position) {
+            return true;
+        }
+
         // Calculate nesting depth at cursor position for rainbow colors
         let depth = if self.rainbow_enabled {
-            self.calculate_nesting_depth(buffer, cursor_position, forward)
+            self.calculate_nesting_depth(buffer, cursor_position, forward, skip_ranges)
         } else {
             0
         };
 
         // Find matching bracket
-        let matching_pos =
-            self.find_matching_bracket(buffer, cursor_position, opening, closing, forward);
+        let matching_pos = self.find_matching_bracket(
+            buffer,
+            cursor_position,
+            opening,
+            closing,
+            forward,
+            skip_ranges,
+        );
 
         // Determine color based on depth
         let color = if self.rainbow_enabled {
@@ -223,8 +264,17 @@ impl BracketHighlightOverlay {
         updated
     }
 
-    /// Calculate the nesting depth of a bracket at a position
-    fn calculate_nesting_depth(&self, buffer: &Buffer, position: usize, is_opening: bool) -> usize {
+    /// Calculate the nesting depth of a bracket at a position.
+    ///
+    /// Brackets inside `skip_ranges` (comments/strings) are ignored so the
+    /// depth reflects only structural punctuation (issue #2405).
+    fn calculate_nesting_depth(
+        &self,
+        buffer: &Buffer,
+        position: usize,
+        is_opening: bool,
+        skip_ranges: &[Range<usize>],
+    ) -> usize {
         // Track nesting depth across all bracket types so rainbow colors follow
         // overall nesting level. Bound the scan to avoid O(n) work on huge files.
         let scan_start = position.saturating_sub(MAX_BRACKET_SEARCH_BYTES);
@@ -234,7 +284,10 @@ impl BracketHighlightOverlay {
         while pos < position {
             let chunk_end = (pos + BRACKET_SCAN_CHUNK).min(position);
             let chunk = buffer.slice_bytes(pos..chunk_end);
-            for &b in &chunk {
+            for (i, &b) in chunk.iter().enumerate() {
+                if pos_in_ranges(skip_ranges, pos + i) {
+                    continue;
+                }
                 let c = b as char;
                 if is_opening_bracket(c) {
                     stack.push(c);
@@ -258,7 +311,10 @@ impl BracketHighlightOverlay {
         }
     }
 
-    /// Find the matching bracket (bounded to MAX_BRACKET_SEARCH_BYTES)
+    /// Find the matching bracket (bounded to MAX_BRACKET_SEARCH_BYTES).
+    ///
+    /// Brackets inside `skip_ranges` (comments/strings) are ignored so the
+    /// match reflects only structural punctuation (issue #2405).
     fn find_matching_bracket(
         &self,
         buffer: &Buffer,
@@ -266,6 +322,7 @@ impl BracketHighlightOverlay {
         opening: char,
         closing: char,
         forward: bool,
+        skip_ranges: &[Range<usize>],
     ) -> Option<usize> {
         let buffer_len = buffer.len();
         let open = opening as u8;
@@ -279,6 +336,9 @@ impl BracketHighlightOverlay {
                 let chunk_end = (pos + BRACKET_SCAN_CHUNK).min(search_limit);
                 let chunk = buffer.slice_bytes(pos..chunk_end);
                 for (i, &b) in chunk.iter().enumerate() {
+                    if pos_in_ranges(skip_ranges, pos + i) {
+                        continue;
+                    }
                     if b == open {
                         depth += 1;
                     } else if b == close {
@@ -297,6 +357,9 @@ impl BracketHighlightOverlay {
                 let chunk_start = pos.saturating_sub(BRACKET_SCAN_CHUNK).max(search_limit);
                 let chunk = buffer.slice_bytes(chunk_start..pos);
                 for (i, &b) in chunk.iter().enumerate().rev() {
+                    if pos_in_ranges(skip_ranges, chunk_start + i) {
+                        continue;
+                    }
                     if b == close {
                         depth += 1;
                     } else if b == open {
@@ -344,6 +407,7 @@ impl BracketHighlightOverlay {
         marker_list: &mut MarkerList,
         viewport_start: usize,
         viewport_end: usize,
+        skip_ranges: &[Range<usize>],
     ) -> bool {
         if viewport_start >= viewport_end || buffer.len() == 0 {
             return self.clear_colorization(overlays, marker_list);
@@ -368,6 +432,13 @@ impl BracketHighlightOverlay {
         for (idx, byte) in bytes.iter().enumerate() {
             let pos = scan_start + idx;
             let c = *byte as char;
+
+            // Brackets inside comments/strings are prose/data, not structural
+            // punctuation — don't colorize them and don't let them affect the
+            // nesting depth of real brackets (issue #2405).
+            if pos_in_ranges(skip_ranges, pos) {
+                continue;
+            }
 
             if is_opening_bracket(c) {
                 let depth = stack.len();
@@ -446,7 +517,7 @@ mod tests {
         let buffer = Buffer::from_str_test("(hello)");
         let overlay = BracketHighlightOverlay::new();
 
-        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true);
+        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]);
         assert_eq!(result, Some(6));
     }
 
@@ -455,7 +526,7 @@ mod tests {
         let buffer = Buffer::from_str_test("(hello)");
         let overlay = BracketHighlightOverlay::new();
 
-        let result = overlay.find_matching_bracket(&buffer, 6, '(', ')', false);
+        let result = overlay.find_matching_bracket(&buffer, 6, '(', ')', false, &[]);
         assert_eq!(result, Some(0));
     }
 
@@ -465,11 +536,11 @@ mod tests {
         let overlay = BracketHighlightOverlay::new();
 
         // Outer opening bracket should match outer closing
-        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true);
+        let result = overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]);
         assert_eq!(result, Some(8));
 
         // Inner opening bracket should match inner closing
-        let result = overlay.find_matching_bracket(&buffer, 1, '(', ')', true);
+        let result = overlay.find_matching_bracket(&buffer, 1, '(', ')', true, &[]);
         assert_eq!(result, Some(7));
     }
 
@@ -479,13 +550,13 @@ mod tests {
         let overlay = BracketHighlightOverlay::new();
 
         // Outermost opening bracket: depth 0
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 0, true), 0);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 0, true, &[]), 0);
 
         // Second level opening bracket: depth 1
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 1, true), 1);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 1, true, &[]), 1);
 
         // Third level opening bracket: depth 2
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 2, true), 2);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 2, true, &[]), 2);
     }
 
     #[test]
@@ -493,11 +564,61 @@ mod tests {
         let buffer = Buffer::from_str_test("({[]})");
         let overlay = BracketHighlightOverlay::new();
 
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 0, true), 0);
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 1, true), 1);
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 2, true), 2);
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 3, false), 2);
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 4, false), 1);
-        assert_eq!(overlay.calculate_nesting_depth(&buffer, 5, false), 0);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 0, true, &[]), 0);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 1, true, &[]), 1);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 2, true, &[]), 2);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 3, false, &[]), 2);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 4, false, &[]), 1);
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 5, false, &[]), 0);
+    }
+
+    #[test]
+    fn test_pos_in_ranges() {
+        let ranges = [2..5, 8..10];
+        assert!(!pos_in_ranges(&ranges, 1));
+        assert!(pos_in_ranges(&ranges, 2)); // inclusive start
+        assert!(pos_in_ranges(&ranges, 4));
+        assert!(!pos_in_ranges(&ranges, 5)); // exclusive end
+        assert!(!pos_in_ranges(&ranges, 6));
+        assert!(pos_in_ranges(&ranges, 9));
+        assert!(!pos_in_ranges(&ranges, 10));
+        assert!(!pos_in_ranges(&[], 0));
+    }
+
+    #[test]
+    fn test_find_matching_bracket_skips_comment_bracket() {
+        // `( # ) )` — the first `)` sits inside a "comment" range and must be
+        // ignored, so the opening `(` matches the second `)`.
+        let buffer = Buffer::from_str_test("(a)b)");
+        let overlay = BracketHighlightOverlay::new();
+
+        // Without skipping, `(` at 0 matches the `)` at 2.
+        assert_eq!(
+            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[]),
+            Some(2)
+        );
+
+        // Treat byte 2 (the first `)`) as inside a comment: it should be
+        // skipped, so the match becomes the `)` at 4.
+        assert_eq!(
+            overlay.find_matching_bracket(&buffer, 0, '(', ')', true, &[2..3]),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn test_nesting_depth_skips_comment_brackets() {
+        // `((x))` with the inner `(` at byte 1 treated as a comment bracket.
+        let buffer = Buffer::from_str_test("((x))");
+        let overlay = BracketHighlightOverlay::new();
+
+        // Normally the bracket at byte 2 would be depth 2.
+        assert_eq!(overlay.calculate_nesting_depth(&buffer, 2, true, &[]), 2);
+
+        // With byte 1 skipped, only the outer `(` counts -> depth 1.
+        assert_eq!(
+            overlay.calculate_nesting_depth(&buffer, 2, true, &[1..2]),
+            1
+        );
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/overlays.rs
@@ -128,6 +128,24 @@ pub(crate) fn decoration_context(
         theme.semantic_highlight_bg,
     );
 
+    // Brackets inside comments and strings are prose/data, not structural
+    // punctuation, so they must be excluded from bracket matching and rainbow
+    // colorization (issue #2405). The highlighter already classifies these
+    // spans; collect their ranges (already sorted by start) to pass down.
+    use fresh_languages::HighlightCategory;
+    let mut bracket_skip_ranges: Vec<std::ops::Range<usize>> = highlight_spans
+        .iter()
+        .filter(|span| {
+            matches!(
+                span.category,
+                Some(HighlightCategory::Comment) | Some(HighlightCategory::String)
+            )
+        })
+        .map(|span| span.range.clone())
+        .collect();
+    // `pos_in_ranges` binary-searches, so the ranges must be sorted by start.
+    bracket_skip_ranges.sort_by_key(|range| range.start);
+
     // Update bracket highlight overlays.
     state.bracket_highlight_overlay.update(
         &state.buffer,
@@ -137,6 +155,7 @@ pub(crate) fn decoration_context(
         primary_cursor_position,
         viewport_start,
         viewport_end,
+        &bracket_skip_ranges,
     );
 
     // Semantic tokens are stored as overlays so their ranges track edits.

--- a/crates/fresh-editor/tests/e2e/issue_2405_brackets_in_comments.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2405_brackets_in_comments.rs
@@ -1,0 +1,86 @@
+//! E2E regression test for issue #2405.
+//!
+//! Rainbow bracket colorization (and bracket-match highlighting) must not
+//! apply to brackets that live inside comments or strings. Those characters
+//! are prose/data, not structural brackets, so they should keep their
+//! syntax color (e.g. the comment color) instead of being painted with a
+//! rainbow color.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+
+/// Open a small Rust file that contains a bracket in real code (line 0) and a
+/// bracket inside a line comment (line 1). The code bracket should be
+/// rainbow-colored; the comment bracket should keep the comment color.
+#[test]
+fn brackets_in_comments_are_not_rainbow_colored() {
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new()
+            .with_project_root()
+            .with_full_grammar_registry(),
+    )
+    .unwrap();
+    let project_dir = harness.project_dir().unwrap();
+
+    // Line 0: a real expression with structural brackets.
+    // Line 1: a comment that merely mentions brackets.
+    let file = project_dir.join("brackets.rs");
+    std::fs::write(&file, "let x = (1);\n// y = (2)\n").unwrap();
+    harness.open_file(&file).unwrap();
+    harness.render().unwrap();
+
+    let theme = harness.editor().theme();
+    let comment_color = theme.syntax_comment;
+    let rainbow_colors = [
+        theme.bracket_rainbow_1,
+        theme.bracket_rainbow_2,
+        theme.bracket_rainbow_3,
+        theme.bracket_rainbow_4,
+        theme.bracket_rainbow_5,
+        theme.bracket_rainbow_6,
+    ];
+
+    let buffer = &harness.editor().active_state().buffer;
+    let gutter = harness.editor().active_viewport().gutter_width(buffer) as u16;
+    let (first_row, _) = harness.content_area_rows();
+    let first_row = first_row as u16;
+
+    // Sanity: the code bracket '(' is at line 0, column 8.
+    let code_x = gutter + 8;
+    assert_eq!(
+        harness.get_cell(code_x, first_row),
+        Some("(".to_string()),
+        "expected '(' of the code expression at line 0 col 8"
+    );
+    let code_style = harness
+        .get_cell_style(code_x, first_row)
+        .expect("style for code bracket cell");
+    assert!(
+        rainbow_colors.contains(&code_style.fg.unwrap()),
+        "structural bracket in code should keep a rainbow color, got {:?}",
+        code_style.fg
+    );
+
+    // The comment bracket '(' is at line 1, column 7.
+    let comment_x = gutter + 7;
+    let comment_row = first_row + 1;
+    assert_eq!(
+        harness.get_cell(comment_x, comment_row),
+        Some("(".to_string()),
+        "expected '(' inside the comment at line 1 col 7"
+    );
+    let comment_style = harness
+        .get_cell_style(comment_x, comment_row)
+        .expect("style for comment bracket cell");
+    assert!(
+        !rainbow_colors.contains(&comment_style.fg.unwrap()),
+        "bracket inside a comment must not be rainbow-colored, got {:?}",
+        comment_style.fg
+    );
+    assert_eq!(
+        comment_style.fg,
+        Some(comment_color),
+        "bracket inside a comment should keep the comment color"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -76,6 +76,7 @@ pub mod issue_2124_quickfix_enter;
 pub mod issue_2345_language_settings;
 pub mod issue_2362_replace_toolbar_theme;
 pub mod issue_2373_buffer_switcher_virtual;
+pub mod issue_2405_brackets_in_comments;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod suspend_process;


### PR DESCRIPTION
## Summary

Fixes #2405. Rainbow bracket colorization (and cursor bracket-match highlighting) was applied to **every** `()[]{}<>` character — including those inside comments and string literals. Those characters are prose/data, not structural punctuation, so coloring them is noisy and misleading.

### Before / After

In a Rust file with `// bracket soup: ( ) [ ] { }` and `/* (a) [b] {c} */`, the brackets in those comments were painted with rainbow colors. Now they keep the comment color, while structural brackets in real code stay rainbow.

## Approach

The syntax highlighter already classifies `Comment` and `String` spans. The fix:

1. **`orchestration/overlays.rs`** — at the decoration call site (which already computes `highlight_spans`), collect the byte ranges of `Comment`/`String` spans (sorted by start) and pass them into the bracket overlay.
2. **`bracket_highlight_overlay.rs`** — a small `pos_in_ranges` binary-search helper lets the overlay skip any bracket inside those ranges, consistently across:
   - rainbow colorization,
   - cursor-on-bracket match highlighting,
   - nesting-depth calculation.

Skipping comment/string brackets in matching/depth is also more correct in general: a `)` inside a comment no longer "closes" a real `(`.

The change is viewport-localized (it reuses the spans already computed for the visible range), so it adds no new full-buffer scans.

## Testing

- **New e2e regression test** (`issue_2405_brackets_in_comments.rs`): opens a `.rs` file and asserts a bracket inside a comment keeps the comment color (not rainbow) while a code bracket stays rainbow. Fails without the fix (comment bracket renders `Cyan`), passes with it.
- **New unit tests** for `pos_in_ranges`, and for `find_matching_bracket` / `calculate_nesting_depth` skipping bracketed positions inside a skip range.
- Existing bracket/rainbow/syntax-highlighting e2e suites pass (164 tests).
- Manually validated in the running TUI (`tmux` + colored `capture-pane`): comment brackets render in the comment grey (`idx253`), code brackets in rainbow indices (`idx2`/`idx3`/`idx6`).

`cargo fmt`, `cargo clippy`, and `cargo check --all-targets` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YKTEX2n9nN7VarkZPv9J3

---
_Generated by [Claude Code](https://claude.ai/code/session_019YKTEX2n9nN7VarkZPv9J3)_