### PR TITLE
fix(markdown-compose): measure table cells by display width

### DIFF
--- a/crates/fresh-editor/plugins/markdown_compose.ts
+++ b/crates/fresh-editor/plugins/markdown_compose.ts
@@ -964,6 +964,11 @@ function concealedText(text: string): string {
   return result;
 }
 
+// Terminal column width (wide glyphs = 2), matching the renderer's layout.
+function displayWidth(text: string): number {
+  return editor.stringWidth(text);
+}
+
 const MIN_COL_W = 3;
 
 /**
@@ -1113,7 +1118,7 @@ function processLineConceals(
             const wrapW = Math.max(1, colWidths[ci] - 2);
             const wrapped = cellWrapped[ci] || [];
             const text = vl < wrapped.length ? wrapped[vl] : '';
-            vline += ' ' + text + ' '.repeat(Math.max(0, wrapW - text.length)) + ' │';
+            vline += ' ' + text + ' '.repeat(Math.max(0, wrapW - displayWidth(text))) + ' │';
           }
           visualLines.push(vline);
         }
@@ -1171,7 +1176,7 @@ function processLineConceals(
       if (!cursorStrictlyOnLine && colWidths) {
         for (let ci = 0; ci < Math.min(cells.length, colWidths.length); ci++) {
           const cellText = concealedText(cells[ci]);
-          if (cellText.length > colWidths[ci]) {
+          if (displayWidth(cellText) > colWidths[ci]) {
             const prevPipe = pipePositions[ci];
             const nextPipe = pipePositions[ci + 1];
             if (prevPipe !== undefined && nextPipe !== undefined) {
@@ -1196,7 +1201,7 @@ function processLineConceals(
           const cellIdx = pipeIdx - 1;
           if (!cursorStrictlyOnLine && colWidths && pipeIdx > 0 && cellIdx < cells.length && cellIdx < colWidths.length) {
             const cellText = concealedText(cells[cellIdx]);
-            const cellWidth = cellText.length;
+            const cellWidth = displayWidth(cellText);
             const allocatedWidth = colWidths[cellIdx];
 
             if (cellWidth > allocatedWidth) {
@@ -1539,7 +1544,7 @@ function processTableAlignment(
           // a row. Concealed rows simply get extra padding.
           const isSep = /^[-:\s]+$/.test(row[col]);
           if (!isSep) {
-            maxW = Math.max(maxW, row[col].length);
+            maxW = Math.max(maxW, displayWidth(row[col]));
           }
         }
       }


### PR DESCRIPTION
## Summary

In Markdown compose/preview mode, the right border of a rendered table is drawn one column too far right on any row whose last cell ends in a 2-cell-wide glyph (emoji such as `✅`, CJK, …). Because the **current (cursor) line** is rendered raw and stays correctly aligned, the border appears to flicker/pop as the cursor moves over each emoji row. Rows without a wide trailing glyph are unaffected. Fixes #2475.

## Root cause

The `markdown_compose` plugin measured cell text with JS `String.length` (UTF-16 code units), so `✅` (U+2705) counted as **1** column while the renderer lays it out as **2**. Non-cursor rows were therefore padded one column too wide, pushing their right `│` past the `┌┐└┘├┼┤` box frame.

## Fix

Add a small `displayWidth()` helper backed by `editor.stringWidth` — the plugin API added in #2401, itself backed by `fresh_core::display_width` — so the plugin measures cells exactly as the editor lays out terminal cells. Routed the four width-measuring sites through it:

- column max-width in `processTableAlignment`
- cell padding width
- the truncation overflow check
- the wrapped-cell padding

```ts
// Terminal column width (wide glyphs = 2), matching the renderer's layout.
function displayWidth(text: string): number {
  return editor.stringWidth(text);
}
```

## Verification

Reproduced and verified in tmux (110×30, `xterm-256color`) with the example file from #2475:

- **Before:** emoji rows draw their right border at column 45 (protruding) except the cursor's row at 44.
- **After:** every emoji row sits at column **44** — flush with the box — at all cursor positions (Ln1–Ln18); no misalignment, no pop. The no-emoji control table is unchanged.

Plugin type checks pass (`plugins/check-types.sh`).

## Related

- #2401 — exposes `editor.charWidth` / `editor.stringWidth` to plugins (the API this fix uses).
- #2400 — skips synchronized-update markers inside tmux; addresses the scroll/stray-glyph facet of the same #2475 report. This PR is complementary: it fixes the underlying cell-width miscalculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)