### PR TITLE
Preserve selection anchor in mark mode for movement commands

### DIFF
--- a/crates/fresh-editor/src/app/text_ops.rs
+++ b/crates/fresh-editor/src/app/text_ops.rs
@@ -75,12 +75,21 @@ impl Editor {
                 }
             };
 
+            // Respect Emacs-style mark mode: preserve the anchor when movement
+            // should keep extending the selection (e.g. after Set Mark), so the
+            // Home key extends the selection instead of collapsing it.
+            let new_anchor = if cursor.deselect_on_move {
+                None
+            } else {
+                cursor.anchor
+            };
+
             events.push(Event::MoveCursor {
                 cursor_id,
                 old_position: cursor.position,
                 new_position: new_pos,
                 old_anchor: cursor.anchor,
-                new_anchor: None,
+                new_anchor,
                 old_sticky_column: cursor.sticky_column,
                 new_sticky_column: 0,
             });
@@ -495,12 +504,20 @@ impl Editor {
         };
 
         if let Some(new_pos) = matching_pos {
+            // Respect Emacs-style mark mode: when movement should preserve the
+            // selection (e.g. after Set Mark), keep the anchor so jumping to the
+            // matching bracket extends the selection instead of collapsing it.
+            let new_anchor = if cursor.deselect_on_move {
+                None
+            } else {
+                cursor.anchor
+            };
             let event = Event::MoveCursor {
                 cursor_id,
                 old_position: cursor.position,
                 new_position: new_pos,
                 old_anchor: cursor.anchor,
-                new_anchor: None,
+                new_anchor,
                 old_sticky_column: cursor.sticky_column,
                 new_sticky_column: 0,
             };

--- a/crates/fresh-editor/tests/e2e/mark_mode_actions.rs
+++ b/crates/fresh-editor/tests/e2e/mark_mode_actions.rs
@@ -419,3 +419,58 @@ fn test_clear_mark_clears_block_selection() {
         "Block selection should be cleared by ClearMark"
     );
 }
+
+/// Regression: after Set Mark, jumping to the matching bracket must produce a
+/// *real* selection, not merely a visual highlight. The observable proof is a
+/// clipboard round-trip — Cut removes exactly the selected range and Paste
+/// restores it — so copy/cut/paste behave correctly on the mark-mode selection.
+#[test]
+fn test_mark_then_matching_bracket_selection_is_cuttable() {
+    let mut harness = EditorTestHarness::new(80, 24).unwrap();
+
+    // Force internal-only clipboard so the test stays isolated from the host.
+    harness.editor_mut().set_clipboard_for_test(String::new());
+
+    harness.type_text("foo(bar)baz").unwrap();
+    harness.assert_buffer_content("foo(bar)baz");
+
+    // Move onto the '(' at byte 3.
+    harness
+        .send_key(KeyCode::Home, KeyModifiers::CONTROL)
+        .unwrap();
+    for _ in 0..3 {
+        harness
+            .send_key(KeyCode::Right, KeyModifiers::NONE)
+            .unwrap();
+    }
+
+    // Enter mark mode, then jump to the matching ')'.
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::SetMark);
+    harness
+        .editor_mut()
+        .dispatch_action_for_tests(Action::GoToMatchingBracket);
+    harness.render().unwrap();
+
+    assert!(
+        harness.has_selection(),
+        "Jumping to the matching bracket in mark mode should extend the selection"
+    );
+
+    // Cut must remove exactly the selected range "(bar" — this only works if
+    // the selection is semantically active, not just highlighted.
+    harness.editor_mut().dispatch_action_for_tests(Action::Cut);
+    harness.render().unwrap();
+    harness.assert_buffer_content("foo)baz");
+    assert_eq!(
+        harness.editor().clipboard_content_for_test(),
+        "(bar",
+        "Cut should capture the mark-mode bracket selection"
+    );
+
+    // Paste restores the original text — the full round trip succeeds.
+    harness.editor_mut().paste_for_test();
+    harness.render().unwrap();
+    harness.assert_buffer_content("foo(bar)baz");
+}

--- a/crates/fresh-editor/tests/semantic/migrated_goto_matching_bracket.rs
+++ b/crates/fresh-editor/tests/semantic/migrated_goto_matching_bracket.rs
@@ -138,6 +138,42 @@ fn anti_goto_matching_bracket_dropping_action_yields_check_err() {
     );
 }
 
+// ── Mark mode: jump should extend the selection ─────────────────────
+
+#[test]
+fn goto_matching_bracket_extends_selection_in_mark_mode() {
+    // Regression: after `Set Mark` (Emacs mark mode), jumping to the
+    // matching bracket must EXTEND the selection rather than collapse it.
+    // Cursor on '(' at byte 3, SetMark anchors there, then the jump moves
+    // to ')' at byte 7 while keeping the anchor at 3.
+    assert_buffer_scenario(BufferScenario {
+        description: "GoToMatchingBracket in mark mode extends selection from '(' to ')'".into(),
+        initial_text: "foo(bar)".into(),
+        actions: repeat(Action::MoveRight, 3)
+            .chain([Action::SetMark, Action::GoToMatchingBracket])
+            .collect(),
+        expected_text: "foo(bar)".into(),
+        expected_primary: CursorExpect::range(3, 7),
+        ..Default::default()
+    });
+}
+
+#[test]
+fn goto_matching_bracket_without_mark_collapses_selection() {
+    // Counterpart to the mark-mode test: with no mark set, the jump must
+    // NOT create a selection — the anchor stays `None`.
+    assert_buffer_scenario(BufferScenario {
+        description: "GoToMatchingBracket without mark mode leaves no selection".into(),
+        initial_text: "foo(bar)".into(),
+        actions: repeat(Action::MoveRight, 3)
+            .chain(std::iter::once(Action::GoToMatchingBracket))
+            .collect(),
+        expected_text: "foo(bar)".into(),
+        expected_primary: CursorExpect::at(7),
+        ..Default::default()
+    });
+}
+
 #[test]
 fn migrated_goto_matching_bracket_from_inside_nested_outer() {
     // Original: `test_goto_matching_bracket_from_inside_outer_of_nested`.

--- a/crates/fresh-editor/tests/semantic/smart_home.rs
+++ b/crates/fresh-editor/tests/semantic/smart_home.rs
@@ -51,3 +51,22 @@ fn theorem_smart_home_toggles_to_byte_zero() {
         ..Default::default()
     });
 }
+
+#[test]
+fn smart_home_extends_selection_in_mark_mode() {
+    // Regression: after `Set Mark` (Emacs mark mode), pressing Home must
+    // EXTEND the selection rather than collapse it. From byte 12 (end of
+    // line) SetMark anchors there, then SmartHome moves to the first
+    // non-whitespace (byte 4) while keeping the anchor at 12.
+    assert_buffer_scenario(BufferScenario {
+        terminal: TerminalSize::default(),
+        description: "SmartHome in mark mode extends the selection".into(),
+        initial_text: "    indented".into(),
+        actions: vec![Action::MoveLineEnd, Action::SetMark, Action::SmartHome],
+        expected_text: "    indented".into(),
+        expected_primary: CursorExpect::range(12, 4),
+        expected_extra_cursors: vec![],
+        expected_selection_text: Some("indented".into()),
+        ..Default::default()
+    });
+}


### PR DESCRIPTION
## Summary
Fix Emacs-style mark mode so that movement commands (Home, GoToMatchingBracket, etc.) extend the selection rather than collapse it. When a mark is set, the selection anchor should be preserved during movement, allowing users to build selections incrementally.

## Key Changes
- **text_ops.rs**: Modified `move_cursor_home` and `go_to_matching_bracket` to respect the `deselect_on_move` flag. When false (mark mode is active), the cursor anchor is preserved instead of being cleared, allowing selections to extend.
- **Tests**: Added comprehensive test coverage:
  - E2E test verifying that mark-mode bracket selection is cuttable (proving it's a real selection, not just visual)
  - Semantic tests for GoToMatchingBracket behavior in both mark mode (extends) and normal mode (collapses)
  - Semantic test for SmartHome extending selection in mark mode

## Implementation Details
The fix leverages the existing `deselect_on_move` cursor property to determine whether movement should preserve the anchor. When `deselect_on_move` is false (set by `SetMark` action), movement commands now pass the existing anchor to the `MoveCursor` event instead of clearing it with `None`. This allows the selection to grow as the cursor moves, matching Emacs mark mode semantics.

https://claude.ai/code/session_01HYup5yLjENprcLSF9qjLiJ