### PR TITLE
feat(file-open): reveal hidden files when the filter starts with "."

### DIFF
--- a/crates/fresh-editor/src/app/file_open.rs
+++ b/crates/fresh-editor/src/app/file_open.rs
@@ -60,7 +60,15 @@ pub struct FileOpenState {
     /// Current directory being browsed
     pub current_dir: PathBuf,
 
-    /// Directory entries with metadata
+    /// Raw, unfiltered directory entries as loaded from the filesystem
+    /// (excludes the synthesized ".." entry). Hidden files are kept here
+    /// even when not currently displayed, so the visible `entries` list can
+    /// be rebuilt — to reveal or hide dotfiles — without re-reading the
+    /// directory from disk.
+    raw_entries: Vec<DirEntry>,
+
+    /// Directory entries with metadata (the currently displayed subset of
+    /// `raw_entries`, with the synthesized ".." prepended).
     pub entries: Vec<FileOpenEntry>,
 
     /// Whether directory is currently loading
@@ -123,6 +131,7 @@ impl FileOpenState {
         let shortcuts = Self::build_shortcuts_sync(&dir, &*filesystem);
         Self {
             current_dir: dir,
+            raw_entries: Vec::new(),
             entries: Vec::new(),
             loading: true,
             error: None,
@@ -245,8 +254,28 @@ impl FileOpenState {
         self.selected_shortcut = 0;
     }
 
-    /// Set entries from filesystem and apply initial sort
+    /// Set entries from filesystem and apply initial sort.
+    ///
+    /// Stores the full listing in `raw_entries` and builds the displayed
+    /// `entries` from it via [`Self::rebuild_entries`], honoring the current
+    /// hidden-file visibility and filter.
     pub fn set_entries(&mut self, entries: Vec<DirEntry>) {
+        self.raw_entries = entries;
+        self.loading = false;
+        self.error = None;
+        self.rebuild_entries();
+        self.sort_entries();
+        // No selection by default - user must type or navigate to select
+        self.selected_index = None;
+        self.scroll_offset = 0;
+    }
+
+    /// Rebuild the displayed `entries` from `raw_entries`, prepending the
+    /// synthesized ".." entry and filtering out hidden files unless they are
+    /// currently revealed (see [`Self::effective_show_hidden`]). Re-evaluates
+    /// the active filter against the resulting set.
+    fn rebuild_entries(&mut self) {
+        let reveal_hidden = self.effective_show_hidden();
         let mut result: Vec<FileOpenEntry> = Vec::new();
 
         // Add ".." entry for parent directory navigation (unless at root)
@@ -260,11 +289,11 @@ impl FileOpenState {
             });
         }
 
-        // Add filtered entries
         result.extend(
-            entries
-                .into_iter()
-                .filter(|e| self.show_hidden || !Self::is_hidden(&e.name))
+            self.raw_entries
+                .iter()
+                .filter(|e| reveal_hidden || !Self::is_hidden(&e.name))
+                .cloned()
                 .map(|fs_entry| FileOpenEntry {
                     fs_entry,
                     matches_filter: true,
@@ -273,13 +302,25 @@ impl FileOpenState {
         );
 
         self.entries = result;
-        self.loading = false;
-        self.error = None;
         self.apply_filter_internal();
-        self.sort_entries();
-        // No selection by default - user must type or navigate to select
-        self.selected_index = None;
-        self.scroll_offset = 0;
+    }
+
+    /// Whether hidden (dotfile) entries should currently be displayed.
+    ///
+    /// True when the user has explicitly enabled "Show Hidden", or when the
+    /// active filter begins with "." — typing a leading dot temporarily
+    /// reveals hidden files matching the query (issue #2407), so they stay
+    /// out of the way until the user asks for them.
+    fn effective_show_hidden(&self) -> bool {
+        self.show_hidden || Self::filter_reveals_hidden(&self.filter)
+    }
+
+    /// A filter "reveals" hidden files when it starts with a dot. The filter
+    /// is just the filename component (directory parts are stripped upstream
+    /// in `update_file_open_filter`), so a leading dot unambiguously signals
+    /// intent to see dotfiles.
+    fn filter_reveals_hidden(filter: &str) -> bool {
+        filter.starts_with('.')
     }
 
     /// Set error state
@@ -299,7 +340,10 @@ impl FileOpenState {
     /// Non-matching entries are de-emphasized visually but stay at the bottom.
     pub fn apply_filter(&mut self, filter: &str) {
         self.filter = filter.to_string();
-        self.apply_filter_internal();
+        // Rebuild the displayed set so a leading-dot filter reveals hidden
+        // files (and clearing it hides them again). This also re-evaluates the
+        // fuzzy match state via `apply_filter_internal`.
+        self.rebuild_entries();
 
         // When filter is non-empty, sort by match score (best matches first)
         if !filter.is_empty() {
@@ -818,6 +862,67 @@ mod tests {
         // Hidden file should be filtered out
         assert_eq!(state.entries.len(), 1);
         assert_eq!(state.entries[0].fs_entry.name, "visible.txt");
+    }
+
+    /// Issue #2407: typing a leading "." in the filter reveals hidden files,
+    /// even though "Show Hidden" is off, and clearing the filter hides them
+    /// again. This mirrors the existing "raise matching files" mechanism.
+    #[test]
+    fn test_leading_dot_filter_reveals_hidden() {
+        // Use root path so no ".." entry is added
+        let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
+        state.show_hidden = false;
+        state.set_entries(vec![
+            make_entry(".bashrc", false),
+            make_entry(".config", true),
+            make_entry("visible.txt", false),
+        ]);
+
+        // Hidden by default.
+        assert!(
+            !state.entries.iter().any(|e| e.fs_entry.name == ".bashrc"),
+            "hidden file should not be listed before typing a dot"
+        );
+
+        // Typing "." surfaces the hidden entries.
+        state.apply_filter(".");
+        assert!(
+            state.entries.iter().any(|e| e.fs_entry.name == ".bashrc"),
+            "leading-dot filter should reveal hidden files"
+        );
+        assert!(
+            state.entries.iter().any(|e| e.fs_entry.name == ".config"),
+            "leading-dot filter should reveal hidden directories"
+        );
+
+        // Clearing the filter hides them again.
+        state.apply_filter("");
+        assert!(
+            !state.entries.iter().any(|e| e.fs_entry.name == ".bashrc"),
+            "clearing the filter should hide dotfiles again"
+        );
+    }
+
+    /// A more specific leading-dot query (e.g. ".bash") reveals and matches
+    /// the corresponding hidden file.
+    #[test]
+    fn test_leading_dot_filter_matches_specific_hidden_file() {
+        let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
+        state.show_hidden = false;
+        state.set_entries(vec![
+            make_entry(".bashrc", false),
+            make_entry(".gitignore", false),
+            make_entry("visible.txt", false),
+        ]);
+
+        state.apply_filter(".bash");
+
+        let bashrc = state
+            .entries
+            .iter()
+            .find(|e| e.fs_entry.name == ".bashrc")
+            .expect(".bashrc should be revealed by the '.bash' filter");
+        assert!(bashrc.matches_filter, ".bashrc should match '.bash'");
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/file_open.rs
+++ b/crates/fresh-editor/src/app/file_open.rs
@@ -272,10 +272,9 @@ impl FileOpenState {
 
     /// Rebuild the displayed `entries` from `raw_entries`, prepending the
     /// synthesized ".." entry and filtering out hidden files unless they are
-    /// currently revealed (see [`Self::effective_show_hidden`]). Re-evaluates
-    /// the active filter against the resulting set.
+    /// currently revealed (see [`Self::is_revealed`]). Re-evaluates the active
+    /// filter against the resulting set.
     fn rebuild_entries(&mut self) {
-        let reveal_hidden = self.effective_show_hidden();
         let mut result: Vec<FileOpenEntry> = Vec::new();
 
         // Add ".." entry for parent directory navigation (unless at root)
@@ -289,10 +288,12 @@ impl FileOpenState {
             });
         }
 
+        let show_hidden = self.show_hidden;
+        let filter = self.filter.as_str();
         result.extend(
             self.raw_entries
                 .iter()
-                .filter(|e| reveal_hidden || !Self::is_hidden(&e.name))
+                .filter(|e| Self::is_revealed(&e.name, show_hidden, filter))
                 .cloned()
                 .map(|fs_entry| FileOpenEntry {
                     fs_entry,
@@ -305,22 +306,22 @@ impl FileOpenState {
         self.apply_filter_internal();
     }
 
-    /// Whether hidden (dotfile) entries should currently be displayed.
+    /// Whether an entry named `name` should be displayed in the list.
     ///
-    /// True when the user has explicitly enabled "Show Hidden", or when the
-    /// active filter begins with "." — typing a leading dot temporarily
-    /// reveals hidden files matching the query (issue #2407), so they stay
-    /// out of the way until the user asks for them.
-    fn effective_show_hidden(&self) -> bool {
-        self.show_hidden || Self::filter_reveals_hidden(&self.filter)
-    }
-
-    /// A filter "reveals" hidden files when it starts with a dot. The filter
-    /// is just the filename component (directory parts are stripped upstream
-    /// in `update_file_open_filter`), so a leading dot unambiguously signals
-    /// intent to see dotfiles.
-    fn filter_reveals_hidden(filter: &str) -> bool {
-        filter.starts_with('.')
+    /// Visible (non-dot) files are always shown. Hidden files are shown when
+    /// the user has explicitly enabled "Show Hidden", or when the active
+    /// filter is a prefix of the file's name (issue #2407). Using a prefix
+    /// rather than a special-cased "." means hidden files stay out of the way
+    /// until the query explicitly reaches for them: typing "." surfaces every
+    /// dotfile (it prefixes them all), while ".ba" narrows to just `.bashrc`,
+    /// and a non-dot query like "bash" never drags dotfiles in. The filter is
+    /// only the filename component (directory parts are stripped upstream in
+    /// `update_file_open_filter`), so the comparison is unambiguous.
+    fn is_revealed(name: &str, show_hidden: bool, filter: &str) -> bool {
+        if show_hidden || !Self::is_hidden(name) {
+            return true;
+        }
+        !filter.is_empty() && name.to_lowercase().starts_with(&filter.to_lowercase())
     }
 
     /// Set error state
@@ -340,9 +341,9 @@ impl FileOpenState {
     /// Non-matching entries are de-emphasized visually but stay at the bottom.
     pub fn apply_filter(&mut self, filter: &str) {
         self.filter = filter.to_string();
-        // Rebuild the displayed set so a leading-dot filter reveals hidden
-        // files (and clearing it hides them again). This also re-evaluates the
-        // fuzzy match state via `apply_filter_internal`.
+        // Rebuild the displayed set so a filter that prefixes a hidden file's
+        // name reveals it (and clearing the filter hides it again). This also
+        // re-evaluates the fuzzy match state via `apply_filter_internal`.
         self.rebuild_entries();
 
         // When filter is non-empty, sort by match score (best matches first)
@@ -864,11 +865,11 @@ mod tests {
         assert_eq!(state.entries[0].fs_entry.name, "visible.txt");
     }
 
-    /// Issue #2407: typing a leading "." in the filter reveals hidden files,
-    /// even though "Show Hidden" is off, and clearing the filter hides them
-    /// again. This mirrors the existing "raise matching files" mechanism.
+    /// Issue #2407: a filter that prefixes a hidden file's name reveals it,
+    /// even though "Show Hidden" is off, and clearing the filter hides it
+    /// again. Typing "." prefixes every dotfile, so it surfaces them all.
     #[test]
-    fn test_leading_dot_filter_reveals_hidden() {
+    fn test_prefix_filter_reveals_hidden() {
         // Use root path so no ".." entry is added
         let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
         state.show_hidden = false;
@@ -884,15 +885,15 @@ mod tests {
             "hidden file should not be listed before typing a dot"
         );
 
-        // Typing "." surfaces the hidden entries.
+        // Typing "." prefixes every dotfile, surfacing the hidden entries.
         state.apply_filter(".");
         assert!(
             state.entries.iter().any(|e| e.fs_entry.name == ".bashrc"),
-            "leading-dot filter should reveal hidden files"
+            "'.' should reveal hidden files"
         );
         assert!(
             state.entries.iter().any(|e| e.fs_entry.name == ".config"),
-            "leading-dot filter should reveal hidden directories"
+            "'.' should reveal hidden directories"
         );
 
         // Clearing the filter hides them again.
@@ -903,10 +904,10 @@ mod tests {
         );
     }
 
-    /// A more specific leading-dot query (e.g. ".bash") reveals and matches
-    /// the corresponding hidden file.
+    /// A more specific prefix (e.g. ".bash") reveals only the hidden files it
+    /// prefixes — `.bashrc` shows, `.gitignore` stays hidden.
     #[test]
-    fn test_leading_dot_filter_matches_specific_hidden_file() {
+    fn test_prefix_filter_reveals_only_matching_hidden_files() {
         let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
         state.show_hidden = false;
         state.set_entries(vec![
@@ -921,8 +922,37 @@ mod tests {
             .entries
             .iter()
             .find(|e| e.fs_entry.name == ".bashrc")
-            .expect(".bashrc should be revealed by the '.bash' filter");
+            .expect(".bashrc should be revealed by the '.bash' prefix");
         assert!(bashrc.matches_filter, ".bashrc should match '.bash'");
+
+        // A hidden file the prefix does not reach stays out of the list.
+        assert!(
+            !state
+                .entries
+                .iter()
+                .any(|e| e.fs_entry.name == ".gitignore"),
+            ".gitignore is not prefixed by '.bash' and should stay hidden"
+        );
+    }
+
+    /// A query that does not start with a dot never drags hidden files in,
+    /// even if it would fuzzy-match them as a subsequence (e.g. "bash" is a
+    /// subsequence of ".bashrc"). The reveal is prefix-based, so the leading
+    /// dot must be typed explicitly.
+    #[test]
+    fn test_non_dot_filter_keeps_hidden_files_hidden() {
+        let mut state = FileOpenState::new(PathBuf::from("/"), false, test_filesystem());
+        state.show_hidden = false;
+        state.set_entries(vec![
+            make_entry(".bashrc", false),
+            make_entry("visible.txt", false),
+        ]);
+
+        state.apply_filter("bash");
+        assert!(
+            !state.entries.iter().any(|e| e.fs_entry.name == ".bashrc"),
+            "a non-dot query must not reveal dotfiles"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/tests/e2e/file_browser.rs
+++ b/crates/fresh-editor/tests/e2e/file_browser.rs
@@ -448,6 +448,59 @@ fn test_file_browser_hides_dotfiles() {
     );
 }
 
+/// Issue #2407: typing a leading "." in the Open File prompt reveals hidden
+/// files (without flipping the "Show Hidden" checkbox), and clearing the dot
+/// hides them again.
+#[test]
+fn test_file_browser_dot_reveals_hidden() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_root = temp_dir.path().to_path_buf();
+
+    fs::write(project_root.join("visible.txt"), "visible").unwrap();
+    fs::write(project_root.join(".secretrc"), "hidden").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        80,
+        24,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+
+    harness
+        .send_key(KeyCode::Char('o'), KeyModifiers::CONTROL)
+        .unwrap();
+
+    // Wait for the visible file to load.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("visible.txt"))
+        .expect("Visible file should appear");
+
+    // Hidden file should not be shown by default.
+    harness.assert_screen_not_contains(".secretrc");
+
+    // Type "." to reveal hidden files.
+    harness.type_text(".").unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains(".secretrc"))
+        .expect("Typing '.' should reveal hidden files");
+
+    // Deleting the "." hides them again.
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| !h.screen_to_string().contains(".secretrc"))
+        .expect("Clearing the filter should hide dotfiles again");
+
+    // The file browser is still open and the visible file remains listed.
+    let screen = harness.screen_to_string();
+    assert!(
+        screen.contains("visible.txt"),
+        "Visible file should remain listed"
+    );
+}
+
 /// Test backspace goes to parent directory when filter is empty
 #[test]
 fn test_file_browser_backspace_parent() {


### PR DESCRIPTION
Closes #2407

## Why

The Open File dialog hides dotfiles unless the **Show Hidden** checkbox is toggled. As #2407 notes, that means you can't see a hidden file without first knowing to flip the checkbox. The request: reuse the prompt's existing "raise matching files" affordance — typing a leading `.` should surface hidden files, and they should stay out of the way until you do.

## What

- Typing a filter that **starts with `.`** now reveals hidden files in the current directory (matching them with the same fuzzy mechanism as everything else). Clearing the dot hides them again.
- The **Show Hidden** checkbox is left untouched — this is a transient, query-driven reveal, not a mode switch.

## How

Instead of re-reading the directory whenever visibility changes, the full listing is now kept in a new `raw_entries` field and the displayed `entries` list is rebuilt from it via `rebuild_entries()`. Hidden files are included when `show_hidden` is on **or** the active filter begins with `.` (`effective_show_hidden`). The filter passed to the dialog is just the filename component (directory parts are stripped upstream), so a leading dot is an unambiguous signal.

This keeps the change small and self-contained — no new config, no change to the existing checkbox/reload behavior, and the visible-list indexing used by rendering/selection is unchanged because `entries` is still a single contiguous vector.

## Testing

- **Unit** (`FileOpenState`): a leading-dot filter reveals dotfiles and re-hides them when cleared; `.bash` reveals and matches `.bashrc`. Existing `test_hidden_files` still passes (default hides dotfiles).
- **E2E** (`test_file_browser_dot_reveals_hidden`): drives `Ctrl+O`, waits for the listing, asserts the hidden file is absent, types `.`, asserts it appears, backspaces, asserts it's hidden again — all on rendered output.
- Full `file_browser` e2e suite (24 tests) green; `cargo fmt` + `cargo clippy` clean for the changed file.
- **Manual validation** in tmux: confirmed the default-hidden → type `.` reveals (checkbox stays unchecked) → backspace re-hides flow against the real binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrdDNgj13YVDhDSH17YraW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JrdDNgj13YVDhDSH17YraW)_