### PR TITLE
Keep indentation guides subdued inside text selections

### DIFF
--- a/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
+++ b/crates/fresh-editor/src/view/ui/split_rendering/orchestration/render_line/cells.rs
@@ -311,10 +311,15 @@ impl CellPass<'_, '_, '_> {
             self.display_cell_text(ch, is_cursor, is_tab_start, &mut indicator_buf)
         };
 
-        // Apply subdued indicator colors from theme. Cursor / selection styling
-        // keeps precedence so guides do not obscure caret and selection state.
+        // Apply subdued indicator colors from theme. Cursor styling keeps
+        // precedence (so guides do not obscure the caret), but selection does
+        // not: a guide keeps its subdued foreground even inside a selection,
+        // layered over the selection background carried by `resolved.style`.
+        // This stops the guide glyph from lighting up to full-contrast text
+        // (which read as a literal glyph) when the leading whitespace is
+        // selected. Whitespace indicators still defer to selection styling.
         let mut style = resolved.style;
-        if is_indentation_guide && !is_cursor && !is_selected {
+        if is_indentation_guide && !is_cursor {
             style = style.fg(self.input.theme.indentation_guide_fg);
         } else if is_whitespace_indicator && !is_cursor && !is_selected {
             style = style.fg(self.input.theme.whitespace_indicator_fg);

--- a/crates/fresh-editor/tests/e2e/indentation_guide.rs
+++ b/crates/fresh-editor/tests/e2e/indentation_guide.rs
@@ -37,6 +37,69 @@ fn indentation_guide_render_configured_glyph_in_editor_flow() {
 }
 
 #[test]
+fn indentation_guide_keeps_subdued_color_inside_selection() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("guides_selected.rs");
+    std::fs::write(
+        &file_path,
+        "fn main() {\n    let child = 1;\n        let grand = child + 1;\n}\n",
+    )
+    .unwrap();
+
+    let mut config = Config::default();
+    config.editor.indentation_guide = IndentationGuideMode::All;
+    config.editor.indentation_guide_glyph = "┊".to_string();
+
+    let mut harness =
+        EditorTestHarness::create(80, 24, HarnessOptions::new().with_config(config)).unwrap();
+    harness.open_file(&file_path).unwrap();
+    harness.render().unwrap();
+
+    // Locate a guide cell on the deeply-indented "grand" line.
+    let (grand_col, grand_row) = harness
+        .find_text_on_screen("let grand")
+        .expect("expected the nested 'grand' line on screen");
+    let guide_col = (0..grand_col)
+        .find(|&x| harness.get_cell(x, grand_row).as_deref() == Some("┊"))
+        .expect("expected an indentation guide glyph before the 'grand' line text");
+
+    // Style of the guide while it is NOT selected.
+    let unselected = harness
+        .get_cell_style(guide_col, grand_row)
+        .expect("guide cell should have a style");
+
+    // Select the whole buffer so the leading-whitespace guide cells fall
+    // inside the selection.
+    harness
+        .send_key(KeyCode::Char('a'), KeyModifiers::CONTROL)
+        .unwrap();
+    harness.render().unwrap();
+
+    // The glyph must still be drawn at the same cell.
+    assert_eq!(
+        harness.get_cell(guide_col, grand_row).as_deref(),
+        Some("┊"),
+        "indentation guide glyph should remain visible inside a selection"
+    );
+
+    let selected = harness
+        .get_cell_style(guide_col, grand_row)
+        .expect("guide cell should have a style while selected");
+
+    // The selection must actually cover this cell (background changed)...
+    assert_ne!(
+        selected.bg, unselected.bg,
+        "selecting the indentation should apply the selection background to the guide cell"
+    );
+    // ...but the guide keeps its subdued foreground rather than lighting up to
+    // the selection's foreground color.
+    assert_eq!(
+        selected.fg, unselected.fg,
+        "indentation guide should keep its subdued foreground color inside a selection"
+    );
+}
+
+#[test]
 fn indentation_guide_all_mode_continues_through_blank_line_in_editor_flow() {
     let temp_dir = TempDir::new().unwrap();
     let file_path = temp_dir.path().join("guides_blank.rs");


### PR DESCRIPTION
## Summary
This change ensures that indentation guide glyphs maintain their subdued foreground color even when the leading whitespace they occupy falls within a text selection. Previously, guides would adopt the selection's foreground color, making them appear as literal glyphs rather than subtle visual aids.

## Key Changes
- **Modified selection styling logic**: Updated the condition in `cells.rs` that applies indentation guide colors to exclude the `is_selected` check. Guides now keep their subdued foreground color (`indentation_guide_fg`) regardless of selection state, while still respecting the selection background.
- **Added comprehensive test**: New test `indentation_guide_keeps_subdued_color_inside_selection` verifies that:
  - Indentation guide glyphs remain visible when selected
  - The selection background is applied to guide cells
  - The guide's foreground color stays subdued (not replaced by selection foreground)

## Implementation Details
The fix distinguishes between cursor styling (which takes precedence) and selection styling (which does not). This allows guides to layer their subdued foreground over the selection background, maintaining visual clarity and preventing guides from appearing as high-contrast literal characters when whitespace is selected. Whitespace indicators continue to defer to selection styling as before.

https://claude.ai/code/session_01RAyW4yr75Uo2wSJyX7y5yf