### PR TITLE
fix(remote): restore integrated terminals after an SSH/kube workspace reconnect

### DIFF
--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -91,12 +91,11 @@ impl Editor {
         // This ensures plugin errors surface quickly instead of causing silent hangs
         self.plugin_manager.write().unwrap().check_thread_health();
 
-        // Catch silent agent-channel reconnects (the background transport
-        // hot-swap in `spawn_reconnect_task`) and respawn any terminals that
-        // died with the dropped carrier. The app-level `RemoteAttachMode::
-        // Reconnect` path handles the dive-into-dormant / manual-reconnect
-        // cases; this covers the automatic recovery that never goes through it.
-        self.detect_remote_terminal_reconnects();
+        // Lazily wire an event-driven reconnect forwarder for each remote
+        // window (idempotent; cheap when already wired). This replaces the old
+        // per-frame connection-state poll: the forwarder awaits the channel's
+        // reconnect notification and posts `RemoteReconnected`.
+        self.ensure_remote_reconnect_forwarders();
 
         let Some(bridge) = &self.async_bridge else {
             return false;
@@ -391,6 +390,9 @@ impl Editor {
                 }
                 AsyncMessage::RemoteAttachReady(ready) => {
                     self.handle_remote_attach_ready(ready);
+                }
+                AsyncMessage::RemoteReconnected { connection_id } => {
+                    self.handle_remote_reconnected(connection_id);
                 }
                 AsyncMessage::RemoteAttachFailed {
                     error,
@@ -803,38 +805,100 @@ impl Editor {
     /// on the automatic recovery path, would otherwise stay dead even though
     /// the filesystem/LSP came back.
     ///
-    /// We sample each remote-agent window's `is_remote_connected()` every
-    /// frame and, on a `false → true` edge, respawn its dead terminals through
-    /// the (already recovered) authority — the same `respawn_terminals_through_
-    /// authority` the manual reconnect handler calls.
-    fn detect_remote_terminal_reconnects(&mut self) {
-        // Gather the reconnected windows without holding a `windows` borrow
-        // across `set_status_message` (which needs `&mut self`).
-        let mut reconnected: Vec<String> = Vec::new();
-        for window in self.windows.values_mut() {
-            // Gate on the *live authority* being remote (an SSH / kube
-            // filesystem), not `authority_spec` — a plain `fresh ssh://…`
-            // launch leaves the spec `Local`. A dormant window's placeholder
-            // authority is local, so `remote_connection_info()` is `None` and
-            // it never produces a spurious edge here; its revival is owned by
-            // the `RemoteAttachMode::Reconnect` path.
+    /// Bring `window_id`'s remote session back to life after its carrier
+    /// reconnected. The single convergence point for *every* reconnect path:
+    ///
+    ///   * the silent background transport hot-swap (`spawn_reconnect_task`),
+    ///     which keeps the existing authority and notifies via
+    ///     `AsyncMessage::RemoteReconnected`; and
+    ///   * the app-level rebuild (`RemoteAttachMode::Reconnect`), which installs
+    ///     a fresh authority first and then calls this.
+    ///
+    /// Either way the embedded terminal PTYs died with the old carrier (a
+    /// separate `ssh -t` / `kubectl exec` from the agent channel), so we respawn
+    /// them in place through the now-live authority, reusing each backing file
+    /// so scrollback continues. `respawn_terminals_through_authority` skips
+    /// still-live terminals, so this is idempotent under duplicate signals.
+    pub(crate) fn reattach_window(&mut self, window_id: fresh_core::WindowId) {
+        let Some(window) = self.windows.get_mut(&window_id) else {
+            return;
+        };
+        window.remote_reconnect_error = None;
+        let revived = window.respawn_terminals_through_authority();
+        if revived > 0 {
+            let label = window.label.clone();
+            self.set_status_message(format!("Reconnected: {label}"));
+        }
+    }
+
+    /// Ensure each remote window has a background task forwarding its agent
+    /// channel's reconnect notifications onto the bridge as
+    /// `AsyncMessage::RemoteReconnected`. Idempotent and cheap: it only spawns
+    /// for channels not already in `remote_reconnect_forwarders`. Called every
+    /// frame so windows born/reconnected after startup are covered without
+    /// hooking each authority-install site.
+    ///
+    /// The forwarder loops (`notified().await` → `send`) so it survives many
+    /// reconnects. A window whose authority is later rebuilt gets a *new*
+    /// channel id and a fresh forwarder; the old forwarder parks forever on a
+    /// notify that can no longer fire (its channel is dropped) — a single idle
+    /// task per rebuild, which is rare. Cleaning those up is a future refinement.
+    fn ensure_remote_reconnect_forwarders(&mut self) {
+        let (Some(runtime), Some(bridge)) =
+            (self.tokio_runtime.as_ref(), self.async_bridge.as_ref())
+        else {
+            return;
+        };
+        // Collect first to avoid spawning while holding the `windows` borrow.
+        let mut to_spawn: Vec<(u64, std::sync::Arc<tokio::sync::Notify>)> = Vec::new();
+        for window in self.windows.values() {
             let fs = &window.authority().filesystem;
-            let is_remote = fs.remote_connection_info().is_some();
-            let connected = fs.is_remote_connected();
-            let was = window.remote_was_connected;
-            window.remote_was_connected = connected;
-            // Only a genuine drop→recover edge on a live remote window.
-            if is_remote && connected && !was {
-                let revived = window.respawn_terminals_through_authority();
-                if revived > 0 {
-                    reconnected.push(window.label.clone());
+            if let (Some(id), Some(notify)) = (fs.remote_channel_id(), fs.remote_reconnect_notify())
+            {
+                if !self.remote_reconnect_forwarders.contains(&id) {
+                    to_spawn.push((id, notify));
                 }
             }
         }
-        // One line is enough even if several windows recovered at once.
-        if let Some(label) = reconnected.first() {
-            self.set_status_message(format!("Reconnected: {label}"));
+        for (id, notify) in to_spawn {
+            self.remote_reconnect_forwarders.insert(id);
+            let sender = bridge.sender();
+            runtime.spawn(async move {
+                loop {
+                    notify.notified().await;
+                    if sender
+                        .send(AsyncMessage::RemoteReconnected { connection_id: id })
+                        .is_err()
+                    {
+                        break; // editor/bridge gone
+                    }
+                }
+            });
         }
+    }
+
+    /// Test-only seam: drive the reconnect dispatch directly, as if a
+    /// `RemoteReconnected` event for `connection_id` had arrived on the bridge.
+    /// Lets component tests exercise the id→window→reattach mapping without a
+    /// live agent channel or tokio runtime.
+    #[doc(hidden)]
+    pub fn test_dispatch_remote_reconnected(&mut self, connection_id: u64) {
+        self.handle_remote_reconnected(connection_id);
+    }
+
+    /// Map a reconnected agent channel (identified by its stable connection id)
+    /// back to the window whose live authority owns it, and reattach. Driven by
+    /// the background reconnect task via `AsyncMessage::RemoteReconnected`.
+    fn handle_remote_reconnected(&mut self, connection_id: u64) {
+        let Some(window_id) = self.windows.iter().find_map(|(id, w)| {
+            (w.authority().filesystem.remote_channel_id() == Some(connection_id)).then_some(*id)
+        }) else {
+            // The window was closed, or its authority was swapped out from under
+            // this connection — nothing to reattach.
+            return;
+        };
+        tracing::info!("agent channel {connection_id} reconnected; reattaching window {window_id}");
+        self.reattach_window(window_id);
     }
 
     fn handle_terminal_exited(
@@ -1070,37 +1134,16 @@ impl Editor {
                         "Reconnected dormant session {window_id} ({})",
                         authority.display_label
                     );
-                    // Clear any prior FailedAttach now the reconnect
-                    // succeeded, so the indicator drops back to
-                    // Connected for this workspace.
-                    if let Some(w) = self.windows.get_mut(&window_id) {
-                        w.remote_reconnect_error = None;
-                    }
+                    // This path *rebuilt* the authority, so install it first,
+                    // then reattach: `reattach_window` clears the FailedAttach
+                    // indicator and respawns the embedded terminal(s) that died
+                    // with the old carrier, through the freshly-installed
+                    // authority. The silent hot-swap path keeps the existing
+                    // authority and reaches the same `reattach_window` via
+                    // `AsyncMessage::RemoteReconnected`.
                     self.set_session_authority(window_id, authority);
                     self.session_keepalives.insert(window_id, keepalive);
-                    // The window's embedded terminal(s) ran over the
-                    // old `ssh -t` carrier, which died with the link
-                    // — the agent-channel reconnect doesn't revive
-                    // them. Respawn each dead PTY through the
-                    // freshly-installed authority so it runs on the
-                    // remote backend again, reusing its backing file
-                    // so scrollback continues.
-                    if let Some(w) = self.windows.get_mut(&window_id) {
-                        w.respawn_terminals_through_authority();
-                        // We just respawned through the freshly-installed
-                        // authority; record the connected state so the
-                        // per-frame `detect_remote_terminal_reconnects` edge
-                        // detector doesn't see a `false → true` transition and
-                        // respawn a second time on the next tick.
-                        w.remote_was_connected = w.authority().filesystem.is_remote_connected();
-                    }
-                    self.set_status_message(format!(
-                        "Reconnected: {}",
-                        self.windows
-                            .get(&window_id)
-                            .map(|w| w.label.clone())
-                            .unwrap_or_default()
-                    ));
+                    self.reattach_window(window_id);
                 } else {
                     // The window was closed while the connect was in
                     // flight — drop the backend we just built.

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -91,6 +91,13 @@ impl Editor {
         // This ensures plugin errors surface quickly instead of causing silent hangs
         self.plugin_manager.write().unwrap().check_thread_health();
 
+        // Catch silent agent-channel reconnects (the background transport
+        // hot-swap in `spawn_reconnect_task`) and respawn any terminals that
+        // died with the dropped carrier. The app-level `RemoteAttachMode::
+        // Reconnect` path handles the dive-into-dormant / manual-reconnect
+        // cases; this covers the automatic recovery that never goes through it.
+        self.detect_remote_terminal_reconnects();
+
         let Some(bridge) = &self.async_bridge else {
             return false;
         };
@@ -785,6 +792,51 @@ impl Editor {
 
     /// Tear down (or preserve, for a pending remote reconnect) a terminal whose
     /// process exited, then fire the `terminal_exit` hook.
+    /// Per-frame detector for *silent* agent-channel reconnects.
+    ///
+    /// The SSH / Kubernetes agent channel re-establishes itself in the
+    /// background by hot-swapping its transport (`spawn_reconnect_task`),
+    /// without ever routing through the app-level `RemoteAttachMode::Reconnect`
+    /// flow — and that flow is the only thing that respawns the embedded
+    /// terminal PTYs. Those PTYs are a *separate* `ssh -t` / `kubectl exec`
+    /// carrier from the agent channel, so they die when the link drops and,
+    /// on the automatic recovery path, would otherwise stay dead even though
+    /// the filesystem/LSP came back.
+    ///
+    /// We sample each remote-agent window's `is_remote_connected()` every
+    /// frame and, on a `false → true` edge, respawn its dead terminals through
+    /// the (already recovered) authority — the same `respawn_terminals_through_
+    /// authority` the manual reconnect handler calls.
+    fn detect_remote_terminal_reconnects(&mut self) {
+        // Gather the reconnected windows without holding a `windows` borrow
+        // across `set_status_message` (which needs `&mut self`).
+        let mut reconnected: Vec<String> = Vec::new();
+        for window in self.windows.values_mut() {
+            // Gate on the *live authority* being remote (an SSH / kube
+            // filesystem), not `authority_spec` — a plain `fresh ssh://…`
+            // launch leaves the spec `Local`. A dormant window's placeholder
+            // authority is local, so `remote_connection_info()` is `None` and
+            // it never produces a spurious edge here; its revival is owned by
+            // the `RemoteAttachMode::Reconnect` path.
+            let fs = &window.authority().filesystem;
+            let is_remote = fs.remote_connection_info().is_some();
+            let connected = fs.is_remote_connected();
+            let was = window.remote_was_connected;
+            window.remote_was_connected = connected;
+            // Only a genuine drop→recover edge on a live remote window.
+            if is_remote && connected && !was {
+                let revived = window.respawn_terminals_through_authority();
+                if revived > 0 {
+                    reconnected.push(window.label.clone());
+                }
+            }
+        }
+        // One line is enough even if several windows recovered at once.
+        if let Some(label) = reconnected.first() {
+            self.set_status_message(format!("Reconnected: {label}"));
+        }
+    }
+
     fn handle_terminal_exited(
         &mut self,
         terminal: fresh_core::WindowTerminalId,
@@ -796,24 +848,24 @@ impl Editor {
         let terminal_id = terminal.terminal;
         let exited_window_id = terminal.window;
         tracing::info!("Terminal {} exited", terminal);
-        // A remote-agent window whose carrier just dropped: its
-        // embedded PTY (a separate `ssh -t` from the agent channel)
-        // died with the link, not because the user exited the shell.
-        // Keep the buffer↔terminal binding (and the backing/command
-        // maps, which this handler already leaves intact) so a later
-        // reconnect can respawn it in place over the new authority
-        // (`respawn_terminals_through_authority`). Removing it here
-        // would strand the buffer as a dead read-only tab with no way
-        // back. A normal exit (remote still connected, or any local
-        // terminal) falls through to the usual permanent teardown.
-        let preserve_for_reconnect = matches!(
-            self.active_window().authority_spec,
-            crate::services::authority::SessionAuthoritySpec::RemoteAgent(_)
-        ) && !self
-            .active_window()
-            .authority()
-            .filesystem
-            .is_remote_connected();
+        // A remote window whose carrier just dropped: its embedded PTY (a
+        // separate `ssh -t` / `kubectl exec` from the agent channel) died with
+        // the link, not because the user exited the shell. Keep the
+        // buffer↔terminal binding (and the backing/command maps, which this
+        // handler already leaves intact) so a reconnect can respawn it in
+        // place (`respawn_terminals_through_authority`, driven on the automatic
+        // path by `detect_remote_terminal_reconnects`). Removing it here would
+        // strand the buffer as a dead read-only tab with no way back.
+        //
+        // The signal is the *live authority*: a remote filesystem that is
+        // currently disconnected. Gating on `authority_spec` instead would
+        // miss a plain `fresh ssh://…` launch, whose spec stays `Local`. A
+        // normal exit (remote still connected, or any local terminal) falls
+        // through to the usual permanent teardown.
+        let preserve_for_reconnect = {
+            let fs = &self.active_window().authority().filesystem;
+            fs.remote_connection_info().is_some() && !fs.is_remote_connected()
+        };
         // Find the buffer associated with this terminal
         if let Some((&buffer_id, _)) = self
             .active_window()
@@ -1035,6 +1087,12 @@ impl Editor {
                     // so scrollback continues.
                     if let Some(w) = self.windows.get_mut(&window_id) {
                         w.respawn_terminals_through_authority();
+                        // We just respawned through the freshly-installed
+                        // authority; record the connected state so the
+                        // per-frame `detect_remote_terminal_reconnects` edge
+                        // detector doesn't see a `false → true` transition and
+                        // respawn a second time on the next tick.
+                        w.remote_was_connected = w.authority().filesystem.is_remote_connected();
                     }
                     self.set_status_message(format!(
                         "Reconnected: {}",

--- a/crates/fresh-editor/src/app/editor_init.rs
+++ b/crates/fresh-editor/src/app/editor_init.rs
@@ -463,6 +463,7 @@ impl Editor {
             key_translator: parts.key_translator,
 
             // Trivial defaults (no external dependencies):
+            remote_reconnect_forwarders: std::collections::HashSet::new(),
             materialize_pending: std::collections::HashSet::new(),
             grammar_reload_pending: false,
             grammar_build_in_progress: false,
@@ -1139,6 +1140,17 @@ impl Editor {
                     crate::services::authority::SessionAuthoritySpec::Local,
                 )
             });
+        // A plain `fresh ssh://…` (or `user@host:path`) launch installs a remote
+        // authority but has no persisted window to carry a spec, so the default
+        // above is `Local` — which left persistence and manual reconnect inert
+        // for CLI remote sessions. Derive the real spec from the live authority
+        // when the resolved one is `Local` but the backend isn't. Never
+        // downgrades an already-remote spec (e.g. a restored dormant session
+        // booted on a local placeholder), since that path is `RemoteAgent` here.
+        let active_authority_spec = match active_authority_spec {
+            crate::services::authority::SessionAuthoritySpec::Local => authority.session_spec(),
+            spec => spec,
+        };
 
         // The active window owns the editor's boot authority outright — moved
         // in, not cloned (there is no editor-wide copy).

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -537,6 +537,14 @@ pub struct Editor {
     /// Bridge for async messages from tokio tasks to main loop
     async_bridge: Option<AsyncBridge>,
 
+    /// Connection ids (`AgentChannel::id`) for which a reconnect-forwarder task
+    /// has already been spawned. The forwarder awaits each channel's
+    /// `reconnect_notify` and turns a hot-swap into an
+    /// `AsyncMessage::RemoteReconnected`, so reconnect handling is event-driven
+    /// rather than polled. `ensure_remote_reconnect_forwarders` registers one
+    /// lazily per remote window; this set makes that idempotent.
+    remote_reconnect_forwarders: std::collections::HashSet<u64>,
+
     /// In-flight async system-clipboard reads, keyed by `request_id`.
     /// Each entry owns an anchor (`VirtualText("▍")`) in some buffer
     /// that floats with edits via the marker tree; when the matching

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -809,7 +809,11 @@ impl Window {
     /// so every terminal-id-keyed entry (buffer→terminal binding, backing/log
     /// files, launch/resume commands, ephemeral marker) is remapped to the new
     /// id and the dead handle is torn down.
-    pub fn respawn_terminals_through_authority(&mut self) {
+    ///
+    /// Returns the number of terminals actually revived (dead handles that were
+    /// respawned), so callers can tailor a status message and skip it when the
+    /// window had no terminals to restore.
+    pub fn respawn_terminals_through_authority(&mut self) -> usize {
         // Snapshot the (buffer, old terminal id) pairs up front — the loop
         // mutates `terminal_buffers` as it remaps ids.
         let bindings: Vec<(BufferId, TerminalId)> = self
@@ -818,6 +822,7 @@ impl Window {
             .map(|(b, t)| (*b, *t))
             .collect();
 
+        let mut revived = 0usize;
         for (buffer_id, old_id) in bindings {
             // Leave a still-live terminal alone; only revive the dead ones.
             let handle = self.terminal_manager.get(old_id);
@@ -903,10 +908,14 @@ impl Window {
                 self.process_groups
                     .register(pid, format!("terminal #{}", new_id.0));
             }
+
+            revived += 1;
         }
 
         // Size the freshly-spawned PTYs to their splits' content areas.
         self.resize_visible_terminals();
+
+        revived
     }
 }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -360,16 +360,6 @@ pub struct Window {
     /// another window's indicator.
     pub remote_reconnect_error: Option<String>,
 
-    /// Last observed remote-connection state for this window's authority,
-    /// sampled each frame by `Editor::detect_remote_terminal_reconnects`. A
-    /// `false → true` transition means the agent channel's background
-    /// transport hot-swap (`spawn_reconnect_task`) silently re-established the
-    /// link — the embedded `ssh -t` / `kubectl exec` terminal PTYs died with
-    /// the old carrier and need respawning, exactly as the app-level
-    /// `RemoteAttachMode::Reconnect` path does. Initialised `true` so a window
-    /// born connected doesn't read as a spurious reconnect on its first frame.
-    pub remote_was_connected: bool,
-
     /// Window-scoped layout hit-test cache: split-leaf rects, tab
     /// rects, the file-explorer rect, separators, scrollbars, and
     /// per-leaf `view_line_mappings` that mouse positioning and
@@ -1785,7 +1775,6 @@ impl Window {
             plugin_state: HashMap::new(),
             authority_spec: crate::services::authority::SessionAuthoritySpec::Local,
             remote_reconnect_error: None,
-            remote_was_connected: true,
             lsp,
             panel_ids: HashMap::new(),
             buffers: WindowBuffers::new(),

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -360,6 +360,16 @@ pub struct Window {
     /// another window's indicator.
     pub remote_reconnect_error: Option<String>,
 
+    /// Last observed remote-connection state for this window's authority,
+    /// sampled each frame by `Editor::detect_remote_terminal_reconnects`. A
+    /// `false → true` transition means the agent channel's background
+    /// transport hot-swap (`spawn_reconnect_task`) silently re-established the
+    /// link — the embedded `ssh -t` / `kubectl exec` terminal PTYs died with
+    /// the old carrier and need respawning, exactly as the app-level
+    /// `RemoteAttachMode::Reconnect` path does. Initialised `true` so a window
+    /// born connected doesn't read as a spurious reconnect on its first frame.
+    pub remote_was_connected: bool,
+
     /// Window-scoped layout hit-test cache: split-leaf rects, tab
     /// rects, the file-explorer rect, separators, scrollbars, and
     /// per-leaf `view_line_mappings` that mouse positioning and
@@ -1775,6 +1785,7 @@ impl Window {
             plugin_state: HashMap::new(),
             authority_spec: crate::services::authority::SessionAuthoritySpec::Local,
             remote_reconnect_error: None,
+            remote_was_connected: true,
             lsp,
             panel_ids: HashMap::new(),
             buffers: WindowBuffers::new(),

--- a/crates/fresh-editor/src/model/filesystem.rs
+++ b/crates/fresh-editor/src/model/filesystem.rs
@@ -664,6 +664,21 @@ pub trait FileSystem: Send + Sync {
         true
     }
 
+    /// Stable id of the remote agent channel backing this filesystem, if any.
+    /// `None` for local filesystems. Lets the editor map a reconnect
+    /// notification back to the owning window. See `AgentChannel::id`.
+    fn remote_channel_id(&self) -> Option<u64> {
+        None
+    }
+
+    /// A handle notified once per successful transport hot-swap of the backing
+    /// agent channel. `None` for local filesystems. The editor awaits this to
+    /// drive event-driven reconnect handling (respawning embedded terminals)
+    /// instead of polling `is_remote_connected()`.
+    fn remote_reconnect_notify(&self) -> Option<std::sync::Arc<tokio::sync::Notify>> {
+        None
+    }
+
     /// Get the home directory for this filesystem
     ///
     /// For local filesystems, returns the local home directory.

--- a/crates/fresh-editor/src/services/async_bridge.rs
+++ b/crates/fresh-editor/src/services/async_bridge.rs
@@ -90,6 +90,14 @@ pub enum AsyncMessage {
     /// authority + keepalive and restart.
     RemoteAttachReady(RemoteAttachReady),
 
+    /// A remote agent channel's transport was silently hot-swapped back in by
+    /// the background reconnect task (`spawn_reconnect_task`). Carries the
+    /// channel's stable id (`AgentChannel::id`); the editor maps it to the
+    /// owning window and reattaches — respawning the embedded terminals that
+    /// died with the dropped carrier. This is the event-driven counterpart to
+    /// the app-level `RemoteAttachMode::Reconnect` rebuild path.
+    RemoteReconnected { connection_id: u64 },
+
     /// An async `attachRemoteAgent` connect failed — reject the plugin's
     /// promise with `error` (the plugin shows it and creates no window); the
     /// editor stays on its current authority. `reconnect_window` is `Some(id)`

--- a/crates/fresh-editor/src/services/authority/mod.rs
+++ b/crates/fresh-editor/src/services/authority/mod.rs
@@ -396,6 +396,56 @@ impl Authority {
         Self::local(scope.trust, scope.env)
     }
 
+    /// The persistable backend descriptor for this *live* authority, derived
+    /// from its [`CommandWrap`]. This is the single source of truth a window's
+    /// `authority_spec` should reflect: it makes a plain `fresh ssh://…` launch
+    /// carry a real `RemoteAgent` spec (so persistence, the dormancy model, and
+    /// the manual-reconnect rebuild in `start_remote_reconnect` all work)
+    /// instead of the historical `Local` default that left those paths inert.
+    ///
+    /// `Direct` (local) and `Prefix` (container — its spec is owned by the
+    /// plugin that built it) map to `Local`; the SSH and Kube wraps reconstruct
+    /// their transport spec from the connection params they already hold.
+    pub fn session_spec(&self) -> SessionAuthoritySpec {
+        match &self.command_wrap {
+            CommandWrap::Ssh { params, remote_dir } => {
+                SessionAuthoritySpec::RemoteAgent(RemoteAgentSpec {
+                    transport: RemoteTransportSpec::Ssh {
+                        user: params.user.clone(),
+                        host: params.host.clone(),
+                        port: params.port,
+                        identity_file: params
+                            .identity_file
+                            .as_ref()
+                            .map(|p| p.to_string_lossy().into_owned()),
+                        remote_path: remote_dir.clone(),
+                        extra_args: params.extra_args.clone(),
+                    },
+                    base_env: Vec::new(),
+                    window: false,
+                    label: None,
+                    command: None,
+                })
+            }
+            CommandWrap::Kube { target, base_env } => {
+                SessionAuthoritySpec::RemoteAgent(RemoteAgentSpec {
+                    transport: RemoteTransportSpec::KubectlExec {
+                        context: target.context.clone(),
+                        namespace: target.namespace.clone(),
+                        pod: target.pod.clone(),
+                        container: target.container.clone(),
+                        workspace: target.workspace.clone(),
+                    },
+                    base_env: base_env.clone(),
+                    window: false,
+                    label: None,
+                    command: None,
+                })
+            }
+            CommandWrap::Direct | CommandWrap::Prefix(_) => SessionAuthoritySpec::Local,
+        }
+    }
+
     /// Build a [`TerminalWrapper`] that runs `argv` as an interactive PTY
     /// child **inside this authority's backend**, rooted at the session's
     /// workspace dir. Local runs it directly; container/remote authorities wrap

--- a/crates/fresh-editor/src/services/remote/channel.rs
+++ b/crates/fresh-editor/src/services/remote/channel.rs
@@ -64,8 +64,23 @@ type BoxedReader = Box<dyn AsyncBufRead + Unpin + Send>;
 /// Boxed async writer type used by the write task.
 type BoxedWriter = Box<dyn AsyncWrite + Unpin + Send>;
 
+/// Process-global source of stable per-channel ids. Lets the editor map an
+/// `AsyncMessage::RemoteReconnected` back to the window whose authority owns
+/// this channel, without the channel knowing anything about windows.
+static NEXT_CHANNEL_ID: AtomicU64 = AtomicU64::new(1);
+
 /// Communication channel with the remote agent
 pub struct AgentChannel {
+    /// Stable identity for this channel, assigned at creation. Survives
+    /// transport hot-swaps (the channel object is reused across reconnects),
+    /// so it's a durable key for "this remote session".
+    id: u64,
+    /// Notified once each time the transport is hot-swapped back in
+    /// (`replace_transport`). The editor spawns a forwarder that turns each
+    /// notification into an `AsyncMessage::RemoteReconnected`, so a silent
+    /// background reconnect reaches the app event-driven rather than by
+    /// polling `is_connected()`.
+    reconnect_notify: Arc<tokio::sync::Notify>,
     /// Sender to the write task
     write_tx: mpsc::Sender<String>,
     /// Pending requests awaiting responses
@@ -154,6 +169,8 @@ impl AgentChannel {
         ));
 
         Self {
+            id: NEXT_CHANNEL_ID.fetch_add(1, Ordering::Relaxed),
+            reconnect_notify: Arc::new(tokio::sync::Notify::new()),
             write_tx,
             pending,
             next_id: AtomicU64::new(1),
@@ -357,8 +374,31 @@ impl AgentChannel {
         if self.new_reader_tx.send(Box::new(reader)).await.is_err() {
             warn!("replace_transport: read task is gone, cannot reconnect");
         }
+        // The carrier was just hot-swapped back in: wake anyone watching for a
+        // reconnect (the editor's forwarder → `AsyncMessage::RemoteReconnected`,
+        // which respawns embedded terminals that died with the old carrier).
+        // Fired here rather than when `connected` flips true because the
+        // terminal respawn opens its own fresh carrier and doesn't depend on
+        // the agent channel's drain completing.
+        //
+        // `notify_one` (not `notify_waiters`) so a swap that lands in the gap
+        // between the forwarder's send and its next `notified()` still stores a
+        // permit and is delivered — reconnect events can't be dropped. Multiple
+        // swaps coalesce to one permit, which is fine: reattach is idempotent.
+        self.reconnect_notify.notify_one();
         // Note: connected is set to true by the read task after it drains
         // stale pending requests and switches to the new reader.
+    }
+
+    /// Stable identity for this channel (see the `id` field).
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// A handle that is notified once per successful transport hot-swap. The
+    /// editor awaits it to drive event-driven reconnect handling.
+    pub fn reconnect_notify(&self) -> Arc<tokio::sync::Notify> {
+        self.reconnect_notify.clone()
     }
 
     /// Replace the underlying transport (blocking version for non-async contexts).

--- a/crates/fresh-editor/src/services/remote/filesystem.rs
+++ b/crates/fresh-editor/src/services/remote/filesystem.rs
@@ -480,6 +480,14 @@ impl FileSystem for RemoteFileSystem {
         self.channel.is_connected()
     }
 
+    fn remote_channel_id(&self) -> Option<u64> {
+        Some(self.channel.id())
+    }
+
+    fn remote_reconnect_notify(&self) -> Option<std::sync::Arc<tokio::sync::Notify>> {
+        Some(self.channel.reconnect_notify())
+    }
+
     fn home_dir(&self) -> io::Result<PathBuf> {
         let result = self
             .channel

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -169,6 +169,7 @@ pub mod preview_tabs;
 pub mod prompt;
 pub mod prompt_editing;
 pub mod recovery;
+pub mod remote_auto_reconnect_terminal;
 pub mod remote_fs_test;
 pub mod remote_indicator_popup;
 pub mod remote_reconnect_terminal;

--- a/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
@@ -12,15 +12,19 @@
 //!
 //! The second path is what `fresh ssh://…` actually uses, and it used to leave
 //! embedded terminals dead even after the filesystem/LSP came back — nothing
-//! respawned them. `Editor::detect_remote_terminal_reconnects` closes that gap:
-//! it samples each remote window's connection state every tick (via
-//! `process_async_messages`) and, on a `disconnected → connected` edge, revives
-//! the dead PTYs in place.
+//! respawned them. The channel now fires a `reconnect_notify` on each transport
+//! hot-swap; a per-window forwarder turns that into an
+//! `AsyncMessage::RemoteReconnected { connection_id }`, and
+//! `Editor::handle_remote_reconnected` maps the id back to its window and
+//! reattaches — respawning the dead PTYs in place.
 //!
-//! This drives that detector directly with a filesystem whose connected state
-//! is a runtime-flippable flag, asserting (a) no respawn while down, (b) respawn
-//! on the recover edge, and (c) no double-respawn on a subsequent steady tick.
-//! Requires a working PTY (`/dev/ptmx`); skips when unavailable.
+//! This drives the reconnect *dispatch* directly (via the
+//! `test_dispatch_remote_reconnected` seam, standing in for the bridge event a
+//! channel's reconnect forwarder posts), with a filesystem that advertises a
+//! fixed remote channel id. It asserts the id→window→reattach mapping revives a
+//! dead terminal, that an event for an unrelated id is a no-op, and that a
+//! repeat event is idempotent (no orphaned re-respawn). Requires a working PTY
+//! (`/dev/ptmx`); skips when unavailable.
 
 use crate::common::harness::{EditorTestHarness, HarnessOptions};
 use fresh::model::filesystem::{
@@ -45,12 +49,15 @@ fn pty_available() -> bool {
 }
 
 /// A filesystem that advertises a remote backend (so `remote_connection_info()`
-/// is `Some`) whose link state is a shared, flippable flag. Real I/O delegates
-/// to `StdFileSystem`; only the connection-state answers are synthetic, so the
-/// detector can be driven across a disconnect/reconnect with no network.
+/// is `Some`) with a fixed channel id and a flippable connected flag. Real I/O
+/// delegates to `StdFileSystem`; only the connection-state and channel-id
+/// answers are synthetic, so the reconnect dispatch can be driven with no
+/// network. `remote_reconnect_notify` is left at its `None` default — the test
+/// drives the dispatch directly rather than through a live forwarder.
 struct ToggleRemoteFs {
     inner: StdFileSystem,
     connected: Arc<AtomicBool>,
+    channel_id: u64,
 }
 
 impl FileSystem for ToggleRemoteFs {
@@ -154,6 +161,9 @@ impl FileSystem for ToggleRemoteFs {
     fn is_remote_connected(&self) -> bool {
         self.connected.load(Ordering::SeqCst)
     }
+    fn remote_channel_id(&self) -> Option<u64> {
+        Some(self.channel_id)
+    }
 }
 
 /// A silent agent-channel reconnect (background transport hot-swap) must revive
@@ -167,11 +177,13 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
         return;
     }
 
+    const CHANNEL_ID: u64 = 4242;
     let temp = tempfile::tempdir().unwrap();
     let connected = Arc::new(AtomicBool::new(true));
     let fs: Arc<dyn FileSystem + Send + Sync> = Arc::new(ToggleRemoteFs {
         inner: StdFileSystem,
         connected: connected.clone(),
+        channel_id: CHANNEL_ID,
     });
     let mut harness = EditorTestHarness::create(
         120,
@@ -199,19 +211,6 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
         .active_window_mut()
         .terminal_manager
         .close(old_id);
-
-    // A tick while still disconnected records the down edge and must NOT
-    // respawn — the link is dead, a new `ssh -t` would just fail.
-    harness.editor_mut().process_async_messages();
-    assert_eq!(
-        harness
-            .editor()
-            .active_window()
-            .terminal_buffers
-            .get(&buffer_id),
-        Some(&old_id),
-        "binding is preserved across the drop, still awaiting respawn"
-    );
     assert!(
         harness
             .editor()
@@ -219,23 +218,41 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
             .terminal_manager
             .get(old_id)
             .is_none(),
-        "no respawn happens while the link is still down"
+        "dead terminal's handle is torn down on the drop"
     );
 
-    // The link comes back via the silent hot-swap. The next tick's detector
-    // should see the disconnected → connected edge and revive the terminal.
+    // A reconnect event for an *unrelated* channel id must not touch this
+    // window — guards the id→window mapping against reattaching the wrong one.
+    harness
+        .editor_mut()
+        .test_dispatch_remote_reconnected(CHANNEL_ID + 1);
+    assert!(
+        harness
+            .editor()
+            .active_window()
+            .terminal_manager
+            .get(old_id)
+            .is_none(),
+        "an event for a different channel id leaves the window untouched"
+    );
+
+    // The link comes back: the channel's reconnect forwarder posts
+    // `RemoteReconnected { connection_id: CHANNEL_ID }`. Dispatching it maps to
+    // this window and revives the terminal in place.
     connected.store(true, Ordering::SeqCst);
-    harness.editor_mut().process_async_messages();
+    harness
+        .editor_mut()
+        .test_dispatch_remote_reconnected(CHANNEL_ID);
 
     let new_id = *harness
         .editor()
         .active_window()
         .terminal_buffers
         .get(&buffer_id)
-        .expect("buffer is still bound to a terminal after auto-reconnect");
+        .expect("buffer is still bound to a terminal after reconnect");
     assert_ne!(
         new_id, old_id,
-        "auto-reconnect respawns into a fresh terminal id, not the dead one"
+        "reconnect respawns into a fresh terminal id, not the dead one"
     );
     assert!(
         harness
@@ -244,13 +261,15 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
             .terminal_manager
             .get(new_id)
             .is_some_and(|h| h.is_alive()),
-        "the auto-respawned terminal is live"
+        "the respawned terminal is live"
     );
 
-    // A subsequent steady-state tick (still connected) must not respawn again —
-    // the edge detector only fires on the transition, not on every connected
-    // tick. Guards against a flip-flop that would orphan PTYs every frame.
-    harness.editor_mut().process_async_messages();
+    // A duplicate reconnect event (coalesced notifies, a second forwarder tick)
+    // must be idempotent: the now-live terminal is left alone, not orphaned by a
+    // second respawn.
+    harness
+        .editor_mut()
+        .test_dispatch_remote_reconnected(CHANNEL_ID);
     assert_eq!(
         harness
             .editor()
@@ -258,6 +277,6 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
             .terminal_buffers
             .get(&buffer_id),
         Some(&new_id),
-        "no second respawn on a steady connected tick"
+        "a duplicate reconnect event does not respawn an already-live terminal"
     );
 }

--- a/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
@@ -1,0 +1,263 @@
+//! Component test for the *automatic* terminal-respawn path on reconnect.
+//!
+//! There are two ways a dropped remote link comes back:
+//!
+//!   * the app-level `RemoteAttachMode::Reconnect` flow (dive into a dormant
+//!     session / click "Reconnect"), which re-points the authority and calls
+//!     `respawn_terminals_through_authority` directly — covered by
+//!     `remote_reconnect_terminal.rs`; and
+//!   * the *silent* background transport hot-swap (`spawn_reconnect_task`),
+//!     which restores the agent channel underneath the existing authority
+//!     without ever routing through that flow.
+//!
+//! The second path is what `fresh ssh://…` actually uses, and it used to leave
+//! embedded terminals dead even after the filesystem/LSP came back — nothing
+//! respawned them. `Editor::detect_remote_terminal_reconnects` closes that gap:
+//! it samples each remote window's connection state every tick (via
+//! `process_async_messages`) and, on a `disconnected → connected` edge, revives
+//! the dead PTYs in place.
+//!
+//! This drives that detector directly with a filesystem whose connected state
+//! is a runtime-flippable flag, asserting (a) no respawn while down, (b) respawn
+//! on the recover edge, and (c) no double-respawn on a subsequent steady tick.
+//! Requires a working PTY (`/dev/ptmx`); skips when unavailable.
+
+use crate::common::harness::{EditorTestHarness, HarnessOptions};
+use fresh::model::filesystem::{
+    DirEntry, FileMetadata, FilePermissions, FileReader, FileSearchCursor, FileSearchOptions,
+    FileSystem, FileWriter, SearchMatch, StdFileSystem,
+};
+use portable_pty::{native_pty_system, PtySize};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+fn pty_available() -> bool {
+    native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_ok()
+}
+
+/// A filesystem that advertises a remote backend (so `remote_connection_info()`
+/// is `Some`) whose link state is a shared, flippable flag. Real I/O delegates
+/// to `StdFileSystem`; only the connection-state answers are synthetic, so the
+/// detector can be driven across a disconnect/reconnect with no network.
+struct ToggleRemoteFs {
+    inner: StdFileSystem,
+    connected: Arc<AtomicBool>,
+}
+
+impl FileSystem for ToggleRemoteFs {
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        self.inner.read_file(path)
+    }
+    fn read_range(&self, path: &Path, offset: u64, len: usize) -> io::Result<Vec<u8>> {
+        self.inner.read_range(path, offset, len)
+    }
+    fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()> {
+        self.inner.write_file(path, data)
+    }
+    fn create_file(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.create_file(path)
+    }
+    fn open_file(&self, path: &Path) -> io::Result<Box<dyn FileReader>> {
+        self.inner.open_file(path)
+    }
+    fn open_file_for_write(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_write(path)
+    }
+    fn open_file_for_append(&self, path: &Path) -> io::Result<Box<dyn FileWriter>> {
+        self.inner.open_file_for_append(path)
+    }
+    fn set_file_length(&self, path: &Path, len: u64) -> io::Result<()> {
+        self.inner.set_file_length(path, len)
+    }
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.inner.rename(from, to)
+    }
+    fn copy(&self, from: &Path, to: &Path) -> io::Result<u64> {
+        self.inner.copy(from, to)
+    }
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_file(path)
+    }
+    fn remove_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.remove_dir(path)
+    }
+    fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.metadata(path)
+    }
+    fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
+        self.inner.symlink_metadata(path)
+    }
+    fn is_dir(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_dir(path)
+    }
+    fn is_file(&self, path: &Path) -> io::Result<bool> {
+        self.inner.is_file(path)
+    }
+    fn set_permissions(&self, path: &Path, permissions: &FilePermissions) -> io::Result<()> {
+        self.inner.set_permissions(path, permissions)
+    }
+    fn read_dir(&self, path: &Path) -> io::Result<Vec<DirEntry>> {
+        self.inner.read_dir(path)
+    }
+    fn create_dir(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir(path)
+    }
+    fn create_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.inner.create_dir_all(path)
+    }
+    fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {
+        self.inner.canonicalize(path)
+    }
+    fn current_uid(&self) -> u32 {
+        self.inner.current_uid()
+    }
+    fn search_file(
+        &self,
+        path: &Path,
+        pattern: &str,
+        opts: &FileSearchOptions,
+        cursor: &mut FileSearchCursor,
+    ) -> io::Result<Vec<SearchMatch>> {
+        self.inner.search_file(path, pattern, opts, cursor)
+    }
+    fn sudo_write(
+        &self,
+        path: &Path,
+        data: &[u8],
+        mode: u32,
+        uid: u32,
+        gid: u32,
+    ) -> io::Result<()> {
+        self.inner.sudo_write(path, data, mode, uid, gid)
+    }
+    fn walk_files(
+        &self,
+        root: &Path,
+        skip_dirs: &[&str],
+        cancel: &AtomicBool,
+        on_file: &mut dyn FnMut(&Path, &str) -> bool,
+    ) -> io::Result<()> {
+        self.inner.walk_files(root, skip_dirs, cancel, on_file)
+    }
+    fn remote_connection_info(&self) -> Option<&str> {
+        Some("root@127.0.0.1")
+    }
+    fn is_remote_connected(&self) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+}
+
+/// A silent agent-channel reconnect (background transport hot-swap) must revive
+/// a terminal that died with the dropped carrier — the bug from issue #2482,
+/// where `fresh ssh://…` terminals stayed dead after the link came back.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Unix PTY shell
+fn auto_reconnect_respawns_a_dead_remote_terminal() {
+    if !pty_available() {
+        eprintln!("Skipping auto-reconnect terminal test: PTY not available");
+        return;
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let connected = Arc::new(AtomicBool::new(true));
+    let fs: Arc<dyn FileSystem + Send + Sync> = Arc::new(ToggleRemoteFs {
+        inner: StdFileSystem,
+        connected: connected.clone(),
+    });
+    let mut harness = EditorTestHarness::create(
+        120,
+        30,
+        HarnessOptions::new()
+            .with_working_dir(temp.path().to_path_buf())
+            .with_filesystem(fs),
+    )
+    .unwrap();
+
+    // A live embedded terminal bound to its buffer — the pre-disconnect state.
+    let (old_id, buffer_id) = harness
+        .editor_mut()
+        .active_window_mut()
+        .open_terminal_in_window()
+        .expect("terminal should spawn");
+
+    // Carrier drop: the link goes down and the PTY dies. We tear down the
+    // handle (what the `TerminalExited` handler does) but keep the
+    // buffer↔terminal binding (the remote-disconnect preserve path), so the
+    // reconnect has something to revive.
+    connected.store(false, Ordering::SeqCst);
+    harness
+        .editor_mut()
+        .active_window_mut()
+        .terminal_manager
+        .close(old_id);
+
+    // A tick while still disconnected records the down edge and must NOT
+    // respawn — the link is dead, a new `ssh -t` would just fail.
+    harness.editor_mut().process_async_messages();
+    assert_eq!(
+        harness
+            .editor()
+            .active_window()
+            .terminal_buffers
+            .get(&buffer_id),
+        Some(&old_id),
+        "binding is preserved across the drop, still awaiting respawn"
+    );
+    assert!(
+        harness
+            .editor()
+            .active_window()
+            .terminal_manager
+            .get(old_id)
+            .is_none(),
+        "no respawn happens while the link is still down"
+    );
+
+    // The link comes back via the silent hot-swap. The next tick's detector
+    // should see the disconnected → connected edge and revive the terminal.
+    connected.store(true, Ordering::SeqCst);
+    harness.editor_mut().process_async_messages();
+
+    let new_id = *harness
+        .editor()
+        .active_window()
+        .terminal_buffers
+        .get(&buffer_id)
+        .expect("buffer is still bound to a terminal after auto-reconnect");
+    assert_ne!(
+        new_id, old_id,
+        "auto-reconnect respawns into a fresh terminal id, not the dead one"
+    );
+    assert!(
+        harness
+            .editor()
+            .active_window()
+            .terminal_manager
+            .get(new_id)
+            .is_some_and(|h| h.is_alive()),
+        "the auto-respawned terminal is live"
+    );
+
+    // A subsequent steady-state tick (still connected) must not respawn again —
+    // the edge detector only fires on the transition, not on every connected
+    // tick. Guards against a flip-flop that would orphan PTYs every frame.
+    harness.editor_mut().process_async_messages();
+    assert_eq!(
+        harness
+            .editor()
+            .active_window()
+            .terminal_buffers
+            .get(&buffer_id),
+        Some(&new_id),
+        "no second respawn on a steady connected tick"
+    );
+}


### PR DESCRIPTION
## Problem

A workspace opened over SSH (`fresh ssh://…`) runs its integrated terminals as a **separate `ssh -t` carrier** from the agent channel. When the link drops, those PTYs hit EOF and are torn down. The agent channel recovers itself in the background by hot-swapping its transport (`spawn_reconnect_task`) — so the filesystem/LSP come back — but nothing revived the terminals: they stayed frozen at `[Terminal process exited]` with no way back. (Reproduced interactively in #2482: kill the SSH session, agent reconnects, terminal stays dead; opening a *new* terminal works, proving the host is reachable.)

Root cause: there were **two divergent reconnect paths**. The app-level `RemoteAttachMode::Reconnect` flow (dive into a dormant session / click "Reconnect") respawned terminals — but the silent background transport hot-swap that production `ssh://` actually uses never routed through it. And a plain `fresh ssh://…` launch left its `authority_spec` as `Local`, so workspace persistence and the manual-reconnect rebuild were inert for it too.

## Fix

Three connected changes that unify the reconnect machinery and make a CLI `ssh://` session first-class:

**Uniform backend spec.** `Authority::session_spec()` derives the persistable `SessionAuthoritySpec` from the live authority's `command_wrap` (SSH/Kube → `RemoteAgent`, local/container → `Local`); `editor_init` uses it to fill a window's `authority_spec` when the resolved one is `Local`. A CLI `ssh://` launch now carries a real `RemoteAgent` spec, so workspace persistence and the manual-reconnect rebuild (`start_remote_reconnect`, which matches on the spec) work for it. Never downgrades an already-remote spec.

**Event-driven reconnect.** `AgentChannel` gets a stable `id` and a `reconnect_notify` fired on each `replace_transport` hot-swap. New `FileSystem::remote_channel_id` / `remote_reconnect_notify` expose them; a lazily-spawned per-window forwarder turns a hot-swap into `AsyncMessage::RemoteReconnected { connection_id }`. This replaces a per-frame `is_remote_connected()` poll — it wakes the loop immediately, carries identity, and can't miss a fast disconnect→reconnect flap.

**One reconnect handler.** `handle_remote_reconnected` maps the connection id back to its window and calls the new `reattach_window`, which clears the disconnect indicator and respawns the embedded terminals that died with the old carrier (reusing each backing file so scrollback continues). The app-level `RemoteAttachMode::Reconnect` rebuild path now routes through the same `reattach_window`, so the silent hot-swap and the manual/dormant rebuild converge on one **idempotent** path (respawn skips live terminals).

## Not included

True remote-terminal **session survival** — a server-side multiplexer so the shell and its running processes outlive the carrier, rather than respawning a *fresh* shell on reconnect — is intentionally left to a separate effort. Over plain SSH the remote login shell is SIGHUP'd when the carrier dies, so "restore" here means a fresh shell in the same cwd with continuous scrollback.

## Testing

- New e2e test drives the reconnect dispatch (id→window→reattach): revive a dead terminal, no-op on an unrelated channel id, and idempotency on a duplicate event.
- Existing reconnect/terminal/indicator e2e suites and the persistence round-trip suite pass.
- Verified interactively against a local `sshd` on a user port: drop the SSH session → agent reconnects → the integrated terminal respawns on its own into a live remote shell, scrollback preserved.

Resolves #2482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SHCFsZ3ReFxbqBgjwwBPdG