### PR TITLE
refactor(widgets): decompose the 313-line collect_list God Function

### DIFF
--- a/crates/fresh-editor/src/widgets/render.rs
+++ b/crates/fresh-editor/src/widgets/render.rs
@@ -1209,6 +1209,210 @@ fn render_list_cards(
     (rendered_cards, item_height)
 }
 
+/// Blank full-height-padding row used to pad a List to its
+/// advertised height. Padding rows aren't clickable.
+fn blank_list_row() -> TextPropertyEntry {
+    let mut padding = TextPropertyEntry {
+        text: String::new(),
+        properties: Default::default(),
+        style: None,
+        inline_overlays: Vec::new(),
+        segments: Vec::new(),
+        pad_to_chars: None,
+        truncate_to_chars: None,
+    };
+    ensure_trailing_newline(&mut padding);
+    padding
+}
+
+/// Style a classic (one-row-per-item) list row as the selected
+/// item: a highlight band that runs to line end behind the text.
+fn mark_list_row_selected(entry: &mut TextPropertyEntry) {
+    let mut style = entry.style.clone().unwrap_or_default();
+    style.bg = Some(OverlayColorSpec::theme_key(KEY_FOCUSED_BG));
+    style.extend_to_line_end = true;
+    entry.style = Some(style);
+}
+
+/// Style one row of a selected *card* so selection reads in any
+/// theme — even when colours are too subtle: a *heavy* box border
+/// (colour-independent marker), bold, and an accent fg on the
+/// pure-border rows. No background band — it reads garish over a
+/// multi-row card and fights theme colours. Every box glyph is 3
+/// bytes in both light and heavy forms, so swapping them preserves
+/// inline-overlay byte offsets.
+fn mark_list_card_selected(entry: &mut TextPropertyEntry) {
+    entry.text = entry
+        .text
+        .replace('╭', "┏")
+        .replace('╮', "┓")
+        .replace('╰', "┗")
+        .replace('╯', "┛")
+        .replace('─', "━")
+        .replace('│', "┃");
+    let mut style = entry.style.clone().unwrap_or_default();
+    style.bold = true;
+    if entry.text.starts_with('┏') || entry.text.starts_with('┗') {
+        // Top / bottom rows are pure border, so a whole-row fg tints
+        // the corner-to-corner run.
+        style.fg = Some(OverlayColorSpec::theme_key("ui.popup_border_fg"));
+        entry.style = Some(style);
+    } else {
+        // Side rows hold the session text between two vertical border
+        // glyphs. A whole-row fg would repaint the name / git text
+        // (which only carries an fg overlay when the row is *active*),
+        // so tint just the leading and trailing `┃` glyphs with
+        // sub-range overlays. This frames the selected card on all
+        // four sides instead of only top + bottom.
+        entry.style = Some(style);
+        let bar = '┃';
+        let bar_len = bar.len_utf8();
+        let first = entry.text.find(bar);
+        let last = entry.text.rfind(bar);
+        for pos in [first, last].into_iter().flatten().collect::<HashSet<_>>() {
+            entry.inline_overlays.push(InlineOverlay {
+                start: pos,
+                end: pos + bar_len,
+                style: OverlayOptions {
+                    fg: Some(OverlayColorSpec::theme_key("ui.popup_border_fg")),
+                    bold: true,
+                    ..Default::default()
+                },
+                properties: Default::default(),
+                unit: OffsetUnit::Byte,
+            });
+        }
+    }
+}
+
+/// Resolved geometry for one [`collect_list`] render: where the
+/// scroll window sits and how items map to rows. All selection /
+/// scroll values are in *item* units; the card path maps each item
+/// to a fixed band of `item_height` rows.
+struct ListLayout {
+    /// Total number of items (classic rows or card specs).
+    total: u32,
+    /// Selection clamped to the current dataset (-1 when none / empty).
+    effective_sel: i32,
+    /// First visible item index.
+    scroll: u32,
+    /// Number of items that fit in the available height.
+    visible_items: u32,
+    /// Uniform card height in rows (1 for the classic path).
+    item_height: u32,
+    /// Pre-rendered card blocks (empty for the classic path).
+    rendered_cards: Vec<Vec<TextPropertyEntry>>,
+    /// Whether the host last scrolled by mouse (suppresses follow).
+    user_scrolled: bool,
+}
+
+/// Resolve the prior host-owned scroll/selection state, (re-)render
+/// any card blocks, and compute the visible window for a List. Pure
+/// bookkeeping — it neither emits rows nor persists state.
+#[allow(clippy::too_many_arguments)]
+fn plan_list_layout(
+    items_len: usize,
+    item_specs: &[WidgetSpec],
+    selected_index: i32,
+    visible_rows: u32,
+    list_key: Option<&str>,
+    prev: &HashMap<String, WidgetInstanceState>,
+    focus_key: &str,
+    panel_width: u32,
+) -> ListLayout {
+    let use_specs = !item_specs.is_empty();
+    let total = if use_specs {
+        item_specs.len() as u32
+    } else {
+        items_len as u32
+    };
+    // Available height, in terminal rows.
+    let avail_rows = visible_rows.max(1);
+
+    // Look up host-owned scroll + selected index from prev state
+    // (becomes authoritative after first render). The spec's
+    // `selected_index` is initial-only on first mount.
+    let (prev_scroll, prev_sel, user_scrolled) = list_key
+        .and_then(|k| prev.get(k))
+        .and_then(|s| match s {
+            WidgetInstanceState::List {
+                scroll_offset,
+                selected_index,
+                user_scrolled,
+                ..
+            } => Some((*scroll_offset, *selected_index, *user_scrolled)),
+            _ => None,
+        })
+        .unwrap_or((0, selected_index, false));
+    // Clamp the previous selection to the current dataset size —
+    // items may have shrunk between renders. Out-of-range selections
+    // collapse to the last item, or -1 if the list is now empty.
+    let effective_sel = if prev_sel < 0 || total == 0 {
+        -1
+    } else if (prev_sel as u32) >= total {
+        (total - 1) as i32
+    } else {
+        prev_sel
+    };
+
+    // Pre-render the card blocks (if any) so we know the uniform card
+    // height; the visible-item count and all the scroll math derive
+    // from it. Nested hits/embeds/overlays/scroll are dropped: a card
+    // is a single `select` target (interactive widgets nested in a
+    // card aren't routed yet).
+    let mut rendered_cards: Vec<Vec<TextPropertyEntry>> = Vec::new();
+    let mut item_height: u32 = 1;
+    if use_specs {
+        (rendered_cards, item_height) = render_list_cards(item_specs, prev, focus_key, panel_width);
+    }
+    // How many items fit, and the per-item scroll window.
+    let visible_items = if use_specs {
+        (avail_rows / item_height).max(1)
+    } else {
+        avail_rows
+    };
+
+    // When the card list overflows, the host paints a scrollbar in the
+    // rightmost column — which would sit on top of each card's right
+    // border. Re-render the cards one column narrower so they leave
+    // that column free. (Row count is width-independent, so
+    // `item_height` stays valid.)
+    if use_specs && total > visible_items && panel_width > 1 {
+        (rendered_cards, _) = render_list_cards(item_specs, prev, focus_key, panel_width - 1);
+    }
+
+    // Compute scroll. Normally we auto-clamp to keep the selection in
+    // view, but once the user has scrolled by mouse (`user_scrolled`)
+    // we respect their offset as-is so the selected card can sit
+    // off-screen — only the range clamp below still applies. Selection
+    // moves (keyboard/click/plugin) clear `user_scrolled`, re-arming
+    // this follow behaviour.
+    let mut scroll = prev_scroll;
+    if effective_sel >= 0 && !user_scrolled {
+        let sel = effective_sel as u32;
+        if sel < scroll {
+            scroll = sel;
+        }
+        if sel >= scroll + visible_items {
+            scroll = sel + 1 - visible_items;
+        }
+    }
+    let max_scroll = total.saturating_sub(visible_items);
+    if scroll > max_scroll {
+        scroll = max_scroll;
+    }
+
+    ListLayout {
+        total,
+        effective_sel,
+        scroll,
+        visible_items,
+        item_height,
+        rendered_cards,
+        user_scrolled,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn collect_list(
     items: &[TextPropertyEntry],
@@ -1235,89 +1439,27 @@ fn collect_list(
     // in *item* units; the card path just maps an item to a
     // fixed band of `item_height` rows instead of one row.
     let use_specs = !item_specs.is_empty();
-    let total = if use_specs {
-        item_specs.len() as u32
-    } else {
-        items.len() as u32
-    };
     // Available height, in terminal rows.
     let avail_rows = visible_rows.max(1);
+    let ListLayout {
+        total,
+        effective_sel,
+        scroll,
+        visible_items,
+        item_height,
+        rendered_cards,
+        user_scrolled,
+    } = plan_list_layout(
+        items.len(),
+        item_specs,
+        selected_index,
+        visible_rows,
+        list_key,
+        prev,
+        focus_key,
+        panel_width,
+    );
 
-    // Look up host-owned scroll + selected index from prev
-    // state (becomes authoritative after first render).
-    // Spec's `selected_index` is initial-only on first mount.
-    let (prev_scroll, prev_sel, prev_user_scrolled) = list_key
-        .and_then(|k| prev.get(k))
-        .and_then(|s| match s {
-            WidgetInstanceState::List {
-                scroll_offset,
-                selected_index,
-                user_scrolled,
-                ..
-            } => Some((*scroll_offset, *selected_index, *user_scrolled)),
-            _ => None,
-        })
-        .unwrap_or((0, selected_index, false));
-    // Clamp the previous selection to the current dataset
-    // size — items may have shrunk between renders. Out-of-
-    // range selections collapse to the last item, or -1 if
-    // the list is now empty.
-    let effective_sel = if prev_sel < 0 || total == 0 {
-        -1
-    } else if (prev_sel as u32) >= total {
-        (total - 1) as i32
-    } else {
-        prev_sel
-    };
-
-    // Pre-render the card blocks (if any) so we know the
-    // uniform card height; the visible-item count and all the
-    // scroll math derive from it. Nested hits/embeds/overlays/
-    // scroll are dropped: a card is a single `select` target
-    // (interactive widgets nested in a card aren't routed yet).
-    let mut rendered_cards: Vec<Vec<TextPropertyEntry>> = Vec::new();
-    let mut item_height: u32 = 1;
-    if use_specs {
-        (rendered_cards, item_height) = render_list_cards(item_specs, prev, focus_key, panel_width);
-    }
-    // How many items fit, and the per-item scroll window.
-    let visible_items = if use_specs {
-        (avail_rows / item_height).max(1)
-    } else {
-        avail_rows
-    };
-
-    // When the card list overflows, the host paints a scrollbar
-    // in the rightmost column — which would sit on top of each
-    // card's right border. Re-render the cards one column
-    // narrower so they leave that column free. (Row count is
-    // width-independent, so `item_height` stays valid.)
-    if use_specs && total > visible_items && panel_width > 1 {
-        // Row count is width-independent, so the re-rendered cards keep
-        // the `item_height` computed above — only their width changes.
-        (rendered_cards, _) = render_list_cards(item_specs, prev, focus_key, panel_width - 1);
-    }
-
-    // Compute scroll. Normally we auto-clamp to keep the
-    // selection in view, but once the user has scrolled by mouse
-    // (`user_scrolled`) we respect their offset as-is so the
-    // selected card can sit off-screen — only the range clamp
-    // below still applies. Selection moves (keyboard/click/plugin)
-    // clear `user_scrolled`, re-arming this follow behaviour.
-    let mut scroll = prev_scroll;
-    if effective_sel >= 0 && !prev_user_scrolled {
-        let sel = effective_sel as u32;
-        if sel < scroll {
-            scroll = sel;
-        }
-        if sel >= scroll + visible_items {
-            scroll = sel + 1 - visible_items;
-        }
-    }
-    let max_scroll = total.saturating_sub(visible_items);
-    if scroll > max_scroll {
-        scroll = max_scroll;
-    }
     // Persist scroll + selection for the next render.
     // Lists without a `key` lose state across updates.
     if let Some(k) = list_key {
@@ -1327,85 +1469,13 @@ fn collect_list(
                 scroll_offset: scroll,
                 selected_index: effective_sel,
                 item_height,
-                user_scrolled: prev_user_scrolled,
+                user_scrolled,
             },
         );
     }
 
     let start = scroll as usize;
     let end = ((scroll + visible_items) as usize).min(total as usize);
-    // Blank full-height-padding row factory.
-    let blank_row = || {
-        let mut padding = TextPropertyEntry {
-            text: String::new(),
-            properties: Default::default(),
-            style: None,
-            inline_overlays: Vec::new(),
-            segments: Vec::new(),
-            pad_to_chars: None,
-            truncate_to_chars: None,
-        };
-        ensure_trailing_newline(&mut padding);
-        padding
-    };
-    // Style a row as the selected item (highlight band that
-    // runs to line end behind a card's borders / text).
-    let mark_selected = |entry: &mut TextPropertyEntry| {
-        let mut style = entry.style.clone().unwrap_or_default();
-        style.bg = Some(OverlayColorSpec::theme_key(KEY_FOCUSED_BG));
-        style.extend_to_line_end = true;
-        entry.style = Some(style);
-    };
-    // Cards indicate selection three ways so it reads in any
-    // theme — even if colours are too subtle: a *heavy* box
-    // border (colour-independent marker), bold, and an accent fg
-    // on the pure-border rows. No background band — it reads
-    // garish over a multi-row card and fights theme colours.
-    // Every box glyph is 3 bytes in both light and heavy forms,
-    // so swapping them preserves inline-overlay byte offsets.
-    let mark_selected_card = |entry: &mut TextPropertyEntry| {
-        entry.text = entry
-            .text
-            .replace('╭', "┏")
-            .replace('╮', "┓")
-            .replace('╰', "┗")
-            .replace('╯', "┛")
-            .replace('─', "━")
-            .replace('│', "┃");
-        let mut style = entry.style.clone().unwrap_or_default();
-        style.bold = true;
-        if entry.text.starts_with('┏') || entry.text.starts_with('┗') {
-            // Top / bottom rows are pure border, so a whole-row fg tints
-            // the corner-to-corner run.
-            style.fg = Some(OverlayColorSpec::theme_key("ui.popup_border_fg"));
-            entry.style = Some(style);
-        } else {
-            // Side rows hold the session text between two vertical border
-            // glyphs. A whole-row fg would repaint the name / git text
-            // (which only carries an fg overlay when the row is *active*),
-            // so tint just the leading and trailing `┃` glyphs with
-            // sub-range overlays. This frames the selected card on all
-            // four sides instead of only top + bottom.
-            entry.style = Some(style);
-            let bar = '┃';
-            let bar_len = bar.len_utf8();
-            let first = entry.text.find(bar);
-            let last = entry.text.rfind(bar);
-            for pos in [first, last].into_iter().flatten().collect::<HashSet<_>>() {
-                entry.inline_overlays.push(InlineOverlay {
-                    start: pos,
-                    end: pos + bar_len,
-                    style: OverlayOptions {
-                        fg: Some(OverlayColorSpec::theme_key("ui.popup_border_fg")),
-                        bold: true,
-                        ..Default::default()
-                    },
-                    properties: Default::default(),
-                    unit: OffsetUnit::Byte,
-                });
-            }
-        }
-    };
 
     let rows_emitted: u32 = if use_specs {
         // Each item occupies a band of `item_height` rows; shorter
@@ -1426,10 +1496,10 @@ fn collect_list(
                 if emitted >= avail_rows {
                     break 'cards;
                 }
-                let mut entry = card.get(r).cloned().unwrap_or_else(blank_row);
+                let mut entry = card.get(r).cloned().unwrap_or_else(blank_list_row);
                 entry.normalize_widths();
                 if is_selected {
-                    mark_selected_card(&mut entry);
+                    mark_list_card_selected(&mut entry);
                 }
                 let byte_end = entry.text.len();
                 ensure_trailing_newline(&mut entry);
@@ -1459,7 +1529,7 @@ fn collect_list(
             let mut entry = item.clone();
             entry.normalize_widths();
             if i as i32 == effective_sel {
-                mark_selected(&mut entry);
+                mark_list_row_selected(&mut entry);
             }
             let byte_end = entry.text.len();
             ensure_trailing_newline(&mut entry);
@@ -1491,7 +1561,7 @@ fn collect_list(
     // occupies its full `visible_rows` (keeps a sibling pane's
     // bottom border aligned). Padding rows aren't clickable.
     for _ in rows_emitted..avail_rows {
-        entries.push(blank_row());
+        entries.push(blank_list_row());
     }
 
     // Surface a scroll region for the host to paint a draggable


### PR DESCRIPTION
## What

Decomposes `collect_list` in `crates/fresh-editor/src/widgets/render.rs` — the worst single function in the largest source file untouched by any open PR.

## Why this file

I audited the project for the highest-ROI maintainability win while **strictly avoiding files under active development**. I cross-referenced the largest Rust files against the changed-file lists of all ~69 open PRs:

- The two biggest God Functions — `app/render.rs::render` (1743 lines) and `plugin_dispatch.rs::handle_plugin_command` (1260 lines) — are both in files touched by multiple open PRs, so they were **off-limits** to avoid merge conflicts.
- `widgets/render.rs` (6508 lines) is the **largest source file with zero pending PR changes**, and its worst offender, `collect_list` (313 lines), matches the size profile of the recently-merged refactors in this branch lineage.

## The offense

`collect_list` was a God Function interleaving four unrelated concerns in one body, all sharing mutable locals:

1. Resolving prior host-owned scroll/selection state and clamping it to the current dataset.
2. Pre-rendering card blocks and computing the scroll window (with a scrollbar re-render pass).
3. **Three inline closures** — including ~40 lines of box-drawing **glyph swapping** for selected cards — wedged between the scroll math and the emit loops.
4. The two divergent row-emit loops (card path vs. classic one-row-per-item path).

## The changes (no behaviour change — pure structural decomposition)

- Extracted all the scroll/selection/card bookkeeping into **`plan_list_layout`**, returning a named **`ListLayout`** struct instead of a tangle of locals.
- Hoisted the three closures into named free functions: **`blank_list_row`**, **`mark_list_row_selected`**, **`mark_list_card_selected`** — isolating the orthogonal border-glyph logic so it's individually nameable and out of the main flow.
- `collect_list` now reads top-to-bottom as **plan → persist → emit → pad → assemble**, dropping from 313 to ~175 lines (the remainder being the two genuine emit loops).

No new traits, generics, or macros. The `#[allow(clippy::too_many_arguments)]` on the new helper matches the existing convention for the sibling `collect_*` functions in this module.

## Verification

- `cargo fmt` — clean.
- `cargo check -p fresh-editor` — passes.
- `cargo clippy -p fresh-editor --lib` — no warnings or errors reference `widgets/render.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015rFDYC1JfnY9vfbvXNG8QB)_