### PR TITLE
feat(grammar): detect language from shebang interpreter (#2357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ The cli now supports `--cmd daemon`, but still accepts the now-deprecated `--cmd
   * Opening the theme editor no longer breaks Orchestrator dock clicks/scrolling — plugin panels are scoped to their owning plugin.
   * Ctrl+Right-Click reports accurate theme keys for the status bar, tab bar, scrollbar, file explorer, menus, and dock, drawing above the dock.
   * The plugin bridge no longer corrupts integers larger than 32 bits (timestamps, byte offsets).
+* Shebang language detection now covers interpreters whose grammars ship no first-line regex — `#!/usr/bin/fish`, Lua, PowerShell, Tcl, Groovy, Elixir, R, Julia, Nushell, Dart, Deno, … — so extensionless scripts highlight from the shebang instead of falling through to plain text (#2357, reported by @shemgp). `env` indirection (`env -S`, `env VAR=val`) and versioned interpreters (`python3.11`) are handled; an existing extension match still wins.
 * Java (jdtls) and other Eclipse LSP4J servers: features registered via `client/registerCapability` now work — their string JSON-RPC ids were misparsed as notifications and dropped (#2340, reported by @maxandersen).
 * LSP/plugin popups follow the active theme's `popup_*` colors instead of a hard-wired dark background (#2379, by @peanball).
 * Paste falls back to the internal clipboard and works again on Termux (#2343, reported by @nightshade427).

--- a/crates/fresh-editor/src/primitives/grammar/mod.rs
+++ b/crates/fresh-editor/src/primitives/grammar/mod.rs
@@ -29,6 +29,7 @@
 // Loader requires filesystem access - runtime only
 #[cfg(feature = "runtime")]
 mod loader;
+mod shebang;
 mod types;
 
 // Re-export all public items for backward compatibility

--- a/crates/fresh-editor/src/primitives/grammar/shebang.rs
+++ b/crates/fresh-editor/src/primitives/grammar/shebang.rs
@@ -1,0 +1,158 @@
+//! Shebang (`#!`) interpreter → language detection.
+//!
+//! Used as the final fallback in [`GrammarRegistry::find_by_path`](super::GrammarRegistry::find_by_path)
+//! when neither the filename/extension nor syntect's first-line regexes match.
+//! Syntect only recognises interpreters whose grammars ship a `first_line_match`
+//! regex (sh/bash, python, ruby, perl, php); many languages Fresh bundles
+//! grammars for — fish, Lua, PowerShell, Tcl, … — define none, so a
+//! `#!/usr/bin/fish` script would otherwise fall through to plain text (#2357).
+//! Parsing the interpreter ourselves closes that gap.
+
+use fresh_languages::Language;
+
+/// Catalog language id, as accepted by
+/// [`GrammarRegistry::find_by_name`](super::GrammarRegistry::find_by_name).
+///
+/// Tree-sitter-backed languages source their id from
+/// [`fresh_languages::Language::id`] so the two stay in sync; the syntect-only
+/// grammars below have no [`Language`] variant and are named explicitly.
+type LanguageId = &'static str;
+
+// Syntect-only grammar ids — no `fresh_languages::Language` variant exists for
+// these. `interpreter_targets_resolve` (in `types.rs`) asserts every id the
+// table can return is present in the built-in catalog.
+const FISH: LanguageId = "fish";
+const PERL: LanguageId = "perl";
+const POWERSHELL: LanguageId = "powershell";
+const TCL: LanguageId = "tcl";
+const GROOVY: LanguageId = "groovy";
+const ELIXIR: LanguageId = "elixir";
+const R: LanguageId = "r";
+const JULIA: LanguageId = "julia";
+const NUSHELL: LanguageId = "nushell";
+const DART: LanguageId = "dart";
+
+/// Resolve a file's first line to a catalog language id when it is a shebang
+/// whose interpreter maps to a grammar Fresh ships. Handles:
+/// - direct interpreters: `#!/bin/sh`, `#! /bin/sh` (leading space)
+/// - `env` indirection: `#!/usr/bin/env python3`, including `env -S deno run`
+///   and `env VAR=val interp`
+/// - version suffixes: `python3.11` → python, `lua5.4` → lua, `ruby2.7` → ruby
+///
+/// Returns `None` for non-shebangs and for interpreters with no Fresh grammar
+/// (e.g. `awk`), leaving the buffer as plain text exactly as before.
+pub(super) fn language_for_shebang(first_line: &str) -> Option<LanguageId> {
+    let rest = first_line.strip_prefix("#!")?;
+    let mut tokens = rest.split_whitespace();
+    let mut base = interpreter_basename(tokens.next()?);
+
+    // `env` runs the first non-option, non-assignment argument as the real
+    // interpreter (`env -S`, `env -i`, `env FOO=bar python` all land here).
+    if base == "env" {
+        base = loop {
+            let tok = tokens.next()?;
+            if tok.starts_with('-') || tok.contains('=') {
+                continue;
+            }
+            break interpreter_basename(tok);
+        };
+    }
+
+    language_for_interpreter(base)
+}
+
+/// The final path component of an interpreter token (`/usr/bin/env` → `env`).
+fn interpreter_basename(token: &str) -> &str {
+    token.rsplit(['/', '\\']).next().unwrap_or(token)
+}
+
+/// Map an interpreter basename to a catalog language id, tolerating version
+/// suffixes (`python3`, `lua5.4`).
+fn language_for_interpreter(base: &str) -> Option<LanguageId> {
+    let lower = base.to_ascii_lowercase();
+    if let Some(lang) = interpreter_table(&lower) {
+        return Some(lang);
+    }
+    // `python3.11` → `python`, `ruby2.7` → `ruby`, `php8` → `php`.
+    let stem = lower.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
+    if stem.len() != lower.len() && !stem.is_empty() {
+        return interpreter_table(stem);
+    }
+    None
+}
+
+/// Interpreter basename → catalog language id.
+///
+/// Tree-sitter-backed targets reuse [`Language::id`] (visibly marking them and
+/// keeping the id in sync with the canonical table); syntect-only grammars use
+/// the named constants above.
+fn interpreter_table(name: &str) -> Option<LanguageId> {
+    Some(match name {
+        "sh" | "bash" | "dash" | "ash" | "ksh" | "mksh" | "pdksh" | "zsh" => Language::Bash.id(),
+        "python" | "pypy" => Language::Python.id(),
+        "ruby" | "jruby" => Language::Ruby.id(),
+        "php" => Language::Php.id(),
+        "node" | "nodejs" => Language::JavaScript.id(),
+        "deno" | "bun" | "ts-node" | "tsx" => Language::TypeScript.id(),
+        "lua" | "luajit" => Language::Lua.id(),
+        "perl" => PERL,
+        "fish" => FISH,
+        "pwsh" | "powershell" => POWERSHELL,
+        "tcl" | "tclsh" | "wish" => TCL,
+        "groovy" => GROOVY,
+        "elixir" => ELIXIR,
+        "r" | "rscript" => R,
+        "julia" => JULIA,
+        "nu" => NUSHELL,
+        "dart" => DART,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_interpreters_and_indirection() {
+        // Direct interpreters, with and without the space-after-#! form (#2357).
+        assert_eq!(language_for_shebang("#!/bin/sh\n"), Some("bash"));
+        assert_eq!(language_for_shebang("#! /bin/sh\n"), Some("bash"));
+        assert_eq!(language_for_shebang("#!/usr/bin/fish\n"), Some("fish"));
+        assert_eq!(language_for_shebang("#!/usr/bin/lua\n"), Some("lua"));
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/pwsh\n"),
+            Some("powershell")
+        );
+        // `env` indirection, options, version suffixes, and assignments.
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/env python3\n"),
+            Some("python")
+        );
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/env -S deno run\n"),
+            Some("typescript")
+        );
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/env FOO=bar ruby\n"),
+            Some("ruby")
+        );
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/python3.11\n"),
+            Some("python")
+        );
+        assert_eq!(language_for_shebang("#!/usr/bin/env Rscript\n"), Some("r"));
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/env node\n"),
+            Some("javascript")
+        );
+        assert_eq!(
+            language_for_shebang("#!/usr/bin/env elixir\n"),
+            Some("elixir")
+        );
+        // Non-shebangs and unknown interpreters stay None (→ plain text).
+        assert_eq!(language_for_shebang("not a shebang\n"), None);
+        assert_eq!(language_for_shebang("#!/usr/bin/awk -f\n"), None);
+        assert_eq!(language_for_shebang("#!/usr/bin/env\n"), None);
+    }
+}

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -1252,13 +1252,9 @@ impl GrammarRegistry {
         }
 
         // Final fallback: map the shebang interpreter directly to a known
-        // grammar. Syntect's `find_syntax_by_first_line` only recognises the
-        // interpreters that ship a `first_line_match` regex (sh/bash, python,
-        // ruby, perl, php, …); many languages Fresh *does* have grammars for
-        // — fish, lua, PowerShell, Tcl, Groovy, Elixir, R, … — define none, so
-        // a `#!/usr/bin/fish` script would otherwise fall through to plain
-        // text (#2357). Parsing the interpreter ourselves closes that gap.
-        let lang = shebang_language(line)?;
+        // grammar, covering interpreters whose grammars ship no syntect
+        // `first_line_match` regex (fish, Lua, PowerShell, …) — see `shebang`.
+        let lang = super::shebang::language_for_shebang(line)?;
         self.find_by_name(lang)
     }
 
@@ -1592,84 +1588,6 @@ impl Default for GrammarRegistry {
     }
 }
 
-/// Resolve a shebang line to a catalog language id, if its interpreter maps to
-/// a grammar Fresh ships.
-///
-/// Used as the final fallback in [`GrammarRegistry::find_by_path`] when neither
-/// the filename/extension nor syntect's first-line regexes match. Handles:
-/// - direct interpreters: `#!/bin/sh`, `#! /bin/sh` (leading space)
-/// - `env` indirection: `#!/usr/bin/env python3`, including `env -S deno run`
-///   and `env VAR=val interp`
-/// - version suffixes: `python3.11` → python, `lua5.4` → lua, `ruby2.7` → ruby
-///
-/// Returns `None` for shebangs whose interpreter has no Fresh grammar (e.g.
-/// `awk`), leaving the buffer as plain text exactly as before.
-fn shebang_language(first_line: &str) -> Option<&'static str> {
-    let rest = first_line.strip_prefix("#!")?;
-    let mut tokens = rest.split_whitespace();
-    let mut base = interpreter_basename(tokens.next()?);
-
-    // `env` runs the first non-option, non-assignment argument as the real
-    // interpreter (`env -S`, `env -i`, `env FOO=bar python` all land here).
-    if base == "env" {
-        base = loop {
-            let tok = tokens.next()?;
-            if tok.starts_with('-') || tok.contains('=') {
-                continue;
-            }
-            break interpreter_basename(tok);
-        };
-    }
-
-    interpreter_language(base)
-}
-
-/// The final path component of an interpreter token (`/usr/bin/env` → `env`).
-fn interpreter_basename(token: &str) -> &str {
-    token.rsplit(['/', '\\']).next().unwrap_or(token)
-}
-
-/// Map an interpreter basename to a catalog language id, tolerating version
-/// suffixes (`python3`, `lua5.4`). The mapping only references grammars that
-/// exist in the catalog, so the returned id always resolves via `find_by_name`.
-fn interpreter_language(base: &str) -> Option<&'static str> {
-    let lower = base.to_ascii_lowercase();
-    if let Some(lang) = interpreter_table(&lower) {
-        return Some(lang);
-    }
-    // `python3.11` → `python`, `ruby2.7` → `ruby`, `php8` → `php`.
-    let stem = lower.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
-    if stem.len() != lower.len() && !stem.is_empty() {
-        return interpreter_table(stem);
-    }
-    None
-}
-
-/// Interpreter basename → catalog language id. Every target id is present in the
-/// built-in grammar catalog (verified by `test_shebang_interpreter_targets_resolve`).
-fn interpreter_table(name: &str) -> Option<&'static str> {
-    Some(match name {
-        "sh" | "bash" | "dash" | "ash" | "ksh" | "mksh" | "pdksh" | "zsh" => "bash",
-        "fish" => "fish",
-        "python" | "pypy" => "python",
-        "ruby" | "jruby" => "ruby",
-        "perl" => "perl",
-        "php" => "php",
-        "node" | "nodejs" => "javascript",
-        "deno" | "bun" | "ts-node" | "tsx" => "typescript",
-        "lua" | "luajit" => "lua",
-        "pwsh" | "powershell" => "powershell",
-        "tcl" | "tclsh" | "wish" => "tcl",
-        "groovy" => "groovy",
-        "elixir" => "elixir",
-        "r" | "rscript" => "r",
-        "julia" => "julia",
-        "nu" => "nushell",
-        "dart" => "dart",
-        _ => return None,
-    })
-}
-
 // VSCode package.json structures for parsing grammar manifests
 
 #[derive(Debug, Deserialize)]
@@ -1806,39 +1724,8 @@ mod tests {
     }
 
     #[test]
-    fn test_shebang_language_parsing() {
-        // Direct interpreters, with and without the space-after-#! form (#2357).
-        assert_eq!(shebang_language("#!/bin/sh\n"), Some("bash"));
-        assert_eq!(shebang_language("#! /bin/sh\n"), Some("bash"));
-        assert_eq!(shebang_language("#!/usr/bin/fish\n"), Some("fish"));
-        assert_eq!(shebang_language("#!/usr/bin/lua\n"), Some("lua"));
-        assert_eq!(shebang_language("#!/usr/bin/pwsh\n"), Some("powershell"));
-        // `env` indirection, options, version suffixes, and assignments.
-        assert_eq!(shebang_language("#!/usr/bin/env python3\n"), Some("python"));
-        assert_eq!(
-            shebang_language("#!/usr/bin/env -S deno run\n"),
-            Some("typescript")
-        );
-        assert_eq!(
-            shebang_language("#!/usr/bin/env FOO=bar ruby\n"),
-            Some("ruby")
-        );
-        assert_eq!(shebang_language("#!/usr/bin/python3.11\n"), Some("python"));
-        assert_eq!(shebang_language("#!/usr/bin/env Rscript\n"), Some("r"));
-        assert_eq!(
-            shebang_language("#!/usr/bin/env node\n"),
-            Some("javascript")
-        );
-        assert_eq!(shebang_language("#!/usr/bin/env elixir\n"), Some("elixir"));
-        // Non-shebangs and unknown interpreters stay None (→ plain text).
-        assert_eq!(shebang_language("not a shebang\n"), None);
-        assert_eq!(shebang_language("#!/usr/bin/awk -f\n"), None);
-        assert_eq!(shebang_language("#!/usr/bin/env\n"), None);
-    }
-
-    #[test]
     fn test_shebang_interpreter_targets_resolve() {
-        // Every language id produced by the interpreter table must exist in the
+        // Every language id the shebang table can return must exist in the
         // built-in catalog, otherwise the fallback would silently no-op.
         let registry = GrammarRegistry::default();
         for name in [
@@ -1861,7 +1748,7 @@ mod tests {
             "/usr/bin/dart",
         ] {
             let line = format!("#!{name}\n");
-            let lang = shebang_language(&line)
+            let lang = super::super::shebang::language_for_shebang(&line)
                 .unwrap_or_else(|| panic!("expected an interpreter mapping for {line:?}"));
             assert!(
                 registry.find_by_name(lang).is_some(),

--- a/crates/fresh-editor/src/primitives/grammar/types.rs
+++ b/crates/fresh-editor/src/primitives/grammar/types.rs
@@ -1245,8 +1245,21 @@ impl GrammarRegistry {
         // catalog entry by name — every syntect syntax has a catalog entry,
         // so this round-trip preserves tree-sitter attachment.
         let line = first_line?;
-        let syntax = self.syntax_set.find_syntax_by_first_line(line)?;
-        self.find_by_name(&syntax.name)
+        if let Some(syntax) = self.syntax_set.find_syntax_by_first_line(line) {
+            if let Some(entry) = self.find_by_name(&syntax.name) {
+                return Some(entry);
+            }
+        }
+
+        // Final fallback: map the shebang interpreter directly to a known
+        // grammar. Syntect's `find_syntax_by_first_line` only recognises the
+        // interpreters that ship a `first_line_match` regex (sh/bash, python,
+        // ruby, perl, php, …); many languages Fresh *does* have grammars for
+        // — fish, lua, PowerShell, Tcl, Groovy, Elixir, R, … — define none, so
+        // a `#!/usr/bin/fish` script would otherwise fall through to plain
+        // text (#2357). Parsing the interpreter ourselves closes that gap.
+        let lang = shebang_language(line)?;
+        self.find_by_name(lang)
     }
 
     /// Look up a grammar entry by file extension (case-insensitive, without dot).
@@ -1579,6 +1592,84 @@ impl Default for GrammarRegistry {
     }
 }
 
+/// Resolve a shebang line to a catalog language id, if its interpreter maps to
+/// a grammar Fresh ships.
+///
+/// Used as the final fallback in [`GrammarRegistry::find_by_path`] when neither
+/// the filename/extension nor syntect's first-line regexes match. Handles:
+/// - direct interpreters: `#!/bin/sh`, `#! /bin/sh` (leading space)
+/// - `env` indirection: `#!/usr/bin/env python3`, including `env -S deno run`
+///   and `env VAR=val interp`
+/// - version suffixes: `python3.11` → python, `lua5.4` → lua, `ruby2.7` → ruby
+///
+/// Returns `None` for shebangs whose interpreter has no Fresh grammar (e.g.
+/// `awk`), leaving the buffer as plain text exactly as before.
+fn shebang_language(first_line: &str) -> Option<&'static str> {
+    let rest = first_line.strip_prefix("#!")?;
+    let mut tokens = rest.split_whitespace();
+    let mut base = interpreter_basename(tokens.next()?);
+
+    // `env` runs the first non-option, non-assignment argument as the real
+    // interpreter (`env -S`, `env -i`, `env FOO=bar python` all land here).
+    if base == "env" {
+        base = loop {
+            let tok = tokens.next()?;
+            if tok.starts_with('-') || tok.contains('=') {
+                continue;
+            }
+            break interpreter_basename(tok);
+        };
+    }
+
+    interpreter_language(base)
+}
+
+/// The final path component of an interpreter token (`/usr/bin/env` → `env`).
+fn interpreter_basename(token: &str) -> &str {
+    token.rsplit(['/', '\\']).next().unwrap_or(token)
+}
+
+/// Map an interpreter basename to a catalog language id, tolerating version
+/// suffixes (`python3`, `lua5.4`). The mapping only references grammars that
+/// exist in the catalog, so the returned id always resolves via `find_by_name`.
+fn interpreter_language(base: &str) -> Option<&'static str> {
+    let lower = base.to_ascii_lowercase();
+    if let Some(lang) = interpreter_table(&lower) {
+        return Some(lang);
+    }
+    // `python3.11` → `python`, `ruby2.7` → `ruby`, `php8` → `php`.
+    let stem = lower.trim_end_matches(|c: char| c.is_ascii_digit() || c == '.');
+    if stem.len() != lower.len() && !stem.is_empty() {
+        return interpreter_table(stem);
+    }
+    None
+}
+
+/// Interpreter basename → catalog language id. Every target id is present in the
+/// built-in grammar catalog (verified by `test_shebang_interpreter_targets_resolve`).
+fn interpreter_table(name: &str) -> Option<&'static str> {
+    Some(match name {
+        "sh" | "bash" | "dash" | "ash" | "ksh" | "mksh" | "pdksh" | "zsh" => "bash",
+        "fish" => "fish",
+        "python" | "pypy" => "python",
+        "ruby" | "jruby" => "ruby",
+        "perl" => "perl",
+        "php" => "php",
+        "node" | "nodejs" => "javascript",
+        "deno" | "bun" | "ts-node" | "tsx" => "typescript",
+        "lua" | "luajit" => "lua",
+        "pwsh" | "powershell" => "powershell",
+        "tcl" | "tclsh" | "wish" => "tcl",
+        "groovy" => "groovy",
+        "elixir" => "elixir",
+        "r" | "rscript" => "r",
+        "julia" => "julia",
+        "nu" => "nushell",
+        "dart" => "dart",
+        _ => return None,
+    })
+}
+
 // VSCode package.json structures for parsing grammar manifests
 
 #[derive(Debug, Deserialize)]
@@ -1712,6 +1803,109 @@ mod tests {
                 syntax.name
             );
         }
+    }
+
+    #[test]
+    fn test_shebang_language_parsing() {
+        // Direct interpreters, with and without the space-after-#! form (#2357).
+        assert_eq!(shebang_language("#!/bin/sh\n"), Some("bash"));
+        assert_eq!(shebang_language("#! /bin/sh\n"), Some("bash"));
+        assert_eq!(shebang_language("#!/usr/bin/fish\n"), Some("fish"));
+        assert_eq!(shebang_language("#!/usr/bin/lua\n"), Some("lua"));
+        assert_eq!(shebang_language("#!/usr/bin/pwsh\n"), Some("powershell"));
+        // `env` indirection, options, version suffixes, and assignments.
+        assert_eq!(shebang_language("#!/usr/bin/env python3\n"), Some("python"));
+        assert_eq!(
+            shebang_language("#!/usr/bin/env -S deno run\n"),
+            Some("typescript")
+        );
+        assert_eq!(
+            shebang_language("#!/usr/bin/env FOO=bar ruby\n"),
+            Some("ruby")
+        );
+        assert_eq!(shebang_language("#!/usr/bin/python3.11\n"), Some("python"));
+        assert_eq!(shebang_language("#!/usr/bin/env Rscript\n"), Some("r"));
+        assert_eq!(
+            shebang_language("#!/usr/bin/env node\n"),
+            Some("javascript")
+        );
+        assert_eq!(shebang_language("#!/usr/bin/env elixir\n"), Some("elixir"));
+        // Non-shebangs and unknown interpreters stay None (→ plain text).
+        assert_eq!(shebang_language("not a shebang\n"), None);
+        assert_eq!(shebang_language("#!/usr/bin/awk -f\n"), None);
+        assert_eq!(shebang_language("#!/usr/bin/env\n"), None);
+    }
+
+    #[test]
+    fn test_shebang_interpreter_targets_resolve() {
+        // Every language id produced by the interpreter table must exist in the
+        // built-in catalog, otherwise the fallback would silently no-op.
+        let registry = GrammarRegistry::default();
+        for name in [
+            "/bin/sh",
+            "/usr/bin/fish",
+            "/usr/bin/env python3",
+            "/usr/bin/env ruby",
+            "/usr/bin/perl",
+            "/usr/bin/env php",
+            "/usr/bin/env node",
+            "/usr/bin/env deno",
+            "/usr/bin/lua",
+            "/usr/bin/pwsh",
+            "/usr/bin/tclsh",
+            "/usr/bin/env groovy",
+            "/usr/bin/env elixir",
+            "/usr/bin/env Rscript",
+            "/usr/bin/env julia",
+            "/usr/bin/nu",
+            "/usr/bin/dart",
+        ] {
+            let line = format!("#!{name}\n");
+            let lang = shebang_language(&line)
+                .unwrap_or_else(|| panic!("expected an interpreter mapping for {line:?}"));
+            assert!(
+                registry.find_by_name(lang).is_some(),
+                "interpreter mapping {line:?} → {lang:?} must resolve to a catalog grammar",
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_by_path_detects_shebang_only_interpreters() {
+        // These interpreters have no syntect first-line regex; before the
+        // interpreter-table fallback an extensionless script fell through to
+        // plain text. Now `find_by_path` resolves them from the shebang alone.
+        let registry = GrammarRegistry::default();
+        let cases = [
+            ("#!/usr/bin/fish\n", "fish"),
+            ("#!/usr/bin/lua\n", "lua"),
+            ("#!/usr/bin/pwsh\n", "powershell"),
+            ("#!/usr/bin/tclsh\n", "tcl"),
+            ("#!/usr/bin/env groovy\n", "groovy"),
+            ("#!/usr/bin/env elixir\n", "elixir"),
+            ("#!/usr/bin/env Rscript\n", "r"),
+        ];
+        for (first_line, expected_id) in cases {
+            let entry = registry
+                .find_by_path(Path::new("scriptfile"), Some(first_line))
+                .unwrap_or_else(|| panic!("no grammar for {first_line:?}"));
+            assert_eq!(
+                entry.language_id, expected_id,
+                "shebang {first_line:?} should detect {expected_id:?}, got {:?}",
+                entry.language_id,
+            );
+        }
+    }
+
+    #[test]
+    fn test_find_by_path_extension_still_wins_over_shebang() {
+        // The interpreter fallback must not override an explicit extension
+        // match — a `.py` file stays Python even with a shell shebang.
+        let registry = GrammarRegistry::default();
+        let entry = registry
+            .find_by_path(Path::new("script.py"), Some("#!/bin/sh\n"))
+            .unwrap();
+        assert_eq!(entry.language_id, "python");
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/issue_2357_shebang_interpreter.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2357_shebang_interpreter.rs
@@ -1,0 +1,58 @@
+//! Reproduction for issue #2357: recognize file type based on shebang.
+//!
+//! Reported by @shemgp: opening a file whose first line is a shebang should
+//! pick up syntax highlighting from the interpreter, not just from the
+//! extension. The #1598 fix covered interpreters syntect recognises via a
+//! `first_line_match` regex (sh/bash, python, ruby, …), but many languages
+//! Fresh ships grammars for — fish, Lua, PowerShell, Tcl, … — define no such
+//! regex, so an extensionless `#!/usr/bin/fish` script still fell through to
+//! plain text.
+//!
+//! Opening such a file should now detect the language from the shebang.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use std::fs;
+use tempfile::TempDir;
+
+fn detect_language_from_shebang(filename: &str, contents: &str) -> String {
+    let temp_dir = TempDir::new().unwrap();
+    let working_dir = temp_dir.path().to_path_buf();
+    let test_file = working_dir.join(filename);
+    fs::write(&test_file, contents).unwrap();
+
+    let mut harness = EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new()
+            .without_empty_plugins_dir()
+            .with_full_grammar_registry()
+            .with_working_dir(working_dir.clone()),
+    )
+    .unwrap();
+
+    harness.open_file(&test_file).unwrap();
+    harness.editor().active_state().language.clone()
+}
+
+#[test]
+fn test_extensionless_fish_shebang_is_detected() {
+    // `fish` has no syntect first-line regex; only the interpreter table
+    // resolves it. Before the fix this returned "text".
+    let language = detect_language_from_shebang(
+        "deploy",
+        "#!/usr/bin/fish\n\nset -x MY_VAR hello\necho $MY_VAR\n",
+    );
+    assert_eq!(
+        language, "fish",
+        "extensionless file with `#!/usr/bin/fish` shebang should be detected as fish, got {language:?}",
+    );
+}
+
+#[test]
+fn test_extensionless_lua_env_shebang_is_detected() {
+    let language = detect_language_from_shebang("run", "#!/usr/bin/env lua\n\nprint('hello')\n");
+    assert_eq!(
+        language, "lua",
+        "extensionless file with `#!/usr/bin/env lua` shebang should be detected as lua, got {language:?}",
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -74,6 +74,7 @@ pub mod issue_2035_preview_renders_buffer_groups;
 pub mod issue_2119_wheel_scroll;
 pub mod issue_2124_quickfix_enter;
 pub mod issue_2345_language_settings;
+pub mod issue_2357_shebang_interpreter;
 pub mod issue_2362_replace_toolbar_theme;
 pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;


### PR DESCRIPTION
## Summary

Fixes #2357. Opening an extensionless script whose first line is a shebang should pick up syntax highlighting from the **interpreter**, not just the extension.

The earlier #1598 fix relied solely on syntect's `find_syntax_by_first_line`, which only recognises interpreters whose grammars ship a `first_line_match` regex — `sh`/`bash`, `python`, `ruby`, `perl`, `php`. Many languages Fresh **does** bundle grammars for define no such regex, so a `#!/usr/bin/fish` script (and Lua, PowerShell, Tcl, Groovy, Elixir, R, Julia, Nushell, Dart, Deno, …) silently fell through to plain text.

## Investigation

Probing `DetectedLanguage::from_path` directly showed the gap precisely — these all returned `text` before the change:

```
#!/usr/bin/fish      -> text      (grammar "fish" exists)
#!/usr/bin/lua       -> text      (grammar "lua" exists)
#!/usr/bin/pwsh      -> text      (grammar "powershell" exists)
#!/usr/bin/env Rscript -> text    (grammar "r" exists)
#!/usr/bin/env elixir  -> text    (grammar "elixir" exists)
```

while sh/bash/python/ruby/perl/php already worked via syntect.

## Change

Added a small interpreter-name table as the **final fallback** in `GrammarRegistry::find_by_path`, running *after* syntect's first-line match. It:

- parses the shebang, tolerating a leading space (`#! /bin/sh`), `env` indirection (`env -S deno run`, `env VAR=val ruby`), and versioned interpreters (`python3.11` → python);
- maps the interpreter basename to a catalog language id (every target id is verified to exist in the built-in catalog);
- only fires when nothing else matched, so an explicit **extension match still wins** (`script.py` with a shell shebang stays Python) — non-regressive by construction.

## Testing

- **Unit** (`grammar/types.rs`): shebang parsing, target-id resolution, `find_by_path` detecting shebang-only interpreters, and the extension-wins guard.
- **E2E** (`issue_2357_shebang_interpreter.rs`): opens `#!/usr/bin/fish` and `#!/usr/bin/env lua` files through the real open path and asserts the detected language.
- **Manual** (tmux): opened a `#!/usr/bin/fish` file in the built `fresh` binary — status bar shows **Fish** and fish syntax highlighting is applied (command-substitution `()` colored), where it previously rendered as plain Text.
- `cargo fmt --check`, `cargo clippy --lib --tests`, and the existing #1598 / language-detection / save-as suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H2vtJGwXxyhnfaCSp2mbWM)_