### PR TITLE
Make tab-bar popups modal with keyboard capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ The cli now supports `--cmd daemon`, but still accepts the now-deprecated `--cmd
 * Occurrence highlighting uses a theme-appropriate background in every shipped theme (#2312).
 * Review Diff lists files inside untracked directories (#2315).
 * The embedded terminal forwards the wheel as a mouse report to mouse-tracking programs, so scrolling no longer cycles their history (#2366).
+* The tab bar's "+" new-tab popup and the tab right-click context menu now grab the keyboard while open: Up/Down navigate, Enter selects, Esc dismisses, and every other key is filtered out instead of leaking into the active buffer underneath.
 * Replace toolbar: checked search options are visible in every theme (#2363).
 * Alt+W and other search toggles no longer leak into the close prompt (#2359).
 * Fixed a crash on a stale soft-wrap position in multi-byte text (#2320).

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -355,6 +355,31 @@ impl Editor {
                 blocks_terminal_input: true,
             });
         }
+        // The tab-bar popups (the "+" new-tab menu and the tab right-click
+        // context menu) are modal chrome: while one is open it owns the
+        // keyboard via a custom dispatcher (`handle_new_tab_menu_key` /
+        // `handle_tab_context_menu_key`, run from `handle_key` ahead of
+        // `KeyContext` resolution), so they expose no `KeyContext` here.
+        // Like any covering overlay they block PTY routing — otherwise keys
+        // would leak into an active terminal buffer underneath instead of
+        // driving the menu. Ranked below `Popup` so the unfocused-popup
+        // `take_while` guard above is unaffected.
+        if self.active_window().new_tab_menu.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::NewTabMenu,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
+        if self.active_window().tab_context_menu.is_some() {
+            layers.push(Layer {
+                kind: LayerKind::TabContextMenu,
+                owns_keyboard: true,
+                key_context: None,
+                blocks_terminal_input: true,
+            });
+        }
         // The centered widget modal (picker / new-session form / plugin
         // overlay) owns the keyboard when focused. It resolves as `Normal`
         // regardless of the underlying buffer's (possibly stale) context so

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -556,6 +556,17 @@ impl Editor {
             }
         }
 
+        // The tab-bar popups (the "+" new-tab menu and the tab right-click
+        // context menu) are modal: while one is open it owns the keyboard so
+        // navigation/selection work and every other key is filtered out
+        // instead of leaking into the active buffer underneath.
+        if let Some(result) = self.handle_new_tab_menu_key(code) {
+            return result;
+        }
+        if let Some(result) = self.handle_tab_context_menu_key(code) {
+            return result;
+        }
+
         // Determine the current context first
         let mut context = self.get_key_context();
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -3576,6 +3576,97 @@ impl Editor {
         Ok(())
     }
 
+    /// Handle keyboard input for the "+" new-tab popup menu.
+    ///
+    /// While the popup is open it owns the keyboard: Up/Down move the
+    /// highlight, Enter activates the highlighted item, Esc dismisses it,
+    /// and *every other key is swallowed* so nothing leaks into the buffer
+    /// underneath. Returns `Some` when a popup is open (the key is always
+    /// consumed in that case), `None` when there is no popup.
+    pub(super) fn handle_new_tab_menu_key(
+        &mut self,
+        code: crossterm::event::KeyCode,
+    ) -> Option<AnyhowResult<()>> {
+        use crossterm::event::KeyCode;
+
+        self.active_window().new_tab_menu.as_ref()?;
+
+        match code {
+            KeyCode::Up => {
+                if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
+                    menu.prev_item();
+                }
+            }
+            KeyCode::Down => {
+                if let Some(ref mut menu) = self.active_window_mut().new_tab_menu {
+                    menu.next_item();
+                }
+            }
+            KeyCode::Enter => {
+                let selected = self.active_window().new_tab_menu.as_ref().map(|menu| {
+                    (
+                        super::types::NewTabMenuItem::all()[menu.highlighted],
+                        menu.split_id,
+                    )
+                });
+                self.active_window_mut().new_tab_menu = None;
+                if let Some((item, split_id)) = selected {
+                    return Some(self.execute_new_tab_menu_action(item, split_id));
+                }
+            }
+            KeyCode::Esc => {
+                self.active_window_mut().new_tab_menu = None;
+            }
+            // Filter out everything else while the popup is focused.
+            _ => {}
+        }
+        Some(Ok(()))
+    }
+
+    /// Handle keyboard input for the tab right-click context menu.
+    ///
+    /// Modal like [`handle_new_tab_menu_key`]: Up/Down navigate, Enter
+    /// activates the highlighted item, Esc dismisses, and all other keys are
+    /// swallowed so they can't reach the buffer underneath.
+    pub(super) fn handle_tab_context_menu_key(
+        &mut self,
+        code: crossterm::event::KeyCode,
+    ) -> Option<AnyhowResult<()>> {
+        use crossterm::event::KeyCode;
+
+        self.active_window().tab_context_menu.as_ref()?;
+
+        match code {
+            KeyCode::Up => {
+                if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
+                    menu.prev_item();
+                }
+            }
+            KeyCode::Down => {
+                if let Some(ref mut menu) = self.active_window_mut().tab_context_menu {
+                    menu.next_item();
+                }
+            }
+            KeyCode::Enter => {
+                let selected = self
+                    .active_window()
+                    .tab_context_menu
+                    .as_ref()
+                    .map(|menu| (menu.highlighted_item(), menu.buffer_id, menu.split_id));
+                self.active_window_mut().tab_context_menu = None;
+                if let Some((item, buffer_id, split_id)) = selected {
+                    return Some(self.execute_tab_context_menu_action(item, buffer_id, split_id));
+                }
+            }
+            KeyCode::Esc => {
+                self.active_window_mut().tab_context_menu = None;
+            }
+            // Filter out everything else while the popup is focused.
+            _ => {}
+        }
+        Some(Ok(()))
+    }
+
     /// Handle keyboard navigation for the file explorer context menu.
     /// Returns `Some` if the key was consumed, `None` to let normal dispatch continue.
     pub(super) fn handle_file_explorer_context_menu_key(

--- a/crates/fresh-editor/src/app/overlay.rs
+++ b/crates/fresh-editor/src/app/overlay.rs
@@ -43,6 +43,14 @@ pub(crate) enum LayerKind {
     Menu,
     Prompt,
     Popup,
+    /// The tab bar's "+" new-tab popup (`active_window().new_tab_menu`). A
+    /// modal chrome menu with a custom key dispatcher
+    /// (`handle_new_tab_menu_key`), so it's transparent to `KeyContext`
+    /// resolution but still blocks PTY routing while open.
+    NewTabMenu,
+    /// The tab right-click context menu (`active_window().tab_context_menu`),
+    /// same treatment as `NewTabMenu`.
+    TabContextMenu,
     /// The centered widget modal (`floating_widget_panel`).
     FloatingModal,
     /// The editor-global left dock (`dock`).

--- a/crates/fresh-editor/tests/e2e/tab_new_button.rs
+++ b/crates/fresh-editor/tests/e2e/tab_new_button.rs
@@ -100,21 +100,17 @@ fn plus_button_menu_captures_keyboard_and_filters_keys() {
     harness.assert_screen_contains("New Terminal");
 
     // The popup is modal: typing while it's open must be swallowed, not
-    // inserted into the active buffer underneath.
+    // inserted into the active buffer underneath. Observed on screen: the
+    // typed text never appears, and the status bar's cursor stays put.
     harness.type_text("ZZZ").unwrap();
     harness.render().unwrap();
-    assert_eq!(
-        harness.get_buffer_content().as_deref(),
-        Some(""),
-        "keystrokes leaked into the buffer while the '+' popup was open"
-    );
+    harness.assert_screen_not_contains("ZZZ");
+    harness.assert_screen_contains("Ln 1, Col 1");
     harness.assert_screen_contains("New Terminal");
 
     // Keyboard navigation drives the popup: Down highlights "New File",
     // Enter activates it (creating a second buffer) and closes the popup.
-    harness
-        .send_key(KeyCode::Down, KeyModifiers::NONE)
-        .unwrap();
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
     harness
         .send_key(KeyCode::Enter, KeyModifiers::NONE)
         .unwrap();
@@ -160,14 +156,12 @@ fn tab_context_menu_captures_keyboard_and_filters_keys() {
     harness.mouse_right_click(2, 1).unwrap();
     harness.assert_screen_contains("Close Others");
 
-    // Modal: typing must not leak into the buffer underneath.
+    // Modal: typing must not leak into the buffer underneath. The menu
+    // overlaps the text area, so observe the status bar's cursor instead —
+    // it stays at "Ln 1, Col 1" rather than advancing to "Col 4".
     harness.type_text("QQQ").unwrap();
     harness.render().unwrap();
-    assert_eq!(
-        harness.get_buffer_content().as_deref(),
-        Some(""),
-        "keystrokes leaked into the buffer while the tab context menu was open"
-    );
+    harness.assert_screen_contains("Ln 1, Col 1");
     harness.assert_screen_contains("Close Others");
 
     // Esc dismisses the menu without taking any action.

--- a/crates/fresh-editor/tests/e2e/tab_new_button.rs
+++ b/crates/fresh-editor/tests/e2e/tab_new_button.rs
@@ -5,6 +5,7 @@
 //! creates a new empty buffer (a second tab appears).
 
 use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
 
 /// Locate the 0-based cell column of `needle` on the given (0-based) screen row.
 fn col_of_char_on_row(screen: &str, row: usize, needle: char) -> Option<u16> {
@@ -84,6 +85,98 @@ fn plus_button_pins_to_right_edge_on_overflow() {
     harness.mouse_click(plus_col, 1).unwrap();
     harness.assert_screen_contains("New Terminal");
     harness.assert_screen_contains("New File");
+}
+
+#[test]
+fn plus_button_menu_captures_keyboard_and_filters_keys() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let plus_col = col_of_char_on_row(&screen, 1, '+').unwrap_or_else(|| {
+        panic!("expected a '+' new-tab button on the tab row. Screen:\n{screen}")
+    });
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+
+    // The popup is modal: typing while it's open must be swallowed, not
+    // inserted into the active buffer underneath.
+    harness.type_text("ZZZ").unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.get_buffer_content().as_deref(),
+        Some(""),
+        "keystrokes leaked into the buffer while the '+' popup was open"
+    );
+    harness.assert_screen_contains("New Terminal");
+
+    // Keyboard navigation drives the popup: Down highlights "New File",
+    // Enter activates it (creating a second buffer) and closes the popup.
+    harness
+        .send_key(KeyCode::Down, KeyModifiers::NONE)
+        .unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("New Terminal"),
+        "popup should be dismissed after Enter. Screen:\n{screen}"
+    );
+    harness.assert_screen_contains("[No Name] 2");
+}
+
+#[test]
+fn plus_button_menu_dismisses_on_escape() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    let plus_col = col_of_char_on_row(&screen, 1, '+').unwrap_or_else(|| {
+        panic!("expected a '+' new-tab button on the tab row. Screen:\n{screen}")
+    });
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("New Terminal"),
+        "Esc should dismiss the '+' popup. Screen:\n{screen}"
+    );
+    assert!(
+        !screen.contains("[No Name] 2"),
+        "Esc should not create a new buffer. Screen:\n{screen}"
+    );
+}
+
+#[test]
+fn tab_context_menu_captures_keyboard_and_filters_keys() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.render().unwrap();
+
+    // Right-click the (only) tab to open its context menu.
+    harness.mouse_right_click(2, 1).unwrap();
+    harness.assert_screen_contains("Close Others");
+
+    // Modal: typing must not leak into the buffer underneath.
+    harness.type_text("QQQ").unwrap();
+    harness.render().unwrap();
+    assert_eq!(
+        harness.get_buffer_content().as_deref(),
+        Some(""),
+        "keystrokes leaked into the buffer while the tab context menu was open"
+    );
+    harness.assert_screen_contains("Close Others");
+
+    // Esc dismisses the menu without taking any action.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Close Others"),
+        "Esc should dismiss the tab context menu. Screen:\n{screen}"
+    );
 }
 
 #[test]

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -43,6 +43,98 @@ macro_rules! harness_or_return {
     };
 }
 
+/// Locate the 0-based column of `needle` on the (0-based) tab row (row 1).
+fn tab_row_col_of(screen: &str, needle: char) -> Option<u16> {
+    screen
+        .lines()
+        .nth(1)?
+        .chars()
+        .position(|c| c == needle)
+        .map(|p| p as u16)
+}
+
+/// Locate the 0-based column where `needle` begins on the tab row (row 1).
+fn tab_row_col_of_str(screen: &str, needle: &str) -> Option<u16> {
+    let line = screen.lines().nth(1)?;
+    let byte_idx = line.find(needle)?;
+    Some(line[..byte_idx].chars().count() as u16)
+}
+
+/// Regression: with the keyboard focused on an *active terminal* buffer
+/// (terminal mode owns the keyboard), opening the tab bar's "+" popup must
+/// still hand the keyboard to the popup. Its navigation keys drive the menu
+/// instead of leaking into the terminal's PTY child.
+///
+/// Without the popup being registered as a terminal-blocking overlay,
+/// `dispatch_terminal_input` (which runs before the popup's key handler)
+/// would swallow the keys: Enter would reach the shell, the popup would stay
+/// open, and no new buffer would be created.
+#[test]
+fn plus_button_menu_grabs_keyboard_from_active_terminal() {
+    let mut harness = harness_or_return!(120, 30);
+
+    // Focus an active terminal buffer.
+    harness.editor_mut().open_terminal();
+    assert!(harness.editor().is_terminal_mode());
+    harness.render().unwrap();
+
+    // Open the tab bar's trailing "+" popup (a left-click on chrome that
+    // leaves the terminal the active, focused buffer).
+    let screen = harness.screen_to_string();
+    let plus_col = tab_row_col_of(&screen, '+').unwrap_or_else(|| {
+        panic!("expected a '+' new-tab button on the tab row. Screen:\n{screen}")
+    });
+    harness.mouse_click(plus_col, 1).unwrap();
+    harness.assert_screen_contains("New Terminal");
+    harness.assert_screen_contains("New File");
+
+    // Drive the popup from the keyboard: Down highlights "New File", Enter
+    // activates it. If the keys leaked into the terminal, the popup would
+    // stay open and no new file buffer would appear.
+    harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("New Terminal"),
+        "popup should close once Enter selects an item. Screen:\n{screen}"
+    );
+    harness.assert_screen_contains("[No Name] 2");
+}
+
+/// Regression: the tab right-click context menu must likewise grab the
+/// keyboard from an active terminal. Opened over the terminal's own tab,
+/// Esc dismisses it — without the fix Esc would reach the PTY instead and
+/// the menu would stay open.
+#[test]
+fn tab_context_menu_grabs_keyboard_from_active_terminal() {
+    let mut harness = harness_or_return!(120, 30);
+
+    harness.editor_mut().open_terminal();
+    assert!(harness.editor().is_terminal_mode());
+    harness.render().unwrap();
+
+    // Right-click the terminal's own tab so the terminal stays the active
+    // buffer (and terminal mode keeps the keyboard).
+    let screen = harness.screen_to_string();
+    let term_col = tab_row_col_of_str(&screen, "Terminal").unwrap_or_else(|| {
+        panic!("expected the '*Terminal 0*' tab on the tab row. Screen:\n{screen}")
+    });
+    harness.mouse_right_click(term_col, 1).unwrap();
+    harness.assert_screen_contains("Close Others");
+
+    // Esc must dismiss the menu rather than leak into the terminal.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    let screen = harness.screen_to_string();
+    assert!(
+        !screen.contains("Close Others"),
+        "Esc should dismiss the tab context menu opened over a terminal. Screen:\n{screen}"
+    );
+}
+
 /// Test opening a terminal creates a buffer and switches to it
 #[test]
 fn test_open_terminal() {


### PR DESCRIPTION
## Summary
This PR makes the tab-bar popups (the "+" new-tab menu and tab right-click context menu) modal by capturing keyboard input while they're open. This prevents keystrokes from leaking into the active buffer underneath and enables keyboard navigation of the menus.

## Key Changes
- **Added keyboard handlers for tab-bar popups** in `mouse_input.rs`:
  - `handle_new_tab_menu_key()`: Handles Up/Down navigation, Enter to activate, Esc to dismiss, and filters all other keys
  - `handle_tab_context_menu_key()`: Similar modal behavior for the tab context menu
  
- **Integrated popup keyboard handling** in `input.rs`:
  - Added early returns in the keyboard dispatch logic to check for open popups before processing normal key commands
  - Ensures popups intercept and consume all keyboard input while open

- **Added comprehensive e2e tests** in `tab_new_button.rs`:
  - `plus_button_menu_captures_keyboard_and_filters_keys()`: Verifies the "+" menu is modal and keyboard navigation works
  - `plus_button_menu_dismisses_on_escape()`: Tests Esc dismissal
  - `tab_context_menu_captures_keyboard_and_filters_keys()`: Tests the tab context menu is also modal

## Implementation Details
- Both popup handlers follow the same pattern: return `Some(Ok(()))` when a popup is open (consuming the key), and `None` when no popup exists (allowing normal dispatch)
- Up/Down keys navigate the menu items, Enter activates the highlighted item and closes the popup, Esc dismisses without action
- All other keys are silently swallowed while a popup is open, preventing unintended buffer modifications

https://claude.ai/code/session_01Maxt15p3P8mMNKpXEbY3aq