### PR TITLE
refactor(composite): decompose the 409-line render_composite_buffer God Function

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -6,7 +6,7 @@
 
 use super::super::spans::{compute_inline_diff, span_color_at};
 use super::super::view_data::build_view_data;
-use crate::model::composite_buffer::CompositeBuffer;
+use crate::model::composite_buffer::{AlignedRow, CompositeBuffer};
 use crate::model::event::BufferId;
 use crate::primitives::display_width::char_width;
 use crate::state::{EditorState, ViewMode};
@@ -36,39 +36,106 @@ pub(crate) fn render_composite_buffer(
     use_terminal_bg: bool,
     show_tilde: bool,
 ) {
-    use crate::model::composite_buffer::{CompositeLayout, RowType};
-
-    // Compute effective editor background: terminal default or theme-defined
+    // Effective editor background: terminal default or theme-defined.
     let effective_editor_bg = if use_terminal_bg {
         Color::Reset
     } else {
         theme.editor_bg
     };
 
-    let scroll_row = view_state.scroll_row;
-    let cursor_row = view_state.cursor_row;
-
-    // Clear the area first
+    // Clear the area first.
     frame.render_widget(Clear, area);
 
-    // Calculate pane widths based on layout
-    let pane_count = composite.sources.len();
-    if pane_count == 0 {
+    if composite.sources.is_empty() {
         return;
     }
 
-    // Extract show_separator from layout
+    let layout = compute_pane_layout(composite, area.width);
+    // Store computed pane widths in view state for cursor movement calculations.
+    view_state.pane_widths = layout.widths.clone();
+
+    render_pane_headers(
+        frame,
+        area,
+        composite,
+        &layout,
+        view_state.focused_pane,
+        theme,
+    );
+
+    // Content area (below the one-row headers).
+    let header_height = 1u16;
+    let content_y = area.y + header_height;
+    let content_height = area.height.saturating_sub(header_height);
+    let visible_rows = content_height as usize;
+    let scroll_row = view_state.scroll_row;
+    let total_rows = composite.alignment.rows.len();
+
+    // Build each pane's ViewLines + syntax highlighting once for the whole
+    // visible range, then paint every aligned row from that prepared data.
+    let pane_render_data = build_pane_render_data(
+        composite,
+        buffers,
+        &layout,
+        scroll_row,
+        visible_rows,
+        content_height,
+        theme,
+    );
+
+    for view_row in 0..visible_rows {
+        let display_row = scroll_row + view_row;
+        let row_y = content_y + view_row as u16;
+        if display_row >= total_rows {
+            render_past_end_row(frame, area.x, row_y, &layout, show_tilde, theme);
+            continue;
+        }
+        render_aligned_row(
+            frame,
+            area.x,
+            row_y,
+            display_row,
+            composite,
+            buffers,
+            &layout,
+            &pane_render_data,
+            view_state,
+            is_active,
+            effective_editor_bg,
+            theme,
+        );
+    }
+}
+
+/// Pane geometry for a composite buffer: the content width of each pane plus
+/// the width and visibility of the vertical separators drawn between them.
+struct PaneLayout {
+    widths: Vec<u16>,
+    separator_width: u16,
+    show_separator: bool,
+}
+
+impl PaneLayout {
+    fn pane_count(&self) -> usize {
+        self.widths.len()
+    }
+}
+
+/// Compute the [`PaneLayout`] from the composite's layout spec and the
+/// available width. Only called once at least one source pane exists.
+fn compute_pane_layout(composite: &CompositeBuffer, area_width: u16) -> PaneLayout {
+    use crate::model::composite_buffer::CompositeLayout;
+
+    let pane_count = composite.sources.len();
     let show_separator = match &composite.layout {
         CompositeLayout::SideBySide { show_separator, .. } => *show_separator,
         _ => false,
     };
-
-    // Calculate pane areas
     let separator_width = if show_separator { 1 } else { 0 };
     let total_separators = (pane_count.saturating_sub(1)) as u16 * separator_width;
-    let available_width = area.width.saturating_sub(total_separators);
+    let available_width = area_width.saturating_sub(total_separators);
 
-    let pane_widths: Vec<u16> = match &composite.layout {
+    let widths: Vec<u16> = match &composite.layout {
         CompositeLayout::SideBySide { ratios, .. } => {
             let default_ratio = 1.0 / pane_count as f32;
             ratios
@@ -84,17 +151,28 @@ pub(crate) fn render_composite_buffer(
         }
     };
 
-    // Store computed pane widths in view state for cursor movement calculations
-    view_state.pane_widths = pane_widths.clone();
+    PaneLayout {
+        widths,
+        separator_width,
+        show_separator,
+    }
+}
 
-    // Render headers first
+/// Render the one-row header bar for each pane (the source label), with the
+/// focused pane drawn in the active-tab style.
+fn render_pane_headers(
+    frame: &mut Frame,
+    area: Rect,
+    composite: &CompositeBuffer,
+    layout: &PaneLayout,
+    focused_pane: usize,
+    theme: &Theme,
+) {
     let header_height = 1u16;
     let mut x_offset = area.x;
-    for (idx, (source, &width)) in composite.sources.iter().zip(&pane_widths).enumerate() {
+    for (idx, (source, &width)) in composite.sources.iter().zip(&layout.widths).enumerate() {
         let header_area = Rect::new(x_offset, area.y, width, header_height);
-        let is_focused = idx == view_state.focused_pane;
-
-        let header_style = if is_focused {
+        let header_style = if idx == focused_pane {
             Style::default()
                 .fg(theme.tab_active_fg)
                 .bg(theme.tab_active_bg)
@@ -108,329 +186,385 @@ pub(crate) fn render_composite_buffer(
         let header = Paragraph::new(header_text).style(header_style);
         frame.render_widget(header, header_area);
 
-        x_offset += width + separator_width;
+        x_offset += width + layout.separator_width;
     }
+}
 
-    // Content area (below headers)
-    let content_y = area.y + header_height;
-    let content_height = area.height.saturating_sub(header_height);
-    let visible_rows = content_height as usize;
+/// Prepared rendering data for one pane: the laid-out [`ViewLine`]s, a map
+/// from source line number to its index in `lines`, and the pane's syntax
+/// highlight spans.
+struct PaneRenderData {
+    lines: Vec<ViewLine>,
+    line_to_view_line: HashMap<usize, usize>,
+    highlight_spans: Vec<crate::primitives::highlighter::HighlightSpan>,
+}
 
-    // Render aligned rows
+/// Build the [`PaneRenderData`] for every pane over the currently visible
+/// range, yielding `None` for a pane with no visible source lines (or whose
+/// source buffer is gone).
+fn build_pane_render_data(
+    composite: &CompositeBuffer,
+    buffers: &mut HashMap<BufferId, EditorState>,
+    layout: &PaneLayout,
+    scroll_row: usize,
+    visible_rows: usize,
+    content_height: u16,
+    theme: &Theme,
+) -> Vec<Option<PaneRenderData>> {
     let alignment = &composite.alignment;
-    let total_rows = alignment.rows.len();
-
-    // Build ViewData and get syntax highlighting for each pane.
-    struct PaneRenderData {
-        lines: Vec<ViewLine>,
-        line_to_view_line: HashMap<usize, usize>,
-        highlight_spans: Vec<crate::primitives::highlighter::HighlightSpan>,
-    }
-
     let mut pane_render_data: Vec<Option<PaneRenderData>> = Vec::new();
 
     for (pane_idx, source) in composite.sources.iter().enumerate() {
-        if let Some(source_state) = buffers.get_mut(&source.buffer_id) {
-            let visible_lines: Vec<usize> = alignment
-                .rows
-                .iter()
-                .skip(scroll_row)
-                .take(visible_rows)
-                .filter_map(|row| row.get_pane_line(pane_idx))
-                .map(|r| r.line)
-                .collect();
-
-            let first_line = visible_lines.iter().copied().min();
-            let last_line = visible_lines.iter().copied().max();
-
-            if let (Some(first_line), Some(last_line)) = (first_line, last_line) {
-                let top_byte = source_state
-                    .buffer
-                    .line_start_offset(first_line)
-                    .unwrap_or(0);
-                let end_byte = source_state
-                    .buffer
-                    .line_start_offset(last_line + 1)
-                    .unwrap_or(source_state.buffer.len());
-
-                let highlight_spans = source_state.highlighter.highlight_viewport(
-                    &source_state.buffer,
-                    top_byte,
-                    end_byte,
-                    theme,
-                    1024, // highlight_context_bytes
-                );
-
-                let pane_width = pane_widths.get(pane_idx).copied().unwrap_or(80);
-                let mut viewport = crate::view::viewport::Viewport::new(pane_width, content_height);
-                viewport.top_byte = top_byte;
-                viewport.line_wrap_enabled = false;
-
-                let pane_width = pane_widths.get(pane_idx).copied().unwrap_or(80) as usize;
-                let gutter_width = 4; // Line number width
-                let content_width = pane_width.saturating_sub(gutter_width);
-
-                let lines_needed = last_line - first_line + 10;
-                let empty_folds = FoldManager::new();
-                let view_data = build_view_data(
-                    source_state,
-                    &viewport,
-                    None,         // No view transform
-                    80,           // estimated_line_length
-                    lines_needed, // visible_count - enough to cover the range
-                    false,        // line_wrap_enabled
-                    content_width,
-                    gutter_width,
-                    &ViewMode::Source, // Composite view uses source mode
-                    &empty_folds,
-                    theme,
-                );
-
-                let mut line_to_view_line: HashMap<usize, usize> = HashMap::new();
-                let mut current_line = first_line;
-                for (idx, view_line) in view_data.lines.iter().enumerate() {
-                    if should_show_line_number(view_line) {
-                        line_to_view_line.insert(current_line, idx);
-                        current_line += 1;
-                    }
-                }
-
-                pane_render_data.push(Some(PaneRenderData {
-                    lines: view_data.lines,
-                    line_to_view_line,
-                    highlight_spans,
-                }));
-            } else {
-                pane_render_data.push(None);
-            }
-        } else {
+        let Some(source_state) = buffers.get_mut(&source.buffer_id) else {
             pane_render_data.push(None);
-        }
-    }
-
-    // Now render aligned rows using ViewLines
-    for view_row in 0..visible_rows {
-        let display_row = scroll_row + view_row;
-        if display_row >= total_rows {
-            let mut x = area.x;
-            for &width in &pane_widths {
-                let eof_area = Rect::new(x, content_y + view_row as u16, width, 1);
-                let pad_width = width as usize;
-                let text = if show_tilde && pad_width > 0 {
-                    format!("~{}", " ".repeat(pad_width.saturating_sub(1)))
-                } else {
-                    " ".repeat(pad_width)
-                };
-                let eof = Paragraph::new(text).style(
-                    Style::default()
-                        .fg(theme.line_number_fg)
-                        .bg(theme.after_eof_bg),
-                );
-                frame.render_widget(eof, eof_area);
-                x += width + separator_width;
-            }
             continue;
+        };
+
+        let visible_lines: Vec<usize> = alignment
+            .rows
+            .iter()
+            .skip(scroll_row)
+            .take(visible_rows)
+            .filter_map(|row| row.get_pane_line(pane_idx))
+            .map(|r| r.line)
+            .collect();
+
+        let (Some(first_line), Some(last_line)) = (
+            visible_lines.iter().copied().min(),
+            visible_lines.iter().copied().max(),
+        ) else {
+            pane_render_data.push(None);
+            continue;
+        };
+
+        let top_byte = source_state
+            .buffer
+            .line_start_offset(first_line)
+            .unwrap_or(0);
+        let end_byte = source_state
+            .buffer
+            .line_start_offset(last_line + 1)
+            .unwrap_or(source_state.buffer.len());
+
+        let highlight_spans = source_state.highlighter.highlight_viewport(
+            &source_state.buffer,
+            top_byte,
+            end_byte,
+            theme,
+            1024, // highlight_context_bytes
+        );
+
+        let pane_width = layout.widths.get(pane_idx).copied().unwrap_or(80);
+        let mut viewport = crate::view::viewport::Viewport::new(pane_width, content_height);
+        viewport.top_byte = top_byte;
+        viewport.line_wrap_enabled = false;
+
+        let pane_width = layout.widths.get(pane_idx).copied().unwrap_or(80) as usize;
+        let gutter_width = 4; // Line number width
+        let content_width = pane_width.saturating_sub(gutter_width);
+
+        let lines_needed = last_line - first_line + 10;
+        let empty_folds = FoldManager::new();
+        let view_data = build_view_data(
+            source_state,
+            &viewport,
+            None,         // No view transform
+            80,           // estimated_line_length
+            lines_needed, // visible_count - enough to cover the range
+            false,        // line_wrap_enabled
+            content_width,
+            gutter_width,
+            &ViewMode::Source, // Composite view uses source mode
+            &empty_folds,
+            theme,
+        );
+
+        let mut line_to_view_line: HashMap<usize, usize> = HashMap::new();
+        let mut current_line = first_line;
+        for (idx, view_line) in view_data.lines.iter().enumerate() {
+            if should_show_line_number(view_line) {
+                line_to_view_line.insert(current_line, idx);
+                current_line += 1;
+            }
         }
 
-        let aligned_row = &alignment.rows[display_row];
-        // Only paint the cursor row / cursor cell when this composite panel
-        // actually holds keyboard focus — otherwise the OLD/NEW cursor lingers
-        // visibly after Tab moves focus to the file list or comments panel.
-        let is_cursor_row = display_row == cursor_row && is_active;
-        let selection_cols = view_state.selection_column_range(display_row);
+        pane_render_data.push(Some(PaneRenderData {
+            lines: view_data.lines,
+            line_to_view_line,
+            highlight_spans,
+        }));
+    }
 
-        // Determine row background based on type (selection is character-level)
-        let row_bg = match aligned_row.row_type {
-            RowType::Addition => Some(theme.diff_add_bg),
-            RowType::Deletion => Some(theme.diff_remove_bg),
-            RowType::Modification => Some(theme.diff_modify_bg),
-            RowType::HunkHeader => Some(theme.current_line_bg),
-            RowType::Context => None,
-        };
+    pane_render_data
+}
 
-        // Compute inline diff for modified rows.
-        let inline_diffs: Vec<Vec<Range<usize>>> = if aligned_row.row_type == RowType::Modification
-        {
-            let mut line_contents: Vec<Option<String>> = Vec::new();
-            for (pane_idx, source) in composite.sources.iter().enumerate() {
-                if let Some(line_ref) = aligned_row.get_pane_line(pane_idx) {
-                    if let Some(source_state) = buffers.get(&source.buffer_id) {
-                        line_contents.push(
-                            source_state
-                                .buffer
-                                .get_line(line_ref.line)
-                                .map(|line| String::from_utf8_lossy(&line).to_string()),
-                        );
-                    } else {
-                        line_contents.push(None);
-                    }
-                } else {
-                    line_contents.push(None);
-                }
-            }
-
-            if line_contents.len() >= 2 {
-                if let (Some(old_text), Some(new_text)) = (&line_contents[0], &line_contents[1]) {
-                    let (old_ranges, new_ranges) = compute_inline_diff(old_text, new_text);
-                    vec![old_ranges, new_ranges]
-                } else {
-                    vec![Vec::new(); composite.sources.len()]
-                }
-            } else {
-                vec![Vec::new(); composite.sources.len()]
-            }
+/// Paint the panes of a row that lies past the end of the aligned content:
+/// blank cells, with a leading `~` per pane when `show_tilde` is set.
+fn render_past_end_row(
+    frame: &mut Frame,
+    area_x: u16,
+    row_y: u16,
+    layout: &PaneLayout,
+    show_tilde: bool,
+    theme: &Theme,
+) {
+    let mut x = area_x;
+    for &width in &layout.widths {
+        let eof_area = Rect::new(x, row_y, width, 1);
+        let pad_width = width as usize;
+        let text = if show_tilde && pad_width > 0 {
+            format!("~{}", " ".repeat(pad_width.saturating_sub(1)))
         } else {
-            vec![Vec::new(); composite.sources.len()]
+            " ".repeat(pad_width)
         };
+        let eof = Paragraph::new(text).style(
+            Style::default()
+                .fg(theme.line_number_fg)
+                .bg(theme.after_eof_bg),
+        );
+        frame.render_widget(eof, eof_area);
+        x += width + layout.separator_width;
+    }
+}
 
-        // Render each pane for this row
-        let mut x_offset = area.x;
-        for (pane_idx, (_source, &width)) in composite.sources.iter().zip(&pane_widths).enumerate()
-        {
-            let pane_area = Rect::new(x_offset, content_y + view_row as u16, width, 1);
+/// Compute the per-pane inline-diff highlight ranges for a modification row
+/// (an empty range list for every other row type, and for any pane whose
+/// line content is unavailable).
+fn compute_modification_inline_diffs(
+    aligned_row: &AlignedRow,
+    composite: &CompositeBuffer,
+    buffers: &HashMap<BufferId, EditorState>,
+) -> Vec<Vec<Range<usize>>> {
+    use crate::model::composite_buffer::RowType;
 
-            let left_column = view_state
-                .get_pane_viewport(pane_idx)
-                .map(|v| v.left_column)
-                .unwrap_or(0);
+    if aligned_row.row_type != RowType::Modification {
+        return vec![Vec::new(); composite.sources.len()];
+    }
 
-            let source_line_opt = aligned_row.get_pane_line(pane_idx);
+    let line_contents: Vec<Option<String>> = composite
+        .sources
+        .iter()
+        .enumerate()
+        .map(|(pane_idx, source)| {
+            let line_ref = aligned_row.get_pane_line(pane_idx)?;
+            let source_state = buffers.get(&source.buffer_id)?;
+            source_state
+                .buffer
+                .get_line(line_ref.line)
+                .map(|line| String::from_utf8_lossy(&line).to_string())
+        })
+        .collect();
 
-            if let Some(source_line_ref) = source_line_opt {
-                let pane_data = pane_render_data.get(pane_idx).and_then(|opt| opt.as_ref());
-                let view_line_opt = pane_data.and_then(|data| {
-                    data.line_to_view_line
-                        .get(&source_line_ref.line)
-                        .and_then(|&idx| data.lines.get(idx))
-                });
-                let highlight_spans = pane_data
-                    .map(|data| data.highlight_spans.as_slice())
-                    .unwrap_or(&[]);
+    if let [Some(old_text), Some(new_text), ..] = line_contents.as_slice() {
+        let (old_ranges, new_ranges) = compute_inline_diff(old_text, new_text);
+        return vec![old_ranges, new_ranges];
+    }
+    vec![Vec::new(); composite.sources.len()]
+}
 
-                let gutter_width = 4usize;
-                let max_content_width = width.saturating_sub(gutter_width as u16) as usize;
+/// Paint one aligned content row: every pane cell plus the separators between
+/// them, at `row_y`.
+#[allow(clippy::too_many_arguments)]
+fn render_aligned_row(
+    frame: &mut Frame,
+    area_x: u16,
+    row_y: u16,
+    display_row: usize,
+    composite: &CompositeBuffer,
+    buffers: &HashMap<BufferId, EditorState>,
+    layout: &PaneLayout,
+    pane_render_data: &[Option<PaneRenderData>],
+    view_state: &CompositeViewState,
+    is_active: bool,
+    effective_editor_bg: Color,
+    theme: &Theme,
+) {
+    use crate::model::composite_buffer::RowType;
 
-                let is_focused_pane = pane_idx == view_state.focused_pane;
+    let aligned_row = &composite.alignment.rows[display_row];
+    // Only paint the cursor row / cursor cell when this composite panel
+    // actually holds keyboard focus — otherwise the OLD/NEW cursor lingers
+    // visibly after Tab moves focus to the file list or comments panel.
+    let is_cursor_row = display_row == view_state.cursor_row && is_active;
+    let selection_cols = view_state.selection_column_range(display_row);
 
-                // Determine background - cursor row highlight only on focused pane.
-                let bg = if is_cursor_row && is_focused_pane {
-                    theme.current_line_bg
-                } else {
-                    row_bg.unwrap_or(effective_editor_bg)
-                };
+    // Row background based on diff type (selection is character-level).
+    let row_bg = match aligned_row.row_type {
+        RowType::Addition => Some(theme.diff_add_bg),
+        RowType::Deletion => Some(theme.diff_remove_bg),
+        RowType::Modification => Some(theme.diff_modify_bg),
+        RowType::HunkHeader => Some(theme.current_line_bg),
+        RowType::Context => None,
+    };
 
-                let pane_selection_cols = if is_focused_pane {
-                    selection_cols
-                } else {
-                    None
-                };
+    let inline_diffs = compute_modification_inline_diffs(aligned_row, composite, buffers);
 
-                let line_num = format!("{:>3} ", source_line_ref.line + 1);
-                let line_num_style = Style::default().fg(theme.line_number_fg).bg(bg);
+    let mut x_offset = area_x;
+    for (pane_idx, &width) in layout.widths.iter().enumerate() {
+        let pane_area = Rect::new(x_offset, row_y, width, 1);
+        render_row_pane(
+            frame,
+            pane_area,
+            pane_idx,
+            width,
+            aligned_row,
+            pane_render_data,
+            view_state,
+            &inline_diffs,
+            selection_cols,
+            is_cursor_row,
+            row_bg,
+            effective_editor_bg,
+            theme,
+        );
+        x_offset += width;
 
-                let is_cursor_pane = is_focused_pane;
-                let cursor_column = view_state.cursor_column;
-
-                let inline_ranges = inline_diffs.get(pane_idx).cloned().unwrap_or_default();
-
-                let highlight_bg = match aligned_row.row_type {
-                    RowType::Deletion => Some(theme.diff_remove_highlight_bg),
-                    RowType::Addition => Some(theme.diff_add_highlight_bg),
-                    RowType::Modification => {
-                        if pane_idx == 0 {
-                            Some(theme.diff_remove_highlight_bg)
-                        } else {
-                            Some(theme.diff_add_highlight_bg)
-                        }
-                    }
-                    _ => None,
-                };
-
-                let mut spans = vec![Span::styled(line_num, line_num_style)];
-
-                if let Some(view_line) = view_line_opt {
-                    render_view_line_content(
-                        &mut spans,
-                        view_line,
-                        highlight_spans,
-                        left_column,
-                        max_content_width,
-                        bg,
-                        theme,
-                        is_cursor_row && is_cursor_pane,
-                        cursor_column,
-                        &inline_ranges,
-                        highlight_bg,
-                        pane_selection_cols,
-                    );
-                } else {
-                    // Unreachable in practice; fall back to a padded blank row.
-                    tracing::warn!(
-                        "ViewLine missing for composite buffer: pane={}, line={}, pane_data={}",
-                        pane_idx,
-                        source_line_ref.line,
-                        pane_data.is_some()
-                    );
-                    let base_style = Style::default().fg(theme.editor_fg).bg(bg);
-                    let padding = " ".repeat(max_content_width);
-                    spans.push(Span::styled(padding, base_style));
-                }
-
-                let line = Line::from(spans);
-                let para = Paragraph::new(line);
-                frame.render_widget(para, pane_area);
-            } else {
-                // No content for this pane (padding/gap line)
-                let is_focused_pane = pane_idx == view_state.focused_pane;
-                let pane_has_selection = is_focused_pane
-                    && selection_cols
-                        .map(|(start, end)| start == 0 && end == usize::MAX)
-                        .unwrap_or(false);
-
-                let bg = if pane_has_selection {
-                    theme.selection_bg
-                } else if is_cursor_row && is_focused_pane {
-                    theme.current_line_bg
-                } else {
-                    row_bg.unwrap_or(effective_editor_bg)
-                };
-                let style = Style::default().fg(theme.line_number_fg).bg(bg);
-
-                let is_cursor_pane = pane_idx == view_state.focused_pane;
-                if is_cursor_row && is_cursor_pane && view_state.cursor_column == 0 {
-                    let cursor_style = Style::default().fg(theme.editor_bg).bg(theme.editor_fg);
-                    let gutter_width = 4usize;
-                    let max_content_width = width.saturating_sub(gutter_width as u16) as usize;
-                    let padding = " ".repeat(max_content_width.saturating_sub(1));
-                    let line = Line::from(vec![
-                        Span::styled("    ", style),
-                        Span::styled(" ", cursor_style),
-                        Span::styled(padding, Style::default().bg(bg)),
-                    ]);
-                    let para = Paragraph::new(line);
-                    frame.render_widget(para, pane_area);
-                } else {
-                    let gap_style = Style::default().bg(bg);
-                    let empty_content = " ".repeat(width as usize);
-                    let para = Paragraph::new(empty_content).style(gap_style);
-                    frame.render_widget(para, pane_area);
-                }
-            }
-
-            x_offset += width;
-
-            if show_separator && pane_idx < pane_count - 1 {
-                let sep_area = Rect::new(x_offset, content_y + view_row as u16, separator_width, 1);
-                let sep = Paragraph::new("│").style(
-                    Style::default()
-                        .fg(theme.split_separator_fg)
-                        .bg(theme.editor_bg),
-                );
-                frame.render_widget(sep, sep_area);
-                x_offset += separator_width;
-            }
+        if layout.show_separator && pane_idx < layout.pane_count() - 1 {
+            let sep_area = Rect::new(x_offset, row_y, layout.separator_width, 1);
+            let sep = Paragraph::new("│").style(
+                Style::default()
+                    .fg(theme.split_separator_fg)
+                    .bg(theme.editor_bg),
+            );
+            frame.render_widget(sep, sep_area);
+            x_offset += layout.separator_width;
         }
     }
+}
+
+/// Paint a single pane cell for one aligned row: either highlighted source
+/// content or a blank gap/padding cell (carrying the focused-pane cursor).
+#[allow(clippy::too_many_arguments)]
+fn render_row_pane(
+    frame: &mut Frame,
+    pane_area: Rect,
+    pane_idx: usize,
+    width: u16,
+    aligned_row: &AlignedRow,
+    pane_render_data: &[Option<PaneRenderData>],
+    view_state: &CompositeViewState,
+    inline_diffs: &[Vec<Range<usize>>],
+    selection_cols: Option<(usize, usize)>,
+    is_cursor_row: bool,
+    row_bg: Option<Color>,
+    effective_editor_bg: Color,
+    theme: &Theme,
+) {
+    use crate::model::composite_buffer::RowType;
+
+    let left_column = view_state
+        .get_pane_viewport(pane_idx)
+        .map(|v| v.left_column)
+        .unwrap_or(0);
+    let is_focused_pane = pane_idx == view_state.focused_pane;
+    let gutter_width = 4usize;
+    let max_content_width = width.saturating_sub(gutter_width as u16) as usize;
+
+    let Some(source_line_ref) = aligned_row.get_pane_line(pane_idx) else {
+        // No content for this pane (padding/gap line).
+        let pane_has_selection = is_focused_pane
+            && selection_cols
+                .map(|(start, end)| start == 0 && end == usize::MAX)
+                .unwrap_or(false);
+
+        let bg = if pane_has_selection {
+            theme.selection_bg
+        } else if is_cursor_row && is_focused_pane {
+            theme.current_line_bg
+        } else {
+            row_bg.unwrap_or(effective_editor_bg)
+        };
+
+        if is_cursor_row && is_focused_pane && view_state.cursor_column == 0 {
+            let style = Style::default().fg(theme.line_number_fg).bg(bg);
+            let cursor_style = Style::default().fg(theme.editor_bg).bg(theme.editor_fg);
+            let padding = " ".repeat(max_content_width.saturating_sub(1));
+            let line = Line::from(vec![
+                Span::styled("    ", style),
+                Span::styled(" ", cursor_style),
+                Span::styled(padding, Style::default().bg(bg)),
+            ]);
+            frame.render_widget(Paragraph::new(line), pane_area);
+        } else {
+            let gap_style = Style::default().bg(bg);
+            let empty_content = " ".repeat(width as usize);
+            frame.render_widget(Paragraph::new(empty_content).style(gap_style), pane_area);
+        }
+        return;
+    };
+
+    let pane_data = pane_render_data.get(pane_idx).and_then(|opt| opt.as_ref());
+    let view_line_opt = pane_data.and_then(|data| {
+        data.line_to_view_line
+            .get(&source_line_ref.line)
+            .and_then(|&idx| data.lines.get(idx))
+    });
+    let highlight_spans = pane_data
+        .map(|data| data.highlight_spans.as_slice())
+        .unwrap_or(&[]);
+
+    // Cursor-row highlight applies only on the focused pane.
+    let bg = if is_cursor_row && is_focused_pane {
+        theme.current_line_bg
+    } else {
+        row_bg.unwrap_or(effective_editor_bg)
+    };
+
+    let pane_selection_cols = if is_focused_pane {
+        selection_cols
+    } else {
+        None
+    };
+
+    let line_num = format!("{:>3} ", source_line_ref.line + 1);
+    let line_num_style = Style::default().fg(theme.line_number_fg).bg(bg);
+
+    let inline_ranges = inline_diffs.get(pane_idx).cloned().unwrap_or_default();
+
+    let highlight_bg = match aligned_row.row_type {
+        RowType::Deletion => Some(theme.diff_remove_highlight_bg),
+        RowType::Addition => Some(theme.diff_add_highlight_bg),
+        RowType::Modification => {
+            if pane_idx == 0 {
+                Some(theme.diff_remove_highlight_bg)
+            } else {
+                Some(theme.diff_add_highlight_bg)
+            }
+        }
+        _ => None,
+    };
+
+    let mut spans = vec![Span::styled(line_num, line_num_style)];
+
+    if let Some(view_line) = view_line_opt {
+        render_view_line_content(
+            &mut spans,
+            view_line,
+            highlight_spans,
+            left_column,
+            max_content_width,
+            bg,
+            theme,
+            is_cursor_row && is_focused_pane,
+            view_state.cursor_column,
+            &inline_ranges,
+            highlight_bg,
+            pane_selection_cols,
+        );
+    } else {
+        // Unreachable in practice; fall back to a padded blank row.
+        tracing::warn!(
+            "ViewLine missing for composite buffer: pane={}, line={}, pane_data={}",
+            pane_idx,
+            source_line_ref.line,
+            pane_data.is_some()
+        );
+        let base_style = Style::default().fg(theme.editor_fg).bg(bg);
+        let padding = " ".repeat(max_content_width);
+        spans.push(Span::styled(padding, base_style));
+    }
+
+    frame.render_widget(Paragraph::new(Line::from(spans)), pane_area);
 }
 
 /// Render ViewLine content with syntax highlighting to spans.


### PR DESCRIPTION
## What & why

`render_composite_buffer` (in `view/ui/split_rendering/orchestration/render_composite.rs`) was a **409-line God Function** — the single worst offender among files **not** currently under active development. It interleaved five unrelated responsibilities in one deeply-nested body:

1. pane-width geometry math,
2. header-bar rendering,
3. per-pane `ViewLine` + syntax-highlight preparation (with a `struct` declared inline),
4. past-end (EOF) row painting,
5. modification inline-diff computation, and the nested per-row / per-pane paint loop.

## The change

Split it into a thin orchestrator (~80 lines) plus cohesive, single-responsibility private helpers:

| Helper | Responsibility |
| --- | --- |
| `PaneLayout` + `compute_pane_layout` | pane widths & separators |
| `render_pane_headers` | the source-label header bar |
| `PaneRenderData` (now module-level) + `build_pane_render_data` | per-pane ViewLines + highlighting for the visible range |
| `render_past_end_row` | blank / `~` rows past the content |
| `compute_modification_inline_diffs` | inline diff ranges per pane |
| `render_aligned_row` / `render_row_pane` | one row, one cell |

Nested `if let … else { push(None) }` blocks became **let-else guard clauses**, flattening the happy path. No new traits, generics, or macros were introduced.

## Safety

- **Behavior-preserving**: pure extraction; the public signature of `render_composite_buffer` is unchanged and `render_view_line_content` is untouched.
- **Conflict-free**: this file is not modified by any open PR (the adjacent `orchestration/mod.rs` PR only moved the *call site*, which this change leaves alone).
- `cargo build -p fresh-editor` passes; `cargo fmt` applied; `cargo clippy` reports **no warnings** for this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS2nzGdNQ8VYnH8yYXELfQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01PS2nzGdNQ8VYnH8yYXELfQ)_