### PR TITLE
refactor(terminal): decompose TerminalManager::spawn god function

### DIFF
--- a/crates/fresh-editor/src/services/terminal/manager.rs
+++ b/crates/fresh-editor/src/services/terminal/manager.rs
@@ -279,6 +279,7 @@ impl TerminalManager {
     ///
     /// # Returns
     /// The terminal ID if successful
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         &mut self,
         cols: u16,
@@ -292,438 +293,141 @@ impl TerminalManager {
         let id = TerminalId(self.next_id);
         self.next_id += 1;
 
-        // Try to spawn a real PTY-backed terminal first.
-        let handle_result: Result<TerminalHandle, String> = (|| {
-            // Create PTY
-            let pty_system = native_pty_system();
-            let pty_pair = pty_system
-                .openpty(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                })
-                .map_err(|e| {
-                    #[cfg(windows)]
-                    {
-                        format!(
-                            "Failed to open PTY: {}. Note: Terminal requires Windows 10 version 1809 or later with ConPTY support.",
-                            e
-                        )
-                    }
-                    #[cfg(not(windows))]
-                    {
-                        format!("Failed to open PTY: {}", e)
-                    }
-                })?;
-
-            // The active authority's terminal wrapper drives the shell
-            // command unconditionally — local wraps `detect_shell()` with
-            // no args; container/remote authorities re-parent into
-            // `docker exec -w …`, `ssh …`, etc. `manages_cwd` says
-            // whether the wrapper's args already establish cwd (in which
-            // case `CommandBuilder::cwd()` is skipped).
-            let TerminalWrapper {
-                command: shell,
-                args: cmd_args,
-                manages_cwd: skip_cwd,
-            } = terminal_wrapper;
-            tracing::info!("Spawning terminal with shell: {}", shell);
-
-            let mut cmd = CommandBuilder::new(&shell);
-            for arg in &cmd_args {
-                cmd.arg(arg);
-            }
-            if !skip_cwd {
-                if let Some(ref dir) = cwd {
-                    // Hand the shell a non-verbatim path. Fresh canonicalizes
-                    // working_dir at startup, which on Windows yields
-                    // `\\?\C:\…`. PowerShell can't infer a drive from a
-                    // verbatim path and falls back to the fully-qualified
-                    // provider form, producing prompts like
-                    // `PS Microsoft.PowerShell.Core\FileSystem::\\?\C:\…>`.
-                    cmd.cwd(strip_verbatim_prefix(dir).as_ref());
-                }
-            }
-
-            // Apply the activated-environment delta (venv/direnv/mise) so the
-            // integrated terminal inherits the same env that LSP servers,
-            // formatters, and plugin `spawnProcess` already get — otherwise the
-            // status bar says "Environment active" while the terminal silently
-            // runs the *system* toolchain with none of the project's vars
-            // (issue #2355; see docs/internal/uniform-env-activation-design.md).
-            // The delta carries only what the recipe changed over a clean login
-            // shell, so there are no volatile shell vars to skip. The caller
-            // passes it only for a local host shell (empty for docker/ssh
-            // wrappers, whose inner shell runs on another host this
-            // `CommandBuilder` env can't reach). Applied before TERM/FRESH_SESSION
-            // below so those control vars win over any same-named delta key.
-            for (k, v) in &env_delta.set {
-                cmd.env(k, v);
-            }
-            for k in &env_delta.unset {
-                cmd.env_remove(k);
-            }
-
-            // Set TERM so programs like less know the terminal capabilities.
-            // The built-in emulator is alacritty-based so xterm-256color is appropriate.
-            cmd.env("TERM", "xterm-256color");
-
-            // Advertise this editor's local control socket to local child
-            // shells via FRESH_SESSION, so a `fresh` launched from inside
-            // this embedded terminal forwards file/dir opens back to us
-            // instead of starting a second editor. Only for the local host
-            // shell: `manages_cwd` (== `skip_cwd`) marks docker/ssh-style
-            // wrappers, whose inner `fresh` runs on another host where this
-            // unix socket isn't reachable. (A nested `fresh` that can't reach
-            // the socket falls back to running inline, so this gate is an
-            // optimization, not a correctness requirement.)
-            if !skip_cwd {
-                if let Some(session_id) = crate::server::local_control::local_session_id() {
-                    cmd.env("FRESH_SESSION", session_id);
-                }
-            }
-
-            // On Windows, set additional environment variables that help with ConPTY
-            #[cfg(windows)]
-            {
-                // Ensure PROMPT is set for cmd.exe
-                if shell.to_lowercase().contains("cmd") {
-                    cmd.env("PROMPT", "$P$G");
-                }
-            }
-
-            // Spawn the shell process
-            let mut child = pty_pair
-                .slave
-                .spawn_command(cmd)
-                .map_err(|e| format!("Failed to spawn shell '{}': {}", shell, e))?;
-
-            tracing::debug!("Shell process spawned successfully");
-
-            // Capture the child's pid before it moves into the
-            // wait-thread. The pty puts the shell at the head of
-            // its own session, so `kill(-pid, signal)` signals
-            // every process the shell has spawned.
-            let child_pid = child.process_id();
-
-            // Pull a separate killer handle so the writer thread
-            // can request termination on `Shutdown` without owning
-            // `child` itself. `child` moves into the dedicated
-            // wait-thread below, where its exit status is captured
-            // and propagated through `AsyncMessage::TerminalExited`.
-            let mut child_killer = child.clone_killer();
-
-            // Create terminal state
-            let state = Arc::new(Mutex::new(TerminalState::new(cols, rows)));
-
-            // Initialize backing_file_history_end if backing file already exists (session restore)
-            // This ensures enter_terminal_mode doesn't truncate existing history to 0
-            if let Some(ref p) = backing_path {
-                if let Ok(metadata) = std::fs::metadata(p) {
-                    if metadata.len() > 0 {
-                        if let Ok(mut s) = state.lock() {
-                            s.set_backing_file_history_end(metadata.len());
-                        }
-                    }
-                }
-            }
-
-            // Create communication channel
-            let (command_tx, command_rx) = mpsc::channel::<TerminalCommand>();
-
-            // Alive flag
-            let alive = Arc::new(AtomicBool::new(true));
-            let alive_clone = alive.clone();
-
-            // Get master for I/O
-            let mut master = pty_pair
-                .master
-                .take_writer()
-                .map_err(|e| format!("Failed to get PTY writer: {}", e))?;
-
-            let mut reader = pty_pair
-                .master
-                .try_clone_reader()
-                .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
-
-            // Clone state for reader thread
-            let state_clone = state.clone();
-            let async_bridge = self.async_bridge.clone();
-
-            // Optional raw log writer for full-session capture (for live terminal resume)
-            let mut log_writer = log_path
-                .as_ref()
-                .and_then(|p| {
-                    std::fs::OpenOptions::new()
-                        .create(true)
-                        .append(true)
-                        .open(p)
-                        .ok()
-                })
-                .map(std::io::BufWriter::new);
-
-            // Backing file writer for incremental scrollback streaming
-            // During session restore, the backing file may already contain scrollback content.
-            // We open for append to continue streaming new scrollback after the existing content.
-            // For new terminals, append mode also works (creates file if needed).
-            let mut backing_writer = backing_path
-                .as_ref()
-                .and_then(|p| {
-                    // Check if backing file exists and has content (session restore case)
-                    let existing_has_content =
-                        p.exists() && std::fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false);
-
-                    if existing_has_content {
-                        // Session restore: open for append to continue streaming new scrollback
-                        // The existing content is preserved and loaded into buffer separately.
-                        // Note: enter_terminal_mode will truncate when user re-enters terminal.
-                        std::fs::OpenOptions::new()
-                            .create(true)
-                            .append(true)
-                            .open(p)
-                            .ok()
-                    } else {
-                        // New terminal: start fresh with truncate
-                        std::fs::OpenOptions::new()
-                            .create(true)
-                            .write(true)
-                            .truncate(true)
-                            .open(p)
-                            .ok()
-                    }
-                })
-                .map(std::io::BufWriter::new);
-
-            // Spawn reader thread
-            let terminal_id = id;
-            // Tag output/exit with the owning window so the main loop
-            // never has to guess which session a `Terminal-N` belongs to
-            // (ids collide across windows). `Copy`, so both threads below
-            // capture it independently.
-            let wt_id = fresh_core::WindowTerminalId::new(self.window_id, terminal_id);
-            let pty_response_tx = command_tx.clone();
-            thread::spawn(move || {
-                tracing::debug!("Terminal {:?} reader thread started", terminal_id);
-                let mut buf = [0u8; 4096];
-                let mut total_bytes = 0usize;
-                loop {
-                    match reader.read(&mut buf) {
-                        Ok(0) => {
-                            // EOF - process exited
-                            tracing::info!(
-                                "Terminal {:?} EOF after {} total bytes",
-                                terminal_id,
-                                total_bytes
-                            );
-                            break;
-                        }
-                        Ok(n) => {
-                            total_bytes += n;
-                            // Per-read logging is on the PTY hot path: a busy
-                            // terminal reads tens of thousands of chunks/sec, so
-                            // this must stay at `trace` (off by default). At
-                            // `debug` it not only floods the log but, if that log
-                            // is being `tail -f`'d into a terminal this manager
-                            // owns, it closes a positive-feedback loop (each read
-                            // logs a line, which tail echoes, which is read and
-                            // logged again). Lifecycle boundaries (EOF, error)
-                            // are logged above/below at higher levels instead.
-                            tracing::trace!(
-                                "Terminal {:?} received {} bytes (total: {})",
-                                terminal_id,
-                                n,
-                                total_bytes
-                            );
-                            // Process output through terminal emulator and stream scrollback
-                            if let Ok(mut state) = state_clone.lock() {
-                                state.process_output(&buf[..n]);
-
-                                // Send any PTY write responses (e.g., DSR cursor position)
-                                // This is critical for Windows ConPTY where PowerShell waits
-                                // for cursor position response before showing the prompt
-                                for response in state.drain_pty_write_queue() {
-                                    tracing::debug!(
-                                        "Terminal {:?} sending PTY response: {:?}",
-                                        terminal_id,
-                                        response
-                                    );
-                                    // Receiver may be dropped if writer thread exited.
-                                    #[allow(clippy::let_underscore_must_use)]
-                                    let _ = pty_response_tx
-                                        .send(TerminalCommand::Write(response.into_bytes()));
-                                }
-
-                                // Incrementally stream new scrollback lines to backing file
-                                if let Some(ref mut writer) = backing_writer {
-                                    match state.flush_new_scrollback(writer) {
-                                        Ok(lines_written) => {
-                                            if lines_written > 0 {
-                                                // Update the history end offset
-                                                if let Ok(pos) = writer.get_ref().metadata() {
-                                                    state.set_backing_file_history_end(pos.len());
-                                                }
-                                                // Best-effort flush; backing file errors handled below.
-                                                #[allow(clippy::let_underscore_must_use)]
-                                                let _ = writer.flush();
-                                            }
-                                        }
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                "Terminal backing file write error: {}",
-                                                e
-                                            );
-                                            backing_writer = None;
-                                        }
-                                    }
-                                }
-                            }
-
-                            // Append raw bytes to log if available (for session restore replay)
-                            if let Some(w) = log_writer.as_mut() {
-                                if let Err(e) = w.write_all(&buf[..n]) {
-                                    tracing::warn!("Terminal log write error: {}", e);
-                                    log_writer = None; // stop logging on error
-                                } else if let Err(e) = w.flush() {
-                                    tracing::warn!("Terminal log flush error: {}", e);
-                                    log_writer = None;
-                                }
-                            }
-
-                            // Notify main loop to redraw (receiver may be dropped during shutdown).
-                            if let Some(ref bridge) = async_bridge {
-                                #[allow(clippy::let_underscore_must_use)]
-                                let _ = bridge.sender().send(
-                                    crate::services::async_bridge::AsyncMessage::TerminalOutput {
-                                        terminal: wt_id,
-                                    },
-                                );
-                            }
-                        }
-                        Err(e) => {
-                            tracing::error!("Terminal read error: {}", e);
-                            break;
-                        }
-                    }
-                }
-                alive_clone.store(false, std::sync::atomic::Ordering::Relaxed);
-                // Best-effort flush of log/backing files during teardown.
-                if let Some(mut w) = log_writer {
-                    #[allow(clippy::let_underscore_must_use)]
-                    let _ = w.flush();
-                }
-                if let Some(mut w) = backing_writer {
-                    #[allow(clippy::let_underscore_must_use)]
-                    let _ = w.flush();
-                }
-                // The wait-thread (spawned below) owns `child` and
-                // is the single source of `TerminalExited`, so the
-                // reader intentionally does not fire it here. Firing
-                // from both threads would race and sometimes produce
-                // `exit_code: None` despite a clean exit.
-            });
-
-            // Wait-thread: blocks on `child.wait()`, captures the
-            // exit status, and fires `TerminalExited` exactly once
-            // with the real code. The reader thread above has
-            // already dropped `alive_clone` to false on PTY EOF, so
-            // by the time we get here the child is either gone or
-            // about to be (the writer thread's killer.kill()
-            // accelerates the latter case for user-initiated
-            // shutdown).
-            let async_bridge_for_wait = self.async_bridge.clone();
-            thread::spawn(move || {
-                let exit_code = match child.wait() {
-                    Ok(status) => Some(status.exit_code() as i32),
-                    Err(e) => {
-                        tracing::warn!("child.wait() failed for {:?}: {}", terminal_id, e);
-                        None
-                    }
-                };
-                if let Some(ref bridge) = async_bridge_for_wait {
-                    #[allow(clippy::let_underscore_must_use)]
-                    let _ = bridge.sender().send(
-                        crate::services::async_bridge::AsyncMessage::TerminalExited {
-                            terminal: wt_id,
-                            exit_code,
-                        },
-                    );
-                }
-            });
-
-            // Capture the PTY master fd before the master moves into the
-            // writer thread below. Used later by `foreground_process_name`
-            // (tmux-style tab auto-naming). The fd stays valid for the
-            // terminal's lifetime because the writer thread owns the master.
-            let master_fd: Option<i32> = {
-                #[cfg(unix)]
-                {
-                    pty_pair.master.as_raw_fd()
-                }
-                #[cfg(not(unix))]
-                {
-                    None
-                }
-            };
-
-            // Spawn writer thread
-            let pty_size_ref = pty_pair.master;
-            thread::spawn(move || {
-                loop {
-                    match command_rx.recv() {
-                        Ok(TerminalCommand::Write(data)) => {
-                            if let Err(e) = master.write_all(&data) {
-                                tracing::error!("Terminal write error: {}", e);
-                                break;
-                            }
-                            // Best-effort flush — PTY write errors are handled above.
-                            #[allow(clippy::let_underscore_must_use)]
-                            let _ = master.flush();
-                        }
-                        Ok(TerminalCommand::Resize { cols, rows }) => {
-                            if let Err(e) = pty_size_ref.resize(PtySize {
-                                rows,
-                                cols,
-                                pixel_width: 0,
-                                pixel_height: 0,
-                            }) {
-                                tracing::warn!("Failed to resize PTY: {}", e);
-                            }
-                        }
-                        Ok(TerminalCommand::Shutdown) | Err(_) => {
-                            break;
-                        }
-                    }
-                }
-                // User-initiated shutdown: ask the OS to terminate
-                // the child via the cloned killer. The wait-thread
-                // (above) owns `child` and will reap the exit status
-                // for us; we don't call `wait` here because that
-                // would race the wait-thread for the exit status.
-                #[allow(clippy::let_underscore_must_use)]
-                let _ = child_killer.kill();
-            });
-
-            // Create handle
-            Ok(TerminalHandle {
-                state,
-                command_tx,
-                alive,
-                cols,
-                rows,
-                cwd: cwd.clone(),
-                shell,
-                pid: child_pid,
-                master_fd,
-            })
-        })();
-
-        let handle = handle_result?;
+        let handle = self.build_terminal(
+            id,
+            cols,
+            rows,
+            cwd,
+            log_path,
+            backing_path,
+            terminal_wrapper,
+            env_delta,
+        )?;
 
         self.terminals.insert(id, handle);
         tracing::info!("Created terminal {:?} ({}x{})", id, cols, rows);
 
         Ok(id)
+    }
+
+    /// Build a PTY-backed terminal: open the pty, launch the shell, and wire up
+    /// the three background threads (reader, wait, writer) that drive it. Kept
+    /// separate from [`TerminalManager::spawn`] so the happy path reads
+    /// top-to-bottom with `?` instead of being buried in an error-handling
+    /// closure.
+    #[allow(clippy::too_many_arguments)]
+    fn build_terminal(
+        &self,
+        id: TerminalId,
+        cols: u16,
+        rows: u16,
+        cwd: Option<std::path::PathBuf>,
+        log_path: Option<std::path::PathBuf>,
+        backing_path: Option<std::path::PathBuf>,
+        terminal_wrapper: TerminalWrapper,
+        env_delta: crate::services::env_provider::EnvDelta,
+    ) -> Result<TerminalHandle, String> {
+        let pty_pair = open_pty(cols, rows)?;
+
+        // The active authority's terminal wrapper drives the shell command
+        // unconditionally — local wraps `detect_shell()` with no args;
+        // container/remote authorities re-parent into `docker exec -w …`,
+        // `ssh …`, etc.
+        let (cmd, shell) = build_shell_command(terminal_wrapper, cwd.as_deref(), &env_delta);
+
+        // Spawn the shell process.
+        let child = pty_pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| format!("Failed to spawn shell '{}': {}", shell, e))?;
+        tracing::debug!("Shell process spawned successfully");
+
+        // Capture the pid (for process-group signalling) and a killer handle
+        // before `child` moves into the wait-thread below.
+        let child_pid = child.process_id();
+        let child_killer = child.clone_killer();
+
+        let state = Arc::new(Mutex::new(TerminalState::new(cols, rows)));
+
+        // If the backing file already exists (session restore), seed the history
+        // end so entering terminal mode doesn't truncate it to 0.
+        if let Some(p) = backing_path.as_ref() {
+            if let Ok(metadata) = std::fs::metadata(p) {
+                if metadata.len() > 0 {
+                    if let Ok(mut s) = state.lock() {
+                        s.set_backing_file_history_end(metadata.len());
+                    }
+                }
+            }
+        }
+
+        let (command_tx, command_rx) = mpsc::channel::<TerminalCommand>();
+        let alive = Arc::new(AtomicBool::new(true));
+
+        let master_writer = pty_pair
+            .master
+            .take_writer()
+            .map_err(|e| format!("Failed to get PTY writer: {}", e))?;
+        let reader = pty_pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| format!("Failed to get PTY reader: {}", e))?;
+
+        let log_writer = open_log_writer(log_path.as_deref());
+        let backing_writer = open_backing_writer(backing_path.as_deref());
+
+        // Tag output/exit with the owning window so the main loop never has to
+        // guess which session a `Terminal-N` belongs to (ids collide across
+        // windows). See `fresh_core::WindowTerminalId`.
+        let wt_id = fresh_core::WindowTerminalId::new(self.window_id, id);
+
+        // Reader thread: drains PTY output, feeds the emulator, streams
+        // scrollback / raw log to disk, and pings the main loop to redraw.
+        let reader_loop = ReaderLoop {
+            reader,
+            state: state.clone(),
+            response_tx: command_tx.clone(),
+            backing_writer,
+            log_writer,
+            async_bridge: self.async_bridge.clone(),
+            wt_id,
+            terminal_id: id,
+            alive: alive.clone(),
+        };
+        thread::spawn(move || reader_loop.run());
+
+        // Wait thread: blocks on `child.wait()` and fires `TerminalExited`
+        // exactly once with the real exit code.
+        spawn_wait_thread(child, self.async_bridge.clone(), wt_id, id);
+
+        // Capture the PTY master fd before the master moves into the writer
+        // thread. Used later by `foreground_process_name` (tab auto-naming).
+        let master_fd: Option<i32> = {
+            #[cfg(unix)]
+            {
+                pty_pair.master.as_raw_fd()
+            }
+            #[cfg(not(unix))]
+            {
+                None
+            }
+        };
+
+        // Writer thread: owns the master, applies queued writes/resizes, and
+        // kills the child on shutdown.
+        spawn_writer_thread(command_rx, master_writer, pty_pair.master, child_killer);
+
+        Ok(TerminalHandle {
+            state,
+            command_tx,
+            alive,
+            cols,
+            rows,
+            cwd,
+            shell,
+            pid: child_pid,
+            master_fd,
+        })
     }
 
     /// Get a terminal handle by ID
@@ -777,6 +481,351 @@ impl TerminalManager {
         }
 
         dead
+    }
+}
+
+/// Open a native PTY of the given size, mapping the platform error into a
+/// human-readable string (with a ConPTY hint on Windows).
+fn open_pty(cols: u16, rows: u16) -> Result<portable_pty::PtyPair, String> {
+    native_pty_system()
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| {
+            #[cfg(windows)]
+            {
+                format!(
+                    "Failed to open PTY: {}. Note: Terminal requires Windows 10 version 1809 or later with ConPTY support.",
+                    e
+                )
+            }
+            #[cfg(not(windows))]
+            {
+                format!("Failed to open PTY: {}", e)
+            }
+        })
+}
+
+/// Build the shell `CommandBuilder` for a terminal from the active authority's
+/// wrapper, returning the command plus the shell executable name (for the
+/// handle / diagnostics). `manages_cwd` wrappers (docker/ssh) already establish
+/// cwd in their own args, so both cwd and the local `FRESH_SESSION`
+/// advertisement are skipped for them — their inner shell runs on another host
+/// this `CommandBuilder`'s env can't reach.
+fn build_shell_command(
+    terminal_wrapper: TerminalWrapper,
+    cwd: Option<&std::path::Path>,
+    env_delta: &crate::services::env_provider::EnvDelta,
+) -> (CommandBuilder, String) {
+    let TerminalWrapper {
+        command: shell,
+        args: cmd_args,
+        manages_cwd: skip_cwd,
+    } = terminal_wrapper;
+    tracing::info!("Spawning terminal with shell: {}", shell);
+
+    let mut cmd = CommandBuilder::new(&shell);
+    for arg in &cmd_args {
+        cmd.arg(arg);
+    }
+    if !skip_cwd {
+        if let Some(dir) = cwd {
+            // Hand the shell a non-verbatim path so PowerShell can infer the
+            // drive; a verbatim `\\?\C:\…` path yields provider-prefixed prompts.
+            cmd.cwd(strip_verbatim_prefix(dir).as_ref());
+        }
+    }
+
+    // Apply the activated-environment delta (venv/direnv/mise) before the
+    // control vars below, so TERM/FRESH_SESSION win over any same-named key
+    // (issue #2355).
+    for (k, v) in &env_delta.set {
+        cmd.env(k, v);
+    }
+    for k in &env_delta.unset {
+        cmd.env_remove(k);
+    }
+
+    // Advertise terminal capabilities; the built-in emulator is alacritty-based.
+    cmd.env("TERM", "xterm-256color");
+
+    // Advertise this editor's local control socket so a nested `fresh` forwards
+    // file/dir opens back to us instead of starting a second editor.
+    if !skip_cwd {
+        if let Some(session_id) = crate::server::local_control::local_session_id() {
+            cmd.env("FRESH_SESSION", session_id);
+        }
+    }
+
+    // On Windows, ensure PROMPT is set for cmd.exe.
+    #[cfg(windows)]
+    {
+        if shell.to_lowercase().contains("cmd") {
+            cmd.env("PROMPT", "$P$G");
+        }
+    }
+
+    (cmd, shell)
+}
+
+/// Open the optional raw-PTY log file (append mode) for full-session capture.
+fn open_log_writer(
+    log_path: Option<&std::path::Path>,
+) -> Option<std::io::BufWriter<std::fs::File>> {
+    log_path
+        .and_then(|p| {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+                .ok()
+        })
+        .map(std::io::BufWriter::new)
+}
+
+/// Open the optional scrollback backing file. On session restore (the file
+/// already has content) we append to continue streaming; otherwise we truncate
+/// to start fresh.
+fn open_backing_writer(
+    backing_path: Option<&std::path::Path>,
+) -> Option<std::io::BufWriter<std::fs::File>> {
+    backing_path
+        .and_then(|p| {
+            let existing_has_content =
+                p.exists() && std::fs::metadata(p).map(|m| m.len() > 0).unwrap_or(false);
+            if existing_has_content {
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(p)
+                    .ok()
+            } else {
+                std::fs::OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(p)
+                    .ok()
+            }
+        })
+        .map(std::io::BufWriter::new)
+}
+
+/// Wait-thread body: block on the child's exit and fire `TerminalExited` once.
+/// Owns `child` so it is the single source of the exit status (the reader
+/// thread deliberately doesn't fire it, to avoid a racing `exit_code: None`).
+fn spawn_wait_thread(
+    mut child: Box<dyn portable_pty::Child + Send + Sync>,
+    async_bridge: Option<AsyncBridge>,
+    wt_id: fresh_core::WindowTerminalId,
+    terminal_id: TerminalId,
+) {
+    thread::spawn(move || {
+        let exit_code = match child.wait() {
+            Ok(status) => Some(status.exit_code() as i32),
+            Err(e) => {
+                tracing::warn!("child.wait() failed for {:?}: {}", terminal_id, e);
+                None
+            }
+        };
+        if let Some(bridge) = &async_bridge {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = bridge.sender().send(
+                crate::services::async_bridge::AsyncMessage::TerminalExited {
+                    terminal: wt_id,
+                    exit_code,
+                },
+            );
+        }
+    });
+}
+
+/// Writer-thread body: own the master, apply queued writes/resizes, and kill
+/// the child on shutdown. The wait-thread reaps the exit status, so this thread
+/// intentionally doesn't call `wait` (which would race it).
+fn spawn_writer_thread(
+    command_rx: mpsc::Receiver<TerminalCommand>,
+    mut master: Box<dyn Write + Send>,
+    pty_master: Box<dyn portable_pty::MasterPty + Send>,
+    mut child_killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+) {
+    thread::spawn(move || {
+        loop {
+            match command_rx.recv() {
+                Ok(TerminalCommand::Write(data)) => {
+                    if let Err(e) = master.write_all(&data) {
+                        tracing::error!("Terminal write error: {}", e);
+                        break;
+                    }
+                    // Best-effort flush — PTY write errors are handled above.
+                    #[allow(clippy::let_underscore_must_use)]
+                    let _ = master.flush();
+                }
+                Ok(TerminalCommand::Resize { cols, rows }) => {
+                    if let Err(e) = pty_master.resize(PtySize {
+                        rows,
+                        cols,
+                        pixel_width: 0,
+                        pixel_height: 0,
+                    }) {
+                        tracing::warn!("Failed to resize PTY: {}", e);
+                    }
+                }
+                Ok(TerminalCommand::Shutdown) | Err(_) => {
+                    break;
+                }
+            }
+        }
+        // User-initiated shutdown: ask the OS to terminate the child via the
+        // cloned killer. The wait-thread owns `child` and reaps the status.
+        #[allow(clippy::let_underscore_must_use)]
+        let _ = child_killer.kill();
+    });
+}
+
+/// Owns everything the PTY reader thread needs. Bundled into one struct so the
+/// thread body is a readable `run(self)` of small steps instead of a closure
+/// capturing a dozen locals at deep nesting.
+struct ReaderLoop {
+    reader: Box<dyn Read + Send>,
+    state: Arc<Mutex<TerminalState>>,
+    /// Sends PTY write-responses (e.g. DSR cursor reports) back to the writer.
+    response_tx: mpsc::Sender<TerminalCommand>,
+    /// Incremental scrollback stream (rendered lines), if a backing file is set.
+    backing_writer: Option<std::io::BufWriter<std::fs::File>>,
+    /// Raw byte log for session-restore replay, if a log file is set.
+    log_writer: Option<std::io::BufWriter<std::fs::File>>,
+    async_bridge: Option<AsyncBridge>,
+    wt_id: fresh_core::WindowTerminalId,
+    terminal_id: TerminalId,
+    alive: Arc<AtomicBool>,
+}
+
+impl ReaderLoop {
+    /// Drain the PTY until EOF or error, then mark the terminal dead and flush.
+    fn run(mut self) {
+        tracing::debug!("Terminal {:?} reader thread started", self.terminal_id);
+        let mut buf = [0u8; 4096];
+        let mut total_bytes = 0usize;
+        loop {
+            match self.reader.read(&mut buf) {
+                Ok(0) => {
+                    // EOF - process exited.
+                    tracing::info!(
+                        "Terminal {:?} EOF after {} total bytes",
+                        self.terminal_id,
+                        total_bytes
+                    );
+                    break;
+                }
+                Ok(n) => {
+                    total_bytes += n;
+                    // Hot path: a busy terminal reads tens of thousands of
+                    // chunks/sec, so this stays at `trace` (off by default) to
+                    // avoid flooding the log — and, if that log is tailed into a
+                    // terminal this manager owns, a positive-feedback loop.
+                    tracing::trace!(
+                        "Terminal {:?} received {} bytes (total: {})",
+                        self.terminal_id,
+                        n,
+                        total_bytes
+                    );
+                    self.process_output(&buf[..n]);
+                    self.append_raw_log(&buf[..n]);
+                    self.notify_redraw();
+                }
+                Err(e) => {
+                    tracing::error!("Terminal read error: {}", e);
+                    break;
+                }
+            }
+        }
+        self.alive
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        // Best-effort flush of log/backing files during teardown. The
+        // wait-thread is the single source of `TerminalExited`, so the reader
+        // intentionally does not fire it here (firing from both races and can
+        // yield `exit_code: None` despite a clean exit).
+        if let Some(mut w) = self.log_writer.take() {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = w.flush();
+        }
+        if let Some(mut w) = self.backing_writer.take() {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = w.flush();
+        }
+    }
+
+    /// Feed `bytes` to the emulator, forward any PTY write-responses, and stream
+    /// new scrollback to the backing file. Holds the state lock for the whole
+    /// step so scrollback offsets stay consistent with the emulator grid.
+    fn process_output(&mut self, bytes: &[u8]) {
+        let Ok(mut state) = self.state.lock() else {
+            return;
+        };
+        state.process_output(bytes);
+
+        // Send any PTY write responses (e.g. DSR cursor position). Critical on
+        // Windows ConPTY, where PowerShell waits for this before prompting.
+        for response in state.drain_pty_write_queue() {
+            tracing::debug!(
+                "Terminal {:?} sending PTY response: {:?}",
+                self.terminal_id,
+                response
+            );
+            // Receiver may be dropped if the writer thread exited.
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = self
+                .response_tx
+                .send(TerminalCommand::Write(response.into_bytes()));
+        }
+
+        // Incrementally stream new scrollback lines to the backing file.
+        if let Some(writer) = self.backing_writer.as_mut() {
+            match state.flush_new_scrollback(writer) {
+                Ok(lines_written) => {
+                    if lines_written > 0 {
+                        if let Ok(pos) = writer.get_ref().metadata() {
+                            state.set_backing_file_history_end(pos.len());
+                        }
+                        #[allow(clippy::let_underscore_must_use)]
+                        let _ = writer.flush();
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("Terminal backing file write error: {}", e);
+                    self.backing_writer = None;
+                }
+            }
+        }
+    }
+
+    /// Append raw bytes to the session log (for restore replay), if enabled.
+    fn append_raw_log(&mut self, bytes: &[u8]) {
+        if let Some(w) = self.log_writer.as_mut() {
+            if let Err(e) = w.write_all(bytes) {
+                tracing::warn!("Terminal log write error: {}", e);
+                self.log_writer = None;
+            } else if let Err(e) = w.flush() {
+                tracing::warn!("Terminal log flush error: {}", e);
+                self.log_writer = None;
+            }
+        }
+    }
+
+    /// Notify the main loop that this terminal produced output (redraw).
+    fn notify_redraw(&self) {
+        if let Some(bridge) = &self.async_bridge {
+            #[allow(clippy::let_underscore_must_use)]
+            let _ = bridge.sender().send(
+                crate::services::async_bridge::AsyncMessage::TerminalOutput {
+                    terminal: self.wt_id,
+                },
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## What & why

`TerminalManager::spawn` (in `crates/fresh-editor/src/services/terminal/manager.rs`) was the worst maintainability offender among the project's *stable* files: a single ~450-line "god function" whose entire body was wrapped in an immediately-invoked closure `(|| { ... })()` purely to fake `?`-style error handling. Inside that closure it interleaved five unrelated responsibilities:

1. PTY creation
2. shell-command construction (cwd, env delta, `TERM`, `FRESH_SESSION`, Windows `PROMPT`)
3. log / backing-file writer setup
4. the full **inline bodies of three spawned threads** (reader, wait, writer)

The reader-thread body alone was a ~120-line, deeply nested block (depth ~12), making the happy path very hard to follow.

## Changes (behavior-preserving)

- `spawn` is now a thin orchestrator; the real work moved into a private `build_terminal` that uses `?` directly instead of the error-handling closure, so the happy path reads top-to-bottom.
- Extracted focused free helpers: `open_pty`, `build_shell_command`, `open_log_writer`, `open_backing_writer`, `spawn_wait_thread`, `spawn_writer_thread`.
- Moved the reader loop into a small `ReaderLoop` struct that owns its resources, with `run` split into named steps: `process_output`, `append_raw_log`, `notify_redraw`. (No new traits/generics/macros.)

The public API and all existing behavior are unchanged — only the internals of one function were restructured, keeping the blast radius minimal. The file's tests cover only unrelated helpers (`strip_verbatim_prefix`, `detect_shell`) and are untouched.

## Conflict avoidance

This file is **not** modified by any of the 68 open PRs (verified by auditing each open PR's changed files), so the refactor shouldn't collide with in-flight work.

## Tooling

- `cargo build -p fresh-editor` — succeeds.
- `cargo fmt` — clean.
- `cargo clippy -p fresh-editor` — **zero** warnings in `manager.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qcU62vKQ1j4ZDUmnju3vf

---
_Generated by [Claude Code](https://claude.ai/code/session_014qcU62vKQ1j4ZDUmnju3vf)_