### PR TITLE
test(e2e): speed up settings-search UTF-8 panic sweep to avoid CI timeout

### DIFF
--- a/crates/fresh-editor/tests/e2e/issue_1718_settings_search_utf8_panic.rs
+++ b/crates/fresh-editor/tests/e2e/issue_1718_settings_search_utf8_panic.rs
@@ -34,29 +34,35 @@ use crossterm::event::{KeyCode, KeyModifiers};
 /// (bytes 92–93) and `→` (bytes 96–98).
 #[test]
 fn settings_search_hidden_does_not_panic_across_widths() {
-    for width in 40u16..=250 {
-        let mut harness = EditorTestHarness::new(width, 40).unwrap();
+    // Open one harness into Settings search, then sweep the terminal width via
+    // resize() (which re-renders) instead of rebuilding the whole editor +
+    // Settings dialog for every width. Re-rendering is the panic site, so
+    // resizing exercises exactly the same truncation cut-points a fresh harness
+    // per width would — but without paying full setup 211 times. The old
+    // per-width rebuild took ~66s solo and timed out (180s) under parallel CI
+    // load.
+    let mut harness = EditorTestHarness::new(40, 40).unwrap();
+    harness.open_settings().unwrap();
 
-        harness.open_settings().unwrap();
-
-        // Enter search mode.
+    // Enter search mode and type the query from the issue report. The
+    // `whitespace_show` setting description fuzzy-matches "hidden" and is
+    // rendered in the results; the render code then byte-slices the description.
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    for ch in "hidden".chars() {
         harness
-            .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+            .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
             .unwrap();
-        harness.render().unwrap();
+    }
+    harness.render().unwrap();
 
-        // Type the query from the issue report.  The `whitespace_show` setting
-        // description fuzzy-matches "hidden" and is rendered in the results; the
-        // render code then byte-slices the description at an unsafe offset.
-        for ch in "hidden".chars() {
-            harness
-                .send_key(KeyCode::Char(ch), KeyModifiers::NONE)
-                .unwrap();
-        }
-
-        // render() is where the panic occurs.
+    // Sweep widths 40–250. Each resize re-renders, exercising every truncation
+    // cut-point through the description, including those that land inside `·`
+    // (bytes 92–93) and `→` (bytes 96–98).
+    for width in 40u16..=250 {
         harness
-            .render()
-            .unwrap_or_else(|e| panic!("width={width}: render failed: {e}"));
+            .resize(width, 40)
+            .unwrap_or_else(|e| panic!("width={width}: resize/render failed: {e}"));
     }
 }


### PR DESCRIPTION
## Problem

`e2e::issue_1718_settings_search_utf8_panic::settings_search_hidden_does_not_panic_across_widths` flakily **times out** in CI (observed `TIMEOUT [180.013s]`).

It is **not a hang** — the test rebuilds a full editor harness *and* re-opens the Settings dialog for each of the **211 widths** in `40..=250`. Measured solo, single-threaded, it takes **66.3s** and passes. Under parallel CI load (CPU contention), that easily crosses the 180s per-test budget → flaky timeout.

## Fix

The panic site is `render()` truncating the search-result description by terminal width, and `resize()` re-renders. So the rewrite does the expensive setup **once**, then sweeps the width via `resize()` on a single harness. This exercises exactly the same truncation cut-points (including those landing inside `·` at bytes 92–93 and `→` at bytes 96–98) without paying full editor + Settings setup 211 times.

## Verification (reproduce-before-claiming)

- **Without the fix** — temporarily restoring the original byte-slice in `render_search_result_item` makes the rewritten test fail in **~2s** with the exact #1718 panic: `byte index 93 is not a char boundary; it is inside '·'`. So it still reproduces the bug.
- **With the fix** — passes in **~3.25s** (was 66.3s).

Production code is untouched; only the test file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6saVv2Aa6J2HKRZX2ci7W)_