### PR TITLE
refactor(render): bundle render params and decompose render()

### DIFF
--- a/crates/fresh-editor/src/app/macro_actions.rs
+++ b/crates/fresh-editor/src/app/macro_actions.rs
@@ -131,8 +131,8 @@ impl Editor {
             log.begin_undo_group();
         }
         let action_count = actions.len();
-        let width = self.active_chrome().last_frame_width;
-        let height = self.active_chrome().last_frame_height;
+        let width = self.active_chrome().last_frame.width;
+        let height = self.active_chrome().last_frame.height;
         for action in actions {
             if let Err(e) = self.handle_action(action) {
                 tracing::warn!("Macro action failed: {}", e);

--- a/crates/fresh-editor/src/app/mod.rs
+++ b/crates/fresh-editor/src/app/mod.rs
@@ -209,7 +209,8 @@ use crate::view::file_tree::{FileTree, FileTreeView};
 use crate::view::prompt::PromptType;
 use crate::view::split::{SplitManager, SplitViewState};
 use crate::view::ui::{
-    FileExplorerRenderer, SplitRenderer, StatusBarRenderer, SuggestionsRenderer,
+    ExplorerDecorations, FileExplorerRenderer, SplitRenderer, StatusBarRenderer,
+    SuggestionsRenderer,
 };
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1289,9 +1289,9 @@ impl Editor {
 
         // Check status bar indicators — one generic hit-test over every
         // clickable segment recorded last frame (encoding, LSP, remote, …).
-        if let Some((status_row, _status_x, _status_width)) = self.active_chrome().status_bar_area {
+        if let Some((status_row, _status_x, _status_width)) = self.active_chrome().status_bar.area {
             if row == status_row {
-                for (id, indicator_row, start, end) in &self.active_chrome().status_bar_clickable {
+                for (id, indicator_row, start, end) in &self.active_chrome().status_bar.clickable {
                     if row == *indicator_row && col >= *start && col < *end {
                         return Some(HoverTarget::StatusBarClickable(*id));
                     }
@@ -2437,14 +2437,14 @@ impl Editor {
     }
 
     fn handle_click_status_bar(&mut self, col: u16, row: u16) -> Option<AnyhowResult<()>> {
-        let (status_row, _status_x, _status_width) = self.active_chrome().status_bar_area?;
+        let (status_row, _status_x, _status_width) = self.active_chrome().status_bar.area?;
         if row != status_row {
             return None;
         }
         // Generic click rail: one hit-test over every clickable segment drawn
         // last frame. The id→Action mapping (and each element's popup-dismiss
         // nuance) lives in `dispatch_status_bar_click`.
-        let clickables = self.active_chrome().status_bar_clickable.clone();
+        let clickables = self.active_chrome().status_bar.clickable.clone();
         for (id, r, s, e) in clickables {
             if row == r && col >= s && col < e {
                 return Some(self.dispatch_status_bar_click(id));
@@ -2455,7 +2455,7 @@ impl Editor {
         // so the registering plugin can react. We split the registry key
         // (`"<plugin>:<token>"`) on the first colon — that's how
         // `register_status_bar_element` builds it.
-        let plugin_areas = self.active_chrome().status_bar_plugin_token_areas.clone();
+        let plugin_areas = self.active_chrome().status_bar.plugin_token_areas.clone();
         for (key, (r, s, e)) in plugin_areas {
             if row == r && col >= s && col < e {
                 let (plugin_name, token_name) = match key.split_once(':') {

--- a/crates/fresh-editor/src/app/mouse_input.rs
+++ b/crates/fresh-editor/src/app/mouse_input.rs
@@ -1007,8 +1007,8 @@ impl Editor {
     fn hover_target_in_floating_overlays(&self, col: u16, row: u16) -> Option<HoverTarget> {
         if let Some(ref menu) = self.active_window().file_explorer_context_menu {
             let (menu_x, menu_y) = menu.clamped_position(
-                self.active_chrome().last_frame_width,
-                self.active_chrome().last_frame_height,
+                self.active_chrome().last_frame.width,
+                self.active_chrome().last_frame.height,
             );
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
             let menu_height = menu.height();
@@ -3295,8 +3295,8 @@ impl Editor {
             }
         }
 
-        let frame_w = self.active_chrome().last_frame_width;
-        let frame_h = self.active_chrome().last_frame_height;
+        let frame_w = self.active_chrome().last_frame.width;
+        let frame_h = self.active_chrome().last_frame.height;
         if let Some(ref menu) = self.active_window().file_explorer_context_menu {
             let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);
             let menu_width = super::types::FILE_EXPLORER_CONTEXT_MENU_WIDTH;
@@ -3686,8 +3686,8 @@ impl Editor {
         row: u16,
     ) -> Option<AnyhowResult<()>> {
         // Extract all needed values while the immutable borrow is live, then mutate.
-        let frame_w = self.active_chrome().last_frame_width;
-        let frame_h = self.active_chrome().last_frame_height;
+        let frame_w = self.active_chrome().last_frame.width;
+        let frame_h = self.active_chrome().last_frame.height;
         let clicked_item: Option<super::types::FileExplorerContextMenuItem> = {
             let menu = self.active_window().file_explorer_context_menu.as_ref()?;
             let (menu_x, menu_y) = menu.clamped_position(frame_w, frame_h);

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -590,7 +590,7 @@ impl Editor {
         // the BottomRight anchor when the LSP segment isn't visible.
         let position = self
             .active_chrome()
-            .status_bar_clickable_area(crate::view::ui::status_bar::StatusBarClickable::Lsp)
+            .status_bar.clickable_area(crate::view::ui::status_bar::StatusBarClickable::Lsp)
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
                     x: col_start,
@@ -907,7 +907,7 @@ impl Editor {
         // even in prompt-auto-hide mode.
         let position = self
             .active_chrome()
-            .status_bar_clickable_area(
+            .status_bar.clickable_area(
                 crate::view::ui::status_bar::StatusBarClickable::RemoteIndicator,
             )
             .map(
@@ -995,7 +995,7 @@ impl Editor {
 
         let position = self
             .active_chrome()
-            .status_bar_clickable_area(crate::view::ui::status_bar::StatusBarClickable::ReadOnly)
+            .status_bar.clickable_area(crate::view::ui::status_bar::StatusBarClickable::ReadOnly)
             .map(
                 |(status_row, col_start, _)| PopupPosition::AboveStatusBarAt {
                     x: col_start,

--- a/crates/fresh-editor/src/app/popup_dialogs.rs
+++ b/crates/fresh-editor/src/app/popup_dialogs.rs
@@ -590,7 +590,8 @@ impl Editor {
         // the BottomRight anchor when the LSP segment isn't visible.
         let position = self
             .active_chrome()
-            .status_bar.clickable_area(crate::view::ui::status_bar::StatusBarClickable::Lsp)
+            .status_bar
+            .clickable_area(crate::view::ui::status_bar::StatusBarClickable::Lsp)
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
                     x: col_start,
@@ -907,9 +908,8 @@ impl Editor {
         // even in prompt-auto-hide mode.
         let position = self
             .active_chrome()
-            .status_bar.clickable_area(
-                crate::view::ui::status_bar::StatusBarClickable::RemoteIndicator,
-            )
+            .status_bar
+            .clickable_area(crate::view::ui::status_bar::StatusBarClickable::RemoteIndicator)
             .map(
                 |(status_row, col_start, _)| crate::view::popup::PopupPosition::AboveStatusBarAt {
                     x: col_start,
@@ -995,7 +995,8 @@ impl Editor {
 
         let position = self
             .active_chrome()
-            .status_bar.clickable_area(crate::view::ui::status_bar::StatusBarClickable::ReadOnly)
+            .status_bar
+            .clickable_area(crate::view::ui::status_bar::StatusBarClickable::ReadOnly)
             .map(
                 |(status_row, col_start, _)| PopupPosition::AboveStatusBarAt {
                     x: col_start,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -898,201 +898,21 @@ impl Editor {
         // with OSC sequences every frame.
         self.update_terminal_title(&display_name);
 
-        let status_message = self.active_window().status_message.clone();
-        let plugin_status_message = self.active_window().plugin_status_message.clone();
         let prompt = self.active_window().prompt.clone();
-        // Compute a simple buffer-aware LSP indicator.
-        // Compose the LSP status-bar segment for the active buffer. This
-        // runs every render — the editor has no precomputed LSP-status
-        // string cached anywhere else, so there is a single source of
-        // truth for what the user sees.
-        //
-        // Priority order (first non-empty wins):
-        //
-        //   1. Active `$/progress` work for this language — e.g.
-        //      "LSP (cpp): indexing (42%)". Conveys the transient
-        //      startup/indexing phase.
-        //   2. A running server — "LSP". Short because detail belongs
-        //      in LSP-specific UI, not the compact status bar pill.
-        //   3. Configured `auto_start=true` servers that haven't started
-        //      (error / crashed / pending) — "LSP off".
-        //   4. Configured `enabled && !auto_start` servers that the user
-        //      has to opt into — "LSP: off (N)".
-        //   5. Nothing.
-        //
-        // Rules 3 and 4 address heuristic eval H-1: without them, a
-        // configured-but-dormant server is indistinguishable from "no
-        // LSP at all."
-        let current_language = self
-            .buffers()
-            .get(&self.active_buffer())
-            .map(|s| s.language.clone())
-            .unwrap_or_default();
-        let buffer_lsp_disabled_reason = self
-            .active_window()
-            .buffer_metadata
-            .get(&self.active_buffer())
-            .filter(|m| !m.lsp_enabled)
-            .and_then(|m| m.lsp_disabled_reason.as_deref());
-        let (lsp_status, lsp_indicator_state) = compose_lsp_status(
-            &current_language,
-            buffer_lsp_disabled_reason,
-            &self.active_window().lsp_progress,
-            &self.active_window().lsp_server_statuses,
-            &self.config.lsp,
-            &self.active_window().user_dismissed_lsp_languages,
-            self.config.lsp_enabled,
-        );
         let theme = self.theme.read().unwrap().clone();
         let keybindings_cloned = self.keybindings.read().unwrap().clone(); // Clone the keybindings
-        let chord_state_cloned = self.active_window_mut().chord_state.clone(); // Clone the chord state
 
-        // Get update availability info
-        let update_available = self.latest_version().map(|v| v.to_string());
-
-        // Render status bar (hidden when toggled off, or when suggestions/file browser popup is shown)
-        if self.active_window_mut().status_bar_visible && !has_suggestions && !has_file_browser {
-            // Get warning level for colored indicator (respects config setting)
-            // LSP warning level is scoped to the current buffer's language
-            let (warning_level, general_warning_count) =
-                if self.config.warnings.show_status_indicator {
-                    let lsp_level = {
-                        use crate::services::async_bridge::LspServerStatus;
-                        let mut level = WarningLevel::None;
-                        for ((lang, _), status) in &self.active_window().lsp_server_statuses {
-                            if lang == &current_language {
-                                match status {
-                                    LspServerStatus::Error => {
-                                        level = WarningLevel::Error;
-                                        break;
-                                    }
-                                    LspServerStatus::Starting | LspServerStatus::Initializing => {
-                                        if level != WarningLevel::Error {
-                                            level = WarningLevel::Warning;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                        }
-                        level
-                    };
-                    (
-                        lsp_level,
-                        self.active_window().warning_domains.general.count,
-                    )
-                } else {
-                    (WarningLevel::None, 0)
-                };
-
-            // Which clickable status-bar segment (if any) the mouse is over —
-            // drives hover styling generically (one variant for the whole bar).
-            let status_bar_hovered = match &self.active_window_mut().mouse_state.hover_target {
-                Some(HoverTarget::StatusBarClickable(id)) => Some(*id),
-                _ => None,
-            };
-
-            let remote_connection = self.connection_display_string();
-            // Active window's last failed-reconnect error (drives a core
-            // FailedAttach indicator for a dormant remote workspace).
-            let remote_reconnect_error = self.active_window().remote_reconnect_error.clone();
-
-            // Get session name for display (only in session mode)
-            let session_name = self.session_name().map(|s| s.to_string());
-
-            let active_split = self.effective_active_split();
-            let active_buf = self.active_buffer();
-            let default_cursors = crate::model::cursor::Cursors::new();
-            let is_read_only = self
-                .active_window()
-                .buffer_metadata
-                .get(&active_buf)
-                .map(|m| m.read_only)
-                .unwrap_or(false);
-            let is_synthetic_placeholder = self
-                .active_window()
-                .buffer_metadata
-                .get(&active_buf)
-                .map(|m| m.synthetic_placeholder)
-                .unwrap_or(false);
-            // Compute plugin-provided status-bar values before taking the
-            // mutable window borrow below.
-            let dynamic_status_bar_elements = self.get_status_bar_element_values(active_buf);
-            // Active session's trust level for the always-present `{trust}`
-            // indicator — read here (Copy) before the mutable window borrow.
-            let workspace_trust_level = self.authority().workspace_trust.level();
-            // Single window borrow, split into buffers + cursors so the
-            // status-bar context can hold both.
-            let __active_id = self.active_window;
-            // Theme-key runs the status bar records as it paints; applied to
-            // the chrome's cell map after the window borrow is released.
-            let mut status_bar_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
-            // Web renders the status bar natively from `status_view`; skip painting
-            // it (the semantic segments + indicator rects are still captured).
-            let sb_draw = !self.suppress_chrome_cells;
-            let __win = self
-                .windows
-                .get_mut(&__active_id)
-                .expect("active window must exist");
-            let status_bar_layout = __win
-                .buffers
-                .with_buffer_and_view_states(active_buf, |state, vs_map| {
-                    let cursors = vs_map
-                        .get(&active_split)
-                        .map(|v| &v.cursors)
-                        .unwrap_or(&default_cursors);
-                    let mut status_ctx = crate::view::ui::status_bar::StatusBarContext {
-                        state,
-                        cursors,
-                        status_message: &status_message,
-                        plugin_status_message: &plugin_status_message,
-                        lsp_status: &lsp_status,
-                        lsp_indicator_state,
-                        theme: &theme,
-                        display_name: &display_name,
-                        keybindings: &keybindings_cloned,
-                        chord_state: &chord_state_cloned,
-                        update_available: update_available.as_deref(),
-                        warning_level,
-                        general_warning_count,
-                        hovered: status_bar_hovered,
-                        remote_connection: remote_connection.as_deref(),
-                        session_name: session_name.as_deref(),
-                        read_only: is_read_only,
-                        remote_state_override: self.remote_indicator_override.as_ref(),
-                        remote_reconnect_error: remote_reconnect_error.as_deref(),
-                        is_synthetic_placeholder,
-                        // Filled in by `render_status` from the user's
-                        // status_bar config; the value here is just a
-                        // safe default for the rare path that builds the
-                        // ctx but doesn't run `render_status`.
-                        remote_indicator_on_bar: false,
-                        dynamic_status_bar_elements: dynamic_status_bar_elements.clone(),
-                        workspace_trust_level,
-                    };
-                    let mut sb_rec =
-                        crate::app::types::CellThemeRecorder::new(&mut status_bar_runs);
-                    StatusBarRenderer::render_status_bar(
-                        frame,
-                        main_chunks[status_bar_idx],
-                        &mut status_ctx,
-                        &self.config.editor.status_bar,
-                        Some(&mut sb_rec),
-                        sb_draw,
-                    )
-                })
-                .expect("active buffer must be present");
-            self.active_chrome_mut().apply_theme_runs(&status_bar_runs);
-
-            // Store status bar layout for click detection
-            let status_bar_area = main_chunks[status_bar_idx];
-            self.active_chrome_mut().status_bar_area =
-                Some((status_bar_area.y, status_bar_area.x, status_bar_area.width));
-            self.active_chrome_mut().status_bar_clickable = status_bar_layout.clickable;
-            self.active_chrome_mut().status_bar_plugin_token_areas =
-                status_bar_layout.plugin_token_areas;
-            self.active_chrome_mut().status_bar_segments = status_bar_layout.segments;
-        }
+        // Status bar (hidden when toggled off, or when a suggestions/file-
+        // browser popup covers the bottom row).
+        self.render_status_bar_row(
+            frame,
+            main_chunks[status_bar_idx],
+            &display_name,
+            &theme,
+            &keybindings_cloned,
+            has_suggestions,
+            has_file_browser,
+        );
 
         // Search-options bar (case / whole-word / regex / confirm toggles),
         // shown only while a search-style prompt is active.
@@ -1708,6 +1528,216 @@ impl Editor {
             None
         };
         self.active_chrome_mut().workspace_trust_dialog = trust_layout;
+    }
+
+    /// Render the status bar into `area`, unless it's toggled off or a
+    /// suggestions / file-browser popup is occupying the bottom row. The
+    /// status-bar-only inputs (LSP segment, messages, chord state, update
+    /// banner, …) are computed here; `display_name`, `theme`, and
+    /// `keybindings` are shared with other chrome and passed in.
+    #[allow(clippy::too_many_arguments)]
+    fn render_status_bar_row(
+        &mut self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+        display_name: &str,
+        theme: &crate::view::theme::Theme,
+        keybindings: &crate::input::keybindings::KeybindingResolver,
+        has_suggestions: bool,
+        has_file_browser: bool,
+    ) {
+        let status_message = self.active_window().status_message.clone();
+        let plugin_status_message = self.active_window().plugin_status_message.clone();
+        // Compute a simple buffer-aware LSP indicator.
+        // Compose the LSP status-bar segment for the active buffer. This
+        // runs every render — the editor has no precomputed LSP-status
+        // string cached anywhere else, so there is a single source of
+        // truth for what the user sees.
+        //
+        // Priority order (first non-empty wins):
+        //
+        //   1. Active `$/progress` work for this language — e.g.
+        //      "LSP (cpp): indexing (42%)". Conveys the transient
+        //      startup/indexing phase.
+        //   2. A running server — "LSP". Short because detail belongs
+        //      in LSP-specific UI, not the compact status bar pill.
+        //   3. Configured `auto_start=true` servers that haven't started
+        //      (error / crashed / pending) — "LSP off".
+        //   4. Configured `enabled && !auto_start` servers that the user
+        //      has to opt into — "LSP: off (N)".
+        //   5. Nothing.
+        //
+        // Rules 3 and 4 address heuristic eval H-1: without them, a
+        // configured-but-dormant server is indistinguishable from "no
+        // LSP at all."
+        let current_language = self
+            .buffers()
+            .get(&self.active_buffer())
+            .map(|s| s.language.clone())
+            .unwrap_or_default();
+        let buffer_lsp_disabled_reason = self
+            .active_window()
+            .buffer_metadata
+            .get(&self.active_buffer())
+            .filter(|m| !m.lsp_enabled)
+            .and_then(|m| m.lsp_disabled_reason.as_deref());
+        let (lsp_status, lsp_indicator_state) = compose_lsp_status(
+            &current_language,
+            buffer_lsp_disabled_reason,
+            &self.active_window().lsp_progress,
+            &self.active_window().lsp_server_statuses,
+            &self.config.lsp,
+            &self.active_window().user_dismissed_lsp_languages,
+            self.config.lsp_enabled,
+        );
+        let chord_state_cloned = self.active_window().chord_state.clone(); // Clone the chord state
+
+        // Get update availability info
+        let update_available = self.latest_version().map(|v| v.to_string());
+
+        // Render status bar (hidden when toggled off, or when suggestions/file browser popup is shown)
+        if self.active_window().status_bar_visible && !has_suggestions && !has_file_browser {
+            // Get warning level for colored indicator (respects config setting)
+            // LSP warning level is scoped to the current buffer's language
+            let (warning_level, general_warning_count) =
+                if self.config.warnings.show_status_indicator {
+                    let lsp_level = {
+                        use crate::services::async_bridge::LspServerStatus;
+                        let mut level = WarningLevel::None;
+                        for ((lang, _), status) in &self.active_window().lsp_server_statuses {
+                            if lang == &current_language {
+                                match status {
+                                    LspServerStatus::Error => {
+                                        level = WarningLevel::Error;
+                                        break;
+                                    }
+                                    LspServerStatus::Starting | LspServerStatus::Initializing => {
+                                        if level != WarningLevel::Error {
+                                            level = WarningLevel::Warning;
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
+                        level
+                    };
+                    (
+                        lsp_level,
+                        self.active_window().warning_domains.general.count,
+                    )
+                } else {
+                    (WarningLevel::None, 0)
+                };
+
+            // Which clickable status-bar segment (if any) the mouse is over —
+            // drives hover styling generically (one variant for the whole bar).
+            let status_bar_hovered = match &self.active_window().mouse_state.hover_target {
+                Some(HoverTarget::StatusBarClickable(id)) => Some(*id),
+                _ => None,
+            };
+
+            let remote_connection = self.connection_display_string();
+            // Active window's last failed-reconnect error (drives a core
+            // FailedAttach indicator for a dormant remote workspace).
+            let remote_reconnect_error = self.active_window().remote_reconnect_error.clone();
+
+            // Get session name for display (only in session mode)
+            let session_name = self.session_name().map(|s| s.to_string());
+
+            let active_split = self.effective_active_split();
+            let active_buf = self.active_buffer();
+            let default_cursors = crate::model::cursor::Cursors::new();
+            let is_read_only = self
+                .active_window()
+                .buffer_metadata
+                .get(&active_buf)
+                .map(|m| m.read_only)
+                .unwrap_or(false);
+            let is_synthetic_placeholder = self
+                .active_window()
+                .buffer_metadata
+                .get(&active_buf)
+                .map(|m| m.synthetic_placeholder)
+                .unwrap_or(false);
+            // Compute plugin-provided status-bar values before taking the
+            // mutable window borrow below.
+            let dynamic_status_bar_elements = self.get_status_bar_element_values(active_buf);
+            // Active session's trust level for the always-present `{trust}`
+            // indicator — read here (Copy) before the mutable window borrow.
+            let workspace_trust_level = self.authority().workspace_trust.level();
+            // Single window borrow, split into buffers + cursors so the
+            // status-bar context can hold both.
+            let __active_id = self.active_window;
+            // Theme-key runs the status bar records as it paints; applied to
+            // the chrome's cell map after the window borrow is released.
+            let mut status_bar_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+            // Web renders the status bar natively from `status_view`; skip painting
+            // it (the semantic segments + indicator rects are still captured).
+            let sb_draw = !self.suppress_chrome_cells;
+            let __win = self
+                .windows
+                .get_mut(&__active_id)
+                .expect("active window must exist");
+            let status_bar_layout = __win
+                .buffers
+                .with_buffer_and_view_states(active_buf, |state, vs_map| {
+                    let cursors = vs_map
+                        .get(&active_split)
+                        .map(|v| &v.cursors)
+                        .unwrap_or(&default_cursors);
+                    let mut status_ctx = crate::view::ui::status_bar::StatusBarContext {
+                        state,
+                        cursors,
+                        status_message: &status_message,
+                        plugin_status_message: &plugin_status_message,
+                        lsp_status: &lsp_status,
+                        lsp_indicator_state,
+                        theme,
+                        display_name,
+                        keybindings,
+                        chord_state: &chord_state_cloned,
+                        update_available: update_available.as_deref(),
+                        warning_level,
+                        general_warning_count,
+                        hovered: status_bar_hovered,
+                        remote_connection: remote_connection.as_deref(),
+                        session_name: session_name.as_deref(),
+                        read_only: is_read_only,
+                        remote_state_override: self.remote_indicator_override.as_ref(),
+                        remote_reconnect_error: remote_reconnect_error.as_deref(),
+                        is_synthetic_placeholder,
+                        // Filled in by `render_status` from the user's
+                        // status_bar config; the value here is just a
+                        // safe default for the rare path that builds the
+                        // ctx but doesn't run `render_status`.
+                        remote_indicator_on_bar: false,
+                        dynamic_status_bar_elements: dynamic_status_bar_elements.clone(),
+                        workspace_trust_level,
+                    };
+                    let mut sb_rec =
+                        crate::app::types::CellThemeRecorder::new(&mut status_bar_runs);
+                    StatusBarRenderer::render_status_bar(
+                        frame,
+                        area,
+                        &mut status_ctx,
+                        &self.config.editor.status_bar,
+                        Some(&mut sb_rec),
+                        sb_draw,
+                    )
+                })
+                .expect("active buffer must be present");
+            self.active_chrome_mut().apply_theme_runs(&status_bar_runs);
+
+            // Store status bar layout for click detection
+            let status_bar_area = area;
+            self.active_chrome_mut().status_bar_area =
+                Some((status_bar_area.y, status_bar_area.x, status_bar_area.width));
+            self.active_chrome_mut().status_bar_clickable = status_bar_layout.clickable;
+            self.active_chrome_mut().status_bar_plugin_token_areas =
+                status_bar_layout.plugin_token_areas;
+            self.active_chrome_mut().status_bar_segments = status_bar_layout.segments;
+        }
     }
 
     /// Render the modal overlays that dim the chrome behind them: settings,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1528,15 +1528,18 @@ impl Editor {
                 .filter(|cb| cb.is_cut)
                 .map(|cb| cb.paths.as_slice())
                 .unwrap_or(empty.as_slice());
+            let deco = ExplorerDecorations {
+                slot_resolver,
+                decorations: &__win.file_explorer_decoration_cache,
+                slot_overrides: &__win.file_explorer_slot_override_cache,
+            };
             FileExplorerRenderer::render(
                 explorer,
                 frame,
                 area,
-                slot_resolver,
+                deco,
                 is_focused,
                 &files_with_unsaved_changes,
-                &__win.file_explorer_decoration_cache,
-                &__win.file_explorer_slot_override_cache,
                 &keybindings,
                 key_context_clone,
                 &*self.theme.read().unwrap(),

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1094,87 +1094,18 @@ impl Editor {
             self.active_chrome_mut().status_bar_segments = status_bar_layout.segments;
         }
 
-        // Render search options bar when in search prompt
-        if show_search_options {
-            // Show "Confirm" option only in replace modes
-            let confirm_each = self.active_window().prompt.as_ref().and_then(|p| {
-                if matches!(
-                    p.prompt_type,
-                    PromptType::ReplaceSearch
-                        | PromptType::Replace { .. }
-                        | PromptType::QueryReplaceSearch
-                        | PromptType::QueryReplace { .. }
-                ) {
-                    Some(self.active_window().search_confirm_each)
-                } else {
-                    None
-                }
-            });
+        // Search-options bar (case / whole-word / regex / confirm toggles),
+        // shown only while a search-style prompt is active.
+        self.render_search_options_bar(
+            frame,
+            main_chunks[search_options_idx],
+            show_search_options,
+            &theme,
+            &keybindings_cloned,
+        );
 
-            // Determine hover state for search options
-            use crate::view::ui::status_bar::SearchOptionsHover;
-            let search_options_hover = match &self.active_window_mut().mouse_state.hover_target {
-                Some(HoverTarget::SearchOptionCaseSensitive) => SearchOptionsHover::CaseSensitive,
-                Some(HoverTarget::SearchOptionWholeWord) => SearchOptionsHover::WholeWord,
-                Some(HoverTarget::SearchOptionRegex) => SearchOptionsHover::Regex,
-                Some(HoverTarget::SearchOptionConfirmEach) => SearchOptionsHover::ConfirmEach,
-                _ => SearchOptionsHover::None,
-            };
-
-            let search_options_layout = StatusBarRenderer::render_search_options(
-                frame,
-                main_chunks[search_options_idx],
-                self.active_window().search_case_sensitive,
-                self.active_window().search_whole_word,
-                self.active_window().search_use_regex,
-                confirm_each,
-                &theme,
-                &keybindings_cloned,
-                search_options_hover,
-            );
-            self.active_chrome_mut().search_options_layout = Some(search_options_layout);
-        } else {
-            self.active_chrome_mut().search_options_layout = None;
-        }
-
-        // Render prompt line if active. Overlay prompts (Live Grep)
-        // skip the bottom-row render entirely — they paint their own
-        // input row inside the centred overlay frame, so the user's
-        // editor view stays unobstructed at the bottom.
-        if let Some(prompt) = &prompt {
-            if !prompt.overlay {
-                // Use specialized renderer for file/folder open prompt to show colorized path
-                if matches!(
-                    prompt.prompt_type,
-                    crate::view::prompt::PromptType::OpenFile
-                        | crate::view::prompt::PromptType::SwitchProject
-                ) {
-                    if let Some(file_open_state) = &self.active_window_mut().file_open_state {
-                        StatusBarRenderer::render_file_open_prompt(
-                            frame,
-                            main_chunks[prompt_line_idx],
-                            prompt,
-                            file_open_state,
-                            &theme,
-                        );
-                    } else {
-                        StatusBarRenderer::render_prompt(
-                            frame,
-                            main_chunks[prompt_line_idx],
-                            prompt,
-                            &theme,
-                        );
-                    }
-                } else {
-                    StatusBarRenderer::render_prompt(
-                        frame,
-                        main_chunks[prompt_line_idx],
-                        prompt,
-                        &theme,
-                    );
-                }
-            }
-        }
+        // Prompt input line (non-overlay prompts only).
+        self.render_prompt_line(frame, main_chunks[prompt_line_idx], &prompt, &theme);
 
         // Float-overlay preview: load the selected match's file (if
         // the file changed) and seed the phantom leaf's cursor before
@@ -1310,6 +1241,96 @@ impl Editor {
             top_is_trust_modal,
             &theme_clone,
         );
+    }
+
+    /// Render the search-options bar into `area` when `show_search_options`
+    /// is set (a search-style prompt is active), or clear its cached layout
+    /// otherwise.
+    fn render_search_options_bar(
+        &mut self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+        show_search_options: bool,
+        theme: &crate::view::theme::Theme,
+        keybindings: &crate::input::keybindings::KeybindingResolver,
+    ) {
+        if show_search_options {
+            // Show "Confirm" option only in replace modes
+            let confirm_each = self.active_window().prompt.as_ref().and_then(|p| {
+                if matches!(
+                    p.prompt_type,
+                    PromptType::ReplaceSearch
+                        | PromptType::Replace { .. }
+                        | PromptType::QueryReplaceSearch
+                        | PromptType::QueryReplace { .. }
+                ) {
+                    Some(self.active_window().search_confirm_each)
+                } else {
+                    None
+                }
+            });
+
+            // Determine hover state for search options
+            use crate::view::ui::status_bar::SearchOptionsHover;
+            let search_options_hover = match &self.active_window().mouse_state.hover_target {
+                Some(HoverTarget::SearchOptionCaseSensitive) => SearchOptionsHover::CaseSensitive,
+                Some(HoverTarget::SearchOptionWholeWord) => SearchOptionsHover::WholeWord,
+                Some(HoverTarget::SearchOptionRegex) => SearchOptionsHover::Regex,
+                Some(HoverTarget::SearchOptionConfirmEach) => SearchOptionsHover::ConfirmEach,
+                _ => SearchOptionsHover::None,
+            };
+
+            let search_options_layout = StatusBarRenderer::render_search_options(
+                frame,
+                area,
+                self.active_window().search_case_sensitive,
+                self.active_window().search_whole_word,
+                self.active_window().search_use_regex,
+                confirm_each,
+                theme,
+                keybindings,
+                search_options_hover,
+            );
+            self.active_chrome_mut().search_options_layout = Some(search_options_layout);
+        } else {
+            self.active_chrome_mut().search_options_layout = None;
+        }
+    }
+
+    /// Render the bottom prompt input line into `area`. Overlay prompts (e.g.
+    /// Live Grep) paint their own input row inside their centred frame and so
+    /// skip this; file/folder open prompts use a path-colorising renderer.
+    fn render_prompt_line(
+        &mut self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+        prompt: &Option<crate::view::prompt::Prompt>,
+        theme: &crate::view::theme::Theme,
+    ) {
+        if let Some(prompt) = prompt {
+            if !prompt.overlay {
+                // Use specialized renderer for file/folder open prompt to show colorized path
+                if matches!(
+                    prompt.prompt_type,
+                    crate::view::prompt::PromptType::OpenFile
+                        | crate::view::prompt::PromptType::SwitchProject
+                ) {
+                    if let Some(file_open_state) = &self.active_window().file_open_state {
+                        StatusBarRenderer::render_file_open_prompt(
+                            frame,
+                            area,
+                            prompt,
+                            file_open_state,
+                            theme,
+                        );
+                    } else {
+                        StatusBarRenderer::render_prompt(frame, area, prompt, theme);
+                    }
+                } else {
+                    StatusBarRenderer::render_prompt(frame, area, prompt, theme);
+                }
+            }
+        }
     }
 
     /// Recompute the on-screen areas of the active buffer's cursor-anchored

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -574,7 +574,7 @@ impl Editor {
             .buffers
             .with_all_mut(|__buffers_mut, __mgr, __vs_map| {
                 SplitRenderer::render_content(
-                    frame,
+                    frame.buffer_mut(),
                     editor_content_area,
                     &*__mgr,
                     __buffers_mut,
@@ -2474,7 +2474,7 @@ impl Editor {
             .buffers
             .with_all_mut(|preview_buffers, mgr, view_states| {
                 let result = crate::view::ui::SplitRenderer::render_content(
-                    frame,
+                    frame.buffer_mut(),
                     inner,
                     &*mgr,
                     preview_buffers,
@@ -3565,7 +3565,7 @@ impl Editor {
                     let folds_ref = &mut buf_state.folds;
                     let event_log = event_logs.get_mut(&buffer_id);
                     let _ = crate::view::ui::SplitRenderer::render_phantom_leaf(
-                        frame,
+                        frame.buffer_mut(),
                         state,
                         &cursors,
                         viewport_ref,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1543,8 +1543,7 @@ impl Editor {
                 close_button_hovered,
                 remote_connection.as_deref(),
                 cut_paths,
-                &self.config.file_explorer.tree_indicator_collapsed,
-                &self.config.file_explorer.tree_indicator_expanded,
+                &self.config.file_explorer,
                 Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
                 fe_draw,
             );

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1198,6 +1198,131 @@ impl Editor {
         let theme_clone = self.theme.read().unwrap().clone();
         let hover_target = self.active_window_mut().mouse_state.hover_target.clone();
 
+        // Cursor-anchored buffer popups (completion, hover, signature help):
+        // recompute their areas for hit-testing and paint them.
+        self.render_buffer_popups(frame, chrome_area, &theme_clone, &hover_target);
+
+        // Render editor-level popups (e.g. plugin action popups) on top of any
+        // buffer content so they stay visible across buffer switches and over
+        // virtual buffers (Dashboard, diagnostics) that own the whole split.
+        // These don't need cursor-relative positioning — they all use absolute
+        // positions like BottomRight or Centered.
+        //
+        // Queue semantics: concurrent action popups stack in `global_popups`,
+        // but only the top one renders & receives input. Deeper popups
+        // surface as the top is resolved — the alternative (drawing all at
+        // the same BottomRight slot) makes them illegible.
+        self.active_chrome_mut().global_popup_areas.clear();
+        // The workspace-trust prompt is a blocking modal: it renders later in
+        // the dedicated modal z-band (alongside settings / wizard) on a dimmed
+        // backdrop, so it can't be lost amongst dashboard/explorer chrome.
+        // Everything else on the global stack renders here, above buffer content.
+        let top_is_trust_modal = self.global_popups.top().is_some_and(|p| {
+            matches!(
+                p.resolver,
+                crate::view::popup::PopupResolver::WorkspaceTrust
+            )
+        });
+        if !top_is_trust_modal {
+            // Global popups render within the chrome area (right of a
+            // left dock) so corner/centred popups don't overrun it.
+            let draw_global_popup = !self.suppress_chrome_cells;
+            self.render_top_global_popup(
+                frame,
+                chrome_area,
+                &theme_clone,
+                hover_target.as_ref(),
+                draw_global_popup,
+            );
+        }
+
+        // Render menu bar last so dropdown appears on top of all other content
+        // Update menu context with current editor state
+        self.update_menu_context();
+
+        // Settings / calibration-wizard / keybinding-editor / event-debug
+        // modals, dimming the chrome behind each. Rendered before the menu
+        // bar so open menus overlay them.
+        self.render_modal_overlays(frame, chrome_area);
+
+        // The workspace-trust prompt is a blocking, top-most security modal.
+        // It dims the *entire* frame (the dock included) and centres in the
+        // full window, so it is rendered at the very end of this method —
+        // after the dock and floating panels — rather than here, where the
+        // dock's later pass would overpaint its left edge. See the bottom of
+        // `render`.
+
+        // Menu bar, drawn last so its dropdowns sit above all other content.
+        self.render_menu_bar(frame, menu_bar_area);
+
+        // Tab / file-explorer / new-tab context menus (TUI cell drawing only).
+        self.render_context_menus(frame);
+
+        // Chrome theme-key provenance (status bar, menu, tabs, file explorer,
+        // scrollbars) is now recorded during each region's own paint.
+
+        // Render tab drag drop zone overlay if dragging a tab
+        let drag_state_clone = self.active_window().mouse_state.dragging_tab.clone();
+        if let Some(ref drag_state) = drag_state_clone {
+            if drag_state.is_dragging() {
+                self.render_tab_drop_zone(frame, drag_state);
+            }
+        }
+
+        // Software mouse cursor (GPM) and keyboard-capture dimming — both
+        // read already-painted cells, so they run after the main draw.
+        self.render_software_cursor_and_capture(frame, size);
+
+        // Commit the active-split hardware cursor (deferred since
+        // `render_content`) unless a popup has been drawn over that cell.
+        // Ratatui draws the hardware caret on top of every cell, so a
+        // popup cannot hide the cursor by painting cells — the only way
+        // to hide it is to leave `Frame::cursor_position` as `None`, which
+        // triggers `Terminal::hide_cursor` at the end of the draw.
+        //
+        // When a prompt is active the prompt renderer already placed the
+        // caret on the prompt line via `frame.set_cursor_position`; don't
+        // override it with the (now-irrelevant) buffer cursor.
+        if let Some((cx, cy)) = pending_hardware_cursor {
+            if self.active_window().prompt.is_none() && !self.cursor_obscured_by_overlay(cx, cy) {
+                frame.set_cursor_position((cx, cy));
+            }
+        }
+
+        // Convert all colors for terminal capability (256/16 color fallback)
+        crate::view::color_support::convert_buffer_colors(
+            frame.buffer_mut(),
+            self.color_capability,
+        );
+
+        // Frame-buffer animations run last so they mutate the final paint.
+        self.active_window_mut()
+            .animations
+            .apply_all(frame.buffer_mut());
+
+        // Dock, floating panel, theme-info popup, and the workspace-trust
+        // modal — the topmost layers, drawn above prompts/popups/animations.
+        self.render_panels_and_modals(
+            frame,
+            size,
+            chrome_area,
+            dock_area,
+            top_is_trust_modal,
+            &theme_clone,
+        );
+    }
+
+    /// Recompute the on-screen areas of the active buffer's cursor-anchored
+    /// popups (completion / hover / signature help), cache them for mouse
+    /// hit-testing, and paint them. `theme_clone` and `hover_target` are
+    /// passed in because `render` reuses them for the global-popup pass.
+    fn render_buffer_popups(
+        &mut self,
+        frame: &mut Frame,
+        chrome_area: ratatui::layout::Rect,
+        theme_clone: &crate::view::theme::Theme,
+        hover_target: &Option<HoverTarget>,
+    ) {
         // Clear popup areas and recalculate
         self.active_chrome_mut().popup_areas.clear();
 
@@ -1369,124 +1494,10 @@ impl Editor {
         if draw_popups && state.popups.is_visible() {
             for (popup_idx, popup) in state.popups.all().iter().enumerate() {
                 if let Some((_, popup_area, _, _, _, _, _)) = popup_info.get(popup_idx) {
-                    popup.render_with_hover(
-                        frame,
-                        *popup_area,
-                        &theme_clone,
-                        hover_target.as_ref(),
-                    );
+                    popup.render_with_hover(frame, *popup_area, theme_clone, hover_target.as_ref());
                 }
             }
         }
-
-        // Render editor-level popups (e.g. plugin action popups) on top of any
-        // buffer content so they stay visible across buffer switches and over
-        // virtual buffers (Dashboard, diagnostics) that own the whole split.
-        // These don't need cursor-relative positioning — they all use absolute
-        // positions like BottomRight or Centered.
-        //
-        // Queue semantics: concurrent action popups stack in `global_popups`,
-        // but only the top one renders & receives input. Deeper popups
-        // surface as the top is resolved — the alternative (drawing all at
-        // the same BottomRight slot) makes them illegible.
-        self.active_chrome_mut().global_popup_areas.clear();
-        // The workspace-trust prompt is a blocking modal: it renders later in
-        // the dedicated modal z-band (alongside settings / wizard) on a dimmed
-        // backdrop, so it can't be lost amongst dashboard/explorer chrome.
-        // Everything else on the global stack renders here, above buffer content.
-        let top_is_trust_modal = self.global_popups.top().is_some_and(|p| {
-            matches!(
-                p.resolver,
-                crate::view::popup::PopupResolver::WorkspaceTrust
-            )
-        });
-        if !top_is_trust_modal {
-            // Global popups render within the chrome area (right of a
-            // left dock) so corner/centred popups don't overrun it.
-            let draw_global_popup = !self.suppress_chrome_cells;
-            self.render_top_global_popup(
-                frame,
-                chrome_area,
-                &theme_clone,
-                hover_target.as_ref(),
-                draw_global_popup,
-            );
-        }
-
-        // Render menu bar last so dropdown appears on top of all other content
-        // Update menu context with current editor state
-        self.update_menu_context();
-
-        // Settings / calibration-wizard / keybinding-editor / event-debug
-        // modals, dimming the chrome behind each. Rendered before the menu
-        // bar so open menus overlay them.
-        self.render_modal_overlays(frame, chrome_area);
-
-        // The workspace-trust prompt is a blocking, top-most security modal.
-        // It dims the *entire* frame (the dock included) and centres in the
-        // full window, so it is rendered at the very end of this method —
-        // after the dock and floating panels — rather than here, where the
-        // dock's later pass would overpaint its left edge. See the bottom of
-        // `render`.
-
-        // Menu bar, drawn last so its dropdowns sit above all other content.
-        self.render_menu_bar(frame, menu_bar_area);
-
-        // Tab / file-explorer / new-tab context menus (TUI cell drawing only).
-        self.render_context_menus(frame);
-
-        // Chrome theme-key provenance (status bar, menu, tabs, file explorer,
-        // scrollbars) is now recorded during each region's own paint.
-
-        // Render tab drag drop zone overlay if dragging a tab
-        let drag_state_clone = self.active_window().mouse_state.dragging_tab.clone();
-        if let Some(ref drag_state) = drag_state_clone {
-            if drag_state.is_dragging() {
-                self.render_tab_drop_zone(frame, drag_state);
-            }
-        }
-
-        // Software mouse cursor (GPM) and keyboard-capture dimming — both
-        // read already-painted cells, so they run after the main draw.
-        self.render_software_cursor_and_capture(frame, size);
-
-        // Commit the active-split hardware cursor (deferred since
-        // `render_content`) unless a popup has been drawn over that cell.
-        // Ratatui draws the hardware caret on top of every cell, so a
-        // popup cannot hide the cursor by painting cells — the only way
-        // to hide it is to leave `Frame::cursor_position` as `None`, which
-        // triggers `Terminal::hide_cursor` at the end of the draw.
-        //
-        // When a prompt is active the prompt renderer already placed the
-        // caret on the prompt line via `frame.set_cursor_position`; don't
-        // override it with the (now-irrelevant) buffer cursor.
-        if let Some((cx, cy)) = pending_hardware_cursor {
-            if self.active_window().prompt.is_none() && !self.cursor_obscured_by_overlay(cx, cy) {
-                frame.set_cursor_position((cx, cy));
-            }
-        }
-
-        // Convert all colors for terminal capability (256/16 color fallback)
-        crate::view::color_support::convert_buffer_colors(
-            frame.buffer_mut(),
-            self.color_capability,
-        );
-
-        // Frame-buffer animations run last so they mutate the final paint.
-        self.active_window_mut()
-            .animations
-            .apply_all(frame.buffer_mut());
-
-        // Dock, floating panel, theme-info popup, and the workspace-trust
-        // modal — the topmost layers, drawn above prompts/popups/animations.
-        self.render_panels_and_modals(
-            frame,
-            size,
-            chrome_area,
-            dock_area,
-            top_is_trust_modal,
-            &theme_clone,
-        );
     }
 
     /// Draw the software mouse cursor (GPM, which can't paint its own caret on

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -193,9 +193,14 @@ impl Editor {
         let search_options_idx = 3;
         let prompt_line_idx = 4;
 
-        // Split the main content area for the file explorer (when shown) and
-        // paint it; the remaining region is the editor content area.
-        let editor_content_area = self.render_file_explorer_pane(frame, main_content_area);
+        // Split the main content area into the explorer sidebar (when shown)
+        // and the editor content area beside it. Painting the explorer is a
+        // separate, composable step that draws only into the returned rect.
+        let (editor_content_area, file_explorer_area) =
+            self.split_file_explorer_area(main_content_area);
+        if let Some(file_explorer_area) = file_explorer_area {
+            self.render_file_explorer(frame, file_explorer_area);
+        }
 
         // Note: Tabs are now rendered within each split by SplitRenderer
 
@@ -1407,142 +1412,146 @@ impl Editor {
         self.active_chrome_mut().workspace_trust_dialog = trust_layout;
     }
 
-    /// Lay out and paint the file-explorer sidebar within `main_content_area`
-    /// (when it should be shown), returning the editor content area that
-    /// remains. When the explorer is hidden the whole region is the editor's
-    /// and the cached explorer rect is cleared. The split is also kept while a
-    /// sync is in progress, to avoid a one-frame flicker.
-    fn render_file_explorer_pane(
+    /// Split `main_content_area` into the editor content area and the
+    /// file-explorer sidebar rect, updating the cached explorer rect for hit
+    /// testing. Returns `(editor_content_area, explorer_rect)`, where
+    /// `explorer_rect` is `None` when the explorer is hidden (the whole region
+    /// is the editor's). The split is kept while a sync is in progress, to
+    /// avoid a one-frame flicker. This decides layout only — painting the
+    /// sidebar is [`render_file_explorer`], which draws into the returned rect.
+    fn split_file_explorer_area(
         &mut self,
-        frame: &mut Frame,
         main_content_area: ratatui::layout::Rect,
-    ) -> ratatui::layout::Rect {
-        let editor_content_area;
+    ) -> (ratatui::layout::Rect, Option<ratatui::layout::Rect>) {
         let file_explorer_should_show = self.file_explorer_visible()
             && (self.file_explorer().is_some()
                 || self.active_window().file_explorer_sync_in_progress);
 
-        if file_explorer_should_show {
-            // Split horizontally based on side placement
-            tracing::trace!(
-                "render: file explorer layout active (present={}, sync_in_progress={}, side={:?})",
-                self.file_explorer().is_some(),
-                self.active_window().file_explorer_sync_in_progress,
-                self.active_window().file_explorer_side
-            );
-            let explorer_cols = self
-                .active_window()
-                .file_explorer_width
-                .to_cols(main_content_area.width);
+        if !file_explorer_should_show {
+            // No file explorer: use entire main content area for editor
+            self.active_layout_mut().file_explorer_area = None;
+            return (main_content_area, None);
+        }
 
-            let (explorer_area, editor_area) = match self.active_window().file_explorer_side {
-                FileExplorerSide::Left => {
-                    let chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
-                        .split(main_content_area);
-                    (chunks[0], chunks[1])
-                }
-                FileExplorerSide::Right => {
-                    let chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Min(0), Constraint::Length(explorer_cols)])
-                        .split(main_content_area);
-                    (chunks[1], chunks[0])
-                }
-            };
+        // Split horizontally based on side placement
+        tracing::trace!(
+            "render: file explorer layout active (present={}, sync_in_progress={}, side={:?})",
+            self.file_explorer().is_some(),
+            self.active_window().file_explorer_sync_in_progress,
+            self.active_window().file_explorer_side
+        );
+        let explorer_cols = self
+            .active_window()
+            .file_explorer_width
+            .to_cols(main_content_area.width);
 
-            self.active_layout_mut().file_explorer_area = Some(explorer_area);
-            editor_content_area = editor_area;
+        let (explorer_area, editor_area) = match self.active_window().file_explorer_side {
+            FileExplorerSide::Left => {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
+                    .split(main_content_area);
+                (chunks[0], chunks[1])
+            }
+            FileExplorerSide::Right => {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Min(0), Constraint::Length(explorer_cols)])
+                    .split(main_content_area);
+                (chunks[1], chunks[0])
+            }
+        };
 
-            // Get connection string before mutable borrow of file_explorer.
-            let remote_connection = self.connection_display_string();
+        self.active_layout_mut().file_explorer_area = Some(explorer_area);
+        (editor_area, Some(explorer_area))
+    }
 
-            // Render file explorer (only if we have it - during sync we just keep the area reserved).
-            // Uses direct `self.windows.get_mut(...)` (not `file_explorer_mut()`) so the body
-            // can keep reading other Editor fields (buffers, theme, keybindings, …) — Rust
-            // splits the borrow on `self.windows` from the borrows on those other fields.
-            let active_id = self.active_window;
-            // Read window-state inputs before taking the &mut borrow on the
-            // window for the explorer/buffer access below.
-            // The explorer reads as focused only when it actually owns the
-            // keyboard — not when a focused orchestrator dock has stolen it
-            // out from under the (still-FileExplorer) window context. Without
-            // this guard the explorer keeps its accent border while the dock
-            // is driving, making it ambiguous which panel is focused.
-            let is_focused = self.active_window().key_context == KeyContext::FileExplorer
-                && !self.dock.as_ref().is_some_and(|d| d.focused);
-            let key_context_clone = self.active_window().key_context.clone();
-            let close_button_hovered = matches!(
-                &self.active_window().mouse_state.hover_target,
-                Some(HoverTarget::FileExplorerCloseButton)
-            );
-            let slot_resolver = self.file_explorer_slot_resolver();
-            // Theme-key runs the explorer records as it paints; applied to the
-            // chrome cell map after the window borrow is released.
-            let mut fe_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
-            // Web renders the sidebar natively from `file_explorer_view`; skip
-            // its cell drawing (layout/viewport still applied).
-            let fe_draw = !self.suppress_chrome_cells;
-            // Take one &mut on the active window; the explorer + buffers
-            // come from disjoint sub-fields so they can coexist.
-            let __win = self
-                .windows
-                .get_mut(&active_id)
-                .expect("active window must exist");
-            let __buffers_ref: &crate::app::window::WindowBuffers = &__win.buffers;
-            if let Some(explorer) = __win.file_explorer.as_mut() {
-                // Build set of files with unsaved changes
-                let mut files_with_unsaved_changes = std::collections::HashSet::new();
-                for (buffer_id, state) in __buffers_ref {
-                    if state.buffer.is_modified() {
-                        if let Some(metadata) = __win.buffer_metadata.get(buffer_id) {
-                            if let Some(file_path) = metadata.file_path() {
-                                files_with_unsaved_changes.insert(file_path.clone());
-                            }
+    /// Paint the file-explorer sidebar into `area`. Composable: it draws only
+    /// into the given rect and makes no layout decisions. A no-op when the
+    /// explorer isn't materialised (mid-sync the rect stays reserved but
+    /// blank).
+    fn render_file_explorer(&mut self, frame: &mut Frame, area: ratatui::layout::Rect) {
+        // Get connection string before mutable borrow of file_explorer.
+        let remote_connection = self.connection_display_string();
+
+        // Render file explorer (only if we have it - during sync we just keep the area reserved).
+        // Uses direct `self.windows.get_mut(...)` (not `file_explorer_mut()`) so the body
+        // can keep reading other Editor fields (buffers, theme, keybindings, …) — Rust
+        // splits the borrow on `self.windows` from the borrows on those other fields.
+        let active_id = self.active_window;
+        // Read window-state inputs before taking the &mut borrow on the
+        // window for the explorer/buffer access below.
+        // The explorer reads as focused only when it actually owns the
+        // keyboard — not when a focused orchestrator dock has stolen it
+        // out from under the (still-FileExplorer) window context. Without
+        // this guard the explorer keeps its accent border while the dock
+        // is driving, making it ambiguous which panel is focused.
+        let is_focused = self.active_window().key_context == KeyContext::FileExplorer
+            && !self.dock.as_ref().is_some_and(|d| d.focused);
+        let key_context_clone = self.active_window().key_context.clone();
+        let close_button_hovered = matches!(
+            &self.active_window().mouse_state.hover_target,
+            Some(HoverTarget::FileExplorerCloseButton)
+        );
+        let slot_resolver = self.file_explorer_slot_resolver();
+        // Theme-key runs the explorer records as it paints; applied to the
+        // chrome cell map after the window borrow is released.
+        let mut fe_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+        // Web renders the sidebar natively from `file_explorer_view`; skip
+        // its cell drawing (layout/viewport still applied).
+        let fe_draw = !self.suppress_chrome_cells;
+        // Take one &mut on the active window; the explorer + buffers
+        // come from disjoint sub-fields so they can coexist.
+        let __win = self
+            .windows
+            .get_mut(&active_id)
+            .expect("active window must exist");
+        let __buffers_ref: &crate::app::window::WindowBuffers = &__win.buffers;
+        if let Some(explorer) = __win.file_explorer.as_mut() {
+            // Build set of files with unsaved changes
+            let mut files_with_unsaved_changes = std::collections::HashSet::new();
+            for (buffer_id, state) in __buffers_ref {
+                if state.buffer.is_modified() {
+                    if let Some(metadata) = __win.buffer_metadata.get(buffer_id) {
+                        if let Some(file_path) = metadata.file_path() {
+                            files_with_unsaved_changes.insert(file_path.clone());
                         }
                     }
                 }
-
-                let keybindings = self.keybindings.read().unwrap();
-                let empty: Vec<std::path::PathBuf> = Vec::new();
-                let cut_paths = __win
-                    .file_explorer_clipboard
-                    .as_ref()
-                    .filter(|cb| cb.is_cut)
-                    .map(|cb| cb.paths.as_slice())
-                    .unwrap_or(empty.as_slice());
-                FileExplorerRenderer::render(
-                    explorer,
-                    frame,
-                    explorer_area,
-                    slot_resolver,
-                    is_focused,
-                    &files_with_unsaved_changes,
-                    &__win.file_explorer_decoration_cache,
-                    &__win.file_explorer_slot_override_cache,
-                    &keybindings,
-                    key_context_clone,
-                    &*self.theme.read().unwrap(),
-                    close_button_hovered,
-                    remote_connection.as_deref(),
-                    cut_paths,
-                    &self.config.file_explorer.tree_indicator_collapsed,
-                    &self.config.file_explorer.tree_indicator_expanded,
-                    Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
-                    fe_draw,
-                );
             }
-            // Note: if file_explorer is None but sync_in_progress is true,
-            // we just leave the area blank (or could render a placeholder)
-            self.active_chrome_mut().apply_theme_runs(&fe_runs);
-        } else {
-            // No file explorer: use entire main content area for editor
-            self.active_layout_mut().file_explorer_area = None;
-            editor_content_area = main_content_area;
-        }
 
-        editor_content_area
+            let keybindings = self.keybindings.read().unwrap();
+            let empty: Vec<std::path::PathBuf> = Vec::new();
+            let cut_paths = __win
+                .file_explorer_clipboard
+                .as_ref()
+                .filter(|cb| cb.is_cut)
+                .map(|cb| cb.paths.as_slice())
+                .unwrap_or(empty.as_slice());
+            FileExplorerRenderer::render(
+                explorer,
+                frame,
+                area,
+                slot_resolver,
+                is_focused,
+                &files_with_unsaved_changes,
+                &__win.file_explorer_decoration_cache,
+                &__win.file_explorer_slot_override_cache,
+                &keybindings,
+                key_context_clone,
+                &*self.theme.read().unwrap(),
+                close_button_hovered,
+                remote_connection.as_deref(),
+                cut_paths,
+                &self.config.file_explorer.tree_indicator_collapsed,
+                &self.config.file_explorer.tree_indicator_expanded,
+                Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
+                fe_draw,
+            );
+        }
+        // Note: if file_explorer is None but sync_in_progress is true,
+        // we just leave the area blank (or could render a placeholder)
+        self.active_chrome_mut().apply_theme_runs(&fe_runs);
     }
 
     /// Render the status bar into `area`, unless it's toggled off or a

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -538,6 +538,10 @@ impl Editor {
             self.background_fade,
             self.software_cursor_only,
         );
+        // `cfg` is captured by the render closure; the theme read-guard and the
+        // `RenderStyle` wrapping it are built *inside* the closure so the
+        // `self.theme` borrow is released before the post-render `&mut self`
+        // chrome updates.
         // Take a single mutable borrow on the active window's splits and
         // split it into (&SplitManager, &mut HashMap<...>) — Rust can
         // destructure the tuple, but we can't make two separate
@@ -573,6 +577,14 @@ impl Editor {
         ) = __win
             .buffers
             .with_all_mut(|__buffers_mut, __mgr, __vs_map| {
+                // Built here so the `self.theme` read-guard lives only for the
+                // render call, not the later `&mut self` chrome updates.
+                let theme_guard = self.theme.read().unwrap();
+                let style = crate::view::ui::RenderStyle {
+                    theme: &theme_guard,
+                    ansi_background: self.ansi_background.as_ref(),
+                    cfg,
+                };
                 SplitRenderer::render_content(
                     frame.buffer_mut(),
                     editor_content_area,
@@ -583,9 +595,7 @@ impl Editor {
                     __event_logs_mut,
                     __composite_buffers_mut,
                     __composite_view_states_mut,
-                    &*self.theme.read().unwrap(),
-                    self.ansi_background.as_ref(),
-                    &cfg,
+                    style,
                     lsp_waiting,
                     Some(__vs_map),
                     __grouped_ref,
@@ -2437,6 +2447,13 @@ impl Editor {
                 self.software_cursor_only,
             )
         };
+        // Group the appearance inputs for the preview pass. `theme` is the
+        // caller-supplied borrow; built before the `&mut self.windows` borrow.
+        let preview_style = crate::view::ui::RenderStyle {
+            theme,
+            ansi_background: self.ansi_background.as_ref(),
+            cfg: preview_cfg,
+        };
         let Some(__win_for_preview) = self.windows.get_mut(&sid) else {
             return;
         };
@@ -2483,9 +2500,7 @@ impl Editor {
                     __preview_event_logs,
                     __preview_composite_buffers,
                     __preview_composite_view_states,
-                    theme,
-                    self.ansi_background.as_ref(),
-                    &preview_cfg,
+                    preview_style,
                     lsp_waiting,
                     Some(view_states),
                     __preview_grouped_subtrees,
@@ -3504,27 +3519,24 @@ impl Editor {
             {
                 self.render_session_preview_into_rect(frame, inner, &theme);
             } else if inner.height > 0 && inner.width > 0 {
-                // Snapshot scalar config values up front so the
-                // mutable-borrow split below has minimal scope.
-                // AnsiBackground isn't Clone, so it's taken as a
-                // borrow; Rust permits disjoint-field splitting
-                // between `&self.ansi_background` and the `&mut`
-                // accesses below because they touch distinct fields.
-                let bg_fade = self.background_fade;
-                let estimated_line_length = self.config.editor.estimated_line_length;
-                let highlight_context_bytes = self.config.editor.highlight_context_bytes;
-                let relative_line_numbers = self.config.editor.relative_line_numbers;
-                let use_terminal_bg = self.config.editor.use_terminal_bg;
+                // Snapshot the per-split scalars and group the appearance
+                // inputs into one `RenderStyle`, all before the `&mut
+                // self.windows` borrow below — they touch only
+                // `self.config`/`self.theme`/`self.ansi_background`, which Rust
+                // splits from `self.windows` as distinct fields.
                 let session_mode = self.session_mode || !self.software_cursor_only;
-                let software_cursor_only = self.software_cursor_only;
-                let diagnostics_inline_text = self.config.editor.diagnostics_inline_text;
                 let show_tilde = false; // preview hides tilde markers
                 let highlight_current_column = self.config.editor.highlight_current_column;
-                let indentation_guide = self.config.editor.indentation_guide;
-                let indentation_guide_glyph = self.config.editor.indentation_guide_glyph.clone();
                 let screen_width = frame.area().width;
-
-                let ansi_ref = self.ansi_background.as_ref();
+                let style = crate::view::ui::RenderStyle {
+                    theme: &theme,
+                    ansi_background: self.ansi_background.as_ref(),
+                    cfg: crate::view::ui::EditorRenderConfig::new(
+                        &self.config.editor,
+                        self.background_fade,
+                        self.software_cursor_only,
+                    ),
+                };
                 let __win = self
                     .windows
                     .get_mut(&self.active_window)
@@ -3572,28 +3584,18 @@ impl Editor {
                         folds_ref,
                         event_log,
                         inner,
-                        &theme,
-                        ansi_ref,
-                        bg_fade,
+                        style,
                         view_mode,
                         compose_width,
                         compose_column_guides,
                         view_transform,
-                        estimated_line_length,
-                        highlight_context_bytes,
                         buffer_id,
-                        relative_line_numbers,
-                        use_terminal_bg,
                         session_mode,
-                        software_cursor_only,
                         &rulers,
                         show_line_numbers,
                         highlight_current_line,
-                        diagnostics_inline_text,
                         show_tilde,
                         highlight_current_column,
-                        indentation_guide,
-                        &indentation_guide_glyph,
                         cell_theme_map,
                         screen_width,
                     );

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1544,7 +1544,7 @@ impl Editor {
                 remote_connection.as_deref(),
                 cut_paths,
                 &self.config.file_explorer,
-                Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
+                &mut crate::app::types::CellThemeRecorder::new(&mut fe_runs),
                 fe_draw,
             );
         }

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1730,13 +1730,11 @@ impl Editor {
             self.active_chrome_mut().apply_theme_runs(&status_bar_runs);
 
             // Store status bar layout for click detection
-            let status_bar_area = area;
-            self.active_chrome_mut().status_bar_area =
-                Some((status_bar_area.y, status_bar_area.x, status_bar_area.width));
-            self.active_chrome_mut().status_bar_clickable = status_bar_layout.clickable;
-            self.active_chrome_mut().status_bar_plugin_token_areas =
-                status_bar_layout.plugin_token_areas;
-            self.active_chrome_mut().status_bar_segments = status_bar_layout.segments;
+            let status_bar = &mut self.active_chrome_mut().status_bar;
+            status_bar.area = Some((area.y, area.x, area.width));
+            status_bar.clickable = status_bar_layout.clickable;
+            status_bar.plugin_token_areas = status_bar_layout.plugin_token_areas;
+            status_bar.segments = status_bar_layout.segments;
         }
     }
 

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1417,85 +1417,10 @@ impl Editor {
         // Update menu context with current editor state
         self.update_menu_context();
 
-        // Render settings modal (before menu bar so menus can overlay)
-        // Check visibility first to avoid borrow conflict with dimming
-        // The web renders Settings natively from `settings_view`; paint cells
-        // only for the TUI.
-        let draw_settings = !self.suppress_chrome_cells;
-        let settings_visible = draw_settings
-            && self
-                .settings_state
-                .as_ref()
-                .map(|s| s.visible)
-                .unwrap_or(false);
-        if settings_visible {
-            // Dim the editor content behind the settings modal. Use the
-            // chrome area (right of a left dock) so the modal sits beside
-            // the persistent dock instead of being overlapped by it.
-            crate::view::dimming::apply_dimming(frame, chrome_area);
-        }
-        if let Some(ref mut settings_state) = self.settings_state {
-            if !draw_settings {
-                // keyboard-driven native render; skip cells (and the focus-state
-                // update tied to the cell layout pass).
-            } else if settings_state.visible {
-                settings_state.update_focus_states();
-                let settings_layout = crate::view::settings::render_settings(
-                    frame,
-                    chrome_area,
-                    settings_state,
-                    &*self.theme.read().unwrap(),
-                );
-                self.active_chrome_mut().settings_layout = Some(settings_layout);
-            }
-        }
-
-        // Render calibration wizard if active. (Deprecated; the web has no native
-        // projection for it, so suppress its cells there rather than bleed.)
-        if !self.suppress_chrome_cells {
-            if let Some(ref wizard) = self.calibration_wizard {
-                // Dim the editor content behind the wizard modal
-                crate::view::dimming::apply_dimming(frame, chrome_area);
-                crate::view::calibration_wizard::render_calibration_wizard(
-                    frame,
-                    chrome_area,
-                    wizard,
-                    &*self.theme.read().unwrap(),
-                );
-            }
-        }
-
-        // Event-debug: the web renders it natively from `aux_modals_view`; paint
-        // cells only for the TUI.
-        let draw_aux = !self.suppress_chrome_cells;
-
-        // Keybinding editor: web renders it natively from `keybinding_editor_view`;
-        // paint cells only for the TUI.
-        if draw_aux {
-            if let Some(ref mut kb_editor) = self.keybinding_editor {
-                crate::view::dimming::apply_dimming(frame, chrome_area);
-                crate::view::keybinding_editor::render_keybinding_editor(
-                    frame,
-                    chrome_area,
-                    kb_editor,
-                    &*self.theme.read().unwrap(),
-                );
-            }
-        }
-
-        // Render event debug dialog if active
-        if draw_aux {
-            if let Some(ref debug) = self.active_window().event_debug {
-                // Dim the editor content behind the dialog modal
-                crate::view::dimming::apply_dimming(frame, chrome_area);
-                crate::view::event_debug::render_event_debug(
-                    frame,
-                    chrome_area,
-                    debug,
-                    &*self.theme.read().unwrap(),
-                );
-            }
-        }
+        // Settings / calibration-wizard / keybinding-editor / event-debug
+        // modals, dimming the chrome behind each. Rendered before the menu
+        // bar so open menus overlay them.
+        self.render_modal_overlays(frame, chrome_area);
 
         // The workspace-trust prompt is a blocking, top-most security modal.
         // It dims the *entire* frame (the dock included) and centres in the
@@ -1504,64 +1429,11 @@ impl Editor {
         // dock's later pass would overpaint its left edge. See the bottom of
         // `render`.
 
-        if self.active_window_mut().menu_bar_visible {
-            // Pre-expand DynamicSubmenu items once per registry; without this
-            // MenuRenderer::render rescans + reparses every theme JSON file
-            // on every frame.
-            self.expanded_menus_cache.update(
-                &self.theme_registry,
-                &self.menus,
-                &self.menu_state.themes_dir,
-            );
-            let hover_target = self.active_window().mouse_state.hover_target.clone();
-            let menu_bar_mnemonics = self.config.editor.menu_bar_mnemonics;
-            let draw_chrome = !self.suppress_chrome_cells;
-            // The single content source shared with the web `menu_view()`
-            // projection (uses the cache populated just above).
-            let all_menus = self.all_menus_expanded();
-            let keybindings = self.keybindings.read().unwrap();
-            let mut menu_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
-            let new_menu_layout = crate::view::ui::MenuRenderer::render(
-                frame,
-                menu_bar_area,
-                &all_menus,
-                &self.menu_state,
-                &keybindings,
-                &*self.theme.read().unwrap(),
-                hover_target.as_ref(),
-                menu_bar_mnemonics,
-                Some(&mut crate::app::types::CellThemeRecorder::new(
-                    &mut menu_runs,
-                )),
-                draw_chrome,
-            );
-            drop(keybindings);
-            self.active_chrome_mut().menu_layout = Some(new_menu_layout);
-            self.active_chrome_mut().apply_theme_runs(&menu_runs);
-        } else {
-            self.active_chrome_mut().menu_layout = None;
-        }
+        // Menu bar, drawn last so its dropdowns sit above all other content.
+        self.render_menu_bar(frame, menu_bar_area);
 
-        // Context menus: the web renders these natively from `context_menu_view`
-        // (no cell drawing); the TUI draws them as before.
-        if !self.suppress_chrome_cells {
-            // Render tab context menu if open
-            let tab_ctx_menu = self.active_window().tab_context_menu.clone();
-            if let Some(menu) = tab_ctx_menu {
-                self.render_tab_context_menu(frame, &menu);
-            }
-
-            let fe_ctx_menu = self.active_window().file_explorer_context_menu.clone();
-            if let Some(menu) = fe_ctx_menu {
-                self.render_file_explorer_context_menu(frame, &menu);
-            }
-
-            // Render the "+" new-tab popup menu if open
-            let new_tab_menu = self.active_window().new_tab_menu.clone();
-            if let Some(menu) = new_tab_menu {
-                self.render_new_tab_menu(frame, &menu);
-            }
-        }
+        // Tab / file-explorer / new-tab context menus (TUI cell drawing only).
+        self.render_context_menus(frame);
 
         // Chrome theme-key provenance (status bar, menu, tabs, file explorer,
         // scrollbars) is now recorded during each region's own paint.
@@ -1767,6 +1639,158 @@ impl Editor {
             None
         };
         self.active_chrome_mut().workspace_trust_dialog = trust_layout;
+    }
+
+    /// Render the modal overlays that dim the chrome behind them: settings,
+    /// calibration wizard, keybinding editor, and event-debug dialog. Each is
+    /// drawn only for the TUI (`!suppress_chrome_cells`); the web projects
+    /// them natively. Rendered before the menu bar so open menus overlay them.
+    fn render_modal_overlays(&mut self, frame: &mut Frame, chrome_area: ratatui::layout::Rect) {
+        // Render settings modal (before menu bar so menus can overlay)
+        // Check visibility first to avoid borrow conflict with dimming
+        // The web renders Settings natively from `settings_view`; paint cells
+        // only for the TUI.
+        let draw_settings = !self.suppress_chrome_cells;
+        let settings_visible = draw_settings
+            && self
+                .settings_state
+                .as_ref()
+                .map(|s| s.visible)
+                .unwrap_or(false);
+        if settings_visible {
+            // Dim the editor content behind the settings modal. Use the
+            // chrome area (right of a left dock) so the modal sits beside
+            // the persistent dock instead of being overlapped by it.
+            crate::view::dimming::apply_dimming(frame, chrome_area);
+        }
+        if let Some(ref mut settings_state) = self.settings_state {
+            if !draw_settings {
+                // keyboard-driven native render; skip cells (and the focus-state
+                // update tied to the cell layout pass).
+            } else if settings_state.visible {
+                settings_state.update_focus_states();
+                let settings_layout = crate::view::settings::render_settings(
+                    frame,
+                    chrome_area,
+                    settings_state,
+                    &*self.theme.read().unwrap(),
+                );
+                self.active_chrome_mut().settings_layout = Some(settings_layout);
+            }
+        }
+
+        // Render calibration wizard if active. (Deprecated; the web has no native
+        // projection for it, so suppress its cells there rather than bleed.)
+        if !self.suppress_chrome_cells {
+            if let Some(ref wizard) = self.calibration_wizard {
+                // Dim the editor content behind the wizard modal
+                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::calibration_wizard::render_calibration_wizard(
+                    frame,
+                    chrome_area,
+                    wizard,
+                    &*self.theme.read().unwrap(),
+                );
+            }
+        }
+
+        // Event-debug: the web renders it natively from `aux_modals_view`; paint
+        // cells only for the TUI.
+        let draw_aux = !self.suppress_chrome_cells;
+
+        // Keybinding editor: web renders it natively from `keybinding_editor_view`;
+        // paint cells only for the TUI.
+        if draw_aux {
+            if let Some(ref mut kb_editor) = self.keybinding_editor {
+                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::keybinding_editor::render_keybinding_editor(
+                    frame,
+                    chrome_area,
+                    kb_editor,
+                    &*self.theme.read().unwrap(),
+                );
+            }
+        }
+
+        // Render event debug dialog if active
+        if draw_aux {
+            if let Some(ref debug) = self.active_window().event_debug {
+                // Dim the editor content behind the dialog modal
+                crate::view::dimming::apply_dimming(frame, chrome_area);
+                crate::view::event_debug::render_event_debug(
+                    frame,
+                    chrome_area,
+                    debug,
+                    &*self.theme.read().unwrap(),
+                );
+            }
+        }
+    }
+
+    /// Render the menu bar into `menu_bar_area`, or clear the cached layout
+    /// when the bar is hidden. Drawn late in `render` so its dropdowns sit
+    /// above all other content.
+    fn render_menu_bar(&mut self, frame: &mut Frame, menu_bar_area: ratatui::layout::Rect) {
+        if self.active_window().menu_bar_visible {
+            // Pre-expand DynamicSubmenu items once per registry; without this
+            // MenuRenderer::render rescans + reparses every theme JSON file
+            // on every frame.
+            self.expanded_menus_cache.update(
+                &self.theme_registry,
+                &self.menus,
+                &self.menu_state.themes_dir,
+            );
+            let hover_target = self.active_window().mouse_state.hover_target.clone();
+            let menu_bar_mnemonics = self.config.editor.menu_bar_mnemonics;
+            let draw_chrome = !self.suppress_chrome_cells;
+            // The single content source shared with the web `menu_view()`
+            // projection (uses the cache populated just above).
+            let all_menus = self.all_menus_expanded();
+            let keybindings = self.keybindings.read().unwrap();
+            let mut menu_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+            let new_menu_layout = crate::view::ui::MenuRenderer::render(
+                frame,
+                menu_bar_area,
+                &all_menus,
+                &self.menu_state,
+                &keybindings,
+                &*self.theme.read().unwrap(),
+                hover_target.as_ref(),
+                menu_bar_mnemonics,
+                Some(&mut crate::app::types::CellThemeRecorder::new(
+                    &mut menu_runs,
+                )),
+                draw_chrome,
+            );
+            drop(keybindings);
+            self.active_chrome_mut().menu_layout = Some(new_menu_layout);
+            self.active_chrome_mut().apply_theme_runs(&menu_runs);
+        } else {
+            self.active_chrome_mut().menu_layout = None;
+        }
+    }
+
+    /// Render the tab, file-explorer, and new-tab context menus. TUI-only
+    /// cell drawing; the web projects these natively from `context_menu_view`.
+    fn render_context_menus(&mut self, frame: &mut Frame) {
+        if !self.suppress_chrome_cells {
+            // Render tab context menu if open
+            let tab_ctx_menu = self.active_window().tab_context_menu.clone();
+            if let Some(menu) = tab_ctx_menu {
+                self.render_tab_context_menu(frame, &menu);
+            }
+
+            let fe_ctx_menu = self.active_window().file_explorer_context_menu.clone();
+            if let Some(menu) = fe_ctx_menu {
+                self.render_file_explorer_context_menu(frame, &menu);
+            }
+
+            // Render the "+" new-tab popup menu if open
+            let new_tab_menu = self.active_window().new_tab_menu.clone();
+            if let Some(menu) = new_tab_menu {
+                self.render_new_tab_menu(frame, &menu);
+            }
+        }
     }
 
     /// Drain plugin commands enqueued before this frame's layout pass.

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -648,6 +648,14 @@ impl Editor {
         // Web renders the tab bar natively from `tab_bar_view`; skip painting it
         // to cells (its TabLayout is still computed). Panes always draw.
         let split_draw_tab_bar = !self.suppress_chrome_cells;
+        // Bundle the immutable editor render settings. Built before the
+        // `&mut self.windows` borrow below; it only borrows `self.config`,
+        // so the two coexist.
+        let cfg = crate::view::ui::EditorRenderConfig::new(
+            &self.config.editor,
+            self.background_fade,
+            self.software_cursor_only,
+        );
         // Take a single mutable borrow on the active window's splits and
         // split it into (&SplitManager, &mut HashMap<...>) — Rust can
         // destructure the tuple, but we can't make two separate
@@ -695,12 +703,8 @@ impl Editor {
                     __composite_view_states_mut,
                     &*self.theme.read().unwrap(),
                     self.ansi_background.as_ref(),
-                    self.background_fade,
+                    &cfg,
                     lsp_waiting,
-                    self.config.editor.large_file_threshold_bytes,
-                    self.config.editor.line_wrap,
-                    self.config.editor.estimated_line_length,
-                    self.config.editor.highlight_context_bytes,
                     Some(__vs_map),
                     __grouped_ref,
                     hide_cursor,
@@ -708,20 +712,9 @@ impl Editor {
                     hovered_close_split,
                     hovered_maximize_split,
                     is_maximized,
-                    self.config.editor.relative_line_numbers,
                     __tab_bar_visible,
-                    self.config.editor.use_terminal_bg,
                     self.session_mode || !self.software_cursor_only,
-                    self.software_cursor_only,
-                    self.config.editor.show_vertical_scrollbar,
-                    self.config.editor.show_horizontal_scrollbar,
                     __terminal_mode,
-                    self.config.editor.diagnostics_inline_text,
-                    self.config.editor.show_tilde,
-                    self.config.editor.highlight_current_column,
-                    self.config.editor.indentation_guide,
-                    &self.config.editor.indentation_guide_glyph,
-                    self.config.editor.hide_current_line_on_selection,
                     __cell_theme_map_mut,
                     size.width,
                     &mut pending_hardware_cursor,
@@ -2282,6 +2275,21 @@ impl Editor {
         // than panic; the next plugin refresh re-emits the spec
         // without the dead embed.
         let preview_draw_tab_bar = !self.suppress_chrome_cells;
+        // Same immutable render settings as the live editor, but with
+        // scrollbars and tildes suppressed — they're noisy in a small
+        // preview rect where the active session's chrome is authoritative.
+        // Built before the `&mut self.windows` borrow (it only borrows
+        // `self.config`).
+        let preview_cfg = crate::view::ui::EditorRenderConfig {
+            show_vertical_scrollbar: false,
+            show_horizontal_scrollbar: false,
+            show_tilde: false,
+            ..crate::view::ui::EditorRenderConfig::new(
+                &self.config.editor,
+                self.background_fade,
+                self.software_cursor_only,
+            )
+        };
         let Some(__win_for_preview) = self.windows.get_mut(&sid) else {
             return;
         };
@@ -2330,12 +2338,8 @@ impl Editor {
                     __preview_composite_view_states,
                     theme,
                     self.ansi_background.as_ref(),
-                    self.background_fade,
+                    &preview_cfg,
                     lsp_waiting,
-                    self.config.editor.large_file_threshold_bytes,
-                    self.config.editor.line_wrap,
-                    self.config.editor.estimated_line_length,
-                    self.config.editor.highlight_context_bytes,
                     Some(view_states),
                     __preview_grouped_subtrees,
                     true, // hide_cursor — the active session owns the hardware caret
@@ -2343,22 +2347,9 @@ impl Editor {
                     None,
                     None,
                     false, // not maximized
-                    self.config.editor.relative_line_numbers,
                     preview_tab_bar_visible,
-                    self.config.editor.use_terminal_bg,
                     self.session_mode || !self.software_cursor_only,
-                    self.software_cursor_only,
-                    // Scrollbars are noisy in a small preview rect; the
-                    // active session's chrome is the source of truth.
-                    false,
-                    false,
                     false, // terminal_mode — scrollbars are off in the preview anyway
-                    self.config.editor.diagnostics_inline_text,
-                    false, // hide tilde markers in the preview
-                    self.config.editor.highlight_current_column,
-                    self.config.editor.indentation_guide,
-                    &self.config.editor.indentation_guide_glyph,
-                    self.config.editor.hide_current_line_on_selection,
                     &mut scratch_cell_theme_map,
                     inner.width,
                     &mut scratch_pending_cursor,

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -1446,48 +1446,9 @@ impl Editor {
             }
         }
 
-        // Render software mouse cursor when GPM is active
-        // GPM can't draw its cursor on the alternate screen buffer used by TUI apps,
-        // so we draw our own cursor at the tracked mouse position.
-        // This must happen LAST in the render flow so we can read the already-rendered
-        // cell content and invert it.
-        if self.active_window_mut().gpm_active {
-            if let Some((col, row)) = self.active_window_mut().mouse_cursor_position {
-                use ratatui::style::Modifier;
-
-                // Only render if within screen bounds
-                if col < size.width && row < size.height {
-                    // Get the cell at this position and add REVERSED modifier to invert colors
-                    let buf = frame.buffer_mut();
-                    if let Some(cell) = buf.cell_mut((col, row)) {
-                        cell.set_style(cell.style().add_modifier(Modifier::REVERSED));
-                    }
-                }
-            }
-        }
-
-        // When keyboard capture mode is active, dim all UI elements outside the terminal
-        // to visually indicate that focus is exclusively on the terminal
-        if self.active_window_mut().keyboard_capture && self.active_window().terminal_mode {
-            // Find the active split's content area
-            let active_split = self
-                .windows
-                .get(&self.active_window)
-                .and_then(|w| w.buffers.splits())
-                .map(|(mgr, _)| mgr)
-                .expect("active window must have a populated split layout")
-                .active_split();
-            let active_split_area = self
-                .active_layout()
-                .split_areas
-                .iter()
-                .find(|(split_id, _, _, _, _, _)| *split_id == active_split)
-                .map(|(_, _, content_rect, _, _, _)| *content_rect);
-
-            if let Some(terminal_area) = active_split_area {
-                self.apply_keyboard_capture_dimming(frame, terminal_area);
-            }
-        }
+        // Software mouse cursor (GPM) and keyboard-capture dimming — both
+        // read already-painted cells, so they run after the main draw.
+        self.render_software_cursor_and_capture(frame, size);
 
         // Commit the active-split hardware cursor (deferred since
         // `render_content`) unless a popup has been drawn over that cell.
@@ -1516,6 +1477,82 @@ impl Editor {
             .animations
             .apply_all(frame.buffer_mut());
 
+        // Dock, floating panel, theme-info popup, and the workspace-trust
+        // modal — the topmost layers, drawn above prompts/popups/animations.
+        self.render_panels_and_modals(
+            frame,
+            size,
+            chrome_area,
+            dock_area,
+            top_is_trust_modal,
+            &theme_clone,
+        );
+    }
+
+    /// Draw the software mouse cursor (GPM, which can't paint its own caret on
+    /// the alt-screen) and the keyboard-capture dimming. Both read cells that
+    /// the main draw already painted, so they run near the end of `render`.
+    fn render_software_cursor_and_capture(
+        &mut self,
+        frame: &mut Frame,
+        size: ratatui::layout::Rect,
+    ) {
+        // Render software mouse cursor when GPM is active
+        // GPM can't draw its cursor on the alternate screen buffer used by TUI apps,
+        // so we draw our own cursor at the tracked mouse position.
+        // This must happen LAST in the render flow so we can read the already-rendered
+        // cell content and invert it.
+        if self.active_window().gpm_active {
+            if let Some((col, row)) = self.active_window().mouse_cursor_position {
+                use ratatui::style::Modifier;
+
+                // Only render if within screen bounds
+                if col < size.width && row < size.height {
+                    // Get the cell at this position and add REVERSED modifier to invert colors
+                    let buf = frame.buffer_mut();
+                    if let Some(cell) = buf.cell_mut((col, row)) {
+                        cell.set_style(cell.style().add_modifier(Modifier::REVERSED));
+                    }
+                }
+            }
+        }
+
+        // When keyboard capture mode is active, dim all UI elements outside the terminal
+        // to visually indicate that focus is exclusively on the terminal
+        if self.active_window().keyboard_capture && self.active_window().terminal_mode {
+            // Find the active split's content area
+            let active_split = self
+                .windows
+                .get(&self.active_window)
+                .and_then(|w| w.buffers.splits())
+                .map(|(mgr, _)| mgr)
+                .expect("active window must have a populated split layout")
+                .active_split();
+            let active_split_area = self
+                .active_layout()
+                .split_areas
+                .iter()
+                .find(|(split_id, _, _, _, _, _)| *split_id == active_split)
+                .map(|(_, _, content_rect, _, _, _)| *content_rect);
+
+            if let Some(terminal_area) = active_split_area {
+                self.apply_keyboard_capture_dimming(frame, terminal_area);
+            }
+        }
+    }
+
+    /// Render the topmost layers: the dock and floating widget panel (each in
+    /// its own slot), the theme-info popup, and the blocking workspace-trust
+    /// modal. Drawn after every other layer so they sit on top.
+    fn render_panels_and_modals(
+        &mut self,
+        frame: &mut Frame,
+        size: ratatui::layout::Rect,
+        chrome_area: ratatui::layout::Rect,
+        dock_area: Option<ratatui::layout::Rect>,
+        top_is_trust_modal: bool,
+        theme_clone: &crate::view::theme::Theme,
+    ) {
         // Panels are drawn last so they sit above every other layer
         // (prompts, popups, animations). The two slots are independent:
         // the dock paints into its carved column (`dock_area`); a
@@ -1631,7 +1668,7 @@ impl Editor {
                     &triggers,
                     &secondary_label,
                     self.workspace_trust_scroll,
-                    &theme_clone,
+                    theme_clone,
                     draw_trust,
                 ),
             )

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -81,8 +81,8 @@ impl Editor {
         self.active_window_mut().animations.capture_before_all();
 
         // Save frame dimensions for recompute_layout (used by macro replay)
-        self.active_chrome_mut().last_frame_width = size.width;
-        self.active_chrome_mut().last_frame_height = size.height;
+        self.active_chrome_mut().last_frame.width = size.width;
+        self.active_chrome_mut().last_frame.height = size.height;
 
         // Reset per-cell theme key map for this frame
         self.active_chrome_mut().reset_cell_theme_map();
@@ -4390,7 +4390,7 @@ impl Editor {
             return;
         }
 
-        let dock_sw = self.active_chrome().last_frame_width;
+        let dock_sw = self.active_chrome().last_frame.width;
         let max_rows = inner.height as usize;
         for (i, entry) in entries.iter().take(max_rows).enumerate() {
             let recorder = is_dock.then(|| {
@@ -4566,7 +4566,7 @@ impl Editor {
         // borders).
         let panel_bg = theme.popup_bg;
         let panel_bg_style = ratatui::style::Style::default().bg(panel_bg);
-        let overlay_sw = self.active_chrome().last_frame_width;
+        let overlay_sw = self.active_chrome().last_frame.width;
         for o in &overlays {
             let row_y = inner.y.saturating_add(o.buffer_row as u16);
             if row_y >= inner.y.saturating_add(inner.height) {

--- a/crates/fresh-editor/src/app/render.rs
+++ b/crates/fresh-editor/src/app/render.rs
@@ -193,132 +193,9 @@ impl Editor {
         let search_options_idx = 3;
         let prompt_line_idx = 4;
 
-        // Split main content area based on file explorer visibility
-        // Also keep the layout split if a sync is in progress (to avoid flicker)
-        let editor_content_area;
-        let file_explorer_should_show = self.file_explorer_visible()
-            && (self.file_explorer().is_some()
-                || self.active_window().file_explorer_sync_in_progress);
-
-        if file_explorer_should_show {
-            // Split horizontally based on side placement
-            tracing::trace!(
-                "render: file explorer layout active (present={}, sync_in_progress={}, side={:?})",
-                self.file_explorer().is_some(),
-                self.active_window().file_explorer_sync_in_progress,
-                self.active_window().file_explorer_side
-            );
-            let explorer_cols = self
-                .active_window()
-                .file_explorer_width
-                .to_cols(main_content_area.width);
-
-            let (explorer_area, editor_area) = match self.active_window().file_explorer_side {
-                FileExplorerSide::Left => {
-                    let chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
-                        .split(main_content_area);
-                    (chunks[0], chunks[1])
-                }
-                FileExplorerSide::Right => {
-                    let chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .constraints([Constraint::Min(0), Constraint::Length(explorer_cols)])
-                        .split(main_content_area);
-                    (chunks[1], chunks[0])
-                }
-            };
-
-            self.active_layout_mut().file_explorer_area = Some(explorer_area);
-            editor_content_area = editor_area;
-
-            // Get connection string before mutable borrow of file_explorer.
-            let remote_connection = self.connection_display_string();
-
-            // Render file explorer (only if we have it - during sync we just keep the area reserved).
-            // Uses direct `self.windows.get_mut(...)` (not `file_explorer_mut()`) so the body
-            // can keep reading other Editor fields (buffers, theme, keybindings, …) — Rust
-            // splits the borrow on `self.windows` from the borrows on those other fields.
-            let active_id = self.active_window;
-            // Read window-state inputs before taking the &mut borrow on the
-            // window for the explorer/buffer access below.
-            // The explorer reads as focused only when it actually owns the
-            // keyboard — not when a focused orchestrator dock has stolen it
-            // out from under the (still-FileExplorer) window context. Without
-            // this guard the explorer keeps its accent border while the dock
-            // is driving, making it ambiguous which panel is focused.
-            let is_focused = self.active_window().key_context == KeyContext::FileExplorer
-                && !self.dock.as_ref().is_some_and(|d| d.focused);
-            let key_context_clone = self.active_window().key_context.clone();
-            let close_button_hovered = matches!(
-                &self.active_window().mouse_state.hover_target,
-                Some(HoverTarget::FileExplorerCloseButton)
-            );
-            let slot_resolver = self.file_explorer_slot_resolver();
-            // Theme-key runs the explorer records as it paints; applied to the
-            // chrome cell map after the window borrow is released.
-            let mut fe_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
-            // Web renders the sidebar natively from `file_explorer_view`; skip
-            // its cell drawing (layout/viewport still applied).
-            let fe_draw = !self.suppress_chrome_cells;
-            // Take one &mut on the active window; the explorer + buffers
-            // come from disjoint sub-fields so they can coexist.
-            let __win = self
-                .windows
-                .get_mut(&active_id)
-                .expect("active window must exist");
-            let __buffers_ref: &crate::app::window::WindowBuffers = &__win.buffers;
-            if let Some(explorer) = __win.file_explorer.as_mut() {
-                // Build set of files with unsaved changes
-                let mut files_with_unsaved_changes = std::collections::HashSet::new();
-                for (buffer_id, state) in __buffers_ref {
-                    if state.buffer.is_modified() {
-                        if let Some(metadata) = __win.buffer_metadata.get(buffer_id) {
-                            if let Some(file_path) = metadata.file_path() {
-                                files_with_unsaved_changes.insert(file_path.clone());
-                            }
-                        }
-                    }
-                }
-
-                let keybindings = self.keybindings.read().unwrap();
-                let empty: Vec<std::path::PathBuf> = Vec::new();
-                let cut_paths = __win
-                    .file_explorer_clipboard
-                    .as_ref()
-                    .filter(|cb| cb.is_cut)
-                    .map(|cb| cb.paths.as_slice())
-                    .unwrap_or(empty.as_slice());
-                FileExplorerRenderer::render(
-                    explorer,
-                    frame,
-                    explorer_area,
-                    slot_resolver,
-                    is_focused,
-                    &files_with_unsaved_changes,
-                    &__win.file_explorer_decoration_cache,
-                    &__win.file_explorer_slot_override_cache,
-                    &keybindings,
-                    key_context_clone,
-                    &*self.theme.read().unwrap(),
-                    close_button_hovered,
-                    remote_connection.as_deref(),
-                    cut_paths,
-                    &self.config.file_explorer.tree_indicator_collapsed,
-                    &self.config.file_explorer.tree_indicator_expanded,
-                    Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
-                    fe_draw,
-                );
-            }
-            // Note: if file_explorer is None but sync_in_progress is true,
-            // we just leave the area blank (or could render a placeholder)
-            self.active_chrome_mut().apply_theme_runs(&fe_runs);
-        } else {
-            // No file explorer: use entire main content area for editor
-            self.active_layout_mut().file_explorer_area = None;
-            editor_content_area = main_content_area;
-        }
+        // Split the main content area for the file explorer (when shown) and
+        // paint it; the remaining region is the editor content area.
+        let editor_content_area = self.render_file_explorer_pane(frame, main_content_area);
 
         // Note: Tabs are now rendered within each split by SplitRenderer
 
@@ -1528,6 +1405,144 @@ impl Editor {
             None
         };
         self.active_chrome_mut().workspace_trust_dialog = trust_layout;
+    }
+
+    /// Lay out and paint the file-explorer sidebar within `main_content_area`
+    /// (when it should be shown), returning the editor content area that
+    /// remains. When the explorer is hidden the whole region is the editor's
+    /// and the cached explorer rect is cleared. The split is also kept while a
+    /// sync is in progress, to avoid a one-frame flicker.
+    fn render_file_explorer_pane(
+        &mut self,
+        frame: &mut Frame,
+        main_content_area: ratatui::layout::Rect,
+    ) -> ratatui::layout::Rect {
+        let editor_content_area;
+        let file_explorer_should_show = self.file_explorer_visible()
+            && (self.file_explorer().is_some()
+                || self.active_window().file_explorer_sync_in_progress);
+
+        if file_explorer_should_show {
+            // Split horizontally based on side placement
+            tracing::trace!(
+                "render: file explorer layout active (present={}, sync_in_progress={}, side={:?})",
+                self.file_explorer().is_some(),
+                self.active_window().file_explorer_sync_in_progress,
+                self.active_window().file_explorer_side
+            );
+            let explorer_cols = self
+                .active_window()
+                .file_explorer_width
+                .to_cols(main_content_area.width);
+
+            let (explorer_area, editor_area) = match self.active_window().file_explorer_side {
+                FileExplorerSide::Left => {
+                    let chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Length(explorer_cols), Constraint::Min(0)])
+                        .split(main_content_area);
+                    (chunks[0], chunks[1])
+                }
+                FileExplorerSide::Right => {
+                    let chunks = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Min(0), Constraint::Length(explorer_cols)])
+                        .split(main_content_area);
+                    (chunks[1], chunks[0])
+                }
+            };
+
+            self.active_layout_mut().file_explorer_area = Some(explorer_area);
+            editor_content_area = editor_area;
+
+            // Get connection string before mutable borrow of file_explorer.
+            let remote_connection = self.connection_display_string();
+
+            // Render file explorer (only if we have it - during sync we just keep the area reserved).
+            // Uses direct `self.windows.get_mut(...)` (not `file_explorer_mut()`) so the body
+            // can keep reading other Editor fields (buffers, theme, keybindings, …) — Rust
+            // splits the borrow on `self.windows` from the borrows on those other fields.
+            let active_id = self.active_window;
+            // Read window-state inputs before taking the &mut borrow on the
+            // window for the explorer/buffer access below.
+            // The explorer reads as focused only when it actually owns the
+            // keyboard — not when a focused orchestrator dock has stolen it
+            // out from under the (still-FileExplorer) window context. Without
+            // this guard the explorer keeps its accent border while the dock
+            // is driving, making it ambiguous which panel is focused.
+            let is_focused = self.active_window().key_context == KeyContext::FileExplorer
+                && !self.dock.as_ref().is_some_and(|d| d.focused);
+            let key_context_clone = self.active_window().key_context.clone();
+            let close_button_hovered = matches!(
+                &self.active_window().mouse_state.hover_target,
+                Some(HoverTarget::FileExplorerCloseButton)
+            );
+            let slot_resolver = self.file_explorer_slot_resolver();
+            // Theme-key runs the explorer records as it paints; applied to the
+            // chrome cell map after the window borrow is released.
+            let mut fe_runs: Vec<crate::app::types::ThemeRun> = Vec::new();
+            // Web renders the sidebar natively from `file_explorer_view`; skip
+            // its cell drawing (layout/viewport still applied).
+            let fe_draw = !self.suppress_chrome_cells;
+            // Take one &mut on the active window; the explorer + buffers
+            // come from disjoint sub-fields so they can coexist.
+            let __win = self
+                .windows
+                .get_mut(&active_id)
+                .expect("active window must exist");
+            let __buffers_ref: &crate::app::window::WindowBuffers = &__win.buffers;
+            if let Some(explorer) = __win.file_explorer.as_mut() {
+                // Build set of files with unsaved changes
+                let mut files_with_unsaved_changes = std::collections::HashSet::new();
+                for (buffer_id, state) in __buffers_ref {
+                    if state.buffer.is_modified() {
+                        if let Some(metadata) = __win.buffer_metadata.get(buffer_id) {
+                            if let Some(file_path) = metadata.file_path() {
+                                files_with_unsaved_changes.insert(file_path.clone());
+                            }
+                        }
+                    }
+                }
+
+                let keybindings = self.keybindings.read().unwrap();
+                let empty: Vec<std::path::PathBuf> = Vec::new();
+                let cut_paths = __win
+                    .file_explorer_clipboard
+                    .as_ref()
+                    .filter(|cb| cb.is_cut)
+                    .map(|cb| cb.paths.as_slice())
+                    .unwrap_or(empty.as_slice());
+                FileExplorerRenderer::render(
+                    explorer,
+                    frame,
+                    explorer_area,
+                    slot_resolver,
+                    is_focused,
+                    &files_with_unsaved_changes,
+                    &__win.file_explorer_decoration_cache,
+                    &__win.file_explorer_slot_override_cache,
+                    &keybindings,
+                    key_context_clone,
+                    &*self.theme.read().unwrap(),
+                    close_button_hovered,
+                    remote_connection.as_deref(),
+                    cut_paths,
+                    &self.config.file_explorer.tree_indicator_collapsed,
+                    &self.config.file_explorer.tree_indicator_expanded,
+                    Some(&mut crate::app::types::CellThemeRecorder::new(&mut fe_runs)),
+                    fe_draw,
+                );
+            }
+            // Note: if file_explorer is None but sync_in_progress is true,
+            // we just leave the area blank (or could render a placeholder)
+            self.active_chrome_mut().apply_theme_runs(&fe_runs);
+        } else {
+            // No file explorer: use entire main content area for editor
+            self.active_layout_mut().file_explorer_area = None;
+            editor_content_area = main_content_area;
+        }
+
+        editor_content_area
     }
 
     /// Render the status bar into `area`, unless it's toggled off or a

--- a/crates/fresh-editor/src/app/theme_inspect.rs
+++ b/crates/fresh-editor/src/app/theme_inspect.rs
@@ -318,8 +318,8 @@ impl Editor {
         let height = line_count + 2; // +2 for borders
 
         // Use the same screen-aware positioning as render to match the actual drawn rect
-        let screen_w = self.active_chrome().last_frame_width;
-        let screen_h = self.active_chrome().last_frame_height;
+        let screen_w = self.active_chrome().last_frame.width;
+        let screen_h = self.active_chrome().last_frame.height;
         let rect = compute_popup_rect(popup.position, width, height, screen_w, screen_h);
 
         Some((rect, button_row_offset))

--- a/crates/fresh-editor/src/app/types/hover.rs
+++ b/crates/fresh-editor/src/app/types/hover.rs
@@ -50,7 +50,7 @@ pub enum HoverTarget {
     /// ending / language / warnings / messages / remote / trust / read-only).
     /// One generic variant carrying the segment's identity — the renderer
     /// styles it and `handle_click_status_bar` dispatches it via a single
-    /// hit-test over `ChromeLayout::status_bar_clickable`.
+    /// hit-test over `StatusBarChrome::clickable`.
     StatusBarClickable(crate::view::ui::status_bar::StatusBarClickable),
     /// Hovering over the search options "Case Sensitive" checkbox
     SearchOptionCaseSensitive,

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -124,31 +124,9 @@ pub(crate) struct ChromeLayout {
     pub settings_layout: Option<crate::view::settings::SettingsLayout>,
     /// Workspace-trust dialog click layout (radios + OK/Quit) for hit testing.
     pub workspace_trust_dialog: Option<crate::view::workspace_trust_dialog::TrustDialogLayout>,
-    /// Status bar area (row, x, width)
-    pub status_bar_area: Option<(u16, u16, u16)>,
-    /// Every clickable built-in status-bar segment drawn last frame, as
-    /// `(id, row, start_col, end_col)`. One generic list (mirroring
-    /// `StatusBarLayout::clickable`) walked by both the hover hit-test and
-    /// `handle_click_status_bar` — no per-indicator field. See
-    /// `StatusBarClickable`.
-    pub status_bar_clickable: Vec<(
-        crate::view::ui::status_bar::StatusBarClickable,
-        u16,
-        u16,
-        u16,
-    )>,
-    /// Plugin-registered status-bar token areas, keyed by
-    /// `"<plugin>:<token>"`. Populated by `render_status_bar`; consumed
-    /// by `handle_click_status_bar` which fires the
-    /// `status_bar_token_clicked` hook on a hit so the registering
-    /// plugin can react (typically by re-opening a deferred prompt).
-    /// See `docs/internal/trust-env-devcontainer-ux-plan.md` for the
-    /// design context.
-    pub status_bar_plugin_token_areas: std::collections::HashMap<String, (u16, u16, u16)>,
-    /// Semantic status-bar model (rendered elements + text + positions), captured
-    /// by the renderer so `status_view` derives the web status bar directly
-    /// instead of scraping the drawn cells.
-    pub status_bar_segments: Vec<crate::view::ui::status_bar::StatusSegmentInfo>,
+    /// Status-bar hit-test layout (area, clickable segments, plugin token
+    /// areas, semantic segment model). See [`StatusBarChrome`].
+    pub status_bar: StatusBarChrome,
     /// Search options layout for checkbox hit testing
     pub search_options_layout: Option<crate::view::ui::status_bar::SearchOptionsLayout>,
     /// Menu bar layout for hit testing
@@ -161,20 +139,54 @@ pub(crate) struct ChromeLayout {
     pub cell_theme_map: Vec<CellThemeInfo>,
 }
 
-impl ChromeLayout {
+/// Status-bar hit-test layout captured each frame by `render_status_bar`.
+/// Grouped so the four related fields travel together rather than as loose
+/// `status_bar_*` members of [`ChromeLayout`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct StatusBarChrome {
+    /// Status bar area (row, x, width)
+    pub area: Option<(u16, u16, u16)>,
+    /// Every clickable built-in status-bar segment drawn last frame, as
+    /// `(id, row, start_col, end_col)`. One generic list (mirroring
+    /// `StatusBarLayout::clickable`) walked by both the hover hit-test and
+    /// `handle_click_status_bar` — no per-indicator field. See
+    /// `StatusBarClickable`.
+    pub clickable: Vec<(
+        crate::view::ui::status_bar::StatusBarClickable,
+        u16,
+        u16,
+        u16,
+    )>,
+    /// Plugin-registered status-bar token areas, keyed by
+    /// `"<plugin>:<token>"`. Populated by `render_status_bar`; consumed
+    /// by `handle_click_status_bar` which fires the
+    /// `status_bar_token_clicked` hook on a hit so the registering
+    /// plugin can react (typically by re-opening a deferred prompt).
+    /// See `docs/internal/trust-env-devcontainer-ux-plan.md` for the
+    /// design context.
+    pub plugin_token_areas: std::collections::HashMap<String, (u16, u16, u16)>,
+    /// Semantic status-bar model (rendered elements + text + positions), captured
+    /// by the renderer so `status_view` derives the web status bar directly
+    /// instead of scraping the drawn cells.
+    pub segments: Vec<crate::view::ui::status_bar::StatusSegmentInfo>,
+}
+
+impl StatusBarChrome {
     /// Screen area `(row, start_col, end_col)` of a given clickable status-bar
     /// segment from the last frame, if it was drawn. Used to anchor popups to
     /// their indicator (e.g. the LSP / remote / read-only menus).
-    pub fn status_bar_clickable_area(
+    pub fn clickable_area(
         &self,
         id: crate::view::ui::status_bar::StatusBarClickable,
     ) -> Option<(u16, u16, u16)> {
-        self.status_bar_clickable
+        self.clickable
             .iter()
             .find(|(cid, _, _, _)| *cid == id)
             .map(|(_, row, start, end)| (*row, *start, *end))
     }
+}
 
+impl ChromeLayout {
     /// Reset the cell theme map for a new frame
     pub fn reset_cell_theme_map(&mut self) {
         let total = self.last_frame_width as usize * self.last_frame_height as usize;

--- a/crates/fresh-editor/src/app/types/layout.rs
+++ b/crates/fresh-editor/src/app/types/layout.rs
@@ -131,12 +131,21 @@ pub(crate) struct ChromeLayout {
     pub search_options_layout: Option<crate::view::ui::status_bar::SearchOptionsLayout>,
     /// Menu bar layout for hit testing
     pub menu_layout: Option<crate::view::ui::menu::MenuLayout>,
-    /// Last frame dimensions — used by recompute_layout for macro replay
-    pub last_frame_width: u16,
-    pub last_frame_height: u16,
+    /// Dimensions of the last rendered frame. See [`FrameDimensions`].
+    pub last_frame: FrameDimensions,
     /// Per-cell theme key provenance recorded during rendering.
-    /// Flat vec indexed as `row * width + col` where `width = last_frame_width`.
+    /// Flat vec indexed as `row * width + col` where `width = last_frame.width`.
     pub cell_theme_map: Vec<CellThemeInfo>,
+}
+
+/// Width and height of the most recently rendered frame. Used to size the
+/// cell-theme map and to clamp / replay layout against the latest frame
+/// extent (macro replay, dock/overlay sizing). Grouped so the pair travels
+/// together rather than as loose `last_frame_*` members of [`ChromeLayout`].
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FrameDimensions {
+    pub width: u16,
+    pub height: u16,
 }
 
 /// Status-bar hit-test layout captured each frame by `render_status_bar`.
@@ -189,14 +198,14 @@ impl StatusBarChrome {
 impl ChromeLayout {
     /// Reset the cell theme map for a new frame
     pub fn reset_cell_theme_map(&mut self) {
-        let total = self.last_frame_width as usize * self.last_frame_height as usize;
+        let total = self.last_frame.width as usize * self.last_frame.height as usize;
         self.cell_theme_map.clear();
         self.cell_theme_map.resize(total, CellThemeInfo::default());
     }
 
     /// Look up the theme info for a screen position
     pub fn cell_theme_at(&self, col: u16, row: u16) -> Option<&CellThemeInfo> {
-        let idx = row as usize * self.last_frame_width as usize + col as usize;
+        let idx = row as usize * self.last_frame.width as usize + col as usize;
         self.cell_theme_map.get(idx)
     }
 
@@ -204,7 +213,7 @@ impl ChromeLayout {
     /// per-cell map. The runs carry screen coordinates; cells outside the
     /// frame are skipped.
     pub fn apply_theme_runs(&mut self, runs: &[super::theme::ThemeRun]) {
-        let width = self.last_frame_width;
+        let width = self.last_frame.width;
         super::theme::apply_theme_runs(&mut self.cell_theme_map, width, runs);
     }
 }

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -368,14 +368,15 @@ impl Editor {
     /// derivation shared by both frontends.
     pub fn status_view(&self) -> Option<StatusView> {
         let chrome = self.active_chrome();
-        let (sy, sx, sw) = chrome.status_bar_area?;
+        let (sy, sx, sw) = chrome.status_bar.area?;
 
         // Read the status bar's semantic model captured by the renderer — no
         // cell scraping. Each rendered element (indicators + text) is a segment,
         // and `side` is the renderer's actual left/right tiling (carried on the
         // segment), not a midpoint guess from `x`.
         let segments: Vec<StatusSegment> = chrome
-            .status_bar_segments
+            .status_bar
+            .segments
             .iter()
             .filter(|s| !s.text.trim().is_empty())
             .map(|s| StatusSegment {

--- a/crates/fresh-editor/src/view/scene.rs
+++ b/crates/fresh-editor/src/view/scene.rs
@@ -832,7 +832,7 @@ impl Editor {
         let w = self.active_window();
         let chrome = self.active_chrome();
         if let Some(m) = &w.file_explorer_context_menu {
-            let (x, y) = m.clamped_position(chrome.last_frame_width, chrome.last_frame_height);
+            let (x, y) = m.clamped_position(chrome.last_frame.width, chrome.last_frame.height);
             return Some(ContextMenuView {
                 kind: "fileExplorer",
                 x,

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -17,6 +17,19 @@ use ratatui::{
 use std::collections::HashSet;
 use std::path::PathBuf;
 
+/// The plugin-driven decoration inputs for the file explorer: the slot
+/// resolver plus the decoration and slot-override caches. These three always
+/// travel together through the render pipeline, so they're bundled rather
+/// than threaded as three parallel parameters. `Copy` (the resolver is two
+/// `&dyn` pointers, the caches are shared refs), so it passes by value into
+/// the per-row closure without cloning.
+#[derive(Clone, Copy)]
+pub struct ExplorerDecorations<'a> {
+    pub slot_resolver: ExplorerSlotResolver<'a>,
+    pub decorations: &'a FileExplorerDecorationCache,
+    pub slot_overrides: &'a FileExplorerSlotOverrideCache,
+}
+
 pub struct FileExplorerRenderer;
 
 impl FileExplorerRenderer {
@@ -39,11 +52,9 @@ impl FileExplorerRenderer {
         view: &mut FileTreeView,
         frame: &mut Frame,
         area: Rect,
-        slot_resolver: ExplorerSlotResolver<'static>,
+        deco: ExplorerDecorations<'_>,
         is_focused: bool,
         files_with_unsaved_changes: &HashSet<PathBuf>,
-        decorations: &FileExplorerDecorationCache,
-        slot_overrides: &FileExplorerSlotOverrideCache,
         keybinding_resolver: &crate::input::keybindings::KeybindingResolver,
         current_context: crate::input::keybindings::KeyContext,
         theme: &Theme,
@@ -125,15 +136,13 @@ impl FileExplorerRenderer {
                 };
                 Self::render_node(
                     view,
-                    slot_resolver,
+                    deco,
                     node_id,
                     indent,
                     is_selected,
                     is_multi_selected,
                     is_focused,
                     files_with_unsaved_changes,
-                    decorations,
-                    slot_overrides,
                     theme,
                     content_width,
                     fuzzy_match.as_ref(),
@@ -288,15 +297,13 @@ impl FileExplorerRenderer {
     #[allow(clippy::too_many_arguments)]
     fn render_node(
         view: &FileTreeView,
-        slot_resolver: ExplorerSlotResolver<'static>,
+        deco: ExplorerDecorations<'_>,
         node_id: NodeId,
         indent: usize,
         is_selected: bool,
         is_multi_selected: bool,
         is_focused: bool,
         files_with_unsaved_changes: &HashSet<PathBuf>,
-        decorations: &FileExplorerDecorationCache,
-        slot_overrides: &FileExplorerSlotOverrideCache,
         theme: &Theme,
         content_width: usize,
         fuzzy_match: Option<&FuzzyMatch>,
@@ -306,15 +313,13 @@ impl FileExplorerRenderer {
     ) -> ListItem<'static> {
         let line = Self::build_node_line(
             view,
-            slot_resolver,
+            deco,
             node_id,
             indent,
             is_selected,
             is_multi_selected,
             is_focused,
             files_with_unsaved_changes,
-            decorations,
-            slot_overrides,
             theme,
             content_width,
             fuzzy_match,
@@ -333,15 +338,13 @@ impl FileExplorerRenderer {
     #[allow(clippy::too_many_arguments)]
     fn build_node_line(
         view: &FileTreeView,
-        slot_resolver: ExplorerSlotResolver<'static>,
+        deco: ExplorerDecorations<'_>,
         node_id: NodeId,
         indent: usize,
         is_selected: bool,
         is_multi_selected: bool,
         is_focused: bool,
         files_with_unsaved_changes: &HashSet<PathBuf>,
-        decorations: &FileExplorerDecorationCache,
-        slot_overrides: &FileExplorerSlotOverrideCache,
         theme: &Theme,
         content_width: usize,
         fuzzy_match: Option<&FuzzyMatch>,
@@ -402,12 +405,12 @@ impl FileExplorerRenderer {
                 .as_ref()
                 .map(|m| m.is_hidden)
                 .unwrap_or(false),
-            decorations,
-            slot_overrides,
+            decorations: deco.decorations,
+            slot_overrides: deco.slot_overrides,
             theme,
             neutral_fg,
         };
-        let slot_resolution = slot_resolver.resolve(&slot_context);
+        let slot_resolution = deco.slot_resolver.resolve(&slot_context);
         let leading_slot_width = slot_resolution
             .leading
             .as_ref()
@@ -669,17 +672,20 @@ mod tests {
         slot_overrides: &FileExplorerSlotOverrideCache,
         theme: &Theme,
     ) -> Line<'static> {
+        let deco = ExplorerDecorations {
+            slot_resolver: crate::view::file_tree::default_slot_providers().resolver(),
+            decorations,
+            slot_overrides,
+        };
         FileExplorerRenderer::build_node_line(
             view,
-            crate::view::file_tree::default_slot_providers().resolver(),
+            deco,
             node_id,
             indent,
             false,
             false,
             false,
             &HashSet::new(),
-            decorations,
-            slot_overrides,
             theme,
             80,
             None,

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -51,7 +51,11 @@ impl FileExplorerRenderer {
         remote_connection: Option<&str>,
         cut_paths: &[PathBuf],
         config: &crate::config::FileExplorerConfig,
-        mut rec: Option<&mut CellThemeRecorder>,
+        // The explorer is only ever painted by the TUI path, which always
+        // records theme-key provenance — so this isn't `Option` like the other
+        // chrome renderers (tabs/menu/status_bar), whose legacy/offscreen
+        // callers pass `None`.
+        rec: &mut CellThemeRecorder,
         // When false, compute layout (viewport height for scrolling) but draw no
         // cells — the frontend renders the sidebar natively from
         // `Editor::file_explorer_view`. The TUI always passes `true`.
@@ -73,17 +77,15 @@ impl FileExplorerRenderer {
 
         // Seed the whole explorer rect with its surface keys so border/content
         // rows resolve to the explorer; the selected row is refined below.
-        if let Some(r) = rec.as_deref_mut() {
-            for row in area.y..area.y + area.height {
-                r.run(
-                    area.x,
-                    row,
-                    area.width,
-                    Some("editor.fg"),
-                    Some("editor.bg"),
-                    "File Explorer",
-                );
-            }
+        for row in area.y..area.y + area.height {
+            rec.run(
+                area.x,
+                row,
+                area.width,
+                Some("editor.fg"),
+                Some("editor.bg"),
+                "File Explorer",
+            );
         }
 
         // Viewport height already applied above (before the `draw` early-out).
@@ -226,26 +228,24 @@ impl FileExplorerRenderer {
 
         // Refine the selected row with its highlight keys (focused → selection
         // background, blurred → current-line background).
-        if let Some(r) = rec {
-            if let Some(selected) = selected_index {
-                if selected >= scroll_offset && selected < scroll_offset + viewport_height {
-                    let row = area.y + 1 + (selected - scroll_offset) as u16;
-                    let inner_x = area.x + 1;
-                    let inner_w = area.width.saturating_sub(2);
-                    let bg_key = if is_focused {
-                        "editor.selection_bg"
-                    } else {
-                        "editor.current_line_bg"
-                    };
-                    r.run(
-                        inner_x,
-                        row,
-                        inner_w,
-                        Some("editor.fg"),
-                        Some(bg_key),
-                        "File Explorer",
-                    );
-                }
+        if let Some(selected) = selected_index {
+            if selected >= scroll_offset && selected < scroll_offset + viewport_height {
+                let row = area.y + 1 + (selected - scroll_offset) as u16;
+                let inner_x = area.x + 1;
+                let inner_w = area.width.saturating_sub(2);
+                let bg_key = if is_focused {
+                    "editor.selection_bg"
+                } else {
+                    "editor.current_line_bg"
+                };
+                rec.run(
+                    inner_x,
+                    row,
+                    inner_w,
+                    Some("editor.fg"),
+                    Some(bg_key),
+                    "File Explorer",
+                );
             }
         }
 

--- a/crates/fresh-editor/src/view/ui/file_explorer.rs
+++ b/crates/fresh-editor/src/view/ui/file_explorer.rs
@@ -50,8 +50,7 @@ impl FileExplorerRenderer {
         close_button_hovered: bool,
         remote_connection: Option<&str>,
         cut_paths: &[PathBuf],
-        tree_indicator_collapsed: &str,
-        tree_indicator_expanded: &str,
+        config: &crate::config::FileExplorerConfig,
         mut rec: Option<&mut CellThemeRecorder>,
         // When false, compute layout (viewport height for scrolling) but draw no
         // cells — the frontend renders the sidebar natively from
@@ -66,6 +65,11 @@ impl FileExplorerRenderer {
             return;
         }
         let search_active = view.is_search_active();
+        // The tree-indicator glyphs are the only config the inner renderers
+        // need; pull them out here and forward as `&str` so the helpers don't
+        // depend on the whole config struct.
+        let tree_indicator_collapsed = config.tree_indicator_collapsed.as_str();
+        let tree_indicator_expanded = config.tree_indicator_expanded.as_str();
 
         // Seed the whole explorer rect with its surface keys so border/content
         // rows resolve to the explorer; the selected row is refined below.

--- a/crates/fresh-editor/src/view/ui/mod.rs
+++ b/crates/fresh-editor/src/view/ui/mod.rs
@@ -52,7 +52,7 @@ pub use expanded_menus_cache::ExpandedMenusCache;
 #[cfg(feature = "runtime")]
 pub use file_browser::{FileBrowserLayout, FileBrowserRenderer};
 #[cfg(feature = "runtime")]
-pub use file_explorer::FileExplorerRenderer;
+pub use file_explorer::{ExplorerDecorations, FileExplorerRenderer};
 pub use focus::FocusManager;
 pub use layout::point_in_rect;
 #[cfg(feature = "runtime")]

--- a/crates/fresh-editor/src/view/ui/mod.rs
+++ b/crates/fresh-editor/src/view/ui/mod.rs
@@ -64,7 +64,7 @@ pub use scroll_panel::{
 };
 pub use scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
 #[cfg(feature = "runtime")]
-pub use split_rendering::{EditorRenderConfig, SplitRenderer};
+pub use split_rendering::{EditorRenderConfig, RenderStyle, SplitRenderer};
 #[cfg(feature = "runtime")]
 pub use status_bar::{truncate_path, StatusBarLayout, StatusBarRenderer, TruncatedPath};
 #[cfg(feature = "runtime")]

--- a/crates/fresh-editor/src/view/ui/mod.rs
+++ b/crates/fresh-editor/src/view/ui/mod.rs
@@ -64,7 +64,7 @@ pub use scroll_panel::{
 };
 pub use scrollbar::{render_scrollbar, ScrollbarColors, ScrollbarState};
 #[cfg(feature = "runtime")]
-pub use split_rendering::SplitRenderer;
+pub use split_rendering::{EditorRenderConfig, SplitRenderer};
 #[cfg(feature = "runtime")]
 pub use status_bar::{truncate_path, StatusBarLayout, StatusBarRenderer, TruncatedPath};
 #[cfg(feature = "runtime")]

--- a/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
@@ -14,8 +14,8 @@ use crate::view::theme::Theme;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::Span;
-use ratatui::widgets::Widget;
 use ratatui::widgets::Block;
+use ratatui::widgets::Widget;
 use std::collections::{BTreeMap, HashSet};
 
 /// Context for rendering the left margin (line numbers, indicators, separator).

--- a/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/gutter.rs
@@ -14,8 +14,8 @@ use crate::view::theme::Theme;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::Span;
+use ratatui::widgets::Widget;
 use ratatui::widgets::Block;
-use ratatui::Frame;
 use std::collections::{BTreeMap, HashSet};
 
 /// Context for rendering the left margin (line numbers, indicators, separator).
@@ -204,7 +204,7 @@ pub(super) fn render_left_margin(
 
 /// Paper-on-desk compose-mode margins flanking the content area.
 pub(super) fn render_compose_margins(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area: Rect,
     layout: &ComposeLayout,
     _view_mode: &ViewMode,
@@ -228,12 +228,12 @@ pub(super) fn render_compose_margins(
 
         if desk_width > 0 {
             let desk_rect = Rect::new(area.x, area.y, desk_width, area.height);
-            frame.render_widget(Block::default().style(desk_style), desk_rect);
+            Block::default().style(desk_style).render(desk_rect, buf);
         }
 
         if paper_edge > 0 {
             let paper_rect = Rect::new(area.x + desk_width, area.y, paper_edge, area.height);
-            frame.render_widget(Block::default().style(paper_style), paper_rect);
+            Block::default().style(paper_style).render(paper_rect, buf);
         }
     }
 
@@ -244,12 +244,12 @@ pub(super) fn render_compose_margins(
 
         if paper_edge > 0 {
             let paper_rect = Rect::new(right_start, area.y, paper_edge, area.height);
-            frame.render_widget(Block::default().style(paper_style), paper_rect);
+            Block::default().style(paper_style).render(paper_rect, buf);
         }
 
         if desk_width > 0 {
             let desk_rect = Rect::new(right_start + paper_edge, area.y, desk_width, area.height);
-            frame.render_widget(Block::default().style(desk_style), desk_rect);
+            Block::default().style(desk_style).render(desk_rect, buf);
         }
     }
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -15,8 +15,8 @@ use crate::view::viewport::Viewport;
 use fresh_core::api::ViewTransformPayload;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
+use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
-use ratatui::Frame;
 use std::collections::HashMap;
 
 /// Anchor describing where to start rendering within a slice of view lines.
@@ -274,7 +274,7 @@ pub(super) fn calculate_viewport_end(
 
 /// Draw the separator line between two splits.
 pub(super) fn render_separator(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     direction: SplitDirection,
     x: u16,
     y: u16,
@@ -289,13 +289,13 @@ pub(super) fn render_separator(
             let line_area = Rect::new(x, y, length, 1);
             let line_text = "─".repeat(length as usize);
             let paragraph = Paragraph::new(line_text).style(style);
-            frame.render_widget(paragraph, line_area);
+            paragraph.render(line_area, buf);
         }
         SplitDirection::Vertical => {
             for offset in 0..length {
                 let cell_area = Rect::new(x, y + offset, 1, 1);
                 let paragraph = Paragraph::new("│").style(style);
-                frame.render_widget(paragraph, cell_area);
+                paragraph.render(cell_area, buf);
             }
         }
     }

--- a/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/layout.rs
@@ -15,8 +15,8 @@ use crate::view::viewport::Viewport;
 use fresh_core::api::ViewTransformPayload;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
 use std::collections::HashMap;
 
 /// Anchor describing where to start rendering within a slice of view lines.

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -34,7 +34,6 @@ use crate::primitives::ansi_background::AnsiBackground;
 use crate::state::EditorState;
 use crate::view::split::SplitManager;
 use ratatui::layout::Rect;
-use ratatui::Frame;
 use std::collections::HashMap;
 
 /// Maximum line width before forced wrapping is applied, even when line wrapping is disabled.
@@ -113,7 +112,7 @@ impl SplitRenderer {
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::type_complexity)]
     pub fn render_content(
-        frame: &mut Frame,
+        buf: &mut ratatui::buffer::Buffer,
         area: Rect,
         split_manager: &SplitManager,
         buffers: &mut HashMap<BufferId, EditorState>,
@@ -161,7 +160,7 @@ impl SplitRenderer {
         )>,
     ) {
         orchestration::render_content(
-            frame,
+            buf,
             area,
             split_manager,
             buffers,
@@ -243,7 +242,7 @@ impl SplitRenderer {
     /// testing — overlay callers may discard them.
     #[allow(clippy::too_many_arguments)]
     pub fn render_phantom_leaf(
-        frame: &mut Frame,
+        buf: &mut ratatui::buffer::Buffer,
         state: &mut EditorState,
         cursors: &crate::model::cursor::Cursors,
         viewport: &mut crate::view::viewport::Viewport,
@@ -285,7 +284,7 @@ impl SplitRenderer {
         //   terminal's hardware cursor away from the prompt input.
         let mut sink: Option<(u16, u16)> = None;
         orchestration::render_buffer_in_split(
-            frame,
+            buf,
             state,
             cursors,
             viewport,

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -101,6 +101,22 @@ impl<'a> EditorRenderConfig<'a> {
     }
 }
 
+/// "How to render" — the appearance/policy inputs that are identical for
+/// every split in a frame: the theme, the ANSI backdrop, and the editor
+/// render config. Built once at the top of the render pass and threaded by
+/// reference through the whole painter chain (`render_content` →
+/// `render_buffer_in_split` → …), so each layer forwards one `RenderStyle`
+/// instead of re-listing ~16 style parameters. Distinct from per-split state
+/// and the draw target, which vary or are mutated.
+//
+// No `Debug` derive — `AnsiBackground` isn't `Debug`.
+#[derive(Clone, Copy)]
+pub struct RenderStyle<'a> {
+    pub theme: &'a crate::view::theme::Theme,
+    pub ansi_background: Option<&'a AnsiBackground>,
+    pub cfg: EditorRenderConfig<'a>,
+}
+
 /// Public façade for split-pane rendering.
 ///
 /// All logic lives in `orchestration::*`. This struct exists only to
@@ -124,9 +140,7 @@ impl SplitRenderer {
             (LeafId, BufferId),
             crate::view::composite_view::CompositeViewState,
         >,
-        theme: &crate::view::theme::Theme,
-        ansi_background: Option<&AnsiBackground>,
-        cfg: &EditorRenderConfig<'_>,
+        style: RenderStyle<'_>,
         lsp_waiting: bool,
         split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
         grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
@@ -169,9 +183,7 @@ impl SplitRenderer {
             event_logs,
             composite_buffers,
             composite_view_states,
-            theme,
-            ansi_background,
-            cfg,
+            style,
             lsp_waiting,
             split_view_states,
             grouped_subtrees,
@@ -249,28 +261,18 @@ impl SplitRenderer {
         folds: &mut crate::view::folding::FoldManager,
         event_log: Option<&mut EventLog>,
         area: Rect,
-        theme: &crate::view::theme::Theme,
-        ansi_background: Option<&AnsiBackground>,
-        background_fade: f32,
+        style: RenderStyle<'_>,
         view_mode: crate::state::ViewMode,
         compose_width: Option<u16>,
         compose_column_guides: Option<Vec<u16>>,
         view_transform: Option<crate::services::plugins::api::ViewTransformPayload>,
-        estimated_line_length: usize,
-        highlight_context_bytes: usize,
         buffer_id: BufferId,
-        relative_line_numbers: bool,
-        use_terminal_bg: bool,
         session_mode: bool,
-        software_cursor_only: bool,
         rulers: &[usize],
         show_line_numbers: bool,
         highlight_current_line: bool,
-        diagnostics_inline_text: bool,
         show_tilde: bool,
         highlight_current_column: bool,
-        indentation_guide: IndentationGuideMode,
-        indentation_guide_glyph: &str,
         cell_theme_map: &mut Vec<crate::app::types::CellThemeInfo>,
         screen_width: u16,
     ) -> Vec<crate::app::types::ViewLineMapping> {
@@ -292,30 +294,20 @@ impl SplitRenderer {
             event_log,
             area,
             /* is_active */ false,
-            theme,
-            ansi_background,
-            background_fade,
+            style,
             /* lsp_waiting */ false,
             view_mode,
             compose_width,
             compose_column_guides,
             view_transform,
-            estimated_line_length,
-            highlight_context_bytes,
             buffer_id,
             /* hide_cursor */ true,
-            relative_line_numbers,
-            use_terminal_bg,
             session_mode,
-            software_cursor_only,
             rulers,
             show_line_numbers,
             highlight_current_line,
-            diagnostics_inline_text,
             show_tilde,
             highlight_current_column,
-            indentation_guide,
-            indentation_guide_glyph,
             cell_theme_map,
             screen_width,
             &mut sink,

--- a/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/mod.rs
@@ -44,6 +44,64 @@ use std::collections::HashMap;
 /// memory usage reasonable (~80KB per ViewLine instead of hundreds of MB).
 const MAX_SAFE_LINE_WIDTH: usize = 10_000;
 
+/// Immutable editor render settings for one frame.
+///
+/// Bundles the static `config.editor.*` flags (plus a couple of stable
+/// `Editor` fields) that `render_content` and its callees only ever read.
+/// Deliberately holds *only* settings — no buffers, view-states, theme,
+/// geometry, output sinks, or per-frame computed flags (hover, cursor,
+/// mode) — so it can be built once and shared without entangling borrows.
+#[derive(Debug, Clone, Copy)]
+pub struct EditorRenderConfig<'a> {
+    pub large_file_threshold_bytes: u64,
+    pub line_wrap: bool,
+    pub estimated_line_length: usize,
+    pub highlight_context_bytes: usize,
+    pub relative_line_numbers: bool,
+    pub use_terminal_bg: bool,
+    pub show_vertical_scrollbar: bool,
+    pub show_horizontal_scrollbar: bool,
+    pub diagnostics_inline_text: bool,
+    pub show_tilde: bool,
+    pub highlight_current_column: bool,
+    pub indentation_guide: IndentationGuideMode,
+    pub indentation_guide_glyph: &'a str,
+    pub hide_current_line_on_selection: bool,
+    pub background_fade: f32,
+    pub software_cursor_only: bool,
+}
+
+impl<'a> EditorRenderConfig<'a> {
+    /// Build from the static editor config plus the two stable `Editor`
+    /// flags that don't live under `config.editor`. Borrows only
+    /// `config.editor`, so it composes with a disjoint `&mut windows`
+    /// borrow at the call site.
+    pub fn new(
+        editor: &'a crate::config::EditorConfig,
+        background_fade: f32,
+        software_cursor_only: bool,
+    ) -> Self {
+        Self {
+            large_file_threshold_bytes: editor.large_file_threshold_bytes,
+            line_wrap: editor.line_wrap,
+            estimated_line_length: editor.estimated_line_length,
+            highlight_context_bytes: editor.highlight_context_bytes,
+            relative_line_numbers: editor.relative_line_numbers,
+            use_terminal_bg: editor.use_terminal_bg,
+            show_vertical_scrollbar: editor.show_vertical_scrollbar,
+            show_horizontal_scrollbar: editor.show_horizontal_scrollbar,
+            diagnostics_inline_text: editor.diagnostics_inline_text,
+            show_tilde: editor.show_tilde,
+            highlight_current_column: editor.highlight_current_column,
+            indentation_guide: editor.indentation_guide,
+            indentation_guide_glyph: &editor.indentation_guide_glyph,
+            hide_current_line_on_selection: editor.hide_current_line_on_selection,
+            background_fade,
+            software_cursor_only,
+        }
+    }
+}
+
 /// Public façade for split-pane rendering.
 ///
 /// All logic lives in `orchestration::*`. This struct exists only to
@@ -69,12 +127,8 @@ impl SplitRenderer {
         >,
         theme: &crate::view::theme::Theme,
         ansi_background: Option<&AnsiBackground>,
-        background_fade: f32,
+        cfg: &EditorRenderConfig<'_>,
         lsp_waiting: bool,
-        large_file_threshold_bytes: u64,
-        line_wrap: bool,
-        estimated_line_length: usize,
-        highlight_context_bytes: usize,
         split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
         grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
         hide_cursor: bool,
@@ -82,20 +136,9 @@ impl SplitRenderer {
         hovered_close_split: Option<LeafId>,
         hovered_maximize_split: Option<LeafId>,
         is_maximized: bool,
-        relative_line_numbers: bool,
         tab_bar_visible: bool,
-        use_terminal_bg: bool,
         session_mode: bool,
-        software_cursor_only: bool,
-        show_vertical_scrollbar: bool,
-        show_horizontal_scrollbar: bool,
         terminal_mode: bool,
-        diagnostics_inline_text: bool,
-        show_tilde: bool,
-        highlight_current_column: bool,
-        indentation_guide: IndentationGuideMode,
-        indentation_guide_glyph: &str,
-        hide_current_line_on_selection: bool,
         cell_theme_map: &mut Vec<crate::app::types::CellThemeInfo>,
         screen_width: u16,
         pending_hardware_cursor: &mut Option<(u16, u16)>,
@@ -129,12 +172,8 @@ impl SplitRenderer {
             composite_view_states,
             theme,
             ansi_background,
-            background_fade,
+            cfg,
             lsp_waiting,
-            large_file_threshold_bytes,
-            line_wrap,
-            estimated_line_length,
-            highlight_context_bytes,
             split_view_states,
             grouped_subtrees,
             hide_cursor,
@@ -142,20 +181,9 @@ impl SplitRenderer {
             hovered_close_split,
             hovered_maximize_split,
             is_maximized,
-            relative_line_numbers,
             tab_bar_visible,
-            use_terminal_bg,
             session_mode,
-            software_cursor_only,
-            show_vertical_scrollbar,
-            show_horizontal_scrollbar,
             terminal_mode,
-            diagnostics_inline_text,
-            show_tilde,
-            highlight_current_column,
-            indentation_guide,
-            indentation_guide_glyph,
-            hide_current_line_on_selection,
             cell_theme_map,
             screen_width,
             pending_hardware_cursor,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -28,9 +28,9 @@ use super::scrollbar::{
     compute_max_line_length, render_composite_scrollbar, render_horizontal_scrollbar,
     render_scrollbar, scrollbar_line_counts,
 };
+use super::EditorRenderConfig;
 use crate::app::types::ViewLineMapping;
 use crate::app::BufferMetadata;
-use super::EditorRenderConfig;
 use crate::config::IndentationGuideMode;
 use crate::model::buffer::Buffer;
 use crate::model::event::{BufferId, EventLog, LeafId, SplitDirection};
@@ -40,8 +40,8 @@ use crate::view::split::SplitManager;
 use crate::view::ui::tabs::TabsRenderer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
 use render_buffer::compute_buffer_layout;
 // Re-exported one level up (split_rendering::SplitRenderer) so the
 // `render_phantom_leaf` façade can forward into the per-leaf
@@ -1177,7 +1177,11 @@ pub(crate) fn build_base_tokens_for_hook(
 /// user closes the last buffer with both `file_explorer.auto_open_on_last_buffer_close`
 /// and `editor.auto_create_empty_buffer_on_last_buffer_close` set to false.
 /// Tells the user how to escape the blank-workspace state.
-fn render_placeholder_hint(buf: &mut ratatui::buffer::Buffer, area: Rect, theme: &crate::view::theme::Theme) {
+fn render_placeholder_hint(
+    buf: &mut ratatui::buffer::Buffer,
+    area: Rect,
+    theme: &crate::view::theme::Theme,
+) {
     const HINT: &str =
         "Ctrl+P  command palette   ·   Ctrl+O  open file   ·   Ctrl+E  file explorer";
     let needed_width = HINT.chars().count() as u16;

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -34,7 +34,6 @@ use super::EditorRenderConfig;
 use crate::config::IndentationGuideMode;
 use crate::model::buffer::Buffer;
 use crate::model::event::{BufferId, EventLog, LeafId, SplitDirection};
-use crate::primitives::ansi_background::AnsiBackground;
 use crate::state::EditorState;
 use crate::view::folding::FoldManager;
 use crate::view::split::SplitManager;
@@ -90,11 +89,10 @@ pub(crate) fn render_content(
         (LeafId, BufferId),
         crate::view::composite_view::CompositeViewState,
     >,
-    theme: &crate::view::theme::Theme,
-    ansi_background: Option<&AnsiBackground>,
-    // Immutable editor render settings (config.editor.* flags + a couple of
-    // stable Editor fields). Destructured into locals at the top of the body.
-    cfg: &EditorRenderConfig<'_>,
+    // Appearance/policy group (theme + ANSI backdrop + editor render config),
+    // identical for every split. Unpacked into locals at the top of the body
+    // and threaded as-is into render_buffer_in_split.
+    style: crate::view::ui::RenderStyle<'_>,
     lsp_waiting: bool,
     mut split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
     grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
@@ -133,26 +131,21 @@ pub(crate) fn render_content(
 ) {
     let _span = tracing::trace_span!("render_content").entered();
 
-    // Unpack the render config into locals so the body below (and its onward
-    // calls) read them by name, unchanged. `line_wrap` is currently unused
-    // here, hence discarded.
-    let &EditorRenderConfig {
+    // Unpack the style group. `theme` is forwarded to the sub-painters; the
+    // whole `style` (incl. `ansi_background` + full `cfg`) is threaded as-is
+    // into render_buffer_in_split. Only the `cfg` flags this layer reads itself
+    // (per-split flag math, scrollbars, composite) are bound below; the rest
+    // ride along inside `style.cfg`.
+    let crate::view::ui::RenderStyle { theme, cfg, .. } = style;
+    let EditorRenderConfig {
         large_file_threshold_bytes,
-        line_wrap: _,
-        estimated_line_length,
-        highlight_context_bytes,
-        relative_line_numbers,
         use_terminal_bg,
         show_vertical_scrollbar,
         show_horizontal_scrollbar,
-        diagnostics_inline_text,
         show_tilde,
         highlight_current_column,
-        indentation_guide,
-        indentation_guide_glyph,
         hide_current_line_on_selection,
-        background_fade,
-        software_cursor_only,
+        ..
     } = cfg;
 
     let base_visible = split_manager.get_visible_buffers(area);
@@ -465,30 +458,20 @@ pub(crate) fn render_content(
                 event_log_opt,
                 layout.content_rect,
                 is_active,
-                theme,
-                ansi_background,
-                background_fade,
+                style,
                 lsp_waiting,
                 view_prefs.view_mode,
                 view_prefs.compose_width,
                 view_prefs.compose_column_guides,
                 view_prefs.view_transform,
-                estimated_line_length,
-                highlight_context_bytes,
                 buffer_id,
                 hide_cursor,
-                relative_line_numbers,
-                use_terminal_bg,
                 session_mode,
-                software_cursor_only,
                 effective_rulers,
                 view_prefs.show_line_numbers,
                 effective_highlight_current_line,
-                diagnostics_inline_text,
                 split_show_tilde,
                 highlight_current_column && state.show_cursors,
-                indentation_guide,
-                indentation_guide_glyph,
                 cell_theme_map,
                 screen_width,
                 pending_hardware_cursor,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -41,8 +41,8 @@ use crate::view::split::SplitManager;
 use crate::view::ui::tabs::TabsRenderer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
+use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
-use ratatui::Frame;
 use render_buffer::compute_buffer_layout;
 // Re-exported one level up (split_rendering::SplitRenderer) so the
 // `render_phantom_leaf` façade can forward into the per-leaf
@@ -76,7 +76,7 @@ type VisibleBuffer = (LeafId, LeafId, BufferId, Rect, RenderKind);
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub(crate) fn render_content(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area: Rect,
     split_manager: &SplitManager,
     buffers: &mut HashMap<BufferId, EditorState>,
@@ -285,7 +285,7 @@ pub(crate) fn render_content(
         // Only render tabs and split control buttons when tab bar is visible
         if split_tab_bar_visible {
             render_split_tab_bar(
-                frame,
+                buf,
                 &layout,
                 split_id,
                 buffer_id,
@@ -329,7 +329,7 @@ pub(crate) fn render_content(
             .get(&buffer_id)
             .is_some_and(|m| m.synthetic_placeholder);
         if is_synthetic_placeholder {
-            render_placeholder_hint(frame, layout.content_rect, theme);
+            render_placeholder_hint(buf, layout.content_rect, theme);
             view_line_mappings.insert(split_id, Vec::new());
             continue;
         }
@@ -341,7 +341,7 @@ pub(crate) fn render_content(
             .is_some_and(|s| s.is_composite_buffer)
         {
             render_composite_split(
-                frame,
+                buf,
                 &layout,
                 split_id,
                 buffer_id,
@@ -457,7 +457,7 @@ pub(crate) fn render_content(
 
             let _render_buf_span = tracing::trace_span!("render_buffer_in_split").entered();
             let split_view_mappings = render_buffer_in_split(
-                frame,
+                buf,
                 state,
                 &split_cursors,
                 &mut viewport,
@@ -510,7 +510,7 @@ pub(crate) fn render_content(
             // Render vertical scrollbar for this split and get thumb position
             let (thumb_start, thumb_end) = if panel_show_vscroll {
                 render_scrollbar(
-                    frame,
+                    buf,
                     state,
                     &viewport,
                     layout.scrollbar_rect,
@@ -541,7 +541,7 @@ pub(crate) fn render_content(
             // Render horizontal scrollbar for this split
             let (hthumb_start, hthumb_end) = if show_horizontal_scrollbar {
                 render_horizontal_scrollbar(
-                    frame,
+                    buf,
                     &viewport,
                     layout.horizontal_scrollbar_rect,
                     is_active,
@@ -594,13 +594,13 @@ pub(crate) fn render_content(
     // active Grouped subtrees dispatched at render time.
     let separators = split_manager.get_separators(area);
     for (direction, x, y, length) in separators {
-        render_separator(frame, direction, x, y, length, theme);
+        render_separator(buf, direction, x, y, length, theme);
     }
     // Walk the visible splits again to render internal separators of any
     // active buffer groups (their Split nodes live in the side-map, not the
     // main split tree, so `split_manager` doesn't know about them).
     let grouped_separator_areas = render_grouped_separators(
-        frame,
+        buf,
         &base_visible,
         split_view_states.as_deref(),
         grouped_subtrees,
@@ -702,7 +702,7 @@ fn expand_visible_buffers(
 /// recording the resulting tab layout and button hit areas for mouse handling.
 #[allow(clippy::too_many_arguments)]
 fn render_split_tab_bar(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     layout: &SplitLayout,
     split_id: LeafId,
     buffer_id: BufferId,
@@ -752,7 +752,7 @@ fn render_split_tab_bar(
     let tab_layout = {
         let mut rec = crate::app::types::CellThemeRecorder::new(&mut tab_runs);
         TabsRenderer::render_for_split(
-            frame,
+            buf,
             layout.tabs_rect,
             split_buffers,
             buffers,
@@ -794,7 +794,7 @@ fn render_split_tab_bar(
         };
         let close_button =
             Paragraph::new("×").style(Style::default().fg(close_fg).bg(theme.tab_separator_bg));
-        frame.render_widget(close_button, Rect::new(btn_x, tab_row, 1, 1));
+        close_button.render(Rect::new(btn_x, tab_row, 1, 1), buf);
         close_split_areas.push((split_id, tab_row, btn_x, btn_x + 1));
         btn_x = btn_x.saturating_sub(2); // 1 space before the next button
     }
@@ -809,7 +809,7 @@ fn render_split_tab_bar(
         let icon = if is_maximized { "⧉" } else { "□" };
         let max_button =
             Paragraph::new(icon).style(Style::default().fg(max_fg).bg(theme.tab_separator_bg));
-        frame.render_widget(max_button, Rect::new(btn_x, tab_row, 1, 1));
+        max_button.render(Rect::new(btn_x, tab_row, 1, 1), buf);
         maximize_split_areas.push((split_id, tab_row, btn_x, btn_x + 1));
     }
 }
@@ -818,7 +818,7 @@ fn render_split_tab_bar(
 /// scrollbar, and record the content/scrollbar areas for mouse handling.
 #[allow(clippy::too_many_arguments)]
 fn render_composite_split(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     layout: &SplitLayout,
     split_id: LeafId,
     buffer_id: BufferId,
@@ -893,7 +893,7 @@ fn render_composite_split(
     }
 
     render_composite_buffer(
-        frame,
+        buf,
         layout.content_rect,
         composite,
         buffers,
@@ -908,7 +908,7 @@ fn render_composite_split(
     let content_height = layout.content_rect.height.saturating_sub(1) as usize; // -1 for header
     let (thumb_start, thumb_end) = if show_vertical_scrollbar && !is_non_scrollable {
         render_composite_scrollbar(
-            frame,
+            buf,
             layout.scrollbar_rect,
             total_rows,
             view_state.scroll_row,
@@ -947,7 +947,7 @@ fn render_composite_split(
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 fn render_grouped_separators(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     base_visible: &[(LeafId, BufferId, Rect)],
     split_view_states: Option<&HashMap<LeafId, crate::view::split::SplitViewState>>,
     grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
@@ -984,7 +984,7 @@ fn render_grouped_separators(
             for (id, direction, x, y, length) in
                 layout.get_separators_with_ids(main_layout.content_rect)
             {
-                render_separator(frame, direction, x, y, length, theme);
+                render_separator(buf, direction, x, y, length, theme);
                 grouped_separator_areas.push((id, direction, x, y, length));
             }
         }
@@ -1194,7 +1194,7 @@ pub(crate) fn build_base_tokens_for_hook(
 /// user closes the last buffer with both `file_explorer.auto_open_on_last_buffer_close`
 /// and `editor.auto_create_empty_buffer_on_last_buffer_close` set to false.
 /// Tells the user how to escape the blank-workspace state.
-fn render_placeholder_hint(frame: &mut Frame, area: Rect, theme: &crate::view::theme::Theme) {
+fn render_placeholder_hint(buf: &mut ratatui::buffer::Buffer, area: Rect, theme: &crate::view::theme::Theme) {
     const HINT: &str =
         "Ctrl+P  command palette   ·   Ctrl+O  open file   ·   Ctrl+E  file explorer";
     let needed_width = HINT.chars().count() as u16;
@@ -1205,5 +1205,5 @@ fn render_placeholder_hint(frame: &mut Frame, area: Rect, theme: &crate::view::t
     let y = area.y + area.height / 2;
     let hint_area = Rect::new(x, y, needed_width, 1);
     let style = Style::default().fg(theme.syntax_comment);
-    frame.render_widget(Paragraph::new(HINT).style(style), hint_area);
+    Paragraph::new(HINT).style(style).render(hint_area, buf);
 }

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/mod.rs
@@ -30,6 +30,7 @@ use super::scrollbar::{
 };
 use crate::app::types::ViewLineMapping;
 use crate::app::BufferMetadata;
+use super::EditorRenderConfig;
 use crate::config::IndentationGuideMode;
 use crate::model::buffer::Buffer;
 use crate::model::event::{BufferId, EventLog, LeafId, SplitDirection};
@@ -91,12 +92,10 @@ pub(crate) fn render_content(
     >,
     theme: &crate::view::theme::Theme,
     ansi_background: Option<&AnsiBackground>,
-    background_fade: f32,
+    // Immutable editor render settings (config.editor.* flags + a couple of
+    // stable Editor fields). Destructured into locals at the top of the body.
+    cfg: &EditorRenderConfig<'_>,
     lsp_waiting: bool,
-    large_file_threshold_bytes: u64,
-    _line_wrap: bool,
-    estimated_line_length: usize,
-    highlight_context_bytes: usize,
     mut split_view_states: Option<&mut HashMap<LeafId, crate::view::split::SplitViewState>>,
     grouped_subtrees: &HashMap<LeafId, crate::view::split::SplitNode>,
     hide_cursor: bool,
@@ -104,24 +103,13 @@ pub(crate) fn render_content(
     hovered_close_split: Option<LeafId>,
     hovered_maximize_split: Option<LeafId>,
     is_maximized: bool,
-    relative_line_numbers: bool,
     tab_bar_visible: bool,
-    use_terminal_bg: bool,
     session_mode: bool,
-    software_cursor_only: bool,
-    show_vertical_scrollbar: bool,
-    show_horizontal_scrollbar: bool,
     // Whether the window is in terminal mode. When set, the active split's
     // terminal buffer is showing its live PTY grid (not the read-only
     // scrollback view), so its vertical scrollbar is suppressed and the grid
     // reclaims that column. Exiting terminal mode brings the scrollbar back.
     terminal_mode: bool,
-    diagnostics_inline_text: bool,
-    show_tilde: bool,
-    highlight_current_column: bool,
-    indentation_guide: IndentationGuideMode,
-    indentation_guide_glyph: &str,
-    hide_current_line_on_selection: bool,
     cell_theme_map: &mut Vec<crate::app::types::CellThemeInfo>,
     screen_width: u16,
     pending_hardware_cursor: &mut Option<(u16, u16)>,
@@ -144,6 +132,28 @@ pub(crate) fn render_content(
     )>, // hit areas for separators inside active Grouped subtrees
 ) {
     let _span = tracing::trace_span!("render_content").entered();
+
+    // Unpack the render config into locals so the body below (and its onward
+    // calls) read them by name, unchanged. `line_wrap` is currently unused
+    // here, hence discarded.
+    let &EditorRenderConfig {
+        large_file_threshold_bytes,
+        line_wrap: _,
+        estimated_line_length,
+        highlight_context_bytes,
+        relative_line_numbers,
+        use_terminal_bg,
+        show_vertical_scrollbar,
+        show_horizontal_scrollbar,
+        diagnostics_inline_text,
+        show_tilde,
+        highlight_current_column,
+        indentation_guide,
+        indentation_guide_glyph,
+        hide_current_line_on_selection,
+        background_fade,
+        software_cursor_only,
+    } = cfg;
 
     let base_visible = split_manager.get_visible_buffers(area);
     let active_split_id = split_manager.active_split();

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -465,7 +465,9 @@ pub(crate) fn draw_buffer_in_split(
     let editor_block = Block::default()
         .borders(Borders::NONE)
         .style(Style::default().bg(effective_editor_bg));
-    Paragraph::new(lines).block(editor_block).render(render_area, buf);
+    Paragraph::new(lines)
+        .block(editor_block)
+        .render(render_area, buf);
 
     let cursor = resolve_cursor_fallback(
         layout_output.render_output.cursor,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -580,34 +580,44 @@ pub(crate) fn render_buffer_in_split(
     event_log: Option<&mut EventLog>,
     area: Rect,
     is_active: bool,
-    theme: &Theme,
-    ansi_background: Option<&AnsiBackground>,
-    background_fade: f32,
+    style: crate::view::ui::RenderStyle<'_>,
     lsp_waiting: bool,
     view_mode: ViewMode,
     compose_width: Option<u16>,
     compose_column_guides: Option<Vec<u16>>,
     view_transform: Option<ViewTransformPayload>,
-    estimated_line_length: usize,
-    highlight_context_bytes: usize,
     _buffer_id: BufferId,
     hide_cursor: bool,
-    relative_line_numbers: bool,
-    use_terminal_bg: bool,
     session_mode: bool,
-    software_cursor_only: bool,
     rulers: &[usize],
     show_line_numbers: bool,
     highlight_current_line: bool,
-    diagnostics_inline_text: bool,
     show_tilde: bool,
     highlight_current_column: bool,
-    indentation_guide: IndentationGuideMode,
-    indentation_guide_glyph: &str,
     cell_theme_map: &mut Vec<CellThemeInfo>,
     screen_width: u16,
     pending_hardware_cursor: &mut Option<(u16, u16)>,
 ) -> Vec<ViewLineMapping> {
+    // The style group provides theme + the appearance flags; unpack into the
+    // locals the body already uses by name. The cfg fields this painter
+    // doesn't read are ignored.
+    let crate::view::ui::RenderStyle {
+        theme,
+        ansi_background,
+        cfg,
+    } = style;
+    let crate::view::ui::EditorRenderConfig {
+        background_fade,
+        estimated_line_length,
+        highlight_context_bytes,
+        relative_line_numbers,
+        use_terminal_bg,
+        software_cursor_only,
+        diagnostics_inline_text,
+        indentation_guide,
+        indentation_guide_glyph,
+        ..
+    } = cfg;
     let layout_output = compute_buffer_layout(
         state,
         cursors,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_buffer.rs
@@ -30,8 +30,8 @@ use crate::view::viewport::Viewport;
 use fresh_core::api::ViewTransformPayload;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::Widget;
 use ratatui::widgets::{Block, Borders, Clear, Paragraph};
-use ratatui::Frame;
 
 /// Output of the pure layout computation phase of buffer rendering.
 ///
@@ -414,7 +414,7 @@ pub(crate) fn compute_buffer_layout(
 /// Draw a buffer into a frame using pre-computed layout output.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn draw_buffer_in_split(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     state: &EditorState,
     cursors: &Cursors,
     layout_output: BufferLayoutOutput,
@@ -437,7 +437,7 @@ pub(crate) fn draw_buffer_in_split(
     let starting_line_num = 0; // used only for background offset
 
     render_compose_margins(
-        frame,
+        buf,
         area,
         &layout_output.compose_layout,
         &layout_output.view_mode,
@@ -461,11 +461,11 @@ pub(crate) fn draw_buffer_in_split(
         );
     }
 
-    frame.render_widget(Clear, render_area);
+    Clear.render(render_area, buf);
     let editor_block = Block::default()
         .borders(Borders::NONE)
         .style(Style::default().bg(effective_editor_bg));
-    frame.render_widget(Paragraph::new(lines).block(editor_block), render_area);
+    Paragraph::new(lines).block(editor_block).render(render_area, buf);
 
     let cursor = resolve_cursor_fallback(
         layout_output.render_output.cursor,
@@ -492,7 +492,7 @@ pub(crate) fn draw_buffer_in_split(
     if !rulers.is_empty() {
         let ruler_cols: Vec<u16> = rulers.iter().map(|&r| r as u16).collect();
         render_ruler_bg(
-            frame,
+            buf,
             &ruler_cols,
             theme.ruler_bg,
             render_area,
@@ -510,7 +510,7 @@ pub(crate) fn draw_buffer_in_split(
             // so skip highlighting if it falls inside the gutter.
             if (cx as usize) >= gutter_width {
                 render_cursor_column_bg(
-                    frame,
+                    buf,
                     render_area,
                     cx,
                     theme.current_line_bg,
@@ -526,7 +526,7 @@ pub(crate) fn draw_buffer_in_split(
             .fg(theme.line_number_fg)
             .add_modifier(Modifier::DIM);
         render_column_guides(
-            frame,
+            buf,
             &guides,
             guide_style,
             render_area,
@@ -547,7 +547,6 @@ pub(crate) fn draw_buffer_in_split(
         // When software_cursor_only the backend has no hardware cursor, so
         // ensure the cell at the cursor position always has REVERSED style.
         if software_cursor_only {
-            let buf = frame.buffer_mut();
             let area = buf.area;
             if screen_x < area.x + area.width && screen_y < area.y + area.height {
                 let cell = &mut buf[(screen_x, screen_y)];
@@ -573,7 +572,7 @@ pub(crate) fn draw_buffer_in_split(
 /// Returns the view line mappings for mouse click handling.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_buffer_in_split(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     state: &mut EditorState,
     cursors: &Cursors,
     viewport: &mut Viewport,
@@ -639,7 +638,7 @@ pub(crate) fn render_buffer_in_split(
     let view_line_mappings = layout_output.view_line_mappings.clone();
 
     draw_buffer_in_split(
-        frame,
+        buf,
         state,
         cursors,
         layout_output,

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -488,7 +488,9 @@ fn render_row_pane(
         } else {
             let gap_style = Style::default().bg(bg);
             let empty_content = " ".repeat(width as usize);
-            Paragraph::new(empty_content).style(gap_style).render(pane_area, buf);
+            Paragraph::new(empty_content)
+                .style(gap_style)
+                .render(pane_area, buf);
         }
         return;
     };

--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_composite.rs
@@ -17,8 +17,8 @@ use crate::view::ui::view_pipeline::{should_show_line_number, ViewLine};
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
+use ratatui::widgets::Widget;
 use ratatui::widgets::{Clear, Paragraph};
-use ratatui::Frame;
 use std::collections::HashMap;
 use std::ops::Range;
 
@@ -26,7 +26,7 @@ use std::ops::Range;
 /// Uses `ViewLine`s for proper syntax highlighting, ANSI handling, etc.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn render_composite_buffer(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area: Rect,
     composite: &CompositeBuffer,
     buffers: &mut HashMap<BufferId, EditorState>,
@@ -44,7 +44,7 @@ pub(crate) fn render_composite_buffer(
     };
 
     // Clear the area first.
-    frame.render_widget(Clear, area);
+    Clear.render(area, buf);
 
     if composite.sources.is_empty() {
         return;
@@ -55,7 +55,7 @@ pub(crate) fn render_composite_buffer(
     view_state.pane_widths = layout.widths.clone();
 
     render_pane_headers(
-        frame,
+        buf,
         area,
         composite,
         &layout,
@@ -87,11 +87,11 @@ pub(crate) fn render_composite_buffer(
         let display_row = scroll_row + view_row;
         let row_y = content_y + view_row as u16;
         if display_row >= total_rows {
-            render_past_end_row(frame, area.x, row_y, &layout, show_tilde, theme);
+            render_past_end_row(buf, area.x, row_y, &layout, show_tilde, theme);
             continue;
         }
         render_aligned_row(
-            frame,
+            buf,
             area.x,
             row_y,
             display_row,
@@ -161,7 +161,7 @@ fn compute_pane_layout(composite: &CompositeBuffer, area_width: u16) -> PaneLayo
 /// Render the one-row header bar for each pane (the source label), with the
 /// focused pane drawn in the active-tab style.
 fn render_pane_headers(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area: Rect,
     composite: &CompositeBuffer,
     layout: &PaneLayout,
@@ -184,7 +184,7 @@ fn render_pane_headers(
 
         let header_text = format!(" {} ", source.label);
         let header = Paragraph::new(header_text).style(header_style);
-        frame.render_widget(header, header_area);
+        header.render(header_area, buf);
 
         x_offset += width + layout.separator_width;
     }
@@ -301,7 +301,7 @@ fn build_pane_render_data(
 /// Paint the panes of a row that lies past the end of the aligned content:
 /// blank cells, with a leading `~` per pane when `show_tilde` is set.
 fn render_past_end_row(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area_x: u16,
     row_y: u16,
     layout: &PaneLayout,
@@ -322,7 +322,7 @@ fn render_past_end_row(
                 .fg(theme.line_number_fg)
                 .bg(theme.after_eof_bg),
         );
-        frame.render_widget(eof, eof_area);
+        eof.render(eof_area, buf);
         x += width + layout.separator_width;
     }
 }
@@ -366,7 +366,7 @@ fn compute_modification_inline_diffs(
 /// them, at `row_y`.
 #[allow(clippy::too_many_arguments)]
 fn render_aligned_row(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     area_x: u16,
     row_y: u16,
     display_row: usize,
@@ -403,7 +403,7 @@ fn render_aligned_row(
     for (pane_idx, &width) in layout.widths.iter().enumerate() {
         let pane_area = Rect::new(x_offset, row_y, width, 1);
         render_row_pane(
-            frame,
+            buf,
             pane_area,
             pane_idx,
             width,
@@ -426,7 +426,7 @@ fn render_aligned_row(
                     .fg(theme.split_separator_fg)
                     .bg(theme.editor_bg),
             );
-            frame.render_widget(sep, sep_area);
+            sep.render(sep_area, buf);
             x_offset += layout.separator_width;
         }
     }
@@ -436,7 +436,7 @@ fn render_aligned_row(
 /// content or a blank gap/padding cell (carrying the focused-pane cursor).
 #[allow(clippy::too_many_arguments)]
 fn render_row_pane(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     pane_area: Rect,
     pane_idx: usize,
     width: u16,
@@ -484,11 +484,11 @@ fn render_row_pane(
                 Span::styled(" ", cursor_style),
                 Span::styled(padding, Style::default().bg(bg)),
             ]);
-            frame.render_widget(Paragraph::new(line), pane_area);
+            Paragraph::new(line).render(pane_area, buf);
         } else {
             let gap_style = Style::default().bg(bg);
             let empty_content = " ".repeat(width as usize);
-            frame.render_widget(Paragraph::new(empty_content).style(gap_style), pane_area);
+            Paragraph::new(empty_content).style(gap_style).render(pane_area, buf);
         }
         return;
     };
@@ -564,7 +564,7 @@ fn render_row_pane(
         spans.push(Span::styled(padding, base_style));
     }
 
-    frame.render_widget(Paragraph::new(Line::from(spans)), pane_area);
+    Paragraph::new(Line::from(spans)).render(pane_area, buf);
 }
 
 /// Render ViewLine content with syntax highlighting to spans.

--- a/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/post_pass.rs
@@ -10,13 +10,12 @@ use crate::view::overlay::Overlay;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::Line;
-use ratatui::Frame;
 use std::ops::Range;
 
 /// Render vertical column guide lines in the editor content area.
 /// Used for both config-based vertical rulers and compose-mode column guides.
 pub(super) fn render_column_guides(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     columns: &[u16],
     style: Style,
     render_area: Rect,
@@ -33,7 +32,7 @@ pub(super) fn render_column_guides(
         let guide_x = render_area.x + gutter_width as u16 + scrolled_col as u16;
         if guide_x < render_area.x + render_area.width {
             for row in 0..guide_height {
-                let cell = &mut frame.buffer_mut()[(guide_x, render_area.y + row as u16)];
+                let cell = &mut buf[(guide_x, render_area.y + row as u16)];
                 cell.set_symbol("│");
                 if let Some(fg) = style.fg {
                     cell.set_fg(fg);
@@ -51,7 +50,7 @@ pub(super) fn render_column_guides(
 /// `render_area.x` (i.e. the same coordinate as `cursor` from
 /// `resolve_cursor_fallback`), and already includes any gutter offset.
 pub(super) fn render_cursor_column_bg(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     render_area: Rect,
     column_x: u16,
     color: Color,
@@ -63,7 +62,7 @@ pub(super) fn render_cursor_column_bg(
     let guide_x = render_area.x + column_x;
     let guide_height = content_height.min(render_area.height as usize);
     for row in 0..guide_height {
-        let cell = &mut frame.buffer_mut()[(guide_x, render_area.y + row as u16)];
+        let cell = &mut buf[(guide_x, render_area.y + row as u16)];
         cell.set_bg(color);
     }
 }
@@ -72,7 +71,7 @@ pub(super) fn render_cursor_column_bg(
 /// Unlike `render_column_guides` which draws │ characters (for compose guides),
 /// this preserves the existing text content and only adjusts the background color.
 pub(super) fn render_ruler_bg(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     columns: &[u16],
     color: Color,
     render_area: Rect,
@@ -88,7 +87,7 @@ pub(super) fn render_ruler_bg(
         let guide_x = render_area.x + gutter_width as u16 + scrolled_col as u16;
         if guide_x < render_area.x + render_area.width {
             for row in 0..guide_height {
-                let cell = &mut frame.buffer_mut()[(guide_x, render_area.y + row as u16)];
+                let cell = &mut buf[(guide_x, render_area.y + row as u16)];
                 cell.set_bg(color);
             }
         }
@@ -103,7 +102,7 @@ pub(super) fn render_ruler_bg(
 /// become clickable in terminals that support the protocol.
 #[allow(dead_code)]
 pub(super) fn apply_hyperlink_overlays(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     viewport_overlays: &[(Overlay, Range<usize>)],
     view_line_mappings: &[ViewLineMapping],
     render_area: Rect,
@@ -119,7 +118,6 @@ pub(super) fn apply_hyperlink_overlays(
         return;
     }
 
-    let buf = frame.buffer_mut();
     for (screen_row, mapping) in view_line_mappings.iter().enumerate() {
         let y = render_area.y + screen_row as u16;
         if y >= render_area.y + render_area.height {

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -9,8 +9,8 @@ use crate::view::theme::Theme;
 use crate::view::viewport::Viewport;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
-use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
 
 /// Compute scrollbar line counts: `(total_lines, top_line)`.
 ///

--- a/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/scrollbar.rs
@@ -9,8 +9,8 @@ use crate::view::theme::Theme;
 use crate::view::viewport::Viewport;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
+use ratatui::widgets::Widget;
 use ratatui::widgets::Paragraph;
-use ratatui::Frame;
 
 /// Compute scrollbar line counts: `(total_lines, top_line)`.
 ///
@@ -148,7 +148,7 @@ pub(super) fn compute_max_line_length(state: &mut EditorState, viewport: &mut Vi
 /// Returns (thumb_start, thumb_end) positions for mouse hit testing.
 #[allow(clippy::too_many_arguments)]
 pub(super) fn render_scrollbar(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     state: &EditorState,
     viewport: &Viewport,
     scrollbar_rect: Rect,
@@ -216,7 +216,7 @@ pub(super) fn render_scrollbar(
         };
 
         let paragraph = Paragraph::new(" ").style(style);
-        frame.render_widget(paragraph, cell_area);
+        paragraph.render(cell_area, buf);
     }
 
     (thumb_start, thumb_end)
@@ -227,7 +227,7 @@ pub(super) fn render_scrollbar(
 /// (from [`compute_max_line_length`]).
 /// Returns (thumb_start_col, thumb_end_col) for mouse hit testing.
 pub(super) fn render_horizontal_scrollbar(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     viewport: &Viewport,
     hscrollbar_rect: Rect,
     _is_active: bool,
@@ -245,7 +245,7 @@ pub(super) fn render_horizontal_scrollbar(
         for col in 0..width {
             let cell_area = Rect::new(hscrollbar_rect.x + col as u16, hscrollbar_rect.y, 1, 1);
             let paragraph = Paragraph::new(" ").style(Style::default().bg(track_color));
-            frame.render_widget(paragraph, cell_area);
+            paragraph.render(cell_area, buf);
         }
         return (0, width);
     }
@@ -283,7 +283,7 @@ pub(super) fn render_horizontal_scrollbar(
         };
 
         let paragraph = Paragraph::new(" ").style(style);
-        frame.render_widget(paragraph, cell_area);
+        paragraph.render(cell_area, buf);
     }
 
     (thumb_start, thumb_end)
@@ -291,7 +291,7 @@ pub(super) fn render_horizontal_scrollbar(
 
 /// Render a scrollbar for composite buffer views.
 pub(super) fn render_composite_scrollbar(
-    frame: &mut Frame,
+    buf: &mut ratatui::buffer::Buffer,
     scrollbar_rect: Rect,
     total_rows: usize,
     scroll_row: usize,
@@ -342,7 +342,7 @@ pub(super) fn render_composite_scrollbar(
         };
 
         let paragraph = Paragraph::new(" ").style(style);
-        frame.render_widget(paragraph, cell_area);
+        paragraph.render(cell_area, buf);
     }
 
     (thumb_start, thumb_end)

--- a/crates/fresh-editor/src/view/ui/tabs.rs
+++ b/crates/fresh-editor/src/view/ui/tabs.rs
@@ -10,8 +10,8 @@ use crate::view::ui::layout::point_in_rect;
 use ratatui::layout::Rect;
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
+use ratatui::widgets::Widget;
 use ratatui::widgets::{Block, Paragraph};
-use ratatui::Frame;
 use rust_i18n::t;
 use std::collections::HashMap;
 
@@ -740,7 +740,7 @@ impl TabsRenderer {
     /// `TabLayout` containing hit areas for mouse interaction.
     #[allow(clippy::too_many_arguments)]
     pub fn render_for_split(
-        frame: &mut Frame,
+        buf: &mut ratatui::buffer::Buffer,
         area: Rect,
         tab_targets: &[TabTarget],
         buffers: &HashMap<BufferId, EditorState>,
@@ -888,7 +888,7 @@ impl TabsRenderer {
         let block = Block::default().style(Style::default().bg(theme.tab_separator_bg));
         let paragraph = Paragraph::new(line).block(block);
         if draw {
-            frame.render_widget(paragraph, area);
+            paragraph.render(area, buf);
         }
 
         // Pinned "+" button: when the tabs overflow, draw the button on top of
@@ -906,7 +906,7 @@ impl TabsRenderer {
                     .bg(theme.tab_inactive_bg),
             )]));
             if draw {
-                frame.render_widget(plus_para, plus_rect);
+                plus_para.render(plus_rect, buf);
             }
             layout.new_tab_area = Some(plus_rect);
         }
@@ -994,44 +994,6 @@ impl TabsRenderer {
         }
 
         layout
-    }
-
-    /// Legacy render function for backward compatibility
-    /// Renders all buffers as tabs (used during transition)
-    #[allow(dead_code)]
-    pub fn render(
-        frame: &mut Frame,
-        area: Rect,
-        buffers: &HashMap<BufferId, EditorState>,
-        buffer_metadata: &HashMap<BufferId, BufferMetadata>,
-        composite_buffers: &HashMap<BufferId, crate::model::composite_buffer::CompositeBuffer>,
-        active_buffer: BufferId,
-        theme: &crate::view::theme::Theme,
-        preview_buffer: Option<BufferId>,
-    ) {
-        // Sort buffer IDs to ensure consistent tab order
-        let mut buffer_ids: Vec<_> = buffers.keys().copied().collect();
-        buffer_ids.sort_by_key(|id| id.0);
-        let tab_targets: Vec<TabTarget> = buffer_ids.into_iter().map(TabTarget::Buffer).collect();
-        let group_names = HashMap::new();
-
-        Self::render_for_split(
-            frame,
-            area,
-            &tab_targets,
-            buffers,
-            buffer_metadata,
-            composite_buffers,
-            TabTarget::Buffer(active_buffer),
-            theme,
-            true, // Legacy behavior: always treat as active
-            0,    // Default tab_scroll_offset for legacy render
-            None, // No hover state for legacy render
-            &group_names,
-            preview_buffer,
-            None, // No theme recording for legacy render
-            true, // Legacy render always draws
-        );
     }
 }
 


### PR DESCRIPTION
## Summary

Reduces parameter-passing churn around `SplitRenderer::render_content` and decomposes the ~1700-line `Editor::render()` into focused phase methods. All changes are mechanical and behaviour-preserving — code is moved verbatim, preserving call order and borrow structure.

## Parameter reduction
- New `EditorRenderConfig<'a>` bundles the 16 immutable `config.editor.*` render flags (plus the two stable `Editor` fields `background_fade`, `software_cursor_only`). Only settings — no mutable state, buffers, theme, geometry, outputs, or per-frame computed flags.
- `render_content` drops from **42 → 27 parameters**; the 42-arg list that was previously written out three times (call site + façade + orchestration) collapses to a single bundled value, destructured back into locals at the orchestration boundary so the renderer interior is untouched.

## `render()` decomposition: 1718 → 883 lines (−49%)
Extracted, each its own commit and `cargo check`-verified:
- `render_file_explorer_pane` — sidebar layout + paint, returns the editor content area
- `render_status_bar_row` — status-bar pass (status-bar-only locals moved inside; only shared `display_name`/`theme`/`keybindings` passed in)
- `render_search_options_bar`, `render_prompt_line`
- `render_buffer_popups` — cursor-anchored popup collect + paint
- `render_software_cursor_and_capture`, `render_panels_and_modals`
- `render_modal_overlays`, `render_menu_bar`, `render_context_menus`

## ChromeLayout field grouping
- `StatusBarChrome` — `area`, `clickable`, `plugin_token_areas`, `segments` + the `clickable_area()` lookup, reached via `chrome.status_bar.*`.
- `FrameDimensions` — `last_frame_width`/`height` → `chrome.last_frame.width`/`.height`.

## Verification
`cargo check -p fresh-editor` clean; no new clippy warnings (the one collapse-`if` near the moved status-bar code is pre-existing, relocated verbatim). Test suite left for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)