### PR TITLE
fix(editor): keep indent guides stable when a block opener scrolls off-screen

### DIFF
--- a/crates/fresh-editor/src/view/folding.rs
+++ b/crates/fresh-editor/src/view/folding.rs
@@ -435,9 +435,17 @@ pub mod indent_folding {
         buf_len
     }
 
-    /// Measure leading indent of a line given as a byte slice (no trailing `\n`).
-    /// Returns `(indent_width, all_blank)` where `all_blank` is true when the
-    /// line has no non-whitespace character. Tabs expand against `tab_size`.
+    /// Measure leading indent of a line. The slice may carry its trailing line
+    /// terminator (`\n` / `\r\n`); the newline ends the scan without counting as
+    /// content. Returns `(indent_width, all_blank)` where `all_blank` is true
+    /// when the line has no non-whitespace character. Tabs expand against
+    /// `tab_size`.
+    ///
+    /// Treating `\n` as a terminator (rather than as ordinary non-whitespace) is
+    /// what lets callers pass a `ViewLine::text` — which keeps its `\n` — and
+    /// still have an empty or whitespace-only line correctly read as blank. Get
+    /// this wrong and a bare `"\n"` measures as indent-0 *content*, which makes
+    /// blank lines masquerade as fold headers and resets indent-guide staircases.
     pub fn slice_indent(line: &[u8], tab_size: usize) -> (usize, bool) {
         let mut indent = 0;
         let mut all_blank = true;
@@ -452,6 +460,9 @@ pub mod indent_folding {
                     }
                 }
                 b'\r' => {}
+                // End of line: everything before was whitespace, so the line is
+                // blank. Stop before scanning into any following line's bytes.
+                b'\n' => break,
                 _ => {
                     all_blank = false;
                     break;
@@ -651,6 +662,17 @@ pub mod indent_folding {
             assert_eq!(slice_indent(b"", 4), (0, true));
             assert_eq!(slice_indent(b"   ", 4), (3, true));
             assert_eq!(slice_indent(b"  \r", 4), (2, true));
+        }
+
+        #[test]
+        fn test_slice_indent_newline_terminated() {
+            // A trailing newline (as kept by `ViewLine::text`) terminates the
+            // line and does not count as content: empty/whitespace-only lines
+            // stay blank, and real content is still detected past its indent.
+            assert_eq!(slice_indent(b"\n", 4), (0, true));
+            assert_eq!(slice_indent(b"    \n", 4), (4, true));
+            assert_eq!(slice_indent(b"  \r\n", 4), (2, true));
+            assert_eq!(slice_indent(b"    code\n", 4), (4, false));
         }
 
         #[test]

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -527,6 +527,101 @@ mod tests {
         )
     }
 
+    /// Render `content` with the viewport scrolled so the buffer byte
+    /// `top_byte` is the first visible row. Used to exercise indentation-guide
+    /// rendering when a block-opening line has scrolled above the viewport.
+    fn render_output_scrolled_with_indentation_guide(
+        content: &str,
+        top_byte: usize,
+    ) -> LineRenderOutput {
+        let mut state = EditorState::new(20, 6, 1024, test_fs());
+        state.buffer = Buffer::from_str(content, 1024, test_fs());
+        let mut cursors = crate::model::cursor::Cursors::new();
+        cursors.primary_mut().position = 0;
+        let mut viewport = Viewport::new(20, 4);
+        viewport.top_byte = top_byte;
+        state.margins.left_config.enabled = false;
+
+        let render_area = Rect::new(0, 0, 20, 4);
+        let visible_count = viewport.visible_line_count();
+        let gutter_width = state.margins.left_total_width();
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+        let empty_folds = FoldManager::new();
+
+        let view_data = build_view_data(
+            &mut state,
+            &viewport,
+            None,
+            content.len().max(1),
+            visible_count,
+            false,
+            render_area.width as usize,
+            gutter_width,
+            &ViewMode::Source,
+            &empty_folds,
+            &theme,
+        );
+        let view_anchor = calculate_view_anchor(&view_data.lines, viewport.top_byte);
+
+        let estimated_lines = (state.buffer.len() / state.buffer.estimated_line_length()).max(1);
+        state.margins.update_width_for_buffer(estimated_lines, true);
+        let gutter_width = state.margins.left_total_width();
+
+        let selection = selection_context(&state, &cursors);
+        let _ = state
+            .buffer
+            .populate_line_cache(viewport.top_byte, visible_count);
+        let viewport_start = viewport.top_byte;
+        let viewport_end = calculate_viewport_end(
+            &mut state,
+            viewport_start,
+            content.len().max(1),
+            visible_count,
+        );
+        let decorations = decoration_context(
+            &mut state,
+            viewport_start,
+            viewport_end,
+            selection.primary_cursor_position,
+            &empty_folds,
+            &theme,
+            100_000,
+            &ViewMode::Source,
+            false,
+            &[],
+        );
+
+        let glyph = crate::config::default_indentation_guide_glyph();
+        let mut dummy_theme_map = Vec::new();
+        render_view_lines(LineRenderInput {
+            state: &state,
+            theme: &theme,
+            view_lines: &view_data.lines,
+            view_anchor,
+            render_area,
+            gutter_width,
+            selection: &selection,
+            decorations: &decorations,
+            visible_line_count: visible_count,
+            lsp_waiting: false,
+            is_active: true,
+            line_wrap: viewport.line_wrap_enabled,
+            estimated_lines,
+            left_column: viewport.left_column,
+            relative_line_numbers: false,
+            session_mode: false,
+            software_cursor_only: false,
+            show_line_numbers: true,
+            byte_offset_mode: false,
+            show_tilde: true,
+            highlight_current_line: true,
+            indentation_guide: IndentationGuideMode::All,
+            indentation_guide_glyph: &glyph,
+            cell_theme_map: &mut dummy_theme_map,
+            screen_width: 0,
+        })
+    }
+
     fn rendered_line_text(output: &LineRenderOutput, line_idx: usize) -> String {
         output.lines[line_idx]
             .spans
@@ -655,6 +750,38 @@ mod tests {
         assert_eq!(rendered_line_text(&output, 1), "▏   a");
         assert_eq!(rendered_line_text(&output, 2), "▏");
         assert_eq!(rendered_line_text(&output, 3), "▏   b");
+    }
+
+    #[test]
+    fn indentation_guide_survives_scroll_past_block_opener() {
+        // A block whose opening lines (`mod m {` at col 0, `fn f() {` at col 4)
+        // have scrolled above the viewport must still draw their guides on the
+        // interior rows below. Previously the all-mode scanner derived its
+        // staircase only from the visible rows, so the off-screen openers'
+        // levels were missing — the col-4 guide vanished on the deeper interior
+        // rows and reappeared only when scrolling the opener back into view.
+        let content = concat!(
+            "mod m {\n",             // col 0  (scrolled off-screen)
+            "    fn f() {\n",        // col 4  (scrolled off-screen)
+            "        let arr = [\n", // col 8  <- first visible row
+            "            a,\n",      // col 12
+            "            b,\n",      // col 12
+            "        ];\n",          // col 8
+            "        let c = 1;\n",  // col 8
+            "    }\n",
+            "}\n",
+        );
+        let top_byte = content.find("        let arr = [").unwrap();
+        let output = render_output_scrolled_with_indentation_guide(content, top_byte);
+
+        // First visible row keeps both ancestor guides (col 0 and col 4) even
+        // though both owning lines are off-screen.
+        assert_eq!(rendered_line_text(&output, 0), "▏   ▏   let arr = [");
+        // Interior rows show the full staircase, including the col-4 guide that
+        // the scroll regression used to drop.
+        assert_eq!(rendered_line_text(&output, 1), "▏   ▏   ▏   a,");
+        assert_eq!(rendered_line_text(&output, 2), "▏   ▏   ▏   b,");
+        assert_eq!(rendered_line_text(&output, 3), "▏   ▏   ];");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -838,6 +838,42 @@ mod tests {
     }
 
     #[test]
+    fn indentation_guide_draws_through_completely_empty_lines() {
+        // A bare `\n` line has no cells for the per-cell pass to restyle, so its
+        // guides are synthesised. At root depth the empty line carries the single
+        // col-0 guide; nested, it carries every ancestor guide of the surrounding
+        // body — keeping the vertical guides continuous through the gap.
+        let root = "int main() {\n\n    greet();\n    \n    return 0;\n}\n";
+        let out = render_output_scrolled_with_indentation_guide(root, 0);
+        assert_eq!(rendered_line_text(&out, 0), "int main() {");
+        assert_eq!(rendered_line_text(&out, 1), "▏"); // empty line, drawn through
+        assert_eq!(rendered_line_text(&out, 2), "▏   greet();");
+        assert_eq!(rendered_line_text(&out, 3), "▏"); // whitespace-only line
+        assert_eq!(rendered_line_text(&out, 4), "▏   return 0;");
+        assert_eq!(rendered_line_text(&out, 5), "}");
+
+        let nested = "fn f() {\n    if x {\n        a;\n\n        b;\n    }\n}\n";
+        let out = render_output_scrolled_with_indentation_guide(nested, 0);
+        assert_eq!(rendered_line_text(&out, 2), "▏   ▏   a;");
+        // The empty interior line carries both the col-0 and col-4 guides.
+        assert_eq!(rendered_line_text(&out, 3), "▏   ▏");
+        assert_eq!(rendered_line_text(&out, 4), "▏   ▏   b;");
+    }
+
+    #[test]
+    fn indentation_guide_empty_line_after_opener_flows_into_body() {
+        // The empty line sits directly under the opener, before any body row —
+        // so the staircase alone (just the opener's level) would under-draw. The
+        // look-ahead to the next content row pulls the body's guide onto the
+        // empty line, so the guide is continuous from the opener down.
+        let content = "if outer {\n\n    inner();\n}\n";
+        let out = render_output_scrolled_with_indentation_guide(content, 0);
+        assert_eq!(rendered_line_text(&out, 0), "if outer {");
+        assert_eq!(rendered_line_text(&out, 1), "▏"); // flows into the body below
+        assert_eq!(rendered_line_text(&out, 2), "▏   inner();");
+    }
+
+    #[test]
     fn indentation_guide_render_for_tabs() {
         let (output, _, _, _) =
             render_output_for_with_indentation_guide("\tchild\n\t\tgrand\n", 0, 0);

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -761,6 +761,25 @@ mod tests {
     }
 
     #[test]
+    fn indentation_guide_empty_line_does_not_collapse_staircase() {
+        // A *completely empty* line (a bare `\n`) inside a nested block must not
+        // reset the indent staircase: the code row below it keeps its full set of
+        // guides. (Before `slice_indent` treated `\n` as a terminator, a bare
+        // "\n" read as indent-0 content, popping the whole stack — so `b;` lost
+        // its col-4 guide and rendered "▏   b;".) The empty row's own rendering is
+        // covered by the draw-through test below.
+        let content = "fn f() {\n    if x {\n        a;\n\n        b;\n    }\n}\n";
+        let output = render_output_scrolled_with_indentation_guide(content, 0);
+
+        assert_eq!(rendered_line_text(&output, 0), "fn f() {");
+        assert_eq!(rendered_line_text(&output, 1), "▏   if x {");
+        assert_eq!(rendered_line_text(&output, 2), "▏   ▏   a;");
+        // row 3 is the empty line — owned by the draw-through test.
+        assert_eq!(rendered_line_text(&output, 4), "▏   ▏   b;");
+        assert_eq!(rendered_line_text(&output, 5), "▏   }");
+    }
+
+    #[test]
     fn indentation_guide_survives_scroll_past_block_opener() {
         // A block whose opening lines (`mod m {` at col 0, `fn f() {` at col 4)
         // have scrolled above the viewport must still draw their guides on the
@@ -1103,6 +1122,48 @@ mod tests {
         assert!(lines
             .iter()
             .any(|l| l.contains("header") && l.contains("...")));
+    }
+
+    #[test]
+    fn fold_indicator_lands_on_header_not_blank_line_after_it() {
+        // A blank line immediately after a foldable header must not steal the
+        // fold marker. The indent-based detector consumes `ViewLine::text`,
+        // which keeps the trailing `\n`; before `slice_indent` treated `\n` as a
+        // terminator, a bare "\n" read as indent-0 *content*, so `int main() {`
+        // looked unfoldable (its next "non-blank" line was the blank one) and the
+        // blank line itself looked like the indent-0 header of the body below.
+        let content = "int main() {\n\n    body();\n    \n    more();\n}\n";
+        let mut state = EditorState::new(40, 10, 1024, test_fs());
+        state.buffer = Buffer::from_str(content, 1024, test_fs());
+        let viewport = Viewport::new(40, 10);
+        let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
+        let folds = FoldManager::new();
+        let view_data = build_view_data(
+            &mut state,
+            &viewport,
+            None,
+            content.len().max(1),
+            viewport.visible_line_count(),
+            false,
+            40,
+            0,
+            &ViewMode::Source,
+            &folds,
+            &theme,
+        );
+
+        let indicators = fold_indicators_for_viewport(&state, &folds, &view_data.lines);
+
+        let header_byte = 0; // `int main() {`
+        let blank_byte = content.find("\n\n").unwrap() + 1; // the empty line
+        assert!(
+            indicators.contains_key(&header_byte),
+            "fold marker should be on the function header"
+        );
+        assert!(
+            !indicators.contains_key(&blank_byte),
+            "fold marker must not be on the blank line"
+        );
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -538,11 +538,11 @@ mod tests {
         state.buffer = Buffer::from_str(content, 1024, test_fs());
         let mut cursors = crate::model::cursor::Cursors::new();
         cursors.primary_mut().position = 0;
-        let mut viewport = Viewport::new(20, 4);
+        let mut viewport = Viewport::new(20, 10);
         viewport.top_byte = top_byte;
         state.margins.left_config.enabled = false;
 
-        let render_area = Rect::new(0, 0, 20, 4);
+        let render_area = Rect::new(0, 0, 20, 10);
         let visible_count = viewport.visible_line_count();
         let gutter_width = state.margins.left_total_width();
         let theme = Theme::load_builtin(theme::THEME_DARK).unwrap();
@@ -740,16 +740,24 @@ mod tests {
 
     #[test]
     fn indentation_guide_all_mode_draws_through_blank_lines() {
-        // A whitespace-only line inside a block continues the enclosing block's
-        // guides rather than leaving a one-row gap (the blank line here has
-        // four trailing spaces, so its column-0 guide cell is present).
-        let (output, _, _, _) =
-            render_output_for_with_indentation_guide("fn main()\n    a\n    \n    b\n", 0, 0);
+        // A whitespace-only line inside a nested block continues *every*
+        // enclosing block's guides straight through it, rather than leaving a
+        // one-row gap. With the block openers (`fn f() {` at col 0, `if x {` at
+        // col 4) on screen, the blank row must still draw both the col-0 and
+        // col-4 guides (it has eight trailing spaces, so those guide cells
+        // exist), and the staircase resumes unchanged on the row below.
+        let blank = " ".repeat(8);
+        let content =
+            format!("fn f() {{\n    if x {{\n        a;\n{blank}\n        b;\n    }}\n}}\n");
+        let output = render_output_scrolled_with_indentation_guide(&content, 0);
 
-        assert_eq!(rendered_line_text(&output, 0), "fn main()");
-        assert_eq!(rendered_line_text(&output, 1), "▏   a");
-        assert_eq!(rendered_line_text(&output, 2), "▏");
-        assert_eq!(rendered_line_text(&output, 3), "▏   b");
+        assert_eq!(rendered_line_text(&output, 0), "fn f() {");
+        assert_eq!(rendered_line_text(&output, 1), "▏   if x {");
+        assert_eq!(rendered_line_text(&output, 2), "▏   ▏   a;");
+        assert_eq!(rendered_line_text(&output, 3), "▏   ▏");
+        assert_eq!(rendered_line_text(&output, 4), "▏   ▏   b;");
+        assert_eq!(rendered_line_text(&output, 5), "▏   }");
+        assert_eq!(rendered_line_text(&output, 6), "}");
     }
 
     #[test]
@@ -782,6 +790,32 @@ mod tests {
         assert_eq!(rendered_line_text(&output, 1), "▏   ▏   ▏   a,");
         assert_eq!(rendered_line_text(&output, 2), "▏   ▏   ▏   b,");
         assert_eq!(rendered_line_text(&output, 3), "▏   ▏   ];");
+    }
+
+    #[test]
+    fn indentation_guide_draws_through_blank_line_when_opener_scrolled_off() {
+        // Combines the two cases that interact here: a whitespace-only line in
+        // the middle of a block (guides must be drawn straight through it) while
+        // the block's openers (`mod m {` at col 0, `fn f() {` at col 4) have
+        // scrolled above the viewport. The primer must skip the blank line as it
+        // walks up to reconstruct the staircase, and the drawn-through guides
+        // must use that primed staircase — otherwise the col-4 guide drops on the
+        // blank row exactly as it did on the textual interior rows.
+        // 12 spaces: a whitespace-only line wide enough to carry guide cells at
+        // columns 0/4/8 (the renderer only replaces existing leading-space cells).
+        let blank = " ".repeat(12);
+        let content = format!(
+            "mod m {{\n    fn f() {{\n        let arr = [\n            alpha_value,\n{blank}\n            beta_value,\n        ];\n        let after = compute();\n    }}\n}}\n"
+        );
+        let top_byte = content.find("        let arr = [").unwrap();
+        let output = render_output_scrolled_with_indentation_guide(&content, top_byte);
+
+        assert_eq!(rendered_line_text(&output, 0), "▏   ▏   let arr = [");
+        assert_eq!(rendered_line_text(&output, 1), "▏   ▏   ▏   alpha_value,");
+        // The whitespace-only row continues the enclosing block's guides — the
+        // col-4 guide (owned by the off-screen `fn f() {`) must be drawn through.
+        assert_eq!(rendered_line_text(&output, 2), "▏   ▏   ▏");
+        assert_eq!(rendered_line_text(&output, 3), "▏   ▏   ▏   beta_value,");
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -242,17 +242,6 @@ struct GuideColumnScanner {
 }
 
 impl GuideColumnScanner {
-    /// Advance the staircase past a row without recording its columns — used to
-    /// prime the scanner over the rows scrolled above the first rendered row.
-    fn advance(&mut self, line: &ViewLine, tab_size: usize) {
-        if let Some((width, true)) = view_line_indent(line, tab_size) {
-            while self.stack.last().is_some_and(|&w| w >= width) {
-                self.stack.pop();
-            }
-            self.stack.push(width);
-        }
-    }
-
     /// Write the guide columns for `line` into `out` and advance the staircase.
     fn columns_for(&mut self, line: &ViewLine, tab_size: usize, out: &mut Vec<usize>) {
         match view_line_indent(line, tab_size) {
@@ -278,6 +267,60 @@ impl GuideColumnScanner {
             None => out.clear(),
         }
     }
+}
+
+/// Reconstruct the open-ancestor indentation stack as of the buffer line
+/// starting at `first_visible_line_start`, by walking the buffer *upward*.
+///
+/// This is exactly the staircase a [`GuideColumnScanner`] would hold had it
+/// scanned every line from the buffer's start: the strictly-increasing indent
+/// widths of the enclosing blocks. Deriving the seed from the buffer's absolute
+/// indentation — rather than from the handful of `view_lines` that precede the
+/// viewport (there are none under vertical scroll, since `view_lines` begins at
+/// the viewport top) — makes a row's guide columns depend only on absolute
+/// indentation. A block whose opening line has scrolled above the viewport then
+/// still contributes its guide to the interior rows below it, instead of the
+/// guide vanishing until the opener scrolls back into view.
+fn prime_guide_stack_from_buffer(
+    buffer: &crate::model::buffer::Buffer,
+    first_visible_line_start: usize,
+    tab_size: usize,
+    max_upward_lines: usize,
+) -> Vec<usize> {
+    use crate::view::folding::indent_folding::{find_line_start_byte, slice_indent};
+
+    // Collected in decreasing order while walking up, then reversed.
+    let mut ancestors_desc: Vec<usize> = Vec::new();
+    let mut min_indent_seen = usize::MAX;
+    let mut line_start = first_visible_line_start;
+
+    // Bound the upward scan to a fixed window (mirroring the active-mode fold
+    // search) so this never degrades into a full-buffer scan for a viewport
+    // sitting deep inside one enormous top-level block.
+    for _ in 0..max_upward_lines {
+        if line_start == 0 {
+            break;
+        }
+        let prev_line_start = find_line_start_byte(buffer, line_start - 1);
+        // Slice the previous line's content *excluding* its trailing `\n` (at
+        // `line_start - 1`) so a whitespace-only line is correctly classified
+        // as blank rather than as content ending in a newline.
+        let content = buffer.slice_bytes(prev_line_start..line_start - 1);
+        let (width, all_blank) = slice_indent(&content, tab_size);
+        // Each strictly-shallower content line opens an enclosing block; once we
+        // reach column 0 the staircase is complete.
+        if !all_blank && width < min_indent_seen {
+            ancestors_desc.push(width);
+            min_indent_seen = width;
+            if width == 0 {
+                break;
+            }
+        }
+        line_start = prev_line_start;
+    }
+
+    ancestors_desc.reverse();
+    ancestors_desc
 }
 
 /// Fill `out` with the guide columns for a line of indent `width` whose open
@@ -362,16 +405,28 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
     );
     // `all`-mode guide columns are scanned lazily, one row at a time, as the
     // render loop walks the viewport. The scanner is only built for `all` mode
-    // (the default `none` and `active` modes skip it entirely), and it is
-    // primed over the rows scrolled above the first rendered row so the visible
-    // top rows see their true ancestor indentation.
+    // (the default `none` and `active` modes skip it entirely). Its staircase is
+    // seeded from the buffer's *absolute* indentation above the first visible
+    // row (not from the preceding `view_lines`, which under vertical scroll
+    // start at the viewport top and so carry no ancestor context). This keeps a
+    // row's guides identical regardless of scroll offset — a block whose opener
+    // has scrolled off the top still draws its guide on the interior rows.
     let mut guide_column_scanner = (indentation_guide == IndentationGuideMode::All).then(|| {
-        let mut scanner = GuideColumnScanner::default();
-        let prime_end = view_anchor.start_line_idx.min(view_lines.len());
-        for line in &view_lines[..prime_end] {
-            scanner.advance(line, state.buffer_settings.tab_size);
-        }
-        scanner
+        let first_visible_source = view_lines
+            .get(view_anchor.start_line_idx..)
+            .into_iter()
+            .flatten()
+            .find_map(|line| line.source_start_byte);
+        let stack = match first_visible_source {
+            Some(src) => prime_guide_stack_from_buffer(
+                &state.buffer,
+                indent_folding::find_line_start_byte(&state.buffer, src),
+                state.buffer_settings.tab_size,
+                crate::config::INDENT_FOLD_MAX_UPWARD_SCAN,
+            ),
+            None => Vec::new(),
+        };
+        GuideColumnScanner { stack }
     });
 
     // Cursors for O(1) amortized span lookups (spans are sorted by byte range)

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/mod.rs
@@ -243,7 +243,16 @@ struct GuideColumnScanner {
 
 impl GuideColumnScanner {
     /// Write the guide columns for `line` into `out` and advance the staircase.
-    fn columns_for(&mut self, line: &ViewLine, tab_size: usize, out: &mut Vec<usize>) {
+    ///
+    /// `next_content_indent` is the indentation of the next non-blank source row
+    /// below `line` (looked up by the caller), used only when `line` is blank.
+    fn columns_for(
+        &mut self,
+        line: &ViewLine,
+        tab_size: usize,
+        next_content_indent: Option<usize>,
+        out: &mut Vec<usize>,
+    ) {
         match view_line_indent(line, tab_size) {
             // Content row: its guides are the open ancestors strictly to its
             // left; it then becomes an ancestor for the rows below.
@@ -254,19 +263,41 @@ impl GuideColumnScanner {
                 fill_guide_columns(&self.stack, width, tab_size, out);
                 self.stack.push(width);
             }
-            // Whitespace-only row: draw the enclosing block's guides straight
-            // through it (so guides stay continuous across blank lines) without
-            // disturbing the staircase.
-            Some((_, false)) => match self.stack.split_last() {
-                Some((&deepest, ancestors)) => {
-                    fill_guide_columns(ancestors, deepest, tab_size, out)
-                }
-                None => out.clear(),
-            },
+            // Blank (empty or whitespace-only) row: draw the enclosing block's
+            // guides straight through it so they stay continuous, without
+            // disturbing the staircase. The guides shown are those of the
+            // *deeper* of the row above (the open block) and the row below (the
+            // upcoming content) — so guides flow into a nested body even when the
+            // blank line sits directly under the block opener, before any body
+            // row has been seen (e.g. the empty line right after `fn f() {`).
+            Some((_, false)) => {
+                let above = self.stack.last().copied().unwrap_or(0);
+                let level = above.max(next_content_indent.unwrap_or(0));
+                let cut = self.stack.partition_point(|&w| w < level);
+                fill_guide_columns(&self.stack[..cut], level, tab_size, out);
+            }
             // Continuation / injected row: no guides, staircase untouched.
             None => out.clear(),
         }
     }
+}
+
+/// Indentation of the next non-blank source row at or after `start_idx`, used to
+/// flow blank-line guides into an upcoming nested body. Blank and
+/// continuation/injected rows are skipped; `None` if none remain.
+fn next_content_indent(
+    view_lines: &[ViewLine],
+    start_idx: usize,
+    tab_size: usize,
+) -> Option<usize> {
+    view_lines
+        .get(start_idx..)
+        .into_iter()
+        .flatten()
+        .find_map(|line| match view_line_indent(line, tab_size) {
+            Some((width, true)) => Some(width),
+            _ => None,
+        })
 }
 
 /// Reconstruct the open-ancestor indentation stack as of the buffer line
@@ -346,6 +377,56 @@ fn fill_guide_columns(ancestors: &[usize], width: usize, tab_size: usize, out: &
     }
 }
 
+/// Append guide glyphs for `guide_columns` lying *beyond* the row's own rendered
+/// content (`content_visual_end` is the first visual column past it). The
+/// per-cell pass already draws guides on existing leading-whitespace cells; this
+/// fills in guide columns that have no cell to restyle — the case for empty rows
+/// (no cells at all) and whitespace-only rows narrower than their guides — so the
+/// vertical guides run continuously through blank lines. Synthesised cells map to
+/// no source byte, exactly like the tail fill. Code rows pass through untouched:
+/// their guide columns all sit inside their indent, so none exceed
+/// `content_visual_end`.
+#[allow(clippy::too_many_arguments)]
+fn append_blank_line_guides(
+    guide_columns: &[usize],
+    content_visual_end: usize,
+    left_col: usize,
+    content_width: usize,
+    glyph: char,
+    style: Style,
+    rendered_cols: &mut usize,
+    line_spans: &mut Vec<Span<'static>>,
+    line_view_map: &mut Vec<Option<usize>>,
+) {
+    // Deepest guide column needing synthesis: past the rendered content and not
+    // scrolled off the left edge.
+    let Some(last_col) = guide_columns
+        .iter()
+        .copied()
+        .filter(|&c| c >= content_visual_end && c >= left_col)
+        .max()
+    else {
+        return;
+    };
+    let start = content_visual_end.max(left_col);
+    // Clamp to the visible content area so guides never spill past the viewport.
+    let end_col = last_col.min(left_col + content_width.saturating_sub(1));
+    if end_col < start {
+        return;
+    }
+
+    let mut text = String::with_capacity(end_col + 1 - start);
+    for col in start..=end_col {
+        text.push(if guide_columns.contains(&col) {
+            glyph
+        } else {
+            ' '
+        });
+    }
+    push_span_with_map(line_spans, line_view_map, text, style, None);
+    *rendered_cols += end_col + 1 - start;
+}
+
 pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput {
     use crate::view::folding::indent_folding;
 
@@ -403,6 +484,16 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         view_lines,
         primary_cursor_position,
     );
+    // Resolve the guide glyph once (single display cell; falls back to `▏`),
+    // matching the per-cell pass — used for blank-line guide synthesis.
+    let guide_glyph_char = {
+        let c = indentation_guide_glyph.trim().chars().next().unwrap_or('▏');
+        if crate::primitives::display_width::char_width(c) != 1 {
+            '▏'
+        } else {
+            c
+        }
+    };
     // `all`-mode guide columns are scanned lazily, one row at a time, as the
     // render loop walks the viewport. The scanner is only built for `all` mode
     // (the default `none` and `active` modes skip it entirely). Its staircase is
@@ -630,14 +721,29 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
         // Advance the `all`-mode guide scanner for this row and capture its
         // guide columns into the reused buffer (empty in `none`/`active` mode).
         if let Some(scanner) = guide_column_scanner.as_mut() {
+            let tab_size = state.buffer_settings.tab_size;
+            // Blank rows look ahead to the next content row so their guides flow
+            // into an upcoming nested body; content rows don't need it.
+            let next_indent = match view_line_indent(current_view_line, tab_size) {
+                Some((_, false)) => {
+                    next_content_indent(view_lines, current_view_line_idx + 1, tab_size)
+                }
+                _ => None,
+            };
             scanner.columns_for(
                 current_view_line,
-                state.buffer_settings.tab_size,
+                tab_size,
+                next_indent,
                 &mut guide_columns_buf,
             );
         } else {
             guide_columns_buf.clear();
         }
+
+        // The single active-mode guide column for this row (None in other
+        // modes); reused by the cell pass and the blank-line guide synthesis.
+        let active_guide_col =
+            active_indentation_guide.and_then(|guide| guide.column_for_line(current_view_line_idx));
 
         // Per-cell pass: walk the line's characters and emit styled spans
         let cells = render_line_cells(
@@ -662,8 +768,7 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
                 indentation_guide,
                 indentation_guide_glyph,
                 indentation_guide_columns: &guide_columns_buf,
-                active_indentation_guide_col: active_indentation_guide
-                    .and_then(|guide| guide.column_for_line(current_view_line_idx)),
+                active_indentation_guide_col: active_guide_col,
             },
             &mut selection_sweep,
             &mut overlay_sweep,
@@ -715,6 +820,41 @@ pub(crate) fn render_view_lines(input: LineRenderInput<'_>) -> LineRenderOutput 
 
         let content_width = render_area.width.saturating_sub(gutter_width as u16) as usize;
         let cursor_line_active = is_on_cursor_line && highlight_current_line && is_active;
+
+        // Draw indentation guides *through* this row at guide columns the
+        // per-cell pass could not reach — i.e. columns past the row's own
+        // leading whitespace. Blank and empty rows have few or no leading-space
+        // cells to restyle, so without this their guides would gap out; here the
+        // missing guide cells (and the plain spaces between them) are synthesised
+        // so guides stay vertically continuous across blank lines. Code rows
+        // never trigger this (their guide columns all fall inside their indent).
+        let row_can_have_guides = current_view_line.source_start_byte.is_some()
+            && !matches!(
+                line_start_type,
+                LineStart::AfterBreak | LineStart::AfterInjectedNewline
+            );
+        if row_can_have_guides {
+            let synth_columns: &[usize] = match indentation_guide {
+                IndentationGuideMode::All => &guide_columns_buf,
+                IndentationGuideMode::Active => active_guide_col.as_slice(),
+                IndentationGuideMode::None => &[],
+            };
+            let mut guide_style = Style::default().fg(theme.indentation_guide_fg);
+            if cursor_line_active {
+                guide_style = guide_style.bg(theme.current_line_bg);
+            }
+            append_blank_line_guides(
+                synth_columns,
+                left_col + rendered_cols,
+                left_col,
+                content_width,
+                guide_glyph_char,
+                guide_style,
+                &mut rendered_cols,
+                &mut line_spans,
+                &mut line_view_map,
+            );
+        }
 
         // Inline diagnostic text: render after line content (before extend_to_line_end fill).
         // Only for non-continuation lines that have a diagnostic overlay.


### PR DESCRIPTION
In `all` mode, a row's indentation-guide columns were derived from a
staircase that the renderer rebuilt by walking only the *visible* rows
top-to-bottom. The intended priming over the rows above the first
rendered row was effectively a no-op: `view_lines` already begins at the
viewport top under vertical scroll, so the scanner started with an empty
ancestor stack. When a block's opening line scrolled above the viewport,
that block's indent level was missing from the stack, so its guide
vanished on interior continuation rows (and reappeared via a fallback
only on rows that carried their own token at that level). Scrolling the
opener back into view restored it — a purely scroll-dependent render
glitch.

Seed the staircase from the buffer's *absolute* indentation instead:
walk upward from the first visible line to reconstruct the enclosing
blocks' indent widths (bounded like the active-mode fold search so it
never becomes a full-buffer scan). A row's guides now depend only on
where it sits in the buffer's indentation structure, never on the scroll
offset, so guides stay continuous as the view scrolls.

Add a regression test that renders a viewport scrolled so two block
openers (at columns 0 and 4) are off-screen and asserts the interior
rows still draw the full guide staircase.