### PR TITLE
fix(workspace): stop reopening a deliberately-closed file explorer on relaunch

### DIFF
--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -184,6 +184,55 @@ impl Editor {
         self.restore_workspace_for(self.active_window)
     }
 
+    /// The single window-restore flow: load and apply window `id`'s
+    /// persisted workspace, then apply the fresh-session file-explorer
+    /// default. Shared by eager startup restore
+    /// ([`Editor::restore_active_window_on_launch`]) and lazy
+    /// dock/preview materialization ([`Editor::materialize_window`]) so a
+    /// directory behaves identically however it is (re-)entered — a
+    /// deliberately-closed explorer stays closed, a brand-new directory
+    /// defaults to the tree. Operates on `windows[id]` directly, so it is
+    /// correct for a background window that is not active yet.
+    ///
+    /// `opened_files` suppresses the explorer default when the launch
+    /// opened specific files instead of a bare directory.
+    pub fn restore_window(
+        &mut self,
+        id: fresh_core::WindowId,
+        opened_files: bool,
+    ) -> Result<bool, WorkspaceError> {
+        let restored = self.restore_workspace_for(id)?;
+        if let Some(win) = self.windows.get_mut(&id) {
+            win.apply_fresh_session_explorer_default(opened_files, restored);
+        }
+        Ok(restored)
+    }
+
+    /// Eager startup restore of the active foreground window, applying
+    /// the fresh-session explorer default. The launch-time counterpart to
+    /// the lazy [`Editor::materialize_window`]; both funnel through
+    /// [`Editor::restore_window`].
+    pub fn restore_active_window_on_launch(
+        &mut self,
+        opened_files: bool,
+    ) -> Result<bool, WorkspaceError> {
+        self.restore_window(self.active_window, opened_files)
+    }
+
+    /// Apply the fresh-session explorer default to the active window for
+    /// launch/enter paths that did *not* run a workspace restore (e.g.
+    /// `--no-restore`, or a new directory opened into a running instance).
+    /// Same rule as [`Editor::restore_window`], just without a restore to
+    /// bundle it with.
+    pub fn apply_active_window_explorer_default(
+        &mut self,
+        opened_files: bool,
+        workspace_restored: bool,
+    ) {
+        self.active_window_mut()
+            .apply_fresh_session_explorer_default(opened_files, workspace_restored);
+    }
+
     /// Apply hot exit recovery to all currently open file-backed buffers.
     ///
     /// This restores unsaved changes from recovery files for buffers that were
@@ -565,7 +614,11 @@ impl Editor {
             return;
         }
         let saved_plugin_state = self.plugin_global_state.clone();
-        match self.restore_workspace_for(id) {
+        // Lazy counterpart to the eager startup restore: same
+        // `restore_window` flow, so a dock-switched directory applies its
+        // persisted explorer visibility (or the fresh-session default)
+        // exactly as a cold launch would. No CLI files on this path.
+        match self.restore_window(id, false) {
             Ok(true) => tracing::debug!("Materialized window {id} from workspace"),
             Ok(false) => {
                 tracing::trace!("No persisted workspace for window {id}; empty seed kept")
@@ -1459,6 +1512,35 @@ impl crate::app::window::Window {
 
         // Keep key_context as Normal so the editor (not the explorer) has focus.
         if self.file_explorer_visible && self.file_explorer.is_none() {
+            self.init_file_explorer();
+        }
+    }
+
+    /// The fresh-session file-explorer default: show the tree for a
+    /// brand-new directory. This is the single rule shared by every way
+    /// of entering a directory — startup restore, the orchestrator
+    /// dock/preview materialization, and the new-window (`fresh <dir>`
+    /// into a running instance) path — all of which funnel their restore
+    /// through [`Editor::restore_window`].
+    ///
+    /// It fires *only* when nothing was restored: a restored workspace
+    /// already carries the explorer's persisted visibility (applied by
+    /// [`Window::restore_file_explorer_settings`]), so re-showing here
+    /// would reopen a deliberately-closed explorer on every relaunch.
+    /// `opened_files` suppresses it when the launch opened specific files
+    /// rather than a bare directory. Visibility only — `key_context`
+    /// stays Normal so the buffer keeps focus, mirroring
+    /// `restore_file_explorer_settings`.
+    pub(crate) fn apply_fresh_session_explorer_default(
+        &mut self,
+        opened_files: bool,
+        workspace_restored: bool,
+    ) {
+        if opened_files || workspace_restored {
+            return;
+        }
+        self.file_explorer_visible = true;
+        if self.file_explorer.is_none() {
             self.init_file_explorer();
         }
     }

--- a/crates/fresh-editor/src/gui/mod.rs
+++ b/crates/fresh-editor/src/gui/mod.rs
@@ -131,16 +131,23 @@ pub fn run_gui(
             for (path, line, col) in &file_locations {
                 editor.queue_file_open(path.clone(), *line, *col, None, None, None, None);
             }
-        } else if show_file_explorer {
-            editor.show_file_explorer();
         }
 
         if workspace_enabled {
-            match editor.try_restore_workspace() {
+            // Shared restore flow (same as the TUI launch and the dock's
+            // `materialize_window`): a restored workspace keeps its
+            // persisted explorer visibility, and only a brand-new
+            // directory defaults to the tree — so a closed explorer is
+            // not re-opened on every relaunch.
+            match editor.restore_active_window_on_launch(!show_file_explorer) {
                 Ok(true) => tracing::info!("Workspace restored"),
                 Ok(false) => tracing::debug!("No previous workspace"),
                 Err(e) => tracing::warn!("Failed to restore workspace: {}", e),
             }
+        } else if show_file_explorer {
+            // No session restore (e.g. --no-session) but a bare directory:
+            // still default to showing the tree.
+            editor.apply_active_window_explorer_default(!show_file_explorer, false);
         }
 
         if let Err(e) = editor.start_recovery_session() {

--- a/crates/fresh-editor/src/main.rs
+++ b/crates/fresh-editor/src/main.rs
@@ -820,7 +820,14 @@ fn handle_first_run_setup(
         && (args.force_restore || editor.config().editor.restore_previous_session);
 
     if restore_full_session {
-        match editor.try_restore_workspace() {
+        // Shared window-restore flow — the same `restore_window` the
+        // orchestrator dock's `materialize_window` uses — so the
+        // foreground directory applies its persisted explorer visibility,
+        // or the fresh-session default, exactly as a dock switch would. A
+        // bare single-directory launch (`show_file_explorer`) defaults to
+        // the tree only when nothing was restored, which keeps a
+        // deliberately-closed explorer closed across relaunches.
+        match editor.restore_active_window_on_launch(!show_file_explorer) {
             Ok(true) => {
                 tracing::info!("Workspace restored successfully");
             }
@@ -865,6 +872,10 @@ fn handle_first_run_setup(
                 tracing::warn!("Failed to restore hot-exit buffers: {}", e);
             }
         }
+        // No workspace was restored, so the persisted explorer visibility
+        // never loaded — apply the same fresh-session default the restore
+        // flow would, so a bare directory launch still opens the tree.
+        editor.apply_active_window_explorer_default(!show_file_explorer, false);
     }
 
     // Handle stdin streaming (takes priority over files)
@@ -900,9 +911,10 @@ fn handle_first_run_setup(
         editor.schedule_hot_exit_recovery();
     }
 
-    if show_file_explorer {
-        editor.show_file_explorer();
-    }
+    // The file-explorer default is applied by the restore/no-restore
+    // branches above (via `restore_window` / `apply_active_window_explorer_default`),
+    // which respect a deliberately-closed explorer rather than re-opening
+    // it unconditionally on every relaunch.
 
     if editor.has_recovery_files().unwrap_or(false) {
         tracing::info!("Recovery files found from previous session, recovering...");
@@ -3484,7 +3496,12 @@ fn run_if_subcommand(
 /// Attempt workspace or hot-exit restore when the editor restarts into a new project.
 fn restore_editor_workspace(editor: &mut Editor, args: &Args) {
     if args.force_restore || editor.config().editor.restore_previous_session {
-        match editor.try_restore_workspace() {
+        // Shared restore flow (same as startup / the dock's
+        // `materialize_window`): applies the new project's persisted
+        // explorer visibility, or the fresh-session default when there is
+        // nothing to restore — so a project whose explorer was closed
+        // does not spring back open on a Switch Project restart.
+        match editor.restore_active_window_on_launch(false) {
             Ok(true) => tracing::info!("Workspace restored successfully"),
             Ok(false) => tracing::debug!("No previous workspace found"),
             Err(e) => tracing::warn!("Failed to restore workspace: {}", e),
@@ -3503,6 +3520,8 @@ fn restore_editor_workspace(editor: &mut Editor, args: &Args) {
             Ok(_) => {}
             Err(e) => tracing::warn!("Failed to restore hot-exit buffers on restart: {}", e),
         }
+        // Nothing restored — apply the bare-directory explorer default.
+        editor.apply_active_window_explorer_default(false, false);
     }
 }
 
@@ -3961,8 +3980,14 @@ fn real_main() -> AnyhowResult<()> {
         } else {
             if restore_workspace_on_restart {
                 restore_editor_workspace(&mut editor, &args);
+            } else {
+                // Not restoring on this restart at all — still default the
+                // explorer for the freshly-entered directory.
+                editor.apply_active_window_explorer_default(false, false);
             }
-            editor.show_file_explorer();
+            // Mid-session restart: reflow so the (possibly toggled) sidebar
+            // and the split/terminal viewports match the new visibility.
+            editor.relayout();
             let path = current_working_dir
                 .as_ref()
                 .map(|p| p.display().to_string())

--- a/crates/fresh-editor/src/server/local_control.rs
+++ b/crates/fresh-editor/src/server/local_control.rs
@@ -204,12 +204,19 @@ pub fn pump(editor: &mut Editor) -> bool {
                         .file_name()
                         .map(|s| s.to_string_lossy().into_owned())
                         .unwrap_or_else(|| path.to_string_lossy().into_owned());
+                    // A directory that already has a session window is
+                    // restored by `set_active_window` → `materialize_window`
+                    // and keeps its persisted explorer visibility. Only a
+                    // brand-new directory gets the fresh-session default,
+                    // mirroring a normal `fresh <dir>` launch instead of
+                    // leaving the new window on an empty buffer.
+                    let known_session = editor.find_window_by_root(&path).is_some();
                     let id = editor.create_window_at(path, label);
                     editor.set_active_window(id);
-                    // Match a normal `fresh <dir>` launch, which opens the
-                    // file explorer for a directory argument (see `main.rs`),
-                    // rather than leaving the new window on an empty buffer.
-                    editor.show_file_explorer();
+                    if !known_session {
+                        editor.apply_active_window_explorer_default(false, false);
+                        editor.relayout();
+                    }
                     changed = true;
                 } else {
                     tracing::warn!("OpenWindow ignored: path must be absolute: {:?}", path);

--- a/crates/fresh-editor/tests/e2e/file_explorer_session_persist.rs
+++ b/crates/fresh-editor/tests/e2e/file_explorer_session_persist.rs
@@ -1,0 +1,141 @@
+//! The file explorer's open/closed state must survive a relaunch.
+//!
+//! Regression: opening a bare directory (`fresh <dir>`) showed the file
+//! explorer by default, but the launch path then re-`show`ed it
+//! unconditionally *after* restore — so a deliberately-closed explorer
+//! sprang back open on every relaunch. The launch/enter flow now defers
+//! to the workspace's persisted `file_explorer_visible`, defaulting to
+//! the tree only for a brand-new directory (see `Editor::restore_window`
+//! / `Window::apply_fresh_session_explorer_default`).
+//!
+//! These drive the real launch entrypoint (`restore_active_window_on_launch`)
+//! and assert on rendered output.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config_io::DirectoryContext;
+use std::fs;
+use tempfile::TempDir;
+
+fn launch_harness(
+    project_dir: &std::path::Path,
+    dir_context: &DirectoryContext,
+) -> EditorTestHarness {
+    EditorTestHarness::create(
+        100,
+        30,
+        HarnessOptions::new()
+            .with_working_dir(project_dir.to_path_buf())
+            .with_shared_dir_context(dir_context.clone())
+            .without_empty_plugins_dir(),
+    )
+    .unwrap()
+}
+
+/// Closed explorer stays closed across a relaunch of the same directory.
+#[test]
+fn explorer_closed_state_survives_relaunch() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("a.txt"), "hello").unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: bare-directory launch shows the explorer by default;
+    // the user closes it (Ctrl+B), then we shut down (saving the
+    // workspace with the explorer closed).
+    {
+        let mut harness = launch_harness(&project_dir, &dir_context);
+        let restored = harness
+            .editor_mut()
+            .restore_active_window_on_launch(false)
+            .unwrap();
+        assert!(!restored, "no workspace exists yet on the first launch");
+        harness
+            .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+            .unwrap();
+
+        // Ctrl+B toggles the sidebar/file-explorer visibility off.
+        harness
+            .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+            .unwrap();
+        harness
+            .wait_until(|h| !h.screen_to_string().contains("File Explorer"))
+            .unwrap();
+
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: relaunching the same directory must NOT re-open the
+    // explorer — the persisted closed state wins.
+    {
+        let mut harness = launch_harness(&project_dir, &dir_context);
+        let restored = harness
+            .editor_mut()
+            .restore_active_window_on_launch(false)
+            .unwrap();
+        assert!(restored, "the saved workspace should restore");
+        harness.render().unwrap();
+        assert!(
+            !harness.screen_to_string().contains("File Explorer"),
+            "explorer must stay closed after being closed in the previous session"
+        );
+
+        // Prove the closed state deterministically (the panel paints its
+        // tree asynchronously, so a single absent frame alone is weak):
+        // from closed, Ctrl+B opens the explorer. If it had wrongly been
+        // re-opened, the same key would close it and the panel would
+        // never appear — hanging this wait into a timeout failure.
+        harness
+            .send_key(KeyCode::Char('b'), KeyModifiers::CONTROL)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+            .unwrap();
+    }
+}
+
+// The orchestrator dock switch (`set_active_window` → `materialize_window`)
+// funnels through the same `Editor::restore_window` these tests exercise,
+// so a directory whose session was active in a previous execution restores
+// its persisted explorer state identically. That path is verified manually
+// (background-session discovery isn't wired up in the vanilla test harness).
+
+/// Inverse control: an explorer left open is restored open, so the fix
+/// is not just "always hide".
+#[test]
+fn explorer_open_state_survives_relaunch() {
+    let temp_dir = TempDir::new().unwrap();
+    let project_dir = temp_dir.path().join("project");
+    fs::create_dir(&project_dir).unwrap();
+    fs::write(project_dir.join("a.txt"), "hello").unwrap();
+    let dir_context = DirectoryContext::for_testing(temp_dir.path());
+
+    // Session 1: leave the default-opened explorer open, then shut down.
+    {
+        let mut harness = launch_harness(&project_dir, &dir_context);
+        harness
+            .editor_mut()
+            .restore_active_window_on_launch(false)
+            .unwrap();
+        harness
+            .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+            .unwrap();
+        harness.shutdown(true).unwrap();
+    }
+
+    // Session 2: the explorer should still be open.
+    {
+        let mut harness = launch_harness(&project_dir, &dir_context);
+        let restored = harness
+            .editor_mut()
+            .restore_active_window_on_launch(false)
+            .unwrap();
+        assert!(restored, "the saved workspace should restore");
+        // The explorer initialises its tree asynchronously; wait for the
+        // restored-open panel to paint rather than asserting on one frame.
+        harness
+            .wait_until(|h| h.screen_to_string().contains("File Explorer"))
+            .unwrap();
+    }
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -38,6 +38,7 @@ pub mod file_browser;
 pub mod file_explorer;
 pub mod file_explorer_compact_chain;
 pub mod file_explorer_open_focus;
+pub mod file_explorer_session_persist;
 pub mod file_permissions;
 pub mod flash;
 pub mod folding;


### PR DESCRIPTION
## Problem

Opening a bare directory (`fresh ~/repos`) shows the file explorer by default. But if you **close** it, exit, and relaunch the same directory, the explorer **re-opens** — your closed state is lost.

Reproduced interactively (tmux): launch → close explorer (Ctrl+B) → quit (saves workspace with `file_explorer.visible = false`) → relaunch → explorer is open again.

## Root cause

The persisted state was correct all along — `restore_file_explorer_settings` restores `file_explorer_visible` faithfully (verified the on-disk workspace had `visible: false`). The bug was that **every** launch/enter path then called `show_file_explorer()` *unconditionally after* restore, clobbering it back to visible:

- `main.rs` cold start (`handle_first_run_setup`)
- `main.rs` Switch Project restart
- `gui/mod.rs` GUI launch
- `local_control.rs` `OpenWindow` (`fresh <dir>` into a running instance)

## Fix — one shared restore flow

Unify the rule behind a single function instead of four ad-hoc force-shows:

- **`Editor::restore_window(id, opened_files)`** — restores a window's workspace, then applies the *fresh-session* explorer default. It shows the tree **only** when nothing was restored; a restored workspace keeps its own persisted visibility.
- **`Window::apply_fresh_session_explorer_default`** — the single rule (`!opened_files && !workspace_restored`). Visibility only, no focus change (matches `restore_file_explorer_settings` and the observed cold-start state).
- Eager startup restore (`restore_active_window_on_launch`) and the lazy **orchestrator-dock** materialization (`materialize_window`) both funnel through `restore_window`, so a directory behaves identically however it is (re-)entered.
- No-restore launch paths (`--no-restore`, new window into a running instance) apply the same rule via `apply_active_window_explorer_default`.

This directly addresses the dock-switch case: switching to a workspace that was active in a previous execution now restores its persisted explorer state, via the *same* code as cold start.

## Tests

`tests/e2e/file_explorer_session_persist.rs` (drives the real launch entrypoint, asserts on rendered output):

- `explorer_closed_state_survives_relaunch` — close → relaunch → stays closed. Uses a deterministic toggle-probe (from closed, Ctrl+B must *open* it) to dodge the explorer's async paint. Verified it **hangs/fails** when the `workspace_restored` gate is removed.
- `explorer_open_state_survives_relaunch` — inverse control: an explorer left open restores open (the fix isn't "always hide").

The orchestrator-dock path shares `restore_window`, so it's covered by construction; it's also verified manually in tmux (background-session discovery isn't wired up in the vanilla test harness).

`cargo fmt`, `cargo clippy --all-targets`, and `cargo check --all-targets --features gui` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #2476
