### PR TITLE
fix(search): stop plugin edits from leaving phantom search matches (#2414)

### DIFF
--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -2876,6 +2876,81 @@ mod tests {
     }
 
     #[test]
+    fn repro_2414_plugin_edit_same_line_next_match() {
+        // Issue #2414: after a plugin replaces the first of two matches on the
+        // SAME line (delete range + insert, net length change), navigating to
+        // the next match lands a few bytes short of the real position.
+        let config = Config::default();
+        let (dir_context, _temp) = test_dir_context();
+        let mut editor = Editor::new(
+            config,
+            80,
+            24,
+            dir_context,
+            crate::view::color_support::ColorCapability::TrueColor,
+            test_filesystem(),
+        )
+        .unwrap();
+
+        // Line 0 has TWO occurrences of "<i>"; line 1 has one.
+        // "<i>a</i> mid <i>b</i>\n<i>c</i>"
+        let cursor_id = editor.active_cursors().primary_id();
+        editor.apply_event_to_active_buffer(&Event::Insert {
+            position: 0,
+            text: "<i>a</i> mid <i>b</i>\n<i>c</i>".to_string(),
+            cursor_id,
+        });
+
+        editor.active_window_mut().search_case_sensitive = true;
+        editor.perform_search("<i>");
+
+        // Sanity: three matches at 0, 13, 22.
+        let m = editor
+            .active_window()
+            .search_state
+            .as_ref()
+            .unwrap()
+            .matches
+            .clone();
+        assert_eq!(m, vec![0, 13, 22], "initial match offsets");
+
+        // Plugin replaces the first element "<i>a</i>" (bytes 0..8) with the
+        // longer "<em>a</em>" (10 bytes, net +2) via the plugin edit path.
+        let buf = editor.active_buffer();
+        editor.handle_delete_range(buf, 0..8);
+        editor.handle_insert_text(buf, 0, "<em>a</em>".to_string());
+
+        // The second "<i>" on line 0 is now at byte 15 (13 + 2).
+        // Move cursor to the start of line 0 and ask for the next match.
+        // Buffer is now "<em>a</em> mid <i>b</i>\n<i>c</i>"; the surviving
+        // "<i>" occurrences sit at bytes 15 (same line) and 24 (next line).
+        assert_eq!(
+            editor.active_state().buffer.to_string().unwrap(),
+            "<em>a</em> mid <i>b</i>\n<i>c</i>"
+        );
+
+        // From the start of line 0, the next match must be the real second
+        // "<i>" at byte 15 — not the phantom overlay (byte 10) left behind when
+        // the plugin's delete collapsed the first match's highlight and the
+        // following insert pushed it forward.
+        editor.active_cursors_mut().primary_mut().move_to(0, false);
+        editor.find_next();
+        assert_eq!(
+            editor.active_cursors().primary().position,
+            15,
+            "next match should land on the shifted same-line '<i>' (byte 15)"
+        );
+
+        // And the following match is the next-line occurrence at byte 24.
+        editor.find_next();
+        assert_eq!(
+            editor.active_cursors().primary().position,
+            24,
+            "subsequent match should land on the next-line '<i>' (byte 24)"
+        );
+    }
+
+    #[test]
     fn test_search_scan_completes_when_capped() {
         // Regression test: when the incremental search scan hits MAX_MATCHES
         // early (e.g. at 15% of the file), the scan's `capped` flag is set to

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -2876,6 +2876,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "plugins")]
     fn repro_2414_plugin_edit_same_line_next_match() {
         // Issue #2414: after a plugin replaces the first of two matches on the
         // SAME line (delete range + insert, net length change), navigating to

--- a/crates/fresh-editor/src/app/plugin_commands.rs
+++ b/crates/fresh-editor/src/app/plugin_commands.rs
@@ -1084,6 +1084,8 @@ impl Editor {
                 view_state.cursors.adjust_for_edit(position, 0, text_len);
             }
         }
+        // Keep search-match highlights consistent with the edit (issue #2414).
+        self.reevaluate_plugin_edit_search_overlays(buffer_id, position, text_len);
     }
 
     /// Handle DeleteRange command
@@ -1133,6 +1135,48 @@ impl Editor {
                     .adjust_for_edit(delete_start, delete_len, 0);
             }
         }
+        // Keep search-match highlights consistent with the edit (issue #2414).
+        self.reevaluate_plugin_edit_search_overlays(buffer_id, delete_start, 0);
+    }
+
+    /// Re-evaluate the active window's search-match overlays around a region a
+    /// plugin just edited.
+    ///
+    /// Plugin text edits (`InsertText` / `DeleteRange`) apply straight to the
+    /// buffer state and bypass `apply_event_to_active_buffer`, so they miss the
+    /// search-overlay reevaluation that normal edits get. Without this, a delete
+    /// that erased a highlighted match would leave the match's overlay clamped to
+    /// the deletion point; a following insert then pushes that collapsed overlay
+    /// forward, producing a phantom match position that "find next" jumps to
+    /// (issue #2414). Re-scanning the edited line(s) clears the stale overlay and
+    /// re-anchors highlights to the text that actually matches.
+    ///
+    /// Scoped to the active buffer: search overlays for the current search live
+    /// in the active buffer's state, so editing a background buffer has no search
+    /// highlights to refresh.
+    fn reevaluate_plugin_edit_search_overlays(
+        &mut self,
+        buffer_id: BufferId,
+        edit_start: usize,
+        edit_new_len: usize,
+    ) {
+        if buffer_id != self.active_buffer() {
+            return;
+        }
+        if self.active_window().interactive_replace_state.is_some() {
+            // Interactive replace manages its own highlight lifecycle.
+            return;
+        }
+        let (search_fg, search_bg) = {
+            let theme = self.theme.read().unwrap();
+            (theme.search_match_fg, theme.search_match_bg)
+        };
+        self.active_window_mut().reevaluate_search_overlays_around(
+            edit_start,
+            edit_new_len,
+            search_fg,
+            search_bg,
+        );
     }
 
     /// Handle InsertAtCursor command

--- a/crates/fresh-editor/src/view/overlay.rs
+++ b/crates/fresh-editor/src/view/overlay.rs
@@ -424,7 +424,23 @@ impl OverlayManager {
                     }
                     let start = marker_list.get_position(o.start_marker).unwrap_or(0);
                     let end = marker_list.get_position(o.end_marker).unwrap_or(0);
-                    start < range.end && range.start < end
+                    if start < end {
+                        // Healthy overlay: remove on genuine half-open overlap.
+                        start < range.end && range.start < end
+                    } else {
+                        // Collapsed (start == end) or inverted (start > end)
+                        // overlay. These arise when an edit erases the overlay's
+                        // anchored text — the markers clamp to the edit point and
+                        // a later insert can even push them past each other
+                        // (issue #2414). A strict overlap test never matches a
+                        // zero-length span, so the dead overlay would linger and
+                        // surface as a phantom search match. Treat it as a point
+                        // and remove it whenever it lands inside the replaced
+                        // range, so it is dropped rather than recreated.
+                        let lo = start.min(end);
+                        let hi = start.max(end);
+                        lo <= range.end && range.start <= hi
+                    }
                 })
                 .collect();
             to_remove.sort_unstable_by(|a, b| b.cmp(a));


### PR DESCRIPTION
## Summary

Fixes #2414.

When a plugin replaces text on a line that contains more than one search match (delete range + insert, with a net length change), "find next" jumped to a **stale position** for the remaining match on the *same* line, while matches on other lines were unaffected — exactly the reporter's observation ("off by two characters… only the ones on the same line").

## Root cause

Two coupled defects:

1. **Collapsed overlays were never cleared.** A search-match highlight overlay whose anchored text is fully deleted collapses to a zero-length span at the deletion point. `OverlayManager::replace_range_in_namespace` used a strict half-open overlap test (`start < range.end && range.start < end`) that can never match a zero-length span — and a subsequent insert could even push the two markers past each other (inverted). The dead overlay therefore lingered and resurfaced as a **phantom match position** that `find_next` snapped to.

2. **Plugin edits skipped overlay reevaluation.** `InsertText` / `DeleteRange` plugin commands apply straight to the buffer and bypass `apply_event_to_active_buffer`, so they never ran the search-overlay reevaluation that ordinary edits get. The collapsed/phantom overlay from (1) was thus never rebuilt.

## Fix

- `replace_range_in_namespace` now treats degenerate (collapsed or inverted) overlays as points and removes them whenever they fall inside the replaced range, so they are dropped instead of recreated. Healthy overlays keep the existing strict-overlap semantics. This function is only used to "clear a namespace's overlays in a range and recreate them" (search highlights, semantic tokens, bracket highlight), so dropping a dead overlay is always safe — a still-valid match is immediately re-added.
- Plugin text edits to the active buffer now re-scan the edited line(s) and refresh search-match highlights, mirroring step 3 of `apply_event_to_active_buffer`. Scoped to the active buffer (where the current search's overlays live) and a no-op when no search is active.

## Testing

- Added `repro_2414_plugin_edit_same_line_next_match`, which drives the plugin edit path (`handle_delete_range` + `handle_insert_text`) on a line with two matches and asserts `find_next` lands on the real shifted match (byte 15) rather than the phantom (byte 10). It fails before the fix and passes after.
- `cargo test -p fresh-editor` overlay / search / plugin / semantic-token / bracket suites pass; `cargo fmt` clean; no new `cargo clippy` warnings.
- Manually validated the regression test in a tmux session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aY2Qr8EGaf9uDQ5DXsxBv

---
_Generated by [Claude Code](https://claude.ai/code/session_017aY2Qr8EGaf9uDQ5DXsxBv)_