### PR TITLE
fix(terminal): keep scrollback backing file on the local filesystem in remote mode

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -840,10 +840,8 @@ impl Editor {
                 .get(&terminal_id)
                 .cloned()
             {
-                if let Ok(mut file) = self
-                    .authority()
-                    .filesystem
-                    .open_file_for_append(&backing_path)
+                if let Ok(mut file) =
+                    crate::app::terminal::terminal_backing_fs().open_file_for_append(&backing_path)
                 {
                     use std::io::Write;
                     if let Err(e) = file.write_all(exit_msg.as_bytes()) {

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -103,7 +103,7 @@ impl Editor {
                 if backing_file.as_ref() != Some(&log_file) {
                     // Best-effort cleanup of temporary terminal files.
                     #[allow(clippy::let_underscore_must_use)]
-                    let _ = self.authority().filesystem.remove_file(&log_file);
+                    let _ = crate::app::terminal::terminal_backing_fs().remove_file(&log_file);
                 }
             }
 
@@ -1159,7 +1159,7 @@ impl Editor {
             .unwrap_or(0);
         let retained = parent.join(format!("{stem}-closed-{epoch_ms}.txt"));
         #[allow(clippy::let_underscore_must_use)]
-        let _ = self.authority().filesystem.rename(path, &retained);
+        let _ = crate::app::terminal::terminal_backing_fs().rename(path, &retained);
         self.gc_retained_terminal_backings(parent);
     }
 
@@ -1169,7 +1169,7 @@ impl Editor {
     /// backing files (no `-closed-` marker) are never touched.
     fn gc_retained_terminal_backings(&self, dir: &std::path::Path) {
         const MAX_RETAINED: usize = 200;
-        let Ok(entries) = self.authority().filesystem.read_dir(dir) else {
+        let Ok(entries) = crate::app::terminal::terminal_backing_fs().read_dir(dir) else {
             return;
         };
         let mut retained: Vec<(u128, std::path::PathBuf)> = entries
@@ -1188,7 +1188,7 @@ impl Editor {
         let remove_count = retained.len() - MAX_RETAINED;
         for (_, p) in retained.into_iter().take(remove_count) {
             #[allow(clippy::let_underscore_must_use)]
-            let _ = self.authority().filesystem.remove_file(&p);
+            let _ = crate::app::terminal::terminal_backing_fs().remove_file(&p);
         }
     }
 }

--- a/crates/fresh-editor/src/app/file_operations.rs
+++ b/crates/fresh-editor/src/app/file_operations.rs
@@ -1128,6 +1128,17 @@ impl Editor {
             .map(|s| (s.buffer_settings.clone(), s.editing_disabled))
             .unwrap_or_default();
 
+        // Reload through the *buffer's own* filesystem rather than the
+        // session authority's. For normal files these are the same handle
+        // (buffers are created with the authority fs), so behaviour is
+        // unchanged — but terminal scrollback buffers are backed by a local
+        // file (see `terminal_backing_fs`), and reverting those through a
+        // remote authority would read a path that only exists locally.
+        let fs = self
+            .buffers()
+            .get(&buffer_id)
+            .map(|s| std::sync::Arc::clone(s.buffer.filesystem()))
+            .unwrap_or_else(|| std::sync::Arc::clone(&self.authority().filesystem));
         // Load the file content fresh from disk
         let mut new_state = EditorState::from_file_with_languages(
             path,
@@ -1136,7 +1147,7 @@ impl Editor {
             self.config.editor.large_file_threshold_bytes as usize,
             &self.grammar_registry,
             &self.config.languages,
-            std::sync::Arc::clone(&self.authority().filesystem),
+            fs,
         )?;
 
         // Get the new file size for clamping

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -32,6 +32,29 @@ use crate::state::EditorState;
 use crate::view::split::SplitViewState;
 use rust_i18n::t;
 use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Filesystem for terminal scrollback backing/log files.
+///
+/// The integrated terminal's PTY is always spawned on the **local** host —
+/// even an SSH terminal runs `ssh` as a *local* child process — and the PTY
+/// read loop renders scrollback into the backing file on the local disk via
+/// `std::fs` (`services/terminal/manager.rs`). Those files therefore always
+/// live on the local machine, at a path under the local `data_dir`,
+/// independent of the session's (possibly remote) authority filesystem.
+///
+/// Routing their create / append / truncate / read through the *remote*
+/// authority filesystem (issue #2424) made every scrollback-mode toggle do a
+/// blocking SSH round-trip against a path that only exists locally: it hung
+/// the UI for the round-trip and failed with "Failed to truncate terminal
+/// backing file", leaving the scrollback view empty. Always use this local
+/// handle for terminal backing/log files so it stays consistent with the read
+/// loop. This honours the "use the `FileSystem` trait" rule (it returns a
+/// trait object, never raw `std::fs` at the call site) while pinning the
+/// backend to local — the correct backend for a local artifact.
+pub(crate) fn terminal_backing_fs() -> Arc<dyn crate::model::filesystem::FileSystem + Send + Sync> {
+    Arc::new(crate::model::filesystem::StdFileSystem)
+}
 
 /// How often [`Window::sync_terminal_titles`] polls each terminal's
 /// foreground process group for tmux-style tab auto-naming. Frequent enough
@@ -165,7 +188,7 @@ impl Window {
 
         let working_dir = cwd.unwrap_or_else(|| self.root.clone());
         let terminal_root = self.resources.dir_context.terminal_dir_for(&working_dir);
-        if let Err(e) = self.authority().filesystem.create_dir_all(&terminal_root) {
+        if let Err(e) = terminal_backing_fs().create_dir_all(&terminal_root) {
             tracing::warn!("Failed to create terminal directory: {}", e);
         }
 
@@ -257,7 +280,7 @@ impl Window {
             .cloned()
             .unwrap_or_else(|| {
                 let root = self.resources.dir_context.terminal_dir_for(&self.root);
-                if let Err(e) = self.authority().filesystem.create_dir_all(&root) {
+                if let Err(e) = terminal_backing_fs().create_dir_all(&root) {
                     tracing::warn!("Failed to create terminal directory: {}", e);
                 }
                 root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
@@ -266,8 +289,8 @@ impl Window {
         // Ensure the file exists — but DON'T truncate if it already has
         // content. The PTY read loop may have already started writing
         // scrollback.
-        if !self.authority().filesystem.exists(&backing_file) {
-            if let Err(e) = self.authority().filesystem.write_file(&backing_file, &[]) {
+        if !terminal_backing_fs().exists(&backing_file) {
+            if let Err(e) = terminal_backing_fs().write_file(&backing_file, &[]) {
                 tracing::warn!("Failed to create terminal backing file: {}", e);
             }
         }
@@ -277,7 +300,7 @@ impl Window {
 
         let mut state = EditorState::new_with_path(
             large_file_threshold,
-            std::sync::Arc::clone(&self.authority().filesystem),
+            terminal_backing_fs(),
             backing_file.clone(),
         );
         state.margins.configure_for_line_numbers(false);
@@ -717,21 +740,21 @@ impl Window {
             .cloned()
             .unwrap_or_else(|| {
                 let root = self.resources.dir_context.terminal_dir_for(&self.root);
-                if let Err(e) = self.authority().filesystem.create_dir_all(&root) {
+                if let Err(e) = terminal_backing_fs().create_dir_all(&root) {
                     tracing::warn!("Failed to create terminal directory: {}", e);
                 }
                 root.join(format!("fresh-terminal-{}.txt", terminal_id.0))
             });
 
-        if !self.authority().filesystem.exists(&backing_file) {
-            if let Err(e) = self.authority().filesystem.write_file(&backing_file, &[]) {
+        if !terminal_backing_fs().exists(&backing_file) {
+            if let Err(e) = terminal_backing_fs().write_file(&backing_file, &[]) {
                 tracing::warn!("Failed to create terminal backing file: {}", e);
             }
         }
 
         let mut state = EditorState::new_with_path(
             large_file_threshold,
-            std::sync::Arc::clone(&self.authority().filesystem),
+            terminal_backing_fs(),
             backing_file.clone(),
         );
         state.margins.configure_for_line_numbers(false);
@@ -976,7 +999,7 @@ impl Editor {
             if let Some(ref path) = backing_file {
                 // Best-effort cleanup of temporary terminal files.
                 #[allow(clippy::let_underscore_must_use)]
-                let _ = self.authority().filesystem.remove_file(path);
+                let _ = terminal_backing_fs().remove_file(path);
             }
             // Clean up raw log file
             if let Some(log_file) = self
@@ -987,7 +1010,7 @@ impl Editor {
                 if backing_file.as_ref() != Some(&log_file) {
                     // Best-effort cleanup of temporary terminal files.
                     #[allow(clippy::let_underscore_must_use)]
-                    let _ = self.authority().filesystem.remove_file(&log_file);
+                    let _ = terminal_backing_fs().remove_file(&log_file);
                 }
             }
 
@@ -1230,10 +1253,8 @@ impl Editor {
                             let truncate_pos = state.backing_file_history_end();
                             // Always truncate to remove appended visible screen
                             // (even if truncate_pos is 0, meaning no scrollback yet)
-                            if let Err(e) = self
-                                .authority()
-                                .filesystem
-                                .set_file_length(backing_path, truncate_pos)
+                            if let Err(e) =
+                                terminal_backing_fs().set_file_length(backing_path, truncate_pos)
                             {
                                 tracing::warn!("Failed to truncate terminal backing file: {}", e);
                             }
@@ -1507,11 +1528,7 @@ impl Window {
                 // screen into history. The PTY read loop also flushes on output,
                 // but an idle terminal that was only resized has pending lines;
                 // capturing them here guarantees the scroll-back view is complete.
-                if let Ok(mut file) = self
-                    .authority()
-                    .filesystem
-                    .open_file_for_append(&backing_file)
-                {
+                if let Ok(mut file) = terminal_backing_fs().open_file_for_append(&backing_file) {
                     let mut writer = BufWriter::new(&mut *file);
                     if let Err(e) = state.flush_new_scrollback(&mut writer) {
                         tracing::error!("Failed to flush terminal scrollback: {}", e);
@@ -1520,17 +1537,13 @@ impl Window {
 
                 // Record the current file size as the history end point
                 // (before appending visible screen) so we can truncate back to it
-                if let Ok(metadata) = self.authority().filesystem.metadata(&backing_file) {
+                if let Ok(metadata) = terminal_backing_fs().metadata(&backing_file) {
                     state.set_backing_file_history_end(metadata.size);
                     history_end_byte = Some(metadata.size);
                 }
 
                 // Open backing file in append mode to add visible screen
-                if let Ok(mut file) = self
-                    .authority()
-                    .filesystem
-                    .open_file_for_append(&backing_file)
-                {
+                if let Ok(mut file) = terminal_backing_fs().open_file_for_append(&backing_file) {
                     let mut writer = BufWriter::new(&mut *file);
                     if let Err(e) = state.append_visible_screen(&mut writer) {
                         tracing::error!("Failed to append visible screen to backing file: {}", e);
@@ -1548,7 +1561,7 @@ impl Window {
             large_file_threshold,
             &self.resources.grammar_registry,
             &self.resources.config.languages,
-            std::sync::Arc::clone(&self.authority().filesystem),
+            terminal_backing_fs(),
         ) {
             let total_bytes = new_state.buffer.total_bytes();
             if let Some(state) = self.buffers.get_mut(&buffer_id) {

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -729,7 +729,7 @@ impl crate::app::window::Window {
 
         // Best-effort directory creation for terminal backing files
         #[allow(clippy::let_underscore_must_use)]
-        let _ = self.authority().filesystem.create_dir_all(
+        let _ = crate::app::terminal::terminal_backing_fs().create_dir_all(
             log_path
                 .parent()
                 .or_else(|| backing_path.parent())
@@ -841,7 +841,7 @@ impl crate::app::window::Window {
             large_file_threshold,
             &self.resources.grammar_registry,
             &self.resources.config.languages,
-            std::sync::Arc::clone(&self.authority().filesystem),
+            crate::app::terminal::terminal_backing_fs(),
         ) {
             self.install_terminal_buffer_state(buffer_id, new_state);
         }
@@ -1639,9 +1639,7 @@ impl crate::app::window::Window {
                     // lines a resize spilled into history on a terminal that was
                     // never viewed before quitting) so a restored workspace keeps
                     // the full scrollback.
-                    if let Ok(mut file) = self
-                        .authority()
-                        .filesystem
+                    if let Ok(mut file) = crate::app::terminal::terminal_backing_fs()
                         .open_file_for_append(&backing_path)
                     {
                         let mut writer = BufWriter::new(&mut *file);
@@ -1654,9 +1652,7 @@ impl crate::app::window::Window {
                         }
                     }
 
-                    if let Ok(mut file) = self
-                        .authority()
-                        .filesystem
+                    if let Ok(mut file) = crate::app::terminal::terminal_backing_fs()
                         .open_file_for_append(&backing_path)
                     {
                         let mut writer = BufWriter::new(&mut *file);

--- a/crates/fresh-editor/tests/remote_terminal_backing_local.rs
+++ b/crates/fresh-editor/tests/remote_terminal_backing_local.rs
@@ -1,0 +1,276 @@
+//! Regression test for issue #2424: in a remote SSH workspace, the integrated
+//! terminal's scrollback *backing file* must be managed on the **local**
+//! filesystem, never through the (remote) session authority filesystem.
+//!
+//! The integrated terminal's PTY always runs on the local host (an SSH
+//! terminal spawns `ssh` as a *local* child), and the PTY read loop renders
+//! scrollback into a backing file on local disk. Before the fix, the editor
+//! routed the backing file's create / exists / append / truncate / read
+//! through `authority().filesystem` — which in remote mode is the SSH
+//! filesystem. That made every scrollback-mode toggle do a blocking SSH
+//! round-trip against a path that only exists locally: the UI hung and the
+//! truncate failed with "Failed to truncate terminal backing file", leaving
+//! scrollback empty.
+//!
+//! This test injects a filesystem that (a) reports itself as a *remote*
+//! connection and (b) records every path it is asked to touch. It then drives
+//! the exact user flow — open a terminal, produce scrollback, toggle into
+//! scrollback mode and back (Ctrl+Space) — and asserts that the remote
+//! filesystem was **never** asked to operate on the terminal directory. With
+//! the bug present this fails (the remote fs sees `…/terminals/…` paths);
+//! with the fix it passes (those ops go to the local filesystem).
+//!
+//! Skips (rather than fails) when a PTY can't be opened in the environment.
+
+mod common;
+
+use common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::model::filesystem::{
+    DirEntry, FileMetadata, FilePermissions, FileReader, FileSearchCursor, FileSearchOptions,
+    FileSystem, FileWriter, SearchMatch, StdFileSystem,
+};
+use portable_pty::{native_pty_system, PtySize};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+/// A filesystem that delegates to the local `StdFileSystem` but pretends to be
+/// a remote SSH connection and records every path it is asked about. We use
+/// the recording to prove the terminal backing file is *not* managed through
+/// this (remote) authority filesystem.
+struct RecordingRemoteFs {
+    inner: StdFileSystem,
+    seen: Mutex<Vec<PathBuf>>,
+}
+
+impl RecordingRemoteFs {
+    fn new() -> Self {
+        Self {
+            inner: StdFileSystem,
+            seen: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record(&self, path: &Path) {
+        self.seen.lock().unwrap().push(path.to_path_buf());
+    }
+
+    /// Paths recorded so far whose components include a `terminals` segment —
+    /// i.e. anything under the terminal backing-file directory.
+    fn terminal_paths(&self) -> Vec<PathBuf> {
+        self.seen
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|p| {
+                p.components()
+                    .any(|c| c.as_os_str().to_string_lossy() == "terminals")
+            })
+            .cloned()
+            .collect()
+    }
+}
+
+impl FileSystem for RecordingRemoteFs {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        self.record(path);
+        self.inner.read_file(path)
+    }
+    fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+        self.record(path);
+        self.inner.read_range(path, offset, len)
+    }
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        self.record(path);
+        self.inner.write_file(path, data)
+    }
+    fn create_file(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.record(path);
+        self.inner.create_file(path)
+    }
+    fn open_file(&self, path: &Path) -> io::Result<Box<dyn FileReader>> {
+        self.record(path);
+        self.inner.open_file(path)
+    }
+    fn open_file_for_write(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.record(path);
+        self.inner.open_file_for_write(path)
+    }
+    fn open_file_for_append(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.record(path);
+        self.inner.open_file_for_append(path)
+    }
+    fn set_file_length(&self, path: &Path, len: u64) -> io::Result<()> {
+        self.record(path);
+        self.inner.set_file_length(path, len)
+    }
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.record(from);
+        self.record(to);
+        self.inner.rename(from, to)
+    }
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<u64> {
+        self.record(from);
+        self.record(to);
+        self.inner.copy(from, to)
+    }
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.record(path);
+        self.inner.remove_file(path)
+    }
+    fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        self.record(path);
+        self.inner.remove_dir(path)
+    }
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.record(path);
+        self.inner.metadata(path)
+    }
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.record(path);
+        self.inner.symlink_metadata(path)
+    }
+    fn is_dir(&self, path: &Path) -> io::Result<bool> {
+        self.record(path);
+        self.inner.is_dir(path)
+    }
+    fn is_file(&self, path: &Path) -> io::Result<bool> {
+        self.record(path);
+        self.inner.is_file(path)
+    }
+    fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()> {
+        self.record(path);
+        self.inner.set_permissions(path, permissions)
+    }
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<DirEntry>> {
+        self.record(path);
+        self.inner.read_dir(path)
+    }
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        self.record(path);
+        self.inner.create_dir(path)
+    }
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.record(path);
+        self.inner.create_dir_all(path)
+    }
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.record(path);
+        self.inner.canonicalize(path)
+    }
+    fn current_uid(&self) -> u32 {
+        self.inner.current_uid()
+    }
+    fn search_file(
+        &self,
+        path: &Path,
+        pattern: &str,
+        opts: &FileSearchOptions,
+        cursor: &mut FileSearchCursor,
+    ) -> io::Result<Vec<SearchMatch>> {
+        self.record(path);
+        self.inner.search_file(path, pattern, opts, cursor)
+    }
+    fn sudo_write(
+        &self,
+        path: &Path,
+        data: &[u8],
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> io::Result<()> {
+        self.record(path);
+        self.inner.sudo_write(path, data, mode, uid, gid)
+    }
+    fn walk_files(
+        &self,
+        root: &Path,
+        skip_dirs: &[&str],
+        cancel: &AtomicBool,
+        on_file: &mut dyn FnMut(&Path, &str) -> bool,
+    ) -> io::Result<()> {
+        self.record(root);
+        self.inner.walk_files(root, skip_dirs, cancel, on_file)
+    }
+    // Present as a live remote connection so the editor treats this authority
+    // as a remote (SSH) backend, exactly as in the bug report.
+    fn remote_connection_info(&self) -> Option<&str> {
+        Some("test@remote")
+    }
+    fn is_remote_connected(&self) -> bool {
+        true
+    }
+}
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // uses a Unix shell to produce scrollback
+fn terminal_backing_file_stays_local_in_remote_mode() {
+    if !pty_available() {
+        eprintln!("Skipping: PTY not available in this environment");
+        return;
+    }
+
+    let fs = Arc::new(RecordingRemoteFs::new());
+    let mut harness = EditorTestHarness::create(
+        80,
+        24,
+        HarnessOptions::new().with_filesystem(fs.clone() as Arc<dyn FileSystem + Send + Sync>),
+    )
+    .expect("create harness with remote-marker filesystem");
+
+    // Open the integrated terminal and produce more output than fits on screen
+    // so scrollback is genuinely streamed to the backing file.
+    harness.editor_mut().open_terminal();
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .send_terminal_input(b"for i in $(seq 1 100); do echo \"Line $i\"; done\n");
+    harness
+        .wait_until(|h| h.screen_to_string().contains("Line 100"))
+        .expect("terminal should print up to Line 100");
+
+    // Toggle into scrollback mode (Ctrl+Space) and back — the round-trip that
+    // truncates the backing file on re-entry (the reported failure point).
+    harness
+        .editor_mut()
+        .handle_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "Ctrl+Space should leave terminal mode for scrollback"
+    );
+    harness.render().unwrap();
+
+    harness
+        .editor_mut()
+        .handle_key(KeyCode::Char(' '), KeyModifiers::CONTROL)
+        .unwrap();
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "Ctrl+Space should re-enter terminal mode"
+    );
+    harness.render().unwrap();
+
+    // The terminal backing file is a local artifact: not one of its
+    // create/exists/append/truncate/read operations may have been routed
+    // through the remote authority filesystem.
+    let leaked = fs.terminal_paths();
+    assert!(
+        leaked.is_empty(),
+        "terminal backing-file I/O leaked onto the remote authority filesystem \
+         (issue #2424): {leaked:?}"
+    );
+}


### PR DESCRIPTION
The integrated terminal's PTY is always spawned on the local host — even an
SSH terminal runs `ssh` as a *local* child — and the PTY read loop renders
scrollback into a backing file on local disk via std::fs. But the editor
layer managed that same file (create_dir_all / exists / write / append /
truncate / read, and the scrollback buffer's filesystem) through
`authority().filesystem`, which in remote (SSH) mode is the remote agent.

In a real remote workspace the backing path (under the *local* data_dir)
doesn't exist on the remote host, so every scrollback-mode toggle issued a
blocking SSH round-trip against it: the UI hung for the round-trip and the
truncate failed with "Failed to truncate terminal backing file", leaving the
scrollback view empty (issue #2424).

Route all terminal backing/log-file I/O through a local FileSystem handle
(`terminal_backing_fs`), consistent with the read loop, so these local
artifacts are never sent over SSH. `revert_buffer_by_id` now reloads through
the buffer's own filesystem (unchanged for normal files, local for terminal
buffers) so the terminal-exit reload reads the local backing file too.

Adds a regression test that injects a remote-marker filesystem and asserts no
terminal backing-file operation reaches it; it fails before this change
(the remote fs sees the `…/terminals/…` paths) and passes after.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SqhMcYY67B41q6azwMxouh