### PR TITLE
fix(vi): make `cw` change to end of word like Vim, preserving trailing space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ For live updates on Fresh, [follow me on X](https://x.com/TheNoamLewis).
 * **Regex search**: `^` / `$` now anchor per line in multi-line `Ctrl+F` search (#2495).
 * **Splits**: closing a buffer shown in two splits no longer desyncs the surviving cursor (#2496).
 * **Terminal**: a terminal restores its live/scrollback mode on refocus, and the last split is no longer left read-only after closing a second terminal (#2485).
+* **Vi mode**: `cw` on a non-blank now changes up to the end of the word like Vim (matching `ce`) instead of swallowing the trailing whitespace (#2437).
 * **Per-language indentation rules** are now actually applied — previously custom patterns were ignored (#2314).
 * **Brackets** are no longer highlighted inside comments and strings (#2405, reported by @TakemiSora).
 * **Quick-open `#` buffer switcher** now lists virtual buffers (#2373).

--- a/crates/fresh-editor/plugins/vi_mode.ts
+++ b/crates/fresh-editor/plugins/vi_mode.ts
@@ -751,6 +751,43 @@ function endWORDIndex(text: string, startIndex: number): number {
   return index;
 }
 
+// Word-class helpers for the `cw` special case (lowercase `w`, which — unlike
+// the whitespace-delimited WORD motions above — treats a run of word characters
+// and a run of punctuation as separate words).
+
+// Return the string index of the last character of the same-class (word or
+// punctuation) run that `index` is in. `index` must point at a non-whitespace
+// character.
+function tokenRunEnd(text: string, index: number): number {
+  const startIsWord = isWordChar(charAtStringIndex(text, index));
+  while (true) {
+    const next = nextStringIndex(text, index);
+    if (next >= text.length || isWhitespaceAt(text, next)) {
+      break;
+    }
+    if (isWordChar(charAtStringIndex(text, next)) !== startIsWord) {
+      break;
+    }
+    index = next;
+  }
+  return index;
+}
+
+// Vim `e`-style advance: from `index`, move forward one character, skip any
+// whitespace, then return the last character of the next word. Used for the
+// trailing words of a `cNw` change. Returns `index` unchanged if there is no
+// further word.
+function viWordEndAdvance(text: string, index: number): number {
+  let next = nextStringIndex(text, index);
+  while (next < text.length && isWhitespaceAt(text, next)) {
+    next = nextStringIndex(text, next);
+  }
+  if (next >= text.length) {
+    return index;
+  }
+  return tokenRunEnd(text, next);
+}
+
 function computeWORDMotionTargetIndex(text: string, startIndex: number, kind: WORDMotionKind, count: number): number {
   let index = startIndex;
   for (let i = 0; i < Math.max(1, count); i++) {
@@ -944,6 +981,36 @@ async function computeWORDOperatorRange(
   }
 
   return { start, end, cursorAfter };
+}
+
+// Compute the change range for `cw` / `cNw`. Vim treats `cw` like `ce` when the
+// cursor is on a non-blank: it changes only up to the end of the word and does
+// NOT consume the trailing whitespace (`:help cw`). Returns null when the cursor
+// is on a blank (or past EOF), in which case the caller falls back to plain `w`
+// (i.e. `dw`-style) semantics.
+async function computeWordChangeRange(count: number): Promise<{ start: number; end: number } | null> {
+  const start = editor.getCursorPosition();
+  if (start === null) {
+    return null;
+  }
+
+  const bufferId = editor.getActiveBufferId();
+  const bufferText = await editor.getBufferText(bufferId, 0, editor.getBufferLength(bufferId));
+  const startIndex = byteOffsetToStringIndex(bufferText, start);
+  if (startIndex >= bufferText.length || isWhitespaceAt(bufferText, startIndex)) {
+    return null;
+  }
+
+  // First word: stop at the end of the current word (no forward advance, so the
+  // cursor sitting on a word's last character changes only that character).
+  // Each additional count behaves like Vim's `e` motion.
+  let endIndex = tokenRunEnd(bufferText, startIndex);
+  for (let i = 1; i < Math.max(1, count); i++) {
+    endIndex = viWordEndAdvance(bufferText, endIndex);
+  }
+
+  const endTarget = stringIndexToByteOffset(bufferText, endIndex);
+  return { start, end: endTarget + byteLengthOfCharAt(bufferText, endIndex) };
 }
 
 async function applyWORDOperatorMotion(
@@ -1732,6 +1799,20 @@ async function vi_repeat() : Promise<void> {
     case "operator-motion": {
       // Operator + motion like dw, cw, d$
       if (change.operator && change.motion) {
+        if (change.motion === "vi_word_change") {
+          // `cw`/`cNw` special case — recompute the change range at the current
+          // cursor position (mirrors the WORD `cW` repeat path).
+          const range = await computeWordChangeRange(count);
+          if (range !== null) {
+            await applyOperatorWithRange("d", range.start, range.end);
+          } else {
+            await applyOperatorWithMotion("d", "move_word_right", count);
+          }
+          if (change.insertedText) {
+            editor.insertAtCursor(change.insertedText);
+          }
+          break;
+        }
         const WORDKind = WORDMotionKindFromRepeatMotion(change.motion);
         if (change.operator === "c") {
           if (WORDKind) {
@@ -2766,6 +2847,21 @@ async function vi_op_right(): Promise<void> {
 registerHandler("vi_op_right", vi_op_right);
 
 async function vi_op_word(): Promise<void> {
+  // Vim special case (`:help cw`): when changing (`c`) with the cursor on a
+  // non-blank character, `cw` behaves like `ce` — it changes only up to the end
+  // of the word and does NOT consume the trailing whitespace. Plain `dw`/`yw`
+  // and `cw` on a blank keep the regular word-forward semantics.
+  if (state.pendingOperator === "c") {
+    const count = consumeCount();
+    const range = await computeWordChangeRange(count);
+    if (range !== null) {
+      state.lastChange = { type: "operator-motion", operator: "c", motion: "vi_word_change", count };
+      await applyOperatorWithRange("c", range.start, range.end);
+      return;
+    }
+    await applyOperatorWithMotion("c", "move_word_right", count);
+    return;
+  }
   await handleMotionWithOperator("move_word_right");
 }
 registerHandler("vi_op_word", vi_op_word);

--- a/crates/fresh-editor/tests/e2e/vi_mode.rs
+++ b/crates/fresh-editor/tests/e2e/vi_mode.rs
@@ -398,6 +398,105 @@ fn test_vi_vim_compat_repeat_change_word_keeps_change_semantics() {
     harness.wait_for_buffer_content("X X four.five\n").unwrap();
 }
 
+// `cw` on a non-blank must behave like `ce` (Vim `:help cw`): change up to the
+// end of the word WITHOUT consuming the trailing whitespace. Regression test for
+// issue #2437, where `cw` ate the following space like `dw`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_keeps_following_space() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo bar\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    // Cursor starts on `h` of `hello`. `cw` should change only `hello`, keeping
+    // the space before `world`.
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X world foo bar\n");
+}
+
+// Unlike the whitespace-delimited `cW`, lowercase `cw` stops at punctuation:
+// `cw` on `one.two` changes only `one`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_stops_at_punctuation() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "one.two three\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X.two three\n");
+}
+
+// `cNw` honors the count and still keeps the trailing whitespace: `c2w` on
+// `hello world foo` changes `hello world`, leaving the space before `foo`.
+#[test]
+fn test_vi_vim_compat_change_lower_word_honors_count() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_key(&mut harness, 'c');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-operator-pending".to_string()))
+        .unwrap();
+    send_vi_key(&mut harness, '2');
+    send_vi_key(&mut harness, 'w');
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-insert".to_string()))
+        .unwrap();
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness.render().unwrap();
+
+    harness.assert_buffer_content("X foo\n");
+}
+
+// `.` repeat of `cw` replays the change semantics (keep trailing space), not a
+// `dw`-style delete.
+#[test]
+fn test_vi_vim_compat_repeat_change_lower_word_keeps_change_semantics() {
+    let (mut harness, _temp_dir) = vi_mode_harness(100, 30);
+
+    let fixture = TestFixture::new("test.txt", "hello world foo bar\n").unwrap();
+    harness.open_file(&fixture.path).unwrap();
+    harness.render().unwrap();
+
+    enable_vi_mode(&mut harness);
+
+    send_vi_operator_motion(&mut harness, 'c', 'w');
+    harness.type_text("X").unwrap();
+    harness.send_key(KeyCode::Esc, KeyModifiers::NONE).unwrap();
+    harness
+        .wait_until(|h| h.editor().editor_mode() == Some("vi-normal".to_string()))
+        .unwrap();
+    harness.assert_buffer_content("X world foo bar\n");
+
+    // `w` moves to the start of `world` (byte 2), then `.` repeats `cw`.
+    send_vi_key(&mut harness, 'w');
+    harness.wait_until(|h| h.cursor_position() == 2).unwrap();
+    send_vi_key(&mut harness, '.');
+
+    harness.wait_for_buffer_content("X X foo bar\n").unwrap();
+}
+
 #[test]
 fn test_vi_vim_compat_repeat_uses_original_operator_count() {
     let (mut harness, _temp_dir) = vi_mode_harness(100, 30);


### PR DESCRIPTION
## Summary

Fixes #2437.

Vim documents `cw`/`cW` as a special case: when the cursor is on a non-blank character they behave like `ce`/`cE` — they change only up to the **end of the word** and do **not** consume the trailing whitespace (`:help cw`). This is what makes `cw` convenient: the space between words is preserved.

Fresh's lowercase `cw` instead behaved like `dw` + insert, deleting the word **and** its trailing space:

- Before: `cw` + `X` on `hello world` (cursor on `h`) → `Xworld` ❌
- After:  `cw` + `X` on `hello world` (cursor on `h`) → `X world` ✅ (matches `ce`)

The uppercase `cW` already implemented this (via `computeWORDOperatorRange`'s change-forward branch), but lowercase `cw` went through the native `move_word_right` motion, which has no such special case.

## Changes

- **`crates/fresh-editor/plugins/vi_mode.ts`**
  - `vi_op_word`: when the pending operator is `c` and the cursor is on a non-blank, compute a word-class-aware change range that stops at the end of the current word instead of advancing to the start of the next word. Plain `dw`/`yw`, and `cw` on a blank, keep the regular word-forward semantics.
  - New helpers `tokenRunEnd` / `viWordEndAdvance` / `computeWordChangeRange`. Unlike the whitespace-delimited `cW`, these respect Vim's word classes, so `cw` on `one.two` changes only `one` (stops at the punctuation).
  - The first word stops at the end of the current word with **no forward advance** (so the cursor on a word's last character changes only that character); each additional count behaves like Vim's `e`.
  - Dot-repeat (`.`) recomputes the range at the new cursor position, mirroring the existing `cW` repeat path.

## Testing

Four new e2e tests in `crates/fresh-editor/tests/e2e/vi_mode.rs` drive real keystrokes and assert on rendered output:

- `cw` keeps the following space (the issue's reproduction)
- `cw` stops at punctuation (`one.two` → `X.two`)
- `c2w` honors the count and still keeps the trailing space
- `.` repeat of `cw` replays the change (keep-space) semantics, not `dw`

Verified the 3 behavioral tests fail against the unfixed plugin and pass with the fix; the full 80-test vi-mode e2e suite still passes. Also manually validated in a tmux session: `cw` + `X` on `hello world foo bar` → `X world foo bar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hiMwSvTcgCZwXL3F8b1Sv

---
_Generated by [Claude Code](https://claude.ai/code/session_012hiMwSvTcgCZwXL3F8b1Sv)_