### PR TITLE
Skip binary detection for terminal scrollback to preserve ANSI colors

### DIFF
--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -1552,9 +1552,12 @@ impl Window {
             }
         }
 
-        // Reload buffer from the backing file (reusing existing file loading)
+        // Reload buffer from the backing file (reusing existing file loading).
+        // Force text mode: raw PTY scrollback can contain control bytes that
+        // would otherwise trip binary detection, dropping ANSI colors and
+        // showing escape-code fragments in scrollback mode (#2449).
         let large_file_threshold = self.resources.config.editor.large_file_threshold_bytes as usize;
-        if let Ok(new_state) = EditorState::from_file_with_languages(
+        if let Ok(new_state) = EditorState::from_file_with_languages_force_text(
             &backing_file,
             self.terminal_width,
             self.terminal_height,

--- a/crates/fresh-editor/src/model/buffer/mod.rs
+++ b/crates/fresh-editor/src/model/buffer/mod.rs
@@ -389,6 +389,31 @@ impl TextBuffer {
         large_file_threshold: usize,
         fs: Arc<dyn FileSystem + Send + Sync>,
     ) -> anyhow::Result<Self> {
+        Self::load_from_file_internal(path, large_file_threshold, fs, false)
+    }
+
+    /// Load a text buffer from a file, forcing it to be treated as text.
+    ///
+    /// Identical to [`load_from_file`](Self::load_from_file) but skips binary
+    /// detection entirely — the buffer is always loaded through the text path
+    /// and `is_binary` stays `false`. Used for the terminal scrollback backing
+    /// file, whose raw PTY output can contain control bytes that would
+    /// otherwise trip binary detection and suppress ANSI-color rendering in
+    /// scrollback mode (issue #2449).
+    pub fn load_from_file_force_text<P: AsRef<Path>>(
+        path: P,
+        large_file_threshold: usize,
+        fs: Arc<dyn FileSystem + Send + Sync>,
+    ) -> anyhow::Result<Self> {
+        Self::load_from_file_internal(path, large_file_threshold, fs, true)
+    }
+
+    fn load_from_file_internal<P: AsRef<Path>>(
+        path: P,
+        large_file_threshold: usize,
+        fs: Arc<dyn FileSystem + Send + Sync>,
+        force_text: bool,
+    ) -> anyhow::Result<Self> {
         let path = path.as_ref();
 
         // Get file size to determine loading strategy
@@ -404,9 +429,9 @@ impl TextBuffer {
 
         // Choose loading strategy based on file size
         if file_size >= threshold {
-            Self::load_large_file(path, file_size, fs)
+            Self::load_large_file_internal(path, file_size, fs, false, force_text)
         } else {
-            Self::load_small_file(path, fs)
+            Self::load_small_file(path, fs, force_text)
         }
     }
 
@@ -428,11 +453,19 @@ impl TextBuffer {
     }
 
     /// Load a small file with full eager loading and line indexing
-    fn load_small_file(path: &Path, fs: Arc<dyn FileSystem + Send + Sync>) -> anyhow::Result<Self> {
+    ///
+    /// When `force_text` is true, binary detection is ignored and the file is
+    /// always loaded through the text path (see `load_from_file_force_text`).
+    fn load_small_file(
+        path: &Path,
+        fs: Arc<dyn FileSystem + Send + Sync>,
+        force_text: bool,
+    ) -> anyhow::Result<Self> {
         let contents = fs.read_file(path)?;
 
         // Use unified encoding/binary detection
-        let (encoding, is_binary) = format::detect_encoding_or_binary(&contents, false);
+        let (encoding, detected_binary) = format::detect_encoding_or_binary(&contents, false);
+        let is_binary = detected_binary && !force_text;
 
         // For binary files, skip encoding conversion to preserve raw bytes
         let mut buffer = if is_binary {
@@ -497,18 +530,6 @@ impl TextBuffer {
         Ok(None)
     }
 
-    /// Load a large file with unloaded buffer (no line indexing, lazy loading)
-    ///
-    /// If `force_full_load` is true, loads the entire file regardless of encoding.
-    /// This should be set to true after user confirms loading a non-resynchronizable encoding.
-    fn load_large_file(
-        path: &Path,
-        file_size: usize,
-        fs: Arc<dyn FileSystem + Send + Sync>,
-    ) -> anyhow::Result<Self> {
-        Self::load_large_file_internal(path, file_size, fs, false)
-    }
-
     /// Load a large file, optionally forcing full load for non-resynchronizable encodings.
     ///
     /// Called with `force_full_load=true` after user confirms the warning about
@@ -520,15 +541,19 @@ impl TextBuffer {
         let path = path.as_ref();
         let metadata = fs.metadata(path)?;
         let file_size = metadata.size as usize;
-        Self::load_large_file_internal(path, file_size, fs, true)
+        Self::load_large_file_internal(path, file_size, fs, true, false)
     }
 
     /// Internal implementation for loading large files.
+    ///
+    /// When `force_text` is true, binary detection is ignored and the file is
+    /// always loaded through the text path (see `load_from_file_force_text`).
     fn load_large_file_internal(
         path: &Path,
         file_size: usize,
         fs: Arc<dyn FileSystem + Send + Sync>,
         force_full_load: bool,
+        force_text: bool,
     ) -> anyhow::Result<Self> {
         use crate::model::piece_tree::{BufferData, BufferLocation};
 
@@ -538,8 +563,9 @@ impl TextBuffer {
         let sample = fs.read_range(path, 0, sample_size)?;
 
         // Use unified encoding/binary detection
-        let (encoding, is_binary) =
+        let (encoding, detected_binary) =
             format::detect_encoding_or_binary(&sample, file_size > sample_size);
+        let is_binary = detected_binary && !force_text;
 
         // Binary files skip encoding conversion to preserve raw bytes
         if is_binary {

--- a/crates/fresh-editor/src/model/buffer/tests.rs
+++ b/crates/fresh-editor/src/model/buffer/tests.rs
@@ -408,6 +408,52 @@ mod large_file_support {
         assert!(buffer.buffers[0].is_loaded());
     }
 
+    /// Content with binary control bytes (a NUL) is normally flagged as
+    /// binary — this guards the precondition for the force-text test below.
+    #[test]
+    fn test_load_binary_content_detected_as_binary() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("scrollback.txt");
+
+        // ANSI-colored text with embedded control bytes (NUL + DEL) such as
+        // raw PTY output can produce.
+        let data = b"\x1b[31mhello\x00world\x7f\x1b[0m\n";
+        File::create(&file_path).unwrap().write_all(data).unwrap();
+
+        let buffer = TextBuffer::load_from_file(&file_path, 0, test_fs()).unwrap();
+        assert!(
+            buffer.is_binary(),
+            "control bytes should trip binary detection on the normal load path"
+        );
+    }
+
+    /// `load_from_file_force_text` must keep the buffer in text mode even when
+    /// the bytes would otherwise be flagged as binary — the terminal
+    /// scrollback path relies on this so ANSI colors render (#2449).
+    #[test]
+    fn test_load_force_text_skips_binary_detection() {
+        let temp_dir = TempDir::new().unwrap();
+
+        // Same binary-tripping content, small-file path.
+        let small = temp_dir.path().join("small.txt");
+        let data = b"\x1b[31mhello\x00world\x7f\x1b[0m\n";
+        File::create(&small).unwrap().write_all(data).unwrap();
+        let buffer = TextBuffer::load_from_file_force_text(&small, 0, test_fs()).unwrap();
+        assert!(
+            !buffer.is_binary(),
+            "force_text small-file load must not flag the buffer binary"
+        );
+
+        // Large-file (lazy) path: force the large branch with a tiny threshold.
+        let large = temp_dir.path().join("large.txt");
+        File::create(&large).unwrap().write_all(data).unwrap();
+        let buffer = TextBuffer::load_from_file_force_text(&large, 1, test_fs()).unwrap();
+        assert!(
+            !buffer.is_binary(),
+            "force_text large-file load must not flag the buffer binary"
+        );
+    }
+
     #[test]
     fn test_load_large_file_lazy_loading() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/fresh-editor/src/state.rs
+++ b/crates/fresh-editor/src/state.rs
@@ -391,6 +391,31 @@ impl EditorState {
         Ok(state)
     }
 
+    /// Create an editor state from a file, always treating it as text.
+    ///
+    /// Like [`from_file_with_languages`](Self::from_file_with_languages) but
+    /// skips binary detection — the backing file is always loaded through the
+    /// text path. Used for the terminal scrollback view so raw PTY output
+    /// containing control bytes never flips the buffer into binary mode, which
+    /// would otherwise suppress ANSI-color rendering in scrollback (#2449).
+    pub fn from_file_with_languages_force_text(
+        path: &std::path::Path,
+        _width: u16,
+        _height: u16,
+        large_file_threshold: usize,
+        registry: &GrammarRegistry,
+        languages: &std::collections::HashMap<String, crate::config::LanguageConfig>,
+        fs: Arc<dyn FileSystem + Send + Sync>,
+    ) -> anyhow::Result<Self> {
+        let buffer = Buffer::load_from_file_force_text(path, large_file_threshold, fs)?;
+        let first_line = buffer.first_line_lossy();
+        let detected =
+            DetectedLanguage::from_path(path, first_line.as_deref(), registry, languages);
+        let mut state = Self::new_from_buffer(buffer);
+        state.apply_language(detected);
+        Ok(state)
+    }
+
     /// Create an editor state from a buffer and a pre-built `DetectedLanguage`.
     ///
     /// This is useful when you have already loaded a buffer with a specific encoding


### PR DESCRIPTION
## Summary
This PR fixes an issue where terminal scrollback content containing control bytes (such as NUL or DEL characters from raw PTY output) would be incorrectly flagged as binary, causing ANSI color codes to be suppressed and escape sequences to be displayed as fragments in the scrollback view.

## Key Changes
- **Added `load_from_file_force_text()` method** to `TextBuffer` that loads files while skipping binary detection entirely, always treating content as text
- **Refactored file loading logic** by extracting a new `load_from_file_internal()` method that accepts a `force_text` parameter, shared by both small and large file loading paths
- **Updated `load_small_file()` and `load_large_file_internal()`** to accept and respect the `force_text` parameter, allowing binary detection to be bypassed when needed
- **Added `from_file_with_languages_force_text()` method** to `EditorState` as a convenience wrapper for loading files with forced text mode
- **Updated terminal scrollback loading** in `Window::reload_scrollback_buffer()` to use the new force-text loading path with explanatory comments
- **Added comprehensive tests** verifying that:
  - Binary content with control bytes is normally detected as binary
  - The force-text path correctly bypasses binary detection for both small and large files

## Implementation Details
- The `force_text` parameter is threaded through the loading pipeline and applied after binary detection, allowing the detection logic to remain unchanged while selectively ignoring its results
- Both small-file (eager) and large-file (lazy) loading paths support the force-text mode
- The change is backward compatible; existing code paths continue to work as before
- Terminal scrollback now explicitly uses the force-text loading to ensure ANSI color rendering is preserved regardless of control byte content (fixes issue #2449)

https://claude.ai/code/session_01AVFUh598uHEt2cKcrgnCvF