### PR TITLE
test(e2e): deflake vi dot-repeat-change test's motion/mode races

### DIFF
--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -374,10 +374,20 @@ fn test_vi_vim_compat_repeat_change_word_keeps_change_semantics() {
     send_vi_operator_motion(&mut harness, 'c', 'W');
     harness.type_text("X").unwrap();
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
-    harness.render().unwrap();
+    // Wait for the Esc to land us back in normal mode before sending more vi
+    // keys — otherwise a not-yet-processed Esc means the following `W` is typed
+    // as a literal character in insert mode.
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
     harness.assert_buffer_content("X three four.five\n");
 
+    // `W` moves the cursor asynchronously to the start of "three" (byte 2 in
+    // "X three four.five"). Wait for it to land before `.`, otherwise the
+    // dot-repeat can replay `cW` at the old position and never produce the
+    // expected buffer (the motion-before-repeat race).
     send_vi_key(&mut harness, 'W');
+    harness.wait_until(|h| h.cursor_position() == 2).unwrap();
     send_vi_key(&mut harness, '.');
 
     // The `.` repeat replays the recorded change (cW → insert "X" → Esc)


### PR DESCRIPTION
## Summary

Deflakes `e2e::vi_mode::test_vi_vim_compat_repeat_change_word_keeps_change_semantics`, which still had two unguarded races against the async vi-mode plugin pipeline — the same class of flake CONTRIBUTING.md's "use semantic waiting, not timers" rule targets. (Reported failing in CI, e.g. https://github.com/sinelaw/fresh/pull/2453/checks.)

The earlier deflake work for the visual-yank tests, the second-file staging test, the menu goldens, and the `settle_until`→`wait_until` migration already landed on `master`; this PR is the one remaining piece.

## The two races

1. **`Esc` → `W` with no normal-mode wait.** The vi-mode switch back to normal mode is asynchronous, so a not-yet-processed `Esc` meant the following `W` was typed as a literal character in insert mode. Now waits for `vi-normal` before sending more vi keys.

2. **`W` → `.` with no cursor wait.** `W` is an async WORD motion (it `await`s `getBufferText`). If the dot-repeat ran before the cursor reached the start of `"three"` (byte 2), it replayed `cW` at the old position and the expected buffer never appeared — hanging the final `wait_for_buffer_content`. Now waits for the cursor to land before `.`.

## Why other sequences in the file are fine

The synchronous motions (`j`/`k`/`h`/`l`/`$`/`0`/`gg`/`G`) are `: void` `executeAction`-based handlers that complete in-handler before the next key is processed, so the `j`→`dd` and `G`→`x` sequences are not affected. Only the word/WORD motions, `x`, and dot-repeat are async.

## Testing

- `test_vi_vim_compat_repeat_change_word_keeps_change_semantics`: **20/20** passes (single-threaded stress run).
- Full `vi_mode::` module: **3/3** green (76 tests each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6saVv2Aa6J2HKRZX2ci7W

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6saVv2Aa6J2HKRZX2ci7W)_