### PR TITLE
refactor(menu): decompose the 235-line render_dropdown_level God Function

### DIFF
--- a/crates/fresh-editor/src/view/ui/menu.rs
+++ b/crates/fresh-editor/src/view/ui/menu.rs
@@ -815,41 +815,13 @@ impl MenuRenderer {
         mut rec: Option<&mut CellThemeRecorder>,
         draw: bool,
     ) -> Rect {
-        let max_width = Self::calculate_dropdown_width(items);
-        let dropdown_height = items.len() + 2; // +2 for borders
-
-        let desired_width = max_width as u16;
-        let desired_height = dropdown_height as u16;
-
-        // Bounds check: ensure dropdown fits within the visible area
-        let adjusted_x = if x.saturating_add(desired_width) > terminal_width {
-            terminal_width.saturating_sub(desired_width)
-        } else {
-            x
-        };
-
-        let available_height = terminal_height.saturating_sub(y);
-        let height = desired_height.min(available_height);
-
-        let available_width = terminal_width.saturating_sub(adjusted_x);
-        let width = desired_width.min(available_width);
+        let dropdown_area = Self::fit_dropdown_area(items, x, y, terminal_width, terminal_height);
 
         // Only render if we have at least minimal space
-        if width < 10 || height < 3 {
-            return Rect {
-                x: adjusted_x,
-                y,
-                width,
-                height,
-            };
+        if dropdown_area.width < 10 || dropdown_area.height < 3 {
+            return dropdown_area;
         }
-
-        let dropdown_area = Rect {
-            x: adjusted_x,
-            y,
-            width,
-            height,
-        };
+        let adjusted_x = dropdown_area.x;
 
         // Seed the dropdown box (border + fill) with its surface keys; each
         // item row overwrites its own cells below.
@@ -868,9 +840,9 @@ impl MenuRenderer {
 
         // Build dropdown content
         let mut lines = Vec::new();
-        let max_items = (height.saturating_sub(2)) as usize;
+        let max_items = (dropdown_area.height.saturating_sub(2)) as usize;
         let items_to_show = items.len().min(max_items);
-        let content_width = (width as usize).saturating_sub(2);
+        let content_width = (dropdown_area.width as usize).saturating_sub(2);
 
         for (idx, item) in items.iter().enumerate().take(items_to_show) {
             let is_highlighted = highlighted_item == Some(idx);
@@ -902,139 +874,27 @@ impl MenuRenderer {
 
             // Record this item's keys, mirroring the per-kind style below.
             if let Some(r) = rec.as_deref_mut() {
-                let (fg, bg) = match item {
-                    MenuItem::Separator { .. } => ("ui.menu_separator_fg", "ui.menu_dropdown_bg"),
-                    MenuItem::Label { .. } => ("ui.menu_disabled_fg", "ui.menu_dropdown_bg"),
-                    _ if !enabled => ("ui.menu_disabled_fg", "ui.menu_disabled_bg"),
-                    _ if is_highlighted || has_open_submenu => {
-                        ("ui.menu_highlight_fg", "ui.menu_highlight_bg")
-                    }
-                    _ => ("ui.menu_dropdown_fg", "ui.menu_dropdown_bg"),
-                };
-                r.run(
-                    item_area.x,
-                    item_area.y,
-                    item_area.width,
-                    Some(fg),
-                    Some(bg),
-                    "Menu Dropdown",
+                Self::record_dropdown_item_run(
+                    r,
+                    item,
+                    item_area,
+                    enabled,
+                    is_highlighted,
+                    has_open_submenu,
                 );
             }
 
-            let line = match item {
-                MenuItem::Action {
-                    label,
-                    action,
-                    checkbox,
-                    ..
-                } => {
-                    let style = if !enabled {
-                        Style::default()
-                            .fg(theme.menu_disabled_fg)
-                            .bg(theme.menu_disabled_bg)
-                    } else if is_highlighted {
-                        Style::default()
-                            .fg(theme.menu_highlight_fg)
-                            .bg(theme.menu_highlight_bg)
-                    } else if is_hovered {
-                        Style::default()
-                            .fg(theme.menu_hover_fg)
-                            .bg(theme.menu_hover_bg)
-                    } else {
-                        Style::default()
-                            .fg(theme.menu_dropdown_fg)
-                            .bg(theme.menu_dropdown_bg)
-                    };
-
-                    let keybinding = keybindings
-                        .find_keybinding_for_action(
-                            action,
-                            crate::input::keybindings::KeyContext::Normal,
-                        )
-                        .unwrap_or_default();
-
-                    let checkbox_icon = if checkbox.is_some() {
-                        if is_checkbox_checked(checkbox, context) {
-                            "☑ "
-                        } else {
-                            "☐ "
-                        }
-                    } else {
-                        ""
-                    };
-
-                    let checkbox_width = if checkbox.is_some() { 2 } else { 0 };
-                    let label_display_width = str_width(label);
-                    let keybinding_display_width = str_width(&keybinding);
-
-                    let text = if keybinding.is_empty() {
-                        let padding_needed =
-                            content_width.saturating_sub(checkbox_width + label_display_width + 1);
-                        format!(" {}{}{}", checkbox_icon, label, " ".repeat(padding_needed))
-                    } else {
-                        let padding_needed = content_width.saturating_sub(
-                            checkbox_width + label_display_width + keybinding_display_width + 2,
-                        );
-                        format!(
-                            " {}{}{} {}",
-                            checkbox_icon,
-                            label,
-                            " ".repeat(padding_needed),
-                            keybinding
-                        )
-                    };
-
-                    Line::from(vec![Span::styled(text, style)])
-                }
-                MenuItem::Separator { .. } => {
-                    let separator = "─".repeat(content_width);
-                    Line::from(vec![Span::styled(
-                        format!(" {separator}"),
-                        Style::default()
-                            .fg(theme.menu_separator_fg)
-                            .bg(theme.menu_dropdown_bg),
-                    )])
-                }
-                MenuItem::Submenu { label, .. } | MenuItem::DynamicSubmenu { label, .. } => {
-                    // Highlight submenu items that have an open child
-                    let style = if is_highlighted || has_open_submenu {
-                        Style::default()
-                            .fg(theme.menu_highlight_fg)
-                            .bg(theme.menu_highlight_bg)
-                    } else if is_hovered {
-                        Style::default()
-                            .fg(theme.menu_hover_fg)
-                            .bg(theme.menu_hover_bg)
-                    } else {
-                        Style::default()
-                            .fg(theme.menu_dropdown_fg)
-                            .bg(theme.menu_dropdown_bg)
-                    };
-
-                    // Format: " Label        > " - label left-aligned, arrow near the end with padding
-                    // content_width minus: leading space (1) + space before arrow (1) + arrow (1) + trailing space (2)
-                    let label_display_width = str_width(label);
-                    let padding_needed = content_width.saturating_sub(label_display_width + 5);
-                    Line::from(vec![Span::styled(
-                        format!(" {}{} >  ", label, " ".repeat(padding_needed)),
-                        style,
-                    )])
-                }
-                MenuItem::Label { info } => {
-                    // Disabled info label - always shown in disabled style
-                    let style = Style::default()
-                        .fg(theme.menu_disabled_fg)
-                        .bg(theme.menu_dropdown_bg);
-                    let info_display_width = str_width(info);
-                    let padding_needed = content_width.saturating_sub(info_display_width);
-                    Line::from(vec![Span::styled(
-                        format!(" {}{}", info, " ".repeat(padding_needed)),
-                        style,
-                    )])
-                }
-            };
-
-            lines.push(line);
+            lines.push(Self::build_dropdown_item_line(
+                item,
+                content_width,
+                enabled,
+                is_highlighted,
+                is_hovered,
+                has_open_submenu,
+                keybindings,
+                theme,
+                context,
+            ));
         }
 
         let block = Block::default()
@@ -1048,6 +908,197 @@ impl MenuRenderer {
         }
 
         dropdown_area
+    }
+
+    /// Compute the on-screen rectangle for a dropdown of `items` anchored at
+    /// (`x`, `y`), clamped to stay within the terminal. The width is derived
+    /// from the longest label; near a screen edge the returned rect may be
+    /// smaller than desired, which callers treat as "no room to render".
+    fn fit_dropdown_area(
+        items: &[MenuItem],
+        x: u16,
+        y: u16,
+        terminal_width: u16,
+        terminal_height: u16,
+    ) -> Rect {
+        let desired_width = Self::calculate_dropdown_width(items) as u16;
+        let desired_height = (items.len() + 2) as u16; // +2 for borders
+
+        // Bounds check: ensure the dropdown fits within the visible area.
+        let adjusted_x = if x.saturating_add(desired_width) > terminal_width {
+            terminal_width.saturating_sub(desired_width)
+        } else {
+            x
+        };
+
+        let width = desired_width.min(terminal_width.saturating_sub(adjusted_x));
+        let height = desired_height.min(terminal_height.saturating_sub(y));
+
+        Rect {
+            x: adjusted_x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    /// Record the theme-key run for one dropdown item row. The fg/bg selection
+    /// mirrors the visual style chosen in [`Self::build_dropdown_item_line`] so
+    /// the theme inspector matches what is painted.
+    fn record_dropdown_item_run(
+        rec: &mut CellThemeRecorder,
+        item: &MenuItem,
+        item_area: Rect,
+        enabled: bool,
+        is_highlighted: bool,
+        has_open_submenu: bool,
+    ) {
+        let (fg, bg) = match item {
+            MenuItem::Separator { .. } => ("ui.menu_separator_fg", "ui.menu_dropdown_bg"),
+            MenuItem::Label { .. } => ("ui.menu_disabled_fg", "ui.menu_dropdown_bg"),
+            _ if !enabled => ("ui.menu_disabled_fg", "ui.menu_disabled_bg"),
+            _ if is_highlighted || has_open_submenu => {
+                ("ui.menu_highlight_fg", "ui.menu_highlight_bg")
+            }
+            _ => ("ui.menu_dropdown_fg", "ui.menu_dropdown_bg"),
+        };
+        rec.run(
+            item_area.x,
+            item_area.y,
+            item_area.width,
+            Some(fg),
+            Some(bg),
+            "Menu Dropdown",
+        );
+    }
+
+    /// Build the styled line for one dropdown item: an action (with optional
+    /// checkbox and keybinding hint), a separator, a submenu row (with the `>`
+    /// arrow), or a disabled info label.
+    #[allow(clippy::too_many_arguments)]
+    fn build_dropdown_item_line(
+        item: &MenuItem,
+        content_width: usize,
+        enabled: bool,
+        is_highlighted: bool,
+        is_hovered: bool,
+        has_open_submenu: bool,
+        keybindings: &crate::input::keybindings::KeybindingResolver,
+        theme: &Theme,
+        context: &MenuContext,
+    ) -> Line<'static> {
+        match item {
+            MenuItem::Action {
+                label,
+                action,
+                checkbox,
+                ..
+            } => {
+                let style = if !enabled {
+                    Style::default()
+                        .fg(theme.menu_disabled_fg)
+                        .bg(theme.menu_disabled_bg)
+                } else if is_highlighted {
+                    Style::default()
+                        .fg(theme.menu_highlight_fg)
+                        .bg(theme.menu_highlight_bg)
+                } else if is_hovered {
+                    Style::default()
+                        .fg(theme.menu_hover_fg)
+                        .bg(theme.menu_hover_bg)
+                } else {
+                    Style::default()
+                        .fg(theme.menu_dropdown_fg)
+                        .bg(theme.menu_dropdown_bg)
+                };
+
+                let keybinding = keybindings
+                    .find_keybinding_for_action(
+                        action,
+                        crate::input::keybindings::KeyContext::Normal,
+                    )
+                    .unwrap_or_default();
+
+                let checkbox_icon = if checkbox.is_some() {
+                    if is_checkbox_checked(checkbox, context) {
+                        "☑ "
+                    } else {
+                        "☐ "
+                    }
+                } else {
+                    ""
+                };
+
+                let checkbox_width = if checkbox.is_some() { 2 } else { 0 };
+                let label_display_width = str_width(label);
+                let keybinding_display_width = str_width(&keybinding);
+
+                let text = if keybinding.is_empty() {
+                    let padding_needed =
+                        content_width.saturating_sub(checkbox_width + label_display_width + 1);
+                    format!(" {}{}{}", checkbox_icon, label, " ".repeat(padding_needed))
+                } else {
+                    let padding_needed = content_width.saturating_sub(
+                        checkbox_width + label_display_width + keybinding_display_width + 2,
+                    );
+                    format!(
+                        " {}{}{} {}",
+                        checkbox_icon,
+                        label,
+                        " ".repeat(padding_needed),
+                        keybinding
+                    )
+                };
+
+                Line::from(vec![Span::styled(text, style)])
+            }
+            MenuItem::Separator { .. } => {
+                let separator = "─".repeat(content_width);
+                Line::from(vec![Span::styled(
+                    format!(" {separator}"),
+                    Style::default()
+                        .fg(theme.menu_separator_fg)
+                        .bg(theme.menu_dropdown_bg),
+                )])
+            }
+            MenuItem::Submenu { label, .. } | MenuItem::DynamicSubmenu { label, .. } => {
+                // Highlight submenu items that have an open child
+                let style = if is_highlighted || has_open_submenu {
+                    Style::default()
+                        .fg(theme.menu_highlight_fg)
+                        .bg(theme.menu_highlight_bg)
+                } else if is_hovered {
+                    Style::default()
+                        .fg(theme.menu_hover_fg)
+                        .bg(theme.menu_hover_bg)
+                } else {
+                    Style::default()
+                        .fg(theme.menu_dropdown_fg)
+                        .bg(theme.menu_dropdown_bg)
+                };
+
+                // Format: " Label        > " - label left-aligned, arrow near the end with padding
+                // content_width minus: leading space (1) + space before arrow (1) + arrow (1) + trailing space (2)
+                let label_display_width = str_width(label);
+                let padding_needed = content_width.saturating_sub(label_display_width + 5);
+                Line::from(vec![Span::styled(
+                    format!(" {}{} >  ", label, " ".repeat(padding_needed)),
+                    style,
+                )])
+            }
+            MenuItem::Label { info } => {
+                // Disabled info label - always shown in disabled style
+                let style = Style::default()
+                    .fg(theme.menu_disabled_fg)
+                    .bg(theme.menu_dropdown_bg);
+                let info_display_width = str_width(info);
+                let padding_needed = content_width.saturating_sub(info_display_width);
+                Line::from(vec![Span::styled(
+                    format!(" {}{}", info, " ".repeat(padding_needed)),
+                    style,
+                )])
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## What & why

`MenuRenderer::render_dropdown_level` in `crates/fresh-editor/src/view/ui/menu.rs` was a 235-line **God Function** that bundled four unrelated responsibilities into a single block:

1. Clamping the dropdown geometry to the screen edges.
2. Seeding the dropdown box's theme-key runs for the inspector.
3. Recording each item's theme-key run.
4. Building each item's styled `Line` via a ~110-line per-kind `match` (action + checkbox + keybinding hint, separator, submenu arrow, info label).

It also carried a quiet maintenance hazard: the per-item foreground/background **precedence was duplicated** — once as theme-key *strings* for the inspector recorder, and again as concrete *colors* in the line `match` — so the two representations could silently drift apart.

## The change

Extracted three focused private helpers, leaving runtime behavior byte-for-byte identical:

- **`fit_dropdown_area`** — the bounds/clamp math, returning the dropdown `Rect`.
- **`record_dropdown_item_run`** — one item's theme-key run for the inspector.
- **`build_dropdown_item_line`** — one item's styled `Line`.

`render_dropdown_level` is now a flat skeleton: fit the area → guard on minimum size → loop calling the helpers. The two duplicated style blocks now sit next to each other as named helpers with a doc note that they must agree, making the coupling explicit instead of accidental.

## Scope & safety

- **One file**, no public API change, no rendering behavior change.
- `render_dropdown_level` is private and called from a single site (`render_dropdown_chain`); the in-file tests don't invoke it directly.
- `cargo fmt` applied; `cargo clippy` reports **no warnings** for `menu.rs`.
- Picked specifically because `menu.rs`'s renderer is **not touched by any of the open PRs**, avoiding merge conflicts with active work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ypP5ME9dLHjZS8yf3tLD5

---
_Generated by [Claude Code](https://claude.ai/code/session_019ypP5ME9dLHjZS8yf3tLD5)_