### PR TITLE
Scope action popups to specific buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The cli now supports `--cmd daemon`, but still accepts the now-deprecated `--cmd
 * Shebang language detection now covers interpreters whose grammars ship no first-line regex — `#!/usr/bin/fish`, Lua, PowerShell, Tcl, Groovy, Elixir, R, Julia, Nushell, Dart, Deno, … — so extensionless scripts highlight from the shebang instead of falling through to plain text (#2357, reported by @shemgp). `env` indirection (`env -S`, `env VAR=val`) and versioned interpreters (`python3.11`) are handled; an existing extension match still wins.
 * Java (jdtls) and other Eclipse LSP4J servers: features registered via `client/registerCapability` now work — their string JSON-RPC ids were misparsed as notifications and dropped (#2340, reported by @maxandersen).
 * LSP/plugin popups follow the active theme's `popup_*` colors instead of a hard-wired dark background (#2379, by @peanball).
+* The asm-lsp "no `.asm-lsp.toml` found" offer is now scoped to the assembly buffer that triggered it — it renders only while that buffer is active instead of floating over every other buffer. Plugins can opt into this with the new `buffer_id` field on `showActionPopup`.
 * Paste falls back to the internal clipboard and works again on Termux (#2343, reported by @nightshade427).
 * npm `.cmd`/`.bat` shims resolve on Windows, so npm-installed language servers spawn (#2324, reported by @SupertigerDev).
 * Occurrence highlighting uses a theme-appropriate background in every shipped theme (#2312).

--- a/crates/fresh-core/src/api.rs
+++ b/crates/fresh-core/src/api.rs
@@ -3424,6 +3424,12 @@ pub enum PluginCommand {
         message: String,
         /// Action buttons to display
         actions: Vec<ActionPopupAction>,
+        /// When `Some`, the popup is scoped to that buffer: it renders only
+        /// while that buffer is active and is torn down when the buffer
+        /// closes, instead of floating over every buffer on the editor-level
+        /// stack. Use for popups raised in response to a specific buffer (an
+        /// `after_file_open` config offer) rather than global notifications.
+        buffer_id: Option<usize>,
     },
 
     /// Contribute (or replace, or clear) a set of menu rows for the
@@ -4114,6 +4120,13 @@ pub struct ActionPopupOptions {
     pub message: String,
     /// Action buttons to display
     pub actions: Vec<ActionPopupAction>,
+    /// Optional buffer to scope the popup to. When set, the popup only
+    /// renders while that buffer is active (and is dismissed when the buffer
+    /// closes), rather than floating over every buffer. Omit for global
+    /// notifications like install help raised from a status-bar click.
+    #[serde(default)]
+    #[ts(optional)]
+    pub buffer_id: Option<usize>,
 }
 
 /// Syntax highlight span for a buffer range

--- a/crates/fresh-editor/plugins/asm-lsp.ts
+++ b/crates/fresh-editor/plugins/asm-lsp.ts
@@ -289,6 +289,11 @@ async function maybeOfferConfig(bufferId: number, path: string) {
   const alternates = ASSEMBLERS.filter((a) => a !== assembler);
   editor.showActionPopup({
     id: "asm-lsp-config-offer",
+    // Scope the offer to the buffer that triggered it: this is a reaction to
+    // opening one assembly file, not a global notification, so it should only
+    // show while that buffer is active (and vanish when it closes) rather than
+    // floating over every other buffer.
+    buffer_id: bufferId,
     title: "Assembly LSP: no .asm-lsp.toml found",
     message:
       `Without a config, asm-lsp assumes GAS syntax on x86/x86-64 — other dialects get wrong diagnostics and docs.\n\n` +

--- a/crates/fresh-editor/plugins/lib/fresh.d.ts
+++ b/crates/fresh-editor/plugins/lib/fresh.d.ts
@@ -577,6 +577,13 @@ type ActionPopupOptions = {
 	* Action buttons to display
 	*/
 	actions: Array<TsActionPopupAction>;
+	/**
+	* Optional buffer to scope the popup to. When set, the popup only
+	* renders while that buffer is active (and is dismissed when the buffer
+	* closes), rather than floating over every buffer. Omit for global
+	* notifications like install help raised from a status-bar click.
+	*/
+	buffer_id?: number;
 };
 type TsLspMenuItem = {
 	/**

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -1228,8 +1228,9 @@ impl Editor {
                 title,
                 message,
                 actions,
+                buffer_id,
             } => {
-                self.handle_show_action_popup(popup_id, title, message, actions);
+                self.handle_show_action_popup(popup_id, title, message, actions, buffer_id);
             }
 
             PluginCommand::SetLspMenuContributions {
@@ -3307,12 +3308,14 @@ impl Editor {
         title: String,
         message: String,
         actions: Vec<fresh_core::api::ActionPopupAction>,
+        buffer_id: Option<usize>,
     ) {
         tracing::info!(
-            "Action popup requested: id={}, title={}, actions={}",
+            "Action popup requested: id={}, title={}, actions={}, buffer_id={:?}",
             popup_id,
             title,
-            actions.len()
+            actions.len(),
+            buffer_id,
         );
 
         // Build popup list items from actions
@@ -3363,6 +3366,43 @@ impl Editor {
         popup_obj.resolver = crate::view::popup::PopupResolver::PluginAction {
             popup_id: popup_id.clone(),
         };
+
+        // Buffer-scoped popup: a plugin raised this for one specific buffer
+        // (e.g. asm-lsp's `.asm-lsp.toml` offer on `after_file_open`), so it
+        // belongs on that buffer's popup stack — it then renders only while
+        // that buffer is active and is dropped when the buffer closes,
+        // instead of floating over every buffer like a global notification.
+        // Fall back to the global stack if the buffer has since closed, so
+        // the popup is never silently lost.
+        if let Some(bid) = buffer_id {
+            let bid = BufferId(bid);
+            let stack = self
+                .windows
+                .values_mut()
+                .find_map(|w| w.buffers.get_mut(&bid))
+                .map(|state| &mut state.popups);
+            if let Some(stack) = stack {
+                // Dedup by `popup_id` within this buffer's stack — repeated
+                // file-open hooks shouldn't pile up duplicate offers.
+                let existing_idx = stack.all().iter().position(|p| {
+                    matches!(
+                        &p.resolver,
+                        crate::view::popup::PopupResolver::PluginAction { popup_id: id } if id == &popup_id,
+                    )
+                });
+                match existing_idx.and_then(|idx| stack.get_mut(idx)) {
+                    Some(slot) => *slot = popup_obj,
+                    None => stack.show(popup_obj),
+                }
+                tracing::info!("Action popup shown on buffer {:?}: id={}", bid, popup_id,);
+                return;
+            }
+            tracing::warn!(
+                "Action popup id={} requested for missing buffer {:?}; showing globally",
+                popup_id,
+                bid,
+            );
+        }
 
         // Dismiss any built-in LSP-status popup that the editor put
         // on `active_state().popups` in response to the same click —

--- a/crates/fresh-editor/tests/e2e/action_popup_global.rs
+++ b/crates/fresh-editor/tests/e2e/action_popup_global.rs
@@ -30,6 +30,7 @@ fn show_devcontainer_attach_popup(harness: &mut EditorTestHarness) {
                     label: "Not now".to_string(),
                 },
             ],
+            buffer_id: None,
         })
         .unwrap();
 }
@@ -212,6 +213,7 @@ fn show_devcontainer_attach_popup_named(
                     label: "Not now".to_string(),
                 },
             ],
+            buffer_id: None,
         })
         .unwrap();
 }
@@ -236,6 +238,7 @@ fn show_generic_popup(
                     label: label.to_string(),
                 })
                 .collect(),
+            buffer_id: None,
         })
         .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
+++ b/crates/fresh-editor/tests/e2e/lsp_indicator_click_bugs.rs
@@ -204,6 +204,7 @@ fn push_plugin_action_popup(
                 id: "dismiss".to_string(),
                 label: "Dismiss".to_string(),
             }],
+            buffer_id: None,
         })?;
     Ok(())
 }

--- a/crates/fresh-editor/tests/e2e/plugins/asm_lsp_config.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/asm_lsp_config.rs
@@ -122,6 +122,51 @@ fn test_asm_lsp_config_offer_detects_gas() {
 }
 
 #[test]
+fn test_asm_lsp_config_offer_is_scoped_to_triggering_buffer() {
+    // The offer is raised in response to opening one assembly file, so it
+    // must be scoped to that buffer: switching to an unrelated buffer should
+    // hide it (it isn't a global notification floating over every buffer),
+    // and switching back should reveal it again since it's still unanswered.
+    let temp = tempfile::TempDir::new().unwrap();
+    let project_root = setup_project(temp.path(), "hello.asm", NASM_SOURCE);
+    let other_path = project_root.join("notes.txt");
+    fs::write(&other_path, "just some prose, not assembly\n").unwrap();
+
+    let mut harness = EditorTestHarness::with_config_and_working_dir(
+        120,
+        40,
+        Default::default(),
+        project_root.clone(),
+    )
+    .unwrap();
+
+    harness.open_file(&project_root.join("hello.asm")).unwrap();
+    harness
+        .wait_for_screen_contains("Assembly LSP: no .asm-lsp.toml found")
+        .unwrap();
+
+    // Switch to the unrelated buffer — the offer must not follow us there.
+    harness.open_file(&other_path).unwrap();
+    harness
+        .wait_until(|h| h.screen_to_string().contains("just some prose"))
+        .unwrap();
+    for _ in 0..10 {
+        harness.tick_and_render().unwrap();
+    }
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Assembly LSP: no .asm-lsp.toml found"),
+        "config offer must not render over an unrelated buffer:\n{screen}"
+    );
+
+    // Back to the assembly buffer — the still-unanswered offer reappears.
+    harness.open_file(&project_root.join("hello.asm")).unwrap();
+    harness
+        .wait_for_screen_contains("Assembly LSP: no .asm-lsp.toml found")
+        .unwrap();
+}
+
+#[test]
 fn test_asm_lsp_config_offer_skipped_when_config_exists() {
     let temp = tempfile::TempDir::new().unwrap();
     let project_root = setup_project(temp.path(), "hello.asm", NASM_SOURCE);

--- a/crates/fresh-editor/tests/e2e/plugins/devcontainer_failed_attach_popup.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/devcontainer_failed_attach_popup.rs
@@ -101,6 +101,7 @@ fn show_failed_attach_popup(harness: &mut EditorTestHarness) {
                     label: "Dismiss (ESC)".to_string(),
                 },
             ],
+            buffer_id: None,
         })
         .unwrap();
 }

--- a/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
+++ b/crates/fresh-plugin-runtime/src/backend/quickjs_backend.rs
@@ -5138,6 +5138,7 @@ impl JsEditorApi {
                 title: opts.title,
                 message: opts.message,
                 actions: opts.actions,
+                buffer_id: opts.buffer_id,
             })
             .is_ok()
     }


### PR DESCRIPTION
## Summary
Add support for scoping action popups to specific buffers, allowing plugins to raise popups that only display while a particular buffer is active. This is useful for buffer-specific notifications like configuration offers that should not float over unrelated buffers.

## Key Changes
- **API Extension**: Added optional `buffer_id` field to `PluginCommand::ShowActionPopup` and `ActionPopupOptions` to allow plugins to scope popups to a specific buffer
- **Buffer-Scoped Rendering**: Modified `handle_show_action_popup()` to place buffer-scoped popups on the target buffer's popup stack instead of the global editor stack, ensuring they only render when that buffer is active
- **Deduplication**: Implemented deduplication by `popup_id` within a buffer's popup stack to prevent repeated file-open hooks from piling up duplicate offers
- **Fallback Behavior**: If the target buffer has closed, the popup falls back to the global stack so it's never silently lost
- **asm-lsp Integration**: Updated the asm-lsp plugin to scope its `.asm-lsp.toml` configuration offer to the buffer that triggered it
- **Test Coverage**: Added `test_asm_lsp_config_offer_is_scoped_to_triggering_buffer()` to verify that buffer-scoped popups hide when switching to other buffers and reappear when returning to the original buffer
- **TypeScript Definitions**: Updated `fresh.d.ts` with the new optional `buffer_id` field

## Implementation Details
- Buffer-scoped popups are stored on `BufferState.popups` rather than the active window's popup stack
- The implementation gracefully handles the case where a buffer has been closed by falling back to global display
- Logging includes buffer ID information for debugging buffer-scoped popup behavior
- All existing test cases updated to explicitly pass `buffer_id: None` for global popups

https://claude.ai/code/session_01RG4jPJ7cYsnQ28AwEC59hZ