### PR TITLE
Fix regex anchors to match line boundaries in multi-line text

### DIFF
--- a/crates/fresh-editor/src/app/regex_replace.rs
+++ b/crates/fresh-editor/src/app/regex_replace.rs
@@ -32,6 +32,11 @@ pub fn build_search_regex(
 
     regex::RegexBuilder::new(&pattern)
         .case_insensitive(!case_sensitive)
+        // Match `^`/`$` at every line boundary, like every editor's find.
+        // `crlf` makes both `\n` and `\r\n` count as terminators so the
+        // anchors behave the same on LF and CRLF buffers.
+        .multi_line(true)
+        .crlf(true)
         .build()
         .map_err(|e| e.to_string())
 }
@@ -56,6 +61,9 @@ pub fn build_regex(
 
     regex::bytes::RegexBuilder::new(&pattern)
         .case_insensitive(!case_sensitive)
+        // Keep `^`/`$` line-anchored in replace, matching the search path.
+        .multi_line(true)
+        .crlf(true)
         .build()
         .ok()
 }
@@ -232,6 +240,50 @@ mod tests {
         // Plain-text mode escapes everything, so even a syntactically-bad
         // regex pattern compiles fine as a literal search.
         assert!(build_search_regex("[unclosed", false, false, true).is_ok());
+    }
+
+    #[test]
+    fn build_search_regex_caret_anchors_every_line() {
+        // Regression: `^use` must match the start of *every* line, not just
+        // the start of the buffer. Without multi-line mode this finds 1.
+        let re = build_search_regex("^use", true, false, true).unwrap();
+        let text = "use a;\nuse b;\nlet use_x = 1;\nuse c;\n";
+        assert_eq!(re.find_iter(text).count(), 3);
+    }
+
+    #[test]
+    fn build_search_regex_dollar_anchors_every_line() {
+        let re = build_search_regex("foo$", true, false, true).unwrap();
+        let text = "foo\nfoobar\nbar foo\n";
+        assert_eq!(re.find_iter(text).count(), 2);
+    }
+
+    #[test]
+    fn build_search_regex_anchors_match_crlf_lines() {
+        // On CRLF buffers `$` must match before `\r\n`, so `foo$` still hits.
+        let re = build_search_regex("foo$", true, false, true).unwrap();
+        let text = "foo\r\nbar\r\nfoo\r\n";
+        assert_eq!(re.find_iter(text).count(), 2);
+    }
+
+    #[test]
+    fn build_search_regex_dot_does_not_cross_newlines() {
+        // Multi-line mode only re-anchors `^`/`$`; `.` must still stop at a
+        // line boundary (no `dot_matches_new_line`). So `a.b` cannot span
+        // "a\nb", but a greedy `a.*` stays within its line.
+        let re = build_search_regex("a.b", true, false, true).unwrap();
+        assert!(!re.is_match("a\nb"));
+        let re2 = build_search_regex("a.*", true, false, true).unwrap();
+        let m = re2.find("axy\nbcd").unwrap();
+        assert_eq!(m.as_str(), "axy");
+    }
+
+    #[test]
+    fn build_regex_caret_anchors_every_line() {
+        // The bytes builder used for replace must anchor per line too.
+        let re = build_regex("^use", true, false, true).unwrap();
+        let text = b"use a;\nuse b;\nuse c;\n";
+        assert_eq!(re.find_iter(text).count(), 3);
     }
 
     #[test]

--- a/crates/fresh-editor/src/app/search_ops.rs
+++ b/crates/fresh-editor/src/app/search_ops.rs
@@ -379,8 +379,13 @@ impl Editor {
         {
             let leaves = state.buffer.piece_tree_leaves();
             // Build a bytes::Regex from the same pattern for the chunked scanner
+            // `as_str()` carries only the pattern, not the builder flags, so
+            // re-apply line-anchoring here to keep `^`/`$` matching every
+            // line boundary in the chunked scan (matches the inline path).
             let bytes_regex = regex::bytes::RegexBuilder::new(regex.as_str())
                 .case_insensitive(!case_sensitive)
+                .multi_line(true)
+                .crlf(true)
                 .build()
                 .expect("regex already validated");
             let scan = state.buffer.search_scan_init(

--- a/crates/fresh-editor/src/app/window/mod.rs
+++ b/crates/fresh-editor/src/app/window/mod.rs
@@ -2852,30 +2852,11 @@ impl Window {
             return;
         }
 
-        let case_sensitive = self.search_case_sensitive;
-        let whole_word = self.search_whole_word;
-        let use_regex = self.search_use_regex;
         let ns = self.search_namespace.clone();
 
-        let regex_pattern = if use_regex {
-            if whole_word {
-                format!(r"\b{}\b", query)
-            } else {
-                query.to_string()
-            }
-        } else {
-            let escaped = regex::escape(query);
-            if whole_word {
-                format!(r"\b{}\b", escaped)
-            } else {
-                escaped
-            }
-        };
-
-        let regex = regex::RegexBuilder::new(&regex_pattern)
-            .case_insensitive(!case_sensitive)
-            .build();
-        let regex = match regex {
+        // Share the one search-regex builder so highlight anchoring (`^`/`$`
+        // line-matching) stays consistent with the actual search results.
+        let regex = match self.build_search_regex(query) {
             Ok(r) => r,
             Err(_) => {
                 self.clear_search_highlights();
@@ -2954,30 +2935,11 @@ impl Window {
             _ => return,
         };
 
-        let case_sensitive = self.search_case_sensitive;
-        let whole_word = self.search_whole_word;
-        let use_regex = self.search_use_regex;
         let ns = self.search_namespace.clone();
 
-        let regex_pattern = if use_regex {
-            if whole_word {
-                format!(r"\b{}\b", query)
-            } else {
-                query
-            }
-        } else {
-            let escaped = regex::escape(&query);
-            if whole_word {
-                format!(r"\b{}\b", escaped)
-            } else {
-                escaped
-            }
-        };
-
-        let regex = match regex::RegexBuilder::new(&regex_pattern)
-            .case_insensitive(!case_sensitive)
-            .build()
-        {
+        // Share the one search-regex builder so re-highlighting after an edit
+        // keeps `^`/`$` line-anchoring consistent with the search results.
+        let regex = match self.build_search_regex(&query) {
             Ok(r) => r,
             Err(_) => return,
         };

--- a/crates/fresh-editor/tests/e2e/search.rs
+++ b/crates/fresh-editor/tests/e2e/search.rs
@@ -2648,6 +2648,51 @@ fn test_regex_replace_with_capture_group() {
     assert_eq!(content, "ooblaoobla");
 }
 
+/// Regex search with a `^` anchor must match the start of *every* line, not
+/// just the start of the buffer. Before the multi-line fix, searching `^use`
+/// reported "Found 1 match"; it should find every line that begins with `use`.
+#[test]
+fn test_regex_caret_anchor_matches_every_line() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.rs");
+    // Four lines start with `use` (1, 2, 4, 5). Line 3's `use_x` is mid-line,
+    // so `^use` must NOT match it — a plain `use` search would find 5.
+    std::fs::write(
+        &file_path,
+        "use a;\nuse b;\nlet use_x = 1;\nuse c;\nuse d;\n",
+    )
+    .unwrap();
+
+    let mut harness = EditorTestHarness::new(100, 24).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Ctrl+F opens search.
+    harness
+        .send_key(KeyCode::Char('f'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_contains("Search: ");
+
+    // Alt+R enables regex mode.
+    harness
+        .send_key(KeyCode::Char('r'), KeyModifiers::ALT)
+        .unwrap();
+    harness.render().unwrap();
+
+    // Search for the anchored pattern and submit.
+    harness.type_text("^use").unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap();
+    harness.process_async_and_render().unwrap();
+
+    // The rendered status bar reports every line-anchored match (the full
+    // message is truncated in the status bar, so match a stable prefix).
+    // Before the fix this read "Found 1 match".
+    harness.assert_screen_contains("Found 4 matches");
+}
+
 /// Reproduce the performance issue where editor_tick takes ~700ms after a large
 /// search completes with many matches. This test uses tracing to identify the
 /// bottleneck. Run with: RUST_LOG=info cargo test -p fresh-editor --test e2e_tests


### PR DESCRIPTION
Fixes #2495

## Summary
This PR fixes regex search and replace to properly handle `^` and `$` anchors in multi-line text. Previously, these anchors only matched the start/end of the entire buffer, not individual lines. Now they match at every line boundary, consistent with standard editor behavior.

## Key Changes

- **Enable multi-line mode in regex builders**: Added `.multi_line(true)` and `.crlf(true)` flags to both `build_search_regex()` and `build_regex()` functions to make `^` and `$` match at line boundaries rather than just buffer boundaries.

- **Unified regex building in window module**: Refactored `window/mod.rs` to use the shared `build_search_regex()` method for both search highlighting and result counting, ensuring consistent anchor behavior across all search operations.

- **Extended regex building in search_ops**: Applied the same multi-line and CRLF flags to the bytes regex builder used in chunked scanning to maintain consistency with the inline search path.

- **Comprehensive test coverage**: Added five new unit tests validating:
  - `^` anchors match every line start, not just buffer start
  - `$` anchors match every line end, not just buffer end
  - CRLF line endings are properly recognized as line boundaries
  - `.` metacharacter still respects line boundaries (doesn&#39;t cross newlines)
  - Bytes regex builder also anchors per-line

- **End-to-end test**: Added `test_regex_caret_anchor_matches_every_line()` demonstrating the fix with a real file containing multiple lines starting with `use`.

## Implementation Details

The `.crlf(true)` flag ensures that both `\n` (LF) and `\r\n` (CRLF) are recognized as line terminators, so anchor behavior is consistent regardless of the buffer&#39;s line ending style. The `.multi_line(true)` flag makes `^` and `$` match at these boundaries rather than only at buffer boundaries.

This change affects search highlighting, search result counting, and regex-based find-and-replace operations.

https://claude.ai/code/session_01BB5RsJ4Ww4CTn5uUCeEUBT