### PR TITLE
JSONC config files: comment-tolerant read/write, no-clobber saves, and a visible save-error alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2387,6 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2e5dea04f54739ca5694ee06e4448ffda065a55b3427d2b131bd5ea697ea2c"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,7 @@ dependencies = [
  "include_dir",
  "insta",
  "interprocess",
+ "jsonc-parser",
  "libc",
  "libloading 0.9.0",
  "lsp-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ fresh-winterm = { version = "0.4.1", path = "crates/fresh-winterm" }
 # External crates
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-jsonc-parser = { version = "0.32", features = ["serde"] }
+jsonc-parser = { version = "0.32", features = ["serde", "serde_json", "cst"] }
 anyhow = { version = "1.0.100", default-features = false }
 tokio = { version = "1.49", features = ["fs", "io-util", "process", "rt", "rt-multi-thread", "sync", "time", "macros"] }
 once_cell = "1.20"

--- a/crates/fresh-editor/Cargo.toml
+++ b/crates/fresh-editor/Cargo.toml
@@ -148,6 +148,8 @@ oxc_span = { workspace = true, optional = true }
 # Always required (for schema generation and runtime)
 serde.workspace = true
 serde_json.workspace = true
+# Comment- and trailing-comma-tolerant JSON parsing for config files (JSONC).
+jsonc-parser.workspace = true
 schemars.workspace = true
 rust-i18n.workspace = true
 once_cell.workspace = true

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Použití nastavení selhalo: %{error}",
   "settings.failed_to_open": "Otevření nastavení selhalo: %{error}",
   "settings.failed_to_save": "Uložení nastavení selhalo: %{error}",
+  "settings.save_failed_title": "Nepodařilo se uložit nastavení",
+  "settings.save_failed_unchanged": "Váš konfigurační soubor zůstal beze změny, takže jej můžete opravit.",
   "settings.field.editor.auto_close": "Automatické uzavírání",
   "settings.field.editor.whitespace_show": "Zobrazit bílé znaky",
   "settings.field.editor.whitespace_spaces_inner": "Vnitřní mezery",

--- a/crates/fresh-editor/locales/cs.json
+++ b/crates/fresh-editor/locales/cs.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Uložení nastavení selhalo: %{error}",
   "settings.save_failed_title": "Nepodařilo se uložit nastavení",
   "settings.save_failed_unchanged": "Váš konfigurační soubor zůstal beze změny, takže jej můžete opravit.",
+  "settings.save_failed_open_hint": "Stiskněte Esc pro otevření konfiguračního souboru a jeho opravu.",
   "settings.field.editor.auto_close": "Automatické uzavírání",
   "settings.field.editor.whitespace_show": "Zobrazit bílé znaky",
   "settings.field.editor.whitespace_spaces_inner": "Vnitřní mezery",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Einstellungen konnten nicht angewendet werden: %{error}",
   "settings.failed_to_open": "Einstellungen konnten nicht geöffnet werden: %{error}",
   "settings.failed_to_save": "Einstellungen konnten nicht gespeichert werden: %{error}",
+  "settings.save_failed_title": "Einstellungen konnten nicht gespeichert werden",
+  "settings.save_failed_unchanged": "Ihre Konfigurationsdatei wurde nicht verändert, damit Sie sie korrigieren können.",
   "settings.field.editor.auto_close": "Automatisches Schließen",
   "settings.field.editor.whitespace_show": "Leerzeichen anzeigen",
   "settings.field.editor.whitespace_spaces_inner": "Innere Leerzeichen",

--- a/crates/fresh-editor/locales/de.json
+++ b/crates/fresh-editor/locales/de.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Einstellungen konnten nicht gespeichert werden: %{error}",
   "settings.save_failed_title": "Einstellungen konnten nicht gespeichert werden",
   "settings.save_failed_unchanged": "Ihre Konfigurationsdatei wurde nicht verändert, damit Sie sie korrigieren können.",
+  "settings.save_failed_open_hint": "Drücken Sie Esc, um Ihre Konfigurationsdatei zu öffnen und zu korrigieren.",
   "settings.field.editor.auto_close": "Automatisches Schließen",
   "settings.field.editor.whitespace_show": "Leerzeichen anzeigen",
   "settings.field.editor.whitespace_spaces_inner": "Innere Leerzeichen",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1366,6 +1366,7 @@
   "settings.failed_to_save": "Failed to save settings: %{error}",
   "settings.save_failed_title": "Couldn't save settings",
   "settings.save_failed_unchanged": "Your config file was left unchanged so you can fix it.",
+  "settings.save_failed_open_hint": "Press Esc to open your config file and fix it.",
   "settings.line_ending_set": "Line ending set to %{value}",
   "settings.pending_changes": "Save or discard pending changes before editing config file",
   "settings.saved_to_layer": "Settings saved to %{layer} layer",

--- a/crates/fresh-editor/locales/en.json
+++ b/crates/fresh-editor/locales/en.json
@@ -1364,6 +1364,8 @@
   "settings.failed_to_apply": "Failed to apply settings: %{error}",
   "settings.failed_to_open": "Failed to open settings: %{error}",
   "settings.failed_to_save": "Failed to save settings: %{error}",
+  "settings.save_failed_title": "Couldn't save settings",
+  "settings.save_failed_unchanged": "Your config file was left unchanged so you can fix it.",
   "settings.line_ending_set": "Line ending set to %{value}",
   "settings.pending_changes": "Save or discard pending changes before editing config file",
   "settings.saved_to_layer": "Settings saved to %{layer} layer",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Error al aplicar configuración: %{error}",
   "settings.failed_to_open": "Error al abrir configuración: %{error}",
   "settings.failed_to_save": "Error al guardar configuración: %{error}",
+  "settings.save_failed_title": "No se pudo guardar la configuración",
+  "settings.save_failed_unchanged": "Tu archivo de configuración no se modificó para que puedas corregirlo.",
   "settings.field.editor.auto_close": "Cierre automático",
   "settings.field.editor.whitespace_show": "Mostrar espacios en blanco",
   "settings.field.editor.whitespace_spaces_inner": "Espacios interiores",

--- a/crates/fresh-editor/locales/es.json
+++ b/crates/fresh-editor/locales/es.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Error al guardar configuración: %{error}",
   "settings.save_failed_title": "No se pudo guardar la configuración",
   "settings.save_failed_unchanged": "Tu archivo de configuración no se modificó para que puedas corregirlo.",
+  "settings.save_failed_open_hint": "Pulsa Esc para abrir tu archivo de configuración y corregirlo.",
   "settings.field.editor.auto_close": "Cierre automático",
   "settings.field.editor.whitespace_show": "Mostrar espacios en blanco",
   "settings.field.editor.whitespace_spaces_inner": "Espacios interiores",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Échec de l'application des paramètres : %{error}",
   "settings.failed_to_open": "Échec de l'ouverture des paramètres : %{error}",
   "settings.failed_to_save": "Échec de l'enregistrement des paramètres : %{error}",
+  "settings.save_failed_title": "Impossible d'enregistrer les paramètres",
+  "settings.save_failed_unchanged": "Votre fichier de configuration n'a pas été modifié afin que vous puissiez le corriger.",
   "settings.field.editor.auto_close": "Fermeture automatique",
   "settings.field.editor.whitespace_show": "Afficher les espaces",
   "settings.field.editor.whitespace_spaces_inner": "Espaces intérieurs",

--- a/crates/fresh-editor/locales/fr.json
+++ b/crates/fresh-editor/locales/fr.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Échec de l'enregistrement des paramètres : %{error}",
   "settings.save_failed_title": "Impossible d'enregistrer les paramètres",
   "settings.save_failed_unchanged": "Votre fichier de configuration n'a pas été modifié afin que vous puissiez le corriger.",
+  "settings.save_failed_open_hint": "Appuyez sur Échap pour ouvrir votre fichier de configuration et le corriger.",
   "settings.field.editor.auto_close": "Fermeture automatique",
   "settings.field.editor.whitespace_show": "Afficher les espaces",
   "settings.field.editor.whitespace_spaces_inner": "Espaces intérieurs",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Impossibile applicare le impostazioni: %{error}",
   "settings.failed_to_open": "Impossibile aprire le impostazioni: %{error}",
   "settings.failed_to_save": "Impossibile salvare le impostazioni: %{error}",
+  "settings.save_failed_title": "Impossibile salvare le impostazioni",
+  "settings.save_failed_unchanged": "Il file di configurazione non è stato modificato così puoi correggerlo.",
   "settings.field.editor.auto_close": "Chiusura automatica",
   "settings.field.editor.whitespace_show": "Mostra spazi bianchi",
   "settings.field.editor.whitespace_spaces_inner": "Spazi interni",

--- a/crates/fresh-editor/locales/it.json
+++ b/crates/fresh-editor/locales/it.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Impossibile salvare le impostazioni: %{error}",
   "settings.save_failed_title": "Impossibile salvare le impostazioni",
   "settings.save_failed_unchanged": "Il file di configurazione non è stato modificato così puoi correggerlo.",
+  "settings.save_failed_open_hint": "Premi Esc per aprire il file di configurazione e correggerlo.",
   "settings.field.editor.auto_close": "Chiusura automatica",
   "settings.field.editor.whitespace_show": "Mostra spazi bianchi",
   "settings.field.editor.whitespace_spaces_inner": "Spazi interni",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "設定の適用に失敗: %{error}",
   "settings.failed_to_open": "設定を開くのに失敗: %{error}",
   "settings.failed_to_save": "設定の保存に失敗: %{error}",
+  "settings.save_failed_title": "設定を保存できませんでした",
+  "settings.save_failed_unchanged": "設定ファイルは変更されていないので修正できます。",
   "settings.field.editor.auto_close": "自動閉じ",
   "settings.field.editor.whitespace_show": "空白文字を表示",
   "settings.field.editor.whitespace_spaces_inner": "内部のスペース",

--- a/crates/fresh-editor/locales/ja.json
+++ b/crates/fresh-editor/locales/ja.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "設定の保存に失敗: %{error}",
   "settings.save_failed_title": "設定を保存できませんでした",
   "settings.save_failed_unchanged": "設定ファイルは変更されていないので修正できます。",
+  "settings.save_failed_open_hint": "Esc キーを押すと設定ファイルを開いて修正できます。",
   "settings.field.editor.auto_close": "自動閉じ",
   "settings.field.editor.whitespace_show": "空白文字を表示",
   "settings.field.editor.whitespace_spaces_inner": "内部のスペース",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "설정 적용 실패: %{error}",
   "settings.failed_to_open": "설정 열기 실패: %{error}",
   "settings.failed_to_save": "설정 저장 실패: %{error}",
+  "settings.save_failed_title": "설정을 저장할 수 없습니다",
+  "settings.save_failed_unchanged": "구성 파일이 변경되지 않았으므로 수정할 수 있습니다.",
   "settings.field.editor.auto_close": "자동 닫기",
   "settings.field.editor.whitespace_show": "공백 표시",
   "settings.field.editor.whitespace_spaces_inner": "내부 공백",

--- a/crates/fresh-editor/locales/ko.json
+++ b/crates/fresh-editor/locales/ko.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "설정 저장 실패: %{error}",
   "settings.save_failed_title": "설정을 저장할 수 없습니다",
   "settings.save_failed_unchanged": "구성 파일이 변경되지 않았으므로 수정할 수 있습니다.",
+  "settings.save_failed_open_hint": "Esc 키를 누르면 구성 파일을 열어 수정할 수 있습니다.",
   "settings.field.editor.auto_close": "자동 닫기",
   "settings.field.editor.whitespace_show": "공백 표시",
   "settings.field.editor.whitespace_spaces_inner": "내부 공백",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Falha ao aplicar configurações: %{error}",
   "settings.failed_to_open": "Falha ao abrir configurações: %{error}",
   "settings.failed_to_save": "Falha ao salvar configurações: %{error}",
+  "settings.save_failed_title": "Não foi possível salvar as configurações",
+  "settings.save_failed_unchanged": "Seu arquivo de configuração não foi alterado para que você possa corrigi-lo.",
   "settings.field.editor.auto_close": "Fechamento automático",
   "settings.field.editor.whitespace_show": "Mostrar espaços em branco",
   "settings.field.editor.whitespace_spaces_inner": "Espaços internos",

--- a/crates/fresh-editor/locales/pt-BR.json
+++ b/crates/fresh-editor/locales/pt-BR.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Falha ao salvar configurações: %{error}",
   "settings.save_failed_title": "Não foi possível salvar as configurações",
   "settings.save_failed_unchanged": "Seu arquivo de configuração não foi alterado para que você possa corrigi-lo.",
+  "settings.save_failed_open_hint": "Pressione Esc para abrir seu arquivo de configuração e corrigi-lo.",
   "settings.field.editor.auto_close": "Fechamento automático",
   "settings.field.editor.whitespace_show": "Mostrar espaços em branco",
   "settings.field.editor.whitespace_spaces_inner": "Espaços internos",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Не удалось сохранить настройки: %{error}",
   "settings.save_failed_title": "Не удалось сохранить настройки",
   "settings.save_failed_unchanged": "Ваш файл конфигурации остался без изменений, чтобы вы могли его исправить.",
+  "settings.save_failed_open_hint": "Нажмите Esc, чтобы открыть файл конфигурации и исправить его.",
   "settings.field.editor.auto_close": "Автозакрытие",
   "settings.field.editor.whitespace_show": "Показать пробелы",
   "settings.field.editor.whitespace_spaces_inner": "Внутренние пробелы",

--- a/crates/fresh-editor/locales/ru.json
+++ b/crates/fresh-editor/locales/ru.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Не удалось применить настройки: %{error}",
   "settings.failed_to_open": "Не удалось открыть настройки: %{error}",
   "settings.failed_to_save": "Не удалось сохранить настройки: %{error}",
+  "settings.save_failed_title": "Не удалось сохранить настройки",
+  "settings.save_failed_unchanged": "Ваш файл конфигурации остался без изменений, чтобы вы могли его исправить.",
   "settings.field.editor.auto_close": "Автозакрытие",
   "settings.field.editor.whitespace_show": "Показать пробелы",
   "settings.field.editor.whitespace_spaces_inner": "Внутренние пробелы",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "ใช้การตั้งค่าไม่สำเร็จ: %{error}",
   "settings.failed_to_open": "เปิดการตั้งค่าไม่สำเร็จ: %{error}",
   "settings.failed_to_save": "บันทึกการตั้งค่าไม่สำเร็จ: %{error}",
+  "settings.save_failed_title": "ไม่สามารถบันทึกการตั้งค่าได้",
+  "settings.save_failed_unchanged": "ไฟล์การตั้งค่าของคุณไม่ถูกเปลี่ยนแปลง คุณจึงสามารถแก้ไขได้",
   "settings.field.editor.auto_close": "ปิดอัตโนมัติ",
   "settings.field.editor.whitespace_show": "แสดงช่องว่าง",
   "settings.field.editor.whitespace_spaces_inner": "ช่องว่างภายใน",

--- a/crates/fresh-editor/locales/th.json
+++ b/crates/fresh-editor/locales/th.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "บันทึกการตั้งค่าไม่สำเร็จ: %{error}",
   "settings.save_failed_title": "ไม่สามารถบันทึกการตั้งค่าได้",
   "settings.save_failed_unchanged": "ไฟล์การตั้งค่าของคุณไม่ถูกเปลี่ยนแปลง คุณจึงสามารถแก้ไขได้",
+  "settings.save_failed_open_hint": "กด Esc เพื่อเปิดไฟล์การตั้งค่าและแก้ไข",
   "settings.field.editor.auto_close": "ปิดอัตโนมัติ",
   "settings.field.editor.whitespace_show": "แสดงช่องว่าง",
   "settings.field.editor.whitespace_spaces_inner": "ช่องว่างภายใน",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Не вдалося зберегти налаштування: %{error}",
   "settings.save_failed_title": "Не вдалося зберегти налаштування",
   "settings.save_failed_unchanged": "Ваш файл конфігурації залишився без змін, тож ви можете його виправити.",
+  "settings.save_failed_open_hint": "Натисніть Esc, щоб відкрити файл конфігурації та виправити його.",
   "settings.field.editor.auto_close": "Автозакриття",
   "settings.field.editor.whitespace_show": "Показати пробіли",
   "settings.field.editor.whitespace_spaces_inner": "Внутрішні пробіли",

--- a/crates/fresh-editor/locales/uk.json
+++ b/crates/fresh-editor/locales/uk.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Не вдалося застосувати налаштування: %{error}",
   "settings.failed_to_open": "Не вдалося відкрити налаштування: %{error}",
   "settings.failed_to_save": "Не вдалося зберегти налаштування: %{error}",
+  "settings.save_failed_title": "Не вдалося зберегти налаштування",
+  "settings.save_failed_unchanged": "Ваш файл конфігурації залишився без змін, тож ви можете його виправити.",
   "settings.field.editor.auto_close": "Автозакриття",
   "settings.field.editor.whitespace_show": "Показати пробіли",
   "settings.field.editor.whitespace_spaces_inner": "Внутрішні пробіли",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "Lưu cài đặt thất bại: %{error}",
   "settings.save_failed_title": "Không thể lưu cài đặt",
   "settings.save_failed_unchanged": "Tệp cấu hình của bạn không bị thay đổi nên bạn có thể sửa nó.",
+  "settings.save_failed_open_hint": "Nhấn Esc để mở tệp cấu hình của bạn và sửa nó.",
   "settings.field.editor.auto_close": "Tự động đóng",
   "settings.field.editor.whitespace_show": "Hiển thị khoảng trắng",
   "settings.field.editor.whitespace_spaces_inner": "Khoảng trắng bên trong",

--- a/crates/fresh-editor/locales/vi.json
+++ b/crates/fresh-editor/locales/vi.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "Áp dụng cài đặt thất bại: %{error}",
   "settings.failed_to_open": "Mở cài đặt thất bại: %{error}",
   "settings.failed_to_save": "Lưu cài đặt thất bại: %{error}",
+  "settings.save_failed_title": "Không thể lưu cài đặt",
+  "settings.save_failed_unchanged": "Tệp cấu hình của bạn không bị thay đổi nên bạn có thể sửa nó.",
   "settings.field.editor.auto_close": "Tự động đóng",
   "settings.field.editor.whitespace_show": "Hiển thị khoảng trắng",
   "settings.field.editor.whitespace_spaces_inner": "Khoảng trắng bên trong",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1347,6 +1347,7 @@
   "settings.failed_to_save": "保存设置失败：%{error}",
   "settings.save_failed_title": "无法保存设置",
   "settings.save_failed_unchanged": "你的配置文件未被更改，你可以修复它。",
+  "settings.save_failed_open_hint": "按 Esc 打开你的配置文件并修复它。",
   "settings.field.editor.auto_close": "自动关闭",
   "settings.field.editor.whitespace_show": "显示空白字符",
   "settings.field.editor.whitespace_spaces_inner": "行内空格",

--- a/crates/fresh-editor/locales/zh-CN.json
+++ b/crates/fresh-editor/locales/zh-CN.json
@@ -1345,6 +1345,8 @@
   "settings.failed_to_apply": "应用设置失败：%{error}",
   "settings.failed_to_open": "打开设置失败：%{error}",
   "settings.failed_to_save": "保存设置失败：%{error}",
+  "settings.save_failed_title": "无法保存设置",
+  "settings.save_failed_unchanged": "你的配置文件未被更改，你可以修复它。",
   "settings.field.editor.auto_close": "自动关闭",
   "settings.field.editor.whitespace_show": "显示空白字符",
   "settings.field.editor.whitespace_spaces_inner": "行内空格",

--- a/crates/fresh-editor/src/app/popup_actions.rs
+++ b/crates/fresh-editor/src/app/popup_actions.rs
@@ -173,6 +173,16 @@ impl Editor {
                 PopupConfirmResult::Done
             }
 
+            Some(PopupResolver::SettingsSaveError { layer }) => {
+                // Acknowledging the save-failed popup opens the offending
+                // config file so the user can fix the syntax error.
+                self.hide_popup();
+                if let Err(e) = self.open_config_file(layer) {
+                    tracing::warn!("Failed to open config file after save error: {}", e);
+                }
+                PopupConfirmResult::Done
+            }
+
             Some(PopupResolver::None) | None => {
                 self.hide_popup();
                 PopupConfirmResult::Done
@@ -385,6 +395,15 @@ impl Editor {
                 // The trust prompt is a forced choice: there is no "undecided"
                 // outcome, so Escape does nothing. The user must pick Trust /
                 // Restricted / Blocked (each records a concrete decision).
+            }
+
+            Some(PopupResolver::SettingsSaveError { layer }) => {
+                // Acknowledging the save-failed popup opens the offending
+                // config file so the user can fix the syntax error.
+                self.hide_popup();
+                if let Err(e) = self.open_config_file(layer) {
+                    tracing::warn!("Failed to open config file after save error: {}", e);
+                }
             }
 
             Some(PopupResolver::None) | None => {

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -1471,6 +1471,51 @@ impl Editor {
         }
     }
 
+    /// Show a prominent, centered modal popup reporting that a settings save
+    /// failed.
+    ///
+    /// Used when the config file on disk can't be parsed: the save is aborted
+    /// and the file is left untouched, but the user must be told loudly. A
+    /// status-bar line is far too easy to miss for "your change didn't take
+    /// effect", so this raises a focused, centered popup (red border) that the
+    /// user has to dismiss with Esc.
+    pub fn show_settings_save_error_popup(&mut self, error: &str) {
+        use crate::view::popup::{Popup, PopupPosition};
+        use ratatui::style::Style;
+
+        let detail = t!("settings.failed_to_save", error = error).to_string();
+        let unchanged = t!("settings.save_failed_unchanged").to_string();
+        let dismiss = t!("warning.dismiss").to_string();
+        let title = t!("settings.save_failed_title").to_string();
+        let md = format!("{detail}\n\n{unchanged}\n\n*Esc — {dismiss}*");
+
+        let popup = {
+            let theme = self.theme.read().unwrap();
+            let mut p = Popup::markdown(&md, &theme, Some(&self.grammar_registry))
+                .with_title(title)
+                .with_focused(true);
+            p.transient = false;
+            p.position = PopupPosition::Centered;
+            p.width = 64;
+            p.max_height = 12;
+            // Red border to read as an error, not a neutral info popup.
+            p.border_style = Style::default().fg(theme.diagnostic_error_fg);
+            p.background_style = Style::default().bg(theme.popup_bg);
+            p
+        };
+
+        let buffer_id = self.active_buffer();
+        if let Some(state) = self
+            .windows
+            .get_mut(&self.active_window)
+            .map(|w| &mut w.buffers)
+            .expect("active window present")
+            .get_mut(&buffer_id)
+        {
+            state.popups.show(popup);
+        }
+    }
+
     /// Get text properties at the cursor position in the active buffer
     pub fn get_text_properties_at_cursor(
         &self,

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -23,6 +23,58 @@ fn is_lsp_status_popup(popup: &crate::view::popup::Popup) -> bool {
     matches!(popup.resolver, crate::view::popup::PopupResolver::LspStatus)
 }
 
+/// Hard-wrap `text` to `width` display columns, breaking words that are longer
+/// than `width` (e.g. a long, space-less config-file path) so they never
+/// overflow a popup's border. Whitespace-separated where possible.
+fn hard_wrap(text: &str, width: usize) -> Vec<String> {
+    use unicode_width::UnicodeWidthChar;
+
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+    let ch_width = |c: char| UnicodeWidthChar::width(c).unwrap_or(1);
+
+    let mut lines = Vec::new();
+    let mut cur = String::new();
+    let mut cur_w = 0usize;
+
+    let mut push_word =
+        |word: &str, lines: &mut Vec<String>, cur: &mut String, cur_w: &mut usize| {
+            for c in word.chars() {
+                let w = ch_width(c);
+                if *cur_w + w > width && !cur.is_empty() {
+                    lines.push(std::mem::take(cur));
+                    *cur_w = 0;
+                }
+                cur.push(c);
+                *cur_w += w;
+            }
+        };
+
+    for word in text.split(' ') {
+        let word_w: usize = word.chars().map(ch_width).sum();
+        if cur.is_empty() {
+            push_word(word, &mut lines, &mut cur, &mut cur_w);
+        } else if cur_w + 1 + word_w <= width {
+            cur.push(' ');
+            cur_w += 1;
+            cur.push_str(word);
+            cur_w += word_w;
+        } else {
+            lines.push(std::mem::take(&mut cur));
+            cur_w = 0;
+            push_word(word, &mut lines, &mut cur, &mut cur_w);
+        }
+    }
+    if !cur.is_empty() {
+        lines.push(cur);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
 /// Max display cells for each variable field (title / message) of the LSP
 /// progress line. Used to pin the popup width so it doesn't jitter as live
 /// progress messages come and go.
@@ -1478,29 +1530,55 @@ impl Editor {
     /// and the file is left untouched, but the user must be told loudly. A
     /// status-bar line is far too easy to miss for "your change didn't take
     /// effect", so this raises a focused, centered popup (red border) that the
-    /// user has to dismiss with Esc.
-    pub fn show_settings_save_error_popup(&mut self, error: &str) {
-        use crate::view::popup::{Popup, PopupPosition};
+    /// user dismisses with Esc — and on dismissal we open the offending config
+    /// file (for `layer`) so they can fix the syntax error right away.
+    ///
+    /// The body is hard-wrapped here (long config paths have no spaces to break
+    /// on) and rendered as plain text so a long file name wraps inside the
+    /// border instead of being clipped.
+    pub fn show_settings_save_error_popup(
+        &mut self,
+        layer: crate::config_io::ConfigLayer,
+        error: &str,
+    ) {
+        use crate::view::popup::{Popup, PopupPosition, PopupResolver};
         use ratatui::style::Style;
+
+        const WIDTH: u16 = 64;
+        // Border (2) + a little inner padding/scrollbar headroom (2).
+        let wrap_width = (WIDTH as usize).saturating_sub(4);
 
         let detail = t!("settings.failed_to_save", error = error).to_string();
         let unchanged = t!("settings.save_failed_unchanged").to_string();
-        let dismiss = t!("warning.dismiss").to_string();
+        let open_hint = t!("settings.save_failed_open_hint").to_string();
         let title = t!("settings.save_failed_title").to_string();
-        let md = format!("{detail}\n\n{unchanged}\n\n*Esc — {dismiss}*");
+
+        // One blank line between paragraphs; each paragraph hard-wrapped so a
+        // long, space-less path breaks rather than overflowing the border.
+        let mut lines: Vec<String> = Vec::new();
+        for (i, para) in [detail.as_str(), unchanged.as_str(), open_hint.as_str()]
+            .iter()
+            .enumerate()
+        {
+            if i > 0 {
+                lines.push(String::new());
+            }
+            lines.extend(hard_wrap(para, wrap_width));
+        }
 
         let popup = {
             let theme = self.theme.read().unwrap();
-            let mut p = Popup::markdown(&md, &theme, Some(&self.grammar_registry))
+            let mut p = Popup::text(lines, &theme)
                 .with_title(title)
                 .with_focused(true);
             p.transient = false;
             p.position = PopupPosition::Centered;
-            p.width = 64;
-            p.max_height = 12;
+            p.width = WIDTH;
+            p.max_height = 14;
             // Red border to read as an error, not a neutral info popup.
             p.border_style = Style::default().fg(theme.diagnostic_error_fg);
             p.background_style = Style::default().bg(theme.popup_bg);
+            p.resolver = PopupResolver::SettingsSaveError { layer };
             p
         };
 

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -273,7 +273,7 @@ impl Editor {
                 self.set_status_message(
                     t!("settings.failed_to_save", error = err.clone()).to_string(),
                 );
-                self.show_settings_save_error_popup(&err);
+                self.show_settings_save_error_popup(target_layer, &err);
             }
         }
     }

--- a/crates/fresh-editor/src/app/settings_actions.rs
+++ b/crates/fresh-editor/src/app/settings_actions.rs
@@ -266,9 +266,14 @@ impl Editor {
                 self.request_full_redraw();
             }
             Err(e) => {
+                // A failed save means the change did not take effect (and the
+                // config file was left untouched). Surface it loudly with a
+                // modal popup, not just the easy-to-miss status bar.
+                let err = e.to_string();
                 self.set_status_message(
-                    t!("settings.failed_to_save", error = e.to_string()).to_string(),
+                    t!("settings.failed_to_save", error = err.clone()).to_string(),
                 );
+                self.show_settings_save_error_popup(&err);
             }
         }
     }

--- a/crates/fresh-editor/src/config.rs
+++ b/crates/fresh-editor/src/config.rs
@@ -3804,9 +3804,11 @@ impl Config {
         let contents = std::fs::read_to_string(path.as_ref())
             .map_err(|e| ConfigError::IoError(e.to_string()))?;
 
-        // Deserialize as PartialConfig first, then resolve with defaults
+        // Parse as JSONC (comments/trailing commas tolerated), then deserialize
+        // as PartialConfig and resolve with defaults.
+        let value = parse_config_jsonc(&contents)?;
         let partial: crate::partial_config::PartialConfig =
-            serde_json::from_str(&contents).map_err(|e| ConfigError::ParseError(e.to_string()))?;
+            serde_json::from_value(value).map_err(|e| ConfigError::ParseError(e.to_string()))?;
 
         Ok(partial.resolve())
     }
@@ -7443,6 +7445,27 @@ impl std::fmt::Display for ConfigError {
 
 impl std::error::Error for ConfigError {}
 
+/// Parse the contents of a config file as JSONC (JSON with comments and
+/// trailing commas), returning a `serde_json::Value`.
+///
+/// Fresh's config files (`config.json`, project `.fresh/config.json`, the
+/// session file, and `--config <file>`) accept the JSONC superset so users
+/// can annotate settings or comment them out, the same way `parse_jsonc`
+/// already works for plugins. An empty or whitespace/comment-only document
+/// parses as an empty object so a file containing only comments still
+/// resolves to "no overrides" rather than failing.
+pub(crate) fn parse_config_jsonc(contents: &str) -> Result<serde_json::Value, ConfigError> {
+    let value: serde_json::Value =
+        jsonc_parser::parse_to_serde_value(contents, &Default::default())
+            .map_err(|e| ConfigError::ParseError(e.to_string()))?;
+    // Empty / comment-only input deserializes to JSON null; treat it as an
+    // empty object so callers get a mergeable "no overrides" value.
+    Ok(match value {
+        serde_json::Value::Null => serde_json::Value::Object(Default::default()),
+        other => other,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -7451,6 +7474,47 @@ mod tests {
     fn test_file_explorer_width_default_is_percent_30() {
         let cfg = FileExplorerConfig::default();
         assert_eq!(cfg.width, ExplorerWidth::Percent(30));
+    }
+
+    #[test]
+    fn parse_config_jsonc_tolerates_comments_and_trailing_commas() {
+        let value = parse_config_jsonc(
+            r#"{
+                // line comment
+                "editor": {
+                    "tab_size": 7, /* block comment */
+                    "line_numbers": false,
+                }
+            }"#,
+        )
+        .expect("JSONC with comments should parse");
+        assert_eq!(
+            value.pointer("/editor/tab_size"),
+            Some(&serde_json::json!(7))
+        );
+        assert_eq!(
+            value.pointer("/editor/line_numbers"),
+            Some(&serde_json::json!(false))
+        );
+    }
+
+    #[test]
+    fn parse_config_jsonc_empty_and_comment_only_is_empty_object() {
+        assert_eq!(
+            parse_config_jsonc("").unwrap(),
+            serde_json::Value::Object(Default::default())
+        );
+        assert_eq!(
+            parse_config_jsonc("// just a comment\n").unwrap(),
+            serde_json::Value::Object(Default::default())
+        );
+    }
+
+    #[test]
+    fn parse_config_jsonc_rejects_truly_invalid_input() {
+        // Comment tolerance must not turn into "accept anything" — a genuinely
+        // malformed document still errors so real mistakes surface.
+        assert!(parse_config_jsonc(r#"{ "editor": { "#).is_err());
     }
 
     #[test]

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -171,8 +171,14 @@ fn find_changed_paths_recursive(
     }
 }
 
-/// Strip defaults/nulls from `value`, serialize to pretty JSON, ensure the parent
-/// directory exists, and write to `path`.
+/// Strip defaults/nulls from `value`, ensure the parent directory exists, and
+/// write to `path`.
+///
+/// When `path` already holds a JSON object, the new values are applied onto the
+/// existing file *text* through the JSONC CST so the user's comments,
+/// formatting, and untouched inline annotations survive the write. Only when
+/// there is no usable existing file (new file, unparseable, or a non-object
+/// root) do we fall back to pretty-printing from scratch.
 fn write_clean_value_to_path(path: &Path, value: Value) -> Result<(), ConfigError> {
     if let Some(parent_dir) = path.parent() {
         std::fs::create_dir_all(parent_dir)
@@ -180,11 +186,109 @@ fn write_clean_value_to_path(path: &Path, value: Value) -> Result<(), ConfigErro
     }
     let stripped = strip_nulls(value).unwrap_or(Value::Object(Default::default()));
     let clean = strip_empty_defaults(stripped).unwrap_or(Value::Object(Default::default()));
-    let json = serde_json::to_string_pretty(&clean)
-        .map_err(|e| ConfigError::SerializeError(e.to_string()))?;
-    std::fs::write(path, json)
+
+    let output = render_config_text(path, &clean)?;
+    std::fs::write(path, output)
         .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
     Ok(())
+}
+
+/// Produce the on-disk text for `clean`, preserving comments from any existing
+/// file at `path` when possible (see `write_clean_value_to_path`).
+fn render_config_text(path: &Path, clean: &Value) -> Result<String, ConfigError> {
+    if let (Value::Object(_), Ok(existing)) = (clean, std::fs::read_to_string(path)) {
+        if let Some(text) = reconcile_preserving_comments(&existing, clean) {
+            return Ok(text);
+        }
+    }
+    serde_json::to_string_pretty(clean).map_err(|e| ConfigError::SerializeError(e.to_string()))
+}
+
+/// Apply `clean` (a JSON object) onto the existing JSONC `existing` text via the
+/// CST, returning the edited text. Returns `None` when `existing` can't be
+/// parsed or its root isn't an object, so the caller can fall back to a fresh
+/// pretty-print.
+fn reconcile_preserving_comments(existing: &str, clean: &Value) -> Option<String> {
+    use jsonc_parser::cst::CstRootNode;
+
+    let Value::Object(target) = clean else {
+        return None;
+    };
+    let root = CstRootNode::parse(existing, &Default::default()).ok()?;
+    // Bail out (pretty-print fresh) if the document root isn't a JSON object —
+    // editing a scalar/array root in place isn't meaningful for our configs.
+    root.value()?.as_object()?;
+    let obj = root.object_value_or_set();
+    reconcile_cst_object(&obj, target);
+    Some(root.to_string())
+}
+
+/// Recursively reconcile a CST object node so it matches `target`, touching as
+/// little as possible: unchanged properties are left exactly as written (commas,
+/// whitespace, and inline comments intact), nested objects recurse, removed keys
+/// are deleted, and new keys are appended.
+fn reconcile_cst_object(
+    obj: &jsonc_parser::cst::CstObject,
+    target: &serde_json::Map<String, Value>,
+) {
+    use jsonc_parser::cst::CstObjectProp;
+
+    let prop_name = |prop: &CstObjectProp| -> Option<String> {
+        prop.name().and_then(|n| n.decoded_value().ok())
+    };
+
+    // Remove properties that are no longer present in the target.
+    for prop in obj.properties() {
+        match prop_name(&prop) {
+            Some(name) if target.contains_key(&name) => {}
+            _ => prop.remove(),
+        }
+    }
+
+    // Insert or update properties from the target.
+    for (key, new_value) in target {
+        match obj.get(key) {
+            Some(prop) => {
+                // Skip writes when the value is already equal so existing
+                // formatting/comments on that value are preserved verbatim.
+                let current = prop.value().and_then(|n| n.to_serde_value());
+                if current.as_ref() == Some(new_value) {
+                    continue;
+                }
+                match (new_value, prop.value().and_then(|n| n.as_object())) {
+                    // Both sides are objects: recurse to keep inner comments.
+                    (Value::Object(child_target), Some(child_obj)) => {
+                        reconcile_cst_object(&child_obj, child_target);
+                    }
+                    // Otherwise replace the value wholesale.
+                    _ => prop.set_value(json_value_to_cst_input(new_value)),
+                }
+            }
+            None => {
+                obj.append(key, json_value_to_cst_input(new_value));
+            }
+        }
+    }
+}
+
+/// Convert a `serde_json::Value` into the CST's input-value representation used
+/// for inserts and replacements.
+fn json_value_to_cst_input(value: &Value) -> jsonc_parser::cst::CstInputValue {
+    use jsonc_parser::cst::CstInputValue;
+    match value {
+        Value::Null => CstInputValue::Null,
+        Value::Bool(b) => CstInputValue::Bool(*b),
+        Value::Number(n) => CstInputValue::Number(n.to_string()),
+        Value::String(s) => CstInputValue::String(s.clone()),
+        Value::Array(arr) => {
+            CstInputValue::Array(arr.iter().map(json_value_to_cst_input).collect())
+        }
+        Value::Object(map) => CstInputValue::Object(
+            map.iter()
+                .map(|(k, v)| (k.clone(), json_value_to_cst_input(v)))
+                .collect(),
+        ),
+    }
 }
 
 /// Read an existing config file as raw JSON, returning an empty object when the file
@@ -1190,6 +1294,114 @@ mod tests {
         let config = Config::load_from_file(&path).expect("commented --config file should load");
         assert_eq!(config.editor.tab_size, 2);
         assert!(!config.editor.line_numbers);
+    }
+
+    #[test]
+    fn reconcile_preserves_comments_and_unchanged_inline_annotations() {
+        // Direct unit test of the comment-preserving writer: changing one
+        // field must keep every comment and leave the untouched field's inline
+        // annotation byte-for-byte.
+        let existing = "{\n  \
+            // top-of-file note\n  \
+            \"editor\": {\n    \
+                \"tab_size\": 7, // my preferred width\n    \
+                \"line_numbers\": true\n  \
+            }\n\
+        }\n";
+
+        let target = serde_json::json!({
+            "editor": { "tab_size": 7, "line_numbers": false }
+        });
+
+        let out =
+            reconcile_preserving_comments(existing, &target).expect("object root should reconcile");
+
+        assert!(
+            out.contains("// top-of-file note"),
+            "file comment lost:\n{out}"
+        );
+        assert!(
+            out.contains("\"tab_size\": 7, // my preferred width"),
+            "inline comment on the unchanged field should be untouched:\n{out}"
+        );
+        // The changed field was actually updated.
+        let reparsed = crate::config::parse_config_jsonc(&out).unwrap();
+        assert_eq!(
+            reparsed.pointer("/editor/line_numbers"),
+            Some(&serde_json::json!(false))
+        );
+    }
+
+    #[test]
+    fn reconcile_appends_new_key_without_disturbing_comments() {
+        let existing = "{\n  // keep me\n  \"editor\": { \"tab_size\": 2 }\n}\n";
+        let target = serde_json::json!({
+            "editor": { "tab_size": 2 },
+            "theme": "dark"
+        });
+
+        let out = reconcile_preserving_comments(existing, &target).unwrap();
+        assert!(out.contains("// keep me"), "comment lost:\n{out}");
+        let reparsed = crate::config::parse_config_jsonc(&out).unwrap();
+        assert_eq!(reparsed.pointer("/theme"), Some(&serde_json::json!("dark")));
+        assert_eq!(
+            reparsed.pointer("/editor/tab_size"),
+            Some(&serde_json::json!(2))
+        );
+    }
+
+    #[test]
+    fn save_changes_to_layer_preserves_user_comments() {
+        // End-to-end through the Settings-UI save path: a commented user
+        // config keeps its comments after a single field is changed.
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &user_config_path,
+            "{\n  \
+                // I like a 7-space tab in this project\n  \
+                \"editor\": {\n    \
+                    \"tab_size\": 7 /* keep this */\n  \
+                }\n\
+            }\n",
+        )
+        .unwrap();
+
+        let mut changes: std::collections::HashMap<String, serde_json::Value> =
+            std::collections::HashMap::new();
+        changes.insert("/editor/line_numbers".to_string(), serde_json::json!(false));
+        resolver
+            .save_changes_to_layer(
+                &changes,
+                &std::collections::HashSet::new(),
+                ConfigLayer::User,
+            )
+            .unwrap();
+
+        let saved = std::fs::read_to_string(&user_config_path).unwrap();
+        assert!(
+            saved.contains("// I like a 7-space tab in this project"),
+            "line comment must survive a settings save:\n{saved}"
+        );
+        assert!(
+            saved.contains("/* keep this */"),
+            "inline comment on the untouched field must survive:\n{saved}"
+        );
+
+        // Both the preserved and the newly written values resolve correctly.
+        let config = resolver.resolve().unwrap();
+        assert_eq!(config.editor.tab_size, 7);
+        assert!(!config.editor.line_numbers);
+        drop(temp);
+    }
+
+    #[test]
+    fn reconcile_falls_back_for_non_object_root() {
+        // A non-object existing document can't be edited in place; the writer
+        // signals a fall-back so the caller pretty-prints fresh.
+        assert!(reconcile_preserving_comments("[1, 2, 3]", &serde_json::json!({"a": 1})).is_none());
     }
 
     #[test]

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -195,7 +195,7 @@ fn read_existing_json(path: &Path) -> Result<Value, ConfigError> {
     }
     let content = std::fs::read_to_string(path)
         .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
-    Ok(serde_json::from_str(&content).unwrap_or(Value::Object(Default::default())))
+    Ok(crate::config::parse_config_jsonc(&content).unwrap_or(Value::Object(Default::default())))
 }
 
 // ============================================================================
@@ -430,8 +430,8 @@ impl ConfigResolver {
         let content = std::fs::read_to_string(path)
             .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
 
-        // Parse as raw JSON first
-        let value: Value = serde_json::from_str(&content)
+        // Parse as raw JSONC first (comments/trailing commas tolerated)
+        let value: Value = crate::config::parse_config_jsonc(&content)
             .map_err(|e| ConfigError::ParseError(format!("{}: {}", path.display(), e)))?;
 
         // Apply migrations
@@ -470,7 +470,10 @@ impl ConfigResolver {
         let existing: PartialConfig = if path.exists() {
             let content = std::fs::read_to_string(&path)
                 .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
-            serde_json::from_str(&content).unwrap_or_default()
+            crate::config::parse_config_jsonc(&content)
+                .ok()
+                .and_then(|v| serde_json::from_value(v).ok())
+                .unwrap_or_default()
         } else {
             PartialConfig::default()
         };
@@ -788,7 +791,7 @@ impl Config {
     pub fn read_user_config_raw(working_dir: &Path) -> serde_json::Value {
         for path in Self::config_search_paths(working_dir) {
             if let Ok(contents) = std::fs::read_to_string(&path) {
-                match serde_json::from_str(&contents) {
+                match crate::config::parse_config_jsonc(&contents) {
                     Ok(value) => return value,
                     Err(e) => {
                         tracing::warn!("Failed to parse config from {}: {}", path.display(), e);
@@ -1078,6 +1081,115 @@ mod tests {
         assert_eq!(config.editor.tab_size, 2);
         assert!(config.editor.line_numbers); // Still default
         drop(temp);
+    }
+
+    #[test]
+    fn resolver_loads_user_layer_with_comments() {
+        // A user config annotated with JSONC comments and a trailing comma
+        // must be honored, not silently dropped to defaults.
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &user_config_path,
+            r#"{
+                // I like a 7-space tab in this project
+                "editor": {
+                    "tab_size": 7, /* trailing comma below is allowed too */
+                    "line_numbers": false,
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let config = resolver.resolve().unwrap();
+        assert_eq!(
+            config.editor.tab_size, 7,
+            "commented user config should still apply tab_size"
+        );
+        assert!(
+            !config.editor.line_numbers,
+            "commented user config should still apply line_numbers"
+        );
+        drop(temp);
+    }
+
+    #[test]
+    fn resolver_loads_project_layer_with_comments() {
+        // The project `.fresh/config.json` layer must also tolerate comments.
+        let (temp, resolver) = create_test_resolver();
+
+        let project_config_path = resolver.project_config_write_path();
+        std::fs::create_dir_all(project_config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &project_config_path,
+            "{\n  // project override\n  \"editor\": { \"tab_size\": 3 }\n}\n",
+        )
+        .unwrap();
+
+        let config = resolver.resolve().unwrap();
+        assert_eq!(config.editor.tab_size, 3);
+        drop(temp);
+    }
+
+    #[test]
+    fn save_preserves_external_commented_values() {
+        // Saving a delta to a layer whose file already contains comments must
+        // not wipe the user's other (commented) settings. The comment is not
+        // required to survive, but the sibling values must.
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &user_config_path,
+            r#"{
+                // hand-edited by the user
+                "editor": {
+                    "tab_size": 7
+                }
+            }"#,
+        )
+        .unwrap();
+
+        // Change a *different* field and save back to the user layer.
+        let mut config = resolver.resolve().unwrap();
+        assert_eq!(config.editor.tab_size, 7);
+        config.editor.line_numbers = false;
+        resolver.save_to_layer(&config, ConfigLayer::User).unwrap();
+
+        // The externally-set tab_size must survive the round-trip.
+        let reloaded = resolver.resolve().unwrap();
+        assert_eq!(
+            reloaded.editor.tab_size, 7,
+            "saving an unrelated field must not drop the commented tab_size"
+        );
+        assert!(!reloaded.editor.line_numbers);
+        drop(temp);
+    }
+
+    #[test]
+    fn load_from_file_accepts_comments() {
+        // The explicit `--config <file>` path (Config::load_from_file) must
+        // accept JSONC instead of refusing to start.
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("config-with-comments.json");
+        std::fs::write(
+            &path,
+            r#"{
+                // 2-space tabs, no gutter
+                "editor": {
+                    "tab_size": 2,
+                    "line_numbers": false /* turn off the gutter */
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let config = Config::load_from_file(&path).expect("commented --config file should load");
+        assert_eq!(config.editor.tab_size, 2);
+        assert!(!config.editor.line_numbers);
     }
 
     #[test]

--- a/crates/fresh-editor/src/config_io.rs
+++ b/crates/fresh-editor/src/config_io.rs
@@ -292,14 +292,25 @@ fn json_value_to_cst_input(value: &Value) -> jsonc_parser::cst::CstInputValue {
 }
 
 /// Read an existing config file as raw JSON, returning an empty object when the file
-/// is absent or unparseable.
+/// is absent or empty.
+///
+/// **Errors** (rather than returning an empty object) when the file exists with
+/// content that can't be parsed. This is used on the read-modify-write save
+/// path: silently treating an unparseable file as empty would make the
+/// subsequent write overwrite the user's entire config with just the new
+/// edits. Failing here instead leaves the file untouched and lets the caller
+/// surface the parse error.
 fn read_existing_json(path: &Path) -> Result<Value, ConfigError> {
     if !path.exists() {
         return Ok(Value::Object(Default::default()));
     }
     let content = std::fs::read_to_string(path)
         .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
-    Ok(crate::config::parse_config_jsonc(&content).unwrap_or(Value::Object(Default::default())))
+    if content.trim().is_empty() {
+        return Ok(Value::Object(Default::default()));
+    }
+    crate::config::parse_config_jsonc(&content)
+        .map_err(|e| ConfigError::ParseError(format!("{}: {}", path.display(), e)))
 }
 
 // ============================================================================
@@ -571,13 +582,19 @@ impl ConfigResolver {
         let delta = diff_partial_config(&current, &parent);
 
         // Preserve any manual edits made externally; delta takes precedence.
+        // Fail loudly on an unparseable existing file rather than discarding it
+        // (which would clobber the user's whole config on write).
         let existing: PartialConfig = if path.exists() {
             let content = std::fs::read_to_string(&path)
                 .map_err(|e| ConfigError::IoError(format!("{}: {}", path.display(), e)))?;
-            crate::config::parse_config_jsonc(&content)
-                .ok()
-                .and_then(|v| serde_json::from_value(v).ok())
-                .unwrap_or_default()
+            if content.trim().is_empty() {
+                PartialConfig::default()
+            } else {
+                let value = crate::config::parse_config_jsonc(&content)
+                    .map_err(|e| ConfigError::ParseError(format!("{}: {}", path.display(), e)))?;
+                serde_json::from_value(value)
+                    .map_err(|e| ConfigError::ParseError(format!("{}: {}", path.display(), e)))?
+            }
         } else {
             PartialConfig::default()
         };
@@ -1402,6 +1419,225 @@ mod tests {
         // A non-object existing document can't be edited in place; the writer
         // signals a fall-back so the caller pretty-prints fresh.
         assert!(reconcile_preserving_comments("[1, 2, 3]", &serde_json::json!({"a": 1})).is_none());
+    }
+
+    /// A realistic user config: comments in two places, a `keybindings` array,
+    /// and a `languages` map. Mirrors the file from the data-loss report.
+    const REALISTIC_USER_CONFIG: &str = r#"{
+  "version": 2,
+  "theme": "builtin://dracula",
+  "editor": {
+    // stuff that's really thingy
+    "hide_current_line_on_selection": true,
+    "auto_read_only": false,
+    "indentation_guide": "all"
+  },
+  // file explorer hooray:
+  "file_explorer": {
+    "show_hidden": true,
+    "custom_ignore_patterns": ["*.log"]
+  },
+  "keybindings": [
+    {
+      "key": "=",
+      "modifiers": ["alt"],
+      "action": "next_window"
+    }
+  ],
+  "languages": {
+    "go": {
+      "extensions": ["go"],
+      "grammar": "go",
+      "use_tabs": true,
+      "tab_size": 8,
+      "formatter": {
+        "command": "gofmt",
+        "stdin": true,
+        "timeout_ms": 10000
+      },
+      "format_on_save": true
+    }
+  },
+  "check_for_updates": false
+}
+"#;
+
+    /// Reproduces the original parse failure: the reported config is perfectly
+    /// legitimate JSON-with-comments, but the strict `serde_json` parser the
+    /// loader used to rely on rejects it (the `key must be a string` error from
+    /// the bug report, raised at the first `//`). Our config loader must accept
+    /// it and read every value correctly.
+    #[test]
+    fn realistic_commented_config_is_rejected_by_strict_json_but_accepted_by_loader() {
+        // Original behavior: strict JSON cannot parse comments — this is the bug.
+        assert!(
+            serde_json::from_str::<serde_json::Value>(REALISTIC_USER_CONFIG).is_err(),
+            "sanity: the sample must actually contain JSONC that strict JSON rejects"
+        );
+
+        // Fixed behavior: the loader parses it and the values are intact.
+        let v = crate::config::parse_config_jsonc(REALISTIC_USER_CONFIG)
+            .expect("loader must accept legitimate JSON-with-comments");
+        assert_eq!(
+            v.pointer("/theme"),
+            Some(&serde_json::json!("builtin://dracula"))
+        );
+        assert_eq!(
+            v.pointer("/languages/go/tab_size"),
+            Some(&serde_json::json!(8))
+        );
+        assert_eq!(
+            v.pointer("/keybindings/0/action"),
+            Some(&serde_json::json!("next_window"))
+        );
+        assert_eq!(
+            v.pointer("/file_explorer/custom_ignore_patterns/0"),
+            Some(&serde_json::json!("*.log"))
+        );
+    }
+
+    /// Reproduces the reported data-loss bug. Saving a single settings change
+    /// onto an existing config file that fails to parse must NOT overwrite the
+    /// whole file with just that change. The save must error (so the UI can
+    /// alert) and leave the file byte-for-byte intact.
+    ///
+    /// Without the guard, `read_existing_json` returns an empty object for an
+    /// unparseable file, the one change is applied on top, and the user's
+    /// entire config is overwritten — exactly the failure that was reported.
+    #[test]
+    fn save_changes_does_not_clobber_unparseable_config() {
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        // Truncated / malformed JSON: missing closing braces.
+        let original = "{\n  \"editor\": {\n    \"tab_size\": 7\n";
+        std::fs::write(&user_config_path, original).unwrap();
+
+        let mut changes = std::collections::HashMap::new();
+        changes.insert("/editor/line_numbers".to_string(), serde_json::json!(false));
+        let result = resolver.save_changes_to_layer(
+            &changes,
+            &std::collections::HashSet::new(),
+            ConfigLayer::User,
+        );
+
+        assert!(
+            result.is_err(),
+            "saving onto an unparseable config must error, not silently succeed and clobber it"
+        );
+        let after = std::fs::read_to_string(&user_config_path).unwrap();
+        assert_eq!(
+            after, original,
+            "a failed save must leave the unparseable config file untouched"
+        );
+        drop(temp);
+    }
+
+    /// Same guarantee for the baseline-based save path used by the Settings UI.
+    #[test]
+    fn save_with_baseline_does_not_clobber_unparseable_config() {
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        let original = "{ \"editor\": { \"tab_size\": 7  oops not json";
+        std::fs::write(&user_config_path, original).unwrap();
+
+        let baseline = Config::default();
+        let mut current = Config::default();
+        current.editor.tab_size = 3;
+        let result = resolver.save_to_layer_with_baseline(&current, &baseline, ConfigLayer::User);
+
+        assert!(result.is_err(), "must error on unparseable existing file");
+        assert_eq!(
+            std::fs::read_to_string(&user_config_path).unwrap(),
+            original,
+            "a failed save must leave the file untouched"
+        );
+        drop(temp);
+    }
+
+    /// Same guarantee for `save_to_layer`.
+    #[test]
+    fn save_to_layer_does_not_clobber_unparseable_config() {
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        let original = "{ broken";
+        std::fs::write(&user_config_path, original).unwrap();
+
+        let mut config = Config::default();
+        config.editor.tab_size = 3;
+        let result = resolver.save_to_layer(&config, ConfigLayer::User);
+
+        assert!(result.is_err(), "must error on unparseable existing file");
+        assert_eq!(
+            std::fs::read_to_string(&user_config_path).unwrap(),
+            original,
+            "a failed save must leave the file untouched"
+        );
+        drop(temp);
+    }
+
+    /// End-to-end: a Settings-UI save of one unrelated field onto the realistic
+    /// commented config preserves every comment, the keybindings array, and the
+    /// languages map, while applying the change. This is the regression that the
+    /// original (strict-parse) code silently failed by wiping the file.
+    #[test]
+    fn settings_save_preserves_full_realistic_config() {
+        let (temp, resolver) = create_test_resolver();
+
+        let user_config_path = resolver.user_config_path();
+        std::fs::create_dir_all(user_config_path.parent().unwrap()).unwrap();
+        std::fs::write(&user_config_path, REALISTIC_USER_CONFIG).unwrap();
+
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(
+            "/editor/auto_read_only".to_string(),
+            serde_json::json!(true),
+        );
+        resolver
+            .save_changes_to_layer(
+                &changes,
+                &std::collections::HashSet::new(),
+                ConfigLayer::User,
+            )
+            .unwrap();
+
+        let saved = std::fs::read_to_string(&user_config_path).unwrap();
+        // Comments survive.
+        assert!(
+            saved.contains("// stuff that's really thingy"),
+            "editor comment lost:\n{saved}"
+        );
+        assert!(
+            saved.contains("// file explorer hooray:"),
+            "file_explorer comment lost:\n{saved}"
+        );
+        // Complex structures survive.
+        let reparsed = crate::config::parse_config_jsonc(&saved).unwrap();
+        assert_eq!(
+            reparsed.pointer("/keybindings/0/action"),
+            Some(&serde_json::json!("next_window")),
+            "keybindings array lost:\n{saved}"
+        );
+        assert_eq!(
+            reparsed.pointer("/languages/go/formatter/command"),
+            Some(&serde_json::json!("gofmt")),
+            "languages map lost:\n{saved}"
+        );
+        assert_eq!(
+            reparsed.pointer("/theme"),
+            Some(&serde_json::json!("builtin://dracula"))
+        );
+        // The change was applied.
+        assert_eq!(
+            reparsed.pointer("/editor/auto_read_only"),
+            Some(&serde_json::json!(true))
+        );
+        drop(temp);
     }
 
     #[test]

--- a/crates/fresh-editor/src/view/popup.rs
+++ b/crates/fresh-editor/src/view/popup.rs
@@ -123,6 +123,12 @@ pub enum PopupResolver {
     /// segment). Confirm dispatches the selected row's `data`
     /// ("toggle_read_only" / "cancel") through `handle_read_only_menu_action`.
     ReadOnly,
+    /// "Couldn't save settings" error popup. Acknowledging it (confirm or
+    /// cancel) opens the offending config file for `layer` in a buffer so the
+    /// user can fix the syntax error that blocked the save.
+    SettingsSaveError {
+        layer: crate::config_io::ConfigLayer,
+    },
 }
 
 /// Content of a popup window

--- a/crates/fresh-editor/tests/e2e/mod.rs
+++ b/crates/fresh-editor/tests/e2e/mod.rs
@@ -201,6 +201,7 @@ pub mod settings_lsp_entry_dialog_bugs;
 pub mod settings_paste;
 pub mod settings_quicklsp_entry_bug;
 pub mod settings_ruler_keyboard_nav;
+pub mod settings_save_error_popup;
 pub mod settings_scrolled_list_click;
 pub mod settings_text_input_focus;
 pub mod settings_tree_view;

--- a/crates/fresh-editor/tests/e2e/settings_save_error_popup.rs
+++ b/crates/fresh-editor/tests/e2e/settings_save_error_popup.rs
@@ -1,0 +1,85 @@
+//! E2E: a failed settings-save must surface a prominent, centered modal popup
+//! — not just a quiet status-bar line — and must leave the (unparseable)
+//! config file untouched.
+//!
+//! Regression for the reported flow: a config the loader can't parse used to be
+//! silently clobbered on save, and even after the no-clobber guard the only
+//! feedback was a truncated status-bar message that's easy to miss.
+use crate::common::harness::EditorTestHarness;
+use crossterm::event::{KeyCode, KeyModifiers};
+use std::fs;
+
+fn send_text(harness: &mut EditorTestHarness, text: &str) {
+    for c in text.chars() {
+        harness
+            .send_key(KeyCode::Char(c), KeyModifiers::NONE)
+            .unwrap();
+    }
+}
+
+#[test]
+fn failed_settings_save_shows_modal_and_keeps_file() {
+    let mut harness = EditorTestHarness::with_temp_project(100, 40).unwrap();
+    harness.render().unwrap();
+
+    // The harness stores the user config at <temp>/config/config.json.
+    let temp_dir = harness
+        .project_dir()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .to_path_buf();
+    let config_dir = temp_dir.join("config");
+    fs::create_dir_all(&config_dir).unwrap();
+    let user_config_path = config_dir.join("config.json");
+
+    // A genuinely unparseable config file (missing commas/braces).
+    let original = "{\n  \"editor\": {\n    \"tab_size\": 7\n    \"line_numbers\": broken\n";
+    fs::write(&user_config_path, original).unwrap();
+
+    // Change a setting and save.
+    harness.open_settings().unwrap();
+    assert!(harness.editor().is_settings_open());
+    harness
+        .send_key(KeyCode::Char('/'), KeyModifiers::NONE)
+        .unwrap();
+    send_text(&mut harness, "tab_size");
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap(); // jump to field
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap(); // enter edit mode
+    harness
+        .send_key(KeyCode::Backspace, KeyModifiers::NONE)
+        .unwrap();
+    send_text(&mut harness, "3"); // change tab_size -> 3
+    harness
+        .send_key(KeyCode::Enter, KeyModifiers::NONE)
+        .unwrap(); // commit value
+    harness.render().unwrap();
+    harness
+        .send_key(KeyCode::Char('s'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // A prominent popup must be on screen with the failure title — not just the
+    // status bar. The title only appears via the popup, so this distinguishes
+    // it from the pre-existing status-bar-only behavior.
+    harness.assert_screen_contains("Couldn't save settings");
+    // And it reassures the user their file is safe.
+    harness.assert_screen_contains("left unchanged");
+
+    // The unparseable file must be byte-for-byte intact.
+    assert_eq!(
+        fs::read_to_string(&user_config_path).unwrap(),
+        original,
+        "a failed save must not modify the config file"
+    );
+
+    // Esc dismisses the modal.
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+    harness.assert_screen_not_contains("Couldn't save settings");
+}

--- a/crates/fresh-editor/tests/e2e/settings_save_error_popup.rs
+++ b/crates/fresh-editor/tests/e2e/settings_save_error_popup.rs
@@ -78,8 +78,13 @@ fn failed_settings_save_shows_modal_and_keeps_file() {
         "a failed save must not modify the config file"
     );
 
-    // Esc dismisses the modal.
+    // Acknowledging the modal (Esc) dismisses it AND opens the offending
+    // config file in a buffer so the user can fix it.
     harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
     harness.render().unwrap();
     harness.assert_screen_not_contains("Couldn't save settings");
+    // The config file's contents are now on screen (the malformed token and
+    // the filename tab), confirming it was opened in a buffer.
+    harness.assert_screen_contains("config.json");
+    harness.assert_screen_contains("broken");
 }


### PR DESCRIPTION
Closes #2497.

## Summary

Config files (`~/.config/fresh/config.json`, project `.fresh/config.json`, the session file, and `--config <file>`) were parsed as strict JSON, so a single `//` or `/* */` comment made the whole file invalid. In the layered flow the parse error was swallowed and the editor silently fell back to defaults; on the next settings save the read-modify-write would then **overwrite the user's entire config** with just the changed setting. `--config` refused to start at all.

This PR makes config files accept JSONC (comments + trailing commas), preserves comments when the editor rewrites a file, refuses to clobber a config it can't parse, and surfaces a failed save loudly instead of via an easy-to-miss status line.

## Changes (by commit)

1. **Accept JSONC (comments + trailing commas) in config files.** A shared `parse_config_jsonc()` helper (backed by `jsonc-parser`) replaces strict `serde_json::from_str` at every config read site — user / project / session layers, the read side of the save paths, `read_user_config_raw`, and `Config::load_from_file` (`--config`). Empty / comment-only input resolves to an empty object; genuinely malformed input still errors.

2. **Preserve comments when rewriting config files.** Writes now go through the JSONC CST instead of re-serializing a `serde_json::Value`: the existing file text is parsed and reconciled against the target value touching as little as possible — unchanged properties (including their inline comments and formatting) are left byte-for-byte, nested objects recurse, removed keys are deleted, new keys appended. New / unparseable / non-object-root files fall back to pretty-printing. Covers `save_to_layer`, `save_to_layer_with_baseline`, and `save_changes_to_layer`.

3. **Never overwrite an unparseable config file on save.** The read side of the save path used to swallow parse failures and substitute an empty object, so a broken file got clobbered on the next save. It now returns a `ParseError` instead, leaving the file byte-for-byte intact and letting the UI report the failure.

4. **Surface a failed settings-save with a modal popup**, not just the status bar — a centered, focused, red-bordered popup with the parse error, the file path + line/column, and a note that the file was left unchanged.

5. **Open the config file on acknowledging the modal; wrap long paths.** Pressing Esc/Enter on the popup opens the offending config file in a buffer so the user can fix it. The body is hard-wrapped so a long, space-less path wraps inside the border instead of being clipped.

## Testing

- Unit + e2e tests for each behavior, written test-first (each fails without its change): JSONC parsing of a realistic commented config (rejected by strict JSON, accepted by the loader), comment-preserving round-trips, three data-loss reproducers (each save path errors and leaves an unparseable file untouched), and an e2e test asserting the save-error modal renders and that acknowledging it opens the config file.
- Verified interactively in tmux across a matrix: non-existent / empty / valid / commented / deeply-nested-comment / malformed configs, plus the save-error modal and file-open flow.
- New user-facing strings translated into all 14 locales; i18n-completeness tests pass. `cargo fmt` / `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t46etH7pT5sFG84CNpQYd