### PR TITLE
test(e2e): deflake visual-yank, second-file staging, and menu golden tests

### DIFF
--- a/crates/fresh-editor/tests/e2e/menu_render_golden.rs
+++ b/crates/fresh-editor/tests/e2e/menu_render_golden.rs
@@ -54,7 +54,15 @@ const FILE_MENU_GOLDEN: &[&str] = &[
 fn menu_render_golden_file_menu() {
     let mut h = EditorTestHarness::with_temp_project_no_plugins(100, 40).unwrap();
     h.send_key(KeyCode::Char('f'), KeyModifiers::ALT).unwrap();
-    h.render().unwrap();
+    // Opening the menu can take an extra tick to paint the dropdown box, so a
+    // single render() may capture the bare menu bar (no box) and flake. Wait
+    // semantically for the dropdown to be fully painted (its bottom border
+    // present) and for the render to settle before snapshotting.
+    h.wait_until_stable(|h| {
+        let rows = menu_region(h);
+        rows.last().is_some_and(|r| r.contains('└'))
+    })
+    .unwrap();
     let rows = menu_region(&h);
     if rows != FILE_MENU_GOLDEN {
         eprintln!("---- ACTUAL FILE MENU ----");
@@ -75,7 +83,15 @@ fn menu_render_golden_view_menu() {
     h.send_key(KeyCode::Char('f'), KeyModifiers::ALT).unwrap();
     h.send_key(KeyCode::Right, KeyModifiers::NONE).unwrap();
     h.send_key(KeyCode::Right, KeyModifiers::NONE).unwrap();
-    h.render().unwrap();
+    // Opening + navigating menus can take an extra tick to repaint the dropdown,
+    // so a single render() may capture a half-painted View menu and flake. Wait
+    // semantically for the View dropdown content to render (and settle) first.
+    h.wait_until_stable(|h| {
+        let rows = menu_region(h);
+        rows.iter().any(|r| r.contains("Line Numbers"))
+            && rows.last().is_some_and(|r| r.contains('└'))
+    })
+    .unwrap();
     let rows = menu_region(&h);
     let joined = rows.join("\n");
     eprintln!("---- VIEW MENU REGION ----\n{joined}\n---- END ----");

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -101,36 +101,22 @@ fn diff_line_of(harness: &mut EditorTestHarness, needle: &str) -> usize {
     );
 }
 
-/// Step the diff cursor down until the status bar reports `target` line.
+/// Step the diff cursor down one row at a time until the status bar reports
+/// `target`. Each Down is followed by a semantic wait for the reported line to
+/// change, rather than spinning on a fixed render budget (CONTRIBUTING.md:
+/// "use semantic waiting, not timers"). The cursor only moves downward here,
+/// so `target` must be at or below the current line.
 fn move_cursor_to_line(harness: &mut EditorTestHarness, target: usize) {
-    for _ in 0..60 {
-        harness.render().unwrap();
-        if status_line_number(harness) == Some(target) {
+    loop {
+        let current = status_line_number(harness);
+        if current == Some(target) {
             return;
         }
         harness.send_key(KeyCode::Down, KeyModifiers::NONE).unwrap();
+        harness
+            .wait_until(|h| status_line_number(h) != current)
+            .unwrap();
     }
-    panic!(
-        "never reached diff line {} (status: {:?}). Screen:\n{}",
-        target,
-        status_line_number(harness),
-        harness.screen_to_string()
-    );
-}
-
-/// Bounded settle loop: pump the async runtime up to ~3s waiting for
-/// `cond` to hold, then return whether it did. Unlike `wait_until`, this
-/// never hangs — a failing operation simply returns `false`.
-fn settle_until<F: Fn() -> bool>(harness: &mut EditorTestHarness, cond: F) -> bool {
-    for _ in 0..60 {
-        harness.tick_and_render().unwrap();
-        if cond() {
-            return true;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
-        harness.advance_time(std::time::Duration::from_millis(50));
-    }
-    cond()
 }
 
 fn cached_diff(repo: &GitTestRepo) -> String {
@@ -165,18 +151,12 @@ fn test_review_visual_stage_single_added_line() {
         .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
         .unwrap();
 
-    // The line-level selection must stage the line. Give the async git
-    // apply + refresh a chance to complete.
-    settle_until(&mut harness, || cached_diff(&repo).contains("+extra line"));
-
-    let staged = cached_diff(&repo);
-    assert!(
-        staged.contains("+extra line"),
-        "line-level visual stage should stage the selected added line; \
-         `git diff --cached` was:\n{}\nScreen:\n{}",
-        staged,
-        harness.screen_to_string()
-    );
+    // The line-level selection must stage the line. Wait (indefinitely, per the
+    // testing guidelines) for the async git apply + refresh to land it in the
+    // index — this wait IS the assertion.
+    harness
+        .wait_until(|_| cached_diff(&repo).contains("+extra line"))
+        .unwrap();
 }
 
 /// A repo with a one-line modification in the working tree (produces a
@@ -217,16 +197,14 @@ fn test_review_visual_stage_modified_line_pair() {
         .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
         .unwrap();
 
-    settle_until(&mut harness, || cached_diff(&repo).contains("+BETA"));
-
-    let staged = cached_diff(&repo);
-    assert!(
-        staged.contains("+BETA") && staged.contains("-beta"),
-        "line-level visual stage should stage the -/+ modification pair; \
-         `git diff --cached` was:\n{}\nScreen:\n{}",
-        staged,
-        harness.screen_to_string()
-    );
+    // Wait for the whole -/+ modification pair to land in the index; the
+    // compound condition is the assertion.
+    harness
+        .wait_until(|_| {
+            let staged = cached_diff(&repo);
+            staged.contains("+BETA") && staged.contains("-beta")
+        })
+        .unwrap();
 }
 
 /// #2317 — `v` then `d` discards the selected added line from the working tree.
@@ -250,19 +228,14 @@ fn test_review_visual_discard_single_added_line() {
         .send_key(KeyCode::Char('d'), KeyModifiers::NONE)
         .unwrap();
 
-    settle_until(&mut harness, || {
-        let content = fs::read_to_string(repo.path.join("README.md")).unwrap_or_default();
-        !content.contains("extra line")
-    });
-
-    let content = fs::read_to_string(repo.path.join("README.md")).unwrap();
-    assert!(
-        !content.contains("extra line"),
-        "line-level visual discard should remove the added line from the \
-         working tree; README.md is:\n{}\nScreen:\n{}",
-        content,
-        harness.screen_to_string()
-    );
+    // Wait for the discard to remove the added line from the working tree; the
+    // worktree read is the assertion.
+    harness
+        .wait_until(|_| {
+            let content = fs::read_to_string(repo.path.join("README.md")).unwrap_or_default();
+            !content.contains("extra line")
+        })
+        .unwrap();
 }
 
 /// A repo whose single hunk contains two *separate* added lines, so a
@@ -301,15 +274,14 @@ fn test_review_visual_stage_only_selected_line_of_hunk() {
         .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
         .unwrap();
 
-    settle_until(&mut harness, || cached_diff(&repo).contains("+ADD1"));
+    // Wait for the selected line to be staged...
+    harness
+        .wait_until(|_| cached_diff(&repo).contains("+ADD1"))
+        .unwrap();
 
+    // ...then assert the *other* line did NOT get staged. This is a distinct
+    // invariant the wait above can't cover, so it stays an explicit assert.
     let staged = cached_diff(&repo);
-    assert!(
-        staged.contains("+ADD1"),
-        "the selected line should be staged; `git diff --cached`:\n{}\nScreen:\n{}",
-        staged,
-        harness.screen_to_string()
-    );
     assert!(
         !staged.contains("+ADD2"),
         "ONLY the selected line should be staged — `+ADD2` must remain \
@@ -371,16 +343,11 @@ fn test_review_visual_stage_line_in_second_file() {
         .send_key(KeyCode::Char('s'), KeyModifiers::NONE)
         .unwrap();
 
-    settle_until(&mut harness, || cached_diff(&repo).contains("+ADDED_B"));
-
-    let staged = cached_diff(&repo);
-    assert!(
-        staged.contains("+ADDED_B"),
-        "line-staging a line in the second (focused) file should stage \
-         `+ADDED_B`; `git diff --cached`:\n{}\nScreen:\n{}",
-        staged,
-        harness.screen_to_string()
-    );
+    // Wait for the second (focused) file's line to land in the index; this wait
+    // is the assertion.
+    harness
+        .wait_until(|_| cached_diff(&repo).contains("+ADDED_B"))
+        .unwrap();
 }
 
 /// A repo with a single added line already staged in the index.
@@ -421,14 +388,9 @@ fn test_review_visual_unstage_single_added_line() {
         .send_key(KeyCode::Char('u'), KeyModifiers::NONE)
         .unwrap();
 
-    settle_until(&mut harness, || !cached_diff(&repo).contains("+extra line"));
-
-    let staged = cached_diff(&repo);
-    assert!(
-        !staged.contains("+extra line"),
-        "line-level visual unstage should unstage the selected line; \
-         `git diff --cached` still shows it:\n{}\nScreen:\n{}",
-        staged,
-        harness.screen_to_string()
-    );
+    // Wait for the selected line to leave the index (unstaged); this wait is the
+    // assertion.
+    harness
+        .wait_until(|_| !cached_diff(&repo).contains("+extra line"))
+        .unwrap();
 }

--- a/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/review_diff_line_staging.rs
@@ -355,6 +355,11 @@ fn test_review_visual_stage_line_in_second_file() {
     harness
         .send_key(KeyCode::Char('n'), KeyModifiers::NONE)
         .unwrap();
+    // Hunk navigation + focus-mode repaint are async: focus mode only paints the
+    // focused file's body, so `+ADDED_B` isn't on screen until the jump to the
+    // second file completes. `diff_line_of` renders just once and panics if the
+    // row is missing, so wait for the second file's body to render first.
+    harness.wait_for_screen_contains("+ADDED_B").unwrap();
     let bravo_added = diff_line_of(&mut harness, "+ADDED_B");
     move_cursor_to_line(&mut harness, bravo_added);
 

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -1676,7 +1676,12 @@ fn test_vi_visual_word_end_yanks_selected_text() {
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
         .unwrap();
+    // The vi-mode plugin applies the WORD-end motion asynchronously; yanking
+    // before it lands would capture a too-short selection. The inclusive visual
+    // selection puts the display cursor one past the end of "elephant" (byte 7),
+    // i.e. at byte 8, so wait for that before yanking.
     send_vi_key(&mut harness, 'E');
+    harness.wait_until(|h| h.cursor_position() == 8).unwrap();
     send_vi_key(&mut harness, 'y');
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
@@ -1703,7 +1708,12 @@ fn test_vi_visual_word_forward_yanks_selected_text() {
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
         .unwrap();
+    // The vi-mode plugin applies the WORD motion asynchronously; yanking before
+    // it lands would capture a too-short selection. The inclusive visual
+    // selection puts the display cursor one past the WORD start ("zebra" at byte
+    // 9), i.e. at byte 10, so wait for that before yanking.
     send_vi_key(&mut harness, 'W');
+    harness.wait_until(|h| h.cursor_position() == 10).unwrap();
     send_vi_key(&mut harness, 'y');
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
@@ -1730,8 +1740,15 @@ fn test_vi_visual_word_forward_accumulates_from_visual_head() {
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-visual".to_string()))
         .unwrap();
+    // The vi-mode plugin applies each WORD motion asynchronously, so yanking
+    // before both `W`s land would capture a too-short selection. The inclusive
+    // visual selection puts the display cursor one past each WORD start ("zebra"
+    // at byte 9 -> cursor 10, then "giraffe" at byte 15 -> cursor 16), so wait
+    // for each before extending / yanking.
     send_vi_key(&mut harness, 'W');
+    harness.wait_until(|h| h.cursor_position() == 10).unwrap();
     send_vi_key(&mut harness, 'W');
+    harness.wait_until(|h| h.cursor_position() == 16).unwrap();
     send_vi_key(&mut harness, 'y');
     harness
         .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))


### PR DESCRIPTION
These e2e tests asserted on state that the async plugin/render pipeline had
not finished producing yet, so they passed or failed depending on timing —
violating CONTRIBUTING.md's "use semantic waiting, not timers" guideline.

- vi_mode visual WORD-motion yanks (`W`, `WW`, `E`): the plugin applies each
  motion asynchronously, so sending `y` immediately could yank a stale,
  too-short selection. Wait for the inclusive visual head (the display cursor,
  which sits one byte past the motion target) to land before yanking, matching
  the already-stable `test_vi_visual_word_back_yanks_selected_text`.

- review_diff second-file line staging: focus mode only paints the focused
  file's body, so `+ADDED_B` isn't on screen until the hunk jump to the second
  file completes; `diff_line_of` renders once and panics if the row is missing.
  Wait for the second file's body to render first.

- menu_render_golden file/view menus: opening (and navigating) the menu can
  take an extra tick to paint the dropdown box, so a single render() could
  snapshot a half-painted menu. Wait for the dropdown to fully render and
  settle before snapshotting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A6saVv2Aa6J2HKRZX2ci7W