### PR TITLE
fix(terminal): restore a terminal's remembered mode on refocus, and model it as per-buffer state

### DIFF
--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -209,8 +209,8 @@ impl Window {
             return;
         }
         let active = self.active_buffer();
-        if self.is_terminal_buffer(active) {
-            if self.is_live_terminal(active) {
+        if let Some(terminal) = self.terminal_buffer(active) {
+            if terminal.is_live() {
                 self.terminal_mode = true;
                 self.key_context = KeyContext::Terminal;
             } else {

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -52,22 +52,10 @@ impl Editor {
         if !self.active_window_mut().set_active_buffer(buffer_id) {
             return;
         }
-        // Restored terminals load read-only (editing disabled) and the
-        // Window-side resume branch only flips the `terminal_mode` flag —
-        // it can't reach the Editor-level `enter_terminal_mode` that
-        // re-enables editing, drops the stale screen tail, and resizes the
-        // PTY. Without that completion, focusing a restored terminal tab
-        // leaves it in the read-only scrollback view (often a blank screen
-        // with no prompt) instead of a live terminal. Detect that exact
-        // state — a terminal we just resumed into terminal mode but whose
-        // buffer is still editing-disabled — and finish the transition.
-        // Live terminals (editing already enabled) are unaffected.
-        if self.active_window().terminal_mode
-            && self.active_window().is_terminal_buffer(buffer_id)
-            && self.active_window().is_editing_disabled()
-        {
-            self.enter_terminal_mode();
-        }
+        // The Window body already synced the `terminal_mode` flag; finish
+        // the restored-terminal transition (re-enable editing, drop the
+        // stale screen tail, resize the PTY) that only the Editor level can.
+        self.complete_terminal_mode_side_effects();
         // Plugin state snapshot reaches editor-wide state (clipboard,
         // windows list, config cache) so it stays on Editor. Run it
         // BEFORE the hook so the handler sees the new active buffer.
@@ -83,10 +71,41 @@ impl Editor {
     /// terminal mode. Window-side body in [`Window::focus_split`].
     pub(super) fn focus_split(&mut self, split_id: LeafId, buffer_id: BufferId) {
         match self.active_window_mut().focus_split(split_id, buffer_id) {
-            FocusSplitOutcome::Handled => {}
+            FocusSplitOutcome::Handled => {
+                // Window body synced the flag; finish any restored-terminal
+                // transition.
+                self.complete_terminal_mode_side_effects();
+            }
             FocusSplitOutcome::DelegateToActiveBuffer(target) => {
                 self.set_active_buffer(target);
             }
+        }
+    }
+
+    /// Bring `terminal_mode` / `key_context` fully in line with the active
+    /// buffer after a focus change that bypassed [`Editor::set_active_buffer`]
+    /// (split focus/navigation, split-collapse on close, opening a terminal
+    /// split). This is the single restore authority: a terminal resumes the
+    /// live/scrollback mode it had when it lost focus, a non-terminal clears
+    /// terminal mode. See issue #2485.
+    pub(crate) fn sync_terminal_mode_to_active_buffer(&mut self) {
+        self.active_window_mut().sync_terminal_mode_flags();
+        self.complete_terminal_mode_side_effects();
+    }
+
+    /// Editor-level completion of a transition *into* live terminal mode:
+    /// restored / read-only terminals load with editing disabled, so finish
+    /// the switch (re-enable editing, truncate the stale screen tail, resize
+    /// the PTY) which only [`Editor::enter_terminal_mode`] can do. A no-op
+    /// for live terminals and non-terminals.
+    pub(super) fn complete_terminal_mode_side_effects(&mut self) {
+        if self.active_window().terminal_mode
+            && self
+                .active_window()
+                .is_terminal_buffer(self.active_buffer())
+            && self.active_window().is_editing_disabled()
+        {
+            self.enter_terminal_mode();
         }
     }
 }
@@ -111,16 +130,6 @@ impl Window {
         // Cancel search/replace prompts when switching buffers
         // (they are buffer-specific and don't make sense across buffers)
         self.cancel_search_prompt_if_active();
-
-        // Track the previous buffer for "Switch to Previous Tab" command
-        let previous = self.active_buffer();
-
-        // If leaving a terminal buffer while in terminal mode, remember it should resume
-        if self.terminal_mode && self.is_terminal_buffer(previous) {
-            self.terminal_mode_resume.insert(previous);
-            self.terminal_mode = false;
-            self.key_context = crate::input::keybindings::KeyContext::Normal;
-        }
 
         // Capture the previous focus target BEFORE set_pane_buffer runs,
         // so the LRU records the right thing.
@@ -147,20 +156,10 @@ impl Window {
             }
         }
 
-        // If switching to a terminal buffer that should resume terminal mode, re-enter it
-        let resume_terminal_mode =
-            self.terminal_mode_resume.contains(&buffer_id) && self.is_terminal_buffer(buffer_id);
-        let is_terminal_buffer = self.is_terminal_buffer(buffer_id);
-        let sync_terminal_readonly = !resume_terminal_mode && is_terminal_buffer;
-        if resume_terminal_mode {
-            self.terminal_mode = true;
-            self.key_context = crate::input::keybindings::KeyContext::Terminal;
-        } else if sync_terminal_readonly {
-            // Switching to terminal in read-only mode — sync buffer to
-            // show current terminal content. Updates backing file +
-            // cursor.
-            self.sync_terminal_to_buffer(buffer_id);
-        }
+        // Bring terminal mode in line with the new active buffer (its
+        // remembered live/scrollback mode). The single authority for the
+        // flag half — see `sync_terminal_mode_flags`.
+        self.sync_terminal_mode_flags();
 
         // Window resize events only resize terminals that are currently the
         // active tab in their split (see `resize_visible_terminals`). A
@@ -168,7 +167,7 @@ impl Window {
         // sees the new size, so its PTY child keeps reporting stale
         // dimensions when the user switches back. Re-running the visible
         // resize here picks up the now-revealed terminal. Issue #1795.
-        if is_terminal_buffer {
+        if self.is_terminal_buffer(buffer_id) {
             self.resize_visible_terminals();
         }
 
@@ -184,6 +183,47 @@ impl Window {
         }
 
         true
+    }
+
+    /// Flag-only half of terminal-mode sync: set `terminal_mode` /
+    /// `key_context` from the active buffer and the mode it remembers.
+    ///
+    /// A terminal's persistent interaction mode lives in
+    /// `terminal_mode_resume` (present ⟺ live/Active, absent ⟺ read-only
+    /// scrollback), so a re-focused terminal keeps whatever mode it had when
+    /// it lost focus. This is the one place the flag is derived from focus;
+    /// every focus path routes through it (directly or via
+    /// [`Editor::sync_terminal_mode_to_active_buffer`]), so none can leave a
+    /// re-focused terminal in the wrong mode (issue #2485).
+    ///
+    /// Only owns the Terminal↔Normal edge: when another surface holds input
+    /// focus (file explorer, a prompt, a popup) `key_context` is something
+    /// other than `Normal`/`Terminal`, and those surfaces manage
+    /// `terminal_mode` themselves, so we leave it untouched. The Editor-level
+    /// side effects of entering live mode (re-enable editing, truncate the
+    /// stale screen tail, resize the PTY) are completed by
+    /// [`Editor::complete_terminal_mode_side_effects`].
+    pub(super) fn sync_terminal_mode_flags(&mut self) {
+        use crate::input::keybindings::KeyContext;
+        if !matches!(self.key_context, KeyContext::Normal | KeyContext::Terminal) {
+            return;
+        }
+        let active = self.active_buffer();
+        if self.is_terminal_buffer(active) {
+            if self.terminal_mode_resume.contains(&active) {
+                self.terminal_mode = true;
+                self.key_context = KeyContext::Terminal;
+            } else {
+                // Read-only scrollback terminal: refresh the file-backed view
+                // (backing file + cursor) and stop routing keys to the PTY.
+                self.sync_terminal_to_buffer(active);
+                self.terminal_mode = false;
+                self.key_context = KeyContext::Normal;
+            }
+        } else if self.terminal_mode {
+            self.terminal_mode = false;
+            self.key_context = KeyContext::Normal;
+        }
     }
 
     /// Window-side body of `focus_split`. Returns a [`FocusSplitOutcome`]
@@ -294,12 +334,6 @@ impl Window {
         }
 
         if split_changed {
-            // Switching to a different split - exit terminal mode if active
-            if self.terminal_mode && self.is_terminal_buffer(previous_buffer) {
-                self.terminal_mode = false;
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
-            }
-
             // Update split manager to focus this split
             self.split_manager_mut()
                 .expect("active window must have a populated split layout")
@@ -311,15 +345,9 @@ impl Window {
             // silently no-op'd (issue #1620).
             self.set_pane_buffer(split_id, buffer_id);
 
-            // Set key context based on target buffer type
-            if self.is_terminal_buffer(buffer_id) {
-                self.terminal_mode = true;
-                self.key_context = crate::input::keybindings::KeyContext::Terminal;
-            } else {
-                // Ensure key context is Normal when focusing a non-terminal buffer
-                // This handles the case of clicking on editor from FileExplorer context
-                self.key_context = crate::input::keybindings::KeyContext::Normal;
-            }
+            // Bring terminal mode in line with the now-active buffer and its
+            // remembered live/scrollback mode — the single flag authority.
+            self.sync_terminal_mode_flags();
 
             // Handle buffer change side effects
             if previous_buffer != buffer_id {

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -82,22 +82,19 @@ impl Editor {
         }
     }
 
-    /// Bring `terminal_mode` / `key_context` fully in line with the active
-    /// buffer after a focus change that bypassed [`Editor::set_active_buffer`]
-    /// (split focus/navigation, split-collapse on close, opening a terminal
-    /// split). This is the single restore authority: a terminal resumes the
-    /// live/scrollback mode it had when it lost focus, a non-terminal clears
-    /// terminal mode. See issue #2485.
+    /// Restore `terminal_mode`/`key_context` after a focus change that bypassed
+    /// [`Editor::set_active_buffer`] (split focus/nav, split-collapse on close,
+    /// opening a terminal split). The single restore authority: a terminal
+    /// resumes the mode it had when it lost focus. Issue #2485.
     pub(crate) fn sync_terminal_mode_to_active_buffer(&mut self) {
         self.active_window_mut().sync_terminal_mode_flags();
         self.complete_terminal_mode_side_effects();
     }
 
-    /// Editor-level completion of a transition *into* live terminal mode:
-    /// restored / read-only terminals load with editing disabled, so finish
-    /// the switch (re-enable editing, truncate the stale screen tail, resize
-    /// the PTY) which only [`Editor::enter_terminal_mode`] can do. A no-op
-    /// for live terminals and non-terminals.
+    /// Finish entering live mode for a terminal that loaded with editing
+    /// disabled (restored / read-only): only [`Editor::enter_terminal_mode`]
+    /// can re-enable editing, truncate the stale screen tail, and resize the
+    /// PTY. No-op otherwise.
     pub(super) fn complete_terminal_mode_side_effects(&mut self) {
         if self.active_window().terminal_mode
             && self
@@ -156,9 +153,6 @@ impl Window {
             }
         }
 
-        // Bring terminal mode in line with the new active buffer (its
-        // remembered live/scrollback mode). The single authority for the
-        // flag half — see `sync_terminal_mode_flags`.
         self.sync_terminal_mode_flags();
 
         // Window resize events only resize terminals that are currently the
@@ -185,24 +179,15 @@ impl Window {
         true
     }
 
-    /// Flag-only half of terminal-mode sync: set `terminal_mode` /
-    /// `key_context` from the active buffer and the mode it remembers.
-    ///
-    /// Each terminal buffer remembers its own interaction mode
-    /// ([`TerminalInteractionMode`] on its [`TerminalBuffer`] record), so a
-    /// re-focused terminal keeps whatever mode it had when it lost focus.
-    /// This is the one place the flag is derived from focus;
-    /// every focus path routes through it (directly or via
-    /// [`Editor::sync_terminal_mode_to_active_buffer`]), so none can leave a
-    /// re-focused terminal in the wrong mode (issue #2485).
-    ///
-    /// Only owns the Terminal↔Normal edge: when another surface holds input
-    /// focus (file explorer, a prompt, a popup) `key_context` is something
-    /// other than `Normal`/`Terminal`, and those surfaces manage
-    /// `terminal_mode` themselves, so we leave it untouched. The Editor-level
-    /// side effects of entering live mode (re-enable editing, truncate the
-    /// stale screen tail, resize the PTY) are completed by
+    /// Derive `terminal_mode`/`key_context` from the active buffer's remembered
+    /// mode. The one place the flags follow focus — every focus path routes
+    /// through it, so none can leave a re-focused terminal in the wrong mode
+    /// (issue #2485). The Editor-level finish for entering live mode is
     /// [`Editor::complete_terminal_mode_side_effects`].
+    ///
+    /// Owns only the Terminal↔Normal edge: while another surface holds focus
+    /// (file explorer, prompt, popup) it manages `terminal_mode` itself, so the
+    /// guard below leaves the flags untouched.
     pub(super) fn sync_terminal_mode_flags(&mut self) {
         use crate::input::keybindings::KeyContext;
         if !matches!(self.key_context, KeyContext::Normal | KeyContext::Terminal) {
@@ -214,8 +199,8 @@ impl Window {
                 self.terminal_mode = true;
                 self.key_context = KeyContext::Terminal;
             } else {
-                // Read-only scrollback terminal: refresh the file-backed view
-                // (backing file + cursor) and stop routing keys to the PTY.
+                // Refresh the file-backed scrollback view before keys stop
+                // routing to the PTY.
                 self.sync_terminal_to_buffer(active);
                 self.terminal_mode = false;
                 self.key_context = KeyContext::Normal;

--- a/crates/fresh-editor/src/app/active_focus.rs
+++ b/crates/fresh-editor/src/app/active_focus.rs
@@ -188,10 +188,10 @@ impl Window {
     /// Flag-only half of terminal-mode sync: set `terminal_mode` /
     /// `key_context` from the active buffer and the mode it remembers.
     ///
-    /// A terminal's persistent interaction mode lives in
-    /// `terminal_mode_resume` (present ⟺ live/Active, absent ⟺ read-only
-    /// scrollback), so a re-focused terminal keeps whatever mode it had when
-    /// it lost focus. This is the one place the flag is derived from focus;
+    /// Each terminal buffer remembers its own interaction mode
+    /// ([`TerminalInteractionMode`] on its [`TerminalBuffer`] record), so a
+    /// re-focused terminal keeps whatever mode it had when it lost focus.
+    /// This is the one place the flag is derived from focus;
     /// every focus path routes through it (directly or via
     /// [`Editor::sync_terminal_mode_to_active_buffer`]), so none can leave a
     /// re-focused terminal in the wrong mode (issue #2485).
@@ -210,7 +210,7 @@ impl Window {
         }
         let active = self.active_buffer();
         if self.is_terminal_buffer(active) {
-            if self.terminal_mode_resume.contains(&active) {
+            if self.is_live_terminal(active) {
                 self.terminal_mode = true;
                 self.key_context = KeyContext::Terminal;
             } else {

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -937,6 +937,17 @@ impl Editor {
             .iter()
             .find(|(_, &tid)| tid == terminal_id)
         {
+            // A genuinely exited terminal becomes a read-only scrollback tab,
+            // so it is no longer "live" — drop it from the live set so a later
+            // focus shows scrollback instead of trying to drive a dead PTY. A
+            // terminal preserved for remote reconnect keeps its live mode so
+            // it comes back live when the carrier respawns it.
+            if !preserve_for_reconnect {
+                self.active_window_mut()
+                    .terminal_mode_resume
+                    .remove(&buffer_id);
+            }
+
             // Exit terminal mode if this is the active buffer
             if self.active_buffer() == buffer_id && self.active_window().terminal_mode {
                 self.active_window_mut().terminal_mode = false;

--- a/crates/fresh-editor/src/app/async_dispatch.rs
+++ b/crates/fresh-editor/src/app/async_dispatch.rs
@@ -731,10 +731,8 @@ impl Editor {
         // automatically re-enter terminal mode
         if self.config.terminal.jump_to_end_on_output && !self.active_window().terminal_mode {
             // Check if active buffer is this terminal
-            if let Some(&active_terminal_id) = self
-                .active_window()
-                .terminal_buffers
-                .get(&self.active_buffer())
+            if let Some(active_terminal_id) =
+                self.active_window().get_terminal_id(self.active_buffer())
             {
                 if active_terminal_id == terminal_id {
                     self.enter_terminal_mode();
@@ -935,17 +933,18 @@ impl Editor {
             .active_window()
             .terminal_buffers
             .iter()
-            .find(|(_, &tid)| tid == terminal_id)
+            .find(|(_, tb)| tb.terminal_id == terminal_id)
         {
             // A genuinely exited terminal becomes a read-only scrollback tab,
-            // so it is no longer "live" — drop it from the live set so a later
-            // focus shows scrollback instead of trying to drive a dead PTY. A
-            // terminal preserved for remote reconnect keeps its live mode so
-            // it comes back live when the carrier respawns it.
+            // so mark it Scrollback — a later focus shows scrollback instead of
+            // trying to drive a dead PTY. A terminal preserved for remote
+            // reconnect keeps its live mode so it comes back live when the
+            // carrier respawns it.
             if !preserve_for_reconnect {
-                self.active_window_mut()
-                    .terminal_mode_resume
-                    .remove(&buffer_id);
+                self.active_window_mut().set_terminal_interaction_mode(
+                    buffer_id,
+                    crate::app::window::TerminalInteractionMode::Scrollback,
+                );
             }
 
             // Exit terminal mode if this is the active buffer

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -612,6 +612,11 @@ impl Editor {
                         e
                     );
                 }
+                // Focus snapped to the surviving split via the low-level
+                // split-collapse path; restore terminal mode for the now-active
+                // buffer. Runs after `close_buffer` so its terminal-mode
+                // teardown can't clobber the restore (issue #2485).
+                self.sync_terminal_mode_to_active_buffer();
                 self.set_status_message(t!("buffer.tab_closed").to_string());
                 return true;
             }
@@ -646,6 +651,7 @@ impl Editor {
             if !has_other_tab {
                 // This is genuinely the only tab in this split — close it.
                 self.handle_close_split(split_id.into());
+                self.sync_terminal_mode_to_active_buffer();
                 return true;
             }
 
@@ -689,6 +695,9 @@ impl Editor {
                 }
             }
 
+            // The replacement tab was activated through the split manager,
+            // bypassing the buffer-focus path; restore terminal mode for it.
+            self.sync_terminal_mode_to_active_buffer();
             self.set_status_message(t!("buffer.tab_closed").to_string());
         }
         true

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -84,8 +84,9 @@ impl Editor {
         }
 
         // If closing a terminal buffer, tear down its terminal-side state.
-        if let Some(terminal_id) = self.active_window_mut().terminal_buffers.remove(&id) {
-            self.cleanup_closed_terminal(id, terminal_id);
+        // Removing the entry drops the buffer's remembered mode with it.
+        if let Some(tb) = self.active_window_mut().terminal_buffers.remove(&id) {
+            self.cleanup_closed_terminal(id, tb.terminal_id);
         }
 
         // Capture before resolving the replacement: the last-resort
@@ -228,8 +229,8 @@ impl Editor {
             }
         }
 
-        // Remove from terminal_mode_resume to prevent stale entries
-        self.active_window_mut().terminal_mode_resume.remove(&id);
+        // The buffer's remembered mode was dropped when its `terminal_buffers`
+        // entry was removed by the caller — nothing else to clean up here.
 
         // Exit terminal mode if we were in it
         if self.active_window().terminal_mode {

--- a/crates/fresh-editor/src/app/buffer_close.rs
+++ b/crates/fresh-editor/src/app/buffer_close.rs
@@ -670,28 +670,42 @@ impl Editor {
                     .expect("has_other_tab")
             };
 
-            // Remove buffer from this split's tabs
-            if let Some(view_state) = self
-                .windows
-                .get_mut(&self.active_window)
-                .and_then(|w| w.split_view_states_mut())
-                .expect("active window must have a populated split layout")
-                .get_mut(&split_id)
-            {
-                view_state.remove_buffer(buffer_id);
-            }
-
-            // Activate the replacement tab — either a sibling buffer or the
-            // remaining group panel.
+            // Activate the replacement tab and drop the closed one. The buffer
+            // case must move the split tree AND the `SplitViewState.active_buffer`
+            // together: routing it through `set_pane_buffer` (not the tree-only
+            // `set_split_buffer`) is the fix for the cursor desync — updating
+            // only the tree stranded the view-state on the just-closed buffer,
+            // so the cursor and render read its zeroed view-state while edits
+            // applied to the tree's (different) buffer.
             match replacement {
                 TabTarget::Buffer(replacement_buffer) => {
-                    self.windows
+                    self.active_window_mut()
+                        .set_pane_buffer(split_id, replacement_buffer);
+                    // The replacement is active now, so removing the closed
+                    // buffer also frees its keyed view-state (`remove_buffer`
+                    // refuses to drop the state of whatever is still active).
+                    if let Some(view_state) = self
+                        .windows
                         .get_mut(&self.active_window)
-                        .and_then(|w| w.split_manager_mut())
+                        .and_then(|w| w.split_view_states_mut())
                         .expect("active window must have a populated split layout")
-                        .set_split_buffer(split_id, replacement_buffer);
+                        .get_mut(&split_id)
+                    {
+                        view_state.remove_buffer(buffer_id);
+                    }
                 }
                 TabTarget::Group(group_leaf) => {
+                    // Drop the closed buffer's tab before activating the group,
+                    // matching the original ordering for the group path.
+                    if let Some(view_state) = self
+                        .windows
+                        .get_mut(&self.active_window)
+                        .and_then(|w| w.split_view_states_mut())
+                        .expect("active window must have a populated split layout")
+                        .get_mut(&split_id)
+                    {
+                        view_state.remove_buffer(buffer_id);
+                    }
                     self.activate_group_tab(split_id, group_leaf);
                 }
             }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -91,13 +91,13 @@ impl Editor {
     /// writing `key_context = FileExplorer` is not enough — if the user
     /// was in a terminal, every keystroke would still be swallowed by
     /// the PTY and the explorer would only *look* focused (issue #2029).
-    /// Clear `terminal_mode`; the terminal keeps its own remembered mode in
-    /// `terminal_mode_resume`, so re-focusing it later restores live mode.
+    /// Clear `terminal_mode`; the terminal keeps its own remembered mode on
+    /// its `TerminalBuffer` record, so re-focusing it later restores it.
     pub(super) fn take_focus_for_file_explorer(&mut self) {
         let win = self.active_window_mut();
         // Stop routing keys to the PTY while the explorer holds focus. The
-        // terminal keeps its own remembered live/scrollback mode (in
-        // `terminal_mode_resume`), so re-focusing it later restores that mode.
+        // terminal keeps its own remembered live/scrollback mode, so
+        // re-focusing it later restores that mode.
         win.terminal_mode = false;
         win.key_context = KeyContext::FileExplorer;
     }

--- a/crates/fresh-editor/src/app/file_explorer.rs
+++ b/crates/fresh-editor/src/app/file_explorer.rs
@@ -91,19 +91,14 @@ impl Editor {
     /// writing `key_context = FileExplorer` is not enough — if the user
     /// was in a terminal, every keystroke would still be swallowed by
     /// the PTY and the explorer would only *look* focused (issue #2029).
-    /// Clear `terminal_mode` and remember the terminal buffer in
-    /// `terminal_mode_resume` so re-focusing the terminal later restores
-    /// live mode, mirroring the buffer-switch path in
-    /// `set_active_buffer`.
+    /// Clear `terminal_mode`; the terminal keeps its own remembered mode in
+    /// `terminal_mode_resume`, so re-focusing it later restores live mode.
     pub(super) fn take_focus_for_file_explorer(&mut self) {
         let win = self.active_window_mut();
-        if win.terminal_mode {
-            let active = win.active_buffer();
-            if win.is_terminal_buffer(active) {
-                win.terminal_mode_resume.insert(active);
-            }
-            win.terminal_mode = false;
-        }
+        // Stop routing keys to the PTY while the explorer holds focus. The
+        // terminal keeps its own remembered live/scrollback mode (in
+        // `terminal_mode_resume`), so re-focusing it later restores that mode.
+        win.terminal_mode = false;
         win.key_context = KeyContext::FileExplorer;
     }
 

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2322,6 +2322,9 @@ impl Editor {
                     .active_window()
                     .is_terminal_buffer(self.active_buffer())
                 {
+                    // Mode change to live: remember it for the next focus.
+                    let active = self.active_buffer();
+                    self.active_window_mut().terminal_mode_resume.insert(active);
                     self.active_window_mut().terminal_mode = true;
                     self.active_window_mut().key_context = KeyContext::Terminal;
                     self.set_status_message(t!("status.terminal_mode_enabled").to_string());
@@ -2330,6 +2333,11 @@ impl Editor {
             Action::TerminalEscape => {
                 // Exit terminal mode back to editor
                 if self.active_window().terminal_mode {
+                    // User dropped to read-only scrollback: remember that mode.
+                    let active = self.active_buffer();
+                    self.active_window_mut()
+                        .terminal_mode_resume
+                        .remove(&active);
                     self.active_window_mut().terminal_mode = false;
                     self.active_window_mut().key_context = KeyContext::Normal;
                     self.set_status_message(t!("status.terminal_mode_disabled").to_string());
@@ -3073,7 +3081,11 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .set_active_split(new_leaf);
 
-        // Mirror open_terminal's post-attach bookkeeping.
+        // Mirror open_terminal's post-attach bookkeeping. A freshly opened
+        // terminal starts live (its remembered mode).
+        self.active_window_mut()
+            .terminal_mode_resume
+            .insert(buffer_id);
         self.active_window_mut().terminal_mode = true;
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         self.active_window_mut().resize_visible_terminals();

--- a/crates/fresh-editor/src/app/input.rs
+++ b/crates/fresh-editor/src/app/input.rs
@@ -2324,7 +2324,10 @@ impl Editor {
                 {
                     // Mode change to live: remember it for the next focus.
                     let active = self.active_buffer();
-                    self.active_window_mut().terminal_mode_resume.insert(active);
+                    self.active_window_mut().set_terminal_interaction_mode(
+                        active,
+                        crate::app::window::TerminalInteractionMode::Live,
+                    );
                     self.active_window_mut().terminal_mode = true;
                     self.active_window_mut().key_context = KeyContext::Terminal;
                     self.set_status_message(t!("status.terminal_mode_enabled").to_string());
@@ -2335,9 +2338,10 @@ impl Editor {
                 if self.active_window().terminal_mode {
                     // User dropped to read-only scrollback: remember that mode.
                     let active = self.active_buffer();
-                    self.active_window_mut()
-                        .terminal_mode_resume
-                        .remove(&active);
+                    self.active_window_mut().set_terminal_interaction_mode(
+                        active,
+                        crate::app::window::TerminalInteractionMode::Scrollback,
+                    );
                     self.active_window_mut().terminal_mode = false;
                     self.active_window_mut().key_context = KeyContext::Normal;
                     self.set_status_message(t!("status.terminal_mode_disabled").to_string());
@@ -3081,11 +3085,9 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .set_active_split(new_leaf);
 
-        // Mirror open_terminal's post-attach bookkeeping. A freshly opened
-        // terminal starts live (its remembered mode).
-        self.active_window_mut()
-            .terminal_mode_resume
-            .insert(buffer_id);
+        // Mirror open_terminal's post-attach bookkeeping. The buffer was
+        // created via `create_terminal_buffer_detached`, so its remembered
+        // mode is already Live.
         self.active_window_mut().terminal_mode = true;
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         self.active_window_mut().resize_visible_terminals();

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -573,13 +573,14 @@ impl Editor {
                 }
             }
             DeferredAction::EnterScrollbackMode => {
+                // Dropping to scrollback is a mode change: remember it so the
+                // terminal stays read-only the next time it is focused.
+                let __b = self.active_buffer();
+                self.active_window_mut().terminal_mode_resume.remove(&__b);
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;
-                {
-                    let __b = self.active_buffer();
-                    self.active_window_mut().sync_terminal_to_buffer(__b);
-                };
+                self.active_window_mut().sync_terminal_to_buffer(__b);
                 self.set_status_message(
                     "Scrollback mode - use PageUp/Down to scroll (Ctrl+Space to resume)"
                         .to_string(),

--- a/crates/fresh-editor/src/app/input_dispatch.rs
+++ b/crates/fresh-editor/src/app/input_dispatch.rs
@@ -560,13 +560,14 @@ impl Editor {
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;
                 if explicit {
-                    // User explicitly exited - don't auto-resume when switching back
+                    // User explicitly exited — remember scrollback so refocus
+                    // doesn't auto-resume into live mode.
                     let buf = self.active_buffer();
-                    self.active_window_mut().terminal_mode_resume.remove(&buf);
-                    {
-                        let __b = self.active_buffer();
-                        self.active_window_mut().sync_terminal_to_buffer(__b);
-                    };
+                    self.active_window_mut().set_terminal_interaction_mode(
+                        buf,
+                        crate::app::window::TerminalInteractionMode::Scrollback,
+                    );
+                    self.active_window_mut().sync_terminal_to_buffer(buf);
                     self.set_status_message(
                         "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
                     );
@@ -576,7 +577,10 @@ impl Editor {
                 // Dropping to scrollback is a mode change: remember it so the
                 // terminal stays read-only the next time it is focused.
                 let __b = self.active_buffer();
-                self.active_window_mut().terminal_mode_resume.remove(&__b);
+                self.active_window_mut().set_terminal_interaction_mode(
+                    __b,
+                    crate::app::window::TerminalInteractionMode::Scrollback,
+                );
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -966,8 +966,9 @@ pub struct Editor {
     /// When false, UI keybindings (split nav, palette, etc.) are processed first.
     // `keyboard_capture` moved onto `Window`.
 
-    // `terminal_mode_resume` moved onto `Window` — terminal buffers
-    // are per-window (Step 0d), so the auto-resume set follows.
+    // A terminal buffer's remembered live/scrollback interaction mode is
+    // part of its per-window `Window::terminal_buffers` record
+    // (`TerminalBuffer::mode`).
     /// Timestamp of the previous mouse click (for multi-click detection)
     // `previous_click_time`, `previous_click_position`, `click_count` moved onto `Window`.
 

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -517,10 +517,11 @@ impl Editor {
                     .active_window()
                     .is_terminal_buffer(self.active_buffer())
             {
-                {
-                    let __b = self.active_buffer();
-                    self.active_window_mut().sync_terminal_to_buffer(__b);
-                };
+                // Scrolling up drops the terminal to read-only scrollback:
+                // remember that mode so re-focusing keeps it in scrollback.
+                let __b = self.active_buffer();
+                self.active_window_mut().terminal_mode_resume.remove(&__b);
+                self.active_window_mut().sync_terminal_to_buffer(__b);
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =
                     crate::input::keybindings::KeyContext::Normal;

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -520,7 +520,10 @@ impl Editor {
                 // Scrolling up drops the terminal to read-only scrollback:
                 // remember that mode so re-focusing keeps it in scrollback.
                 let __b = self.active_buffer();
-                self.active_window_mut().terminal_mode_resume.remove(&__b);
+                self.active_window_mut().set_terminal_interaction_mode(
+                    __b,
+                    crate::app::window::TerminalInteractionMode::Scrollback,
+                );
                 self.active_window_mut().sync_terminal_to_buffer(__b);
                 self.active_window_mut().terminal_mode = false;
                 self.active_window_mut().key_context =

--- a/crates/fresh-editor/src/app/plugin_dispatch.rs
+++ b/crates/fresh-editor/src/app/plugin_dispatch.rs
@@ -5130,7 +5130,7 @@ impl Editor {
             .active_window()
             .terminal_buffers
             .iter()
-            .find(|(_, &tid)| tid == terminal_id)
+            .find(|(_, tb)| tb.terminal_id == terminal_id)
             .map(|(&bid, _)| bid);
         if let Some(buffer_id) = buffer_to_close {
             if let Err(e) = self.close_buffer(buffer_id) {

--- a/crates/fresh-editor/src/app/split_actions.rs
+++ b/crates/fresh-editor/src/app/split_actions.rs
@@ -235,6 +235,11 @@ impl Editor {
             }
         }
 
+        // Focus snapped to the surviving split through the split manager,
+        // bypassing the buffer-focus path — restore terminal mode so a
+        // re-focused terminal keeps the mode it remembers (issue #2485).
+        self.sync_terminal_mode_to_active_buffer();
+
         // Closing a split gives its space back to the surviving panes.
         // Reflow through the single layout funnel so their terminals grow
         // into the reclaimed area.
@@ -255,13 +260,6 @@ impl Editor {
 
     /// Common split switching logic
     fn switch_split(&mut self, next: bool) {
-        // Capture what was active before the switch so we can mirror the
-        // mouse-click path in `focus_split`: leaving a terminal buffer must
-        // stop routing keyboard input to it. The terminal's visible pane
-        // keeps rendering live because `render_terminal_splits` ignores
-        // `terminal_mode` whenever the terminal isn't the active buffer.
-        let previous_buffer = self.active_buffer();
-
         // `next_split`/`prev_split` auto-unmaximize so the newly-active
         // split is visible (issue #1961). Detect that here so terminal
         // PTYs can be resized to match the restored layout.
@@ -309,27 +307,16 @@ impl Editor {
 
         let buffer_id = self.active_buffer();
 
-        // Leaving a terminal buffer: stop capturing keyboard for the
-        // terminal. Symmetric with the mouse-click path in `focus_split`.
-        if self.active_window().terminal_mode
-            && self.active_window().is_terminal_buffer(previous_buffer)
-            && !self.active_window().is_terminal_buffer(buffer_id)
-        {
-            self.active_window_mut().terminal_mode = false;
-            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Normal;
-        }
+        // Bring terminal mode in line with the newly focused split: a
+        // terminal resumes the live/scrollback mode it remembers, a
+        // non-terminal clears terminal mode. Single restore authority.
+        self.sync_terminal_mode_to_active_buffer();
 
         // Emit buffer_activated hook for plugins
         self.plugin_manager.read().unwrap().run_hook(
             "buffer_activated",
             crate::services::plugins::hooks::HookArgs::BufferActivated { buffer_id },
         );
-
-        // Enter terminal mode if switching to a terminal split
-        if self.active_window().is_terminal_buffer(buffer_id) {
-            self.active_window_mut().terminal_mode = true;
-            self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
-        }
     }
 
     /// Adjust the size of the active split

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -550,6 +550,8 @@ impl Window {
         // next event flips `terminal_mode` — typically the next
         // printable keystroke via `should_enter_terminal_mode`.
         // Mirrors `open_terminal_in_window`'s post-spawn flip.
+        // A freshly opened terminal starts live (its remembered mode).
+        self.terminal_mode_resume.insert(buffer_id);
         if self.active_buffer() == buffer_id {
             self.terminal_mode = true;
             self.key_context = crate::input::keybindings::KeyContext::Terminal;
@@ -722,6 +724,8 @@ impl Window {
         // Window-side activation: per-window mutation only — the
         // editor-wide plugin hook fires in the Editor wrapper.
         self.set_active_buffer(buffer_id);
+        // A freshly opened terminal starts live (its remembered mode).
+        self.terminal_mode_resume.insert(buffer_id);
         self.terminal_mode = true;
         self.key_context = crate::input::keybindings::KeyContext::Terminal;
         self.resize_visible_terminals();
@@ -1049,7 +1053,13 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .set_active_split(new_leaf);
 
-        // Mirror open_terminal's post-attach bookkeeping.
+        // Mirror open_terminal's post-attach bookkeeping. The new terminal
+        // starts live (its remembered mode); the previously-active terminal
+        // keeps its own remembered mode, so closing this split later restores
+        // it correctly (issue #2485).
+        self.active_window_mut()
+            .terminal_mode_resume
+            .insert(buffer_id);
         self.active_window_mut().terminal_mode = true;
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         self.active_window_mut().resize_visible_terminals();
@@ -1301,14 +1311,15 @@ impl Editor {
                 crossterm::event::KeyCode::Char(' ')
                 | crossterm::event::KeyCode::Char(']')
                 | crossterm::event::KeyCode::Char('`') => {
-                    // Exit terminal mode and sync buffer
+                    // Exit terminal mode and sync buffer. The user dropped to
+                    // read-only scrollback: remember that mode so re-focusing
+                    // the terminal keeps it in scrollback.
+                    let __b = self.active_buffer();
+                    self.active_window_mut().terminal_mode_resume.remove(&__b);
                     self.active_window_mut().terminal_mode = false;
                     self.active_window_mut().key_context =
                         crate::input::keybindings::KeyContext::Normal;
-                    {
-                        let __b = self.active_buffer();
-                        self.active_window_mut().sync_terminal_to_buffer(__b);
-                    };
+                    self.active_window_mut().sync_terminal_to_buffer(__b);
                     self.set_status_message(
                         "Terminal mode disabled - read only (Ctrl+Space to resume)".to_string(),
                     );
@@ -1333,6 +1344,12 @@ impl Editor {
             .active_window()
             .is_terminal_buffer(self.active_buffer())
         {
+            // Resuming into live mode is a mode change: remember it so the
+            // terminal comes back live the next time it is focused.
+            let __active = self.active_buffer();
+            self.active_window_mut()
+                .terminal_mode_resume
+                .insert(__active);
             self.active_window_mut().terminal_mode = true;
             self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
 

--- a/crates/fresh-editor/src/app/terminal.rs
+++ b/crates/fresh-editor/src/app/terminal.rs
@@ -23,7 +23,7 @@
 //!   - Resumes live terminal rendering
 //!   - Performance: O(1) ≈ 1ms
 
-use super::window::Window;
+use super::window::{TerminalBuffer, TerminalInteractionMode, Window};
 use super::{BufferId, BufferMetadata, Editor};
 use crate::model::event::LeafId;
 use crate::services::authority::TerminalWrapper;
@@ -314,7 +314,8 @@ impl Window {
             false,
         );
         self.buffer_metadata.insert(buffer_id, metadata);
-        self.terminal_buffers.insert(buffer_id, terminal_id);
+        self.terminal_buffers
+            .insert(buffer_id, TerminalBuffer::new_live(terminal_id));
         self.event_logs
             .insert(buffer_id, crate::model::event::EventLog::new());
 
@@ -549,9 +550,9 @@ impl Window {
         // terminal mode) and the user sees a blank tab until the
         // next event flips `terminal_mode` — typically the next
         // printable keystroke via `should_enter_terminal_mode`.
-        // Mirrors `open_terminal_in_window`'s post-spawn flip.
-        // A freshly opened terminal starts live (its remembered mode).
-        self.terminal_mode_resume.insert(buffer_id);
+        // Mirrors `open_terminal_in_window`'s post-spawn flip. The buffer was
+        // inserted with `TerminalBuffer::new_live`, so its remembered mode is
+        // already Live; just flip the focus flags if it's the active buffer.
         if self.active_buffer() == buffer_id {
             self.terminal_mode = true;
             self.key_context = crate::input::keybindings::KeyContext::Terminal;
@@ -647,7 +648,7 @@ impl Window {
         if interval_due {
             self.terminal_fg_poll_at = Some(now);
         }
-        for (buffer_id, terminal_id) in self.terminal_buffers.iter() {
+        for (buffer_id, tb) in self.terminal_buffers.iter() {
             if self.terminal_explicit_titles.contains(buffer_id) {
                 continue;
             }
@@ -656,7 +657,7 @@ impl Window {
             }
             let name = self
                 .terminal_manager
-                .get(*terminal_id)
+                .get(tb.terminal_id)
                 .and_then(|h| h.foreground_process_name())
                 .map(|n| crate::services::terminal_title::sanitize_title(&n))
                 .filter(|n| !n.is_empty());
@@ -675,18 +676,21 @@ impl Window {
         // Snapshot first so the mutable `buffer_metadata` borrow doesn't
         // overlap the immutable reads above.
         let mut updates: Vec<(BufferId, String)> = Vec::new();
-        for (buffer_id, terminal_id) in self.terminal_buffers.iter() {
+        for (buffer_id, tb) in self.terminal_buffers.iter() {
             if self.terminal_explicit_titles.contains(buffer_id) {
                 continue;
             }
             let pty = self.terminal_fg_cache.get(buffer_id).cloned();
-            let osc = self.terminal_manager.get(*terminal_id).and_then(|handle| {
-                let osc = handle.state.lock().ok()?.title().to_string();
-                let sanitized = crate::services::terminal_title::sanitize_title(&osc);
-                (!sanitized.is_empty()).then_some(sanitized)
-            });
+            let osc = self
+                .terminal_manager
+                .get(tb.terminal_id)
+                .and_then(|handle| {
+                    let osc = handle.state.lock().ok()?.title().to_string();
+                    let sanitized = crate::services::terminal_title::sanitize_title(&osc);
+                    (!sanitized.is_empty()).then_some(sanitized)
+                });
             let name = combine_terminal_title(pty.as_deref(), osc.as_deref())
-                .unwrap_or_else(|| format!("*Terminal {}*", terminal_id.0));
+                .unwrap_or_else(|| format!("*Terminal {}*", tb.terminal_id.0));
             updates.push((*buffer_id, name));
         }
 
@@ -724,8 +728,8 @@ impl Window {
         // Window-side activation: per-window mutation only — the
         // editor-wide plugin hook fires in the Editor wrapper.
         self.set_active_buffer(buffer_id);
-        // A freshly opened terminal starts live (its remembered mode).
-        self.terminal_mode_resume.insert(buffer_id);
+        // The buffer was inserted with `TerminalBuffer::new_live`, so its
+        // remembered mode is already Live.
         self.terminal_mode = true;
         self.key_context = crate::input::keybindings::KeyContext::Terminal;
         self.resize_visible_terminals();
@@ -770,7 +774,8 @@ impl Window {
             false,
         );
         self.buffer_metadata.insert(buffer_id, metadata);
-        self.terminal_buffers.insert(buffer_id, terminal_id);
+        self.terminal_buffers
+            .insert(buffer_id, TerminalBuffer::new_live(terminal_id));
         self.event_logs
             .insert(buffer_id, crate::model::event::EventLog::new());
 
@@ -786,13 +791,17 @@ impl Window {
         if let Some((mgr, _)) = self.buffers.splits() {
             let terminal_of_leaf = |leaf: LeafId| {
                 mgr.get_buffer_id(leaf.into())
-                    .and_then(|buffer_id| self.terminal_buffers.get(&buffer_id).copied())
+                    .and_then(|buffer_id| self.terminal_buffers.get(&buffer_id))
+                    .map(|tb| tb.terminal_id)
             };
             if let Some(leaf) = mgr.last_focused_where(|leaf| terminal_of_leaf(leaf).is_some()) {
                 return terminal_of_leaf(leaf);
             }
         }
-        self.terminal_buffers.values().copied().max_by_key(|t| t.0)
+        self.terminal_buffers
+            .values()
+            .map(|tb| tb.terminal_id)
+            .max_by_key(|t| t.0)
     }
 
     /// Respawn this window's dead embedded terminals through its *current*
@@ -823,7 +832,7 @@ impl Window {
         let bindings: Vec<(BufferId, TerminalId)> = self
             .terminal_buffers
             .iter()
-            .map(|(b, t)| (*b, *t))
+            .map(|(b, tb)| (*b, tb.terminal_id))
             .collect();
 
         let mut revived = 0usize;
@@ -888,7 +897,10 @@ impl Window {
 
             // Remap every terminal-id-keyed entry from old_id → new_id.
             if new_id != old_id {
-                self.terminal_buffers.insert(buffer_id, new_id);
+                // Remap the PTY id but preserve the buffer's remembered mode.
+                if let Some(tb) = self.terminal_buffers.get_mut(&buffer_id) {
+                    tb.terminal_id = new_id;
+                }
                 if let Some(p) = self.terminal_backing_files.remove(&old_id) {
                     self.terminal_backing_files.insert(new_id, p);
                 }
@@ -1053,13 +1065,10 @@ impl Editor {
             .expect("active window must have a populated split layout")
             .set_active_split(new_leaf);
 
-        // Mirror open_terminal's post-attach bookkeeping. The new terminal
-        // starts live (its remembered mode); the previously-active terminal
-        // keeps its own remembered mode, so closing this split later restores
-        // it correctly (issue #2485).
-        self.active_window_mut()
-            .terminal_mode_resume
-            .insert(buffer_id);
+        // Mirror open_terminal's post-attach bookkeeping. The new terminal was
+        // inserted with `TerminalBuffer::new_live` so its remembered mode is
+        // already Live; the previously-active terminal keeps its own remembered
+        // mode, so closing this split later restores it correctly (#2485).
         self.active_window_mut().terminal_mode = true;
         self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
         self.active_window_mut().resize_visible_terminals();
@@ -1110,7 +1119,7 @@ impl Editor {
     pub fn close_terminal(&mut self) {
         let buffer_id = self.active_buffer();
 
-        if let Some(&terminal_id) = self.active_window().terminal_buffers.get(&buffer_id) {
+        if let Some(terminal_id) = self.active_window().get_terminal_id(buffer_id) {
             // Close the terminal
             self.active_window_mut().terminal_manager.close(terminal_id);
             self.active_window_mut().terminal_buffers.remove(&buffer_id);
@@ -1204,7 +1213,7 @@ impl Editor {
             .active_window()
             .terminal_buffers
             .iter()
-            .find_map(|(buffer, terminal)| (*terminal == terminal_id).then_some(*buffer))
+            .find_map(|(buffer, tb)| (tb.terminal_id == terminal_id).then_some(*buffer))
         else {
             return;
         };
@@ -1315,7 +1324,8 @@ impl Editor {
                     // read-only scrollback: remember that mode so re-focusing
                     // the terminal keeps it in scrollback.
                     let __b = self.active_buffer();
-                    self.active_window_mut().terminal_mode_resume.remove(&__b);
+                    self.active_window_mut()
+                        .set_terminal_interaction_mode(__b, TerminalInteractionMode::Scrollback);
                     self.active_window_mut().terminal_mode = false;
                     self.active_window_mut().key_context =
                         crate::input::keybindings::KeyContext::Normal;
@@ -1348,8 +1358,7 @@ impl Editor {
             // terminal comes back live the next time it is focused.
             let __active = self.active_buffer();
             self.active_window_mut()
-                .terminal_mode_resume
-                .insert(__active);
+                .set_terminal_interaction_mode(__active, TerminalInteractionMode::Live);
             self.active_window_mut().terminal_mode = true;
             self.active_window_mut().key_context = crate::input::keybindings::KeyContext::Terminal;
 
@@ -1371,11 +1380,7 @@ impl Editor {
             }
 
             // Truncate backing file to remove visible screen tail and scroll to bottom
-            if let Some(&terminal_id) = self
-                .active_window()
-                .terminal_buffers
-                .get(&self.active_buffer())
-            {
+            if let Some(terminal_id) = self.active_window().get_terminal_id(self.active_buffer()) {
                 // Truncate backing file to remove visible screen that was appended
                 if let Some(backing_path) = self
                     .active_window()
@@ -1416,8 +1421,8 @@ impl Editor {
         &self,
         buffer_id: BufferId,
     ) -> Option<Vec<Vec<crate::services::terminal::TerminalCell>>> {
-        let terminal_id = self.active_window().terminal_buffers.get(&buffer_id)?;
-        let handle = self.active_window().terminal_manager.get(*terminal_id)?;
+        let terminal_id = self.active_window().get_terminal_id(buffer_id)?;
+        let handle = self.active_window().terminal_manager.get(terminal_id)?;
         let state = handle.state.lock().ok()?;
 
         let (_, rows) = state.size();
@@ -1436,15 +1441,15 @@ impl Window {
     pub fn get_active_terminal_state(
         &self,
     ) -> Option<std::sync::MutexGuard<'_, crate::services::terminal::TerminalState>> {
-        let terminal_id = self.terminal_buffers.get(&self.active_buffer())?;
-        let handle = self.terminal_manager.get(*terminal_id)?;
+        let terminal_id = self.get_terminal_id(self.active_buffer())?;
+        let handle = self.terminal_manager.get(terminal_id)?;
         handle.state.lock().ok()
     }
 
     /// Send input bytes to this window's active terminal (no-op if the
     /// active buffer is not a terminal).
     pub fn send_terminal_input(&mut self, data: &[u8]) {
-        if let Some(&terminal_id) = self.terminal_buffers.get(&self.active_buffer()) {
+        if let Some(terminal_id) = self.get_terminal_id(self.active_buffer()) {
             if let Some(handle) = self.terminal_manager.get(terminal_id) {
                 handle.write(data);
             }
@@ -1543,7 +1548,7 @@ impl Window {
     /// Check if the given terminal buffer in this window is in
     /// alternate-screen mode (vim/less/htop etc.).
     pub fn is_terminal_in_alternate_screen(&self, buffer_id: BufferId) -> bool {
-        if let Some(&terminal_id) = self.terminal_buffers.get(&buffer_id) {
+        if let Some(terminal_id) = self.get_terminal_id(buffer_id) {
             if let Some(handle) = self.terminal_manager.get(terminal_id) {
                 if let Ok(state) = handle.state.lock() {
                     return state.is_alternate_screen();
@@ -1556,7 +1561,7 @@ impl Window {
     /// Resize a single terminal buffer's PTY (only if `buffer_id`
     /// belongs to this window's terminal_buffers map).
     pub fn resize_terminal(&mut self, buffer_id: BufferId, cols: u16, rows: u16) {
-        if let Some(&terminal_id) = self.terminal_buffers.get(&buffer_id) {
+        if let Some(terminal_id) = self.get_terminal_id(buffer_id) {
             if let Some(handle) = self.terminal_manager.get_mut(terminal_id) {
                 handle.resize(cols, rows);
             }
@@ -1637,7 +1642,7 @@ impl Window {
     ///
     /// Performance: O(screen_size) instead of O(total_history).
     pub fn sync_terminal_to_buffer(&mut self, buffer_id: BufferId) {
-        let Some(&terminal_id) = self.terminal_buffers.get(&buffer_id) else {
+        let Some(terminal_id) = self.get_terminal_id(buffer_id) else {
             return;
         };
         // Get the backing file path
@@ -1821,7 +1826,7 @@ impl Window {
         for (_split_id, buffer_id, content_rect, _scrollbar_rect, _thumb_start, _thumb_end) in
             split_areas
         {
-            let Some(&terminal_id) = self.terminal_buffers.get(buffer_id) else {
+            let Some(terminal_id) = self.get_terminal_id(*buffer_id) else {
                 continue;
             };
             // When the user's current tab is a terminal but they're
@@ -1877,13 +1882,6 @@ impl Editor {
     /// Check if terminal mode is active (for testing)
     pub fn is_terminal_mode(&self) -> bool {
         self.active_window().terminal_mode
-    }
-
-    /// Check if a buffer is in terminal_mode_resume set (for testing/debugging)
-    pub fn is_in_terminal_mode_resume(&self, buffer_id: BufferId) -> bool {
-        self.active_window()
-            .terminal_mode_resume
-            .contains(&buffer_id)
     }
 
     /// Check if keyboard capture is enabled in terminal mode (for testing)

--- a/crates/fresh-editor/src/app/terminal_mouse.rs
+++ b/crates/fresh-editor/src/app/terminal_mouse.rs
@@ -71,7 +71,7 @@ impl Window {
         let term_col = col.saturating_sub(content_rect.x) as usize;
         let term_row = row.saturating_sub(content_rect.y);
 
-        let &terminal_id = self.terminal_buffers.get(&buffer_id)?;
+        let terminal_id = self.get_terminal_id(buffer_id)?;
         let handle = self.terminal_manager.get(terminal_id)?;
         let (line, cwd) = {
             let state = handle.state.lock().ok()?;
@@ -162,9 +162,8 @@ impl Window {
 
         let link = crate::services::terminal::path_link::detect_link_at(line, char_col)?;
         let cwd = self
-            .terminal_buffers
-            .get(&active)
-            .and_then(|tid| self.terminal_manager.get(*tid))
+            .get_terminal_id(active)
+            .and_then(|tid| self.terminal_manager.get(tid))
             .and_then(|h| {
                 h.state
                     .lock()

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -114,6 +114,20 @@ impl TerminalBuffer {
             mode: TerminalInteractionMode::Live,
         }
     }
+
+    /// Whether this terminal remembers the **live** mode (keystrokes routed to
+    /// the PTY). False for scrollback.
+    pub fn is_live(&self) -> bool {
+        matches!(self.mode, TerminalInteractionMode::Live)
+    }
+
+    /// Record this terminal's interaction mode. The transitions that call it
+    /// are the real live↔scrollback edges (open/resume, Ctrl+Space, scroll-up,
+    /// exit); route them through [`Window::set_terminal_interaction_mode`] so
+    /// the write stays single-sited.
+    pub fn set_mode(&mut self, mode: TerminalInteractionMode) {
+        self.mode = mode;
+    }
 }
 
 pub struct Window {
@@ -2256,9 +2270,23 @@ impl Window {
 
     // ---- Terminal-buffer query helpers ----
 
+    /// The [`TerminalBuffer`] record for a buffer, or `None` if `buffer_id`
+    /// isn't a terminal buffer in this window. The single lookup the per-record
+    /// helpers below build on; reach for it directly when you need more than
+    /// one field off the record.
+    pub fn terminal_buffer(&self, buffer_id: BufferId) -> Option<&TerminalBuffer> {
+        self.terminal_buffers.get(&buffer_id)
+    }
+
+    /// Mutable [`TerminalBuffer`] record for a buffer, or `None` if it isn't a
+    /// terminal buffer in this window.
+    pub fn terminal_buffer_mut(&mut self, buffer_id: BufferId) -> Option<&mut TerminalBuffer> {
+        self.terminal_buffers.get_mut(&buffer_id)
+    }
+
     /// Check if a buffer is a terminal buffer (in this window).
     pub fn is_terminal_buffer(&self, buffer_id: BufferId) -> bool {
-        self.terminal_buffers.contains_key(&buffer_id)
+        self.terminal_buffer(buffer_id).is_some()
     }
 
     /// Get the terminal ID for a buffer (if it's a terminal buffer in
@@ -2267,28 +2295,7 @@ impl Window {
         &self,
         buffer_id: BufferId,
     ) -> Option<crate::services::terminal::TerminalId> {
-        self.terminal_buffers
-            .get(&buffer_id)
-            .map(|tb| tb.terminal_id)
-    }
-
-    /// The remembered interaction mode of a terminal buffer, or `None` if
-    /// `buffer_id` is not a terminal buffer in this window.
-    pub fn terminal_interaction_mode(
-        &self,
-        buffer_id: BufferId,
-    ) -> Option<TerminalInteractionMode> {
-        self.terminal_buffers.get(&buffer_id).map(|tb| tb.mode)
-    }
-
-    /// Whether a terminal buffer currently remembers the **live** mode
-    /// (keystrokes routed to the PTY). False for scrollback terminals and
-    /// for non-terminal buffers.
-    pub fn is_live_terminal(&self, buffer_id: BufferId) -> bool {
-        matches!(
-            self.terminal_interaction_mode(buffer_id),
-            Some(TerminalInteractionMode::Live)
-        )
+        self.terminal_buffer(buffer_id).map(|tb| tb.terminal_id)
     }
 
     /// Record a terminal buffer's interaction mode. No-op if `buffer_id`
@@ -2300,8 +2307,8 @@ impl Window {
         buffer_id: BufferId,
         mode: TerminalInteractionMode,
     ) {
-        if let Some(tb) = self.terminal_buffers.get_mut(&buffer_id) {
-            tb.mode = mode;
+        if let Some(tb) = self.terminal_buffer_mut(buffer_id) {
+            tb.set_mode(mode);
         }
     }
 

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -421,9 +421,16 @@ pub struct Window {
     /// has its own terminal set + active buffer.
     pub terminal_mode: bool,
 
-    /// Set of terminal buffer ids that should auto-resume terminal
-    /// mode when switched back to. Per-window because terminal
-    /// buffers are per-window (Step 0d).
+    /// Per-terminal interaction mode: the set of terminal buffer ids whose
+    /// mode is **live** (capturing keyboard), as opposed to read-only
+    /// scrollback. Membership is the terminal's remembered mode and persists
+    /// across focus changes, so re-focusing a terminal (tab switch, split
+    /// focus/navigation, split-collapse on close) restores the mode it had
+    /// when it lost focus — see `Window::sync_terminal_mode_flags`. A
+    /// terminal is added when opened or resumed and removed when the user
+    /// drops it to scrollback (Ctrl+Space / scroll-up), when its process
+    /// exits, or when it is closed. Per-window because terminal buffers are
+    /// per-window.
     pub terminal_mode_resume: std::collections::HashSet<BufferId>,
 
     /// Path-link currently highlighted under a Ctrl+hover over the live

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -78,6 +78,44 @@ pub struct TerminalLinkHover {
     pub cols: std::ops::Range<usize>,
 }
 
+/// How a terminal buffer routes input — the buffer's remembered interaction
+/// mode, restored whenever it regains focus (see
+/// `Window::sync_terminal_mode_flags`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalInteractionMode {
+    /// Keystrokes are forwarded to the PTY and the buffer mirrors the live
+    /// terminal screen. This is the mode a terminal opens in.
+    Live,
+    /// Read-only scrollback: keys do ordinary editor navigation and the
+    /// buffer shows captured history. Entered via Ctrl+Space, scroll-up, or
+    /// when the process exits.
+    Scrollback,
+}
+
+/// Per-terminal-buffer editor state, keyed by `BufferId` in
+/// [`Window::terminal_buffers`]. Holds the editor-facing facts about a
+/// terminal buffer: which service-layer terminal feeds it, and the
+/// interaction mode it remembers across focus changes. (PTY I/O state lives
+/// in the `TerminalManager`; the byte-stream backing files stay keyed by
+/// `TerminalId` in `terminal_backing_files`.)
+#[derive(Debug, Clone)]
+pub struct TerminalBuffer {
+    /// The PTY session feeding this buffer, scoped to this window.
+    pub terminal_id: crate::services::terminal::TerminalId,
+    /// Remembered live/scrollback interaction mode.
+    pub mode: TerminalInteractionMode,
+}
+
+impl TerminalBuffer {
+    /// A freshly opened/attached terminal buffer, which starts live.
+    pub fn new_live(terminal_id: crate::services::terminal::TerminalId) -> Self {
+        Self {
+            terminal_id,
+            mode: TerminalInteractionMode::Live,
+        }
+    }
+}
+
 pub struct Window {
     /// Stable identifier. The base window is always `WindowId(1)`.
     pub id: WindowId,
@@ -300,8 +338,10 @@ pub struct Window {
     /// PTY threads — no orphan agents survive a `closeWindow`.
     pub terminal_manager: crate::services::terminal::TerminalManager,
 
-    /// Maps a terminal-buffer id to its PTY id, scoped to this window.
-    pub terminal_buffers: HashMap<BufferId, crate::services::terminal::TerminalId>,
+    /// Per-terminal-buffer editor state, keyed by buffer id and scoped to
+    /// this window: the PTY id feeding the buffer plus its remembered
+    /// live/scrollback interaction mode. See [`TerminalBuffer`].
+    pub terminal_buffers: HashMap<BufferId, TerminalBuffer>,
 
     /// Backing files for terminal buffers (the rendered visible-screen
     /// + scrollback content the buffer actually displays).
@@ -420,18 +460,6 @@ pub struct Window {
     /// the active terminal buffer). Per-window because each window
     /// has its own terminal set + active buffer.
     pub terminal_mode: bool,
-
-    /// Per-terminal interaction mode: the set of terminal buffer ids whose
-    /// mode is **live** (capturing keyboard), as opposed to read-only
-    /// scrollback. Membership is the terminal's remembered mode and persists
-    /// across focus changes, so re-focusing a terminal (tab switch, split
-    /// focus/navigation, split-collapse on close) restores the mode it had
-    /// when it lost focus — see `Window::sync_terminal_mode_flags`. A
-    /// terminal is added when opened or resumed and removed when the user
-    /// drops it to scrollback (Ctrl+Space / scroll-up), when its process
-    /// exits, or when it is closed. Per-window because terminal buffers are
-    /// per-window.
-    pub terminal_mode_resume: std::collections::HashSet<BufferId>,
 
     /// Path-link currently highlighted under a Ctrl+hover over the live
     /// terminal grid. `Some` means the renderer underlines the given grid row
@@ -1838,7 +1866,6 @@ impl Window {
             preview: None,
             terminal_mode: false,
             terminal_link_hover: None,
-            terminal_mode_resume: std::collections::HashSet::new(),
             seen_byte_ranges: HashMap::new(),
             previous_viewports: HashMap::new(),
             same_buffer_scroll_sync: false,
@@ -2240,7 +2267,42 @@ impl Window {
         &self,
         buffer_id: BufferId,
     ) -> Option<crate::services::terminal::TerminalId> {
-        self.terminal_buffers.get(&buffer_id).copied()
+        self.terminal_buffers
+            .get(&buffer_id)
+            .map(|tb| tb.terminal_id)
+    }
+
+    /// The remembered interaction mode of a terminal buffer, or `None` if
+    /// `buffer_id` is not a terminal buffer in this window.
+    pub fn terminal_interaction_mode(
+        &self,
+        buffer_id: BufferId,
+    ) -> Option<TerminalInteractionMode> {
+        self.terminal_buffers.get(&buffer_id).map(|tb| tb.mode)
+    }
+
+    /// Whether a terminal buffer currently remembers the **live** mode
+    /// (keystrokes routed to the PTY). False for scrollback terminals and
+    /// for non-terminal buffers.
+    pub fn is_live_terminal(&self, buffer_id: BufferId) -> bool {
+        matches!(
+            self.terminal_interaction_mode(buffer_id),
+            Some(TerminalInteractionMode::Live)
+        )
+    }
+
+    /// Record a terminal buffer's interaction mode. No-op if `buffer_id`
+    /// isn't a terminal buffer in this window. This is the only writer of
+    /// the remembered mode; the transitions that call it are the real
+    /// live↔scrollback edges (open/resume, Ctrl+Space, scroll-up, exit).
+    pub fn set_terminal_interaction_mode(
+        &mut self,
+        buffer_id: BufferId,
+        mode: TerminalInteractionMode,
+    ) {
+        if let Some(tb) = self.terminal_buffers.get_mut(&buffer_id) {
+            tb.mode = mode;
+        }
     }
 
     /// Clear the visual search overlays for the active buffer,

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -78,31 +78,23 @@ pub struct TerminalLinkHover {
     pub cols: std::ops::Range<usize>,
 }
 
-/// How a terminal buffer routes input — the buffer's remembered interaction
-/// mode, restored whenever it regains focus (see
-/// `Window::sync_terminal_mode_flags`).
+/// A terminal buffer's remembered interaction mode, restored whenever it
+/// regains focus (see `Window::sync_terminal_mode_flags`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TerminalInteractionMode {
-    /// Keystrokes are forwarded to the PTY and the buffer mirrors the live
-    /// terminal screen. This is the mode a terminal opens in.
+    /// Keystrokes forwarded to the PTY; the buffer mirrors the live screen.
     Live,
-    /// Read-only scrollback: keys do ordinary editor navigation and the
-    /// buffer shows captured history. Entered via Ctrl+Space, scroll-up, or
-    /// when the process exits.
+    /// Read-only scrollback. Entered via Ctrl+Space, scroll-up, or process exit.
     Scrollback,
 }
 
 /// Per-terminal-buffer editor state, keyed by `BufferId` in
-/// [`Window::terminal_buffers`]. Holds the editor-facing facts about a
-/// terminal buffer: which service-layer terminal feeds it, and the
-/// interaction mode it remembers across focus changes. (PTY I/O state lives
-/// in the `TerminalManager`; the byte-stream backing files stay keyed by
-/// `TerminalId` in `terminal_backing_files`.)
+/// [`Window::terminal_buffers`]. PTY I/O lives in the `TerminalManager`; the
+/// byte-stream backing files stay keyed by `TerminalId`.
 #[derive(Debug, Clone)]
 pub struct TerminalBuffer {
     /// The PTY session feeding this buffer, scoped to this window.
     pub terminal_id: crate::services::terminal::TerminalId,
-    /// Remembered live/scrollback interaction mode.
     pub mode: TerminalInteractionMode,
 }
 
@@ -115,16 +107,12 @@ impl TerminalBuffer {
         }
     }
 
-    /// Whether this terminal remembers the **live** mode (keystrokes routed to
-    /// the PTY). False for scrollback.
     pub fn is_live(&self) -> bool {
         matches!(self.mode, TerminalInteractionMode::Live)
     }
 
-    /// Record this terminal's interaction mode. The transitions that call it
-    /// are the real live↔scrollback edges (open/resume, Ctrl+Space, scroll-up,
-    /// exit); route them through [`Window::set_terminal_interaction_mode`] so
-    /// the write stays single-sited.
+    /// Route writes through [`Window::set_terminal_interaction_mode`] to keep
+    /// the mode single-sited.
     pub fn set_mode(&mut self, mode: TerminalInteractionMode) {
         self.mode = mode;
     }
@@ -2270,16 +2258,13 @@ impl Window {
 
     // ---- Terminal-buffer query helpers ----
 
-    /// The [`TerminalBuffer`] record for a buffer, or `None` if `buffer_id`
-    /// isn't a terminal buffer in this window. The single lookup the per-record
-    /// helpers below build on; reach for it directly when you need more than
-    /// one field off the record.
+    /// The [`TerminalBuffer`] record for a buffer, or `None` if it isn't a
+    /// terminal buffer in this window. The single lookup the helpers below
+    /// build on.
     pub fn terminal_buffer(&self, buffer_id: BufferId) -> Option<&TerminalBuffer> {
         self.terminal_buffers.get(&buffer_id)
     }
 
-    /// Mutable [`TerminalBuffer`] record for a buffer, or `None` if it isn't a
-    /// terminal buffer in this window.
     pub fn terminal_buffer_mut(&mut self, buffer_id: BufferId) -> Option<&mut TerminalBuffer> {
         self.terminal_buffers.get_mut(&buffer_id)
     }
@@ -2298,10 +2283,9 @@ impl Window {
         self.terminal_buffer(buffer_id).map(|tb| tb.terminal_id)
     }
 
-    /// Record a terminal buffer's interaction mode. No-op if `buffer_id`
-    /// isn't a terminal buffer in this window. This is the only writer of
-    /// the remembered mode; the transitions that call it are the real
-    /// live↔scrollback edges (open/resume, Ctrl+Space, scroll-up, exit).
+    /// The only writer of a terminal's remembered mode — the real
+    /// live↔scrollback edges (open/resume, Ctrl+Space, scroll-up, exit) all
+    /// route here. No-op if `buffer_id` isn't a terminal buffer in this window.
     pub fn set_terminal_interaction_mode(
         &mut self,
         buffer_id: BufferId,

--- a/crates/fresh-editor/src/app/workspace.rs
+++ b/crates/fresh-editor/src/app/workspace.rs
@@ -657,14 +657,17 @@ impl crate::app::window::Window {
             if let Some(buffer_id) = self.restore_terminal_from_workspace(terminal) {
                 terminal_buffer_map.insert(terminal.terminal_index, buffer_id);
                 // The terminal was live when the workspace was saved and the
-                // user never explicitly exited it, so focusing it should
-                // bring back a live terminal rather than the read-only
-                // scrollback view. Seed the resume set so `set_active_buffer`
-                // re-enters terminal mode when the tab is focused (the
-                // editing-disabled completion in `Editor::set_active_buffer`
-                // finishes the read-only → live transition). An explicit
-                // Ctrl+Space exit later removes it from the set as usual.
-                self.terminal_mode_resume.insert(buffer_id);
+                // user never explicitly exited it, so focusing it should bring
+                // back a live terminal rather than the read-only scrollback
+                // view. Mark it Live so `set_active_buffer` re-enters terminal
+                // mode when the tab is focused (the editing-disabled completion
+                // in `Editor::set_active_buffer` finishes the read-only → live
+                // transition). An explicit Ctrl+Space exit later flips it back
+                // to Scrollback as usual.
+                self.set_terminal_interaction_mode(
+                    buffer_id,
+                    crate::app::window::TerminalInteractionMode::Live,
+                );
             }
         }
         terminal_buffer_map
@@ -1721,7 +1724,7 @@ impl crate::app::window::Window {
         let terminals_to_sync: Vec<_> = self
             .terminal_buffers
             .values()
-            .copied()
+            .map(|tb| tb.terminal_id)
             .filter_map(|terminal_id| {
                 self.terminal_backing_files
                     .get(&terminal_id)
@@ -2170,7 +2173,7 @@ impl crate::app::window::Window {
         let mut terminals = Vec::new();
         let mut terminal_indices: HashMap<TerminalId, usize> = HashMap::new();
         let mut seen = HashSet::new();
-        for terminal_id in self.terminal_buffers.values().copied() {
+        for terminal_id in self.terminal_buffers.values().map(|tb| tb.terminal_id) {
             if seen.insert(terminal_id) {
                 let command = self.terminal_commands.get(&terminal_id).cloned();
                 // Ephemeral terminals (plugin tool UIs, agent shells) are
@@ -2234,11 +2237,19 @@ impl crate::app::window::Window {
             .splits()
             .expect("window must have a populated split layout");
 
+        // Serialization helpers only need the buffer→PTY-id association, not
+        // the interaction mode, so project the terminal-buffer map down to it.
+        let terminal_id_map: HashMap<BufferId, TerminalId> = self
+            .terminal_buffers
+            .iter()
+            .map(|(b, tb)| (*b, tb.terminal_id))
+            .collect();
+
         let split_layout = serialize_split_node(
             mgr.root(),
             &self.buffer_metadata,
             &self.root,
-            &self.terminal_buffers,
+            &terminal_id_map,
             &terminal_indices,
             mgr.labels(),
         );
@@ -2259,7 +2270,7 @@ impl crate::app::window::Window {
                 &self.buffer_metadata,
                 &self.root,
                 active_buffer,
-                &self.terminal_buffers,
+                &terminal_id_map,
                 &terminal_indices,
             );
             split_states.insert(leaf_id.0 .0, serialized);

--- a/crates/fresh-editor/tests/e2e/close_buffer_shared_split_cursor.rs
+++ b/crates/fresh-editor/tests/e2e/close_buffer_shared_split_cursor.rs
@@ -1,0 +1,69 @@
+//! Regression test: closing a buffer that is *also* open in another split must
+//! leave the surviving tab's cursor usable.
+//!
+//! When the same buffer is shown in two splits and you close it from a split
+//! that has another tab to fall back to, the close took the "remove this tab,
+//! there are other viewports" path. That path activated the replacement tab by
+//! moving only the split *tree* (`set_split_buffer`) and never the matching
+//! `SplitViewState.active_buffer`, so the view-state stayed stranded on the
+//! just-closed buffer. The cursor and render then read that stale view-state
+//! (anchored at offset 0) while typed text went into the tree's actual buffer:
+//! every keystroke inserted at the start of the buffer, reversed (`1234` →
+//! `4321`), with the cursor frozen.
+//!
+//! The test drives the flow through the command palette and asserts only on
+//! rendered output: typed characters must append at the cursor in the
+//! surviving buffer, not pile up reversed at its top.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+
+fn run_command(harness: &mut EditorTestHarness, command: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(command).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+#[test]
+fn typing_after_closing_a_split_shared_buffer_targets_the_surviving_buffer() {
+    let mut harness = EditorTestHarness::new(120, 30).unwrap();
+    harness.load_buffer_from_text("AAAA\n").unwrap();
+    harness.render().unwrap();
+
+    // Duplicate the buffer across two vertical splits (both show it).
+    run_command(&mut harness, "Split Vertical");
+
+    // Open a new buffer in the active split and type three lines into it,
+    // leaving the cursor at the end of "line three".
+    run_command(&mut harness, "New File");
+    harness.type_text("line one").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("line two").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.type_text("line three").unwrap();
+    harness.render().unwrap();
+
+    // Switch back to the duplicated buffer's tab in this split, then close it.
+    // The split still has the new-file tab to fall back to, and the buffer is
+    // still open in the other split — this is the multi-viewport close path.
+    run_command(&mut harness, "Previous Buffer");
+    run_command(&mut harness, "Close Buffer");
+
+    // Focus is on the surviving new-file buffer with its cursor preserved.
+    // Typing must append to "line three", not insert reversed at offset 0.
+    harness.type_text("1234").unwrap();
+    harness.render().unwrap();
+
+    harness.assert_screen_contains("line three1234");
+    harness.assert_screen_not_contains("4321");
+}

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -84,6 +84,7 @@ pub mod issue_779_after_eof_shade;
 pub mod issue_close_file_in_split_hides_buffer_group;
 pub mod suspend_process;
 
+pub mod close_buffer_shared_split_cursor;
 pub mod keybinding_editor;
 pub mod language_features_e2e;
 pub mod large_file_inplace_write_bug;

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -232,6 +232,7 @@ pub mod terminal;
 pub mod terminal_close;
 pub mod terminal_link;
 pub mod terminal_resize;
+pub mod terminal_resume_mode_after_close;
 pub mod terminal_split_focus_live;
 pub mod test_scrollbar_keybinds_cursor;
 pub mod theme;

--- a/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_session_renders.rs
+++ b/crates/fresh-editor/tests/e2e/plugins/orchestrator_new_session_renders.rs
@@ -123,7 +123,7 @@ fn new_session_renders_terminal_output_without_keypress() {
     harness
         .wait_until(|h| {
             let win = h.editor().active_window();
-            let Some(&terminal_id) = win.terminal_buffers.get(&terminal_buffer) else {
+            let Some(terminal_id) = win.get_terminal_id(terminal_buffer) else {
                 return false;
             };
             let Some(handle) = win.terminal_manager.get(terminal_id) else {
@@ -231,7 +231,7 @@ fn new_session_atomic_api_seeds_terminal_as_only_tab() {
     harness
         .wait_until(|h| {
             let win = h.editor().active_window();
-            let Some(&tid) = win.terminal_buffers.get(&terminal_buffer) else {
+            let Some(tid) = win.get_terminal_id(terminal_buffer) else {
                 return false;
             };
             let Some(handle) = win.terminal_manager.get(tid) else {

--- a/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_auto_reconnect_terminal.rs
@@ -244,11 +244,10 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
         .editor_mut()
         .test_dispatch_remote_reconnected(CHANNEL_ID);
 
-    let new_id = *harness
+    let new_id = harness
         .editor()
         .active_window()
-        .terminal_buffers
-        .get(&buffer_id)
+        .get_terminal_id(buffer_id)
         .expect("buffer is still bound to a terminal after reconnect");
     assert_ne!(
         new_id, old_id,
@@ -271,12 +270,8 @@ fn auto_reconnect_respawns_a_dead_remote_terminal() {
         .editor_mut()
         .test_dispatch_remote_reconnected(CHANNEL_ID);
     assert_eq!(
-        harness
-            .editor()
-            .active_window()
-            .terminal_buffers
-            .get(&buffer_id),
-        Some(&new_id),
+        harness.editor().active_window().get_terminal_id(buffer_id),
+        Some(new_id),
         "a duplicate reconnect event does not respawn an already-live terminal"
     );
 }

--- a/crates/fresh-editor/tests/e2e/remote_reconnect_terminal.rs
+++ b/crates/fresh-editor/tests/e2e/remote_reconnect_terminal.rs
@@ -71,8 +71,8 @@ fn reconnect_respawns_a_dead_embedded_terminal_in_place() {
         "dead terminal's handle is torn down"
     );
     assert_eq!(
-        window.terminal_buffers.get(&buffer_id),
-        Some(&old_id),
+        window.get_terminal_id(buffer_id),
+        Some(old_id),
         "binding is preserved across the drop, awaiting respawn"
     );
 
@@ -80,9 +80,8 @@ fn reconnect_respawns_a_dead_embedded_terminal_in_place() {
     window.respawn_terminals_through_authority();
 
     // The buffer is bound to a *new, live* terminal.
-    let new_id = *window
-        .terminal_buffers
-        .get(&buffer_id)
+    let new_id = window
+        .get_terminal_id(buffer_id)
         .expect("buffer is still bound to a terminal after respawn");
     assert_ne!(
         new_id, old_id,
@@ -142,8 +141,8 @@ fn respawn_leaves_a_live_terminal_untouched() {
     window.respawn_terminals_through_authority();
 
     assert_eq!(
-        window.terminal_buffers.get(&buffer_id),
-        Some(&id),
+        window.get_terminal_id(buffer_id),
+        Some(id),
         "a live terminal keeps its id (not respawned)"
     );
 }

--- a/crates/fresh-editor/tests/e2e/terminal.rs
+++ b/crates/fresh-editor/tests/e2e/terminal.rs
@@ -767,21 +767,24 @@ fn test_terminal_buffer_cursor_movement() {
 
     assert!(!harness.editor().is_terminal_mode());
 
-    // Get initial cursor position
+    // Get initial cursor position. Exiting terminal mode anchors the cursor
+    // at the top of the just-exited visible screen (see
+    // `sync_terminal_to_buffer`), so navigate downward into the content.
     let initial_pos = harness.editor().get_cursor_position(buffer_id);
 
-    // Move cursor up
+    // Move cursor down
     harness
         .editor_mut()
-        .handle_key(KeyCode::Up, KeyModifiers::NONE)
+        .handle_key(KeyCode::Down, KeyModifiers::NONE)
         .unwrap();
 
-    let pos_after_up = harness.editor().get_cursor_position(buffer_id);
+    let pos_after_down = harness.editor().get_cursor_position(buffer_id);
 
-    // Cursor should have moved (different position)
+    // Cursor should have moved (arrow keys do buffer navigation, not PTY input,
+    // once terminal mode is disabled).
     assert_ne!(
-        initial_pos, pos_after_up,
-        "Cursor should move when pressing Up in disabled terminal mode"
+        initial_pos, pos_after_down,
+        "Cursor should move when pressing Down in disabled terminal mode"
     );
 }
 

--- a/crates/fresh-editor/tests/e2e/terminal_resume_mode_after_close.rs
+++ b/crates/fresh-editor/tests/e2e/terminal_resume_mode_after_close.rs
@@ -1,0 +1,147 @@
+//! Regression test for issue #2485: a terminal that becomes the active
+//! split after a *second* terminal split is closed must keep the mode it
+//! had when it was defocused.
+//!
+//! Before the fix, closing the second terminal snapped focus back to the
+//! first terminal through the low-level split-collapse path, which never
+//! re-synced terminal mode — so a terminal that was actively capturing
+//! keyboard was left in read-only scrollback, and the user had to press
+//! `Ctrl+Space` to resume.
+//!
+//! The bug is masked for a terminal that keeps producing output, because
+//! `jump_to_end_on_output` re-enters terminal mode on the next byte. These
+//! tests disable that setting so they assert the focus-restore logic itself.
+
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use fresh::config::Config;
+use fresh::model::event::SplitDirection;
+use portable_pty::{native_pty_system, PtySize};
+
+fn config_no_jump_to_end() -> Config {
+    let mut config = Config::default();
+    // Isolate the focus-restore behaviour from the output-driven auto-resume
+    // that would otherwise paper over the bug.
+    config.terminal.jump_to_end_on_output = false;
+    config
+}
+
+fn harness_or_skip(width: u16, height: u16) -> Option<EditorTestHarness> {
+    if native_pty_system()
+        .openpty(PtySize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .is_err()
+    {
+        eprintln!("Skipping terminal test: PTY not available in this environment");
+        return None;
+    }
+    EditorTestHarness::with_config(width, height, config_no_jump_to_end()).ok()
+}
+
+/// Run a command through the command palette (mirrors the user driving the
+/// "Close Buffer" / "Exit Terminal Mode" commands).
+fn run_command(harness: &mut EditorTestHarness, command: &str) {
+    harness
+        .send_key(KeyCode::Char('p'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.type_text(command).unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.render().unwrap();
+}
+
+/// First terminal is active (capturing keyboard). Opening a second terminal
+/// split and then closing it must return focus to the first terminal *in
+/// terminal mode* — it was active when it lost focus.
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses a PTY shell
+fn first_terminal_resumes_terminal_mode_after_closing_second_split() {
+    let mut harness = match harness_or_skip(120, 30) {
+        Some(h) => h,
+        None => return,
+    };
+
+    // First terminal — becomes the active buffer in terminal mode.
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    let first = harness.editor().active_buffer_id();
+    assert!(harness.editor().active_window().is_terminal_buffer(first));
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "first terminal should start in terminal mode"
+    );
+
+    // Second terminal in a new split — becomes active.
+    harness
+        .editor_mut()
+        .open_terminal_split(SplitDirection::Vertical);
+    harness.render().unwrap();
+    let second = harness.editor().active_buffer_id();
+    assert_ne!(first, second, "second terminal should be a distinct buffer");
+    assert!(harness.editor().is_terminal_mode());
+
+    // Close the second terminal's buffer; focus snaps back to the first.
+    run_command(&mut harness, "Close Buffer");
+
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        first,
+        "closing the second terminal should focus the first terminal"
+    );
+    assert!(
+        harness.editor().is_terminal_mode(),
+        "the first terminal was active when defocused, so it must resume \
+         terminal mode when it becomes the last remaining split"
+    );
+}
+
+/// If the first terminal was left in read-only scrollback when it lost
+/// focus, closing the second terminal must *not* silently re-activate it —
+/// it should stay in scrollback (the mode it had when defocused).
+#[test]
+#[cfg_attr(target_os = "windows", ignore)] // Uses a PTY shell
+fn first_terminal_stays_in_scrollback_after_closing_second_split() {
+    let mut harness = match harness_or_skip(120, 30) {
+        Some(h) => h,
+        None => return,
+    };
+
+    harness.editor_mut().open_terminal();
+    harness.render().unwrap();
+    let first = harness.editor().active_buffer_id();
+    assert!(harness.editor().is_terminal_mode());
+
+    // User explicitly leaves terminal mode → read-only scrollback.
+    run_command(&mut harness, "Exit Terminal Mode");
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "explicit exit should drop the first terminal to read-only"
+    );
+
+    // Open and then close a second terminal split.
+    harness
+        .editor_mut()
+        .open_terminal_split(SplitDirection::Vertical);
+    harness.render().unwrap();
+    let second = harness.editor().active_buffer_id();
+    assert_ne!(first, second);
+
+    run_command(&mut harness, "Close Buffer");
+
+    assert_eq!(
+        harness.editor().active_buffer_id(),
+        first,
+        "closing the second terminal should focus the first terminal"
+    );
+    assert!(
+        !harness.editor().is_terminal_mode(),
+        "the first terminal was in scrollback when defocused, so it must \
+         stay read-only rather than being re-activated"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #2485, plus a follow-up refactor that makes a terminal's interaction mode proper per-buffer state. Two commits:

1. **`fix(terminal):`** restore a terminal's remembered mode on refocus
2. **`refactor(terminal):`** fold live/scrollback mode into per-buffer `TerminalBuffer` state

### 1 — The bug

A terminal that became the active split after another split/buffer was closed came back as **read-only scrollback** instead of the mode it had when it lost focus.

**Repro:** with a terminal as the only split (in terminal mode), open a second terminal split → `exit` it → close its buffer. Focus snaps back to the first terminal, but it's read-only until you press `Ctrl+Space`. Easy to miss: `jump_to_end_on_output` (default on) silently re-enters terminal mode on the terminal's next byte, so only an **idle** terminal stays visibly stuck.

**Root cause:** focus logic was duplicated and inconsistent — `set_active_buffer`, `focus_split`, `switch_split`, `open_terminal_split` each decided terminal mode independently, and the split-collapse close paths decided nothing.

**Fix — one rule, one place:** every focus change routes through a single authority (`Window::sync_terminal_mode_flags` + `Editor::sync_terminal_mode_to_active_buffer`) that derives `terminal_mode`/`key_context` from the active buffer's remembered mode. No path can leave a re-focused terminal in the wrong mode; a terminal left in scrollback stays in scrollback.

### 2 — The refactor

Replaces the free-floating `Window::terminal_mode_resume: HashSet` with proper per-terminal-buffer state. `terminal_buffers` now maps each buffer id to a `TerminalBuffer { terminal_id, mode }`, where `mode` is a two-state `TerminalInteractionMode { Live, Scrollback }` enum instead of presence-in-a-set.

- The mode is a property *of the terminal buffer*, so it now lives on the buffer's record (keyed by `BufferId`, colocated with its PTY id) — self-documenting, no parallel map, no ambiguous "absent" state.
- Mode writers are a single accessor (`set_terminal_interaction_mode`); transitions are explicit: open/resume → `Live`, Ctrl+Space / scroll-up / process-exit → `Scrollback`, close drops the whole record. Creation seeds `Live`, so the old per-site resume-inserts are gone. (Per-record read/write — `is_live`, `set_mode` — lives on `TerminalBuffer`; the window keeps a single `terminal_buffer(id)` lookup the helpers delegate to.)
- The byte-stream backing-file map stays keyed by `TerminalId` (genuinely I/O-layer state); serialization projects the buffer→PTY-id association out of the richer map. Reconnect respawn remaps the PTY id in place, preserving mode.

One incidental cleanup falls out: a terminal now opens cleanly `Live`, so the spurious read-only `sync_terminal_to_buffer` that used to run mid-open no longer prepends a phantom blank screen to the backing file. The cursor-movement test that relied on that artifact was updated to navigate down from the (deliberately) top-anchored cursor.

## Also fixes #2496 — close-buffer cursor desync across splits

While manually testing the terminal close paths, surfaced a **pre-existing** (reproduces on `master`) cursor bug, fixed here in its own commit since it's adjacent to this work.

Closing a buffer that is also open in another split takes the "remove this tab, other viewports remain" path, which activated the replacement tab by moving only the split *tree* (`set_split_buffer`) and never the matching `SplitViewState.active_buffer`. The view-state stayed stranded on the just-closed buffer, so the cursor/render read its zeroed view-state while typed text went into the tree's actual buffer — every keystroke inserted at offset 0, reversed (`1234` → `4321`), cursor frozen. The fix routes the replacement through `set_pane_buffer` (tree + view-state together) and frees the closed buffer's keyed view-state once the replacement is active. See #2496 for the standalone repro.

## Tests

New `terminal_resume_mode_after_close.rs`: a live terminal resumes live after the second split closes (**verified failing on the parent of commit 1**), and a scrollback terminal stays read-only (guards against an over-aggressive "always activate" fix). Both disable `jump_to_end_on_output` so they assert the focus-restore path itself.

New `close_buffer_shared_split_cursor.rs` (for #2496): drives the palette flow and asserts on rendered output that typing lands in the surviving buffer (`line three1234`, not `4321line one`); **verified failing without the buffer_close.rs fix**.

Green after the refactor: `terminal` (61), `dock` (52), `workspace` (52, exercises serialization), `split_view` (33), `split_tabs` (17), `terminal_close`, `terminal_split_focus_live`, `terminal_resize`, `terminal_link`, `restored_terminal_focus`, `restored_agent_terminal`, `remote_reconnect_terminal`, `remote_auto_reconnect_terminal`, `issue_2029`, `issue_1620`, `orchestrator_new_session_renders`. `cargo fmt`/`clippy` clean; smoke-tested the real repro in tmux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gs6jWvADjsBXFXrGJP6da