### PR TITLE
Fix ANSI colors vanishing on soft-wrapped continuation rows

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -91,11 +91,23 @@ pub(super) fn render_line_cells<'a>(
     overlay_sweep: &mut OverlayActiveSet<'a>,
     span_cursors: &mut SpanCursors,
     cursor: &mut CursorTracker,
+    ansi_parser: &mut Option<AnsiParser>,
     cell_theme_map: &mut [CellThemeInfo],
     line_spans: &mut Vec<Span<'static>>,
     line_view_map: &mut Vec<Option<usize>>,
 ) -> CellPassOutput {
     let line_content: &'a str = &input.view_line.text;
+
+    // The ANSI parser is threaded across the soft-wrapped rows of one
+    // logical line (the caller resets it to `None` at each new logical
+    // line). Create it lazily the first time a row carries ESC so that
+    // colors — and a multi-byte SGR sequence split across a wrap
+    // boundary — continue onto the wrapped continuation rows instead of
+    // resetting to the default style at every row. Rows whose logical
+    // line never contains ESC keep the `None` fast path.
+    if ansi_parser.is_none() && line_content.contains('\x1b') {
+        *ansi_parser = Some(AnsiParser::new());
+    }
 
     // Reset the per-row touched set. Wrap continuations inherit overlays
     // still active from the previous row of the same source line; new
@@ -103,9 +115,8 @@ pub(super) fn render_line_cells<'a>(
     overlay_sweep.enter_row(matches!(input.view_line.line_start, LineStart::AfterBreak));
 
     let mut pass = CellPass {
-        // ANSI parser for this line to handle escape sequences.
-        // Optimization: only create parser if line contains ESC byte.
-        ansi_parser: line_content.contains('\x1b').then(AnsiParser::new),
+        // ANSI parser threaded from the caller across wrapped rows.
+        ansi_parser,
         // Debug mode: track active highlight/overlay spans for
         // WordPerfect-style reveal codes.
         debug_tracker: input
@@ -157,7 +168,7 @@ struct CellPass<'a, 'b> {
     /// Merges consecutive characters with the same style — critical for
     /// proper rendering of combining characters (Thai, etc.)
     span_acc: SpanAccumulator,
-    ansi_parser: Option<AnsiParser>,
+    ansi_parser: &'b mut Option<AnsiParser>,
     debug_tracker: Option<DebugSpanTracker>,
     /// First/last non-whitespace char indices (whitespace indicators).
     non_ws: (Option<usize>, Option<usize>),
@@ -595,8 +606,8 @@ impl CellPass<'_, '_> {
     /// Run `ch` through the line's ANSI parser; `None` means the char is
     /// part of an escape sequence. Lines without ESC use the fast path.
     fn parse_ansi(&mut self, ch: char) -> Option<Style> {
-        match self.ansi_parser {
-            Some(ref mut parser) => parser.parse_char(ch),
+        match self.ansi_parser.as_mut() {
+            Some(parser) => parser.parse_char(ch),
             None => Some(Style::default()),
         }
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -188,6 +188,14 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     let mut lines_rendered = 0usize;
     let mut view_iter_idx = view_anchor.start_line_idx;
     let mut cursor = CursorTracker::default();
+    // ANSI parser state threaded across the soft-wrapped continuation rows
+    // of a single logical line. Terminal scrollback stores each terminal
+    // line as one *unwrapped* logical line, so a long colored line wraps
+    // into several view rows here; without carrying the parser, every row
+    // after the first reset to the default style (colors vanished, and an
+    // SGR sequence split across the wrap showed up as literal text). Reset
+    // at each new logical line below.
+    let mut ansi_parser: Option<crate::primitives::ansi::AnsiParser> = None;
     let mut last_line_end: Option<LastLineEnd> = None;
     let mut last_gutter_num: Option<usize> = None;
     let mut trailing_empty_line_rendered = false;
@@ -345,6 +353,13 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         };
         let max_chars_to_process = left_col.saturating_add(max_visible_chars);
 
+        // A soft-wrap continuation (`AfterBreak`) keeps the running ANSI
+        // state so colors persist across the wrap; any other line start
+        // begins a fresh logical line, so reset to the default style.
+        if line_start_type != LineStart::AfterBreak {
+            ansi_parser = None;
+        }
+
         // Per-cell pass: walk the line's characters and emit styled spans
         let cells = render_line_cells(
             CellPassInput {
@@ -370,6 +385,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
             &mut overlay_sweep,
             &mut span_cursors,
             &mut cursor,
+            &mut ansi_parser,
             cell_theme_map.as_mut_slice(),
             &mut line_spans,
             &mut line_view_map,

--- a/crates/fresh-editor/tests/e2e/issue_2449_scrollback_wrapped_ansi_color.rs
+++ b/crates/fresh-editor/tests/e2e/issue_2449_scrollback_wrapped_ansi_color.rs
@@ -1,0 +1,73 @@
+//! End-to-end regression test for issue #2449: ANSI colors vanish on the
+//! soft-wrapped continuation rows of a colored line.
+//!
+//! Terminal scrollback stores each terminal line as one *unwrapped* logical
+//! line that the read-only view soft-wraps, so a long colored line occupies
+//! several visual rows. The bug rendered only the *first* of those rows in
+//! color; every wrapped continuation row fell back to the default foreground
+//! (the colors "disappeared" the moment you entered scrollback). The same
+//! buffer-level ANSI rendering powers viewing any colored log file, so this
+//! test drives that flow directly: open an ANSI-colored file in a viewport
+//! narrow enough to force wrapping and assert — from rendered output only —
+//! that a wrapped continuation row keeps the color.
+
+use crate::common::harness::EditorTestHarness;
+use fresh::config::Config;
+use ratatui::style::Color;
+use tempfile::TempDir;
+
+fn config_with_wrap() -> Config {
+    let mut config = Config::default();
+    config.editor.line_wrap = true;
+    config
+}
+
+/// Foreground color of the first cell on `row` whose rendered character is
+/// `ch`. Scans the whole row so the gutter (line numbers) is skipped
+/// naturally — observes only what is painted on screen.
+fn fg_of_first_char(harness: &EditorTestHarness, row: u16, ch: &str, width: u16) -> Option<Color> {
+    (0..width)
+        .find(|&x| harness.get_cell(x, row).as_deref() == Some(ch))
+        .and_then(|x| harness.get_cell_style(x, row))
+        .and_then(|style| style.fg)
+}
+
+#[test]
+fn issue_2449_ansi_color_persists_across_wrapped_rows() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("colored.log");
+
+    // One logical line, colored truecolor red (`38;2;r;g;b` => Color::Rgb),
+    // long enough to wrap several times at 40 columns. The 'X' marker recurs
+    // every few characters so every wrapped row contains one.
+    let red = "\x1b[38;2;220;50;47m";
+    let reset = "\x1b[0m";
+    let body = "REDX ".repeat(40); // 200 chars -> multiple wrapped rows
+    std::fs::write(&path, format!("{red}{body}{reset}\n")).unwrap();
+
+    let width = 40u16;
+    let mut harness = EditorTestHarness::with_config(width, 24, config_with_wrap()).unwrap();
+    harness.open_file(&path).unwrap();
+    harness.render().unwrap();
+
+    let expected = Color::Rgb(220, 50, 47);
+    let (first_content_row, _) = harness.content_area_rows();
+    let first_row = first_content_row as u16;
+    let continuation_row = first_row + 1;
+
+    // Precondition: the first row of the wrapped line is colored.
+    assert_eq!(
+        fg_of_first_char(&harness, first_row, "X", width),
+        Some(expected),
+        "precondition: first wrapped row should carry the ANSI color"
+    );
+
+    // Regression: the wrapped continuation row must ALSO carry the color.
+    // Before the fix it rendered with the default foreground (color lost
+    // after the soft-wrap).
+    assert_eq!(
+        fg_of_first_char(&harness, continuation_row, "X", width),
+        Some(expected),
+        "wrapped continuation row lost its ANSI color (issue #2449)"
+    );
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -78,6 +78,7 @@ pub mod issue_2357_shebang_interpreter;
 pub mod issue_2362_replace_toolbar_theme;
 pub mod issue_2373_buffer_switcher_virtual;
 pub mod issue_2405_brackets_in_comments;
+pub mod issue_2449_scrollback_wrapped_ansi_color;
 pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod suspend_process;


### PR DESCRIPTION
## Summary
Fixes issue #2449 where ANSI color codes were lost on soft-wrapped continuation rows when viewing colored terminal output or log files in the scrollback buffer.

## Problem
Terminal scrollback stores each terminal line as a single unwrapped logical line. When a long colored line is soft-wrapped across multiple visual rows in a narrow viewport, only the first row retained the ANSI color styling. Continuation rows after the wrap would reset to the default foreground color, making the colors appear to "vanish" when entering scrollback.

## Root Cause
The ANSI parser was being created fresh for each visual row, rather than being threaded across the soft-wrapped continuation rows of a single logical line. This caused the parser state (current color, style attributes, etc.) to be lost at each wrap boundary.

## Solution
Thread the ANSI parser state across soft-wrapped continuation rows of the same logical line:

- **render_line/mod.rs**: Introduce `ansi_parser` as a persistent state variable that carries across wrapped rows. Reset it only when starting a new logical line (not on `LineStart::AfterBreak`).
- **render_line/cells.rs**: Accept the parser as a mutable reference from the caller instead of creating it locally. Lazily initialize it only when the line contains ESC sequences, preserving the fast path for non-colored lines.
- **tests/e2e/issue_2449_scrollback_wrapped_ansi_color.rs**: Add regression test that verifies ANSI colors persist across wrapped rows by opening a long colored line in a narrow viewport and asserting that continuation rows maintain their RGB color styling.

## Implementation Details
- The parser is reset to `None` at each new logical line boundary (when `line_start_type != LineStart::AfterBreak`)
- Soft-wrap continuations (`LineStart::AfterBreak`) inherit the running parser state from the previous row
- The optimization of only creating the parser when ESC is present is preserved
- The test uses a 40-column viewport with a 200-character colored line to force multiple wrapped rows and verify color persistence

https://claude.ai/code/session_01CaJWfyDdVuHFLpW4Bi99vZ