### PR TITLE
feat(file-explorer): follow the active buffer by default, incl. jumps (#2365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **`NextPane` / `PrevPane`** - cycle through every split+tab pane as one flat list, distinct from `NextSplit`/`PrevSplit` and `NextWindow`/`PrevWindow`; landing on a terminal now also switches it into terminal mode (#2562, by @masmu).
 * **Orchestrator dock: organize workspaces into custom folders** - create/rename/delete folders and move workspaces between them ("Move to Folder…" via the context menu, `F2`, right-click, or the palette); the layout survives a crash. The toolbar is condensed to a "New Task…" dropdown and a search field, with other filters in a collapsible section (#2703).
 * **Search in Project: file filter** - a new **Files** field limits project search & replace to comma-separated globs like `*.rs` or `src/**` (#2699, by @asukaminato0721).
+* **File explorer follows the active buffer by default** - with the sidebar open, the tree now expands to and highlights the current file automatically, including when you jump to it via Quick Open (`Ctrl+P`), Open File, or Live Grep, so a jumped-to file is always revealed in the tree (#2365). Turn it off with File Explorer > "Follow Active Buffer".
 
 ### Bug Fixes
 

--- a/crates/fresh-editor/plugins/config-schema.json
+++ b/crates/fresh-editor/plugins/config-schema.json
@@ -148,7 +148,7 @@
         "preview_tabs": true,
         "side": "left",
         "auto_open_on_last_buffer_close": true,
-        "follow_active_buffer": false,
+        "follow_active_buffer": true,
         "compact_directories": true,
         "tree_indicator_collapsed": ">",
         "tree_indicator_expanded": "▼"
@@ -1166,9 +1166,9 @@
           "default": true
         },
         "follow_active_buffer": {
-          "description": "When the file explorer sidebar is open, automatically expand the\ntree and highlight the file that corresponds to the active buffer\nwhenever you switch tabs. Set to `true` to keep the explorer\nselection in sync with the active tab.\nDefault: false",
+          "description": "When the file explorer sidebar is open, automatically expand the\ntree and highlight the file that corresponds to the active buffer\nwhenever you switch tabs or jump to a file (Quick Open, Open File,\nLive Grep). Set to `false` to keep the explorer selection fixed and\nonly move it when you click within the tree.\nDefault: true",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "compact_directories": {
           "description": "Render single-child directory chains on a single line, e.g.\n`src/main/java/com/example`. Only applies when each intermediate\ndirectory in the chain is expanded and has exactly one visible\nchild that is itself a directory. Mirrors VSCode's\n`explorer.compactFolders`.\nDefault: true",

--- a/crates/fresh-editor/src/app/prompt_actions.rs
+++ b/crates/fresh-editor/src/app/prompt_actions.rs
@@ -1773,6 +1773,22 @@ impl Editor {
                 // for the same reason.
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;
+                // Reveal the jumped-to file in the explorer, honouring
+                // `follow_active_buffer`. Quick Open, Open File and Live Grep
+                // are explicit "take me to this file" gestures, so a
+                // jumped-to file should surface in the tree just like a tab
+                // switch does. The passive hook in `set_active_buffer` can't
+                // cover this path: it runs inside `open_file` above, *before*
+                // the `key_context` reset, so at that point the jump is still
+                // in the file-explorer/prompt context and the hook is gated
+                // out. Triggering it here — after the reset — keeps the jump
+                // tied to the same setting, so turning `follow_active_buffer`
+                // off leaves the explorer put on a jump. The call is a no-op
+                // when the explorer is closed and de-dupes against the passive
+                // sync via `file_explorer_sync_in_progress`. (issue #2365)
+                if self.config.file_explorer.follow_active_buffer {
+                    self.active_window_mut().sync_file_explorer_to_active_file();
+                }
                 self.set_status_message(
                     t!("buffer.opened", name = full_path.display().to_string()).to_string(),
                 );

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -1966,10 +1966,11 @@ pub struct FileExplorerConfig {
 
     /// When the file explorer sidebar is open, automatically expand the
     /// tree and highlight the file that corresponds to the active buffer
-    /// whenever you switch tabs. Set to `true` to keep the explorer
-    /// selection in sync with the active tab.
-    /// Default: false
-    #[serde(default = "default_false")]
+    /// whenever you switch tabs or jump to a file (Quick Open, Open File,
+    /// Live Grep). Set to `false` to keep the explorer selection fixed and
+    /// only move it when you click within the tree.
+    /// Default: true
+    #[serde(default = "default_true")]
     pub follow_active_buffer: bool,
 
     /// Render single-child directory chains on a single line, e.g.
@@ -2423,7 +2424,7 @@ impl Default for FileExplorerConfig {
             preview_tabs: true,
             side: default_explorer_side(),
             auto_open_on_last_buffer_close: true,
-            follow_active_buffer: false,
+            follow_active_buffer: true,
             compact_directories: true,
             tree_indicator_collapsed: default_tree_indicator_collapsed(),
             tree_indicator_expanded: default_tree_indicator_expanded(),

--- a/crates/fresh-editor/tests/e2e/issue_2365_quick_open_reveals_in_explorer.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2365_quick_open_reveals_in_explorer.rs
@@ -1,0 +1,148 @@
+//! E2E regression tests for issue #2365: using Quick Open (Ctrl+P) to jump to
+//! a file should also expand the file explorer down to that file — but only
+//! when `file_explorer.follow_active_buffer` is enabled.
+//!
+//! Repro (manual):
+//!   1. Open the file explorer (Ctrl+B) with a nested project; leave a
+//!      sub-directory collapsed.
+//!   2. With focus in the editor, press Ctrl+P and jump to a file inside that
+//!      collapsed sub-directory.
+//!   3. Expected (follow on, now the default): the explorer expands the
+//!      ancestor directories and reveals the freshly opened file.
+//!   4. Actual (before the fix): the explorer stayed put — the sub-directory
+//!      remained collapsed even with the setting on, because the jump path
+//!      never triggered the follow sync.
+//!
+//! The fix makes `follow_active_buffer` default to `true` *and* wires the jump
+//! path (Quick Open / Open File / Live Grep) into the same follow sync, gated
+//! on the setting. The two tests below lock in both halves of that contract:
+//! with the setting on, a jump reveals the file; with it off, a jump must leave
+//! the explorer exactly where it was.
+//!
+//! <https://github.com/sinelaw/fresh/issues/2365>
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use std::fs;
+
+/// Returns `true` when `name` appears on a file-explorer *tree* line (one that
+/// also carries a tree connector), mirroring the `wait_for_file_explorer_item`
+/// heuristic. This distinguishes the tree from the tab bar, which shows the
+/// opened file's name without a tree connector. Reads only rendered output.
+fn explorer_tree_shows(harness: &EditorTestHarness, name: &str) -> bool {
+    harness.screen_to_string().lines().any(|line| {
+        line.contains(name) && (line.contains('│') || line.contains('>') || line.contains('▼'))
+    })
+}
+
+/// Build a temp project whose `nested/` directory (holding the jump target)
+/// starts collapsed, open the explorer with focus in the editor, and assert the
+/// precondition that the target is not yet revealed. The `sibling/` directory
+/// keeps the root from collapsing into a single compacted chain.
+fn setup(config: Config) -> EditorTestHarness {
+    let mut harness = EditorTestHarness::with_temp_project_and_config(120, 40, config).unwrap();
+    let project_root = harness.project_dir().unwrap();
+
+    fs::create_dir_all(project_root.join("nested")).unwrap();
+    fs::create_dir_all(project_root.join("sibling")).unwrap();
+    fs::write(
+        project_root.join("nested/deep_target.txt"),
+        "needle-content",
+    )
+    .unwrap();
+    fs::write(project_root.join("sibling/other.txt"), "other").unwrap();
+
+    // Open the explorer but keep focus in the editor — the exact scenario from
+    // the report (sidebar open while editing).
+    harness.editor_mut().toggle_file_explorer();
+    harness.editor_mut().active_window_mut().focus_editor();
+
+    // Wait for the tree to load (the collapsed `nested` row appears).
+    harness.wait_for_file_explorer_item("nested").unwrap();
+
+    // Precondition: `nested` is collapsed, so its child is not in the tree yet.
+    assert!(
+        !explorer_tree_shows(&harness, "deep_target.txt"),
+        "Precondition: `nested` should be collapsed (deep_target.txt not yet \
+         visible) before the Quick Open jump.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+    harness
+}
+
+/// Jump to `nested/deep_target.txt` via Quick Open and wait until the buffer's
+/// content renders, proving the file actually opened (independently of whatever
+/// the explorer does).
+fn quick_open_jump(harness: &mut EditorTestHarness) {
+    // Ctrl+P opens command mode by default; Backspace drops the command prefix
+    // to switch to file mode.
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("deep_target.txt").unwrap();
+    // Wait for the picker to actually surface the match before committing. The
+    // file list is populated asynchronously (a directory walk / `git ls-files`
+    // provider), so on slower filesystems pressing Enter immediately can commit
+    // an empty result set and open nothing — which showed up as a Windows-only
+    // timeout. The result row renders the relative path with forward slashes on
+    // every platform ("nested/deep_target.txt"), which the typed input line
+    // ("deep_target.txt") does not contain, so this is an unambiguous signal.
+    harness
+        .wait_until(|h| h.screen_to_string().contains("nested/deep_target.txt"))
+        .expect("Quick Open should list nested/deep_target.txt before it is opened");
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("needle-content"))
+        .expect("Quick Open should open the jumped-to file");
+}
+
+/// With `follow_active_buffer` on (the default), a Quick Open jump expands the
+/// explorer down to the opened file. Before the fix this row never appeared and
+/// the wait timed out.
+#[test]
+fn test_quick_open_jump_reveals_file_when_following() {
+    let mut harness = setup(Config::default());
+    quick_open_jump(&mut harness);
+    harness
+        .wait_for_file_explorer_item("deep_target.txt")
+        .expect(
+        "with follow_active_buffer on, a Quick Open jump should expand the explorer to the file",
+    );
+}
+
+/// With `follow_active_buffer` off, a Quick Open jump must NOT move the
+/// explorer: `nested` stays collapsed and its child never appears in the tree,
+/// even though the file itself opens. Guards against the reveal being wired up
+/// unconditionally.
+#[test]
+fn test_quick_open_jump_leaves_explorer_when_not_following() {
+    let mut config = Config::default();
+    config.file_explorer.follow_active_buffer = false;
+
+    let mut harness = setup(config);
+    quick_open_jump(&mut harness);
+
+    // The reveal is gated synchronously on the setting (neither the jump-path
+    // trigger nor the passive `set_active_buffer` hook schedules a sync when
+    // it is off), so once the file has opened the tree state is final.
+    assert!(
+        !explorer_tree_shows(&harness, "deep_target.txt"),
+        "with follow_active_buffer off, a Quick Open jump must NOT expand the \
+         explorer to the target.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+    // The explorer is still open (the collapsed `nested` row is present), so the
+    // assertion above means "collapsed", not "explorer absent".
+    assert!(
+        explorer_tree_shows(&harness, "nested"),
+        "the file explorer should still be showing the collapsed `nested` \
+         directory.\nScreen:\n{}",
+        harness.screen_to_string()
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -78,6 +78,7 @@ pub mod issue_2124_quickfix_enter;
 pub mod issue_2345_language_settings;
 pub mod issue_2357_shebang_interpreter;
 pub mod issue_2362_replace_toolbar_theme;
+pub mod issue_2365_quick_open_reveals_in_explorer;
 pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;
 pub mod issue_2449_scrollback_wrapped_ansi_color;


### PR DESCRIPTION
## Summary

Fixes #2365 — "ctrl + p jump to a file and also file explorer can also expand until that file".

Makes `file_explorer.follow_active_buffer` **default to `true`** and extends the follow behaviour to explicit **jumps** (Quick Open / Open File / Live Grep). With the explorer sidebar open, the tree now expands to and highlights the file for the active buffer out of the box — including when you jump to a file with Ctrl+P into a collapsed directory. Turning the setting **off** restores the old behaviour: a jump leaves the explorer exactly where it was.

## Why the default flip alone wasn't enough

The passive follow hook lives in `set_active_buffer` and already handled tab switches. But it does **not** cover the jump path: `set_active_buffer` runs *inside* `open_file`, which is called *before* the jump handler resets `key_context` out of the file-explorer/prompt context — so on a jump the hook was gated out and the jumped-to file stayed hidden. (An earlier commit that only flipped the default demonstrated exactly this: its reproducer timed out in CI because the Ctrl+P jump never revealed the file.)

## Changes

- **`config.rs`** — flip both the `Default` impl and the `#[serde(default)]` attribute to `true`; update the doc comment.
- **`prompt_actions.rs`** — in the jump handler, after the `key_context` reset, trigger the explorer sync **gated on `follow_active_buffer`**. Because it's gated on the setting, turning following off leaves the explorer put on a jump. De-dupes against the passive sync via the existing `file_explorer_sync_in_progress` guard.
- **`plugins/config-schema.json`** — regenerated via `scripts/gen_schema.sh` so the Settings UI's schema-derived defaults track the Rust default.
- **`CHANGELOG.md`** — user-facing entry under 0.4.4.

## Testing

Two e2e tests (drive real keys, assert only on rendered output; the tree check is connector-aware so it doesn't match the file's tab-bar entry):

- `test_quick_open_jump_reveals_file_when_following` — default config: a Quick Open jump into a collapsed dir reveals the file in the tree.
- `test_quick_open_jump_leaves_explorer_when_not_following` — with the setting off: the same jump opens the file but the explorer stays collapsed.

Locally: both pass; the `file_explorer` e2e module (95 tests) passes; `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Mqvpw2dASXgN1QsApyb99